### PR TITLE
[Enhancement] Scope Histogram stat collection to mcv and/or buckets

### DIFF
--- a/docs/en/sql-reference/sql-statements/cbo_stats/ANALYZE_TABLE.md
+++ b/docs/en/sql-reference/sql-statements/cbo_stats/ANALYZE_TABLE.md
@@ -97,6 +97,7 @@ PROPERTIES (property [,property]);
 | histogram_mcv_size             | INT      | 100               | The number of most common values (MCV) for a histogram.      |
 | histogram_sample_ratio         | FLOAT    | 0.1               | The sampling ratio for a histogram.                          |
 | histogram_max_sample_row_count | LONG     | 10000000          | The maximum number of rows to collect for a histogram.       |
+| histogram_stats_scope          | STRING   | both               | The scope of statistics to collect for a histogram: `mcv` (only most common values), `buckets` (only equi-height buckets), or `both` (both MCVs and buckets). |
 
 The number of rows to collect for a histogram is controlled by multiple parameters. It is the larger value between `statistic_sample_collect_rows` and table row count * `histogram_sample_ratio`. The number cannot exceed the value specified by `histogram_max_sample_row_count`. If the value is exceeded, `histogram_max_sample_row_count` takes precedence.
 
@@ -111,6 +112,12 @@ ANALYZE TABLE tbl_name UPDATE HISTOGRAM ON v1,v2 WITH 32 BUCKETS
 PROPERTIES(
    "histogram_mcv_size" = "32",
    "histogram_sample_ratio" = "0.5"
+);
+
+-- Manually collect only MCVs on v1, skipping bucket collection.
+ANALYZE TABLE tbl_name UPDATE HISTOGRAM ON v1
+PROPERTIES(
+   "histogram_stats_scope" = "mcv"
 );
 ```
 

--- a/docs/en/sql-reference/sql-statements/cbo_stats/ANALYZE_TABLE.md
+++ b/docs/en/sql-reference/sql-statements/cbo_stats/ANALYZE_TABLE.md
@@ -97,7 +97,7 @@ PROPERTIES (property [,property]);
 | histogram_mcv_size             | INT      | 100               | The number of most common values (MCV) for a histogram.      |
 | histogram_sample_ratio         | FLOAT    | 0.1               | The sampling ratio for a histogram.                          |
 | histogram_max_sample_row_count | LONG     | 10000000          | The maximum number of rows to collect for a histogram.       |
-| histogram_stats_scope          | STRING   | both               | The scope of statistics to collect for a histogram: `mcv` (only most common values), `buckets` (only equi-height buckets), or `both` (both MCVs and buckets). |
+| histogram_stats_scope          | STRING   | `mcv,buckets`     | The kinds of statistics to collect for a histogram, as a comma-separated set of `mcv` (most common values) and `buckets` (equi-height buckets). Omit the property to collect every kind. When `buckets` is not collected, a single all-encompassing bucket is stored so that the row count stays correct. |
 
 The number of rows to collect for a histogram is controlled by multiple parameters. It is the larger value between `statistic_sample_collect_rows` and table row count * `histogram_sample_ratio`. The number cannot exceed the value specified by `histogram_max_sample_row_count`. If the value is exceeded, `histogram_max_sample_row_count` takes precedence.
 

--- a/docs/en/using_starrocks/Cost_based_optimizer.md
+++ b/docs/en/using_starrocks/Cost_based_optimizer.md
@@ -333,6 +333,7 @@ Parameter description:
 | histogram_sample_ratio            | FLOAT    | 0.1               | The sampling ratio for a histogram.                          |
 | histogram_max_sample_row_count    | LONG     | 10000000          | The maximum number of rows to collect for a histogram.       |
 | histogram_collect_bucket_ndv_mode | STRING   | none              | The mode for estimating the number of distinct values (NDV) per histogram bucket. `none` (default, no distinct count collected), `hll` (uses HyperLogLog for accurate estimation), or `sample` (uses a low overhead sample-based estimator). |
+| histogram_stats_scope              | STRING   | both               | The scope of statistics to collect for a histogram: `mcv` (only most common values), `buckets` (only equi-height buckets), or `both` (both MCVs and buckets). |
 
 The number of rows to collect for a histogram is controlled by multiple parameters. It is the larger value between `statistic_sample_collect_rows` and table row count * `histogram_sample_ratio`. The number cannot exceed the value specified by `histogram_max_sample_row_count`. If the value is exceeded, `histogram_max_sample_row_count` takes precedence.
 

--- a/docs/en/using_starrocks/Cost_based_optimizer.md
+++ b/docs/en/using_starrocks/Cost_based_optimizer.md
@@ -333,7 +333,7 @@ Parameter description:
 | histogram_sample_ratio            | FLOAT    | 0.1               | The sampling ratio for a histogram.                          |
 | histogram_max_sample_row_count    | LONG     | 10000000          | The maximum number of rows to collect for a histogram.       |
 | histogram_collect_bucket_ndv_mode | STRING   | none              | The mode for estimating the number of distinct values (NDV) per histogram bucket. `none` (default, no distinct count collected), `hll` (uses HyperLogLog for accurate estimation), or `sample` (uses a low overhead sample-based estimator). |
-| histogram_stats_scope              | STRING   | both               | The scope of statistics to collect for a histogram: `mcv` (only most common values), `buckets` (only equi-height buckets), or `both` (both MCVs and buckets). |
+| histogram_stats_scope             | STRING   | `mcv,buckets`     | The kinds of statistics to collect for a histogram, as a comma-separated set of `mcv` (most common values) and `buckets` (equi-height buckets). Omit the property to collect every kind. When `buckets` is not collected, a single all-encompassing bucket is stored so that the row count stays correct. |
 
 The number of rows to collect for a histogram is controlled by multiple parameters. It is the larger value between `statistic_sample_collect_rows` and table row count * `histogram_sample_ratio`. The number cannot exceed the value specified by `histogram_max_sample_row_count`. If the value is exceeded, `histogram_max_sample_row_count` takes precedence.
 

--- a/docs/ja/sql-reference/sql-statements/cbo_stats/ANALYZE_TABLE.md
+++ b/docs/ja/sql-reference/sql-statements/cbo_stats/ANALYZE_TABLE.md
@@ -99,6 +99,7 @@ PROPERTIES (property [,property]);
 | histogram_mcv_size             | INT      | 100               | ヒストグラムの最も一般的な値 (MCV) の数。                    |
 | histogram_sample_ratio         | FLOAT    | 0.1               | ヒストグラムのサンプリング比率。                             |
 | histogram_max_sample_row_count | LONG     | 10000000          | ヒストグラムのために収集する最大行数。                       |
+| histogram_stats_scope          | STRING   | both              | ヒストグラムで収集する統計情報の範囲: `mcv` (最も一般的な値のみ)、`buckets` (等高バケットのみ)、または `both` (MCV とバケットの両方)。 |
 
 ヒストグラムのために収集する行数は、複数のパラメーターによって制御されます。それは `statistic_sample_collect_rows` とテーブル行数 * `histogram_sample_ratio` の間の大きい方の値です。この数は `histogram_max_sample_row_count` で指定された値を超えることはできません。値が超えた場合、`histogram_max_sample_row_count` が優先されます。
 
@@ -113,6 +114,12 @@ ANALYZE TABLE tbl_name UPDATE HISTOGRAM ON v1,v2 WITH 32 BUCKETS
 PROPERTIES(
    "histogram_mcv_size" = "32",
    "histogram_sample_ratio" = "0.5"
+);
+
+-- v1 の MCV のみを手動で収集し、バケットの収集をスキップします。
+ANALYZE TABLE tbl_name UPDATE HISTOGRAM ON v1
+PROPERTIES(
+   "histogram_stats_scope" = "mcv"
 );
 ```
 

--- a/docs/ja/sql-reference/sql-statements/cbo_stats/ANALYZE_TABLE.md
+++ b/docs/ja/sql-reference/sql-statements/cbo_stats/ANALYZE_TABLE.md
@@ -99,7 +99,7 @@ PROPERTIES (property [,property]);
 | histogram_mcv_size             | INT      | 100               | ヒストグラムの最も一般的な値 (MCV) の数。                    |
 | histogram_sample_ratio         | FLOAT    | 0.1               | ヒストグラムのサンプリング比率。                             |
 | histogram_max_sample_row_count | LONG     | 10000000          | ヒストグラムのために収集する最大行数。                       |
-| histogram_stats_scope          | STRING   | both              | ヒストグラムで収集する統計情報の範囲: `mcv` (最も一般的な値のみ)、`buckets` (等高バケットのみ)、または `both` (MCV とバケットの両方)。 |
+| histogram_stats_scope          | STRING   | `mcv,buckets`     | ヒストグラムで収集する統計情報の種類。`mcv` (最も一般的な値) と `buckets` (等高バケット) のカンマ区切りの集合で指定します。プロパティを省略するとすべての種類を収集します。`buckets` を収集しない場合は、行数が正しく保たれるように全体を覆う単一のバケットが保存されます。 |
 
 ヒストグラムのために収集する行数は、複数のパラメーターによって制御されます。それは `statistic_sample_collect_rows` とテーブル行数 * `histogram_sample_ratio` の間の大きい方の値です。この数は `histogram_max_sample_row_count` で指定された値を超えることはできません。値が超えた場合、`histogram_max_sample_row_count` が優先されます。
 

--- a/docs/ja/using_starrocks/Cost_based_optimizer.md
+++ b/docs/ja/using_starrocks/Cost_based_optimizer.md
@@ -335,6 +335,7 @@ ANALYZE TABLE tbl_name UPDATE HISTOGRAM ON col_name [, col_name]
 | histogram_sample_ratio            | FLOAT    | 0.1               | ヒストグラムのサンプリング比率。                          |
 | histogram_max_sample_row_count    | LONG     | 10000000          | ヒストグラムのために収集する最大行数。       |
 | histogram_collect_bucket_ndv_mode | STRING   | none              | ヒストグラムバケットごとの重複排除カウント (NDV) を推定するモード。`none` (デフォルト、重複排除カウントは収集されません)、`hll` (HyperLogLog を使用して正確に推定)、または `sample` (低オーバーヘッドのサンプルベースの推定器を使用)。 |
+| histogram_stats_scope             | STRING   | both              | ヒストグラムで収集する統計情報の範囲: `mcv` (最も一般的な値のみ)、`buckets` (等高バケットのみ)、または `both` (MCV とバケットの両方)。 |
 
 ヒストグラムのために収集する行数は、複数のパラメータによって制御されます。それは `statistic_sample_collect_rows` とテーブル行数 * `histogram_sample_ratio` の間の大きい値です。この数は `histogram_max_sample_row_count` で指定された値を超えることはできません。値を超えた場合、`histogram_max_sample_row_count` が優先されます。
 

--- a/docs/ja/using_starrocks/Cost_based_optimizer.md
+++ b/docs/ja/using_starrocks/Cost_based_optimizer.md
@@ -335,7 +335,7 @@ ANALYZE TABLE tbl_name UPDATE HISTOGRAM ON col_name [, col_name]
 | histogram_sample_ratio            | FLOAT    | 0.1               | ヒストグラムのサンプリング比率。                          |
 | histogram_max_sample_row_count    | LONG     | 10000000          | ヒストグラムのために収集する最大行数。       |
 | histogram_collect_bucket_ndv_mode | STRING   | none              | ヒストグラムバケットごとの重複排除カウント (NDV) を推定するモード。`none` (デフォルト、重複排除カウントは収集されません)、`hll` (HyperLogLog を使用して正確に推定)、または `sample` (低オーバーヘッドのサンプルベースの推定器を使用)。 |
-| histogram_stats_scope             | STRING   | both              | ヒストグラムで収集する統計情報の範囲: `mcv` (最も一般的な値のみ)、`buckets` (等高バケットのみ)、または `both` (MCV とバケットの両方)。 |
+| histogram_stats_scope             | STRING   | `mcv,buckets`     | ヒストグラムで収集する統計情報の種類。`mcv` (最も一般的な値) と `buckets` (等高バケット) のカンマ区切りの集合で指定します。プロパティを省略するとすべての種類を収集します。`buckets` を収集しない場合は、行数が正しく保たれるように全体を覆う単一のバケットが保存されます。 |
 
 ヒストグラムのために収集する行数は、複数のパラメータによって制御されます。それは `statistic_sample_collect_rows` とテーブル行数 * `histogram_sample_ratio` の間の大きい値です。この数は `histogram_max_sample_row_count` で指定された値を超えることはできません。値を超えた場合、`histogram_max_sample_row_count` が優先されます。
 

--- a/docs/zh/sql-reference/sql-statements/cbo_stats/ANALYZE_TABLE.md
+++ b/docs/zh/sql-reference/sql-statements/cbo_stats/ANALYZE_TABLE.md
@@ -94,6 +94,7 @@ PROPERTIES (property [,property]);
 | histogram_mcv_size             | INT      | 100        | 直方图 most common value (MCV) 的数量。                      |
 | histogram_sample_ratio         | FLOAT    | 0.1        | 直方图采样比例。                                             |
 | histogram_max_sample_row_count | LONG     | 10000000   | 直方图最大采样行数。                                         |
+| histogram_stats_scope          | STRING   | both       | 直方图采集的统计信息范围：`mcv`（仅采集 most common value）、`buckets`（仅采集等深分桶）或 `both`（同时采集 MCV 和分桶）。 |
 
 直方图的采样行数由多个参数共同控制，采样行数取 `statistic_sample_collect_rows` 和表总行数 `histogram_sample_ratio` 两者中的最大值。最多不超过 `histogram_max_sample_row_count` 指定的行数。如果超过，则按照该参数定义的上限行数进行采集。
 
