### PR TITLE
[BugFix] Fix CBO table-prune Memo self-reference in Memo instead of by salting operators

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Memo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Memo.java
@@ -165,14 +165,66 @@ public class Memo {
     }
 
     private void mergeGroup(Group srcGroup, Group dstGroup) {
+        // A merge rewrites, removes and re-appends GroupExpressions across arbitrary groups -- not just
+        // srcGroup and dstGroup -- so it can rotate which expression is a group's FIRST logical one.
+        // Record every group that currently has a stats-derived first expression, so the rotation can be
+        // compensated for afterwards; see restoreStatsDerivedRepresentative.
+        Map<Group, GroupExpression> derivedFirstBefore = Maps.newIdentityHashMap();
+        for (Group group : groups) {
+            if (!group.getLogicalExpressions().isEmpty() && group.getFirstLogicalExpression().isStatsDerived()) {
+                derivedFirstBefore.put(group, group.getFirstLogicalExpression());
+            }
+        }
+
         mergeGroupImpl(srcGroup, dstGroup);
         removeSelfReferencing(dstGroup);
         // When some rule merge two groups to one group, or
         // the GroupExpressions of one group are all removed.
         // The group is empty, We should remove it.
-        Set<Group> groups = getAllEmptyGroups();
-        for (Group group : groups) {
+        Set<Group> emptyGroups = getAllEmptyGroups();
+        for (Group group : emptyGroups) {
             removeOneGroup(group);
+        }
+
+        // Must run last: removeOneGroup above also drops GroupExpressions from arbitrary groups and can
+        // rotate their first logical expression again.
+        restoreStatsDerivedRepresentative(derivedFirstBefore);
+    }
+
+    /**
+     * Statistics are a group-level property shared by every logically-equivalent expression in a group,
+     * but the derived marker lives on each GroupExpression and DeriveStatsTask only ever checks it on a
+     * child group's FIRST logical expression. When a merge rotates a group's first logical expression
+     * away from an already-derived one, that check would start failing for a group whose statistics are
+     * in fact already derived, so re-mark the new first expression as derived.
+     * <p>
+     * Gated on the group having had a derived first expression before the merge: a group that never
+     * derived its statistics is left untouched, so this never claims derivation that did not happen.
+     */
+    private void restoreStatsDerivedRepresentative(Map<Group, GroupExpression> derivedFirstBefore) {
+        for (Group group : groups) {
+            GroupExpression previousFirst = derivedFirstBefore.get(group);
+            if (previousFirst == null || group.getLogicalExpressions().isEmpty()) {
+                continue;
+            }
+            if (group.getFirstLogicalExpression() != previousFirst) {
+                markStatsDerivedRepresentative(group);
+            }
+        }
+    }
+
+    /**
+     * Mark the group's current first logical expression as stats-derived. Only ever called for a group
+     * whose statistics are already derived, so this records where the derivation lives rather than
+     * claiming a derivation that did not happen.
+     */
+    private void markStatsDerivedRepresentative(Group group) {
+        if (group.getLogicalExpressions().isEmpty()) {
+            return;
+        }
+        GroupExpression representative = group.getFirstLogicalExpression();
+        if (!representative.isStatsDerived()) {
+            representative.setStatsDerived();
         }
     }
 
@@ -189,6 +241,9 @@ public class Memo {
             }
         }
         for (GroupExpression ge : removeList) {
+            // Mark unused so any ApplyRuleTask already queued on the scheduler stack that still holds
+            // this GE is skipped by its isUnused() guard, instead of resurrecting the self-reference.
+            ge.setUnused(true);
             group.removeGroupExpression(ge);
             groupExpressions.remove(ge);
         }
