### PR TITLE
[BugFix] Report bRPC method error bvars as counters

### DIFF
--- a/be/src/http/action/metrics_action.cpp
+++ b/be/src/http/action/metrics_action.cpp
@@ -161,6 +161,16 @@ void PrometheusMetricsVisitor::_visit_simple_metric(const std::string& name, con
     _ss << " " << metric->to_string() << "\n";
 }
 
+// bRPC method error bvars is a counter type, instead of a gauge one.
+// https://github.com/apache/brpc/blob/1.9.0/src/brpc/details/method_status.h#L108
+// TODO: refactor and ensure all counter-typed bvars are correctly reported, including those exposed by StarRocks
+static const char* bvar_metric_type(const butil::StringPiece& name) {
+    if (name.starts_with("rpc_server_") && name.ends_with("_error")) {
+        return "counter";
+    }
+    return "gauge";
+}
+
 bool PrometheusMetricsVisitor::dump(const std::string& name, const butil::StringPiece& desc) {
     if (!desc.empty() && desc[0] == '"') {
         // there is no necessary to monitor string in prometheus
@@ -171,7 +181,9 @@ bool PrometheusMetricsVisitor::dump(const std::string& name, const butil::String
         // Leave it to _dump_latency_recorder_suffix to output Summary.
         return true;
     }
-    _ss << "# HELP " << name << '\n' << "# TYPE " << name << " gauge" << '\n' << name << " " << desc << '\n';
+    _ss << "# HELP " << name << '\n'
+        << "# TYPE " << name << " " << bvar_metric_type(name) << '\n'
+        << name << " " << desc << '\n';
     return true;
 }
 

--- a/be/test/http/metrics_action_test.cpp
+++ b/be/test/http/metrics_action_test.cpp
@@ -34,6 +34,8 @@
 
 #include "http/action/metrics_action.h"
 
+#include <bvar/bvar.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "base/metrics.h"
@@ -52,11 +54,24 @@ namespace starrocks {
 extern bool sDisableStarOSMetrics;
 #endif
 
+namespace {
+// Test-only exposed bvars with unique names for dump_metrics_with_bvar coverage.
+bvar::Adder<int64_t> g_metrics_action_test_gauge_bvar("metrics_action_test_gauge_bvar");
+bvar::Adder<int64_t> g_metrics_action_test_rpc_error("rpc_server_metrics_action_test_method_error");
+} // namespace
+
 // Mock part
 const char* s_expect_response = nullptr;
+std::string* s_captured_response = nullptr;
 
 void mock_send_reply(const std::string& content) {
     ASSERT_STREQ(s_expect_response, content.c_str());
+}
+
+void mock_capture_reply(const std::string& content) {
+    if (s_captured_response != nullptr) {
+        *s_captured_response = content;
+    }
 }
 
 class MetricsActionTest : public testing::Test {
@@ -185,6 +200,27 @@ TEST_F(MetricsActionTest, json_output_with_table_metrics) {
     request.add_param("type", "json");
     MetricsAction action(&registry, &mock_send_reply);
     action.handle(&request);
+}
+
+TEST_F(MetricsActionTest, prometheus_output_with_bvar_metrics) {
+    config::dump_metrics_with_bvar = true;
+    g_metrics_action_test_gauge_bvar << 1;
+    g_metrics_action_test_rpc_error << 1;
+
+    ProcessMetricsRegistry registry("test");
+    std::string response;
+    s_captured_response = &response;
+    HttpRequest request(_evhttp_req);
+    MetricsAction action(&registry, mock_capture_reply);
+    action.handle(&request);
+    s_captured_response = nullptr;
+
+    EXPECT_THAT(response, testing::HasSubstr("# HELP metrics_action_test_gauge_bvar\n"));
+    EXPECT_THAT(response, testing::HasSubstr("# TYPE metrics_action_test_gauge_bvar gauge\n"));
+    EXPECT_THAT(response, testing::HasSubstr("metrics_action_test_gauge_bvar "));
+    EXPECT_THAT(response, testing::HasSubstr("# HELP rpc_server_metrics_action_test_method_error\n"));
+    EXPECT_THAT(response, testing::HasSubstr("# TYPE rpc_server_metrics_action_test_method_error counter\n"));
+    EXPECT_THAT(response, testing::HasSubstr("rpc_server_metrics_action_test_method_error "));
 }
 
 TEST_F(MetricsActionTest, core_output_does_not_collect_table_metrics) {


### PR DESCRIPTION
## Why I'm doing:

bRPC exposes per-method error status bvars (`rpc_server_*_error`) as monotonically increasing counters (https://github.com/apache/brpc/blob/1.9.0/src/brpc/details/method_status.h#L108), but the Prometheus visitor emitted every bvar with `"# TYPE ... gauge"`. Prometheus / Datadog therefore cannot process this metric correctly.

## What I'm doing:

As mentioned above.

TODO: refactor and ensure all counter-typed bvars are correctly reported, including those exposed by StarRocks

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
