### PR TITLE
[Enhancement] Pass limit to Paimon getRemoteFiles in partition pruning phase

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
@@ -458,7 +458,7 @@ public class OptExternalPartitionPruner {
                     .collect(Collectors.toList());
             GetRemoteFilesParams params =
                     GetRemoteFilesParams.newBuilder().setPredicate(operator.getPredicate()).setFieldNames(fieldNames)
-                            .setTableVersionRange(operator.getTvrVersionRange()).build();
+                            .setTableVersionRange(operator.getTvrVersionRange()).setLimit(operator.getLimit()).build();
             List<RemoteFileInfo> fileInfos = GlobalStateMgr.getCurrentState().getMetadataMgr().getRemoteFiles(table, params);
             if (fileInfos.isEmpty()) {
                 return;


### PR DESCRIPTION

## Why I'm doing:
A simple SELECT * FROM paimon_table LIMIT 10 on a large Paimon table (hundreds
  of partitions, millions of data files) takes an unexpectedly long time in the
  planning phase — scanning all manifests and generating splits for the entire
  table, even though only 10 rows are needed.

  Root cause — optimizer rule ordering and a missing limit parameter.
  ExternalScanPartitionPruneRule (which calls OptExternalPartitionPruner.computePartitionInfo())
  fires during PARTITION_PRUNE_RULES, which executes before MERGE_LIMIT_RULES
  in the logical rewrite phase. the Paimon branch builds
  GetRemoteFilesParams without setting limit:

  GetRemoteFilesParams params =
      GetRemoteFilesParams.newBuilder().setPredicate(operator.getPredicate()).setFieldNames(fieldNames)
              .setTableVersionRange(operator.getTvrVersionRange()).build();

  PaimonMetadata.getRemoteFiles() checks params.getLimit() != -1 to decide
  whether to call Paimon's ReadBuilder.withLimit() for manifest pruning. With
  limit=-1 (the default), all manifests are expanded into splits.

## What I'm doing:

OptExternalPartitionPruner.computePartitionInfo(): pass operator.getLimit()
  to GetRemoteFilesParams.Builder.setLimit() so that Paimon's manifest-level
  pruning takes effect when a limit is already present on the scan operator at
  partition-prune time. For queries where limit has not yet been pushed down
  (e.g. complex plans with joins/aggregations above the scan), the operator's
  limit remains at its default -1, which is the no-op sentinel in
  PaimonMetadata — no behavioral change for those paths.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
