### PR TITLE
[BugFix] Skip unsupported column types for histogram statistics   (backport #76550)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
@@ -361,12 +361,26 @@ public class AnalyzeStmtAnalyzer {
                     throw new SemanticException("Can't create histogram statistics on table type is %s",
                             analyzeTable.getType().name());
                 }
+                // Explicitly-listed columns: reject unsupported types outright.
                 for (Expr column : columns) {
-                    if (column.getType().isComplexType()
-                            || column.getType().isJsonType()
-                            || column.getType().isOnlyMetricType()) {
+                    if (StatisticUtils.isUnsupportedHistogramColumnType(column.getType())) {
                         throw new SemanticException("Can't create histogram statistics on column type is %s",
                                 column.getType().toSql());
+                    }
+                }
+
+                // Filters out unsupported types from the list of columns to analyze, if no columns were explicitly listed.
+                if (columns.isEmpty() && statement instanceof AnalyzeStmt) {
+                    AnalyzeStmt analyzeStmt = (AnalyzeStmt) statement;
+                    if (CollectionUtils.isNotEmpty(analyzeStmt.getColumnNames())) {
+                        List<String> supported = analyzeStmt.getColumnNames().stream()
+                                .filter(name -> {
+                                    Column col = analyzeTable.getColumn(name);
+                                    return col != null && !StatisticUtils.isUnsupportedHistogramColumnType(col.getType());
+                                })
+                                .collect(Collectors.toList());
+
+                        analyzeStmt.setColumnNames(supported);
                     }
                 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -473,6 +473,10 @@ public class StatisticUtils {
         return columns;
     }
 
+    public static boolean isUnsupportedHistogramColumnType(Type type) {
+        return type.isComplexType() || type.isJsonType() || type.isOnlyMetricType() || type.isBinaryType();
+    }
+
     public static double multiplyRowCount(double left, double right) {
         left = Math.min(left, StatisticsEstimateCoefficient.MAXIMUM_ROW_COUNT);
         right = Math.min(right, StatisticsEstimateCoefficient.MAXIMUM_ROW_COUNT);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
@@ -17,6 +17,7 @@ package com.starrocks.statistic;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.TableName;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
@@ -117,6 +118,15 @@ public class StatisticsCollectJobFactory {
                                                                  boolean isManualJob) {
         if (CollectionUtils.isEmpty(columnNames)) {
             columnNames = StatisticUtils.getCollectibleColumns(table);
+
+            if (analyzeType.equals(StatsConstants.AnalyzeType.HISTOGRAM)) {
+                columnNames = columnNames.stream()
+                        .filter(name -> {
+                            Column col = table.getColumn(name);
+                            return col != null && !StatisticUtils.isUnsupportedHistogramColumnType(col.getType());
+                        })
+                        .collect(Collectors.toList());
+            }
             columnTypes = columnNames.stream().map(col -> table.getColumn(col).getType()).collect(Collectors.toList());
         }
         // for compatibility, if columnTypes is null, we will get column types from table

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateAnalyzeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateAnalyzeJobTest.java
@@ -15,6 +15,8 @@
 
 package com.starrocks.sql.analyzer;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
@@ -26,6 +28,8 @@ import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.statistic.NativeAnalyzeJob;
 import com.starrocks.statistic.StatisticAutoCollector;
+import com.starrocks.statistic.StatisticsCollectJob;
+import com.starrocks.statistic.StatisticsCollectJobFactory;
 import com.starrocks.statistic.StatsConstants;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
@@ -62,6 +66,14 @@ public class AnalyzeCreateAnalyzeJobTest {
                 "properties('replication_num'='1') ");
         starRocksAssert.ddl("alter table db.tbl1 add partition p1 values in ('1')");
         starRocksAssert.ddl("alter table db.tbl1 add partition p2 values in ('2')");
+        starRocksAssert.withTable("create table db.tbl_histo("
+                + "k1 int, "
+                + "c_array array<int>, "
+                + "c_struct struct<a int>, "
+                + "c_map map<int, int>, "
+                + "c_json json, "
+                + "c_varbinary varbinary) "
+                + "DUPLICATE KEY(k1) distributed by hash(k1) buckets 3 properties('replication_num' = '1');");
     }
 
     @Test
@@ -155,6 +167,22 @@ public class AnalyzeCreateAnalyzeJobTest {
 
         // drop analyze
         starRocksAssert.ddl("drop analyze " + jobId);
+    }
+
+    @Test
+    public void testCreateHistogramAllColumnsStaysAdaptiveAndFiltersUnsupported() {
+        CreateAnalyzeJobStmt analyzeStmt = (CreateAnalyzeJobStmt) analyzeSuccess(
+                "create analyze table db.tbl_histo update histogram on all columns");
+        Assertions.assertTrue(analyzeStmt.getColumnNames().isEmpty());
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "tbl_histo");
+        StatisticsCollectJob collectJob = StatisticsCollectJobFactory.buildStatisticsCollectJob(
+                db, table, null, Lists.newArrayList(), Lists.newArrayList(),
+                StatsConstants.AnalyzeType.HISTOGRAM, StatsConstants.ScheduleType.SCHEDULE,
+                Maps.newHashMap(), List.of(), List.of(), false);
+        Assertions.assertEquals(List.of("k1"), collectJob.getColumnNames());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
@@ -110,6 +110,24 @@ public class AnalyzeStmtTest {
                 + "DUPLICATE KEY(kk1) distributed by hash(kk1) buckets 3 properties('replication_num' = '1');";
         starRocksAssert.withTable(createTblStmtStr);
 
+        createTblStmtStr = "create table db.tb_unsupported_histogram("
+                + "k1 int, "
+                + "c_array array<int>, "
+                + "c_struct struct<a int>, "
+                + "c_map map<int, int>, "
+                + "c_json json, "
+                + "c_varbinary varbinary) "
+                + "DUPLICATE KEY(k1) distributed by hash(k1) buckets 3 properties('replication_num' = '1');";
+        starRocksAssert.withTable(createTblStmtStr);
+
+        createTblStmtStr = "create table db.tb_metric_histogram("
+                + "k1 int, "
+                + "c_hll hll hll_union, "
+                + "c_bitmap bitmap bitmap_union, "
+                + "c_percentile percentile percentile_union) "
+                + "AGGREGATE KEY(k1) distributed by hash(k1) buckets 3 properties('replication_num' = '1');";
+        starRocksAssert.withTable(createTblStmtStr);
+
         String createStructTableSql = "CREATE TABLE struct_a(\n" +
                 "a INT, \n" +
                 "b STRUCT<a INT, c INT> COMMENT 'smith',\n" +
@@ -557,6 +575,30 @@ public class AnalyzeStmtTest {
         DropHistogramStmt dropHistogramStmt = (DropHistogramStmt) analyzeSuccess(sql);
         Assertions.assertEquals(dropHistogramStmt.getTableName().toSql(), "`test`.`t0`");
         Assertions.assertEquals(dropHistogramStmt.getColumnNames().toString(), "[v1]");
+    }
+
+    @Test
+    public void testHistogramUnsupportedColumnType() {
+        String msg = "Can't create histogram statistics on column type is";
+        // complex types
+        analyzeFail("analyze table db.tb_unsupported_histogram update histogram on c_array with 256 buckets", msg);
+        analyzeFail("analyze table db.tb_unsupported_histogram update histogram on c_struct with 256 buckets", msg);
+        analyzeFail("analyze table db.tb_unsupported_histogram update histogram on c_map with 256 buckets", msg);
+        // json type
+        analyzeFail("analyze table db.tb_unsupported_histogram update histogram on c_json with 256 buckets", msg);
+        // binary type
+        analyzeFail("analyze table db.tb_unsupported_histogram update histogram on c_varbinary with 256 buckets", msg);
+        // only-metric types
+        analyzeFail("analyze table db.tb_metric_histogram update histogram on c_hll with 256 buckets", msg);
+        analyzeFail("analyze table db.tb_metric_histogram update histogram on c_bitmap with 256 buckets", msg);
+        analyzeFail("analyze table db.tb_metric_histogram update histogram on c_percentile with 256 buckets", msg);
+    }
+
+    @Test
+    public void testHistogramAllColumnsSkipsUnsupportedColumnType() {
+        AnalyzeStmt analyzeStmt = (AnalyzeStmt) analyzeSuccess(
+                "analyze table db.tb_unsupported_histogram update histogram on all columns");
+        Assertions.assertEquals(List.of("k1"), analyzeStmt.getColumnNames());
     }
 
     @Test


### PR DESCRIPTION
Backport of #76550 to `branch-3.5-cc`.

Original commit: ad6698e426363f69806e490243c06b8e0668b481
Original PR: https://github.com/StarRocks/starrocks/pull/76550

---

<!-- Original PR description below -->

## Why I'm doing:

`ANALYZE ..  UPDATE HISTOGRAM ON ALL COLUMNS` does not filter out unsupported columns.
It will fail during computation on BE side.
Example:
```sql
CREATE TABLE `t2` (
  `c1` int(11) NULL COMMENT "",
  `c2` varbinary(1048576) NULL COMMENT ""
) ENGINE=OLAP
DUPLICATE KEY(`c1`, `c2`)
DISTRIBUTED BY RANDOM
PROPERTIES (
"bucket_size" = "1073741824",
"compression" = "LZ4",
"fast_schema_evolution" = "true",
"replicated_storage" = "true",
"replication_num" = "1"
); |
+-------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.01 sec)

mysql> truncate table t2;
Query OK, 0 rows affected (0.01 sec)

mysql> insert into t2 values (1, "1234");
Query OK, 1 row affected (0.23 sec)
{'label':'insert_019f6fa1-4e13-7c2d-ac15-4f2e858f4298', 'status':'VISIBLE', 'txnId':'4024'}

mysql>   ANALYZE TABLE t2 UPDATE HISTOGRAM ON c2;
+---------+-----------+----------+----------------------------------------------------------------+
| Table   | Op        | Msg_type | Msg_text                                                       |
+---------+-----------+----------+----------------------------------------------------------------+
| test.t2 | histogram | error    | Not support cast VARBINARY(-1) to DOUBLE. backend [id=10001] [ |
+---------+-----------+----------+----------------------------------------------------------------+
1 row in set (0.07 sec)
```
## What I'm doing:
This PR adds validation so that collection of varbinary columns fails early + filters out unsupported columns if histograms are collected for all columns

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
