### PR TITLE
[Tool] reverse-sync: executor + cd-sync CI gate

### DIFF
--- a/.github/workflows/cd-repo-sync.yml
+++ b/.github/workflows/cd-repo-sync.yml
@@ -1,0 +1,191 @@
+name: CD Repo Sync
+run-name: CD Repo Sync(#${{ inputs.PR_ID }} [${{ inputs.BRANCH }}])
+
+# Reverse sync executor: cherry-pick a CelerData open-source PR's commit onto
+# StarRocks main and open a "(cd-sync #N)" PR. Mirror of celerdata-enterprise's
+# repo-sync.yml (repo-sync-main job) with direction reversed (source=CelerData,
+# target=StarRocks). Dispatched by elastic-service/lib/sync_cd_to_sr.py.
+#
+# Runner prerequisites (SR-side self-hosted sync runner):
+#   - /var/lib/starrocks           : target working copy (StarRocks)
+#   - /var/lib/elastic-service     : sync tooling
+#   - /var/local/env/ci-source-code/celerdata-enterprise : source mirror (CelerData)
+
+on:
+  workflow_dispatch:
+    inputs:
+      PR_ID:
+        description: 'ORI PR ID (on SOURCE_REPO)'
+        required: true
+        type: string
+      COMMIT_ID:
+        description: 'ORI COMMIT ID'
+        required: true
+        type: string
+      BRANCH:
+        description: 'TARGET BRANCH'
+        required: true
+        type: string
+        default: 'main'
+      SOURCE_REPO:
+        description: 'SOURCE REPOSITORY'
+        required: true
+        type: string
+        default: 'CelerData/celerdata-enterprise'
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+env:
+  source_repo: ${{ inputs.SOURCE_REPO }}
+
+jobs:
+
+  pr-info:
+    name: Add PR Information
+    runs-on: [self-hosted, sync]
+    env:
+      PR_ID: ${{ inputs.PR_ID }}
+      SYNC_PAT: ${{ secrets.SYNC_PAT }}
+      SOURCE_REPO: ${{ inputs.SOURCE_REPO }}
+    outputs:
+      assignees: ${{ steps.ori_pr_info.outputs.assignees }}
+      title: ${{ steps.ori_pr_info.outputs.title }}
+    steps:
+      - name: Ori PR Info
+        id: ori_pr_info
+        run: |
+          cd /var/lib/elastic-service
+          git pull || true
+          ./lib/get_pr_info.sh
+
+  cd-repo-sync-main:
+    name: CD Repo Sync - main
+    runs-on: [self-hosted, sync]
+    if: inputs.BRANCH == 'main'
+    needs: pr-info
+    env:
+      GITHUB_TOKEN: ${{ secrets.SYNC_PAT }}
+      GH_TOKEN: ${{ secrets.SYNC_PAT }}
+    steps:
+      - name: clean
+        run: |
+          rm -rf ${{ github.workspace }}
+          mkdir -p ${{ github.workspace }}
+
+      - name: checkout code
+        run: |
+          shopt -s dotglob
+          cp -rf /var/lib/starrocks/* ${{ github.workspace }}
+          shopt -u dotglob
+
+      - name: Clean Branches
+        env:
+          source_branch: ${{ inputs.BRANCH }}-cd-sync-${{ inputs.PR_ID }}
+          destination_branch: ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.PR_ID }}
+        run: |
+          curl -s -X DELETE -u username:${{secrets.GITHUB_TOKEN}} https://api.github.com/repos/${{ github.repository }}/git/refs/heads/${{ env.source_branch }}
+          curl -s -X DELETE -u username:${{secrets.GITHUB_TOKEN}} https://api.github.com/repos/${{ github.repository }}/git/refs/heads/${{ env.destination_branch }}
+
+      - name: sync repo to branch
+        env:
+          source_branch: ${{ inputs.BRANCH }}
+          destination_branch: ${{ inputs.BRANCH }}-cd-sync-${{ inputs.PR_ID }}
+          github_token: ${{ secrets.SYNC_PAT }}
+        run: |
+          source_repo_dir=${source_repo#*/}
+          cp -rf /var/local/env/ci-source-code/${source_repo_dir} ${source_repo_dir}
+          cd ${source_repo_dir} && git pull
+          git checkout ${source_branch}
+          git remote set-url origin https://${github_token}@github.com/${{ github.repository }}.git
+          git push origin ${source_branch}:${destination_branch}
+
+      - name: checkout tools
+        run: |
+          cp -rf /var/lib/elastic-service ./elastic-service
+          cd elastic-service
+          git pull
+
+      - name: pr branch
+        run: |
+          git pull
+          git checkout ${{ inputs.BRANCH }}
+          pr_branch=${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.PR_ID }}
+          git branch ${pr_branch} ${{ inputs.BRANCH }}
+          git checkout ${pr_branch}
+          git push -u origin ${pr_branch}
+
+      - name: refresh base before cherry-pick
+        run: |
+          cd ${{ github.workspace }}
+          git fetch origin ${{ inputs.BRANCH }}
+          git reset --hard origin/${{ inputs.BRANCH }}
+
+      - name: cherry pick
+        id: cherry-pick
+        run: |
+          cd ${{ github.workspace }}/elastic-service
+          ./lib/run_cherry_pick.sh --pr ${{ inputs.PR_ID }}
+          cd ${{ github.workspace }}
+          git push -u origin ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.PR_ID }}
+
+      - name: Create pull request
+        id: create_pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.SYNC_PAT }}
+          PR_LABEL: sync,cd-sync,${{ steps.cherry-pick.outputs.LABEL }}${{ steps.cherry-pick.outputs.CONFLICT_LABEL }}
+          HEAD: ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.PR_ID }}
+          TITLE: "${{ needs.pr-info.outputs.title }}(cd-sync #${{ inputs.PR_ID }})"
+          BODY: "Reverse sync of ${{ inputs.SOURCE_REPO }}#${{ inputs.PR_ID }} (commit ${{ inputs.COMMIT_ID }})."
+          REVIEWER: ${{ needs.pr-info.outputs.assignees }}
+          BASE: ${{ inputs.BRANCH }}
+        run: |
+          cd ${{ github.workspace }}/elastic-service
+          ./scripts/create_sync_repo.sh
+
+      # Write back the marker onto the CelerData SOURCE PR for idempotency.
+      - name: Mark source PR
+        if: always() && steps.create_pr.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_PAT }}
+        run: |
+          if [[ "${{ steps.cherry-pick.outputs.CONFLICT_LABEL }}" != '' ]]; then
+            MARK="cd-sync-conflict"
+          else
+            MARK="sr-synced"
+          fi
+          gh api -X POST \
+            "repos/${{ inputs.SOURCE_REPO }}/issues/${{ inputs.PR_ID }}/labels" \
+            -f "labels[]=${MARK}" || echo "::warning::failed to add ${MARK} to ${{ inputs.SOURCE_REPO }}#${{ inputs.PR_ID }}"
+
+      - name: notify
+        if: always()
+        env:
+          branch: ${{ inputs.BRANCH }}
+          source_pr: ${{ inputs.PR_ID }}
+          source_commit_id: ${{ inputs.COMMIT_ID }}
+          action_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+        run: |
+          cd ${{ github.workspace }}
+          if [[ ! -d ${{ github.workspace }}/elastic-service ]]; then
+            cp -rf /var/lib/elastic-service ./elastic-service
+          fi
+          cd elastic-service && git pull
+          if [[ "${{ steps.cherry-pick.outputs.CONFLICT_LABEL }}" != '' && "${{ steps.create_pr.outcome }}" == 'success' ]]; then
+            msg_type="conflict"
+            this_pr_url=${{ steps.create_pr.outputs.pr_url }}
+          elif [[ "${{ steps.create_pr.outcome }}" == 'success' ]]; then
+            exit 0
+          else
+            msg_type="error"
+            this_pr_url=""
+          fi
+          python3 lib/sync_notify.py ${msg_type} ${branch} ${source_pr} ${source_commit_id} ${action_url} ${this_pr_url}
+
+      - name: clean
+        if: always()
+        run: |
+          rm -rf ${{ github.workspace }} && mkdir -p ${{ github.workspace }}

