### PR TITLE
[BugFix] Fix dictionary_get false NULL rejection (backport #76881)

### DIFF
--- a/be/src/exprs/dictionary_get_expr.cpp
+++ b/be/src/exprs/dictionary_get_expr.cpp
@@ -36,14 +36,15 @@ StatusOr<ColumnPtr> DictionaryGetExpr::evaluate_checked(ExprContext* context, Ch
     }
 
     for (auto& column : columns) {
-        if (column->has_null()) {
+        if (column->has_null() && ColumnHelper::count_nulls(column) > 0) {
             return Status::InternalError("invalid parameter for dictionary_get function: get NULL paramenter");
         }
         if (column->is_constant()) {
             column = ColumnHelper::unpack_and_duplicate_const_column(size, column);
         }
         if (column->is_nullable()) {
-            column = ColumnHelper::update_column_nullable(false, std::move(column), size);
+            auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>(column.get());
+            column = nullable_column->data_column();
         }
     }
 

--- a/be/test/storage/dictionary_cache_manager_test.cpp
+++ b/be/test/storage/dictionary_cache_manager_test.cpp
@@ -20,6 +20,8 @@
 
 #include <fstream>
 
+#include "column/column_helper.h"
+#include "column/nullable_column.h"
 #include "exec/tablet_info.h"
 #include "exprs/dictionary_get_expr.h"
 #include "exprs/mock_vectorized_expr.h"
@@ -243,6 +245,42 @@ public:
         return e;
     }
 
+    static std::unique_ptr<DictionaryGetExpr> new_dictionary_get_expr(int64_t dict_id, int64_t txn_id,
+                                                                      ColumnPtr key_column, ObjectPool& objpool) {
+        TypeDescriptor type;
+        type.type = LogicalType::TYPE_STRUCT;
+        type.field_names.emplace_back("k2");
+        type.field_names.emplace_back("k3");
+        type.children.emplace_back();
+        type.children.back().type = LogicalType::TYPE_BIGINT;
+        type.children.emplace_back();
+        type.children.back().type = LogicalType::TYPE_BIGINT;
+
+        TDictionaryGetExpr t_dictionary_get_expr;
+        t_dictionary_get_expr.__set_dict_id(dict_id);
+        t_dictionary_get_expr.__set_txn_id(txn_id);
+        t_dictionary_get_expr.__set_key_size(1);
+
+        TExprNode node;
+        node.__set_node_type(TExprNodeType::DICTIONARY_GET_EXPR);
+        node.__set_is_nullable(false);
+        node.__set_type(type.to_thrift());
+        node.__set_num_children(0);
+        node.__set_dictionary_get_expr(t_dictionary_get_expr);
+
+        auto dictionary_get_expr = std::make_unique<DictionaryGetExpr>(node);
+
+        TypeDescriptor type_varchar(LogicalType::TYPE_VARCHAR);
+        type_varchar.len = 100;
+        std::string dictionary_name("dictionary_name");
+        Slice slice(dictionary_name);
+        dictionary_get_expr->add_child(
+                new_mock_expr(ColumnTestHelper::build_column<Slice>({slice}), type_varchar, objpool));
+
+        dictionary_get_expr->add_child(new_mock_expr(std::move(key_column), LogicalType::TYPE_BIGINT, objpool));
+        return dictionary_get_expr;
+    }
+
     starrocks::DictionaryCacheManager* dictionary_cache_manager = StorageEngine::instance()->dictionary_cache_manager();
     TabletSharedPtr test_tablet = nullptr;
 };
