### PR TITLE
[BugFix] Restore once-per-scan-node guard on the scan-range heap-safety check

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -208,6 +208,11 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
     // Set just once per query.
     private boolean alreadyFoundSomeLivingCn = false;
 
+    // Set once the scan-range heap-safety warning has been evaluated for this scan node. MUST stay an
+    // instance field: a method-local flag makes planning quadratic in the number of physical
+    // partitions, which is the regression #64158 introduced and this field restores.
+    private boolean alreadyCheckedScanRangeNumSafe = false;
+
     private boolean usePreparedPhysicalSplitScan = false;
 
     boolean enableTopnFilterBackPressure = false;
@@ -630,7 +635,6 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
         selectedPartitionNames.add(partition.getName());
 
         checkSomeAliveComputeNode();
-        boolean checkScanRangeSize = false;
 
         // Batch retrieve all tablets' location info in shared-data mode
         Map<Long, List<Long>> tabletLocationInfo = new HashMap<>();
@@ -759,11 +763,7 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
             scanRangeLocations.setScan_range(scanRange);
 
             bucketSeq2locations.put(tabletId2BucketSeq.get(tabletId), scanRangeLocations);
-            if (!checkScanRangeSize) {
-                long scanRangeSize = getEstimatedScanRangeFootprint(scanRange);
-                checkIfScanRangeNumSafe(scanRangeSize);
-                checkScanRangeSize = true;
-            }
+            checkScanRangeNumSafeOnce(scanRange);
 
             result.add(scanRangeLocations);
         }
@@ -858,7 +858,36 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
         }
     }
 
