### PR TITLE
[BugFix] Keep IVM iceberg delta boundary off skipped REPLACE snapshots

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -960,7 +960,12 @@ public class IcebergMetadata implements ConnectorMetadata {
             // Skip REPLACE (compaction) snapshots - they rewrite files without changing logical data,
             // consistent with Iceberg's IncrementalAppendScan and IncrementalChangelogScan behavior.
             if (DataOperations.REPLACE.equals(snapshot.operation())) {
-                lastSnapshotId = snapshot.snapshotId();
+                // A REPLACE still ends the range preceding it, so it stays a usable boundary for an older
+                // delta. Before anything is emitted it would instead strand the range end on a snapshot
+                // no delta covers, which the caller reads as a lineage break.
+                if (!tvrDeltaTraits.isEmpty()) {
+                    lastSnapshotId = snapshot.snapshotId();
+                }
                 continue;
             }
             long currentSnapshotId = snapshot.snapshotId();
@@ -972,6 +977,12 @@ public class IcebergMetadata implements ConnectorMetadata {
                 tvrDeltaTraits.add(TvrTableDeltaTrait.ofRetractable(delta, stats));
             }
             lastSnapshotId = currentSnapshotId;
+        }
+        if (tvrDeltaTraits.isEmpty()) {
+            // Nothing but skipped REPLACEs in range: emit one zero-stats delta spanning it so the caller
+            // advances past the compaction. An empty list means "no delta derivable" and fails the refresh.
+            return List.of(TvrTableDeltaTrait.ofMonotonic(
+                    TvrTableDelta.of(fromSnapshotExclusive.to, toSnapshotInclusive.to), TvrDeltaStats.EMPTY));
         }
         // reserve to ensure the last snapshot is in the last of the collection.
         Collections.reverse(tvrDeltaTraits);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -4289,8 +4289,8 @@ public class IcebergMetadataTest extends TableTestBase {
         Assertions.assertTrue(traits.get(0).isAppendOnly());
         Assertions.assertTrue(traits.get(1).isAppendOnly());
 
-        // Verify contiguous delta boundaries: snap2→snap3, snap4→snap4
-        // (snap3 is the REPLACE snapshot ID — used as boundary but not emitted as a trait)
+        // A mid-range REPLACE keeps owning the boundary: cutting a refresh batch at snap3 covers snap2's
+        // appends and nothing more, which is exactly what this trait's stats account for.
         TvrTableDelta delta0 = traits.get(0).getTvrDelta();
         Assertions.assertEquals(snap2.snapshotId(), delta0.start().get());
         Assertions.assertEquals(snap3.snapshotId(), delta0.end().get());
@@ -4301,7 +4301,7 @@ public class IcebergMetadataTest extends TableTestBase {
     }
 
     @Test
-    public void testListTableDeltaTraitsAllReplaceReturnsEmpty() {
+    public void testListTableDeltaTraitsAllReplaceSpansWholeRangeWithoutStats() {
         // snap1: APPEND (used as exclusive start)
         mockedNativeTableA.newAppend().appendFile(FILE_A).commit();
         Snapshot snap1 = mockedNativeTableA.currentSnapshot();
@@ -4323,8 +4323,53 @@ public class IcebergMetadataTest extends TableTestBase {
 
         List<TvrTableDeltaTrait> traits = metadata.listTableDeltaTraits("db", icebergTable, from, to);
 
-        // Only REPLACE in range — should return empty
-        Assertions.assertTrue(traits.isEmpty());
+        // Compaction-only range: one append-only delta spanning it, carrying no rows. An empty list would
+        // read as "no delta derivable" and permanently break the incremental refresh.
+        Assertions.assertEquals(1, traits.size());
+        Assertions.assertTrue(traits.get(0).isAppendOnly());
+        Assertions.assertEquals(snap1.snapshotId(), traits.get(0).getTvrDelta().start().get());
+        Assertions.assertEquals(snap2.snapshotId(), traits.get(0).getTvrDelta().end().get());
+        Assertions.assertEquals(0, traits.get(0).getTvrDeltaStats().getAddedRows());
+        Assertions.assertEquals(0, traits.get(0).getTvrDeltaStats().getAddedFileSize());
+    }
+
+    @Test
+    public void testListTableDeltaTraitsTrailingConsecutiveReplacesKeepRangeEnd() {
+        // snap1: APPEND (used as exclusive start)
+        mockedNativeTableA.newAppend().appendFile(FILE_A).commit();
+        Snapshot snap1 = mockedNativeTableA.currentSnapshot();
+
+        // snap2: APPEND — the only logical change in range
+        mockedNativeTableA.newAppend().appendFile(FILE_A_1).commit();
+        Snapshot snap2 = mockedNativeTableA.currentSnapshot();
+
+        // snap3, snap4: two back-to-back compactions closing the range
+        mockedNativeTableA.newRewrite().deleteFile(FILE_A).addFile(FILE_A_2).commit();
+        Snapshot snap3 = mockedNativeTableA.currentSnapshot();
+        Assertions.assertEquals("replace", snap3.operation());
+        mockedNativeTableA.newRewrite().deleteFile(FILE_A_2).addFile(FILE_A).commit();
+        Snapshot snap4 = mockedNativeTableA.currentSnapshot();
+        Assertions.assertEquals("replace", snap4.operation());
+
+        IcebergTable icebergTable = new IcebergTable(1, "testTbl", CATALOG_NAME, CATALOG_NAME,
+                "db", "testTbl", "", Lists.newArrayList(), mockedNativeTableA, Maps.newHashMap());
+
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT,
+                new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG),
+                Executors.newSingleThreadExecutor(), null);
+
+        TvrTableSnapshot from = TvrTableSnapshot.of(Optional.of(snap1.snapshotId()));
+        TvrTableSnapshot to = TvrTableSnapshot.of(Optional.of(snap4.snapshotId()));
+
+        List<TvrTableDeltaTrait> traits = metadata.listTableDeltaTraits("db", icebergTable, from, to);
+
+        // MVIVMRefreshProcessor rejects the refresh unless the newest delta ends exactly at the range end,
+        // so a trailing run of skipped REPLACEs must not pull that boundary back onto one of them.
+        Assertions.assertEquals(1, traits.size());
+        Assertions.assertTrue(traits.get(0).isAppendOnly());
+        Assertions.assertEquals(snap2.snapshotId(), traits.get(0).getTvrDelta().start().get());
+        Assertions.assertEquals(snap4.snapshotId(), traits.get(0).getTvrDelta().end().get());
+        Assertions.assertNotEquals(snap3.snapshotId(), traits.get(0).getTvrDelta().end().get());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessorTest.java
@@ -92,6 +92,19 @@ public class MVIVMRefreshProcessorTest {
     }
 
     @Test
+    public void compactionMidRangeStillSplitsTheFollowingLargeAppend() {
+        // What IcebergMetadata emits for APPEND(11) -> REPLACE(12) -> APPEND(13): the compaction owns 11's
+        // end boundary, so 13's rows are still weighed before the cut can reach them.
+        List<TvrTableDeltaTrait> traits = List.of(
+                TvrTableDeltaTrait.ofMonotonic(TvrTableDelta.of(11L, 12L), new TvrDeltaStats(1L, 0L)),
+                TvrTableDeltaTrait.ofMonotonic(TvrTableDelta.of(13L, 13L), new TvrDeltaStats(10L, 0L)));
+        MVIVMRefreshProcessor.AdaptiveDelta r =
+                MVIVMRefreshProcessor.computeAdaptiveDelta(TABLE, traits, TvrTableDelta.of(10L, 13L), 2, MAX_BYTES);
+        assertEquals(TvrTableDelta.of(10L, 12L), r.delta);
+        assertTrue(r.hasNext);
+    }
+
+    @Test
     public void wholeRangeUnderCapRefreshesAtOnce() {
         List<TvrTableDeltaTrait> traits = appendChain(10, 1, 1, 1);
         MVIVMRefreshProcessor.AdaptiveDelta r =

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_compaction
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_compaction
@@ -1,0 +1,172 @@
+-- name: test_ivm_with_iceberg_compaction
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_ice_db_${uuid0};
+-- result:
+-- !result
+use mv_ice_db_${uuid0};
+-- result:
+-- !result
+create table t1 (k int, v int);
+-- result:
+-- !result
+insert into t1 values (1, 10);
+-- result:
+-- !result
+insert into t1 values (2, 20);
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+set enable_materialized_view_rewrite = false;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1
+DISTRIBUTED BY HASH(k)
+REFRESH DEFERRED MANUAL
+properties ("refresh_mode" = "incremental")
+AS SELECT k, v FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+-- result:
+-- !result
+[UC]TASK_NAME=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='test_mv1';
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+SUCCESS
+-- !result
+SELECT k, v FROM test_mv1 ORDER BY k;
+-- result:
+1	10
+2	20
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (3, 30);
+-- result:
+-- !result
+[UC]ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE rewrite_data_files(rewrite_all = true);
+SELECT count(1) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1$snapshots WHERE operation = 'replace';
+-- result:
+1
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+SUCCESS
+-- !result
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+INCREMENTAL
+-- !result
+SELECT k, v FROM test_mv1 ORDER BY k;
+-- result:
+1	10
+2	20
+3	30
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (4, 40);
+-- result:
+-- !result
+[UC]ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE rewrite_data_files(rewrite_all = true);
+[UC]ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE rewrite_data_files(rewrite_all = true);
+SELECT count(1) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1$snapshots WHERE operation = 'replace';
+-- result:
+3
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+SUCCESS
+-- !result
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+INCREMENTAL
+-- !result
+SELECT k, v FROM test_mv1 ORDER BY k;
+-- result:
+1	10
+2	20
+3	30
+4	40
+-- !result
+[UC]ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE rewrite_data_files(rewrite_all = true);
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+SUCCESS
+-- !result
+SELECT k, v FROM test_mv1 ORDER BY k;
+-- result:
+1	10
+2	20
+3	30
+4	40
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+SKIPPED
+-- !result
+[UC]ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE rewrite_data_files(rewrite_all = true);
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (5, 50);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+SUCCESS
+-- !result
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+-- result:
+INCREMENTAL
+-- !result
+SELECT k, v FROM test_mv1 ORDER BY k;
+-- result:
+1	10
+2	20
+3	30
+4	40
+5	50
+-- !result
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_mv1';
+-- result:
+true
+-- !result
+SELECT k, v FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY k;
+-- result:
+1	10
+2	20
+3	30
+4	40
+5	50
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+-- result:
+-- !result
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+-- result:
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result
+drop catalog mv_iceberg_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_compaction
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_compaction
@@ -1,0 +1,107 @@
+-- name: test_ivm_with_iceberg_compaction
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog mv_iceberg_${uuid0};
+create database mv_ice_db_${uuid0};
+use mv_ice_db_${uuid0};
+
+create table t1 (k int, v int);
+
+-- Two separate commits so the first compaction has more than one file to merge.
+insert into t1 values (1, 10);
+insert into t1 values (2, 20);
+
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+set enable_materialized_view_rewrite = false;
+
+CREATE MATERIALIZED VIEW test_mv1
+DISTRIBUTED BY HASH(k)
+REFRESH DEFERRED MANUAL
+properties ("refresh_mode" = "incremental")
+AS SELECT k, v FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+
+[UC]TASK_NAME=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='test_mv1';
+
+-- Baseline: first refresh bootstraps the TVR anchor through PCT.
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT k, v FROM test_mv1 ORDER BY k;
+
+-- ==============================================================
+-- Case A: one compaction closing the delta, after an append.
+-- Passed before the fix too; kept because it is the shape that masked the bug.
+-- ==============================================================
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (3, 30);
+[UC]ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE rewrite_data_files(rewrite_all = true);
+
+-- Guard the premise: compaction must really have committed a REPLACE snapshot,
+-- otherwise the cases below would silently assert nothing.
+SELECT count(1) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1$snapshots WHERE operation = 'replace';
+
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT k, v FROM test_mv1 ORDER BY k;
+
+-- ==============================================================
+-- Case B: two back-to-back compactions closing the delta, after an append.
+-- The reported failure: refresh died with "tvr delta lineage inconsistent".
+-- ==============================================================
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (4, 40);
+[UC]ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE rewrite_data_files(rewrite_all = true);
+[UC]ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE rewrite_data_files(rewrite_all = true);
+SELECT count(1) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1$snapshots WHERE operation = 'replace';
+
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT k, v FROM test_mv1 ORDER BY k;
+
+-- ==============================================================
+-- Case C: compaction only, with no append since the last refresh.
+-- Needs just one compaction: refresh died with "no tvr delta traits found".
+-- ==============================================================
+[UC]ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE rewrite_data_files(rewrite_all = true);
+
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT k, v FROM test_mv1 ORDER BY k;
+
+-- The anchor must move past the compaction, not merely survive it: a stalled
+-- anchor re-derives the same delta and reports SUCCESS again instead of SKIPPED.
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+
+-- ==============================================================
+-- Case D: compaction in the middle of the delta, followed by an append.
+-- The surviving delta must reach over the REPLACE to the range end without
+-- losing the appended row.
+-- ==============================================================
+[UC]ALTER TABLE mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 EXECUTE rewrite_data_files(rewrite_all = true);
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values (5, 50);
+
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT STATE FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT get_json_string(EXTRA_MESSAGE, '$.refreshMode') FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' ORDER BY FINISH_TIME DESC LIMIT 1;
+SELECT k, v FROM test_mv1 ORDER BY k;
+
+-- Compaction is routine table maintenance; it must never inactivate the MV.
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_mv1';
+
+-- MV contents must equal a direct read of the base table.
+SELECT k, v FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 ORDER BY k;
+
+DROP MATERIALIZED VIEW test_mv1;
+
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+drop database db_${uuid0} force;
+drop catalog mv_iceberg_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

Running compaction on an Iceberg base table permanently inactivates any INCREMENTAL materialized view built on it. `rewrite_data_files` is routine table maintenance, so this is easy to hit in production, and recovery requires dropping and recreating the MV.

`listTableDeltaTraits` walks the base table's snapshot ancestry newest-first and skips REPLACE (compaction) snapshots, which is correct — compaction rewrites files without changing logical data. But the skip branch also advanced `lastSnapshotId` onto the snapshot it had just skipped:

```java
if (DataOperations.REPLACE.equals(snapshot.operation())) {
    lastSnapshotId = snapshot.snapshotId();   // <-- skipped snapshot takes the boundary
    continue;
}
```

`lastSnapshotId` is the end boundary handed to the next emitted delta. Only a snapshot that actually owns a delta may hold it, otherwise the newest emitted delta stops ending at `toSnapshotIdInclusive`.

Two distinct failures follow, and both surface as a permanently inactive MV because `MVIVMRefreshProcessor` tags them with the non-append-only marker, which `TaskRun` turns into `inactiveMvAndLog`:

**1. A trailing run of two or more REPLACEs.** For chain `baseline <- APPEND(sA) <- REPLACE(s2) <- REPLACE(s3=current)`:

| iter | snapshot | branch | `lastSnapshotId` after | emitted |
|------|----------|--------|------------------------|---------|
| 1 | `s3` | skip | `s3` (identity write, harmless) | — |
| 2 | `s2` | skip | **`s2`** — boundary moves backwards | — |
| 3 | `sA` | emit | `sA` | `(sA, s2]` |

The newest delta now ends at `s2`, not `s3`, so the lineage check rejects the refresh:

```
Cannot incrementally refresh materialized view mv: tvr delta lineage inconsistent
for base table db.t (last delta snapshot Snapshot@(186729340241766537)
!= max delta snapshot Snapshot@(7891483664042347281)).
```

A single trailing REPLACE was harmless only because the first loop iteration's write is an identity assignment — which is why this survived into released versions.

**2. A range holding nothing but REPLACEs** (compaction with no append since the last refresh) emits no trait at all, and the same caller reads an empty list as "no delta could be derived":

```
Cannot incrementally refresh materialized view mv: no tvr delta traits found for base table db.t.
```

This one needs only **one** compaction, so it is the more likely production trigger of the two.

Introduced by #69825 (`87c7794`), backported to branch-4.1 by #70830. Affected released versions: **4.1.0, 4.1.1**. branch-4.0 and branch-3.5 have no `listTableDeltaTraits`, so Iceberg IVM does not exist there and they are unaffected.

## What I'm doing:

Both fixes are contained in `IcebergMetadata.listTableDeltaTraits`. The upstream lineage check in `MVIVMRefreshProcessor` is deliberately left untouched — it correctly guards against a range end that no delta covers (genuine ancestry breakage, e.g. snapshot expiration), and relaxing it would weaken that.

1. **Suppress the boundary write only while nothing has been emitted yet**, i.e. for a trailing run of REPLACEs. A mid-range REPLACE genuinely ends the range preceding it and stays a usable boundary: cutting a refresh batch there covers exactly the appends the preceding trait's stats account for, since the REPLACE contributes no appends of its own. Handing that boundary to the next append instead would let `computeAdaptiveDelta` advance its cut past uncounted rows and defeat `mv_max_rows_per_refresh` — so mid-range behaviour is deliberately left as-is.

2. **Emit one zero-stats append-only delta spanning the range when nothing but REPLACEs was found.** An empty list cannot express "no logical change" distinctly from "nothing could be derived", so the caller has to reject it. Reporting the range explicitly lets the caller advance its bookmark past the compaction and refresh zero rows.

Advancing the bookmark matters beyond the current refresh. Simply skipping the run would leave the anchor pinned to an older snapshot while the range grows with every compaction, and once `expire_snapshots` drops that snapshot the chain breaks for real (`isParentAncestorOf` fails → ancestry-broken error → inactive MV). The `Config.mv_max_rows_per_refresh` batching path already handles a zero-stats trait correctly: it cannot trip the cap, so the cut point lands on the range end and `hasNext` stays false.

### Behavior matrix

| Chain (fromExclusive → … → toInclusive) | Before | After |
|---|---|---|
| `APPEND(sA) → REPLACE(s2) → REPLACE(s3=to)` | throws `tvr delta lineage inconsistent` | `[(sA, s3]]` |
| `REPLACE(s2=to)` only | throws `no tvr delta traits found` | `[(from, s2]]`, zero stats |
| `APPEND(s1) → APPEND(s2) → REPLACE(s3) → APPEND(s4=to)` | `[(s1,s2], (s2,s3], (s4,s4]]` | unchanged — a mid-range REPLACE stays a boundary |
| `APPEND(s1) → REPLACE(s2=to)` after an earlier refresh | `[]` → throws | `[(s1, s2]]`, zero stats |
| `APPEND(s1) → REPLACE(s2) → APPEND(s3=to)` | `[(s3,s3]]` | `[(s3,s3]]` (unchanged) |

Note this supersedes the closed #75654, which fixed only the first failure mode and additionally relaxed the upstream lineage check.

Fixes https://github.com/StarRocks/StarRocksTest/issues/11631

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Verification

### Unit tests

`IcebergMetadataTest` 113/113, `MVIVMRefreshProcessorTest` 11/11, `IVMAdaptiveBatchingIcebergTest` 1/1 — 125 tests, 0 failures, checkstyle clean.

One pre-existing assertion pinned the buggy behavior and is updated here: `testListTableDeltaTraitsAllReplaceReturnsEmpty` asserted the empty list that upstream rejects, so it is renamed to `...AllReplaceSpansWholeRangeWithoutStats` and inverted.

New coverage:
- `testListTableDeltaTraitsTrailingConsecutiveReplacesKeepRangeEnd` — the reported chain; asserts the newest delta still ends at the range end.
- `MVIVMRefreshProcessorTest.compactionMidRangeStillSplitsTheFollowingLargeAppend` — guards the batching interaction: with a mid-range REPLACE the cut must stop at it so the following large append is weighed against the cap rather than swallowed.

Reverting the production change while keeping the new assertions fails them, confirming the assertions have teeth (TestTables snapshot ids are small integers, so `expected <4> but was <3>` reads literally as "the boundary stopped on the skipped REPLACE instead of the range end"):

```
testListTableDeltaTraitsTrailingConsecutiveReplacesKeepRangeEnd    expected: <4> but was: <3>
testListTableDeltaTraitsAllReplaceSpansWholeRangeWithoutStats      expected: <1> but was: <0>
```

### Cluster end-to-end

New T/R case `test_ivm_with_iceberg_compaction`, run on a shared-data cluster against a real Iceberg catalog using `EXECUTE rewrite_data_files(rewrite_all = true)` to produce genuine REPLACE snapshots.

Reproduced on the pre-fix build first:

| Chain | Result |
|---|---|
| append + 2 compactions | `tvr delta lineage inconsistent (last=186729340241766537 != max=7891483664042347281)` |
| 1 compaction, no append | `no tvr delta traits found` |
| either | `IS_ACTIVE=false`, `incremental refresh broken by non-append-only base change` |

The two snapshot ids in that error are exactly the first of the two trailing compactions and the current snapshot, matching the trace above.

After the fix, all four chain shapes refresh incrementally:

| Case | STATE | refreshMode | rows |
|---|---|---|---|
| A — one compaction after an append | SUCCESS | INCREMENTAL | correct |
| B — two compactions after an append | SUCCESS | INCREMENTAL | correct |
| C — compaction only | SUCCESS | INCREMENTAL | unchanged |
| C — immediate second refresh | SKIPPED | — | — |
| D — compaction mid-range, then an append | SUCCESS | INCREMENTAL | correct |

MV contents match a direct read of the base table, and `IS_ACTIVE` stays `true` throughout. The `SKIPPED` on Case C's second refresh is the assertion that proves the bookmark advanced past the compaction rather than stalling — a stalled anchor would re-derive the same delta and report `SUCCESS` again.

The T case marks the `rewrite_data_files` statements `[UC]`: their result row carries `duration_ms` and the `${uuid0}`-expanded database name, both non-deterministic. The `count(1) ... WHERE operation = 'replace'` assertions guard the premise that compaction actually committed a REPLACE snapshot, so the cases cannot silently pass without exercising anything. The recorded R replays cleanly across repeated independent runs.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
