### PR TITLE
[BugFix] Fix tablet-scheduler NPE on a disk with no reported storage medium

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/BackendLoadStatistic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/BackendLoadStatistic.java
@@ -293,9 +293,19 @@ public class BackendLoadStatistic {
 
         ImmutableMap<String, DiskInfo> disks = be.getDisks();
         Set<TStorageMedium> mediaOnBackend = EnumSet.noneOf(TStorageMedium.class);
+        boolean anyMediumUnknown = false;
         for (DiskInfo diskInfo : disks.values()) {
             TStorageMedium medium = diskInfo.getStorageMedium();
-            mediaOnBackend.add(medium);
+            if (medium == null) {
+                // A disk's medium is not persisted in the image, it is only filled in by the BE's
+                // disk report, so it stays null from a leader restart until that BE's first report
+                // (forever for a BE that never comes back). Such a disk must be kept out of the
+                // EnumSet, which rejects null; leaving its medium unknown is also what the
+                // hasMedium() checks below have always done with it.
+                anyMediumUnknown = true;
+            } else {
+                mediaOnBackend.add(medium);
+            }
             if (diskInfo.getState() == DiskState.ONLINE) {
                 // we only collect online disk's capacity
                 totalCapacityMap
@@ -312,13 +322,13 @@ public class BackendLoadStatistic {
 
         totalReplicaNumMap = Maps.newHashMap();
         if (mediaOnBackend.isEmpty()) {
-            // BE has not reported any disks yet (newly added / dead / pre-heartbeat). Skip the
-            // per-tablet scan -- with no pathStatistics, the hasMedium() post-pass would zero
-            // every count anyway. Match that outcome directly.
+            // No disk with a known medium (BE newly added / dead / pre-report). Skip the
+            // per-tablet scan -- with no pathStatistics carrying a medium, the hasMedium()
+            // post-pass would zero every count anyway. Match that outcome directly.
             for (TStorageMedium medium : TStorageMedium.values()) {
                 totalReplicaNumMap.put(medium, 0L);
             }
-        } else if (mediaOnBackend.size() == 1) {
+        } else if (mediaOnBackend.size() == 1 && !anyMediumUnknown) {
             // Homogeneous-disk BE: every replica on the BE physically resides on its only
             // medium, so we can read the count directly from the backend->tablet index in O(1)
             // instead of scanning every TabletMeta. This avoids holding the inverted-index walk
@@ -331,19 +341,24 @@ public class BackendLoadStatistic {
             // replicas to the medium the BE physically lacks, and the post-pass below would
             // zero them out -- making the replicas vanish from the load-balance averages.
             // Counting by physical placement here is both cheaper and more accurate.
+            //
+            // A disk whose medium is still unknown disqualifies the shortcut: it may hold replicas
+            // of the other medium, so "one known medium" is not "one medium on the BE". Such a
+            // backend falls through to the per-tablet scan, the way it was counted before this
+            // shortcut existed.
             TStorageMedium onlyMedium = mediaOnBackend.iterator().next();
             long totalOnBe = invertedIndex.getTabletNumByBackendId(beId);
             for (TStorageMedium medium : TStorageMedium.values()) {
                 totalReplicaNumMap.put(medium, medium == onlyMedium ? totalOnBe : 0L);
             }
         } else {
-            // Mixed-medium BE (BE has both HDD and SSD disks): per-tablet scan so the count
-            // reflects each replica's TabletMeta.storageMedium, which is what drives migration
-            // scheduling on BEs that actually have both media available.
+            // Either a mixed-medium BE (both HDD and SSD disks) or one that is not fully
+            // classified yet: per-tablet scan so the count reflects each replica's
+            // TabletMeta.storageMedium, which is what drives migration scheduling on BEs that
+            // actually have both media available.
             totalReplicaNumMap = invertedIndex.getReplicaNumByBeIdAndStorageMedium(beId);
-            // Defensive post-pass: zero a medium if the BE has no disks of that type. With
-            // mediaOnBackend.size() == 2 both media are present, so this is currently a no-op;
-            // kept for parity with the historical behavior if disk reporting becomes partial.
+            // Post-pass: zero a medium the BE has no disk of. A no-op when both media are present,
+            // load-bearing when we got here with a single known medium plus an unclassified disk.
             for (TStorageMedium medium : TStorageMedium.values()) {
                 if (!hasMedium(medium)) {
                     totalReplicaNumMap.put(medium, 0L);

--- a/fe/fe-core/src/test/java/com/starrocks/clone/ClusterLoadStatisticsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/ClusterLoadStatisticsTest.java
@@ -290,6 +290,111 @@ public class ClusterLoadStatisticsTest {
                 "mixed-medium BE must keep the per-tablet scan counts");
     }
 
+    /**
+     * A DiskInfo restored from the image carries no storage medium: the field is not persisted and
+     * is only filled in by the BE's disk report, so it is null from a leader restart until that
+     * report arrives -- forever for a BE that never comes back.
+     */
+    private static Backend backendWithUnreportedMedium(long beId, String host) {
+        Backend be = new Backend(beId, host, 9051);
+        Map<String, DiskInfo> disks = Maps.newHashMap();
+        DiskInfo disk1 = new DiskInfo("/path1");
+        disk1.setTotalCapacityB(1_000_000);
+        disk1.setAvailableCapacityB(900_000);
+        disk1.setDataUsedCapacityB(100_000);
+        // The image-restored state; DiskInfo's no-arg persist constructor is private, and the
+        // public one defaults to HDD, so clear the medium explicitly.
+        disk1.setStorageMedium(null);
+        disks.put(disk1.getRootPath(), disk1);
+
+        DiskInfo disk2 = new DiskInfo("/path2");
+        disk2.setTotalCapacityB(2_000_000);
+        disk2.setAvailableCapacityB(1_800_000);
+        disk2.setDataUsedCapacityB(200_000);
+        disk2.setStorageMedium(null);
+        disks.put(disk2.getRootPath(), disk2);
+
+        be.setDisks(ImmutableMap.copyOf(disks));
+        return be;
+    }
+
+    @Test
+    public void testInit_unreportedDiskMediumDoesNotThrow() throws LoadBalanceException {
+        Backend unreportedBe = backendWithUnreportedMedium(11004, "192.168.0.14");
+        SystemInfoService localInfo = new SystemInfoService();
+        localInfo.addBackend(unreportedBe);
+
+        TabletInvertedIndex localIndex = new TabletInvertedIndex();
+        long tabletId = 83000;
+        for (int i = 0; i < 3; i++, tabletId++) {
+            localIndex.addTablet(tabletId, new TabletMeta(1, 2, 3, 4, TStorageMedium.HDD));
+            localIndex.addReplica(tabletId, new Replica(tabletId + 100, unreportedBe.getId(), 0, ReplicaState.NORMAL));
+        }
+
+        BackendLoadStatistic stat = new BackendLoadStatistic(
+                unreportedBe.getId(), SystemInfoService.DEFAULT_CLUSTER, localInfo, localIndex);
+        stat.init();
+
+        // Same outcome as before the single-medium shortcut existed: a disk whose medium is
+        // unknown belongs to no medium, so hasMedium() is false and every count is zeroed.
+        Assertions.assertFalse(stat.hasMedium(TStorageMedium.HDD));
+        Assertions.assertFalse(stat.hasMedium(TStorageMedium.SSD));
+        Assertions.assertEquals(0L, stat.getReplicaNum(TStorageMedium.HDD));
+        Assertions.assertEquals(0L, stat.getReplicaNum(TStorageMedium.SSD));
+    }
+
+    @Test
+    public void testInit_oneKnownMediumPlusUnknownFallsBackToPerTabletScan() throws LoadBalanceException {
+        // updateDisks() fills the media of a BE's disks one DiskInfo at a time under no lock the
+        // scheduler shares, so a refresh can see one disk already HDD and the next still unknown.
+        // The single-medium shortcut must not fire there: the unclassified disk may hold replicas
+        // of the other medium, so counting every replica on the BE as HDD would inflate its HDD
+        // load score. Fall back to the per-tablet scan instead, as before the shortcut existed.
+        Backend partialBe = backendWithUnreportedMedium(11005, "192.168.0.15");
+        partialBe.getDisks().get("/path1").setStorageMedium(TStorageMedium.HDD);
+
+        SystemInfoService localInfo = new SystemInfoService();
+        localInfo.addBackend(partialBe);
+
+        TabletInvertedIndex localIndex = new TabletInvertedIndex();
+        long tabletId = 84000;
+        for (int i = 0; i < 5; i++, tabletId++) {
+            localIndex.addTablet(tabletId, new TabletMeta(1, 2, 3, 4, TStorageMedium.HDD));
+            localIndex.addReplica(tabletId, new Replica(tabletId + 100, partialBe.getId(), 0, ReplicaState.NORMAL));
+        }
+        for (int i = 0; i < 2; i++, tabletId++) {
+            localIndex.addTablet(tabletId, new TabletMeta(1, 2, 3, 5, TStorageMedium.SSD));
+            localIndex.addReplica(tabletId, new Replica(tabletId + 100, partialBe.getId(), 0, ReplicaState.NORMAL));
+        }
+
+        BackendLoadStatistic stat = new BackendLoadStatistic(
+                partialBe.getId(), SystemInfoService.DEFAULT_CLUSTER, localInfo, localIndex);
+        stat.init();
+
+        Assertions.assertTrue(stat.hasMedium(TStorageMedium.HDD));
+        Assertions.assertEquals(5L, stat.getReplicaNum(TStorageMedium.HDD),
+                "must count only the HDD-declared replicas, not all 7 on the backend");
+        Assertions.assertEquals(0L, stat.getReplicaNum(TStorageMedium.SSD),
+                "the BE has no known SSD disk, so its SSD count stays zeroed");
+    }
+
+    @Test
+    public void testClusterInitNotAbortedByUnreportedDiskMedium() {
+        // ClusterLoadStatistic.init() only catches LoadBalanceException, so anything else thrown
+        // for a single BE escapes to LeaderDaemon and kills the whole tablet-scheduler cycle.
+        systemInfoService.addBackend(backendWithUnreportedMedium(11006, "192.168.0.16"));
+
+        ClusterLoadStatistic loadStatistic = new ClusterLoadStatistic(systemInfoService, invertedIndex);
+        loadStatistic.init();
+
+        // The three healthy BEs are still classified, and the medium-less one is kept but reports
+        // no medium of its own.
+        Assertions.assertEquals(3, loadStatistic.getBackendLoadStats(TStorageMedium.HDD).size());
+        BackendLoadStatistic unreportedStat = loadStatistic.getBackendLoadStatistic(11006);
+        Assertions.assertNotNull(unreportedStat);
+        Assertions.assertEquals(0L, unreportedStat.getReplicaNum(TStorageMedium.HDD));
+    }
+
     @Test
     public void testToString() {
         ClusterLoadStatistic clusterLoad = new ClusterLoadStatistic(systemInfoService, invertedIndex);


### PR DESCRIPTION
## Why I'm doing:

```
2026-07-30 10:11:20.834+08:00 ERROR (tablet-scheduler|107) [LeaderDaemon.loop():158] tablet-scheduler got exception
 java.lang.NullPointerException: Cannot invoke "Object.getClass()" because "e" is null
        at java.base/java.util.EnumSet.typeCheck(EnumSet.java:397)
        at java.base/java.util.RegularEnumSet.add(RegularEnumSet.java:162)
        at java.base/java.util.RegularEnumSet.add(RegularEnumSet.java:36)
        at com.starrocks.clone.BackendLoadStatistic.init(BackendLoadStatistic.java:298)
        at com.starrocks.clone.ClusterLoadStatistic.init(ClusterLoadStatistic.java:96)
        at com.starrocks.clone.TabletScheduler.updateClusterLoadStatistic(TabletScheduler.java:529)
        at com.starrocks.clone.TabletScheduler.updateClusterLoadStatisticsAndPriority(TabletScheduler.java:511)
        at com.starrocks.clone.TabletScheduler.runAfterLeaseValid(TabletScheduler.java:461)
        at com.starrocks.common.util.LeaderDaemon.runOneCycle(LeaderDaemon.java:194)
        at com.starrocks.common.util.LeaderDaemon.loop(LeaderDaemon.java:151)
        at java.base/java.lang.Thread.run(Thread.java:840)
```

DiskInfo.storageMedium is not persisted in the image and is only filled in by the BE's disk report (Backend.updateDisks), so it stays null from a leader restart until that BE's first report -- forever for a BE that never comes back. Since #73555, BackendLoadStatistic.init() puts every disk's medium into an EnumSet, which rejects null:

  java.lang.NullPointerException: Cannot invoke "Object.getClass()" because "e" is null
        at java.base/java.util.EnumSet.typeCheck(EnumSet.java:397)
        at java.base/java.util.RegularEnumSet.add(RegularEnumSet.java:162)
        at com.starrocks.clone.BackendLoadStatistic.init(BackendLoadStatistic.java:298)
        at com.starrocks.clone.ClusterLoadStatistic.init(ClusterLoadStatistic.java:96)
        at com.starrocks.clone.TabletScheduler.updateClusterLoadStatistic(TabletScheduler.java:529)
        at com.starrocks.clone.TabletScheduler.runAfterLeaseValid(TabletScheduler.java:461)
        at com.starrocks.common.util.LeaderDaemon.runOneCycle(LeaderDaemon.java:194)

ClusterLoadStatistic.init() only catches LoadBalanceException, so the NPE escapes to LeaderDaemon and aborts the whole tablet-scheduler cycle -- no repair, clone or balance for any tablet in the cluster -- and it repeats every second for as long as some BE has a disk with an unknown medium.

Skip such disks when collecting the media present on a backend. They then belong to no medium, which is exactly how the hasMedium() checks treated them before #73555.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
