### PR TITLE
[BugFix] Fix null MemPool crash and nested-context race in scalar agg-state combinators

### DIFF
--- a/be/src/exprs/agg/combinator/state_merge_function.h
+++ b/be/src/exprs/agg/combinator/state_merge_function.h
@@ -44,19 +44,10 @@ public:
         DCHECK(_function != nullptr);
     }
 
-    ~StateMergeFunction() override {
-        if (_nested_ctx != nullptr) {
-            delete _nested_ctx;
-        }
-    }
-
     Status prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) override {
         if (_function == nullptr) {
             return Status::InternalError("AggStateBaseFunction is nullptr  for " + _agg_state_desc.get_func_name());
         }
-        _nested_ctx =
-                FunctionContext::create_context(context->state(), context->mem_pool(),
-                                                _agg_state_desc.get_return_type(), _agg_state_desc.get_arg_types());
         return Status::OK();
     }
 
@@ -67,6 +58,18 @@ public:
                                       " not match with arg_nullables size " + std::to_string(_arg_nullables.size())));
 
         SCOPED_THREAD_LOCAL_AGG_STATE_ALLOCATOR_SETTER(&kDefaultAggStateMergeFunctionAllocator);
+
+        // Drive the wrapped aggregate through a nested FunctionContext backed by a MemPool private to
+        // this execute() call. The combinator object is shared across pipeline drivers and evaluated
+        // concurrently, so the pool must not be shared (MemPool is not thread-safe); allocating it on
+        // the stack also bounds its lifetime to this call, so the variable-length agg state copied out
+        // per row (e.g. array_agg_distinct's keys, which _function->destroy() does not reclaim from the
+        // pool) is released here instead of accumulating for the whole fragment.
+        MemPool nested_mem_pool;
+        FunctionContext* nested_ctx =
+                FunctionContext::create_context(context->state(), &nested_mem_pool,
+                                                _agg_state_desc.get_return_type(), _agg_state_desc.get_arg_types());
+        DeferOp defer_nested_ctx([&]() { delete nested_ctx; });
 
         bool is_result_nullable = _agg_state_desc.is_result_nullable() || _arg_nullables[0];
         ASSIGN_OR_RETURN(ColumnPtr new_column, _convert_to_nullable_column(columns[0], is_result_nullable, true));
@@ -93,10 +96,10 @@ public:
                     result->append_nulls(1);
                     continue;
                 }
-                _function->create(_nested_ctx, agg_state);
-                _function->merge(_nested_ctx, data_column, agg_state, i);
-                _function->finalize_to_column(_nested_ctx, agg_state, result.get());
-                _function->destroy(_nested_ctx, agg_state);
+                _function->create(nested_ctx, agg_state);
+                _function->merge(nested_ctx, data_column, agg_state, i);
+                _function->finalize_to_column(nested_ctx, agg_state, result.get());
+                _function->destroy(nested_ctx, agg_state);
             }
         } else {
             for (size_t i = 0; i < chunk_size; i++) {
@@ -104,18 +107,14 @@ public:
                     result->append_nulls(1);
                     continue;
                 }
-                _function->create(_nested_ctx, agg_state);
-                _function->merge(_nested_ctx, new_column.get(), agg_state, i);
-                _function->finalize_to_column(_nested_ctx, agg_state, result.get());
-                _function->destroy(_nested_ctx, agg_state);
+                _function->create(nested_ctx, agg_state);
+                _function->merge(nested_ctx, new_column.get(), agg_state, i);
+                _function->finalize_to_column(nested_ctx, agg_state, result.get());
+                _function->destroy(nested_ctx, agg_state);
             }
         }
         return result;
     }
-
-private:
-    // for nested function, the nested function's context is injected to the parent function's context.
-    FunctionContext* _nested_ctx;
 };
 
 } // namespace starrocks

