### PR TITLE
[Enhancement] Release the reshard output shards' placement pin when the job finishes

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
@@ -289,7 +289,9 @@ public class MergeTabletJob extends TabletReshardJob {
      * 2. Remove old versions of materialized index
      * 3. Unregister resharding tablets
      * 4. Set tablet state to NORMAL
-     * 5. Set job state to FINISHED
+     * 5. Update metrics
+     * 6. Release the merged shards' creation-time placement pin
+     * 7. Set job state to FINISHED
      */
     @Override
     protected void runCleaningJob() {
@@ -322,7 +324,11 @@ public class MergeTabletJob extends TabletReshardJob {
             MetricRepo.HISTO_TABLET_RESHARD_JOB_DURATION.update(System.currentTimeMillis() - createdTimeMs);
         }
 
-        // 6. Set job state to FINISHED
+        // 6. Release the merged shards' creation-time placement pin so the balancer can spread them
+        //    now, instead of when the source shards are finally reclaimed tens of minutes later.
+        clearPlacementPreference(reshardingPhysicalPartitions);
+
+        // 7. Set job state to FINISHED
         setJobState(JobState.FINISHED);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
@@ -96,6 +96,7 @@ public class MergeTabletJob extends TabletReshardJob {
         return tableId;
     }
 
+    @Override
     public Map<Long, ReshardingPhysicalPartition> getReshardingPhysicalPartitions() {
         return reshardingPhysicalPartitions;
     }
@@ -326,7 +327,7 @@ public class MergeTabletJob extends TabletReshardJob {
 
         // 6. Release the merged shards' creation-time placement pin so the balancer can spread them
         //    now, instead of when the source shards are finally reclaimed tens of minutes later.
-        clearPlacementPreference(reshardingPhysicalPartitions);
+        clearPlacementPreference();
 
         // 7. Set job state to FINISHED
         setJobState(JobState.FINISHED);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
@@ -96,7 +96,6 @@ public class MergeTabletJob extends TabletReshardJob {
         return tableId;
     }
 
-    @Override
     public Map<Long, ReshardingPhysicalPartition> getReshardingPhysicalPartitions() {
         return reshardingPhysicalPartitions;
     }
@@ -327,7 +326,7 @@ public class MergeTabletJob extends TabletReshardJob {
 
         // 6. Release the merged shards' creation-time placement pin so the balancer can spread them
         //    now, instead of when the source shards are finally reclaimed tens of minutes later.
-        clearPlacementPreference();
+        clearPlacementPreference(reshardingPhysicalPartitions);
 
         // 7. Set job state to FINISHED
         setJobState(JobState.FINISHED);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -322,7 +322,9 @@ public class SplitTabletJob extends TabletReshardJob {
      * 2. Remove old versions of materialized index
      * 3. Unregister resharding tablets
      * 4. Set tablet state to NORMAL
-     * 5. Set job state to FINISHED
+     * 5. Update metrics
+     * 6. Release the new shards' creation-time placement pin
+     * 7. Set job state to FINISHED
      */
     @Override
     protected void runCleaningJob() {
@@ -355,7 +357,11 @@ public class SplitTabletJob extends TabletReshardJob {
             MetricRepo.HISTO_TABLET_RESHARD_JOB_DURATION.update(System.currentTimeMillis() - createdTimeMs);
         }
 
-        // 6. Set job state to FINISHED
+        // 6. Release the child shards' creation-time placement pin so the balancer can spread them
+        //    now, instead of when the parent shards are finally reclaimed tens of minutes later.
+        clearPlacementPreference(reshardingPhysicalPartitions);
+
+        // 7. Set job state to FINISHED
         setJobState(JobState.FINISHED);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -108,7 +108,6 @@ public class SplitTabletJob extends TabletReshardJob {
         return tableId;
     }
 
-    @Override
     public Map<Long, ReshardingPhysicalPartition> getReshardingPhysicalPartitions() {
         return reshardingPhysicalPartitions;
     }
@@ -360,7 +359,7 @@ public class SplitTabletJob extends TabletReshardJob {
 
         // 6. Release the child shards' creation-time placement pin so the balancer can spread them
         //    now, instead of when the parent shards are finally reclaimed tens of minutes later.
-        clearPlacementPreference();
+        clearPlacementPreference(reshardingPhysicalPartitions);
 
         // 7. Set job state to FINISHED
         setJobState(JobState.FINISHED);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -108,6 +108,7 @@ public class SplitTabletJob extends TabletReshardJob {
         return tableId;
     }
 
+    @Override
     public Map<Long, ReshardingPhysicalPartition> getReshardingPhysicalPartitions() {
         return reshardingPhysicalPartitions;
     }
@@ -359,7 +360,7 @@ public class SplitTabletJob extends TabletReshardJob {
 
         // 6. Release the child shards' creation-time placement pin so the balancer can spread them
         //    now, instead of when the parent shards are finally reclaimed tens of minutes later.
-        clearPlacementPreference(reshardingPhysicalPartitions);
+        clearPlacementPreference();
 
         // 7. Set job state to FINISHED
         setJobState(JobState.FINISHED);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
@@ -297,6 +297,8 @@ public abstract class TabletReshardJob implements Writable {
 
     public abstract TTabletReshardJobsItem getInfo();
 
+    public abstract Map<Long, ReshardingPhysicalPartition> getReshardingPhysicalPartitions();
+
     /**
      * Shared reshard-cleanup step for split and merge: for every superseded (old) materialized index,
      * schedule its removal in the {@code CatalogRecycleBin} at index granularity, so an in-flight query
@@ -351,10 +353,9 @@ public abstract class TabletReshardJob implements Writable {
      * <p>Best-effort by design: a failure only degrades to that old behavior, so it must never
      * interrupt the job. The caller is the leader-only cleaning path; replay paths do not call this.
      */
-    protected void clearPlacementPreference(
-            Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions) {
+    protected void clearPlacementPreference() {
         Set<Long> newTabletIds = new HashSet<>();
-        for (ReshardingPhysicalPartition partition : reshardingPhysicalPartitions.values()) {
+        for (ReshardingPhysicalPartition partition : getReshardingPhysicalPartitions().values()) {
             for (ReshardingMaterializedIndex index : partition.getReshardingIndexes().values()) {
                 for (ReshardingTablet tablet : index.getReshardingTablets()) {
                     newTabletIds.addAll(tablet.getNewTabletIds());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
@@ -28,7 +28,9 @@ import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /*
  * TabletReshardJob is for tablet splitting and merging.
@@ -336,6 +338,36 @@ public abstract class TabletReshardJob implements Writable {
                 GlobalStateMgr.getCurrentState().getRecycleBin().recycleMaterializedIndex(
                         new RecycleMaterializedIndexInfo(dbId, olapTable.getId(), physicalPartitionId, oldIndexId));
             }
+        }
+    }
+
+    /**
+     * Shared reshard-completion step for split and merge: drop the creation-time placement pin on
+     * every new shard, so the background balancer can spread them right away. StarOS only drops the
+     * pin on its own once the superseded (old / source) shards are reclaimed, which happens a
+     * recycle-bin retention plus a {@code StarMgrMetaSyncer} cycle later -- and for the whole of
+     * that window the new shards cannot be moved off the source worker at all.
+     *
+     * <p>Best-effort by design: a failure only degrades to that old behavior, so it must never
+     * interrupt the job. The caller is the leader-only cleaning path; replay paths do not call this.
+     */
+    protected void clearPlacementPreference(
+            Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions) {
+        Set<Long> newTabletIds = new HashSet<>();
+        for (ReshardingPhysicalPartition partition : reshardingPhysicalPartitions.values()) {
+            for (ReshardingMaterializedIndex index : partition.getReshardingIndexes().values()) {
+                for (ReshardingTablet tablet : index.getReshardingTablets()) {
+                    newTabletIds.addAll(tablet.getNewTabletIds());
+                }
+            }
+        }
+        if (newTabletIds.isEmpty()) {
+            return;
+        }
+        try {
+            GlobalStateMgr.getCurrentState().getStarOSAgent().clearPlacementPreference(newTabletIds);
+        } catch (Exception e) {
+            LOG.warn("Failed to clear placement preference for reshard job {}: {}", jobId, e.getMessage());
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
@@ -28,9 +28,9 @@ import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /*
  * TabletReshardJob is for tablet splitting and merging.
@@ -353,19 +353,28 @@ public abstract class TabletReshardJob implements Writable {
      */
     protected void clearPlacementPreference(
             Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions) {
-        Set<Long> newTabletIds = new HashSet<>();
+        // Name the members of each preference group rather than just the new shards: StarOS needs to
+        // know which preference is meant, since a new shard here becomes the pin target of the next
+        // reshard on the same tablet. Every (superseded, new) combination of a resharding tablet is
+        // exactly one preference, which reproduces what createShardsForSplit/ForMerge established --
+        // a split pins each child to its one parent, a merge pins the one output to each source.
+        List<List<Long>> preferenceMembers = new ArrayList<>();
         for (ReshardingPhysicalPartition partition : reshardingPhysicalPartitions.values()) {
             for (ReshardingMaterializedIndex index : partition.getReshardingIndexes().values()) {
                 for (ReshardingTablet tablet : index.getReshardingTablets()) {
-                    newTabletIds.addAll(tablet.getNewTabletIds());
+                    for (long oldTabletId : tablet.getOldTabletIds()) {
+                        for (long newTabletId : tablet.getNewTabletIds()) {
+                            preferenceMembers.add(List.of(oldTabletId, newTabletId));
+                        }
+                    }
                 }
             }
         }
-        if (newTabletIds.isEmpty()) {
+        if (preferenceMembers.isEmpty()) {
             return;
         }
         try {
-            GlobalStateMgr.getCurrentState().getStarOSAgent().clearPlacementPreference(newTabletIds);
+            GlobalStateMgr.getCurrentState().getStarOSAgent().clearPlacementPreference(preferenceMembers);
         } catch (Exception e) {
             // Log the throwable, not just its message: this catch is broad enough to swallow a
             // programming error (an NPE would otherwise be recorded as a bare "null"), and the job

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
@@ -297,8 +297,6 @@ public abstract class TabletReshardJob implements Writable {
 
     public abstract TTabletReshardJobsItem getInfo();
 
-    public abstract Map<Long, ReshardingPhysicalPartition> getReshardingPhysicalPartitions();
-
     /**
      * Shared reshard-cleanup step for split and merge: for every superseded (old) materialized index,
      * schedule its removal in the {@code CatalogRecycleBin} at index granularity, so an in-flight query
@@ -353,9 +351,10 @@ public abstract class TabletReshardJob implements Writable {
      * <p>Best-effort by design: a failure only degrades to that old behavior, so it must never
      * interrupt the job. The caller is the leader-only cleaning path; replay paths do not call this.
      */
-    protected void clearPlacementPreference() {
+    protected void clearPlacementPreference(
+            Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions) {
         Set<Long> newTabletIds = new HashSet<>();
-        for (ReshardingPhysicalPartition partition : getReshardingPhysicalPartitions().values()) {
+        for (ReshardingPhysicalPartition partition : reshardingPhysicalPartitions.values()) {
             for (ReshardingMaterializedIndex index : partition.getReshardingIndexes().values()) {
                 for (ReshardingTablet tablet : index.getReshardingTablets()) {
                     newTabletIds.addAll(tablet.getNewTabletIds());
@@ -368,7 +367,10 @@ public abstract class TabletReshardJob implements Writable {
         try {
             GlobalStateMgr.getCurrentState().getStarOSAgent().clearPlacementPreference(newTabletIds);
         } catch (Exception e) {
-            LOG.warn("Failed to clear placement preference for reshard job {}: {}", jobId, e.getMessage());
+            // Log the throwable, not just its message: this catch is broad enough to swallow a
+            // programming error (an NPE would otherwise be recorded as a bare "null"), and the job
+            // goes on to FINISHED either way, so the stack trace is the only trace left.
+            LOG.warn("Failed to clear placement preference for reshard job {}", jobId, e);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -577,21 +577,27 @@ public class StarOSAgent {
     }
 
     /**
-     * Drop the anonymous PACK groups StarOS created from these shards' creation-time placement
-     * preferences -- the WITH_SHARD pin a tablet split/merge uses so the new shards reuse the source
-     * worker's warm cache. Until the pin is dropped the new shards cannot be spread across workers
-     * by the background balancer, and StarOS only drops it on its own when the superseded shards are
-     * deleted, which is tens of minutes later. Idempotent on the StarOS side.
+     * Dissolve the anonymous PACK groups StarOS created from creation-time placement preferences --
+     * the WITH_SHARD pin a tablet split/merge uses so the new shards reuse the source worker's warm
+     * cache. Until the pin is dropped the new shards cannot be spread across workers by the
+     * background balancer, and StarOS only drops it on its own when the superseded shards are
+     * deleted, which is tens of minutes later.
+     *
+     * <p>Each entry of {@code preferenceMembers} names the shards forming one preference group -- for
+     * a reshard, the superseded shard the pin targeted and the new shard created with it. Naming the
+     * members is what makes the request unambiguous: a shard can be the target of one preference and
+     * the owner of another, so "every group containing this shard" would dissolve pins that belong to
+     * a later reshard. Idempotent on the StarOS side.
      */
-    public void clearPlacementPreference(Set<Long> shardIds) throws DdlException {
-        if (shardIds.isEmpty()) {
+    public void clearPlacementPreference(List<List<Long>> preferenceMembers) throws DdlException {
+        if (preferenceMembers.isEmpty()) {
             return;
         }
         prepare();
         try {
-            client.clearPlacementPreference(serviceId, new ArrayList<>(shardIds));
+            client.clearPlacementPreference(serviceId, preferenceMembers);
         } catch (StarClientException e) {
-            throw new DdlException("Failed to clear placement preference for shards " + shardIds
+            throw new DdlException("Failed to clear placement preference for " + preferenceMembers
                     + ". error: " + e.getMessage());
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -576,6 +576,26 @@ public class StarOSAgent {
         }
     }
 
+    /**
+     * Drop the anonymous PACK groups StarOS created from these shards' creation-time placement
+     * preferences -- the WITH_SHARD pin a tablet split/merge uses so the new shards reuse the source
+     * worker's warm cache. Until the pin is dropped the new shards cannot be spread across workers
+     * by the background balancer, and StarOS only drops it on its own when the superseded shards are
+     * deleted, which is tens of minutes later. Idempotent on the StarOS side.
+     */
+    public void clearPlacementPreference(Set<Long> shardIds) throws DdlException {
+        if (shardIds.isEmpty()) {
+            return;
+        }
+        prepare();
+        try {
+            client.clearPlacementPreference(serviceId, new ArrayList<>(shardIds));
+        } catch (StarClientException e) {
+            throw new DdlException("Failed to clear placement preference for shards " + shardIds
+                    + ". error: " + e.getMessage());
+        }
+    }
+
     public List<ShardGroupInfo> listShardGroup() throws DdlException {
         prepare();
         try {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
@@ -70,7 +70,6 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -767,27 +766,31 @@ public class MergeTabletJobTest {
                 }
             };
 
-            AtomicReference<Set<Long>> cleared = new AtomicReference<>();
+            AtomicReference<List<List<Long>>> cleared = new AtomicReference<>();
             AtomicReference<TabletReshardJob.JobState> stateAtCall = new AtomicReference<>();
             AtomicInteger calls = new AtomicInteger();
             new MockUp<StarOSAgent>() {
                 @Mock
-                public void clearPlacementPreference(Set<Long> shardIds) {
+                public void clearPlacementPreference(List<List<Long>> preferenceMembers) {
                     calls.incrementAndGet();
-                    cleared.set(new HashSet<>(shardIds));
+                    cleared.set(new ArrayList<>(preferenceMembers));
                     stateAtCall.set(mergeJob.getJobState());
                 }
             };
 
-            Set<Long> expected = new HashSet<>();
+            List<List<Long>> expected = new ArrayList<>();
             for (ReshardingPhysicalPartition partition : mergeJob.getReshardingPhysicalPartitions().values()) {
                 for (ReshardingMaterializedIndex index : partition.getReshardingIndexes().values()) {
                     for (ReshardingTablet tablet : index.getReshardingTablets()) {
-                        expected.addAll(tablet.getNewTabletIds());
+                        for (long oldId : tablet.getOldTabletIds()) {
+                            for (long newId : tablet.getNewTabletIds()) {
+                                expected.add(List.of(oldId, newId));
+                            }
+                        }
                     }
                 }
             }
-            Assertions.assertFalse(expected.isEmpty(), "test fixture must produce new tablet ids");
+            Assertions.assertFalse(expected.isEmpty(), "test fixture must produce preference members");
 
             mergeJob.runCleaningJob();
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
@@ -70,6 +70,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -77,6 +78,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class MergeTabletJobTest {
@@ -731,6 +733,74 @@ public class MergeTabletJobTest {
         int oldTabletCount = oldIndex.getTablets().size();
         int newTabletCount = reshardingIndex.getMaterializedIndex().getTablets().size();
         Assertions.assertEquals(oldTabletCount - 1, newTabletCount);
+    }
+
+    @Test
+    public void testCleaningClearsPlacementPreferenceBeforeFinishing() throws Exception {
+        ensureTabletCount(3);
+        PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
+        MaterializedIndex oldIndex = physicalPartition.getLatestBaseIndex();
+        List<Tablet> orderedTablets = new ArrayList<>(oldIndex.getTablets());
+        TabletGroupList tabletGroupList = new TabletGroupList(
+                List.of(List.of(orderedTablets.get(0).getId(), orderedTablets.get(1).getId())));
+        MergeTabletClause clause = new MergeTabletClause(null, tabletGroupList, null);
+        MergeTabletJobFactory factory = new MergeTabletJobFactory(db, table, clause);
+        MergeTabletJob mergeJob = (MergeTabletJob) factory.createTabletReshardJob();
+
+        mergeJob.init();   // reserves the table: NORMAL -> TABLET_RESHARD
+        try {
+            mergeJob.setJobState(TabletReshardJob.JobState.CLEANING);
+            mergeJob.endTransactionId = 5000L;
+
+            new MockUp<CompactionMgr>() {
+                @Mock
+                public Set<Long> cancelPreviousCompactions(long endTransactionId, long dbId, long tableId,
+                        Set<Long> includePartitionIds) {
+                    return Set.of();
+                }
+            };
+            new MockUp<GlobalTransactionMgr>() {
+                @Mock
+                public boolean isPreviousTransactionsFinished(long endTransactionId, long dbId,
+                        List<Long> tableIds, Set<Long> excludeTransactionIds) {
+                    return true;
+                }
+            };
+
+            AtomicReference<Set<Long>> cleared = new AtomicReference<>();
+            AtomicReference<TabletReshardJob.JobState> stateAtCall = new AtomicReference<>();
+            AtomicInteger calls = new AtomicInteger();
+            new MockUp<StarOSAgent>() {
+                @Mock
+                public void clearPlacementPreference(Set<Long> shardIds) {
+                    calls.incrementAndGet();
+                    cleared.set(new HashSet<>(shardIds));
+                    stateAtCall.set(mergeJob.getJobState());
+                }
+            };
+
+            Set<Long> expected = new HashSet<>();
+            for (ReshardingPhysicalPartition partition : mergeJob.getReshardingPhysicalPartitions().values()) {
+                for (ReshardingMaterializedIndex index : partition.getReshardingIndexes().values()) {
+                    for (ReshardingTablet tablet : index.getReshardingTablets()) {
+                        expected.addAll(tablet.getNewTabletIds());
+                    }
+                }
+            }
+            Assertions.assertFalse(expected.isEmpty(), "test fixture must produce new tablet ids");
+
+            mergeJob.runCleaningJob();
+
+            Assertions.assertEquals(TabletReshardJob.JobState.FINISHED, mergeJob.getJobState());
+            Assertions.assertEquals(1, calls.get(), "the finish path must clear the pin exactly once");
+            Assertions.assertEquals(expected, cleared.get());
+            Assertions.assertEquals(TabletReshardJob.JobState.CLEANING, stateAtCall.get(),
+                    "the pin must be cleared before the job is marked FINISHED");
+        } finally {
+            if (table.getState() == OlapTable.OlapTableState.TABLET_RESHARD) {
+                mergeJob.replayAbortedJob();   // restores NORMAL on the shared table fixture
+            }
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
@@ -64,6 +64,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -71,6 +72,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 
@@ -756,6 +758,111 @@ public class SplitTabletJobTest {
         Assertions.assertEquals(splitJob.getReshardingPhysicalPartitions().keySet(), includePartitionIdsArg.get());
         Assertions.assertEquals(ignoredCompactionTxnIds, excludeTxnIdsArg.get());
         Assertions.assertEquals(TabletReshardJob.JobState.CLEANING, splitJob.getJobState());
+    }
+
+    @Test
+    public void testCleaningClearsPlacementPreferenceBeforeFinishing() throws Exception {
+        SplitTabletJob splitJob = (SplitTabletJob) createTabletReshardJob();
+        splitJob.init();   // reserves the table: NORMAL -> TABLET_RESHARD
+        try {
+            splitJob.setJobState(TabletReshardJob.JobState.CLEANING);
+            splitJob.endTransactionId = 5000L;
+
+            new MockUp<CompactionMgr>() {
+                @Mock
+                public Set<Long> cancelPreviousCompactions(long endTransactionId, long dbId, long tableId,
+                        Set<Long> includePartitionIds) {
+                    return Set.of();
+                }
+            };
+            new MockUp<GlobalTransactionMgr>() {
+                @Mock
+                public boolean isPreviousTransactionsFinished(long endTransactionId, long dbId,
+                        List<Long> tableIds, Set<Long> excludeTransactionIds) {
+                    return true;
+                }
+            };
+
+            AtomicReference<Set<Long>> cleared = new AtomicReference<>();
+            AtomicReference<TabletReshardJob.JobState> stateAtCall = new AtomicReference<>();
+            AtomicInteger calls = new AtomicInteger();
+            new MockUp<StarOSAgent>() {
+                @Mock
+                public void clearPlacementPreference(Set<Long> shardIds) {
+                    // Capture only; assert outside the mock so a binding failure cannot hide a
+                    // failed assertion.
+                    calls.incrementAndGet();
+                    cleared.set(new HashSet<>(shardIds));
+                    stateAtCall.set(splitJob.getJobState());
+                }
+            };
+
+            Set<Long> expected = new HashSet<>();
+            for (ReshardingPhysicalPartition partition : splitJob.getReshardingPhysicalPartitions().values()) {
+                for (ReshardingMaterializedIndex index : partition.getReshardingIndexes().values()) {
+                    for (ReshardingTablet tablet : index.getReshardingTablets()) {
+                        expected.addAll(tablet.getNewTabletIds());
+                    }
+                }
+            }
+            Assertions.assertFalse(expected.isEmpty(), "test fixture must produce new tablet ids");
+
+            splitJob.runCleaningJob();
+
+            Assertions.assertEquals(TabletReshardJob.JobState.FINISHED, splitJob.getJobState());
+            Assertions.assertEquals(1, calls.get(), "the finish path must clear the pin exactly once");
+            Assertions.assertEquals(expected, cleared.get());
+            Assertions.assertEquals(TabletReshardJob.JobState.CLEANING, stateAtCall.get(),
+                    "the pin must be cleared before the job is marked FINISHED");
+        } finally {
+            if (table.getState() == OlapTable.OlapTableState.TABLET_RESHARD) {
+                splitJob.replayAbortedJob();   // restores NORMAL on the shared table fixture
+            }
+        }
+    }
+
+    @Test
+    public void testCleaningStillFinishesWhenClearingPlacementPreferenceFails() throws Exception {
+        SplitTabletJob splitJob = (SplitTabletJob) createTabletReshardJob();
+        splitJob.init();
+        try {
+            splitJob.setJobState(TabletReshardJob.JobState.CLEANING);
+            splitJob.endTransactionId = 5000L;
+
+            new MockUp<CompactionMgr>() {
+                @Mock
+                public Set<Long> cancelPreviousCompactions(long endTransactionId, long dbId, long tableId,
+                        Set<Long> includePartitionIds) {
+                    return Set.of();
+                }
+            };
+            new MockUp<GlobalTransactionMgr>() {
+                @Mock
+                public boolean isPreviousTransactionsFinished(long endTransactionId, long dbId,
+                        List<Long> tableIds, Set<Long> excludeTransactionIds) {
+                    return true;
+                }
+            };
+            AtomicInteger calls = new AtomicInteger();
+            new MockUp<StarOSAgent>() {
+                @Mock
+                public void clearPlacementPreference(Set<Long> shardIds) throws DdlException {
+                    calls.incrementAndGet();
+                    throw new DdlException("simulated StarOS failure");
+                }
+            };
+
+            // Best-effort: clearing the pin is an optimization, so a StarOS failure must not keep
+            // the job from finishing.
+            splitJob.runCleaningJob();
+
+            Assertions.assertEquals(1, calls.get(), "the failing mock must actually have been invoked");
+            Assertions.assertEquals(TabletReshardJob.JobState.FINISHED, splitJob.getJobState());
+        } finally {
+            if (table.getState() == OlapTable.OlapTableState.TABLET_RESHARD) {
+                splitJob.replayAbortedJob();
+            }
+        }
     }
 
     private TabletReshardJob createTabletReshardJob() throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
@@ -64,7 +64,6 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -783,29 +782,33 @@ public class SplitTabletJobTest {
                 }
             };
 
-            AtomicReference<Set<Long>> cleared = new AtomicReference<>();
+            AtomicReference<List<List<Long>>> cleared = new AtomicReference<>();
             AtomicReference<TabletReshardJob.JobState> stateAtCall = new AtomicReference<>();
             AtomicInteger calls = new AtomicInteger();
             new MockUp<StarOSAgent>() {
                 @Mock
-                public void clearPlacementPreference(Set<Long> shardIds) {
+                public void clearPlacementPreference(List<List<Long>> preferenceMembers) {
                     // Capture only; assert outside the mock so a binding failure cannot hide a
                     // failed assertion.
                     calls.incrementAndGet();
-                    cleared.set(new HashSet<>(shardIds));
+                    cleared.set(new ArrayList<>(preferenceMembers));
                     stateAtCall.set(splitJob.getJobState());
                 }
             };
 
-            Set<Long> expected = new HashSet<>();
+            List<List<Long>> expected = new ArrayList<>();
             for (ReshardingPhysicalPartition partition : splitJob.getReshardingPhysicalPartitions().values()) {
                 for (ReshardingMaterializedIndex index : partition.getReshardingIndexes().values()) {
                     for (ReshardingTablet tablet : index.getReshardingTablets()) {
-                        expected.addAll(tablet.getNewTabletIds());
+                        for (long oldId : tablet.getOldTabletIds()) {
+                            for (long newId : tablet.getNewTabletIds()) {
+                                expected.add(List.of(oldId, newId));
+                            }
+                        }
                     }
                 }
             }
-            Assertions.assertFalse(expected.isEmpty(), "test fixture must produce new tablet ids");
+            Assertions.assertFalse(expected.isEmpty(), "test fixture must produce preference members");
 
             splitJob.runCleaningJob();
 
@@ -846,7 +849,7 @@ public class SplitTabletJobTest {
             AtomicInteger calls = new AtomicInteger();
             new MockUp<StarOSAgent>() {
                 @Mock
-                public void clearPlacementPreference(Set<Long> shardIds) throws DdlException {
+                public void clearPlacementPreference(List<List<Long>> preferenceMembers) throws DdlException {
                     calls.incrementAndGet();
                     throw new DdlException("simulated StarOS failure");
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
@@ -68,9 +68,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class StarOSAgentTest {
@@ -457,6 +460,53 @@ public class StarOSAgentTest {
             Assertions.assertEquals(PlacementRelationship.WITH_SHARD, pref.getPlacementRelationship());
             Assertions.assertEquals(oldShardId, pref.getRelationshipTargetId());
         }
+    }
+
+    @Test
+    public void testClearPlacementPreference() throws StarClientException, DdlException {
+        List<Long> captured = new ArrayList<>();
+        AtomicInteger calls = new AtomicInteger();
+        new Expectations(client) {
+            {
+                client.clearPlacementPreference("1", (List<Long>) any);
+                result = new Delegate<Void>() {
+                    @SuppressWarnings("unused")
+                    void clearPlacementPreference(String sid, List<Long> shardIds) {
+                        // Capture only; assert outside the mock so a binding failure cannot hide a
+                        // failed assertion.
+                        calls.incrementAndGet();
+                        captured.clear();
+                        captured.addAll(shardIds);
+                    }
+                };
+                minTimes = 0;
+            }
+        };
+        Deencapsulation.setField(starosAgent, "serviceId", "1");
+
+        starosAgent.clearPlacementPreference(Set.of(10L, 11L));
+        Assertions.assertEquals(1, calls.get());
+        Assertions.assertEquals(Set.of(10L, 11L), new HashSet<>(captured));
+
+        // An empty shard set must short-circuit before the RPC.
+        starosAgent.clearPlacementPreference(Set.of());
+        Assertions.assertEquals(1, calls.get(), "empty shard set must not issue an RPC");
+    }
+
+    @Test
+    public void testClearPlacementPreferenceWrapsStarClientException() throws StarClientException {
+        new Expectations(client) {
+            {
+                client.clearPlacementPreference("1", (List<Long>) any);
+                result = new StarClientException(StatusCode.INVALID_ARGUMENT, "mocked exception");
+            }
+        };
+        Deencapsulation.setField(starosAgent, "serviceId", "1");
+
+        DdlException thrown = Assertions.assertThrows(DdlException.class,
+                () -> starosAgent.clearPlacementPreference(Set.of(10L)));
+        Assertions.assertTrue(thrown.getMessage().contains("mocked exception"),
+                "expected the cause message, got: " + thrown.getMessage());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
@@ -68,11 +68,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -464,19 +462,19 @@ public class StarOSAgentTest {
 
     @Test
     public void testClearPlacementPreference() throws StarClientException, DdlException {
-        List<Long> captured = new ArrayList<>();
+        List<List<Long>> captured = new ArrayList<>();
         AtomicInteger calls = new AtomicInteger();
         new Expectations(client) {
             {
-                client.clearPlacementPreference("1", (List<Long>) any);
+                client.clearPlacementPreference("1", (List<List<Long>>) any);
                 result = new Delegate<Void>() {
                     @SuppressWarnings("unused")
-                    void clearPlacementPreference(String sid, List<Long> shardIds) {
+                    void clearPlacementPreference(String sid, List<List<Long>> preferenceMembers) {
                         // Capture only; assert outside the mock so a binding failure cannot hide a
                         // failed assertion.
                         calls.incrementAndGet();
                         captured.clear();
-                        captured.addAll(shardIds);
+                        captured.addAll(preferenceMembers);
                     }
                 };
                 minTimes = 0;
@@ -484,27 +482,27 @@ public class StarOSAgentTest {
         };
         Deencapsulation.setField(starosAgent, "serviceId", "1");
 
-        starosAgent.clearPlacementPreference(Set.of(10L, 11L));
+        starosAgent.clearPlacementPreference(List.of(List.of(10L, 11L)));
         Assertions.assertEquals(1, calls.get());
-        Assertions.assertEquals(Set.of(10L, 11L), new HashSet<>(captured));
+        Assertions.assertEquals(List.of(List.of(10L, 11L)), captured);
 
-        // An empty shard set must short-circuit before the RPC.
-        starosAgent.clearPlacementPreference(Set.of());
-        Assertions.assertEquals(1, calls.get(), "empty shard set must not issue an RPC");
+        // Nothing to clear must short-circuit before the RPC.
+        starosAgent.clearPlacementPreference(List.of());
+        Assertions.assertEquals(1, calls.get(), "an empty request must not issue an RPC");
     }
 
     @Test
     public void testClearPlacementPreferenceWrapsStarClientException() throws StarClientException {
         new Expectations(client) {
             {
-                client.clearPlacementPreference("1", (List<Long>) any);
+                client.clearPlacementPreference("1", (List<List<Long>>) any);
                 result = new StarClientException(StatusCode.INVALID_ARGUMENT, "mocked exception");
             }
         };
         Deencapsulation.setField(starosAgent, "serviceId", "1");
 
         DdlException thrown = Assertions.assertThrows(DdlException.class,
-                () -> starosAgent.clearPlacementPreference(Set.of(10L)));
+                () -> starosAgent.clearPlacementPreference(List.of(List.of(10L, 11L))));
         Assertions.assertTrue(thrown.getMessage().contains("mocked exception"),
                 "expected the cause message, got: " + thrown.getMessage());
     }


### PR DESCRIPTION
## Why I'm doing:

An online tablet split creates each child shard pinned to its parent's worker, so the child reuses the
parent's warm local cache — child and parent share the same physical files, and the starlet cache key is
node-independent, so co-location means a fully warm cache. `StarOSAgent.createShardsForSplit` expresses that
as `PlacementPreference{PACK, WITH_SHARD, oldShardId}`; merge does the same per source shard.

The problem is how long that pin lasts. StarOS implements the preference as a **permanent** anonymous PACK
group `{parent, child}`, reclaimed only when the parent shard is deleted. For a reshard that happens after:

```
split FINISHED
  -> recycleOldMaterializedIndexes parks the old index in CatalogRecycleBin
  -> eraseMaterializedIndex waits partition_recycle_retention_period_secs   (default 30 min)
  -> StarMgrMetaSyncer deletes the shards on its next cycle                 (default 600 s)
  -> the anonymous group is finally reclaimed
```

**~30-40 minutes**, during which the children cannot be spread across workers *at all*:

- `ShardChecker`'s spread balancer drops any shard in a higher-precedence PACK group
  (`PACK` = 100 > `SPREAD` = 50, and the anonymous group has 2 members).
- Its fallback path builds the PACK transitive closure; since every anonymous group shares the one parent,
  that closure is the whole split family, so the only available move is relocating the family as a unit, which
  does not improve the spread score and is rejected.

So a split — whose whole purpose is to use more than one node — leaves the partition on a single node for tens
of minutes. With repeated splits the window rolls forward: a child created at `t` is only free at `t+40min`,
and if it is split again at `t+20min` its own children wait until `t+60min`. A partition under active ingest
can therefore stay pinned to one node's CPU, disk and network more or less indefinitely, which is exactly the
period when spreading matters most.

This also blocks range-colocate tables from balancing at all: the anonymous groups weld parent plus every child
into one closure spanning several colocate ranges, so even the per-range PACK group cannot be relocated as a
unit the way `balancePackShardGroup` intends.

## What I'm doing:

Releasing the pin explicitly once the reshard job's cleaning phase is done and the new shards are the only
serving index, instead of waiting for the superseded shards to be reclaimed.

- `StarOSAgent.clearPlacementPreference(List<List<Long>>)` wraps the new StarOS `ClearPlacementPreference` RPC
  (StarRocks/staros#1281). Each entry names the shards forming one preference group, and StarOS dissolves only
  a group whose membership is exactly that set. Naming the members rather than just the new shards is what makes
  the request unambiguous: a new shard here becomes the pin *target* of the next reshard on the same tablet, so
  "every group containing this shard" would drop a later reshard's pin as well. Idempotent on the StarOS side.
- `TabletReshardJob.clearPlacementPreference(...)` builds one entry per `(superseded, new)` combination of each
  resharding tablet, which reproduces exactly what `createShardsForSplit`/`ForMerge` established — a split pins
  each child to its one parent, a merge pins the one output to each source. Because that is the cross product of
  `getOldTabletIds()` and `getNewTabletIds()`, it needs no per-reshard-kind branching and covers all three
  `ReshardingTablet` implementations uniformly: `SplittingTablet`, `MergingTablet` and `IdenticalTablet` all
  produce new tablet ids and all get a pin at creation.
- `SplitTabletJob.runCleaningJob()` and `MergeTabletJob.runCleaningJob()` each call it right before
  `setJobState(FINISHED)` — after the table is back to `NORMAL`, so no table lock is held across the RPC.

Deliberately **best-effort**: a StarOS failure is logged and the job still finishes, because failing to clear
the pin only degrades to today's behavior (the pin is released when the superseded shards are deleted). There
is no retry and no new persisted state.

The creation-time placement is unchanged — children still land on the parent's worker and still start with a
warm cache. Only the release moves earlier. The subsequent migration is not new work either: the balancer
already moved these shards once the pin expired; this change pays that cost at `T+seconds` instead of
`T+40min`.

Not marking this as a behavior change: it touches no SQL syntax, no user-exposed configuration, and no
external interface, and it does not change any query result — it changes when an internal scheduling
constraint is lifted. Happy to flip it if a maintainer sees it differently.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

---

## Validation

`fe/pom.xml` on main already points at `<staros.version>4.2-rc3</staros.version>`, and StarRocks/staros#1281
shipped in that release, so this PR carries no version bump of its own and the FE code compiles against the
released artifact.

- FE unit tests **136/136** — `StarOSAgentTest` 48, `MergeTabletJobTest` 34, `TabletReshardJobMgrTest` 18,
  `SplitTabletJobTest` 17, `SplitTabletJobColocateTest` 16, `SplitTabletJobShardPlacementTest` 3.
- `:fe-core:checkstyleMain` / `:fe-core:checkstyleTest` clean.

The FE tests drive the real `runCleaningJob()` path and assert the captured preference entries, exactly one
invocation, and that the job state at the moment of the call is still `CLEANING` — so moving the call after
`setJobState(FINISHED)` would fail them. Failure injection asserts the job still reaches `FINISHED`.

On the StarOS side, `ShardCheckerTest.testPlacementPinBlocksSpreadBalanceUntilCleared` reproduces the stuck
state in a unit test and asserts the fix frees it; neutering the new RPC makes it fail with every child still
on the pinned worker.

Shared-data cluster e2e on two TSP clusters (1 FE + 3 CN each), forcing a 3-way split of a 160k-row
range-distributed table and sampling `SHOW TABLET`'s `BackendId` from the moment the job reaches `FINISHED`.
In both runs all three children start pinned to the parent's node, so the pin is verified present, not assumed:

| build | `FINISHED` -> children span >1 node |
|---|---|
| `f91dd69` (this PR's merge-base, plain main) | **1846 s** |
| `ec00bf3` (this PR) | **15 s** |

The baseline's 1846 s matches the mechanism rather than merely being slow: those clusters run
`star_mgr_meta_sync_interval_sec=60`, so 1800 s of recycle-bin retention plus one meta-sync cycle is
1800-1860 s. Both runs converge on the same final placement — the migration always happened, this only stops
it from waiting for the parent shard to be reclaimed. Details, and the two false-pass traps a reproducer
should know about, are in a comment below.

