### PR TITLE
[BugFix] Fix NPE when deparsing INSERT ... VALUES (DEFAULT, ...)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/ExprExplainVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/ExprExplainVisitor.java
@@ -508,7 +508,9 @@ public class ExprExplainVisitor implements AstVisitorExtendInterface<String, Voi
 
     @Override
     public String visitDefaultValueExpr(DefaultValueExpr node, Void context) {
-        return null;
+        // Returning null here made every caller that joins child strings throw NPE, e.g. deparsing
+        // `INSERT INTO t VALUES (DEFAULT, 3)`. DEFAULT is also the literal input syntax, so it round-trips.
+        return "DEFAULT";
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AstToSQLBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AstToSQLBuilderTest.java
@@ -249,11 +249,49 @@ public class AstToSQLBuilderTest {
     public void testValuesInDerivedTablePositionKeepsParentheses() {
         // Counterpart to testInsertValuesRoundTrip: outside the INSERT source, a VALUES relation sits in
         // derived-table position and *must* stay parenthesized.
-        String sql = "select * from (values (1, 'a'), (2, 'b')) tt(x, y)";
-        StatementBase stmt = SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
-        String serializedSql = AstToSQLBuilder.toSQL(stmt);
-        Assertions.assertEquals("SELECT *\nFROM (VALUES(1, 'a'), (2, 'b')) tt(x,y)", serializedSql);
-        Assertions.assertDoesNotThrow(() -> SqlParser.parseSingleStatement(serializedSql, SqlModeHelper.MODE_DEFAULT));
+        String[][] cases = {
+                // explicit column names
+                {"select * from (values (1, 'a'), (2, 'b')) tt(x, y)",
+                        "SELECT *\nFROM (VALUES(1, 'a'), (2, 'b')) tt(x,y)"},
+                // alias without column names: the deparser supplies the generated column_0
+                {"select cast(column_0 as datetime) from (values ('2020.02.29')) as tmp",
+                        "SELECT CAST(`column_0` AS DATETIME)\nFROM (VALUES('2020.02.29')) tmp(column_0)"},
+                // VALUES nested under an INSERT ... SELECT: the INSERT source is the SELECT, not the
+                // VALUES, so the inner relation must still be parenthesized
+                {"insert into t0 select cast(column_0 as int) from (values ('1')) as tmp",
+                        "INSERT INTO `t0` SELECT CAST(`column_0` AS INT)\nFROM (VALUES('1')) tmp(column_0)"},
+        };
+        for (String[] c : cases) {
+            StatementBase stmt = SqlParser.parseSingleStatement(c[0], SqlModeHelper.MODE_DEFAULT);
+            String serializedSql = AstToSQLBuilder.toSQL(stmt);
+            Assertions.assertEquals(c[1], serializedSql, c[0]);
+            Assertions.assertDoesNotThrow(() -> SqlParser.parseSingleStatement(serializedSql, SqlModeHelper.MODE_DEFAULT),
+                    c[0]);
+            Assertions.assertEquals(serializedSql,
+                    AstToSQLBuilder.toSQL(SqlParser.parseSingleStatement(serializedSql, SqlModeHelper.MODE_DEFAULT)),
+                    c[0]);
+        }
+    }
+
+    @Test
+    public void testInsertValuesWithDefaultKeyword() {
+        // DefaultValueExpr used to serialize to null, so joining the row's child strings threw NPE.
+        String[][] cases = {
+                {"insert into t0 (v1, v2) values (DEFAULT, 3)", "INSERT INTO `t0` (`v1`,`v2`) VALUES(DEFAULT, 3)"},
+                {"insert into t0 values (DEFAULT)", "INSERT INTO `t0` VALUES(DEFAULT)"},
+                {"insert into t0 (v1, v2) values (1, DEFAULT), (2, 3)",
+                        "INSERT INTO `t0` (`v1`,`v2`) VALUES(1, DEFAULT), (2, 3)"},
+                {"insert into t0 (v1, v2) values (DEFAULT, DEFAULT)",
+                        "INSERT INTO `t0` (`v1`,`v2`) VALUES(DEFAULT, DEFAULT)"},
+        };
+        for (String[] c : cases) {
+            StatementBase stmt = SqlParser.parseSingleStatement(c[0], SqlModeHelper.MODE_DEFAULT);
+            String serializedSql = Assertions.assertDoesNotThrow(() -> AstToSQLBuilder.toSQL(stmt), c[0]);
+            Assertions.assertEquals(c[1], serializedSql, c[0]);
+            Assertions.assertEquals(serializedSql,
+                    AstToSQLBuilder.toSQL(SqlParser.parseSingleStatement(serializedSql, SqlModeHelper.MODE_DEFAULT)),
+                    c[0]);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

ExprExplainVisitor.visitDefaultValueExpr returned null, so every caller that joins a node's child strings threw NullPointerException instead of producing SQL. Deparsing `INSERT INTO t (c1, c2) VALUES (DEFAULT, 3)` hit this through AstToSQLBuilder -> ExprToSql.toSql, because Joiner rejects null elements.

Return the DEFAULT keyword instead. That is the literal input syntax, so the statement round-trips, and it is also strictly better than null for the other caller of this visitor, PlanNode explain output.

Also extends the derived-table VALUES regression cases added with the earlier INSERT ... VALUES parenthesization fix, covering an alias without explicit column names and a VALUES relation nested under INSERT ... SELECT.

Measured over 25861 statements from test/sql and the FE test resources, deparser exceptions drop from 1233 to 1193, with no statement that previously round-tripped cleanly changing category.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
