### PR TITLE
[Tool] Set fe version to 4.1.4

### DIFF
--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -214,14 +214,14 @@ mkdir -p ${meta_dir:-"$STARROCKS_HOME/meta"}
 for f in $STARROCKS_HOME/lib/*.jar; do
   CLASSPATH=$f:${CLASSPATH};
 done
-# Explicitly put fe-core-4.1.jar at the front of classpath to ensure StarRocks' 
+# Explicitly put fe-core-4.1.4.jar at the front of classpath to ensure StarRocks' 
 # customized classes (e.g., HiveMetaStoreClient) are loaded before the original 
 # ones from third-party JARs (e.g., hive-apache-3.1.2-22.jar).
 # This prevents ClassLoader conflicts where the original HiveMetaStoreClient 
 # (which uses old thrift paths like org.apache.thrift.transport.TFramedTransport)
 # might be loaded instead of StarRocks' version (which uses the correct new paths
 # like org.apache.thrift.transport.layered.TFramedTransport).
-export CLASSPATH=${STARROCKS_HOME}/lib/fe-core-4.1.jar:${STARROCKS_HOME}/lib/starrocks-hadoop-ext.jar:${CLASSPATH}:${STARROCKS_HOME}/lib:${STARROCKS_HOME}/conf
+export CLASSPATH=${STARROCKS_HOME}/lib/fe-core-4.1.4.jar:${STARROCKS_HOME}/lib/starrocks-hadoop-ext.jar:${CLASSPATH}:${STARROCKS_HOME}/lib:${STARROCKS_HOME}/conf
 
 pidfile=$PID_DIR/fe.pid
 

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>4.1</version>
+        <version>4.1.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1346,7 +1346,7 @@ public class Config extends ConfigBase {
      * Default spark dpp version
      */
     @ConfField
-    public static String spark_dpp_version = "4.1";
+    public static String spark_dpp_version = "4.1.4";
     /**
      * Default spark load timeout
      */

--- a/fe/fe-grammar/pom.xml
+++ b/fe/fe-grammar/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>4.1</version>
+        <version>4.1.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/fe-parser/pom.xml
+++ b/fe/fe-parser/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>4.1</version>
+        <version>4.1.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/fe-server/pom.xml
+++ b/fe/fe-server/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>4.1</version>
+        <version>4.1.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/fe-spi/pom.xml
+++ b/fe/fe-spi/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>4.1</version>
+        <version>4.1.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/fe-testing/pom.xml
+++ b/fe/fe-testing/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>4.1</version>
+        <version>4.1.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/fe-type/pom.xml
+++ b/fe/fe-type/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>4.1</version>
+        <version>4.1.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/fe-utils/pom.xml
+++ b/fe/fe-utils/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>starrocks-fe</artifactId>
         <groupId>com.starrocks</groupId>
-        <version>4.1</version>
+        <version>4.1.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fe/plugin/hive-udf/pom.xml
+++ b/fe/plugin/hive-udf/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>starrocks-fe</artifactId>
         <groupId>com.starrocks</groupId>
-        <version>4.1</version>
+        <version>4.1.4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/fe/plugin/spark-dpp/pom.xml
+++ b/fe/plugin/spark-dpp/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>com.starrocks</groupId>
         <artifactId>starrocks-fe</artifactId>
-        <version>4.1</version>
+        <version>4.1.4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -25,7 +25,7 @@ under the License.
 
     <groupId>com.starrocks</groupId>
     <artifactId>starrocks-fe</artifactId>
-    <version>4.1</version>
+    <version>4.1.4</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
## Why I'm doing:

After branch `branch-4.1.4` is created, the fe code still references the version `4.1` in multiple places. They need to be replaced with the actual release version `4.1.4` before the release build.

This mirrors https://github.com/StarRocks/starrocks/pull/75943 (which did the same for `4.1.3`).

## What I'm doing:

- `bin/start_fe.sh`: `fe-core-4.1.jar` → `fe-core-4.1.4.jar`
- 11 `fe/**/pom.xml`: `<version>4.1</version>` → `<version>4.1.4</version>`
- `fe/fe-core/src/main/java/com/starrocks/common/Config.java`: `spark_dpp_version = "4.1"` → `"4.1.4"`

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
