### PR TITLE
[BugFix][CVE] bump Thrift to 0.24.0

### DIFF
--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -78,7 +78,7 @@ subprojects {
         set("puppycrawl.version", "10.21.1")
         set("spark.version", "3.5.7")
         set("staros.version", "4.2-rc2")
-        set("thrift.version", "0.23.0")
+        set("thrift.version", "0.24.0")
         set("tomcat.version", "8.5.70")
         set("lz4-java.version", "1.10.1")
         // var sync end

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -94,7 +94,7 @@ under the License.
         <async-profiler.version>4.0</async-profiler.version>
         <maven.surefire.plugin.version>3.2.5</maven.surefire.plugin.version>
         <bouncycastle.version>1.84</bouncycastle.version>
-        <thrift.version>0.23.0</thrift.version>
+        <thrift.version>0.24.0</thrift.version>
     </properties>
 
     <profiles>

--- a/fs_brokers/apache_hdfs_broker/src/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/src/pom.xml
@@ -44,7 +44,7 @@ under the License.
         <guava.version>32.0.1-jre</guava.version>
         <zookeeper.version>3.9.5</zookeeper.version>
         <protobuf.version>3.25.5</protobuf.version>
-        <thrift.version>0.23.0</thrift.version>
+        <thrift.version>0.24.0</thrift.version>
         <tomcat.version>9.0.118</tomcat.version>
         <log4j.version>2.17.1</log4j.version>
         <jackson.version>2.21.4</jackson.version>

--- a/java-extensions/pom.xml
+++ b/java-extensions/pom.xml
@@ -65,7 +65,7 @@
         <lz4-java.version>1.10.1</lz4-java.version>
         <httpclient5.version>5.4.3</httpclient5.version>
         <bouncycastle.version>1.84</bouncycastle.version>
-        <thrift.version>0.23.0</thrift.version>
+        <thrift.version>0.24.0</thrift.version>
     </properties>
 
     <profiles>

--- a/nix/thirdparty-archives.nix
+++ b/nix/thirdparty-archives.nix
@@ -334,10 +334,10 @@ let
       md5 = "251d9200d27dda9120653b4928a23a86";
       sha256 = "0287mwpqc83rgs7rmc3iilsl6bnnldf8791ppgs7j2zrh8sl1wmh";
     };