@@ -110,6 +111,12 @@ ANALYZE TABLE tbl_name UPDATE HISTOGRAM ON v1,v2 WITH 32 BUCKETS
 PROPERTIES(
    "histogram_mcv_size" = "32",
    "histogram_sample_ratio" = "0.5"
+);
+
+-- 手动仅采集 v1 列的 MCV 信息，跳过分桶采集。
+ANALYZE TABLE tbl_name UPDATE HISTOGRAM ON v1
+PROPERTIES(
+   "histogram_stats_scope" = "mcv"
 );
 ```
 

--- a/docs/zh/sql-reference/sql-statements/cbo_stats/ANALYZE_TABLE.md
+++ b/docs/zh/sql-reference/sql-statements/cbo_stats/ANALYZE_TABLE.md
@@ -94,7 +94,7 @@ PROPERTIES (property [,property]);
 | histogram_mcv_size             | INT      | 100        | 直方图 most common value (MCV) 的数量。                      |
 | histogram_sample_ratio         | FLOAT    | 0.1        | 直方图采样比例。                                             |
 | histogram_max_sample_row_count | LONG     | 10000000   | 直方图最大采样行数。                                         |
-| histogram_stats_scope          | STRING   | both       | 直方图采集的统计信息范围：`mcv`（仅采集 most common value）、`buckets`（仅采集等深分桶）或 `both`（同时采集 MCV 和分桶）。 |
+| histogram_stats_scope          | STRING   | `mcv,buckets` | 直方图采集的统计信息种类，取值为 `mcv`（most common value）和 `buckets`（等深分桶）组成的逗号分隔集合。不指定该属性时采集全部种类。未采集 `buckets` 时，会存储一个覆盖全部数据的分桶，以保证行数估算正确。 |
 
 直方图的采样行数由多个参数共同控制，采样行数取 `statistic_sample_collect_rows` 和表总行数 `histogram_sample_ratio` 两者中的最大值。最多不超过 `histogram_max_sample_row_count` 指定的行数。如果超过，则按照该参数定义的上限行数进行采集。
 

--- a/docs/zh/using_starrocks/Cost_based_optimizer.md
+++ b/docs/zh/using_starrocks/Cost_based_optimizer.md
@@ -328,6 +328,7 @@ ANALYZE TABLE tbl_name UPDATE HISTOGRAM ON col_name [, col_name]
 | histogram_buckets_size                      | LONG    | 64           | 直方图默认分桶数。                                                                                             |
 | histogram_max_sample_row_count    | LONG   | 10000000 | 直方图最大采样行数。                       |
 | histogram_collect_bucket_ndv_mode | STRING   | none              | 估算每个直方图桶的去重（NDV）值的模式。`none`（默认，不采集去重值）、`hll`（使用 HyperLogLog 进行精准估算）或 `sample`（使用低开销的基于采样的估算器）。 |
+| histogram_stats_scope             | STRING   | both              | 直方图采集的统计信息范围：`mcv`（仅采集 most common value）、`buckets`（仅采集等深分桶）或 `both`（同时采集 MCV 和分桶）。 |
 
 直方图的采样行数由多个参数共同控制，采样行数取 `statistic_sample_collect_rows` 和表总行数 `histogram_sample_ratio` 两者中的最大值。最多不超过 `histogram_max_sample_row_count` 指定的行数。如果超过，则按照该参数定义的上限行数进行采集。
 

--- a/docs/zh/using_starrocks/Cost_based_optimizer.md
+++ b/docs/zh/using_starrocks/Cost_based_optimizer.md
@@ -328,7 +328,7 @@ ANALYZE TABLE tbl_name UPDATE HISTOGRAM ON col_name [, col_name]
 | histogram_buckets_size                      | LONG    | 64           | 直方图默认分桶数。                                                                                             |
 | histogram_max_sample_row_count    | LONG   | 10000000 | 直方图最大采样行数。                       |
 | histogram_collect_bucket_ndv_mode | STRING   | none              | 估算每个直方图桶的去重（NDV）值的模式。`none`（默认，不采集去重值）、`hll`（使用 HyperLogLog 进行精准估算）或 `sample`（使用低开销的基于采样的估算器）。 |
-| histogram_stats_scope             | STRING   | both              | 直方图采集的统计信息范围：`mcv`（仅采集 most common value）、`buckets`（仅采集等深分桶）或 `both`（同时采集 MCV 和分桶）。 |
+| histogram_stats_scope             | STRING   | `mcv,buckets`     | 直方图采集的统计信息种类，取值为 `mcv`（most common value）和 `buckets`（等深分桶）组成的逗号分隔集合。不指定该属性时采集全部种类。未采集 `buckets` 时，会存储一个覆盖全部数据的分桶，以保证行数估算正确。 |
 
 直方图的采样行数由多个参数共同控制，采样行数取 `statistic_sample_collect_rows` 和表总行数 `histogram_sample_ratio` 两者中的最大值。最多不超过 `histogram_max_sample_row_count` 指定的行数。如果超过，则按照该参数定义的上限行数进行采集。
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
@@ -491,6 +491,17 @@ public class AnalyzeStmtAnalyzer {
                         p -> String.valueOf(Config.histogram_mcv_size));
                 properties.computeIfAbsent(StatsConstants.HISTOGRAM_SAMPLE_RATIO,
                         p -> String.valueOf(Config.histogram_sample_ratio));
+
+                String histStatScope = properties.computeIfAbsent(StatsConstants.HISTOGRAM_STATS_SCOPE,
+                        p -> StatsConstants.HISTOGRAM_STATS_SCOPE_BOTH);
+                if (!histStatScope.equalsIgnoreCase(StatsConstants.HISTOGRAM_STATS_SCOPE_MCV)
+                        && !histStatScope.equalsIgnoreCase(StatsConstants.HISTOGRAM_STATS_SCOPE_BUCKETS)
+                        && !histStatScope.equalsIgnoreCase(StatsConstants.HISTOGRAM_STATS_SCOPE_BOTH)) {
+                    throw new SemanticException("Property '%s' must be one of '%s', '%s', '%s'",
+                            StatsConstants.HISTOGRAM_STATS_SCOPE, StatsConstants.HISTOGRAM_STATS_SCOPE_MCV,
+                            StatsConstants.HISTOGRAM_STATS_SCOPE_BUCKETS, StatsConstants.HISTOGRAM_STATS_SCOPE_BOTH);
+                }
+
                 properties.computeIfAbsent(StatsConstants.HISTOGRAM_COLLECT_BUCKET_NDV_MODE,
                         p -> String.valueOf(Config.histogram_collect_bucket_ndv_mode));
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
@@ -493,14 +493,17 @@ public class AnalyzeStmtAnalyzer {
                 properties.computeIfAbsent(StatsConstants.HISTOGRAM_SAMPLE_RATIO,
                         p -> String.valueOf(Config.histogram_sample_ratio));
 
-                String histStatScope = properties.computeIfAbsent(StatsConstants.HISTOGRAM_STATS_SCOPE,
-                        p -> StatsConstants.HISTOGRAM_STATS_SCOPE_BOTH);
-                if (!histStatScope.equalsIgnoreCase(StatsConstants.HISTOGRAM_STATS_SCOPE_MCV)
-                        && !histStatScope.equalsIgnoreCase(StatsConstants.HISTOGRAM_STATS_SCOPE_BUCKETS)
-                        && !histStatScope.equalsIgnoreCase(StatsConstants.HISTOGRAM_STATS_SCOPE_BOTH)) {
-                    throw new SemanticException("Property '%s' must be one of '%s', '%s', '%s'",
-                            StatsConstants.HISTOGRAM_STATS_SCOPE, StatsConstants.HISTOGRAM_STATS_SCOPE_MCV,
-                            StatsConstants.HISTOGRAM_STATS_SCOPE_BUCKETS, StatsConstants.HISTOGRAM_STATS_SCOPE_BOTH);
+                // Validated but deliberately not defaulted into the map: omitting the property already
+                // means "collect every kind", so there is nothing to materialise.
+                if (properties.containsKey(StatsConstants.HISTOGRAM_STATS_SCOPE)) {
+                    try {
+                        StatsConstants.parseHistogramStatsScope(
+                                properties.get(StatsConstants.HISTOGRAM_STATS_SCOPE));
+                    } catch (IllegalArgumentException e) {
+                        throw new SemanticException("Property '%s' must be a comma-separated subset of %s: %s",
+                                StatsConstants.HISTOGRAM_STATS_SCOPE, StatsConstants.HISTOGRAM_STATS_SCOPE_VALUES,
+                                e.getMessage());
+                    }
                 }
 
                 properties.computeIfAbsent(StatsConstants.HISTOGRAM_COLLECT_BUCKET_NDV_MODE,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
@@ -91,6 +91,7 @@ public class AnalyzeStmtAnalyzer {
             StatsConstants.HISTOGRAM_BUCKET_NUM,
             StatsConstants.HISTOGRAM_MCV_SIZE,
             StatsConstants.HISTOGRAM_SAMPLE_RATIO,
+            StatsConstants.HISTOGRAM_STATS_SCOPE,
             StatsConstants.HISTOGRAM_COLLECT_BUCKET_NDV_MODE,
             StatsConstants.INIT_SAMPLE_STATS_JOB,
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalHistogramStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalHistogramStatisticsCollectJob.java
@@ -19,6 +19,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.Pair;
 import com.starrocks.common.util.SqlUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -27,14 +28,17 @@ import com.starrocks.sql.ast.expression.NullLiteral;
 import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.thrift.TStatisticData;
 import com.starrocks.type.Type;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.velocity.VelocityContext;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.starrocks.statistic.HistogramStatisticsUtils.batchInsertPrefixSize;
 import static com.starrocks.statistic.HistogramStatisticsUtils.buildBatchInsertPrefix;
@@ -69,19 +73,33 @@ public class ExternalHistogramStatisticsCollectJob extends StatisticsCollectJob 
                     " and $columnName is not null $MCVExclude" +
                     " ORDER BY $columnName LIMIT $totalRows) t";
 
-    // For char-family columns we skip the histogram() bucket aggregate, but we still need
-    // Histogram.getTotalRows() to reflect the column's real cardinality. So instead of storing
-    // NULL buckets we store a single placeholder bucket that represents "all values excluding
-    // the MCVs".
-    private static final String COLLECT_DEFAULT_BUCKET_STATISTIC_TEMPLATE =
+    // A single bucket replaces the histogram() aggregate in two cases: char-family columns (whose buckets we
+    // cannot build) and jobs whose histogram_stats_scope excludes buckets. Either way we still need
+    // Histogram.getTotalRows() to reflect the column's real cardinality, so instead of storing NULL buckets we
+    // store one bucket representing "all values excluding the MCVs". Its bounds are the sampled min/max when
+    // the column type can carry them, and the INFINITE_BOUND placeholder otherwise.
+    private static final String COLLECT_SINGLE_BUCKET_STATISTIC_TEMPLATE =
             "SELECT '$tableUUID', '$columnNameStr', '$catalogName', '$dbName', '$tableName'," +
                     " $bucketExpr, $mcv, NOW()" +
                     " FROM `$catalogName`.`$dbName`.`$tableName`";
 
-    private static final String QUERY_DEFAULT_BUCKET_STATISTIC_TEMPLATE =
+    private static final String QUERY_SINGLE_BUCKET_STATISTIC_TEMPLATE =
             "SELECT cast(" + StatsConstants.STATISTIC_EXTERNAL_HISTOGRAM_VERSION + " as INT)," +
                     " '$columnNameStr', $bucketExpr" +
                     " FROM `$catalogName`.`$dbName`.`$tableName`";
+
+    // Bounds of the single bucket stored when the bucket aggregate is skipped. Three result columns, because
+    // that is what the external-histogram statistic result writer expects (version, varchar, varchar), so the
+    // min lands in TStatisticData.columnName and the max in TStatisticData.histogram.
+    private static final String SAMPLE_MIN_MAX_TEMPLATE =
+            "SELECT cast(" + StatsConstants.STATISTIC_EXTERNAL_HISTOGRAM_VERSION + " as INT)," +
+                    " cast($minFunction as varchar), cast($maxFunction as varchar)" +
+                    " FROM (SELECT $columnName as column_key" +
+                    " FROM `$catalogName`.`$dbName`.`$tableName`" +
+                    " where rand() <= $sampleRatio and $columnName is not null" +
+                    " LIMIT $totalRows) t";
+
+    private static final String INFINITE_BOUND = "Infinity";
 
     private static final String COLLECT_MCV_STATISTIC_TEMPLATE =
             "select cast(version as INT), " +
@@ -120,32 +138,42 @@ public class ExternalHistogramStatisticsCollectJob extends StatisticsCollectJob 
         double sampleRatio = Double.parseDouble(properties.get(StatsConstants.HISTOGRAM_SAMPLE_RATIO));
         long bucketNum = Long.parseLong(properties.get(StatsConstants.HISTOGRAM_BUCKET_NUM));
         long mcvSize = Long.parseLong(properties.get(StatsConstants.HISTOGRAM_MCV_SIZE));
+        String statScope = properties.getOrDefault(StatsConstants.HISTOGRAM_STATS_SCOPE,
+                StatsConstants.HISTOGRAM_STATS_SCOPE_BOTH);
+        boolean collectMcv = statScope.equalsIgnoreCase(StatsConstants.HISTOGRAM_STATS_SCOPE_MCV)
+                || statScope.equalsIgnoreCase(StatsConstants.HISTOGRAM_STATS_SCOPE_BOTH);
+        boolean collectBuckets = statScope.equalsIgnoreCase(StatsConstants.HISTOGRAM_STATS_SCOPE_BUCKETS)
+                || statScope.equalsIgnoreCase(StatsConstants.HISTOGRAM_STATS_SCOPE_BOTH);
 
         if (Config.enable_batch_insert_histogram_statistics && columnNames.size() > 1) {
-            collectBatched(context, analyzeStatus, sampleRatio, bucketNum, mcvSize);
+            collectBatched(context, analyzeStatus, sampleRatio, bucketNum, mcvSize, collectMcv, collectBuckets);
         } else {
-            collectLegacy(context, analyzeStatus, sampleRatio, bucketNum, mcvSize);
+            collectLegacy(context, analyzeStatus, sampleRatio, bucketNum, mcvSize, collectMcv, collectBuckets);
         }
     }
 
     private void collectLegacy(ConnectContext context, AnalyzeStatus analyzeStatus, double sampleRatio, long bucketNum,
-                               long mcvSize) throws Exception {
+                               long mcvSize, boolean collectMcv, boolean collectBuckets) throws Exception {
         long finishedSQLNum = 0;
         long totalCollectSQL = columnNames.size();
 
+        StatisticExecutor statisticExecutor = new StatisticExecutor();
         for (int i = 0; i < columnNames.size(); i++) {
             String columnName = columnNames.get(i);
             Type columnType = columnTypes.get(i);
-            String sql = buildCollectMCV(db, table, mcvSize, columnName);
-            StatisticExecutor statisticExecutor = new StatisticExecutor();
-            List<TStatisticData> mcv = statisticExecutor.queryMCV(context, sql);
 
-            Map<String, String> mostCommonValues = new HashMap<>();
-            for (TStatisticData tStatisticData : mcv) {
-                mostCommonValues.put(tStatisticData.columnName, tStatisticData.histogram);
+            Map<String, String> mostCommonValues = collectMcv
+                    ? collectMostCommonValues(context, statisticExecutor, mcvSize, columnName)
+                    : Collections.emptyMap();
+
+            String sql;
+            if (collectBuckets && !shouldSkipHistogramBuckets(columnType)) {
+                sql = buildCollectHistogram(db, table, sampleRatio, bucketNum, mostCommonValues, columnName, columnType);
+            } else {
+                Optional<Pair<String, String>> minMax =
+                        sampleColumnMinMax(context, statisticExecutor, columnName, columnType, sampleRatio);
+                sql = buildCollectSingleBucket(db, table, mostCommonValues, columnName, minMax);
             }
-
-            sql = buildCollectHistogram(db, table, sampleRatio, bucketNum, mostCommonValues, columnName, columnType);
             collectStatisticSync(sql, context, analyzeStatus);
             // Best-effort: remove the stale raw-keyed row this column's fresh hashed-keyed row just
             // superseded. The read side no longer depends on this for correctness (it dedups by
@@ -162,7 +190,7 @@ public class ExternalHistogramStatisticsCollectJob extends StatisticsCollectJob 
     }
 
     private void collectBatched(ConnectContext context, AnalyzeStatus analyzeStatus, double sampleRatio, long bucketNum,
-                                long mcvSize) throws Exception {
+                                long mcvSize, boolean collectMcv, boolean collectBuckets) throws Exception {
         List<List<Expr>> rowsBuffer = new ArrayList<>();
         List<String> sqlBuffer = new ArrayList<>();
         List<String> columnsBuffer = new ArrayList<>();
@@ -178,17 +206,16 @@ public class ExternalHistogramStatisticsCollectJob extends StatisticsCollectJob 
                 String rowSql;
                 long rowSize;
                 try {
-                    List<TStatisticData> mcv = queryStatisticSync(
-                            buildCollectMCV(db, table, mcvSize, columnName), context, analyzeStatus);
-                    Map<String, String> mostCommonValues = new HashMap<>();
-                    for (TStatisticData tStatisticData : mcv) {
-                        mostCommonValues.put(tStatisticData.columnName, tStatisticData.histogram);
-                    }
+                    Map<String, String> mostCommonValues = collectMcv
+                            ? buildMostCommonValues(queryStatisticSync(
+                                    buildCollectMCV(db, table, mcvSize, columnName), context, analyzeStatus))
+                            : Collections.emptyMap();
 
-                    String histogramQuery = buildQueryHistogram(
-                            db, table, sampleRatio, bucketNum, mostCommonValues, columnName, columnType);
+                    String bucketQuery = buildBatchedBucketQuery(
+                            context, analyzeStatus, sampleRatio, bucketNum, mostCommonValues, columnName, columnType,
+                            collectBuckets);
                     String buckets = getSingleHistogramResult(
-                            queryStatisticSync(histogramQuery, context, analyzeStatus), columnName).histogram;
+                            queryStatisticSync(bucketQuery, context, analyzeStatus), columnName).histogram;
                     String mcvJson = buildMcvJson(mostCommonValues);
                     row = buildBatchInsertRow(columnName, buckets, mcvJson);
                     rowSql = buildBatchInsertRowSql(columnName, buckets, mcvJson);
@@ -228,6 +255,20 @@ public class ExternalHistogramStatisticsCollectJob extends StatisticsCollectJob 
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().addAnalyzeStatus(analyzeStatus);
     }
 
+    // The batched path needs the bucket value as a literal, so it queries the buckets instead of computing them
+    // inside the INSERT. Which query to run is decided here - the single decision point shared with collectLegacy.
+    private String buildBatchedBucketQuery(ConnectContext context, AnalyzeStatus analyzeStatus, double sampleRatio,
+                                           long bucketNum, Map<String, String> mostCommonValues, String columnName,
+                                           Type columnType, boolean collectBuckets) throws DdlException {
+        if (collectBuckets && !shouldSkipHistogramBuckets(columnType)) {
+            return buildQueryHistogram(db, table, sampleRatio, bucketNum, mostCommonValues, columnName, columnType);
+        }
+
+        Optional<Pair<String, String>> minMax =
+                queryColumnMinMax(context, analyzeStatus, columnName, columnType, sampleRatio);
+        return buildQuerySingleBucket(db, table, mostCommonValues, columnName, minMax);
+    }
+
     private void flushBatchInsertOnCollectionFailure(
             List<List<Expr>> rowsBuffer, List<String> sqlBuffer, List<String> columnsBuffer,
             List<String> insertedColumns, ConnectContext context, AnalyzeStatus analyzeStatus,
@@ -261,6 +302,74 @@ public class ExternalHistogramStatisticsCollectJob extends StatisticsCollectJob 
         }
     }
 
+    private Map<String, String> collectMostCommonValues(ConnectContext context, StatisticExecutor statisticExecutor,
+                                                        long mcvSize, String columnName) {
+        String sql = buildCollectMCV(db, table, mcvSize, columnName);
+        return buildMostCommonValues(statisticExecutor.queryMCV(context, sql));
+    }
+
+    private Map<String, String> buildMostCommonValues(List<TStatisticData> mcv) {
+        Map<String, String> mostCommonValues = new HashMap<>();
+        for (TStatisticData tStatisticData : mcv) {
+            mostCommonValues.put(tStatisticData.columnName, tStatisticData.histogram);
+        }
+        return mostCommonValues;
+    }
+
+    // Legacy path: the bounds query runs through StatisticExecutor directly.
+    private Optional<Pair<String, String>> sampleColumnMinMax(ConnectContext context,
+                                                              StatisticExecutor statisticExecutor, String columnName,
+                                                              Type columnType, double sampleRatio) {
+        if (!canCarrySampledBounds(columnType)) {
+            return Optional.empty();
+        }
+
+        String sql = buildSampleMinMax(db, table, columnName, columnType, sampleRatio);
+        return parseSampledBounds(statisticExecutor.executeStatisticDQL(context, sql), columnName, columnType);
+    }
+
+    // Batched path: same query, but routed through queryStatisticSync so analyze cancellation and the remaining
+    // timeout are still honoured.
+    private Optional<Pair<String, String>> queryColumnMinMax(ConnectContext context, AnalyzeStatus analyzeStatus,
+                                                             String columnName, Type columnType, double sampleRatio)
+            throws DdlException {
+        if (!canCarrySampledBounds(columnType)) {
+            return Optional.empty();
+        }
+
+        String sql = buildSampleMinMax(db, table, columnName, columnType, sampleRatio);
+        return parseSampledBounds(queryStatisticSync(sql, context, analyzeStatus), columnName, columnType);
+    }
+
+    private Optional<Pair<String, String>> parseSampledBounds(List<TStatisticData> sampled, String columnName,
+                                                             Type columnType) {
+        if (sampled.isEmpty()) {
+            return Optional.empty();
+        }
+
+        // The sql result is parsed and min and max values are stored
+        // in the variables named below.
+        String minValue = sampled.get(0).columnName;
+        String maxValue = sampled.get(0).histogram;
+        if (!isUsableBucketBound(minValue, columnType) || !isUsableBucketBound(maxValue, columnType)) {
+            LOG.info("[ExternalStats] unusable sampled bounds, falling back to placeholder bucket | catalog={} db={} " +
+                            "table={} column={} min={} max={}", catalogName, db.getOriginName(), table.getName(), columnName,
+                    minValue, maxValue);
+            return Optional.empty();
+        }
+        return Optional.of(Pair.create(minValue, maxValue));
+    }
+
+    private static boolean canCarrySampledBounds(Type columnType) {
+        return columnType.getPrimitiveType().isNumericType() || columnType.getPrimitiveType().isDateType();
+    }
+
+    private static boolean isUsableBucketBound(String value, Type columnType) {
+        return canCarrySampledBounds(columnType)
+                && !StringUtils.isBlank(value)
+                && !StringUtils.containsAny(value, '"', '\'', '\\');
+    }
+
     private String buildCollectMCV(Database database, Table table, Long topN, String columnName) {
         VelocityContext context = new VelocityContext();
         context.put("columnName", StatisticUtils.quoting(table, columnName));
@@ -272,43 +381,48 @@ public class ExternalHistogramStatisticsCollectJob extends StatisticsCollectJob 
         return build(context, COLLECT_MCV_STATISTIC_TEMPLATE);
     }
 
+    private String buildSampleMinMax(Database database, Table table, String columnName, Type columnType,
+                                     double sampleRatio) {
+        VelocityContext context = buildBaseContext(database, table, columnName);
+        context.put("minFunction", getMinMaxFunction(columnType, "`column_key`", false));
+        context.put("maxFunction", getMinMaxFunction(columnType, "`column_key`", true));
+        context.put("sampleRatio", sampleRatio);
+        context.put("totalRows", Config.histogram_max_sample_row_count);
+
+        return build(context, SAMPLE_MIN_MAX_TEMPLATE);
+    }
+
+    private String buildCollectSingleBucket(Database database, Table table, Map<String, String> mostCommonValues,
+                                            String columnName, Optional<Pair<String, String>> minMax) {
+        VelocityContext context = buildBaseContext(database, table, columnName);
+        putMcv(context, mostCommonValues);
+        putSingleBucketExpr(context, table, mostCommonValues, columnName, minMax);
+
+        return buildInsertIntoHistogramStatistics(build(context, COLLECT_SINGLE_BUCKET_STATISTIC_TEMPLATE));
+    }
+
+    private String buildQuerySingleBucket(Database database, Table table, Map<String, String> mostCommonValues,
+                                          String columnName, Optional<Pair<String, String>> minMax) {
+        VelocityContext context = buildBaseContext(database, table, columnName);
+        putSingleBucketExpr(context, table, mostCommonValues, columnName, minMax);
+
+        return build(context, QUERY_SINGLE_BUCKET_STATISTIC_TEMPLATE);
+    }
+
     private String buildCollectHistogram(Database database, Table table, double sampleRatio,
                                          Long bucketNum, Map<String, String> mostCommonValues, String columnName,
                                          Type columnType) {
-        List<String> targetColumnNames = buildStatsTargetColumnNames(EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME);
-        String columnNames = "(" + String.join(", ", targetColumnNames) + ")";
-        StringBuilder builder = new StringBuilder("INSERT INTO ").append(EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME)
-                .append(columnNames).append(" ");
-
         String quoteColumName = StatisticUtils.quoting(table, columnName);
 
         VelocityContext context = buildBaseContext(database, table, columnName);
-        context.put("tableUUID", StatisticUtils.hashTableUuidForPkStorage(table.getUUID()));
-
-        String mcvJson = buildMcvJson(mostCommonValues);
-        if (mcvJson == null) {
-            context.put("mcv", "NULL");
-        } else {
-            context.put("mcv", quoteSqlString(mcvJson));
-        }
-
+        putMcv(context, mostCommonValues);
         putMcvExclude(context, mostCommonValues, quoteColumName, columnType);
-
-        if (shouldSkipHistogramBuckets(columnType)) {
-            long mcvSum = mostCommonValues.values().stream().mapToLong(Long::parseLong).sum();
-            context.put("bucketExpr",
-                    "concat('[[\"Infinity\",\"Infinity\",', cast(greatest(0, count(" + quoteColumName +
-                            ") - " + mcvSum + ") as varchar), ',0]]')");
-            builder.append(build(context, COLLECT_DEFAULT_BUCKET_STATISTIC_TEMPLATE));
-            return builder.toString();
-        }
 
         context.put("bucketNum", bucketNum);
         context.put("sampleRatio", sampleRatio);
         context.put("totalRows", Config.histogram_max_sample_row_count);
 
-        builder.append(build(context, COLLECT_HISTOGRAM_STATISTIC_TEMPLATE));
-        return builder.toString();
+        return buildInsertIntoHistogramStatistics(build(context, COLLECT_HISTOGRAM_STATISTIC_TEMPLATE));
     }
 
     private String buildQueryHistogram(Database database, Table table, double sampleRatio, Long bucketNum,
@@ -317,28 +431,50 @@ public class ExternalHistogramStatisticsCollectJob extends StatisticsCollectJob 
         VelocityContext context = buildBaseContext(database, table, columnName);
         putMcvExclude(context, mostCommonValues, quoteColumnName, columnType);
 
-        if (shouldSkipHistogramBuckets(columnType)) {
-            long mcvSum = mostCommonValues.values().stream().mapToLong(Long::parseLong).sum();
-            context.put("bucketExpr",
-                    "concat('[[\"Infinity\",\"Infinity\",', cast(greatest(0, count(" + quoteColumnName +
-                            ") - " + mcvSum + ") as varchar), ',0]]')");
-            return build(context, QUERY_DEFAULT_BUCKET_STATISTIC_TEMPLATE);
-        }
-
         context.put("bucketNum", bucketNum);
         context.put("sampleRatio", sampleRatio);
         context.put("totalRows", Config.histogram_max_sample_row_count);
         return build(context, QUERY_HISTOGRAM_STATISTIC_TEMPLATE);
     }
 
+    // The single bucket spans everything except the MCVs, so both the INSERT and the batched query variant share
+    // this expression - they cannot drift apart.
+    private void putSingleBucketExpr(VelocityContext context, Table table, Map<String, String> mostCommonValues,
+                                     String columnName, Optional<Pair<String, String>> minMax) {
+        String quoteColumnName = StatisticUtils.quoting(table, columnName);
+        long mcvSum = mostCommonValues.values().stream().mapToLong(Long::parseLong).sum();
+        String minValue = minMax.map(minAndMax -> minAndMax.first).orElse(INFINITE_BOUND);
+        String maxValue = minMax.map(minAndMax -> minAndMax.second).orElse(INFINITE_BOUND);
+
+        context.put("bucketExpr",
+                "concat('[[\"" + minValue + "\",\"" + maxValue + "\",', cast(greatest(0, count(" + quoteColumnName +
+                        ") - " + mcvSum + ") as varchar), ',0]]')");
+    }
+
     private VelocityContext buildBaseContext(Database database, Table table, String columnName) {
         VelocityContext context = new VelocityContext();
+        context.put("tableUUID", StatisticUtils.hashTableUuidForPkStorage(table.getUUID()));
         context.put("columnName", StatisticUtils.quoting(table, columnName));
         context.put("columnNameStr", SqlUtils.escapeSqlString(columnName));
         context.put("catalogName", catalogName);
         context.put("dbName", database.getOriginName());
         context.put("tableName", table.getName());
         return context;
+    }
+
+    private void putMcv(VelocityContext context, Map<String, String> mostCommonValues) {
+        String mcvJson = buildMcvJson(mostCommonValues);
+        if (mcvJson == null) {
+            context.put("mcv", "NULL");
+        } else {
+            context.put("mcv", quoteSqlString(mcvJson));
+        }
+    }
+
+    private static String buildInsertIntoHistogramStatistics(String selectSql) {
+        List<String> targetColumnNames = buildStatsTargetColumnNames(EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME);
+        return "INSERT INTO " + EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME +
+                "(" + String.join(", ", targetColumnNames) + ") " + selectSql;
     }
 
     private TStatisticData getSingleHistogramResult(List<TStatisticData> results, String columnName)

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalHistogramStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalHistogramStatisticsCollectJob.java
@@ -35,6 +35,7 @@ import org.apache.velocity.VelocityContext;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -76,8 +77,7 @@ public class ExternalHistogramStatisticsCollectJob extends StatisticsCollectJob 
     // A single bucket replaces the histogram() aggregate in two cases: char-family columns (whose buckets we
     // cannot build) and jobs whose histogram_stats_scope excludes buckets. Either way we still need
     // Histogram.getTotalRows() to reflect the column's real cardinality, so instead of storing NULL buckets we
-    // store one bucket representing "all values excluding the MCVs". Its bounds are the sampled min/max when
-    // the column type can carry them, and the INFINITE_BOUND placeholder otherwise.
+    // store one bucket representing "all values excluding the MCVs".
     private static final String COLLECT_SINGLE_BUCKET_STATISTIC_TEMPLATE =
             "SELECT '$tableUUID', '$columnNameStr', '$catalogName', '$dbName', '$tableName'," +
                     " $bucketExpr, $mcv, NOW()" +
@@ -88,16 +88,12 @@ public class ExternalHistogramStatisticsCollectJob extends StatisticsCollectJob 
                     " '$columnNameStr', $bucketExpr" +
                     " FROM `$catalogName`.`$dbName`.`$tableName`";
 
-    // Bounds of the single bucket stored when the bucket aggregate is skipped. Three result columns, because
-    // that is what the external-histogram statistic result writer expects (version, varchar, varchar), so the
-    // min lands in TStatisticData.columnName and the max in TStatisticData.histogram.
     private static final String SAMPLE_MIN_MAX_TEMPLATE =
             "SELECT cast(" + StatsConstants.STATISTIC_EXTERNAL_HISTOGRAM_VERSION + " as INT)," +
                     " cast($minFunction as varchar), cast($maxFunction as varchar)" +
                     " FROM (SELECT $columnName as column_key" +
                     " FROM `$catalogName`.`$dbName`.`$tableName`" +
-                    " where rand() <= $sampleRatio and $columnName is not null" +
-                    " LIMIT $totalRows) t";
+                    " where rand() <= $sampleRatio and $columnName is not null $MCVExclude) t";
 
     private static final String INFINITE_BOUND = "Infinity";
 
@@ -138,12 +134,10 @@ public class ExternalHistogramStatisticsCollectJob extends StatisticsCollectJob 
         double sampleRatio = Double.parseDouble(properties.get(StatsConstants.HISTOGRAM_SAMPLE_RATIO));
         long bucketNum = Long.parseLong(properties.get(StatsConstants.HISTOGRAM_BUCKET_NUM));
         long mcvSize = Long.parseLong(properties.get(StatsConstants.HISTOGRAM_MCV_SIZE));
-        String statScope = properties.getOrDefault(StatsConstants.HISTOGRAM_STATS_SCOPE,
-                StatsConstants.HISTOGRAM_STATS_SCOPE_BOTH);
-        boolean collectMcv = statScope.equalsIgnoreCase(StatsConstants.HISTOGRAM_STATS_SCOPE_MCV)
-                || statScope.equalsIgnoreCase(StatsConstants.HISTOGRAM_STATS_SCOPE_BOTH);
-        boolean collectBuckets = statScope.equalsIgnoreCase(StatsConstants.HISTOGRAM_STATS_SCOPE_BUCKETS)
-                || statScope.equalsIgnoreCase(StatsConstants.HISTOGRAM_STATS_SCOPE_BOTH);
+        EnumSet<StatsConstants.HistogramStatKind> statScope = StatsConstants.parseHistogramStatsScope(
+                properties.get(StatsConstants.HISTOGRAM_STATS_SCOPE));
+        boolean collectMcv = statScope.contains(StatsConstants.HistogramStatKind.MCV);
+        boolean collectBuckets = statScope.contains(StatsConstants.HistogramStatKind.BUCKETS);
 
         if (Config.enable_batch_insert_histogram_statistics && columnNames.size() > 1) {
             collectBatched(context, analyzeStatus, sampleRatio, bucketNum, mcvSize, collectMcv, collectBuckets);
@@ -162,17 +156,22 @@ public class ExternalHistogramStatisticsCollectJob extends StatisticsCollectJob 
             String columnName = columnNames.get(i);
             Type columnType = columnTypes.get(i);
 
-            Map<String, String> mostCommonValues = collectMcv
+            // Buckets are impossible for char-family columns, so their MCVs are the only payload worth
+            // storing - collect them whatever the requested scope says, or we would store a row carrying
+            // neither MCVs nor real buckets. Such a row is worse than no histogram at all: the IN-predicate
+            // estimator switches to the histogram path merely because a histogram exists.
+            boolean skipBuckets = shouldSkipHistogramBuckets(columnType);
+            Map<String, String> mostCommonValues = collectMcv || skipBuckets
                     ? collectMostCommonValues(context, statisticExecutor, mcvSize, columnName)
                     : Collections.emptyMap();
 
             String sql;
-            if (collectBuckets && !shouldSkipHistogramBuckets(columnType)) {
+            if (collectBuckets && !skipBuckets) {
                 sql = buildCollectHistogram(db, table, sampleRatio, bucketNum, mostCommonValues, columnName, columnType);
             } else {
-                Optional<Pair<String, String>> minMax =
-                        sampleColumnMinMax(context, statisticExecutor, columnName, columnType, sampleRatio);
-                sql = buildCollectSingleBucket(db, table, mostCommonValues, columnName, minMax);
+                Optional<Pair<String, String>> minMax = sampleColumnMinMax(context, statisticExecutor, columnName,
+                        columnType, sampleRatio, mostCommonValues);
+                sql = buildCollectSingleBucket(db, table, mostCommonValues, columnName, columnType, minMax);
             }
             collectStatisticSync(sql, context, analyzeStatus);
             // Best-effort: remove the stale raw-keyed row this column's fresh hashed-keyed row just
@@ -206,9 +205,10 @@ public class ExternalHistogramStatisticsCollectJob extends StatisticsCollectJob 
                 String rowSql;
                 long rowSize;
                 try {
-                    Map<String, String> mostCommonValues = collectMcv
+                    // See collectLegacy: char-family columns keep their MCVs whatever the scope says.
+                    Map<String, String> mostCommonValues = collectMcv || shouldSkipHistogramBuckets(columnType)
                             ? buildMostCommonValues(queryStatisticSync(
-                                    buildCollectMCV(db, table, mcvSize, columnName), context, analyzeStatus))
+                            buildCollectMCV(db, table, mcvSize, columnName), context, analyzeStatus))
                             : Collections.emptyMap();
 
                     String bucketQuery = buildBatchedBucketQuery(
@@ -264,9 +264,9 @@ public class ExternalHistogramStatisticsCollectJob extends StatisticsCollectJob 
             return buildQueryHistogram(db, table, sampleRatio, bucketNum, mostCommonValues, columnName, columnType);
         }
 
-        Optional<Pair<String, String>> minMax =
-                queryColumnMinMax(context, analyzeStatus, columnName, columnType, sampleRatio);
-        return buildQuerySingleBucket(db, table, mostCommonValues, columnName, minMax);
+        Optional<Pair<String, String>> minMax = queryColumnMinMax(context, analyzeStatus, columnName, columnType,
+                sampleRatio, mostCommonValues);
+        return buildQuerySingleBucket(db, table, mostCommonValues, columnName, columnType, minMax);
     }
 
     private void flushBatchInsertOnCollectionFailure(
@@ -316,33 +316,34 @@ public class ExternalHistogramStatisticsCollectJob extends StatisticsCollectJob 
         return mostCommonValues;
     }
 
-    // Legacy path: the bounds query runs through StatisticExecutor directly.
     private Optional<Pair<String, String>> sampleColumnMinMax(ConnectContext context,
                                                               StatisticExecutor statisticExecutor, String columnName,
-                                                              Type columnType, double sampleRatio) {
+                                                              Type columnType, double sampleRatio,
+                                                              Map<String, String> mostCommonValues) {
         if (!canCarrySampledBounds(columnType)) {
             return Optional.empty();
         }
 
-        String sql = buildSampleMinMax(db, table, columnName, columnType, sampleRatio);
+        String sql = buildSampleMinMax(db, table, columnName, columnType, sampleRatio, mostCommonValues);
         return parseSampledBounds(statisticExecutor.executeStatisticDQL(context, sql), columnName, columnType);
     }
 
     // Batched path: same query, but routed through queryStatisticSync so analyze cancellation and the remaining
     // timeout are still honoured.
     private Optional<Pair<String, String>> queryColumnMinMax(ConnectContext context, AnalyzeStatus analyzeStatus,
-                                                             String columnName, Type columnType, double sampleRatio)
+                                                             String columnName, Type columnType, double sampleRatio,
+                                                             Map<String, String> mostCommonValues)
             throws DdlException {
         if (!canCarrySampledBounds(columnType)) {
             return Optional.empty();
         }
 
-        String sql = buildSampleMinMax(db, table, columnName, columnType, sampleRatio);
+        String sql = buildSampleMinMax(db, table, columnName, columnType, sampleRatio, mostCommonValues);
         return parseSampledBounds(queryStatisticSync(sql, context, analyzeStatus), columnName, columnType);
     }
 
     private Optional<Pair<String, String>> parseSampledBounds(List<TStatisticData> sampled, String columnName,
-                                                             Type columnType) {
+                                                              Type columnType) {
         if (sampled.isEmpty()) {
             return Optional.empty();
         }
@@ -377,29 +378,31 @@ public class ExternalHistogramStatisticsCollectJob extends StatisticsCollectJob 
     }
 
     private String buildSampleMinMax(Database database, Table table, String columnName, Type columnType,
-                                     double sampleRatio) {
+                                     double sampleRatio, Map<String, String> mostCommonValues) {
         VelocityContext context = buildBaseContext(database, table, columnName);
+        putMcvExclude(context, mostCommonValues, StatisticUtils.quoting(table, columnName), columnType);
         context.put("minFunction", getMinMaxFunction(columnType, "`column_key`", false));
         context.put("maxFunction", getMinMaxFunction(columnType, "`column_key`", true));
         context.put("sampleRatio", sampleRatio);
-        context.put("totalRows", Config.histogram_max_sample_row_count);
 
         return build(context, SAMPLE_MIN_MAX_TEMPLATE);
     }
 
     private String buildCollectSingleBucket(Database database, Table table, Map<String, String> mostCommonValues,
-                                            String columnName, Optional<Pair<String, String>> minMax) {
+                                            String columnName, Type columnType,
+                                            Optional<Pair<String, String>> minMax) {
         VelocityContext context = buildBaseContext(database, table, columnName);
         putMcv(context, mostCommonValues);
-        putSingleBucketExpr(context, table, mostCommonValues, columnName, minMax);
+        putSingleBucketExpr(context, table, mostCommonValues, columnName, columnType, minMax);
 
         return buildInsertIntoHistogramStatistics(build(context, COLLECT_SINGLE_BUCKET_STATISTIC_TEMPLATE));
     }
 
     private String buildQuerySingleBucket(Database database, Table table, Map<String, String> mostCommonValues,
-                                          String columnName, Optional<Pair<String, String>> minMax) {
+                                          String columnName, Type columnType,
+                                          Optional<Pair<String, String>> minMax) {
         VelocityContext context = buildBaseContext(database, table, columnName);
-        putSingleBucketExpr(context, table, mostCommonValues, columnName, minMax);
+        putSingleBucketExpr(context, table, mostCommonValues, columnName, columnType, minMax);
 
         return build(context, QUERY_SINGLE_BUCKET_STATISTIC_TEMPLATE);
     }
@@ -432,10 +435,8 @@ public class ExternalHistogramStatisticsCollectJob extends StatisticsCollectJob 
         return build(context, QUERY_HISTOGRAM_STATISTIC_TEMPLATE);
     }
 
-    // The single bucket spans everything except the MCVs, so both the INSERT and the batched query variant share
-    // this expression - they cannot drift apart.
     private void putSingleBucketExpr(VelocityContext context, Table table, Map<String, String> mostCommonValues,
-                                     String columnName, Optional<Pair<String, String>> minMax) {
+                                     String columnName, Type columnType, Optional<Pair<String, String>> minMax) {
         String quoteColumnName = StatisticUtils.quoting(table, columnName);
         long mcvSum = mostCommonValues.values().stream().mapToLong(Long::parseLong).sum();
         String minValue = minMax.map(minAndMax -> minAndMax.first).orElse(INFINITE_BOUND);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalHistogramStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalHistogramStatisticsCollectJob.java
@@ -351,7 +351,8 @@ public class ExternalHistogramStatisticsCollectJob extends StatisticsCollectJob 
         // in the variables named below.
         String minValue = sampled.get(0).columnName;
         String maxValue = sampled.get(0).histogram;
-        if (!isUsableBucketBound(minValue, columnType) || !isUsableBucketBound(maxValue, columnType)) {
+
+        if (StringUtils.isBlank(minValue) || StringUtils.isBlank(maxValue)) {
             LOG.info("[ExternalStats] unusable sampled bounds, falling back to placeholder bucket | catalog={} db={} " +
                             "table={} column={} min={} max={}", catalogName, db.getOriginName(), table.getName(), columnName,
                     minValue, maxValue);
@@ -362,12 +363,6 @@ public class ExternalHistogramStatisticsCollectJob extends StatisticsCollectJob 
 
     private static boolean canCarrySampledBounds(Type columnType) {
         return columnType.getPrimitiveType().isNumericType() || columnType.getPrimitiveType().isDateType();
-    }
-
-    private static boolean isUsableBucketBound(String value, Type columnType) {
-        return canCarrySampledBounds(columnType)
-                && !StringUtils.isBlank(value)
-                && !StringUtils.containsAny(value, '"', '\'', '\\');
     }
 
     private String buildCollectMCV(Database database, Table table, Long topN, String columnName) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/HistogramStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/HistogramStatisticsCollectJob.java
@@ -41,6 +41,7 @@ import org.apache.velocity.VelocityContext;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -113,8 +114,7 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
     // A single bucket replaces the histogram() aggregate in two cases: char-family columns (whose buckets we
     // cannot build) and jobs whose histogram_stats_scope excludes buckets. Either way we still need
     // Histogram.getTotalRows() to reflect the column's real cardinality, so instead of storing NULL buckets we
-    // store one bucket representing "all values excluding the MCVs". Its bounds are the sampled min/max when
-    // the column type can carry them, and the INFINITE_BOUND placeholder otherwise.
+    // store one bucket representing "all values excluding the MCVs".
     private static final String COLLECT_SINGLE_BUCKET_STATISTIC_TEMPLATE =
             "SELECT $tableId, '$columnNameStr', $dbId, '$dbName.$tableName'," +
                     " $bucketExpr," +
@@ -137,8 +137,7 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
                     " cast($minFunction as varchar), cast($maxFunction as varchar)" +
                     " FROM (SELECT $columnName as column_key" +
                     " FROM `$dbName`.`$tableName` $sampleClause" +
-                    " WHERE $randFilter and $columnName is not null" +
-                    " LIMIT $totalRows) t";
+                    " WHERE $randFilter and $columnName is not null $MCVExclude) t";
 
     private static final String INFINITE_BOUND = "Infinity";
 
@@ -169,12 +168,10 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
         long bucketNum = Long.parseLong(properties.get(StatsConstants.HISTOGRAM_BUCKET_NUM));
         long mcvSize = Long.parseLong(properties.get(StatsConstants.HISTOGRAM_MCV_SIZE));
         StatsConstants.HistogramCollectBucketNdvMode ndvMode = getHistogramCollectBucketNdvMode();
-        String statScope = properties.getOrDefault(StatsConstants.HISTOGRAM_STATS_SCOPE,
-                StatsConstants.HISTOGRAM_STATS_SCOPE_BOTH);
-        boolean collectMcv = statScope.equalsIgnoreCase(StatsConstants.HISTOGRAM_STATS_SCOPE_MCV)
-                || statScope.equalsIgnoreCase(StatsConstants.HISTOGRAM_STATS_SCOPE_BOTH);
-        boolean collectBuckets = statScope.equalsIgnoreCase(StatsConstants.HISTOGRAM_STATS_SCOPE_BUCKETS)
-                || statScope.equalsIgnoreCase(StatsConstants.HISTOGRAM_STATS_SCOPE_BOTH);
+        EnumSet<StatsConstants.HistogramStatKind> statScope = StatsConstants.parseHistogramStatsScope(
+                properties.get(StatsConstants.HISTOGRAM_STATS_SCOPE));
+        boolean collectMcv = statScope.contains(StatsConstants.HistogramStatKind.MCV);
+        boolean collectBuckets = statScope.contains(StatsConstants.HistogramStatKind.BUCKETS);
 
         if (table.isTemporaryTable()) {
             context.setSessionId(((OlapTable) table).getSessionId());
@@ -199,18 +196,20 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
             String columnName = columnNames.get(i);
             Type columnType = columnTypes.get(i);
 
-            Map<String, String> mostCommonValues = collectMcv
+            boolean skipBuckets = shouldSkipHistogramBuckets(columnType);
+            Map<String, String> mostCommonValues = collectMcv || skipBuckets
                     ? collectMostCommonValues(context, statisticExecutor, mcvSize, columnName, sampleRatio)
                     : Collections.emptyMap();
 
             String sql;
-            if (collectBuckets && !shouldSkipHistogramBuckets(columnType)) {
+            if (collectBuckets && !skipBuckets) {
                 sql = buildCollectBuckets(context, statisticExecutor, sampleRatio, bucketNum, mostCommonValues,
                         columnName, columnType, ndvMode);
             } else {
-                Optional<Pair<String, String>> minMax =
-                        sampleColumnMinMax(context, statisticExecutor, columnName, columnType, sampleRatio);
-                sql = buildCollectSingleBucket(db, table, sampleRatio, mostCommonValues, columnName, minMax);
+                Optional<Pair<String, String>> minMax = sampleColumnMinMax(context, statisticExecutor, columnName,
+                        columnType, sampleRatio, mostCommonValues);
+                sql = buildCollectSingleBucket(db, table, sampleRatio, mostCommonValues, columnName, columnType,
+                        minMax);
             }
             collectStatisticSync(sql, context, analyzeStatus);
 
@@ -235,10 +234,10 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
             String rowSql;
             long rowSize;
             try {
-                Map<String, String> mostCommonValues = collectMcv
+                Map<String, String> mostCommonValues = collectMcv || shouldSkipHistogramBuckets(columnType)
                         ? buildMostCommonValues(queryStatisticSync(
                                 buildCollectMCV(db, table, mcvSize, columnName, sampleRatio), context, analyzeStatus),
-                                sampleRatio)
+                        sampleRatio)
                         : Collections.emptyMap();
 
                 String bucketQuery = buildBatchedBucketQuery(
@@ -301,9 +300,9 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
             StatsConstants.HistogramCollectBucketNdvMode ndvMode, Map<String, String> mostCommonValues,
             String columnName, Type columnType, boolean collectBuckets) throws Exception {
         if (!collectBuckets || shouldSkipHistogramBuckets(columnType)) {
-            Optional<Pair<String, String>> minMax =
-                    queryColumnMinMax(context, analyzeStatus, columnName, columnType, sampleRatio);
-            return buildQuerySingleBucket(db, table, sampleRatio, mostCommonValues, columnName, minMax);
+            Optional<Pair<String, String>> minMax = queryColumnMinMax(context, analyzeStatus, columnName, columnType,
+                    sampleRatio, mostCommonValues);
+            return buildQuerySingleBucket(db, table, sampleRatio, mostCommonValues, columnName, columnType, minMax);
         }
 
         if (ndvMode == StatsConstants.HistogramCollectBucketNdvMode.NONE) {
@@ -363,28 +362,29 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
                 false);
     }
 
-    // Legacy path: the bounds query runs through StatisticExecutor directly.
     private Optional<Pair<String, String>> sampleColumnMinMax(ConnectContext context,
                                                               StatisticExecutor statisticExecutor, String columnName,
-                                                              Type columnType, double sampleRatio) {
+                                                              Type columnType, double sampleRatio,
+                                                              Map<String, String> mostCommonValues) {
         if (!canCarrySampledBounds(columnType)) {
             return Optional.empty();
         }
 
-        String sql = buildSampleMinMax(db, table, columnName, columnType, sampleRatio);
+        String sql = buildSampleMinMax(db, table, columnName, columnType, sampleRatio, mostCommonValues);
         return parseSampledBounds(statisticExecutor.executeStatisticDQL(context, sql), columnName, columnType);
     }
 
     // Batched path: same query, but routed through queryStatisticSync so analyze cancellation and the remaining
     // timeout are still honoured.
     private Optional<Pair<String, String>> queryColumnMinMax(ConnectContext context, AnalyzeStatus analyzeStatus,
-                                                             String columnName, Type columnType, double sampleRatio)
+                                                             String columnName, Type columnType, double sampleRatio,
+                                                             Map<String, String> mostCommonValues)
             throws DdlException {
         if (!canCarrySampledBounds(columnType)) {
             return Optional.empty();
         }
 
-        String sql = buildSampleMinMax(db, table, columnName, columnType, sampleRatio);
+        String sql = buildSampleMinMax(db, table, columnName, columnType, sampleRatio, mostCommonValues);
         return parseSampledBounds(queryStatisticSync(sql, context, analyzeStatus), columnName, columnType);
     }
 
@@ -409,11 +409,11 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
     }
 
     private String buildSampleMinMax(Database database, Table table, String columnName, Type columnType,
-                                     double sampleRatio) {
+                                     double sampleRatio, Map<String, String> mostCommonValues) {
         VelocityContext context = buildBaseContext(database, table, columnName);
+        addMcvExcludeToContext(context, mostCommonValues, columnName, columnType);
         context.put("minFunction", getMinMaxFunction(columnType, "`column_key`", false));
         context.put("maxFunction", getMinMaxFunction(columnType, "`column_key`", true));
-        context.put("totalRows", Config.histogram_max_sample_row_count);
         putSampleClause(context, sampleRatio);
 
         return build(context, SAMPLE_MIN_MAX_TEMPLATE);
@@ -571,27 +571,27 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
     // In case we skip histogram collection, we simply add one tail bucket that contains all values - sum(MCVs).
     // Its bounds are the sampled min/max when the column type can carry them, and the placeholder otherwise.
     private String buildCollectSingleBucket(Database database, Table table, double sampleRatio,
-                                            Map<String, String> mostCommonValues, String columnName,
+                                            Map<String, String> mostCommonValues, String columnName, Type columnType,
                                             Optional<Pair<String, String>> minMax) {
         VelocityContext context = buildBaseContext(database, table, columnName);
         addMcvToContext(context, mostCommonValues);
-        addSingleBucketToContext(context, table, sampleRatio, mostCommonValues, columnName, minMax);
+        addSingleBucketToContext(context, table, sampleRatio, mostCommonValues, columnName, columnType, minMax);
 
         return buildInsertIntoHistogramStatistics(build(context, COLLECT_SINGLE_BUCKET_STATISTIC_TEMPLATE));
     }
 
     private String buildQuerySingleBucket(Database database, Table table, double sampleRatio,
-                                          Map<String, String> mostCommonValues, String columnName,
+                                          Map<String, String> mostCommonValues, String columnName, Type columnType,
                                           Optional<Pair<String, String>> minMax) {
         VelocityContext context = buildBaseContext(database, table, columnName);
-        addSingleBucketToContext(context, table, sampleRatio, mostCommonValues, columnName, minMax);
+        addSingleBucketToContext(context, table, sampleRatio, mostCommonValues, columnName, columnType, minMax);
 
         return build(context, QUERY_SINGLE_BUCKET_STATISTIC_TEMPLATE);
     }
 
     // Shared by the INSERT and the batched query variant so the two cannot drift apart.
     private void addSingleBucketToContext(VelocityContext context, Table table, double sampleRatio,
-                                          Map<String, String> mostCommonValues, String columnName,
+                                          Map<String, String> mostCommonValues, String columnName, Type columnType,
                                           Optional<Pair<String, String>> minMax) {
         String quoteColumName = StatisticUtils.quoting(table, columnName);
         String countExpr;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/HistogramStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/HistogramStatisticsCollectJob.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
@@ -395,7 +396,7 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
 
         String minValue = sampled.get(0).columnName;
         String maxValue = sampled.get(0).histogram;
-        if (!isUsableBucketBound(minValue, columnType) || !isUsableBucketBound(maxValue, columnType)) {
+        if (StringUtils.isBlank(minValue) || StringUtils.isBlank(maxValue)) {
             LOG.info("[Stats] unusable sampled bounds, falling back to placeholder bucket | db={} table={} " +
                     "column={} min={} max={}", db.getOriginName(), table.getName(), columnName, minValue, maxValue);
             return Optional.empty();
@@ -405,12 +406,6 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
 
     private static boolean canCarrySampledBounds(Type columnType) {
         return columnType.getPrimitiveType().isNumericType() || columnType.getPrimitiveType().isDateType();
-    }
-
-    private static boolean isUsableBucketBound(String value, Type columnType) {
-        return canCarrySampledBounds(columnType)
-                && !StringUtils.isBlank(value)
-                && !StringUtils.containsAny(value, '"', '\'', '\\');
     }
 
     private String buildSampleMinMax(Database database, Table table, String columnName, Type columnType,
@@ -553,7 +548,7 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
             context.put("sampleClause", sampleClause);
             context.put("randFilter", "TRUE");
         } else {
-            String randFilter = String.format(" rand() <= %f", sampleRatio);
+            String randFilter = String.format(Locale.ROOT, " rand() <= %f", sampleRatio);
             context.put("randFilter", randFilter);
             context.put("sampleClause", "");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/HistogramStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/HistogramStatisticsCollectJob.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.Pair;
 import com.starrocks.common.util.SqlUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -32,15 +33,18 @@ import com.starrocks.thrift.TStatisticData;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.Type;
 import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.velocity.VelocityContext;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.starrocks.statistic.HistogramStatisticsUtils.batchInsertPrefixSize;
 import static com.starrocks.statistic.HistogramStatisticsUtils.buildBatchInsertPrefix;
@@ -105,22 +109,37 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
                     " and $columnName is not null $MCVExclude" +
                     " ORDER BY $columnName LIMIT $totalRows) t";
 
-    // For char-family columns we skip the histogram() bucket aggregate, but we still need
-    // Histogram.getTotalRows() to reflect the column's real cardinality. So instead of storing
-    // NULL buckets we store a single placeholder bucket that represents "all values excluding
-    // the MCVs".
-    private static final String COLLECT_DEFAULT_BUCKET_STATISTIC_TEMPLATE =
+    // A single bucket replaces the histogram() aggregate in two cases: char-family columns (whose buckets we
+    // cannot build) and jobs whose histogram_stats_scope excludes buckets. Either way we still need
+    // Histogram.getTotalRows() to reflect the column's real cardinality, so instead of storing NULL buckets we
+    // store one bucket representing "all values excluding the MCVs". Its bounds are the sampled min/max when
+    // the column type can carry them, and the INFINITE_BOUND placeholder otherwise.
+    private static final String COLLECT_SINGLE_BUCKET_STATISTIC_TEMPLATE =
             "SELECT $tableId, '$columnNameStr', $dbId, '$dbName.$tableName'," +
                     " $bucketExpr," +
                     " $mcv," +
                     " NOW()" +
                     " FROM `$dbName`.`$tableName`$sampleClause$randFilter";
 
-    private static final String QUERY_DEFAULT_BUCKET_STATISTIC_TEMPLATE =
+    private static final String QUERY_SINGLE_BUCKET_STATISTIC_TEMPLATE =
             "SELECT cast(" + StatsConstants.STATISTIC_HISTOGRAM_VERSION + " as INT)," +
                     " cast($dbId as BIGINT), cast($tableId as BIGINT), '$columnNameStr'," +
                     " $bucketExpr" +
                     " FROM `$dbName`.`$tableName`$sampleClause$randFilter";
+
+    // Bounds of the single bucket stored when the bucket aggregate is skipped. Five result columns, because that
+    // is what the version-2 statistic result writer expects (version, dbId, tableId, varchar, varchar), so the
+    // min lands in TStatisticData.columnName and the max in TStatisticData.histogram.
+    private static final String SAMPLE_MIN_MAX_TEMPLATE =
+            "SELECT cast(" + StatsConstants.STATISTIC_HISTOGRAM_VERSION + " as INT)," +
+                    " cast($dbId as BIGINT), cast($tableId as BIGINT)," +
+                    " cast($minFunction as varchar), cast($maxFunction as varchar)" +
+                    " FROM (SELECT $columnName as column_key" +
+                    " FROM `$dbName`.`$tableName` $sampleClause" +
+                    " WHERE $randFilter and $columnName is not null" +
+                    " LIMIT $totalRows) t";
+
+    private static final String INFINITE_BOUND = "Infinity";
 
     private static final String COLLECT_MCV_STATISTIC_TEMPLATE =
             "select cast(version as INT), cast(db_id as BIGINT), cast(table_id as BIGINT), " +
@@ -149,43 +168,48 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
         long bucketNum = Long.parseLong(properties.get(StatsConstants.HISTOGRAM_BUCKET_NUM));
         long mcvSize = Long.parseLong(properties.get(StatsConstants.HISTOGRAM_MCV_SIZE));
         StatsConstants.HistogramCollectBucketNdvMode ndvMode = getHistogramCollectBucketNdvMode();
+        String statScope = properties.getOrDefault(StatsConstants.HISTOGRAM_STATS_SCOPE,
+                StatsConstants.HISTOGRAM_STATS_SCOPE_BOTH);
+        boolean collectMcv = statScope.equalsIgnoreCase(StatsConstants.HISTOGRAM_STATS_SCOPE_MCV)
+                || statScope.equalsIgnoreCase(StatsConstants.HISTOGRAM_STATS_SCOPE_BOTH);
+        boolean collectBuckets = statScope.equalsIgnoreCase(StatsConstants.HISTOGRAM_STATS_SCOPE_BUCKETS)
+                || statScope.equalsIgnoreCase(StatsConstants.HISTOGRAM_STATS_SCOPE_BOTH);
 
         if (table.isTemporaryTable()) {
             context.setSessionId(((OlapTable) table).getSessionId());
         }
 
         if (Config.enable_batch_insert_histogram_statistics && columnNames.size() > 1) {
-            collectBatched(context, analyzeStatus, sampleRatio, bucketNum, mcvSize, ndvMode);
+            collectBatched(context, analyzeStatus, sampleRatio, bucketNum, mcvSize, ndvMode, collectMcv,
+                    collectBuckets);
         } else {
-            collectLegacy(context, analyzeStatus, sampleRatio, bucketNum, mcvSize, ndvMode);
+            collectLegacy(context, analyzeStatus, sampleRatio, bucketNum, mcvSize, ndvMode, collectMcv, collectBuckets);
         }
     }
 
     private void collectLegacy(ConnectContext context, AnalyzeStatus analyzeStatus, double sampleRatio, long bucketNum,
-                               long mcvSize, StatsConstants.HistogramCollectBucketNdvMode ndvMode) throws Exception {
+                               long mcvSize, StatsConstants.HistogramCollectBucketNdvMode ndvMode, boolean collectMcv,
+                               boolean collectBuckets) throws Exception {
         long finishedSQLNum = 0;
         long totalCollectSQL = columnNames.size();
+
+        StatisticExecutor statisticExecutor = new StatisticExecutor();
         for (int i = 0; i < columnNames.size(); i++) {
             String columnName = columnNames.get(i);
             Type columnType = columnTypes.get(i);
-            String sql = buildCollectMCV(db, table, mcvSize, columnName, sampleRatio);
-            StatisticExecutor statisticExecutor = new StatisticExecutor();
-            List<TStatisticData> mcv = statisticExecutor.queryMCV(context, sql);
 
-            Map<String, String> mostCommonValues = buildMostCommonValues(mcv, sampleRatio);
+            Map<String, String> mostCommonValues = collectMcv
+                    ? collectMostCommonValues(context, statisticExecutor, mcvSize, columnName, sampleRatio)
+                    : Collections.emptyMap();
 
-            if (shouldSkipHistogramBuckets(columnType)) {
-                sql = buildCollectDefaultBucket(db, table, sampleRatio, mostCommonValues, columnName);
-            } else if (ndvMode == StatsConstants.HistogramCollectBucketNdvMode.NONE) {
-                sql = buildCollectHistogram(db, table, sampleRatio, bucketNum, mostCommonValues, columnName,
-                        columnType, false);
-            } else if (ndvMode == StatsConstants.HistogramCollectBucketNdvMode.SAMPLE) {
-                sql = buildCollectHistogram(db, table, sampleRatio, bucketNum, mostCommonValues, columnName,
-                        columnType, true);
-            } else if (ndvMode == StatsConstants.HistogramCollectBucketNdvMode.HLL) {
-                sql = buildCollectBucketsWithoutNdv(db, table, sampleRatio, bucketNum, mostCommonValues, columnName, columnType);
-                List<TStatisticData> buckets = statisticExecutor.executeStatisticDQL(context, sql);
-                sql = buildCollectHistogramWithHllNdv(db, table, mostCommonValues, buckets.get(0).histogram, columnName);
+            String sql;
+            if (collectBuckets && !shouldSkipHistogramBuckets(columnType)) {
+                sql = buildCollectBuckets(context, statisticExecutor, sampleRatio, bucketNum, mostCommonValues,
+                        columnName, columnType, ndvMode);
+            } else {
+                Optional<Pair<String, String>> minMax =
+                        sampleColumnMinMax(context, statisticExecutor, columnName, columnType, sampleRatio);
+                sql = buildCollectSingleBucket(db, table, sampleRatio, mostCommonValues, columnName, minMax);
             }
             collectStatisticSync(sql, context, analyzeStatus);
 
@@ -196,7 +220,8 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
     }
 
     private void collectBatched(ConnectContext context, AnalyzeStatus analyzeStatus, double sampleRatio, long bucketNum,
-                                long mcvSize, StatsConstants.HistogramCollectBucketNdvMode ndvMode) throws Exception {
+                                long mcvSize, StatsConstants.HistogramCollectBucketNdvMode ndvMode, boolean collectMcv,
+                                boolean collectBuckets) throws Exception {
         List<List<Expr>> rowsBuffer = new ArrayList<>();
         List<String> sqlBuffer = new ArrayList<>();
         long bufferSize = batchInsertPrefixSize(HISTOGRAM_STATISTICS_TABLE_NAME);
@@ -209,16 +234,18 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
             String rowSql;
             long rowSize;
             try {
-                List<TStatisticData> mcv = queryStatisticSync(
-                        buildCollectMCV(db, table, mcvSize, columnName, sampleRatio), context, analyzeStatus);
-                Map<String, String> mostCommonValues = buildMostCommonValues(mcv, sampleRatio);
+                Map<String, String> mostCommonValues = collectMcv
+                        ? buildMostCommonValues(queryStatisticSync(
+                                buildCollectMCV(db, table, mcvSize, columnName, sampleRatio), context, analyzeStatus),
+                                sampleRatio)
+                        : Collections.emptyMap();
 
-                String histogramQuery = buildBatchedHistogramQuery(
+                String bucketQuery = buildBatchedBucketQuery(
                         context, analyzeStatus, sampleRatio, bucketNum, ndvMode,
-                        mostCommonValues, columnName, columnType);
+                        mostCommonValues, columnName, columnType, collectBuckets);
 
                 String buckets = getSingleHistogramResult(
-                        queryStatisticSync(histogramQuery, context, analyzeStatus), columnName).histogram;
+                        queryStatisticSync(bucketQuery, context, analyzeStatus), columnName).histogram;
                 String mcvJson = buildMcvJson(mostCommonValues);
                 row = buildBatchInsertRow(columnName, buckets, mcvJson);
                 rowSql = buildBatchInsertRowSql(columnName, buckets, mcvJson);
@@ -266,12 +293,16 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
         }
     }
 
-    private String buildBatchedHistogramQuery(
+    // The batched path needs the bucket value as a literal, so it queries the buckets instead of computing them
+    // inside the INSERT. Which query to run is decided here - the single decision point shared with collectLegacy.
+    private String buildBatchedBucketQuery(
             ConnectContext context, AnalyzeStatus analyzeStatus, double sampleRatio, long bucketNum,
             StatsConstants.HistogramCollectBucketNdvMode ndvMode, Map<String, String> mostCommonValues,
-            String columnName, Type columnType) throws Exception {
-        if (shouldSkipHistogramBuckets(columnType)) {
-            return buildQueryDefaultBucket(db, table, sampleRatio, mostCommonValues, columnName);
+            String columnName, Type columnType, boolean collectBuckets) throws Exception {
+        if (!collectBuckets || shouldSkipHistogramBuckets(columnType)) {
+            Optional<Pair<String, String>> minMax =
+                    queryColumnMinMax(context, analyzeStatus, columnName, columnType, sampleRatio);
+            return buildQuerySingleBucket(db, table, sampleRatio, mostCommonValues, columnName, minMax);
         }
 
         if (ndvMode == StatsConstants.HistogramCollectBucketNdvMode.NONE) {
@@ -292,6 +323,12 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
                 normalizeBucketsForHll(getSingleHistogramResult(buckets, columnName).histogram), columnName);
     }
 
+    private Map<String, String> collectMostCommonValues(ConnectContext context, StatisticExecutor statisticExecutor,
+                                                        long mcvSize, String columnName, double sampleRatio) {
+        String sql = buildCollectMCV(db, table, mcvSize, columnName, sampleRatio);
+        return buildMostCommonValues(statisticExecutor.queryMCV(context, sql), sampleRatio);
+    }
+
     private Map<String, String> buildMostCommonValues(List<TStatisticData> mcv, double sampleRatio) {
         Map<String, String> mostCommonValues = new HashMap<>();
         for (TStatisticData tStatisticData : mcv) {
@@ -304,6 +341,87 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
             }
         }
         return mostCommonValues;
+    }
+
+    private String buildCollectBuckets(ConnectContext context, StatisticExecutor statisticExecutor, double sampleRatio,
+                                       long bucketNum, Map<String, String> mostCommonValues, String columnName,
+                                       Type columnType, StatsConstants.HistogramCollectBucketNdvMode ndvMode) {
+        if (ndvMode == StatsConstants.HistogramCollectBucketNdvMode.SAMPLE) {
+            return buildCollectHistogram(db, table, sampleRatio, bucketNum, mostCommonValues, columnName, columnType,
+                    true);
+        }
+
+        if (ndvMode == StatsConstants.HistogramCollectBucketNdvMode.HLL) {
+            String bucketSql = buildCollectBucketsWithoutNdv(db, table, sampleRatio, bucketNum, mostCommonValues,
+                    columnName, columnType);
+            List<TStatisticData> buckets = statisticExecutor.executeStatisticDQL(context, bucketSql);
+            return buildCollectHistogramWithHllNdv(db, table, mostCommonValues, buckets.get(0).histogram, columnName);
+        }
+
+        return buildCollectHistogram(db, table, sampleRatio, bucketNum, mostCommonValues, columnName, columnType,
+                false);
+    }
+
+    // Legacy path: the bounds query runs through StatisticExecutor directly.
+    private Optional<Pair<String, String>> sampleColumnMinMax(ConnectContext context,
+                                                              StatisticExecutor statisticExecutor, String columnName,
+                                                              Type columnType, double sampleRatio) {
+        if (!canCarrySampledBounds(columnType)) {
+            return Optional.empty();
+        }
+
+        String sql = buildSampleMinMax(db, table, columnName, columnType, sampleRatio);
+        return parseSampledBounds(statisticExecutor.executeStatisticDQL(context, sql), columnName, columnType);
+    }
+
+    // Batched path: same query, but routed through queryStatisticSync so analyze cancellation and the remaining
+    // timeout are still honoured.
+    private Optional<Pair<String, String>> queryColumnMinMax(ConnectContext context, AnalyzeStatus analyzeStatus,
+                                                             String columnName, Type columnType, double sampleRatio)
+            throws DdlException {
+        if (!canCarrySampledBounds(columnType)) {
+            return Optional.empty();
+        }
+
+        String sql = buildSampleMinMax(db, table, columnName, columnType, sampleRatio);
+        return parseSampledBounds(queryStatisticSync(sql, context, analyzeStatus), columnName, columnType);
+    }
+
+    private Optional<Pair<String, String>> parseSampledBounds(List<TStatisticData> sampled, String columnName,
+                                                              Type columnType) {
+        if (sampled.isEmpty()) {
+            return Optional.empty();
+        }
+
+        String minValue = sampled.get(0).columnName;
+        String maxValue = sampled.get(0).histogram;
+        if (!isUsableBucketBound(minValue, columnType) || !isUsableBucketBound(maxValue, columnType)) {
+            LOG.info("[Stats] unusable sampled bounds, falling back to placeholder bucket | db={} table={} " +
+                    "column={} min={} max={}", db.getOriginName(), table.getName(), columnName, minValue, maxValue);
+            return Optional.empty();
+        }
+        return Optional.of(Pair.create(minValue, maxValue));
+    }
+
+    private static boolean canCarrySampledBounds(Type columnType) {
+        return columnType.getPrimitiveType().isNumericType() || columnType.getPrimitiveType().isDateType();
+    }
+
+    private static boolean isUsableBucketBound(String value, Type columnType) {
+        return canCarrySampledBounds(columnType)
+                && !StringUtils.isBlank(value)
+                && !StringUtils.containsAny(value, '"', '\'', '\\');
+    }
+
+    private String buildSampleMinMax(Database database, Table table, String columnName, Type columnType,
+                                     double sampleRatio) {
+        VelocityContext context = buildBaseContext(database, table, columnName);
+        context.put("minFunction", getMinMaxFunction(columnType, "`column_key`", false));
+        context.put("maxFunction", getMinMaxFunction(columnType, "`column_key`", true));
+        context.put("totalRows", Config.histogram_max_sample_row_count);
+        putSampleClause(context, sampleRatio);
+
+        return build(context, SAMPLE_MIN_MAX_TEMPLATE);
     }
 
     private StatsConstants.HistogramCollectBucketNdvMode getHistogramCollectBucketNdvMode() {
@@ -400,15 +518,6 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
         }
     }
 
-    private String buildHistogramFunctionWithoutNdv(Database database, Table table, double sampleRatio, Long bucketNum,
-                                          String columnName) {
-        VelocityContext context = buildBaseContext(database, table, columnName);
-        context.put("bucketNum", bucketNum);
-        context.put("sampleRatio", sampleRatio);
-
-        return build(context, HISTOGRAM_FUNCTION_WITHOUT_NDV_TEMPLATE);
-    }
-
     private String buildHistogramFunction(Database database, Table table, double sampleRatio, Long bucketNum,
                                           String columnName, boolean withSampleNdv) {
         VelocityContext context = buildBaseContext(database, table, columnName);
@@ -432,8 +541,13 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
         context.put("histogramFunction", buildHistogramFunction(database, table, sampleRatio, bucketNum, columnName,
                 withSampleNdv));
         context.put("totalRows", Config.histogram_max_sample_row_count);
+        putSampleClause(context, sampleRatio);
 
-        // TODO: use it by default and remove this switch
+        return buildInsertIntoHistogramStatistics(build(context, COLLECT_HISTOGRAM_STATISTIC_TEMPLATE));
+    }
+
+    // TODO: use it by default and remove this switch
+    private void putSampleClause(VelocityContext context, double sampleRatio) {
         if (Config.enable_use_table_sample_collect_statistics && sampleRatio > 0.0 && sampleRatio < 1.0) {
             String sampleClause = String.format("SAMPLE('percent'='%s')", formatSamplePercent(sampleRatio));
             context.put("sampleClause", sampleClause);
@@ -443,8 +557,6 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
             context.put("randFilter", randFilter);
             context.put("sampleClause", "");
         }
-
-        return buildInsertIntoHistogramStatistics(build(context, COLLECT_HISTOGRAM_STATISTIC_TEMPLATE));
     }
 
     private String buildQueryHistogram(Database database, Table table, double sampleRatio, Long bucketNum,
@@ -456,38 +568,36 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
         context.put("histogramFunction", buildHistogramFunction(database, table, sampleRatio, bucketNum, columnName,
                 withSampleNdv));
         context.put("totalRows", Config.histogram_max_sample_row_count);
-
-        if (Config.enable_use_table_sample_collect_statistics && sampleRatio > 0.0 && sampleRatio < 1.0) {
-            String sampleClause = String.format("SAMPLE('percent'='%s')", formatSamplePercent(sampleRatio));
-            context.put("sampleClause", sampleClause);
-            context.put("randFilter", "TRUE");
-        } else {
-            context.put("randFilter", String.format(" rand() <= %f", sampleRatio));
-            context.put("sampleClause", "");
-        }
+        putSampleClause(context, sampleRatio);
 
         return build(context, QUERY_HISTOGRAM_STATISTIC_TEMPLATE);
     }
 
-    // In case we skip histogram collection, we simply add one tail bucket that contains all values - sum(MCVs)
-    private String buildCollectDefaultBucket(Database database, Table table, double sampleRatio,
-                                             Map<String, String> mostCommonValues, String columnName) {
+    // In case we skip histogram collection, we simply add one tail bucket that contains all values - sum(MCVs).
+    // Its bounds are the sampled min/max when the column type can carry them, and the placeholder otherwise.
+    private String buildCollectSingleBucket(Database database, Table table, double sampleRatio,
+                                            Map<String, String> mostCommonValues, String columnName,
+                                            Optional<Pair<String, String>> minMax) {
         VelocityContext context = buildBaseContext(database, table, columnName);
         addMcvToContext(context, mostCommonValues);
-        addDefaultBucketToContext(context, table, sampleRatio, mostCommonValues, columnName);
+        addSingleBucketToContext(context, table, sampleRatio, mostCommonValues, columnName, minMax);
 
-        return buildInsertIntoHistogramStatistics(build(context, COLLECT_DEFAULT_BUCKET_STATISTIC_TEMPLATE));
+        return buildInsertIntoHistogramStatistics(build(context, COLLECT_SINGLE_BUCKET_STATISTIC_TEMPLATE));
     }
 
-    private String buildQueryDefaultBucket(Database database, Table table, double sampleRatio,
-                                           Map<String, String> mostCommonValues, String columnName) {
+    private String buildQuerySingleBucket(Database database, Table table, double sampleRatio,
+                                          Map<String, String> mostCommonValues, String columnName,
+                                          Optional<Pair<String, String>> minMax) {
         VelocityContext context = buildBaseContext(database, table, columnName);
-        addDefaultBucketToContext(context, table, sampleRatio, mostCommonValues, columnName);
-        return build(context, QUERY_DEFAULT_BUCKET_STATISTIC_TEMPLATE);
+        addSingleBucketToContext(context, table, sampleRatio, mostCommonValues, columnName, minMax);
+
+        return build(context, QUERY_SINGLE_BUCKET_STATISTIC_TEMPLATE);
     }
 
-    private void addDefaultBucketToContext(VelocityContext context, Table table, double sampleRatio,
-                                           Map<String, String> mostCommonValues, String columnName) {
+    // Shared by the INSERT and the batched query variant so the two cannot drift apart.
+    private void addSingleBucketToContext(VelocityContext context, Table table, double sampleRatio,
+                                          Map<String, String> mostCommonValues, String columnName,
+                                          Optional<Pair<String, String>> minMax) {
         String quoteColumName = StatisticUtils.quoting(table, columnName);
         String countExpr;
         if (sampleRatio > 0.0 && sampleRatio < 1.0) {
@@ -510,11 +620,13 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
         String nonMcvExpr = "greatest(0, " + countExpr + " - " + mcvSum + ")";
 
         context.put("bucketExpr",
-                "concat('[[\"Infinity\",\"Infinity\",', cast(cast(" + nonMcvExpr + " as bigint) as varchar), ',0]]')");
+                "concat('[[\"" + minMax.map(minAndMax -> minAndMax.first).orElse(INFINITE_BOUND) + "\",\"" +
+                        minMax.map(minAndMax -> minAndMax.second).orElse(INFINITE_BOUND) + "\",', cast(cast(" +
+                        nonMcvExpr + " as bigint) as varchar), ',0]]')");
     }
 
     private String buildCollectHistogramWithHllNdv(Database database, Table table, Map<String, String> mostCommonValues,
-                                                String buckets, String columnName) {
+                                                   String buckets, String columnName) {
         VelocityContext context = buildBaseContext(database, table, columnName);
         addMcvToContext(context, mostCommonValues);
         context.put("buckets", buckets);
@@ -529,8 +641,8 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
     }
 
     private String buildCollectBucketsWithoutNdv(Database database, Table table, double sampleRatio,
-                                      Long bucketNum, Map<String, String> mostCommonValues, String columnName,
-                                      Type columnType) {
+                                                 Long bucketNum, Map<String, String> mostCommonValues, String columnName,
+                                                 Type columnType) {
         VelocityContext context = buildBaseContext(database, table, columnName);
         context.put("histogramFunction", buildHistogramFunction(database, table, sampleRatio, bucketNum, columnName, false));
         context.put("sampleRatio", sampleRatio);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
@@ -18,8 +18,11 @@ package com.starrocks.statistic;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 
+import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class StatsConstants {
     public static final long DEFAULT_ALL_ID = -1;
@@ -107,7 +110,6 @@ public class StatsConstants {
     public static final String HISTOGRAM_STATS_SCOPE = "histogram_stats_scope";
     public static final String HISTOGRAM_STATS_SCOPE_MCV = "mcv";
     public static final String HISTOGRAM_STATS_SCOPE_BUCKETS = "buckets";
-    public static final String HISTOGRAM_STATS_SCOPE_BOTH = "both";
 
     public static final String HISTOGRAM_COLLECT_BUCKET_NDV_MODE = "histogram_collect_bucket_ndv_mode";
 
@@ -170,6 +172,60 @@ public class StatsConstants {
         NONE,
         SAMPLE,
         HLL
+    }
+
+    // The kinds of statistic a histogram job can collect. Modelled as a set rather than an enum of
+    // combinations so that adding a third kind does not multiply the accepted property values.
+    public enum HistogramStatKind {
+        MCV(HISTOGRAM_STATS_SCOPE_MCV),
+        BUCKETS(HISTOGRAM_STATS_SCOPE_BUCKETS);
+
+        private final String propertyValue;
+
+        HistogramStatKind(String propertyValue) {
+            this.propertyValue = propertyValue;
+        }
+
+        public String propertyValue() {
+            return propertyValue;
+        }
+    }
+
+    public static final String HISTOGRAM_STATS_SCOPE_VALUES = Arrays.stream(HistogramStatKind.values())
+            .map(HistogramStatKind::propertyValue)
+            .collect(Collectors.joining("', '", "'", "'"));
+
+    /**
+     * Parse the {@link #HISTOGRAM_STATS_SCOPE} property into the set of statistic kinds to collect.
+     * A null value - the property is absent - means "collect every kind", so callers do not need to
+     * materialise a default. Otherwise the value is a comma-separated set, e.g. {@code "mcv"} or
+     * {@code "mcv,buckets"}. A value that is present but names no kind is an error rather than a
+     * silent "everything": spelling it out empty is a mistake worth reporting.
+     *
+     * @throws IllegalArgumentException if a kind is unknown, or the value is present but names no kind
+     */
+    public static EnumSet<HistogramStatKind> parseHistogramStatsScope(String rawScope) {
+        if (rawScope == null) {
+            return EnumSet.allOf(HistogramStatKind.class);
+        }
+
+        EnumSet<HistogramStatKind> kinds = EnumSet.noneOf(HistogramStatKind.class);
+        for (String token : rawScope.split(",", -1)) {
+            String kind = token.trim();
+            if (kind.isEmpty()) {
+                continue;
+            }
+            kinds.add(Arrays.stream(HistogramStatKind.values())
+                    .filter(candidate -> candidate.propertyValue().equalsIgnoreCase(kind))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException(
+                            "unknown histogram statistic kind '" + kind + "'")));
+        }
+
+        if (kinds.isEmpty()) {
+            throw new IllegalArgumentException("no histogram statistic kind specified");
+        }
+        return kinds;
     }
 
     public static Map<String, String> buildInitStatsProp() {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
@@ -104,6 +104,11 @@ public class StatsConstants {
     public static final String HISTOGRAM_BUCKET_NUM = "histogram_bucket_num";
     public static final String HISTOGRAM_MCV_SIZE = "histogram_mcv_size";
     public static final String HISTOGRAM_SAMPLE_RATIO = "histogram_sample_ratio";
+    public static final String HISTOGRAM_STATS_SCOPE = "histogram_stats_scope";
+    public static final String HISTOGRAM_STATS_SCOPE_MCV = "mcv";
+    public static final String HISTOGRAM_STATS_SCOPE_BUCKETS = "buckets";
+    public static final String HISTOGRAM_STATS_SCOPE_BOTH = "both";
+
     public static final String HISTOGRAM_COLLECT_BUCKET_NDV_MODE = "histogram_collect_bucket_ndv_mode";
 
     // SQL plan manager table

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateAnalyzeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateAnalyzeJobTest.java
@@ -165,8 +165,7 @@ public class AnalyzeCreateAnalyzeJobTest {
         String jobId = jobDesc.get(0);
         Assertions.assertEquals(
                 List.of("default_catalog", "db", "tbl1", "c1,c2", "HISTOGRAM", "SCHEDULE",
-                        "{histogram_stats_scope=both, histogram_sample_ratio=1, " +
-                                "histogram_collect_bucket_ndv_mode=none, histogram_mcv_size=100, " +
+                        "{histogram_sample_ratio=1, histogram_collect_bucket_ndv_mode=none, histogram_mcv_size=100, " +
                                 "histogram_bucket_num=128}"),
                 jobDesc.subList(1, jobDesc.size() - 3));
 
@@ -179,9 +178,8 @@ public class AnalyzeCreateAnalyzeJobTest {
             jobId = jobDesc.get(0);
             Assertions.assertEquals(
                     List.of("default_catalog", "db", "tbl1", "c1,c2", "HISTOGRAM", "SCHEDULE",
-                            "{histogram_stats_scope=both, histogram_sample_ratio=1, " +
-                                    "histogram_collect_bucket_ndv_mode=none, histogram_mcv_size=100, " +
-                                    "histogram_bucket_num=128}",
+                            "{histogram_sample_ratio=1, histogram_collect_bucket_ndv_mode=none, " +
+                                    "histogram_mcv_size=100, histogram_bucket_num=128}",
                             "FINISH"),
                     jobDesc.subList(1, jobDesc.size() - 2));
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateAnalyzeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateAnalyzeJobTest.java
@@ -165,7 +165,8 @@ public class AnalyzeCreateAnalyzeJobTest {
         String jobId = jobDesc.get(0);
         Assertions.assertEquals(
                 List.of("default_catalog", "db", "tbl1", "c1,c2", "HISTOGRAM", "SCHEDULE",
-                        "{histogram_sample_ratio=1, histogram_collect_bucket_ndv_mode=none, histogram_mcv_size=100, " +
+                        "{histogram_stats_scope=both, histogram_sample_ratio=1, " +
+                                "histogram_collect_bucket_ndv_mode=none, histogram_mcv_size=100, " +
                                 "histogram_bucket_num=128}"),
                 jobDesc.subList(1, jobDesc.size() - 3));
 
@@ -178,8 +179,9 @@ public class AnalyzeCreateAnalyzeJobTest {
             jobId = jobDesc.get(0);
             Assertions.assertEquals(
                     List.of("default_catalog", "db", "tbl1", "c1,c2", "HISTOGRAM", "SCHEDULE",
-                            "{histogram_sample_ratio=1, histogram_collect_bucket_ndv_mode=none, " +
-                                    "histogram_mcv_size=100, histogram_bucket_num=128}",
+                            "{histogram_stats_scope=both, histogram_sample_ratio=1, " +
+                                    "histogram_collect_bucket_ndv_mode=none, histogram_mcv_size=100, " +
+                                    "histogram_bucket_num=128}",
                             "FINISH"),
                     jobDesc.subList(1, jobDesc.size() - 2));
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
@@ -700,6 +700,33 @@ public class AnalyzeStmtTest {
     }
 
     @Test
+    public void testHistogramStatsScope() {
+        // Given the histogram_stats_scope property
+        // CASE WHEN it names a comma-separated subset of the known kinds THEN it is accepted verbatim
+        //      WHEN it is omitted THEN it stays absent, which the collect jobs read as "every kind"
+        //      ELSE it is rejected END
+
+        String prefix = "analyze table db.tbl update histogram on kk1 with 256 buckets ";
+
+        for (String scope : List.of("mcv", "buckets", "mcv,buckets", "buckets,mcv", "MCV, BUCKETS", " mcv , buckets ")) {
+            AnalyzeStmt stmt = (AnalyzeStmt) analyzeSuccess(
+                    prefix + "properties(\"histogram_stats_scope\"=\"" + scope + "\")");
+            // Accepted as written - normalising it would only make SHOW ANALYZE STATUS disagree with the DDL.
+            Assertions.assertEquals(scope, stmt.getProperties().get(StatsConstants.HISTOGRAM_STATS_SCOPE));
+        }
+
+        // Omitted means every kind, so there is no default to materialise.
+        AnalyzeStmt noScope = (AnalyzeStmt) analyzeSuccess(prefix);
+        Assertions.assertFalse(noScope.getProperties().containsKey(StatsConstants.HISTOGRAM_STATS_SCOPE));
+
+        // 'both' was replaced by naming the kinds; a bare unknown kind and an empty set are errors too.
+        for (String invalid : List.of("both", "", " ", ",", "mcv,nonsense", "mcv;buckets")) {
+            analyzeFail(prefix + "properties(\"histogram_stats_scope\"=\"" + invalid + "\")",
+                    "Property 'histogram_stats_scope' must be a comma-separated subset of");
+        }
+    }
+
+    @Test
     public void testDropStats() {
         String sql = "drop stats t0";
         DropStatsStmt dropStatsStmt = (DropStatsStmt) analyzeSuccess(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -600,7 +600,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         stringMcv.put("1", "10");
         stringMcv.put("2", "20");
         String defaultBucketSql = Deencapsulation.invoke(histogramStatisticsCollectJob, "buildCollectSingleBucket",
-                db, olapTable, 0.1, stringMcv, "v2", Optional.empty());
+                db, olapTable, 0.1, stringMcv, "v2", VarcharType.VARCHAR, Optional.empty());
         String defaultBucketNormalized = normalize.apply(defaultBucketSql);
         Assertions.assertEquals(normalize.apply(String.format("INSERT INTO histogram_statistics(" +
                         "table_id, column_name, db_id, table_name, buckets, mcv, update_time) SELECT %d, 'v2', %d, " +
@@ -619,7 +619,8 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         try {
             Config.enable_use_table_sample_collect_statistics = false;
             String randDefaultBucketSql = Deencapsulation.invoke(histogramStatisticsCollectJob,
-                    "buildCollectSingleBucket", db, olapTable, 0.1, stringMcv, "v2", Optional.empty());
+                    "buildCollectSingleBucket", db, olapTable, 0.1, stringMcv, "v2", VarcharType.VARCHAR,
+                    Optional.empty());
             String randDefaultBucketNormalized = normalize.apply(randDefaultBucketSql);
             Assertions.assertEquals(normalize.apply(String.format("INSERT INTO histogram_statistics(" +
                             "table_id, column_name, db_id, table_name, buckets, mcv, update_time) SELECT %d, 'v2', %d, " +
@@ -711,6 +712,17 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         Assertions.assertTrue(collectedSql.get(0).toLowerCase().contains("histogram_hll_ndv"));
     }
 
+    // The sampled MIN/MAX bounds query, by its IFNULL(MIN(...)) signature. The scope tests assert that no
+    // bounds query runs for a column whose bounds cannot be carried, so they must match on the query itself
+    // rather than on a bare executor call count, which also sees unrelated statistics traffic.
+    private static boolean isSampledBoundsQuery(String sql) {
+        return sql != null && sql.contains("IFNULL(MIN(");
+    }
+
+    private static final String ALL_HISTOGRAM_STATS_SCOPES =
+            StatsConstants.HISTOGRAM_STATS_SCOPE_MCV + "," + StatsConstants.HISTOGRAM_STATS_SCOPE_BUCKETS;
+
+    // A null statScope leaves the property out entirely, which means "collect every kind".
     private static HistogramStatisticsCollectJob histogramStatsWithScopeJob(Database db, OlapTable table, String columnName,
                                                                             Type columnType, String statScope) {
         Map<String, String> properties = new HashMap<>();
@@ -718,7 +730,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         properties.put(StatsConstants.HISTOGRAM_BUCKET_NUM, "64");
         properties.put(StatsConstants.HISTOGRAM_MCV_SIZE, "100");
         properties.put(StatsConstants.HISTOGRAM_COLLECT_BUCKET_NDV_MODE, "none");
-        properties.put(StatsConstants.HISTOGRAM_STATS_SCOPE, statScope);
+        if (statScope != null) {
+            properties.put(StatsConstants.HISTOGRAM_STATS_SCOPE, statScope);
+        }
 
         return new HistogramStatisticsCollectJob(db, table, Lists.newArrayList(columnName),
                 Lists.newArrayList(columnType), StatsConstants.ScheduleType.ONCE, properties);
@@ -739,7 +753,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
         for (Type unparseable : Lists.<Type>newArrayList(VarcharType.VARCHAR, BooleanType.BOOLEAN)) {
             Optional<Pair<String, String>> bounds = Deencapsulation.invoke(job, "sampleColumnMinMax",
-                    connectContext, new StatisticExecutor(), "v2", unparseable, 0.1);
+                    connectContext, new StatisticExecutor(), "v2", unparseable, 0.1, ImmutableMap.of("1", "10"));
 
             Assertions.assertTrue(bounds.isEmpty());
         }
@@ -756,11 +770,16 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         HistogramStatisticsCollectJob job = histogramStatsWithScopeJob(db, olapTable, "v4", DateType.DATE,
                 StatsConstants.HISTOGRAM_STATS_SCOPE_MCV);
 
-        String sql = Deencapsulation.invoke(job, "buildSampleMinMax", db, olapTable, "v4", DateType.DATE, 0.1);
+        String sql = Deencapsulation.invoke(job, "buildSampleMinMax", db, olapTable, "v4", DateType.DATE, 0.1,
+                ImmutableMap.of("2020-01-01", "10"));
 
         Assertions.assertTrue(sql.contains("cast(2 as INT)"), sql);
         Assertions.assertTrue(sql.contains("cast(IFNULL(MIN(`column_key`), '') as varchar)"), sql);
         Assertions.assertTrue(sql.contains("cast(IFNULL(MAX(`column_key`), '') as varchar)"), sql);
+        // The bucket's count subtracts the MCV rows, so its bounds must be sampled over the same population.
+        Assertions.assertTrue(sql.contains("and `v4` not in (\"2020-01-01\")"), sql);
+        // No LIMIT: without an ORDER BY it would bias min/max towards an arbitrary scan-order prefix.
+        Assertions.assertFalse(sql.toLowerCase().contains("limit"), sql);
     }
 
     @Test
@@ -786,7 +805,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
             @Mock
             public List<TStatisticData> executeStatisticDQL(ConnectContext ctx, String sql) {
-                boundsQueries.incrementAndGet();
+                if (isSampledBoundsQuery(sql)) {
+                    boundsQueries.incrementAndGet();
+                }
                 TStatisticData data = new TStatisticData();
                 data.columnName = "0";
                 data.histogram = "4";
@@ -825,11 +846,23 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         Assertions.assertTrue(collectedSql.get(0).contains("histogram(`column_key`"),
                 "stats collection sql is unexpected. The sql is " + collectedSql.get(0));
 
-        // both scope
+        // both kinds, named explicitly as a set
         mcvQueries.set(0);
         boundsQueries.set(0);
         collectedSql.clear();
-        histogramStatsWithScopeJob(db, olapTable, "v2", IntegerType.BIGINT, StatsConstants.HISTOGRAM_STATS_SCOPE_BOTH)
+        histogramStatsWithScopeJob(db, olapTable, "v2", IntegerType.BIGINT, ALL_HISTOGRAM_STATS_SCOPES)
+                .collect(connectContext, new NativeAnalyzeStatus());
+        Assertions.assertEquals(1, mcvQueries.get());
+        Assertions.assertEquals(0, boundsQueries.get());
+        Assertions.assertEquals(1, collectedSql.size());
+        Assertions.assertTrue(collectedSql.get(0).contains("histogram(`column_key`"),
+                "stats collection sql is unexpected. The sql is " + collectedSql.get(0));
+
+        // omitting the property means the same thing as naming every kind
+        mcvQueries.set(0);
+        boundsQueries.set(0);
+        collectedSql.clear();
+        histogramStatsWithScopeJob(db, olapTable, "v2", IntegerType.BIGINT, null)
                 .collect(connectContext, new NativeAnalyzeStatus());
         Assertions.assertEquals(1, mcvQueries.get());
         Assertions.assertEquals(0, boundsQueries.get());
@@ -839,8 +872,8 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
     }
 
     @Test
-    public void testHistogramScopeIsBothAndTypeIsString() throws Exception {
-        // Given a histogram job on a varchar column with the both stats scope
+    public void testHistogramAllScopesAndTypeIsString() throws Exception {
+        // Given a histogram job on a varchar column naming every stats scope
         // CASE WHEN the column is char-family THEN the bucket collection is skipped and one placeholder bucket carries
         //      the row count next to the MCVs END
 
@@ -862,7 +895,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
             @Mock
             public List<TStatisticData> executeStatisticDQL(ConnectContext ctx, String sql) {
-                boundsQueries.incrementAndGet();
+                if (isSampledBoundsQuery(sql)) {
+                    boundsQueries.incrementAndGet();
+                }
                 return Lists.newArrayList();
             }
         };
@@ -875,7 +910,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
             }
         };
 
-        histogramStatsWithScopeJob(db, olapTable, "v2", VarcharType.VARCHAR, StatsConstants.HISTOGRAM_STATS_SCOPE_BOTH)
+        histogramStatsWithScopeJob(db, olapTable, "v2", VarcharType.VARCHAR, ALL_HISTOGRAM_STATS_SCOPES)
                 .collect(connectContext, new NativeAnalyzeStatus());
 
         Assertions.assertEquals(1, mcvQueries.get());
@@ -888,10 +923,10 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
     }
 
     @Test
-    public void testHistogramScopeIsBucketsAndTypeIsString() throws Exception {
+    public void testHistogramScopeIsBucketsAndTypeIsStringStillCollectsMcv() throws Exception {
         // Given a histogram job on a varchar column with the buckets stats scope
-        // CASE WHEN the column is char-family THEN no query of either kind runs and the placeholder bucket replaces the
-        //      aggregate END
+        // CASE WHEN the column is char-family THEN buckets are impossible, so the MCVs are collected anyway rather
+        //      than storing a row with neither MCVs nor real buckets END
 
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         OlapTable olapTable =
@@ -911,7 +946,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
             @Mock
             public List<TStatisticData> executeStatisticDQL(ConnectContext ctx, String sql) {
-                boundsQueries.incrementAndGet();
+                if (isSampledBoundsQuery(sql)) {
+                    boundsQueries.incrementAndGet();
+                }
                 return Lists.newArrayList();
             }
         };
@@ -927,11 +964,48 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         histogramStatsWithScopeJob(db, olapTable, "v2", VarcharType.VARCHAR, StatsConstants.HISTOGRAM_STATS_SCOPE_BUCKETS)
                 .collect(connectContext, new NativeAnalyzeStatus());
 
-        Assertions.assertEquals(0, mcvQueries.get());
+        Assertions.assertEquals(1, mcvQueries.get());
         Assertions.assertEquals(0, boundsQueries.get());
         Assertions.assertEquals(1, collectedSql.size());
         Assertions.assertTrue(collectedSql.get(0).contains("concat('[[\"Infinity\",\"Infinity\",'"), collectedSql.get(0));
+        // 10 / 0.1 - the MCV count is scaled back to full-table. Without this the stored row would carry no
+        // information at all, and the IN-predicate estimator would still prefer it over the char NDV path.
+        Assertions.assertTrue(collectedSql.get(0).contains("'[[\"1\",\"100\"]]'"), collectedSql.get(0));
         Assertions.assertFalse(collectedSql.get(0).contains("histogram("), collectedSql.get(0));
+    }
+
+    @Test
+    public void testHistogramSingleBucketIsNullWhenDateBoundsAreMissing() throws Exception {
+        // Given a histogram job on a date column whose scope excludes buckets
+        // CASE WHEN the sampled bounds come back unusable THEN buckets are stored as NULL rather than the
+        //      Infinity placeholder, because HistogramUtils.convertBuckets cannot parse it as a date and would
+        //      drop the bucket, losing the non-MCV count from getTotalRows() END
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable olapTable =
+                (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t0_stats");
+
+        HistogramStatisticsCollectJob job = histogramStatsWithScopeJob(db, olapTable, "v4", DateType.DATE,
+                StatsConstants.HISTOGRAM_STATS_SCOPE_MCV);
+
+        for (Type dateType : Lists.<Type>newArrayList(DateType.DATE, DateType.DATETIME)) {
+            String sql = Deencapsulation.invoke(job, "buildCollectSingleBucket",
+                    db, olapTable, 0.1, ImmutableMap.of("2020-01-01", "10"), "v4", dateType, Optional.empty());
+
+            Assertions.assertTrue(sql.contains("'test.t0_stats', NULL,"), sql);
+            Assertions.assertFalse(sql.contains("Infinity"), sql);
+        }
+
+        // A numeric column keeps the placeholder: "Infinity" round-trips through Double.parseDouble.
+        String numericSql = Deencapsulation.invoke(job, "buildCollectSingleBucket",
+                db, olapTable, 0.1, ImmutableMap.of("1", "10"), "v2", IntegerType.BIGINT, Optional.empty());
+        Assertions.assertTrue(numericSql.contains("concat('[[\"Infinity\",\"Infinity\",'"), numericSql);
+
+        // And with usable bounds a date column stores a real bucket.
+        String boundedSql = Deencapsulation.invoke(job, "buildCollectSingleBucket",
+                db, olapTable, 0.1, ImmutableMap.of("2020-01-01", "10"), "v4", DateType.DATE,
+                Optional.of(Pair.create("2020-01-02", "2020-06-30")));
+        Assertions.assertTrue(boundedSql.contains("concat('[[\"2020-01-02\",\"2020-06-30\",'"), boundedSql);
     }
 
     @Test
@@ -992,15 +1066,19 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                 Lists.newArrayList("r_regionkey"), StatsConstants.AnalyzeType.HISTOGRAM,
                 StatsConstants.ScheduleType.ONCE, Maps.newHashMap(), LocalDateTime.now()));
 
-        Assertions.assertEquals(2, queriedSql.size());
-        Assertions.assertTrue(queriedSql.get(1).contains("IFNULL(MIN(`column_key`), '')"), queriedSql.get(1));
+        // Match on the queries themselves rather than on an exact call count, which also sees unrelated
+        // statistics traffic: the MCV query stands in for the bucket aggregate, and the bounds query supplies
+        // the single bucket's min/max.
+        Assertions.assertTrue(queriedSql.stream().anyMatch(sql -> sql.contains("group by")), queriedSql.toString());
+        Assertions.assertTrue(queriedSql.stream().anyMatch(StatisticsCollectJobTest::isSampledBoundsQuery),
+                queriedSql.toString());
         Assertions.assertEquals(1, collectedSql.size());
         Assertions.assertTrue(collectedSql.get(0).contains("concat('[[\"0\",\"4\",'"), collectedSql.get(0));
         Assertions.assertFalse(collectedSql.get(0).contains("histogram("), collectedSql.get(0));
     }
 
     @Test
-    public void testExternalHistogramBothScopeCollectsMcvAndBuckets() throws Exception {
+    public void testExternalHistogramAllScopesCollectsMcvAndBuckets() throws Exception {
         // Given an external histogram job on an int column with the both stats scope
         // CASE WHEN the scope covers MCVs and buckets THEN the MCV query runs, the bounds query does not, and the
         //      sorted aggregate runs with the MCVs excluded END
@@ -1013,7 +1091,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         properties.put(StatsConstants.HISTOGRAM_SAMPLE_RATIO, "0.1");
         properties.put(StatsConstants.HISTOGRAM_BUCKET_NUM, "64");
         properties.put(StatsConstants.HISTOGRAM_MCV_SIZE, "100");
-        properties.put(StatsConstants.HISTOGRAM_STATS_SCOPE, StatsConstants.HISTOGRAM_STATS_SCOPE_BOTH);
+        properties.put(StatsConstants.HISTOGRAM_STATS_SCOPE, ALL_HISTOGRAM_STATS_SCOPES);
 
         ExternalHistogramStatisticsCollectJob job = new ExternalHistogramStatisticsCollectJob(
                 "hive0", db, region, Lists.newArrayList("r_regionkey"), Lists.newArrayList(IntegerType.INT),
@@ -1033,7 +1111,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
             @Mock
             public List<TStatisticData> executeStatisticDQL(ConnectContext ctx, String sql) {
-                boundsQueries.incrementAndGet();
+                if (isSampledBoundsQuery(sql)) {
+                    boundsQueries.incrementAndGet();
+                }
                 return Lists.newArrayList();
             }
 
@@ -1091,7 +1171,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
             @Mock
             public List<TStatisticData> executeStatisticDQL(ConnectContext ctx, String sql) {
-                queryCalls.incrementAndGet();
+                if (isSampledBoundsQuery(sql)) {
+                    queryCalls.incrementAndGet();
+                }
                 return Lists.newArrayList();
             }
 
@@ -1119,7 +1201,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
     }
 
     @Test
-    public void testExternalHistogramBothScopeSkipsBucketQueryForStringColumns() throws Exception {
+    public void testExternalHistogramAllScopesSkipsBucketQueryForStringColumns() throws Exception {
         // Given an external histogram job on a varchar column with the both stats scope
         // CASE WHEN the column is char-family THEN the bucket aggregate is skipped and one placeholder bucket carries
         //      the row count next to the MCVs ELSE the sorted aggregate runs END
@@ -1132,7 +1214,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         properties.put(StatsConstants.HISTOGRAM_SAMPLE_RATIO, "0.1");
         properties.put(StatsConstants.HISTOGRAM_BUCKET_NUM, "64");
         properties.put(StatsConstants.HISTOGRAM_MCV_SIZE, "100");
-        properties.put(StatsConstants.HISTOGRAM_STATS_SCOPE, StatsConstants.HISTOGRAM_STATS_SCOPE_BOTH);
+        properties.put(StatsConstants.HISTOGRAM_STATS_SCOPE, ALL_HISTOGRAM_STATS_SCOPES);
 
         ExternalHistogramStatisticsCollectJob job = new ExternalHistogramStatisticsCollectJob(
                 "hive0", db, region, Lists.newArrayList("r_name"), Lists.newArrayList(VarcharType.VARCHAR),
@@ -1152,7 +1234,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
             @Mock
             public List<TStatisticData> executeStatisticDQL(ConnectContext ctx, String sql) {
-                boundsQueries.incrementAndGet();
+                if (isSampledBoundsQuery(sql)) {
+                    boundsQueries.incrementAndGet();
+                }
                 return Lists.newArrayList();
             }
 
@@ -1183,10 +1267,10 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
     }
 
     @Test
-    public void testExternalHistogramBucketsScopeStoresPlaceholderWithoutMcvForStringColumns() throws Exception {
+    public void testExternalHistogramBucketsScopeStillCollectsMcvForStringColumns() throws Exception {
         // Given an external histogram job on a varchar column with the buckets stats scope
-        // CASE WHEN the column is char-family THEN no query of either kind runs and the placeholder bucket replaces the
-        //      aggregate END
+        // CASE WHEN the column is char-family THEN buckets are impossible, so the MCVs are collected anyway and the
+        //      placeholder bucket only carries the row count END
 
         Table region = connectContext.getGlobalStateMgr().getMetadataMgr()
                 .getTable(connectContext, "hive0", "tpch", "region");
@@ -1202,17 +1286,23 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                 "hive0", db, region, Lists.newArrayList("r_name"), Lists.newArrayList(VarcharType.VARCHAR),
                 StatsConstants.AnalyzeType.HISTOGRAM, StatsConstants.ScheduleType.ONCE, properties);
 
-        AtomicInteger queryCalls = new AtomicInteger(0);
+        AtomicInteger mcvQueries = new AtomicInteger(0);
+        AtomicInteger boundsQueries = new AtomicInteger(0);
         new MockUp<StatisticExecutor>() {
             @Mock
             public List<TStatisticData> queryMCV(ConnectContext ctx, String sql) {
-                queryCalls.incrementAndGet();
-                return Lists.newArrayList();
+                mcvQueries.incrementAndGet();
+                TStatisticData data = new TStatisticData();
+                data.columnName = "AFRICA";
+                data.histogram = "10";
+                return Lists.newArrayList(data);
             }
 
             @Mock
             public List<TStatisticData> executeStatisticDQL(ConnectContext ctx, String sql) {
-                queryCalls.incrementAndGet();
+                if (isSampledBoundsQuery(sql)) {
+                    boundsQueries.incrementAndGet();
+                }
                 return Lists.newArrayList();
             }
 
@@ -1234,9 +1324,11 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                 Lists.newArrayList("r_name"), StatsConstants.AnalyzeType.HISTOGRAM,
                 StatsConstants.ScheduleType.ONCE, Maps.newHashMap(), LocalDateTime.now()));
 
-        Assertions.assertEquals(0, queryCalls.get());
+        Assertions.assertEquals(1, mcvQueries.get());
+        Assertions.assertEquals(0, boundsQueries.get());
         Assertions.assertEquals(1, collectedSql.size());
         Assertions.assertTrue(collectedSql.get(0).contains("concat('[[\"Infinity\",\"Infinity\",'"), collectedSql.get(0));
+        Assertions.assertTrue(collectedSql.get(0).contains("'[[\"AFRICA\",\"10\"]]'"), collectedSql.get(0));
         Assertions.assertFalse(collectedSql.get(0).contains("histogram("), collectedSql.get(0));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.Pair;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.partitiontraits.DefaultTraits;
@@ -36,8 +37,10 @@ import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.sql.plan.PlanTestNoneDBBase;
 import com.starrocks.thrift.TStatisticData;
+import com.starrocks.type.BooleanType;
 import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
+import com.starrocks.type.Type;
 import com.starrocks.type.VarcharType;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
@@ -59,6 +62,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -588,15 +592,15 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                         "'[[\"1\",\"10\"],[\"2\",\"20\"]]', NOW() FROM `test`.`t0_stats`;",
                 t0StatsTableId, dbid)), normalize.apply(sql));
 
-        // buildCollectDefaultBucket produces a placeholder-bucket SQL (no histogram() aggregate, no sort): the
-        // bucket carries count(non-null, non-MCV rows) scaled to full-table, so getTotalRows() reflects the real
-        // cardinality. This is the SQL collect() substitutes for char-family columns (see the
-        // testHistogramCollectSkipsBucketQueryForStringColumnsInHllMode end-to-end test).
+        // buildCollectSingleBucket with no sampled bounds produces a placeholder-bucket SQL (no histogram()
+        // aggregate, no sort): the bucket carries count(non-null, non-MCV rows) scaled to full-table, so
+        // getTotalRows() reflects the real cardinality. This is the SQL collect() substitutes for char-family
+        // columns (see the testHistogramCollectSkipsBucketQueryForStringColumnsInHllMode end-to-end test).
         Map<String, String> stringMcv = new HashMap<>();
         stringMcv.put("1", "10");
         stringMcv.put("2", "20");
-        String defaultBucketSql = Deencapsulation.invoke(histogramStatisticsCollectJob, "buildCollectDefaultBucket",
-                db, olapTable, 0.1, stringMcv, "v2");
+        String defaultBucketSql = Deencapsulation.invoke(histogramStatisticsCollectJob, "buildCollectSingleBucket",
+                db, olapTable, 0.1, stringMcv, "v2", Optional.empty());
         String defaultBucketNormalized = normalize.apply(defaultBucketSql);
         Assertions.assertEquals(normalize.apply(String.format("INSERT INTO histogram_statistics(" +
                         "table_id, column_name, db_id, table_name, buckets, mcv, update_time) SELECT %d, 'v2', %d, " +
@@ -609,13 +613,13 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         Assertions.assertFalse(defaultBucketNormalized.contains("order by"));
         Assertions.assertFalse(defaultBucketNormalized.contains("is not null"));
 
-        // When enable_use_table_sample_collect_statistics is off, buildCollectDefaultBucket must fall back to a
+        // When enable_use_table_sample_collect_statistics is off, buildCollectSingleBucket must fall back to a
         // row-level rand() bernoulli filter instead of the SAMPLE clause, matching buildCollectHistogram.
         boolean originalSampleForDefaultBucket = Config.enable_use_table_sample_collect_statistics;
         try {
             Config.enable_use_table_sample_collect_statistics = false;
             String randDefaultBucketSql = Deencapsulation.invoke(histogramStatisticsCollectJob,
-                    "buildCollectDefaultBucket", db, olapTable, 0.1, stringMcv, "v2");
+                    "buildCollectSingleBucket", db, olapTable, 0.1, stringMcv, "v2", Optional.empty());
             String randDefaultBucketNormalized = normalize.apply(randDefaultBucketSql);
             Assertions.assertEquals(normalize.apply(String.format("INSERT INTO histogram_statistics(" +
                             "table_id, column_name, db_id, table_name, buckets, mcv, update_time) SELECT %d, 'v2', %d, " +
@@ -705,6 +709,535 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         Assertions.assertEquals(1, bucketQueryCalls.get());
         Assertions.assertEquals(1, collectedSql.size());
         Assertions.assertTrue(collectedSql.get(0).toLowerCase().contains("histogram_hll_ndv"));
+    }
+
+    private static HistogramStatisticsCollectJob histogramStatsWithScopeJob(Database db, OlapTable table, String columnName,
+                                                                            Type columnType, String statScope) {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(StatsConstants.HISTOGRAM_SAMPLE_RATIO, "0.1");
+        properties.put(StatsConstants.HISTOGRAM_BUCKET_NUM, "64");
+        properties.put(StatsConstants.HISTOGRAM_MCV_SIZE, "100");
+        properties.put(StatsConstants.HISTOGRAM_COLLECT_BUCKET_NDV_MODE, "none");
+        properties.put(StatsConstants.HISTOGRAM_STATS_SCOPE, statScope);
+
+        return new HistogramStatisticsCollectJob(db, table, Lists.newArrayList(columnName),
+                Lists.newArrayList(columnType), StatsConstants.ScheduleType.ONCE, properties);
+    }
+
+    @Test
+    public void testHistogramSampleMinMaxSkipsUnparseableTypes() {
+        // Given a histogram job whose scope excludes buckets, so the single bucket's bounds come from a sampled MIN/MAX
+        // CASE WHEN the column type cannot be read back as a bucket bound THEN sampleColumnMinMax returns empty  
+        // ELSE it returns the sampled bounds END
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable olapTable =
+                (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t0_stats");
+
+        HistogramStatisticsCollectJob job = histogramStatsWithScopeJob(db, olapTable, "v2", VarcharType.VARCHAR,
+                StatsConstants.HISTOGRAM_STATS_SCOPE_MCV);
+
+        for (Type unparseable : Lists.<Type>newArrayList(VarcharType.VARCHAR, BooleanType.BOOLEAN)) {
+            Optional<Pair<String, String>> bounds = Deencapsulation.invoke(job, "sampleColumnMinMax",
+                    connectContext, new StatisticExecutor(), "v2", unparseable, 0.1);
+
+            Assertions.assertTrue(bounds.isEmpty());
+        }
+    }
+
+    @Test
+    public void testSampleMinMaxAreSetForDateTypes() {
+        // Given a histogram job on a date column, THEN sampled bounds are querried END
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable olapTable =
+                (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t0_stats");
+
+        HistogramStatisticsCollectJob job = histogramStatsWithScopeJob(db, olapTable, "v4", DateType.DATE,
+                StatsConstants.HISTOGRAM_STATS_SCOPE_MCV);
+
+        String sql = Deencapsulation.invoke(job, "buildSampleMinMax", db, olapTable, "v4", DateType.DATE, 0.1);
+
+        Assertions.assertTrue(sql.contains("cast(2 as INT)"), sql);
+        Assertions.assertTrue(sql.contains("cast(IFNULL(MIN(`column_key`), '') as varchar)"), sql);
+        Assertions.assertTrue(sql.contains("cast(IFNULL(MAX(`column_key`), '') as varchar)"), sql);
+    }
+
+    @Test
+    public void testHistogramStatsScopeDispatch() throws Exception {
+        // CASE WHEN the scope is mcv THEN the MCV and bounds queries run and a single bucket replaces the aggregate
+        //      WHEN the scope is buckets THEN neither query runs and the sorted buckets are kept
+        //      ELSE the scope is both, so the MCV query runs and histogram func is called END
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable olapTable =
+                (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t0_stats");
+
+        AtomicInteger mcvQueries = new AtomicInteger(0);
+        AtomicInteger boundsQueries = new AtomicInteger(0);
+        new MockUp<StatisticExecutor>() {
+            @Mock
+            public List<TStatisticData> queryMCV(ConnectContext ctx, String sql) {
+                mcvQueries.incrementAndGet();
+                TStatisticData data = new TStatisticData();
+                data.columnName = "1";
+                data.histogram = "10";
+                return Lists.newArrayList(data);
+            }
+
+            @Mock
+            public List<TStatisticData> executeStatisticDQL(ConnectContext ctx, String sql) {
+                boundsQueries.incrementAndGet();
+                TStatisticData data = new TStatisticData();
+                data.columnName = "0";
+                data.histogram = "4";
+                return Lists.newArrayList(data);
+            }
+        };
+
+        List<String> collectedSql = new ArrayList<>();
+        new MockUp<HistogramStatisticsCollectJob>() {
+            @Mock
+            public void collectStatisticSync(String sql, ConnectContext ctx, AnalyzeStatus status) {
+                collectedSql.add(sql);
+            }
+        };
+
+        // mcv scope
+        histogramStatsWithScopeJob(db, olapTable, "v2", IntegerType.BIGINT, StatsConstants.HISTOGRAM_STATS_SCOPE_MCV)
+                .collect(connectContext, new NativeAnalyzeStatus());
+        Assertions.assertEquals(1, mcvQueries.get());
+        Assertions.assertEquals(1, boundsQueries.get());
+        Assertions.assertEquals(1, collectedSql.size());
+        Assertions.assertTrue(collectedSql.get(0).contains("concat('[[\"0\",\"4\",'"),
+                "stats collection sql is unexpected. The sql is " + collectedSql.get(0));
+        Assertions.assertFalse(collectedSql.get(0).contains("histogram("),
+                "stats collection sql is unexpected. The sql is " + collectedSql.get(0));
+
+        // buckets scope
+        mcvQueries.set(0);
+        boundsQueries.set(0);
+        collectedSql.clear();
+        histogramStatsWithScopeJob(db, olapTable, "v2", IntegerType.BIGINT, StatsConstants.HISTOGRAM_STATS_SCOPE_BUCKETS)
+                .collect(connectContext, new NativeAnalyzeStatus());
+        Assertions.assertEquals(0, mcvQueries.get());
+        Assertions.assertEquals(0, boundsQueries.get());
+        Assertions.assertEquals(1, collectedSql.size());
+        Assertions.assertTrue(collectedSql.get(0).contains("histogram(`column_key`"),
+                "stats collection sql is unexpected. The sql is " + collectedSql.get(0));
+
+        // both scope
+        mcvQueries.set(0);
+        boundsQueries.set(0);
+        collectedSql.clear();
+        histogramStatsWithScopeJob(db, olapTable, "v2", IntegerType.BIGINT, StatsConstants.HISTOGRAM_STATS_SCOPE_BOTH)
+                .collect(connectContext, new NativeAnalyzeStatus());
+        Assertions.assertEquals(1, mcvQueries.get());
+        Assertions.assertEquals(0, boundsQueries.get());
+        Assertions.assertEquals(1, collectedSql.size());
+        Assertions.assertTrue(collectedSql.get(0).contains("histogram(`column_key`"),
+                "stats collection sql is unexpected. The sql is " + collectedSql.get(0));
+    }
+
+    @Test
+    public void testHistogramScopeIsBothAndTypeIsString() throws Exception {
+        // Given a histogram job on a varchar column with the both stats scope
+        // CASE WHEN the column is char-family THEN the bucket collection is skipped and one placeholder bucket carries
+        //      the row count next to the MCVs END
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable olapTable =
+                (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t0_stats");
+
+        AtomicInteger mcvQueries = new AtomicInteger(0);
+        AtomicInteger boundsQueries = new AtomicInteger(0);
+        new MockUp<StatisticExecutor>() {
+            @Mock
+            public List<TStatisticData> queryMCV(ConnectContext ctx, String sql) {
+                mcvQueries.incrementAndGet();
+                TStatisticData data = new TStatisticData();
+                data.columnName = "1";
+                data.histogram = "10";
+                return Lists.newArrayList(data);
+            }
+
+            @Mock
+            public List<TStatisticData> executeStatisticDQL(ConnectContext ctx, String sql) {
+                boundsQueries.incrementAndGet();
+                return Lists.newArrayList();
+            }
+        };
+
+        List<String> collectedSql = new ArrayList<>();
+        new MockUp<HistogramStatisticsCollectJob>() {
+            @Mock
+            public void collectStatisticSync(String sql, ConnectContext ctx, AnalyzeStatus status) {
+                collectedSql.add(sql);
+            }
+        };
+
+        histogramStatsWithScopeJob(db, olapTable, "v2", VarcharType.VARCHAR, StatsConstants.HISTOGRAM_STATS_SCOPE_BOTH)
+                .collect(connectContext, new NativeAnalyzeStatus());
+
+        Assertions.assertEquals(1, mcvQueries.get());
+        Assertions.assertEquals(0, boundsQueries.get());
+        Assertions.assertEquals(1, collectedSql.size());
+        Assertions.assertTrue(collectedSql.get(0).contains("concat('[[\"Infinity\",\"Infinity\",'"), collectedSql.get(0));
+        // 10 / 0.1 - collectMostCommonValues scales the sampled MCV count back to full-table.
+        Assertions.assertTrue(collectedSql.get(0).contains("'[[\"1\",\"100\"]]'"), collectedSql.get(0));
+        Assertions.assertFalse(collectedSql.get(0).contains("histogram("), collectedSql.get(0));
+    }
+
+    @Test
+    public void testHistogramScopeIsBucketsAndTypeIsString() throws Exception {
+        // Given a histogram job on a varchar column with the buckets stats scope
+        // CASE WHEN the column is char-family THEN no query of either kind runs and the placeholder bucket replaces the
+        //      aggregate END
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable olapTable =
+                (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t0_stats");
+
+        AtomicInteger mcvQueries = new AtomicInteger(0);
+        AtomicInteger boundsQueries = new AtomicInteger(0);
+        new MockUp<StatisticExecutor>() {
+            @Mock
+            public List<TStatisticData> queryMCV(ConnectContext ctx, String sql) {
+                mcvQueries.incrementAndGet();
+                TStatisticData data = new TStatisticData();
+                data.columnName = "1";
+                data.histogram = "10";
+                return Lists.newArrayList(data);
+            }
+
+            @Mock
+            public List<TStatisticData> executeStatisticDQL(ConnectContext ctx, String sql) {
+                boundsQueries.incrementAndGet();
+                return Lists.newArrayList();
+            }
+        };
+
+        List<String> collectedSql = new ArrayList<>();
+        new MockUp<HistogramStatisticsCollectJob>() {
+            @Mock
+            public void collectStatisticSync(String sql, ConnectContext ctx, AnalyzeStatus status) {
+                collectedSql.add(sql);
+            }
+        };
+
+        histogramStatsWithScopeJob(db, olapTable, "v2", VarcharType.VARCHAR, StatsConstants.HISTOGRAM_STATS_SCOPE_BUCKETS)
+                .collect(connectContext, new NativeAnalyzeStatus());
+
+        Assertions.assertEquals(0, mcvQueries.get());
+        Assertions.assertEquals(0, boundsQueries.get());
+        Assertions.assertEquals(1, collectedSql.size());
+        Assertions.assertTrue(collectedSql.get(0).contains("concat('[[\"Infinity\",\"Infinity\",'"), collectedSql.get(0));
+        Assertions.assertFalse(collectedSql.get(0).contains("histogram("), collectedSql.get(0));
+    }
+
+    @Test
+    public void testExternalHistogramMcvScopeSkipsBucketAggregate() throws Exception {
+        // Given an external histogram job on an int column with the mcv stats scope
+        // CASE WHEN the scope excludes buckets THEN the MCV and bounds queries run in place of the bucket aggregate,
+        //      and the stored row holds a single bucket spanning the sampled bounds END
+
+        Table region = connectContext.getGlobalStateMgr().getMetadataMgr()
+                .getTable(connectContext, "hive0", "tpch", "region");
+        Database db = connectContext.getGlobalStateMgr().getMetadataMgr().getDb(connectContext, "hive0", "tpch");
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(StatsConstants.HISTOGRAM_SAMPLE_RATIO, "0.1");
+        properties.put(StatsConstants.HISTOGRAM_BUCKET_NUM, "64");
+        properties.put(StatsConstants.HISTOGRAM_MCV_SIZE, "100");
+        properties.put(StatsConstants.HISTOGRAM_STATS_SCOPE, StatsConstants.HISTOGRAM_STATS_SCOPE_MCV);
+
+        ExternalHistogramStatisticsCollectJob job = new ExternalHistogramStatisticsCollectJob(
+                "hive0", db, region, Lists.newArrayList("r_regionkey"), Lists.newArrayList(IntegerType.INT),
+                StatsConstants.AnalyzeType.HISTOGRAM, StatsConstants.ScheduleType.ONCE, properties);
+        List<String> queriedSql = new ArrayList<>();
+
+        new MockUp<StatisticExecutor>() {
+            @Mock
+            public List<TStatisticData> queryMCV(ConnectContext ctx, String sql) {
+                queriedSql.add(sql);
+                TStatisticData data = new TStatisticData();
+                data.columnName = "1";
+                data.histogram = "10";
+                return Lists.newArrayList(data);
+            }
+
+            @Mock
+            public List<TStatisticData> executeStatisticDQL(ConnectContext ctx, String sql) {
+                queriedSql.add(sql);
+                TStatisticData data = new TStatisticData();
+                data.columnName = "0";
+                data.histogram = "4";
+                return Lists.newArrayList(data);
+            }
+
+            @Mock
+            public boolean dropExternalHistogramRawColumn(ConnectContext ctx, String tableUUID, String columnName) {
+                return true;
+            }
+        };
+
+        List<String> collectedSql = new ArrayList<>();
+        new MockUp<ExternalHistogramStatisticsCollectJob>() {
+            @Mock
+            public void collectStatisticSync(String sql, ConnectContext ctx, AnalyzeStatus status) {
+                collectedSql.add(sql);
+            }
+        };
+
+        job.collect(connectContext, new ExternalAnalyzeStatus(1, "hive0", "tpch", "region", region.getUUID(),
+                Lists.newArrayList("r_regionkey"), StatsConstants.AnalyzeType.HISTOGRAM,
+                StatsConstants.ScheduleType.ONCE, Maps.newHashMap(), LocalDateTime.now()));
+
+        Assertions.assertEquals(2, queriedSql.size());
+        Assertions.assertTrue(queriedSql.get(1).contains("IFNULL(MIN(`column_key`), '')"), queriedSql.get(1));
+        Assertions.assertEquals(1, collectedSql.size());
+        Assertions.assertTrue(collectedSql.get(0).contains("concat('[[\"0\",\"4\",'"), collectedSql.get(0));
+        Assertions.assertFalse(collectedSql.get(0).contains("histogram("), collectedSql.get(0));
+    }
+
+    @Test
+    public void testExternalHistogramBothScopeCollectsMcvAndBuckets() throws Exception {
+        // Given an external histogram job on an int column with the both stats scope
+        // CASE WHEN the scope covers MCVs and buckets THEN the MCV query runs, the bounds query does not, and the
+        //      sorted aggregate runs with the MCVs excluded END
+
+        Table region = connectContext.getGlobalStateMgr().getMetadataMgr()
+                .getTable(connectContext, "hive0", "tpch", "region");
+        Database db = connectContext.getGlobalStateMgr().getMetadataMgr().getDb(connectContext, "hive0", "tpch");
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(StatsConstants.HISTOGRAM_SAMPLE_RATIO, "0.1");
+        properties.put(StatsConstants.HISTOGRAM_BUCKET_NUM, "64");
+        properties.put(StatsConstants.HISTOGRAM_MCV_SIZE, "100");
+        properties.put(StatsConstants.HISTOGRAM_STATS_SCOPE, StatsConstants.HISTOGRAM_STATS_SCOPE_BOTH);
+
+        ExternalHistogramStatisticsCollectJob job = new ExternalHistogramStatisticsCollectJob(
+                "hive0", db, region, Lists.newArrayList("r_regionkey"), Lists.newArrayList(IntegerType.INT),
+                StatsConstants.AnalyzeType.HISTOGRAM, StatsConstants.ScheduleType.ONCE, properties);
+
+        AtomicInteger mcvQueries = new AtomicInteger(0);
+        AtomicInteger boundsQueries = new AtomicInteger(0);
+        new MockUp<StatisticExecutor>() {
+            @Mock
+            public List<TStatisticData> queryMCV(ConnectContext ctx, String sql) {
+                mcvQueries.incrementAndGet();
+                TStatisticData data = new TStatisticData();
+                data.columnName = "1";
+                data.histogram = "10";
+                return Lists.newArrayList(data);
+            }
+
+            @Mock
+            public List<TStatisticData> executeStatisticDQL(ConnectContext ctx, String sql) {
+                boundsQueries.incrementAndGet();
+                return Lists.newArrayList();
+            }
+
+            @Mock
+            public boolean dropExternalHistogramRawColumn(ConnectContext ctx, String tableUUID, String columnName) {
+                return true;
+            }
+        };
+
+        List<String> collectedSql = new ArrayList<>();
+        new MockUp<ExternalHistogramStatisticsCollectJob>() {
+            @Mock
+            public void collectStatisticSync(String sql, ConnectContext ctx, AnalyzeStatus status) {
+                collectedSql.add(sql);
+            }
+        };
+
+        job.collect(connectContext, new ExternalAnalyzeStatus(4, "hive0", "tpch", "region", region.getUUID(),
+                Lists.newArrayList("r_regionkey"), StatsConstants.AnalyzeType.HISTOGRAM,
+                StatsConstants.ScheduleType.ONCE, Maps.newHashMap(), LocalDateTime.now()));
+
+        Assertions.assertEquals(1, mcvQueries.get());
+        Assertions.assertEquals(0, boundsQueries.get());
+        Assertions.assertEquals(1, collectedSql.size());
+        Assertions.assertTrue(collectedSql.get(0).contains("histogram(`column_key`"), collectedSql.get(0));
+        Assertions.assertTrue(collectedSql.get(0).contains("'[[\"1\",\"10\"]]'"), collectedSql.get(0));
+    }
+
+    @Test
+    public void testExternalHistogramBucketsScopeSkipsMcvQuery() throws Exception {
+        // Given an external histogram job on an int column with the buckets stats scope
+        // CASE WHEN the scope excludes MCVs THEN neither the MCV nor the bounds query run
+        // and histogram func is called END
+        Table region = connectContext.getGlobalStateMgr().getMetadataMgr()
+                .getTable(connectContext, "hive0", "tpch", "region");
+        Database db = connectContext.getGlobalStateMgr().getMetadataMgr().getDb(connectContext, "hive0", "tpch");
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(StatsConstants.HISTOGRAM_SAMPLE_RATIO, "0.1");
+        properties.put(StatsConstants.HISTOGRAM_BUCKET_NUM, "64");
+        properties.put(StatsConstants.HISTOGRAM_MCV_SIZE, "100");
+        properties.put(StatsConstants.HISTOGRAM_STATS_SCOPE, StatsConstants.HISTOGRAM_STATS_SCOPE_BUCKETS);
+
+        ExternalHistogramStatisticsCollectJob job = new ExternalHistogramStatisticsCollectJob(
+                "hive0", db, region, Lists.newArrayList("r_regionkey"), Lists.newArrayList(IntegerType.INT),
+                StatsConstants.AnalyzeType.HISTOGRAM, StatsConstants.ScheduleType.ONCE, properties);
+
+        AtomicInteger queryCalls = new AtomicInteger(0);
+        new MockUp<StatisticExecutor>() {
+            @Mock
+            public List<TStatisticData> queryMCV(ConnectContext ctx, String sql) {
+                queryCalls.incrementAndGet();
+                return Lists.newArrayList();
+            }
+
+            @Mock
+            public List<TStatisticData> executeStatisticDQL(ConnectContext ctx, String sql) {
+                queryCalls.incrementAndGet();
+                return Lists.newArrayList();
+            }
+
+            @Mock
+            public boolean dropExternalHistogramRawColumn(ConnectContext ctx, String tableUUID, String columnName) {
+                return true;
+            }
+        };
+
+        List<String> collectedSql = new ArrayList<>();
+        new MockUp<ExternalHistogramStatisticsCollectJob>() {
+            @Mock
+            public void collectStatisticSync(String sql, ConnectContext ctx, AnalyzeStatus status) {
+                collectedSql.add(sql);
+            }
+        };
+
+        job.collect(connectContext, new ExternalAnalyzeStatus(2, "hive0", "tpch", "region", region.getUUID(),
+                Lists.newArrayList("r_regionkey"), StatsConstants.AnalyzeType.HISTOGRAM,
+                StatsConstants.ScheduleType.ONCE, Maps.newHashMap(), LocalDateTime.now()));
+
+        Assertions.assertEquals(0, queryCalls.get());
+        Assertions.assertEquals(1, collectedSql.size());
+        Assertions.assertTrue(collectedSql.get(0).contains("histogram(`column_key`"), collectedSql.get(0));
+    }
+
+    @Test
+    public void testExternalHistogramBothScopeSkipsBucketQueryForStringColumns() throws Exception {
+        // Given an external histogram job on a varchar column with the both stats scope
+        // CASE WHEN the column is char-family THEN the bucket aggregate is skipped and one placeholder bucket carries
+        //      the row count next to the MCVs ELSE the sorted aggregate runs END
+
+        Table region = connectContext.getGlobalStateMgr().getMetadataMgr()
+                .getTable(connectContext, "hive0", "tpch", "region");
+        Database db = connectContext.getGlobalStateMgr().getMetadataMgr().getDb(connectContext, "hive0", "tpch");
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(StatsConstants.HISTOGRAM_SAMPLE_RATIO, "0.1");
+        properties.put(StatsConstants.HISTOGRAM_BUCKET_NUM, "64");
+        properties.put(StatsConstants.HISTOGRAM_MCV_SIZE, "100");
+        properties.put(StatsConstants.HISTOGRAM_STATS_SCOPE, StatsConstants.HISTOGRAM_STATS_SCOPE_BOTH);
+
+        ExternalHistogramStatisticsCollectJob job = new ExternalHistogramStatisticsCollectJob(
+                "hive0", db, region, Lists.newArrayList("r_name"), Lists.newArrayList(VarcharType.VARCHAR),
+                StatsConstants.AnalyzeType.HISTOGRAM, StatsConstants.ScheduleType.ONCE, properties);
+
+        AtomicInteger mcvQueries = new AtomicInteger(0);
+        AtomicInteger boundsQueries = new AtomicInteger(0);
+        new MockUp<StatisticExecutor>() {
+            @Mock
+            public List<TStatisticData> queryMCV(ConnectContext ctx, String sql) {
+                mcvQueries.incrementAndGet();
+                TStatisticData data = new TStatisticData();
+                data.columnName = "AFRICA";
+                data.histogram = "10";
+                return Lists.newArrayList(data);
+            }
+
+            @Mock
+            public List<TStatisticData> executeStatisticDQL(ConnectContext ctx, String sql) {
+                boundsQueries.incrementAndGet();
+                return Lists.newArrayList();
+            }
+
+            @Mock
+            public boolean dropExternalHistogramRawColumn(ConnectContext ctx, String tableUUID, String columnName) {
+                return true;
+            }
+        };
+
+        List<String> collectedSql = new ArrayList<>();
+        new MockUp<ExternalHistogramStatisticsCollectJob>() {
+            @Mock
+            public void collectStatisticSync(String sql, ConnectContext ctx, AnalyzeStatus status) {
+                collectedSql.add(sql);
+            }
+        };
+
+        job.collect(connectContext, new ExternalAnalyzeStatus(5, "hive0", "tpch", "region", region.getUUID(),
+                Lists.newArrayList("r_name"), StatsConstants.AnalyzeType.HISTOGRAM,
+                StatsConstants.ScheduleType.ONCE, Maps.newHashMap(), LocalDateTime.now()));
+
+        Assertions.assertEquals(1, mcvQueries.get());
+        Assertions.assertEquals(0, boundsQueries.get());
+        Assertions.assertEquals(1, collectedSql.size());
+        Assertions.assertTrue(collectedSql.get(0).contains("concat('[[\"Infinity\",\"Infinity\",'"), collectedSql.get(0));
+        Assertions.assertTrue(collectedSql.get(0).contains("'[[\"AFRICA\",\"10\"]]'"), collectedSql.get(0));
+        Assertions.assertFalse(collectedSql.get(0).contains("histogram("), collectedSql.get(0));
+    }
+
+    @Test
+    public void testExternalHistogramBucketsScopeStoresPlaceholderWithoutMcvForStringColumns() throws Exception {
+        // Given an external histogram job on a varchar column with the buckets stats scope
+        // CASE WHEN the column is char-family THEN no query of either kind runs and the placeholder bucket replaces the
+        //      aggregate END
+
+        Table region = connectContext.getGlobalStateMgr().getMetadataMgr()
+                .getTable(connectContext, "hive0", "tpch", "region");
+        Database db = connectContext.getGlobalStateMgr().getMetadataMgr().getDb(connectContext, "hive0", "tpch");
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(StatsConstants.HISTOGRAM_SAMPLE_RATIO, "0.1");
+        properties.put(StatsConstants.HISTOGRAM_BUCKET_NUM, "64");
+        properties.put(StatsConstants.HISTOGRAM_MCV_SIZE, "100");
+        properties.put(StatsConstants.HISTOGRAM_STATS_SCOPE, StatsConstants.HISTOGRAM_STATS_SCOPE_BUCKETS);
+
+        ExternalHistogramStatisticsCollectJob job = new ExternalHistogramStatisticsCollectJob(
+                "hive0", db, region, Lists.newArrayList("r_name"), Lists.newArrayList(VarcharType.VARCHAR),
+                StatsConstants.AnalyzeType.HISTOGRAM, StatsConstants.ScheduleType.ONCE, properties);
+
+        AtomicInteger queryCalls = new AtomicInteger(0);
+        new MockUp<StatisticExecutor>() {
+            @Mock
+            public List<TStatisticData> queryMCV(ConnectContext ctx, String sql) {
+                queryCalls.incrementAndGet();
+                return Lists.newArrayList();
+            }
+
+            @Mock
+            public List<TStatisticData> executeStatisticDQL(ConnectContext ctx, String sql) {
+                queryCalls.incrementAndGet();
+                return Lists.newArrayList();
+            }
+
+            @Mock
+            public boolean dropExternalHistogramRawColumn(ConnectContext ctx, String tableUUID, String columnName) {
+                return true;
+            }
+        };
+
+        List<String> collectedSql = new ArrayList<>();
+        new MockUp<ExternalHistogramStatisticsCollectJob>() {
+            @Mock
+            public void collectStatisticSync(String sql, ConnectContext ctx, AnalyzeStatus status) {
+                collectedSql.add(sql);
+            }
+        };
+
+        job.collect(connectContext, new ExternalAnalyzeStatus(6, "hive0", "tpch", "region", region.getUUID(),
+                Lists.newArrayList("r_name"), StatsConstants.AnalyzeType.HISTOGRAM,
+                StatsConstants.ScheduleType.ONCE, Maps.newHashMap(), LocalDateTime.now()));
+
+        Assertions.assertEquals(0, queryCalls.get());
+        Assertions.assertEquals(1, collectedSql.size());
+        Assertions.assertTrue(collectedSql.get(0).contains("concat('[[\"Infinity\",\"Infinity\",'"), collectedSql.get(0));
+        Assertions.assertFalse(collectedSql.get(0).contains("histogram("), collectedSql.get(0));
     }
 
     @Test
@@ -1547,7 +2080,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                         StatsConstants.ScheduleType.ONCE,
                         Maps.newHashMap());
 
-        List<List<String>> collectSqlList =  collectJob.buildCollectSQLList(1);
+        List<List<String>> collectSqlList = collectJob.buildCollectSQLList(1);
         assertContains(collectSqlList.get(0).toString(), "date` = '2020-01-01'");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Pair;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.expression.Expr;
