### PR TITLE
[Enhancement] Improve diagnostics for unfinished fragment instances

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -137,6 +137,10 @@ public class DefaultCoordinator extends Coordinator {
     private static final Logger LOG = LogManager.getLogger(DefaultCoordinator.class);
 
     private static final int DEFAULT_PROFILE_TIMEOUT_SECOND = 2;
+    // How often join() reports the instances it is still waiting for. Only affects logging.
+    private static final long STALL_LOG_INTERVAL_MS = TimeUnit.SECONDS.toMillis(30);
+    // Cap on how many pending instances are named individually, so a wide fan-out cannot blow up the log.
+    private static final int MAX_LOGGED_UNREPORTED_INSTANCES = 20;
     private static final ExecutorService EXTERNAL_RESOURCE_CLEANUP_EXECUTOR =
             ThreadPoolManager.newDaemonCacheThreadPool(32, 1024, "external-resource-cleanup", false);
 
@@ -1176,6 +1180,80 @@ public class DefaultCoordinator extends Coordinator {
         }
     }
 
+    /**
+     * Log the fragment instances that have not sent their final report yet, if any.
+     * <p>
+     * An instance is only counted down by a {@code done=true} report, so an instance whose worker stops
+     * finalizing never leaves this set and {@link #join} keeps waiting for it. Naming these instances makes
+     * it possible to distinguish a stalled fragment from a slow one by reading the FE log.
+     */
+    private void logUnreportedInstances(String context) {
+        try {
+            List<String> unreported = describeUnreportedInstances();
+            if (unreported.isEmpty()) {
+                return;
+            }
+            // A wide fan-out query can leave thousands of instances pending, and this runs every 30s during
+            // an incident, so log the per-worker counts in full (bounded by the cluster size, and the part
+            // that actually identifies the culprit node) but only a sample of the instances themselves.
+            List<String> sample = unreported.size() <= MAX_LOGGED_UNREPORTED_INSTANCES
+                    ? unreported
+                    : unreported.subList(0, MAX_LOGGED_UNREPORTED_INSTANCES);
+            LOG.warn("query {} {}, {} instance(s) have not reported yet, pending per worker: {}, first {}: {}",
+                    DebugUtil.printId(jobSpec.getQueryId()), context, unreported.size(),
+                    countUnreportedInstancesPerWorker(), sample.size(), sample);
+        } catch (Throwable e) {
+            // join() calls this without the coordinator lock, and phased scheduling can add executions
+            // concurrently. Diagnostics must never break the wait they are describing.
+            LOG.warn("failed to describe unreported instances of query {}",
+                    DebugUtil.printId(jobSpec.getQueryId()), e);
+        }
+    }
+
+    /**
+     * Describe every instance still missing from the profile latch as {@code <instanceId>@<workerId>(<state>)},
+     * so the log points at the worker to look at rather than at an opaque instance id.
+     */
+    @VisibleForTesting
+    public List<String> describeUnreportedInstances() {
+        List<String> unreportedIds = queryProfile.getUnfinishedInstanceIds();
+        if (unreportedIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Map<String, String> idToDescription = Maps.newHashMap();
+        for (FragmentInstanceExecState execState : executionDAG.getExecutions()) {
+            String instanceId = DebugUtil.printId(execState.getInstanceId());
+            ComputeNode worker = execState.getWorker();
+            String workerId = worker == null ? "not-deployed" : String.valueOf(worker.getId());
+            idToDescription.put(instanceId, String.format("%s@%s(%s)",
+                    instanceId, workerId, execState.getState()));
+        }
+        return unreportedIds.stream()
+                .map(instanceId -> idToDescription.getOrDefault(instanceId, instanceId + "(not-deployed)"))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Count the instances that have not reported yet per worker. This is bounded by the number of workers
+     * rather than by the fan-out, and it is what tells a single stalled node apart from a cluster-wide stall.
+     */
+    @VisibleForTesting
+    public Map<Long, Long> countUnreportedInstancesPerWorker() {
+        Set<String> unreportedIds = Sets.newHashSet(queryProfile.getUnfinishedInstanceIds());
+        Map<Long, Long> perWorker = Maps.newTreeMap();
+        if (unreportedIds.isEmpty()) {
+            return perWorker;
+        }
+        for (FragmentInstanceExecState execState : executionDAG.getExecutions()) {
+            ComputeNode worker = execState.getWorker();
+            if (worker != null && unreportedIds.contains(DebugUtil.printId(execState.getInstanceId()))) {
+                perWorker.merge(worker.getId(), 1L, Long::sum);
+            }
+        }
+        return perWorker;
+    }
+
     @Override
     public void clearExternalResources() {
         if (!externalResourcesCleared.compareAndSet(false, true)) {
@@ -1340,8 +1418,11 @@ public class DefaultCoordinator extends Coordinator {
                 ctx.setErrorCodeOnce(status.getErrorCodeString());
             }
             if (!status.isSuppressedError()) {
-                LOG.warn("exec state report failed status={}, query_id={}, instance_id={}, backend_id={}",
-                        status, DebugUtil.printId(jobSpec.getQueryId()),
+                // The report itself arrived; it is the reported execution that failed. Say so explicitly,
+                // and include done= because only a done=true report retires the instance.
+                LOG.warn("received failed exec state report, status={}, done={}, query_id={}, instance_id={}, " +
+                                "backend_id={}",
+                        status, params.isDone(), DebugUtil.printId(jobSpec.getQueryId()),
                         DebugUtil.printId(params.getFragment_instance_id()),
                         params.getBackend_id());
             }
@@ -1476,8 +1557,10 @@ public class DefaultCoordinator extends Coordinator {
     public boolean join(int timeoutS) {
         final long fixedMaxWaitTime = 5;
 
-        long leftTimeoutMs = timeoutS * 1000L;
+        long totalTimeoutMs = timeoutS * 1000L;
+        long leftTimeoutMs = totalTimeoutMs;
         boolean awaitRes = false;
+        long nextStallLogMs = STALL_LOG_INTERVAL_MS;
         while (leftTimeoutMs > 0) {
             // Check before blocking, otherwise a profile timeout of 0 would still wait out a whole round.
             if (profileWaitAfterCancelExpired()) {
@@ -1506,6 +1589,13 @@ public class DefaultCoordinator extends Coordinator {
             }
 
             leftTimeoutMs -= waitTimeMs;
+
+            long waitedMs = totalTimeoutMs - leftTimeoutMs;
+            if (waitedMs >= nextStallLogMs) {
+                nextStallLogMs += STALL_LOG_INTERVAL_MS;
+                logUnreportedInstances(String.format("has waited %ds of %ds [status=%s]",
+                        TimeUnit.MILLISECONDS.toSeconds(waitedMs), timeoutS, queryStatus.getErrorCodeString()));
+            }
 
             if (cancelledAtMs >= 0) {
                 // Recompute the remaining profile timeout after this wait round observes cancellation.
@@ -1549,10 +1639,7 @@ public class DefaultCoordinator extends Coordinator {
         }
 
         long waitedMs = System.currentTimeMillis() - cancelledAtMs;
-        List<String> unreported = queryProfile.getUnfinishedInstanceIds();
-        LOG.warn("query {} was cancelled {}ms ago and {} instance(s) still have not reported, " +
-                        "giving up on their profile: {}",
-                DebugUtil.printId(jobSpec.getQueryId()), waitedMs, unreported.size(), unreported);
+        logUnreportedInstances(String.format("was cancelled %dms ago; giving up on the remaining profile", waitedMs));
         // Release the latch so isDone() holds and the caller does not mistake this for a timeout.
         queryProfile.finishAllInstances(Status.OK);
         return true;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -1189,70 +1189,63 @@ public class DefaultCoordinator extends Coordinator {
      */
     private void logUnreportedInstances(String context) {
         try {
-            List<String> unreported = describeUnreportedInstances();
-            if (unreported.isEmpty()) {
+            UnreportedInstanceSummary summary = summarizeUnreportedInstances();
+            if (summary.total() == 0) {
                 return;
             }
-            // A wide fan-out query can leave thousands of instances pending, and this runs every 30s during
-            // an incident, so log the per-worker counts in full (bounded by the cluster size, and the part
-            // that actually identifies the culprit node) but only a sample of the instances themselves.
-            List<String> sample = unreported.size() <= MAX_LOGGED_UNREPORTED_INSTANCES
-                    ? unreported
-                    : unreported.subList(0, MAX_LOGGED_UNREPORTED_INSTANCES);
             LOG.warn("query {} {}, {} instance(s) have not reported yet, pending per worker: {}, first {}: {}",
-                    DebugUtil.printId(jobSpec.getQueryId()), context, unreported.size(),
-                    countUnreportedInstancesPerWorker(), sample.size(), sample);
+                    DebugUtil.printId(jobSpec.getQueryId()), context, summary.total(),
+                    summary.pendingPerWorker(), summary.sample().size(), summary.sample());
         } catch (Throwable e) {
             // join() calls this without the coordinator lock, and phased scheduling can add executions
             // concurrently. Diagnostics must never break the wait they are describing.
-            LOG.warn("failed to describe unreported instances of query {}",
+            LOG.warn("failed to summarize unreported instances of query {}",
                     DebugUtil.printId(jobSpec.getQueryId()), e);
         }
     }
 
     /**
-     * Describe every instance still missing from the profile latch as {@code <instanceId>@<workerId>(<state>)},
-     * so the log points at the worker to look at rather than at an opaque instance id.
+     * Summarize instances still missing from the profile latch without formatting every instance in a wide
+     * fan-out. Per-worker counts identify the affected nodes, while the formatted sample stays bounded.
      */
     @VisibleForTesting
-    public List<String> describeUnreportedInstances() {
+    public UnreportedInstanceSummary summarizeUnreportedInstances() {
         List<String> unreportedIds = queryProfile.getUnfinishedInstanceIds();
         if (unreportedIds.isEmpty()) {
-            return Collections.emptyList();
+            return new UnreportedInstanceSummary(0, Collections.emptyMap(), Collections.emptyList());
         }
 
-        Map<String, String> idToDescription = Maps.newHashMap();
+        Set<String> unmatchedIds = Sets.newHashSet(unreportedIds);
+        Map<Long, Long> pendingPerWorker = Maps.newTreeMap();
+        List<String> sample = Lists.newArrayListWithCapacity(
+                Math.min(unreportedIds.size(), MAX_LOGGED_UNREPORTED_INSTANCES));
         for (FragmentInstanceExecState execState : executionDAG.getExecutions()) {
             String instanceId = DebugUtil.printId(execState.getInstanceId());
+            if (!unmatchedIds.remove(instanceId)) {
+                continue;
+            }
+
             ComputeNode worker = execState.getWorker();
             String workerId = worker == null ? "not-deployed" : String.valueOf(worker.getId());
-            idToDescription.put(instanceId, String.format("%s@%s(%s)",
-                    instanceId, workerId, execState.getState()));
-        }
-        return unreportedIds.stream()
-                .map(instanceId -> idToDescription.getOrDefault(instanceId, instanceId + "(not-deployed)"))
-                .collect(Collectors.toList());
-    }
-
-    /**
-     * Count the instances that have not reported yet per worker. This is bounded by the number of workers
-     * rather than by the fan-out, and it is what tells a single stalled node apart from a cluster-wide stall.
-     */
-    @VisibleForTesting
-    public Map<Long, Long> countUnreportedInstancesPerWorker() {
-        Set<String> unreportedIds = Sets.newHashSet(queryProfile.getUnfinishedInstanceIds());
-        Map<Long, Long> perWorker = Maps.newTreeMap();
-        if (unreportedIds.isEmpty()) {
-            return perWorker;
-        }
-        for (FragmentInstanceExecState execState : executionDAG.getExecutions()) {
-            ComputeNode worker = execState.getWorker();
-            if (worker != null && unreportedIds.contains(DebugUtil.printId(execState.getInstanceId()))) {
-                perWorker.merge(worker.getId(), 1L, Long::sum);
+            if (worker != null) {
+                pendingPerWorker.merge(worker.getId(), 1L, Long::sum);
+            }
+            if (sample.size() < MAX_LOGGED_UNREPORTED_INSTANCES) {
+                sample.add(String.format("%s@%s(%s)", instanceId, workerId, execState.getState()));
             }
         }
-        return perWorker;
+
+        for (String instanceId : unmatchedIds) {
+            if (sample.size() >= MAX_LOGGED_UNREPORTED_INSTANCES) {
+                break;
+            }
+            sample.add(instanceId + "@not-deployed(UNKNOWN)");
+        }
+        return new UnreportedInstanceSummary(unreportedIds.size(), pendingPerWorker, sample);
     }
+
+    @VisibleForTesting
+    public record UnreportedInstanceSummary(int total, Map<Long, Long> pendingPerWorker, List<String> sample) {}
 
     @Override
     public void clearExternalResources() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -137,8 +137,6 @@ public class DefaultCoordinator extends Coordinator {
     private static final Logger LOG = LogManager.getLogger(DefaultCoordinator.class);
 
     private static final int DEFAULT_PROFILE_TIMEOUT_SECOND = 2;
-    // How often join() reports the instances it is still waiting for. Only affects logging.
-    private static final long STALL_LOG_INTERVAL_MS = TimeUnit.SECONDS.toMillis(30);
     // Cap on how many pending instances are named individually, so a wide fan-out cannot blow up the log.
     private static final int MAX_LOGGED_UNREPORTED_INSTANCES = 20;
     private static final ExecutorService EXTERNAL_RESOURCE_CLEANUP_EXECUTOR =
@@ -1184,8 +1182,8 @@ public class DefaultCoordinator extends Coordinator {
      * Log the fragment instances that have not sent their final report yet, if any.
      * <p>
      * An instance is only counted down by a {@code done=true} report, so an instance whose worker stops
-     * finalizing never leaves this set and {@link #join} keeps waiting for it. Naming these instances makes
-     * it possible to distinguish a stalled fragment from a slow one by reading the FE log.
+     * finalizing never leaves this set and {@link #join} keeps waiting for it after cancellation. Naming these
+     * instances identifies the affected worker when the cancellation grace period expires.
      */
     private void logUnreportedInstances(String context) {
         try {
@@ -1550,10 +1548,8 @@ public class DefaultCoordinator extends Coordinator {
     public boolean join(int timeoutS) {
         final long fixedMaxWaitTime = 5;
 
-        long totalTimeoutMs = timeoutS * 1000L;
-        long leftTimeoutMs = totalTimeoutMs;
+        long leftTimeoutMs = timeoutS * 1000L;
         boolean awaitRes = false;
-        long nextStallLogMs = STALL_LOG_INTERVAL_MS;
         while (leftTimeoutMs > 0) {
             // Check before blocking, otherwise a profile timeout of 0 would still wait out a whole round.
             if (profileWaitAfterCancelExpired()) {
@@ -1582,13 +1578,6 @@ public class DefaultCoordinator extends Coordinator {
             }
 
             leftTimeoutMs -= waitTimeMs;
-
-            long waitedMs = totalTimeoutMs - leftTimeoutMs;
-            if (waitedMs >= nextStallLogMs) {
-                nextStallLogMs += STALL_LOG_INTERVAL_MS;
-                logUnreportedInstances(String.format("has waited %ds of %ds [status=%s]",
-                        TimeUnit.MILLISECONDS.toSeconds(waitedMs), timeoutS, queryStatus.getErrorCodeString()));
-            }
 
             if (cancelledAtMs >= 0) {
                 // Recompute the remaining profile timeout after this wait round observes cancellation.

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/JoinTest.java
@@ -263,6 +263,46 @@ public class JoinTest extends SchedulerTestBase {
     }
 
     @Test
+    public void testDescribeUnreportedInstances() throws Exception {
+        String sql = "insert into lineitem select * from lineitem";
+        DefaultCoordinator scheduler = startScheduling(sql);
+
+        // Nothing has reported yet, so every deployed instance is still pending.
+        List<String> unreported = scheduler.describeUnreportedInstances();
+        Assertions.assertEquals(scheduler.getExecutionDAG().getExecutions().size(), unreported.size());
+
+        // Each entry must name the worker that owns the instance, that is what makes the log actionable.
+        Set<String> expectedWorkers = scheduler.getExecutionDAG().getExecutions().stream()
+                .map(execState -> String.valueOf(execState.getWorker().getId()))
+                .collect(Collectors.toSet());
+        for (String description : unreported) {
+            int at = description.indexOf('@');
+            int stateStart = description.indexOf('(');
+            Assertions.assertTrue(at > 0 && stateStart > at, description);
+            Assertions.assertTrue(expectedWorkers.contains(description.substring(at + 1, stateStart)), description);
+        }
+
+        // The per-worker breakdown is what the log leans on when the fan-out is too wide to name, so it
+        // must account for every pending instance.
+        Map<Long, Long> perWorker = scheduler.countUnreportedInstancesPerWorker();
+        Assertions.assertEquals(unreported.size(),
+                perWorker.values().stream().mapToLong(Long::longValue).sum());
+        Assertions.assertTrue(expectedWorkers.containsAll(
+                perWorker.keySet().stream().map(String::valueOf).collect(Collectors.toSet())));
+
+        // A done report retires its instance, so it must drop out of the list.
+        FragmentInstanceExecState reported = scheduler.getExecutionDAG().getExecutions().iterator().next();
+        TReportExecStatusParams request = new TReportExecStatusParams(FrontendServiceVersion.V1);
+        request.setBackend_num(reported.getIndexInJob())
+                .setDone(true)
+                .setStatus(new TStatus(TStatusCode.OK))
+                .setFragment_instance_id(reported.getInstanceId());
+        scheduler.updateFragmentExecStatus(request);
+
+        Assertions.assertEquals(unreported.size() - 1, scheduler.describeUnreportedInstances().size());
+    }
+
+    @Test
     public void testUpdateExecStatusConcurrently() throws Exception {
         String sql = "insert into lineitem select a.* from lineitem a join lineitem b on a.L_ORDERKEY=b.L_ORDERKEY";
         DefaultCoordinator scheduler = startScheduling(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/JoinTest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.load.loadv2.LoadJob;
 import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.qe.SessionVariable;
@@ -34,6 +35,7 @@ import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TTabletCommitInfo;
 import com.starrocks.thrift.TTabletFailInfo;
+import com.starrocks.thrift.TUniqueId;
 import mockit.Mock;
 import mockit.MockUp;
 import org.awaitility.Awaitility;
@@ -263,19 +265,19 @@ public class JoinTest extends SchedulerTestBase {
     }
 
     @Test
-    public void testDescribeUnreportedInstances() throws Exception {
+    public void testSummarizeUnreportedInstances() throws Exception {
         String sql = "insert into lineitem select * from lineitem";
         DefaultCoordinator scheduler = startScheduling(sql);
 
         // Nothing has reported yet, so every deployed instance is still pending.
-        List<String> unreported = scheduler.describeUnreportedInstances();
-        Assertions.assertEquals(scheduler.getExecutionDAG().getExecutions().size(), unreported.size());
+        DefaultCoordinator.UnreportedInstanceSummary summary = scheduler.summarizeUnreportedInstances();
+        Assertions.assertEquals(scheduler.getExecutionDAG().getExecutions().size(), summary.total());
 
         // Each entry must name the worker that owns the instance, that is what makes the log actionable.
         Set<String> expectedWorkers = scheduler.getExecutionDAG().getExecutions().stream()
                 .map(execState -> String.valueOf(execState.getWorker().getId()))
                 .collect(Collectors.toSet());
-        for (String description : unreported) {
+        for (String description : summary.sample()) {
             int at = description.indexOf('@');
             int stateStart = description.indexOf('(');
             Assertions.assertTrue(at > 0 && stateStart > at, description);
@@ -284,11 +286,10 @@ public class JoinTest extends SchedulerTestBase {
 
         // The per-worker breakdown is what the log leans on when the fan-out is too wide to name, so it
         // must account for every pending instance.
-        Map<Long, Long> perWorker = scheduler.countUnreportedInstancesPerWorker();
-        Assertions.assertEquals(unreported.size(),
-                perWorker.values().stream().mapToLong(Long::longValue).sum());
+        Assertions.assertEquals(summary.total(),
+                summary.pendingPerWorker().values().stream().mapToLong(Long::longValue).sum());
         Assertions.assertTrue(expectedWorkers.containsAll(
-                perWorker.keySet().stream().map(String::valueOf).collect(Collectors.toSet())));
+                summary.pendingPerWorker().keySet().stream().map(String::valueOf).collect(Collectors.toSet())));
 
         // A done report retires its instance, so it must drop out of the list.
         FragmentInstanceExecState reported = scheduler.getExecutionDAG().getExecutions().iterator().next();
@@ -299,7 +300,18 @@ public class JoinTest extends SchedulerTestBase {
                 .setFragment_instance_id(reported.getInstanceId());
         scheduler.updateFragmentExecStatus(request);
 
-        Assertions.assertEquals(unreported.size() - 1, scheduler.describeUnreportedInstances().size());
+        Assertions.assertEquals(summary.total() - 1, scheduler.summarizeUnreportedInstances().total());
+
+        // Keep the expensive formatted descriptions bounded even if the profile latch contains a wide fan-out.
+        QueryRuntimeProfile queryProfile = Deencapsulation.getField(scheduler, "queryProfile");
+        List<TUniqueId> wideFanOut = new ArrayList<>();
+        for (int i = 0; i < 25; i++) {
+            wideFanOut.add(new TUniqueId(0, i));
+        }
+        queryProfile.attachInstances(wideFanOut);
+        summary = scheduler.summarizeUnreportedInstances();
+        Assertions.assertEquals(wideFanOut.size(), summary.total());
+        Assertions.assertEquals(20, summary.sample().size());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

#76909 bounds how long a cancelled load/DML task waits for missing final profile reports. Even with that
behavioral fix, the coordinator log only contains opaque instance IDs when the grace period expires, so it
does not identify the worker that stopped reporting.

The existing warning `exec state report failed` is also misleading: it is emitted after FE receives an
execution report whose status is failed, not when receiving the report itself fails.

## What I'm doing:

- Describe unfinished instances as `<instanceId>@<workerId>(<state>)` and include per-worker counts.
- Reuse the bounded summary when #76909's cancellation grace period expires.
- Avoid periodic diagnostics for non-cancelled `join()` waits, so normal long-running DML/load tasks do not create log noise.
- Reword the failed execution report warning and include `done=`.
- Add coverage in `JoinTest`.

Diagnostics only; no change to cancellation or timeout behavior.

Validation:

```text
JAVA_HOME=/Users/luoyixin/Library/Java/JavaVirtualMachines/openjdk-19/Contents/Home \
  ./run-fe-ut.sh --test com.starrocks.qe.scheduler.JoinTest

Tests run: 7, Failures: 0, Errors: 0, Skipped: 2
BUILD SUCCESS
```

Fixes: N/A

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