--- a/.github/workflows/cd-repo-sync.yml
+++ b/.github/workflows/cd-repo-sync.yml
@@ -117,6 +117,19 @@ jobs:
           git checkout ${pr_branch}
           git push -u origin ${pr_branch}
 
+      # Ordering: if a file-overlapping, earlier-merged cd-sync PR is still open,
+      # this PR must wait -> RES != True -> created as pending (see Create pending pr).
+      - name: previous check
+        id: previous-check
+        run: |
+          cd ${{ github.workspace }}/elastic-service
+          check_res=$(python3 lib/pr_sequence_checker_reverse.py new ${{ inputs.BRANCH }} ${{ inputs.PR_ID }} ${{ inputs.COMMIT_ID }})
+          echo "${check_res}"
+          conflict_prs=$(echo ${check_res} | awk -F'Files:' '{print $1}' | awk -F' ' '{print $NF}')
+          echo CONFLICT_PRS=${conflict_prs} >> $GITHUB_OUTPUT
+          res=$(echo ${check_res} | tail -n 1)
+          echo RES=${res} >> $GITHUB_OUTPUT
+
       - name: refresh base before cherry-pick
         run: |
           cd ${{ github.workspace }}
@@ -133,12 +146,31 @@ jobs:
 
       - name: Create pull request
         id: create_pr