@@ -34,6 +35,7 @@ import com.starrocks.statistic.sample.PrimitiveTypeColumnStats;
 import com.starrocks.statistic.sample.SampleInfo;
 import com.starrocks.statistic.sample.TabletSampleManager;
 import com.starrocks.type.ArrayType;
+import com.starrocks.type.BooleanType;
 import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.JsonType;
@@ -52,6 +54,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class StatisticsSQLTest extends PlanTestBase {
@@ -289,25 +292,100 @@ public class StatisticsSQLTest extends PlanTestBase {
     }
 
     @Test
-    public void testExternalHistogramSkipsBucketQueryForStringColumns() throws Exception {
+    public void testExternalHistogramMcvScopeUsesSingleSampledBucket() throws Exception {
         Table region = GlobalStateMgr.getCurrentState().getMetadataMgr()
                 .getTable(connectContext, "hive0", "tpch", "region");
         Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(connectContext, "hive0", "tpch");
 
-        ExternalHistogramStatisticsCollectJob job = new ExternalHistogramStatisticsCollectJob(
-                "hive0", db, region, Lists.newArrayList("r_name"), Lists.<Type>newArrayList(VarcharType.VARCHAR),
-                StatsConstants.AnalyzeType.HISTOGRAM, StatsConstants.ScheduleType.ONCE, Maps.newHashMap());
+        ExternalHistogramStatisticsCollectJob job = newMcvScopeRegionJob(db, region);
 
-        String sql = Deencapsulation.invoke(job, "buildCollectHistogram",
-                db, region, 0.1, 10L, ImmutableMap.of("a", "10"), "r_name", VarcharType.VARCHAR);
+        String sql = Deencapsulation.invoke(job, "buildCollectSingleBucket",
+                db, region, ImmutableMap.of("1", "10"), "r_regionkey",
+                Optional.of(Pair.create("0", "4")));
 
-        Assertions.assertTrue(sql.contains("concat('[[\"Infinity\",\"Infinity\",', " +
-                "cast(greatest(0, count(`r_name`) - 10) as varchar), ',0]]')"), sql);
+        Assertions.assertTrue(sql.contains("concat('[[\"0\",\"4\",', " +
+                "cast(greatest(0, count(`r_regionkey`) - 10) as varchar), ',0]]')"), sql);
+        Assertions.assertTrue(sql.contains("'[[\"1\",\"10\"]]'"), sql);
         Assertions.assertTrue(sql.contains("FROM `hive0`.`tpch`.`region`"), sql);
         Assertions.assertFalse(sql.contains("histogram("), sql);
         Assertions.assertFalse(sql.toLowerCase().contains("order by"), sql);
-        Assertions.assertFalse(sql.toLowerCase().contains("is not null"), sql);
-        Assertions.assertFalse(sql.toLowerCase().contains("sample("), sql);
+
+        starRocksAssert.useDatabase("_statistics_");
+        String plan = getFragmentPlan(sql.substring(sql.indexOf("SELECT")));
+        assertCContains(plan, "TABLE: region");
+    }
+
+    @Test
+    public void testExternalHistogramSampleMinMaxSQL() throws Exception {
+        Table region = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                .getTable(connectContext, "hive0", "tpch", "region");
+        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(connectContext, "hive0", "tpch");
+
+        ExternalHistogramStatisticsCollectJob job = newMcvScopeRegionJob(db, region);
+
+        String sql = Deencapsulation.invoke(job, "buildSampleMinMax",
+                db, region, "r_regionkey", IntegerType.INT, 0.1);
+
+        Assertions.assertTrue(sql.contains("cast(IFNULL(MIN(`column_key`), '') as varchar)"), sql);
+        Assertions.assertTrue(sql.contains("cast(IFNULL(MAX(`column_key`), '') as varchar)"), sql);
+        Assertions.assertTrue(sql.contains("where rand() <= 0.1 and `r_regionkey` is not null"), sql);
+        // ORDER BY would bias MAX towards the smallest sampled rows, and the bucket aggregate is what we are avoiding.
+        Assertions.assertFalse(sql.toLowerCase().contains("order by"), sql);
+        Assertions.assertFalse(sql.contains("histogram("), sql);
+
+        starRocksAssert.useDatabase("_statistics_");
+        String plan = getFragmentPlan(sql);
+        assertCContains(plan, "TABLE: region");
+        Assertions.assertTrue(plan.contains("min(") && plan.contains("max("), plan);
+    }
+
+    @Test
+    public void testExternalHistogramSampleMinMaxSQLForDateColumn() throws Exception {
+        Table orders = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                .getTable(connectContext, "hive0", "tpch", "orders");
+        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(connectContext, "hive0", "tpch");
+
+        ExternalHistogramStatisticsCollectJob job = new ExternalHistogramStatisticsCollectJob(
+                "hive0", db, orders, Lists.newArrayList("o_orderdate"), Lists.<Type>newArrayList(DateType.DATE),
+                StatsConstants.AnalyzeType.HISTOGRAM, StatsConstants.ScheduleType.ONCE,
+                ImmutableMap.of(StatsConstants.HISTOGRAM_STATS_SCOPE, StatsConstants.HISTOGRAM_STATS_SCOPE_MCV));
+
+        String sql = Deencapsulation.invoke(job, "buildSampleMinMax",
+                db, orders, "o_orderdate", DateType.DATE, 0.1);
+
+        Assertions.assertTrue(sql.contains("cast(IFNULL(MIN(`column_key`), '') as varchar)"), sql);
+
+        // IFNULL mixes DATE with a VARCHAR literal, so the real check is that this still analyzes and plans.
+        starRocksAssert.useDatabase("_statistics_");
+        String plan = getFragmentPlan(sql);
+        assertCContains(plan, "TABLE: orders");
+        Assertions.assertTrue(plan.contains("min(") && plan.contains("max("), plan);
+    }
+
+    @Test
+    public void testExternalHistogramSampleMinMaxSkipsUnparseableTypes() throws Exception {
+        Table region = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                .getTable(connectContext, "hive0", "tpch", "region");
+        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(connectContext, "hive0", "tpch");
+
+        ExternalHistogramStatisticsCollectJob job = newMcvScopeRegionJob(db, region);
+
+        // Char-family and boolean bounds cannot be read back (Double.parseDouble on "AFRICA" / "TRUE" throws), so
+        // sampleColumnMinMax refuses them before it even runs the MIN/MAX query - which is why the bucket builder
+        // no longer re-checks.
+        for (Type unparseable : Lists.<Type>newArrayList(VarcharType.VARCHAR, BooleanType.BOOLEAN)) {
+            Optional<Pair<String, String>> bounds = Deencapsulation.invoke(job, "sampleColumnMinMax",
+                    connectContext, new StatisticExecutor(), "r_name", unparseable, 0.1);
+
+            Assertions.assertTrue(bounds.isEmpty());
+        }
+    }
+
+    private static ExternalHistogramStatisticsCollectJob newMcvScopeRegionJob(Database db, Table region) {
+        return new ExternalHistogramStatisticsCollectJob(
+                "hive0", db, region, Lists.newArrayList("r_regionkey"), Lists.<Type>newArrayList(IntegerType.INT),
+                StatsConstants.AnalyzeType.HISTOGRAM, StatsConstants.ScheduleType.ONCE,
+                ImmutableMap.of(StatsConstants.HISTOGRAM_STATS_SCOPE, StatsConstants.HISTOGRAM_STATS_SCOPE_MCV));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
@@ -255,6 +255,97 @@ public class StatisticsSQLTest extends PlanTestBase {
     }
 
     @Test
+    public void testHistogramMcvScopeUsesSingleSampledBucket() throws Exception {
+        // Given a histogram job whose scope excludes buckets
+        // WHEN sampled bounds are available THEN the single bucket spans them and carries the non-MCV 
+        // row count END
+
+        Table t0 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTable("stat0");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+
+        HistogramStatisticsCollectJob job = mcvOnlyHistogramJob(db, t0, "v1", IntegerType.BIGINT);
+
+        String sql = Deencapsulation.invoke(job, "buildCollectSingleBucket",
+                db, t0, 0.1, ImmutableMap.of("1", "10", "2", "20"), "v1",
+                Optional.of(Pair.create("1", "100")));
+
+        // 10 + 20 MCV rows are excluded from the bucket, and count() is divided by the sample ratio.
+        Assertions.assertTrue(sql.contains("concat('[[\"1\",\"100\",', " +
+                "cast(cast(greatest(0, count(`v1`) / cast(0.1 as double) - 30) as bigint) as varchar), ',0]]')"), sql);
+        Assertions.assertTrue(sql.contains("'[[\"1\",\"10\"],[\"2\",\"20\"]]'"), sql);
+        Assertions.assertFalse(sql.contains("histogram("), sql);
+    }
+
+    @Test
+    public void testHistogramSingleBucketUsesPlaceholderBoundsForStringColumn() throws Exception {
+        // Given a histogram job on a char-family column THEN no MIN/MAX query runs and the single bucket
+        //      falls back to the infinite placeholder bounds END
+
+        Table t0 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTable("stat0");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+
+        HistogramStatisticsCollectJob job = mcvOnlyHistogramJob(db, t0, "s1", StringType.STRING);
+
+        Optional<Pair<String, String>> bounds = Deencapsulation.invoke(job, "sampleColumnMinMax",
+                connectContext, new StatisticExecutor(), "s1", StringType.STRING, 0.1);
+        Assertions.assertTrue(bounds.isEmpty());
+
+        String sql = Deencapsulation.invoke(job, "buildCollectSingleBucket",
+                db, t0, 0.1, ImmutableMap.of("a", "10"), "s1", bounds);
+
+        Assertions.assertTrue(sql.contains("concat('[[\"Infinity\",\"Infinity\",', " +
+                "cast(cast(greatest(0, count(`s1`) / cast(0.1 as double) - 10) as bigint) as varchar), ',0]]')"), sql);
+        Assertions.assertFalse(sql.contains("histogram("), sql);
+    }
+
+    @Test
+    public void testHistogramSampleMinMaxSQL() throws Exception {
+        // Given a histogram job whose scope excludes buckets
+        // THEN the bucket bounds come from a sampled MIN/MAX over the column END
+
+        Table t0 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTable("stat0");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+
+        HistogramStatisticsCollectJob job = mcvOnlyHistogramJob(db, t0, "v1", IntegerType.BIGINT);
+
+        String sql = Deencapsulation.invoke(job, "buildSampleMinMax",
+                db, t0, "v1", IntegerType.BIGINT, 0.1);
+
+        Assertions.assertTrue(sql.contains("cast(" + StatsConstants.STATISTIC_HISTOGRAM_VERSION + " as INT)"), sql);
+        Assertions.assertTrue(sql.contains("cast(IFNULL(MIN(`column_key`), '') as varchar)"), sql);
+        Assertions.assertTrue(sql.contains("cast(IFNULL(MAX(`column_key`), '') as varchar)"), sql);
+        Assertions.assertTrue(sql.contains("SAMPLE('percent'='10')"), sql);
+    }
+
+    @Test
+    public void testHistogramSampleMinMaxSQLForDateAndDatetimeColumns() throws Exception {
+        // Given a histogram job on a date or datetime column
+        // THEN the bucket bounds are sampled and are not hardcoded to infinity END
+
+        Table t0 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getTable("stat0");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+
+        for (Pair<String, Type> column : ImmutableList.of(
+                Pair.create("v4", (Type) DateType.DATE), Pair.create("v5", (Type) DateType.DATETIME))) {
+            HistogramStatisticsCollectJob job = mcvOnlyHistogramJob(db, t0, column.first, column.second);
+
+            String sql = Deencapsulation.invoke(job, "buildSampleMinMax",
+                    db, t0, column.first, column.second, 0.1);
+
+            Assertions.assertTrue(sql.contains("cast(IFNULL(MIN(`column_key`), '') as varchar)"), sql);
+            Assertions.assertTrue(sql.contains("cast(IFNULL(MAX(`column_key`), '') as varchar)"), sql);
+
+        }
+    }
+
+    private static HistogramStatisticsCollectJob mcvOnlyHistogramJob(Database db, Table table, String columnName,
+                                                                     Type columnType) {
+        return new HistogramStatisticsCollectJob(db, table, Lists.newArrayList(columnName),
+                Lists.newArrayList(columnType), StatsConstants.ScheduleType.ONCE,
+                ImmutableMap.of(StatsConstants.HISTOGRAM_STATS_SCOPE, StatsConstants.HISTOGRAM_STATS_SCOPE_MCV));
+    }
+
+    @Test
     public void testHiveHistogramStatisticsSQLWithStruct() throws Exception {
         Table t0 = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(connectContext, "hive0", "subfield_db",
                 "subfield");
@@ -297,7 +388,7 @@ public class StatisticsSQLTest extends PlanTestBase {
                 .getTable(connectContext, "hive0", "tpch", "region");
         Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(connectContext, "hive0", "tpch");
 
-        ExternalHistogramStatisticsCollectJob job = newMcvScopeRegionJob(db, region);
+        ExternalHistogramStatisticsCollectJob job = mcvOnlyExtHistogramJob(db, region);
 
         String sql = Deencapsulation.invoke(job, "buildCollectSingleBucket",
                 db, region, ImmutableMap.of("1", "10"), "r_regionkey",
@@ -308,7 +399,6 @@ public class StatisticsSQLTest extends PlanTestBase {
         Assertions.assertTrue(sql.contains("'[[\"1\",\"10\"]]'"), sql);
         Assertions.assertTrue(sql.contains("FROM `hive0`.`tpch`.`region`"), sql);
         Assertions.assertFalse(sql.contains("histogram("), sql);
-        Assertions.assertFalse(sql.toLowerCase().contains("order by"), sql);
 
         starRocksAssert.useDatabase("_statistics_");
         String plan = getFragmentPlan(sql.substring(sql.indexOf("SELECT")));
@@ -321,7 +411,7 @@ public class StatisticsSQLTest extends PlanTestBase {
                 .getTable(connectContext, "hive0", "tpch", "region");
         Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(connectContext, "hive0", "tpch");
 
-        ExternalHistogramStatisticsCollectJob job = newMcvScopeRegionJob(db, region);
+        ExternalHistogramStatisticsCollectJob job = mcvOnlyExtHistogramJob(db, region);
 
         String sql = Deencapsulation.invoke(job, "buildSampleMinMax",
                 db, region, "r_regionkey", IntegerType.INT, 0.1);
@@ -368,7 +458,7 @@ public class StatisticsSQLTest extends PlanTestBase {
                 .getTable(connectContext, "hive0", "tpch", "region");
         Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(connectContext, "hive0", "tpch");
 
-        ExternalHistogramStatisticsCollectJob job = newMcvScopeRegionJob(db, region);
+        ExternalHistogramStatisticsCollectJob job = mcvOnlyExtHistogramJob(db, region);
 
         // Char-family and boolean bounds cannot be read back (Double.parseDouble on "AFRICA" / "TRUE" throws), so
         // sampleColumnMinMax refuses them before it even runs the MIN/MAX query - which is why the bucket builder
@@ -381,7 +471,7 @@ public class StatisticsSQLTest extends PlanTestBase {
         }
     }
 
-    private static ExternalHistogramStatisticsCollectJob newMcvScopeRegionJob(Database db, Table region) {
+    private static ExternalHistogramStatisticsCollectJob mcvOnlyExtHistogramJob(Database db, Table region) {
         return new ExternalHistogramStatisticsCollectJob(
                 "hive0", db, region, Lists.newArrayList("r_regionkey"), Lists.<Type>newArrayList(IntegerType.INT),
                 StatsConstants.AnalyzeType.HISTOGRAM, StatsConstants.ScheduleType.ONCE,

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
@@ -266,7 +266,7 @@ public class StatisticsSQLTest extends PlanTestBase {
         HistogramStatisticsCollectJob job = mcvOnlyHistogramJob(db, t0, "v1", IntegerType.BIGINT);
 
         String sql = Deencapsulation.invoke(job, "buildCollectSingleBucket",
-                db, t0, 0.1, ImmutableMap.of("1", "10", "2", "20"), "v1",
+                db, t0, 0.1, ImmutableMap.of("1", "10", "2", "20"), "v1", IntegerType.BIGINT,
                 Optional.of(Pair.create("1", "100")));
 
         // 10 + 20 MCV rows are excluded from the bucket, and count() is divided by the sample ratio.
@@ -287,11 +287,12 @@ public class StatisticsSQLTest extends PlanTestBase {
         HistogramStatisticsCollectJob job = mcvOnlyHistogramJob(db, t0, "s1", StringType.STRING);
 
         Optional<Pair<String, String>> bounds = Deencapsulation.invoke(job, "sampleColumnMinMax",
-                connectContext, new StatisticExecutor(), "s1", StringType.STRING, 0.1);
+                connectContext, new StatisticExecutor(), "s1", StringType.STRING, 0.1,
+                ImmutableMap.of("a", "10"));
         Assertions.assertTrue(bounds.isEmpty());
 
         String sql = Deencapsulation.invoke(job, "buildCollectSingleBucket",
-                db, t0, 0.1, ImmutableMap.of("a", "10"), "s1", bounds);
+                db, t0, 0.1, ImmutableMap.of("a", "10"), "s1", StringType.STRING, bounds);
 
         Assertions.assertTrue(sql.contains("concat('[[\"Infinity\",\"Infinity\",', " +
                 "cast(cast(greatest(0, count(`s1`) / cast(0.1 as double) - 10) as bigint) as varchar), ',0]]')"), sql);
@@ -309,12 +310,16 @@ public class StatisticsSQLTest extends PlanTestBase {
         HistogramStatisticsCollectJob job = mcvOnlyHistogramJob(db, t0, "v1", IntegerType.BIGINT);
 
         String sql = Deencapsulation.invoke(job, "buildSampleMinMax",
-                db, t0, "v1", IntegerType.BIGINT, 0.1);
+                db, t0, "v1", IntegerType.BIGINT, 0.1, ImmutableMap.of("1", "10", "2", "20"));
 
         Assertions.assertTrue(sql.contains("cast(" + StatsConstants.STATISTIC_HISTOGRAM_VERSION + " as INT)"), sql);
         Assertions.assertTrue(sql.contains("cast(IFNULL(MIN(`column_key`), '') as varchar)"), sql);
         Assertions.assertTrue(sql.contains("cast(IFNULL(MAX(`column_key`), '') as varchar)"), sql);
         Assertions.assertTrue(sql.contains("SAMPLE('percent'='10')"), sql);
+        // The bucket's count subtracts the MCV rows, so its bounds are sampled over the same population.
+        Assertions.assertTrue(sql.contains("and `v1` not in (1,2)"), sql);
+        // No LIMIT: without an ORDER BY it would bias min/max towards an arbitrary scan-order prefix.
+        Assertions.assertFalse(sql.toLowerCase().contains("limit"), sql);
     }
 
     @Test
@@ -330,7 +335,7 @@ public class StatisticsSQLTest extends PlanTestBase {
             HistogramStatisticsCollectJob job = mcvOnlyHistogramJob(db, t0, column.first, column.second);
 
             String sql = Deencapsulation.invoke(job, "buildSampleMinMax",
-                    db, t0, column.first, column.second, 0.1);
+                    db, t0, column.first, column.second, 0.1, ImmutableMap.of("2020-01-01", "10"));
 
             Assertions.assertTrue(sql.contains("cast(IFNULL(MIN(`column_key`), '') as varchar)"), sql);
             Assertions.assertTrue(sql.contains("cast(IFNULL(MAX(`column_key`), '') as varchar)"), sql);
@@ -391,7 +396,7 @@ public class StatisticsSQLTest extends PlanTestBase {
         ExternalHistogramStatisticsCollectJob job = mcvOnlyExtHistogramJob(db, region);
 
         String sql = Deencapsulation.invoke(job, "buildCollectSingleBucket",
-                db, region, ImmutableMap.of("1", "10"), "r_regionkey",
+                db, region, ImmutableMap.of("1", "10"), "r_regionkey", IntegerType.INT,
                 Optional.of(Pair.create("0", "4")));
 
         Assertions.assertTrue(sql.contains("concat('[[\"0\",\"4\",', " +
@@ -414,11 +419,14 @@ public class StatisticsSQLTest extends PlanTestBase {
         ExternalHistogramStatisticsCollectJob job = mcvOnlyExtHistogramJob(db, region);
 
         String sql = Deencapsulation.invoke(job, "buildSampleMinMax",
-                db, region, "r_regionkey", IntegerType.INT, 0.1);
+                db, region, "r_regionkey", IntegerType.INT, 0.1, ImmutableMap.of("1", "10"));
 
         Assertions.assertTrue(sql.contains("cast(IFNULL(MIN(`column_key`), '') as varchar)"), sql);
         Assertions.assertTrue(sql.contains("cast(IFNULL(MAX(`column_key`), '') as varchar)"), sql);
-        Assertions.assertTrue(sql.contains("where rand() <= 0.1 and `r_regionkey` is not null"), sql);
+        Assertions.assertTrue(sql.contains(
+                "where rand() <= 0.1 and `r_regionkey` is not null  and `r_regionkey` not in (1)"), sql);
+        // No LIMIT: without an ORDER BY it would bias min/max towards an arbitrary scan-order prefix.
+        Assertions.assertFalse(sql.toLowerCase().contains("limit"), sql);
         // ORDER BY would bias MAX towards the smallest sampled rows, and the bucket aggregate is what we are avoiding.
         Assertions.assertFalse(sql.toLowerCase().contains("order by"), sql);
         Assertions.assertFalse(sql.contains("histogram("), sql);
@@ -441,7 +449,7 @@ public class StatisticsSQLTest extends PlanTestBase {
                 ImmutableMap.of(StatsConstants.HISTOGRAM_STATS_SCOPE, StatsConstants.HISTOGRAM_STATS_SCOPE_MCV));
 
         String sql = Deencapsulation.invoke(job, "buildSampleMinMax",
-                db, orders, "o_orderdate", DateType.DATE, 0.1);
+                db, orders, "o_orderdate", DateType.DATE, 0.1, ImmutableMap.of("1993-01-01", "10"));
 
         Assertions.assertTrue(sql.contains("cast(IFNULL(MIN(`column_key`), '') as varchar)"), sql);
 
@@ -465,7 +473,8 @@ public class StatisticsSQLTest extends PlanTestBase {
         // no longer re-checks.
         for (Type unparseable : Lists.<Type>newArrayList(VarcharType.VARCHAR, BooleanType.BOOLEAN)) {
             Optional<Pair<String, String>> bounds = Deencapsulation.invoke(job, "sampleColumnMinMax",
-                    connectContext, new StatisticExecutor(), "r_name", unparseable, 0.1);
+                    connectContext, new StatisticExecutor(), "r_name", unparseable, 0.1,
+                    ImmutableMap.of("AFRICA", "10"));
 
             Assertions.assertTrue(bounds.isEmpty());
         }

--- a/test/sql/test_histogram_stats_collection/R/test_histogram_stats_collection
+++ b/test/sql/test_histogram_stats_collection/R/test_histogram_stats_collection
@@ -1,0 +1,247 @@
+-- name: test_histogram_scope_default
+create database histo_test_${uuid0};
+-- result:
+-- !result
+use histo_test_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t1` (
+    `k_num`  bigint,
+    `k_low`  int,
+    `k_str`  varchar(32)
+)
+PROPERTIES ('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO t1
+SELECT g1, g1 % 20, concat('v_', g1 % 40)
+FROM TABLE(generate_series(1, 5000)) AS t(g1);
+-- result:
+-- !result
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_num PROPERTIES('histogram_sample_ratio' = '1') WITH SYNC MODE;
+select count(1) from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1';
+-- result:
+1
+-- !result
+select mcv is not null, buckets is not null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_num';
+-- result:
+1	1
+-- !result
+drop database histo_test_${uuid0} force;
+-- result:
+-- !result
+
+-- name: test_histogram_scope_mcv
+create database histo_test_${uuid0};
+-- result:
+-- !result
+use histo_test_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t1` (
+    `k_num`  bigint,
+    `k_low`  int,
+    `k_str`  varchar(32)
+)
+PROPERTIES ('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO t1
+SELECT g1, g1 % 20, concat('v_', g1 % 40)
+FROM TABLE(generate_series(1, 5000)) AS t(g1);
+-- result:
+-- !result
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_num PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'mcv') WITH SYNC MODE;
+select mcv is not null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_num';
+-- result:
+1
+-- !result
+select buckets like '[["Infinity"%' from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_num';
+-- result:
+0
+-- !result
+select buckets like '[["1","5000",%' from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_num';
+-- result:
+1
+-- !result
+select json_length(parse_json(buckets)) from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_num';
+-- result:
+1
+-- !result
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_num PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'MCV') WITH SYNC MODE;
+select mcv is not null, buckets like '[["1","5000",%' from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_num';
+-- result:
+1	1
+-- !result
+drop database histo_test_${uuid0} force;
+-- result:
+-- !result
+
+-- name: test_histogram_scope_buckets
+create database histo_test_${uuid0};
+-- result:
+-- !result
+use histo_test_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t1` (
+    `k_num`  bigint,
+    `k_low`  int,
+    `k_str`  varchar(32)
+)
+PROPERTIES ('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO t1
+SELECT g1, g1 % 20, concat('v_', g1 % 40)
+FROM TABLE(generate_series(1, 5000)) AS t(g1);
+-- result:
+-- !result
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_num PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'buckets') WITH SYNC MODE;
+select mcv is null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_num';
+-- result:
+1
+-- !result
+select buckets is not null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_num';
+-- result:
+1
+-- !result
+select json_length(parse_json(buckets)) > 1 from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_num';
+-- result:
+1
+-- !result
+select buckets like '[["Infinity"%' from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_num';
+-- result:
+0
+-- !result
+drop database histo_test_${uuid0} force;
+-- result:
+-- !result
+
+-- name: test_histogram_scope_both
+create database histo_test_${uuid0};
+-- result:
+-- !result
+use histo_test_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t1` (
+    `k_num`  bigint,
+    `k_low`  int,
+    `k_str`  varchar(32)
+)
+PROPERTIES ('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO t1
+SELECT g1, g1 % 20, concat('v_', g1 % 40)
+FROM TABLE(generate_series(1, 5000)) AS t(g1);
+-- result:
+-- !result
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_num PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'both') WITH SYNC MODE;
+select mcv is not null, buckets is not null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_num';
+-- result:
+1	1
+-- !result
+select json_length(parse_json(buckets)) > 1 from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_num';
+-- result:
+1
+-- !result
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_num, k_str PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'both') WITH SYNC MODE;
+[ORDER] select column_name, mcv is not null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' order by column_name;
+-- result:
+k_num	1
+k_str	1
+-- !result
+drop database histo_test_${uuid0} force;
+-- result:
+-- !result
+
+-- name: test_histogram_scope_low_cardinality
+create database histo_test_${uuid0};
+-- result:
+-- !result
+use histo_test_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t1` (
+    `k_num`  bigint,
+    `k_low`  int,
+    `k_str`  varchar(32)
+)
+PROPERTIES ('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO t1
+SELECT g1, g1 % 20, concat('v_', g1 % 40)
+FROM TABLE(generate_series(1, 5000)) AS t(g1);
+-- result:
+-- !result
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_low PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'both') WITH SYNC MODE;
+select mcv is not null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_low';
+-- result:
+1
+-- !result
+select buckets is null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_low';
+-- result:
+1
+-- !result
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_low PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'buckets') WITH SYNC MODE;
+select mcv is null, buckets is not null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_low';
+-- result:
+1	1
+-- !result
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_low PROPERTIES('histogram_sample_ratio' = '1', 'histogram_mcv_size' = '5', 'histogram_stats_scope' = 'both') WITH SYNC MODE;
+select mcv is not null, buckets is not null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_low';
+-- result:
+1	1
+-- !result
+drop database histo_test_${uuid0} force;
+-- result:
+-- !result
+
+-- name: test_histogram_scope_varchar
+create database histo_test_${uuid0};
+-- result:
+-- !result
+use histo_test_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t1` (
+    `k_num`  bigint,
+    `k_low`  int,
+    `k_str`  varchar(32)
+)
+PROPERTIES ('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO t1
+SELECT g1, g1 % 20, concat('v_', g1 % 40)
+FROM TABLE(generate_series(1, 5000)) AS t(g1);
+-- result:
+-- !result
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_str PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'mcv') WITH SYNC MODE;
+select mcv is not null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_str';
+-- result:
+1
+-- !result
+select buckets like '[["Infinity","Infinity",%' from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_str';
+-- result:
+1
+-- !result
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_str PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'buckets') WITH SYNC MODE;
+select mcv is null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_str';
+-- result:
+1
+-- !result
+select buckets like '[["Infinity","Infinity",%' from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_str';
+-- result:
+1
+-- !result
+select buckets = '[["Infinity","Infinity",5000,0]]' from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_str';
+-- result:
+1
+-- !result
+drop database histo_test_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_histogram_stats_collection/T/test_histogram_stats_collection
+++ b/test/sql/test_histogram_stats_collection/T/test_histogram_stats_collection
@@ -1,0 +1,209 @@
+-- name: test_histogram_scope_default
+
+create database histo_test_${uuid0};
+use histo_test_${uuid0};
+
+-- k_num: 5000 distinct values, above histogram_mcv_size (100), so MCV exclusion
+--        leaves rows behind and the histogram() aggregate produces real buckets.
+-- k_low: 20 distinct values, below histogram_mcv_size, so the MCVs cover every
+--        value and the bucket subquery ends up empty.
+-- k_str: char family, which always takes the placeholder bucket path.
+CREATE TABLE `t1` (
+    `k_num`  bigint,
+    `k_low`  int,
+    `k_str`  varchar(32)
+)
+PROPERTIES ('replication_num' = '1');
+
+INSERT INTO t1
+SELECT g1, g1 % 20, concat('v_', g1 % 40)
+FROM TABLE(generate_series(1, 5000)) AS t(g1);
+
+-- histogram_sample_ratio is pinned to 1 in every ANALYZE below. The analyzer already
+-- rewrites it to 1 for tables under statistic_sample_collect_rows rows, but only when
+-- the table's reported row count is non-zero, and that count lags tablet reports right
+-- after an INSERT. Passing it explicitly keeps the collected values stable.
+
+-- No histogram_stats_scope property: should behave exactly like scope 'both'.
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_num PROPERTIES('histogram_sample_ratio' = '1') WITH SYNC MODE;
+
+select count(1) from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1';
+select mcv is not null, buckets is not null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_num';
+
+drop database histo_test_${uuid0} force;
+
+
+-- name: test_histogram_scope_mcv
+
+create database histo_test_${uuid0};
+use histo_test_${uuid0};
+
+CREATE TABLE `t1` (
+    `k_num`  bigint,
+    `k_low`  int,
+    `k_str`  varchar(32)
+)
+PROPERTIES ('replication_num' = '1');
+
+INSERT INTO t1
+SELECT g1, g1 % 20, concat('v_', g1 % 40)
+FROM TABLE(generate_series(1, 5000)) AS t(g1);
+
+-- scope 'mcv' skips the bucket aggregate entirely. A numeric column can carry sampled
+-- bounds, so the single placeholder bucket gets real min/max rather than the Infinity
+-- fallback used for types that cannot carry bounds.
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_num PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'mcv') WITH SYNC MODE;
+
+select mcv is not null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_num';
+
+-- These two are opposite polarity: the Infinity fallback must NOT be used (expects 0) and
+-- the real sampled bounds must be (expects 1). Together they pin the placeholder bucket to
+-- [["1","5000",<non-mcv count>,0]].
+select buckets like '[["Infinity"%' from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_num';
+select buckets like '[["1","5000",%' from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_num';
+
+-- The placeholder is a single bucket. This is what separates it from a real histogram,
+-- since both are non-null.
+select json_length(parse_json(buckets)) from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_num';
+
+-- Scope value matching is case insensitive.
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_num PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'MCV') WITH SYNC MODE;
+select mcv is not null, buckets like '[["1","5000",%' from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_num';
+
+drop database histo_test_${uuid0} force;
+
+
+-- name: test_histogram_scope_buckets
+
+create database histo_test_${uuid0};
+use histo_test_${uuid0};
+
+CREATE TABLE `t1` (
+    `k_num`  bigint,
+    `k_low`  int,
+    `k_str`  varchar(32)
+)
+PROPERTIES ('replication_num' = '1');
+
+INSERT INTO t1
+SELECT g1, g1 % 20, concat('v_', g1 % 40)
+FROM TABLE(generate_series(1, 5000)) AS t(g1);
+
+-- scope 'buckets' skips MCV collection, so mcv is written as SQL NULL and no values are
+-- excluded from the bucket aggregate.
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_num PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'buckets') WITH SYNC MODE;
+
+select mcv is null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_num';
+select buckets is not null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_num';
+
+-- A real histogram, not the single placeholder bucket: more than one bucket, and the
+-- lower bound is a collected value rather than the Infinity fallback.
+select json_length(parse_json(buckets)) > 1 from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_num';
+select buckets like '[["Infinity"%' from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_num';
+
+drop database histo_test_${uuid0} force;
+
+
+-- name: test_histogram_scope_both
+
+create database histo_test_${uuid0};
+use histo_test_${uuid0};
+
+CREATE TABLE `t1` (
+    `k_num`  bigint,
+    `k_low`  int,
+    `k_str`  varchar(32)
+)
+PROPERTIES ('replication_num' = '1');
+
+INSERT INTO t1
+SELECT g1, g1 % 20, concat('v_', g1 % 40)
+FROM TABLE(generate_series(1, 5000)) AS t(g1);
+
+-- scope 'both' collects MCVs and real buckets in the same row.
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_num PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'both') WITH SYNC MODE;
+
+select mcv is not null, buckets is not null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_num';
+select json_length(parse_json(buckets)) > 1 from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_num';
+
+-- Multiple columns in one statement each get their own row.
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_num, k_str PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'both') WITH SYNC MODE;
+[ORDER] select column_name, mcv is not null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' order by column_name;
+
+drop database histo_test_${uuid0} force;
+
+
+-- name: test_histogram_scope_low_cardinality
+
+create database histo_test_${uuid0};
+use histo_test_${uuid0};
+
+CREATE TABLE `t1` (
+    `k_num`  bigint,
+    `k_low`  int,
+    `k_str`  varchar(32)
+)
+PROPERTIES ('replication_num' = '1');
+
+INSERT INTO t1
+SELECT g1, g1 % 20, concat('v_', g1 % 40)
+FROM TABLE(generate_series(1, 5000)) AS t(g1);
+
+-- k_low has 20 distinct values, under the default histogram_mcv_size of 100, so every
+-- value becomes an MCV and the bucket subquery excludes all rows. The bucket aggregate
+-- then sees no input and writes SQL NULL. This is the intended behaviour: the MCVs
+-- already describe the column completely.
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_low PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'both') WITH SYNC MODE;
+
+select mcv is not null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_low';
+select buckets is null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_low';
+
+-- Same column under scope 'buckets': no MCVs are collected, so nothing is excluded and
+-- real buckets are produced even though the cardinality is low.
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_low PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'buckets') WITH SYNC MODE;
+
+select mcv is null, buckets is not null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_low';
+
+-- Capping the MCV size below the cardinality leaves values for the buckets.
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_low PROPERTIES('histogram_sample_ratio' = '1', 'histogram_mcv_size' = '5', 'histogram_stats_scope' = 'both') WITH SYNC MODE;
+
+select mcv is not null, buckets is not null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_low';
+
+drop database histo_test_${uuid0} force;
+
+
+-- name: test_histogram_scope_varchar
+
+create database histo_test_${uuid0};
+use histo_test_${uuid0};
+
+CREATE TABLE `t1` (
+    `k_num`  bigint,
+    `k_low`  int,
+    `k_str`  varchar(32)
+)
+PROPERTIES ('replication_num' = '1');
+
+INSERT INTO t1
+SELECT g1, g1 % 20, concat('v_', g1 % 40)
+FROM TABLE(generate_series(1, 5000)) AS t(g1);
+
+-- Char family columns always skip the bucket aggregate, and they cannot carry sampled
+-- bounds, so the placeholder bucket uses the Infinity fallback for both bounds.
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_str PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'mcv') WITH SYNC MODE;
+
+select mcv is not null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_str';
+select buckets like '[["Infinity","Infinity",%' from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_str';
+
+-- scope 'buckets' on a char family column yields neither statistic: MCV collection is
+-- switched off and the bucket aggregate is skipped by type, leaving only the placeholder.
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_str PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'buckets') WITH SYNC MODE;
+
+select mcv is null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_str';
+select buckets like '[["Infinity","Infinity",%' from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_str';
+
+-- Without MCVs the placeholder count is the full non-null row count.
+select buckets = '[["Infinity","Infinity",5000,0]]' from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_str';
+
+drop database histo_test_${uuid0} force;
+

