### PR TITLE
[Enhancement] Say why EXPLAIN REFRESH has no plan for an up-to-date MV

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
@@ -160,11 +160,12 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
     }
 
     /**
-     * Get the execution plan for refreshing the materialized view.
-     * @return the execution plan for refreshing the materialized view, or null if no refresh is needed.
+     * Build the refresh plan for the materialized view, keeping the skip reason so the caller can tell why
+     * there is no plan.
+     * @return the would-be task run result; its execPlan is null when nothing was planned
      * @throws Exception if an error occurs while getting the execution plan.
      */
-    public ExecPlan getMVRefreshExecPlan() throws Exception {
+    public MVRefreshProcessor.ProcessExecPlan getMVRefreshProcessExecPlan() throws Exception {
         Preconditions.checkNotNull(mvTaskRunContext);
         Preconditions.checkNotNull(mvRefreshProcessor);
 
@@ -174,10 +175,11 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
         MVRefreshProcessor.ProcessExecPlan processExecPlan =
                 mvRefreshProcessor.getProcessExecPlan(mvTaskRunContext);
         if (processExecPlan == null || processExecPlan.state() != Constants.TaskRunState.SUCCESS) {
-            logger.info("No need to refresh mv: {}, because the materialized view is up to date.", mv.getName());
-            return null;
+            logger.info("No refresh plan for mv: {}, state: {}, skip reason: {}", mv.getName(),
+                    processExecPlan == null ? null : processExecPlan.state(),
+                    processExecPlan == null ? null : processExecPlan.skipReason());
         }
-        return processExecPlan.execPlan();
+        return processExecPlan;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -45,6 +45,7 @@ import com.starrocks.qe.ShowResultSet;
 import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.scheduler.history.TaskRunHistory;
+import com.starrocks.scheduler.mv.MVRefreshProcessor;
 import com.starrocks.scheduler.persist.ArchiveTaskRunsLog;
 import com.starrocks.scheduler.persist.DropTasksLog;
 import com.starrocks.scheduler.persist.TaskRunStatus;
@@ -386,15 +387,40 @@ public class TaskManager implements MemoryTrackable {
             return null;
         }
         TaskRun taskRun = buildTaskRun(task, option);
-        ExecPlan execPlan = getMVRefreshExecPlan(taskRun, task, option, statement);
+        MVRefreshProcessor.ProcessExecPlan processExecPlan =
+                getMVRefreshProcessExecPlan(taskRun, task, option, statement);
+        ExecPlan execPlan = processExecPlan == null ? null : processExecPlan.execPlan();
         String explainString = StmtExecutor.buildExplainString(execPlan, statement,
                 ConnectContext.get(), ResourceGroupClassifier.QueryType.MV, statement.getExplainLevel());
+        if (execPlan == null) {
+            // A planning failure never lands here -- it propagates as DmlException.
+            if (!explainString.endsWith("\n")) {
+                // TRACE TIMES/LOGS output ends without a trailing newline.
+                explainString += "\n";
+            }
+            explainString += noRefreshPlanMessage(processExecPlan) + "\n";
+        }
         // add extra info
         String extraInfo = getExtraExplainInfo(taskRun, statement);
         if (!Strings.isNullOrEmpty(extraInfo)) {
             explainString += "\n" + extraInfo;
         }
         return explainString;
+    }
+
+    private static String noRefreshPlanMessage(MVRefreshProcessor.ProcessExecPlan processExecPlan) {
+        MVRefreshProcessor.ProcessExecPlan.SkipReason skipReason =
+                processExecPlan == null ? null : processExecPlan.skipReason();
+        if (skipReason == null) {
+            return "REFRESH SKIPPED: no refresh plan was produced";
+        }
+        // Exhaustive on purpose: a new SkipReason must not silently inherit an "up to date" claim.
+        return switch (skipReason) {
+            case MV_UP_TO_DATE -> "NO REFRESH NEEDED: the materialized view is already up to date";
+            case SCOPE_UP_TO_DATE -> "NO REFRESH NEEDED: the requested partitions are already up to date, "
+                    + "other partitions of the materialized view may still be stale";
+            case STALE_PINNED_BATCH -> "REFRESH SKIPPED: another refresh job owns the pinned partition ranges";
+        };
     }
 
     public TaskRun buildTaskRun(Task task, ExecuteOption option) {
@@ -426,7 +452,9 @@ public class TaskManager implements MemoryTrackable {
     /**
      * Get the MV refresh execution plan for the given task.
      */
-    public ExecPlan getMVRefreshExecPlan(TaskRun taskRun, Task task, ExecuteOption option, StatementBase statement) {
+    public MVRefreshProcessor.ProcessExecPlan getMVRefreshProcessExecPlan(TaskRun taskRun, Task task,
+                                                                          ExecuteOption option,
+                                                                          StatementBase statement) {
         if (statement == null || !statement.isExplain()) {
             return null;
         }
@@ -447,7 +475,7 @@ public class TaskManager implements MemoryTrackable {
             // prepare the task run context
             taskRunContext = mvRefreshProcessor.prepare(taskRunContext);
             // execute the task run
-            return mvRefreshProcessor.getMVRefreshExecPlan();
+            return mvRefreshProcessor.getMVRefreshProcessExecPlan();
         } catch (Exception e) {
             LOG.warn("Failed to get MV refresh explain for task: {}", task.getName(), e);
             throw new DmlException("Failed to get MV refresh explain for task: %s, error: %s", e,

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessor.java
@@ -136,10 +136,32 @@ public abstract class MVRefreshProcessor {
      * @param state      the state of the task run
      * @param execPlan   the execution plan for the task run
      * @param insertStmt the insert statement for the task run
+     * @param skipReason why no plan was produced; {@code null} unless the state is SKIPPED
      */
     public record ProcessExecPlan(Constants.TaskRunState state,
                                   ExecPlan execPlan,
-                                  InsertStmt insertStmt) {
+                                  InsertStmt insertStmt,
+                                  SkipReason skipReason) {
+
+        /**
+         * Why a task run produced no exec plan. SKIPPED alone cannot be reported as "up to date": only
+         * MV_UP_TO_DATE and SCOPE_UP_TO_DATE mean the data was checked and found fresh.
+         */
+        public enum SkipReason {
+            MV_UP_TO_DATE,
+            // The partitions the user asked for are fresh; others may still be stale.
+            SCOPE_UP_TO_DATE,
+            // Another refresh job owns the pinning, so this batch's partitions are left unrefreshed.
+            STALE_PINNED_BATCH
+        }
+
+        public static ProcessExecPlan success(ExecPlan execPlan, InsertStmt insertStmt) {
+            return new ProcessExecPlan(Constants.TaskRunState.SUCCESS, execPlan, insertStmt, null);
+        }
+
+        public static ProcessExecPlan skipped(SkipReason skipReason) {
+            return new ProcessExecPlan(Constants.TaskRunState.SKIPPED, null, null, skipReason);
+        }
     }
 
     public MVRefreshProcessor(Database db, MaterializedView mv,

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
@@ -142,7 +142,8 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
                         mv.getName());
                 // No base-table change means the MV is confirmed fresh as of this run's start.
                 confirmFreshness();
-                return new ProcessExecPlan(Constants.TaskRunState.SKIPPED, null, null);
+                // IVM rejects partial refresh above, so the whole MV is fresh, not just a range.
+                return ProcessExecPlan.skipped(ProcessExecPlan.SkipReason.MV_UP_TO_DATE);
             }
         }
 
@@ -164,7 +165,7 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
             insertStmt = prepareRefreshPlan();
         }
         recordImvSourceRangesOnTaskRun();
-        return new ProcessExecPlan(Constants.TaskRunState.SUCCESS, mvContext.getExecPlan(), insertStmt);
+        return ProcessExecPlan.success(mvContext.getExecPlan(), insertStmt);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshProcessor.java
@@ -131,7 +131,7 @@ public final class MVPCTRefreshProcessor extends MVRefreshProcessor {
     @Override
     public ProcessExecPlan getProcessExecPlan(TaskRunContext taskRunContext) throws Exception {
         if (isStalePinnedBatch()) {
-            return new ProcessExecPlan(Constants.TaskRunState.SKIPPED, null, null);
+            return ProcessExecPlan.skipped(ProcessExecPlan.SkipReason.STALE_PINNED_BATCH);
         }
 
         // sync and check partitions of base tables
@@ -153,7 +153,11 @@ public final class MVPCTRefreshProcessor extends MVRefreshProcessor {
             if (refreshScope == null || refreshScope.isEmpty()) {
                 // An empty refresh scope means base tables were checked and the MV is already fresh.
                 confirmFreshness();
-                return new ProcessExecPlan(Constants.TaskRunState.SKIPPED, null, null);
+                // A partition-scoped request only proves its own range is fresh -- the same rule
+                // MVVersionManager applies before advancing LAST_FRESHNESS_CONFIRMED_AT.
+                return ProcessExecPlan.skipped(mvRefreshParams.isCompleteRefresh()
+                        ? ProcessExecPlan.SkipReason.MV_UP_TO_DATE
+                        : ProcessExecPlan.SkipReason.SCOPE_UP_TO_DATE);
             }
         }
 
@@ -164,7 +168,7 @@ public final class MVPCTRefreshProcessor extends MVRefreshProcessor {
             insertStmt = prepareRefreshPlan(refreshScope.getMvPartitionsToRefresh(),
                     toTableKeyedRefreshPartitions(refreshScope.getRefTableRefreshPartitions()));
         }
-        return new ProcessExecPlan(Constants.TaskRunState.SUCCESS, mvContext.getExecPlan(), insertStmt);
+        return ProcessExecPlan.success(mvContext.getExecPlan(), insertStmt);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshNonPartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshNonPartitionOlapTest.java
@@ -71,6 +71,7 @@ public class PCTRefreshNonPartitionOlapTest extends MVTestBase {
             String plan = explainMVRefreshExecPlan(mv, "explain refresh materialized " +
                     "view test_mv1;");
             Assertions.assertTrue(plan.contains("PLAN NOT AVAILABLE"));
+            Assertions.assertTrue(plan.contains("NO REFRESH NEEDED"), plan);
         }
 
         // refresh with force

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshRangePartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshRangePartitionOlapTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @TestMethodOrder(MethodName.class)
@@ -112,6 +113,49 @@ public class PCTRefreshRangePartitionOlapTest extends MVTestBase {
                     "     partitions=2/2");
             Assertions.assertNotNull(execPlan);
         }
+    }
+
+    @Test
+    public void testExplainRefreshOnFreshPartitionRange() throws Exception {
+        String partitionTable = "CREATE TABLE range_t1 (dt1 date, int1 int)\n" +
+                "PARTITION BY date_trunc('day', dt1)";
+        starRocksAssert.withTable(partitionTable);
+        addRangePartition("range_t1", "p1", "2024-01-04", "2024-01-05");
+        addRangePartition("range_t1", "p2", "2024-01-05", "2024-01-06");
+        String[] sqls = {
+                "INSERT INTO range_t1 partition(p1) VALUES (\"2024-01-04\",1);",
+                "INSERT INTO range_t1 partition(p2) VALUES (\"2024-01-05\",1);"
+        };
+        for (String sql : sqls) {
+            executeInsertSql(sql);
+        }
+
+        String mvQuery = "CREATE MATERIALIZED VIEW test_mv1 " +
+                "PARTITION BY date_trunc('day', dt1) " +
+                "REFRESH DEFERRED MANUAL PROPERTIES (\"partition_refresh_number\"=\"-1\")\n" +
+                "AS SELECT dt1,sum(int1) from range_t1 group by dt1";
+        starRocksAssert.withMaterializedView(mvQuery);
+
+        MaterializedView mv = getMv("test_mv1");
+        refreshMV("test", mv);
+
+        // only p2 goes stale, so the p1 range is fresh while the mv as a whole is not
+        executeInsertSql("INSERT INTO range_t1 partition(p2) VALUES (\"2024-01-05\",2);");
+
+        Map<String, String> props = new HashMap<>();
+        props.put(TaskRun.PARTITION_START, "2024-01-04");
+        props.put(TaskRun.PARTITION_END, "2024-01-05");
+        String scopedPlan = explainMVRefreshExecPlan(mv, new ExecuteOption(70, false, props),
+                "explain refresh materialized view test_mv1 partition start (\"2024-01-04\") " +
+                        "end (\"2024-01-05\");");
+        Assertions.assertTrue(scopedPlan.contains("PLAN NOT AVAILABLE"), scopedPlan);
+        Assertions.assertTrue(
+                scopedPlan.contains("NO REFRESH NEEDED: the requested partitions are already up to date"),
+                scopedPlan);
+        Assertions.assertFalse(scopedPlan.contains("the materialized view is already up to date"), scopedPlan);
+
+        String wholePlan = explainMVRefreshExecPlan(mv, "explain refresh materialized view test_mv1;");
+        Assertions.assertFalse(wholePlan.contains("NO REFRESH NEEDED"), wholePlan);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
@@ -53,6 +53,7 @@ import com.starrocks.scheduler.TaskRunBuilder;
 import com.starrocks.scheduler.TaskRunManager;
 import com.starrocks.scheduler.TaskRunProcessor;
 import com.starrocks.scheduler.mv.BaseTableSnapshotInfo;
+import com.starrocks.scheduler.mv.MVRefreshProcessor;
 import com.starrocks.scheduler.mv.pct.MVPCTRefreshProcessor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Analyzer;
@@ -757,7 +758,9 @@ public abstract class MVTestBase extends StarRocksTestBase {
         Assertions.assertTrue(stmt != null, "Expected a valid StatementBase but got null:" + explainQuery);
         ExecuteOption executeOption = buildExecuteOption(stmt);
         TaskRun taskRun = taskManager.buildTaskRun(task, executeOption);
-        return taskManager.getMVRefreshExecPlan(taskRun, task, executeOption, stmt);
+        MVRefreshProcessor.ProcessExecPlan processExecPlan =
+                taskManager.getMVRefreshProcessExecPlan(taskRun, task, executeOption, stmt);
+        return processExecPlan == null ? null : processExecPlan.execPlan();
     }
 
     public static List<String> extractColumnValues(String sql, int columnIndex) {

--- a/test/sql/test_materialized_view_refresh/R/test_explain_mv_refresh.sql
+++ b/test/sql/test_materialized_view_refresh/R/test_explain_mv_refresh.sql
@@ -35,6 +35,10 @@ trace logs optimizer refresh materialized view test_mv1 partition start ('2023-1
 -- result:
 NOT AVAILABLE
 -- !result
+function: assert_query_contains("explain refresh materialized view test_mv1", "NO REFRESH NEEDED")
+-- result:
+None
+-- !result
 INSERT INTO t1 VALUES 
   ('2023-12-01', 100),
   ('2023-12-01', 200),
@@ -42,6 +46,10 @@ INSERT INTO t1 VALUES
   ('2023-12-02', 400),
   ('2023-12-03', 500);
 -- result:
+-- !result
+function: assert_query_not_contains("explain refresh materialized view test_mv1", "NO REFRESH NEEDED")
+-- result:
+None
 -- !result
 function: assert_query_contains("explain refresh materialized view test_mv1", "test_mv1")
 -- result:
@@ -104,6 +112,34 @@ function: assert_query_contains("trace times optimizer refresh materialized view
 None
 -- !result
 function: assert_query_contains("trace logs optimizer refresh materialized view test_mv1 partition start ('2023-12-01') end ('2023-12-02')", "t1")
+-- result:
+None
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: assert_query_contains("explain refresh materialized view test_mv1", "NO REFRESH NEEDED: the materialized view is already up to date")
+-- result:
+None
+-- !result
+function: assert_query_contains("explain verbose refresh materialized view test_mv1", "NO REFRESH NEEDED")
+-- result:
+None
+-- !result
+function: assert_query_not_contains("explain refresh materialized view test_mv1 force", "NO REFRESH NEEDED")
+-- result:
+None
+-- !result
+INSERT INTO t1 VALUES ('2023-12-04', 600);
+-- result:
+-- !result
+function: assert_query_contains("explain refresh materialized view test_mv1 partition start ('2023-12-01') end ('2023-12-02')", "NO REFRESH NEEDED: the requested partitions are already up to date")
+-- result:
+None
+-- !result
+function: assert_query_not_contains("explain refresh materialized view test_mv1 partition start ('2023-12-01') end ('2023-12-02')", "the materialized view is already up to date")
+-- result:
+None
+-- !result
+function: assert_query_not_contains("explain refresh materialized view test_mv1", "NO REFRESH NEEDED")
 -- result:
 None
 -- !result

--- a/test/sql/test_materialized_view_refresh/T/test_explain_mv_refresh.sql
+++ b/test/sql/test_materialized_view_refresh/T/test_explain_mv_refresh.sql
@@ -23,12 +23,16 @@ trace times optimizer refresh materialized view test_mv1 force;
 trace times optimizer refresh materialized view test_mv1 with sync mode;
 trace logs optimizer refresh materialized view test_mv1 partition start ('2023-12-01') end ('2023-12-02');
 
+function: assert_query_contains("explain refresh materialized view test_mv1", "NO REFRESH NEEDED")
+
 INSERT INTO t1 VALUES 
   ('2023-12-01', 100),
   ('2023-12-01', 200),
   ('2023-12-02', 300),
   ('2023-12-02', 400),
   ('2023-12-03', 500);
+
+function: assert_query_not_contains("explain refresh materialized view test_mv1", "NO REFRESH NEEDED")
 
 function: assert_query_contains("explain refresh materialized view test_mv1", "test_mv1")
 function: assert_query_contains("explain refresh materialized view test_mv1 force", "test_mv1")
@@ -48,5 +52,17 @@ function: assert_query_contains("trace times optimizer refresh materialized view
 function: assert_query_contains("trace times optimizer refresh materialized view test_mv1 force", "Analyzer")
 function: assert_query_contains("trace times optimizer refresh materialized view test_mv1 with sync mode", "Analyzer")
 function: assert_query_contains("trace logs optimizer refresh materialized view test_mv1 partition start ('2023-12-01') end ('2023-12-02')", "t1")
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: assert_query_contains("explain refresh materialized view test_mv1", "NO REFRESH NEEDED: the materialized view is already up to date")
+function: assert_query_contains("explain verbose refresh materialized view test_mv1", "NO REFRESH NEEDED")
+function: assert_query_not_contains("explain refresh materialized view test_mv1 force", "NO REFRESH NEEDED")
+
+INSERT INTO t1 VALUES ('2023-12-04', 600);
+
+function: assert_query_contains("explain refresh materialized view test_mv1 partition start ('2023-12-01') end ('2023-12-02')", "NO REFRESH NEEDED: the requested partitions are already up to date")
+function: assert_query_not_contains("explain refresh materialized view test_mv1 partition start ('2023-12-01') end ('2023-12-02')", "the materialized view is already up to date")
+function: assert_query_not_contains("explain refresh materialized view test_mv1", "NO REFRESH NEEDED")
 
 


### PR DESCRIPTION
## Why I'm doing:

`EXPLAIN REFRESH MATERIALIZED VIEW` on an MV that has nothing to refresh prints only:

```
PLAN NOT AVAILABLE

RefreshMode: INCREMENTAL
```

`PLAN NOT AVAILABLE` reads like a failure, so a user cannot tell "there is nothing to refresh" from "planning
broke". The MV layer knows the difference but threw it away: `MVTaskRunProcessor.getMVRefreshExecPlan()`
collapsed every non-`SUCCESS` `ProcessExecPlan` into `null`, and logged *"because the materialized view is up
to date"* for all of them. A planning failure is a separate path — it propagates as `DmlException`.

## What I'm doing:

`ProcessExecPlan` now carries a `SkipReason`, and `TaskManager.getMVRefreshExplain()` maps it to the message
instead of assuming freshness whenever the plan is null:

| `SkipReason` | Emitted line |
|---|---|
| `MV_UP_TO_DATE` | `NO REFRESH NEEDED: the materialized view is already up to date` |
| `SCOPE_UP_TO_DATE` | `NO REFRESH NEEDED: the requested partitions are already up to date, other partitions of the materialized view may still be stale` |
| `STALE_PINNED_BATCH` | `REFRESH SKIPPED: another refresh job owns the pinned partition ranges` |

The `switch` is exhaustive, so adding a `SkipReason` is a compile error rather than a silent inheritance of the
"up to date" claim — the property that makes the wording locally verifiable instead of resting on which skip
sites happen to be reachable from `EXPLAIN` today.

**Rewording `StmtExecutor.buildExplainString()` was rejected.** That `PLAN NOT AVAILABLE` string is shared by
every EXPLAIN path — its own comment notes *"marked delete will get execPlan null"* — so claiming "no delta"
there would be wrong for a marked delete, and three existing tests assert it
(`PCTRefreshListPartitionOlapTest`, `PCTRefreshNonPartitionOlapTest`, `PCTRefreshRangePartitionOlapTest`).
Emitting the MV-specific line from the MV-specific path keeps the generic line and all three tests untouched,
and makes the new information purely additive.

**`SCOPE_UP_TO_DATE` exists because of a Codex review finding on this PR.** A partition-scoped request only
proves its own range is fresh: `MVPCTRefreshPartitioner` intersects the changed partitions with the requested
scope (*"it should be refreshed according to the user-specified range, not all partitions"*), so
`EXPLAIN REFRESH ... PARTITION START/END` over a fresh range returns no plan while other partitions are still
stale. Claiming whole-MV freshness there also contradicts the rule the codebase already applies before
advancing `LAST_FRESHNESS_CONFIRMED_AT`: *"A user-scoped partial refresh only covers the requested range, so it
cannot confirm whole-MV freshness"* (`MVVersionManager`).

`STALE_PINNED_BATCH` is not reachable from `EXPLAIN` today — it needs `PINNED_REFRESH_JOB_ID`, which only
spawned batch runs carry — but it is the one skip site that means "there is work, deliberately not done", so it
gets a message that does not claim freshness.

`PCTRefreshNonPartitionOlapTest#testMVForceRefresh` now also asserts the new line, and
`PCTRefreshRangePartitionOlapTest#testExplainRefreshOnFreshPartitionRange` covers the scoped wording: refresh
the MV fully, dirty only `p2`, then `EXPLAIN REFRESH` the `p1` range and assert it does *not* claim the whole MV
is up to date, while a whole-MV `EXPLAIN REFRESH` still produces a plan. Verified both ways:
reverting only the `TaskManager` change and rerunning
`mvn -pl fe-core -am -Dtest=PCTRefreshNonPartitionOlapTest` fails with

```
org.opentest4j.AssertionFailedError:
RefreshMode: PCT ==> expected: <true> but was: <false>
  at PCTRefreshNonPartitionOlapTest.testMVForceRefresh(PCTRefreshNonPartitionOlapTest.java:74)
```

restoring it passes (`Tests run: 1, Failures: 0`).

**The append needs a newline guard, which only a cluster run revealed.**
`TRACE TIMES OPTIMIZER REFRESH MATERIALIZED VIEW` and `TRACE LOGS OPTIMIZER ...` reach the same path, and
their output ends with `Tracer Cost: 52us` — no trailing newline — so the first version of this change produced:

```
Tracer Cost: 52usNO REFRESH NEEDED: the materialized view is already up to date
```

The FE unit test could not catch it: it only exercises plain `EXPLAIN`. Fixed by appending `\n` first when the
explain string does not already end with one.

## End-to-end verification

A cluster was built from this PR's head commit and the deployed binary confirmed before any assertion was
trusted — `SELECT @@version_comment` returns `main-03a4f65`, and the CN reports the same, so the behavior below
is this change's and not a stale binary's.

Four states were probed directly, and `test_explain_mv_refresh` now asserts all of them:

| State | `EXPLAIN REFRESH` output | Assertion |
|---|---|---|
| Empty base table, MV never refreshed | `PLAN NOT AVAILABLE` + the new line | `assert_query_contains(..., "NO REFRESH NEEDED")` |
| Refreshed, up to date | `PLAN NOT AVAILABLE` + the new line (also under `EXPLAIN VERBOSE`) | 2 × `assert_query_contains` |
| New data landed, refresh pending | a real plan, no new line | `assert_query_not_contains` |
| Up to date, `FORCE` | always plans, so no new line | `assert_query_not_contains` |
| Requested range fresh, another partition stale | the scope-limited line, never the whole-MV claim | `assert_query_contains` + 2 × `assert_query_not_contains` |

The `R` golden was updated by hand rather than by re-recording the case: re-recording rewrites the
`trace times optimizer` blocks with live timings (`0ms|-- Parser[1] 0`, `Tracer Cost: 81us`), which would rot.
Only the five new deterministic `function:` blocks are added; every pre-existing block is byte-identical.

The new assertions were confirmed to have teeth — with the expected string replaced by an absent sentinel the
case fails with `AssertionError: ... is not found in plan`, so a regression that drops the line would be
caught rather than silently passing.

A cluster was rebuilt from the final head — `SELECT @@version_comment` and the CN both report
`main-cbccab9` — and every message checked directly there:

```
-- requested range fresh, another partition stale
PLAN NOT AVAILABLE
NO REFRESH NEEDED: the requested partitions are already up to date, other partitions of the
materialized view may still be stale

-- same moment, whole-MV EXPLAIN REFRESH: a real plan, zero occurrences of NO REFRESH NEEDED

-- after a full refresh
PLAN NOT AVAILABLE
NO REFRESH NEEDED: the materialized view is already up to date
```

The newline guard was confirmed on both trace statements:

```
PLAN NOT AVAILABLE
...
Tracer Cost: 70us
NO REFRESH NEEDED: the materialized view is already up to date
```

`test_explain_mv_refresh` passes there, and so does the rest of `test_materialized_view_refresh` — 35 cases,
one unrelated failure in `test_mv_event_trigger_with_stream_load`, whose `shell: curl ... _stream_load` step
returns `There is no 100-continue header` because the run reached the cluster through an SSH port-forward. That
case contains no `EXPLAIN REFRESH` statement, and it fails identically on a build without this change.

On the FE side the whole `com.starrocks.scheduler` package was run: 48 classes, 496 tests, 0 failures.

The documentation fixes found in the same audit are sent separately so this one stays a single behavior change.

Fixes #issue: N/A — found by inspection while auditing MV refresh observability, no user-filed issue.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

`EXPLAIN REFRESH MATERIALIZED VIEW` on an up-to-date MV gains one output line. The existing
`PLAN NOT AVAILABLE` line is unchanged, so assertions matching it still hold.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