+        if: steps.previous-check.outputs.RES == 'True'
         env:
           GITHUB_TOKEN: ${{ secrets.SYNC_PAT }}
           PR_LABEL: sync,cd-sync,${{ steps.cherry-pick.outputs.LABEL }}${{ steps.cherry-pick.outputs.CONFLICT_LABEL }}
           HEAD: ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.PR_ID }}
           TITLE: "${{ needs.pr-info.outputs.title }}(cd-sync #${{ inputs.PR_ID }})"
           BODY: "Reverse sync of ${{ inputs.SOURCE_REPO }}#${{ inputs.PR_ID }} (commit ${{ inputs.COMMIT_ID }})."
+          REVIEWER: ${{ needs.pr-info.outputs.assignees }}
+          BASE: ${{ inputs.BRANCH }}
+        run: |
+          cd ${{ github.workspace }}/elastic-service
+          ./scripts/create_sync_repo.sh
+
+      # A file-overlapping predecessor is still open -> hold this PR as pending.
+      # cd-sync-pipeline.yml skips `pending` PRs; cd-scan-pending.yml releases it
+      # (removes pending + re-dispatches this workflow) once predecessors merge.
+      - name: Create pending pull request
+        id: create_pending_pr
+        if: steps.previous-check.outputs.RES != 'True'
+        env:
+          GITHUB_TOKEN: ${{ secrets.SYNC_PAT }}
+          PR_LABEL: sync,cd-sync,${{ steps.cherry-pick.outputs.LABEL }},pending
+          HEAD: ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.PR_ID }}
+          TITLE: "${{ needs.pr-info.outputs.title }}(cd-sync #${{ inputs.PR_ID }})"
+          BODY: "Previous prs: ${{ steps.previous-check.outputs.CONFLICT_PRS }}"
           REVIEWER: ${{ needs.pr-info.outputs.assignees }}
           BASE: ${{ inputs.BRANCH }}
         run: |
