### PR TITLE
[BugFix] Fix INSERT INTO VALUES deparsing to unparseable SQL

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2SQLVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2SQLVisitor.java
@@ -584,9 +584,9 @@ public class AST2SQLVisitor extends AST2StringVisitor {
     }
 
     @Override
-    public String visitValues(ValuesRelation node, Void scope) {
+    protected String visitValueRows(ValuesRelation node) {
         if (!options.isEnableDigest()) {
-            return super.visitValues(node, scope);
+            return super.visitValueRows(node);
         }
 
         if (node.isNullValues()) {
@@ -603,6 +603,15 @@ public class AST2SQLVisitor extends AST2StringVisitor {
             sqlBuilder.append(rowBuilder);
         }
         return sqlBuilder.toString();
+    }
+
+    @Override
+    public String visitValues(ValuesRelation node, Void scope) {
+        if (!options.isEnableDigest()) {
+            return super.visitValues(node, scope);
+        }
+        // The digest form is deliberately unparenthesized and keeps only the first row.
+        return visitValueRows(node);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
@@ -772,14 +772,13 @@ public class AST2StringVisitor implements AstVisitorExtendInterface<String, Void
         return sqlBuilder.toString();
     }
 
-    @Override
-    public String visitValues(ValuesRelation node, Void scope) {
+    /**
+     * Renders the bare {@code VALUES (...), (...)} list, without the parentheses that
+     * {@link #visitValues} wraps around it for derived-table position.
+     */
+    protected String visitValueRows(ValuesRelation node) {
         StringBuilder sqlBuilder = new StringBuilder();
-        if (node.isNullValues()) {
-            return null;
-        }
-
-        sqlBuilder.append("(VALUES");
+        sqlBuilder.append("VALUES");
         List<String> values = new ArrayList<>();
         for (int i = 0; i < node.getRows().size(); ++i) {
             StringBuilder rowBuilder = new StringBuilder();
@@ -791,7 +790,20 @@ public class AST2StringVisitor implements AstVisitorExtendInterface<String, Void
             values.add(rowBuilder.toString());
         }
         sqlBuilder.append(Joiner.on(", ").join(values));
-        sqlBuilder.append(")");
+        return sqlBuilder.toString();
+    }
+
+    @Override
+    public String visitValues(ValuesRelation node, Void scope) {
+        StringBuilder sqlBuilder = new StringBuilder();
+        if (node.isNullValues()) {
+            return null;
+        }
+
+        // Parenthesized: reaching a ValuesRelation through the generic relation path means it sits in
+        // derived-table position, as in `FROM (VALUES (1), (2)) t`. The INSERT source position wants the
+        // bare list instead and goes through visitInsertSource().
+        sqlBuilder.append("(").append(visitValueRows(node)).append(")");
         if (node.getAlias() != null) {
             sqlBuilder.append(" ").append(node.getAlias().getTbl());
 
@@ -1024,9 +1036,28 @@ public class AST2StringVisitor implements AstVisitorExtendInterface<String, Void
 
         // source
         if (insert.getQueryStatement() != null) {
-            sb.append(visit(insert.getQueryStatement()));
+            sb.append(visitInsertSource(insert.getQueryStatement(), context));
         }
         return sb.toString();
+    }
+
+    /**
+     * INSERT takes a bare {@code VALUES (...), (...)} list as its source; the parenthesized form
+     * {@link #visitValues} emits for derived-table position does not parse here.
+     */
+    protected String visitInsertSource(QueryStatement queryStatement, Void context) {
+        QueryRelation relation = queryStatement.getQueryRelation();
+        // Anything the generic path decorates the relation with (CTEs, alias, ORDER BY, LIMIT) falls back
+        // to visitQueryStatement so those clauses are not dropped.
+        if (relation instanceof ValuesRelation
+                && !relation.hasWithClause()
+                && relation.getAlias() == null
+                && !relation.hasOrderByClause()
+                && relation.getLimit() == null
+                && !((ValuesRelation) relation).isNullValues()) {
+            return visitValueRows((ValuesRelation) relation);
+        }
+        return visit(queryStatement);
     }
 
     protected void visitInsertLabel(String label, StringBuilder sb) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AstToSQLBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AstToSQLBuilderTest.java
@@ -220,4 +220,47 @@ public class AstToSQLBuilderTest {
             Assertions.assertDoesNotThrow(() -> SqlParser.parseSingleStatement(serializedSql, SqlModeHelper.MODE_DEFAULT));
         }
     }
+
+    @Test
+    public void testInsertValuesRoundTrip() {
+        // The INSERT source takes a bare VALUES list. Emitting the parenthesized derived-table form
+        // `INSERT INTO t (cols) (VALUES ...)` produces SQL the parser rejects.
+        String[][] cases = {
+                {"insert into t0 (v1, v2) values (1, 111)", "INSERT INTO `t0` (`v1`,`v2`) VALUES(1, 111)"},
+                {"insert into t0 values (1, 2), (3, 4)", "INSERT INTO `t0` VALUES(1, 2), (3, 4)"},
+                {"insert into t0 values (1, null)", "INSERT INTO `t0` VALUES(1, NULL)"},
+                {"insert overwrite t0 (v1) values (1)", "INSERT OVERWRITE `t0` (`v1`) VALUES(1)"},
+                {"insert into t0 with label lb (v1) values (1)", "INSERT INTO `t0` WITH LABEL `lb` (`v1`) VALUES(1)"},
+        };
+        for (String[] c : cases) {
+            StatementBase stmt = SqlParser.parseSingleStatement(c[0], SqlModeHelper.MODE_DEFAULT);
+            String serializedSql = AstToSQLBuilder.toSQL(stmt);
+            Assertions.assertEquals(c[1], serializedSql, c[0]);
+            Assertions.assertDoesNotThrow(() -> SqlParser.parseSingleStatement(serializedSql, SqlModeHelper.MODE_DEFAULT),
+                    c[0]);
+            // Deparsing is a fixpoint: re-serializing the output must not change it again.
+            Assertions.assertEquals(serializedSql,
+                    AstToSQLBuilder.toSQL(SqlParser.parseSingleStatement(serializedSql, SqlModeHelper.MODE_DEFAULT)),
+                    c[0]);
+        }
+    }
+
+    @Test
+    public void testValuesInDerivedTablePositionKeepsParentheses() {
+        // Counterpart to testInsertValuesRoundTrip: outside the INSERT source, a VALUES relation sits in
+        // derived-table position and *must* stay parenthesized.
+        String sql = "select * from (values (1, 'a'), (2, 'b')) tt(x, y)";
+        StatementBase stmt = SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
+        String serializedSql = AstToSQLBuilder.toSQL(stmt);
+        Assertions.assertEquals("SELECT *\nFROM (VALUES(1, 'a'), (2, 'b')) tt(x,y)", serializedSql);
+        Assertions.assertDoesNotThrow(() -> SqlParser.parseSingleStatement(serializedSql, SqlModeHelper.MODE_DEFAULT));
+    }
+
+    @Test
+    public void testInsertValuesDigestUnaffected() {
+        // The digest form stays unparenthesized and keeps only the first row.
+        StatementBase stmt = SqlParser.parseSingleStatement(
+                "insert into t0 (v1, v2) values (1, 111), (2, 222)", SqlModeHelper.MODE_DEFAULT);
+        Assertions.assertEquals("INSERT INTO `t0` (`v1`,`v2`) VALUES(?, ?)", AstToSQLBuilder.toDigest(stmt));
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

AstToSQLBuilder serialized `INSERT INTO t (c1, c2) VALUES (1, 2)` as `INSERT INTO `t` (`c1`,`c2`) (VALUES(1, 2))`, which the parser then rejects with "No viable statement for input '(VALUES'". This breaks the contract stated on AstToSQLBuilder, that the SQL it generates must be legal SQL, and records non-executable statements in the audit log and query profile whenever those go through the deparser (multi-statement requests, credential-bearing statements, or enable_sql_desensitize_in_log).

visitValues() parenthesizes the VALUES list because a ValuesRelation reached through the generic relation path sits in derived-table position, as in `FROM (VALUES (1), (2)) t`, where the parentheses are required. Only the INSERT source position wants the bare list.

Extract the bare list into visitValueRows() and route the INSERT source through it via visitInsertSource(). Sources carrying a CTE, alias, ORDER BY or LIMIT fall back to visitQueryStatement() so those clauses are not dropped. The digest form is unchanged: its branch moves into a visitValueRows() override and emits the same bytes as before.

Measured over 25861 statements collected from test/sql and the FE test resources, deparser round-trip failures drop from 2325 to 174, and the clean round-trip rate for INSERT rises from 30.6% to 90.0%. No statement that round -tripped cleanly before changes category.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