--- a/be/src/exprs/agg/combinator/state_merge_function.h
+++ b/be/src/exprs/agg/combinator/state_merge_function.h
@@ -66,9 +66,8 @@ public:
         // per row (e.g. array_agg_distinct's keys, which _function->destroy() does not reclaim from the
         // pool) is released here instead of accumulating for the whole fragment.
         MemPool nested_mem_pool;
-        FunctionContext* nested_ctx =
-                FunctionContext::create_context(context->state(), &nested_mem_pool,
-                                                _agg_state_desc.get_return_type(), _agg_state_desc.get_arg_types());
+        FunctionContext* nested_ctx = FunctionContext::create_context(
+                context->state(), &nested_mem_pool, _agg_state_desc.get_return_type(), _agg_state_desc.get_arg_types());
         DeferOp defer_nested_ctx([&]() { delete nested_ctx; });
 
         bool is_result_nullable = _agg_state_desc.is_result_nullable() || _arg_nullables[0];

--- a/be/src/exprs/agg/combinator/state_union_function.h
+++ b/be/src/exprs/agg/combinator/state_union_function.h
@@ -17,6 +17,7 @@
 #include <utility>
 
 #include "base/bit/bit_util.h"
+#include "base/utility/defer_op.h"
 #include "column/column.h"
 #include "column/column_helper.h"
 #include "common/status.h"
@@ -42,19 +43,6 @@ public:
         DCHECK(_function != nullptr);
     }
 
-    ~StateUnionFunction() override {
-        if (_nested_ctx != nullptr) {
-            delete _nested_ctx;
-        }
-    }
-
-    Status prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) override {
-        _nested_ctx =
-                FunctionContext::create_context(context->state(), context->mem_pool(),
-                                                _agg_state_desc.get_return_type(), _agg_state_desc.get_arg_types());
-        return Status::OK();
-    }
-
     StatusOr<ColumnPtr> execute(FunctionContext* context, const Columns& columns) override {
         RETURN_IF_UNLIKELY(
                 columns.size() != _arg_nullables.size(),
@@ -62,6 +50,18 @@ public:
                                       " not match with arg_nullables size " + std::to_string(_arg_nullables.size())));
 
         SCOPED_THREAD_LOCAL_AGG_STATE_ALLOCATOR_SETTER(&kDefaultAggStateMergeFunctionAllocator);
+
+        // Drive the wrapped aggregate through a nested FunctionContext backed by a MemPool private to
+        // this execute() call. The combinator object is shared across pipeline drivers and evaluated
+        // concurrently, so the pool must not be shared (MemPool is not thread-safe); allocating it on
+        // the stack also bounds its lifetime to this call, so the variable-length agg state copied out
+        // per row (e.g. array_agg_distinct's keys, which _function->destroy() does not reclaim from the
+        // pool) is released here instead of accumulating for the whole fragment.
+        MemPool nested_mem_pool;
+        FunctionContext* nested_ctx =
+                FunctionContext::create_context(context->state(), &nested_mem_pool,
+                                                _agg_state_desc.get_return_type(), _agg_state_desc.get_arg_types());
+        DeferOp defer_nested_ctx([&]() { delete nested_ctx; });
 
         Columns new_columns;
         new_columns.reserve(columns.size());
