### PR TITLE
[BugFix] Compare range-colocate split bounds by value, not serialized bytes

### DIFF
--- a/be/src/storage/lake/tablet_range_helper.cpp
+++ b/be/src/storage/lake/tablet_range_helper.cpp
@@ -676,8 +676,8 @@ Status TabletRangeHelper::validate_new_tablet_ranges(
     // 2. First range's lower bound must match the old tablet's lower bound.
     const auto& first = new_tablet_ranges[0];
     ASSIGN_OR_RETURN(bool first_lower_matches,
-                     tuple_bound_equal(first.has_lower_bound(), first.lower_bound(),
-                                       old_tablet_range.has_lower_bound(), old_tablet_range.lower_bound()));
+                     tuple_bound_equal(first.has_lower_bound(), first.lower_bound(), old_tablet_range.has_lower_bound(),
+                                       old_tablet_range.lower_bound()));
     if (!first_lower_matches) {
         return Status::InvalidArgument("validate_new_tablet_ranges: first.lower_bound != old_tablet_range.lower_bound");
     }
@@ -688,8 +688,8 @@ Status TabletRangeHelper::validate_new_tablet_ranges(
     // 3. Last range's upper bound must match the old tablet's upper bound.
     const auto& last = new_tablet_ranges[new_tablet_ranges.size() - 1];
     ASSIGN_OR_RETURN(bool last_upper_matches,
-                     tuple_bound_equal(last.has_upper_bound(), last.upper_bound(),
-                                       old_tablet_range.has_upper_bound(), old_tablet_range.upper_bound()));
+                     tuple_bound_equal(last.has_upper_bound(), last.upper_bound(), old_tablet_range.has_upper_bound(),
+                                       old_tablet_range.upper_bound()));
     if (!last_upper_matches) {
         return Status::InvalidArgument("validate_new_tablet_ranges: last.upper_bound != old_tablet_range.upper_bound");
     }

