### PR TITLE
[BugFix] Skip colocate scan dispatch when a range-colocate group is unstable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/DistributionSpecHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/DistributionSpecHelper.java
@@ -64,6 +64,17 @@ public final class DistributionSpecHelper {
         if (groupId == null || !colocateTableIndex.isRangeColocateGroup(groupId)) {
             return null;
         }
+        // An unstable group is mid-alignment: its tablet ranges do not yet tile the group's
+        // colocate ranges, so no colocate bucket assignment can be built for a scan of it.
+        // Mirrors the hash single-table guard in HashDistributionSpec#isSatisfy and the range
+        // join guard in RangeDistributionSpec#isSatisfy. Without it even a plain single-table
+        // scan advertises a colocate distribution, ExecutionFragment builds a colocated
+        // assignment, and RangeColocateScanDispatch#requireAligned then throws — turning an
+        // ordinary reshard into a user-visible query failure instead of the intended fall
+        // back to a non-colocate plan.
+        if (colocateTableIndex.isGroupUnstable(groupId)) {
+            return null;
+        }
         ColocateGroupSchema groupSchema = colocateTableIndex.getGroupSchema(groupId);
         if (groupSchema == null) {
             // Metadata inconsistency (e.g. partial replay); fall back to ANY.

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/base/DistributionSpecHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/base/DistributionSpecHelperTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link DistributionSpecHelper#buildRangeDistributionSpecSkeleton}.
- * Covers the null-fallback paths (unknown group, non-range group, missing
+ * Covers the null-fallback paths (unknown group, non-range group, unstable group, missing
  * groupSchema, catalog-schema-too-short, column not in map) plus the happy path.
  */
 class DistributionSpecHelperTest {
@@ -119,6 +119,40 @@ class DistributionSpecHelperTest {
                 result = groupId;
                 colocateTableIndex.isRangeColocateGroup(groupId);
                 result = false;
+            }
+        };
+        assertNull(DistributionSpecHelper.buildRangeDistributionSpecSkeleton(
+                olapTable, mapping(col("a"))));
+    }
+
+    /**
+     * Regression: an unstable group is mid-alignment, so a scan of it must fall back to ANY
+     * rather than advertise a colocate distribution. Advertising it made ExecutionFragment
+     * build a colocated assignment, which {@code RangeColocateScanDispatch#requireAligned}
+     * then rejected — a plain single-table scan failed with "range colocate group N is in an
+     * unaligned state" for as long as the group stayed unstable.
+     */
+    @Test
+    void nullWhenGroupUnstable(@Mocked OlapTable olapTable,
+                               @Mocked GlobalStateMgr globalStateMgr,
+                               @Mocked ColocateTableIndex colocateTableIndex) {
+        ColocateTableIndex.GroupId groupId = new ColocateTableIndex.GroupId(1L, 2L);
+        new Expectations() {
+            {
+                olapTable.getId();
+                result = TABLE_ID;
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getColocateTableIndex();
+                result = colocateTableIndex;
+                colocateTableIndex.isColocateTable(TABLE_ID);
+                result = true;
+                colocateTableIndex.getGroup(TABLE_ID);
+                result = groupId;
+                colocateTableIndex.isRangeColocateGroup(groupId);
+                result = true;
+                colocateTableIndex.isGroupUnstable(groupId);
+                result = true;
             }
         };
         assertNull(DistributionSpecHelper.buildRangeDistributionSpecSkeleton(


### PR DESCRIPTION
## Why I'm doing:

While a range-colocate group is unstable, a plain **single-table** query on a member table can
fail outright:

```
ERROR 1064 (HY000): range colocate group 15543 is in an unaligned state in physical
partition 15742; cannot dispatch colocate join until alignment is restored
```

`buildRangeDistributionSpecSkeleton` hands back a `RangeDistributionSpec` regardless of group
stability. The scan therefore advertises a colocate distribution, `ExecutionFragment` builds a
colocated assignment, `OlapScanNode#getBucketNums` reaches
`RangeColocateScanDispatch#requireAligned`, and that guard throws — instead of the intended
fall back to a non-colocate plan.

The guard itself is right to fail closed: a stale bucket assignment under colocate dispatch
could silently produce wrong results. The problem is that the plan should never have chosen
colocate dispatch for a group already known to be unstable, so the guard fires for the whole
duration of a reshard rather than only in the narrow plan-vs-execute race window it exists for.

Both sibling paths already carry this check and behave correctly:

- `HashDistributionSpec#isSatisfy` — hash single-table: `!colocateIndex.isGroupUnstable(...)`
- `RangeDistributionSpec#isSatisfy` — range join: `isGroupUnstable(leftGroupId) || isGroupUnstable(rightGroupId)`

Only the range single-table scan path was missing it. That is why, in the soak below, colocate
joins degraded correctly to shuffle (`colocate: true` disappeared from the plan) while
single-table scans hard-failed.

Measured on an 8h soak of a 100-partition range-colocate table under continuous import: once
the group went unstable it stayed unstable for 6h40m, and **662 of 11,370 queries (5.8%)
failed** — all of them the same single-table scan shape, whose own failure rate was 34.9%. The
other five query shapes in the workload, including the colocate join, never failed. Row counts
and checksums matched throughout, so this is an availability problem, not a correctness one.

## What I'm doing:

Return `null` from `buildRangeDistributionSpecSkeleton` when the colocate group is unstable, so
the caller falls back to `AnyDistributionSpec` and the scan is planned without colocate
dispatch. This mirrors the hash and join guards cited above; the runtime `requireAligned` guard
stays exactly as it is, and now only covers the genuine plan-vs-execute race.

Adds `nullWhenGroupUnstable` to `DistributionSpecHelperTest`.

Note this is the symptom side of the incident. The reason the group stayed unstable for hours
in the first place is a separate defect in the BE-side split-bound comparison, fixed in
#76968. This PR is independent of it and worth having on its own: any reshard makes a group
transiently unstable, and single-table queries should ride that out.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