@@ -196,6 +251,14 @@ public class Memo {
 
     // Merge srcGroup to dstGroup, srcGroup will be deleted
     private void mergeGroupImpl(Group srcGroup, Group dstGroup) {
+        // Every expression that referenced srcGroup is rewritten below to reference dstGroup, and
+        // Group.mergeGroup hands dstGroup srcGroup's statistics when it has none of its own. So a parent
+        // DeriveStatsTask already queued on the scheduler stack, which used to check srcGroup's
+        // representative, ends up checking dstGroup's -- the derived marker has to travel along with the
+        // statistics, or that check fails for a group whose statistics are in fact derived.
+        boolean srcRepresentativeDerived = !srcGroup.getLogicalExpressions().isEmpty()
+                && srcGroup.getFirstLogicalExpression().isStatsDerived();
+
         groups.remove(srcGroup);
         // Reset root group, rewrite rule maybe eliminate the root group
         if (srcGroup == rootGroup) {
@@ -268,7 +331,19 @@ public class Memo {
         }
         dstGroup.mergeGroup(srcGroup);
 
-        needMergeGroup.forEach(this::mergeGroupImpl);
+        // Cascade sub-merges call mergeGroupImpl directly, so they bypass the cleanup mergeGroup does for
+        // the top-level pair. A rewrite inside one of them can turn an expression in the cascade
+        // destination into a self reference, which would stay registered and be fed back into copyIn by an
+        // already-queued ApplyRuleTask, so clean each cascade destination as well.
+        needMergeGroup.forEach((cascadeSrc, cascadeDst) -> {
+            mergeGroupImpl(cascadeSrc, cascadeDst);
+            removeSelfReferencing(cascadeDst);
+        });
+
+        // Last, so that any first-expression rotation done by the cascade above is accounted for.
+        if (srcRepresentativeDerived) {
+            markStatsDerivedRepresentative(dstGroup);
+        }
     }
 
     private Set<Group> getAllEmptyGroups() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Operator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Operator.java
@@ -19,10 +19,6 @@ import com.google.common.collect.Lists;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.RowOutputInfo;
-import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
-import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
-import com.starrocks.sql.optimizer.operator.physical.PhysicalJoinOperator;
-import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.property.DomainProperty;
@@ -32,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
 
 public abstract class Operator {
     public static final long DEFAULT_LIMIT = -1;
@@ -45,7 +40,6 @@ public abstract class Operator {
     // common sub operators in predicate
     protected Map<ColumnRefOperator, ScalarOperator> predicateCommonOperators = null;
 
-    private static final AtomicLong SALT_GENERATOR = new AtomicLong(0);
     /**
      * Before entering the Cascades search framework,
      * we need to merge LogicalProject and child children into one node
@@ -55,13 +49,6 @@ public abstract class Operator {
     protected Projection projection;
 
     protected RowOutputInfo rowOutputInfo;
-
-    // Add salt make the original equivalent operators nonequivalent to avoid Group
-    // mutual reference in Memo.
-    // Only LogicalScanOperator/PhysicalScanOperator yielded by CboTablePruneRule has salt.
-    // if no salt, two different Groups will be merged into one, that leads to mutual reference
-    // or self reference of groups
-    protected long salt = 0;
 
     // mark which rule(bit) has been applied to the operator.
     protected BitSet opRuleBits = new BitSet();
@@ -147,28 +134,6 @@ public abstract class Operator {
 
     public void setProjection(Projection projection) {
         this.projection = projection;
-    }
-
-    public void addSalt() {
-        if ((this instanceof LogicalJoinOperator) || (this instanceof LogicalScanOperator)) {
-            this.salt = SALT_GENERATOR.incrementAndGet();
-        }
-    }
-
-    public void setSalt(long salt) {
-        if ((this instanceof LogicalJoinOperator) ||
-                (this instanceof LogicalScanOperator) ||
-                (this instanceof PhysicalScanOperator) ||
-                (this instanceof PhysicalJoinOperator)) {
-            this.salt = salt;
-        }
-    }
-    public boolean hasSalt() {
-        return salt > 0;
-    }
-
-    public long getSalt() {
-        return salt;
     }
 
     public void setOpRuleBit(int bit) {
@@ -284,13 +249,12 @@ public abstract class Operator {
         Operator operator = (Operator) o;
         return limit == operator.limit && opType == operator.opType &&
                 Objects.equals(predicate, operator.predicate) &&
-                Objects.equals(projection, operator.projection) &&
-                Objects.equals(salt, operator.salt);
+                Objects.equals(projection, operator.projection);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(opType.ordinal(), limit, predicate, projection, salt);
+        return Objects.hash(opType.ordinal(), limit, predicate, projection);
     }
 
     public abstract static class Builder<O extends Operator, B extends Builder> {
@@ -307,7 +271,6 @@ public abstract class Operator {
             // defined and the plan fails InputDependenciesChecker.
             builder.predicateCommonOperators = operator.predicateCommonOperators;
             builder.projection = operator.projection;
-            builder.salt = operator.salt;
             builder.equivalentOp = operator.equivalentOp;
             builder.opRuleBits.or(operator.opRuleBits);
             builder.opAppliedMVs.addAll(operator.opAppliedMVs);
@@ -348,11 +311,6 @@ public abstract class Operator {
 
         public B setProjection(Projection projection) {
             builder.projection = projection;
-            return (B) this;
-        }
-
-        public B addSalt() {
-            builder.salt = SALT_GENERATOR.incrementAndGet();
             return (B) this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/OlapScanImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/OlapScanImplementationRule.java
@@ -36,7 +36,6 @@ public class OlapScanImplementationRule extends ImplementationRule {
         LogicalOlapScanOperator scan = (LogicalOlapScanOperator) input.getOp();
         PhysicalOlapScanOperator physicalOlapScan = new PhysicalOlapScanOperator(scan);
 
-        physicalOlapScan.setSalt(scan.getSalt());
         physicalOlapScan.setColumnAccessPaths(scan.getColumnAccessPaths());
         OptExpression result = new OptExpression(physicalOlapScan);
         return Lists.newArrayList(result);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/pruner/CboTablePruneRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/pruner/CboTablePruneRule.java
@@ -352,7 +352,6 @@ public class CboTablePruneRule extends TransformationRule {
         // set new ColumnRefToColumnMap in case that when the same tables join on UK/PK
         newColRefToColumnMap.ifPresent(newOpBuilder::setColRefToColumnMetaMap);
         Operator newScan = newOpBuilder.build();
-        newScan.addSalt();
         return Collections.singletonList(OptExpression.create(newScan));
     }
 
@@ -379,7 +378,6 @@ public class CboTablePruneRule extends TransformationRule {
 
         Operator newScan = OperatorBuilderFactory.build(retainOpt.getOp()).withOperator(retainOpt.getOp())
                 .setProjection(newProjection).build();
-        newScan.addSalt();
         return Collections.singletonList(OptExpression.create(newScan));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MemoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MemoTest.java
@@ -24,11 +24,15 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalLimitOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
+import com.starrocks.sql.optimizer.statistics.Statistics;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MemoTest {
     @Test
@@ -108,6 +112,383 @@ public class MemoTest {
         assertEquals(memo.getGroupExpressions().size(), 5);
         assertEquals(memo.getGroups().get(3).getLogicalExpressions().size(), 2);
         assertEquals(memo.getGroups().get(3).getPhysicalExpressions().size(), 0);
+    }
+
+    /**
+     * A merge must leave every group that had a stats-derived first logical expression with a
+     * stats-derived first logical expression.
+     * <p>
+     * DeriveStatsTask reads a child group's FIRST logical expression and asserts isStatsDerived() on it,
+     * while the statistics themselves are group-level and shared by every logically-equivalent expression
+     * in the group. Merging rewrites the inputs of expressions all over the Memo, and the expression it
+     * rewrites is taken out of its group and put back at the end, so a group that is neither the merge
+     * source nor its target can end up with a different -- and never-derived -- first expression. A
+     * parent DeriveStatsTask already queued on the scheduler stack would then fail that assertion.
+     * <p>
+     * The memo below is built by hand so the rotation is deterministic: thirdGroup holds
+     * [refersToSrc, other], its first expression refers to srcGroup and is derived, and `other` is not.
+     * Merging srcGroup away rewrites refersToSrc, which moves it behind `other`.
+     */
+    @Test
+    public void testMergeKeepsStatsDerivedFirstExpression() {
+        Memo memo = new Memo();
+
+        // Leaves.
+        GroupExpression leftLeaf = new GroupExpression(LogicalLimitOperator.init(1, 1), Lists.newArrayList());
+        memo.insertGroupExpression(leftLeaf, null);
+        Group leftGroup = leftLeaf.getGroup();
+
+        GroupExpression rightLeaf = new GroupExpression(LogicalLimitOperator.init(2, 2), Lists.newArrayList());
+        memo.insertGroupExpression(rightLeaf, null);
+        Group rightGroup = rightLeaf.getGroup();
+
+        // The group that gets merged away, plus the target it is merged into.
+        Operator srcOp = LogicalLimitOperator.init(3, 3);
+        GroupExpression srcExpr = new GroupExpression(srcOp, Lists.newArrayList(leftGroup, rightGroup));
+        memo.insertGroupExpression(srcExpr, null);
+        Group srcGroup = srcExpr.getGroup();
+
+        GroupExpression dstExpr = new GroupExpression(LogicalLimitOperator.init(4, 4), Lists.newArrayList(srcGroup));
+        memo.insertGroupExpression(dstExpr, null);
+        Group dstGroup = dstExpr.getGroup();
+
+        // A third group, parent of srcGroup as well, holding two alternatives. Its FIRST one refers to
+        // srcGroup, so the merge will rewrite it and move it to the back of the list.
+        Operator thirdOp = LogicalLimitOperator.init(5, 5);
+        GroupExpression refersToSrc = new GroupExpression(thirdOp, Lists.newArrayList(srcGroup));
+        memo.insertGroupExpression(refersToSrc, null);
+        Group thirdGroup = refersToSrc.getGroup();
+        GroupExpression other = new GroupExpression(thirdOp, Lists.newArrayList(rightGroup));
+        memo.insertGroupExpression(other, thirdGroup);
+
+        // Everything has had its statistics derived except `other`, which is only an alternative and has
+        // never been the group's representative.
+        leftLeaf.setStatsDerived();
+        rightLeaf.setStatsDerived();
+        srcExpr.setStatsDerived();
+        dstExpr.setStatsDerived();
+        refersToSrc.setStatsDerived();
+
+        assertSame(refersToSrc, thirdGroup.getFirstLogicalExpression());
+        assertTrue(thirdGroup.getFirstLogicalExpression().isStatsDerived());
+
+        // Re-inserting an expression equal to srcGroup's into dstGroup merges srcGroup into dstGroup.
+        GroupExpression duplicateOfSrc = new GroupExpression(srcOp, Lists.newArrayList(leftGroup, rightGroup));
+        memo.insertGroupExpression(duplicateOfSrc, dstGroup);
+
+        // thirdGroup survived the merge, so whatever expression now represents it must still be derived.
+        assertTrue(memo.getGroups().contains(thirdGroup));
+        assertTrue(thirdGroup.getFirstLogicalExpression().isStatsDerived(),
+                "first logical expression of a surviving group lost its derived statistics marker");
+    }
+
+    /**
+     * A merge folds a group into a group that (transitively) has it as an input, which turns the parent
+     * expression into one whose own input is the group it lives in. Such an expression must not survive
+     * in the Memo, and it must be marked unused: an ApplyRuleTask may already be queued on the scheduler
+     * stack holding it, and JoinCommutativityRule-style rules would otherwise transform it and copy the
+     * result back into its own group, tripping checkState(group != targetGroup) in copyIn.
+     */
+    @Test
+    public void testMergeMarksSelfReferencingExpressionUnused() {
+        Memo memo = new Memo();
+
+        GroupExpression leaf = new GroupExpression(LogicalLimitOperator.init(1, 1), Lists.newArrayList());
+        memo.insertGroupExpression(leaf, null);
+        Group leafGroup = leaf.getGroup();
+
+        Operator srcOp = LogicalLimitOperator.init(2, 2);
+        GroupExpression srcExpr = new GroupExpression(srcOp, Lists.newArrayList(leafGroup));
+        memo.insertGroupExpression(srcExpr, null);
+        Group srcGroup = srcExpr.getGroup();
+
+        // parent lives in dstGroup and takes srcGroup as input, so merging srcGroup into dstGroup makes
+        // parent reference dstGroup -- itself.
+        GroupExpression parent = new GroupExpression(LogicalLimitOperator.init(3, 3), Lists.newArrayList(srcGroup));
+        memo.insertGroupExpression(parent, null);
+        Group dstGroup = parent.getGroup();
+        // A second alternative so dstGroup does not become empty once parent is dropped.
+        GroupExpression survivor = new GroupExpression(LogicalLimitOperator.init(4, 4), Lists.newArrayList(leafGroup));
+        memo.insertGroupExpression(survivor, dstGroup);
+
+        GroupExpression duplicateOfSrc = new GroupExpression(srcOp, Lists.newArrayList(leafGroup));
+        memo.insertGroupExpression(duplicateOfSrc, dstGroup);
+
+        assertTrue(parent.isUnused(), "self-referencing expression was dropped but not marked unused");
+        for (Group group : memo.getGroups()) {
+            for (GroupExpression expression : group.getLogicalExpressions()) {
+                assertTrue(expression.getInputs().stream().noneMatch(input -> input == group),
+                        "a self-referencing group expression survived the merge");
+            }
+        }
+        assertFalse(memo.getGroupExpressions().containsValue(parent),
+                "self-referencing expression is still registered in the Memo");
+    }
+
+    /**
+     * Dropping the self-referencing expression can itself rotate the group's representative, when the
+     * dropped expression was the group's first logical one. The group's statistics are still derived --
+     * they are group-level -- so the marker has to move to the new representative.
+     */
+    @Test
+    public void testDroppingSelfReferenceKeepsDerivedRepresentative() {
+        Memo memo = new Memo();
+
+        GroupExpression leaf = new GroupExpression(LogicalLimitOperator.init(1, 1), Lists.newArrayList());
+        memo.insertGroupExpression(leaf, null);
+        Group leafGroup = leaf.getGroup();
+
+        Operator srcOp = LogicalLimitOperator.init(2, 2);
+        GroupExpression srcExpr = new GroupExpression(srcOp, Lists.newArrayList(leafGroup));
+        memo.insertGroupExpression(srcExpr, null);
+        Group srcGroup = srcExpr.getGroup();
+
+        // becomesSelfReference is dstGroup's FIRST expression and is derived; laterAlternative is not.
+        GroupExpression becomesSelfReference =
+                new GroupExpression(LogicalLimitOperator.init(3, 3), Lists.newArrayList(srcGroup));
+        memo.insertGroupExpression(becomesSelfReference, null);
+        Group dstGroup = becomesSelfReference.getGroup();
+        GroupExpression laterAlternative =
+                new GroupExpression(LogicalLimitOperator.init(4, 4), Lists.newArrayList(leafGroup));
+        memo.insertGroupExpression(laterAlternative, dstGroup);
+
+        leaf.setStatsDerived();
+        srcExpr.setStatsDerived();
+        becomesSelfReference.setStatsDerived();
+
+        assertSame(becomesSelfReference, dstGroup.getFirstLogicalExpression());
+
+        GroupExpression duplicateOfSrc = new GroupExpression(srcOp, Lists.newArrayList(leafGroup));
+        memo.insertGroupExpression(duplicateOfSrc, dstGroup);
+
+        assertTrue(dstGroup.getFirstLogicalExpression().isStatsDerived(),
+                "dropping the self-reference left the group without a derived representative");
+    }
+
+    /**
+     * The compensation must not invent derivation. A group whose statistics were never derived -- which is
+     * a legitimate state, e.g. a group created by copyIn with statistics carried over from
+     * ReorderJoinRule but no expression put through DeriveStatsTask yet -- has to come out of a merge
+     * still undelivered, otherwise its own DeriveStatsTask would return early and skip the real work.
+     */
+    @Test
+    public void testMergeDoesNotInventDerivationForNeverDerivedGroup() {
+        Memo memo = new Memo();
+
+        GroupExpression leaf = new GroupExpression(LogicalLimitOperator.init(1, 1), Lists.newArrayList());
+        memo.insertGroupExpression(leaf, null);
+        Group leafGroup = leaf.getGroup();
+
+        Operator srcOp = LogicalLimitOperator.init(2, 2);
+        GroupExpression srcExpr = new GroupExpression(srcOp, Lists.newArrayList(leafGroup));
+        memo.insertGroupExpression(srcExpr, null);
+        Group srcGroup = srcExpr.getGroup();
+
+        GroupExpression dstExpr = new GroupExpression(LogicalLimitOperator.init(3, 3), Lists.newArrayList(srcGroup));
+        memo.insertGroupExpression(dstExpr, null);
+        Group dstGroup = dstExpr.getGroup();
+
+        // A third group whose expressions were never derived at all.
+        Operator thirdOp = LogicalLimitOperator.init(4, 4);
+        GroupExpression neverDerivedFirst = new GroupExpression(thirdOp, Lists.newArrayList(srcGroup));
+        memo.insertGroupExpression(neverDerivedFirst, null);
+        Group neverDerivedGroup = neverDerivedFirst.getGroup();
+        GroupExpression neverDerivedSecond = new GroupExpression(thirdOp, Lists.newArrayList(leafGroup));
+        memo.insertGroupExpression(neverDerivedSecond, neverDerivedGroup);
+
+        GroupExpression duplicateOfSrc = new GroupExpression(srcOp, Lists.newArrayList(leafGroup));
+        memo.insertGroupExpression(duplicateOfSrc, dstGroup);
+
+        for (GroupExpression expression : neverDerivedGroup.getLogicalExpressions()) {
+            assertFalse(expression.isStatsDerived(),
+                    "merge marked an expression derived in a group that never derived its statistics");
+        }
+    }
+
+    /**
+     * The statistics themselves live on the Group ({@code Group.statistics}); a GroupExpression only
+     * carries the derived marker. So moving the marker to the new representative is not a claim that
+     * statistics exist -- they demonstrably already do, computed while the old representative was derived,
+     * and they are what DeriveStatsTask's checkNotNull and ExpressionContext actually read.
+     */
+    @Test
+    public void testGroupKeepsItsStatisticsAcrossMerge() {
+        Memo memo = new Memo();
+
+        GroupExpression leaf = new GroupExpression(LogicalLimitOperator.init(1, 1), Lists.newArrayList());
+        memo.insertGroupExpression(leaf, null);
+        Group leafGroup = leaf.getGroup();
+
+        Operator srcOp = LogicalLimitOperator.init(2, 2);
+        GroupExpression srcExpr = new GroupExpression(srcOp, Lists.newArrayList(leafGroup));
+        memo.insertGroupExpression(srcExpr, null);
+        Group srcGroup = srcExpr.getGroup();
+
+        GroupExpression dstExpr = new GroupExpression(LogicalLimitOperator.init(3, 3), Lists.newArrayList(srcGroup));
+        memo.insertGroupExpression(dstExpr, null);
+        Group dstGroup = dstExpr.getGroup();
+
+        Operator thirdOp = LogicalLimitOperator.init(4, 4);
+        GroupExpression refersToSrc = new GroupExpression(thirdOp, Lists.newArrayList(srcGroup));
+        memo.insertGroupExpression(refersToSrc, null);
+        Group thirdGroup = refersToSrc.getGroup();
+        GroupExpression other = new GroupExpression(thirdOp, Lists.newArrayList(leafGroup));
+        memo.insertGroupExpression(other, thirdGroup);
+
+        // Mirror what a completed DeriveStatsTask leaves behind: statistics on the group, marker on the
+        // expression that computed them.
+        Statistics derived = Statistics.builder().setOutputRowCount(1234).build();
+        thirdGroup.setStatistics(derived);
+        refersToSrc.setStatsDerived();
+        leaf.setStatsDerived();
+        srcExpr.setStatsDerived();
+        dstExpr.setStatsDerived();
+
+        GroupExpression duplicateOfSrc = new GroupExpression(srcOp, Lists.newArrayList(leafGroup));
+        memo.insertGroupExpression(duplicateOfSrc, dstGroup);
+
+        // The statistics are untouched by the merge; only which expression carries the marker changed.
+        assertSame(derived, thirdGroup.getStatistics());
+        assertTrue(thirdGroup.getFirstLogicalExpression().isStatsDerived());
+        assertEquals(1234, thirdGroup.getStatistics().getOutputRowCount(), 0.0);
+    }
+
+    /**
+     * The merge source is destroyed and every expression that referenced it is rewritten to reference the
+     * destination, so a queued parent DeriveStatsTask that used to check the source's representative now
+     * checks the destination's. Group.mergeGroup already carries the source's statistics over to a
+     * destination that had none, so the derived marker has to travel with them -- otherwise the parent
+     * passes the checkNotNull on the inherited statistics and then fails isStatsDerived() on the
+     * destination's never-derived first expression.
+     */
+    @Test
+    public void testMergeCarriesDerivedMarkerFromSourceToDestination() {
+        Memo memo = new Memo();
+
+        GroupExpression leaf = new GroupExpression(LogicalLimitOperator.init(1, 1), Lists.newArrayList());
+        memo.insertGroupExpression(leaf, null);
+        Group leafGroup = leaf.getGroup();
+
+        // srcGroup: derived representative, and statistics to go with it.
+        Operator srcOp = LogicalLimitOperator.init(2, 2);
+        GroupExpression srcExpr = new GroupExpression(srcOp, Lists.newArrayList(leafGroup));
+        memo.insertGroupExpression(srcExpr, null);
+        Group srcGroup = srcExpr.getGroup();
+        srcGroup.setStatistics(Statistics.builder().setOutputRowCount(4321).build());
+        leaf.setStatsDerived();
+        srcExpr.setStatsDerived();
+
+        // dstGroup: never derived, no statistics of its own, and it is a parent of srcGroup so the merge
+        // rewrites its expression to point at itself and that self reference gets dropped.
+        GroupExpression dstFirst = new GroupExpression(LogicalLimitOperator.init(3, 3), Lists.newArrayList(srcGroup));
+        memo.insertGroupExpression(dstFirst, null);
+        Group dstGroup = dstFirst.getGroup();
+        GroupExpression dstSecond = new GroupExpression(LogicalLimitOperator.init(4, 4), Lists.newArrayList(leafGroup));
+        memo.insertGroupExpression(dstSecond, dstGroup);
+
+        GroupExpression duplicateOfSrc = new GroupExpression(srcOp, Lists.newArrayList(leafGroup));
+        memo.insertGroupExpression(duplicateOfSrc, dstGroup);
+
+        // The destination absorbed the source, statistics included, so it must also present a derived
+        // representative to any parent that now points at it.
+        assertTrue(memo.getGroups().contains(dstGroup));
+        assertTrue(dstGroup.getStatistics() != null,
+                "destination did not inherit the source statistics");
+        assertTrue(dstGroup.getFirstLogicalExpression().isStatsDerived(),
+                "destination inherited the source statistics but not a derived representative");
+    }
+
+    /**
+     * When rewriting a child makes two parent expressions equal, mergeGroupImpl recursively merges their
+     * groups by calling itself, which bypasses the cleanup mergeGroup does for the top-level pair. A
+     * rewrite inside such a cascade can turn an expression in the cascade destination into a self
+     * reference; it would stay registered because the top-level cleanup never visits that group, and a
+     * queued ApplyRuleTask could feed it back into copyIn.
+     */
+    @Test
+    public void testCascadeMergeLeavesNoSelfReference() {
+        Memo memo = new Memo();
+
+        GroupExpression leaf = new GroupExpression(LogicalLimitOperator.init(1, 1), Lists.newArrayList());
+        memo.insertGroupExpression(leaf, null);
+        Group leafGroup = leaf.getGroup();
+
+        Operator srcOp = LogicalLimitOperator.init(2, 2);
+        GroupExpression srcExpr = new GroupExpression(srcOp, Lists.newArrayList(leafGroup));
+        memo.insertGroupExpression(srcExpr, null);
+        Group srcGroup = srcExpr.getGroup();
+
+        GroupExpression dstExpr = new GroupExpression(LogicalLimitOperator.init(3, 3), Lists.newArrayList(srcGroup));
+        memo.insertGroupExpression(dstExpr, null);
+        Group dstGroup = dstExpr.getGroup();
+
+        // Two parents of srcGroup, in two different groups, carrying the same operator. Once srcGroup is
+        // rewritten to dstGroup they become equal, which is what queues a cascade sub-merge.
+        Operator parentOp = LogicalLimitOperator.init(4, 4);
+        GroupExpression parentA = new GroupExpression(parentOp, Lists.newArrayList(srcGroup));
+        memo.insertGroupExpression(parentA, null);
+        Group parentGroupA = parentA.getGroup();
+        GroupExpression parentB = new GroupExpression(parentOp, Lists.newArrayList(dstGroup));
+        memo.insertGroupExpression(parentB, null);
+        Group parentGroupB = parentB.getGroup();
+        // Keep both parent groups alive with a second alternative each.
+        memo.insertGroupExpression(
+                new GroupExpression(LogicalLimitOperator.init(5, 5), Lists.newArrayList(leafGroup)), parentGroupA);
+        memo.insertGroupExpression(
+                new GroupExpression(LogicalLimitOperator.init(6, 6), Lists.newArrayList(leafGroup)), parentGroupB);
+
+        GroupExpression duplicateOfSrc = new GroupExpression(srcOp, Lists.newArrayList(leafGroup));
+        memo.insertGroupExpression(duplicateOfSrc, dstGroup);
+
+        for (Group group : memo.getGroups()) {
+            for (GroupExpression expression : group.getLogicalExpressions()) {
+                assertTrue(expression.getInputs().stream().noneMatch(input -> input == group),
+                        "a self reference survived in group " + group.getId());
+            }
+            for (GroupExpression expression : group.getPhysicalExpressions()) {
+                assertTrue(expression.getInputs().stream().noneMatch(input -> input == group),
+                        "a physical self reference survived in group " + group.getId());
+            }
+        }
+    }
+
+    /**
+     * Physical expressions are scanned for self references too, and a merge that empties a group must
+     * leave the Memo consistent rather than keeping a group nothing can represent.
+     */
+    @Test
+    public void testMergeEmptyingAGroupLeavesNoDanglingReference() {
+        Memo memo = new Memo();
+
+        GroupExpression leaf = new GroupExpression(LogicalLimitOperator.init(1, 1), Lists.newArrayList());
+        memo.insertGroupExpression(leaf, null);
+        Group leafGroup = leaf.getGroup();
+
+        Operator srcOp = LogicalLimitOperator.init(2, 2);
+        GroupExpression srcExpr = new GroupExpression(srcOp, Lists.newArrayList(leafGroup));
+        memo.insertGroupExpression(srcExpr, null);
+        Group srcGroup = srcExpr.getGroup();
+
+        // dstGroup's only expression becomes self-referencing, so the group loses everything it had.
+        GroupExpression onlyExpr = new GroupExpression(LogicalLimitOperator.init(3, 3), Lists.newArrayList(srcGroup));
+        memo.insertGroupExpression(onlyExpr, null);
+        Group dstGroup = onlyExpr.getGroup();
+
+        GroupExpression duplicateOfSrc = new GroupExpression(srcOp, Lists.newArrayList(leafGroup));
+        memo.insertGroupExpression(duplicateOfSrc, dstGroup);
+
+        // Whatever survives, no registered expression may point at a group that has no logical expression,
+        // because Group.getFirstLogicalExpression() would blow up on it.
+        for (GroupExpression expression : memo.getGroupExpressions().values()) {
+            for (Group input : expression.getInputs()) {
+                assertFalse(input.getLogicalExpressions().isEmpty(),
+                        "a registered group expression points at a group with no logical expression");
+            }
+        }
+        for (Group group : memo.getGroups()) {
+            assertFalse(group.getLogicalExpressions().isEmpty(),
+                    "an empty group is still registered in the Memo");
+        }
     }
 
 }


### PR DESCRIPTION
## Why I'm doing:

#76542 fixed the `Memo.copyIn` self-reference crash by restoring `Operator.salt`. That works, but salt pays for it with operator dedup: it participates in `Operator.equals`/`hashCode`, which is exactly what the Memo dedups on, so giving every `CboTablePruneRule`-produced scan a unique value switches dedup off for those operators.

The effect is visible in a real memo dump from the reported query — one group accumulating dozens of structurally identical scans that differ only in salt:

```
Group: 6
  LogicalScanOperator {table='3084027', outputColumns=[1: account_id, 2: activity_date, 3: tenant_id, 5: person_id]}
  LogicalScanOperator {table='3084027', outputColumns=[1: account_id, 2: activity_date, 3: tenant_id, 5: person_id]}
  ... (~40 identical entries)
```

`OptimizeExpressionTask` queues a `DeriveStatsTask` per GroupExpression while the `statsDerived` guard lives on each GroupExpression, so every duplicate re-runs statistics estimation. This memo growth is what #67095 removed salt for in the first place, so restoring salt reintroduces it.

This PR removes salt again and fixes the crash in the Memo merge instead, so the crash is gone *and* dedup keeps working.

## What I'm doing:

Let the merge happen, and repair the two places where it leaves inconsistent state behind. Both changes are in `Memo.java`; `DeriveStatsTask`'s assertion is untouched.

**1. `setUnused(true)` on removed self-referencing GroupExpressions.**
An `ApplyRuleTask` may already be queued on the scheduler stack holding one of them. Without the flag it still fires — its group and children are all non-empty, so the `hasEmptyRootGroup`/`hasEmptyChildGroup` parts of `isUnused()` do not catch it — and `JoinCommutativityRule` re-creates the self reference through `copyIn`. `mergeGroupImpl` already does exactly this for the redundant expressions it drops; this applies the same convention to `removeSelfReferencing`.

**2. `restoreStatsDerivedRepresentative()` at the end of a merge.**
A merge takes a GroupExpression out of its group and appends it back, and dropping a self reference removes one outright, so it can rotate which expression is a group's *first* logical one. `DeriveStatsTask` checks `isStatsDerived()` on a child group's FIRST logical expression, while the statistics themselves live on the `Group` (`Group.statistics`) and are shared by every logically-equivalent expression in it. So a rotation makes that check fail for a group whose statistics are in fact already derived — nothing is missing but the marker. Move the marker to the new representative, gated on the group having had a derived one before the merge, so derivation is never claimed for a group that never derived it (e.g. a group created by `copyIn` with statistics carried over from `ReorderJoinRule`). It runs after the empty-group cleanup because `removeOneGroup` drops expressions from arbitrary groups too.

### Both parts are load-bearing

Ablation on `CboTablePruneMemoSelfRefTest`, each variant compiled and run:

| variant | result |
|---|---|
| neither | crash at `Memo.copyIn` |
| `setUnused` only | crash relocated to `DeriveStatsTask` |
| stats repair only | crash at `Memo.copyIn` |
| both | passes |

There are two independent rotation sources and both are reachable from the repro query: addressing only the take-out-and-append in `mergeGroupImpl`, or only the drop in `removeSelfReferencing`, still leaves `DeriveStatsTask` failing.

### The rotation predates #67095

`mergeGroupImpl`'s take-out-and-append is unchanged since the salt era — the salt-era `Memo.java` differs from today's only by `removeSelfReferencing` — and the new `MemoTest` case fails on that revision too. Salt only kept the rotation unreachable for this query by preventing the merge, so it was masked twice over: first by salt, then by the `copyIn` crash firing earlier.

## Verification

- **1115 tests green** on a clean build with salt removed: `MemoTest`, `CboTablePruneMemoSelfRefTest`, `TablePruningTest`(+TPCDS), `PruneUKFKJoinRuleTest`, `AggregateWithUKFKTest`, `TPCHPlanTest`(+WithCost), `TPCDSPlanTest`, `CTEPlanTest`, `SubqueryTest`, `MultiJoinReorderTest`, `OuterJoinReorderTest`, `ReplayFromDumpTest` (82 dump replays), and the MV suite (`MaterializedViewTest` 219, `MvRewriteEnumerateTest`, `MvRewritePreprocessorTest`, `BestMvSelectorTest`, `ReplayWithMVFromDumpTest`, …).
- **`CboTablePruneMemoSelfRefTest` from #76542 passes with salt removed** — the end-to-end guard for the original customer query still holds without salt.
- **Memo invariants asserted at runtime.** With a temporary probe checking the whole memo after every merge across 658 tests: no surviving self reference, no group left without a derived representative, and no expression pointing at a group with no logical expression — 0 violations.
- **Cost is negligible.** Instrumented over the suite: merges are rare (50 merges, max 61 groups in the memo, average 35 groups snapshotted), so the snapshot/restore pair is a few thousand pointer comparisons in total.

## Tests

`MemoTest` gains six hand-built Memo cases, each failing on exactly the change it guards:

- `testMergeMarksSelfReferencingExpressionUnused` — the self reference is dropped, marked unused, and none survives anywhere.
- `testMergeKeepsStatsDerivedFirstExpression` — a third group (neither merge source nor target) keeps a derived representative.
- `testDroppingSelfReferenceKeepsDerivedRepresentative` — same, for the rotation the drop itself causes in the merge target.
- `testGroupKeepsItsStatisticsAcrossMerge` — the `Group`'s `Statistics` object is untouched by the merge; only the marker moved.
- `testMergeDoesNotInventDerivationForNeverDerivedGroup` — a group that never derived statistics is still not derived afterwards, so its own `DeriveStatsTask` is not suppressed.
- `testMergeEmptyingAGroupLeavesNoDanglingReference` — no expression points at a group with no logical expression, and no empty group stays registered.

The last two pass on unmodified upstream as well: they guard against overreach.

Known limitations, stated plainly:
- The compensation moves a marker rather than removing the rotation. The rotation could be removed at the source by re-inserting at the original index in `mergeGroupImpl`; that touches the merge flow more deeply, so it is not in this PR.
- Marking the new representative means its own `DeriveStatsTask` returns early, skipping one `needUpdateGroupStatistics` refinement opportunity. No plan differences appeared in the cost-sensitive suites (`TPCHPlanWithCostTest`, `BestMvSelectorTest`), but it is a trade-off rather than a proof.
- Pre-existing issues in this area that this PR neither worsens nor fixes: `removeSelfReferencing` drops expressions without clearing `Group.lowestCostExpressions` (`deleteBestExpression` has no callers), the empty-group sweep in `mergeGroup` is single-pass rather than a fixpoint, and `needMergeGroup` is a `HashMap` so one group needing two merges would lose one. Happy to file these separately.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