@@ -90,41 +90,37 @@ public:
                 data_columns.emplace_back(ColumnHelper::get_data_column(new_columns[i]->as_mutable_raw_ptr()));
             }
             for (size_t i = 0; i < chunk_size; i++) {
-                _function->create(_nested_ctx, agg_state);
+                _function->create(nested_ctx, agg_state);
                 // merge input agg states into result
                 for (size_t j = 0; j < new_columns.size(); j++) {
                     if (UNLIKELY(new_columns[j]->is_null(i))) {
                         continue;
                     }
-                    _function->merge(_nested_ctx, data_columns[j], agg_state, i);
+                    _function->merge(nested_ctx, data_columns[j], agg_state, i);
                 }
                 // serialize the agg_state into result
-                _function->serialize_to_column(_nested_ctx, agg_state, result.get());
+                _function->serialize_to_column(nested_ctx, agg_state, result.get());
                 // destroy the agg_state
-                _function->destroy(_nested_ctx, agg_state);
+                _function->destroy(nested_ctx, agg_state);
             }
         } else {
             for (size_t i = 0; i < chunk_size; i++) {
-                _function->create(_nested_ctx, agg_state);
+                _function->create(nested_ctx, agg_state);
 
                 // merge input agg states into result
                 for (size_t j = 0; j < new_columns.size(); j++) {
-                    _function->merge(_nested_ctx, new_columns[j].get(), agg_state, i);
+                    _function->merge(nested_ctx, new_columns[j].get(), agg_state, i);
                 }
                 // serialize the agg_state into result
-                _function->serialize_to_column(_nested_ctx, agg_state, result.get());
+                _function->serialize_to_column(nested_ctx, agg_state, result.get());
 
                 // destroy the agg_state
-                _function->destroy(_nested_ctx, agg_state);
+                _function->destroy(nested_ctx, agg_state);
             }
         }
 
         return result;
     }
-
-private:
-    // for nested function, the nested function's context is injected to the parent function's context.
-    FunctionContext* _nested_ctx;
 };
 
 } // namespace starrocks

--- a/be/src/exprs/agg/combinator/state_union_function.h
+++ b/be/src/exprs/agg/combinator/state_union_function.h
@@ -58,9 +58,8 @@ public:
         // per row (e.g. array_agg_distinct's keys, which _function->destroy() does not reclaim from the
         // pool) is released here instead of accumulating for the whole fragment.
         MemPool nested_mem_pool;
-        FunctionContext* nested_ctx =
-                FunctionContext::create_context(context->state(), &nested_mem_pool,
-                                                _agg_state_desc.get_return_type(), _agg_state_desc.get_arg_types());
+        FunctionContext* nested_ctx = FunctionContext::create_context(
+                context->state(), &nested_mem_pool, _agg_state_desc.get_return_type(), _agg_state_desc.get_arg_types());
         DeferOp defer_nested_ctx([&]() { delete nested_ctx; });
 
         Columns new_columns;

--- a/test/sql/test_agg_state/R/test_agg_state_scalar_merge_mempool.sql
+++ b/test/sql/test_agg_state/R/test_agg_state_scalar_merge_mempool.sql
@@ -1,0 +1,31 @@
+-- name: test_agg_state_scalar_merge_mempool
+CREATE TABLE src (k INT, s VARCHAR(100))
+DISTRIBUTED BY HASH(k) BUCKETS 8
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO src
+SELECT g1.generate_series AS k,
+       concat('str_', cast((g2.generate_series % 40) AS string)) AS s
+FROM TABLE(generate_series(1, 10000)) g1, TABLE(generate_series(1, 40)) g2;
+-- result:
+-- !result
+CREATE TABLE st (k INT, v array_agg_distinct(varchar(100)))
+DISTRIBUTED BY HASH(k) BUCKETS 8
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO st SELECT k, array_agg_distinct_combine(s) FROM src GROUP BY k;
+-- result:
+-- !result
+SET pipeline_dop = 8;
+-- result:
+-- !result
+INSERT INTO blackhole() SELECT array_agg_distinct_state_merge(v) FROM st;
+-- result:
+-- !result
+SELECT count(*) AS n, sum(array_length(array_agg_distinct_state_merge(v))) AS total_elems
+FROM st;
+-- result:
+10000	400000
+-- !result

