### PR TITLE
[BugFix] Propagate compression_level to synthetic sub-column metas

### DIFF
--- a/be/src/base/compression/block_compression.cpp
+++ b/be/src/base/compression/block_compression.cpp
@@ -1131,10 +1131,19 @@ Status get_block_compression_codec(CompressionTypePB type, const BlockCompressio
         *codec = ZlibBlockCompression::instance();
         break;
     case CompressionTypePB::ZSTD:
-        if (compression_level != -1) {
+        // ZSTD is the only codec that consumes the level. Treat any out-of-range level as "use the
+        // default": ColumnMetaPB::compression_level has no default sentinel in segment.proto, so a meta
+        // that never set it reads back 0, and instance(0) would hand back nullptr.
+        if (compression_level >= 1 && compression_level <= 22) {
             *codec = ZstdBlockCompression::instance(compression_level);
         } else {
             *codec = ZstdBlockCompression::instance();
+        }
+        // A null codec means NO_COMPRESSION to every caller -- PageIO writes the raw page body. Never
+        // reach that state by accident, or compression silently turns itself off.
+        if (*codec == nullptr) {
+            return Status::InternalError(
+                    strings::Substitute("failed to get zstd codec for compression level $0", compression_level));
         }
         break;
     case CompressionTypePB::GZIP:

--- a/be/src/storage/rowset/array_column_writer.cpp
+++ b/be/src/storage/rowset/array_column_writer.cpp
@@ -109,6 +109,7 @@ StatusOr<std::unique_ptr<ColumnWriter>> create_array_column_writer(const ColumnW
         null_options.meta->set_length(1);
         null_options.meta->set_encoding(DEFAULT_ENCODING);
         null_options.meta->set_compression(opts.meta->compression());
+        null_options.meta->set_compression_level(opts.meta->compression_level());
         null_options.meta->set_is_nullable(false);
 
         TypeInfoPtr tinyint_type_info = get_type_info(TYPE_TINYINT);
@@ -123,6 +124,7 @@ StatusOr<std::unique_ptr<ColumnWriter>> create_array_column_writer(const ColumnW
     array_size_options.meta->set_length(4);
     array_size_options.meta->set_encoding(DEFAULT_ENCODING);
     array_size_options.meta->set_compression(opts.meta->compression());
+    array_size_options.meta->set_compression_level(opts.meta->compression_level());
     array_size_options.meta->set_is_nullable(false);
     array_size_options.need_zone_map = false;
     array_size_options.need_bloom_filter = false;

--- a/be/src/storage/rowset/json_column_writer.cpp
+++ b/be/src/storage/rowset/json_column_writer.cpp
@@ -201,11 +201,13 @@ Status FlatJsonColumnWriter::_init_flat_writers() {
             (!_has_remain || i != _flat_paths.size() - 1)) {
             // try to use dict encoding for flat json
             opts.meta->set_encoding(EncodingTypePB::DICT_ENCODING);
-            opts.meta->set_compression(_json_meta->compression());
         } else {
             opts.meta->set_encoding(EncodingTypePB::DEFAULT_ENCODING);
-            opts.meta->set_compression(_json_meta->compression());
         }
+        // Inherit both the codec and its level from the parent JSON column: the level must be carried
+        // along, otherwise the sub-column meta reads back level 0 and ZSTD falls back to its default.
+        opts.meta->set_compression(_json_meta->compression());
+        opts.meta->set_compression_level(_json_meta->compression_level());
 
         if (_flat_types[i] == LogicalType::TYPE_JSON) {
             opts.meta->mutable_json_meta()->set_format_version(kJsonMetaDefaultFormatVersion);

--- a/be/src/storage/rowset/map_column_writer.cpp
+++ b/be/src/storage/rowset/map_column_writer.cpp
@@ -117,6 +117,7 @@ StatusOr<std::unique_ptr<ColumnWriter>> create_map_column_writer(const ColumnWri
         null_options.meta->set_length(1);
         null_options.meta->set_encoding(DEFAULT_ENCODING);
         null_options.meta->set_compression(opts.meta->compression());
+        null_options.meta->set_compression_level(opts.meta->compression_level());
         null_options.meta->set_is_nullable(false);
 
         TypeInfoPtr tinyint_type_info = get_type_info(TYPE_TINYINT);
@@ -133,6 +134,7 @@ StatusOr<std::unique_ptr<ColumnWriter>> create_map_column_writer(const ColumnWri
         offsets_options.meta->set_length(4);
         offsets_options.meta->set_encoding(DEFAULT_ENCODING);
         offsets_options.meta->set_compression(opts.meta->compression());
+        offsets_options.meta->set_compression_level(opts.meta->compression_level());
         offsets_options.meta->set_is_nullable(false);
         offsets_options.need_zone_map = false;
         offsets_options.need_bloom_filter = false;

--- a/be/src/storage/rowset/struct_column_writer.cpp
+++ b/be/src/storage/rowset/struct_column_writer.cpp
@@ -87,6 +87,7 @@ StatusOr<std::unique_ptr<ColumnWriter>> create_struct_column_writer(const Column
         null_options.meta->set_length(1);
         null_options.meta->set_encoding(DEFAULT_ENCODING);
         null_options.meta->set_compression(opts.meta->compression());
+        null_options.meta->set_compression_level(opts.meta->compression_level());
         null_options.meta->set_is_nullable(false);
 
         TypeInfoPtr tiny_type_info = get_type_info(TYPE_TINYINT);

--- a/be/test/base/compression/block_compression_test.cpp
+++ b/be/test/base/compression/block_compression_test.cpp
@@ -157,6 +157,52 @@ TEST_F(BlockCompressionTest, single) {
     test_single_slice(starrocks::CompressionTypePB::LZ4_HADOOP);
 }
 
+// A ColumnMetaPB that never set compression_level reads back 0 (segment.proto declares no default
+// sentinel). ZSTD must fall back to its default level rather than handing back a null codec, which
+// callers such as PageIO interpret as "write the page body uncompressed".
+TEST_F(BlockCompressionTest, zstd_unset_compression_level_is_not_no_compression) {
+    for (int level : {0, -1, -5, 23, 100}) {
+        const BlockCompressionCodec* codec = nullptr;
+        ASSERT_TRUE(get_block_compression_codec(starrocks::CompressionTypePB::ZSTD, &codec, level).ok())
+                << "level=" << level;
+        ASSERT_NE(nullptr, codec) << "level=" << level;
+    }
+
+    // In-range levels still get the level-specific instance.
+    for (int level : {1, 3, 22}) {
+        const BlockCompressionCodec* codec = nullptr;
+        ASSERT_TRUE(get_block_compression_codec(starrocks::CompressionTypePB::ZSTD, &codec, level).ok())
+                << "level=" << level;
+        ASSERT_NE(nullptr, codec) << "level=" << level;
+    }
+
+    // NO_COMPRESSION is the only type allowed to yield a null codec.
+    const BlockCompressionCodec* none_codec = nullptr;
+    ASSERT_TRUE(get_block_compression_codec(starrocks::CompressionTypePB::NO_COMPRESSION, &none_codec).ok());
+    ASSERT_EQ(nullptr, none_codec);
+}
+
+// A page written with an unset level must round-trip as genuinely compressed data.
+TEST_F(BlockCompressionTest, zstd_unset_compression_level_actually_compresses) {
+    const BlockCompressionCodec* codec = nullptr;
+    ASSERT_TRUE(get_block_compression_codec(starrocks::CompressionTypePB::ZSTD, &codec, 0).ok());
+    ASSERT_NE(nullptr, codec);
+
+    // Highly repetitive input, so a working codec must shrink it substantially.
+    std::string orig(64 * 1024, 'a');
+    std::string compressed;
+    compressed.resize(codec->max_compressed_len(orig.size()));
+    Slice compressed_slice(compressed);
+    ASSERT_TRUE(codec->compress(orig, &compressed_slice).ok());
+    ASSERT_LT(compressed_slice.get_size(), orig.size() / 10);
+
+    std::string uncompressed;
+    uncompressed.resize(orig.size());
+    Slice uncompressed_slice(uncompressed);
+    ASSERT_TRUE(codec->decompress(compressed_slice, &uncompressed_slice).ok());
+    ASSERT_EQ(orig, uncompressed_slice.to_string());
+}
+
 TEST_F(BlockCompressionTest, lz4_explicit_options) {
     const BlockCompressionCodec* codec = nullptr;
     ASSERT_TRUE(get_block_compression_codec(starrocks::CompressionTypePB::LZ4, &codec).ok());


### PR DESCRIPTION
## Why I'm doing:

Under `"compression" = "zstd"`, flat-JSON sub-columns and the synthetic null/offset sub-columns of
ARRAY / MAP / STRUCT columns were written as **raw, uncompressed pages**.

The decisive symptom, from the original investigation (same cluster, same DDL, same 9,996,778 rows,
compression algorithm as the only variable, reproduced on three independent clusters):

| variant | compression | on-disk |
|---|---|---|
| `t_zstd` | zstd | **9.385 GB** |
| `t_lz4` | lz4 | **4.975 GB** |

The weaker codec produced a 47% *smaller* table. That direction is impossible for a correct
implementation, and it is the exact signature of "zstd path wrote raw pages while the lz4 path really
compressed".

Root cause chain:

1. `ColumnMetaPB::compression_level` (`gensrc/proto/segment.proto:206`) is declared
   `optional int32 compression_level = 34;` with **no `[default]` sentinel**. The file has no `syntax`
   line, so it is proto2, and a field that was never set **reads back 0**.
2. `FlatJsonColumnWriter::_init_flat_writers()` and the ARRAY / MAP / STRUCT writers build synthetic
   child `ColumnMetaPB` by hand and call `set_compression(...)` but never `set_compression_level(...)`.
3. `ScalarColumnWriter::init()` (`be/src/storage/rowset/column_writer.cpp:392`) passes that level —
   now **0** — to `get_block_compression_codec()`.
4. ZSTD is the only codec that consumes the level. The old branch was
   `if (compression_level != -1) *codec = ZstdBlockCompression::instance(compression_level);`, and
   `instance(int)` opens with `if (level < 1 || level > 22) return nullptr;`. So `instance(0)` returned
   **nullptr while the factory still returned `Status::OK()`** — no caller checked for a null codec.
5. `PageIO::compress_page_body()` requires a non-null codec; a null codec makes
   `compress_and_write_page()` fall through to `write_page(wfile, body, ...)`, writing the
   **uncompressed body**.

Everything affected by this was silently zero-compressed: all flat-JSON sub-columns, the `nulls`
sub-column, the `remain` JSON column, and their dictionary / ordinal-index / zonemap pages.

Native columns were never affected, which is why this hid for so long: they go through
`SegmentWriter::_init_column_meta`, which sets **both** fields
(`be/src/storage/rowset/segment_writer.cpp:96-97`), and `tablet_schema.proto:98` declares
`compression_level` with `[default=-1]` — and `-1` is the "use the default level" branch.

Note the bug does **not** require the user to request a level: the reproducing DDL used a bare
`"compression" = "zstd"`. The parent's level is irrelevant because the child meta's level was never
set at all.

Introduced by #46976 ("[Enhancement] Support zstd level"), which added both the proto field and the
`column_writer` call site. Every release branch containing that commit is affected — verified locally
for branch-3.4, branch-3.5 and branch-4.0.

## What I'm doing:

**1. Make an out-of-range ZSTD level fall back to the default level, and never let a null codec pass
silently** (`be/src/base/compression/block_compression.cpp`).

The load-bearing change is the predicate flip from `!= -1` to `>= 1 && <= 22`, which routes the
proto-default 0 to the valid default-level codec instead of to `instance(0)` → `nullptr`. The added
null check is deliberate belt-and-suspenders so that compression can never again silently turn itself
off; it is scoped to the ZSTD branch specifically because `NO_COMPRESSION` legitimately yields a null
codec and ~24 call sites depend on that contract (documented at `block_compression.h:119-121`).

This one change alone makes the whole bug class fail-safe: an unset level now degrades to "default
zstd level", never to "raw pages".

**2. Propagate `compression_level` at the six synthetic child-meta sites** so that an explicitly
configured `zstd(N)` actually reaches sub-columns instead of quietly falling back to the default
level:

- `json_column_writer.cpp` — flat-JSON sub-columns (hoisted out of the encoding if/else so both
  branches inherit it)
- `array_column_writer.cpp` — null + array_size
- `map_column_writer.cpp` — null + offsets
- `struct_column_writer.cpp` — null

Nested value columns were already correct and are intentionally untouched:
`SegmentWriter::_init_column_meta` recurses into every subcolumn setting both fields
(`segment_writer.cpp:108`), and `struct_column_writer.cpp:70` *reuses* those metas via
`mutable_children_columns(i)` rather than building its own. Only the synthetic children needed
patching.

**3. Two unit tests** (`be/test/base/compression/block_compression_test.cpp`) pinning the invariant:
no type other than `NO_COMPRESSION` may yield a null codec (probing levels 0, -1, -5, 23, 100), and a
codec obtained with an unset level genuinely compresses and round-trips.

### Compatibility

No format change. Segments already written raw by this bug stay readable: the read path never passes a
level (`column_reader.cpp:169`), so readers always had a valid codec, and `page_io.cpp:239` decides
"already uncompressed" from `body_size == footer->uncompressed_size()`. **Historical data will not
shrink on its own** — those pages must be rewritten by a reload or compaction to benefit.

### Behavior-change note for reviewers

On upgrade, affected tables start actually compressing this data. Expect on-disk size to drop
substantially and write-side CPU to rise correspondingly, since work that was previously skipped
entirely is now performed. That is the intended fix, but it is a real change in resource profile for
existing `zstd` tables with JSON / ARRAY / MAP / STRUCT columns.

### Validation status

Static analysis plus the new unit tests. The end-to-end confirmation — rebuild, re-run the two-table
comparison, and verify the direction has **reversed** so that zstd is now clearly smaller than lz4 —
is worth doing on top of CI before this is considered fully proven.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

branch-3.4 also contains #46976 and is therefore affected, but is not offered as an auto-backport
target here; flagging it in case a maintainer wants it cherry-picked as well.