@@ -290,42 +328,11 @@ TEST_F(DictionaryCacheManagerTest, large_column_refresh_and_read) {
 
 // NOLINTNEXTLINE
 TEST_F(DictionaryCacheManagerTest, dictionary_get_expr_test) {
-    auto test_tablet = create_tablet(9145, 6545);
+    test_tablet = create_tablet(9145, 6545);
     create_new_dictionary_cache(dictionary_cache_manager, 400, 1, test_tablet);
     ObjectPool objpool;
 
-    TypeDescriptor type;
-    type.type = LogicalType::TYPE_STRUCT;
-    type.field_names.emplace_back("k2");
-    type.field_names.emplace_back("k3");
-    type.children.emplace_back();
-    type.children.back().type = LogicalType::TYPE_BIGINT;
-    type.children.emplace_back();
-    type.children.back().type = LogicalType::TYPE_BIGINT;
-
-    TDictionaryGetExpr t_dictionary_get_expr;
-    t_dictionary_get_expr.__set_dict_id(400);
-    t_dictionary_get_expr.__set_txn_id(1);
-    t_dictionary_get_expr.__set_key_size(1);
-
-    TExprNode node;
-    node.__set_node_type(TExprNodeType::DICTIONARY_GET_EXPR);
-    node.__set_is_nullable(false);
-    node.__set_type(type.to_thrift());
-    node.__set_num_children(0);
-    node.__set_dictionary_get_expr(t_dictionary_get_expr);
-
-    auto dictionary_get_expr = std::make_unique<DictionaryGetExpr>(node);
-
-    TypeDescriptor type_varchar(LogicalType::TYPE_VARCHAR);
-    type_varchar.len = 100;
-    std::string dictionary_name("dictionary_name");
-    Slice slice(dictionary_name);
-    dictionary_get_expr->add_child(
-            new_mock_expr(ColumnTestHelper::build_column<Slice>({slice}), type_varchar, objpool));
-
-    dictionary_get_expr->add_child(
-            new_mock_expr(ColumnTestHelper::build_column<long>({0}), LogicalType::TYPE_BIGINT, objpool));
+    auto dictionary_get_expr = new_dictionary_get_expr(400, 1, ColumnTestHelper::build_column<int64_t>({0}), objpool);
 
     ASSERT_TRUE(dictionary_get_expr->prepare(nullptr, nullptr).ok());
     auto res = dictionary_get_expr->evaluate_checked(nullptr, nullptr);
@@ -336,6 +343,48 @@ TEST_F(DictionaryCacheManagerTest, dictionary_get_expr_test) {
     auto struct_column =
             down_cast<const StructColumn*>(down_cast<const NullableColumn*>(res_column.get())->data_column().get());
     ASSERT_TRUE(struct_column->fields().size() == 2);
+}
+
+// NOLINTNEXTLINE
+TEST_F(DictionaryCacheManagerTest, dictionary_get_expr_accepts_all_zero_null_bitmap) {
+    test_tablet = create_tablet(9146, 6546);
+    create_new_dictionary_cache(dictionary_cache_manager, 401, 1, test_tablet);
+    ObjectPool objpool;
+
+    auto key_column = NullableColumn::create(ColumnTestHelper::build_column<int64_t>({0}), NullColumn::create(1, 0));
+    key_column->set_has_null(true);
+    ASSERT_TRUE(key_column->has_null());
+    ASSERT_EQ(0, ColumnHelper::count_nulls(key_column));
+
+    auto dictionary_get_expr = new_dictionary_get_expr(401, 1, std::move(key_column), objpool);
+
+    ASSERT_TRUE(dictionary_get_expr->prepare(nullptr, nullptr).ok());
+    auto res = dictionary_get_expr->evaluate_checked(nullptr, nullptr);
+    ASSERT_TRUE(res.ok()) << res.status().message();
+
+    auto res_column = std::move(res.value());
+    ASSERT_EQ(1, res_column->size());
+    auto struct_column =
+            down_cast<const StructColumn*>(down_cast<const NullableColumn*>(res_column.get())->data_column().get());
+    ASSERT_EQ(2, struct_column->fields().size());
+}
+
+// NOLINTNEXTLINE
+TEST_F(DictionaryCacheManagerTest, dictionary_get_expr_rejects_real_null) {
+    test_tablet = create_tablet(9147, 6547);
+    create_new_dictionary_cache(dictionary_cache_manager, 402, 1, test_tablet);
+    ObjectPool objpool;
+
+    auto key_column = NullableColumn::create(ColumnTestHelper::build_column<int64_t>({0}), NullColumn::create(1, 1));
+    ASSERT_TRUE(key_column->has_null());
+    ASSERT_EQ(1, ColumnHelper::count_nulls(key_column));
+
+    auto dictionary_get_expr = new_dictionary_get_expr(402, 1, std::move(key_column), objpool);
+
+    ASSERT_TRUE(dictionary_get_expr->prepare(nullptr, nullptr).ok());
+    auto res = dictionary_get_expr->evaluate_checked(nullptr, nullptr);
+    ASSERT_FALSE(res.ok());
+    ASSERT_EQ("invalid parameter for dictionary_get function: get NULL paramenter", res.status().message());
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

`DICTIONARY_GET` rejects a non-NULL key when the input is a nullable column whose cached `has_null` flag remains conservatively true even though its null bitmap is all zero. This can affect values produced by expressions such as `COALESCE`; wrapping the value in `CONCAT` only masks the issue by rematerializing the column.

## What I'm doing:

- Keep `has_null()` as the O(1) fast path, then count the actual null bitmap only when the cached flag is true.
- Reject arguments only when the bitmap contains a real NULL.
- Unwrap a verified all-zero nullable column directly before probing the dictionary cache, avoiding the stale-flag debug assertion in `update_column_nullable`.
- Add regression tests for both an all-zero bitmap with forced `has_null=true` and a bitmap containing a real NULL.
- Fixes https://github.com/StarRocks/starrocks/pull/76881

Validation:

- Debug compilation of the changed BE implementation and test translation units with release-branch dependencies
- `git diff --check`

Backport note:

- Kept the release branches' `StorageEngine` dictionary-cache setup and older test interfaces while preserving the source fix's behavior.

No linked issue.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

