### PR TITLE
[BugFix] fix pre agg streaming oom (backport #76702)

### DIFF
--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -205,6 +205,14 @@ static const int STREAMING_HT_MIN_REDUCTION_SIZE =
 struct LimitedMemAggState {
     size_t limited_memory_size{};
     bool has_limited(const Aggregator& aggregator) const;
+
+    // Compute the LIMITED_MEM budget as min(memory_usage, cap), floored at 1. Both streaming
+    // pre-agg sinks cap by config::streaming_agg_limited_memory_size. The floor is essential:
+    // set_execute_mode() latches this budget exactly once (enter_low_memory_mode() is a
+    // one-shot latch) and has_limited() tests `limited_memory_size > 0 && ...`, so a 0 budget
+    // would make has_limited() permanently false, silently degrading LIMITED_MEM back to AUTO
+    // with no memory cap and reintroducing the streaming pre-aggregation OOM.
+    static size_t clamp_budget(int64_t memory_usage, int64_t cap);
 };
 
 using AggregatorPtr = std::shared_ptr<Aggregator>;
@@ -643,6 +651,13 @@ protected:
 
 inline bool LimitedMemAggState::has_limited(const Aggregator& aggregator) const {
     return limited_memory_size > 0 && aggregator.memory_usage() >= limited_memory_size;
+}
+
+inline size_t LimitedMemAggState::clamp_budget(int64_t memory_usage, int64_t cap) {
+    if (memory_usage > cap) {
+        return cap;
+    }
+    return memory_usage > 0 ? static_cast<size_t>(memory_usage) : 1;
 }
 
 template <class T>

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
@@ -78,7 +78,13 @@ void AggregateDistinctStreamingSinkOperator::set_execute_mode(int performance_le
     if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::AUTO) {
         _aggregator->streaming_preaggregation_mode() = TStreamingPreaggregationMode::LIMITED_MEM;
     }
-    _limited_mem_state.limited_memory_size = _aggregator->hash_map_memory_usage();
+    // Distinct aggregation stores keys in the hash SET and never initializes _hash_map_variant,
+    // so hash_map_memory_usage() would std::visit a default variant and dereference a null
+    // unique_ptr (latent UB, currently masked only because variant slot 0 is a SmallFixedSizeHashMap
+    // whose dump_bound() folds to a compile-time constant). memory_usage() reports the hash-set-based
+    // footprint safely; cap it by config like the aggregate-with-functions sink, and keep it > 0.
+    _limited_mem_state.limited_memory_size =
+            LimitedMemAggState::clamp_budget(_aggregator->memory_usage(), config::streaming_agg_limited_memory_size);
 }
 
 Status AggregateDistinctStreamingSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -70,11 +70,8 @@ void AggregateStreamingSinkOperator::set_execute_mode(int performance_level) {
     if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::AUTO) {
         _aggregator->streaming_preaggregation_mode() = TStreamingPreaggregationMode::LIMITED_MEM;
     }
