### PR TITLE
[Refactor] Rename TSortNode.analytic_partition_skewed to analytic_need_merge

### DIFF
--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -164,7 +164,7 @@ void TopNNode::close(RuntimeState* state) {
 
 template <class ContextFactory, class SinkFactory, class SourceFactory>
 StatusOr<pipeline::OpFactories> TopNNode::_decompose_to_pipeline(pipeline::PipelineBuilderContext* context,
-                                                                 bool is_partition_topn, bool is_partition_skewed,
+                                                                 bool is_partition_topn, bool analytic_need_merge,
                                                                  bool need_merge, bool enable_parallel_merge,
                                                                  bool is_per_pipeline) {
     using namespace pipeline;
@@ -185,7 +185,7 @@ StatusOr<pipeline::OpFactories> TopNNode::_decompose_to_pipeline(pipeline::Pipel
         if (enable_parallel_merge) {
             ops_sink_with_sort = ::starrocks::pipeline::builder::maybe_interpolate_local_passthrough_exchange(
                     context, runtime_state(), id(), ops_sink_with_sort, context->degree_of_parallelism(),
-                    is_partition_skewed);
+                    analytic_need_merge);
         }
     } else if (!is_per_pipeline) {
         // prepend local shuffle to PartitionSortSinkOperator
@@ -290,9 +290,8 @@ StatusOr<pipeline::OpFactories> TopNNode::decompose_to_pipeline(pipeline::Pipeli
     bool is_per_pipeline = _tnode.sort_node.__isset.per_pipeline && _tnode.sort_node.per_pipeline;
     // need_merge = true means gather is needed for multiple streams of data
     // need_merge = false means gather is no longer needed
-    bool is_partition_skewed =
-            _tnode.sort_node.__isset.analytic_partition_skewed && _tnode.sort_node.analytic_partition_skewed;
-    bool need_merge = !is_per_pipeline && (_analytic_partition_exprs.empty() || is_partition_skewed);
+    bool analytic_need_merge = _tnode.sort_node.__isset.analytic_need_merge && _tnode.sort_node.analytic_need_merge;
+    bool need_merge = !is_per_pipeline && (_analytic_partition_exprs.empty() || analytic_need_merge);
     bool enable_parallel_merge = _tnode.sort_node.__isset.enable_parallel_merge &&
                                  _tnode.sort_node.enable_parallel_merge &&
                                  !_sort_exec_exprs.lhs_ordering_expr_ctxs().empty();
@@ -304,7 +303,7 @@ StatusOr<pipeline::OpFactories> TopNNode::decompose_to_pipeline(pipeline::Pipeli
                 operators_source_with_sort,
                 (_decompose_to_pipeline<LocalPartitionTopnContextFactory, LocalPartitionTopnSinkOperatorFactory,
                                         LocalPartitionTopnSourceOperatorFactory>(
-                        context, is_partition_topn, is_partition_skewed, need_merge, enable_parallel_merge,
+                        context, is_partition_topn, analytic_need_merge, need_merge, enable_parallel_merge,
                         is_per_pipeline)));
     } else {
         if (runtime_state()->enable_spill() && runtime_state()->enable_sort_spill()) {
@@ -312,13 +311,13 @@ StatusOr<pipeline::OpFactories> TopNNode::decompose_to_pipeline(pipeline::Pipeli
                 ASSIGN_OR_RETURN(operators_source_with_sort,
                                  (_decompose_to_pipeline<SortContextFactory, SpillablePartitionSortSinkOperatorFactory,
                                                          LocalParallelMergeSortSourceOperatorFactory>(
-                                         context, is_partition_topn, is_partition_skewed, need_merge,
+                                         context, is_partition_topn, analytic_need_merge, need_merge,
                                          enable_parallel_merge, is_per_pipeline)));
             } else {
                 ASSIGN_OR_RETURN(operators_source_with_sort,
                                  (_decompose_to_pipeline<SortContextFactory, SpillablePartitionSortSinkOperatorFactory,
                                                          LocalMergeSortSourceOperatorFactory>(
-                                         context, is_partition_topn, is_partition_skewed, need_merge,
+                                         context, is_partition_topn, analytic_need_merge, need_merge,
                                          enable_parallel_merge, is_per_pipeline)));
             }
         } else {
@@ -326,13 +325,13 @@ StatusOr<pipeline::OpFactories> TopNNode::decompose_to_pipeline(pipeline::Pipeli
                 ASSIGN_OR_RETURN(operators_source_with_sort,
                                  (_decompose_to_pipeline<SortContextFactory, PartitionSortSinkOperatorFactory,
                                                          LocalParallelMergeSortSourceOperatorFactory>(
-                                         context, is_partition_topn, is_partition_skewed, need_merge,
+                                         context, is_partition_topn, analytic_need_merge, need_merge,
                                          enable_parallel_merge, is_per_pipeline)));
             } else {
                 ASSIGN_OR_RETURN(operators_source_with_sort,
                                  (_decompose_to_pipeline<SortContextFactory, PartitionSortSinkOperatorFactory,
                                                          LocalMergeSortSourceOperatorFactory>(
-                                         context, is_partition_topn, is_partition_skewed, need_merge,
+                                         context, is_partition_topn, analytic_need_merge, need_merge,
                                          enable_parallel_merge, is_per_pipeline)));
             }
         }

--- a/be/src/exec/topn_node.h
+++ b/be/src/exec/topn_node.h
@@ -42,7 +42,7 @@ public:
 private:
     template <class ContextFactory, class SinkFactory, class SourceFactory>
     StatusOr<pipeline::OpFactories> _decompose_to_pipeline(pipeline::PipelineBuilderContext* context,
-                                                           bool is_partition_topn, bool is_partition_skewed,
+                                                           bool is_partition_topn, bool analytic_need_merge,
                                                            bool is_merging, bool enable_parallel_merge,
                                                            bool is_per_pipeline);
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
@@ -78,7 +78,11 @@ public class SortNode extends PlanNode implements RuntimeFilterBuildNode {
     // also added to TopNNode to hint that local shuffle operator is prepended to TopNNode in
     // order to eliminate merging operation in pipeline execution engine.
     private List<Expr> analyticPartitionExprs = Collections.emptyList();
-    private boolean analyticPartitionSkewed = false;
+
+    // When true, forces the SortNode to produce a single merged output stream instead of
+    // partition-sorted streams. Required when the downstream AnalyticNode consumes a single,
+    // globally-ordered input (currently the skewed-partition path).
+    private boolean analyticNeedsMerge = false;
 
     // info_.sortTupleSlotExprs_ substituted with the outputSmap_ for materialized slots in init().
     public List<Expr> resolvedTupleExprs;
@@ -96,8 +100,8 @@ public class SortNode extends PlanNode implements RuntimeFilterBuildNode {
         this.analyticPartitionExprs = exprs;
     }
 
-    public void setAnalyticPartitionSkewed(boolean isSkewed) {
-        analyticPartitionSkewed = isSkewed;
+    public void setAnalyticNeedsMerge(boolean needsMerge) {
+        analyticNeedsMerge = needsMerge;
     }
 
     private DataPartition inputPartition;
@@ -258,7 +262,7 @@ public class SortNode extends PlanNode implements RuntimeFilterBuildNode {
         msg.sort_node.setIs_asc_order(info.getIsAscOrder());
         msg.sort_node.setNulls_first(info.getNullsFirst());
         msg.sort_node.setAnalytic_partition_exprs(ExprToThrift.treesToThrift(analyticPartitionExprs));
-        msg.sort_node.setAnalytic_partition_skewed(analyticPartitionSkewed);
+        msg.sort_node.setAnalytic_need_merge(analyticNeedsMerge);
         if (info.getSortTupleSlotExprs() != null) {
             msg.sort_node.setSort_tuple_slot_exprs(ExprToThrift.treesToThrift(info.getSortTupleSlotExprs()));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -3642,9 +3642,13 @@ public class PlanFragmentBuilder {
          * In new planner.
          * Add partition exprs of AnalyticEvalNode to SortNode, it is used in pipeline execution engine
          * to eliminate time-consuming LocalMergeSortSourceOperator and parallelize AnalyticNode.
+         *
+         * @param needsMerge when true, forces the SortNode to produce a single merged output stream
+         *                   instead of partition-sorted streams, because the downstream AnalyticNode
+         *                   consumes a single globally-ordered input.
          */
         private static void passPartitionByToSortNode(ExecPlan context, PlanNode childRoot, List<Expr> partitionExprs,
-                                                      boolean isSkewed) {
+                                                      boolean needsMerge) {
             SortNode sortNode = null;
             if (childRoot instanceof SortNode) {
                 sortNode = (SortNode) childRoot;
@@ -3676,7 +3680,7 @@ public class PlanFragmentBuilder {
 
             if (sortNode != null) {
                 // If the data is skewed, we prefer to perform the standard sort-merge process to enhance performance.
-                sortNode.setAnalyticPartitionSkewed(isSkewed);
+                sortNode.setAnalyticNeedsMerge(needsMerge);
             }
         }
 

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -1076,7 +1076,7 @@ struct TSortNode {
   28: optional i64 max_buffered_bytes;
   29: optional bool late_materialization;
   30: optional bool enable_parallel_merge;
-  31: optional bool analytic_partition_skewed;
+  31: optional bool analytic_need_merge;
   32: optional list<Exprs.TExpr> pre_agg_exprs;
   33: optional list<Types.TSlotId> pre_agg_output_slot_id;
   34: optional bool pre_agg_insert_local_shuffle;


### PR DESCRIPTION
## Why I'm doing:
The flag tells the BE's `TopNNode` to emit one merged stream instead of partition-sorted streams. It
happens to be set only on the skewed path today, but the condition it expresses is "the downstream
AnalyticNode needs one globally-ordered input", not "the data is skewed". A follow-up PR adds a
second rule to set it.

## What I'm doing:

Rename `TSortNode.analytic_partition_skewed` to `analytic_need_merge`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