--- a/test/sql/test_histogram_stats_collection/T/test_histogram_stats_collection
+++ b/test/sql/test_histogram_stats_collection/T/test_histogram_stats_collection
@@ -24,7 +24,7 @@ FROM TABLE(generate_series(1, 5000)) AS t(g1);
 -- the table's reported row count is non-zero, and that count lags tablet reports right
 -- after an INSERT. Passing it explicitly keeps the collected values stable.
 
--- No histogram_stats_scope property: should behave exactly like scope 'both'.
+-- No histogram_stats_scope property: should collect every kind, like 'mcv,buckets'.
 [UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_num PROPERTIES('histogram_sample_ratio' = '1') WITH SYNC MODE;
 
 select count(1) from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1';
@@ -104,7 +104,7 @@ select buckets like '[["Infinity"%' from _statistics_.histogram_statistics where
 drop database histo_test_${uuid0} force;
 
 
--- name: test_histogram_scope_both
+-- name: test_histogram_scope_all_kinds
 
 create database histo_test_${uuid0};
 use histo_test_${uuid0};
@@ -120,14 +120,14 @@ INSERT INTO t1
 SELECT g1, g1 % 20, concat('v_', g1 % 40)
 FROM TABLE(generate_series(1, 5000)) AS t(g1);
 
--- scope 'both' collects MCVs and real buckets in the same row.
-[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_num PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'both') WITH SYNC MODE;
+-- Naming both kinds collects MCVs and real buckets in the same row.
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_num PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'mcv,buckets') WITH SYNC MODE;
 
 select mcv is not null, buckets is not null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_num';
 select json_length(parse_json(buckets)) > 1 from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_num';
 
 -- Multiple columns in one statement each get their own row.