-    public void checkIfScanRangeNumSafe(long scanRangeSize) {
+    /**
+     * Runs {@link #checkIfScanRangeNumSafe} the first time it is called on this scan node, and does
+     * nothing on every later call -- every call after the first is a single field read, so this is
+     * safe to call from the per-tablet loop.
+     *
+     * <p>The guard lives here rather than at the call site on purpose. The check is O(selected
+     * physical partitions), while callers run once per physical partition, so a caller-side guard is
+     * what made planning quadratic (#64158). Keeping it here means a new call site cannot
+     * reintroduce that by forgetting to hoist a flag.
+     *
+     * <p>{@code sampleScanRange} is only a size sample: {@link #getEstimatedScanRangeFootprint}
+     * measures it once per JVM and reuses that figure for every table thereafter.
+     */
+    private void checkScanRangeNumSafeOnce(TScanRange sampleScanRange) {
+        if (alreadyCheckedScanRangeNumSafe) {
+            return;
+        }
+        checkIfScanRangeNumSafe(getEstimatedScanRangeFootprint(sampleScanRange));
+        alreadyCheckedScanRangeNumSafe = true;
+    }
+
+    /**
+     * Warn when this scan node's scan ranges look large enough to threaten the FE heap.
+     * Diagnostic only: it never alters the plan.
+     *
+     * <p>O(selected physical partitions). Do not call directly from a per-partition or per-tablet
+     * loop -- go through {@link #checkScanRangeNumSafeOnce}.
+     */
+    @VisibleForTesting // package-private, not private: this JMockit version cannot fake private methods
+    void checkIfScanRangeNumSafe(long scanRangeSize) {
         long totalPartitionNum = 0;
         long totalTabletsNum = 0;
         for (long partitionId : selectedPartitionIds) {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/ScanNodeComputeScanRangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/ScanNodeComputeScanRangeTest.java
@@ -24,10 +24,12 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.Pair;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
+import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TOlapTablePartition;
 import com.starrocks.thrift.TOlapTablePartitionParam;
@@ -41,6 +43,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -63,7 +67,16 @@ public class ScanNodeComputeScanRangeTest {
         starRocksAssert = new StarRocksAssert(connectContext);
         starRocksAssert.withDatabase("test").useDatabase("test")
                 .withTable("CREATE TABLE test.t1(k1 int, k2 int, k3 int)" +
-                        " distributed by hash(k1) buckets 10 properties('replication_num' = '1');");
+                        " distributed by hash(k1) buckets 10 properties('replication_num' = '1');")
+                // 4 partitions x 3 buckets = 12 tablets, so a per-partition regression in the
+                // scan-range heap-safety check is visible as a call count of 4 instead of 1.
+                .withTable("CREATE TABLE test.t_multi_partition(k1 date, k2 int)" +
+                        " partition by range(k1) (" +
+                        "   partition p1 values less than ('2024-01-01')," +
+                        "   partition p2 values less than ('2024-02-01')," +
+                        "   partition p3 values less than ('2024-03-01')," +
+                        "   partition p4 values less than ('2024-04-01'))" +
+                        " distributed by hash(k1) buckets 3 properties('replication_num' = '1');");
     }
 
     @Test
@@ -96,6 +109,88 @@ public class ScanNodeComputeScanRangeTest {
         Assertions.assertDoesNotThrow(() -> scanNode.addScanRangeLocations(partition, physicalPartition, selectedIndex,
                 selectedIndex.getTablets(), List.of(), -1));
         Assertions.assertEquals(1, invokeCounter.get());
+    }
+
+    /**
+     * Records how many scan ranges the observed node had already built each time the heap-safety
+     * check ran, for scan nodes over {@code tableName} only -- the MockUp intercepts every
+     * OlapScanNode in the JVM, so scan nodes over other tables would otherwise contaminate the
+     * capture, possibly off-thread.
+     */
+    private static List<Integer> captureHeapSafetyCheckCalls(String tableName) {
+        List<Integer> scanRangesAtCheckTime = Collections.synchronizedList(new ArrayList<>());
+        new MockUp<OlapScanNode>() {
+            @Mock
+            public void checkIfScanRangeNumSafe(Invocation invocation, long scanRangeSize) {
+                OlapScanNode node = invocation.getInvokedInstance();
+                if (tableName.equals(node.getOlapTable().getName())) {
+                    scanRangesAtCheckTime.add(node.getScanRangeLocations(0).size());
+                }
+                invocation.proceed(scanRangeSize);
+            }
+        };
+        return scanRangesAtCheckTime;
+    }
+
+    /**
+     * The scan-range heap-safety check walks every selected partition and sub-partition, so it must
+     * run once per scan node. Guarding it with a method-local flag inside addScanRangeLocations(),
+     * which runs once per physical partition, made planning quadratic in the number of physical
+     * partitions. See #64158. The guard has to be an instance field.
+     */
+    @Test
+    public void testHeapSafetyCheckRunsOncePerScanNodeNotPerAddScanRangeCall() {
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable("test", "t1");
+        Assertions.assertInstanceOf(OlapTable.class, table);
+        desc.setTable(table);
+        OlapTable olapTable = (OlapTable) table;
+        OlapScanNode scanNode =
+                new OlapScanNode(new PlanNodeId(1), desc, "OlapScanNode", olapTable.getBaseIndexMetaId());
+        long partitionId = olapTable.getAllPartitionIds().get(0);
+        Partition partition = olapTable.getPartition(partitionId);
+        PhysicalPartition physicalPartition = partition.getDefaultPhysicalPartition();
+        MaterializedIndex selectedIndex = physicalPartition.getLatestIndex(olapTable.getBaseIndexMetaId());
+
+        List<Integer> checkCalls = captureHeapSafetyCheckCalls("t1");
+
+        // Twice, because the defect was a method-local flag that re-armed itself on every
+        // addScanRangeLocations() invocation. With an instance field, the second call is a no-op.
+        Assertions.assertDoesNotThrow(() -> scanNode.addScanRangeLocations(partition, physicalPartition, selectedIndex,
+                selectedIndex.getTablets(), List.of(), -1));
+        Assertions.assertDoesNotThrow(() -> scanNode.addScanRangeLocations(partition, physicalPartition, selectedIndex,
+                selectedIndex.getTablets(), List.of(), -1));
+        // A method-local guard re-arms per call and yields [0, 10] here instead.
+        Assertions.assertEquals(1, checkCalls.size(),
+                "the heap-safety check must run once per scan node, not once per addScanRangeLocations() call");
+        Assertions.assertEquals(0, checkCalls.get(0),
+                "the check must fire before the first scan range is appended, while the heap is still intact");
+        // Anchor: both calls really did build scan ranges (10 buckets each), so the single capture
+        // cannot be an artifact of addScanRangeLocations() doing nothing.
+        Assertions.assertEquals(20, scanNode.getScanRangeLocations(0).size());
+    }
+
+    /**
+     * Same contract driven through the real CBO planner, where addScanRangeLocations() is called once
+     * per physical partition: four partitions must still yield exactly one check.
+     */
+    @Test
+    public void testHeapSafetyCheckRunsOncePerScanNodeInCboPath() throws Exception {
+        List<Integer> checkCalls = captureHeapSafetyCheckCalls("t_multi_partition");
+
+        Pair<String, ExecPlan> plan =
+                UtFrameUtils.getPlanAndFragment(connectContext, "select * from test.t_multi_partition");
+
+        // A method-local guard re-arms per physical partition and yields [0, 3, 6, 9] here instead.
+        Assertions.assertEquals(1, checkCalls.size(),
+                "the heap-safety check must run once per scan node, not once per physical partition");
+        Assertions.assertEquals(0, checkCalls.get(0),
+                "the check must fire before the first scan range is appended, while the heap is still intact");
+        // Anchor: all 4 partitions x 3 buckets really were scanned. Without this, a future change that
+        // left only one physical partition selected would let the test pass while losing its ability
+        // to detect a per-partition guard.
+        OlapScanNode scanNode = (OlapScanNode) plan.second.getScanNodes().get(0);
+        Assertions.assertEquals(12, scanNode.getScanRangeLocations(0).size());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

`checkIfScanRangeNumSafe()` walks every selected partition and sub-partition to warn
when a scan node's scan ranges may exhaust the FE heap. #51528 added it behind an
instance field, so it ran once per scan node. #64158 replaced that with a
method-local flag inside addScanRangeLocations(), which runs once per physical
partition, so the walk became quadratic in the number of physical partitions.

On a table with ~50k physical partitions that burns minutes of FE CPU per scan node
per plan attempt, plus O(N^2) Long boxing from the selectedPartitionIds loop. Under
concurrency every query thread saturates and jstack shows them all RUNNABLE inside
checkIfScanRangeNumSafe. 

## What I'm doing:

Restore the instance-field guard, and move it into a `checkScanRangeNumSafeOnce()`
facade so a future call site cannot reintroduce the regression by forgetting to
hoist a flag. The footprint estimate moves into the facade with it, leaving the
check's own body untouched. Behaviour otherwise matches #51528: same threshold,
same warning, fired on the first tablet before the bulk of the allocation it
predicts. 

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