-    "thrift-0.23.0.tar.gz" = {
-      url = "https://archive.apache.org/dist/thrift/0.23.0/thrift-0.23.0.tar.gz";
-      md5 = "7b62f4258ded41e233a638fe8b9fcf64";
-      sha256 = "0vzlx0xv0g8xs6zz4l7zll8664cc40qnj6asdk8i67xfs8rdjn8q";
+    "thrift-0.24.0.tar.gz" = {
+      url = "https://archive.apache.org/dist/thrift/0.24.0/thrift-0.24.0.tar.gz";
+      md5 = "232e035ff80c5fb4b7243f0be3a76b02";
+      sha256 = "1r66jr1wx0jgzlzzpag3zvia9gzbak2z474kn0qxdhf5lhwmiyp0";
     };
     "vectorscan-5.4.12.tar.gz" = {
       url = "https://github.com/VectorCamp/vectorscan/archive/refs/tags/vectorscan/5.4.12.tar.gz";
@@ -463,7 +463,7 @@ let
       "starrocks-clucene-2026.06.23.tar.gz"
       "libevent-24236aed01798303745470e6c498bf606e88724a.zip"
       "openssl-OpenSSL_1_1_1m.tar.gz"
-      "thrift-0.23.0.tar.gz"
+      "thrift-0.24.0.tar.gz"
       "protobuf-3.16.1.tar.gz"
       "gflags-2.2.2.tar.gz"
       "glog-0.7.1.tar.gz"
@@ -534,7 +534,7 @@ let
       "starrocks-clucene-2026.06.23.tar.gz"
       "libevent-24236aed01798303745470e6c498bf606e88724a.zip"
       "openssl-OpenSSL_1_1_1m.tar.gz"
-      "thrift-0.23.0.tar.gz"
+      "thrift-0.24.0.tar.gz"
       "protobuf-3.16.1.tar.gz"
       "gflags-2.2.2.tar.gz"
       "glog-0.7.1.tar.gz"
@@ -603,7 +603,7 @@ let
       "starrocks-clucene-2026.06.23.tar.gz"
       "libevent-24236aed01798303745470e6c498bf606e88724a.zip"
       "openssl-OpenSSL_1_1_1m.tar.gz"
-      "thrift-0.23.0.tar.gz"
+      "thrift-0.24.0.tar.gz"
       "protobuf-3.16.1.tar.gz"
       "gflags-2.2.2.tar.gz"
       "glog-0.7.1.tar.gz"

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -709,6 +709,18 @@ fi
 echo "Finished patching $RAPIDJSON_SOURCE"
 cd -
 
+# patch opentelemetry
+cd $TP_SOURCE_DIR/$OPENTELEMETRY_SOURCE
+if [ ! -f $PATCHED_MARK ] && [ $OPENTELEMETRY_SOURCE = "opentelemetry-cpp-1.2.0" ]; then
+    # thrift 0.24.0 dropped <boost/numeric/conversion/cast.hpp> from
+    # TTransportException.h, which used to drag in <unistd.h>. The jaeger
+    # exporter calls ::close via THRIFT_CLOSESOCKET, so include it directly.
+    patch -p1 < $TP_PATCH_DIR/opentelemetry-cpp-1.2.0-thrift-0.24-unistd.patch
+    touch $PATCHED_MARK
+fi
+echo "Finished patching $OPENTELEMETRY_SOURCE"
+cd -
+
 # patch arrow
 if [[ -d $TP_SOURCE_DIR/$ARROW_SOURCE ]] ; then
     cd $TP_SOURCE_DIR/$ARROW_SOURCE

--- a/thirdparty/patches/opentelemetry-cpp-1.2.0-thrift-0.24-unistd.patch
+++ b/thirdparty/patches/opentelemetry-cpp-1.2.0-thrift-0.24-unistd.patch
@@ -1,0 +1,11 @@
+diff --git a/exporters/jaeger/src/TUDPTransport.h b/exporters/jaeger/src/TUDPTransport.h
+--- a/exporters/jaeger/src/TUDPTransport.h
++++ b/exporters/jaeger/src/TUDPTransport.h
+@@ -10,6 +10,7 @@
+ #  include <string.h>
+ #  include <sys/socket.h>
+ #  include <sys/types.h>
++#  include <unistd.h>
+ #endif
+ 
+ #include <opentelemetry/version.h>

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -100,10 +100,10 @@ OPENSSL_SOURCE=openssl-OpenSSL_1_1_1m
 OPENSSL_MD5SUM="710c2368d28f1a25ab92e25b5b9b11ec"
 
 # thrift
-THRIFT_DOWNLOAD="https://archive.apache.org/dist/thrift/0.23.0/thrift-0.23.0.tar.gz"
-THRIFT_NAME=thrift-0.23.0.tar.gz
-THRIFT_SOURCE=thrift-0.23.0
-THRIFT_MD5SUM="7b62f4258ded41e233a638fe8b9fcf64"
+THRIFT_DOWNLOAD="https://archive.apache.org/dist/thrift/0.24.0/thrift-0.24.0.tar.gz"
+THRIFT_NAME=thrift-0.24.0.tar.gz
+THRIFT_SOURCE=thrift-0.24.0
+THRIFT_MD5SUM="232e035ff80c5fb4b7243f0be3a76b02"
 
 # protobuf
 PROTOBUF_DOWNLOAD="https://github.com/google/protobuf/archive/v3.16.1.tar.gz"


### PR DESCRIPTION
Upgrade Apache Thrift from 0.23.0 to 0.24.0 across the C++ thirdparty toolchain and every Java tree that consumes org.apache.thrift:libthrift.

CVE-2026-55971 (CVSS 9.8, CWE-122) - heap-based buffer overflow (write) in THeaderTransport::untransform() in the Thrift C++ bindings. Affects all versions before 0.24.0. Reached StarRocks through the C++ thrift built from thirdparty/vars.sh and linked into BE.

CVE-2026-43871 (CVSS 7.5, CWE-835) - loop with unreachable exit condition (infinite loop) in the Thrift Python, Go, PHP and Java bindings. Affects all versions before 0.24.0. Reached StarRocks through org.apache.thrift:libthrift, which ships in output/fe/lib and in the paimon-reader lib directory.

Both are fixed in 0.24.0.

Changes:
- thirdparty/vars.sh: THRIFT_DOWNLOAD/NAME/SOURCE to 0.24.0 and THRIFT_MD5SUM to 232e035ff80c5fb4b7243f0be3a76b02, verified against the MD5 and SHA-256 published on archive.apache.org.
- fe/pom.xml, java-extensions/pom.xml and fs_brokers/apache_hdfs_broker/src/pom.xml: thrift.version to 0.24.0. Submodule POMs inherit the version from dependencyManagement, so no submodule edits are needed.
- fe/build.gradle.kts: thrift.version ext to 0.24.0, keeping the Gradle constraint in sync with the Maven property.

libthrift 0.24.0 declares an identical transitive dependency set to 0.23.0, so no exclusion changes are required. All 22 thrift headers included by be/src are present in 0.24.0.

Because gensrc Java stubs are generated by the thirdparty-built thrift compiler (${starrocks.thrift}), thirdparty must be rebuilt so the generator and the libthrift runtime both land on 0.24.0.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
