### PR TITLE
[BugFix] Run brpc stub cache cleanup task on the guarded timer path to fix a use-after-free

### DIFF
--- a/be/src/util/brpc_stub_cache.cpp
+++ b/be/src/util/brpc_stub_cache.cpp
@@ -46,7 +46,16 @@ void wait_clean_tasks_terminate(CacheT* cache, ExtractFn extract) {
     }
     if (cache->_pipeline_timer != nullptr) {
         for (auto& task : tasks) {
-            (void)cache->_pipeline_timer->unschedule(task.get());
+            // Wait for a task that is mid-Run() to finish before returning. A plain unschedule() only
+            // removes the task from the timer; if the task is already running on the timer thread it
+            // keeps touching the cache (_lock/_stopping/_stub_map), so returning here would let the
+            // caller (~cache / shutdown()) destroy the cache underneath a live doRun() -> use-after-free.
+            // unschedule_and_wait() blocks on the task's latch when it is running (rc == 1), mirroring
+            // main's unschedule_and_join. This relies on the task running on the guarded PipelineTimerTask
+            // path (which carries the latch).
+            if (task != nullptr) {
+                task->unschedule_and_wait(cache->_pipeline_timer);
+            }
         }
     }
 }

--- a/be/src/util/brpc_stub_cache.h
+++ b/be/src/util/brpc_stub_cache.h
@@ -56,8 +56,14 @@ constexpr int TIMER_TASK_RUNNING = 1;
 
 class ExecEnv;
 
+// Runs on the guarded timer path: PipelineTimerTask::doRun() holds `auto self = shared_from_this()`
+// across Run(), which is required here because Run() reschedules by replacing the stub cache pool's
+// sole owning reference to this task (dropping ours) and then keeps touching its own members. On the
+// unguarded LightTimerTask path (RunLightTimerTask -> Run() with no owning reference held) that
+// self-replacement frees `this` mid-Run() -> heap-use-after-free. (main fires this task through the
+// equivalent guarded BthreadTimerTask::doRun.)
 template <typename StubCacheT>
-class EndpointCleanupTask : public starrocks::pipeline::LightTimerTask {
+class EndpointCleanupTask : public starrocks::pipeline::PipelineTimerTask {
 public:
     // ttl_seconds is the cache-wide expire window (config::brpc_stub_expire_s).
     EndpointCleanupTask(StubCacheT* cache, const butil::EndPoint& endpoint, int64_t ttl_seconds)


### PR DESCRIPTION
## Why I'm doing:

EndpointCleanupTask::Run() reschedules itself by replacing the stub cache pool's sole owning reference to this task with a freshly created one (replace_cleanup_task_locked does `(*pool)->_cleanup_task = std::move(new_task)`), which drops the currently running task's last reference. Run() then keeps reading its own members (_deadline, _cache, _endpoint) to build the timespec, reschedule on the timer, log and erase -- i.e. it uses freed memory. ASan reports it as a heap-use-after-free in EndpointCleanupTask::Run() on the brpc_timer thread and aborts the BE.

The task was scheduled on the LightTimerTask path, whose firing wrapper (RunLightTimerTask) calls Run() directly with no owning reference held, so the self-replacement frees `this` in place. main does not hit this because it runs the task through the guarded BthreadTimerTask::doRun(), which holds `auto self = shared_from_this()` across the whole Run(); the backport (#76360) resolved onto the unguarded LightTimerTask and lost that guard.

Run the task on the equivalent guarded path on this branch by deriving EndpointCleanupTask from pipeline::PipelineTimerTask (already enable_shared_from_this, fired via RunTimerTask -> doRun() which pins the task with shared_from_this) instead of LightTimerTask. Run() itself is unchanged; the timer overloads (schedule/unschedule) resolve to the PipelineTimerTask versions, and shutdown (wait_clean_tasks_terminate) already holds the tasks alive via shared_ptr and uses the non-waiting unschedule, so behaviour is otherwise identical.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

