### PR TITLE
[BugFix] Pass purge to Iceberg REST catalog when dropping table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -346,9 +346,11 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
     @Override
     public boolean dropTable(ConnectContext context, String dbName, String tableName, boolean purge) {
+        TableIdentifier identifier = TableIdentifier.of(convertDbNameToNamespace(dbName), tableName);
         try {
-            return withAuthRecovery(() -> delegate.get().dropTable(buildContext(context),
-                    TableIdentifier.of(convertDbNameToNamespace(dbName), tableName)));
+            return withAuthRecovery(() -> purge
+                    ? delegate.get().purgeTable(buildContext(context), identifier)
+                    : delegate.get().dropTable(buildContext(context), identifier));
         } catch (RESTException re) {
             LOG.error("Failed to drop table using REST Catalog, for dbName {} tableName {}", dbName, tableName, re);
             throw new StarRocksConnectorException("Failed to drop table using REST Catalog", re);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
@@ -212,6 +212,54 @@ public class IcebergRESTCatalogTest {
     }
 
     @Test
+    public void testDropTableWithPurge(@Mocked RESTSessionCatalog restCatalog) {
+        IcebergRESTCatalog icebergRESTCatalog = new IcebergRESTCatalog(restCatalog, new Configuration());
+
+        new Expectations() {
+            {
+                restCatalog.purgeTable((SessionContext) any, (TableIdentifier) any);
+                result = true;
+                times = 1;
+
+                restCatalog.dropTable((SessionContext) any, (TableIdentifier) any);
+                times = 0;
+            }
+        };
+        assertTrue(icebergRESTCatalog.dropTable(connectContext, "db", "tb1", true));
+    }
+
+    @Test
+    public void testDropTableWithoutPurge(@Mocked RESTSessionCatalog restCatalog) {
+        IcebergRESTCatalog icebergRESTCatalog = new IcebergRESTCatalog(restCatalog, new Configuration());
+
+        new Expectations() {
+            {
+                restCatalog.dropTable((SessionContext) any, (TableIdentifier) any);
+                result = true;
+                times = 1;
+
+                restCatalog.purgeTable((SessionContext) any, (TableIdentifier) any);
+                times = 0;
+            }
+        };
+        assertTrue(icebergRESTCatalog.dropTable(connectContext, "db", "tb1", false));
+    }
+
+    @Test
+    public void testDropTableWithPurgeException(@Mocked RESTSessionCatalog restCatalog) {
+        IcebergRESTCatalog icebergRESTCatalog = new IcebergRESTCatalog(restCatalog, new Configuration());
+
+        new Expectations() {
+            {
+                restCatalog.purgeTable((SessionContext) any, (TableIdentifier) any);
+                result = new RESTException("access denied");
+            }
+        };
+        ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class, "Failed to drop table using REST Catalog",
+                () -> icebergRESTCatalog.dropTable(connectContext, "db", "tb1", true));
+    }
+
+    @Test
     public void testDropView(@Mocked RESTSessionCatalog restCatalog) {
         IcebergMetadata metadata = buildIcebergMetadata(restCatalog);
         new MockUp<IcebergMetadata>() {


### PR DESCRIPTION
## Why I'm doing:

On an Iceberg REST catalog, `DROP TABLE t FORCE` returns OK but no data or metadata file is deleted from the object storage. No error and no warning, so the user believes the storage is cleaned but it is not.

`IcebergRESTCatalog.dropTable()` receives the `purge` parameter but does not use it. `IcebergHiveCatalog` and `IcebergGlueCatalog` pass `purge` to the delegate correctly. Only the REST catalog implementation is missing it.

## What I'm doing:

Call `purgeTable()` instead of `dropTable()` on the REST delegate when `purge` is true.

One note about the semantics: for the REST catalog, purge is sent to the server as `DELETE .../tables/{table}?purgeRequested=true`, and the actual file deletion is done by the catalog server. This is different from
Hive/Glue where the client (FE) deletes the files. So after this fix, whether the files are really deleted depends on the server. Also, if the server refuses purge (for example Polaris with `polaris.config.drop-with-purge.enabled` not set), the server error now surfaces to the user instead of being silently ignored.

Verified with unit tests (purge=true calls `purgeTable`, purge=false calls `dropTable`, exception propagation), and on a real cluster with Apache Polaris + MinIO.

```
DELETE /api/catalog/v1/.../tables/t_drop_plain HTTP/1.1 -> 204        (normal DROP: no purge, files remain)
DELETE /api/catalog/v1/.../tables/t_drop_force?purgeRequested=true -> 204   (FORCE: server deleted all data/metadata files)
```

Fixes #76929

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
