### PR TITLE
[BugFix] Do not run parallel-compaction filesystem IO on the brpc bthread (#76882)

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -2180,38 +2180,12 @@ void LakeServiceImpl::repair_tablet_metadata(::google::protobuf::RpcController* 
         return;
     }
 
-    // 2. do some cleanup before repairing tablet metadata, such as drop local data cache and meta cache.
-    // _cleanup_before_repair() performs StarOS/Starlet filesystem IO (drop_local_cache ->
-    // StarletFileSystem::drop_local_cache -> get_shard_filesystem, which takes StarOSWorker::_cache_mtx,
-    // a std::shared_mutex). This RPC handler runs on a brpc bthread; doing such IO on a bthread can make
-    // pthread_rwlock_wrlock return EDEADLK on an unrelated bthread sharing the same worker pthread, which
-    // std::shared_mutex turns into an uncaught std::system_error and aborts the CN (same mechanism as
-    // issue #76882 / CompactionScheduler::compact). Offload the cleanup to the pthread pool (as this same
-    // handler already does for the put_* tasks below) and wait for it to finish.
-    {
-        Status cleanup_st;
-        auto latch = BThreadCountDownLatch(1);
-        auto task = std::make_shared<CancellableRunnable>(
-                [&] {
-                    DeferOp defer([&] { latch.count_down(); });
-                    cleanup_st = _cleanup_before_repair(request);
-                },
-                [&] {
-                    cleanup_st = Status::Cancelled("repair tablet metadata cleanup task has been cancelled");
-                    latch.count_down();
-                });
-        auto submit_st = thread_pool->submit(std::move(task));
-        if (!submit_st.ok()) {
-            // Task was never enqueued (neither run() nor cancel() will fire); do not wait on the latch.
-            cleanup_st = submit_st;
-        } else {
-            latch.wait();
-        }
-        if (!cleanup_st.ok()) {
-            // cleanup failure will affect correctness, so the rpc should fail immediately when cleanup fails
-            cleanup_st.to_protobuf(response->mutable_status());
-            return;
-        }
+    // 2. do some cleanup before repairing tablet metadata, such as drop local data cache and meta cache
+    auto st = _cleanup_before_repair(request);
+    if (!st.ok()) {
+        // cleanup failure will affect correctness, so the rpc should fail immediately when cleanup fails
+        st.to_protobuf(response->mutable_status());
+        return;
     }
 
     // 3. put new tablet metadatas

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -2180,12 +2180,38 @@ void LakeServiceImpl::repair_tablet_metadata(::google::protobuf::RpcController* 
         return;
     }
 
-    // 2. do some cleanup before repairing tablet metadata, such as drop local data cache and meta cache
-    auto st = _cleanup_before_repair(request);
-    if (!st.ok()) {
-        // cleanup failure will affect correctness, so the rpc should fail immediately when cleanup fails
-        st.to_protobuf(response->mutable_status());
-        return;
+    // 2. do some cleanup before repairing tablet metadata, such as drop local data cache and meta cache.
+    // _cleanup_before_repair() performs StarOS/Starlet filesystem IO (drop_local_cache ->
+    // StarletFileSystem::drop_local_cache -> get_shard_filesystem, which takes StarOSWorker::_cache_mtx,
+    // a std::shared_mutex). This RPC handler runs on a brpc bthread; doing such IO on a bthread can make
+    // pthread_rwlock_wrlock return EDEADLK on an unrelated bthread sharing the same worker pthread, which
+    // std::shared_mutex turns into an uncaught std::system_error and aborts the CN (same mechanism as
+    // issue #76882 / CompactionScheduler::compact). Offload the cleanup to the pthread pool (as this same
+    // handler already does for the put_* tasks below) and wait for it to finish.
+    {
+        Status cleanup_st;
+        auto latch = BThreadCountDownLatch(1);
+        auto task = std::make_shared<CancellableRunnable>(
+                [&] {
+                    DeferOp defer([&] { latch.count_down(); });
+                    cleanup_st = _cleanup_before_repair(request);
+                },
+                [&] {
+                    cleanup_st = Status::Cancelled("repair tablet metadata cleanup task has been cancelled");
+                    latch.count_down();
+                });
+        auto submit_st = thread_pool->submit(std::move(task));
+        if (!submit_st.ok()) {
+            // Task was never enqueued (neither run() nor cancel() will fire); do not wait on the latch.
+            cleanup_st = submit_st;
+        } else {
+            latch.wait();
+        }
+        if (!cleanup_st.ok()) {
+            // cleanup failure will affect correctness, so the rpc should fail immediately when cleanup fails
+            cleanup_st.to_protobuf(response->mutable_status());
+            return;
+        }
     }
 
     // 3. put new tablet metadatas

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -19,7 +19,9 @@
 #include <bthread/condition_variable.h>
 #include <butil/time.h> // NOLINT
 
+#include <atomic>
 #include <chrono>
+#include <memory>
 #include <thread>
 
 #include "base/testutil/sync_point.h"
@@ -502,8 +504,30 @@ bool CompactionScheduler::try_hand_off_to_parallel(std::unique_ptr<CompactionTas
         return false;
     }
 
-    AcquireTokenFunc acquire_token = [this]() { return _limiter.acquire(); };
-    ReleaseTokenFunc release_token = [this](bool mem_limit_exceeded) {
+    // This worker already holds one of the limiter's tokens for as long as do_compaction() runs, and
+    // thread_task() credits it back when we return. Lend that token to the subtasks so planning needs
+    // max_parallel_per_tablet tokens instead of one more than that: the subtasks are acquired
+    // all-or-nothing, so needing an extra one means a single other compaction running anywhere on the CN
+    // is enough to fail the acquisition and quietly downgrade every tablet to serial compaction --
+    // with the defaults (3 subtasks, compact_threads=4) that is almost always.
+    //
+    // Both flags only ever go false->true, so the lent token is handed out at most once and repaid at
+    // most once; it can never be lent again after being repaid.
+    auto lent_out = std::make_shared<std::atomic<bool>>(false);
+    auto repaid = std::make_shared<std::atomic<bool>>(false);
+    AcquireTokenFunc acquire_token = [this, lent_out]() {
+        if (!lent_out->exchange(true)) {
+            return true; // hand out the token this worker is already holding
+        }
+        return _limiter.acquire();
+    };
+    ReleaseTokenFunc release_token = [this, lent_out, repaid](bool mem_limit_exceeded) {
+        if (lent_out->load() && !repaid->exchange(true)) {
+            // Repays the lent token. Record this task's concurrency feedback, but leave the token itself
+            // to thread_task(), which credits it back after do_compaction() returns.
+            _limiter.release_borrowed_token(mem_limit_exceeded);
+            return;
+        }
         if (mem_limit_exceeded) {
             _limiter.memory_limit_exceeded();
         } else {
@@ -541,9 +565,9 @@ bool CompactionScheduler::try_hand_off_to_parallel(std::unique_ptr<CompactionTas
             // is a silent downgrade to serial compaction, so say it once per occurrence class.
             LOG_IF(WARNING, result.status().is_resource_busy())
                     << "Not enough compaction limiter tokens to run tablet " << tablet_id
-                    << " in parallel (holding one of " << _limiter.concurrency()
-                    << "); compacting it serially. Parallel compaction wants compact_threads to exceed "
-                       "max_parallel_per_tablet.";
+                    << " in parallel out of a concurrency of " << _limiter.concurrency()
+                    << "; compacting it serially. Other compactions are holding tokens -- parallel "
+                       "compaction wants compact_threads to be at least max_parallel_per_tablet.";
             VLOG(1) << "Parallel compaction planning failed for tablet " << tablet_id << ": " << result.status()
                     << ", compacting serially";
         } else {

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -462,8 +462,13 @@ void CompactionScheduler::thread_task(int id) {
         }
 
         if (context != nullptr) {
-            auto st = do_compaction(std::move(context));
-            if (st.is_mem_limit_exceeded()) {
+            // do_compaction() may hand this tablet to parallel subtasks, which take over the token; it then
+            // reports that this worker is no longer holding one and there is nothing here to credit back.
+            bool token_given_up = false;
+            auto st = do_compaction(std::move(context), &token_given_up);
+            if (token_given_up) {
+                // Deliberately no credit: the token belongs to whoever took it over.
+            } else if (st.is_mem_limit_exceeded()) {
                 _limiter.memory_limit_exceeded();
             } else {
                 _limiter.no_memory_limit_exceeded();
@@ -485,7 +490,11 @@ Status compaction_should_cancel(CompactionTaskContext* context) {
 // and |context| has been unlinked and destroyed -- the caller must not touch it, nor the callback, again.
 // Returns false if parallel compaction does not apply (or planning failed), leaving |context| untouched so
 // the caller can compact the tablet serially with it.
-bool CompactionScheduler::try_hand_off_to_parallel(std::unique_ptr<CompactionTaskContext>& context) {
+//
+// Sets |*token_given_up| when this worker no longer holds its limiter token, so that thread_task() does not
+// credit back a token it does not have.
+bool CompactionScheduler::try_hand_off_to_parallel(std::unique_ptr<CompactionTaskContext>& context,
+                                                   bool* token_given_up) {
     const auto tablet_id = context->tablet_id;
     const auto txn_id = context->txn_id;
 
@@ -504,30 +513,38 @@ bool CompactionScheduler::try_hand_off_to_parallel(std::unique_ptr<CompactionTas
         return false;
     }
 
-    // This worker already holds one of the limiter's tokens for as long as do_compaction() runs, and
-    // thread_task() credits it back when we return. Lend that token to the subtasks so planning needs
-    // max_parallel_per_tablet tokens instead of one more than that: the subtasks are acquired
-    // all-or-nothing, so needing an extra one means a single other compaction running anywhere on the CN
-    // is enough to fail the acquisition and quietly downgrade every tablet to serial compaction --
-    // with the defaults (3 subtasks, compact_threads=4) that is almost always.
+    // This worker holds one of the limiter's tokens for as long as do_compaction() runs. Hand it back
+    // before planning, for two reasons:
     //
-    // Both flags only ever go false->true, so the lent token is handed out at most once and repaid at
-    // most once; it can never be lent again after being repaid.
-    auto lent_out = std::make_shared<std::atomic<bool>>(false);
-    auto repaid = std::make_shared<std::atomic<bool>>(false);
-    AcquireTokenFunc acquire_token = [this, lent_out]() {
-        if (!lent_out->exchange(true)) {
-            return true; // hand out the token this worker is already holding
-        }
-        return _limiter.acquire();
-    };
-    ReleaseTokenFunc release_token = [this, lent_out, repaid](bool mem_limit_exceeded) {
-        if (lent_out->load() && !repaid->exchange(true)) {
-            // Repays the lent token. Record this task's concurrency feedback, but leave the token itself
-            // to thread_task(), which credits it back after do_compaction() returns.
-            _limiter.release_borrowed_token(mem_limit_exceeded);
+    //  - the subtasks are reserved all-or-nothing, so holding onto it would make parallel compaction need
+    //    max_parallel_per_tablet + 1 free tokens; with the defaults (3 subtasks, compact_threads=4) a
+    //    single other compaction anywhere on the CN would then be enough to quietly downgrade every
+    //    tablet to serial compaction;
+    //  - keeping it and settling up later cannot work: a handed-off do_compaction() returns while the
+    //    subtasks are still running, so thread_task() would credit the token back and leave a phantom
+    //    free token -- letting compactions exceed the configured (or memory-reduced) concurrency for as
+    //    long as the subtasks run.
+    //
+    // The subtasks now simply acquire and release tokens like any other task. What is left is telling
+    // thread_task() not to credit a token it no longer holds, which |token_returned| below does.
+    _limiter.return_token();
+    bool handed_off = false;
+    DeferOp settle_token([&]() {
+        if (handed_off) {
+            // The subtasks hold the tokens now and release them as they finish; this worker has none.
+            *token_given_up = true;
             return;
         }
+        // Not handing off after all: this worker compacts the tablet serially, so take a token back for
+        // thread_task() to credit. If none is free -- someone claimed it while we were planning -- carry on
+        // without one rather than blocking, and tell thread_task() not to credit what we do not hold.
+        if (!_limiter.acquire()) {
+            *token_given_up = true;
+        }
+    });
+
+    AcquireTokenFunc acquire_token = [this]() { return _limiter.acquire(); };
+    ReleaseTokenFunc release_token = [this](bool mem_limit_exceeded) {
         if (mem_limit_exceeded) {
             _limiter.memory_limit_exceeded();
         } else {
@@ -560,9 +577,8 @@ bool CompactionScheduler::try_hand_off_to_parallel(std::unique_ptr<CompactionTas
 
     if (!result.ok() || result.value() <= 0) {
         if (!result.ok()) {
-            // Planning pre-acquires one limiter token per subtask, and this worker is already holding one
-            // of the compact_threads tokens, so a busy scheduler can leave too few for the whole set. That
-            // is a silent downgrade to serial compaction, so say it once per occurrence class.
+            // Planning reserves one limiter token per subtask, all or nothing, so a busy scheduler can
+            // leave too few for the whole set. That is a silent downgrade to serial compaction.
             LOG_IF(WARNING, result.status().is_resource_busy())
                     << "Not enough compaction limiter tokens to run tablet " << tablet_id
                     << " in parallel out of a concurrency of " << _limiter.concurrency()
@@ -587,10 +603,11 @@ bool CompactionScheduler::try_hand_off_to_parallel(std::unique_ptr<CompactionTas
         context->RemoveFromList();
     }
     context.reset();
+    handed_off = true;
     return true;
 }
 
-Status CompactionScheduler::do_compaction(std::unique_ptr<CompactionTaskContext> context) {
+Status CompactionScheduler::do_compaction(std::unique_ptr<CompactionTaskContext> context, bool* token_given_up) {
     const auto start_time = ::time(nullptr);
     const auto start_time_ns = MonotonicNanos();
     const auto tablet_id = context->tablet_id;
@@ -619,7 +636,7 @@ Status CompactionScheduler::do_compaction(std::unique_ptr<CompactionTaskContext>
     // bthread it aborts the CN (issue #76882). Done before _tablet_mgr->compact() because that would
     // otherwise load the tablet and pick rowsets only for the work to be thrown away.
     if (context->parallel_requested && _parallel_mgr != nullptr) {
-        auto handed_off = try_hand_off_to_parallel(context);
+        auto handed_off = try_hand_off_to_parallel(context, token_given_up);
         if (handed_off) {
             // The subtasks own this tablet's single finish_task() from here on, so `context` must not
             // complete it. It has already been unlinked and destroyed; nothing below may touch it.

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -560,9 +560,14 @@ bool CompactionScheduler::try_hand_off_to_parallel(std::unique_ptr<CompactionTas
     auto result = [&]() -> StatusOr<int> {
         try {
             TEST_SYNC_POINT("CompactionScheduler::try_hand_off_to_parallel:create_parallel_tasks");
+            // Pass on the queue wait already recorded on this context: it is destroyed at the hand-off,
+            // so the merged context has to inherit it or CompactResponse under-reports the queue time by
+            // exactly the wait this hand-off introduces.
             return _parallel_mgr->create_parallel_tasks(tablet_id, txn_id, context->version, parallel_config,
                                                         context->callback, context->force_base_compaction,
-                                                        _threads.get(), acquire_token, release_token);
+                                                        _threads.get(), acquire_token, release_token,
+                                                        context->stats->in_queue_time_sec,
+                                                        context->stats->queue_wait_ns);
         } catch (const std::exception& e) {
             LOG(WARNING) << "Exception while planning parallel compaction, compacting serially instead. tablet_id="
                          << tablet_id << ", txn_id=" << txn_id << ": " << e.what();

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -273,6 +273,11 @@ void CompactionScheduler::stop() {
     if (changed) {
         _threads->shutdown();
         abort_all();
+        // Tablets handed off to parallel subtasks are not in _task_queues, so abort_all() cannot reach
+        // them. Any whose subtasks were dropped by the shutdown above would otherwise never complete.
+        if (_parallel_mgr != nullptr) {
+            _parallel_mgr->abort_pending_states();
+        }
     }
 }
 

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -317,9 +317,47 @@ void CompactionScheduler::compact(::google::protobuf::RpcController* controller,
 
     // Handle parallel compaction mode
     if (enable_parallel && _parallel_mgr != nullptr) {
-        lock.unlock();
+        // process_parallel_compaction() loads tablet metadata and builds the StarOS/Starlet
+        // filesystem, i.e. it performs blocking remote IO while creating the subtasks. This RPC
+        // handler runs on a brpc bthread, and a bthread can be suspended on one worker pthread and
+        // resumed on another. Doing such IO here is unsafe: a pthread rwlock held across the yield
+        // point (e.g. StarOSWorker::_cache_mtx, a std::shared_mutex held while an evicted FileSystem
+        // instance is destroyed and closes its remote connection) makes pthread_rwlock_wrlock return
+        // EDEADLK on an unrelated bthread that happens to be resumed on the same worker pthread.
+        // std::shared_mutex turns EDEADLK into an uncaught std::system_error("Resource deadlock
+        // avoided") and aborts the whole CN (issue #76882). Offload the IO-heavy task creation to the
+        // dedicated pthread pool, mirroring the non-parallel path which never touches the filesystem
+        // on the bthread.
+        //
+        // Hand ownership of `done` to `cb` before submitting: the pool task may run `done` (via
+        // CompactionTaskCallback::finish_task on another thread) as soon as it is scheduled, so the
+        // ClosureGuard here must no longer own it. `request`/`response` stay alive until `done` runs,
+        // and both the runnable (via `cb`) and the canceller keep them referenced, so reading them
+        // from either callback is safe.
+        //
+        // `done` must run exactly once. We use CancellableRunnable (not submit_func, whose runnable has
+        // a no-op cancel()) so that all three mutually-exclusive outcomes complete the RPC exactly once:
+        //   * task runs      -> process_parallel_compaction -> finish_task runs `done`;
+        //   * task cancelled -> stop()/_threads->shutdown() pops the still-queued task and calls
+        //                       cancel() == complete_with_reject (a no-op cancel() would leak `done` and
+        //                       hang the RPC forever);
+        //   * submit fails   -> the task was never enqueued (so neither run() nor cancel() fires), and we
+        //                       call complete_with_reject() inline below.
         guard.release();
-        process_parallel_compaction(request, response, cb);
+        auto complete_with_reject = [this, controller, request, response, done]() {
+            reject_request(controller, request, response);
+            done->Run();
+        };
+        auto runnable = std::make_shared<CancellableRunnable>(
+                [this, request, response, cb]() { process_parallel_compaction(request, response, cb); },
+                complete_with_reject);
+        auto submit_st = _threads->submit(std::move(runnable));
+        lock.unlock();
+        if (!submit_st.ok()) {
+            LOG(WARNING) << "Fail to submit parallel compaction task, txn_id=" << request->txn_id() << ": "
+                         << submit_st;
+            complete_with_reject();
+        }
         return;
     }
 
@@ -340,6 +378,9 @@ void CompactionScheduler::compact(::google::protobuf::RpcController* controller,
 
 void CompactionScheduler::process_parallel_compaction(const CompactRequest* request, CompactResponse* response,
                                                       const std::shared_ptr<CompactionTaskCallback>& callback) {
+    // Regression hook for #76882: this must run on a `_threads` pthread pool worker, never on the brpc
+    // bthread that invoked compact(). The test callback records std::this_thread::get_id() here.
+    TEST_SYNC_POINT("CompactionScheduler::process_parallel_compaction:enter");
     VLOG(1) << "Processing parallel compaction request. txn_id: " << request->txn_id()
             << ", tablet_ids size: " << request->tablet_ids_size()
             << ", max_parallel: " << request->parallel_config().max_parallel_per_tablet()

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -414,23 +414,12 @@ void CompactionScheduler::process_parallel_compaction(const CompactRequest* requ
         // would be unsafe: tablets scheduled by earlier iterations are still writing into `response` from their
         // own threads, and completing the RPC frees it under them.
         //
-        // The fallback is only safe when NO subtask was submitted for this tablet. create_parallel_tasks()
-        // registers the tablet state before submitting, and submit_subtasks_from_groups() submits the groups
-        // one at a time, so a throw (e.g. std::bad_alloc from the per-group bookkeeping) can land *after* some
-        // subtasks are already running. Those subtasks own the tablet's single finish_task():
-        // TabletParallelCompactionState::is_complete() is `running_subtasks.empty() && total_subtasks_created > 0`,
-        // so it still fires once the last of them completes. Falling back as well would create a SECOND context
-        // for the same tablet id, so finish_task() would run twice, push _contexts past tablet_ids_size() and
-        // dereference the `_response` that the first completion already nulled out -> SIGSEGV. So on a throw,
-        // only fall back if nothing was submitted; otherwise report the subtasks that are already in flight.
-        auto submitted_subtasks = [&]() -> int {
-            auto state = _parallel_mgr->get_tablet_state(tablet_id, request->txn_id());
-            if (state == nullptr) {
-                return 0;
-            }
-            std::lock_guard<std::mutex> l(state->mutex);
-            return state->total_subtasks_created;
-        };
+        // Falling back is only safe when NO subtask was submitted for this tablet: an already-running subtask
+        // owns the tablet's single finish_task(), so a fallback context would produce a second one for the same
+        // tablet id, push _contexts past tablet_ids_size() and dereference the `_response` that the first
+        // completion already nulled out -> SIGSEGV. That decision cannot be made here -- it is only race-free
+        // inside create_parallel_tasks(), which tracks the submitted count on its own stack -- so it handles the
+        // "already submitted" case itself and only lets an exception escape when nothing was submitted.
         auto result = [&]() -> StatusOr<int> {
             try {
                 TEST_SYNC_POINT("CompactionScheduler::process_parallel_compaction:create_parallel_tasks");
@@ -438,22 +427,15 @@ void CompactionScheduler::process_parallel_compaction(const CompactRequest* requ
                         tablet_id, request->txn_id(), request->version(), request->parallel_config(), callback,
                         request->force_base_compaction(), _threads.get(), acquire_token, release_token);
             } catch (const std::exception& e) {
-                auto in_flight = submitted_subtasks();
-                LOG(WARNING) << "Exception while creating parallel compaction tasks. tablet_id=" << tablet_id
-                             << ", txn_id=" << request->txn_id() << ", subtasks already submitted=" << in_flight << ": "
-                             << e.what();
-                if (in_flight > 0) {
-                    return in_flight;
-                }
+                LOG(WARNING) << "Exception while creating parallel compaction tasks, falling back to normal "
+                                "compaction. tablet_id="
+                             << tablet_id << ", txn_id=" << request->txn_id() << ": " << e.what();
                 _parallel_mgr->cleanup_tablet(tablet_id, request->txn_id());
                 return Status::InternalError(fmt::format("exception in create_parallel_tasks: {}", e.what()));
             } catch (...) {
-                auto in_flight = submitted_subtasks();
-                LOG(WARNING) << "Unknown exception while creating parallel compaction tasks. tablet_id=" << tablet_id
-                             << ", txn_id=" << request->txn_id() << ", subtasks already submitted=" << in_flight;
-                if (in_flight > 0) {
-                    return in_flight;
-                }
+                LOG(WARNING) << "Unknown exception while creating parallel compaction tasks, falling back to "
+                                "normal compaction. tablet_id="
+                             << tablet_id << ", txn_id=" << request->txn_id();
                 _parallel_mgr->cleanup_tablet(tablet_id, request->txn_id());
                 return Status::InternalError("unknown exception in create_parallel_tasks");
             }

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -440,8 +440,8 @@ void CompactionScheduler::process_parallel_compaction(const CompactRequest* requ
             } catch (const std::exception& e) {
                 auto in_flight = submitted_subtasks();
                 LOG(WARNING) << "Exception while creating parallel compaction tasks. tablet_id=" << tablet_id
-                             << ", txn_id=" << request->txn_id() << ", subtasks already submitted=" << in_flight
-                             << ": " << e.what();
+                             << ", txn_id=" << request->txn_id() << ", subtasks already submitted=" << in_flight << ": "
+                             << e.what();
                 if (in_flight > 0) {
                     return in_flight;
                 }

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -400,9 +400,37 @@ void CompactionScheduler::process_parallel_compaction(const CompactRequest* requ
     };
 
     for (auto tablet_id : request->tablet_ids()) {
-        auto result = _parallel_mgr->create_parallel_tasks(
-                tablet_id, request->txn_id(), request->version(), request->parallel_config(), callback,
-                request->force_base_compaction(), _threads.get(), acquire_token, release_token);
+        // create_parallel_tasks() loads the tablet metadata and builds the StarOS/Starlet filesystem, so it can
+        // throw: std::system_error("Resource deadlock avoided") is exactly the #76882 failure mode, and
+        // std::bad_alloc is always possible. Now that this function runs on a `_threads` worker instead of the
+        // brpc bthread, an escaping exception would silently hang the RPC: ThreadPool::dispatch_thread only logs
+        // it (it does not call the runnable's cancel()), compact() has already done `guard.release()`, and
+        // ~CompactionTaskCallback() does not run `done`. finish_task() completes the RPC only once it has
+        // collected one context per tablet id, so a skipped tablet means `done` never runs -- the FE's compact
+        // RPC blocks until its timeout and `request`/`response` are leaked.
+        //
+        // Translate the exception into a Status and take the existing fallback-to-normal-compaction path, which
+        // keeps the "exactly one finish_task() per tablet id" invariant intact. Running `done` here instead
+        // would be unsafe: tablets scheduled by earlier iterations are still writing into `response` from their
+        // own threads, and completing the RPC frees it under them.
+        auto result = [&]() -> StatusOr<int> {
+            try {
+                TEST_SYNC_POINT("CompactionScheduler::process_parallel_compaction:create_parallel_tasks");
+                return _parallel_mgr->create_parallel_tasks(
+                        tablet_id, request->txn_id(), request->version(), request->parallel_config(), callback,
+                        request->force_base_compaction(), _threads.get(), acquire_token, release_token);
+            } catch (const std::exception& e) {
+                LOG(WARNING) << "Exception while creating parallel compaction tasks, falling back to normal "
+                                "compaction. tablet_id="
+                             << tablet_id << ", txn_id=" << request->txn_id() << ": " << e.what();
+                return Status::InternalError(fmt::format("exception in create_parallel_tasks: {}", e.what()));
+            } catch (...) {
+                LOG(WARNING) << "Unknown exception while creating parallel compaction tasks, falling back to "
+                                "normal compaction. tablet_id="
+                             << tablet_id << ", txn_id=" << request->txn_id();
+                return Status::InternalError("unknown exception in create_parallel_tasks");
+            }
+        }();
 
         if (result.ok() && result.value() > 0) {
             // Parallel compaction tasks created successfully

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -338,25 +338,25 @@ void CompactionScheduler::compact(::google::protobuf::RpcController* controller,
         // `done` must run exactly once. We use CancellableRunnable (not submit_func, whose runnable has
         // a no-op cancel()) so that all three mutually-exclusive outcomes complete the RPC exactly once:
         //   * task runs      -> process_parallel_compaction -> finish_task runs `done`;
-        //   * task cancelled -> stop()/_threads->shutdown() pops the still-queued task and calls
-        //                       cancel() == complete_with_reject (a no-op cancel() would leak `done` and
-        //                       hang the RPC forever);
+        //   * task cancelled -> stop()/_threads->shutdown() pops the still-queued task and calls cancel(),
+        //                       which rejects with the shutdown-in-progress status and runs `done` (a
+        //                       no-op cancel() would leak `done` and hang the RPC forever);
         //   * submit fails   -> the task was never enqueued (so neither run() nor cancel() fires), and we
-        //                       call complete_with_reject() inline below.
+        //                       surface the real submit error and run `done` inline below.
         guard.release();
-        auto complete_with_reject = [this, controller, request, response, done]() {
-            reject_request(controller, request, response);
-            done->Run();
-        };
         auto runnable = std::make_shared<CancellableRunnable>(
                 [this, request, response, cb]() { process_parallel_compaction(request, response, cb); },
-                complete_with_reject);
+                [this, controller, request, response, done]() {
+                    reject_request(controller, request, response);
+                    done->Run();
+                });
         auto submit_st = _threads->submit(std::move(runnable));
         lock.unlock();
         if (!submit_st.ok()) {
             LOG(WARNING) << "Fail to submit parallel compaction task, txn_id=" << request->txn_id() << ": "
                          << submit_st;
-            complete_with_reject();
+            submit_st.to_protobuf(response->mutable_status());
+            done->Run();
         }
         return;
     }

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -563,11 +563,10 @@ bool CompactionScheduler::try_hand_off_to_parallel(std::unique_ptr<CompactionTas
             // Pass on the queue wait already recorded on this context: it is destroyed at the hand-off,
             // so the merged context has to inherit it or CompactResponse under-reports the queue time by
             // exactly the wait this hand-off introduces.
-            return _parallel_mgr->create_parallel_tasks(tablet_id, txn_id, context->version, parallel_config,
-                                                        context->callback, context->force_base_compaction,
-                                                        _threads.get(), acquire_token, release_token,
-                                                        context->stats->in_queue_time_sec,
-                                                        context->stats->queue_wait_ns);
+            return _parallel_mgr->create_parallel_tasks(
+                    tablet_id, txn_id, context->version, parallel_config, context->callback,
+                    context->force_base_compaction, _threads.get(), acquire_token, release_token,
+                    context->stats->in_queue_time_sec, context->stats->queue_wait_ns);
         } catch (const std::exception& e) {
             LOG(WARNING) << "Exception while planning parallel compaction, compacting serially instead. tablet_id="
                          << tablet_id << ", txn_id=" << txn_id << ": " << e.what();

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -753,6 +753,25 @@ Status CompactionScheduler::abort(int64_t txn_id) {
             return Status::OK();
         }
     }
+    l.unlock();
+
+    // A tablet handed off to parallel subtasks has no node in _contexts between the hand-off and its
+    // merged context being appended, so the walk above misses it and would report the whole txn as not
+    // found. Ask the parallel manager instead; its subtasks poll the callback through their cancel_func,
+    // so marking it is what actually stops them.
+    //
+    // The lock was released first on purpose: the existing order is _contexts_lock -> _states_mutex
+    // (remove_states() -> cleanup_tablet()), and update_status() takes the callback's own mutex, so
+    // neither is held here.
+    if (_parallel_mgr != nullptr) {
+        auto callbacks = _parallel_mgr->collect_callbacks_for_txn(txn_id);
+        for (auto& cb : callbacks) {
+            cb->update_status(Status::Aborted("aborted on demand"));
+        }
+        if (!callbacks.empty()) {
+            return Status::OK();
+        }
+    }
     return Status::NotFound(fmt::format("no compaction task with txn id {}", txn_id));
 }
 

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -300,6 +300,15 @@ void CompactionScheduler::compact(::google::protobuf::RpcController* controller,
         auto context = std::make_unique<CompactionTaskContext>(request->txn_id(), tablet_id, request->version(),
                                                                request->force_base_compaction(),
                                                                request->skip_write_txnlog(), cb);
+        // Snapshot the parallel-compaction request here, on the bthread. The worker that later plans the
+        // subtasks reads these instead of `request`, which it must not touch: `request`/`response` are only
+        // guaranteed to outlive the worker while some tablet still has an unfinished context, and once the
+        // last finish_task() runs `done` brpc frees them.
+        if (enable_parallel && _parallel_mgr != nullptr) {
+            context->parallel_requested = true;
+            context->parallel_max_parallel_per_tablet = request->parallel_config().max_parallel_per_tablet();
+            context->parallel_max_bytes_per_subtask = request->parallel_config().max_bytes_per_subtask();
+        }
         contexts_vec.push_back(std::move(context));
         // DO NOT touch `context` from here!
     }
@@ -315,53 +324,16 @@ void CompactionScheduler::compact(::google::protobuf::RpcController* controller,
         return;
     }
 
-    // Handle parallel compaction mode
-    if (enable_parallel && _parallel_mgr != nullptr) {
-        // process_parallel_compaction() loads tablet metadata and builds the StarOS/Starlet
-        // filesystem, i.e. it performs blocking remote IO while creating the subtasks. This RPC
-        // handler runs on a brpc bthread, and a bthread can be suspended on one worker pthread and
-        // resumed on another. Doing such IO here is unsafe: a pthread rwlock held across the yield
-        // point (e.g. StarOSWorker::_cache_mtx, a std::shared_mutex held while an evicted FileSystem
-        // instance is destroyed and closes its remote connection) makes pthread_rwlock_wrlock return
-        // EDEADLK on an unrelated bthread that happens to be resumed on the same worker pthread.
-        // std::shared_mutex turns EDEADLK into an uncaught std::system_error("Resource deadlock
-        // avoided") and aborts the whole CN (issue #76882). Offload the IO-heavy task creation to the
-        // dedicated pthread pool, mirroring the non-parallel path which never touches the filesystem
-        // on the bthread.
-        //
-        // Hand ownership of `done` to `cb` before submitting: the pool task may run `done` (via
-        // CompactionTaskCallback::finish_task on another thread) as soon as it is scheduled, so the
-        // ClosureGuard here must no longer own it. `request`/`response` stay alive until `done` runs,
-        // and both the runnable (via `cb`) and the canceller keep them referenced, so reading them
-        // from either callback is safe.
-        //
-        // `done` must run exactly once. We use CancellableRunnable (not submit_func, whose runnable has
-        // a no-op cancel()) so that all three mutually-exclusive outcomes complete the RPC exactly once:
-        //   * task runs      -> process_parallel_compaction -> finish_task runs `done`;
-        //   * task cancelled -> stop()/_threads->shutdown() pops the still-queued task and calls cancel(),
-        //                       which rejects with the shutdown-in-progress status and runs `done` (a
-        //                       no-op cancel() would leak `done` and hang the RPC forever);
-        //   * submit fails   -> the task was never enqueued (so neither run() nor cancel() fires), and we
-        //                       surface the real submit error and run `done` inline below.
-        guard.release();
-        auto runnable = std::make_shared<CancellableRunnable>(
-                [this, request, response, cb]() { process_parallel_compaction(request, response, cb); },
-                [this, controller, request, response, done]() {
-                    reject_request(controller, request, response);
-                    done->Run();
-                });
-        auto submit_st = _threads->submit(std::move(runnable));
-        lock.unlock();
-        if (!submit_st.ok()) {
-            LOG(WARNING) << "Fail to submit parallel compaction task, txn_id=" << request->txn_id() << ": "
-                         << submit_st;
-            submit_st.to_protobuf(response->mutable_status());
-            done->Run();
-        }
-        return;
-    }
-
-    // Original non-parallel mode
+    // Both modes publish their contexts the same way from here on. Planning the parallel subtasks needs
+    // blocking StarOS/Starlet filesystem IO, which must not run on this brpc bthread -- a pthread rwlock
+    // held across a bthread yield (StarOSWorker::_cache_mtx while an evicted FileSystem is destroyed)
+    // makes pthread_rwlock_wrlock return EDEADLK, which std::shared_mutex turns into an uncaught
+    // std::system_error and which aborts the CN (issue #76882). So the planning happens later, in
+    // do_compaction(), on the resident thread_task() worker that already runs every other bit of
+    // compaction IO. Publishing all contexts here, before any worker can dequeue one, is also what keeps
+    // CompactionTaskCallback::finish_task() from completing the RPC before every tablet has a context --
+    // the worker reads `request`/`response` through the callback, so an early completion would leave it
+    // dereferencing memory brpc has already freed.
     {
         std::lock_guard l(_contexts_lock);
         for (auto& ctx : contexts_vec) {
@@ -374,106 +346,6 @@ void CompactionScheduler::compact(::google::protobuf::RpcController* controller,
     guard.release();
 
     TEST_SYNC_POINT("CompactionScheduler::compact:return");
-}
-
-void CompactionScheduler::process_parallel_compaction(const CompactRequest* request, CompactResponse* response,
-                                                      const std::shared_ptr<CompactionTaskCallback>& callback) {
-    // Regression hook for #76882: this must run on a `_threads` pthread pool worker, never on the brpc
-    // bthread that invoked compact(). The test callback records std::this_thread::get_id() here.
-    TEST_SYNC_POINT("CompactionScheduler::process_parallel_compaction:enter");
-    VLOG(1) << "Processing parallel compaction request. txn_id: " << request->txn_id()
-            << ", tablet_ids size: " << request->tablet_ids_size()
-            << ", max_parallel: " << request->parallel_config().max_parallel_per_tablet()
-            << ", max_bytes: " << request->parallel_config().max_bytes_per_subtask();
-
-    int total_subtasks = 0;
-    int successful_tablets = 0;
-
-    // Create limiter callbacks for parallel compaction
-    AcquireTokenFunc acquire_token = [this]() { return _limiter.acquire(); };
-    ReleaseTokenFunc release_token = [this](bool mem_limit_exceeded) {
-        if (mem_limit_exceeded) {
-            _limiter.memory_limit_exceeded();
-        } else {
-            _limiter.no_memory_limit_exceeded();
-        }
-    };
-
-    for (auto tablet_id : request->tablet_ids()) {
-        // create_parallel_tasks() loads the tablet metadata and builds the StarOS/Starlet filesystem, so it can
-        // throw: std::system_error("Resource deadlock avoided") is exactly the #76882 failure mode, and
-        // std::bad_alloc is always possible. Now that this function runs on a `_threads` worker instead of the
-        // brpc bthread, an escaping exception would silently hang the RPC: ThreadPool::dispatch_thread only logs
-        // it (it does not call the runnable's cancel()), compact() has already done `guard.release()`, and
-        // ~CompactionTaskCallback() does not run `done`. finish_task() completes the RPC only once it has
-        // collected one context per tablet id, so a skipped tablet means `done` never runs -- the FE's compact
-        // RPC blocks until its timeout and `request`/`response` are leaked.
-        //
-        // Translate the exception into a Status and take the existing fallback-to-normal-compaction path, which
-        // keeps the "exactly one finish_task() per tablet id" invariant intact. Running `done` here instead
-        // would be unsafe: tablets scheduled by earlier iterations are still writing into `response` from their
-        // own threads, and completing the RPC frees it under them.
-        //
-        // Falling back is only safe when NO subtask was submitted for this tablet: an already-running subtask
-        // owns the tablet's single finish_task(), so a fallback context would produce a second one for the same
-        // tablet id, push _contexts past tablet_ids_size() and dereference the `_response` that the first
-        // completion already nulled out -> SIGSEGV. That decision cannot be made here -- it is only race-free
-        // inside create_parallel_tasks(), which tracks the submitted count on its own stack -- so it handles the
-        // "already submitted" case itself and only lets an exception escape when nothing was submitted.
-        auto result = [&]() -> StatusOr<int> {
-            try {
-                TEST_SYNC_POINT("CompactionScheduler::process_parallel_compaction:create_parallel_tasks");
-                return _parallel_mgr->create_parallel_tasks(
-                        tablet_id, request->txn_id(), request->version(), request->parallel_config(), callback,
-                        request->force_base_compaction(), _threads.get(), acquire_token, release_token);
-            } catch (const std::exception& e) {
-                LOG(WARNING) << "Exception while creating parallel compaction tasks, falling back to normal "
-                                "compaction. tablet_id="
-                             << tablet_id << ", txn_id=" << request->txn_id() << ": " << e.what();
-                _parallel_mgr->cleanup_tablet(tablet_id, request->txn_id());
-                return Status::InternalError(fmt::format("exception in create_parallel_tasks: {}", e.what()));
-            } catch (...) {
-                LOG(WARNING) << "Unknown exception while creating parallel compaction tasks, falling back to "
-                                "normal compaction. tablet_id="
-                             << tablet_id << ", txn_id=" << request->txn_id();
-                _parallel_mgr->cleanup_tablet(tablet_id, request->txn_id());
-                return Status::InternalError("unknown exception in create_parallel_tasks");
-            }
-        }();
-
-        if (result.ok() && result.value() > 0) {
-            // Parallel compaction tasks created successfully
-            total_subtasks += result.value();
-            successful_tablets++;
-            VLOG(1) << "Created " << result.value() << " parallel subtasks for tablet " << tablet_id;
-        } else {
-            // Fall back to non-parallel mode for this tablet if:
-            // 1. create_parallel_tasks failed (result.status() is not OK)
-            // 2. create_parallel_tasks returned 0 (indicates fallback, e.g., data size too small)
-            if (!result.ok()) {
-                VLOG(1) << "Failed to create parallel tasks for tablet " << tablet_id << ": " << result.status()
-                        << ", falling back to normal compaction";
-            } else {
-                VLOG(1) << "Parallel compaction not applicable for tablet " << tablet_id
-                        << ", falling back to normal compaction";
-            }
-            auto context = std::make_unique<CompactionTaskContext>(request->txn_id(), tablet_id, request->version(),
-                                                                   request->force_base_compaction(),
-                                                                   request->skip_write_txnlog(), callback);
-            context->enqueue_time_sec = ::time(nullptr);
-
-            {
-                std::lock_guard l(_contexts_lock);
-                _contexts.Append(context.get());
-            }
-
-            std::unique_lock lock(_mutex);
-            _task_queues.put_by_txn_id(request->txn_id(), context);
-        }
-    }
-
-    VLOG(1) << "Parallel compaction request processed. txn_id: " << request->txn_id()
-            << ", total_subtasks: " << total_subtasks << ", successful_tablets: " << successful_tablets;
 }
 
 void CompactionScheduler::list_tasks(std::vector<CompactionTaskInfo>* infos) {
@@ -605,6 +477,95 @@ Status compaction_should_cancel(CompactionTaskContext* context) {
     return context->callback->is_txn_still_valid();
 }
 
+// Tries to replace this tablet's serial compaction with parallel subtasks.
+//
+// Returns true only if subtasks were submitted, in which case they own the tablet's single finish_task()
+// and |context| has been unlinked and destroyed -- the caller must not touch it, nor the callback, again.
+// Returns false if parallel compaction does not apply (or planning failed), leaving |context| untouched so
+// the caller can compact the tablet serially with it.
+bool CompactionScheduler::try_hand_off_to_parallel(std::unique_ptr<CompactionTaskContext>& context) {
+    const auto tablet_id = context->tablet_id;
+    const auto txn_id = context->txn_id;
+
+    // Don't start subtasks we cannot finish. ThreadPool::shutdown() drops queued tasks and calls the
+    // no-op FunctionRunnable::cancel() on them, so a subtask queued during shutdown never reports back,
+    // its tablet never drains, and nothing would complete the RPC. Compacting serially instead keeps the
+    // context in the queue, where abort_all() finds and aborts it.
+    if (_stopped.load(std::memory_order_acquire)) {
+        return false;
+    }
+
+    // A txn that FE already cancelled, or one whose deadline has passed, would spawn subtasks that cannot
+    // be cancelled (abort() does not reach them) and would run to completion for nothing. The serial path
+    // notices the same condition through should_cancel and fails fast.
+    if (context->callback != nullptr && !context->callback->has_error().ok()) {
+        return false;
+    }
+
+    AcquireTokenFunc acquire_token = [this]() { return _limiter.acquire(); };
+    ReleaseTokenFunc release_token = [this](bool mem_limit_exceeded) {
+        if (mem_limit_exceeded) {
+            _limiter.memory_limit_exceeded();
+        } else {
+            _limiter.no_memory_limit_exceeded();
+        }
+    };
+
+    TabletParallelConfig parallel_config;
+    parallel_config.set_enable_parallel(true);
+    parallel_config.set_max_parallel_per_tablet(context->parallel_max_parallel_per_tablet);
+    parallel_config.set_max_bytes_per_subtask(context->parallel_max_bytes_per_subtask);
+
+    auto result = [&]() -> StatusOr<int> {
+        try {
+            TEST_SYNC_POINT("CompactionScheduler::try_hand_off_to_parallel:create_parallel_tasks");
+            return _parallel_mgr->create_parallel_tasks(tablet_id, txn_id, context->version, parallel_config,
+                                                        context->callback, context->force_base_compaction,
+                                                        _threads.get(), acquire_token, release_token);
+        } catch (const std::exception& e) {
+            LOG(WARNING) << "Exception while planning parallel compaction, compacting serially instead. tablet_id="
+                         << tablet_id << ", txn_id=" << txn_id << ": " << e.what();
+            return Status::InternalError(fmt::format("exception in create_parallel_tasks: {}", e.what()));
+        } catch (...) {
+            LOG(WARNING) << "Unknown exception while planning parallel compaction, compacting serially instead. "
+                            "tablet_id="
+                         << tablet_id << ", txn_id=" << txn_id;
+            return Status::InternalError("unknown exception in create_parallel_tasks");
+        }
+    }();
+
+    if (!result.ok() || result.value() <= 0) {
+        if (!result.ok()) {
+            // Planning pre-acquires one limiter token per subtask, and this worker is already holding one
+            // of the compact_threads tokens, so a busy scheduler can leave too few for the whole set. That
+            // is a silent downgrade to serial compaction, so say it once per occurrence class.
+            LOG_IF(WARNING, result.status().is_resource_busy())
+                    << "Not enough compaction limiter tokens to run tablet " << tablet_id
+                    << " in parallel (holding one of " << _limiter.concurrency()
+                    << "); compacting it serially. Parallel compaction wants compact_threads to exceed "
+                       "max_parallel_per_tablet.";
+            VLOG(1) << "Parallel compaction planning failed for tablet " << tablet_id << ": " << result.status()
+                    << ", compacting serially";
+        } else {
+            VLOG(1) << "Parallel compaction not applicable for tablet " << tablet_id << ", compacting serially";
+        }
+        return false;
+    }
+
+    VLOG(1) << "Created " << result.value() << " parallel subtasks for tablet " << tablet_id << ", txn_id=" << txn_id;
+
+    // The subtasks are running and will complete this tablet, so retire our context. It has to leave
+    // _contexts before it is destroyed: the list holds a bare pointer that list_tasks() and abort() walk
+    // under _contexts_lock, and CompactionTaskContext's debug destructor asserts the node was unlinked.
+    // Destroy it outside the lock -- it may drop the last reference to the callback.
+    {
+        std::lock_guard l(_contexts_lock);
+        context->RemoveFromList();
+    }
+    context.reset();
+    return true;
+}
+
 Status CompactionScheduler::do_compaction(std::unique_ptr<CompactionTaskContext> context) {
     const auto start_time = ::time(nullptr);
     const auto start_time_ns = MonotonicNanos();
@@ -628,6 +589,22 @@ Status CompactionScheduler::do_compaction(std::unique_ptr<CompactionTaskContext>
     const int attempt = context->runs.fetch_add(1, std::memory_order_relaxed) + 1;
     context->stats->task_attempt_count = attempt;
     context->publish_stats_snapshot();
+
+    // Plan the parallel subtasks here rather than in compact(): this runs on a resident thread_task()
+    // worker, so the blocking StarOS/Starlet filesystem IO it needs is fine, whereas on compact()'s brpc
+    // bthread it aborts the CN (issue #76882). Done before _tablet_mgr->compact() because that would
+    // otherwise load the tablet and pick rowsets only for the work to be thrown away.
+    if (context->parallel_requested && _parallel_mgr != nullptr) {
+        auto handed_off = try_hand_off_to_parallel(context);
+        if (handed_off) {
+            // The subtasks own this tablet's single finish_task() from here on, so `context` must not
+            // complete it. It has already been unlinked and destroyed; nothing below may touch it.
+            return Status::OK();
+        }
+        // Not applicable, or planning failed: fall through and compact this tablet serially with the very
+        // same context. Reusing it -- instead of creating a second one, as the old dispatcher did -- is
+        // what makes a duplicate finish_task() for one tablet impossible by construction.
+    }
 
     auto status = Status::OK();
     auto task_prepare_start_ns = MonotonicNanos();

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -497,7 +497,9 @@ Status compaction_should_cancel(CompactionTaskContext* context) {
 // the caller can compact the tablet serially with it.
 //
 // Sets |*token_given_up| when this worker no longer holds its limiter token, so that thread_task() does not
-// credit back a token it does not have.
+// credit back a token it does not have. Returning false with |*token_given_up| set is the third outcome:
+// planning failed and the token was claimed by another worker meanwhile, so the caller must reschedule the
+// tablet instead of compacting it outside the limiter.
 bool CompactionScheduler::try_hand_off_to_parallel(std::unique_ptr<CompactionTaskContext>& context,
                                                    bool* token_given_up) {
     const auto tablet_id = context->tablet_id;
@@ -541,10 +543,18 @@ bool CompactionScheduler::try_hand_off_to_parallel(std::unique_ptr<CompactionTas
             return;
         }
         // Not handing off after all: this worker compacts the tablet serially, so take a token back for
-        // thread_task() to credit. If none is free -- someone claimed it while we were planning -- carry on
-        // without one rather than blocking, and tell thread_task() not to credit what we do not hold.
+        // thread_task() to credit. If none is free -- another worker claimed it while we were planning --
+        // do not compact without one: that work would run outside the limiter, right next to whoever took
+        // the token, and several planning fallbacks at once would then exceed the configured (or
+        // memory-reduced) concurrency, which is the memory pressure the limiter exists to prevent. Leave
+        // |*token_given_up| set; do_compaction() reads it as "reschedule this tablet".
         if (!_limiter.acquire()) {
             *token_given_up = true;
+            // Take the parallel path off the table for the retry. Returning the token mid-flight is the
+            // only thing that can strand a worker without one, so a serial retry cannot land here again --
+            // which is what bounds this to a single reschedule.
+            context->parallel_requested = false;
+            TEST_SYNC_POINT("CompactionScheduler::try_hand_off_to_parallel:token_lost");
         }
     });
 
@@ -649,6 +659,18 @@ Status CompactionScheduler::do_compaction(std::unique_ptr<CompactionTaskContext>
         if (handed_off) {
             // The subtasks own this tablet's single finish_task() from here on, so `context` must not
             // complete it. It has already been unlinked and destroyed; nothing below may touch it.
+            return Status::OK();
+        }
+        if (*token_given_up) {
+            // Planning gave this worker's limiter token back and another worker claimed it before we could
+            // take it over again. Reschedule rather than compact outside the limiter -- the retry has the
+            // parallel path disabled, so it cannot end up here a second time.
+            LOG(WARNING) << "Lost the compaction limiter token while planning parallel compaction, "
+                            "rescheduling tablet "
+                         << tablet_id << " version=" << version << " txn_id=" << txn_id;
+            context->progress.update(0);
+            context->start_time.store(0, std::memory_order_relaxed);
+            _task_queues.put_by_txn_id(txn_id, context);
             return Status::OK();
         }
         // Not applicable, or planning failed: fall through and compact this tablet serially with the very

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -413,6 +413,24 @@ void CompactionScheduler::process_parallel_compaction(const CompactRequest* requ
         // keeps the "exactly one finish_task() per tablet id" invariant intact. Running `done` here instead
         // would be unsafe: tablets scheduled by earlier iterations are still writing into `response` from their
         // own threads, and completing the RPC frees it under them.
+        //
+        // The fallback is only safe when NO subtask was submitted for this tablet. create_parallel_tasks()
+        // registers the tablet state before submitting, and submit_subtasks_from_groups() submits the groups
+        // one at a time, so a throw (e.g. std::bad_alloc from the per-group bookkeeping) can land *after* some
+        // subtasks are already running. Those subtasks own the tablet's single finish_task():
+        // TabletParallelCompactionState::is_complete() is `running_subtasks.empty() && total_subtasks_created > 0`,
+        // so it still fires once the last of them completes. Falling back as well would create a SECOND context
+        // for the same tablet id, so finish_task() would run twice, push _contexts past tablet_ids_size() and
+        // dereference the `_response` that the first completion already nulled out -> SIGSEGV. So on a throw,
+        // only fall back if nothing was submitted; otherwise report the subtasks that are already in flight.
+        auto submitted_subtasks = [&]() -> int {
+            auto state = _parallel_mgr->get_tablet_state(tablet_id, request->txn_id());
+            if (state == nullptr) {
+                return 0;
+            }
+            std::lock_guard<std::mutex> l(state->mutex);
+            return state->total_subtasks_created;
+        };
         auto result = [&]() -> StatusOr<int> {
             try {
                 TEST_SYNC_POINT("CompactionScheduler::process_parallel_compaction:create_parallel_tasks");
@@ -420,14 +438,23 @@ void CompactionScheduler::process_parallel_compaction(const CompactRequest* requ
                         tablet_id, request->txn_id(), request->version(), request->parallel_config(), callback,
                         request->force_base_compaction(), _threads.get(), acquire_token, release_token);
             } catch (const std::exception& e) {
-                LOG(WARNING) << "Exception while creating parallel compaction tasks, falling back to normal "
-                                "compaction. tablet_id="
-                             << tablet_id << ", txn_id=" << request->txn_id() << ": " << e.what();
+                auto in_flight = submitted_subtasks();
+                LOG(WARNING) << "Exception while creating parallel compaction tasks. tablet_id=" << tablet_id
+                             << ", txn_id=" << request->txn_id() << ", subtasks already submitted=" << in_flight
+                             << ": " << e.what();
+                if (in_flight > 0) {
+                    return in_flight;
+                }
+                _parallel_mgr->cleanup_tablet(tablet_id, request->txn_id());
                 return Status::InternalError(fmt::format("exception in create_parallel_tasks: {}", e.what()));
             } catch (...) {
-                LOG(WARNING) << "Unknown exception while creating parallel compaction tasks, falling back to "
-                                "normal compaction. tablet_id="
-                             << tablet_id << ", txn_id=" << request->txn_id();
+                auto in_flight = submitted_subtasks();
+                LOG(WARNING) << "Unknown exception while creating parallel compaction tasks. tablet_id=" << tablet_id
+                             << ", txn_id=" << request->txn_id() << ", subtasks already submitted=" << in_flight;
+                if (in_flight > 0) {
+                    return in_flight;
+                }
+                _parallel_mgr->cleanup_tablet(tablet_id, request->txn_id());
                 return Status::InternalError("unknown exception in create_parallel_tasks");
             }
         }();

--- a/be/src/storage/lake/compaction_scheduler.h
+++ b/be/src/storage/lake/compaction_scheduler.h
@@ -149,15 +149,10 @@ class CompactionScheduler {
         // Compaction task finished with Status::MemoryLimitExceeded error.
         void memory_limit_exceeded();
 
-        // A compaction task that ran on a BORROWED token finished: applies the same concurrency feedback as
-        // the two methods above, but does not credit a token back to the pool because the lender returns
-        // the one it is holding itself. Crediting here as well would inflate the pool by one token.
-        //
-        // Note this is not simply "the same minus one _free++": on the memory-limit path the token is
-        // normally converted into a reserved slot rather than returned, and only the floor case hands it
-        // back -- that hand-back is what has to be skipped. On the success path the restore branch's
-        // increment un-reserves a slot rather than returning the borrowed token, so it is kept.
-        void release_borrowed_token(bool mem_limit_exceeded);
+        // Puts a token back without recording a task outcome, for a holder that is handing its token over
+        // instead of having finished work with it. Unlike no_memory_limit_exceeded() this does not count a
+        // success towards restoring reserved concurrency: nothing completed, so there is nothing to judge.
+        void return_token();
 
         int16_t concurrency() const;
 
@@ -260,7 +255,9 @@ private:
 
     void thread_task(int id);
 
-    Status do_compaction(std::unique_ptr<CompactionTaskContext> context);
+    // |token_given_up| is set when the worker's limiter token was taken over by parallel subtasks
+    // (or could not be reclaimed), meaning the caller must not credit a token back.
+    Status do_compaction(std::unique_ptr<CompactionTaskContext> context, bool* token_given_up);
 
     void abort_compaction(std::unique_ptr<CompactionTaskContext> context);
 
@@ -282,7 +279,7 @@ private:
     // i.e. on a resident worker where the planning IO is safe. Returns true only if subtasks were
     // submitted, in which case they own the tablet's completion and |context| has been unlinked and
     // destroyed; returns false to have the caller compact the tablet serially with the same context.
-    bool try_hand_off_to_parallel(std::unique_ptr<CompactionTaskContext>& context);
+    bool try_hand_off_to_parallel(std::unique_ptr<CompactionTaskContext>& context, bool* token_given_up);
 };
 
 inline bool CompactionScheduler::Limiter::acquire() {
@@ -317,25 +314,9 @@ inline void CompactionScheduler::Limiter::memory_limit_exceeded() {
     }
 }
 
-inline void CompactionScheduler::Limiter::release_borrowed_token(bool mem_limit_exceeded) {
+inline void CompactionScheduler::Limiter::return_token() {
     std::lock_guard l(_mtx);
-    if (mem_limit_exceeded) {
-        _success = 0;
-        if (_reserved + 1 < _total) { // Cannot reduce the concurrency to zero.
-            _reserved++;
-            LOG(INFO) << "Decreased maximum compaction concurrency to " << (_total - _reserved);
-        }
-        // At the floor memory_limit_exceeded() would hand the token back instead of reserving it; the
-        // lender hands this one back, so there is nothing left to do.
-    } else {
-        if (_reserved > 0 && ++_success == kConcurrencyRestoreTimes) {
-            --_reserved;
-            // Un-reserves a slot. This is not the borrowed token being returned.
-            ++_free;
-            _success = 0;
-            LOG(INFO) << "Increased maximum compaction concurrency to " << (_total - _reserved);
-        }
-    }
+    _free++;
 }
 
 inline int16_t CompactionScheduler::Limiter::concurrency() const {

--- a/be/src/storage/lake/compaction_scheduler.h
+++ b/be/src/storage/lake/compaction_scheduler.h
@@ -245,6 +245,11 @@ public:
 
     void stop();
 
+    // Lets a test play the part of a competing worker and take limiter tokens out of circulation, so that
+    // the "token claimed by someone else while we were planning" path can be driven deterministically.
+    bool acquire_token_for_test() { return _limiter.acquire(); }
+    void return_token_for_test() { _limiter.return_token(); }
+
 private:
     friend class CompactionTaskCallback;
 

--- a/be/src/storage/lake/compaction_scheduler.h
+++ b/be/src/storage/lake/compaction_scheduler.h
@@ -149,6 +149,16 @@ class CompactionScheduler {
         // Compaction task finished with Status::MemoryLimitExceeded error.
         void memory_limit_exceeded();
 
+        // A compaction task that ran on a BORROWED token finished: applies the same concurrency feedback as
+        // the two methods above, but does not credit a token back to the pool because the lender returns
+        // the one it is holding itself. Crediting here as well would inflate the pool by one token.
+        //
+        // Note this is not simply "the same minus one _free++": on the memory-limit path the token is
+        // normally converted into a reserved slot rather than returned, and only the floor case hands it
+        // back -- that hand-back is what has to be skipped. On the success path the restore branch's
+        // increment un-reserves a slot rather than returning the borrowed token, so it is kept.
+        void release_borrowed_token(bool mem_limit_exceeded);
+
         int16_t concurrency() const;
 
         void adapt_to_task_queue_size(int16_t new_val);
@@ -304,6 +314,27 @@ inline void CompactionScheduler::Limiter::memory_limit_exceeded() {
         LOG(INFO) << "Decreased maximum compaction concurrency to " << (_total - _reserved);
     } else {
         _free++;
+    }
+}
+
+inline void CompactionScheduler::Limiter::release_borrowed_token(bool mem_limit_exceeded) {
+    std::lock_guard l(_mtx);
+    if (mem_limit_exceeded) {
+        _success = 0;
+        if (_reserved + 1 < _total) { // Cannot reduce the concurrency to zero.
+            _reserved++;
+            LOG(INFO) << "Decreased maximum compaction concurrency to " << (_total - _reserved);
+        }
+        // At the floor memory_limit_exceeded() would hand the token back instead of reserving it; the
+        // lender hands this one back, so there is nothing left to do.
+    } else {
+        if (_reserved > 0 && ++_success == kConcurrencyRestoreTimes) {
+            --_reserved;
+            // Un-reserves a slot. This is not the borrowed token being returned.
+            ++_free;
+            _success = 0;
+            LOG(INFO) << "Increased maximum compaction concurrency to " << (_total - _reserved);
+        }
     }
 }
 

--- a/be/src/storage/lake/compaction_scheduler.h
+++ b/be/src/storage/lake/compaction_scheduler.h
@@ -268,9 +268,11 @@ private:
     // Per-tablet parallel compaction manager
     std::unique_ptr<TabletParallelCompactionManager> _parallel_mgr;
 
-    // Process compaction request with parallel mode
-    void process_parallel_compaction(const CompactRequest* request, CompactResponse* response,
-                                     const std::shared_ptr<CompactionTaskCallback>& callback);
+    // Tries to replace one tablet's serial compaction with parallel subtasks. Called from do_compaction(),
+    // i.e. on a resident worker where the planning IO is safe. Returns true only if subtasks were
+    // submitted, in which case they own the tablet's completion and |context| has been unlinked and
+    // destroyed; returns false to have the caller compact the tablet serially with the same context.
+    bool try_hand_off_to_parallel(std::unique_ptr<CompactionTaskContext>& context);
 };
 
 inline bool CompactionScheduler::Limiter::acquire() {

--- a/be/src/storage/lake/compaction_task_context.h
+++ b/be/src/storage/lake/compaction_task_context.h
@@ -193,6 +193,13 @@ struct CompactionTaskContext : public butil::LinkNode<CompactionTaskContext> {
     std::shared_ptr<TxnLogPB> txn_log;
     int64_t table_id;
     int64_t partition_id;
+    // Parallel-compaction request snapshot, taken from CompactRequest::parallel_config on the brpc
+    // bthread so that the worker which later plans the subtasks never dereferences the RPC's `request`.
+    // Kept as plain scalars rather than the TabletParallelConfig proto to avoid pulling
+    // gen_cpp/lake_service.pb.h into every translation unit that includes this header.
+    bool parallel_requested = false;
+    int32_t parallel_max_parallel_per_tablet = 0;
+    int64_t parallel_max_bytes_per_subtask = 0;
     int32_t subtask_id = -1; // -1 means not a parallel compaction subtask
     // Number of subtasks in this compaction (1 for normal compaction, >1 for parallel compaction)
     int32_t subtask_count = 1;

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -2057,6 +2057,24 @@ StatusOr<int> TabletParallelCompactionManager::submit_subtasks_from_groups(
     VLOG(1) << "Parallel compaction: acquired all " << tokens_acquired << " tokens for tablet " << tablet_id
             << ", txn_id=" << txn_id;
 
+    int subtasks_created = 0;
+    int64_t submitted_bytes = 0;
+
+    // All `total_groups` tokens are held from here on, and each submitted subtask releases its own on
+    // completion. Every ordinary exit below settles the rest explicitly and sets `tokens_settled`; an exception
+    // would otherwise strand them, and with compact_threads defaulting to 4, leaking a couple per failure
+    // starves lake compaction for the whole BE until it restarts. So install this guard immediately after the
+    // acquisition succeeds -- everything below it, including the split bookkeeping, can throw std::bad_alloc.
+    bool tokens_settled = false;
+    DeferOp release_unused_tokens([&] {
+        if (tokens_settled) {
+            return;
+        }
+        for (int32_t j = subtasks_created; j < total_groups; j++) {
+            release_token(false);
+        }
+    });
+
     // Record expected split counts for each large rowset as a safety net.
     // Even though we've acquired all tokens, thread pool submission can still fail.
     // This allows get_merged_txn_log() to detect incomplete splits.
@@ -2082,23 +2100,6 @@ StatusOr<int> TabletParallelCompactionManager::submit_subtasks_from_groups(
     // Now create and submit all subtasks. Since we've acquired all tokens,
     // we won't have partial large-rowset splits due to token exhaustion.
     // Thread pool submission failures are still possible but rare.
-    int subtasks_created = 0;
-    int64_t submitted_bytes = 0;
-
-    // All `total_groups` tokens are held now, and each submitted subtask releases its own on completion. Every
-    // exit below settles the rest explicitly and sets `tokens_settled` -- except an exception, which would
-    // otherwise strand them: with compact_threads defaulting to 4, leaking a couple per failure quickly starves
-    // lake compaction for the whole BE until it restarts. Give them back while unwinding.
-    bool tokens_settled = false;
-    DeferOp release_unused_tokens([&] {
-        if (tokens_settled) {
-            return;
-        }
-        for (int32_t j = subtasks_created; j < total_groups; j++) {
-            release_token(false);
-        }
-    });
-
     for (size_t group_idx = 0; group_idx < groups.size(); group_idx++) {
         auto& group = groups[group_idx];
         int32_t subtask_id = static_cast<int32_t>(group_idx);
@@ -2116,6 +2117,7 @@ StatusOr<int> TabletParallelCompactionManager::submit_subtasks_from_groups(
             if (!registered || submitted) {
                 return;
             }
+            bool nothing_left_running = false;
             {
                 std::lock_guard<std::mutex> lock(state_ptr->mutex);
                 auto it = state_ptr->running_subtasks.find(subtask_id);
@@ -2128,8 +2130,18 @@ StatusOr<int> TabletParallelCompactionManager::submit_subtasks_from_groups(
                     state_ptr->running_subtasks.erase(it);
                     state_ptr->total_subtasks_created--;
                 }
+                nothing_left_running = state_ptr->running_subtasks.empty();
             }
             _running_subtasks--;
+            if (nothing_left_running && submitted_out != nullptr) {
+                // Every subtask submitted so far has already completed, and each of those completions saw
+                // this registration still present -- is_complete() requires running_subtasks to be empty --
+                // so none of them performed the completion transition. Removing the entry here does not
+                // re-check it, and no further completion is coming, so nothing would ever call finish_task()
+                // and the compact RPC would hang. Report that no subtask owns this tablet's completion, which
+                // sends the caller down the fallback path instead.
+                *submitted_out = 0;
+            }
         });
 
         // Collect rowset IDs

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -637,7 +637,8 @@ StatusOr<int> TabletParallelCompactionManager::submit_subtasks(
 StatusOr<int> TabletParallelCompactionManager::create_parallel_tasks(
         int64_t tablet_id, int64_t txn_id, int64_t version, const TabletParallelConfig& config,
         std::shared_ptr<CompactionTaskCallback> callback, bool force_base_compaction, ThreadPool* thread_pool,
-        const AcquireTokenFunc& acquire_token, const ReleaseTokenFunc& release_token) {
+        const AcquireTokenFunc& acquire_token, const ReleaseTokenFunc& release_token,
+        int64_t handoff_in_queue_time_sec, int64_t handoff_queue_wait_ns) {
     // Validate configuration
     // max_parallel comes from table property (via FE)
     // max_bytes comes from BE config if FE passes 0
@@ -706,6 +707,12 @@ StatusOr<int> TabletParallelCompactionManager::create_parallel_tasks(
     // Step 3: Create and register tablet state
     ASSIGN_OR_RETURN(auto state_ptr, create_and_register_tablet_state(tablet_id, txn_id, version, max_parallel,
                                                                       max_bytes, std::move(callback), release_token));
+    {
+        // Carry over the queue wait of the caller's context, which is about to be destroyed.
+        std::lock_guard<std::mutex> lock(state_ptr->mutex);
+        state_ptr->handoff_in_queue_time_sec = handoff_in_queue_time_sec;
+        state_ptr->handoff_queue_wait_ns = handoff_queue_wait_ns;
+    }
 
     // Step 4: Submit subtasks
     //
@@ -935,6 +942,10 @@ void TabletParallelCompactionManager::finalize_tablet_completion(
                 *(merged_context->stats) = *(merged_context->stats) + *(subtask_ctx->stats);
             }
         }
+        // Add the pre-hand-off queue wait once, not per subtask: it was spent by the single context that
+        // waited for a worker, not by each subtask.
+        merged_context->stats->in_queue_time_sec += state->handoff_in_queue_time_sec;
+        merged_context->stats->queue_wait_ns += state->handoff_queue_wait_ns;
 
         // Only mark as failed if ALL subtasks failed
         // If at least one subtask succeeded, the compaction is considered (partially) successful

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -2057,7 +2057,6 @@ StatusOr<int> TabletParallelCompactionManager::submit_subtasks_from_groups(
     VLOG(1) << "Parallel compaction: acquired all " << tokens_acquired << " tokens for tablet " << tablet_id
             << ", txn_id=" << txn_id;
 
-
     // Record expected split counts for each large rowset as a safety net.
     // Even though we've acquired all tokens, thread pool submission can still fail.
     // This allows get_merged_txn_log() to detect incomplete splits.

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -725,6 +725,9 @@ StatusOr<int> TabletParallelCompactionManager::create_parallel_tasks(
             LOG(WARNING) << "Exception after submitting " << submitted << " parallel compaction subtask(s); they own "
                          << "the tablet's completion. tablet_id=" << tablet_id << ", txn_id=" << txn_id << ": "
                          << e.what();
+            // submit_subtasks_from_groups() never reached its own seal, so do it here: those subtasks are
+            // the only ones that can complete this tablet, and they cannot do it while it is unsealed.
+            seal_submission(tablet_id, txn_id, state_ptr);
             return submitted;
         }
         cleanup_tablet(tablet_id, txn_id);
@@ -734,6 +737,7 @@ StatusOr<int> TabletParallelCompactionManager::create_parallel_tasks(
         if (submitted > 0) {
             LOG(WARNING) << "Unknown exception after submitting " << submitted << " parallel compaction subtask(s); "
                          << "they own the tablet's completion. tablet_id=" << tablet_id << ", txn_id=" << txn_id;
+            seal_submission(tablet_id, txn_id, state_ptr);
             return submitted;
         }
         cleanup_tablet(tablet_id, txn_id);
@@ -800,7 +804,7 @@ void TabletParallelCompactionManager::on_subtask_complete(int64_t tablet_id, int
         _running_subtasks--;
         _completed_subtasks++;
 
-        all_complete = state->is_complete();
+        all_complete = state->claim_completion();
         callback = state->callback;
 
         VLOG(1) << "Parallel compaction subtask completed, tablet=" << tablet_id << ", txn_id=" << txn_id
@@ -809,118 +813,159 @@ void TabletParallelCompactionManager::on_subtask_complete(int64_t tablet_id, int
     }
 
     // If all subtasks are complete, notify the callback
+    // The completion transition is claimed exactly once (see claim_completion), so whoever gets
+    // here -- the last finishing subtask, or the end of submission -- is the only one who runs it.
     if (all_complete && callback) {
-        // Build merged context.
-        // Honor the ORIGINATING request's skip_write_txnlog intent for the merged log:
-        //  - aggregate/file-bundling path (skip=true): keep skip=true so the merged log is returned
-        //    inline via CompactResponse.txn_logs for the aggregator to combine and persist once;
-        //  - regular path (skip=false): the individual subtasks were forced to skip_write_txnlog=true
-        //    only so their partial logs could be merged into one (a single tablet+txn has exactly one
-        //    txn log location). There is NO aggregator on this path, so the merged context must carry
-        //    skip=false and we persist the merged log below, exactly as a serial compaction would.
-        const bool req_skip_write_txnlog = callback->skip_write_txnlog();
-        auto merged_context = std::make_unique<CompactionTaskContext>(
-                txn_id, tablet_id, state->version, false /* force_base_compaction */, req_skip_write_txnlog, callback);
-
-        // Copy table_id and partition_id from one of the completed subtask contexts.
-        // These values are populated in TabletManager::compact() from shard info,
-        // and are needed for downstream processes (e.g., metrics, catalog operations).
-        {
-            std::lock_guard<std::mutex> lock(state->mutex);
-            for (const auto& subtask_ctx : state->completed_subtasks) {
-                if (subtask_ctx->table_id != 0) {
-                    merged_context->table_id = subtask_ctx->table_id;
-                }
-                if (subtask_ctx->partition_id != 0) {
-                    merged_context->partition_id = subtask_ctx->partition_id;
-                }
-                // All subtasks belong to the same tablet, so table_id and partition_id
-                // should be the same. Break once we've found valid values.
-                if (merged_context->table_id != 0 && merged_context->partition_id != 0) {
-                    break;
-                }
-            }
-        }
-
-        // Merge TxnLogs
-        auto merged_txn_log_or = get_merged_txn_log(tablet_id, txn_id);
-        if (merged_txn_log_or.ok()) {
-            merged_context->txn_log = std::make_unique<TxnLogPB>(std::move(merged_txn_log_or.value()));
-        } else {
-            merged_context->status = merged_txn_log_or.status();
-        }
-
-        // Set status based on subtask statuses
-        // Support partial success: only fail if ALL subtasks failed
-        {
-            std::lock_guard<std::mutex> lock(state->mutex);
-            int successful_count = 0;
-            int failed_count = 0;
-            Status first_failure;
-
-            for (const auto& subtask_ctx : state->completed_subtasks) {
-                if (subtask_ctx->status.ok()) {
-                    successful_count++;
-                } else {
-                    failed_count++;
-                    if (first_failure.ok()) {
-                        first_failure = subtask_ctx->status;
-                    }
-                }
-                // Merge stats from all subtasks (including failed ones for diagnostic purposes)
-                if (subtask_ctx->stats) {
-                    *(merged_context->stats) = *(merged_context->stats) + *(subtask_ctx->stats);
-                }
-            }
-
-            // Only mark as failed if ALL subtasks failed
-            // If at least one subtask succeeded, the compaction is considered (partially) successful
-            if (successful_count == 0 && failed_count > 0) {
-                merged_context->status = first_failure;
-                LOG(WARNING) << "Parallel compaction failed: all " << failed_count
-                             << " subtasks failed for tablet=" << tablet_id << ", txn_id=" << txn_id
-                             << ", first_error=" << first_failure;
-            } else if (failed_count > 0) {
-                // Partial success: some subtasks failed but at least one succeeded
-                VLOG(1) << "Parallel compaction partial success: tablet=" << tablet_id << ", txn_id=" << txn_id
-                        << ", successful=" << successful_count << ", failed=" << failed_count;
-            }
-        }
-
-        // Persist the merged txn log on the regular (non-aggregate) path.
-        // On this path FE never sets skip_write_txnlog and there is no aggregator to consume
-        // CompactResponse.txn_logs, so if the merged log is not written to object storage here it is
-        // silently dropped: FE still sees an empty failed_tablets and commits the compaction txn, but
-        // the publish daemon later 404s on a txn log that was never written and the txn is stuck in
-        // COMMITTED forever, blocking every subsequent txn on the partition. Writing it here mirrors
-        // what a serial (non-parallel) compaction does in CompactionTask::execute(). put_txn_log()
-        // normalizes the log before saving. On the aggregate/file-bundling path
-        // (req_skip_write_txnlog == true) the log is instead returned via the RPC response and
-        // persisted as a single combined txn log by the aggregator, so we must NOT write it here.
-        if (!req_skip_write_txnlog && merged_context->status.ok() && merged_context->txn_log != nullptr) {
-            if (auto st = _tablet_mgr->put_txn_log(merged_context->txn_log); !st.ok()) {
-                LOG(WARNING) << "Failed to write merged parallel-compaction txn log, tablet=" << tablet_id
-                             << ", txn_id=" << txn_id << ": " << st;
-                merged_context->status.update(st);
-            }
-        }
-
-        // Mark as parallel merged context so that cleanup_tablet will be called
-        // by CompactionScheduler::remove_states after RPC response is sent.
-        // This ensures parallel compaction tasks remain visible in list_tasks
-        // until all tablets complete, consistent with normal compaction behavior.
-        merged_context->is_parallel_merged = true;
-
-        // Set subtask_count to the actual number of subtasks
-        {
-            std::lock_guard<std::mutex> lock(state->mutex);
-            merged_context->subtask_count = static_cast<int32_t>(state->completed_subtasks.size());
-        }
-
-        callback->finish_task(std::move(merged_context));
-        // Note: Do NOT call cleanup_tablet here. The cleanup will be done by
-        // CompactionScheduler::remove_states when RPC response is sent.
+        finalize_tablet_completion(tablet_id, txn_id, state, callback);
     }
+}
+
+// Declares that no further subtasks will be registered for this tablet, then runs the completion
+// transition if every subtask has already finished in the meantime.
+//
+// Sealing is what makes is_complete() trustworthy: while submission is in progress running_subtasks can
+// be empty simply because the next group has not been registered yet. It must therefore happen on EVERY
+// path that stops registering subtasks while leaving some of them running -- the normal end of
+// submission and an exception unwinding out of it -- or the last subtask's completion (which found the
+// tablet unsealed and skipped the transition) would be the last chance anyone had, and the compact RPC
+// would hang forever.
+void TabletParallelCompactionManager::seal_submission(int64_t tablet_id, int64_t txn_id,
+                                                      const std::shared_ptr<TabletParallelCompactionState>& state) {
+    if (state == nullptr) {
+        return;
+    }
+    bool claimed = false;
+    std::shared_ptr<CompactionTaskCallback> callback;
+    {
+        std::lock_guard<std::mutex> lock(state->mutex);
+        state->submission_done = true;
+        claimed = state->claim_completion();
+        callback = state->callback;
+    }
+    if (claimed && callback) {
+        VLOG(1) << "Parallel compaction: all subtasks already finished when submission was sealed, tablet="
+                << tablet_id << ", txn_id=" << txn_id;
+        finalize_tablet_completion(tablet_id, txn_id, state, callback);
+    }
+}
+
+// Runs the one-time completion transition for a tablet whose parallel subtasks have all finished:
+// merges their txn logs into a single merged context and hands it to the request callback. The caller
+// must already have won TabletParallelCompactionState::claim_completion(), which is what makes this
+// exactly-once; this function itself does not re-check completeness.
+void TabletParallelCompactionManager::finalize_tablet_completion(
+        int64_t tablet_id, int64_t txn_id, const std::shared_ptr<TabletParallelCompactionState>& state,
+        const std::shared_ptr<CompactionTaskCallback>& callback) {
+    // Build merged context.
+    // Honor the ORIGINATING request's skip_write_txnlog intent for the merged log:
+    //  - aggregate/file-bundling path (skip=true): keep skip=true so the merged log is returned
+    //    inline via CompactResponse.txn_logs for the aggregator to combine and persist once;
+    //  - regular path (skip=false): the individual subtasks were forced to skip_write_txnlog=true
+    //    only so their partial logs could be merged into one (a single tablet+txn has exactly one
+    //    txn log location). There is NO aggregator on this path, so the merged context must carry
+    //    skip=false and we persist the merged log below, exactly as a serial compaction would.
+    const bool req_skip_write_txnlog = callback->skip_write_txnlog();
+    auto merged_context = std::make_unique<CompactionTaskContext>(
+            txn_id, tablet_id, state->version, false /* force_base_compaction */, req_skip_write_txnlog, callback);
+
+    // Copy table_id and partition_id from one of the completed subtask contexts.
+    // These values are populated in TabletManager::compact() from shard info,
+    // and are needed for downstream processes (e.g., metrics, catalog operations).
+    {
+        std::lock_guard<std::mutex> lock(state->mutex);
+        for (const auto& subtask_ctx : state->completed_subtasks) {
+            if (subtask_ctx->table_id != 0) {
+                merged_context->table_id = subtask_ctx->table_id;
+            }
+            if (subtask_ctx->partition_id != 0) {
+                merged_context->partition_id = subtask_ctx->partition_id;
+            }
+            // All subtasks belong to the same tablet, so table_id and partition_id
+            // should be the same. Break once we've found valid values.
+            if (merged_context->table_id != 0 && merged_context->partition_id != 0) {
+                break;
+            }
+        }
+    }
+
+    // Merge TxnLogs
+    auto merged_txn_log_or = get_merged_txn_log(tablet_id, txn_id);
+    if (merged_txn_log_or.ok()) {
+        merged_context->txn_log = std::make_unique<TxnLogPB>(std::move(merged_txn_log_or.value()));
+    } else {
+        merged_context->status = merged_txn_log_or.status();
+    }
+
+    // Set status based on subtask statuses
+    // Support partial success: only fail if ALL subtasks failed
+    {
+        std::lock_guard<std::mutex> lock(state->mutex);
+        int successful_count = 0;
+        int failed_count = 0;
+        Status first_failure;
+
+        for (const auto& subtask_ctx : state->completed_subtasks) {
+            if (subtask_ctx->status.ok()) {
+                successful_count++;
+            } else {
+                failed_count++;
+                if (first_failure.ok()) {
+                    first_failure = subtask_ctx->status;
+                }
+            }
+            // Merge stats from all subtasks (including failed ones for diagnostic purposes)
+            if (subtask_ctx->stats) {
+                *(merged_context->stats) = *(merged_context->stats) + *(subtask_ctx->stats);
+            }
+        }
+
+        // Only mark as failed if ALL subtasks failed
+        // If at least one subtask succeeded, the compaction is considered (partially) successful
+        if (successful_count == 0 && failed_count > 0) {
+            merged_context->status = first_failure;
+            LOG(WARNING) << "Parallel compaction failed: all " << failed_count
+                         << " subtasks failed for tablet=" << tablet_id << ", txn_id=" << txn_id
+                         << ", first_error=" << first_failure;
+        } else if (failed_count > 0) {
+            // Partial success: some subtasks failed but at least one succeeded
+            VLOG(1) << "Parallel compaction partial success: tablet=" << tablet_id << ", txn_id=" << txn_id
+                    << ", successful=" << successful_count << ", failed=" << failed_count;
+        }
+    }
+
+    // Persist the merged txn log on the regular (non-aggregate) path.
+    // On this path FE never sets skip_write_txnlog and there is no aggregator to consume
+    // CompactResponse.txn_logs, so if the merged log is not written to object storage here it is
+    // silently dropped: FE still sees an empty failed_tablets and commits the compaction txn, but
+    // the publish daemon later 404s on a txn log that was never written and the txn is stuck in
+    // COMMITTED forever, blocking every subsequent txn on the partition. Writing it here mirrors
+    // what a serial (non-parallel) compaction does in CompactionTask::execute(). put_txn_log()
+    // normalizes the log before saving. On the aggregate/file-bundling path
+    // (req_skip_write_txnlog == true) the log is instead returned via the RPC response and
+    // persisted as a single combined txn log by the aggregator, so we must NOT write it here.
+    if (!req_skip_write_txnlog && merged_context->status.ok() && merged_context->txn_log != nullptr) {
+        if (auto st = _tablet_mgr->put_txn_log(merged_context->txn_log); !st.ok()) {
+            LOG(WARNING) << "Failed to write merged parallel-compaction txn log, tablet=" << tablet_id
+                         << ", txn_id=" << txn_id << ": " << st;
+            merged_context->status.update(st);
+        }
+    }
+
+    // Mark as parallel merged context so that cleanup_tablet will be called
+    // by CompactionScheduler::remove_states after RPC response is sent.
+    // This ensures parallel compaction tasks remain visible in list_tasks
+    // until all tablets complete, consistent with normal compaction behavior.
+    merged_context->is_parallel_merged = true;
+
+    // Set subtask_count to the actual number of subtasks
+    {
+        std::lock_guard<std::mutex> lock(state->mutex);
+        merged_context->subtask_count = static_cast<int32_t>(state->completed_subtasks.size());
+    }
+
+    callback->finish_task(std::move(merged_context));
+    // Note: Do NOT call cleanup_tablet here. The cleanup will be done by
+    // CompactionScheduler::remove_states when RPC response is sent.
 }
 
 bool TabletParallelCompactionManager::is_tablet_complete(int64_t tablet_id, int64_t txn_id) {
@@ -2323,6 +2368,11 @@ StatusOr<int> TabletParallelCompactionManager::submit_subtasks_from_groups(
 
     VLOG(1) << "Parallel compaction: successfully created " << subtasks_created << " subtasks for tablet " << tablet_id
             << ", txn_id=" << txn_id << ", total_bytes=" << submitted_bytes;
+
+    // No more subtasks will be registered for this tablet. Any subtask that finished while the remaining
+    // groups were still being registered deliberately skipped the completion transition, so this is where
+    // it gets run if they have all finished already.
+    seal_submission(tablet_id, txn_id, state_ptr);
 
     return subtasks_created;
 }

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -2060,6 +2060,36 @@ StatusOr<int> TabletParallelCompactionManager::submit_subtasks_from_groups(
         auto& group = groups[group_idx];
         int32_t subtask_id = static_cast<int32_t>(group_idx);
 
+        // Nothing below is exception-safe on its own: the bookkeeping (vector growth, the
+        // running_subtasks[] node allocation) and submit_func() itself can throw std::bad_alloc. If that
+        // happens once this subtask has been registered but before it was handed to the thread pool, the
+        // entry would describe a subtask that never runs, so running_subtasks could never drain and
+        // is_complete() (`running_subtasks.empty() && total_subtasks_created > 0`) would never become true
+        // -- the tablet would never call finish_task() and its compact RPC would hang. Undo the
+        // registration while unwinding so the state keeps describing only subtasks that are really running.
+        bool registered = false;
+        bool submitted = false;
+        DeferOp rollback_registration([&] {
+            if (!registered || submitted) {
+                return;
+            }
+            {
+                std::lock_guard<std::mutex> lock(state_ptr->mutex);
+                auto it = state_ptr->running_subtasks.find(subtask_id);
+                if (it != state_ptr->running_subtasks.end()) {
+                    unmark_rowsets_compacting(state_ptr.get(), it->second.input_rowset_ids);
+                    if (group.type == SubtaskType::LARGE_ROWSET_PART) {
+                        auto& split_ids = state_ptr->large_rowset_split_groups[group.large_rowset_id];
+                        split_ids.erase(std::remove(split_ids.begin(), split_ids.end(), subtask_id),
+                                        split_ids.end());
+                    }
+                    state_ptr->running_subtasks.erase(it);
+                    state_ptr->total_subtasks_created--;
+                }
+            }
+            _running_subtasks--;
+        });
+
         // Collect rowset IDs
         std::vector<uint32_t> rowset_ids;
         int64_t input_bytes = group.total_bytes;
@@ -2109,6 +2139,9 @@ StatusOr<int> TabletParallelCompactionManager::submit_subtasks_from_groups(
         }
 
         _running_subtasks++;
+        // From here on the subtask is registered: rollback_registration owns undoing it until the submit
+        // below succeeds.
+        registered = true;
 
         // Submit task to thread pool (token already acquired)
         Status submit_st;
@@ -2164,6 +2197,9 @@ StatusOr<int> TabletParallelCompactionManager::submit_subtasks_from_groups(
                 }
             }
             _running_subtasks--;
+            // This branch has just undone the registration itself; stop rollback_registration from
+            // repeating it.
+            registered = false;
 
             // Release token for this failed subtask
             release_token(false);
@@ -2187,6 +2223,9 @@ StatusOr<int> TabletParallelCompactionManager::submit_subtasks_from_groups(
         }
 
         subtasks_created++;
+        // The subtask is now owned by the thread pool and will report its own completion, so the
+        // registration must survive this scope.
+        submitted = true;
 
         // Test hook: lets a test throw from here, i.e. *after* a subtask has been submitted and is running.
         // A throw in this window must not route the tablet into the caller's fallback path, or the tablet

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -2057,6 +2057,7 @@ StatusOr<int> TabletParallelCompactionManager::submit_subtasks_from_groups(
     VLOG(1) << "Parallel compaction: acquired all " << tokens_acquired << " tokens for tablet " << tablet_id
             << ", txn_id=" << txn_id;
 
+
     // Record expected split counts for each large rowset as a safety net.
     // Even though we've acquired all tokens, thread pool submission can still fail.
     // This allows get_merged_txn_log() to detect incomplete splits.
@@ -2084,6 +2085,20 @@ StatusOr<int> TabletParallelCompactionManager::submit_subtasks_from_groups(
     // Thread pool submission failures are still possible but rare.
     int subtasks_created = 0;
     int64_t submitted_bytes = 0;
+
+    // All `total_groups` tokens are held now, and each submitted subtask releases its own on completion. Every
+    // exit below settles the rest explicitly and sets `tokens_settled` -- except an exception, which would
+    // otherwise strand them: with compact_threads defaulting to 4, leaking a couple per failure quickly starves
+    // lake compaction for the whole BE until it restarts. Give them back while unwinding.
+    bool tokens_settled = false;
+    DeferOp release_unused_tokens([&] {
+        if (tokens_settled) {
+            return;
+        }
+        for (int32_t j = subtasks_created; j < total_groups; j++) {
+            release_token(false);
+        }
+    });
 
     for (size_t group_idx = 0; group_idx < groups.size(); group_idx++) {
         auto& group = groups[group_idx];
@@ -2171,6 +2186,11 @@ StatusOr<int> TabletParallelCompactionManager::submit_subtasks_from_groups(
         // below succeeds.
         registered = true;
 
+        // Test hook for the opposite window of ":after_submit": lets a test throw while this subtask is
+        // registered but has NOT been handed to the thread pool, which is the case rollback_registration
+        // exists for.
+        TEST_SYNC_POINT("TabletParallelCompactionManager::submit_subtasks_from_groups:after_register");
+
         // Submit task to thread pool (token already acquired)
         Status submit_st;
         if (group.type == SubtaskType::NORMAL) {
@@ -2237,6 +2257,9 @@ StatusOr<int> TabletParallelCompactionManager::submit_subtasks_from_groups(
             for (int32_t j = 0; j < remaining_tokens; j++) {
                 release_token(false);
             }
+            // This branch has accounted for every unused token; release_unused_tokens must not repeat it,
+            // whether we return just below or break out of the loop.
+            tokens_settled = true;
 
             if (subtasks_created == 0) {
                 cleanup_tablet(tablet_id, txn_id);
@@ -2277,6 +2300,8 @@ StatusOr<int> TabletParallelCompactionManager::submit_subtasks_from_groups(
                     << ", is_last=" << group.is_last_range << ", input_bytes=" << input_bytes;
         }
     }
+    // The loop ran to completion (or broke out after settling tokens itself), so nothing is stranded.
+    tokens_settled = true;
 
     if (subtasks_created == 0) {
         cleanup_tablet(tablet_id, txn_id);

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -820,6 +820,23 @@ void TabletParallelCompactionManager::on_subtask_complete(int64_t tablet_id, int
     }
 }
 
+std::vector<std::shared_ptr<CompactionTaskCallback>> TabletParallelCompactionManager::collect_callbacks_for_txn(
+        int64_t txn_id) const {
+    std::vector<std::shared_ptr<CompactionTaskCallback>> callbacks;
+    std::lock_guard<std::mutex> lock(_states_mutex);
+    for (const auto& entry : _tablet_states) {
+        const auto& state = entry.second;
+        if (state == nullptr) {
+            continue;
+        }
+        std::lock_guard<std::mutex> state_lock(state->mutex);
+        if (state->txn_id == txn_id && state->callback != nullptr) {
+            callbacks.push_back(state->callback);
+        }
+    }
+    return callbacks;
+}
+
 // Declares that no further subtasks will be registered for this tablet, then runs the completion
 // transition if every subtask has already finished in the meantime.
 //
@@ -1592,11 +1609,23 @@ void TabletParallelCompactionManager::execute_subtask(int64_t tablet_id, int64_t
     // inside the lambda, we safely check if the state still exists before accessing it.
     auto cancel_func = [this, tablet_id, txn_id, subtask_id, version]() {
         // Check if tablet state still exists - if not, the compaction has been cancelled/timed out
-        if (get_tablet_state(tablet_id, txn_id) == nullptr) {
+        auto state = get_tablet_state(tablet_id, txn_id);
+        if (state == nullptr) {
             return Status::Cancelled(strings::Substitute(
                     "Tablet parallel compaction state has been cleaned up: tablet_id=$0, txn_id=$1, "
                     "version=$2, subtask_id=$3",
                     tablet_id, txn_id, version, subtask_id));
+        }
+        // Also honour a cancellation of the originating request. abort() and the request deadline are
+        // recorded on the callback, not on the tablet state, so without this a subtask keeps burning IO
+        // and CPU to completion for a txn that FE has already given up on.
+        std::shared_ptr<CompactionTaskCallback> callback;
+        {
+            std::lock_guard<std::mutex> lock(state->mutex);
+            callback = state->callback;
+        }
+        if (callback != nullptr) {
+            RETURN_IF_ERROR(callback->has_error());
         }
         return Status::OK();
     };
@@ -2511,11 +2540,23 @@ void TabletParallelCompactionManager::execute_subtask_segment_range(int64_t tabl
     const auto& compaction_task = compaction_task_or.value();
     // Execute compaction
     auto cancel_func = [this, tablet_id, txn_id, subtask_id, version]() {
-        if (get_tablet_state(tablet_id, txn_id) == nullptr) {
+        auto state = get_tablet_state(tablet_id, txn_id);
+        if (state == nullptr) {
             return Status::Cancelled(strings::Substitute(
                     "Tablet parallel compaction state has been cleaned up: tablet_id=$0, txn_id=$1, "
                     "version=$2, subtask_id=$3",
                     tablet_id, txn_id, version, subtask_id));
+        }
+        // Also honour a cancellation of the originating request. abort() and the request deadline are
+        // recorded on the callback, not on the tablet state, so without this a subtask keeps burning IO
+        // and CPU to completion for a txn that FE has already given up on.
+        std::shared_ptr<CompactionTaskCallback> callback;
+        {
+            std::lock_guard<std::mutex> lock(state->mutex);
+            callback = state->callback;
+        }
+        if (callback != nullptr) {
+            RETURN_IF_ERROR(callback->has_error());
         }
         return Status::OK();
     };
@@ -2922,11 +2963,23 @@ void TabletParallelCompactionManager::execute_subtask_range_split(
     auto compaction_task = compaction_task_or.value();
 
     auto cancel_func = [this, tablet_id, txn_id, subtask_id, version]() {
-        if (get_tablet_state(tablet_id, txn_id) == nullptr) {
+        auto state = get_tablet_state(tablet_id, txn_id);
+        if (state == nullptr) {
             return Status::Cancelled(strings::Substitute(
                     "Tablet parallel compaction state has been cleaned up: tablet_id=$0, txn_id=$1, "
                     "version=$2, subtask_id=$3",
                     tablet_id, txn_id, version, subtask_id));
+        }
+        // Also honour a cancellation of the originating request. abort() and the request deadline are
+        // recorded on the callback, not on the tablet state, so without this a subtask keeps burning IO
+        // and CPU to completion for a txn that FE has already given up on.
+        std::shared_ptr<CompactionTaskCallback> callback;
+        {
+            std::lock_guard<std::mutex> lock(state->mutex);
+            callback = state->callback;
+        }
+        if (callback != nullptr) {
+            RETURN_IF_ERROR(callback->has_error());
         }
         return Status::OK();
     };

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -18,6 +18,7 @@
 #include <sstream>
 #include <utility>
 
+#include "base/testutil/sync_point.h"
 #include "base/time/time.h"
 #include "base/utility/defer_op.h"
 #include "column/datum_convert.h"
@@ -2186,6 +2187,11 @@ StatusOr<int> TabletParallelCompactionManager::submit_subtasks_from_groups(
         }
 
         subtasks_created++;
+
+        // Test hook: lets a test throw from here, i.e. *after* a subtask has been submitted and is running.
+        // A throw in this window must not route the tablet into the caller's fallback path, or the tablet
+        // would get a second CompactionTaskContext and thus a second finish_task().
+        TEST_SYNC_POINT("TabletParallelCompactionManager::submit_subtasks_from_groups:after_submit");
 
         if (group.type == SubtaskType::NORMAL) {
             VLOG(1) << "Parallel compaction: created NORMAL subtask " << subtask_id << " for tablet " << tablet_id

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -2080,8 +2080,7 @@ StatusOr<int> TabletParallelCompactionManager::submit_subtasks_from_groups(
                     unmark_rowsets_compacting(state_ptr.get(), it->second.input_rowset_ids);
                     if (group.type == SubtaskType::LARGE_ROWSET_PART) {
                         auto& split_ids = state_ptr->large_rowset_split_groups[group.large_rowset_id];
-                        split_ids.erase(std::remove(split_ids.begin(), split_ids.end(), subtask_id),
-                                        split_ids.end());
+                        split_ids.erase(std::remove(split_ids.begin(), split_ids.end(), subtask_id), split_ids.end());
                     }
                     state_ptr->running_subtasks.erase(it);
                     state_ptr->total_subtasks_created--;

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -259,9 +259,8 @@ std::vector<std::vector<RowsetPtr>> TabletParallelCompactionManager::_group_rows
             for (const auto& r : current_group) {
                 group_ids.push_back(r->id());
             }
-            std::string reason = has_adjacency_gap       ? " (adjacency gap)"
-                                 : would_exceed_segments ? " (segment limit)"
-                                                         : "";
+            std::string reason =
+                    has_adjacency_gap ? " (adjacency gap)" : would_exceed_segments ? " (segment limit)" : "";
             VLOG(1) << "Parallel compaction: tablet=" << tablet_id << " group " << valid_groups.size() << ": "
                     << current_group.size() << " rowsets, " << current_bytes << " bytes, " << current_segments
                     << " segments, ids=[" << JoinInts(group_ids, ",") << "]" << reason;
@@ -412,10 +411,11 @@ std::vector<std::vector<RowsetPtr>> TabletParallelCompactionManager::split_rowse
         for (const auto& r : all_rowsets) {
             group_ids.push_back(r->id());
         }
-        std::string reason = stats.has_delete_predicate ? "has_delete_predicate"
-                             : (max_parallel <= 1)      ? "max_parallel<=1"
-                             : not_enough_segments      ? "not_enough_segments"
-                                                        : "data_size_small";
+        std::string reason = stats.has_delete_predicate
+                                     ? "has_delete_predicate"
+                                     : (max_parallel <= 1)
+                                               ? "max_parallel<=1"
+                                               : not_enough_segments ? "not_enough_segments" : "data_size_small";
         VLOG(1) << "Parallel compaction: tablet=" << tablet_id << " fallback to normal compaction (" << reason
                 << "): " << all_rowsets.size() << " rowsets, " << stats.total_segments << " segments, "
                 << stats.total_bytes << " bytes, ids=[" << JoinInts(group_ids, ",") << "]";
@@ -2056,10 +2056,11 @@ std::vector<SubtaskGroup> TabletParallelCompactionManager::_create_subtask_group
 
     if (stats.total_bytes <= max_bytes_per_subtask || max_parallel <= 1 || stats.has_delete_predicate ||
         not_enough_segments) {
-        std::string reason = stats.has_delete_predicate ? "has_delete_predicate"
-                             : (max_parallel <= 1)      ? "max_parallel<=1"
-                             : not_enough_segments      ? "not_enough_segments"
-                                                        : "data_size_small";
+        std::string reason = stats.has_delete_predicate
+                                     ? "has_delete_predicate"
+                                     : (max_parallel <= 1)
+                                               ? "max_parallel<=1"
+                                               : not_enough_segments ? "not_enough_segments" : "data_size_small";
         VLOG(1) << "Parallel compaction: tablet=" << tablet_id << " fallback to normal compaction (" << reason
                 << "): " << rowsets.size() << " rowsets, " << stats.total_segments << " segments, " << stats.total_bytes
                 << " bytes";

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -827,6 +827,57 @@ void TabletParallelCompactionManager::on_subtask_complete(int64_t tablet_id, int
     }
 }
 
+void TabletParallelCompactionManager::abort_pending_states() {
+    // Must run only after the thread pool has shut down: ThreadPool::shutdown() drops subtasks that were
+    // queued but never started and "cancels" them through FunctionRunnable's no-op cancel(), so those
+    // subtasks never call on_subtask_complete(). Their tablet's own context was already destroyed at the
+    // hand-off, which leaves nobody able to drain the state or complete the tablet -- the compact RPC would
+    // hang until its deadline. Checking `_stopped` before planning narrows that window but cannot close it:
+    // stop() can begin right after the check and still drop a subtask submitted a moment later.
+    //
+    // By this point no subtask can be running or about to start, so this is the one place where the
+    // remaining states can be settled without racing anyone.
+    std::vector<std::shared_ptr<TabletParallelCompactionState>> states;
+    {
+        std::lock_guard<std::mutex> lock(_states_mutex);
+        states.reserve(_tablet_states.size());
+        for (const auto& entry : _tablet_states) {
+            if (entry.second != nullptr) {
+                states.push_back(entry.second);
+            }
+        }
+    }
+
+    for (const auto& state : states) {
+        bool claimed = false;
+        std::shared_ptr<CompactionTaskCallback> callback;
+        int64_t tablet_id = 0;
+        int64_t txn_id = 0;
+        {
+            std::lock_guard<std::mutex> lock(state->mutex);
+            tablet_id = state->tablet_id;
+            txn_id = state->txn_id;
+            if (state->total_subtasks_created == 0) {
+                // Nothing was ever submitted for this tablet, so its context is still in the scheduler's
+                // task queue and abort_all() takes care of it.
+                continue;
+            }
+            // Those subtasks were dropped and will never report back.
+            state->running_subtasks.clear();
+            state->submission_done = true;
+            claimed = state->claim_completion();
+            callback = state->callback;
+        }
+        if (claimed && callback) {
+            LOG(WARNING) << "Completing parallel compaction on shutdown, its subtasks were dropped. tablet_id="
+                         << tablet_id << ", txn_id=" << txn_id;
+            // Reports whatever the finished subtasks produced; an incomplete set fails the merge, so the
+            // RPC finishes with an error instead of hanging.
+            finalize_tablet_completion(tablet_id, txn_id, state, callback);
+        }
+    }
+}
+
 std::vector<std::shared_ptr<CompactionTaskCallback>> TabletParallelCompactionManager::collect_callbacks_for_txn(
         int64_t txn_id) const {
     std::vector<std::shared_ptr<CompactionTaskCallback>> callbacks;

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -637,8 +637,8 @@ StatusOr<int> TabletParallelCompactionManager::submit_subtasks(
 StatusOr<int> TabletParallelCompactionManager::create_parallel_tasks(
         int64_t tablet_id, int64_t txn_id, int64_t version, const TabletParallelConfig& config,
         std::shared_ptr<CompactionTaskCallback> callback, bool force_base_compaction, ThreadPool* thread_pool,
-        const AcquireTokenFunc& acquire_token, const ReleaseTokenFunc& release_token,
-        int64_t handoff_in_queue_time_sec, int64_t handoff_queue_wait_ns) {
+        const AcquireTokenFunc& acquire_token, const ReleaseTokenFunc& release_token, int64_t handoff_in_queue_time_sec,
+        int64_t handoff_queue_wait_ns) {
     // Validate configuration
     // max_parallel comes from table property (via FE)
     // max_bytes comes from BE config if FE passes 0

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -259,8 +259,9 @@ std::vector<std::vector<RowsetPtr>> TabletParallelCompactionManager::_group_rows
             for (const auto& r : current_group) {
                 group_ids.push_back(r->id());
             }
-            std::string reason =
-                    has_adjacency_gap ? " (adjacency gap)" : would_exceed_segments ? " (segment limit)" : "";
+            std::string reason = has_adjacency_gap       ? " (adjacency gap)"
+                                 : would_exceed_segments ? " (segment limit)"
+                                                         : "";
             VLOG(1) << "Parallel compaction: tablet=" << tablet_id << " group " << valid_groups.size() << ": "
                     << current_group.size() << " rowsets, " << current_bytes << " bytes, " << current_segments
                     << " segments, ids=[" << JoinInts(group_ids, ",") << "]" << reason;
@@ -411,11 +412,10 @@ std::vector<std::vector<RowsetPtr>> TabletParallelCompactionManager::split_rowse
         for (const auto& r : all_rowsets) {
             group_ids.push_back(r->id());
         }
-        std::string reason = stats.has_delete_predicate
-                                     ? "has_delete_predicate"
-                                     : (max_parallel <= 1)
-                                               ? "max_parallel<=1"
-                                               : not_enough_segments ? "not_enough_segments" : "data_size_small";
+        std::string reason = stats.has_delete_predicate ? "has_delete_predicate"
+                             : (max_parallel <= 1)      ? "max_parallel<=1"
+                             : not_enough_segments      ? "not_enough_segments"
+                                                        : "data_size_small";
         VLOG(1) << "Parallel compaction: tablet=" << tablet_id << " fallback to normal compaction (" << reason
                 << "): " << all_rowsets.size() << " rowsets, " << stats.total_segments << " segments, "
                 << stats.total_bytes << " bytes, ids=[" << JoinInts(group_ids, ",") << "]";
@@ -853,10 +853,12 @@ void TabletParallelCompactionManager::abort_pending_states() {
         std::shared_ptr<CompactionTaskCallback> callback;
         int64_t tablet_id = 0;
         int64_t txn_id = 0;
+        int64_t version = 0;
         {
             std::lock_guard<std::mutex> lock(state->mutex);
             tablet_id = state->tablet_id;
             txn_id = state->txn_id;
+            version = state->version;
             if (state->total_subtasks_created == 0) {
                 // Nothing was ever submitted for this tablet, so its context is still in the scheduler's
                 // task queue and abort_all() takes care of it.
@@ -869,11 +871,23 @@ void TabletParallelCompactionManager::abort_pending_states() {
             callback = state->callback;
         }
         if (claimed && callback) {
-            LOG(WARNING) << "Completing parallel compaction on shutdown, its subtasks were dropped. tablet_id="
+            LOG(WARNING) << "Aborting parallel compaction on shutdown, its subtasks were dropped. tablet_id="
                          << tablet_id << ", txn_id=" << txn_id;
-            // Reports whatever the finished subtasks produced; an incomplete set fails the merge, so the
-            // RPC finishes with an error instead of hanging.
-            finalize_tablet_completion(tablet_id, txn_id, state, callback);
+            // Report the same abort a serial compaction reports when stop() interrupts it (see
+            // CompactionScheduler::abort_compaction) rather than finalizing whatever the subtasks that did
+            // run produced. finalize_tablet_completion() would keep an OK status for such a partial set --
+            // it only fails when EVERY completed subtask failed, and dropped subtasks are not counted as
+            // failures at all -- and on the regular path it would then persist that partial (or, when
+            // nothing completed, empty) merged log, telling FE that a compaction happened which largely,
+            // or entirely, did not run.
+            auto context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version,
+                                                                   false /* force_base_compaction */,
+                                                                   callback->skip_write_txnlog(), callback);
+            // Marked merged so that CompactionScheduler::remove_states cleans this tablet's state up, and
+            // so list_tasks() keeps hiding it, exactly as for a finalized parallel compaction.
+            context->is_parallel_merged = true;
+            context->status = Status::Aborted("Parallel compaction aborted due to BE/CN shutdown!");
+            callback->finish_task(std::move(context));
         }
     }
 }
@@ -2042,11 +2056,10 @@ std::vector<SubtaskGroup> TabletParallelCompactionManager::_create_subtask_group
 
     if (stats.total_bytes <= max_bytes_per_subtask || max_parallel <= 1 || stats.has_delete_predicate ||
         not_enough_segments) {
-        std::string reason = stats.has_delete_predicate
-                                     ? "has_delete_predicate"
-                                     : (max_parallel <= 1)
-                                               ? "max_parallel<=1"
-                                               : not_enough_segments ? "not_enough_segments" : "data_size_small";
+        std::string reason = stats.has_delete_predicate ? "has_delete_predicate"
+                             : (max_parallel <= 1)      ? "max_parallel<=1"
+                             : not_enough_segments      ? "not_enough_segments"
+                                                        : "data_size_small";
         VLOG(1) << "Parallel compaction: tablet=" << tablet_id << " fallback to normal compaction (" << reason
                 << "): " << rowsets.size() << " rowsets, " << stats.total_segments << " segments, " << stats.total_bytes
                 << " bytes";

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -708,8 +708,37 @@ StatusOr<int> TabletParallelCompactionManager::create_parallel_tasks(
                                                                       max_bytes, std::move(callback), release_token));
 
     // Step 4: Submit subtasks
-    return submit_subtasks_from_groups(state_ptr, std::move(subtask_groups), force_base_compaction, thread_pool,
-                                       acquire_token, release_token);
+    //
+    // Decide here whether an escaping exception may be reported to the caller, because only here is the
+    // "did anything get submitted" answer race-free. `submitted` is on this stack, so it survives; the
+    // tablet state does not answer the question reliably -- a subtask that fails fast (a missing segment
+    // file, an unreachable object store) can complete, run finish_task() and have the state cleaned up
+    // before the exception is even handled, which would make the state look like "nothing was submitted".
+    // Acting on that stale answer lets the caller fall back to normal compaction for a tablet that has
+    // already completed, producing a second finish_task() for one tablet id and a SIGSEGV in it.
+    int submitted = 0;
+    try {
+        return submit_subtasks_from_groups(state_ptr, std::move(subtask_groups), force_base_compaction, thread_pool,
+                                           acquire_token, release_token, &submitted);
+    } catch (const std::exception& e) {
+        if (submitted > 0) {
+            LOG(WARNING) << "Exception after submitting " << submitted << " parallel compaction subtask(s); they own "
+                         << "the tablet's completion. tablet_id=" << tablet_id << ", txn_id=" << txn_id << ": "
+                         << e.what();
+            return submitted;
+        }
+        cleanup_tablet(tablet_id, txn_id);
+        return Status::InternalError(
+                strings::Substitute("exception while submitting parallel compaction subtasks: $0", e.what()));
+    } catch (...) {
+        if (submitted > 0) {
+            LOG(WARNING) << "Unknown exception after submitting " << submitted << " parallel compaction subtask(s); "
+                         << "they own the tablet's completion. tablet_id=" << tablet_id << ", txn_id=" << txn_id;
+            return submitted;
+        }
+        cleanup_tablet(tablet_id, txn_id);
+        return Status::InternalError("unknown exception while submitting parallel compaction subtasks");
+    }
 }
 
 std::shared_ptr<TabletParallelCompactionState> TabletParallelCompactionManager::get_tablet_state(int64_t tablet_id,
@@ -1989,7 +2018,7 @@ std::vector<SubtaskGroup> TabletParallelCompactionManager::_create_subtask_group
 StatusOr<int> TabletParallelCompactionManager::submit_subtasks_from_groups(
         const std::shared_ptr<TabletParallelCompactionState>& state_ptr, std::vector<SubtaskGroup> groups,
         bool force_base_compaction, ThreadPool* thread_pool, const AcquireTokenFunc& acquire_token,
-        const ReleaseTokenFunc& release_token) {
+        const ReleaseTokenFunc& release_token, int* submitted_out) {
     int64_t tablet_id = state_ptr->tablet_id;
     int64_t txn_id = state_ptr->txn_id;
     int64_t version = state_ptr->version;
@@ -2225,6 +2254,9 @@ StatusOr<int> TabletParallelCompactionManager::submit_subtasks_from_groups(
         // The subtask is now owned by the thread pool and will report its own completion, so the
         // registration must survive this scope.
         submitted = true;
+        if (submitted_out != nullptr) {
+            *submitted_out = subtasks_created;
+        }
 
         // Test hook: lets a test throw from here, i.e. *after* a subtask has been submitted and is running.
         // A throw in this window must not route the tablet into the caller's fallback path, or the tablet

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -843,8 +843,8 @@ void TabletParallelCompactionManager::seal_submission(int64_t tablet_id, int64_t
         callback = state->callback;
     }
     if (claimed && callback) {
-        VLOG(1) << "Parallel compaction: all subtasks already finished when submission was sealed, tablet="
-                << tablet_id << ", txn_id=" << txn_id;
+        VLOG(1) << "Parallel compaction: all subtasks already finished when submission was sealed, tablet=" << tablet_id
+                << ", txn_id=" << txn_id;
         finalize_tablet_completion(tablet_id, txn_id, state, callback);
     }
 }

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.h
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.h
@@ -163,6 +163,19 @@ struct TabletParallelCompactionState {
     // Mutex for thread-safe access
     mutable std::mutex mutex;
 
+    // Set once submit_subtasks_from_groups() has stopped registering subtasks for this tablet.
+    // Subtasks are registered and submitted one group at a time, so without this the tablet can look
+    // "complete" in the middle of submission: a subtask that finishes before the next group is registered
+    // finds running_subtasks empty and drives the completion transition, and a later subtask drives it
+    // AGAIN -- two finish_task() calls for one tablet id, which pushes CompactionTaskCallback::_contexts
+    // past the request's tablet count, completes the RPC while other tablets are still running, and leaves
+    // the next real completion dereferencing an already-nulled _response.
+    bool submission_done = false;
+
+    // Guards the completion transition so it runs exactly once per tablet, taken by whoever gets there
+    // first: the last finishing subtask, or the end of submission if every subtask already finished.
+    bool completion_claimed = false;
+
     // Check if we can create a new subtask
     bool can_create_subtask() const { return running_subtasks.size() < static_cast<size_t>(max_parallel); }
 
@@ -172,8 +185,18 @@ struct TabletParallelCompactionState {
         return it != compacting_rowsets.end() && it->second > 0;
     }
 
-    // Check if all subtasks are completed
-    bool is_complete() const { return running_subtasks.empty() && total_subtasks_created > 0; }
+    // Check if all subtasks are completed. Requires submission to be sealed -- see submission_done.
+    bool is_complete() const { return submission_done && running_subtasks.empty() && total_subtasks_created > 0; }
+
+    // Take the right to run the completion transition, if it is due and nobody has taken it yet.
+    // Caller must hold `mutex`.
+    bool claim_completion() {
+        if (!is_complete() || completion_claimed) {
+            return false;
+        }
+        completion_claimed = true;
+        return true;
+    }
 };
 
 // Manager for per-tablet parallel compaction
@@ -199,6 +222,18 @@ public:
     // Subtask completion callback
     void on_subtask_complete(int64_t tablet_id, int64_t txn_id, int32_t subtask_id,
                              std::unique_ptr<CompactionTaskContext> context);
+
+    // Declare that no further subtasks will be registered for |tablet_id|, and run the completion
+    // transition if they have all finished already. Must be called on every path that stops registering
+    // subtasks while leaving some running; see TabletParallelCompactionState::submission_done.
+    void seal_submission(int64_t tablet_id, int64_t txn_id,
+                         const std::shared_ptr<TabletParallelCompactionState>& state);
+
+    // Run the one-time completion transition for a tablet. The caller must already have won
+    // TabletParallelCompactionState::claim_completion().
+    void finalize_tablet_completion(int64_t tablet_id, int64_t txn_id,
+                                    const std::shared_ptr<TabletParallelCompactionState>& state,
+                                    const std::shared_ptr<CompactionTaskCallback>& callback);
 
     // Check if all subtasks for a tablet are complete
     bool is_tablet_complete(int64_t tablet_id, int64_t txn_id);

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.h
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.h
@@ -268,11 +268,14 @@ private:
                                   const ReleaseTokenFunc& release_token);
 
     // Submit subtasks from SubtaskGroup to thread pool (new API for large rowset split)
-    // Returns the number of subtasks successfully submitted
+    // Returns the number of subtasks successfully submitted.
+    // |submitted_out|, when non-null, is kept up to date with that count as the subtasks are handed to the
+    // thread pool, so it stays readable if this throws. The tablet state cannot be used for that: a subtask
+    // may already have completed and cleaned the state up by the time the exception is handled.
     StatusOr<int> submit_subtasks_from_groups(const std::shared_ptr<TabletParallelCompactionState>& state_ptr,
                                               std::vector<SubtaskGroup> groups, bool force_base_compaction,
                                               ThreadPool* thread_pool, const AcquireTokenFunc& acquire_token,
-                                              const ReleaseTokenFunc& release_token);
+                                              const ReleaseTokenFunc& release_token, int* submitted_out = nullptr);
 
     // Execute a single subtask for large rowset split (segment range mode)
     void execute_subtask_segment_range(int64_t tablet_id, int64_t txn_id, int32_t subtask_id,

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.h
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.h
@@ -223,8 +223,8 @@ public:
                                         const TabletParallelConfig& config,
                                         std::shared_ptr<CompactionTaskCallback> callback, bool force_base_compaction,
                                         ThreadPool* thread_pool, const AcquireTokenFunc& acquire_token,
-                                        const ReleaseTokenFunc& release_token,
-                                        int64_t handoff_in_queue_time_sec = 0, int64_t handoff_queue_wait_ns = 0);
+                                        const ReleaseTokenFunc& release_token, int64_t handoff_in_queue_time_sec = 0,
+                                        int64_t handoff_queue_wait_ns = 0);
 
     // Get tablet's parallel state (for testing/monitoring)
     // Returns shared_ptr to ensure the state remains valid while being used.

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.h
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.h
@@ -163,6 +163,13 @@ struct TabletParallelCompactionState {
     // Mutex for thread-safe access
     mutable std::mutex mutex;
 
+    // Time this tablet's context spent queued before a worker picked it up and planned the subtasks.
+    // That context is destroyed at the hand-off, so without carrying these the merged context would only
+    // report each subtask's own queue wait and CompactResponse would under-report the total -- missing
+    // exactly the wait that the hand-off introduces.
+    int64_t handoff_in_queue_time_sec = 0;
+    int64_t handoff_queue_wait_ns = 0;
+
     // Set once submit_subtasks_from_groups() has stopped registering subtasks for this tablet.
     // Subtasks are registered and submitted one group at a time, so without this the tablet can look
     // "complete" in the middle of submission: a subtask that finishes before the next group is registered
@@ -209,11 +216,15 @@ public:
 
     // Create parallel compaction tasks for a tablet
     // Returns the number of subtasks created
+    // |handoff_in_queue_time_sec| / |handoff_queue_wait_ns| carry the queue wait already accumulated by
+    // the caller's context, which is destroyed once the subtasks take over; they are added once to the
+    // merged context so the reported queue time stays complete.
     StatusOr<int> create_parallel_tasks(int64_t tablet_id, int64_t txn_id, int64_t version,
                                         const TabletParallelConfig& config,
                                         std::shared_ptr<CompactionTaskCallback> callback, bool force_base_compaction,
                                         ThreadPool* thread_pool, const AcquireTokenFunc& acquire_token,
-                                        const ReleaseTokenFunc& release_token);
+                                        const ReleaseTokenFunc& release_token,
+                                        int64_t handoff_in_queue_time_sec = 0, int64_t handoff_queue_wait_ns = 0);
 
     // Get tablet's parallel state (for testing/monitoring)
     // Returns shared_ptr to ensure the state remains valid while being used.

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.h
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.h
@@ -234,6 +234,12 @@ public:
     void on_subtask_complete(int64_t tablet_id, int64_t txn_id, int32_t subtask_id,
                              std::unique_ptr<CompactionTaskContext> context);
 
+    // Settles every tablet still being compacted in parallel, for shutdown. MUST be called only after the
+    // compaction thread pool has shut down, because it assumes no subtask can still run: shutdown() drops
+    // queued subtasks through a no-op cancel(), and their tablet's context is already gone, so without this
+    // nothing would ever complete those tablets and the compact RPC would hang.
+    void abort_pending_states();
+
     // Collects the request callbacks of every tablet currently being compacted in parallel under |txn_id|.
     // CompactionScheduler::abort() needs this because a tablet handed off to subtasks has no node in
     // CompactionScheduler::_contexts between the hand-off and the merged context being appended, so a walk

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.h
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.h
@@ -223,6 +223,12 @@ public:
     void on_subtask_complete(int64_t tablet_id, int64_t txn_id, int32_t subtask_id,
                              std::unique_ptr<CompactionTaskContext> context);
 
+    // Collects the request callbacks of every tablet currently being compacted in parallel under |txn_id|.
+    // CompactionScheduler::abort() needs this because a tablet handed off to subtasks has no node in
+    // CompactionScheduler::_contexts between the hand-off and the merged context being appended, so a walk
+    // of that list alone reports the txn as not found and cancels nothing.
+    std::vector<std::shared_ptr<CompactionTaskCallback>> collect_callbacks_for_txn(int64_t txn_id) const;
+
     // Declare that no further subtasks will be registered for |tablet_id|, and run the completion
     // transition if they have all finished already. Must be called on every path that stops registering
     // subtasks while leaving some running; see TabletParallelCompactionState::submission_done.

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.h
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.h
@@ -253,9 +253,16 @@ public:
     void list_tasks(std::vector<CompactionTaskInfo>* infos);
 
     // Test-only: Register a pre-created tablet state for unit testing
-    // This allows tests to bypass the normal create_parallel_tasks flow
+    // This allows tests to bypass the normal create_parallel_tasks flow.
+    // The handed-over state already lists every subtask the test intends to run, which is exactly what
+    // submit_subtasks_from_groups() would have sealed on its way out, so seal it here too -- otherwise
+    // is_complete() stays false forever and the subtasks could never complete the tablet.
     void register_tablet_state_for_test(int64_t tablet_id, int64_t txn_id,
                                         std::shared_ptr<TabletParallelCompactionState> state) {
+        if (state != nullptr) {
+            std::lock_guard<std::mutex> state_lock(state->mutex);
+            state->submission_done = true;
+        }
         std::lock_guard<std::mutex> lock(_states_mutex);
         std::string key = make_state_key(tablet_id, txn_id);
         _tablet_states[key] = std::move(state);

--- a/be/test/storage/lake/compaction_scheduler_test.cpp
+++ b/be/test/storage/lake/compaction_scheduler_test.cpp
@@ -23,6 +23,7 @@
 #include "base/testutil/sync_point.h"
 #include "base/utility/scoped_cleanup.h"
 #include "common/config_compaction_fwd.h"
+#include "common/thread/threadpool.h"
 #include "gen_cpp/lake_service.pb.h"
 #include "runtime/descriptors.h"
 #include "storage/lake/compaction_task_context.h"
@@ -529,6 +530,57 @@ TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_runs_off_caller_thr
     EXPECT_TRUE(fired.load());
     // The offloaded task runs on a _threads pool worker, never on the caller (gtest) thread.
     EXPECT_TRUE(ran_off_caller_thread.load());
+}
+
+// Regression test for the #76882 fix's shutdown-safety guarantee. When the deferred parallel-compaction
+// task is cancelled in the thread pool (as happens when stop()/shutdown() drains the queue), the
+// CancellableRunnable's canceller MUST still complete the RPC (run `done`), otherwise the FE's compact RPC
+// hangs forever and the closure leaks. A plain submit_func() runnable has a no-op cancel() and would
+// exhibit exactly that hang; this test pins the CancellableRunnable choice.
+//
+// The "ThreadPool::do_submit:replace_task" sync point runs its callback synchronously inside submit() on
+// the caller thread, so we cancel the just-submitted dispatcher there (and swap in a no-op runnable). This
+// makes the whole test deterministic: `done` runs during compact() via the canceller, so latch->wait()
+// returns without depending on any background thread timing.
+TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_cancelled_completes_rpc) {
+    class MockRunnable : public Runnable {
+    public:
+        void run() override {}
+        void cancel() override {}
+    };
+
+    auto* sync_point = SyncPoint::GetInstance();
+    sync_point->SetCallBack("ThreadPool::do_submit:replace_task", [](void* arg) {
+        auto ptr = (*(std::shared_ptr<Runnable>*)arg);
+        ptr->cancel(); // invoke the dispatcher's canceller (must reject_request + run `done`)
+        (*(std::shared_ptr<Runnable>*)arg) = std::make_shared<MockRunnable>();
+    });
+    sync_point->EnableProcessing();
+    SCOPED_CLEANUP({
+        sync_point->ClearCallBack("ThreadPool::do_submit:replace_task");
+        sync_point->DisableProcessing();
+    });
+
+    auto txn_id = next_id();
+    auto latch = std::make_shared<CountDownLatch>(1);
+    CompactRequest request;
+    CompactResponse response;
+    request.add_tablet_ids(_tablet_metadata->id());
+    request.set_timeout_ms(60 * 1000);
+    request.set_txn_id(txn_id);
+    request.set_version(1);
+    auto* parallel_config = request.mutable_parallel_config();
+    parallel_config->set_enable_parallel(true);
+    parallel_config->set_max_parallel_per_tablet(3);
+    parallel_config->set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    auto cb = ::google::protobuf::NewCallback(notify_for_callback, latch);
+    _compaction_scheduler.compact(nullptr, &request, &response, cb);
+    // The canceller ran `done` synchronously during submit(); wait() must not hang.
+    latch->wait();
+
+    // The RPC was completed (not leaked) with a non-OK status.
+    EXPECT_NE(0, response.status().status_code());
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/compaction_scheduler_test.cpp
+++ b/be/test/storage/lake/compaction_scheduler_test.cpp
@@ -725,4 +725,70 @@ TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_exception_after_reg
     }
 }
 
+// Planning hands the worker's limiter token back before it starts, so another worker can claim it. Compacting
+// the tablet anyway would run it outside the limiter, next to whoever took the token; it has to be
+// rescheduled for a worker that holds one instead -- and still complete its RPC exactly once.
+TEST_F(LakeCompactionSchedulerTest, test_parallel_planning_token_loss_reschedules) {
+    // Single worker, single token: the token freed for planning cannot go anywhere but to the drain below.
+    _compaction_scheduler.update_compact_threads(1);
+
+    std::atomic<bool> drained_once{false};
+    std::atomic<int> tokens_held{0};
+    std::atomic<int> reschedules{0};
+    auto give_tokens_back = [&]() {
+        for (int i = tokens_held.exchange(0); i > 0; i--) {
+            _compaction_scheduler.return_token_for_test();
+        }
+    };
+
+    auto* sync_point = SyncPoint::GetInstance();
+    // Reached after the worker returned its token and before planning: act as the competing worker and take
+    // every free token. Planning then fails to reserve its all-or-nothing set, and the reclaim that follows
+    // finds nothing left either.
+    sync_point->SetCallBack("CompactionScheduler::try_hand_off_to_parallel:create_parallel_tasks", [&](void* /*arg*/) {
+        if (drained_once.exchange(true)) {
+            return;
+        }
+        while (_compaction_scheduler.acquire_token_for_test()) {
+            tokens_held.fetch_add(1);
+        }
+    });
+    // The reclaim failed and the tablet is about to be rescheduled. Release the tokens: with none free, no
+    // worker could ever pick it up again.
+    sync_point->SetCallBack("CompactionScheduler::try_hand_off_to_parallel:token_lost", [&](void* /*arg*/) {
+        reschedules.fetch_add(1);
+        give_tokens_back();
+    });
+    sync_point->EnableProcessing();
+    SCOPED_CLEANUP({
+        sync_point->ClearCallBack("CompactionScheduler::try_hand_off_to_parallel:create_parallel_tasks");
+        sync_point->ClearCallBack("CompactionScheduler::try_hand_off_to_parallel:token_lost");
+        sync_point->DisableProcessing();
+        give_tokens_back();
+    });
+
+    auto txn_id = next_id();
+    auto latch = std::make_shared<CountDownLatch>(1);
+    CompactRequest request;
+    CompactResponse response;
+    request.add_tablet_ids(_tablet_metadata->id());
+    request.set_timeout_ms(60 * 1000);
+    request.set_txn_id(txn_id);
+    request.set_version(1);
+    auto* parallel_config = request.mutable_parallel_config();
+    parallel_config->set_enable_parallel(true);
+    parallel_config->set_max_parallel_per_tablet(3);
+    parallel_config->set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    auto cb = ::google::protobuf::NewCallback(notify_for_callback, latch);
+    _compaction_scheduler.compact(nullptr, &request, &response, cb);
+    // Hangs here if a rescheduled tablet is dropped instead of being compacted by the next worker.
+    latch->wait();
+
+    // Disabling the parallel path on the retry is what bounds this: only planning returns a token mid-flight,
+    // so a rescheduled tablet cannot lose one again and bounce forever.
+    EXPECT_LE(reschedules.load(), 1);
+    EXPECT_EQ(1, response.compact_stats_size());
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/compaction_scheduler_test.cpp
+++ b/be/test/storage/lake/compaction_scheduler_test.cpp
@@ -15,6 +15,7 @@
 #include "storage/lake/compaction_scheduler.h"
 
 #include <atomic>
+#include <new>
 #include <system_error>
 #include <thread>
 
@@ -673,6 +674,72 @@ TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_exception_completes
 
         EXPECT_TRUE(injected.load());
     }
+}
+
+// Companion to the test above, for the dangerous arm it cannot reach. That test injects its throw at the
+// ":create_parallel_tasks" hook, which fires *before* create_parallel_tasks() runs, so no subtask has been
+// submitted yet and falling back to normal compaction is safe.
+//
+// Here the throw lands *after* a subtask was already submitted and is running (the real shape of a
+// std::bad_alloc from the per-group bookkeeping in submit_subtasks_from_groups). That subtask already owns
+// the tablet's single finish_task(): TabletParallelCompactionState::is_complete() is
+// `running_subtasks.empty() && total_subtasks_created > 0`, so it fires when the subtask completes. If the
+// tablet were *also* routed into the fallback path, finish_task() would run twice for one tablet id, push
+// _contexts past tablet_ids_size(), and dereference the `_response` the first completion already nulled ->
+// SIGSEGV. So the RPC must complete exactly once.
+TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_exception_after_submit_completes_rpc_once) {
+    auto metadata = generate_simple_tablet_metadata(DUP_KEYS);
+    metadata->set_id(next_id());
+    metadata->set_version(11);
+    for (int i = 0; i < 10; i++) {
+        auto* rowset = metadata->add_rowsets();
+        rowset->set_id(i);
+        rowset->set_overlapped(true);
+        rowset->set_num_rows(100);
+        rowset->set_data_size(1024 * 1024);
+        auto* segment_meta = rowset->add_segment_metas();
+        segment_meta->set_filename(fmt::format("segment_{}.dat", i));
+        segment_meta->set_size(1024 * 1024);
+    }
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*metadata));
+
+    // Throw only on the first submitted subtask, so at least one subtask stays in flight.
+    std::atomic<bool> thrown{false};
+    auto* sync_point = SyncPoint::GetInstance();
+    sync_point->SetCallBack("TabletParallelCompactionManager::submit_subtasks_from_groups:after_submit",
+                            [&](void* /*arg*/) {
+                                if (!thrown.exchange(true)) {
+                                    throw std::bad_alloc();
+                                }
+                            });
+    sync_point->EnableProcessing();
+    SCOPED_CLEANUP({
+        sync_point->ClearCallBack("TabletParallelCompactionManager::submit_subtasks_from_groups:after_submit");
+        sync_point->DisableProcessing();
+    });
+
+    auto txn_id = next_id();
+    auto latch = std::make_shared<CountDownLatch>(1);
+    CompactRequest request;
+    CompactResponse response;
+    request.add_tablet_ids(metadata->id());
+    request.set_timeout_ms(60 * 1000);
+    request.set_txn_id(txn_id);
+    request.set_version(11);
+    auto* parallel_config = request.mutable_parallel_config();
+    parallel_config->set_enable_parallel(true);
+    parallel_config->set_max_parallel_per_tablet(3);
+    parallel_config->set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    auto cb = ::google::protobuf::NewCallback(notify_for_callback, latch);
+    _compaction_scheduler.compact(nullptr, &request, &response, cb);
+    // The in-flight subtask completes the RPC; wait() must not hang.
+    latch->wait();
+
+    EXPECT_TRUE(thrown.load());
+    // Exactly one finish_task() ran for the single tablet: finish_task() appends one compact_stat per call,
+    // so a second (crashing) completion would show up here as an extra entry.
+    EXPECT_EQ(1, response.compact_stats_size());
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/compaction_scheduler_test.cpp
+++ b/be/test/storage/lake/compaction_scheduler_test.cpp
@@ -491,11 +491,14 @@ TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_runs_off_caller_thr
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*metadata));
 
     const auto caller_id = std::this_thread::get_id();
+    // Compute the "ran off the caller thread" result inside the callback (where both ids are known) and
+    // publish it via an atomic, so the main thread never reads a std::thread::id written on another
+    // thread. caller_id is set before compact() and only read here, so it is not racy.
     std::atomic<bool> fired{false};
-    std::thread::id worker_id{};
+    std::atomic<bool> ran_off_caller_thread{false};
     auto* sync_point = SyncPoint::GetInstance();
     sync_point->SetCallBack("CompactionScheduler::process_parallel_compaction:enter", [&](void* /*arg*/) {
-        worker_id = std::this_thread::get_id();
+        ran_off_caller_thread.store(std::this_thread::get_id() != caller_id);
         fired.store(true);
     });
     sync_point->EnableProcessing();
@@ -525,7 +528,7 @@ TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_runs_off_caller_thr
 
     EXPECT_TRUE(fired.load());
     // The offloaded task runs on a _threads pool worker, never on the caller (gtest) thread.
-    EXPECT_NE(caller_id, worker_id);
+    EXPECT_TRUE(ran_off_caller_thread.load());
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/compaction_scheduler_test.cpp
+++ b/be/test/storage/lake/compaction_scheduler_test.cpp
@@ -535,8 +535,6 @@ TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_runs_off_caller_thr
     EXPECT_TRUE(ran_off_caller_thread.load());
 }
 
-
-
 // Once the IO-heavy task creation is offloaded to `_threads`, an exception escaping it stops being a crash
 // and becomes a silent hang: ThreadPool::dispatch_thread only logs an escaping exception (it does not run
 // the runnable's cancel()), compact() has already released the ClosureGuard, and ~CompactionTaskCallback()

--- a/be/test/storage/lake/compaction_scheduler_test.cpp
+++ b/be/test/storage/lake/compaction_scheduler_test.cpp
@@ -333,7 +333,7 @@ TEST_F(LakeCompactionSchedulerTest, test_abort_with_not_write_txnlog) {
     SyncPoint::GetInstance()->DisableProcessing();
 }
 
-// Test for process_parallel_compaction (lines 299-369 in compaction_scheduler.cpp)
+// Tests for the parallel compaction path driven through compact()
 TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_basic) {
     // Create a tablet with multiple rowsets for parallel compaction
     auto metadata = generate_simple_tablet_metadata(DUP_KEYS);
@@ -468,13 +468,14 @@ TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_multiple_tablets) {
     latch->wait();
 }
 
-// Regression test for issue #76882: CompactionScheduler::compact() must NOT run the IO-heavy
-// process_parallel_compaction() (tablet-metadata load + StarletFileSystem creation) on the calling
-// brpc bthread. Running blocking filesystem IO on a bthread can make a pthread rwlock (StarOSWorker's
-// std::shared_mutex _cache_mtx) return EDEADLK on an unrelated bthread sharing the same worker pthread,
-// which surfaces as an uncaught std::system_error("Resource deadlock avoided") and aborts the CN. The
-// fix offloads process_parallel_compaction() to the dedicated _threads pthread pool. This test pins the
-// offload: it asserts process_parallel_compaction() executes on a thread different from the caller.
+// Regression test for issue #76882: the IO-heavy part of parallel compaction -- loading the tablet
+// metadata and building the StarOS/Starlet filesystem while planning the subtasks -- must NOT run on the
+// brpc bthread that called compact(). Blocking filesystem IO on a bthread can make a pthread rwlock
+// (StarOSWorker's std::shared_mutex _cache_mtx) return EDEADLK on an unrelated bthread sharing the same
+// worker pthread, which surfaces as an uncaught std::system_error("Resource deadlock avoided") and aborts
+// the CN. compact() therefore only builds and queues the contexts, exactly as the serial path does, and
+// the planning happens later in do_compaction() on a resident worker. This test pins that: the planning
+// hook must fire on a thread other than the caller.
 // (The other parallel tests above only prove "did not crash / did complete"; they pass against the old
 // inline code too, so they cannot catch a regression back to on-bthread execution.)
 TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_runs_off_caller_thread) {
@@ -500,13 +501,13 @@ TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_runs_off_caller_thr
     std::atomic<bool> fired{false};
     std::atomic<bool> ran_off_caller_thread{false};
     auto* sync_point = SyncPoint::GetInstance();
-    sync_point->SetCallBack("CompactionScheduler::process_parallel_compaction:enter", [&](void* /*arg*/) {
+    sync_point->SetCallBack("CompactionScheduler::try_hand_off_to_parallel:create_parallel_tasks", [&](void* /*arg*/) {
         ran_off_caller_thread.store(std::this_thread::get_id() != caller_id);
         fired.store(true);
     });
     sync_point->EnableProcessing();
     SCOPED_CLEANUP({
-        sync_point->ClearCallBack("CompactionScheduler::process_parallel_compaction:enter");
+        sync_point->ClearCallBack("CompactionScheduler::try_hand_off_to_parallel:create_parallel_tasks");
         sync_point->DisableProcessing();
     });
 
@@ -525,7 +526,7 @@ TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_runs_off_caller_thr
 
     auto cb = ::google::protobuf::NewCallback(notify_for_callback, latch);
     _compaction_scheduler.compact(nullptr, &request, &response, cb);
-    // done->Run() (hence latch) only fires after process_parallel_compaction has entered, so the hook is
+    // done->Run() (hence latch) only fires after the planning hook has been reached, so the hook is
     // guaranteed to have run by the time wait() returns.
     latch->wait();
 
@@ -534,94 +535,7 @@ TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_runs_off_caller_thr
     EXPECT_TRUE(ran_off_caller_thread.load());
 }
 
-// Regression test for the #76882 fix's shutdown-safety guarantee. When the deferred parallel-compaction
-// task is cancelled in the thread pool (as happens when stop()/shutdown() drains the queue), the
-// CancellableRunnable's canceller MUST still complete the RPC (run `done`), otherwise the FE's compact RPC
-// hangs forever and the closure leaks. A plain submit_func() runnable has a no-op cancel() and would
-// exhibit exactly that hang; this test pins the CancellableRunnable choice.
-//
-// The "ThreadPool::do_submit:replace_task" sync point runs its callback synchronously inside submit() on
-// the caller thread, so we cancel the just-submitted dispatcher there (and swap in a no-op runnable). This
-// makes the whole test deterministic: `done` runs during compact() via the canceller, so latch->wait()
-// returns without depending on any background thread timing.
-TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_cancelled_completes_rpc) {
-    class MockRunnable : public Runnable {
-    public:
-        void run() override {}
-        void cancel() override {}
-    };
 
-    auto* sync_point = SyncPoint::GetInstance();
-    sync_point->SetCallBack("ThreadPool::do_submit:replace_task", [](void* arg) {
-        auto ptr = (*(std::shared_ptr<Runnable>*)arg);
-        ptr->cancel(); // invoke the dispatcher's canceller (must reject_request + run `done`)
-        (*(std::shared_ptr<Runnable>*)arg) = std::make_shared<MockRunnable>();
-    });
-    sync_point->EnableProcessing();
-    SCOPED_CLEANUP({
-        sync_point->ClearCallBack("ThreadPool::do_submit:replace_task");
-        sync_point->DisableProcessing();
-    });
-
-    auto txn_id = next_id();
-    auto latch = std::make_shared<CountDownLatch>(1);
-    CompactRequest request;
-    CompactResponse response;
-    request.add_tablet_ids(_tablet_metadata->id());
-    request.set_timeout_ms(60 * 1000);
-    request.set_txn_id(txn_id);
-    request.set_version(1);
-    auto* parallel_config = request.mutable_parallel_config();
-    parallel_config->set_enable_parallel(true);
-    parallel_config->set_max_parallel_per_tablet(3);
-    parallel_config->set_max_bytes_per_subtask(5 * 1024 * 1024);
-
-    auto cb = ::google::protobuf::NewCallback(notify_for_callback, latch);
-    _compaction_scheduler.compact(nullptr, &request, &response, cb);
-    // The canceller ran `done` synchronously during submit(); wait() must not hang.
-    latch->wait();
-
-    // The RPC was completed (not leaked) with a non-OK status.
-    EXPECT_NE(0, response.status().status_code());
-}
-
-// Third and last `done`-exactly-once path of the #76882 fix: when submitting the deferred
-// parallel-compaction task to the pool FAILS, the task was never enqueued (so neither run() nor cancel()
-// will ever fire) and compact() itself must complete the RPC, surfacing the real submit error. If it
-// didn't, the FE's compact RPC would hang forever.
-//
-// "ThreadPool::do_submit:1" hands the callback a pointer to the pool's computed capacity_remaining;
-// forcing it to 0 makes submit() return ServiceUnavailable deterministically.
-TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_submit_failure_completes_rpc) {
-    auto* sync_point = SyncPoint::GetInstance();
-    sync_point->SetCallBack("ThreadPool::do_submit:1", [](void* arg) { *(int64_t*)arg = 0; });
-    sync_point->EnableProcessing();
-    SCOPED_CLEANUP({
-        sync_point->ClearCallBack("ThreadPool::do_submit:1");
-        sync_point->DisableProcessing();
-    });
-
-    auto txn_id = next_id();
-    auto latch = std::make_shared<CountDownLatch>(1);
-    CompactRequest request;
-    CompactResponse response;
-    request.add_tablet_ids(_tablet_metadata->id());
-    request.set_timeout_ms(60 * 1000);
-    request.set_txn_id(txn_id);
-    request.set_version(1);
-    auto* parallel_config = request.mutable_parallel_config();
-    parallel_config->set_enable_parallel(true);
-    parallel_config->set_max_parallel_per_tablet(3);
-    parallel_config->set_max_bytes_per_subtask(5 * 1024 * 1024);
-
-    auto cb = ::google::protobuf::NewCallback(notify_for_callback, latch);
-    _compaction_scheduler.compact(nullptr, &request, &response, cb);
-    // compact() ran `done` inline on the submit-failure path; wait() must not hang.
-    latch->wait();
-
-    // The real submit error is surfaced, not a generic shutdown status.
-    EXPECT_NE(0, response.status().status_code());
-}
 
 // Once the IO-heavy task creation is offloaded to `_threads`, an exception escaping it stops being a crash
 // and becomes a silent hang: ThreadPool::dispatch_thread only logs an escaping exception (it does not run
@@ -630,9 +544,9 @@ TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_submit_failure_comp
 //
 // Inject the #76882 exception itself -- std::system_error("Resource deadlock avoided"), what a pthread rwlock
 // returning EDEADLK raises through std::shared_mutex -- into create_parallel_tasks() and assert the RPC still
-// completes. process_parallel_compaction() must absorb it and fall back to normal compaction, which keeps one
-// finish_task() per tablet id and therefore still runs `done`. Both handlers are exercised: the std::exception
-// one and the catch-all that covers a foreign exception thrown through the same call.
+// completes. do_compaction() must absorb it and compact the tablet serially with the same context, which
+// keeps one finish_task() per tablet id and therefore still runs `done`. Both handlers are exercised: the
+// std::exception one and the catch-all that covers a foreign exception thrown through the same call.
 TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_exception_completes_rpc) {
     struct ForeignException {};
 
@@ -640,7 +554,7 @@ TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_exception_completes
         std::atomic<bool> injected{false};
         auto* sync_point = SyncPoint::GetInstance();
         sync_point->SetCallBack(
-                "CompactionScheduler::process_parallel_compaction:create_parallel_tasks", [&](void* /*arg*/) {
+                "CompactionScheduler::try_hand_off_to_parallel:create_parallel_tasks", [&](void* /*arg*/) {
                     injected.store(true);
                     if (foreign) {
                         throw ForeignException{};
@@ -650,7 +564,7 @@ TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_exception_completes
                 });
         sync_point->EnableProcessing();
         SCOPED_CLEANUP({
-            sync_point->ClearCallBack("CompactionScheduler::process_parallel_compaction:create_parallel_tasks");
+            sync_point->ClearCallBack("CompactionScheduler::try_hand_off_to_parallel:create_parallel_tasks");
             sync_point->DisableProcessing();
         });
 

--- a/be/test/storage/lake/compaction_scheduler_test.cpp
+++ b/be/test/storage/lake/compaction_scheduler_test.cpp
@@ -14,9 +14,13 @@
 
 #include "storage/lake/compaction_scheduler.h"
 
+#include <atomic>
+#include <thread>
+
 #include "base/bthreads/util.h"
 #include "base/concurrency/countdown_latch.h"
 #include "base/testutil/assert.h"
+#include "base/testutil/sync_point.h"
 #include "base/utility/scoped_cleanup.h"
 #include "common/config_compaction_fwd.h"
 #include "gen_cpp/lake_service.pb.h"
@@ -459,6 +463,69 @@ TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_multiple_tablets) {
     auto cb = ::google::protobuf::NewCallback(notify_for_callback, latch);
     _compaction_scheduler.compact(nullptr, &request, &response, cb);
     latch->wait();
+}
+
+// Regression test for issue #76882: CompactionScheduler::compact() must NOT run the IO-heavy
+// process_parallel_compaction() (tablet-metadata load + StarletFileSystem creation) on the calling
+// brpc bthread. Running blocking filesystem IO on a bthread can make a pthread rwlock (StarOSWorker's
+// std::shared_mutex _cache_mtx) return EDEADLK on an unrelated bthread sharing the same worker pthread,
+// which surfaces as an uncaught std::system_error("Resource deadlock avoided") and aborts the CN. The
+// fix offloads process_parallel_compaction() to the dedicated _threads pthread pool. This test pins the
+// offload: it asserts process_parallel_compaction() executes on a thread different from the caller.
+// (The other parallel tests above only prove "did not crash / did complete"; they pass against the old
+// inline code too, so they cannot catch a regression back to on-bthread execution.)
+TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_runs_off_caller_thread) {
+    auto metadata = generate_simple_tablet_metadata(DUP_KEYS);
+    metadata->set_id(next_id());
+    metadata->set_version(11);
+    for (int i = 0; i < 10; i++) {
+        auto* rowset = metadata->add_rowsets();
+        rowset->set_id(i);
+        rowset->set_overlapped(true);
+        rowset->set_num_rows(100);
+        rowset->set_data_size(1024 * 1024);
+        auto* segment_meta = rowset->add_segment_metas();
+        segment_meta->set_filename(fmt::format("segment_{}.dat", i));
+        segment_meta->set_size(1024 * 1024);
+    }
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*metadata));
+
+    const auto caller_id = std::this_thread::get_id();
+    std::atomic<bool> fired{false};
+    std::thread::id worker_id{};
+    auto* sync_point = SyncPoint::GetInstance();
+    sync_point->SetCallBack("CompactionScheduler::process_parallel_compaction:enter", [&](void* /*arg*/) {
+        worker_id = std::this_thread::get_id();
+        fired.store(true);
+    });
+    sync_point->EnableProcessing();
+    SCOPED_CLEANUP({
+        sync_point->ClearCallBack("CompactionScheduler::process_parallel_compaction:enter");
+        sync_point->DisableProcessing();
+    });
+
+    auto txn_id = next_id();
+    auto latch = std::make_shared<CountDownLatch>(1);
+    CompactRequest request;
+    CompactResponse response;
+    request.add_tablet_ids(metadata->id());
+    request.set_timeout_ms(60 * 1000);
+    request.set_txn_id(txn_id);
+    request.set_version(11);
+    auto* parallel_config = request.mutable_parallel_config();
+    parallel_config->set_enable_parallel(true);
+    parallel_config->set_max_parallel_per_tablet(3);
+    parallel_config->set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    auto cb = ::google::protobuf::NewCallback(notify_for_callback, latch);
+    _compaction_scheduler.compact(nullptr, &request, &response, cb);
+    // done->Run() (hence latch) only fires after process_parallel_compaction has entered, so the hook is
+    // guaranteed to have run by the time wait() returns.
+    latch->wait();
+
+    EXPECT_TRUE(fired.load());
+    // The offloaded task runs on a _threads pool worker, never on the caller (gtest) thread.
+    EXPECT_NE(caller_id, worker_id);
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/compaction_scheduler_test.cpp
+++ b/be/test/storage/lake/compaction_scheduler_test.cpp
@@ -583,4 +583,42 @@ TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_cancelled_completes
     EXPECT_NE(0, response.status().status_code());
 }
 
+// Third and last `done`-exactly-once path of the #76882 fix: when submitting the deferred
+// parallel-compaction task to the pool FAILS, the task was never enqueued (so neither run() nor cancel()
+// will ever fire) and compact() itself must complete the RPC, surfacing the real submit error. If it
+// didn't, the FE's compact RPC would hang forever.
+//
+// "ThreadPool::do_submit:1" hands the callback a pointer to the pool's computed capacity_remaining;
+// forcing it to 0 makes submit() return ServiceUnavailable deterministically.
+TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_submit_failure_completes_rpc) {
+    auto* sync_point = SyncPoint::GetInstance();
+    sync_point->SetCallBack("ThreadPool::do_submit:1", [](void* arg) { *(int64_t*)arg = 0; });
+    sync_point->EnableProcessing();
+    SCOPED_CLEANUP({
+        sync_point->ClearCallBack("ThreadPool::do_submit:1");
+        sync_point->DisableProcessing();
+    });
+
+    auto txn_id = next_id();
+    auto latch = std::make_shared<CountDownLatch>(1);
+    CompactRequest request;
+    CompactResponse response;
+    request.add_tablet_ids(_tablet_metadata->id());
+    request.set_timeout_ms(60 * 1000);
+    request.set_txn_id(txn_id);
+    request.set_version(1);
+    auto* parallel_config = request.mutable_parallel_config();
+    parallel_config->set_enable_parallel(true);
+    parallel_config->set_max_parallel_per_tablet(3);
+    parallel_config->set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    auto cb = ::google::protobuf::NewCallback(notify_for_callback, latch);
+    _compaction_scheduler.compact(nullptr, &request, &response, cb);
+    // compact() ran `done` inline on the submit-failure path; wait() must not hang.
+    latch->wait();
+
+    // The real submit error is surfaced, not a generic shutdown status.
+    EXPECT_NE(0, response.status().status_code());
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/compaction_scheduler_test.cpp
+++ b/be/test/storage/lake/compaction_scheduler_test.cpp
@@ -15,6 +15,7 @@
 #include "storage/lake/compaction_scheduler.h"
 
 #include <atomic>
+#include <system_error>
 #include <thread>
 
 #include "base/bthreads/util.h"
@@ -619,6 +620,59 @@ TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_submit_failure_comp
 
     // The real submit error is surfaced, not a generic shutdown status.
     EXPECT_NE(0, response.status().status_code());
+}
+
+// Once the IO-heavy task creation is offloaded to `_threads`, an exception escaping it stops being a crash
+// and becomes a silent hang: ThreadPool::dispatch_thread only logs an escaping exception (it does not run
+// the runnable's cancel()), compact() has already released the ClosureGuard, and ~CompactionTaskCallback()
+// does not run `done`. Nothing would ever complete the RPC, so the FE would block until its compact timeout.
+//
+// Inject the #76882 exception itself -- std::system_error("Resource deadlock avoided"), what a pthread rwlock
+// returning EDEADLK raises through std::shared_mutex -- into create_parallel_tasks() and assert the RPC still
+// completes. process_parallel_compaction() must absorb it and fall back to normal compaction, which keeps one
+// finish_task() per tablet id and therefore still runs `done`. Both handlers are exercised: the std::exception
+// one and the catch-all that covers a foreign exception thrown through the same call.
+TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_exception_completes_rpc) {
+    struct ForeignException {};
+
+    for (bool foreign : {false, true}) {
+        std::atomic<bool> injected{false};
+        auto* sync_point = SyncPoint::GetInstance();
+        sync_point->SetCallBack(
+                "CompactionScheduler::process_parallel_compaction:create_parallel_tasks", [&](void* /*arg*/) {
+                    injected.store(true);
+                    if (foreign) {
+                        throw ForeignException{};
+                    }
+                    throw std::system_error(std::make_error_code(std::errc::resource_deadlock_would_occur),
+                                            "Resource deadlock avoided");
+                });
+        sync_point->EnableProcessing();
+        SCOPED_CLEANUP({
+            sync_point->ClearCallBack("CompactionScheduler::process_parallel_compaction:create_parallel_tasks");
+            sync_point->DisableProcessing();
+        });
+
+        auto txn_id = next_id();
+        auto latch = std::make_shared<CountDownLatch>(1);
+        CompactRequest request;
+        CompactResponse response;
+        request.add_tablet_ids(_tablet_metadata->id());
+        request.set_timeout_ms(60 * 1000);
+        request.set_txn_id(txn_id);
+        request.set_version(1);
+        auto* parallel_config = request.mutable_parallel_config();
+        parallel_config->set_enable_parallel(true);
+        parallel_config->set_max_parallel_per_tablet(3);
+        parallel_config->set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+        auto cb = ::google::protobuf::NewCallback(notify_for_callback, latch);
+        _compaction_scheduler.compact(nullptr, &request, &response, cb);
+        // The exception was absorbed into the fallback path, which completes the RPC; wait() must not hang.
+        latch->wait();
+
+        EXPECT_TRUE(injected.load());
+    }
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/compaction_scheduler_test.cpp
+++ b/be/test/storage/lake/compaction_scheduler_test.cpp
@@ -742,4 +742,75 @@ TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_exception_after_sub
     EXPECT_EQ(1, response.compact_stats_size());
 }
 
+// The remaining window: the throw lands while a subtask is registered in running_subtasks but has NOT been
+// handed to the thread pool. Nobody will ever complete that subtask, so if the registration survived,
+// is_complete() (`running_subtasks.empty() && total_subtasks_created > 0`) could never become true and the
+// tablet would never call finish_task() -- the compact RPC would hang forever. rollback_registration must
+// undo it, after which create_parallel_tasks() sees nothing submitted and reports an error so the caller
+// falls back to normal compaction, which then completes the RPC exactly once.
+//
+// Runs both arms so the `catch (const std::exception&)` and the `catch (...)` handlers are both exercised.
+TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_exception_after_register_completes_rpc_once) {
+    struct ForeignException {};
+
+    for (bool foreign : {false, true}) {
+        auto metadata = generate_simple_tablet_metadata(DUP_KEYS);
+        metadata->set_id(next_id());
+        metadata->set_version(11);
+        for (int i = 0; i < 10; i++) {
+            auto* rowset = metadata->add_rowsets();
+            rowset->set_id(i);
+            rowset->set_overlapped(true);
+            rowset->set_num_rows(100);
+            rowset->set_data_size(1024 * 1024);
+            auto* segment_meta = rowset->add_segment_metas();
+            segment_meta->set_filename(fmt::format("segment_{}.dat", i));
+            segment_meta->set_size(1024 * 1024);
+        }
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*metadata));
+
+        // Throw on the first registration only, so exactly one subtask is left registered-but-unsubmitted.
+        std::atomic<bool> thrown{false};
+        auto* sync_point = SyncPoint::GetInstance();
+        sync_point->SetCallBack("TabletParallelCompactionManager::submit_subtasks_from_groups:after_register",
+                                [&](void* /*arg*/) {
+                                    if (thrown.exchange(true)) {
+                                        return;
+                                    }
+                                    if (foreign) {
+                                        throw ForeignException{};
+                                    }
+                                    throw std::bad_alloc();
+                                });
+        sync_point->EnableProcessing();
+        SCOPED_CLEANUP({
+            sync_point->ClearCallBack("TabletParallelCompactionManager::submit_subtasks_from_groups:after_register");
+            sync_point->DisableProcessing();
+        });
+
+        auto txn_id = next_id();
+        auto latch = std::make_shared<CountDownLatch>(1);
+        CompactRequest request;
+        CompactResponse response;
+        request.add_tablet_ids(metadata->id());
+        request.set_timeout_ms(60 * 1000);
+        request.set_txn_id(txn_id);
+        request.set_version(11);
+        auto* parallel_config = request.mutable_parallel_config();
+        parallel_config->set_enable_parallel(true);
+        parallel_config->set_max_parallel_per_tablet(3);
+        parallel_config->set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+        auto cb = ::google::protobuf::NewCallback(notify_for_callback, latch);
+        _compaction_scheduler.compact(nullptr, &request, &response, cb);
+        // Hangs here if the stranded registration was not rolled back.
+        latch->wait();
+
+        EXPECT_TRUE(thrown.load());
+        // The fallback owns the completion, and it is the only one: a second finish_task() would add another
+        // compact_stat (and crash on the already-nulled _response).
+        EXPECT_EQ(1, response.compact_stats_size());
+    }
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
+++ b/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
@@ -7468,4 +7468,106 @@ TEST_F(TabletParallelCompactionManagerTest, test_create_parallel_tasks_range_spl
     }
 }
 
+// stop() settles tablets whose subtasks the shutting-down thread pool dropped without ever running them:
+// ThreadPool::shutdown() removes queued tasks and FunctionRunnable::cancel() is a no-op, so they never
+// report back. Nothing else can complete such a tablet -- its scheduler context was destroyed when it was
+// handed off to the subtasks -- so without this pass the compact RPC would hang until it timed out.
+TEST_F(TabletParallelCompactionManagerTest, test_abort_pending_states_completes_dropped_subtasks) {
+    int64_t tablet_id = 10007;
+    int64_t txn_id = 20007;
+    int64_t version = 11;
+
+    create_tablet_with_rowsets(tablet_id, 10, 1024 * 1024);
+
+    CompactRequest request;
+    request.set_skip_write_txnlog(true);
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    auto state = std::make_shared<TabletParallelCompactionState>();
+    state->tablet_id = tablet_id;
+    state->txn_id = txn_id;
+    state->version = version;
+    state->max_parallel = 2;
+    state->callback = callback;
+    {
+        SubtaskInfo info0;
+        info0.subtask_id = 0;
+        info0.input_rowset_ids = {0, 1, 2, 3, 4};
+        info0.input_bytes = 5 * 1024 * 1024;
+        info0.start_time = ::time(nullptr);
+        state->running_subtasks[0] = std::move(info0);
+
+        SubtaskInfo info1;
+        info1.subtask_id = 1;
+        info1.input_rowset_ids = {5, 6, 7, 8, 9};
+        info1.input_bytes = 5 * 1024 * 1024;
+        info1.start_time = ::time(nullptr);
+        state->running_subtasks[1] = std::move(info1);
+        state->total_subtasks_created = 2;
+    }
+    for (int i = 0; i < 10; i++) {
+        state->compacting_rowsets[i] = 1;
+    }
+    _manager->register_tablet_state_for_test(tablet_id, txn_id, state);
+
+    // Subtask 0 reports back; subtask 1 is the one the pool dropped, so it stays in running_subtasks and
+    // the tablet cannot reach completion on its own.
+    auto ctx0 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx0->subtask_id = 0;
+    ctx0->txn_log = std::make_unique<TxnLogPB>();
+    ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(0);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(50);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_data_size(500);
+    _manager->on_subtask_complete(tablet_id, txn_id, 0, std::move(ctx0));
+    ASSERT_FALSE(closure.is_finished());
+
+    _manager->abort_pending_states();
+
+    // The RPC is completed instead of being left hanging. It completes with a failure -- the dropped
+    // subtask produced no result to merge -- which is the point: the caller learns rather than waits.
+    EXPECT_TRUE(closure.is_finished());
+
+    // Completion is claimed once, so a second settling pass must not complete the same tablet again:
+    // finish_task() has already released the request and response that a second call would touch.
+    auto txn_logs_after_first = response.txn_logs_size();
+    _manager->abort_pending_states();
+    EXPECT_EQ(txn_logs_after_first, response.txn_logs_size());
+
+    _manager->cleanup_tablet(tablet_id, txn_id);
+}
+
+// abort() walks the scheduler's own context list first, but a handed-off tablet is no longer on it: that
+// context was destroyed when the subtasks took over. The manager is then the only place still holding the
+// txn's callback, which is what lets an abort reach subtasks that are already running.
+TEST_F(TabletParallelCompactionManagerTest, test_collect_callbacks_for_txn) {
+    int64_t tablet_id = 10008;
+    int64_t txn_id = 20008;
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    auto state = std::make_shared<TabletParallelCompactionState>();
+    state->tablet_id = tablet_id;
+    state->txn_id = txn_id;
+    state->version = 11;
+    state->max_parallel = 2;
+    state->callback = callback;
+    _manager->register_tablet_state_for_test(tablet_id, txn_id, state);
+
+    auto callbacks = _manager->collect_callbacks_for_txn(txn_id);
+    ASSERT_EQ(1, callbacks.size());
+    EXPECT_EQ(callback.get(), callbacks[0].get());
+
+    // Another txn's abort must not pick up this tablet's callback.
+    EXPECT_TRUE(_manager->collect_callbacks_for_txn(txn_id + 1).empty());
+
+    _manager->cleanup_tablet(tablet_id, txn_id);
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
+++ b/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
@@ -128,9 +128,20 @@ TEST_F(TabletParallelCompactionStateTest, test_is_complete) {
     _state->running_subtasks.erase(0);
     EXPECT_FALSE(_state->is_complete());
 
-    // Complete all
+    // Complete all -- still NOT complete, because submission has not been sealed. While
+    // submit_subtasks_from_groups() registers groups one at a time, an empty running_subtasks only means
+    // "the next group has not been registered yet"; treating that as completion is what allowed two
+    // subtasks to each drive the completion transition for one tablet.
     _state->running_subtasks.erase(1);
+    EXPECT_FALSE(_state->is_complete());
+
+    // Sealing submission is what makes the predicate meaningful.
+    _state->submission_done = true;
     EXPECT_TRUE(_state->is_complete());
+
+    // And the transition can be claimed exactly once, however many callers race for it.
+    EXPECT_TRUE(_state->claim_completion());
+    EXPECT_FALSE(_state->claim_completion());
 }
 
 class TabletParallelCompactionManagerTest : public TestBase {

--- a/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
+++ b/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
@@ -7526,15 +7526,20 @@ TEST_F(TabletParallelCompactionManagerTest, test_abort_pending_states_completes_
 
     _manager->abort_pending_states();
 
-    // The RPC is completed instead of being left hanging. It completes with a failure -- the dropped
-    // subtask produced no result to merge -- which is the point: the caller learns rather than waits.
+    // The RPC is completed instead of being left hanging...
     EXPECT_TRUE(closure.is_finished());
+    // ...and it is completed as an abort, like a serial compaction interrupted by stop(). Reporting the
+    // tablet as failed is what keeps FE from committing this compaction.
+    ASSERT_EQ(1, response.failed_tablets_size());
+    EXPECT_EQ(tablet_id, response.failed_tablets(0));
+    // Nothing is published for the work that did run: subtask 0's log must not be merged and handed back
+    // as if the whole tablet had been compacted, because subtask 1's rowsets were never touched.
+    EXPECT_EQ(0, response.txn_logs_size());
 
     // Completion is claimed once, so a second settling pass must not complete the same tablet again:
     // finish_task() has already released the request and response that a second call would touch.
-    auto txn_logs_after_first = response.txn_logs_size();
     _manager->abort_pending_states();
-    EXPECT_EQ(txn_logs_after_first, response.txn_logs_size());
+    EXPECT_EQ(1, response.failed_tablets_size());
 
     _manager->cleanup_tablet(tablet_id, txn_id);
 }


### PR DESCRIPTION
## Why I'm doing:

Fixes #76882.

In shared-data (storage-compute separated) mode the CN aborts with an uncaught
`std::system_error` whose message is `Resource deadlock avoided` (EDEADLK):

```
terminate called after throwing an instance of 'std::system_error'
  what():  Resource deadlock avoided
  @  std::__throw_system_error(int)
  @  starrocks::StarOSWorker::new_shared_filesystem(...)
  @  starrocks::StarOSWorker::build_filesystem_from_shard_info(...)
  @  starrocks::StarletFileSystem::new_random_access_file(...)
  @  starrocks::ProtobufFile::load(...)
  @  starrocks::lake::TabletManager::load_tablet_metadata(...)
  @  starrocks::lake::TabletParallelCompactionManager::create_parallel_tasks(...)
  @  starrocks::lake::CompactionScheduler::compact(...)
  @  brpc::policy::ProcessRpcRequest(...)
  @  bthread::TaskGroup::task_runner(long)
```

**Root cause — blocking filesystem IO executed on a brpc bthread.**
`CompactionScheduler::compact()` ran `process_parallel_compaction()` — which
loads tablet metadata and builds the StarOS/Starlet filesystem (blocking remote
IO) — *inline on the brpc bthread*. `StarOSWorker::new_shared_filesystem()` takes
a write lock on `_cache_mtx` (a `std::shared_mutex`) and, while holding it,
destroys an evicted `FileSystem` (closing its remote connection). On a bthread
that blocking point can yield the worker pthread to a *different* bthread, which
then takes the same rwlock. Because pthread rwlock ownership is keyed on the OS
thread, `pthread_rwlock_wrlock` returns `EDEADLK`, and `std::shared_mutex` turns
`EDEADLK` into an uncaught `std::system_error` → `std::terminate` → `SIGABRT`.

The non-parallel compaction path never has this problem because it keeps all
filesystem IO off the bthread (it only enqueues a context served by the
`_threads` pthread pool).

## What I'm doing:

- **Dispatch parallel compaction the way serial compaction is dispatched.**
  `compact()` no longer plans subtasks on the bthread and no longer has a
  separate parallel dispatcher: for both modes it only builds one
  `CompactionTaskContext` per tablet (snapshotting the parallel config on it,
  since `request` must not be touched later) and queues them all, under one
  `_contexts_lock`, before any worker can dequeue one. The planning
  (`try_hand_off_to_parallel()`) runs later inside `do_compaction()` on a
  resident `thread_task()` worker, where blocking filesystem IO is safe. If
  subtasks were submitted they take over the tablet's single `finish_task()`
  and the context is retired; otherwise the very same context compacts the
  tablet serially, which makes a duplicate `finish_task()` per tablet
  impossible by construction and removes the old dispatcher's dependence on
  the pool spawning an extra pthread.

- **Limiter tokens.** The worker hands its token back before planning
  (`Limiter::return_token()`, no task outcome recorded), because subtasks are
  reserved all-or-nothing and holding it would have made parallel compaction
  need `max_parallel_per_tablet + 1` free tokens. If the token is gone when
  planning falls back, the tablet is rescheduled (parallel disabled for the
  retry) rather than compacted outside the limiter.

- **Exactly-once completion under failure.** `submit_subtasks_from_groups()`
  rolls back a registration whose submit never happened, releases every
  pre-acquired token while unwinding, seals submission so a fast first subtask
  cannot complete the tablet early, and `stop()` settles handed-off tablets
  whose queued subtasks the pool dropped (`abort_pending_states()`, reported
  as `Aborted` so FE does not commit a partial log). `abort()` reaches
  handed-off tablets through the manager's callbacks.

- **`ThreadPool::do_submit()` strong exception guarantee.** The token is
  queued before its entry is pushed and unwound if the push throws, so a
  `submit()` that throws leaves no retained runnable behind for any caller.

- **Tests**: `test_parallel_compaction_runs_off_caller_thread` pins the
  planning hook to a non-caller thread (the pre-existing parallel tests pass
  against the inline code too); exception-after-submit / after-register,
  token-loss reschedule, shutdown settling, abort lookup, and
  `ThreadPoolTest.TestThrowingSubmitLeavesNothingBehind` cover the paths above.

Note: `LakeServiceImpl::repair_tablet_metadata()` has the same bthread-IO class
(its `_cleanup_before_repair()` calls `drop_local_cache()` → `StarletFileSystem`
→ `_cache_mtx` inline on the bthread). It is a lower-frequency admin path and is
intentionally left out of this PR; it will be fixed in a dedicated PR (with the
matching `test_repair_tablet_metadata` changes).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

Parallel-compaction planning now happens on a pthread pool worker instead of
the brpc bthread; the RPC contract and results are unchanged.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