-[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_num, k_str PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'both') WITH SYNC MODE;
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_num, k_str PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'mcv,buckets') WITH SYNC MODE;
 [ORDER] select column_name, mcv is not null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' order by column_name;
 
 drop database histo_test_${uuid0} force;
@@ -153,7 +153,7 @@ FROM TABLE(generate_series(1, 5000)) AS t(g1);
 -- value becomes an MCV and the bucket subquery excludes all rows. The bucket aggregate
 -- then sees no input and writes SQL NULL. This is the intended behaviour: the MCVs
 -- already describe the column completely.
-[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_low PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'both') WITH SYNC MODE;
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_low PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'mcv,buckets') WITH SYNC MODE;
 
 select mcv is not null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_low';
 select buckets is null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_low';
@@ -165,12 +165,46 @@ select buckets is null from _statistics_.histogram_statistics where table_name =
 select mcv is null, buckets is not null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_low';
 
 -- Capping the MCV size below the cardinality leaves values for the buckets.
-[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_low PROPERTIES('histogram_sample_ratio' = '1', 'histogram_mcv_size' = '5', 'histogram_stats_scope' = 'both') WITH SYNC MODE;
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_low PROPERTIES('histogram_sample_ratio' = '1', 'histogram_mcv_size' = '5', 'histogram_stats_scope' = 'mcv,buckets') WITH SYNC MODE;
 
 select mcv is not null, buckets is not null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_low';
 
 drop database histo_test_${uuid0} force;
 
+
+-- name: test_histogram_scope_date_bounds
+
+create database histo_test_${uuid0};
+use histo_test_${uuid0};
+
+CREATE TABLE `t1` (
+    `k_num`   bigint,
+    `k_date`  date,
+    `k_low_date` date
+)
+PROPERTIES ('replication_num' = '1');
+
+-- k_date spans 1000 distinct days (above histogram_mcv_size), so sampled bounds are usable.
+-- k_low_date has 10 distinct days, all of which become MCVs, so the bounds subquery excludes
+-- every row and comes back empty.
+INSERT INTO t1
+SELECT g1, days_add('2024-01-01', g1 % 1000), days_add('2024-01-01', g1 % 10)
+FROM TABLE(generate_series(1, 5000)) AS t(g1);
+
+-- Bounds are sampled from the non-MCV rows, so the bucket carries real dates rather than Infinity.
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_date PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'mcv') WITH SYNC MODE;
+
+select mcv is not null, buckets is not null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_date';
+select buckets not like '%Infinity%' from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_date';
+
+-- With no usable bounds a date column stores NULL buckets, not the Infinity placeholder:
+-- HistogramUtils.convertBuckets cannot parse "Infinity" as a date and would drop the bucket,
+-- silently losing the non-MCV count from getTotalRows().
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_low_date PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'mcv') WITH SYNC MODE;
+
+select mcv is not null, buckets is null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_low_date';
+
+drop database histo_test_${uuid0} force;
 
 -- name: test_histogram_scope_varchar
 