@@ -177,6 +209,9 @@ jobs:
           if [[ "${{ steps.cherry-pick.outputs.CONFLICT_LABEL }}" != '' && "${{ steps.create_pr.outcome }}" == 'success' ]]; then
             msg_type="conflict"
             this_pr_url=${{ steps.create_pr.outputs.pr_url }}
+          elif [[ "${{ steps.create_pending_pr.outcome }}" == 'success' ]]; then
+            msg_type="pending"
+            this_pr_url=${{ steps.create_pending_pr.outputs.pr_url }}
           elif [[ "${{ steps.create_pr.outcome }}" == 'success' ]]; then
             exit 0
           else
@@ -184,6 +219,15 @@ jobs:
             this_pr_url=""
           fi
           python3 lib/sync_notify.py ${msg_type} ${branch} ${source_pr} ${source_commit_id} ${action_url} ${this_pr_url}
+
+      # Kick the pending scan so a just-created pending PR is (re)evaluated promptly,
+      # and any now-releasable pending PR (predecessor merged) gets picked up.
+      - name: Trigger pending scan
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_PAT }}
+        run: |
+          gh workflow run cd-scan-pending.yml -R ${{ github.repository }} || true
 
       - name: clean
         if: always()

--- a/.github/workflows/cd-scan-pending.yml
+++ b/.github/workflows/cd-scan-pending.yml
@@ -1,0 +1,38 @@
+name: CD SCAN PENDING PRS
+
+# Reverse-sync ordering release loop. Mirror of celerdata-enterprise's
+# sync-scan-pending.yml, direction reversed (runs on StarRocks; releases pending
+# cd-sync PRs once their file-overlapping predecessors merge). Triggered on a
+# 30-min cron and by cd-repo-sync.yml (workflow_dispatch after each executor run).
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  actions: write
+
+concurrency:
+  group: PENDING-SCAN-CD
+  cancel-in-progress: false
+
+jobs:
+
+  scan-pending-cd-pr:
+    name: SCAN PENDING CD-SYNC PRS
+    runs-on: [self-hosted, sync]
+    if: github.repository == 'StarRocks/starrocks'
+    steps:
+      - name: scan
+        id: scan
+        env:
+          GITHUB_TOKEN: ${{ secrets.SYNC_PAT }}
+          GH_TOKEN: ${{ secrets.SYNC_PAT }}
+        run: |
+          cd /var/lib/elastic-service
+          git pull || true
+          python3 lib/pr_sequence_checker_reverse.py scan