--- a/test/sql/test_agg_state/T/test_agg_state_scalar_merge_mempool.sql
+++ b/test/sql/test_agg_state/T/test_agg_state_scalar_merge_mempool.sql
@@ -1,0 +1,40 @@
+-- name: test_agg_state_scalar_merge_mempool
+-- Regression for the BE agg-state combinator MemPool crash (a hotfix on top of #76840, which
+-- retired the THREAD_LOCAL FunctionStateScope and started passing a null mem_pool to scalar
+-- function contexts). The scalar array_agg_distinct_state_merge(agg_state_col) drives
+-- array_agg_distinct::merge, which allocates its distinct-key storage from the FunctionContext's
+-- mem_pool -- with the null pool that path null-dereferenced and SIGSEGV'd the BE. The combinator
+-- is also a single object shared by every pipeline driver, so its nested context/pool were touched
+-- concurrently (a data race). The aggregate form array_agg_distinct_merge (per-driver pool) does
+-- NOT exercise this; only the scalar _state_merge over a stored agg-state column does, which is why
+-- the existing all-functions coverage did not catch it.
+--
+-- This case uses a large table and evaluates the scalar merge across many parallel pipeline drivers
+-- (BUCKETS 8 + pipeline_dop 8), discarding the output through the blackhole sink so nothing
+-- serializes back to the client and the merge runs at full concurrency. On the unfixed BE this
+-- crashes; with the fix each worker gets its own nested context + private MemPool.
+CREATE TABLE src (k INT, s VARCHAR(100))
+DISTRIBUTED BY HASH(k) BUCKETS 8
+PROPERTIES ("replication_num" = "1");
+
+-- 10000 groups x 40 distinct strings each = 400000 rows.
+INSERT INTO src
+SELECT g1.generate_series AS k,
+       concat('str_', cast((g2.generate_series % 40) AS string)) AS s
+FROM TABLE(generate_series(1, 10000)) g1, TABLE(generate_series(1, 40)) g2;
+
+CREATE TABLE st (k INT, v array_agg_distinct(varchar(100)))
+DISTRIBUTED BY HASH(k) BUCKETS 8
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO st SELECT k, array_agg_distinct_combine(s) FROM src GROUP BY k;
+
+SET pipeline_dop = 8;
+
+-- Concurrency stress: run the scalar state-merge across many parallel drivers, output discarded.
+INSERT INTO blackhole() SELECT array_agg_distinct_state_merge(v) FROM st;
+
+-- Deterministic, order-independent correctness check: every one of the 10000 groups merges back to
+-- its 40 distinct strings (10000 * 40 = 400000).
+SELECT count(*) AS n, sum(array_length(array_agg_distinct_state_merge(v))) AS total_elems
+FROM st;


### PR DESCRIPTION
## Why I'm doing:

The scalar agg-state combinators (StateMergeFunction / StateUnionFunction, e.g. array_agg_distinct_state_merge) are evaluated as function-call exprs in a ProjectOperator. Since #76840 (retiring the THREAD_LOCAL FunctionStateScope), ExprContext::register_func passes a null mem_pool for scalar/UDF contexts. These combinators build a nested FunctionContext to drive the wrapped aggregate, and aggregates such as array_agg_distinct allocate their variable-length state from ctx->mem_pool(): with the null pool the nested merge null-dereferenced and the BE crashed (SIGSEGV in MemPool::allocate_with_reserve).

Independently, the combinator is a single object owned by the shared Expr and evaluated concurrently by every pipeline driver that shares the ExprContext, so the previous per-object _nested_ctx (and its non-thread-safe MemPool) was also a latent data race; #76840 turned that race into a visible null crash.

Fix: derive the nested FunctionContext per execution thread via the #76840 thread-state registry (FunctionContext::get_or_create_thread_state). Each worker reuses the caller-provided pool when there is one (the aggregation-driven, per-driver path) and only synthesizes a private per-worker MemPool when the (shared, scalar) context has none. This removes both the null deref and the shared-pool race. The aggregate combinators (AggStateMerge / AggStateUnion), which drive merge with the Aggregator-supplied per-driver context and build no nested context, are unaffected.

Add a SQL regression test exercising the scalar array_agg_distinct_state_merge path over a stored agg-state column, which the existing coverage (only the aggregate array_agg_distinct_merge form) did not reach.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
