### PR TITLE
[BugFix] Keep the TEMPORARY qualifier when deparsing a partition reference

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2SQLVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2SQLVisitor.java
@@ -401,6 +401,11 @@ public class AST2SQLVisitor extends AST2StringVisitor {
         if (node.getPartitionNames() != null) {
             List<String> partitionNames = node.getPartitionNames().getPartitionNames();
             if (partitionNames != null && !partitionNames.isEmpty()) {
+                // Temporary and formal partitions are separate namespaces, so dropping the qualifier
+                // does not merely lose formatting: it names a different partition.
+                if (node.getPartitionNames().isTemp()) {
+                    sqlBuilder.append(" TEMPORARY");
+                }
                 sqlBuilder.append(" PARTITION (");
                 sqlBuilder.append(partitionNames.stream().map(c -> "`" + c + "`")
                         .collect(Collectors.joining(", ")));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
@@ -1020,6 +1020,11 @@ public class AST2StringVisitor implements AstVisitorExtendInterface<String, Void
                 org.apache.commons.collections4.CollectionUtils.isNotEmpty(
                         insert.getTargetPartitionNames().getPartitionNames())) {
             List<String> names = insert.getTargetPartitionNames().getPartitionNames();
+            // Same namespace distinction as in the FROM clause: without the qualifier this names a
+            // formal partition, i.e. a different write target.
+            if (insert.getTargetPartitionNames().isTemp()) {
+                sb.append("TEMPORARY ");
+            }
             sb.append("PARTITION (").append(Joiner.on(",").join(names)).append(") ");
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AstToSQLBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AstToSQLBuilderTest.java
@@ -263,4 +263,37 @@ public class AstToSQLBuilderTest {
                 "insert into t0 (v1, v2) values (1, 111), (2, 222)", SqlModeHelper.MODE_DEFAULT);
         Assertions.assertEquals("INSERT INTO `t0` (`v1`,`v2`) VALUES(?, ?)", AstToSQLBuilder.toDigest(stmt));
     }
+
+    @Test
+    public void testTemporaryPartitionQualifierIsPreserved() throws Exception {
+        // Temporary and formal partitions are separate namespaces. Dropping TEMPORARY on the way out
+        // makes the text name a different partition, and a view stores exactly this text: creating a
+        // view over a temporary partition used to succeed and then never resolve again.
+        AnalyzeTestUtil.getStarRocksAssert().withTable("CREATE TABLE tp_tbl (k date, v int)\n"
+                + "DUPLICATE KEY(k)\n"
+                + "PARTITION BY RANGE(k) (PARTITION p1 VALUES LESS THAN ('2020-01-01'))\n"
+                + "DISTRIBUTED BY HASH(k) BUCKETS 1 PROPERTIES('replication_num'='1')");
+        AnalyzeTestUtil.getStarRocksAssert()
+                .ddl("ALTER TABLE tp_tbl ADD TEMPORARY PARTITION tp1 VALUES LESS THAN ('2020-01-01')");
+
+        String temp = AstToSQLBuilder.toSQL(
+                SqlParser.parseSingleStatement("select * from tp_tbl temporary partition(tp1)",
+                        SqlModeHelper.MODE_DEFAULT));
+        String formal = AstToSQLBuilder.toSQL(
+                SqlParser.parseSingleStatement("select * from tp_tbl partition(p1)",
+                        SqlModeHelper.MODE_DEFAULT));
+        Assertions.assertTrue(temp.contains("TEMPORARY PARTITION (`tp1`)"), temp);
+        Assertions.assertFalse(formal.contains("TEMPORARY"), formal);
+
+        // The INSERT target carries the same qualifier, and losing it would redirect the write.
+        String insert = AstToSQLBuilder.toSQL(
+                SqlParser.parseSingleStatement("insert into tp_tbl temporary partition(tp1) select * from tp_tbl",
+                        SqlModeHelper.MODE_DEFAULT));
+        Assertions.assertTrue(insert.contains("TEMPORARY PARTITION (tp1)"), insert);
+
+        // Round trip: the serialized form must still resolve to the temporary partition.
+        StatementBase again = SqlParser.parse(temp, AnalyzeTestUtil.getConnectContext().getSessionVariable()).get(0);
+        Assertions.assertDoesNotThrow(() -> Analyzer.analyze(again, AnalyzeTestUtil.getConnectContext()),
+                () -> "deparsed form no longer analyzes: " + temp);
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

Creating a view over a temporary partition succeeds, and the view can then never be queried:

  ALTER TABLE t ADD TEMPORARY PARTITION tp1 VALUES LESS THAN ('2020-01-01');
  CREATE VIEW v AS SELECT * FROM t TEMPORARY PARTITION (tp1);
  -- no error, no warning

  SELECT * FROM v;
  ERROR: View db.v references invalid table(s) or column(s) or function(s) ...
         Unknown partition 'tp1' in table 't'

A view stores its definition as the deparsed text, and visitTable emitted " PARTITION (" without consulting PartitionNames.isTemp(), so the stored text named a formal partition that does not exist. PartitionNames.toString() already gets this right; the deparser hand-rolled its own rendering and left the qualifier out. The same omission applies to an INSERT target, where the text would name a different write target.

Temporary and formal partitions are separate namespaces, but a name may not be reused across them -- ALTER TABLE rejects that with "Duplicate partition name" -- so the failure mode is an error, not a silently wrong partition.

Found by round-tripping the statements in test/sql through parse -> analyze -> deparse -> parse -> analyze, and independently rediscovered by an AST-mutation fuzzer over the same corpus.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
