### PR TITLE
[BugFix] add arrow-compression module for Arrow Flight SQL

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -906,6 +906,16 @@ under the License.
         </dependency>
         <dependency>
             <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-compression</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
             <artifactId>flight-core</artifactId>
         </dependency>
         <dependency>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -1403,6 +1403,12 @@ under the License.
 
             <dependency>
                 <groupId>org.apache.arrow</groupId>
+                <artifactId>arrow-compression</artifactId>
+                <version>${arrow.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.arrow</groupId>
                 <artifactId>flight-sql</artifactId>
                 <version>${arrow.version}</version>
             </dependency>


### PR DESCRIPTION
Declare org.apache.arrow:arrow-compression in the fe dependencyManagement block (pinned to ${arrow.version}) and pull it into fe-core so the LZ4/ZSTD Arrow IPC codecs are on the classpath for the Flight SQL service.

Exclude the transitive org.apache.commons:commons-compress, matching the exclusion already applied to the other commons-compress providers in the fe poms so the pinned version stays authoritative.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
