### PR TITLE
[BugFix] Null-safe SparseRangeIterator::has_more() — fix physical-split empty-tablet CN crash (#75203) (backport #75985)

### DIFF
--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -623,6 +623,11 @@ Status PhysicalSplitMorselQueue::_init_segment() {
             return Status::OK();
         }
         RETURN_IF_ERROR(rowset->load());
+        // Prime the segment list so a transient load failure fails the query here instead of
+        // leaving the split iterator with a null _range that later crashes has_more(). Unlike
+        // get_segments(), get_segments_checked() surfaces the real load status (issue #75203).
+        auto segments_or = rowset->get_segments_checked();
+        RETURN_IF_ERROR(segments_or.status());
     }
 
     _num_segment_rest_rows = 0;

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -546,17 +546,26 @@ RowsetId Rowset::rowset_id() const {
     return rowset_id;
 }
 
-std::vector<SegmentSharedPtr> Rowset::get_segments() {
-    if (!_segments.empty()) {
+StatusOr<std::vector<SegmentSharedPtr>> Rowset::get_segments_checked() {
+    // Lock-free lazy init: callers must serialize calls on a given Rowset (the split morsel queues
+    // hold _mutex; lake Rowsets are per-reader over immutable metadata). Not std::call_once -- that
+    // marks init done even on a transient failure and would defeat the retry (issue #75203).
+    if (_segments_loaded) {
         return _segments;
     }
-
-    auto segments_or = segments(true);
-    if (!segments_or.ok()) {
-        return {};
-    }
-    _segments = std::move(segments_or.value());
+    // Propagate a transient load failure as its real (retryable) Status instead of swallowing it;
+    // _segments_loaded stays false so a later call retries.
+    ASSIGN_OR_RETURN(auto segs, segments(true));
+    _segments = std::move(segs);
+    _segments_loaded = true;
     return _segments;
+}
+
+std::vector<SegmentSharedPtr> Rowset::get_segments() {
+    // Best-effort shim for callers that tolerate an empty result on a transient failure; callers
+    // that must not proceed on failure use get_segments_checked() and check the Status.
+    auto res = get_segments_checked();
+    return res.ok() ? std::move(res).value() : std::vector<SegmentSharedPtr>{};
 }
 
 StatusOr<std::vector<SegmentPtr>> Rowset::segments(bool fill_cache) {

--- a/be/src/storage/lake/rowset.h
+++ b/be/src/storage/lake/rowset.h
@@ -146,6 +146,7 @@ public:
     [[nodiscard]] const RowsetMetadataPB& metadata() const { return *_metadata; }
 
     [[nodiscard]] std::vector<SegmentSharedPtr> get_segments() override;
+    [[nodiscard]] StatusOr<std::vector<SegmentSharedPtr>> get_segments_checked() override;
 
     StatusOr<std::vector<SegmentPtr>> segments(bool fill_cache);
 
@@ -191,6 +192,10 @@ private:
     TabletSchemaPtr _tablet_schema;
     TabletMetadataPtr _tablet_metadata;
     std::vector<SegmentSharedPtr> _segments;
+    // Set once get_segments_checked() materializes _segments. Keyed on an explicit flag (not
+    // _segments.empty()) so a zero-segment rowset loads once, and stays false on a transient
+    // failure so a retry re-attempts it (issue #75203).
+    bool _segments_loaded = false;
     bool _parallel_load;
     // only takes effect when rowset is overlapped, tells how many segments will be used in compaction,
     // default is 0 means every segment will be used.

--- a/be/src/storage/range.h
+++ b/be/src/storage/range.h
@@ -391,7 +391,10 @@ inline SparseRangeIterator<T>::SparseRangeIterator(const SparseRange<T>* r) : _r
 
 template <typename T>
 inline bool SparseRangeIterator<T>::has_more() const {
-    return _index < _range->_ranges.size();
+    // A default-constructed iterator (_range == nullptr) has no ranges; guard the null before
+    // dereferencing. PhysicalSplitMorselQueue can reach has_more() on such an iterator when
+    // _init_segment() early-returns without assigning it (issue #75203).
+    return _range != nullptr && _index < _range->_ranges.size();
 }
 
 template <typename T>

--- a/be/src/storage/rowset/base_rowset.h
+++ b/be/src/storage/rowset/base_rowset.h
@@ -17,6 +17,7 @@
 #include <memory>
 #include <vector>
 
+#include "common/statusor.h"
 #include "storage/olap_common.h"
 
 namespace starrocks {
@@ -35,6 +36,14 @@ public:
     virtual bool is_overlapped() const = 0;
     //virtual StatusOr<std::vector<SegmentSharedPtr>> get_segments() = 0;
     virtual std::vector<SegmentSharedPtr> get_segments() = 0;
+
+    // Like get_segments(), but surfaces a segment-load failure as a non-OK Status instead of
+    // silently returning an empty vector. Local rowsets load segments eagerly in load() and never
+    // fail here, so the default just wraps get_segments(); lake rowsets override this to propagate
+    // the real (retryable) load status. See issue #75203: the swallowed error left a scan-split
+    // iterator uninitialized and crashed the CN.
+    virtual StatusOr<std::vector<SegmentSharedPtr>> get_segments_checked() { return get_segments(); }
+
     virtual Status load() { return Status::OK(); };
 
     virtual bool has_data_files() const = 0;

--- a/be/test/exec/pipeline/scan/physical_split_morsel_queue_test.cpp
+++ b/be/test/exec/pipeline/scan/physical_split_morsel_queue_test.cpp
@@ -15,8 +15,13 @@
 #include <gtest/gtest.h>
 
 #include "exec/pipeline/scan/morsel.h"
+#include "fs/fs.h"
 #include "gen_cpp/InternalService_types.h"
 #include "storage/lake/tablet.h"
+#include "storage/rowset/base_rowset.h"
+#include "storage/rowset/segment.h"
+#include "storage/tablet_schema.h"
+#include "testutil/assert.h"
 
 namespace starrocks::pipeline {
 
@@ -65,6 +70,97 @@ TEST_F(PhysicalSplitMorselQueueTest, test_empty_rowset) {
     ASSERT_TRUE(result.ok());
     ASSERT_EQ(result.value(), nullptr);
     ASSERT_TRUE(queue.empty());
+}
+
+namespace {
+// A BaseRowset whose get_segments() returns an EMPTY list on its first call and a non-empty segment list
+// on every call after that. This models a *transient* Rowset::get_segments() failure: lake Rowset returns
+// {} on a load failure and does NOT cache it, so the immediate retry re-loads and can succeed. This is the
+// exact precondition for issue #75203 -- the first (failing) call makes _init_segment() early-return before
+// assigning _segment_range_iter, and the second (succeeding) call lets checks 1-3 fall through to check 4.
+class TransientEmptyRowset : public BaseRowset {
+public:
+    explicit TransientEmptyRowset(SegmentSharedPtr segment) : _segment(std::move(segment)) {}
+    RowsetId rowset_id() const override { return RowsetId{}; }
+    int64_t num_rows() const override { return 100; }
+    bool is_overlapped() const override { return false; }
+    std::vector<SegmentSharedPtr> get_segments() override {
+        if (_calls++ == 0) {
+            return {}; // transient failure: empty list, deliberately uncached
+        }
+        return {_segment}; // retry succeeds
+    }
+    bool has_data_files() const override { return true; }
+    int64_t start_version() const override { return 0; }
+    int64_t end_version() const override { return 0; }
+
+private:
+    SegmentSharedPtr _segment;
+    int _calls = 0;
+};
+} // namespace
+
+// Path-level regression for issue #75203: reproduce the crash through the REAL
+// PhysicalSplitMorselQueue::_try_get_split_from_single_tablet control flow, driven by a transient
+// get_segments() failure (empty then non-empty).
+//
+// Trace: check 1 (!_has_init_any_segment) fires first; _next_segment() flips it true and _init_segment()
+// calls _cur_segment() -> get_segments() call #1 -> {} -> segment==nullptr -> early-return WITHOUT setting
+// _segment_range_iter (its _range stays nullptr). Re-eval: check 1 false; check 2 (_cur_segment()==nullptr)
+// calls get_segments() #2 -> real segment -> false; check 3 (num_rows()==0) -> false; control reaches
+// check 4 (!_segment_range_iter.has_more()). WITHOUT any fix, has_more() dereferences the null _range and
+// crashes. WITH the source-level fix (get_segments_checked() primed once in _init_segment), the segment
+// list is materialized before check 4, so the range iterator is initialized and the segment's rows are
+// actually scanned. try_get() then returns a real split morsel instead of silently dropping the segment,
+// which is what the bare has_more() null-guard alone would do.
+TEST_F(PhysicalSplitMorselQueueTest, test_transient_get_segments_null_range_75203) {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(DUP_KEYS);
+    schema_pb.set_num_short_key_columns(1);
+    auto* col = schema_pb.add_column();
+    col->set_unique_id(0);
+    col->set_name("c0");
+    col->set_type("INT");
+    col->set_is_key(true);
+    col->set_is_nullable(false);
+    col->set_length(4);
+    col->set_index_length(4);
+    auto tablet_schema = TabletSchema::create(schema_pb);
+    ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString("/tmp/sr75203_transient"));
+
+    // Bare segment reporting rows > 0 so check 3 (`_cur_segment()->num_rows() == 0`) is false on the retry.
+    auto segment = std::make_shared<Segment>(fs, FileInfo{"/tmp/sr75203_transient/0.dat"}, /*seg_id=*/0, tablet_schema,
+                                             /*tablet_manager=*/nullptr);
+    segment->set_num_rows(100);
+
+    // Build the scan range inline (this branch has no make_scan_range() helper).
+    TScanRange scan_range;
+    TInternalScanRange internal_scan_range;
+    internal_scan_range.tablet_id = 10001;
+    internal_scan_range.version = "1";
+    internal_scan_range.partition_id = 1;
+    scan_range.__set_internal_scan_range(internal_scan_range);
+
+    Morsels morsels;
+    morsels.emplace_back(std::make_unique<ScanMorsel>(1, scan_range));
+    PhysicalSplitMorselQueue queue(std::move(morsels), /*degree_of_parallelism=*/1, /*splitted_scan_rows=*/1024);
+
+    auto tablet = std::make_shared<lake::Tablet>(nullptr, 10001);
+    std::vector<BaseTabletSharedPtr> tablets{tablet};
+    queue.set_tablets(tablets);
+
+    // Exactly one rowset, whose first get_segments() transiently returns empty.
+    std::vector<std::vector<BaseRowsetSharedPtr>> tablet_rowsets;
+    tablet_rowsets.push_back({std::make_shared<TransientEmptyRowset>(segment)});
+    queue.set_tablet_rowsets(tablet_rowsets);
+    queue.set_tablet_schema(tablet_schema);
+
+    // WITHOUT any fix: SIGSEGV in SparseRangeIterator::has_more(). WITH the source-level fix: the prime
+    // materializes the segment, so the split iterator is initialized and the segment's rows are scanned
+    // rather than dropped -- try_get() returns a real morsel instead of nullptr.
+    auto result = queue.try_get();
+    ASSERT_TRUE(result.ok());
+    ASSERT_NE(result.value(), nullptr);
 }
 
 } // namespace starrocks::pipeline

--- a/be/test/storage/lake/tablet_reader_test.cpp
+++ b/be/test/storage/lake/tablet_reader_test.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <iomanip>
 #include <utility>
 
@@ -24,8 +25,10 @@
 #include "column/fixed_length_column.h"
 #include "column/schema.h"
 #include "column/vectorized_fwd.h"
+#include "common/config.h"
 #include "common/logging.h"
 #include "exec/pipeline/scan/morsel.h"
+#include "gen_cpp/InternalService_types.h"
 #include "storage/chunk_helper.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
@@ -169,6 +172,101 @@ TEST_F(LakeDuplicateTabletReaderTest, test_read_success) {
     ASSERT_TRUE(reader->get_next(read_chunk_ptr.get()).is_end_of_file());
 
     reader->close();
+}
+
+// Regression test for issue #75203: a transient object-storage failure while a physical-split scan
+// lazily loads a lake rowset's segments used to leave PhysicalSplitMorselQueue's range iterator
+// uninitialized; a successful retry inside the same loop then dereferenced a null _range in
+// SparseRangeIterator::has_more() -> SIGSEGV @0x0.
+//
+// We reproduce the exact non-idempotency window with a SyncPoint that fails the FIRST segment-load
+// attempt and succeeds afterward, then drive PhysicalSplitMorselQueue::try_get(). With the fix
+// (Rowset::get_segments_checked() primed in _init_segment), the failure surfaces as its real,
+// retryable Status instead of crashing, and repeated try_get() calls stay crash-free.
+TEST_F(LakeDuplicateTabletReaderTest, test_issue_75203_physical_split_transient_segment_load) {
+    // 1. Write one rowset with one segment that has rows.
+    std::vector<int> k{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    std::vector<int> v{10, 20, 30, 40, 50, 60, 70, 80, 90, 100};
+    auto c0 = Int32Column::create();
+    auto c1 = Int32Column::create();
+    c0->append_numbers(k.data(), k.size() * sizeof(int));
+    c1->append_numbers(v.data(), v.size() * sizeof(int));
+    Chunk chunk({std::move(c0), std::move(c1)}, _schema);
+
+    VersionedTablet tablet(_tablet_mgr.get(), _tablet_metadata);
+    {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+        ASSERT_OK(writer->open());
+        ASSERT_OK(writer->write(chunk));
+        ASSERT_OK(writer->finish());
+        auto* rowset_meta = _tablet_metadata->add_rowsets();
+        rowset_meta->set_overlapped(false);
+        rowset_meta->set_id(1);
+        for (const auto& file : writer->segments()) {
+            auto* seg = rowset_meta->add_segment_metas();
+            seg->set_filename(file.path);
+            seg->set_size(file.size.value());
+        }
+        writer->close();
+    }
+    _tablet_metadata->set_version(2);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+
+    // 2. Enable parallel segment load so the injectable sync point fires.
+    auto old_parallel = config::enable_load_segment_parallel;
+    config::enable_load_segment_parallel = true;
+    DeferOp restore_cfg([&]() { config::enable_load_segment_parallel = old_parallel; });
+
+    // 3. Fail the FIRST segment-load attempt, succeed after: the #75203 non-idempotency window.
+    std::atomic<int> load_calls{0};
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("Rowset::load_segments::parallel_load", [&](void* arg) {
+        if (load_calls.fetch_add(1) == 0) {
+            *reinterpret_cast<Status*>(arg) = Status::IOError("injected transient segment load failure (#75203)");
+        }
+    });
+    DeferOp clear_sp([]() {
+        SyncPoint::GetInstance()->ClearCallBack("Rowset::load_segments::parallel_load");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    // 4. Fresh lake rowsets (empty _segments, so the first checked load actually hits object storage).
+    auto rowsets = Rowset::get_rowsets(_tablet_mgr.get(), _tablet_metadata);
+    ASSERT_FALSE(rowsets.empty());
+
+    // 5. Build a PhysicalSplitMorselQueue over the tablet + rowset (physical split; small
+    //    splitted_scan_rows forces the split walk).
+    TScanRange scan_range;
+    TInternalScanRange internal_scan_range;
+    internal_scan_range.tablet_id = _tablet_metadata->id();
+    internal_scan_range.version = "2";
+    internal_scan_range.partition_id = 1;
+    scan_range.__set_internal_scan_range(internal_scan_range);
+
+    pipeline::Morsels morsels;
+    morsels.emplace_back(std::make_unique<pipeline::ScanMorsel>(1, scan_range));
+    pipeline::PhysicalSplitMorselQueue queue(std::move(morsels), 1, 1);
+
+    auto lake_tablet = std::make_shared<Tablet>(_tablet_mgr.get(), _tablet_metadata->id());
+    std::vector<BaseTabletSharedPtr> tablets{lake_tablet};
+    queue.set_tablets(tablets);
+
+    std::vector<std::vector<BaseRowsetSharedPtr>> tablet_rowsets;
+    tablet_rowsets.push_back({rowsets[0]});
+    queue.set_tablet_rowsets(tablet_rowsets);
+    queue.set_tablet_schema(_tablet_schema);
+
+    // 6. Without the fix this crashes (@0x0) in has_more(); with the fix the transient failure
+    //    surfaces as its real Status from try_get(), no crash.
+    auto result = queue.try_get();
+    ASSERT_FALSE(result.ok());
+    EXPECT_NE(result.status().to_string().find("injected"), std::string::npos) << result.status().to_string();
+
+    // The crash repetition ends: a second call also does not crash (queue is exhausted).
+    auto again = queue.try_get();
+    ASSERT_TRUE(again.ok());
+    ASSERT_EQ(again.value(), nullptr);
 }
 
 class LakeAggregateTabletReaderTest : public TestBase {

--- a/be/test/storage/range_test.cpp
+++ b/be/test/storage/range_test.cpp
@@ -204,4 +204,21 @@ TEST(SparseRangeIteratorTest, intersect_test) {
     }
 }
 
+// Regression test for issue #75203: CN SIGSEGV @0x0 in
+// PhysicalSplitMorselQueue::_try_get_split_from_single_tablet().
+//
+// The physical-split loop evaluates `_segment_range_iter.has_more()` in its while
+// condition. On empty/edge tablets the iterator can still be default-constructed
+// (its _range pointer is null) when has_more() is reached. Before the fix has_more()
+// did an unconditional `_index < _range->_ranges.size()`, dereferencing the null
+// _range -> std::vector::size() read at address 0 -> SIGSEGV @0x0 (exactly the crash
+// stack in the issue: has_more() inlined into _try_get_split_from_single_tablet()).
+//
+// A default-constructed iterator has no ranges, so has_more() must report false
+// rather than dereference null. Without the fix this line is an ASAN
+// null/heap-buffer-overflow read; with it, it returns false.
+TEST(SparseRangeIteratorTest, has_more_on_default_constructed_is_null_safe) {
+    SparseRangeIterator<> iter; // default-constructed: _range == nullptr
+    EXPECT_FALSE(iter.has_more());
+}
 } // namespace starrocks


### PR DESCRIPTION
Backport of #75985 to `branch-4.1`. Fixes the shared-data CN `SIGSEGV @0x0` in
`PhysicalSplitMorselQueue::_try_get_split_from_single_tablet()` (issue #75203).
Original PR #75985 merged to main as `b15da32`.

## Why this is a manual backport

Mergify's auto-backport could not cherry-pick cleanly because the release-branch code
layout differs from main. The **functional fix is identical** to #75985; only paths and a
few symbol names were adapted:

- The physical-split morsel-queue logic still lives in `be/src/exec/pipeline/scan/morsel.cpp`
  on this branch (it was extracted into `storage/query/split_morsel_queue.cpp` only on main),
  so the `_init_segment()` `get_segments_checked()` prime is applied there.
- `range.h` / `range_test.cpp` are under `be/src/storage/` and `be/test/storage/`
  (not `storage_primitive/`).
- The path-level test uses `FileSystem::CreateSharedFromString` and `common/config.h`
  (the `FileSystemFactory` rename and the config forward-header system are main-only).
- `get_non_null_segments()` and the pre-existing `remaining_rows` unit test are main-only
  siblings surfaced by the 3-way merge; they are **not** part of #75985 and were excluded.

## Fix summary (unchanged from #75985)

`BaseRowset::get_segments_checked()` surfaces a transient lake segment-load failure as a
retryable `Status` instead of swallowing it and returning `{}`. `_init_segment()` primes the
load and `RETURN_IF_ERROR`s before the split loop can reach `has_more()` on an uninitialized
iterator, and `SparseRangeIterator::has_more()` gets a null-`_range` guard as a backstop.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

Fixes #75203