@@ -195,15 +229,15 @@ FROM TABLE(generate_series(1, 5000)) AS t(g1);
 select mcv is not null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_str';
 select buckets like '[["Infinity","Infinity",%' from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_str';
 
--- scope 'buckets' on a char family column yields neither statistic: MCV collection is
--- switched off and the bucket aggregate is skipped by type, leaving only the placeholder.
+-- scope 'buckets' on a char family column cannot produce buckets, so the MCVs are collected
+-- anyway rather than storing a row that carries no information at all.
 [UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON k_str PROPERTIES('histogram_sample_ratio' = '1', 'histogram_stats_scope' = 'buckets') WITH SYNC MODE;
 
-select mcv is null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_str';
+select mcv is not null from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_str';
 select buckets like '[["Infinity","Infinity",%' from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_str';
 
--- Without MCVs the placeholder count is the full non-null row count.
-select buckets = '[["Infinity","Infinity",5000,0]]' from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_str';
+-- 40 distinct values over 5000 rows, all captured as MCVs, so the placeholder carries no rows.
+select buckets = '[["Infinity","Infinity",0,0]]' from _statistics_.histogram_statistics where table_name = 'histo_test_${uuid0}.t1' and column_name = 'k_str';
 
 drop database histo_test_${uuid0} force;
 


### PR DESCRIPTION
## Why I'm doing:
Collecting buckets stats whilst collecting histogram stats is expensive due to the sorting involved. Histogram stat collection currently gathers MCVs and Buckets statistics even if only MCVs were needed.

## What I'm doing:
Decopling MCV and Buckets collection. Analyze statements can now specify the scope of histogram stats collection to MCV only, buckets only or both. In case of MCV only, a single all encompassing bucket is still created. The min and max values of the bucket are set accordingly. 

For numeric and date types: a sampling of the column is done to calculate min and max values. These values are used in the single bucket. This is necessary to correctly calculate rowCount. 

For other types: min and max are set to infinity. 

Should the MCV capture the entire column (small column where all variables are distinct), the bucket is set to NULL. rowCount will then only use MCV to estimate total number of rows which, in this case, will yield the correct result.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5