### PR TITLE
[BugFix] drop unused lambda captures and arch-specific constant

### DIFF
--- a/be/src/base/simd/filter.cpp
+++ b/be/src/base/simd/filter.cpp
@@ -36,7 +36,9 @@ namespace {
 // lanes survive. Below this many set bits in a batch the 64-bit path falls back
 // to scalar. (The 32-bit path packs 16 lanes/group, so its fixed cost is lower
 // and it always takes the vectorised path.)
+#if defined(__x86_64__)
 constexpr int kCompressMinBits = 6;
+#endif
 
 // Trivially-copyable stand-in for element widths without a native integer type
 // (3/12/16/32-byte: uint24 / int96 / decimal12 / int128 / DecimalV2 / int256).

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -948,7 +948,7 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
 
         if (config::enable_load_segment_parallel) {
             auto task = std::make_shared<std::packaged_task<StatusOr<std::vector<ChunkIteratorPtr>>()>>(
-                    [&, rowset_idx, rowset]() {
+                    [&, rowset]() {
 #ifdef BE_TEST
                         Status injected_st;
                         TEST_SYNC_POINT_CALLBACK("TabletReader::get_segment_iterators::parallel_read", &injected_st);

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -947,17 +947,16 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
         }
 
         if (config::enable_load_segment_parallel) {
-            auto task = std::make_shared<std::packaged_task<StatusOr<std::vector<ChunkIteratorPtr>>()>>(
-                    [&, rowset]() {
+            auto task = std::make_shared<std::packaged_task<StatusOr<std::vector<ChunkIteratorPtr>>()>>([&, rowset]() {
 #ifdef BE_TEST
-                        Status injected_st;
-                        TEST_SYNC_POINT_CALLBACK("TabletReader::get_segment_iterators::parallel_read", &injected_st);
-                        if (!injected_st.ok()) {
-                            return StatusOr<std::vector<ChunkIteratorPtr>>(injected_st);
-                        }
+                Status injected_st;
+                TEST_SYNC_POINT_CALLBACK("TabletReader::get_segment_iterators::parallel_read", &injected_st);
+                if (!injected_st.ok()) {
+                    return StatusOr<std::vector<ChunkIteratorPtr>>(injected_st);
+                }
 #endif
-                        return enhance_error_prompt(rowset->read(schema(), rs_opts));
-                    });
+                return enhance_error_prompt(rowset->read(schema(), rs_opts));
+            });
 
             auto packaged_func = [task]() { (*task)(); };
             if (auto st = RuntimeEnv::GetInstance()->load_rowset_thread_pool()->submit_func(std::move(packaged_func));

--- a/be/test/agent/agent_task_test.cpp
+++ b/be/test/agent/agent_task_test.cpp
@@ -462,7 +462,7 @@ TEST_F(AgentTaskTest, drop_tablet_proceeds_when_no_clone_task) {
 
     // Set up sync point to verify DROP task succeeds
     bool drop_succeeded = false;
-    DeferOp defer([&drop_succeeded]() {
+    DeferOp defer([]() {
         SyncPoint::GetInstance()->ClearCallBack("FinishAgentTask::input");
         SyncPoint::GetInstance()->DisableProcessing();
     });


### PR DESCRIPTION
Silence -Wunused-lambda-capture / -Wunused-const-variable warnings:

- filter.cpp: guard kCompressMinBits with __x86_64__ since its only use is inside the x86-only compress path.
- lake/tablet_reader.cpp: remove the rowset_idx capture from the parallel segment-read task; the body only uses rowset.
- agent_task_test.cpp: remove the drop_succeeded capture from the DeferOp cleanup lambda, which does not reference it.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