--- a/.github/workflows/cd-sync-pipeline.yml
+++ b/.github/workflows/cd-sync-pipeline.yml
@@ -1,0 +1,319 @@
+name: CD SYNC CI PIPELINE
+
+# CI gate for reverse-sync PRs (title "(cd-sync #N)", label cd-sync) opened on
+# StarRocks main by cd-repo-sync.yml. Mirror of celerdata-enterprise's
+# sync-ci-pipeline.yml, trimmed for v1: BUILD chain only (no UT), auto-merge on
+# green. Runs on [self-hosted, normal] (mirrors ci-pipeline's heavy-job pool;
+# the tiny [sync] pool is reserved for the executor + ci-sync trigger).
+# Requires SR-side secret: PAT.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.event.number }}-cd-sync-checker
+  cancel-in-progress: true
+
+permissions:
+  checks: write
+  actions: write
+  contents: write
+  issues: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  pr-label:
+    runs-on: [self-hosted, normal]
+    name: PR LABEL
+    env:
+      PR_NUMBER: ${{ github.event.number }}
+    outputs:
+      labels: ${{ steps.labels.outputs.LABELS }}
+    steps:
+      - run: sleep 10
+      - name: Get PR labels
+        id: labels
+        run: |
+          set -x
+          labels=`curl -L \
+                  -H "Accept: application/vnd.github+json" \
+                  -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                  -H "X-GitHub-Api-Version: 2022-11-28" \
+                  https://api.github.com/repos/${{ github.repository }}/pulls/${PR_NUMBER} 2>/dev/null \
+                  | jq '.labels[].name'`
+          labels=`echo "$labels" | tr "\"" " " | tr "\n" " "`
+          echo "LABELS=$labels" >> $GITHUB_OUTPUT
+
+  cd-sync-checker:
+    runs-on: [self-hosted, normal]
+    needs: pr-label
+    if: >
+      contains(github.event.pull_request.title, '(cd-sync #') &&
+      contains(needs.pr-label.outputs.labels, 'cd-sync') &&
+      !contains(needs.pr-label.outputs.labels, 'pending') &&
+      !contains(needs.pr-label.outputs.labels, 'force-check')
+    name: RUN CHECKER
+    steps:
+      - run: echo "success"
+
+  code-checker:
+    runs-on: [self-hosted, normal]
+    needs: cd-sync-checker
+    name: CODE FILTER
+    outputs:
+      output1: ${{ steps.changes-info.outputs.be }}
+      output2: ${{ steps.changes-info.outputs.thirdparty }}
+      output3: ${{ steps.changes-info.outputs.fe }}
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            be:
+              - 'be/**'
+              - 'gensrc/**'
+              - 'run-be-ut.sh'
+              - 'build.sh'
+              - 'thirdparty/**'
+              - 'docker/dockerfiles/dev-env/dev-env.Dockerfile'
+            fe:
+              - 'fe/**'
+              - 'gensrc/**'
+              - 'run-fe-ut.sh'
+              - 'java-extensions/**'
+              - 'build.sh'
+              - 'test/**'
+
+      - uses: dorny/paths-filter@v3
+        id: linux-thirdparty-filter
+        with:
+          predicate-quantifier: every
+          filters: |
+            thirdparty:
+              - 'thirdparty/**'
+              - '!thirdparty/build-thirdparty-darwin.sh'
+              - '!thirdparty/vars-darwin-aarch64.sh'
+            dev_env:
+              - 'docker/dockerfiles/dev-env/dev-env.Dockerfile'
+
+      - name: CHECK INFO
+        id: changes-info
+        run: |
+          thirdparty=false
+          if [[ "${{ steps.linux-thirdparty-filter.outputs.thirdparty }}" == 'true' || "${{ steps.linux-thirdparty-filter.outputs.dev_env }}" == 'true' ]]; then
+            thirdparty=true
+          fi
+          echo "be=${{ steps.changes.outputs.be }}" >> $GITHUB_OUTPUT
+          echo "thirdparty=${thirdparty}" >> $GITHUB_OUTPUT
+          echo "fe=${{ steps.changes.outputs.fe }}" >> $GITHUB_OUTPUT
+
+  thirdparty-update:
+    runs-on: [self-hosted, normal]
+    needs: [code-checker]
+    name: Thirdparty Update
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        linux: [centos7, ubuntu]
+    env:
+      PR_NUMBER: ${{ github.event.number }}
+      BRANCH: ${{ github.base_ref }}
+      REPO: ${{ github.repository }}
+    if: >
+      (!contains(needs.pr-label.outputs.labels, 'conflict') || github.event.action != 'opened') &&
+      (needs.code-checker.outputs.output1 == 'true' ||
+      needs.code-checker.outputs.output2 == 'true' ||
+      needs.code-checker.outputs.output3 == 'true')
+    steps:
+      - name: clean
+        run: |
+          rm -rf ${{ github.workspace }}
+          mkdir -p ${{ github.workspace }}
+
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Update Image (${{ matrix.linux }})
+        id: update-image
+        if: needs.code-checker.outputs.output2 == 'true'
+        env:
+          linux_distro: ${{ matrix.linux }}
+        run: |
+          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
+          ./bin/run-pr-update-image.sh
+
+      - name: Upload Thirdparty Result
+        uses: actions/upload-artifact@v4
+        with:
+          name: THIRDPARTY-RESULT-${{ matrix.linux }}
+          path: image_cache.info
+          retention-days: 1
+          overwrite: true
+
+      - name: Clean ENV
+        if: always() && needs.code-checker.outputs.output2 == 'true'
+        run: |
+          cd ci-tool && source lib/init.sh
+          ./bin/elastic-cluster.sh --delete
+          rm -rf ${{ github.workspace }}/*
+
+  thirdparty-info:
+    runs-on: [self-hosted, normal]
+    needs:
+      - thirdparty-update
+    name: Thirdparty Info
+    outputs:
+      centos7_image_cache_id: ${{ steps.info.outputs.centos7_image_cache_id }}
+      ubuntu_image_cache_id: ${{ steps.info.outputs.ubuntu_image_cache_id }}
+    steps:
+      - name: clean
+        run: |
+          rm -rf ${{ github.workspace }}
+          mkdir -p ${{ github.workspace }}
+
+      - name: Check Result
+        run: |
+          if [[ "${{ needs.thirdparty-update.result }}" == 'failure' ]]; then
+            echo "::error:: Thirdparty Update Error!"
+            exit 1
+          fi
+
+      - name: Download Thirdparty Artifact
+        uses: actions/download-artifact@v4
+        with:
+          pattern: THIRDPARTY-RESULT-*
+          path: outputs
+
+      - name: Read Info
+        id: info
+        if: needs.thirdparty-update.result == 'success'
+        run: |
+          image_cache_id=$(cat "./outputs/THIRDPARTY-RESULT-centos7/image_cache.info" || echo "")
+          echo "centos7_image_cache_id=${image_cache_id}" >> $GITHUB_OUTPUT
+          image_cache_id=$(cat "./outputs/THIRDPARTY-RESULT-ubuntu/image_cache.info" || echo "")
+          echo "ubuntu_image_cache_id=${image_cache_id}" >> $GITHUB_OUTPUT
+
+  build:
+    runs-on: [self-hosted, normal]
+    needs: [thirdparty-info]
+    name: BUILD
+    env:
+      PR_NUMBER: ${{ github.event.number }}
+      BRANCH: ${{ github.base_ref }}
+      LINUX_DISTRO: ubuntu
+    outputs:
+      build_output_tar: ${{ steps.run_build.outputs.OUTPUT_TAR }}
+      base_version: ${{ steps.run_build.outputs.BASE_VERSION }}
+    steps:
+      - name: clean
+        run: |
+          rm -rf ${{ github.workspace }}
+          mkdir -p ${{ github.workspace }}
+
+      - name: BRANCH INFO
+        id: branch
+        run: |
+          echo ${{ github.base_ref }}
+          echo "branch=${{ github.base_ref }}" >> $GITHUB_OUTPUT
+
+      - name: UPDATE ECI & RUN BUILD
+        id: run_build
+        shell: bash
+        timeout-minutes: 90
+        env:
+          SKIP_OSS: 'true'
+        run: |
+          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
+          if [[ "${{ needs.thirdparty-info.outputs.ubuntu_image_cache_id }}" != '' ]]; then
+              export image_cache_id=${{ needs.thirdparty-info.outputs.ubuntu_image_cache_id }}
+              export image_tag=$BRANCH-$PR_NUMBER
+          fi
+          ./bin/elastic-build.sh --pr ${PR_NUMBER} --branch ${BRANCH} --repository ${{ github.repository }} --linuxdistro ${LINUX_DISTRO}
+
+      - name: build result
+        run: |
+          echo ${{ steps.run_build.outputs.OUTPUT_TAR }}
+
+      - name: clean ECI
+        if: always()
+        run: |
+          echo ${{ steps.run_build.outputs.ECI_ID }}
+          eci rm ${{ steps.run_build.outputs.ECI_ID }}
+
+      - name: Clean ENV
+        if: always()
+        run: |
+          rm -f ${{ steps.run_build.outputs.RES_FILE }}
+          rm -f ${{ steps.run_build.outputs.RES_LOG }}
+
+  result:
+    runs-on: [self-hosted, normal]
+    needs: [pr-label, code-checker, build]
+    name: RESULT
+    if: >
+      always() && (!contains(needs.pr-label.outputs.labels, 'conflict') || github.event.action != 'opened')
+    steps:
+      - name: add label
+        uses: actions-ecosystem/action-add-labels@v1
+        if: needs.build.result == 'failure'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: ERROR
+
+      - name: remove label
+        uses: actions-ecosystem/action-remove-labels@v1
+        if: needs.build.result != 'failure'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: ERROR
+
+  auto-merge:
+    needs: [pr-label, code-checker, build]
+    name: Auto Merge
+    runs-on: [self-hosted, normal]
+    if: >
+      always() &&
+      contains(github.event.pull_request.title, '(cd-sync #') &&
+      contains(needs.pr-label.outputs.labels, 'cd-sync') &&
+      !contains(needs.pr-label.outputs.labels, 'conflict') &&
+      !contains(needs.pr-label.outputs.labels, 'pending') &&
+      !contains(needs.pr-label.outputs.labels, 'ERROR') &&
+      (
+        needs.build.result == 'success' ||
+        (
+          needs.build.result == 'skipped' &&
+          needs.code-checker.result == 'success' &&
+          needs.code-checker.outputs.output1 != 'true' &&
+          needs.code-checker.outputs.output2 != 'true' &&
+          needs.code-checker.outputs.output3 != 'true'
+        )
+      )
+    steps:
+      - name: clean
+        run: |
+          rm -rf ${{ github.workspace }}
+          mkdir -p ${{ github.workspace }}
+
+      - name: add automerge label
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: automerge
+
+      # StarRocks pattern (see pr-checker.yml): enable automerge with secrets.PAT,
+      # no separate auto-approve step. merge-method squash to match SR bot merges.
+      - name: automerge
+        uses: peter-evans/enable-pull-request-automerge@v2
+        with:
+          token: ${{ secrets.PAT }}
+          pull-request-number: ${{ github.event.pull_request.number }}
+          merge-method: squash


### PR DESCRIPTION
## Why I'm doing:

open-source-confirmed PRs are synced back to StarRocks
`main`. This adds the **StarRocks-side** half of that reverse-sync (Phase 2+3).
The-side scanner + manual entry are separate PRs
(StarRocks/elastic-service#1369,

## What I'm doing:

Two workflows, mirroring the existing forward-sync (repo-sync.yml / sync-ci-pipeline.yml):

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

---

## Ordering / serialization (mirrors the forward pending+scan mechanism)

When several PRs of the same open-source issue are dependent (incremental delivery, a later
PR built on an earlier one), a later PR's cherry-pick onto SR `main` must wait until the
earlier cd-sync PR merges, otherwise it conflicts / produces broken code.

The forward path solves this with a **pending label + scan-pending workflow**:
`pr_sequence_checker.py new` marks a sync PR `pending` (with `Previous prs:` in the body) when
a file-overlapping predecessor is unmerged, and `sync-scan-pending.yml` (cron + event) releases
it once predecessors merge. Reverse sync will **mirror** this — executor marks `cd-sync,pending`,
a new `cd-scan-pending.yml` releases, and `pr_sequence_checker.py` gains a direction-aware branch
(forward logic unchanged; reverse adds source=CelerData / sync=StarRocks / `cd-sync` labels).

**Status:** the scanner already dispatches in `mergedAt` order; the pending+scan mirror
(component 4 in the design spec) is **not yet implemented in this PR** — it is a required
follow-up before reverse-sync goes real. The dry-run path does no real cherry-pick, so it is
unaffected. See the design spec, "组件 4 — 保序:镜像正向 pending + scan".