--- a/be/src/storage/lake/tablet_range_helper.cpp
+++ b/be/src/storage/lake/tablet_range_helper.cpp
@@ -139,6 +139,24 @@ static StatusOr<DatumVariant> read_time_default(const TabletColumn& column) {
 // byte-identical protos are not guaranteed even when the value is unchanged (e.g. an optional type or
 // variant_type field present on one side and defaulted on the other). Used to check that a trailing ADD
 // preserves the existing range prefix without spuriously rejecting an equivalent re-encoding.
+static Status validate_variant_type_shape(const VariantPB& value) {
+    if (!value.has_type()) {
+        return Status::OK();
+    }
+    const auto& type = value.type();
+    if (type.types_size() != 1) {
+        return Status::InvalidArgument(
+                fmt::format("range-bound variant type must contain exactly one node, got {}", type.types_size()));
+    }
+    const auto& node = type.types(0);
+    if (static_cast<TTypeNodeType::type>(node.type()) != TTypeNodeType::SCALAR || !node.has_scalar_type()) {
+        return Status::InvalidArgument(
+                fmt::format("range-bound variant type must be scalar (node_type={}, has_scalar_type={})", node.type(),
+                            node.has_scalar_type()));
+    }
+    return Status::OK();
+}
+
 static StatusOr<bool> leading_value_preserved(const VariantPB& old_value, const VariantPB& new_value) {
     if (old_value.variant_type() != new_value.variant_type()) {
         return false;
@@ -146,6 +164,8 @@ static StatusOr<bool> leading_value_preserved(const VariantPB& old_value, const 
     if (old_value.has_type() != new_value.has_type()) {
         return false;
     }
+    RETURN_IF_ERROR(validate_variant_type_shape(old_value));
+    RETURN_IF_ERROR(validate_variant_type_shape(new_value));
     if (old_value.has_type()) {
         const auto old_type = TypeDescriptor::from_protobuf(old_value.type());
         const auto new_type = TypeDescriptor::from_protobuf(new_value.type());

--- a/be/src/storage/lake/tablet_range_helper.cpp
+++ b/be/src/storage/lake/tablet_range_helper.cpp
@@ -14,8 +14,6 @@
 
 #include "storage/lake/tablet_range_helper.h"
 
-#include <google/protobuf/util/message_differencer.h>
-
 #include <memory>
 
 #include "column/binary_column.h"
@@ -438,17 +436,47 @@ StatusOr<TabletRangePB> TabletRangeHelper::convert_t_range_to_pb_range(const TTa
     return pb_range;
 }
 
-// Structural (proto byte-for-byte) equality of two TuplePB messages. Used by
-// validate_new_tablet_ranges to detect zero-width and adjacency-tile mismatches.
+// Whether two TuplePB messages denote the same sort-key value, compared position by
+// position with leading_value_preserved — i.e. semantically (variant kind, logical type,
+// decoded value), not by raw proto bytes. Used by validate_new_tablet_ranges to detect
+// zero-width ranges, adjacency-tile mismatches, and endpoint mismatches against the parent
+// tablet's range.
+//
+// A byte-level comparison here (MessageDifferencer::Equals) rejected every
+// external-boundaries split of a tablet that already had an explicit bound, because the two
+// sides of that comparison are produced by different serializers: the parent's bound was
+// written by BE and the new-tablet bounds arrive from FE. BE's TypeDescriptor::to_protobuf
+// always sets PScalarType::len (be/src/types/type_descriptor.cpp) while FE's
+// TypeSerializer.scalarTypeToProtobuf sets it only for CHAR/VARCHAR/VARBINARY/HLL, and
+// PScalarType::len is `optional`, so for an integer or date sort key the encodings differ
+// byte-for-byte while denoting the same type. leading_value_preserved already documents and
+// handles exactly this hazard for the trailing-sort-key-ADD check; the endpoint checks need
+// the same treatment.
+//
+// The consequence of rejecting was not a failed split but a wedged table: the split fell
+// back to an identical tablet, so the layout never changed, TableAlignmentLatch suppressed
+// further alignment, the range-colocate group never re-stabilised, and the size-driven split
+// stayed blocked behind the unstable-group guard in SplitTabletJobFactory. Parents with no
+// bound were unaffected because tuple_bound_equal short-circuits on absence, which is why
+// alignment only ever failed once a tablet had already been split.
 namespace {
-bool tuple_pb_equal(const TuplePB& lhs, const TuplePB& rhs) {
-    return google::protobuf::util::MessageDifferencer::Equals(lhs, rhs);
+StatusOr<bool> tuple_pb_equal(const TuplePB& lhs, const TuplePB& rhs) {
+    if (lhs.values_size() != rhs.values_size()) {
+        return false;
+    }
+    for (int i = 0; i < lhs.values_size(); ++i) {
+        ASSIGN_OR_RETURN(bool equal, leading_value_preserved(lhs.values(i), rhs.values(i)));
+        if (!equal) {
+            return false;
+        }
+    }
+    return true;
 }
 
 // Same as tuple_pb_equal but treats "neither side has the bound" as equal —
 // used at the first.lower / last.upper endpoint checks where the parent range
 // may be unbounded.
-bool tuple_bound_equal(bool lhs_has, const TuplePB& lhs, bool rhs_has, const TuplePB& rhs) {
+StatusOr<bool> tuple_bound_equal(bool lhs_has, const TuplePB& lhs, bool rhs_has, const TuplePB& rhs) {
     if (lhs_has != rhs_has) return false;
     if (!lhs_has) return true;
     return tuple_pb_equal(lhs, rhs);
@@ -629,23 +657,28 @@ Status TabletRangeHelper::validate_new_tablet_ranges(
     RETURN_IF_ERROR(validate_tablet_range(old_tablet_range));
 
     // 1. Each new-tablet range must be individually well-formed, and the two
-    //    bounds (when both set) must not be byte-equal (catches zero-width
+    //    bounds (when both set) must not denote the same value (catches zero-width
     //    children). Strict semantic ordering (lower < upper) requires a
     //    schema for type-aware comparison and is the caller's responsibility
     //    (e.g., compute_split_ranges_from_external_boundaries compares via
     //    the tablet schema).
     for (const auto& r : new_tablet_ranges) {
         RETURN_IF_ERROR(validate_tablet_range(r));
-        if (r.has_lower_bound() && r.has_upper_bound() && tuple_pb_equal(r.lower_bound(), r.upper_bound())) {
-            return Status::InvalidArgument(
-                    "validate_new_tablet_ranges: range with lower_bound == upper_bound (zero-width)");
+        if (r.has_lower_bound() && r.has_upper_bound()) {
+            ASSIGN_OR_RETURN(bool zero_width, tuple_pb_equal(r.lower_bound(), r.upper_bound()));
+            if (zero_width) {
+                return Status::InvalidArgument(
+                        "validate_new_tablet_ranges: range with lower_bound == upper_bound (zero-width)");
+            }
         }
     }
 
     // 2. First range's lower bound must match the old tablet's lower bound.
     const auto& first = new_tablet_ranges[0];
-    if (!tuple_bound_equal(first.has_lower_bound(), first.lower_bound(), old_tablet_range.has_lower_bound(),
-                           old_tablet_range.lower_bound())) {
+    ASSIGN_OR_RETURN(bool first_lower_matches,
+                     tuple_bound_equal(first.has_lower_bound(), first.lower_bound(),
+                                       old_tablet_range.has_lower_bound(), old_tablet_range.lower_bound()));
+    if (!first_lower_matches) {
         return Status::InvalidArgument("validate_new_tablet_ranges: first.lower_bound != old_tablet_range.lower_bound");
     }
     if (first.has_lower_bound() && !first.lower_bound_included()) {
@@ -654,8 +687,10 @@ Status TabletRangeHelper::validate_new_tablet_ranges(
 
     // 3. Last range's upper bound must match the old tablet's upper bound.
     const auto& last = new_tablet_ranges[new_tablet_ranges.size() - 1];
-    if (!tuple_bound_equal(last.has_upper_bound(), last.upper_bound(), old_tablet_range.has_upper_bound(),
-                           old_tablet_range.upper_bound())) {
+    ASSIGN_OR_RETURN(bool last_upper_matches,
+                     tuple_bound_equal(last.has_upper_bound(), last.upper_bound(),
+                                       old_tablet_range.has_upper_bound(), old_tablet_range.upper_bound()));
+    if (!last_upper_matches) {
         return Status::InvalidArgument("validate_new_tablet_ranges: last.upper_bound != old_tablet_range.upper_bound");
     }
     if (last.has_upper_bound() && last.upper_bound_included()) {
@@ -677,7 +712,8 @@ Status TabletRangeHelper::validate_new_tablet_ranges(
                                 "(left must be exclusive, right must be inclusive)",
                                 i));
         }
-        if (!tuple_pb_equal(current_range.upper_bound(), next_range.lower_bound())) {
+        ASSIGN_OR_RETURN(bool tiles, tuple_pb_equal(current_range.upper_bound(), next_range.lower_bound()));
+        if (!tiles) {
             return Status::InvalidArgument(
                     fmt::format("validate_new_tablet_ranges: gap or overlap at boundary {} "
                                 "(ranges[i].upper_bound != ranges[i+1].lower_bound)",

--- a/be/test/storage/lake/tablet_range_helper_test.cpp
+++ b/be/test/storage/lake/tablet_range_helper_test.cpp
@@ -1001,6 +1001,85 @@ TEST(TabletRangeHelperTest, validate_new_tablet_ranges_happy_path_unbounded_pare
     ASSERT_TRUE(s.ok()) << s;
 }
 
+namespace {
+
+// Re-encodes a bound the way FE serializes it: PScalarType::len is left unset for
+// non-string types (TypeSerializer.scalarTypeToProtobuf), whereas BE's
+// TypeDescriptor::to_protobuf always sets it. Same declared type, different bytes.
+static TuplePB as_fe_encoded_tuple(TuplePB tuple_pb) {
+    for (int i = 0; i < tuple_pb.values_size(); ++i) {
+        tuple_pb.mutable_values(i)->mutable_type()->mutable_types(0)->mutable_scalar_type()->clear_len();
+    }
+    return tuple_pb;
+}
+
+// [lower, upper) with FE-encoded bounds. nullopt skips the corresponding bound.
+static TabletRangePB make_fe_encoded_int_range_pb(std::optional<int32_t> lower, std::optional<int32_t> upper) {
+    TabletRangePB r;
+    if (lower.has_value()) {
+        *r.mutable_lower_bound() = as_fe_encoded_tuple(make_int_tuple_pb(*lower));
+        r.set_lower_bound_included(true);
+    }
+    if (upper.has_value()) {
+        *r.mutable_upper_bound() = as_fe_encoded_tuple(make_int_tuple_pb(*upper));
+        r.set_upper_bound_included(false);
+    }
+    return r;
+}
+
+} // namespace
+
+// Regression: the endpoint checks must compare a bound's value, not its serialized bytes.
+// A bounded parent's range is written by BE (PScalarType::len set) while the new-tablet
+// ranges arrive from FE (len unset), so a byte-level comparison rejected every alignment
+// split of an already-split tablet. The rejection fell back to an identical tablet, so the
+// layout never changed, the range-colocate group never re-stabilised, and the size-driven
+// split stayed blocked behind the unstable-group guard.
+TEST(TabletRangeHelperTest, validate_new_tablet_ranges_accepts_fe_encoded_bounds_on_bounded_parent) {
+    TabletRangePB parent = make_int_range_pb(0, 100);
+    auto ranges = as_pb_list({make_fe_encoded_int_range_pb(0, 50), make_fe_encoded_int_range_pb(50, 100)});
+    // Guard the premise: the two encodings really are byte-distinct, so this case would
+    // have been rejected before the fix.
+    ASSERT_NE(parent.upper_bound().SerializeAsString(),
+              ranges.Get(ranges.size() - 1).upper_bound().SerializeAsString());
+    auto s = TabletRangeHelper::validate_new_tablet_ranges(parent, ranges);
+    ASSERT_TRUE(s.ok()) << s;
+}
+
+// The relaxation covers the encoding only: a genuinely different endpoint value is still
+// rejected, so malformed FE input cannot slip a non-tiling split through.
+TEST(TabletRangeHelperTest, validate_new_tablet_ranges_fe_encoded_last_upper_value_mismatch_rejected) {
+    TabletRangePB parent = make_int_range_pb(0, 100);
+    auto ranges = as_pb_list({make_fe_encoded_int_range_pb(0, 50), make_fe_encoded_int_range_pb(50, 99)});
+    auto s = TabletRangeHelper::validate_new_tablet_ranges(parent, ranges);
+    ASSERT_FALSE(s.ok());
+    ASSERT_TRUE(s.is_invalid_argument()) << s;
+    ASSERT_THAT(s.to_string(), testing::HasSubstr("last.upper_bound != old_tablet_range.upper_bound"));
+}
+
+TEST(TabletRangeHelperTest, validate_new_tablet_ranges_fe_encoded_first_lower_value_mismatch_rejected) {
+    TabletRangePB parent = make_int_range_pb(0, 100);
+    auto ranges = as_pb_list({make_fe_encoded_int_range_pb(1, 50), make_fe_encoded_int_range_pb(50, 100)});
+    auto s = TabletRangeHelper::validate_new_tablet_ranges(parent, ranges);
+    ASSERT_FALSE(s.ok());
+    ASSERT_TRUE(s.is_invalid_argument()) << s;
+    ASSERT_THAT(s.to_string(), testing::HasSubstr("first.lower_bound != old_tablet_range.lower_bound"));
+}
+
+// A tuple arity mismatch must not read as equality now that the comparison walks positions
+// instead of delegating to whole-message equality.
+TEST(TabletRangeHelperTest, validate_new_tablet_ranges_arity_mismatch_rejected) {
+    TabletRangePB parent = make_int_range_pb(0, 100);
+    TabletRangePB only = make_int_range_pb(0, 100);
+    // Give the child's upper bound a second value so its arity no longer matches the parent's.
+    *only.mutable_upper_bound()->add_values() = make_int_tuple_pb(7).values(0);
+    auto ranges = as_pb_list({only});
+    auto s = TabletRangeHelper::validate_new_tablet_ranges(parent, ranges);
+    ASSERT_FALSE(s.ok());
+    ASSERT_TRUE(s.is_invalid_argument()) << s;
+    ASSERT_THAT(s.to_string(), testing::HasSubstr("last.upper_bound != old_tablet_range.upper_bound"));
+}
+
 // =============================================================================
 // validate_range_structural / validate_range_transition: schema-aware validators
 // for the metadata-only trailing sort-key ADD.


### PR DESCRIPTION
## Why I'm doing:

`validate_new_tablet_ranges` compares a new-tablet range endpoint against the parent
tablet's stored bound with proto byte equality (`MessageDifferencer::Equals`). FE and BE do
not encode `VariantPB::type` identically:

- BE `TypeDescriptor::to_protobuf` **always** sets `PScalarType::len` (`be/src/types/type_descriptor.cpp`)
- FE `TypeSerializer.scalarTypeToProtobuf` sets it **only** for `CHAR`/`VARCHAR`/`VARBINARY`/`HLL`

`PScalarType::len` is `optional`, so for an integer or date sort key the two encodings
differ byte-for-byte while denoting the same type. Every external-boundaries split of a
tablet that already has an explicit bound is therefore rejected, because the parent bound is
BE-written while the child bounds arrive from FE:

```
tablet_splitter.cpp:1584 external-boundaries validation/compute failed; identical fallback.
tablet_id=17468, version=37, txn_id=4585,
status=Invalid argument: validate_new_tablet_ranges:
        last.upper_bound != old_tablet_range.upper_bound
```

That rejection falls back to an identical tablet, so the layout never changes. For a
range-colocate group the consequences compound into a deadlock:

1. the alignment split makes no progress, so `TableAlignmentLatch` suppresses further attempts
   (`colocate table ... alignment made no progress on an unchanged layout`);
2. the group stays `IsStable=false`;
3. the size-driven split is then refused by design — `SplitTabletJobFactory.validateTableLevel`,
   `Cannot split tablets for range-colocate group N: group is unstable`.

Splitting needs a stable group, the group only stabilises through alignment, and alignment is
permanently rejected. Nothing breaks the cycle.

Found by an 8h soak on a 100-partition range-colocate table (2 hot partitions under
continuous import, `tablet_reshard_target_size=1GB`). After the first partition split on a
non-canonical boundary the group went unstable and never recovered for the remaining 6h40m:
272 reshard jobs all FINISHED but all no-ops, only 4 real auto-splits in 8h, and tablets grew
to **8.8GB against a 1GB target**. Data correctness was unaffected throughout (row counts and
checksums matched, and colocate joins degraded correctly to shuffle).

Parents with no bound were unaffected, because `tuple_bound_equal` short-circuits when
neither side has the bound. That is why alignment only ever failed *after* a tablet had
already been split once, and why partitions still at `(-inf, +inf)` — including never-loaded
empty ones — aligned fine.

## What I'm doing:

Compare the bounds position by position with `leading_value_preserved` instead of comparing
the serialized messages. That helper already exists in the same file and already documents
this exact hazard for the trailing-sort-key-ADD check:

> The FE re-encodes a reprojected range's leading Variants -- and a reshard persists boundary
> Variants through a different path -- so byte-identical protos are not guaranteed even when
> the value is unchanged (e.g. an optional type or variant_type field present on one side and
> defaulted on the other).

So the codebase already concluded that these protos cannot be byte-compared across the FE/BE
boundary; the endpoint and tiling checks in `validate_new_tablet_ranges` simply had not been
switched over. Reusing it compares variant kind, logical type, and decoded value, which also
makes the check immune to any rendering difference in the `value` string (dates, decimals),
not just to the `len` presence difference.

`tuple_pb_equal` / `tuple_bound_equal` now return `StatusOr<bool>`, and the four call sites in
`validate_new_tablet_ranges` use `ASSIGN_OR_RETURN`.

Tests added to `tablet_range_helper_test.cpp`:

- FE-encoded bounds on a bounded parent are accepted, with an assertion that the two encodings
  really are byte-distinct so the case would fail before this change;
- a genuinely different endpoint value is still rejected, on both the `first.lower` and
  `last.upper` side;
- a tuple arity mismatch is still rejected, now that the comparison walks positions rather
  than delegating to whole-message equality.

Symptom-side follow-up, independent of this PR: while a range-colocate group is unstable a
plain single-table scan can fail with `range colocate group N is in an unaligned state`
instead of falling back to a non-colocate plan. Fixed separately.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
