### PR TITLE
[BugFix] Fix static PARTITION insert when partition column is not the last column for Iceberg tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -685,6 +685,10 @@ public class InsertPlanner {
         ValuesRelation values = (ValuesRelation) insertStatement.getQueryStatement().getQueryRelation();
         RelationFields fields = insertStatement.getQueryStatement().getQueryRelation().getRelationFields();
 
+        // The values rows do not contain the columns skipped by needToSkip() (e.g. partition columns of
+        // a static partition insert, which may be at any position for Iceberg tables) nor generated
+        // columns, so the source rows are indexed separately from the target schema.
+        int sourceIdx = 0;
         for (int columnIdx = 0; columnIdx < outputBaseSchema.size(); ++columnIdx) {
             if (needToSkip(insertStatement, columnIdx)) {
                 continue;
@@ -694,24 +698,25 @@ public class InsertPlanner {
             if (targetColumn.isGeneratedColumn()) {
                 continue;
             }
+            int valueIdx = sourceIdx++;
             boolean isAutoIncrement = targetColumn.isAutoIncrement();
             if (insertStatement.getTargetColumnNames() == null) {
                 for (List<Expr> row : values.getRows()) {
-                    if (isAutoIncrement && row.get(columnIdx).getType() == NullType.NULL) {
+                    if (isAutoIncrement && row.get(valueIdx).getType() == NullType.NULL) {
                         throw new SemanticException(" `NULL` value is not supported for an AUTO_INCREMENT column: " +
                                 targetColumn.getName() + " You can use `default` for an" +
                                 " AUTO INCREMENT column");
                     }
-                    if (row.get(columnIdx) instanceof DefaultValueExpr) {
+                    if (row.get(valueIdx) instanceof DefaultValueExpr) {
                         if (isAutoIncrement) {
-                            row.set(columnIdx, new NullLiteral());
+                            row.set(valueIdx, new NullLiteral());
                         } else {
-                            row.set(columnIdx, new StringLiteral(targetColumn.calculatedDefaultValue()));
+                            row.set(valueIdx, new StringLiteral(targetColumn.calculatedDefaultValue()));
                         }
                     }
-                    row.set(columnIdx, TypeManager.addCastExpr(row.get(columnIdx), targetColumn.getType()));
+                    row.set(valueIdx, TypeManager.addCastExpr(row.get(valueIdx), targetColumn.getType()));
                 }
-                fields.getFieldByIndex(columnIdx).setType(targetColumn.getType());
+                fields.getFieldByIndex(valueIdx).setType(targetColumn.getType());
             } else {
                 int idx = insertStatement.getTargetColumnNames().indexOf(targetColumn.getName().toLowerCase());
                 if (idx != -1) {
@@ -741,6 +746,9 @@ public class InsertPlanner {
                                             InsertStmt insertStatement, List<ColumnRefOperator> outputColumns) {
         Map<ColumnRefOperator, ScalarOperator> columnRefMap = new HashMap<>();
 
+        // Same as castLiteralToTargetColumnsType(): the query output does not contain skipped
+        // partition columns nor generated columns, so it is indexed separately.
+        int sourceIdx = 0;
         for (int columnIdx = 0; columnIdx < outputBaseSchema.size(); ++columnIdx) {
             if (needToSkip(insertStatement, columnIdx)) {
                 continue;
@@ -750,10 +758,11 @@ public class InsertPlanner {
             if (targetColumn.isGeneratedColumn()) {
                 continue;
             }
+            int outputIdx = sourceIdx++;
             if (insertStatement.getTargetColumnNames() == null) {
-                outputColumns.add(logicalPlan.getOutputColumn().get(columnIdx));
-                columnRefMap.put(logicalPlan.getOutputColumn().get(columnIdx),
-                        logicalPlan.getOutputColumn().get(columnIdx));
+                outputColumns.add(logicalPlan.getOutputColumn().get(outputIdx));
+                columnRefMap.put(logicalPlan.getOutputColumn().get(outputIdx),
+                        logicalPlan.getOutputColumn().get(outputIdx));
             } else {
                 int idx = insertStatement.getTargetColumnNames().indexOf(targetColumn.getName().toLowerCase());
                 if (idx == -1) {
@@ -1146,7 +1155,8 @@ public class InsertPlanner {
         List<Expr> partitionColValues = insertStatement.getTargetPartitionNames().getPartitionColValues();
         List<String> tablePartitionColumnNames = targetTable.getPartitionColumnNames();
 
-        for (Column column : targetTable.getFullSchema()) {
+        for (int columnIdx = 0; columnIdx < outputFullSchema.size(); ++columnIdx) {
+            Column column = outputFullSchema.get(columnIdx);
             String columnName = column.getName();
             if (tablePartitionColumnNames.contains(columnName)) {
                 int index = partitionColNames.indexOf(columnName);
@@ -1156,7 +1166,7 @@ public class InsertPlanner {
                         ConstantOperator.createObject(expr.getRealObjectValue(), type);
                 ColumnRefOperator col = columnRefFactory
                         .create(scalarOperator, scalarOperator.getType(), scalarOperator.isNullable());
-                outputColumns.add(col);
+                outputColumns.add(columnIdx, col);
                 columnRefMap.put(col, scalarOperator);
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -1064,6 +1064,111 @@ public class InsertPlanTest extends PlanTestBase {
     }
 
     @Test
+    public void testInsertIcebergStaticPartitionColumnInMiddle() throws Exception {
+        Schema schema = new Schema(
+                Types.NestedField.optional(1, "id", Types.LongType.get()),
+                Types.NestedField.optional(2, "dt", Types.DateType.get()),
+                Types.NestedField.optional(3, "v", Types.LongType.get()));
+        PartitionSpec spec = PartitionSpec.builderFor(schema).identity("dt").build();
+        Column id = new Column("id", IntegerType.BIGINT);
+        Column dt = new Column("dt", DateType.DATE);
+        Column v = new Column("v", IntegerType.BIGINT);
+
+        String plan = getIcebergStaticPartitionInsertExecPlan("iceberg_catalog_static_mid", "t_mid", 12345601L,
+                schema, spec, Lists.newArrayList(id, dt, v), Lists.newArrayList(dt), Lists.newArrayList(1),
+                "partition(dt='2026-07-02') values (101, 1001)");
+        // The partition constant must land in the dt slot (middle of the schema), not be appended last.
+        String expected = "PLAN FRAGMENT 0\n" +
+                " OUTPUT EXPRS:1: column_0 | 3: expr | 2: column_1\n" +
+                "  PARTITION: UNPARTITIONED\n" +
+                "\n" +
+                "  Iceberg TABLE SINK\n" +
+                "    TABLE: 12345601\n" +
+                "    TUPLE ID: 2\n" +
+                "    RANDOM\n" +
+                "\n" +
+                "  1:Project\n" +
+                "  |  <slot 1> : 1: column_0\n" +
+                "  |  <slot 2> : 2: column_1\n" +
+                "  |  <slot 3> : '2026-07-02'\n" +
+                "  |  \n" +
+                "  0:UNION\n" +
+                "     constant exprs: \n" +
+                "         101 | 1001\n";
+        Assertions.assertEquals(expected, plan);
+    }
+
+    @Test
+    public void testInsertIcebergStaticPartitionColumnInMiddleWithSelect() throws Exception {
+        Schema schema = new Schema(
+                Types.NestedField.optional(1, "id", Types.LongType.get()),
+                Types.NestedField.optional(2, "dt", Types.DateType.get()),
+                Types.NestedField.optional(3, "v", Types.LongType.get()));
+        PartitionSpec spec = PartitionSpec.builderFor(schema).identity("dt").build();
+        Column id = new Column("id", IntegerType.BIGINT);
+        Column dt = new Column("dt", DateType.DATE);
+        Column v = new Column("v", IntegerType.BIGINT);
+
+        String plan = getIcebergStaticPartitionInsertExecPlan("iceberg_catalog_static_mid_sel", "t_mid_sel",
+                12345602L, schema, spec, Lists.newArrayList(id, dt, v), Lists.newArrayList(dt),
+                Lists.newArrayList(1), "partition(dt='2026-07-02') select 101, 1001");
+        // The partition constant must land in the dt slot (middle of the schema), not be appended last.
+        String expected = "PLAN FRAGMENT 0\n" +
+                " OUTPUT EXPRS:5: id | 4: expr | 6: v\n" +
+                "  PARTITION: UNPARTITIONED\n" +
+                "\n" +
+                "  Iceberg TABLE SINK\n" +
+                "    TABLE: 12345602\n" +
+                "    TUPLE ID: 2\n" +
+                "    RANDOM\n" +
+                "\n" +
+                "  1:Project\n" +
+                "  |  <slot 4> : '2026-07-02'\n" +
+                "  |  <slot 5> : 101\n" +
+                "  |  <slot 6> : 1001\n" +
+                "  |  \n" +
+                "  0:UNION\n" +
+                "     constant exprs: \n" +
+                "         NULL\n";
+        Assertions.assertEquals(expected, plan);
+    }
+
+    @Test
+    public void testInsertIcebergStaticPartitionColumnAtLast() throws Exception {
+        Schema schema = new Schema(
+                Types.NestedField.optional(1, "id", Types.LongType.get()),
+                Types.NestedField.optional(2, "v", Types.LongType.get()),
+                Types.NestedField.optional(3, "dt", Types.DateType.get()));
+        PartitionSpec spec = PartitionSpec.builderFor(schema).identity("dt").build();
+        Column id = new Column("id", IntegerType.BIGINT);
+        Column v = new Column("v", IntegerType.BIGINT);
+        Column dt = new Column("dt", DateType.DATE);
+
+        String plan = getIcebergStaticPartitionInsertExecPlan("iceberg_catalog_static_last", "t_last",
+                12345603L, schema, spec, Lists.newArrayList(id, v, dt), Lists.newArrayList(dt),
+                Lists.newArrayList(2), "partition(dt='2026-07-02') values (101, 1001)");
+        // Regression case: partition column at the last position keeps the constant appended last.
+        String expected = "PLAN FRAGMENT 0\n" +
+                " OUTPUT EXPRS:1: column_0 | 2: column_1 | 3: expr\n" +
+                "  PARTITION: UNPARTITIONED\n" +
+                "\n" +
+                "  Iceberg TABLE SINK\n" +
+                "    TABLE: 12345603\n" +
+                "    TUPLE ID: 2\n" +
+                "    RANDOM\n" +
+                "\n" +
+                "  1:Project\n" +
+                "  |  <slot 1> : 1: column_0\n" +
+                "  |  <slot 2> : 2: column_1\n" +
+                "  |  <slot 3> : '2026-07-02'\n" +
+                "  |  \n" +
+                "  0:UNION\n" +
+                "     constant exprs: \n" +
+                "         101 | 1001\n";
+        Assertions.assertEquals(expected, plan);
+    }
+
+    @Test
     public void testInsertIcebergWithGlobalShuffle() throws Exception {
         Schema icebergSchema = new Schema(
                 Types.NestedField.required(1, "k1", Types.IntegerType.get()),
@@ -1532,6 +1637,105 @@ public class InsertPlanTest extends PlanTestBase {
         } finally {
             connectContext.getSessionVariable().setEnableMaterializedViewRewrite(enableMaterializedViewRewrite);
         }
+    }
+
+    private String getIcebergStaticPartitionInsertExecPlan(String catalogName, String tableName, long tableId,
+                                                           Schema icebergSchema, PartitionSpec partitionSpec,
+                                                           List<Column> fullSchema, List<Column> partitionColumns,
+                                                           List<Integer> partitionColumnIndexes, String insertSuffix)
+            throws Exception {
+        String createIcebergCatalogStmt = String.format(
+                "create external catalog %s properties (\"type\"=\"iceberg\", " +
+                        "\"hive.metastore.uris\"=\"thrift://hms:9083\", \"iceberg.catalog.type\"=\"hive\")",
+                catalogName);
+        starRocksAssert.withCatalog(createIcebergCatalogStmt);
+        MetadataMgr metadata = starRocksAssert.getCtx().getGlobalStateMgr().getMetadataMgr();
+
+        Table nativeTable = new BaseTable(null, null);
+        IcebergTable.Builder builder = IcebergTable.builder();
+        builder.setCatalogName(catalogName);
+        builder.setCatalogDBName("iceberg_db");
+        builder.setCatalogTableName(tableName);
+        builder.setSrTableName(tableName);
+        builder.setFullSchema(fullSchema);
+        builder.setNativeTable(nativeTable);
+        IcebergTable icebergTable = builder.build();
+
+        new Expectations(icebergTable) {
+            {
+                icebergTable.getUUID();
+                result = tableId;
+                minTimes = 0;
+
+                icebergTable.isUnPartitioned();
+                result = false;
+                minTimes = 0;
+
+                icebergTable.getPartitionColumns();
+                result = partitionColumns;
+                minTimes = 0;
+
+                icebergTable.partitionColumnIndexes();
+                result = partitionColumnIndexes;
+                minTimes = 0;
+            }
+        };
+
+        new Expectations(nativeTable) {
+            {
+                nativeTable.sortOrder();
+                result = SortOrder.unsorted();
+                minTimes = 0;
+
+                nativeTable.location();
+                result = "hdfs://fake_location";
+                minTimes = 0;
+
+                nativeTable.properties();
+                result = new HashMap<String, String>();
+                minTimes = 0;
+
+                nativeTable.io();
+                result = new HadoopFileIO();
+                minTimes = 0;
+
+                nativeTable.spec();
+                result = partitionSpec;
+                minTimes = 0;
+
+                nativeTable.schema();
+                result = icebergSchema;
+                minTimes = 0;
+            }
+        };
+
+        new Expectations(metadata) {
+            {
+                metadata.getDb((ConnectContext) any, catalogName, "iceberg_db");
+                result = new Database(tableId, "iceberg_db");
+                minTimes = 0;
+
+                metadata.getTable((ConnectContext) any, catalogName, "iceberg_db", tableName);
+                result = icebergTable;
+                minTimes = 0;
+            }
+        };
+
+        new MockUp<MetaUtils>() {
+            @Mock
+            public Database getDatabase(String currentCatalogName, String dbName) {
+                return new Database(tableId, "iceberg_db");
+            }
+
+            @Mock
+            public com.starrocks.catalog.Table getSessionAwareTable(
+                    ConnectContext context, Database database, TableName currentTableName) {
+                return icebergTable;
+            }
+        };
+
+        return getInsertExecPlan(String.format(
+                "explain insert into %s.iceberg_db.%s %s", catalogName, tableName, insertSuffix));
     }
 
     private void assertHashPartitionedByExpression(String actualRes, String expectedExpr) {


### PR DESCRIPTION
## Why I'm doing:

INSERT with static PARTITION clause on an Iceberg table fails with `IndexOutOfBoundsException` when the partition column is not the last column of the schema.

```sql
CREATE TABLE t_a (id BIGINT, dt DATE, v BIGINT) PARTITION BY (dt);
INSERT OVERWRITE t_a PARTITION(dt='2026-07-02') VALUES (101, 1001);
-- ERROR 1064 (HY000): Index 2 out of bounds for length 2
```

The code assumes the partition column is at the end of the schema. That is always true for Hive, but not for Iceberg.

## What I'm doing:

Fix three places in `InsertPlanner.java`

1. `castLiteralToTargetColumnsType()` and `fillDefaultValue()` looped over the schema index and accessed the source (VALUES row / query output) with the same index. The source does not contain the skipped partition columns, so the index shifted after a skipped column and went out of bounds. Use a separate source index that does not advance on skipped
columns.

2. `fillKeyPartitionsColumn()` appended the partition constant at the end of the output columns. Later steps map output columns to the sink tuple by position, so with only fix 1 the values would go into wrong columns. Insert the constant at its schema position instead.

No behavior change for the cases that worked before: when all partition columns are at the end of the schema, the new code produces the same result as before. When they are not, the old code always failed with IndexOutOfBoundsException, so no query result changes silently.

Verified with plan unit tests, and on a real cluster with a REST catalog (Apache Polaris + MinIO): static partition insert with VALUES and with SELECT, partition column in the middle and at the end, and dynamic overwrite.

Fixes #76923

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5