### PR TITLE
[Refactor] Replace RowDescriptor with RecordDescriptor in the BE

### DIFF
--- a/be/src/compute_env/data_stream/data_stream_mgr.cpp
+++ b/be/src/compute_env/data_stream/data_stream_mgr.cpp
@@ -90,7 +90,7 @@ inline uint32_t DataStreamMgr::get_bucket(const TUniqueId& fragment_instance_id)
 }
 
 std::shared_ptr<DataStreamRecvr> DataStreamMgr::create_recvr(
-        RuntimeState* state, const RowDescriptor& row_desc, const TUniqueId& fragment_instance_id,
+        RuntimeState* state, const RecordDescriptor& record_desc, const TUniqueId& fragment_instance_id,
         PlanNodeId dest_node_id, int num_senders, int buffer_size, bool is_merging,
         std::shared_ptr<QueryStatisticsRecvr> sub_plan_query_statistics_recvr, bool is_pipeline,
         int32_t degree_of_parallelism, bool keep_order) {
@@ -98,7 +98,7 @@ std::shared_ptr<DataStreamRecvr> DataStreamMgr::create_recvr(
     PassThroughChunkBuffer* pass_through_chunk_buffer = get_pass_through_chunk_buffer(state->query_id());
     DCHECK(pass_through_chunk_buffer != nullptr);
     std::shared_ptr<DataStreamRecvr> recvr(
-            new DataStreamRecvr(this, state, row_desc, fragment_instance_id, dest_node_id, num_senders, is_merging,
+            new DataStreamRecvr(this, state, record_desc, fragment_instance_id, dest_node_id, num_senders, is_merging,
                                 buffer_size, std::move(sub_plan_query_statistics_recvr), is_pipeline,
                                 degree_of_parallelism, keep_order, pass_through_chunk_buffer));
 

--- a/be/src/compute_env/data_stream/data_stream_mgr.h
+++ b/be/src/compute_env/data_stream/data_stream_mgr.h
@@ -92,7 +92,7 @@ public:
     // single stream.
     // Ownership of the receiver is shared between this DataStream mgr instance and the
     // caller.
-    std::shared_ptr<DataStreamRecvr> create_recvr(RuntimeState* state, const RowDescriptor& row_desc,
+    std::shared_ptr<DataStreamRecvr> create_recvr(RuntimeState* state, const RecordDescriptor& record_desc,
                                                   const TUniqueId& fragment_instance_id, PlanNodeId dest_node_id,
                                                   int num_senders, int buffer_size, bool is_merging,
                                                   std::shared_ptr<QueryStatisticsRecvr> sub_plan_query_statistics_recvr,

--- a/be/src/compute_env/data_stream/data_stream_recvr.cpp
+++ b/be/src/compute_env/data_stream/data_stream_recvr.cpp
@@ -149,9 +149,9 @@ std::vector<merge_path::MergePathChunkProvider> DataStreamRecvr::create_merge_pa
     return chunk_providers;
 }
 
-DataStreamRecvr::DataStreamRecvr(DataStreamMgr* stream_mgr, RuntimeState* runtime_state, const RowDescriptor& row_desc,
-                                 const TUniqueId& fragment_instance_id, PlanNodeId dest_node_id, int num_senders,
-                                 bool is_merging, int total_buffer_limit,
+DataStreamRecvr::DataStreamRecvr(DataStreamMgr* stream_mgr, RuntimeState* runtime_state,
+                                 const RecordDescriptor& record_desc, const TUniqueId& fragment_instance_id,
+                                 PlanNodeId dest_node_id, int num_senders, bool is_merging, int total_buffer_limit,
                                  std::shared_ptr<QueryStatisticsRecvr> sub_plan_query_statistics_recvr,
                                  bool is_pipeline, int32_t degree_of_parallelism, bool keep_order,
                                  PassThroughChunkBuffer* pass_through_chunk_buffer)
@@ -159,7 +159,7 @@ DataStreamRecvr::DataStreamRecvr(DataStreamMgr* stream_mgr, RuntimeState* runtim
           _fragment_instance_id(fragment_instance_id),
           _dest_node_id(dest_node_id),
           _total_buffer_limit(total_buffer_limit),
-          _row_desc(row_desc),
+          _record_desc(record_desc),
           _is_merging(is_merging),
           _num_buffered_bytes(0),
           _instance_profile(runtime_state->runtime_profile_ptr()),

--- a/be/src/compute_env/data_stream/data_stream_recvr.h
+++ b/be/src/compute_env/data_stream/data_stream_recvr.h
@@ -119,7 +119,6 @@ public:
 
     const TUniqueId& fragment_instance_id() const { return _fragment_instance_id; }
     PlanNodeId dest_node_id() const { return _dest_node_id; }
-    const RowDescriptor& row_desc() const { return _row_desc; }
 
     void add_sub_plan_statistics(const PQueryStatistics& statistics, int sender_id) {
         if (_sub_plan_query_statistics_recvr) {
@@ -158,7 +157,7 @@ private:
     class PipelineSenderQueue;
     struct Metrics;
 
-    DataStreamRecvr(DataStreamMgr* stream_mgr, RuntimeState* runtime_state, const RowDescriptor& row_desc,
+    DataStreamRecvr(DataStreamMgr* stream_mgr, RuntimeState* runtime_state, const RecordDescriptor& record_desc,
                     const TUniqueId& fragment_instance_id, PlanNodeId dest_node_id, int num_senders, bool is_merging,
                     int total_buffer_limit, std::shared_ptr<QueryStatisticsRecvr> sub_plan_query_statistics_recvr,
                     bool is_pipeline, int32_t degree_of_parallelism, bool keep_order,
@@ -193,8 +192,8 @@ private:
     // exceeds this value
     size_t _total_buffer_limit;
 
-    // Row schema, copied from the caller of CreateRecvr().
-    RowDescriptor _row_desc;
+    // Describes the record the senders produce, used to type the incoming chunks.
+    RecordDescriptor _record_desc;
 
     // True if this reciver merges incoming rows from different senders. Per-sender
     // row batch queues are maintained in this case.

--- a/be/src/compute_env/data_stream/sender_queue.cpp
+++ b/be/src/compute_env/data_stream/sender_queue.cpp
@@ -54,19 +54,16 @@ Status DataStreamRecvr::SenderQueue::_build_chunk_meta(const ChunkPB& pb_chunk) 
     size_t column_index = 0;
     _chunk_meta.types.resize(pb_chunk.is_nulls().size());
     std::set<SlotId> hit_flags;
-    for (auto tuple_desc : _recvr->_row_desc.tuple_descriptors()) {
-        const std::vector<SlotDescriptor*>& slots = tuple_desc->slots();
-        phmap::flat_hash_map<SlotId, TypeDescriptor> slot_id_to_type;
-        std::for_each(slots.begin(), slots.end(), [&](SlotDescriptor* slot) {
-            slot_id_to_type.insert({slot->id(), slot->type()});
-        });
-        for (const auto& kv : _chunk_meta.slot_id_to_index) {
-            auto iter = slot_id_to_type.find(kv.first);
-            if (iter != slot_id_to_type.end()) {
-                _chunk_meta.types[kv.second] = iter->second;
-                ++column_index;
-                hit_flags.insert(kv.first);
-            }
+    phmap::flat_hash_map<SlotId, TypeDescriptor> slot_id_to_type;
+    for (const auto* slot : _recvr->_record_desc.slots()) {
+        slot_id_to_type.insert({slot->id(), slot->type()});
+    }
+    for (const auto& kv : _chunk_meta.slot_id_to_index) {
+        auto iter = slot_id_to_type.find(kv.first);
+        if (iter != slot_id_to_type.end()) {
+            _chunk_meta.types[kv.second] = iter->second;
+            ++column_index;
+            hit_flags.insert(kv.first);
         }
     }
 

--- a/be/src/compute_env/dictionary_cache/chunk_util.cpp
+++ b/be/src/compute_env/dictionary_cache/chunk_util.cpp
@@ -83,9 +83,9 @@ Status DictionaryCacheChunkUtil::compress_and_serialize_chunk(const Chunk* src, 
 
 Status DictionaryCacheChunkUtil::uncompress_and_deserialize_chunk(const ChunkPB& pchunk, Chunk& chunk,
                                                                   faststring* uncompressed_buffer,
-                                                                  const RowDescriptor& row_desc) {
+                                                                  const RecordDescriptor& record_desc) {
     // build chunk meta
-    StatusOr<serde::ProtobufChunkMeta> res = serde::build_protobuf_chunk_meta(row_desc, pchunk);
+    StatusOr<serde::ProtobufChunkMeta> res = serde::build_protobuf_chunk_meta(record_desc, pchunk);
     if (!res.ok()) {
         return res.status();
     }

--- a/be/src/compute_env/dictionary_cache/chunk_util.h
+++ b/be/src/compute_env/dictionary_cache/chunk_util.h
@@ -30,7 +30,7 @@ public:
 
     static Status compress_and_serialize_chunk(const Chunk* src, ChunkPB* dst);
     static Status uncompress_and_deserialize_chunk(const ChunkPB& pchunk, Chunk& chunk, faststring* uncompressed_buffer,
-                                                   const RowDescriptor& row_desc);
+                                                   const RecordDescriptor& record_desc);
     static Status check_chunk_has_null(const Chunk& chunk);
 };
 

--- a/be/src/compute_env/dictionary_cache/dictionary_cache_manager.cpp
+++ b/be/src/compute_env/dictionary_cache/dictionary_cache_manager.cpp
@@ -54,9 +54,9 @@ Status DictionaryCacheManager::refresh(const PProcessDictionaryCacheRequest* req
     auto schema = std::make_shared<OlapTableSchemaParam>();
     RETURN_IF_ERROR(schema->init(pschema));
     auto chunk = std::make_unique<Chunk>();
-    RowDescriptor row_desc(schema->tuple_desc());
+    RecordDescriptor record_desc(schema->tuple_desc());
     RETURN_IF_ERROR(DictionaryCacheChunkUtil::uncompress_and_deserialize_chunk(pchunk, *chunk.get(),
-                                                                               &uncompressed_buffer, row_desc));
+                                                                               &uncompressed_buffer, record_desc));
     RETURN_IF_ERROR(DictionaryCacheChunkUtil::check_chunk_has_null(*chunk.get()));
 
     // 2. split into key chunk and value chunk in ordered

--- a/be/src/compute_env/sorting/merge_path.cpp
+++ b/be/src/compute_env/sorting/merge_path.cpp
@@ -644,7 +644,7 @@ ChunkPtr detail::LeafNode::_generate_ordinal(const size_t chunk_id, const size_t
 
 MergePathCascadeMerger::MergePathCascadeMerger(const size_t chunk_size, const int32_t degree_of_parallelism,
                                                std::vector<ExprContext*> sort_exprs, const SortDescs& sort_descs,
-                                               const TupleDescriptor* tuple_desc, const TTopNType::type topn_type,
+                                               RecordDescriptor record_desc, const TTopNType::type topn_type,
                                                const int64_t offset, const int64_t limit,
                                                std::vector<MergePathChunkProvider> chunk_providers,
                                                TLateMaterializeMode::type mode)
@@ -653,7 +653,7 @@ MergePathCascadeMerger::MergePathCascadeMerger(const size_t chunk_size, const in
           _degree_of_parallelism(degree_of_parallelism),
           _sort_exprs(std::move(sort_exprs)),
           _sort_descs(sort_descs),
-          _tuple_desc(tuple_desc),
+          _record_desc(std::move(record_desc)),
           _topn_type(topn_type),
           _offset(offset),
           _limit(limit),
@@ -1157,7 +1157,7 @@ void MergePathCascadeMerger::_init_late_materialization() {
         }
     }
     size_t non_orderby_materialized_cost_per_level = 0;
-    for (auto* slot : _tuple_desc->slots()) {
+    for (const auto* slot : _record_desc.slots()) {
         if (early_materialized_slots.count(slot->id()) > 0) {
             continue;
         }

--- a/be/src/compute_env/sorting/merge_path.h
+++ b/be/src/compute_env/sorting/merge_path.h
@@ -376,7 +376,7 @@ class MergePathCascadeMerger {
 public:
     MergePathCascadeMerger(const size_t chunk_size, const int32_t degree_of_parallelism,
                            std::vector<ExprContext*> sort_exprs, const SortDescs& sort_descs,
-                           const TupleDescriptor* tuple_desc, const TTopNType::type topn_type, const int64_t offset,
+                           RecordDescriptor record_desc, const TTopNType::type topn_type, const int64_t offset,
                            const int64_t limit, std::vector<MergePathChunkProvider> chunk_providers,
                            TLateMaterializeMode::type mode = TLateMaterializeMode::AUTO);
     const std::vector<ExprContext*>& sort_exprs() const { return _sort_exprs; }
@@ -463,7 +463,7 @@ private:
     const int32_t _degree_of_parallelism;
     const std::vector<ExprContext*> _sort_exprs;
     const SortDescs _sort_descs;
-    const TupleDescriptor* _tuple_desc;
+    const RecordDescriptor _record_desc;
     const TTopNType::type _topn_type;
     const int64_t _offset;
     const int64_t _limit;

--- a/be/src/connector/file/scanner/file_scanner.cpp
+++ b/be/src/connector/file/scanner/file_scanner.cpp
@@ -52,7 +52,6 @@ FileScanner::FileScanner(starrocks::RuntimeState* state, starrocks::RuntimeProfi
           _profile(profile),
           _params(params),
           _counter(counter),
-          _row_desc(nullptr),
 
           _file_format_str("UNKNOWN"),
           _schema_only(schema_only) {
@@ -92,8 +91,6 @@ Status FileScanner::init_expr_ctx() {
 
         _src_slot_descriptors.emplace_back(it->second);
     }
-
-    _row_desc = std::make_unique<RowDescriptor>(_state->desc_tbl(), std::vector<TupleId>{_params.src_tuple_id});
 
     // destination
     _dest_tuple_desc = _state->desc_tbl().get_tuple_descriptor(_params.dest_tuple_id);

--- a/be/src/connector/file/scanner/file_scanner.h
+++ b/be/src/connector/file/scanner/file_scanner.h
@@ -95,8 +95,6 @@ protected:
     const TBrokerScanRangeParams& _params;
     ScannerCounter* _counter;
 
-    std::unique_ptr<RowDescriptor> _row_desc;
-
     bool _strict_mode{false};
     int64_t _error_counter{0};
     // When column mismatch, files query/load and other type load have different behaviors.

--- a/be/src/data_sink/exchange/data_stream_sender.cpp
+++ b/be/src/data_sink/exchange/data_stream_sender.cpp
@@ -363,8 +363,7 @@ void DataStreamSender::Channel::close_wait(RuntimeState* state) {
     _chunk.reset();
 }
 
-DataStreamSender::DataStreamSender(RuntimeState* state, int sender_id, const RowDescriptor& row_desc,
-                                   const TDataStreamSink& sink,
+DataStreamSender::DataStreamSender(RuntimeState* state, int sender_id, const TDataStreamSink& sink,
                                    const std::vector<TPlanFragmentDestination>& destinations,
                                    bool send_query_statistics_with_every_batch, bool enable_exchange_pass_through,
                                    bool enable_exchange_perf)

--- a/be/src/data_sink/exchange/data_stream_sender.h
+++ b/be/src/data_sink/exchange/data_stream_sender.h
@@ -54,7 +54,6 @@ class IOBuf;
 namespace starrocks {
 
 class ExprContext;
-class RowDescriptor;
 class TDataStreamSink;
 class TNetworkAddress;
 class TPlanFragmentDestination;
@@ -74,9 +73,8 @@ class DataStreamSender final : public DataSink {
 public:
     // Construct a sender according to the output specification (sink),
     // sending to the given destinations.
-    // The RowDescriptor must live until close() is called.
     // NOTE: supported partition types are UNPARTITIONED (broadcast) and HASH_PARTITIONED
-    DataStreamSender(RuntimeState* state, int sender_id, const RowDescriptor& row_desc, const TDataStreamSink& sink,
+    DataStreamSender(RuntimeState* state, int sender_id, const TDataStreamSink& sink,
                      const std::vector<TPlanFragmentDestination>& destinations,
                      bool send_query_statistics_with_every_batch, bool enable_exchange_pass_through,
                      bool enable_exchange_perf);

--- a/be/src/data_sink/external/export_sink.cpp
+++ b/be/src/data_sink/external/export_sink.cpp
@@ -51,8 +51,7 @@
 
 namespace starrocks {
 
-ExportSink::ExportSink(ObjectPool* pool, const RowDescriptor& row_desc, const std::vector<TExpr>& t_exprs)
-        : _pool(pool), _t_output_expr(t_exprs) {}
+ExportSink::ExportSink(ObjectPool* pool, const std::vector<TExpr>& t_exprs) : _pool(pool), _t_output_expr(t_exprs) {}
 
 ExportSink::~ExportSink() = default;
 

--- a/be/src/data_sink/external/export_sink.h
+++ b/be/src/data_sink/external/export_sink.h
@@ -44,7 +44,6 @@
 
 namespace starrocks {
 
-class RowDescriptor;
 class TExpr;
 class RuntimeState;
 class RuntimeProfile;
@@ -56,7 +55,7 @@ class FileBuilder;
 // This class is a sinker, which put export data to external storage by broker.
 class ExportSink : public DataSink {
 public:
-    ExportSink(ObjectPool* pool, const RowDescriptor& row_desc, const std::vector<TExpr>& t_exprs);
+    ExportSink(ObjectPool* pool, const std::vector<TExpr>& t_exprs);
 
     ~ExportSink() override;
 

--- a/be/src/data_sink/external/mysql_table_sink.cpp
+++ b/be/src/data_sink/external/mysql_table_sink.cpp
@@ -52,7 +52,7 @@ namespace starrocks {
 const int MYSQL_SINK_BATCH_SIZE = 1024;
 #endif
 
-MysqlTableSink::MysqlTableSink(ObjectPool* pool, const RowDescriptor& row_desc, const std::vector<TExpr>& t_exprs)
+MysqlTableSink::MysqlTableSink(ObjectPool* pool, const std::vector<TExpr>& t_exprs)
         : _pool(pool), _t_output_expr(t_exprs) {}
 
 MysqlTableSink::~MysqlTableSink() = default;

--- a/be/src/data_sink/external/mysql_table_sink.h
+++ b/be/src/data_sink/external/mysql_table_sink.h
@@ -43,7 +43,6 @@
 
 namespace starrocks {
 
-class RowDescriptor;
 class TExpr;
 class TMysqlTableSink;
 class RuntimeState;
@@ -53,7 +52,7 @@ class ExprContext;
 // This class is a sinker, which put input data to mysql table
 class MysqlTableSink : public DataSink {
 public:
-    MysqlTableSink(ObjectPool* pool, const RowDescriptor& row_desc, const std::vector<TExpr>& t_exprs);
+    MysqlTableSink(ObjectPool* pool, const std::vector<TExpr>& t_exprs);
 
     ~MysqlTableSink() override;
 

--- a/be/src/data_sink/external/schema_table_sink.cpp
+++ b/be/src/data_sink/external/schema_table_sink.cpp
@@ -37,7 +37,7 @@
 
 namespace starrocks {
 
-SchemaTableSink::SchemaTableSink(ObjectPool* pool, const RowDescriptor& row_desc, const std::vector<TExpr>& t_exprs)
+SchemaTableSink::SchemaTableSink(ObjectPool* pool, const std::vector<TExpr>& t_exprs)
         : _pool(pool), _t_output_expr(t_exprs) {}
 
 SchemaTableSink::~SchemaTableSink() = default;

--- a/be/src/data_sink/external/schema_table_sink.h
+++ b/be/src/data_sink/external/schema_table_sink.h
@@ -22,7 +22,6 @@
 
 namespace starrocks {
 
-class RowDescriptor;
 class TExpr;
 class TMysqlTableSink;
 class RuntimeState;
@@ -33,7 +32,7 @@ class StarRocksNodesInfo;
 // This class is a sinker, which modifies BE related schema tables
 class SchemaTableSink : public DataSink {
 public:
-    SchemaTableSink(ObjectPool* pool, const RowDescriptor& row_desc, const std::vector<TExpr>& t_exprs);
+    SchemaTableSink(ObjectPool* pool, const std::vector<TExpr>& t_exprs);
 
     ~SchemaTableSink() override;
 

--- a/be/src/data_sink/result/arrow_result_writer.cpp
+++ b/be/src/data_sink/result/arrow_result_writer.cpp
@@ -40,14 +40,12 @@ namespace starrocks {
 // - sinker: the result sink (BufferControlBlock) to which Arrow batches will be written
 // - output_expr_ctxs: a list of output expression contexts to be evaluated on the Chunk
 // - parent_profile: the parent runtime profile for performance tracking
-// - row_desc: the row descriptor (schema) of the output
 ArrowResultWriter::ArrowResultWriter(BufferControlBlock* sinker, std::vector<ExprContext*>& output_expr_ctxs,
                                      const std::vector<std::string>& output_column_names,
-                                     RuntimeProfile* parent_profile, const RowDescriptor& row_desc)
+                                     RuntimeProfile* parent_profile)
         : BufferControlResultWriter(sinker, parent_profile),
           _output_expr_ctxs(output_expr_ctxs),
-          _output_column_names(output_column_names),
-          _row_desc(row_desc) {}
+          _output_column_names(output_column_names) {}
 
 // ┌────────────────────────────────────────────────────────────┐
 // │ init(): Initialize ArrowResultWriter                       │
@@ -55,7 +53,7 @@ ArrowResultWriter::ArrowResultWriter(BufferControlBlock* sinker, std::vector<Exp
 // [1] Init performance timer
 // [2] Check sinker is not null
 // [3] Build column ID → name map
-// [4] Convert RowDescriptor → Arrow Schema
+// [4] Convert the output expressions → Arrow Schema
 // [5] Register Arrow Schema to ResultMgr
 Status ArrowResultWriter::init(RuntimeState* state) {
     _init_profile();
@@ -65,7 +63,7 @@ Status ArrowResultWriter::init(RuntimeState* state) {
 
     std::unordered_map<int64_t, std::string> temp_id_to_col_name;
 
-    RETURN_IF_ERROR(convert_to_arrow_schema(_row_desc, temp_id_to_col_name, &_arrow_schema, _output_expr_ctxs,
+    RETURN_IF_ERROR(convert_to_arrow_schema(temp_id_to_col_name, &_arrow_schema, _output_expr_ctxs,
                                             &_output_column_names, state->arrow_flight_sql_version()));
 
     auto* query_execution_services = state->query_execution_services();

--- a/be/src/data_sink/result/arrow_result_writer.h
+++ b/be/src/data_sink/result/arrow_result_writer.h
@@ -27,7 +27,6 @@ namespace starrocks {
 class ExprContext;
 class BufferControlBlock;
 class RuntimeProfile;
-class RowDescriptor;
 using TFetchDataResultPtr = std::unique_ptr<TFetchDataResult>;
 using TFetchDataResultPtrs = std::vector<TFetchDataResultPtr>;
 
@@ -35,8 +34,7 @@ using TFetchDataResultPtrs = std::vector<TFetchDataResultPtr>;
 class ArrowResultWriter final : public BufferControlResultWriter {
 public:
     ArrowResultWriter(BufferControlBlock* sinker, std::vector<ExprContext*>& output_expr_ctxs,
-                      const std::vector<std::string>& output_column_names, RuntimeProfile* parent_profile,
-                      const RowDescriptor& row_desc);
+                      const std::vector<std::string>& output_column_names, RuntimeProfile* parent_profile);
 
     Status init(RuntimeState* state) override;
 
@@ -51,8 +49,6 @@ private:
 
     std::vector<ExprContext*>& _output_expr_ctxs;
     const std::vector<std::string>& _output_column_names;
-
-    const RowDescriptor& _row_desc;
 
     std::shared_ptr<arrow::Schema> _arrow_schema;
 };

--- a/be/src/data_sink/result/memory_scratch_sink.cpp
+++ b/be/src/data_sink/result/memory_scratch_sink.cpp
@@ -52,21 +52,16 @@
 
 namespace starrocks {
 
-MemoryScratchSink::MemoryScratchSink(const RowDescriptor& row_desc, const std::vector<TExpr>& t_output_expr,
+MemoryScratchSink::MemoryScratchSink(RecordDescriptor record_desc, const std::vector<TExpr>& t_output_expr,
                                      const TMemoryScratchSink& sink)
-        : _row_desc(row_desc), _t_output_expr(t_output_expr) {}
+        : _record_desc(std::move(record_desc)), _t_output_expr(t_output_expr) {}
 
 MemoryScratchSink::~MemoryScratchSink() = default;
 
 void MemoryScratchSink::_prepare_id_to_col_name_map() {
-    for (auto* tuple_desc : _row_desc.tuple_descriptors()) {
-        auto& slots = tuple_desc->slots();
-        int64_t tuple_id = tuple_desc->id();
-        for (auto slot : slots) {
-            int64_t slot_id = slot->id();
-            int64_t id = tuple_id << 32 | slot_id;
-            _id_to_col_name.emplace(id, slot->col_name());
-        }
+    for (const auto* slot : _record_desc.slots()) {
+        int64_t id = static_cast<int64_t>(slot->parent()) << 32 | slot->id();
+        _id_to_col_name.emplace(id, slot->col_name());
     }
 }
 
@@ -80,7 +75,7 @@ Status MemoryScratchSink::prepare_exprs(RuntimeState* state) {
     // Prepare id_to_col_name map
     _prepare_id_to_col_name_map();
     // generate the arrow schema
-    RETURN_IF_ERROR(convert_to_arrow_schema(_row_desc, _id_to_col_name, &_arrow_schema, _output_expr_ctxs));
+    RETURN_IF_ERROR(convert_to_arrow_schema(_id_to_col_name, &_arrow_schema, _output_expr_ctxs));
     return Status::OK();
 }
 
@@ -129,10 +124,6 @@ Status MemoryScratchSink::close(RuntimeState* state, const Status& exec_status) 
     ExprExecutor::close(_output_expr_ctxs, state);
     _closed = true;
     return Status::OK();
-}
-
-const RowDescriptor MemoryScratchSink::get_row_desc() {
-    return _row_desc;
 }
 
 } // namespace starrocks

--- a/be/src/data_sink/result/memory_scratch_sink.h
+++ b/be/src/data_sink/result/memory_scratch_sink.h
@@ -41,6 +41,7 @@
 #include "exec_primitive/data_sink.h"
 #include "gen_cpp/PlanNodes_types.h"
 #include "gen_cpp/StarrocksExternalService_types.h"
+#include "runtime/descriptors.h"
 
 namespace arrow {
 
@@ -65,9 +66,8 @@ class MemTracker;
 class MemoryScratchSink : public DataSink {
 public:
     // construct a buffer for the result need send to blocking queue.
-    // row_desc used for convert RowBatch to TRowBatch
     // buffer_size is the buffer size allocated to each scan
-    MemoryScratchSink(const RowDescriptor& row_desc, const std::vector<TExpr>& select_exprs,
+    MemoryScratchSink(RecordDescriptor record_desc, const std::vector<TExpr>& select_exprs,
                       const TMemoryScratchSink& sink);
 
     ~MemoryScratchSink() override;
@@ -87,15 +87,14 @@ public:
 
     std::vector<TExpr> get_output_expr() { return _t_output_expr; }
 
-    const RowDescriptor get_row_desc();
+    const RecordDescriptor& get_record_desc() const { return _record_desc; }
 
 private:
     Status prepare_exprs(RuntimeState* state);
 
     void _prepare_id_to_col_name_map();
 
-    // Owned by the RuntimeState.
-    const RowDescriptor& _row_desc;
+    const RecordDescriptor _record_desc;
     std::shared_ptr<arrow::Schema> _arrow_schema;
     std::unordered_map<int64_t, std::string> _id_to_col_name;
 

--- a/be/src/data_sink/result/result_sink.cpp
+++ b/be/src/data_sink/result/result_sink.cpp
@@ -56,9 +56,8 @@
 
 namespace starrocks {
 
-ResultSink::ResultSink(const RowDescriptor& row_desc, const std::vector<TExpr>& t_output_expr, const TResultSink& sink,
-                       int buffer_size)
-        : _row_desc(row_desc), _t_output_expr(t_output_expr), _buf_size(buffer_size) {
+ResultSink::ResultSink(const std::vector<TExpr>& t_output_expr, const TResultSink& sink, int buffer_size)
+        : _t_output_expr(t_output_expr), _buf_size(buffer_size) {
     if (!sink.__isset.type || sink.type == TResultSinkType::MYSQL_PROTOCAL) {
         _sink_type = TResultSinkType::MYSQL_PROTOCAL;
     } else {

--- a/be/src/data_sink/result/result_sink.h
+++ b/be/src/data_sink/result/result_sink.h
@@ -54,10 +54,8 @@ class MemTracker;
 class ResultSink final : public DataSink {
 public:
     // construct a buffer for the result need send to coordinator.
-    // row_desc used for convert RowBatch to TRowBatch
     // buffer_size is the buffer size allocated to each query
-    ResultSink(const RowDescriptor& row_desc, const std::vector<TExpr>& select_exprs, const TResultSink& sink,
-               int buffer_size);
+    ResultSink(const std::vector<TExpr>& select_exprs, const TResultSink& sink, int buffer_size);
     ~ResultSink() override = default;
     Status prepare(RuntimeState* state) override;
     Status open(RuntimeState* state) override;
@@ -81,13 +79,10 @@ public:
 
     bool isBinaryFormat() const { return _is_binary_format; }
 
-    const RowDescriptor& get_row_desc() const { return _row_desc; }
-
     const std::vector<std::string>& get_output_column_names() const { return _output_column_names; }
 
 private:
     Status prepare_exprs(RuntimeState* state);
-    const RowDescriptor& _row_desc;
     TResultSinkType::type _sink_type;
     bool _is_binary_format;
     // It is non-empty only for ARROW_FLIGHT_PROTOCAL.

--- a/be/src/data_sink/tablet/tablet_sink_index_channel.h
+++ b/be/src/data_sink/tablet/tablet_sink_index_channel.h
@@ -315,8 +315,6 @@ private:
     // data sending is finished
     bool _finished{false};
 
-    std::unique_ptr<RowDescriptor> _row_desc;
-
     std::shared_ptr<PInternalService_RecoverableStub> _stub;
     std::vector<RefCountClosure<PTabletWriterOpenResult>*> _open_closures;
 

--- a/be/src/data_workflows/load/tablet_writer/load_channel.cpp
+++ b/be/src/data_workflows/load/tablet_writer/load_channel.cpp
@@ -128,8 +128,8 @@ void LoadChannel::open(const LoadChannelOpenContext& open_context) {
             _schema = std::make_shared<OlapTableSchemaParam>();
             RETURN_RESPONSE_IF_ERROR(_schema->init(request.schema()), response);
         }
-        if (_row_desc == nullptr) {
-            _row_desc = std::make_unique<RowDescriptor>(_schema->tuple_desc());
+        if (_record_desc == nullptr) {
+            _record_desc = std::make_unique<RecordDescriptor>(_schema->tuple_desc());
         }
         auto it = _tablets_channels.find(key);
         if (it == _tablets_channels.end()) {
@@ -357,10 +357,10 @@ Status LoadChannel::_build_chunk_meta(const ChunkPB& pb_chunk) {
     if (_has_chunk_meta.load(std::memory_order_acquire)) {
         return Status::OK();
     }
-    if (_row_desc == nullptr) {
+    if (_record_desc == nullptr) {
         return Status::InternalError(fmt::format("load channel not open yet, load id: {}", _load_id.to_string()));
     }
-    StatusOr<serde::ProtobufChunkMeta> res = serde::build_protobuf_chunk_meta(*_row_desc, pb_chunk);
+    StatusOr<serde::ProtobufChunkMeta> res = serde::build_protobuf_chunk_meta(*_record_desc, pb_chunk);
     if (!res.ok()) return res.status();
     _chunk_meta = std::move(res).value();
     _has_chunk_meta.store(true, std::memory_order_release);

--- a/be/src/data_workflows/load/tablet_writer/load_channel.h
+++ b/be/src/data_workflows/load/tablet_writer/load_channel.h
@@ -141,7 +141,7 @@ private:
     mutable bthread::Mutex _chunk_meta_lock;
     serde::ProtobufChunkMeta _chunk_meta;
     std::shared_ptr<OlapTableSchemaParam> _schema;
-    std::unique_ptr<RowDescriptor> _row_desc;
+    std::unique_ptr<RecordDescriptor> _record_desc;
 
     std::unique_ptr<MemTracker> _mem_tracker;
     std::atomic<time_t> _last_updated_time;

--- a/be/src/exec/analytic_node.cpp
+++ b/be/src/exec/analytic_node.cpp
@@ -114,7 +114,7 @@ StatusOr<pipeline::OpFactories> AnalyticNode::decompose_to_pipeline(pipeline::Pi
     auto degree_of_parallelism = upstream_source_op->degree_of_parallelism();
 
     AnalytorFactoryPtr analytor_factory = std::make_shared<AnalytorFactory>(
-            degree_of_parallelism, _tnode, child(0)->row_desc(), _result_tuple_desc, _use_hash_based_partition);
+            degree_of_parallelism, _tnode, _result_tuple_desc, _use_hash_based_partition);
     auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(2, std::move(this->runtime_filter_collector()));
 
     ops_with_sink.emplace_back(

--- a/be/src/exec/analytor.cpp
+++ b/be/src/exec/analytor.cpp
@@ -66,16 +66,8 @@ Analytor::~Analytor() {
     }
 }
 
-Analytor::Analytor(const TPlanNode& tnode, const RowDescriptor& child_row_desc,
-                   const TupleDescriptor* result_tuple_desc, bool use_hash_based_partition)
-        : _tnode(tnode),
-          _child_row_desc(child_row_desc),
-          _result_tuple_desc(result_tuple_desc),
-          _use_hash_based_partition(use_hash_based_partition) {
-    if (tnode.analytic_node.__isset.buffered_tuple_id) {
-        _buffered_tuple_id = tnode.analytic_node.buffered_tuple_id;
-    }
-
+Analytor::Analytor(const TPlanNode& tnode, const TupleDescriptor* result_tuple_desc, bool use_hash_based_partition)
+        : _tnode(tnode), _result_tuple_desc(result_tuple_desc), _use_hash_based_partition(use_hash_based_partition) {
     if (!config::pipeline_analytic_enable_streaming_process) {
         _need_partition_materializing = true;
     }
@@ -419,17 +411,11 @@ Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* 
         RETURN_IF_ERROR(ExprExecutor::prepare(ctx, state));
     }
 
-    if (!_partition_ctxs.empty() || !_order_ctxs.empty()) {
-        vector<TTupleId> tuple_ids;
-        tuple_ids.push_back(_child_row_desc.tuple_descriptors()[0]->id());
-        tuple_ids.push_back(_buffered_tuple_id);
-        RowDescriptor cmp_row_desc(state->desc_tbl(), tuple_ids);
-        if (!_partition_ctxs.empty()) {
-            RETURN_IF_ERROR(ExprExecutor::prepare(_partition_ctxs, state));
-        }
-        if (!_order_ctxs.empty()) {
-            RETURN_IF_ERROR(ExprExecutor::prepare(_order_ctxs, state));
-        }
+    if (!_partition_ctxs.empty()) {
+        RETURN_IF_ERROR(ExprExecutor::prepare(_partition_ctxs, state));
+    }
+    if (!_order_ctxs.empty()) {
+        RETURN_IF_ERROR(ExprExecutor::prepare(_order_ctxs, state));
     }
     if (_range_start_boundary.expr_ctx != nullptr) {
         RETURN_IF_ERROR(ExprExecutor::prepare(_range_start_boundary.expr_ctx, state));
@@ -1676,8 +1662,7 @@ void Analytor::_set_partition_size_for_function() {
 
 AnalytorPtr AnalytorFactory::create(int i) {
     if (!_analytors[i]) {
-        _analytors[i] =
-                std::make_shared<Analytor>(_tnode, _child_row_desc, _result_tuple_desc, _use_hash_based_partition);
+        _analytors[i] = std::make_shared<Analytor>(_tnode, _result_tuple_desc, _use_hash_based_partition);
     }
     return _analytors[i];
 }

--- a/be/src/exec/analytor.h
+++ b/be/src/exec/analytor.h
@@ -20,6 +20,7 @@
 
 #include "base/utility/defer_op.h"
 #include "column/chunk.h"
+#include "common/global_types.h"
 #include "common/memory/mem_hook_allocator.h"
 #include "common/runtime_profile.h"
 #include "exec/pipeline/context_with_dependency.h"
@@ -117,8 +118,7 @@ class Analytor final : public pipeline::ContextWithDependency {
 
 public:
     ~Analytor() override;
-    Analytor(const TPlanNode& tnode, const RowDescriptor& child_row_desc, const TupleDescriptor* result_tuple_desc,
-             bool use_hash_based_partition);
+    Analytor(const TPlanNode& tnode, const TupleDescriptor* result_tuple_desc, bool use_hash_based_partition);
 
     Status prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* runtime_profile);
     Status open(RuntimeState* state);
@@ -281,7 +281,6 @@ private:
     bool _is_closed = false;
     // TPlanNode is only valid in the PREPARE and INIT phase
     const TPlanNode& _tnode;
-    const RowDescriptor& _child_row_desc;
     const TupleDescriptor* _result_tuple_desc;
     const bool _use_hash_based_partition;
 
@@ -329,11 +328,6 @@ private:
 
     std::vector<ExprContext*> _order_ctxs;
     MutableColumns _order_columns;
-
-    // Tuple id of the buffered tuple (identical to the input child tuple, which is
-    // assumed to come from a single SortNode). NULL if both partition_exprs and
-    // order_by_exprs are empty.
-    TTupleId _buffered_tuple_id = 0;
 
     bool _has_udaf = false;
     // There are many reasons requiring the materializing processing.
@@ -427,11 +421,10 @@ class AnalytorFactory;
 using AnalytorFactoryPtr = std::shared_ptr<AnalytorFactory>;
 class AnalytorFactory {
 public:
-    AnalytorFactory(size_t dop, const TPlanNode& tnode, const RowDescriptor& child_row_desc,
-                    const TupleDescriptor* result_tuple_desc, const bool use_hash_based_partition)
+    AnalytorFactory(size_t dop, const TPlanNode& tnode, const TupleDescriptor* result_tuple_desc,
+                    const bool use_hash_based_partition)
             : _analytors(dop),
               _tnode(tnode),
-              _child_row_desc(child_row_desc),
               _result_tuple_desc(result_tuple_desc),
               _use_hash_based_partition(use_hash_based_partition) {}
     AnalytorPtr create(int i);
@@ -439,7 +432,6 @@ public:
 private:
     Analytors _analytors;
     const TPlanNode& _tnode;
-    const RowDescriptor& _child_row_desc;
     const TupleDescriptor* _result_tuple_desc;
     const bool _use_hash_based_partition;
 };

--- a/be/src/exec/chunks_sorter.cpp
+++ b/be/src/exec/chunks_sorter.cpp
@@ -58,19 +58,22 @@ void ChunksSorter::setup_runtime(RuntimeState* state, RuntimeProfile* profile, M
     profile->add_info_string("UseGermanString", is_use_german_string() ? "True" : "False");
 }
 
-StatusOr<ChunkPtr> ChunksSorter::materialize_chunk_before_sort(Chunk* chunk, TupleDescriptor* materialized_tuple_desc,
+StatusOr<ChunkPtr> ChunksSorter::materialize_chunk_before_sort(Chunk* chunk,
+                                                               const RecordDescriptor& materialized_record_desc,
                                                                const SortExecExprs& sort_exec_exprs,
                                                                const std::vector<OrderByType>& order_by_types) {
     ChunkPtr materialize_chunk = std::make_shared<Chunk>();
 
     // materialize all sorting columns: replace old columns with evaluated columns
     const size_t row_num = chunk->num_rows();
-    const auto& slots_in_row_descriptor = materialized_tuple_desc->slots();
+    auto slots_in_record_descriptor = materialized_record_desc.slots();
     const auto& slots_in_sort_exprs = sort_exec_exprs.sort_tuple_slot_expr_ctxs();
 
-    DCHECK_EQ(slots_in_row_descriptor.size(), slots_in_sort_exprs.size());
+    DCHECK_EQ(materialized_record_desc.num_slots(), slots_in_sort_exprs.size());
 
-    for (size_t i = 0; i < slots_in_sort_exprs.size(); ++i) {
+    auto slot_iter = slots_in_record_descriptor.begin();
+    for (size_t i = 0; i < slots_in_sort_exprs.size(); ++i, ++slot_iter) {
+        const SlotDescriptor* slot = *slot_iter;
         ExprContext* expr_ctx = slots_in_sort_exprs[i];
         ColumnPtr col = EVALUATE_NULL_IF_ERROR(expr_ctx, expr_ctx->root(), chunk);
         if (col->is_constant()) {
@@ -79,7 +82,7 @@ StatusOr<ChunkPtr> ChunksSorter::materialize_chunk_before_sort(Chunk* chunk, Tup
                 // so replace it by a nullable column of original data type filled with all NULLs.
                 MutableColumnPtr new_col = ColumnHelper::create_column(order_by_types[i].type_desc, true);
                 new_col->append_nulls(row_num);
-                materialize_chunk->append_column(std::move(new_col), slots_in_row_descriptor[i]->id());
+                materialize_chunk->append_column(std::move(new_col), slot->id());
             } else {
                 // Case 1: an expression may generate a constant column which will be reused by
                 // another call of evaluate(). We clone its data column to resize it as same as
@@ -95,9 +98,9 @@ StatusOr<ChunkPtr> ChunksSorter::materialize_chunk_before_sort(Chunk* chunk, Tup
                 if (order_by_types[i].is_nullable) {
                     ColumnPtr nullable_column =
                             NullableColumn::create(std::move(new_col), NullColumn::create(row_num, 0));
-                    materialize_chunk->append_column(std::move(nullable_column), slots_in_row_descriptor[i]->id());
+                    materialize_chunk->append_column(std::move(nullable_column), slot->id());
                 } else {
-                    materialize_chunk->append_column(std::move(new_col), slots_in_row_descriptor[i]->id());
+                    materialize_chunk->append_column(std::move(new_col), slot->id());
                 }
             }
         } else {
@@ -105,7 +108,7 @@ StatusOr<ChunkPtr> ChunksSorter::materialize_chunk_before_sort(Chunk* chunk, Tup
             if (!col->is_nullable() && order_by_types[i].is_nullable) {
                 col = NullableColumn::create(col, NullColumn::create(col->size(), 0));
             }
-            materialize_chunk->append_column(std::move(col), slots_in_row_descriptor[i]->id());
+            materialize_chunk->append_column(std::move(col), slot->id());
         }
     }
 

--- a/be/src/exec/chunks_sorter.h
+++ b/be/src/exec/chunks_sorter.h
@@ -57,7 +57,8 @@ public:
                  const bool is_topn);
     virtual ~ChunksSorter();
 
-    static StatusOr<ChunkPtr> materialize_chunk_before_sort(Chunk* chunk, TupleDescriptor* materialized_tuple_desc,
+    static StatusOr<ChunkPtr> materialize_chunk_before_sort(Chunk* chunk,
+                                                            const RecordDescriptor& materialized_record_desc,
                                                             const SortExecExprs& sort_exec_exprs,
                                                             const std::vector<OrderByType>& order_by_types);
 

--- a/be/src/exec/cross_join_node.cpp
+++ b/be/src/exec/cross_join_node.cpp
@@ -177,8 +177,8 @@ StatusOr<pipeline::OpFactories> CrossJoinNode::_decompose_to_pipeline(pipeline::
     ASSIGN_OR_RETURN(auto left_ops, _children[0]->decompose_to_pipeline(context));
     // communication with CrossJoinRight through shared_data.
     auto left_factory = std::make_shared<ProbeFactory>(
-            context->next_operator_id(), id(), _row_descriptor, child(0)->row_desc(), child(1)->row_desc(),
-            _sql_join_conjuncts, std::move(_join_conjuncts), std::move(_conjunct_ctxs), std::move(_common_expr_ctxs),
+            context->next_operator_id(), id(), child(0)->record_desc(), child(1)->record_desc(), _sql_join_conjuncts,
+            std::move(_join_conjuncts), std::move(_conjunct_ctxs), std::move(_common_expr_ctxs),
             std::move(cross_join_context), _join_op);
     // Initialize OperatorFactory's fields involving runtime filters.
     pipeline::init_runtime_filter_for_operator(*this, left_factory.get(), context, rc_rf_probe_collector);

--- a/be/src/exec/data_sinks/data_sink_factory.cpp
+++ b/be/src/exec/data_sinks/data_sink_factory.cpp
@@ -42,31 +42,30 @@
 namespace starrocks {
 
 static std::unique_ptr<DataStreamSender> create_data_stream_sink(
-        RuntimeState* state, const TDataStreamSink& data_stream_sink, const RowDescriptor& row_desc,
-        const TPlanFragmentExecParams& params, int32_t sender_id,
-        const std::vector<TPlanFragmentDestination>& destinations) {
+        RuntimeState* state, const TDataStreamSink& data_stream_sink, const TPlanFragmentExecParams& params,
+        int32_t sender_id, const std::vector<TPlanFragmentDestination>& destinations) {
     bool send_query_statistics_with_every_batch =
             params.__isset.send_query_statistics_with_every_batch && params.send_query_statistics_with_every_batch;
     bool enable_exchange_pass_through =
             params.__isset.enable_exchange_pass_through && params.enable_exchange_pass_through;
     bool enable_exchange_perf = params.__isset.enable_exchange_perf && params.enable_exchange_perf;
 
-    return std::make_unique<DataStreamSender>(state, sender_id, row_desc, data_stream_sink, destinations,
+    return std::make_unique<DataStreamSender>(state, sender_id, data_stream_sink, destinations,
                                               send_query_statistics_with_every_batch, enable_exchange_pass_through,
                                               enable_exchange_perf);
 }
 
 Status DataSink::create_data_sink(RuntimeState* state, const TDataSink& thrift_sink,
                                   const std::vector<TExpr>& output_exprs, const TPlanFragmentExecParams& params,
-                                  int32_t sender_id, const RowDescriptor& row_desc, std::unique_ptr<DataSink>* sink) {
+                                  int32_t sender_id, const RecordDescriptor& record_desc,
+                                  std::unique_ptr<DataSink>* sink) {
     DCHECK(sink != nullptr);
     switch (thrift_sink.type) {
     case TDataSinkType::DATA_STREAM_SINK: {
         if (!thrift_sink.__isset.stream_sink) {
             return Status::InternalError("Missing data stream sink.");
         }
-        *sink = create_data_stream_sink(state, thrift_sink.stream_sink, row_desc, params, sender_id,
-                                        params.destinations);
+        *sink = create_data_stream_sink(state, thrift_sink.stream_sink, params, sender_id, params.destinations);
         break;
     }
     case TDataSinkType::RESULT_SINK:
@@ -75,20 +74,20 @@ Status DataSink::create_data_sink(RuntimeState* state, const TDataSink& thrift_s
         }
 
         // TODO: figure out good buffer size based on size of output row
-        *sink = std::make_unique<ResultSink>(row_desc, output_exprs, thrift_sink.result_sink, 1024);
+        *sink = std::make_unique<ResultSink>(output_exprs, thrift_sink.result_sink, 1024);
         break;
     case TDataSinkType::MEMORY_SCRATCH_SINK:
         if (!thrift_sink.__isset.memory_scratch_sink) {
             return Status::InternalError("Missing data buffer sink.");
         }
-        *sink = std::make_unique<MemoryScratchSink>(row_desc, output_exprs, thrift_sink.memory_scratch_sink);
+        *sink = std::make_unique<MemoryScratchSink>(record_desc, output_exprs, thrift_sink.memory_scratch_sink);
         break;
     case TDataSinkType::MYSQL_TABLE_SINK: {
         if (!thrift_sink.__isset.mysql_table_sink) {
             return Status::InternalError("Missing data buffer sink.");
         }
         // TODO: figure out good buffer size based on size of output row
-        *sink = std::make_unique<MysqlTableSink>(state->obj_pool(), row_desc, output_exprs);
+        *sink = std::make_unique<MysqlTableSink>(state->obj_pool(), output_exprs);
         break;
     }
 
@@ -96,7 +95,7 @@ Status DataSink::create_data_sink(RuntimeState* state, const TDataSink& thrift_s
         if (!thrift_sink.__isset.export_sink) {
             return Status::InternalError("Missing export sink sink.");
         }
-        *sink = std::make_unique<ExportSink>(state->obj_pool(), row_desc, output_exprs);
+        *sink = std::make_unique<ExportSink>(state->obj_pool(), output_exprs);
         break;
     }
     case TDataSinkType::OLAP_TABLE_SINK: {
@@ -121,7 +120,7 @@ Status DataSink::create_data_sink(RuntimeState* state, const TDataSink& thrift_s
         for (size_t i = 0; i < thrift_mcast_stream_sink.sinks.size(); i++) {
             const auto& sink = thrift_mcast_stream_sink.sinks[i];
             const auto& destinations = thrift_mcast_stream_sink.destinations[i];
-            auto ret = create_data_stream_sink(state, sink, row_desc, params, sender_id, destinations);
+            auto ret = create_data_stream_sink(state, sink, params, sender_id, destinations);
             mcast_data_stream_sink->add_data_stream_sink(std::move(ret));
         }
         *sink = std::move(mcast_data_stream_sink);
@@ -137,7 +136,7 @@ Status DataSink::create_data_sink(RuntimeState* state, const TDataSink& thrift_s
         for (size_t i = 0; i < thrift_split_stream_sink.sinks.size(); i++) {
             const auto& sink = thrift_split_stream_sink.sinks[i];
             const auto& destinations = thrift_split_stream_sink.destinations[i];
-            auto ret = create_data_stream_sink(state, sink, row_desc, params, sender_id, destinations);
+            auto ret = create_data_stream_sink(state, sink, params, sender_id, destinations);
             split_data_stream_sink->add_data_stream_sink(std::move(ret));
         }
         *sink = std::move(split_data_stream_sink);
@@ -147,7 +146,7 @@ Status DataSink::create_data_sink(RuntimeState* state, const TDataSink& thrift_s
         if (!thrift_sink.__isset.schema_table_sink) {
             return Status::InternalError("Missing schema table sink.");
         }
-        *sink = std::make_unique<SchemaTableSink>(state->obj_pool(), row_desc, output_exprs);
+        *sink = std::make_unique<SchemaTableSink>(state->obj_pool(), output_exprs);
         break;
     }
 #ifndef __APPLE__

--- a/be/src/exec/data_sinks/data_sink_pipeline.cpp
+++ b/be/src/exec/data_sinks/data_sink_pipeline.cpp
@@ -95,7 +95,7 @@ Status DataSink::decompose_data_sink_to_pipeline(pipeline::PipelineBuilderContex
             op = std::make_shared<ResultSinkOperatorFactory>(
                     context->next_operator_id(), dop, result_sink->get_sink_type(), result_sink->isBinaryFormat(),
                     result_sink->get_format_type(), result_sink->get_output_exprs(), fragment_ctx,
-                    result_sink->get_row_desc(), result_sink->get_output_column_names());
+                    result_sink->get_output_column_names());
         }
         // Add result sink operator to last pipeline
         prev_operators.emplace_back(op);
@@ -270,10 +270,9 @@ Status DataSink::decompose_data_sink_to_pipeline(pipeline::PipelineBuilderContex
     } else if (typeid(*this) == typeid(MemoryScratchSink)) {
         auto* memory_scratch_sink = down_cast<MemoryScratchSink*>(this);
         auto output_expr = memory_scratch_sink->get_output_expr();
-        auto row_desc = memory_scratch_sink->get_row_desc();
         DCHECK_EQ(dop, 1);
-        OpFactoryPtr op = std::make_shared<MemoryScratchSinkOperatorFactory>(context->next_operator_id(), row_desc,
-                                                                             output_expr, fragment_ctx);
+        OpFactoryPtr op = std::make_shared<MemoryScratchSinkOperatorFactory>(
+                context->next_operator_id(), memory_scratch_sink->get_record_desc(), output_expr, fragment_ctx);
 
         prev_operators.emplace_back(op);
         context->add_pipeline(prev_operators);

--- a/be/src/exec/data_sinks/pipeline_sink_builder.cpp
+++ b/be/src/exec/data_sinks/pipeline_sink_builder.cpp
@@ -35,8 +35,7 @@ std::string sink_type_name(TDataSinkType::type type) {
 } // namespace
 
 Status PipelineSinkBuilder::build(pipeline::PipelineBuilderContext* context, pipeline::OpFactories upstream,
-                                  const pipeline::UnifiedExecPlanFragmentParams& request,
-                                  const RowDescriptor& row_desc) {
+                                  const pipeline::UnifiedExecPlanFragmentParams& request) {
     const TDataSink& thrift_sink = request.output_sink();
 
     switch (thrift_sink.type) {

--- a/be/src/exec/data_sinks/pipeline_sink_builder.h
+++ b/be/src/exec/data_sinks/pipeline_sink_builder.h
@@ -19,8 +19,6 @@
 
 namespace starrocks {
 
-class RowDescriptor;
-
 namespace pipeline {
 class UnifiedExecPlanFragmentParams;
 }
@@ -28,7 +26,7 @@ class UnifiedExecPlanFragmentParams;
 class PipelineSinkBuilder {
 public:
     static Status build(pipeline::PipelineBuilderContext* context, pipeline::OpFactories upstream,
-                        const pipeline::UnifiedExecPlanFragmentParams& request, const RowDescriptor& row_desc);
+                        const pipeline::UnifiedExecPlanFragmentParams& request);
 };
 
 } // namespace starrocks

--- a/be/src/exec/dict_decode_node.cpp
+++ b/be/src/exec/dict_decode_node.cpp
@@ -55,11 +55,8 @@ Status DictDecodeNode::init(const TPlanNode& tnode, RuntimeState* state) {
         _decode_column_cids.emplace_back(decode_id);
     }
 
-    auto& tuple_id = this->_tuple_ids[0];
     for (const auto& dict_id : _decode_column_cids) {
-        auto idx = this->row_desc().get_tuple_idx(tuple_id);
-        auto& tuple = this->row_desc().tuple_descriptors()[idx];
-        for (const auto& slot : tuple->slots()) {
+        for (const auto* slot : record_desc().slots()) {
             if (slot->id() == dict_id) {
                 _decode_column_types.emplace_back(&slot->type());
                 break;

--- a/be/src/exec/dict_decode_node.h
+++ b/be/src/exec/dict_decode_node.h
@@ -53,7 +53,7 @@ private:
     ChunkPtr _input_chunk;
     std::vector<int32_t> _encode_column_cids;
     std::vector<int32_t> _decode_column_cids;
-    std::vector<TypeDescriptor*> _decode_column_types;
+    std::vector<const TypeDescriptor*> _decode_column_types;
     std::vector<GlobalDictDecoderPtr> _decoders;
 
     std::vector<ExprContext*> _expr_ctxs;

--- a/be/src/exec/exchange_node.cpp
+++ b/be/src/exec/exchange_node.cpp
@@ -59,7 +59,7 @@ ExchangeNode::ExchangeNode(ObjectPool* pool, const TPlanNode& tnode, const Descr
           _texchange_node(tnode.exchange_node),
 
           _stream_recvr(nullptr),
-          _input_row_desc(descs, tnode.exchange_node.input_row_tuples),
+          _input_record_desc(descs, tnode.exchange_node.input_row_tuples),
           _is_merging(tnode.exchange_node.__isset.sort_info),
           _is_parallel_merge(tnode.exchange_node.__isset.enable_parallel_merge &&
                              tnode.exchange_node.enable_parallel_merge),
@@ -86,11 +86,11 @@ Status ExchangeNode::prepare(RuntimeState* state) {
     _sub_plan_query_statistics_recvr = std::make_shared<QueryStatisticsRecvr>();
     auto* query_execution_services = state->query_execution_services();
     _stream_recvr = query_execution_services->runtime->stream_mgr->create_recvr(
-            state, _input_row_desc, state->fragment_instance_id(), _id, _num_senders,
+            state, _input_record_desc, state->fragment_instance_id(), _id, _num_senders,
             config::exchg_node_buffer_size_bytes, _is_merging, _sub_plan_query_statistics_recvr, false, 1, false);
     _stream_recvr->bind_profile(0, _runtime_profile);
     if (_is_merging) {
-        RETURN_IF_ERROR(_sort_exec_exprs.prepare(state, _row_descriptor, _row_descriptor));
+        RETURN_IF_ERROR(_sort_exec_exprs.prepare(state));
     }
     return Status::OK();
 }
@@ -255,7 +255,7 @@ StatusOr<pipeline::OpFactories> ExchangeNode::decompose_to_pipeline(pipeline::Pi
     if (!_is_merging) {
         auto* query_ctx = context->runtime_state()->query_ctx();
         auto exchange_source_op = std::make_shared<ExchangeSourceOperatorFactory>(
-                context->next_operator_id(), id(), _texchange_node, _num_senders, _input_row_desc,
+                context->next_operator_id(), id(), _texchange_node, _num_senders, _input_record_desc,
                 query_ctx->enable_pipeline_level_shuffle());
         exchange_source_op->set_degree_of_parallelism(context->degree_of_parallelism());
         operators.emplace_back(exchange_source_op);
@@ -268,8 +268,8 @@ StatusOr<pipeline::OpFactories> ExchangeNode::decompose_to_pipeline(pipeline::Pi
         if ((_is_parallel_merge || _sort_exec_exprs.is_constant_lhs_ordering()) &&
             !_sort_exec_exprs.lhs_ordering_expr_ctxs().empty()) {
             auto exchange_merge_sort_source_operator = std::make_shared<ExchangeParallelMergeSourceOperatorFactory>(
-                    context->next_operator_id(), id(), _num_senders, _input_row_desc, &_sort_exec_exprs, _is_asc_order,
-                    _nulls_first, _offset, _limit);
+                    context->next_operator_id(), id(), _num_senders, _input_record_desc, &_sort_exec_exprs,
+                    _is_asc_order, _nulls_first, _offset, _limit);
             if (_texchange_node.__isset.parallel_merge_late_materialize_mode) {
                 exchange_merge_sort_source_operator->set_materialized_mode(
                         _texchange_node.parallel_merge_late_materialize_mode);
@@ -282,8 +282,8 @@ StatusOr<pipeline::OpFactories> ExchangeNode::decompose_to_pipeline(pipeline::Pi
                     context, runtime_state(), id(), operators);
         } else {
             auto exchange_merge_sort_source_operator = std::make_shared<ExchangeMergeSortSourceOperatorFactory>(
-                    context->next_operator_id(), id(), _num_senders, _input_row_desc, &_sort_exec_exprs, _is_asc_order,
-                    _nulls_first, _offset, _limit);
+                    context->next_operator_id(), id(), _num_senders, _input_record_desc, &_sort_exec_exprs,
+                    _is_asc_order, _nulls_first, _offset, _limit);
             exchange_merge_sort_source_operator->set_degree_of_parallelism(1);
             operators.emplace_back(std::move(exchange_merge_sort_source_operator));
         }

--- a/be/src/exec/exchange_node.h
+++ b/be/src/exec/exchange_node.h
@@ -90,7 +90,7 @@ private:
     std::shared_ptr<DataStreamRecvr> _stream_recvr;
 
     // our input rows are a prefix of the rows we produce
-    RowDescriptor _input_row_desc;
+    RecordDescriptor _input_record_desc;
 
     ChunkUniquePtr _input_chunk;
     bool _is_finished = false;

--- a/be/src/exec/hash_join_components.cpp
+++ b/be/src/exec/hash_join_components.cpp
@@ -571,12 +571,10 @@ size_t AdaptivePartitionHashJoinBuilder::_estimate_hash_table_probing_bytes_per_
     }
 
     // 3. output bytes
-    for (auto* tuple : param.build_row_desc->tuple_descriptors()) {
-        for (const auto* slot : tuple->slots()) {
-            if (param.build_output_slots.empty() || param.build_output_slots.contains(slot->id())) {
-                estimated_each_row += get_size_of_fixed_length_type(slot->type().type);
-                estimated_each_row += type_estimated_overhead_bytes(slot->type().type);
-            }
+    for (auto* slot : param.build_record_desc->slots()) {
+        if (param.build_output_slots.empty() || param.build_output_slots.contains(slot->id())) {
+            estimated_each_row += get_size_of_fixed_length_type(slot->type().type);
+            estimated_each_row += type_estimated_overhead_bytes(slot->type().type);
         }
     }
 
@@ -588,11 +586,9 @@ size_t AdaptivePartitionHashJoinBuilder::_estimate_probe_row_bytes(const HashTab
     size_t size = 0;
 
     // shuffling probe bytes
-    for (auto* tuple : param.probe_row_desc->tuple_descriptors()) {
-        for (const auto* slot : tuple->slots()) {
-            size += get_size_of_fixed_length_type(slot->type().type);
-            size += type_estimated_overhead_bytes(slot->type().type);
-        }
+    for (auto* slot : param.probe_record_desc->slots()) {
+        size += get_size_of_fixed_length_type(slot->type().type);
+        size += type_estimated_overhead_bytes(slot->type().type);
     }
 
     return std::max<size_t>(size, 1);

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -229,7 +229,7 @@ StatusOr<pipeline::OpFactories> HashJoinNode::_decompose_to_pipeline(pipeline::P
 
     auto* pool = context->fragment_context()->runtime_state()->obj_pool();
     HashJoinerParam param(pool, _hash_join_node, _is_null_safes, _build_expr_ctxs, _probe_expr_ctxs,
-                          _other_join_conjunct_ctxs, _conjunct_ctxs, child(1)->row_desc(), child(0)->row_desc(),
+                          _other_join_conjunct_ctxs, _conjunct_ctxs, child(1)->record_desc(), child(0)->record_desc(),
                           child(1)->type(), child(0)->type(), child(1)->conjunct_ctxs().empty(), _build_runtime_filters,
                           _output_slots, _output_slots, context->degree_of_parallelism(), _distribution_mode,
                           _enable_late_materialization, _enable_partition_hash_join, _is_skew_join, _common_expr_ctxs,

--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -78,8 +78,8 @@ HashJoiner::HashJoiner(const HashJoinerParam& param)
           _other_join_conjunct_ctxs(param._other_join_conjunct_ctxs),
           _conjunct_ctxs(param._conjunct_ctxs),
           _common_expr_ctxs(param._common_expr_ctxs),
-          _build_row_descriptor(param._build_row_descriptor),
-          _probe_row_descriptor(param._probe_row_descriptor),
+          _build_record_descriptor(param._build_record_descriptor),
+          _probe_record_descriptor(param._probe_record_descriptor),
           _build_node_type(param._build_node_type),
           _probe_node_type(param._probe_node_type),
           _build_conjunct_ctxs_is_empty(param._build_conjunct_ctxs_is_empty),
@@ -167,8 +167,8 @@ Status HashJoiner::prepare_prober(RuntimeState* state, RuntimeProfile* runtime_p
 void HashJoiner::_init_hash_table_param(HashTableParam* param, RuntimeState* state) {
     param->with_other_conjunct = !_other_join_conjunct_ctxs.empty();
     param->join_type = _join_type;
-    param->build_row_desc = &_build_row_descriptor;
-    param->probe_row_desc = &_probe_row_descriptor;
+    param->build_record_desc = &_build_record_descriptor;
+    param->probe_record_desc = &_probe_record_descriptor;
     param->build_output_slots = _build_output_slots;
     param->probe_output_slots = _probe_output_slots;
     param->enable_late_materialization = _enable_late_materialization;

--- a/be/src/exec/hash_joiner.h
+++ b/be/src/exec/hash_joiner.h
@@ -68,7 +68,7 @@ struct HashJoinerParam {
     HashJoinerParam(ObjectPool* pool, const THashJoinNode& hash_join_node, std::vector<bool> is_null_safes,
                     std::vector<ExprContext*> build_expr_ctxs, std::vector<ExprContext*> probe_expr_ctxs,
                     std::vector<ExprContext*> other_join_conjunct_ctxs, std::vector<ExprContext*> conjunct_ctxs,
-                    const RowDescriptor& build_row_descriptor, const RowDescriptor& probe_row_descriptor,
+                    const RecordDescriptor& build_record_desc, const RecordDescriptor& probe_record_desc,
                     TPlanNodeType::type build_node_type, TPlanNodeType::type probe_node_type,
                     bool build_conjunct_ctxs_is_empty, std::list<RuntimeFilterBuildDescriptor*> build_runtime_filters,
                     std::set<SlotId> build_output_slots, std::set<SlotId> probe_output_slots, size_t max_dop,
@@ -83,8 +83,8 @@ struct HashJoinerParam {
               _probe_expr_ctxs(std::move(probe_expr_ctxs)),
               _other_join_conjunct_ctxs(std::move(other_join_conjunct_ctxs)),
               _conjunct_ctxs(std::move(conjunct_ctxs)),
-              _build_row_descriptor(build_row_descriptor),
-              _probe_row_descriptor(probe_row_descriptor),
+              _build_record_descriptor(build_record_desc),
+              _probe_record_descriptor(probe_record_desc),
               _build_node_type(build_node_type),
               _probe_node_type(probe_node_type),
               _build_conjunct_ctxs_is_empty(build_conjunct_ctxs_is_empty),
@@ -112,8 +112,8 @@ struct HashJoinerParam {
     const std::vector<ExprContext*> _probe_expr_ctxs;
     const std::vector<ExprContext*> _other_join_conjunct_ctxs;
     const std::vector<ExprContext*> _conjunct_ctxs;
-    const RowDescriptor _build_row_descriptor;
-    const RowDescriptor _probe_row_descriptor;
+    const RecordDescriptor _build_record_descriptor;
+    const RecordDescriptor _probe_record_descriptor;
     TPlanNodeType::type _build_node_type;
     TPlanNodeType::type _probe_node_type;
     bool _build_conjunct_ctxs_is_empty;
@@ -453,8 +453,8 @@ private:
     // Conjuncts in Join followed by a filter predicate, usually in Where and Having.
     const std::vector<ExprContext*>& _conjunct_ctxs;
     const std::map<SlotId, ExprContext*>& _common_expr_ctxs;
-    const RowDescriptor& _build_row_descriptor;
-    const RowDescriptor& _probe_row_descriptor;
+    const RecordDescriptor& _build_record_descriptor;
+    const RecordDescriptor& _probe_record_descriptor;
     const TPlanNodeType::type _build_node_type;
     const TPlanNodeType::type _probe_node_type;
     const bool _build_conjunct_ctxs_is_empty;

--- a/be/src/exec/join/join_hash_table.cpp
+++ b/be/src/exec/join/join_hash_table.cpp
@@ -467,9 +467,9 @@ void JoinHashTable::create(const HashTableParam& param) {
 }
 
 void JoinHashTable::_init_probe_column(const HashTableParam& param) {
-    const auto& probe_desc = *param.probe_row_desc;
-    for (const auto& tuple_desc : probe_desc.tuple_descriptors()) {
-        for (const auto& slot : tuple_desc->slots()) {
+    const auto& probe_desc = *param.probe_record_desc;
+    for (auto* slot : probe_desc.slots()) {
+        {
             HashTableSlotDescriptor hash_table_slot;
             hash_table_slot.slot = slot;
 
@@ -525,15 +525,15 @@ void JoinHashTable::_init_probe_column(const HashTableParam& param) {
 }
 
 void JoinHashTable::_init_build_column(const HashTableParam& param) {
-    const auto& build_desc = *param.build_row_desc;
+    const auto& build_desc = *param.build_record_desc;
     std::unordered_set<SlotId> join_key_col_refs;
     for (const auto& join_key : param.join_keys) {
         if (join_key.col_ref != nullptr) {
             join_key_col_refs.insert(join_key.col_ref->slot_id());
         }
     }
-    for (const auto& tuple_desc : build_desc.tuple_descriptors()) {
-        for (const auto& slot : tuple_desc->slots()) {
+    for (auto* slot : build_desc.slots()) {
+        {
             HashTableSlotDescriptor hash_table_slot;
             hash_table_slot.slot = slot;
 

--- a/be/src/exec/join/join_hash_table_descriptor.h
+++ b/be/src/exec/join/join_hash_table_descriptor.h
@@ -339,8 +339,8 @@ struct HashTableParam {
     long column_view_concat_bytes_limit = -1L;
 
     TJoinOp::type join_type = TJoinOp::INNER_JOIN;
-    const RowDescriptor* build_row_desc = nullptr;
-    const RowDescriptor* probe_row_desc = nullptr;
+    const RecordDescriptor* build_record_desc = nullptr;
+    const RecordDescriptor* probe_record_desc = nullptr;
     std::set<SlotId> build_output_slots;
     std::set<SlotId> probe_output_slots;
     std::set<SlotId> predicate_slots;

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -319,7 +319,7 @@ Status SpillableAggregateBlockingSinkOperatorFactory::prepare(RuntimeState* stat
     RETURN_IF_ERROR(_sort_exprs.init(group_by_expr, nullptr, &_pool, state));
     _sort_desc = SortDescs::asc_null_first(group_by_expr.size());
 
-    RETURN_IF_ERROR(_sort_exprs.prepare(state, {}, {}));
+    RETURN_IF_ERROR(_sort_exprs.prepare(state));
     RETURN_IF_ERROR(_sort_exprs.open(state));
 
     // init spill options

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
@@ -145,7 +145,7 @@ Status SpillableAggregateDistinctBlockingSinkOperatorFactory::prepare(RuntimeSta
     RETURN_IF_ERROR(_sort_exprs.init(group_by_expr, nullptr, &_pool, state));
     _sort_desc = SortDescs::asc_null_first(group_by_expr.size());
 
-    RETURN_IF_ERROR(_sort_exprs.prepare(state, {}, {}));
+    RETURN_IF_ERROR(_sort_exprs.prepare(state));
     RETURN_IF_ERROR(_sort_exprs.open(state));
 
     // init spill options

--- a/be/src/exec/pipeline/assert_num_rows_operator.cpp
+++ b/be/src/exec/pipeline/assert_num_rows_operator.cpp
@@ -26,12 +26,10 @@ Status AssertNumRowsOperator::prepare(RuntimeState* state) {
     // AssertNumRows should return exactly one row, report error if more than one row, return null if empty input
     ChunkPtr chunk = std::make_shared<Chunk>();
 
-    for (const auto& desc : _factory->row_desc()->tuple_descriptors()) {
-        for (const auto& slot : desc->slots()) {
-            MutableColumnPtr column = ColumnHelper::create_column(slot->type(), true);
-            column->append_nulls(1);
-            chunk->append_column(std::move(column), slot->id());
-        }
+    for (const auto* slot : _factory->record_desc()->slots()) {
+        MutableColumnPtr column = ColumnHelper::create_column(slot->type(), true);
+        column->append_nulls(1);
+        chunk->append_column(std::move(column), slot->id());
     }
 
     _cur_chunk = std::move(chunk);

--- a/be/src/exec/pipeline/dict_decode_operator.cpp
+++ b/be/src/exec/pipeline/dict_decode_operator.cpp
@@ -41,7 +41,7 @@ Status DictDecodeOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk
     MutableColumns decode_columns(_encode_column_cids.size());
     for (size_t i = 0; i < _encode_column_cids.size(); i++) {
         const ColumnPtr& encode_column = chunk->get_column_by_slot_id(_encode_column_cids[i]);
-        TypeDescriptor* desc = _decode_column_types[i];
+        const TypeDescriptor* desc = _decode_column_types[i];
         decode_columns[i] = ColumnHelper::create_column(*desc, encode_column->is_nullable());
         if (encode_column->only_null()) {
             bool res = decode_columns[i]->append_nulls(encode_column->size());

--- a/be/src/exec/pipeline/dict_decode_operator.h
+++ b/be/src/exec/pipeline/dict_decode_operator.h
@@ -26,7 +26,8 @@ class DictDecodeOperator final : public Operator {
 public:
     DictDecodeOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
                        std::vector<int32_t>& encode_column_cids, std::vector<int32_t>& decode_column_cids,
-                       std::vector<TypeDescriptor*>& decode_column_types, std::vector<GlobalDictDecoderPtr>& decoders)
+                       std::vector<const TypeDescriptor*>& decode_column_types,
+                       std::vector<GlobalDictDecoderPtr>& decoders)
             : Operator(factory, id, "dict_decode", plan_node_id, false, driver_sequence),
               _encode_column_cids(encode_column_cids),
               _decode_column_cids(decode_column_cids),
@@ -59,7 +60,7 @@ public:
 private:
     const std::vector<int32_t>& _encode_column_cids;
     const std::vector<int32_t>& _decode_column_cids;
-    const std::vector<TypeDescriptor*>& _decode_column_types;
+    const std::vector<const TypeDescriptor*>& _decode_column_types;
     const std::vector<GlobalDictDecoderPtr>& _decoders;
 
     bool _is_finished = false;
@@ -70,7 +71,8 @@ class DictDecodeOperatorFactory final : public OperatorFactory {
 public:
     DictDecodeOperatorFactory(int32_t id, int32_t plan_node_id, std::vector<int32_t>&& encode_column_cids,
                               std::vector<int32_t>&& decode_column_cids,
-                              std::vector<TypeDescriptor*>&& decode_column_types, std::vector<ExprContext*>&& expr_ctxs,
+                              std::vector<const TypeDescriptor*>&& decode_column_types,
+                              std::vector<ExprContext*>&& expr_ctxs,
                               std::map<SlotId, std::pair<ExprContext*, DictOptimizeContext>>&& string_functions)
             : OperatorFactory(id, "dict_decode", plan_node_id),
               _encode_column_cids(std::move(encode_column_cids)),
@@ -92,7 +94,7 @@ public:
 private:
     std::vector<int32_t> _encode_column_cids;
     std::vector<int32_t> _decode_column_cids;
-    std::vector<TypeDescriptor*> _decode_column_types;
+    std::vector<const TypeDescriptor*> _decode_column_types;
     std::vector<GlobalDictDecoderPtr> _decoders;
 
     std::vector<ExprContext*> _expr_ctxs;

--- a/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
@@ -30,7 +30,7 @@ Status ExchangeMergeSortSourceOperator::prepare(RuntimeState* state) {
     auto query_statistic_recv = RuntimeStateHelper::query_recv(state);
     auto* query_execution_services = state->query_execution_services();
     _stream_recvr = query_execution_services->runtime->stream_mgr->create_recvr(
-            state, _row_desc, state->fragment_instance_id(), _plan_node_id, _num_sender,
+            state, _record_desc, state->fragment_instance_id(), _plan_node_id, _num_sender,
             config::exchg_node_buffer_size_bytes, true, query_statistic_recv, true, 1, true);
     _stream_recvr->bind_profile(_driver_sequence, _unique_metrics);
     _stream_recvr->attach_observer(state, this->observer());
@@ -147,7 +147,7 @@ Status ExchangeMergeSortSourceOperator::get_next_merging(RuntimeState* state, Ch
 
 Status ExchangeMergeSortSourceOperatorFactory::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(OperatorFactory::prepare(state));
-    RETURN_IF_ERROR(_sort_exec_exprs->prepare(state, _row_desc, _row_desc));
+    RETURN_IF_ERROR(_sort_exec_exprs->prepare(state));
     RETURN_IF_ERROR(_sort_exec_exprs->open(state));
     return Status::OK();
 }

--- a/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.h
@@ -20,18 +20,17 @@
 
 namespace starrocks {
 class DataStreamRecvr;
-class RowDescriptor;
 class SortExecExprs;
 namespace pipeline {
 class ExchangeMergeSortSourceOperator : public SourceOperator {
 public:
     ExchangeMergeSortSourceOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
-                                    int32_t num_sender, const RowDescriptor& row_desc, SortExecExprs* sort_exec_exprs,
-                                    const std::vector<bool>& is_asc_order, const std::vector<bool>& nulls_first,
-                                    int64_t offset, int64_t limit)
+                                    int32_t num_sender, const RecordDescriptor& record_desc,
+                                    SortExecExprs* sort_exec_exprs, const std::vector<bool>& is_asc_order,
+                                    const std::vector<bool>& nulls_first, int64_t offset, int64_t limit)
             : SourceOperator(factory, id, "global_merge_source", plan_node_id, false, driver_sequence),
               _num_sender(num_sender),
-              _row_desc(row_desc),
+              _record_desc(record_desc),
               _sort_exec_exprs(sort_exec_exprs),
               _is_asc_order(is_asc_order),
               _nulls_first(nulls_first),
@@ -56,7 +55,7 @@ private:
     Status get_next_merging(RuntimeState* state, ChunkPtr* chunk);
 
     int32_t _num_sender;
-    const RowDescriptor& _row_desc;
+    const RecordDescriptor& _record_desc;
 
     SortExecExprs* _sort_exec_exprs;
     const std::vector<bool>& _is_asc_order;
@@ -74,12 +73,12 @@ private:
 class ExchangeMergeSortSourceOperatorFactory final : public SourceOperatorFactory {
 public:
     ExchangeMergeSortSourceOperatorFactory(int32_t id, int32_t plan_node_id, int32_t num_sender,
-                                           const RowDescriptor& row_desc, SortExecExprs* sort_exec_exprs,
+                                           RecordDescriptor record_desc, SortExecExprs* sort_exec_exprs,
                                            const std::vector<bool>& is_asc_order, const std::vector<bool>& nulls_first,
                                            int64_t offset, int64_t limit)
             : SourceOperatorFactory(id, "global_merge_source", plan_node_id),
               _num_sender(num_sender),
-              _row_desc(row_desc),
+              _record_desc(std::move(record_desc)),
               _sort_exec_exprs(sort_exec_exprs),
               _is_asc_order(is_asc_order),
               _nulls_first(nulls_first),
@@ -91,7 +90,7 @@ public:
 
     OperatorPtr create(int32_t driver_instance_count, int32_t driver_sequence) override {
         return std::make_shared<ExchangeMergeSortSourceOperator>(this, _id, _plan_node_id, driver_sequence, _num_sender,
-                                                                 _row_desc, _sort_exec_exprs, _is_asc_order,
+                                                                 _record_desc, _sort_exec_exprs, _is_asc_order,
                                                                  _nulls_first, _offset, _limit);
     }
 
@@ -102,7 +101,7 @@ public:
 
 private:
     int32_t _num_sender;
-    const RowDescriptor& _row_desc;
+    const RecordDescriptor _record_desc;
     SortExecExprs* _sort_exec_exprs;
     const std::vector<bool>& _is_asc_order;
     const std::vector<bool>& _nulls_first;

--- a/be/src/exec/pipeline/exchange/exchange_parallel_merge_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_parallel_merge_source_operator.cpp
@@ -81,7 +81,7 @@ std::string ExchangeParallelMergeSourceOperator::get_name() const {
 
 Status ExchangeParallelMergeSourceOperatorFactory::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(OperatorFactory::prepare(state));
-    RETURN_IF_ERROR(_sort_exec_exprs->prepare(state, _row_desc, _row_desc));
+    RETURN_IF_ERROR(_sort_exec_exprs->prepare(state));
     RETURN_IF_ERROR(_sort_exec_exprs->open(state));
     return Status::OK();
 }
@@ -101,7 +101,7 @@ DataStreamRecvr* ExchangeParallelMergeSourceOperatorFactory::get_stream_recvr(Ru
         auto query_statistic_recv = RuntimeStateHelper::query_recv(state);
         auto* query_execution_services = state->query_execution_services();
         _stream_recvr = query_execution_services->runtime->stream_mgr->create_recvr(
-                state, _row_desc, state->fragment_instance_id(), _plan_node_id, _num_sender,
+                state, _record_desc, state->fragment_instance_id(), _plan_node_id, _num_sender,
                 config::exchg_node_buffer_size_bytes, true, query_statistic_recv, true, _degree_of_parallelism, true);
     }
     return _stream_recvr.get();
@@ -114,8 +114,7 @@ merge_path::MergePathCascadeMerger* ExchangeParallelMergeSourceOperatorFactory::
         SortDescs sort_descs(_is_asc_order, _nulls_first);
         _merger = std::make_unique<merge_path::MergePathCascadeMerger>(
                 state->chunk_size(), degree_of_parallelism(), _sort_exec_exprs->lhs_ordering_expr_ctxs(), sort_descs,
-                _row_desc.tuple_descriptors()[0], TTopNType::ROW_NUMBER, _offset, _limit, chunk_providers,
-                _late_materialize_mode);
+                _record_desc, TTopNType::ROW_NUMBER, _offset, _limit, chunk_providers, _late_materialize_mode);
     }
     return _merger.get();
 }

--- a/be/src/exec/pipeline/exchange/exchange_parallel_merge_source_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_parallel_merge_source_operator.h
@@ -85,12 +85,12 @@ private:
 class ExchangeParallelMergeSourceOperatorFactory final : public SourceOperatorFactory {
 public:
     ExchangeParallelMergeSourceOperatorFactory(int32_t id, int32_t plan_node_id, int32_t num_sender,
-                                               const RowDescriptor& row_desc, SortExecExprs* sort_exec_exprs,
+                                               RecordDescriptor record_desc, SortExecExprs* sort_exec_exprs,
                                                const std::vector<bool>& is_asc_order,
                                                const std::vector<bool>& nulls_first, int64_t offset, int64_t limit)
             : SourceOperatorFactory(id, "global_parallel_merge_source", plan_node_id),
               _num_sender(num_sender),
-              _row_desc(row_desc),
+              _record_desc(std::move(record_desc)),
               _sort_exec_exprs(sort_exec_exprs),
               _is_asc_order(is_asc_order),
               _nulls_first(nulls_first),
@@ -115,7 +115,7 @@ public:
 
 private:
     const int32_t _num_sender;
-    const RowDescriptor& _row_desc;
+    const RecordDescriptor _record_desc;
     SortExecExprs* _sort_exec_exprs;
     const std::vector<bool>& _is_asc_order;
     const std::vector<bool>& _nulls_first;

--- a/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
@@ -90,7 +90,7 @@ std::shared_ptr<DataStreamRecvr> ExchangeSourceOperatorFactory::create_stream_re
     auto query_statistic_recv = RuntimeStateHelper::query_recv(state);
     auto* query_execution_services = state->query_execution_services();
     _stream_recvr = query_execution_services->runtime->stream_mgr->create_recvr(
-            state, _row_desc, state->fragment_instance_id(), _plan_node_id, _num_sender,
+            state, _record_desc, state->fragment_instance_id(), _plan_node_id, _num_sender,
             config::exchg_node_buffer_size_bytes, false, query_statistic_recv, true, _degree_of_parallelism, false);
 
     return _stream_recvr;

--- a/be/src/exec/pipeline/exchange/exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.h
@@ -20,7 +20,6 @@
 
 namespace starrocks {
 class DataStreamRecvr;
-class RowDescriptor;
 namespace pipeline {
 class ExchangeSourceOperator : public SourceOperator {
 public:
@@ -51,11 +50,11 @@ private:
 class ExchangeSourceOperatorFactory final : public SourceOperatorFactory {
 public:
     ExchangeSourceOperatorFactory(int32_t id, int32_t plan_node_id, const TExchangeNode& texchange_node,
-                                  int32_t num_sender, const RowDescriptor& row_desc, bool enable_pipeline_level_shuffle)
+                                  int32_t num_sender, RecordDescriptor record_desc, bool enable_pipeline_level_shuffle)
             : SourceOperatorFactory(id, "exchange_source", plan_node_id),
               _texchange_node(texchange_node),
               _num_sender(num_sender),
-              _row_desc(row_desc),
+              _record_desc(std::move(record_desc)),
               _enable_pipeline_level_shuffle(enable_pipeline_level_shuffle) {}
 
     ~ExchangeSourceOperatorFactory() override;
@@ -82,7 +81,7 @@ public:
 private:
     const TExchangeNode& _texchange_node;
     const int32_t _num_sender;
-    const RowDescriptor& _row_desc;
+    const RecordDescriptor _record_desc;
     const bool _enable_pipeline_level_shuffle;
     std::shared_ptr<DataStreamRecvr> _stream_recvr = nullptr;
     std::atomic<int64_t> _stream_recvr_cnt = 0;

--- a/be/src/exec/pipeline/exec_node_pipeline_adapter.cpp
+++ b/be/src/exec/pipeline/exec_node_pipeline_adapter.cpp
@@ -26,7 +26,7 @@ void init_runtime_filter_for_operator(
         const ExecNode& exec_node, OperatorFactory* op, PipelineBuilderContext* context,
         const std::shared_ptr<RefCountedRuntimeFilterProbeCollector>& rc_rf_probe_collector) {
     op->init_runtime_filter(context->fragment_context()->runtime_filter_hub(), exec_node.get_tuple_ids(),
-                            exec_node.local_rf_waiting_set(), exec_node.row_desc(), rc_rf_probe_collector,
+                            exec_node.local_rf_waiting_set(), exec_node.record_desc(), rc_rf_probe_collector,
                             exec_node.filter_null_value_columns(), exec_node.tuple_slot_mappings());
 }
 

--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
@@ -809,18 +809,14 @@ OperatorExecStatsSnapshot NLJoinProbeOperator::exec_stats_snapshot() const {
     return snapshot;
 }
 
-void NLJoinProbeOperatorFactory::_init_row_desc() {
-    for (auto& tuple_desc : _left_row_desc.tuple_descriptors()) {
-        for (auto& slot : tuple_desc->slots()) {
-            _col_types.emplace_back(slot);
-            _probe_column_count++;
-        }
+void NLJoinProbeOperatorFactory::_init_col_types() {
+    for (auto* slot : _left_record_desc.slots()) {
+        _col_types.emplace_back(slot);
+        _probe_column_count++;
     }
-    for (auto& tuple_desc : _right_row_desc.tuple_descriptors()) {
-        for (auto& slot : tuple_desc->slots()) {
-            _col_types.emplace_back(slot);
-            _build_column_count++;
-        }
+    for (auto* slot : _right_record_desc.slots()) {
+        _col_types.emplace_back(slot);
+        _build_column_count++;
     }
 }
 
@@ -836,7 +832,7 @@ Status NLJoinProbeOperatorFactory::prepare(RuntimeState* state) {
     // Unref is called in _cross_join_context->decr_prober, when call probe operators have called decr_prober.
     _cross_join_context->ref();
 
-    _init_row_desc();
+    _init_col_types();
 
     RETURN_IF_ERROR(ExprExecutor::prepare(_common_expr_ctxs, state));
     RETURN_IF_ERROR(ExprExecutor::open(_common_expr_ctxs, state));

--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.h
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.h
@@ -148,16 +148,15 @@ private:
 
 class NLJoinProbeOperatorFactory final : public OperatorWithDependencyFactory {
 public:
-    NLJoinProbeOperatorFactory(int32_t id, int32_t plan_node_id, const RowDescriptor& row_descriptor,
-                               const RowDescriptor& left_row_desc, const RowDescriptor& right_row_desc,
-                               std::string sql_join_conjuncts, std::vector<ExprContext*>&& join_conjuncts,
-                               std::vector<ExprContext*>&& conjunct_ctxs,
+    NLJoinProbeOperatorFactory(int32_t id, int32_t plan_node_id, RecordDescriptor left_record_desc,
+                               RecordDescriptor right_record_desc, std::string sql_join_conjuncts,
+                               std::vector<ExprContext*>&& join_conjuncts, std::vector<ExprContext*>&& conjunct_ctxs,
                                std::map<SlotId, ExprContext*>&& common_expr_ctxs,
                                std::shared_ptr<NLJoinContext>&& cross_join_context, TJoinOp::type join_op)
             : OperatorWithDependencyFactory(id, "cross_join_left", plan_node_id),
               _join_op(join_op),
-              _left_row_desc(left_row_desc),
-              _right_row_desc(right_row_desc),
+              _left_record_desc(std::move(left_record_desc)),
+              _right_record_desc(std::move(right_record_desc)),
               _sql_join_conjuncts(std::move(sql_join_conjuncts)),
               _join_conjuncts(std::move(join_conjuncts)),
               _conjunct_ctxs(std::move(conjunct_ctxs)),
@@ -172,11 +171,11 @@ public:
     void close(RuntimeState* state) override;
 
 private:
-    void _init_row_desc();
+    void _init_col_types();
 
     const TJoinOp::type _join_op;
-    const RowDescriptor& _left_row_desc;
-    const RowDescriptor& _right_row_desc;
+    const RecordDescriptor _left_record_desc;
+    const RecordDescriptor _right_record_desc;
 
     std::vector<SlotDescriptor*> _col_types;
     size_t _probe_column_count = 0;

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.cpp
@@ -233,18 +233,14 @@ void SpillableNLJoinProbeOperator::_init_chunk_stream() const {
     }
 }
 
-void SpillableNLJoinProbeOperatorFactory::_init_row_desc() {
-    for (auto& tuple_desc : _left_row_desc.tuple_descriptors()) {
-        for (auto& slot : tuple_desc->slots()) {
-            _col_types.emplace_back(slot);
-            _probe_column_count++;
-        }
+void SpillableNLJoinProbeOperatorFactory::_init_col_types() {
+    for (auto* slot : _left_record_desc.slots()) {
+        _col_types.emplace_back(slot);
+        _probe_column_count++;
     }
-    for (auto& tuple_desc : _right_row_desc.tuple_descriptors()) {
-        for (auto& slot : tuple_desc->slots()) {
-            _col_types.emplace_back(slot);
-            _build_column_count++;
-        }
+    for (auto* slot : _right_record_desc.slots()) {
+        _col_types.emplace_back(slot);
+        _build_column_count++;
     }
 }
 
@@ -259,7 +255,7 @@ Status SpillableNLJoinProbeOperatorFactory::prepare(RuntimeState* state) {
 
     _cross_join_context->ref();
 
-    _init_row_desc();
+    _init_col_types();
     RETURN_IF_ERROR(ExprExecutor::prepare(_join_conjuncts, state));
     RETURN_IF_ERROR(ExprExecutor::open(_join_conjuncts, state));
     RETURN_IF_ERROR(ExprExecutor::prepare(_conjunct_ctxs, state));

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.h
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.h
@@ -151,16 +151,16 @@ private:
 
 class SpillableNLJoinProbeOperatorFactory final : public OperatorWithDependencyFactory {
 public:
-    SpillableNLJoinProbeOperatorFactory(int32_t id, int32_t plan_node_id, const RowDescriptor& row_descriptor,
-                                        const RowDescriptor& left_row_desc, const RowDescriptor& right_row_desc,
-                                        std::string sql_join_conjuncts, std::vector<ExprContext*>&& join_conjuncts,
+    SpillableNLJoinProbeOperatorFactory(int32_t id, int32_t plan_node_id, RecordDescriptor left_record_desc,
+                                        RecordDescriptor right_record_desc, std::string sql_join_conjuncts,
+                                        std::vector<ExprContext*>&& join_conjuncts,
                                         std::vector<ExprContext*>&& conjunct_ctxs,
                                         std::map<SlotId, ExprContext*>&& common_expr_ctxs,
                                         std::shared_ptr<NLJoinContext>&& cross_join_context, TJoinOp::type join_op)
             : OperatorWithDependencyFactory(id, "spillable_nl_join_left", plan_node_id),
               _join_op(join_op),
-              _left_row_desc(left_row_desc),
-              _right_row_desc(right_row_desc),
+              _left_record_desc(std::move(left_record_desc)),
+              _right_record_desc(std::move(right_record_desc)),
               _sql_join_conjuncts(std::move(sql_join_conjuncts)),
               _join_conjuncts(std::move(join_conjuncts)),
               _conjunct_ctxs(std::move(conjunct_ctxs)),
@@ -175,11 +175,11 @@ public:
     void close(RuntimeState* state) override;
 
 private:
-    void _init_row_desc();
+    void _init_col_types();
 
     const TJoinOp::type _join_op;
-    const RowDescriptor& _left_row_desc;
-    const RowDescriptor& _right_row_desc;
+    const RecordDescriptor _left_record_desc;
+    const RecordDescriptor _right_record_desc;
 
     std::vector<SlotDescriptor*> _col_types;
     size_t _probe_column_count = 0;

--- a/be/src/exec/pipeline/set/union_passthrough_operator.h
+++ b/be/src/exec/pipeline/set/union_passthrough_operator.h
@@ -81,12 +81,11 @@ class UnionPassthroughOperatorFactory final : public OperatorFactory {
 public:
     UnionPassthroughOperatorFactory(int32_t id, int32_t plan_node_id,
                                     UnionPassthroughOperator::SlotMap* dst2src_slot_map,
-                                    const std::vector<SlotDescriptor*>& dst_slots,
-                                    const std::vector<SlotDescriptor*>& src_slots)
+                                    std::vector<SlotDescriptor*> dst_slots, std::vector<SlotDescriptor*> src_slots)
             : OperatorFactory(id, "union_passthrough", plan_node_id),
               _dst2src_slot_map(dst2src_slot_map),
-              _dst_slots(dst_slots),
-              _src_slots(src_slots) {}
+              _dst_slots(std::move(dst_slots)),
+              _src_slots(std::move(src_slots)) {}
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
         return std::make_shared<UnionPassthroughOperator>(this, _id, _plan_node_id, driver_sequence, _dst2src_slot_map,
@@ -97,8 +96,8 @@ private:
     // It will be nullptr, if _pass_through_slot_maps of UnionNode is empty.
     UnionPassthroughOperator::SlotMap* _dst2src_slot_map;
 
-    const std::vector<SlotDescriptor*>& _dst_slots;
-    const std::vector<SlotDescriptor*>& _src_slots;
+    const std::vector<SlotDescriptor*> _dst_slots;
+    const std::vector<SlotDescriptor*> _src_slots;
 };
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/sink/export_sink_operator.h
+++ b/be/src/exec/pipeline/sink/export_sink_operator.h
@@ -24,8 +24,6 @@
 
 namespace starrocks {
 
-class RowDescriptor;
-
 namespace pipeline {
 
 class ExportSinkIOBuffer;

--- a/be/src/exec/pipeline/sink/memory_scratch_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/memory_scratch_sink_operator.cpp
@@ -123,11 +123,11 @@ void MemoryScratchSinkOperator::try_to_put_sentinel() {
     }
 }
 
-MemoryScratchSinkOperatorFactory::MemoryScratchSinkOperatorFactory(int32_t id, const RowDescriptor& row_desc,
+MemoryScratchSinkOperatorFactory::MemoryScratchSinkOperatorFactory(int32_t id, RecordDescriptor record_desc,
                                                                    std::vector<TExpr> t_output_expr,
                                                                    FragmentContext* const fragment_ctx)
         : OperatorFactory(id, "memory_scratch_sink", Operator::s_pseudo_plan_node_id_for_final_sink),
-          _row_desc(row_desc),
+          _record_desc(std::move(record_desc)),
           _t_output_expr(std::move(t_output_expr)) {}
 
 Status MemoryScratchSinkOperatorFactory::prepare(RuntimeState* state) {
@@ -136,7 +136,7 @@ Status MemoryScratchSinkOperatorFactory::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(ExprExecutor::prepare(_output_expr_ctxs, state));
     RETURN_IF_ERROR(ExprExecutor::open(_output_expr_ctxs, state));
     _prepare_id_to_col_name_map();
-    RETURN_IF_ERROR(convert_to_arrow_schema(_row_desc, _id_to_col_name, &_arrow_schema, _output_expr_ctxs));
+    RETURN_IF_ERROR(convert_to_arrow_schema(_id_to_col_name, &_arrow_schema, _output_expr_ctxs));
 
     TUniqueId fragment_instance_id = state->fragment_instance_id();
     auto* query_execution_services = state->query_execution_services();
@@ -150,14 +150,9 @@ void MemoryScratchSinkOperatorFactory::close(RuntimeState* state) {
 }
 
 void MemoryScratchSinkOperatorFactory::_prepare_id_to_col_name_map() {
-    for (auto* tuple_desc : _row_desc.tuple_descriptors()) {
-        auto& slots = tuple_desc->slots();
-        int64_t tuple_id = tuple_desc->id();
-        for (auto slot : slots) {
-            int64_t slot_id = slot->id();
-            int64_t id = tuple_id << 32 | slot_id;
-            _id_to_col_name.emplace(id, slot->col_name());
-        }
+    for (const auto* slot : _record_desc.slots()) {
+        int64_t id = static_cast<int64_t>(slot->parent()) << 32 | slot->id();
+        _id_to_col_name.emplace(id, slot->col_name());
     }
 }
 

--- a/be/src/exec/pipeline/sink/memory_scratch_sink_operator.h
+++ b/be/src/exec/pipeline/sink/memory_scratch_sink_operator.h
@@ -21,6 +21,7 @@
 #include "exec/pipeline/fragment_context.h"
 #include "exec_primitive/pipeline/operator_factory.h"
 #include "gen_cpp/InternalService_types.h"
+#include "runtime/descriptors.h"
 
 namespace arrow {
 class MemoryPool;
@@ -80,7 +81,7 @@ private:
 
 class MemoryScratchSinkOperatorFactory final : public OperatorFactory {
 public:
-    MemoryScratchSinkOperatorFactory(int32_t id, const RowDescriptor& row_desc, std::vector<TExpr> t_output_expr,
+    MemoryScratchSinkOperatorFactory(int32_t id, RecordDescriptor record_desc, std::vector<TExpr> t_output_expr,
                                      FragmentContext* const fragment_ctx);
 
     ~MemoryScratchSinkOperatorFactory() override = default;
@@ -99,7 +100,7 @@ private:
     void _increment_num_sinkers_no_barrier() { _num_sinkers.fetch_add(1, std::memory_order_relaxed); }
     void _prepare_id_to_col_name_map();
 
-    const RowDescriptor _row_desc;
+    const RecordDescriptor _record_desc;
     std::shared_ptr<arrow::Schema> _arrow_schema;
     std::vector<TExpr> _t_output_expr;
     std::vector<ExprContext*> _output_expr_ctxs;

--- a/be/src/exec/pipeline/sink/result_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/result_sink_operator.cpp
@@ -74,8 +74,7 @@ Status ResultSinkOperator::prepare(RuntimeState* state) {
         _writer = std::make_shared<CustomizedResultWriter>(_sender.get(), _output_expr_ctxs, profile);
         break;
     case TResultSinkType::ARROW_FLIGHT_PROTOCAL:
-        _writer = std::make_shared<ArrowResultWriter>(_sender.get(), _output_expr_ctxs, _output_column_names, profile,
-                                                      _row_desc);
+        _writer = std::make_shared<ArrowResultWriter>(_sender.get(), _output_expr_ctxs, _output_column_names, profile);
         break;
     default:
         return Status::InternalError("Unknown result sink type");

--- a/be/src/exec/pipeline/sink/result_sink_operator.h
+++ b/be/src/exec/pipeline/sink/result_sink_operator.h
@@ -33,8 +33,7 @@ public:
                        TResultSinkType::type sink_type, bool is_binary_format, TResultSinkFormatType::type format_type,
                        std::vector<ExprContext*> output_expr_ctxs, const std::shared_ptr<BufferControlBlock>& sender,
                        std::atomic<int32_t>& num_sinks, std::atomic<int64_t>& num_written_rows,
-                       const std::vector<std::string>& output_column_names, FragmentContext* const fragment_ctx,
-                       const RowDescriptor& row_desc)
+                       const std::vector<std::string>& output_column_names, FragmentContext* const fragment_ctx)
             : Operator(factory, id, "result_sink", plan_node_id, false, driver_sequence),
               _sink_type(sink_type),
               _is_binary_format(is_binary_format),
@@ -44,8 +43,7 @@ public:
               _num_sinkers(num_sinks),
               _num_written_rows(num_written_rows),
               _output_column_names(output_column_names),
-              _fragment_ctx(fragment_ctx),
-              _row_desc(row_desc) {}
+              _fragment_ctx(fragment_ctx) {}
 
     ~ResultSinkOperator() override = default;
 
@@ -91,15 +89,13 @@ private:
     bool _is_finished = false;
 
     FragmentContext* const _fragment_ctx;
-    const RowDescriptor& _row_desc;
 };
 
 class ResultSinkOperatorFactory final : public OperatorFactory {
 public:
     ResultSinkOperatorFactory(int32_t id, size_t dop, TResultSinkType::type sink_type, bool is_binary_format,
                               TResultSinkFormatType::type format_type, std::vector<TExpr> t_output_expr,
-                              FragmentContext* const fragment_ctx, const RowDescriptor& row_desc,
-                              std::vector<std::string> output_column_names)
+                              FragmentContext* const fragment_ctx, std::vector<std::string> output_column_names)
             : OperatorFactory(id, "result_sink", Operator::s_pseudo_plan_node_id_for_final_sink),
               _dop(dop),
               _sink_type(sink_type),
@@ -107,7 +103,6 @@ public:
               _format_type(format_type),
               _t_output_expr(std::move(t_output_expr)),
               _fragment_ctx(fragment_ctx),
-              _row_desc(row_desc),
               _output_column_names(std::move(output_column_names)) {}
 
     ~ResultSinkOperatorFactory() override = default;
@@ -120,10 +115,9 @@ public:
         // of increasing _num_sinkers to ResultSinkOperator::close is guaranteed by pipeline driver queue,
         // so it doesn't need memory barrier here.
         _increment_num_sinkers_no_barrier();
-        return std::make_shared<ResultSinkOperator>(this, _id, _plan_node_id, driver_sequence, _sink_type,
-                                                    _is_binary_format, _format_type, _output_expr_ctxs, _sender,
-                                                    _num_sinkers, _num_written_rows, _output_column_names,
-                                                    _fragment_ctx, _row_desc);
+        return std::make_shared<ResultSinkOperator>(
+                this, _id, _plan_node_id, driver_sequence, _sink_type, _is_binary_format, _format_type,
+                _output_expr_ctxs, _sender, _num_sinkers, _num_written_rows, _output_column_names, _fragment_ctx);
     }
 
     Status prepare(RuntimeState* state) override;
@@ -149,7 +143,6 @@ private:
     std::atomic<int64_t> _num_written_rows = 0;
 
     FragmentContext* const _fragment_ctx;
-    const RowDescriptor& _row_desc;
 
     const std::vector<std::string> _output_column_names;
 };

--- a/be/src/exec/pipeline/sort/local_parallel_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/sort/local_parallel_merge_sort_source_operator.cpp
@@ -155,7 +155,7 @@ OperatorPtr LocalParallelMergeSortSourceOperatorFactory::create(int32_t degree_o
             }
             _mergers.push_back(std::make_unique<merge_path::MergePathCascadeMerger>(
                     _state->chunk_size(), degree_of_parallelism, sort_context->sort_exprs(), sort_context->sort_descs(),
-                    _tuple_desc, sort_context->topn_type(), sort_context->offset(), sort_context->limit(),
+                    _record_desc, sort_context->topn_type(), sort_context->offset(), sort_context->limit(),
                     chunk_providers, _late_materialize_mode));
         }
         return std::make_shared<LocalParallelMergeSortSourceOperator>(
@@ -166,7 +166,7 @@ OperatorPtr LocalParallelMergeSortSourceOperatorFactory::create(int32_t degree_o
         DCHECK(chunks_sorter != nullptr);
         chunk_providers.emplace_back(chunk_provider_factory(chunks_sorter));
         _mergers.push_back(std::make_unique<merge_path::MergePathCascadeMerger>(
-                _state->chunk_size(), 1, sort_context->sort_exprs(), sort_context->sort_descs(), _tuple_desc,
+                _state->chunk_size(), 1, sort_context->sort_exprs(), sort_context->sort_descs(), _record_desc,
                 sort_context->topn_type(), sort_context->offset(), sort_context->limit(), chunk_providers));
         return std::make_shared<LocalParallelMergeSortSourceOperator>(this, _id, _plan_node_id, driver_sequence,
                                                                       sort_context.get(), _is_gathered,

--- a/be/src/exec/pipeline/sort/local_parallel_merge_sort_source_operator.h
+++ b/be/src/exec/pipeline/sort/local_parallel_merge_sort_source_operator.h
@@ -109,12 +109,12 @@ public:
     Status prepare(RuntimeState* state) override;
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override;
 
-    void set_tuple_desc(const TupleDescriptor* tuple_desc) { _tuple_desc = tuple_desc; }
+    void set_record_desc(RecordDescriptor record_desc) { _record_desc = std::move(record_desc); }
     void set_is_gathered(const bool is_gathered) { _is_gathered = is_gathered; }
     void set_materialized_mode(TLateMaterializeMode::type mode) { _late_materialize_mode = mode; }
 
 private:
-    const TupleDescriptor* _tuple_desc;
+    RecordDescriptor _record_desc;
     bool _is_gathered = true;
     RuntimeState* _state;
     TLateMaterializeMode::type _late_materialize_mode = TLateMaterializeMode::AUTO;

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
@@ -69,7 +69,7 @@ StatusOr<ChunkPtr> PartitionSortSinkOperator::pull_chunk(RuntimeState* state) {
 }
 
 Status PartitionSortSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
-    auto materialize_chunk = ChunksSorter::materialize_chunk_before_sort(chunk.get(), _materialized_tuple_desc,
+    auto materialize_chunk = ChunksSorter::materialize_chunk_before_sort(chunk.get(), _materialized_record_desc,
                                                                          _sort_exec_exprs, _order_by_types);
     RETURN_IF_ERROR(materialize_chunk);
     TRY_CATCH_BAD_ALLOC(RETURN_IF_ERROR(_chunks_sorter->update(state, materialize_chunk.value())));
@@ -118,7 +118,7 @@ Status PartitionSortSinkOperator::set_finishing(RuntimeState* state) {
 
 Status PartitionSortSinkOperatorFactory::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(OperatorFactory::prepare(state));
-    RETURN_IF_ERROR(_sort_exec_exprs.prepare(state, _parent_node_row_desc, _parent_node_child_row_desc));
+    RETURN_IF_ERROR(_sort_exec_exprs.prepare(state));
     RETURN_IF_ERROR(_sort_exec_exprs.open(state));
     RETURN_IF_ERROR(ExprExecutor::prepare(_analytic_partition_exprs, state));
     RETURN_IF_ERROR(ExprExecutor::open(_analytic_partition_exprs, state));
@@ -148,7 +148,7 @@ OperatorPtr PartitionSortSinkOperatorFactory::create(int32_t dop, int32_t driver
     auto sort_context = _sort_context_factory->create(driver_sequence);
     sort_context->add_partition_chunks_sorter(chunks_sorter);
     auto ope = std::make_shared<PartitionSortSinkOperator>(this, _id, _plan_node_id, driver_sequence, chunks_sorter,
-                                                           _sort_exec_exprs, _order_by_types, _materialized_tuple_desc,
+                                                           _sort_exec_exprs, _order_by_types, _materialized_record_desc,
                                                            sort_context.get(), _runtime_filter_hub);
     return ope;
 }

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
@@ -46,13 +46,14 @@ class PartitionSortSinkOperator : public Operator {
 public:
     PartitionSortSinkOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
                               std::shared_ptr<ChunksSorter> chunks_sorter, SortExecExprs& sort_exec_exprs,
-                              const std::vector<OrderByType>& order_by_types, TupleDescriptor* materialized_tuple_desc,
-                              SortContext* sort_context, RuntimeFilterHub* hub, const char* name = "local_sort_sink")
+                              const std::vector<OrderByType>& order_by_types,
+                              const RecordDescriptor& materialized_record_desc, SortContext* sort_context,
+                              RuntimeFilterHub* hub, const char* name = "local_sort_sink")
             : Operator(factory, id, name, plan_node_id, false, driver_sequence),
               _chunks_sorter(std::move(chunks_sorter)),
               _sort_exec_exprs(sort_exec_exprs),
               _order_by_types(order_by_types),
-              _materialized_tuple_desc(materialized_tuple_desc),
+              _materialized_record_desc(materialized_record_desc),
               _sort_context(sort_context),
               _hub(hub) {}
 
@@ -86,8 +87,8 @@ protected:
     SortExecExprs& _sort_exec_exprs;
     const std::vector<OrderByType>& _order_by_types;
 
-    // Cached descriptor for the materialized tuple. Assigned in Prepare().
-    TupleDescriptor* _materialized_tuple_desc;
+    // Describes the record materialized before sorting.
+    const RecordDescriptor& _materialized_record_desc;
 
     SortContext* _sort_context;
     RuntimeFilterHub* _hub;
@@ -100,8 +101,7 @@ public:
             int32_t id, int32_t plan_node_id, std::shared_ptr<SortContextFactory> sort_context_factory,
             SortExecExprs& sort_exec_exprs, std::vector<bool> is_asc_order, std::vector<bool> is_null_first,
             std::string sort_keys, int64_t offset, int64_t limit, const TTopNType::type topn_type,
-            const std::vector<OrderByType>& order_by_types, TupleDescriptor* materialized_tuple_desc,
-            const RowDescriptor& parent_node_row_desc, const RowDescriptor& parent_node_child_row_desc,
+            const std::vector<OrderByType>& order_by_types, RecordDescriptor materialized_record_desc,
             std::vector<ExprContext*> analytic_partition_exprs, int64_t max_buffered_rows, int64_t max_buffered_bytes,
             std::vector<SlotId> early_materialized_slots, SpillProcessChannelFactoryPtr spill_channel_factory,
             const char* name = "local_sort_sink")
@@ -115,9 +115,7 @@ public:
               _limit(limit),
               _topn_type(topn_type),
               _order_by_types(order_by_types),
-              _materialized_tuple_desc(materialized_tuple_desc),
-              _parent_node_row_desc(parent_node_row_desc),
-              _parent_node_child_row_desc(parent_node_child_row_desc),
+              _materialized_record_desc(std::move(materialized_record_desc)),
               _analytic_partition_exprs(std::move(analytic_partition_exprs)),
               _max_buffered_rows(max_buffered_rows),
               _max_buffered_bytes(max_buffered_bytes),
@@ -145,12 +143,10 @@ protected:
     const TTopNType::type _topn_type;
     const std::vector<OrderByType>& _order_by_types;
 
-    // Cached descriptor for the materialized tuple. Assigned in Prepare().
-    TupleDescriptor* _materialized_tuple_desc;
+    // Describes the record materialized before sorting.
+    const RecordDescriptor _materialized_record_desc;
 
     // Used to get needed data from TopNNode.
-    const RowDescriptor& _parent_node_row_desc;
-    const RowDescriptor& _parent_node_child_row_desc;
     std::vector<ExprContext*> _analytic_partition_exprs;
     int64_t _max_buffered_rows;
     int64_t _max_buffered_bytes;

--- a/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
@@ -139,7 +139,7 @@ OperatorPtr SpillablePartitionSortSinkOperatorFactory::create(int32_t degree_of_
     sort_context->add_partition_chunks_sorter(chunks_sorter);
     auto ope = std::make_shared<SpillablePartitionSortSinkOperator>(
             this, _id, _plan_node_id, driver_sequence, chunks_sorter, _sort_exec_exprs, _order_by_types,
-            _materialized_tuple_desc, sort_context.get(), _runtime_filter_hub);
+            _materialized_record_desc, sort_context.get(), _runtime_filter_hub);
 
     return ope;
 }

--- a/be/src/exec/project_node.cpp
+++ b/be/src/exec/project_node.cpp
@@ -63,7 +63,7 @@ Status ProjectNode::init(const TPlanNode& tnode, RuntimeState* state) {
     _type_is_nullable.reserve(column_size);
 
     std::map<SlotId, bool> slot_null_mapping;
-    for (auto const& slot : row_desc().tuple_descriptors()[0]->slots()) {
+    for (auto const& slot : record_desc().slots()) {
         slot_null_mapping[slot->id()] = slot->is_nullable();
     }
 
@@ -240,7 +240,7 @@ void ProjectNode::push_down_join_runtime_filter(RuntimeState* state, RuntimeFilt
             if (_slot_ids[i] == slot_id) {
                 // replace with new probe expr
                 ExprContext* new_probe_expr_ctx = _expr_ctxs[i];
-                rf_desc->replace_probe_expr_ctx(state, row_desc(), new_probe_expr_ctx);
+                rf_desc->replace_probe_expr_ctx(state, new_probe_expr_ctx);
                 match = true;
                 break;
             }

--- a/be/src/exec/short_circuit.cpp
+++ b/be/src/exec/short_circuit.cpp
@@ -178,7 +178,7 @@ Status ShortCircuitExecutor::prepare(TExecShortCircuitParams& common_request) {
         // sink is not mysql result sink
         TPlanFragmentExecParams t_params;
         RETURN_IF_ERROR(DataSink::create_data_sink(runtime_state(), _common_request->data_sink, output_exprs, t_params,
-                                                   0, _source->row_desc(), &_sink));
+                                                   0, _source->record_desc(), &_sink));
     } else {
         bool is_binary_format = _common_request->is_binary_row;
         _sink = std::make_unique<MysqlResultMemorySink>(output_exprs, is_binary_format, _results);

--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -47,7 +47,6 @@ TopNNode::TopNNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl
         : PipelineNode(pool, tnode, descs), _tnode(tnode) {
     _sort_keys = tnode.sort_node.__isset.sql_sort_keys ? tnode.sort_node.sql_sort_keys : "NONE";
     _offset = tnode.sort_node.__isset.offset ? tnode.sort_node.offset : 0;
-    _materialized_tuple_desc = nullptr;
 }
 
 TopNNode::~TopNNode() {
@@ -103,8 +102,7 @@ Status TopNNode::init(const TPlanNode& tnode, RuntimeState* state) {
 
     DCHECK_EQ(_conjuncts.size(), 0) << "TopNNode should never have predicates to evaluate.";
     _abort_on_default_limit_exceeded = tnode.sort_node.is_default_limit;
-    _materialized_tuple_desc = _row_descriptor.tuple_descriptors()[0];
-    DCHECK(_materialized_tuple_desc != nullptr);
+    DCHECK(_tuple_ids.size() == 1) << "TopNNode should only have one tuple id.";
 
     bool all_slot_ref = true;
     std::unordered_set<SlotId> early_materialized_slots;
@@ -126,7 +124,7 @@ Status TopNNode::init(const TPlanNode& tnode, RuntimeState* state) {
     // but if c0 is tinyint, the byte width of the element of c0 is 1, obviously permuting ordinal column costs more.
     // The permutation cost is proportion of the total size of bytes of the elements of non-group-by columns.
     int materialized_cost = 0;
-    for (auto* slot : _materialized_tuple_desc->slots()) {
+    for (auto* slot : _record_descriptor.slots()) {
         if (early_materialized_slots.count(slot->id())) {
             continue;
         }
@@ -234,11 +232,12 @@ StatusOr<pipeline::OpFactories> TopNNode::_decompose_to_pipeline(pipeline::Pipel
         max_buffered_rows = _tnode.sort_node.max_buffered_rows;
     }
 
-    sink_operator = std::make_shared<SinkFactory>(
-            context->next_operator_id(), id(), context_factory, _sort_exec_exprs, _is_asc_order, _is_null_first,
-            _sort_keys, _offset, _limit, _tnode.sort_node.topn_type, _order_by_types, _materialized_tuple_desc,
-            child(0)->row_desc(), _row_descriptor, _analytic_partition_exprs, max_buffered_rows, max_buffered_bytes,
-            _early_materialized_slots, spill_channel_factory);
+    // The record produced by TopNNode is the record materialized before sorting.
+    sink_operator = std::make_shared<SinkFactory>(context->next_operator_id(), id(), context_factory, _sort_exec_exprs,
+                                                  _is_asc_order, _is_null_first, _sort_keys, _offset, _limit,
+                                                  _tnode.sort_node.topn_type, _order_by_types, _record_descriptor,
+                                                  _analytic_partition_exprs, max_buffered_rows, max_buffered_bytes,
+                                                  _early_materialized_slots, spill_channel_factory);
 
     // Initialize OperatorFactory's fields involving runtime filters.
     pipeline::init_runtime_filter_for_operator(*this, sink_operator.get(), context, rc_rf_probe_collector);
@@ -249,7 +248,7 @@ StatusOr<pipeline::OpFactories> TopNNode::_decompose_to_pipeline(pipeline::Pipel
     source_operator = std::make_shared<SourceFactory>(context->next_operator_id(), id(), context_factory);
     if constexpr (std::is_same_v<LocalParallelMergeSortSourceOperatorFactory, SourceFactory>) {
         down_cast<LocalParallelMergeSortSourceOperatorFactory*>(source_operator.get())
-                ->set_tuple_desc(_materialized_tuple_desc);
+                ->set_record_desc(_record_descriptor);
         down_cast<LocalParallelMergeSortSourceOperatorFactory*>(source_operator.get())->set_is_gathered(need_merge);
         if (_tnode.sort_node.__isset.parallel_merge_late_materialize_mode) {
             down_cast<LocalParallelMergeSortSourceOperatorFactory*>(source_operator.get())

--- a/be/src/exec/topn_node.h
+++ b/be/src/exec/topn_node.h
@@ -65,9 +65,6 @@ private:
 
     std::vector<ExprContext*> _local_partition_exprs;
 
-    // Cached descriptor for the materialized tuple. Assigned in Prepare().
-    TupleDescriptor* _materialized_tuple_desc;
-
     // True if the _limit comes from DEFAULT_ORDER_BY_LIMIT and option
     // ABORT_ON_DEFAULT_LIMIT_EXCEEDED is set.
     bool _abort_on_default_limit_exceeded = false;

--- a/be/src/exec/union_node.cpp
+++ b/be/src/exec/union_node.cpp
@@ -264,8 +264,6 @@ Status UnionNode::_get_next_const(RuntimeState* state, ChunkPtr* chunk) {
 }
 
 void UnionNode::_move_passthrough_chunk(ChunkPtr& src_chunk, ChunkPtr& dest_chunk) {
-    const auto& tuple_descs = child(_child_idx)->row_desc().tuple_descriptors();
-
     if (!_pass_through_slot_maps.empty()) {
         for (auto* dest_slot : _tuple_desc->slots()) {
             auto slot_item = _pass_through_slot_maps[_child_idx][dest_slot->id()];
@@ -279,15 +277,7 @@ void UnionNode::_move_passthrough_chunk(ChunkPtr& src_chunk, ChunkPtr& dest_chun
             }
         }
     } else {
-        // For backward compatibility
-        // TODO(kks): when StarRocks 2.0 release, we could remove this branch.
-        size_t index = 0;
-        // When pass through, the child tuple size must be 1;
-        for (auto* src_slot : tuple_descs[0]->slots()) {
-            auto* dest_slot = _tuple_desc->slots()[index++];
-            ColumnPtr& column = src_chunk->get_column_by_slot_id(src_slot->id());
-            _move_column(dest_chunk, column, dest_slot, src_chunk->num_rows());
-        }
+        DCHECK(false) << "unreachable path";
     }
 }
 
@@ -384,12 +374,11 @@ StatusOr<pipeline::OpFactories> UnionNode::decompose_to_pipeline(pipeline::Pipel
                 context->fragment_context()->runtime_state()->desc_tbl().get_tuple_descriptor(_tuple_id);
         const auto& dst_slots = dst_tuple_desc->slots();
 
-        // When pass through, the child tuple size must be 1;
-        const auto& tuple_descs = child(i)->row_desc().tuple_descriptors();
-        const auto& src_slots = tuple_descs[0]->slots();
+        auto src_slots_view = child(i)->record_desc().slots();
+        std::vector<SlotDescriptor*> src_slots(src_slots_view.begin(), src_slots_view.end());
 
         auto union_passthrough_op = std::make_shared<UnionPassthroughOperatorFactory>(
-                context->next_operator_id(), id(), dst2src_slot_map, dst_slots, src_slots);
+                context->next_operator_id(), id(), dst2src_slot_map, dst_slots, std::move(src_slots));
         operators_list[i].emplace_back(std::move(union_passthrough_op));
         // Initialize OperatorFactory's fields involving runtime filters.
         pipeline::init_runtime_filter_for_operator(*this, operators_list[i].back().get(), context,

--- a/be/src/exec_primitive/arrow/result_to_arrow_converter.cpp
+++ b/be/src/exec_primitive/arrow/result_to_arrow_converter.cpp
@@ -50,8 +50,7 @@ ColumnRef* find_first_column_ref(Expr* expr) {
 
 } // namespace
 
-Status convert_to_arrow_schema(const RowDescriptor& row_desc,
-                               const std::unordered_map<int64_t, std::string>& id_to_col_name,
+Status convert_to_arrow_schema(const std::unordered_map<int64_t, std::string>& id_to_col_name,
                                std::shared_ptr<arrow::Schema>* result,
                                const std::vector<ExprContext*>& output_expr_ctxs,
                                const std::vector<std::string>* output_column_names, int32_t flight_sql_version) {
@@ -73,7 +72,7 @@ Status convert_to_arrow_schema(const RowDescriptor& row_desc,
         } else if (auto it = id_to_col_name.find(id); it != id_to_col_name.end()) {
             col_name = it->second;
         } else {
-            LOG(WARNING) << "Can't find the RefSlot in the row_desc.";
+            LOG(WARNING) << "Can't find the RefSlot in the record descriptor.";
         }
 
         if (flight_sql_version <= 0) {

--- a/be/src/exec_primitive/arrow/result_to_arrow_converter.h
+++ b/be/src/exec_primitive/arrow/result_to_arrow_converter.h
@@ -36,11 +36,9 @@ namespace starrocks {
 
 class Chunk;
 class ExprContext;
-class RowDescriptor;
 struct TypeDescriptor;
 
-Status convert_to_arrow_schema(const RowDescriptor& row_desc,
-                               const std::unordered_map<int64_t, std::string>& id_to_col_name,
+Status convert_to_arrow_schema(const std::unordered_map<int64_t, std::string>& id_to_col_name,
                                std::shared_ptr<arrow::Schema>* result,
                                const std::vector<ExprContext*>& output_expr_ctxs,
                                const std::vector<std::string>* output_column_names = nullptr,

--- a/be/src/exec_primitive/data_sink.h
+++ b/be/src/exec_primitive/data_sink.h
@@ -50,7 +50,7 @@ class Chunk;
 class DataStreamSender;
 class ObjectPool;
 class QueryStatistics;
-class RowDescriptor;
+class RecordDescriptor;
 class RuntimeProfile;
 class RuntimeState;
 class TPlanFragmentExecParams;
@@ -89,7 +89,8 @@ public:
     // new sink is written to *sink, and is owned by the caller.
     static Status create_data_sink(RuntimeState* state, const TDataSink& thrift_sink,
                                    const std::vector<TExpr>& output_exprs, const TPlanFragmentExecParams& params,
-                                   int32_t sender_id, const RowDescriptor& row_desc, std::unique_ptr<DataSink>* sink);
+                                   int32_t sender_id, const RecordDescriptor& record_desc,
+                                   std::unique_ptr<DataSink>* sink);
 
     // Returns the runtime profile for the sink.
     virtual RuntimeProfile* profile() = 0;

--- a/be/src/exec_primitive/exec_node.cpp
+++ b/be/src/exec_primitive/exec_node.cpp
@@ -68,7 +68,7 @@ ExecNode::ExecNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl
           _type(tnode.node_type),
           _pool(pool),
           _tuple_ids(tnode.row_tuples),
-          _row_descriptor(descs, tnode.row_tuples),
+          _record_descriptor(descs, tnode.row_tuples),
           _limit(tnode.limit) {
     init_runtime_profile(print_plan_node_type(tnode.node_type));
 }

--- a/be/src/exec_primitive/exec_node.h
+++ b/be/src/exec_primitive/exec_node.h
@@ -173,7 +173,7 @@ public:
 
     int id() const { return _id; }
     TPlanNodeType::type type() const { return _type; }
-    const RowDescriptor& row_desc() const { return _row_descriptor; }
+    const RecordDescriptor& record_desc() const { return _record_descriptor; }
     int64_t rows_returned() const { return _num_rows_returned; }
     int64_t limit() const { return _limit; }
     bool reached_limit() { return _limit != -1 && _num_rows_returned >= _limit; }
@@ -221,7 +221,7 @@ protected:
     std::set<TPlanNodeId> _local_rf_waiting_set;
 
     std::vector<ExecNode*> _children;
-    RowDescriptor _row_descriptor;
+    RecordDescriptor _record_descriptor;
 
     // debug-only: if _debug_action is not INVALID, node will perform action in
     // _debug_phase

--- a/be/src/exec_primitive/pipeline/operator_factory.h
+++ b/be/src/exec_primitive/pipeline/operator_factory.h
@@ -17,6 +17,7 @@
 #include <mutex>
 
 #include "exec_primitive/pipeline/operator.h"
+#include "exec_primitive/pipeline/runtime_filter_core_types.h"
 
 namespace starrocks::pipeline {
 
@@ -42,14 +43,14 @@ public:
 
     // Invoked by the ExecNode-to-pipeline adapter to initialize fields involving runtime filter.
     void init_runtime_filter(RuntimeFilterHub* runtime_filter_hub, const std::vector<TTupleId>& tuple_ids,
-                             const LocalRFWaitingSet& rf_waiting_set, const RowDescriptor& row_desc,
+                             const LocalRFWaitingSet& rf_waiting_set, const RecordDescriptor& record_desc,
                              const std::shared_ptr<RefCountedRuntimeFilterProbeCollector>& runtime_filter_collector,
                              const std::vector<SlotId>& filter_null_value_columns,
                              const std::vector<TupleSlotMapping>& tuple_slot_mappings) {
         _runtime_filter_hub = runtime_filter_hub;
         _tuple_ids = tuple_ids;
         _rf_waiting_set = rf_waiting_set;
-        _row_desc = row_desc;
+        _record_desc = &record_desc;
         _runtime_filter_collector = runtime_filter_collector;
         _filter_null_value_columns = filter_null_value_columns;
         _tuple_slot_mappings = tuple_slot_mappings;
@@ -75,7 +76,7 @@ public:
 
     RuntimeState* runtime_state() const { return _state; }
 
-    RowDescriptor* row_desc() { return &_row_desc; }
+    const RecordDescriptor* record_desc() const { return _record_desc; }
 
     // Whether it has any runtime in-filter or bloom-filter.
     // MUST be invoked after init_runtime_filter.
@@ -115,7 +116,7 @@ protected:
     // a set of TPlanNodeIds of HashJoinNode who generates Local RF that take effects on this operator.
     LocalRFWaitingSet _rf_waiting_set;
     std::once_flag _prepare_runtime_in_filters_once;
-    RowDescriptor _row_desc;
+    const RecordDescriptor* _record_desc = nullptr;
     std::vector<ExprContext*> _runtime_in_filters;
     std::shared_ptr<RefCountedRuntimeFilterProbeCollector> _runtime_filter_collector = nullptr;
     std::vector<SlotId> _filter_null_value_columns;

--- a/be/src/exec_primitive/runtime_filter/runtime_filter_probe.cpp
+++ b/be/src/exec_primitive/runtime_filter/runtime_filter_probe.cpp
@@ -114,8 +114,7 @@ void RuntimeFilterProbeDescriptor::close(RuntimeState* state) {
     }
 }
 
-void RuntimeFilterProbeDescriptor::replace_probe_expr_ctx(RuntimeState* state, const RowDescriptor& row_desc,
-                                                          ExprContext* new_probe_expr_ctx) {
+void RuntimeFilterProbeDescriptor::replace_probe_expr_ctx(RuntimeState* state, ExprContext* new_probe_expr_ctx) {
     // close old probe expr
     _probe_expr_ctx->close(state);
     // create new probe expr and open it.

--- a/be/src/exec_primitive/runtime_filter/runtime_filter_probe.h
+++ b/be/src/exec_primitive/runtime_filter/runtime_filter_probe.h
@@ -41,7 +41,6 @@
 namespace starrocks {
 
 class HashJoinNode;
-class RowDescriptor;
 class RuntimeProfile;
 class RuntimeFilterCache;
 
@@ -79,7 +78,7 @@ public:
         return true;
     }
     LogicalType probe_expr_type() const { return _probe_expr_ctx->root()->type().type; }
-    void replace_probe_expr_ctx(RuntimeState* state, const RowDescriptor& row_desc, ExprContext* new_probe_expr_ctx);
+    void replace_probe_expr_ctx(RuntimeState* state, ExprContext* new_probe_expr_ctx);
     std::string debug_string() const;
     bool is_local() const { return _is_local; }
     TPlanNodeId build_plan_node_id() const { return _build_plan_node_id; }

--- a/be/src/exprs/sort_exec_exprs.cpp
+++ b/be/src/exprs/sort_exec_exprs.cpp
@@ -56,8 +56,7 @@ Status SortExecExprs::init(const std::vector<ExprContext*>& lhs_ordering_expr_ct
     return Status::OK();
 }
 
-Status SortExecExprs::prepare(RuntimeState* state, const RowDescriptor& child_row_desc,
-                              const RowDescriptor& output_row_desc) {
+Status SortExecExprs::prepare(RuntimeState* state) {
     _runtime_state = state;
     if (_materialize_tuple) {
         RETURN_IF_ERROR(ExprExecutor::prepare(_sort_tuple_slot_expr_ctxs, state));

--- a/be/src/exprs/sort_exec_exprs.h
+++ b/be/src/exprs/sort_exec_exprs.h
@@ -19,7 +19,6 @@
 
 namespace starrocks {
 
-class RowDescriptor;
 class TSortInfo;
 
 // Helper class to Prepare() , Open() and Close() the ordering expressions used to perform
@@ -42,7 +41,7 @@ public:
                 ObjectPool* pool, RuntimeState* state);
 
     // prepare all expressions used for sorting and tuple materialization.
-    Status prepare(RuntimeState* state, const RowDescriptor& child_row_desc, const RowDescriptor& output_row_desc);
+    Status prepare(RuntimeState* state);
 
     // open all expressions used for sorting and tuple materialization.
     Status open(RuntimeState* state);

--- a/be/src/orchestration/fragment_executor.cpp
+++ b/be/src/orchestration/fragment_executor.cpp
@@ -797,7 +797,7 @@ Status FragmentExecutor::_prepare_pipeline_driver(ExecEnv* exec_env, const Unifi
             _query_ctx->set_final_sink();
         }
         RETURN_IF_ERROR(DataSink::create_data_sink(runtime_state, tsink, fragment.output_exprs, params,
-                                                   request.sender_id(), plan->row_desc(), &datasink));
+                                                   request.sender_id(), plan->record_desc(), &datasink));
         RETURN_IF_ERROR(datasink->decompose_data_sink_to_pipeline(&context, runtime_state, std::move(exec_ops), request,
                                                                   tsink, fragment.output_exprs));
     }

--- a/be/src/orchestration/plan_fragment_executor.cpp
+++ b/be/src/orchestration/plan_fragment_executor.cpp
@@ -170,8 +170,8 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request) {
     // set up sink, if required
     if (request.fragment.__isset.output_sink) {
         RETURN_IF_ERROR(DataSink::create_data_sink(_runtime_state, request.fragment.output_sink,
-                                                   request.fragment.output_exprs, params, params.sender_id, row_desc(),
-                                                   &_sink));
+                                                   request.fragment.output_exprs, params, params.sender_id,
+                                                   record_desc(), &_sink));
         DCHECK(_sink != nullptr);
         RETURN_IF_ERROR(_sink->prepare(runtime_state()));
         _sink->set_query_statistics(_query_statistics);
@@ -251,7 +251,7 @@ Status PlanFragmentExecutor::_open_internal_vectorized() {
 
         if (VLOG_ROW_IS_ON) {
             VLOG_ROW << "_open_internal_vectorized: #rows=" << chunk->num_rows()
-                     << " desc=" << row_desc().debug_string() << " columns=" << chunk->debug_columns();
+                     << " desc=" << record_desc().debug_string() << " columns=" << chunk->debug_columns();
             // TODO(kks): support chunk debug log
         }
 
@@ -422,8 +422,8 @@ void PlanFragmentExecutor::cancel() {
     }
 }
 
-const RowDescriptor& PlanFragmentExecutor::row_desc() {
-    return _plan->row_desc();
+const RecordDescriptor& PlanFragmentExecutor::record_desc() {
+    return _plan->record_desc();
 }
 
 RuntimeProfile* PlanFragmentExecutor::profile() {

--- a/be/src/orchestration/plan_fragment_executor.h
+++ b/be/src/orchestration/plan_fragment_executor.h
@@ -44,13 +44,13 @@
 #include "common/runtime_profile.h"
 #include "common/status.h"
 #include "gen_cpp/Types_types.h"
+#include "runtime/descriptors.h"
 #include "runtime/exec_env_fwd.h"
 #include "runtime/mem_tracker.h"
 
 namespace starrocks {
 
 class ExecNode;
-class RowDescriptor;
 class DataSink;
 class DataStreamMgr;
 class DescriptorTbl;
@@ -107,7 +107,7 @@ public:
 
     // prepare for execution. Call this prior to open().
     // This call won't block.
-    // runtime_state() and row_desc() will not be valid until prepare() is called.
+    // runtime_state() and record_desc() will not be valid until prepare() is called.
     // If request.query_options.mem_limit > 0, it is used as an approximate limit on the
     // number of bytes this query can consume at runtime.
     // The query will be aborted (MEM_LIMIT_EXCEEDED) if it goes over that limit.
@@ -134,7 +134,7 @@ public:
 
     void set_runtime_state(RuntimeState* runtime_state) { _runtime_state = runtime_state; }
 
-    const RowDescriptor& row_desc();
+    const RecordDescriptor& record_desc();
 
     // Profile information for plan and output sink.
     RuntimeProfile* profile();

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -31,7 +31,6 @@
 #include "runtime/runtime_state.h"
 
 namespace starrocks {
-const int RowDescriptor::INVALID_IDX = -1;
 SlotDescriptor::SlotDescriptor(SlotId id, std::string name, TypeDescriptor type, std::pmr::memory_resource* mr)
         : _id(id),
           _type(std::move(type)),
@@ -165,61 +164,33 @@ std::string TupleDescriptor::debug_string() const {
     return out.str();
 }
 
-RowDescriptor::RowDescriptor(const DescriptorTbl& desc_tbl, const std::vector<TTupleId>& row_tuples) {
-    DCHECK_GT(row_tuples.size(), 0);
-
-    for (int row_tuple : row_tuples) {
-        TupleDescriptor* tupleDesc = desc_tbl.get_tuple_descriptor(row_tuple);
-        _tuple_desc_map.push_back(tupleDesc);
-        DCHECK(_tuple_desc_map.back() != nullptr);
-    }
-
-    init_tuple_idx_map();
-}
-
-RowDescriptor::RowDescriptor(TupleDescriptor* tuple_desc) : _tuple_desc_map(1, tuple_desc) {
-    init_tuple_idx_map();
-}
-
-void RowDescriptor::init_tuple_idx_map() {
-    // find max id
-    TupleId max_id = 0;
-    for (auto& i : _tuple_desc_map) {
-        max_id = std::max(i->id(), max_id);
-    }
-
-    _tuple_idx_map.resize(max_id + 1, INVALID_IDX);
-    for (int i = 0; i < _tuple_desc_map.size(); ++i) {
-        _tuple_idx_map[_tuple_desc_map[i]->id()] = i;
+RecordDescriptor::RecordDescriptor(const DescriptorTbl& desc_tbl, const std::vector<TTupleId>& tuple_ids) {
+    _tuple_descs.reserve(tuple_ids.size());
+    for (int tuple_id : tuple_ids) {
+        TupleDescriptor* tuple_desc = desc_tbl.get_tuple_descriptor(tuple_id);
+        DCHECK(tuple_desc != nullptr);
+        _tuple_descs.push_back(tuple_desc);
     }
 }
 
-int RowDescriptor::get_tuple_idx(TupleId id) const {
-    DCHECK_LT(id, _tuple_idx_map.size()) << "RowDescriptor: " << debug_string();
-    return _tuple_idx_map[id];
+size_t RecordDescriptor::num_slots() const {
+    size_t num_slots = 0;
+    for (const auto* tuple_desc : _tuple_descs) {
+        num_slots += tuple_desc->slots().size();
+    }
+    return num_slots;
 }
 
-std::string RowDescriptor::debug_string() const {
+std::string RecordDescriptor::debug_string() const {
     std::stringstream ss;
-
-    ss << "tuple_desc_map: [";
-    for (int i = 0; i < _tuple_desc_map.size(); ++i) {
-        ss << _tuple_desc_map[i]->debug_string();
-        if (i != _tuple_desc_map.size() - 1) {
+    ss << "record_desc: [";
+    for (size_t i = 0; i < _tuple_descs.size(); ++i) {
+        if (i != 0) {
             ss << ", ";
         }
+        ss << _tuple_descs[i]->debug_string();
     }
-    ss << "] ";
-
-    ss << "tuple_id_map: [";
-    for (int i = 0; i < _tuple_idx_map.size(); ++i) {
-        ss << _tuple_idx_map[i];
-        if (i != _tuple_idx_map.size() - 1) {
-            ss << ", ";
-        }
-    }
-    ss << "] ";
-
+    ss << "]";
     return ss.str();
 }
 

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <memory_resource>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -222,44 +223,31 @@ private:
     friend class ObjectPool;
 };
 
-// Records positions of tuples within row produced by ExecNode.
-// TODO: this needs to differentiate between tuples contained in row
-// and tuples produced by ExecNode (parallel to PlanNode.rowTupleIds and
-// PlanNode.tupleIds); right now, we conflate the two (and distinguish based on
-// context; for instance, HdfsScanNode uses these tids to create row batches, ie, the
-// first case, whereas TopNNode uses these tids to copy output rows, ie, the second
-// case)
-class RowDescriptor {
+// Describes the record produced by an ExecNode.
+//
+// It does not expose how the record is split into tuples: consumers only care about the
+// slots the record carries, so they are presented as a single flat sequence and the tuple
+// boundaries are invisible.
+class RecordDescriptor {
 public:
-    RowDescriptor(const DescriptorTbl& desc_tbl, const std::vector<TTupleId>& row_tuples);
+    RecordDescriptor() = default;
+    RecordDescriptor(const DescriptorTbl& desc_tbl, const std::vector<TTupleId>& tuple_ids);
+    explicit RecordDescriptor(TupleDescriptor* tuple_desc) : _tuple_descs(1, tuple_desc) {}
 
-    // standard copy c'tor, made explicit here
-    RowDescriptor(const RowDescriptor& desc) = default;
+    // All the slots of the record, in order of appearance.
+    auto slots() const {
+        return _tuple_descs | std::ranges::views::transform([](const TupleDescriptor* tuple) -> const auto& {
+                   return tuple->slots();
+               }) |
+               std::ranges::views::join;
+    }
 
-    RowDescriptor(TupleDescriptor* tuple_desc);
-
-    // dummy descriptor, needed for the JNI EvalPredicate() function
-    RowDescriptor() = default;
-
-    static const int INVALID_IDX;
-
-    // Returns INVALID_IDX if id not part of this row.
-    int get_tuple_idx(TupleId id) const;
-
-    // Return descriptors for all tuples in this row, in order of appearance.
-    const std::vector<TupleDescriptor*>& tuple_descriptors() const { return _tuple_desc_map; }
+    size_t num_slots() const;
 
     std::string debug_string() const;
 
 private:
-    // Initializes tupleIdxMap during c'tor using the _tuple_desc_map.
-    void init_tuple_idx_map();
-
-    // map from position of tuple w/in row to its descriptor
-    std::vector<TupleDescriptor*> _tuple_desc_map;
-
-    // map from TupleId to position of tuple w/in row
-    std::vector<int> _tuple_idx_map;
+    std::vector<TupleDescriptor*> _tuple_descs;
 };
 
 // used to describe row position, only used in global late materialization

--- a/be/src/runtime/descriptors_fwd.h
+++ b/be/src/runtime/descriptors_fwd.h
@@ -21,7 +21,7 @@ class TableDescriptor;
 class TypeDescriptor;
 class TupleDescriptor;
 class SlotDescriptor;
-class RowDescriptor;
+class RecordDescriptor;
 class RowPositionDescriptor;
 
 } // namespace starrocks

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -71,7 +71,6 @@ class MemTracker;
 class DataStreamRecvr;
 class ResultBufferMgr;
 class LoadErrorHub;
-class RowDescriptor;
 class RuntimeProfile;
 class RuntimeFilterPort;
 class RuntimeFilterRegistry;

--- a/be/src/runtime/serde/protobuf_chunk_serde.cpp
+++ b/be/src/runtime/serde/protobuf_chunk_serde.cpp
@@ -151,9 +151,9 @@ StatusOr<ChunkPB> ProtobufChunkSerde::serialize_without_meta(const Chunk& chunk,
     return std::move(chunk_pb);
 }
 
-StatusOr<Chunk> ProtobufChunkSerde::deserialize(const RowDescriptor& row_desc, const ChunkPB& chunk_pb,
+StatusOr<Chunk> ProtobufChunkSerde::deserialize(const RecordDescriptor& record_desc, const ChunkPB& chunk_pb,
                                                 const int encode_level) {
-    auto res = build_protobuf_chunk_meta(row_desc, chunk_pb);
+    auto res = build_protobuf_chunk_meta(record_desc, chunk_pb);
     if (!res.ok()) {
         return res.status();
     }
@@ -290,7 +290,7 @@ StatusOr<Chunk> ProtobufChunkDeserializer::deserialize(std::string_view buff, in
     return Chunk(std::move(columns), _meta.slot_id_to_index, std::move(chunk_extra_data));
 }
 
-StatusOr<ProtobufChunkMeta> build_protobuf_chunk_meta(const RowDescriptor& row_desc, const ChunkPB& chunk_pb) {
+StatusOr<ProtobufChunkMeta> build_protobuf_chunk_meta(const RecordDescriptor& record_desc, const ChunkPB& chunk_pb) {
     ProtobufChunkMeta chunk_meta;
     if (UNLIKELY(chunk_pb.is_nulls().empty() || chunk_pb.slot_id_map().empty())) {
         return Status::InternalError("chunk_pb _meta could not be empty");
@@ -308,15 +308,12 @@ StatusOr<ProtobufChunkMeta> build_protobuf_chunk_meta(const RowDescriptor& row_d
 
     size_t column_index = 0;
     chunk_meta.types.resize(chunk_pb.is_nulls().size());
-    for (auto* tuple_desc : row_desc.tuple_descriptors()) {
-        const std::vector<SlotDescriptor*>& slots = tuple_desc->slots();
-        for (const auto& kv : chunk_meta.slot_id_to_index) {
-            for (auto slot : slots) {
-                if (kv.first == slot->id()) {
-                    chunk_meta.types[kv.second] = slot->type();
-                    ++column_index;
-                    break;
-                }
+    for (const auto& kv : chunk_meta.slot_id_to_index) {
+        for (const auto* slot : record_desc.slots()) {
+            if (kv.first == slot->id()) {
+                chunk_meta.types[kv.second] = slot->type();
+                ++column_index;
+                break;
             }
         }
     }

--- a/be/src/runtime/serde/protobuf_chunk_serde.h
+++ b/be/src/runtime/serde/protobuf_chunk_serde.h
@@ -26,7 +26,7 @@
 #include "runtime/serde/chunk_encode_context.h"
 
 namespace starrocks {
-class RowDescriptor;
+class RecordDescriptor;
 class Schema;
 } // namespace starrocks
 
@@ -54,7 +54,7 @@ public:
     //  - tuple_id_map()
     //  - is_nulls()
     //  - is_consts()
-    static StatusOr<Chunk> deserialize(const RowDescriptor& row_desc, const ChunkPB& chunk_pb,
+    static StatusOr<Chunk> deserialize(const RecordDescriptor& record_desc, const ChunkPB& chunk_pb,
                                        const int encode_level = 0);
 
     static StatusOr<Chunk> deserialize_with_schema(const Schema& schema, std::string_view buff);
@@ -91,6 +91,6 @@ private:
     std::vector<int> _encode_level;
 };
 
-StatusOr<ProtobufChunkMeta> build_protobuf_chunk_meta(const RowDescriptor& row_desc, const ChunkPB& chunk_pb);
+StatusOr<ProtobufChunkMeta> build_protobuf_chunk_meta(const RecordDescriptor& record_desc, const ChunkPB& chunk_pb);
 
 } // namespace starrocks::serde

--- a/be/src/storage/table_reader.cpp
+++ b/be/src/storage/table_reader.cpp
@@ -66,7 +66,6 @@ Status TableReader::init(const TableReaderParams& params) {
     RETURN_IF_ERROR(_partition_param->init(nullptr));
     _location_param = std::make_unique<OlapTableLocationParam>(params.location_param);
     _nodes_info = std::make_unique<StarRocksNodesInfo>(params.nodes_info);
-    _row_desc = std::make_unique<RowDescriptor>(_schema_param->tuple_desc());
     return Status::OK();
 }
 

--- a/be/src/storage/table_reader.h
+++ b/be/src/storage/table_reader.h
@@ -31,7 +31,6 @@ class OlapTableLocationParam;
 class StarRocksNodesInfo;
 class LocalTabletReader;
 class PInternalService_RecoverableStub;
-class RowDescriptor;
 
 namespace serde {
 struct ProtobufChunkMeta;
@@ -136,7 +135,6 @@ private:
     std::unique_ptr<OlapTablePartitionParam> _partition_param;
     std::unique_ptr<OlapTableLocationParam> _location_param;
     std::unique_ptr<StarRocksNodesInfo> _nodes_info;
-    std::unique_ptr<RowDescriptor> _row_desc;
 };
 
 } // namespace starrocks

--- a/be/test/compute_env/spill/spill_test.cpp
+++ b/be/test/compute_env/spill/spill_test.cpp
@@ -295,7 +295,7 @@ StatusOr<SpillTestContext*> no_partition_context(ObjectPool* pool, RuntimeState*
     //
     if (!order_bys.empty()) {
         RETURN_IF_ERROR(context->sort_exprs.init(order_bys, &tuple, &context->pool, runtime_state));
-        RETURN_IF_ERROR(context->sort_exprs.prepare(runtime_state, {}, {}));
+        RETURN_IF_ERROR(context->sort_exprs.prepare(runtime_state));
         RETURN_IF_ERROR(context->sort_exprs.open(runtime_state));
     }
 
@@ -1181,7 +1181,7 @@ TEST_F(SpillTest, file_group_test) {
     auto order_bys = order_by_slots_builder.get_res();
 
     ASSERT_OK(sort_exprs.init(order_bys, nullptr, &pool, &dummy_rt_st));
-    ASSERT_OK(sort_exprs.prepare(&dummy_rt_st, {}, {}));
+    ASSERT_OK(sort_exprs.prepare(&dummy_rt_st));
     ASSERT_OK(sort_exprs.open(&dummy_rt_st));
 
     SortDescs descs = SortDescs::asc_null_first(1);

--- a/be/test/connector/elasticsearch/es_scroll_parser_test.cpp
+++ b/be/test/connector/elasticsearch/es_scroll_parser_test.cpp
@@ -81,8 +81,7 @@ TupleDescriptor* ScrollParserTest::_create_tuple_desc(SlotDesc* descs) {
     DescriptorTbl* tbl = nullptr;
     CHECK(DescriptorTbl::create(_runtime_state, &_pool, table_desc_builder.desc_tbl(), &tbl, config::vector_chunk_size)
                   .ok());
-    auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples));
-    auto* tuple_desc = row_desc->tuple_descriptors()[0];
+    auto* tuple_desc = tbl->get_tuple_descriptor(row_tuples[0]);
     return tuple_desc;
 }
 

--- a/be/test/connector/hive/scanner/cache_select_scanner_test.cpp
+++ b/be/test/connector/hive/scanner/cache_select_scanner_test.cpp
@@ -133,8 +133,7 @@ TupleDescriptor* CacheSelectScannerTest::_create_tuple_desc(SlotDesc* descs) {
     DescriptorTbl* tbl = nullptr;
     CHECK(DescriptorTbl::create(_runtime_state, &_pool, table_desc_builder.desc_tbl(), &tbl, config::vector_chunk_size)
                   .ok());
-    auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples));
-    auto* tuple_desc = row_desc->tuple_descriptors()[0];
+    auto* tuple_desc = tbl->get_tuple_descriptor(row_tuples[0]);
     return tuple_desc;
 }
 

--- a/be/test/connector/hive/scanner/hdfs_scanner_test.cpp
+++ b/be/test/connector/hive/scanner/hdfs_scanner_test.cpp
@@ -186,8 +186,7 @@ TupleDescriptor* HdfsScannerTest::_create_tuple_desc_with_nullable(SlotDesc* des
     DescriptorTbl* tbl = nullptr;
     CHECK(DescriptorTbl::create(_runtime_state, &_pool, table_desc_builder.desc_tbl(), &tbl, config::vector_chunk_size)
                   .ok());
-    auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples));
-    auto* tuple_desc = row_desc->tuple_descriptors()[0];
+    auto* tuple_desc = tbl->get_tuple_descriptor(row_tuples[0]);
     return tuple_desc;
 }
 
@@ -752,8 +751,7 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithMinMaxFilterNoRows) {
         CHECK(DescriptorTbl::create(_runtime_state, &_pool, table_desc_builder.desc_tbl(), &tbl,
                                     config::vector_chunk_size)
                       .ok());
-        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples));
-        min_max_tuple_desc = row_desc->tuple_descriptors()[0];
+        min_max_tuple_desc = tbl->get_tuple_descriptor(row_tuples[0]);
     }
 
     ctx->min_max_tuple_desc = min_max_tuple_desc;

--- a/be/test/connector/hive/scanner/jni_scanner_test.cpp
+++ b/be/test/connector/hive/scanner/jni_scanner_test.cpp
@@ -89,8 +89,7 @@ public:
         CHECK(DescriptorTbl::create(_runtime_state, &_pool, table_desc_builder.desc_tbl(), &tbl,
                                     config::vector_chunk_size)
                       .ok());
-        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples));
-        auto* tuple_desc = row_desc->tuple_descriptors()[0];
+        auto* tuple_desc = tbl->get_tuple_descriptor(row_tuples[0]);
         return tuple_desc;
     }
 

--- a/be/test/data_sink/result/arrow_result_writer_test.cpp
+++ b/be/test/data_sink/result/arrow_result_writer_test.cpp
@@ -36,11 +36,9 @@ TEST(ArrowResultWriterTest, close) {
     std::vector<ExprContext*> output_expr_ctxs;
     std::vector<std::string> output_column_names;
 
-    RowDescriptor row_desc;
-
     RuntimeProfile* profile = new RuntimeProfile("ArrowResultWriterTest");
 
-    ArrowResultWriter writer(sinker, output_expr_ctxs, output_column_names, profile, row_desc);
+    ArrowResultWriter writer(sinker, output_expr_ctxs, output_column_names, profile);
 
     Status st = writer.close();
     ASSERT_TRUE(st.ok());

--- a/be/test/data_sink/result/memory_scratch_sink_test.cpp
+++ b/be/test/data_sink/result/memory_scratch_sink_test.cpp
@@ -191,7 +191,7 @@ private:
     TDescriptorTable _t_desc_table;
     RuntimeState* _state = nullptr;
     TPlanNode _tnode;
-    RowDescriptor* _row_desc = nullptr;
+    RecordDescriptor* _record_desc = nullptr;
     TMemoryScratchSink _tsink;
     DescriptorTbl* _desc_tbl = nullptr;
     std::vector<TExpr> _exprs;
@@ -268,7 +268,7 @@ void MemoryScratchSinkTest::init_desc_tbl() {
     std::vector<TTupleId> row_tids;
     row_tids.push_back(0);
 
-    _row_desc = _obj_pool.add(new RowDescriptor(*_desc_tbl, row_tids));
+    _record_desc = _obj_pool.add(new RecordDescriptor(*_desc_tbl, row_tids));
 
     // node
     _tnode.node_id = 0;
@@ -295,7 +295,7 @@ TEST_F(MemoryScratchSinkTest, work_flow_normal) {
     auto st = scanner->open();
     ASSERT_TRUE(st.ok()) << st.to_string();
 
-    MemoryScratchSink sink(*_row_desc, _exprs, _tsink);
+    MemoryScratchSink sink(*_record_desc, _exprs, _tsink);
     TDataSink data_sink;
     data_sink.memory_scratch_sink = _tsink;
     ASSERT_TRUE(sink.init(data_sink, nullptr).ok());

--- a/be/test/data_sink/result/memory_scratch_sink_test_issue_8676.cpp
+++ b/be/test/data_sink/result/memory_scratch_sink_test_issue_8676.cpp
@@ -214,7 +214,7 @@ private:
     TDescriptorTable _t_desc_table;
     RuntimeState* _state = nullptr;
     TPlanNode _tnode;
-    RowDescriptor* _row_desc = nullptr;
+    RecordDescriptor* _record_desc = nullptr;
     TMemoryScratchSink _tsink;
     DescriptorTbl* _desc_tbl = nullptr;
     std::vector<TExpr> _exprs;
@@ -309,7 +309,7 @@ void MemoryScratchSinkIssue8676Test::init_desc_tbl() {
     std::vector<TTupleId> row_tids;
     row_tids.push_back(0);
 
-    _row_desc = _obj_pool.add(new RowDescriptor(*_desc_tbl, row_tids));
+    _record_desc = _obj_pool.add(new RecordDescriptor(*_desc_tbl, row_tids));
 
     // node
     _tnode.node_id = 0;
@@ -337,7 +337,7 @@ TEST_F(MemoryScratchSinkIssue8676Test, work_flow_normal) {
     auto st = scanner->open();
     ASSERT_TRUE(st.ok()) << st.to_string();
 
-    MemoryScratchSink sink(*_row_desc, _exprs, _tsink);
+    MemoryScratchSink sink(*_record_desc, _exprs, _tsink);
     TDataSink data_sink;
     data_sink.memory_scratch_sink = _tsink;
     ASSERT_TRUE(sink.init(data_sink, nullptr).ok());

--- a/be/test/data_workflows/migration/engine_storage_migration_task_test.cpp
+++ b/be/test/data_workflows/migration/engine_storage_migration_task_test.cpp
@@ -318,8 +318,7 @@ public:
         DescriptorTbl* tbl = nullptr;
         DescriptorTbl::create(&_runtime_state, &_pool, table_builder.desc_tbl(), &tbl, config::vector_chunk_size);
 
-        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples));
-        auto* tuple_desc = row_desc->tuple_descriptors()[0];
+        auto* tuple_desc = tbl->get_tuple_descriptor(row_tuples[0]);
 
         return tuple_desc;
     }
@@ -350,8 +349,7 @@ public:
         DescriptorTbl* tbl = nullptr;
         DescriptorTbl::create(&_runtime_state, &_pool, table_builder.desc_tbl(), &tbl, config::vector_chunk_size);
 
-        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples));
-        auto* tuple_desc = row_desc->tuple_descriptors()[0];
+        auto* tuple_desc = tbl->get_tuple_descriptor(row_tuples[0]);
 
         return tuple_desc;
     }

--- a/be/test/exec/analytor_test.cpp
+++ b/be/test/exec/analytor_test.cpp
@@ -29,8 +29,7 @@ public:
 // NOLINTNEXTLINE
 TEST_F(AnalytorTest, find_peer_group_end) {
     TPlanNode plan_node;
-    RowDescriptor row_desc;
-    Analytor analytor(plan_node, row_desc, nullptr, false);
+    Analytor analytor(plan_node, nullptr, false);
 
     int32_t v;
     auto c1 = Int32Column::create();
@@ -52,8 +51,7 @@ TEST_F(AnalytorTest, find_peer_group_end) {
 // NOLINTNEXTLINE
 TEST_F(AnalytorTest, reset_state_for_next_partition) {
     TPlanNode plan_node;
-    RowDescriptor row_desc;
-    Analytor analytor(plan_node, row_desc, nullptr, false);
+    Analytor analytor(plan_node, nullptr, false);
 
     analytor._partition.start = 10;
     analytor._partition.is_real = true;
@@ -67,8 +65,7 @@ TEST_F(AnalytorTest, reset_state_for_next_partition) {
 // NOLINTNEXTLINE
 TEST_F(AnalytorTest, find_partition_end) {
     TPlanNode plan_node;
-    RowDescriptor row_desc;
-    Analytor analytor1(plan_node, row_desc, nullptr, false);
+    Analytor analytor1(plan_node, nullptr, false);
 
     int32_t v;
     auto c1 = Int32Column::create();
@@ -108,7 +105,7 @@ TEST_F(AnalytorTest, find_partition_end) {
     ASSERT_EQ(analytor1._partition.end, 20);
 
     // partition columns is empty
-    Analytor analytor2(plan_node, row_desc, nullptr, false);
+    Analytor analytor2(plan_node, nullptr, false);
     analytor2._input_rows += 20;
     analytor1._input_eos = true;
 
@@ -118,7 +115,7 @@ TEST_F(AnalytorTest, find_partition_end) {
     ASSERT_EQ(analytor2._partition.end, 20);
 
     // input rows = 0
-    Analytor analytor3(plan_node, row_desc, nullptr, false);
+    Analytor analytor3(plan_node, nullptr, false);
     analytor3._input_rows = 0;
     analytor1._input_eos = true;
 

--- a/be/test/exec/data_sinks/pipeline_sink_builder_test.cpp
+++ b/be/test/exec/data_sinks/pipeline_sink_builder_test.cpp
@@ -61,10 +61,8 @@ protected:
         PipelineSinkTestRequest request(sink);
         pipeline::UnifiedExecPlanFragmentParams unified(request.common, request.unique);
         pipeline::OpFactories upstream{std::make_shared<pipeline::EmptySetOperatorFactory>(0, 0)};
-        return PipelineSinkBuilder::build(_context.get(), std::move(upstream), unified, _row_desc);
+        return PipelineSinkBuilder::build(_context.get(), std::move(upstream), unified);
     }
-
-    RowDescriptor _row_desc;
     std::shared_ptr<pipeline::FragmentContext> _fragment_context;
     std::unique_ptr<pipeline::PipelineBuilderContext> _context;
 };

--- a/be/test/exec/join_hash_map_test.cpp
+++ b/be/test/exec/join_hash_map_test.cpp
@@ -65,9 +65,8 @@ protected:
                                      bool nullable, size_t column_count = 3);
     DescriptorTbl* create_descriptor_tbl(TDescriptorTableBuilder* table_desc_builder);
     static std::shared_ptr<RuntimeProfile> create_runtime_profile();
-    std::shared_ptr<RowDescriptor> create_row_desc(TDescriptorTableBuilder* table_desc_builder);
-    std::shared_ptr<RowDescriptor> create_probe_desc(TDescriptorTableBuilder* probe_desc_builder);
-    std::shared_ptr<RowDescriptor> create_build_desc(TDescriptorTableBuilder* build_desc_builder);
+    std::shared_ptr<RecordDescriptor> create_probe_desc(TDescriptorTableBuilder* probe_desc_builder);
+    std::shared_ptr<RecordDescriptor> create_build_desc(TDescriptorTableBuilder* build_desc_builder);
     static std::shared_ptr<RuntimeState> create_runtime_state();
 
     static void check_probe_index(const Buffer<uint32_t>& probe_index, uint32_t step, uint32_t match_count,
@@ -143,8 +142,8 @@ protected:
     TypeDescriptor _int_type;
     TypeDescriptor _tinyint_type;
     TypeDescriptor _varchar_type;
-    std::shared_ptr<RowDescriptor> _probe_desc;
-    std::shared_ptr<RowDescriptor> _build_desc;
+    std::shared_ptr<RecordDescriptor> _probe_desc;
+    std::shared_ptr<RecordDescriptor> _build_desc;
 };
 
 void JoinHashMapTest::check_probe_output_slot_ids(const JoinHashTableItems& table_items,
@@ -247,8 +246,8 @@ HashTableParam JoinHashMapTest::create_table_param_int(TJoinOp::type join_type, 
         param.probe_output_slots.emplace(i);
         param.build_output_slots.emplace(i);
     }
-    param.build_row_desc = _build_desc.get();
-    param.probe_row_desc = _probe_desc.get();
+    param.build_record_desc = _build_desc.get();
+    param.probe_record_desc = _probe_desc.get();
     param.probe_output_slots = {1};
     param.build_output_slots = {4};
     param.predicate_slots = {2, 5};
@@ -806,14 +805,14 @@ void JoinHashMapTest::check_empty_hash_map(TJoinOp::type join_type, int num_prob
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false);
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false);
 
-    auto probe_row_desc = create_probe_desc(&row_desc_builder);
-    auto build_row_desc = create_build_desc(&row_desc_builder);
+    auto probe_record_desc = create_probe_desc(&row_desc_builder);
+    auto build_record_desc = create_build_desc(&row_desc_builder);
 
     HashTableParam param = create_table_param(join_type, 6);
     param.join_keys.emplace_back(JoinKeyDesc{&_int_type, false, nullptr});
     param.join_keys.emplace_back(JoinKeyDesc{&_int_type, false, nullptr});
-    param.probe_row_desc = probe_row_desc.get();
-    param.build_row_desc = build_row_desc.get();
+    param.probe_record_desc = probe_record_desc.get();
+    param.build_record_desc = build_record_desc.get();
 
     JoinHashTable hash_table;
     hash_table.create(param);
@@ -901,22 +900,16 @@ DescriptorTbl* JoinHashMapTest::create_descriptor_tbl(TDescriptorTableBuilder* t
     return tbl;
 }
 
-std::shared_ptr<RowDescriptor> JoinHashMapTest::create_row_desc(TDescriptorTableBuilder* table_desc_builder) {
-    std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0, 1};
-    auto* tbl = create_descriptor_tbl(table_desc_builder);
-    return std::make_shared<RowDescriptor>(*tbl, row_tuples);
-}
-
-std::shared_ptr<RowDescriptor> JoinHashMapTest::create_probe_desc(TDescriptorTableBuilder* probe_desc_builder) {
+std::shared_ptr<RecordDescriptor> JoinHashMapTest::create_probe_desc(TDescriptorTableBuilder* probe_desc_builder) {
     std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
     auto* tbl = create_descriptor_tbl(probe_desc_builder);
-    return std::make_shared<RowDescriptor>(*tbl, row_tuples);
+    return std::make_shared<RecordDescriptor>(*tbl, row_tuples);
 }
 
-std::shared_ptr<RowDescriptor> JoinHashMapTest::create_build_desc(TDescriptorTableBuilder* build_desc_builder) {
+std::shared_ptr<RecordDescriptor> JoinHashMapTest::create_build_desc(TDescriptorTableBuilder* build_desc_builder) {
     std::vector<TTupleId> row_tuples = std::vector<TTupleId>{1};
     auto* tbl = create_descriptor_tbl(build_desc_builder);
-    return std::make_shared<RowDescriptor>(*tbl, row_tuples);
+    return std::make_shared<RecordDescriptor>(*tbl, row_tuples);
 }
 
 std::shared_ptr<RuntimeState> JoinHashMapTest::create_runtime_state() {
@@ -1084,9 +1077,9 @@ TEST_F(JoinHashMapTest, ProbeNullOutput) {
     TDescriptorTableBuilder row_desc_builder;
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false);
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false);
-    auto row_desc = create_row_desc(&row_desc_builder);
+    auto record_desc = create_probe_desc(&row_desc_builder);
     vector<HashTableSlotDescriptor> hash_table_slot_vec;
-    for (auto& slot : row_desc->tuple_descriptors()[0]->slots()) {
+    for (auto* slot : record_desc->slots()) {
         HashTableSlotDescriptor hash_table_slot{};
         hash_table_slot.slot = slot;
         hash_table_slot.need_output = true;
@@ -1118,10 +1111,10 @@ TEST_F(JoinHashMapTest, BuildDefaultOutput) {
     TDescriptorTableBuilder row_desc_builder;
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false);
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false);
-    auto row_desc = create_row_desc(&row_desc_builder);
+    auto record_desc = create_probe_desc(&row_desc_builder);
 
     vector<HashTableSlotDescriptor> hash_table_slot_vec;
-    for (auto& slot : row_desc->tuple_descriptors()[0]->slots()) {
+    for (auto* slot : record_desc->slots()) {
         HashTableSlotDescriptor hash_table_slot{};
         hash_table_slot.slot = slot;
         hash_table_slot.need_output = true;
@@ -1254,12 +1247,12 @@ TEST_F(JoinHashMapTest, DirectMappingJoinBuildProbeFunc) {
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_TINYINT, false, 1);
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_TINYINT, false, 1);
 
-    auto probe_row_desc = create_probe_desc(&row_desc_builder);
-    auto build_row_desc = create_build_desc(&row_desc_builder);
+    auto probe_record_desc = create_probe_desc(&row_desc_builder);
+    auto build_record_desc = create_build_desc(&row_desc_builder);
 
     HashTableParam param = create_table_param(TJoinOp::INNER_JOIN, 2);
-    param.probe_row_desc = probe_row_desc.get();
-    param.build_row_desc = build_row_desc.get();
+    param.probe_record_desc = probe_record_desc.get();
+    param.build_record_desc = build_record_desc.get();
     param.join_keys.emplace_back(JoinKeyDesc{&_tinyint_type, false, nullptr});
 
     JoinHashTable ht;
@@ -1303,12 +1296,12 @@ TEST_F(JoinHashMapTest, DirectMappingJoinBuildProbeFuncNullable) {
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_TINYINT, true, 1);
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_TINYINT, true, 1);
 
-    auto probe_row_desc = create_probe_desc(&row_desc_builder);
-    auto build_row_desc = create_build_desc(&row_desc_builder);
+    auto probe_record_desc = create_probe_desc(&row_desc_builder);
+    auto build_record_desc = create_build_desc(&row_desc_builder);
 
     HashTableParam param = create_table_param(TJoinOp::INNER_JOIN, 2);
-    param.probe_row_desc = probe_row_desc.get();
-    param.build_row_desc = build_row_desc.get();
+    param.probe_record_desc = probe_record_desc.get();
+    param.build_record_desc = build_record_desc.get();
     param.join_keys.emplace_back(JoinKeyDesc{&_tinyint_type, false, nullptr});
 
     JoinHashTable ht;
@@ -2053,13 +2046,13 @@ TEST_F(JoinHashMapTest, OneKeyJoinHashTable) {
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false);
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false);
 
-    auto probe_row_desc = create_probe_desc(&row_desc_builder);
-    auto build_row_desc = create_build_desc(&row_desc_builder);
+    auto probe_record_desc = create_probe_desc(&row_desc_builder);
+    auto build_record_desc = create_build_desc(&row_desc_builder);
 
     HashTableParam param = create_table_param(TJoinOp::INNER_JOIN, 6);
     param.join_keys.emplace_back(JoinKeyDesc{&_int_type, false, nullptr});
-    param.probe_row_desc = probe_row_desc.get();
-    param.build_row_desc = build_row_desc.get();
+    param.probe_record_desc = probe_record_desc.get();
+    param.build_record_desc = build_record_desc.get();
 
     JoinHashTable hash_table;
     hash_table.create(param);
@@ -2104,13 +2097,13 @@ TEST_F(JoinHashMapTest, OneNullableKeyJoinHashTable) {
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, true);
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, true);
 
-    auto probe_row_desc = create_probe_desc(&row_desc_builder);
-    auto build_row_desc = create_build_desc(&row_desc_builder);
+    auto probe_record_desc = create_probe_desc(&row_desc_builder);
+    auto build_record_desc = create_build_desc(&row_desc_builder);
 
     HashTableParam param = create_table_param(TJoinOp::INNER_JOIN, 6);
     param.join_keys.emplace_back(JoinKeyDesc{&_int_type, false, nullptr});
-    param.probe_row_desc = probe_row_desc.get();
-    param.build_row_desc = build_row_desc.get();
+    param.probe_record_desc = probe_record_desc.get();
+    param.build_record_desc = build_record_desc.get();
 
     JoinHashTable hash_table;
     hash_table.create(param);
@@ -2156,14 +2149,14 @@ TEST_F(JoinHashMapTest, FixedSizeJoinHashTable) {
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false);
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false);
 
-    auto probe_row_desc = create_probe_desc(&row_desc_builder);
-    auto build_row_desc = create_build_desc(&row_desc_builder);
+    auto probe_record_desc = create_probe_desc(&row_desc_builder);
+    auto build_record_desc = create_build_desc(&row_desc_builder);
 
     HashTableParam param = create_table_param(TJoinOp::INNER_JOIN, 6);
     param.join_keys.emplace_back(JoinKeyDesc{&_int_type, false, nullptr});
     param.join_keys.emplace_back(JoinKeyDesc{&_int_type, false, nullptr});
-    param.probe_row_desc = probe_row_desc.get();
-    param.build_row_desc = build_row_desc.get();
+    param.probe_record_desc = probe_record_desc.get();
+    param.build_record_desc = build_record_desc.get();
 
     JoinHashTable hash_table;
     hash_table.create(param);
@@ -2207,14 +2200,14 @@ TEST_F(JoinHashMapTest, SerializeJoinHashTable) {
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_VARCHAR, false);
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_VARCHAR, false);
 
-    auto probe_row_desc = create_probe_desc(&row_desc_builder);
-    auto build_row_desc = create_build_desc(&row_desc_builder);
+    auto probe_record_desc = create_probe_desc(&row_desc_builder);
+    auto build_record_desc = create_build_desc(&row_desc_builder);
 
     HashTableParam param = create_table_param(TJoinOp::INNER_JOIN, 6);
     param.join_keys.emplace_back(JoinKeyDesc{&_varchar_type, false, nullptr});
     param.join_keys.emplace_back(JoinKeyDesc{&_varchar_type, false, nullptr});
-    param.probe_row_desc = probe_row_desc.get();
-    param.build_row_desc = build_row_desc.get();
+    param.probe_record_desc = probe_record_desc.get();
+    param.build_record_desc = build_record_desc.get();
 
     JoinHashTable hash_table;
     hash_table.create(param);
@@ -2522,15 +2515,15 @@ TEST_F(JoinHashMapTest, EmptyHashMapTestLazyFilter) {
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false, 3);
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false, 3);
 
-    auto probe_row_desc = create_probe_desc(&row_desc_builder);
-    auto build_row_desc = create_build_desc(&row_desc_builder);
+    auto probe_record_desc = create_probe_desc(&row_desc_builder);
+    auto build_record_desc = create_build_desc(&row_desc_builder);
 
     JoinHashTable ht;
 
     HashTableParam param;
     param.enable_late_materialization = true;
-    param.probe_row_desc = probe_row_desc.get();
-    param.build_row_desc = build_row_desc.get();
+    param.probe_record_desc = probe_record_desc.get();
+    param.build_record_desc = build_record_desc.get();
     param.probe_output_slots = {1};
     param.build_output_slots = {4};
     param.predicate_slots = {2, 5};
@@ -2577,15 +2570,15 @@ TEST_F(JoinHashMapTest, EmptyHashMapTestLazyOutputAll) {
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false, 3);
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false, 3);
 
-    auto probe_row_desc = create_probe_desc(&row_desc_builder);
-    auto build_row_desc = create_build_desc(&row_desc_builder);
+    auto probe_record_desc = create_probe_desc(&row_desc_builder);
+    auto build_record_desc = create_build_desc(&row_desc_builder);
 
     JoinHashTable ht;
 
     HashTableParam param;
     param.enable_late_materialization = true;
-    param.probe_row_desc = probe_row_desc.get();
-    param.build_row_desc = build_row_desc.get();
+    param.probe_record_desc = probe_record_desc.get();
+    param.build_record_desc = build_record_desc.get();
     param.probe_output_slots = {1};
     param.build_output_slots = {4};
     param.predicate_slots = {2, 5};
@@ -2921,15 +2914,15 @@ TEST_F(JoinHashMapTest, TestOutputSlotsEmpty) {
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false, 3);
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false, 3);
 
-    auto probe_row_desc = create_probe_desc(&row_desc_builder);
-    auto build_row_desc = create_build_desc(&row_desc_builder);
+    auto probe_record_desc = create_probe_desc(&row_desc_builder);
+    auto build_record_desc = create_build_desc(&row_desc_builder);
 
     JoinHashTable ht;
 
     HashTableParam param;
     param.enable_late_materialization = false;
-    param.probe_row_desc = probe_row_desc.get();
-    param.build_row_desc = build_row_desc.get();
+    param.probe_record_desc = probe_record_desc.get();
+    param.build_record_desc = build_record_desc.get();
 
     ht.create(param);
 
@@ -2948,15 +2941,15 @@ TEST_F(JoinHashMapTest, TestOutputSlotsNormal) {
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false, 3);
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false, 3);
 
-    auto probe_row_desc = create_probe_desc(&row_desc_builder);
-    auto build_row_desc = create_build_desc(&row_desc_builder);
+    auto probe_record_desc = create_probe_desc(&row_desc_builder);
+    auto build_record_desc = create_build_desc(&row_desc_builder);
 
     JoinHashTable ht;
 
     HashTableParam param;
     param.enable_late_materialization = false;
-    param.probe_row_desc = probe_row_desc.get();
-    param.build_row_desc = build_row_desc.get();
+    param.probe_record_desc = probe_record_desc.get();
+    param.build_record_desc = build_record_desc.get();
     param.probe_output_slots = {1};
     param.build_output_slots = {4};
     param.predicate_slots = {2, 5};
@@ -2978,15 +2971,15 @@ TEST_F(JoinHashMapTest, TestLazyOutputSlotsEmpty) {
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false, 3);
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false, 3);
 
-    auto probe_row_desc = create_probe_desc(&row_desc_builder);
-    auto build_row_desc = create_build_desc(&row_desc_builder);
+    auto probe_record_desc = create_probe_desc(&row_desc_builder);
+    auto build_record_desc = create_build_desc(&row_desc_builder);
 
     JoinHashTable ht;
 
     HashTableParam param;
     param.enable_late_materialization = true;
-    param.probe_row_desc = probe_row_desc.get();
-    param.build_row_desc = build_row_desc.get();
+    param.probe_record_desc = probe_record_desc.get();
+    param.build_record_desc = build_record_desc.get();
 
     ht.create(param);
 
@@ -3005,15 +2998,15 @@ TEST_F(JoinHashMapTest, TestLazyPredicateSlotsEmpty) {
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false, 3);
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false, 3);
 
-    auto probe_row_desc = create_probe_desc(&row_desc_builder);
-    auto build_row_desc = create_build_desc(&row_desc_builder);
+    auto probe_record_desc = create_probe_desc(&row_desc_builder);
+    auto build_record_desc = create_build_desc(&row_desc_builder);
 
     JoinHashTable ht;
 
     HashTableParam param;
     param.enable_late_materialization = true;
-    param.probe_row_desc = probe_row_desc.get();
-    param.build_row_desc = build_row_desc.get();
+    param.probe_record_desc = probe_record_desc.get();
+    param.build_record_desc = build_record_desc.get();
     param.probe_output_slots = {1};
     param.build_output_slots = {4};
     param.predicate_slots = {};
@@ -3035,15 +3028,15 @@ TEST_F(JoinHashMapTest, TestLazyPredicateSlotsNormal) {
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false, 3);
     add_tuple_descriptor(&row_desc_builder, LogicalType::TYPE_INT, false, 3);
 
-    auto probe_row_desc = create_probe_desc(&row_desc_builder);
-    auto build_row_desc = create_build_desc(&row_desc_builder);
+    auto probe_record_desc = create_probe_desc(&row_desc_builder);
+    auto build_record_desc = create_build_desc(&row_desc_builder);
 
     JoinHashTable ht;
 
     HashTableParam param;
     param.enable_late_materialization = true;
-    param.probe_row_desc = probe_row_desc.get();
-    param.build_row_desc = build_row_desc.get();
+    param.probe_record_desc = probe_record_desc.get();
+    param.build_record_desc = build_record_desc.get();
     param.probe_output_slots = {1};
     param.build_output_slots = {4};
     param.predicate_slots = {2, 5};

--- a/be/test/exec/pipeline/enforce_unique_row_locator_operator_test.cpp
+++ b/be/test/exec/pipeline/enforce_unique_row_locator_operator_test.cpp
@@ -342,8 +342,8 @@ class EnforceUniqueRowLocatorNodeTest : public ::testing::Test {
 protected:
     void SetUp() override {
         TDescriptorTable t_desc_table;
-        // ExecNode builds a RowDescriptor from row_tuples and requires at least one
-        // tuple, so register a single tuple (id 1) holding the two row-locator slots.
+        // ExecNode builds a RecordDescriptor from row_tuples, so register a single
+        // tuple (id 1) holding the two row-locator slots.
         TTupleDescriptor t_tuple_desc;
         t_tuple_desc.id = 1;
         t_desc_table.tupleDescriptors.push_back(t_tuple_desc);

--- a/be/test/exec/pipeline/exchange_bucket_aware_test.cpp
+++ b/be/test/exec/pipeline/exchange_bucket_aware_test.cpp
@@ -130,8 +130,8 @@ TEST_F(ExchangeBucketAwareTest, test_exchange_bucket_aware) {
             /*output_columns*/ std::vector<int32_t>(), bucket_properies);
     _exchange_sink_factory->set_runtime_state(_runtime_state.get());
 
-    RowDescriptor input_row_desc;
-    _recvr = _exec_env->stream_mgr()->create_recvr(_runtime_state.get(), input_row_desc, _fragment_id, 0, 3,
+    RecordDescriptor input_record_desc;
+    _recvr = _exec_env->stream_mgr()->create_recvr(_runtime_state.get(), input_record_desc, _fragment_id, 0, 3,
                                                    config::exchg_node_buffer_size_bytes, _dest_node_id,
                                                    std::make_shared<QueryStatisticsRecvr>(),
                                                    /*is_pipeline*/ true, 2, /*keep_order*/ false);

--- a/be/test/exec/pipeline/exchange_pass_through_test.cpp
+++ b/be/test/exec/pipeline/exchange_pass_through_test.cpp
@@ -80,9 +80,9 @@ public:
 
         _sink_buffer = std::make_shared<SinkBuffer>(_fragment_context.get(), _destinations, /*is_dest_merge*/ false);
 
-        RowDescriptor input_row_desc;
+        RecordDescriptor input_record_desc;
         _recvr = _exec_env->stream_mgr()->create_recvr(
-                _runtime_state.get(), input_row_desc, _fragment_id, 0, 1, config::exchg_node_buffer_size_bytes,
+                _runtime_state.get(), input_record_desc, _fragment_id, 0, 1, config::exchg_node_buffer_size_bytes,
                 _dest_node_id, std::make_shared<QueryStatisticsRecvr>(),
                 /*is_pipeline*/ true, _degree_of_parallelism, /*keep_order*/ false);
         std::stringstream ss;

--- a/be/test/exec/pipeline/nljoin_probe_operator_test.cpp
+++ b/be/test/exec/pipeline/nljoin_probe_operator_test.cpp
@@ -78,14 +78,14 @@ protected:
     // OperatorRuntimeAccess (DCHECK'd non-null). _init_output_chunk never touches it.
     std::unique_ptr<NLJoinProbeOperatorFactory> make_factory(const std::shared_ptr<NLJoinContext>& ctx,
                                                              TJoinOp::type join_op) {
-        return std::make_unique<NLJoinProbeOperatorFactory>(0, 1, _empty_row_desc, _empty_row_desc, _empty_row_desc, "",
+        return std::make_unique<NLJoinProbeOperatorFactory>(0, 1, _empty_record_desc, _empty_record_desc, "",
                                                             std::vector<ExprContext*>{}, std::vector<ExprContext*>{},
                                                             std::map<SlotId, ExprContext*>{},
                                                             std::shared_ptr<NLJoinContext>(ctx), join_op);
     }
 
     ObjectPool _pool;
-    RowDescriptor _empty_row_desc;
+    RecordDescriptor _empty_record_desc;
     std::vector<ExprContext*> _no_exprs;
     std::map<SlotId, ExprContext*> _no_common_exprs;
     std::string _no_sql;

--- a/be/test/exec/pipeline/sink/memory_scratch_sink_operator_test.cpp
+++ b/be/test/exec/pipeline/sink/memory_scratch_sink_operator_test.cpp
@@ -113,11 +113,11 @@ TEST(MemoryScratchSinkOperatorTest, test_cancel) {
     _runtime_state->set_fragment_dict_state(_fragment_ctx->dict_state());
 
     std::vector<TExpr> t_output_expr;
-    RowDescriptor row_desc;
+    RecordDescriptor record_desc;
 
     MockEmptyOperatorFactory factory1(1, "mock_op_factory", 2);
     EXPECT_TRUE(factory1.prepare(_runtime_state).ok());
-    MemoryScratchSinkOperatorFactory factory2(2, row_desc, t_output_expr, _fragment_ctx);
+    MemoryScratchSinkOperatorFactory factory2(2, record_desc, t_output_expr, _fragment_ctx);
     EXPECT_TRUE(factory2.prepare(_runtime_state).ok());
 
     Status result_st;

--- a/be/test/exec_primitive/exec_node_exec_primitive_test.cpp
+++ b/be/test/exec_primitive/exec_node_exec_primitive_test.cpp
@@ -27,17 +27,6 @@
 namespace starrocks {
 namespace {
 
-ChunkPtr make_int_chunk(int32_t first, int num_rows) {
-    auto column = Int32Column::create();
-    for (int i = 0; i < num_rows; ++i) {
-        column->append(first + i);
-    }
-
-    auto chunk = std::make_shared<Chunk>();
-    chunk->append_column(std::move(column), 0);
-    return chunk;
-}
-
 class ExecNodeExecPrimitiveTest : public ::testing::Test {
 public:
     ExecNodeExecPrimitiveTest() : _runtime_state(TQueryGlobals()) {}

--- a/be/test/exec_primitive/result_to_arrow_converter_exec_primitive_test.cpp
+++ b/be/test/exec_primitive/result_to_arrow_converter_exec_primitive_test.cpp
@@ -41,11 +41,9 @@ TEST(ResultToArrowConverterExecPrimitiveTest, BuildsSchemaAndConvertsChunkThroug
     ASSERT_OK(expr_context.prepare(&runtime_state));
     ASSERT_OK(expr_context.open(&runtime_state));
     std::vector<ExprContext*> output_expr_ctxs{&expr_context};
-
-    RowDescriptor row_desc;
     std::unordered_map<int64_t, std::string> id_to_col_name{{(int64_t{kTupleId} << 32) | kSlotId, "answer"}};
     std::shared_ptr<arrow::Schema> schema;
-    ASSERT_OK(convert_to_arrow_schema(row_desc, id_to_col_name, &schema, output_expr_ctxs));
+    ASSERT_OK(convert_to_arrow_schema(id_to_col_name, &schema, output_expr_ctxs));
     ASSERT_NE(nullptr, schema);
     ASSERT_EQ(1, schema->num_fields());
     EXPECT_EQ("answer", schema->field(0)->name());

--- a/be/test/formats/orc/orc_chunk_reader_test.cpp
+++ b/be/test/formats/orc/orc_chunk_reader_test.cpp
@@ -83,8 +83,7 @@ void create_tuple_descriptor(RuntimeState* state, ObjectPool* pool, const SlotDe
     DescriptorTbl* tbl = nullptr;
     auto st = DescriptorTbl::create(state, pool, table_desc_builder.desc_tbl(), &tbl, config::vector_chunk_size);
     CHECK(st.ok()) << st;
-    RowDescriptor* row_desc = pool->add(new RowDescriptor(*tbl, row_tuples));
-    *tuple_desc = row_desc->tuple_descriptors()[0];
+    *tuple_desc = tbl->get_tuple_descriptor(row_tuples[0]);
     return;
 }
 

--- a/be/test/formats/orc/orc_file_writer_test.cpp
+++ b/be/test/formats/orc/orc_file_writer_test.cpp
@@ -99,8 +99,7 @@ protected:
         DescriptorTbl* tbl = nullptr;
         DescriptorTbl::create(state, pool, table_desc_builder.desc_tbl(), &tbl, config::vector_chunk_size);
 
-        RowDescriptor* row_desc = pool->add(new RowDescriptor(*tbl, row_tuples));
-        *tuple_desc = row_desc->tuple_descriptors()[0];
+        *tuple_desc = tbl->get_tuple_descriptor(row_tuples[0]);
         return;
     }
 

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -348,7 +348,6 @@ protected:
     std::string _filter_row_group_path_3 =
             "./be/test/formats/parquet/test_data/file_read_test_filter_row_group_update_rf.parquet";
 
-    std::shared_ptr<RowDescriptor> _row_desc = nullptr;
     RuntimeState* _runtime_state = nullptr;
     std::unique_ptr<FragmentDictState> _fragment_dict_state;
     ObjectPool _pool;

--- a/be/test/formats/parquet/iceberg_schema_evolution_file_reader_test.cpp
+++ b/be/test/formats/parquet/iceberg_schema_evolution_file_reader_test.cpp
@@ -119,7 +119,6 @@ protected:
         ctx->format_scan_context.scan_range_length = scan_range->length;
     }
 
-    std::shared_ptr<RowDescriptor> _row_desc = nullptr;
     RuntimeState* _runtime_state = nullptr;
     ObjectPool _pool;
 

--- a/be/test/formats/parquet/parquet_cli_reader.h
+++ b/be/test/formats/parquet/parquet_cli_reader.h
@@ -229,8 +229,7 @@ private:
         std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
         DescriptorTbl* tbl = nullptr;
         CHECK(DescriptorTbl::create(state, pool, table_desc_builder.desc_tbl(), &tbl, config::vector_chunk_size).ok());
-        RowDescriptor* row_desc = pool->add(new RowDescriptor(*tbl, row_tuples));
-        return row_desc->tuple_descriptors()[0];
+        return tbl->get_tuple_descriptor(row_tuples[0]);
     }
 
     static void _make_column_info_vector(const TupleDescriptor* tuple_desc, std::vector<FormatColumnInfo>* columns) {

--- a/be/test/formats/parquet/parquet_test_util/util.h
+++ b/be/test/formats/parquet/parquet_test_util/util.h
@@ -61,8 +61,7 @@ public:
         DescriptorTbl* tbl = nullptr;
         CHECK(DescriptorTbl::create(state, pool, table_desc_builder.desc_tbl(), &tbl, config::vector_chunk_size).ok());
 
-        RowDescriptor* row_desc = pool->add(new RowDescriptor(*tbl, row_tuples));
-        return row_desc->tuple_descriptors()[0];
+        return tbl->get_tuple_descriptor(row_tuples[0]);
     }
 
     static void make_column_info_vector(const TupleDescriptor* tuple_desc, std::vector<FormatColumnInfo>* columns) {

--- a/be/test/runtime/merge_cascade_test.cpp
+++ b/be/test/runtime/merge_cascade_test.cpp
@@ -40,7 +40,7 @@ TEST(MergeCascadeTest, merge_cursor_test) {
     auto order_bys = order_by_slots_builder.get_res();
 
     ASSERT_OK(sort_exprs.init(order_bys, nullptr, &pool, &dummy_rt_st));
-    ASSERT_OK(sort_exprs.prepare(&dummy_rt_st, {}, {}));
+    ASSERT_OK(sort_exprs.prepare(&dummy_rt_st));
     ASSERT_OK(sort_exprs.open(&dummy_rt_st));
 
     struct ChannelChunkProvider {
@@ -183,7 +183,7 @@ TEST(MergeCascadeTest, merge_sorted_chunks) {
     auto order_bys = order_by_slots_builder.get_res();
 
     ASSERT_OK(sort_exprs.init(order_bys, nullptr, &pool, &dummy_rt_st));
-    ASSERT_OK(sort_exprs.prepare(&dummy_rt_st, {}, {}));
+    ASSERT_OK(sort_exprs.prepare(&dummy_rt_st));
     ASSERT_OK(sort_exprs.open(&dummy_rt_st));
     auto desc = SortDescs::asc_null_first(1);
     {

--- a/be/test/storage/conjunctive_predicates_test.cpp
+++ b/be/test/storage/conjunctive_predicates_test.cpp
@@ -353,8 +353,7 @@ public:
         CHECK(DescriptorTbl::create(&_runtime_state, &_pool, table_builder.desc_tbl(), &tbl, config::vector_chunk_size)
                       .ok());
 
-        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples));
-        auto* tuple_desc = row_desc->tuple_descriptors()[0];
+        auto* tuple_desc = tbl->get_tuple_descriptor(row_tuples[0]);
 
         return tuple_desc;
     }

--- a/be/test/storage/publish_version_task_test.cpp
+++ b/be/test/storage/publish_version_task_test.cpp
@@ -207,8 +207,7 @@ public:
         CHECK(DescriptorTbl::create(&_runtime_state, &_pool, table_builder.desc_tbl(), &tbl, config::vector_chunk_size)
                       .ok());
 
-        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples));
-        auto* tuple_desc = row_desc->tuple_descriptors()[0];
+        auto* tuple_desc = tbl->get_tuple_descriptor(row_tuples[0]);
 
         return tuple_desc;
     }

--- a/be/test/storage/segment_flush_executor_test.cpp
+++ b/be/test/storage/segment_flush_executor_test.cpp
@@ -117,8 +117,7 @@ public:
         std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
         DescriptorTbl* tbl = nullptr;
         DescriptorTbl::create(&_runtime_state, &_pool, table_builder.desc_tbl(), &tbl, config::vector_chunk_size);
-        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples));
-        auto* tuple_desc = row_desc->tuple_descriptors()[0];
+        auto* tuple_desc = tbl->get_tuple_descriptor(row_tuples[0]);
 
         return tuple_desc;
     }


### PR DESCRIPTION
## Why I'm doing:

An ExecNode now exposes a RecordDescriptor: a flat view over the slots of the record it produces. Unlike RowDescriptor it does not expose how the record is split into tuples, which is what consumers actually wanted -- almost every one of them only iterated the tuples to reach their slots.

Threading it through revealed how little of the old plumbing was live:

- DataStreamSender, ExportSink, MysqlTableSink, SchemaTableSink, ResultSink, ArrowResultWriter, convert_to_arrow_schema and PipelineSinkBuilder::build took a row descriptor they never read; the parameter is gone.
- FileScanner, TableReader and TabletSinkIndexChannel held a row descriptor member that was assigned but never used; the members are gone.
- Analytor built a comparison RowDescriptor that nothing consumed, so the child tuple id it was built from is gone as well.
- DataStreamRecvr's descriptor looks equally dead but is read by SenderQueue through friend access to type incoming chunks, so it stays, as a RecordDescriptor; its per-tuple slot maps collapse into a single flat one.

The sort path takes a RecordDescriptor instead of the materialized tuple descriptor, and serde::build_protobuf_chunk_meta plus its load and dictionary cache callers follow, which leaves RowDescriptor with no users at all -- so it is deleted. Test helpers that built one only to reach tuple_descriptors()[0] now ask the descriptor table for that tuple directly.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
