### PR TITLE
[BugFix] Avoid invalid statistics lookup for array element subfields

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -290,9 +290,11 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
             Map<ColumnRefOperator, SubfieldOperator> subfieldColumns = Maps.newHashMap();
             Preconditions.checkState(projection.getCommonSubOperatorMap().isEmpty());
             for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : projection.getColumnRefMap().entrySet()) {
-                if (entry.getValue() instanceof SubfieldOperator && (node instanceof LogicalScanOperator ||
-                        node instanceof PhysicalScanOperator)) {
-                    subfieldColumns.put(entry.getKey(), (SubfieldOperator) entry.getValue());
+                if (entry.getValue() instanceof SubfieldOperator subfieldOperator &&
+                        (node instanceof LogicalScanOperator ||
+                        node instanceof PhysicalScanOperator) &&
+                        canUseSubfieldStatistics(subfieldOperator)) {
+                    subfieldColumns.put(entry.getKey(), subfieldOperator);
                 } else {
                     statisticsBuilder.addColumnStatistic(entry.getKey(),
                             ExpressionStatisticCalculator.calculate(entry.getValue(), statisticsBuilder.build()));
@@ -305,6 +307,12 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
         }
         context.setStatistics(statisticsBuilder.build());
         return null;
+    }
+
+    private static boolean canUseSubfieldStatistics(SubfieldOperator subfieldOperator) {
+        // Persistent subfield statistics paths must be rooted directly at a table column. Expression roots such as
+        // array_col[1] cannot be represented by a persistent STRUCT path.
+        return subfieldOperator.getChild(0) instanceof ColumnRefOperator;
     }
 
     private void addSubFiledStatistics(Operator node, Map<ColumnRefOperator, SubfieldOperator> subfieldColumns,
@@ -1140,11 +1148,12 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
 
         for (ColumnRefOperator requiredColumnRefOperator : columnRefMap.keySet()) {
             ScalarOperator mapOperator = columnRefMap.get(requiredColumnRefOperator);
-            if (mapOperator instanceof SubfieldOperator && context.getOptExpression() != null) {
+            if (mapOperator instanceof SubfieldOperator subfieldOperator &&
+                    canUseSubfieldStatistics(subfieldOperator) &&
+                    context.getOptExpression() != null) {
                 Operator child = context.getOptExpression().inputAt(0).getOp();
                 if (child instanceof LogicalScanOperator || child instanceof PhysicalScanOperator) {
-                    addSubFiledStatistics(child, ImmutableMap.of(requiredColumnRefOperator,
-                            (SubfieldOperator) mapOperator), builder);
+                    addSubFiledStatistics(child, ImmutableMap.of(requiredColumnRefOperator, subfieldOperator), builder);
                     continue;
                 }
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
@@ -35,6 +35,7 @@ import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.Group;
 import com.starrocks.sql.optimizer.GroupExpression;
+import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.OptimizerFactory;
 import com.starrocks.sql.optimizer.Utils;
@@ -42,22 +43,30 @@ import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.LogicalProperty;
 import com.starrocks.sql.optimizer.operator.AggType;
+import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalEsScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalKuduScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CollectionElementOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.operator.scalar.SubfieldOperator;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.type.ArrayType;
 import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
+import com.starrocks.type.StructField;
+import com.starrocks.type.StructType;
+import com.starrocks.type.Type;
 import com.starrocks.type.VarcharType;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
@@ -297,6 +306,137 @@ public class StatisticsCalculatorTest {
             Assertions.assertEquals(1000 * partitions.size(), expressionContext.getStatistics().getOutputRowCount(), 0.001);
             Assertions.assertEquals(ref.getType().getTypeSize() * 1000 * partitions.size(),
                     expressionContext.getStatistics().getComputeSize(), 0.001);
+        }
+    }
+
+    @Test
+    public void testSkipStatisticsForSubfieldOfArrayElement() {
+        GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
+        OlapTable table = (OlapTable) globalStateMgr.getLocalMetastore().getDb("statistics_test")
+                .getTable("test_all_type");
+        List<Long> partitionIds = table.getPartitions().stream()
+                .mapToLong(Partition::getId).boxed().collect(Collectors.toList());
+
+        Type structType = new StructType(
+                new ArrayList<>(List.of(new StructField("bucket_id", IntegerType.INT))));
+        Type arrayType = new ArrayType(structType);
+        Column arrayColumn = new Column("bucket_array", arrayType, true);
+        ColumnRefOperator arrayRef = columnRefFactory.create("bucket_array", arrayType, true);
+        ColumnRefOperator outputRef = columnRefFactory.create("bucket_id", IntegerType.INT, true);
+        CollectionElementOperator arrayElement = new CollectionElementOperator(
+                structType, arrayRef, ConstantOperator.createInt(1), false);
+        SubfieldOperator subfield = new SubfieldOperator(
+                arrayElement, IntegerType.INT, List.of("bucket_id"));
+
+        LogicalOlapScanOperator scanOperator = new LogicalOlapScanOperator(table,
+                ImmutableMap.of(arrayRef, arrayColumn),
+                ImmutableMap.of(arrayColumn, arrayRef),
+                null, -1, null,
+                table.getBaseIndexMetaId(),
+                partitionIds,
+                null,
+                false,
+                Lists.newArrayList(),
+                Lists.newArrayList(),
+                Lists.newArrayList(),
+                false);
+        scanOperator.setProjection(new Projection(ImmutableMap.of(outputRef, subfield)));
+
+        List<String> requestedColumns = new ArrayList<>();
+        StatisticStorage originalStorage = globalStateMgr.getStatisticStorage();
+        globalStateMgr.setStatisticStorage(new EmptyStatisticStorage() {
+            @Override
+            public List<ColumnStatistic> getColumnStatistics(Table table, List<String> columns) {
+                requestedColumns.addAll(columns);
+                return super.getColumnStatistics(table, columns);
+            }
+        });
+        try {
+            GroupExpression groupExpression = new GroupExpression(scanOperator, Lists.newArrayList());
+            groupExpression.setGroup(new Group(0));
+            ExpressionContext expressionContext = new ExpressionContext(groupExpression);
+
+            new StatisticsCalculator(expressionContext, columnRefFactory, optimizerContext).estimatorStats();
+
+            Assertions.assertTrue(requestedColumns.contains("bucket_array"));
+            Assertions.assertFalse(requestedColumns.stream().anyMatch(column -> column.contains(",")));
+            Assertions.assertTrue(expressionContext.getStatistics().getColumnStatistic(outputRef).isUnknown());
+
+            requestedColumns.clear();
+            scanOperator.setProjection(null);
+            OptExpression scanExpression = OptExpression.create(scanOperator);
+            scanExpression.setStatistics(Statistics.builder()
+                    .setOutputRowCount(100)
+                    .addColumnStatistic(arrayRef, ColumnStatistic.unknown())
+                    .build());
+            OptExpression projectExpression = OptExpression.create(
+                    new LogicalProjectOperator(ImmutableMap.of(outputRef, subfield)), scanExpression);
+            ExpressionContext projectContext = new ExpressionContext(projectExpression);
+
+            new StatisticsCalculator(projectContext, columnRefFactory, optimizerContext).estimatorStats();
+
+            Assertions.assertTrue(requestedColumns.isEmpty());
+            Assertions.assertTrue(projectContext.getStatistics().getColumnStatistic(outputRef).isUnknown());
+        } finally {
+            globalStateMgr.setStatisticStorage(originalStorage);
+        }
+    }
+
+    @Test
+    public void testStatisticsForDirectSubfield() {
+        GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
+        OlapTable table = (OlapTable) globalStateMgr.getLocalMetastore().getDb("statistics_test")
+                .getTable("test_all_type");
+        List<Long> partitionIds = table.getPartitions().stream()
+                .mapToLong(Partition::getId).boxed().collect(Collectors.toList());
+
+        Type structType = new StructType(
+                new ArrayList<>(List.of(new StructField("bucket_id", IntegerType.INT))));
+        Column structColumn = new Column("bucket_struct", structType, true);
+        ColumnRefOperator structRef = columnRefFactory.create("bucket_struct", structType, true);
+        ColumnRefOperator outputRef = columnRefFactory.create("bucket_id", IntegerType.INT, true);
+        SubfieldOperator subfield = new SubfieldOperator(
+                structRef, IntegerType.INT, List.of("bucket_id"));
+
+        LogicalOlapScanOperator scanOperator = new LogicalOlapScanOperator(table,
+                ImmutableMap.of(structRef, structColumn),
+                ImmutableMap.of(structColumn, structRef),
+                null, -1, null,
+                table.getBaseIndexMetaId(),
+                partitionIds,
+                null,
+                false,
+                Lists.newArrayList(),
+                Lists.newArrayList(),
+                Lists.newArrayList(),
+                false);
+        scanOperator.setProjection(new Projection(ImmutableMap.of(outputRef, subfield)));
+
+        ColumnStatistic expected = new ColumnStatistic(1, 10, 0, 8, 5);
+        StatisticStorage originalStorage = globalStateMgr.getStatisticStorage();
+        globalStateMgr.setStatisticStorage(new EmptyStatisticStorage() {
+            @Override
+            public List<ColumnStatistic> getColumnStatistics(Table table, List<String> columns) {
+                if (columns.equals(List.of("bucket_struct.bucket_id"))) {
+                    return List.of(expected);
+                }
+                return super.getColumnStatistics(table, columns);
+            }
+        });
+        try {
+            GroupExpression groupExpression = new GroupExpression(scanOperator, Lists.newArrayList());
+            groupExpression.setGroup(new Group(0));
+            ExpressionContext expressionContext = new ExpressionContext(groupExpression);
+
+            new StatisticsCalculator(expressionContext, columnRefFactory, optimizerContext).estimatorStats();
+
+            ColumnStatistic actual = expressionContext.getStatistics().getColumnStatistic(outputRef);
+            Assertions.assertFalse(actual.isUnknown());
+            Assertions.assertEquals(expected.getMinValue(), actual.getMinValue());
+            Assertions.assertEquals(expected.getMaxValue(), actual.getMaxValue());
+            Assertions.assertEquals(expected.getDistinctValuesCount(), actual.getDistinctValuesCount());
+        } finally {
+            globalStateMgr.setStatisticStorage(originalStorage);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
@@ -29,6 +29,7 @@ import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.JoinOperator;
 import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.common.StarRocksPlannerException;
@@ -61,6 +62,8 @@ import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.SubfieldOperator;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.statistic.StatisticUtils;
+import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
@@ -309,6 +312,12 @@ public class StatisticsCalculatorTest {
         }
     }
 
+    /**
+     * Operator level test for both call sites that ask the statistics storage for a subfield path: the projection of a
+     * scan operator, and a LogicalProject on top of a scan. A query reaches the first one, see
+     * {@link #testQueryWithSubfieldOfArrayElement()}, but not the second one, because the project is merged into the
+     * scan projection before statistics are estimated. That branch is therefore covered by a hand built operator tree.
+     */
     @Test
     public void testSkipStatisticsForSubfieldOfArrayElement() {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
@@ -437,6 +446,71 @@ public class StatisticsCalculatorTest {
             Assertions.assertEquals(expected.getDistinctValuesCount(), actual.getDistinctValuesCount());
         } finally {
             globalStateMgr.setStatisticStorage(originalStorage);
+        }
+    }
+
+    /**
+     * Query level regression test for the same bug. `ass[1].a` reaches the optimizer as a SubfieldOperator whose root
+     * is an expression instead of a table column, so before the fix the scan asked the statistics storage for the path
+     * `3: ass,1.a`, which no table column can ever match.
+     * <p>
+     * The statistics storage below reproduces what production then does with such a path: the loader behind
+     * CachedStatisticStorage resolves every requested path with StatisticUtils#getQueryStatisticsColumnType, which
+     * rejects an unknown root column, and CachedStatisticStorage falls back to unknown statistics for the whole
+     * requested batch. Since one scan requests all of its subfield paths in a single batch, the unsupported path also
+     * throws away the statistics of the valid `st1.s1` path selected by the same query. That is the user visible
+     * impact: a repeated failing statistics lookup plus worse cost estimates for the other columns of the projection.
+     */
+    @Test
+    public void testQueryWithSubfieldOfArrayElement() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE `test_subfield_statistics` (\n" +
+                "  `v1` bigint NULL,\n" +
+                "  `st1` struct<s1 int, s2 int> NULL,\n" +
+                "  `ass` array<struct<a int, b int>> NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`v1`)\n" +
+                "DISTRIBUTED BY HASH(`v1`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");");
+
+        ColumnStatistic structSubfieldStatistic = new ColumnStatistic(1, 10, 0, 4, 5);
+        List<String> requestedColumns = new ArrayList<>();
+        List<String> rejectedRequests = new ArrayList<>();
+        GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
+        StatisticStorage originalStorage = globalStateMgr.getStatisticStorage();
+        // the test table has no data, keep the scan instead of letting PruneEmptyScanRule replace it with values
+        boolean originalPruneEmptyOutputScan = FeConstants.enablePruneEmptyOutputScan;
+        FeConstants.enablePruneEmptyOutputScan = false;
+        globalStateMgr.setStatisticStorage(new EmptyStatisticStorage() {
+            @Override
+            public List<ColumnStatistic> getColumnStatistics(Table table, List<String> columns) {
+                requestedColumns.addAll(columns);
+                try {
+                    columns.forEach(column -> StatisticUtils.getQueryStatisticsColumnType(table, column));
+                } catch (SemanticException e) {
+                    rejectedRequests.add(columns.toString());
+                    return super.getColumnStatistics(table, columns);
+                }
+                return columns.stream()
+                        .map(column -> "st1.s1".equals(column) ? structSubfieldStatistic : ColumnStatistic.unknown())
+                        .collect(Collectors.toList());
+            }
+        });
+        try {
+            String plan = UtFrameUtils.getPlanAndFragment(connectContext,
+                            "select ass[1].a, st1.s1 from test_subfield_statistics")
+                    .second.getExplainString(TExplainLevel.COSTS);
+
+            Assertions.assertTrue(rejectedRequests.isEmpty(),
+                    "unsupported statistics path requested: " + rejectedRequests);
+            Assertions.assertTrue(requestedColumns.contains("st1.s1"),
+                    "statistics of the supported subfield path were not requested: " + requestedColumns);
+            Assertions.assertTrue(plan.contains("-->[1.0, 10.0, 0.0, 4.0, 5.0] ESTIMATE"), plan);
+        } finally {
+            FeConstants.enablePruneEmptyOutputScan = originalPruneEmptyOutputScan;
+            globalStateMgr.setStatisticStorage(originalStorage);
+            starRocksAssert.dropTable("test_subfield_statistics");
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

Persistent subfield statistics can only represent paths rooted directly at a table column, such as `struct_col.field`.

However, `StatisticsCalculator` treats every `SubfieldOperator` as a persistent subfield path. For an expression such as `array_col[1].field`, this can produce an invalid statistics path such as `array_col,1.field` and trigger a column statistics lookup failure.

## What I'm doing:

- Use persistent subfield statistics only when the subfield is rooted directly at a `ColumnRefOperator`.
- Apply the validation to both scan projections and `LogicalProject` operators above scans.
- Fall back to unknown expression statistics for array, map, and other expression-rooted subfields.
- Preserve the existing persistent statistics lookup for direct `STRUCT` subfields.
- Add regression tests covering both unsupported array-element subfields and supported direct `STRUCT` subfields.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: expression-rooted subfields now skip unsupported persistent statistics lookup and fall back to unknown statistics

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Tests

- `./run-fe-ut.sh --test com.starrocks.sql.optimizer.statistics.StatisticsCalculatorTest`
  - 32 tests passed
  - 0 failures and 0 errors
  - 0 Checkstyle violations
  - JaCoCo checks and the FE reactor build passed

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5



Related: #65692