-    if (_aggregator->hash_map_memory_usage() > config::streaming_agg_limited_memory_size) {
-        _limited_mem_state.limited_memory_size = config::streaming_agg_limited_memory_size;
-    } else {
-        _limited_mem_state.limited_memory_size = _aggregator->hash_map_memory_usage();
-    }
+    _limited_mem_state.limited_memory_size = LimitedMemAggState::clamp_budget(
+            _aggregator->hash_map_memory_usage(), config::streaming_agg_limited_memory_size);
 }
 
 Status AggregateStreamingSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(EXEC_FILES
+        ./exec/aggregator_limited_mem_state_test.cpp
         ./agent/agent_task_test.cpp
         ./agent/heartbeat_server_test.cpp
         ./agent/master_info_test.cpp

--- a/be/test/exec/aggregator_limited_mem_state_test.cpp
+++ b/be/test/exec/aggregator_limited_mem_state_test.cpp
@@ -1,0 +1,183 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <gtest/gtest.h>
+
+#include "common/config.h"
+#include "exec/aggregator.h"
+#include "exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h"
+#include "exec/pipeline/aggregate/aggregate_streaming_sink_operator.h"
+#include "gen_cpp/PlanNodes_types.h"
+#include "runtime/runtime_state.h"
+
+namespace starrocks {
+
+// Unit tests for LimitedMemAggState::clamp_budget, the guard behind the streaming
+// pre-aggregation OOM fix.
+//
+// AggregateStreamingSinkOperator / AggregateDistinctStreamingSinkOperator::set_execute_mode()
+// latch the LIMITED_MEM budget into LimitedMemAggState::limited_memory_size exactly once (the
+// driver's enter_low_memory_mode() is a one-shot latch). has_limited() then evaluates
+// `limited_memory_size > 0 && memory_usage() >= limited_memory_size`. If the budget were
+// latched to 0, has_limited() would be false forever, degrading LIMITED_MEM back to AUTO with
+// no memory cap and letting a high-cardinality group-by OOM. clamp_budget() computes
+// min(usage, cap) but floors the result at 1 so the budget is never 0.
+class LimitedMemAggStateTest : public ::testing::Test {};
+
+// Representative cap: config::streaming_agg_limited_memory_size default = 128 MiB.
+static constexpr int64_t kCap = 128LL * 1024 * 1024;
+
+// Heart of the fix: a 0 usage must be floored to 1, never left at 0.
+TEST_F(LimitedMemAggStateTest, zero_usage_is_floored_to_one) {
+    EXPECT_EQ(1u, LimitedMemAggState::clamp_budget(0, kCap));
+}
+
+// Positive usage below the cap passes through unchanged.
+TEST_F(LimitedMemAggStateTest, usage_below_cap_passthrough) {
+    EXPECT_EQ(1u, LimitedMemAggState::clamp_budget(1, kCap));
+    // 24 = empty phmap flat_hash_map dump_bound (sizeof(size_t) * 3); 256 = default fixed hash map.
+    EXPECT_EQ(24u, LimitedMemAggState::clamp_budget(24, kCap));
+    EXPECT_EQ(256u, LimitedMemAggState::clamp_budget(256, kCap));
+    EXPECT_EQ(static_cast<size_t>(kCap - 1), LimitedMemAggState::clamp_budget(kCap - 1, kCap));
+}
+
+// Usage at or above the cap is clamped down to the cap.
+TEST_F(LimitedMemAggStateTest, usage_at_or_above_cap_clamped) {
+    EXPECT_EQ(static_cast<size_t>(kCap), LimitedMemAggState::clamp_budget(kCap, kCap));
+    EXPECT_EQ(static_cast<size_t>(kCap), LimitedMemAggState::clamp_budget(kCap + 1, kCap));
+    EXPECT_EQ(static_cast<size_t>(kCap), LimitedMemAggState::clamp_budget(kCap * 4, kCap));
+}
+
+// The invariant that actually prevents the OOM regression: the budget is always > 0, so
+// has_limited() can never be permanently disabled, whatever memory usage is reported.
+TEST_F(LimitedMemAggStateTest, budget_is_always_positive) {
+    const int64_t usages[] = {0, 1, 24, 256, kCap - 1, kCap, kCap + 1, kCap * 10};
+    for (int64_t usage : usages) {
+        EXPECT_GT(LimitedMemAggState::clamp_budget(usage, kCap), 0u) << "usage=" << usage;
+    }
+}
+
+} // namespace starrocks
+
+namespace starrocks::pipeline {
+
+// Operator-level tests: drive the real AggregateStreamingSinkOperator /
+// AggregateDistinctStreamingSinkOperator::set_execute_mode() implementations, i.e. the code
+// the pipeline driver invokes when it downgrades a releaseable sink under memory pressure.
+// The aggregator is not prepare()d (that needs a full plan-fragment context); instead the few
+// fields set_execute_mode() reads are set directly — tests compile with -fno-access-control.
+class StreamingAggSinkExecuteModeTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        _state.set_chunk_size(4096);
+        _tnode.__set_node_id(1);
+        _tnode.__set_node_type(TPlanNodeType::AGGREGATION_NODE);
+        _tnode.__set_num_children(1);
+        _tnode.__set_limit(-1);
+        TAggregationNode agg_node;
+        agg_node.__set_use_streaming_preaggregation(true);
+        _tnode.__set_agg_node(agg_node);
+    }
+
+    RuntimeState _state;
+    RuntimeProfile _profile{"test"};
+    AggStatistics _agg_stat{&_profile};
+    TPlanNode _tnode;
+    // AggregateStreamingSinkOperatorFactory keeps a reference to this vector.
+    std::vector<RuntimeFilterBuildDescriptor*> _no_runtime_filters;
+};
+
+TEST_F(StreamingAggSinkExecuteModeTest, streaming_sink_latches_positive_capped_budget) {
+    auto aggregator_factory = std::make_shared<AggregatorFactory>(_tnode);
+    AggregateStreamingSinkOperatorFactory factory(1, 1, aggregator_factory, _no_runtime_filters);
+    auto op = factory.create(1, 0);
+    auto aggregator = aggregator_factory->get_or_create(0);
+
+    aggregator->_streaming_preaggregation_mode = TStreamingPreaggregationMode::AUTO;
+    aggregator->_hash_map_variant.init(&_state, AggHashMapVariant::Type::phase1_int32, &_agg_stat);
+
+    op->set_execute_mode(1);
+
+    // AUTO is downgraded to LIMITED_MEM and the latched budget is positive and config-capped.
+    EXPECT_EQ(TStreamingPreaggregationMode::LIMITED_MEM, aggregator->streaming_preaggregation_mode());
+    auto* sink = static_cast<AggregateStreamingSinkOperator*>(op.get());
+    EXPECT_GT(sink->_limited_mem_state.limited_memory_size, 0u);
+    EXPECT_LE(sink->_limited_mem_state.limited_memory_size,
+              static_cast<size_t>(config::streaming_agg_limited_memory_size));
+    EXPECT_EQ(LimitedMemAggState::clamp_budget(aggregator->hash_map_memory_usage(),
+                                               config::streaming_agg_limited_memory_size),
+              sink->_limited_mem_state.limited_memory_size);
+}
+
+TEST_F(StreamingAggSinkExecuteModeTest, streaming_sink_keeps_non_auto_mode) {
+    auto aggregator_factory = std::make_shared<AggregatorFactory>(_tnode);
+    AggregateStreamingSinkOperatorFactory factory(1, 1, aggregator_factory, _no_runtime_filters);
+    auto op = factory.create(1, 0);
+    auto aggregator = aggregator_factory->get_or_create(0);
+
+    aggregator->_streaming_preaggregation_mode = TStreamingPreaggregationMode::FORCE_STREAMING;
+    aggregator->_hash_map_variant.init(&_state, AggHashMapVariant::Type::phase1_int32, &_agg_stat);
+
+    op->set_execute_mode(1);
+
+    // Only AUTO is downgraded; an explicit mode is preserved but the budget is still latched.
+    EXPECT_EQ(TStreamingPreaggregationMode::FORCE_STREAMING, aggregator->streaming_preaggregation_mode());
+    auto* sink = static_cast<AggregateStreamingSinkOperator*>(op.get());
+    EXPECT_GT(sink->_limited_mem_state.limited_memory_size, 0u);
+}
+
+TEST_F(StreamingAggSinkExecuteModeTest, distinct_sink_uses_hash_set_metric_and_caps_budget) {
+    auto aggregator_factory = std::make_shared<AggregatorFactory>(_tnode);
+    AggregateDistinctStreamingSinkOperatorFactory factory(1, 1, aggregator_factory);
+    auto op = factory.create(1, 0);
+    auto aggregator = aggregator_factory->get_or_create(0);
+
+    // Distinct aggregation: only the hash SET is initialized, _hash_map_variant never is.
+    aggregator->_streaming_preaggregation_mode = TStreamingPreaggregationMode::AUTO;
+    aggregator->_is_only_group_by_columns = true;
+    aggregator->_hash_set_variant.init(&_state, AggHashSetVariant::Type::phase1_int32, &_agg_stat);
+
+    op->set_execute_mode(1);
+
+    EXPECT_EQ(TStreamingPreaggregationMode::LIMITED_MEM, aggregator->streaming_preaggregation_mode());
+    auto* sink = static_cast<AggregateDistinctStreamingSinkOperator*>(op.get());
+    // The budget comes from the hash-set-based memory_usage(), stays positive, and is
+    // config-capped — the same scale has_limited() compares against.
+    EXPECT_GT(sink->_limited_mem_state.limited_memory_size, 0u);
+    EXPECT_LE(sink->_limited_mem_state.limited_memory_size,
+              static_cast<size_t>(config::streaming_agg_limited_memory_size));
+    EXPECT_EQ(LimitedMemAggState::clamp_budget(aggregator->memory_usage(), config::streaming_agg_limited_memory_size),
+              sink->_limited_mem_state.limited_memory_size);
+}
+
+TEST_F(StreamingAggSinkExecuteModeTest, distinct_sink_floors_zero_usage_budget_to_one) {
+    auto aggregator_factory = std::make_shared<AggregatorFactory>(_tnode);
+    AggregateDistinctStreamingSinkOperatorFactory factory(1, 1, aggregator_factory);
+    auto op = factory.create(1, 0);
+    auto aggregator = aggregator_factory->get_or_create(0);
+
+    // With no group-by state at all, memory_usage() reports 0. The latched budget must be
+    // floored to 1: a 0 budget would make has_limited() permanently false (its predicate is
+    // `limited_memory_size > 0 && ...`), silently degrading LIMITED_MEM back to AUTO.
+    aggregator->_streaming_preaggregation_mode = TStreamingPreaggregationMode::AUTO;
+    ASSERT_EQ(0, aggregator->memory_usage());
+
+    op->set_execute_mode(1);
+
+    auto* sink = static_cast<AggregateDistinctStreamingSinkOperator*>(op.get());
+    EXPECT_EQ(1u, sink->_limited_mem_state.limited_memory_size);
+}
+
+} // namespace starrocks::pipeline


