### PR TITLE
[BugFix] Fix ClassCastException on array_contains/array_position with an untyped NULL

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PolymorphicFunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PolymorphicFunctionAnalyzer.java
@@ -352,7 +352,12 @@ public class PolymorphicFunctionAnalyzer {
         String fnName = fn.getFunctionName().getFunction();
         if (FunctionSet.ARRAY_CONTAINS.equalsIgnoreCase(fnName) ||
                 FunctionSet.ARRAY_POSITION.equalsIgnoreCase(fnName))  {
-            Type elementType = ((ArrayType) inputArgTypes[0]).getItemType();
+            // An untyped NULL is a valid ANY_ARRAY argument -- ExpressionAnalyzer admits it explicitly
+            // for these functions -- and reaches this point as NullType, so it cannot be cast directly.
+            // Normalize it the same way resolveArgTypes does for pseudo-type positions; that path only
+            // covers functions with a single pseudo-type argument, so it never sees these two.
+            Type arrayArgType = inputArgTypes[0].isNull() ? new ArrayType(inputArgTypes[0]) : inputArgTypes[0];
+            Type elementType = ((ArrayType) arrayArgType).getItemType();
             Type commonType = TypeManager.getCommonSuperType(elementType, inputArgTypes[1]);
             if (commonType == null) {
                 return null;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeArrayTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeArrayTest.java
@@ -91,4 +91,21 @@ public class AnalyzeArrayTest {
         analyzeSuccess("select null_or_empty([1, 2, 3])");
         analyzeSuccess("select null_or_empty([[1, 2], [1, 4]])");
     }
+
+    @Test
+    public void testUntypedNullInArrayPosition() {
+        // An untyped NULL reaches resolvePolymorphicArrayFunction as NullType. Casting it to ArrayType
+        // threw ClassCastException whenever the element argument was a complex type, even though the
+        // same call with a scalar element already resolved.
+        analyzeSuccess("select array_contains(NULL, 1)");
+        analyzeSuccess("select array_contains(NULL, 'x')");
+        analyzeSuccess("select array_contains(NULL, NULL)");
+        analyzeSuccess("select array_contains(NULL, [1, 2])");
+        analyzeSuccess("select array_contains(NULL, row(20, 'world'))");
+        analyzeSuccess("select array_position(NULL, 1)");
+        analyzeSuccess("select array_position(NULL, [1, 2])");
+        // Typed arrays and a NULL element keep working.
+        analyzeSuccess("select array_contains([1, 2], NULL)");
+        analyzeSuccess("select array_contains(cast(NULL as array<int>), 1)");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

```
> select array_contains(NULL, [1, 2]);
  ERROR 1064 (HY000): class com.starrocks.type.NullType cannot be cast to class com.starrocks.type.ArrayType

```

resolvePolymorphicArrayFunction casts the ANY_ARRAY argument to ArrayType unconditionally. An untyped NULL literal arrives as NullType, so `array_contains(NULL, [1, 2])` and `array_position(NULL, [1, 2])` failed with

  ClassCastException: class com.starrocks.type.NullType cannot be cast to
                      class com.starrocks.type.ArrayType

NULL is a legitimate argument in that position: ExpressionAnalyzer admits it explicitly for these functions, rejecting only types that are neither an array nor NULL. The same call with a scalar element already worked — `array_contains(NULL, 1)` resolves earlier and never reaches this branch — so the crash only surfaced when the element argument was itself a complex type such as an array or a struct.

Normalize the argument the way resolveArgTypes already does for pseudo-type positions ("change NULL into Array[NULL]"); that path only covers functions with a single pseudo-type argument, so it never sees these two. Doing it here keeps the element-type alignment intact, so `array_contains(NULL, 3.5)` widens to (ARRAY<DECIMAL32>, DECIMAL32) just like the fully typed call does.

Verified on a live cluster: before the change the three statements above fail with ERROR 1064; after it they return NULL, matching array_contains(NULL, 1). A non-constant control over real array columns still evaluates on the BE and returns the correct per-row results, confirming the nested-array signature is executable and not merely constant-folded in the FE.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