### PR DESCRIPTION
## Why I'm doing:

When a streaming pre-aggregation runs with `enable_spill=true` and hits memory pressure,
the pipeline driver downgrades the sink to `LIMITED_MEM` via `set_execute_mode()`, which
latches a memory budget into `LimitedMemAggState::limited_memory_size`. Because
`enter_low_memory_mode()` is a one-shot latch, that budget is computed exactly once and
never revised. Two defects make the latched budget wrong:

1. **The budget can be frozen at 0.** `has_limited()` is
   `limited_memory_size > 0 && memory_usage() >= limited_memory_size`. A 0 budget makes it
   permanently `false`, so `LIMITED_MEM` silently degrades back to `AUTO` with no memory
   cap — the streaming pre-aggregation OOM.

2. **The distinct sink used the wrong memory metric (latent UB).**
   `AggregateDistinctStreamingSinkOperator::set_execute_mode()` read `hash_map_memory_usage()`,
   but distinct aggregation keeps keys in the hash **set** and never initializes
   `_hash_map_variant`. That `std::visit`s a default-constructed variant and dereferences a
   null `unique_ptr` — undefined behavior, currently masked only because variant slot 0 is a
   `SmallFixedSizeHashMap` whose `dump_bound()` folds to a compile-time constant (256). The
   budget is also the wrong scale and lacks the config cap the group-by path applies.

## What I'm doing:

- Extract the budget computation into `LimitedMemAggState::clamp_budget(int64_t memory_usage,
  int64_t cap)` = `min(memory_usage, cap)` floored at `1`, so the budget is never 0.
- `AggregateStreamingSinkOperator::set_execute_mode()`: behavior-identical, now expressed via
  `clamp_budget(hash_map_memory_usage(), config::streaming_agg_limited_memory_size)`.
- `AggregateDistinctStreamingSinkOperator::set_execute_mode()`: now uses
  `clamp_budget(memory_usage(), config::streaming_agg_limited_memory_size)` — `memory_usage()`
  reads the initialized hash-set state (correct scale, no null-deref UB), applies the config
  cap, and stays `> 0`.
- Add unit tests for `clamp_budget`.

Fixes https://github.com/StarRocks/starrocks/pull/76702

Backport notes:

- Preserved the release branch's test list while adding the new test, and used the release-compatible
  `common/config.h` include because the main-only config forward header is not present.
- Validation: the changed aggregate operator and test translation units compile against the release
  headers, and an executable probe passed the zero, boundary, cap, and always-positive budget checks.
  The full `starrocks_test` binary was not run locally because the available shared third-party
  toolchain does not match the release branch's pinned dependency versions.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

