### PR TITLE
[BugFix] Guard legacy NGRAMBF indexes without gram_num

### DIFF
--- a/be/src/exprs/function_call_expr.cpp
+++ b/be/src/exprs/function_call_expr.cpp
@@ -226,6 +226,13 @@ StatusOr<ColumnPtr> VectorizedFunctionCallExpr::evaluate_checked(starrocks::Expr
 
 bool VectorizedFunctionCallExpr::ngram_bloom_filter(ExprContext* context, const BloomFilter* bf,
                                                     const NgramBloomFilterReaderOptions& reader_options) const {
+    // Legacy NGRAMBF metadata can omit gram_num. Do not use such an index for
+    // pruning. This check must precede the cached NgramBloomFilterState because
+    // one ExprContext can scan rowsets with different index metadata.
+    if (reader_options.index_gram_num == 0) {
+        return true;
+    }
+
     FunctionContext* fn_ctx = context->fn_context(_fn_context_index);
     std::unique_ptr<NgramBloomFilterState>& ngram_state = fn_ctx->get_ngram_state();
 
@@ -317,13 +324,6 @@ bool VectorizedFunctionCallExpr::split_normal_string_to_ngram(const Slice& needl
                                                               const std::string& func_name) {
     size_t index_gram_num = reader_options.index_gram_num;
     bool index_case_sensitive = reader_options.index_case_sensitive;
-
-    // Legacy NGRAMBF metadata can omit gram_num. Do not use such an index for
-    // pruning: a zero gram size would otherwise make the loop below read past
-    // the end of the UTF-8 offset vector.
-    if (index_gram_num == 0) {
-        return false;
-    }
 
     auto gram_num_column = fn_ctx->get_constant_column(2);
     if (gram_num_column != nullptr) {

--- a/be/src/exprs/function_call_expr.cpp
+++ b/be/src/exprs/function_call_expr.cpp
@@ -318,6 +318,13 @@ bool VectorizedFunctionCallExpr::split_normal_string_to_ngram(const Slice& needl
     size_t index_gram_num = reader_options.index_gram_num;
     bool index_case_sensitive = reader_options.index_case_sensitive;
 
+    // Legacy NGRAMBF metadata can omit gram_num. Do not use such an index for
+    // pruning: a zero gram size would otherwise make the loop below read past
+    // the end of the UTF-8 offset vector.
+    if (index_gram_num == 0) {
+        return false;
+    }
+
     auto gram_num_column = fn_ctx->get_constant_column(2);
     if (gram_num_column != nullptr) {
         size_t predicate_gram_num = ColumnHelper::get_const_value<TYPE_INT>(gram_num_column);

--- a/be/src/storage/rowset/bloom_filter_index_writer.cpp
+++ b/be/src/storage/rowset/bloom_filter_index_writer.cpp
@@ -213,6 +213,13 @@ public:
 
     void add_values(const void* values, size_t count) override {
         size_t gram_num = this->_bf_options.gram_num;
+        // Older materialized views could persist an NGRAMBF index without its
+        // properties. Such an index reaches BE with gram_num == 0. Treat it as
+        // inactive rather than indexing zero-length grams and reading past the
+        // UTF-8 offset vector below.
+        if (gram_num == 0) {
+            return;
+        }
         const auto* cur_slice = reinterpret_cast<const Slice*>(values);
         for (int i = 0; i < count; ++i) {
             // For a case-insensitive index, lowercase the whole value once and build ngrams from the

--- a/be/src/storage/rowset/bloom_filter_index_writer.cpp
+++ b/be/src/storage/rowset/bloom_filter_index_writer.cpp
@@ -213,13 +213,6 @@ public:
 
     void add_values(const void* values, size_t count) override {
         size_t gram_num = this->_bf_options.gram_num;
-        // Older materialized views could persist an NGRAMBF index without its
-        // properties. Such an index reaches BE with gram_num == 0. Treat it as
-        // inactive rather than indexing zero-length grams and reading past the
-        // UTF-8 offset vector below.
-        if (gram_num == 0) {
-            return;
-        }
         const auto* cur_slice = reinterpret_cast<const Slice*>(values);
         for (int i = 0; i < count; ++i) {
             // For a case-insensitive index, lowercase the whole value once and build ngrams from the
@@ -274,6 +267,9 @@ struct BloomFilterBuilderFunctor {
 // TODO currently we don't support bloom filter index for tinyint/hll/float/double
 Status BloomFilterIndexWriter::create(const BloomFilterOptions& bf_options, const TypeInfoPtr& typeinfo,
                                       std::unique_ptr<BloomFilterIndexWriter>* res) {
+    if (bf_options.use_ngram && bf_options.gram_num == 0) {
+        return Status::InvalidArgument("NGRAMBF index requires gram_num greater than zero");
+    }
     return field_type_dispatch_bloomfilter(typeinfo->type(), BloomFilterBuilderFunctor(), res, bf_options, typeinfo);
 }
 

--- a/be/test/exprs/function_call_expr_test.cpp
+++ b/be/test/exprs/function_call_expr_test.cpp
@@ -457,4 +457,32 @@ TEST_F(NgramBloomFilterPushdownTest, InvalidUtf8NeedleDisablesIndex) {
     ExprExecutor::close(expr_ctxs, &_runtime_state);
 }
 
+TEST_F(NgramBloomFilterPushdownTest, ZeroGramNumDisablesIndex) {
+    TExprNode varchar_node = make_typed_node(TPrimitiveType::VARCHAR);
+    TExprNode int_node = make_typed_node(TPrimitiveType::INT);
+    TExprNode parent_node = build_ngram_call_node();
+
+    VectorizedFunctionCallExpr expr(parent_node);
+    MockColumnExpr haystack(varchar_node, BinaryColumn::create());
+    MockConstVectorizedExpr<TYPE_VARCHAR> needle(varchar_node, "legacy-ngram-index");
+    MockConstVectorizedExpr<TYPE_INT> gram_num(int_node, 3);
+    expr.add_child(&haystack);
+    expr.add_child(&needle);
+    expr.add_child(&gram_num);
+
+    ExprContext expr_context(&expr);
+    std::vector<ExprContext*> expr_ctxs = {&expr_context};
+    ASSERT_OK(ExprExecutor::prepare(expr_ctxs, &_runtime_state));
+    ASSERT_OK(ExprExecutor::open(expr_ctxs, &_runtime_state));
+
+    NgramBloomFilterReaderOptions opts;
+    opts.index_gram_num = 0;
+
+    // A legacy schema without gram_num must leave the page unpruned.
+    auto bf = make_bf_with_cyrillic_lowered_trigrams();
+    EXPECT_TRUE(expr.ngram_bloom_filter(&expr_context, bf.get(), opts));
+
+    ExprExecutor::close(expr_ctxs, &_runtime_state);
+}
+
 } // namespace starrocks

--- a/be/test/exprs/function_call_expr_test.cpp
+++ b/be/test/exprs/function_call_expr_test.cpp
@@ -476,10 +476,19 @@ TEST_F(NgramBloomFilterPushdownTest, ZeroGramNumDisablesIndex) {
     ASSERT_OK(ExprExecutor::open(expr_ctxs, &_runtime_state));
 
     NgramBloomFilterReaderOptions opts;
-    opts.index_gram_num = 0;
+    opts.index_gram_num = 3;
+    opts.index_case_sensitive = false;
+    std::unique_ptr<BloomFilter> bf;
+    ASSERT_OK(BloomFilter::create(BLOCK_BLOOM_FILTER, &bf));
+    ASSERT_OK(bf->init(16, 0.05, HashStrategyPB::HASH_MURMUR3_X64_64));
 
-    // A legacy schema without gram_num must leave the page unpruned.
-    auto bf = make_bf_with_cyrillic_lowered_trigrams();
+    // Populate the expression-local cache from a valid rowset first. The
+    // empty bloom filter makes the valid 3-gram probe reject the page.
+    EXPECT_FALSE(expr.ngram_bloom_filter(&expr_context, bf.get(), opts));
+
+    // A later legacy rowset must still leave the page unpruned, rather than
+    // using the ngrams cached for the earlier valid rowset.
+    opts.index_gram_num = 0;
     EXPECT_TRUE(expr.ngram_bloom_filter(&expr_context, bf.get(), opts));
 
     ExprExecutor::close(expr_ctxs, &_runtime_state);

--- a/be/test/storage/rowset/bloom_filter_index_reader_writer_test.cpp
+++ b/be/test/storage/rowset/bloom_filter_index_reader_writer_test.cpp
@@ -165,6 +165,23 @@ protected:
     OlapReaderStatistics _stats;
 };
 
+TEST_F(BloomFilterIndexReaderWriterTest, test_ngram_zero_gram_num_is_inactive) {
+    BloomFilterOptions bf_options;
+    bf_options.use_ngram = true;
+    bf_options.gram_num = 0;
+
+    std::unique_ptr<BloomFilterIndexWriter> writer;
+    ASSERT_OK(BloomFilterIndexWriter::create(bf_options, get_type_info(TYPE_VARCHAR), &writer));
+
+    const std::string value = "legacy-ngram-index";
+    const Slice slice(value);
+    writer->add_values(&slice, 1);
+
+    // A legacy schema without gram_num must not generate zero-length grams or
+    // allocate index values. It is intentionally treated as an inactive index.
+    ASSERT_EQ(0, writer->size());
+}
+
 TEST_F(BloomFilterIndexReaderWriterTest, test_int) {
     size_t num = 1024 * 3 - 1;
     int* val = new int[num];

--- a/be/test/storage/rowset/bloom_filter_index_reader_writer_test.cpp
+++ b/be/test/storage/rowset/bloom_filter_index_reader_writer_test.cpp
@@ -165,21 +165,17 @@ protected:
     OlapReaderStatistics _stats;
 };
 
-TEST_F(BloomFilterIndexReaderWriterTest, test_ngram_zero_gram_num_is_inactive) {
+TEST_F(BloomFilterIndexReaderWriterTest, test_ngram_zero_gram_num_is_rejected) {
     BloomFilterOptions bf_options;
     bf_options.use_ngram = true;
     bf_options.gram_num = 0;
 
     std::unique_ptr<BloomFilterIndexWriter> writer;
-    ASSERT_OK(BloomFilterIndexWriter::create(bf_options, get_type_info(TYPE_VARCHAR), &writer));
+    Status status = BloomFilterIndexWriter::create(bf_options, get_type_info(TYPE_VARCHAR), &writer);
 
-    const std::string value = "legacy-ngram-index";
-    const Slice slice(value);
-    writer->add_values(&slice, 1);
-
-    // A legacy schema without gram_num must not generate zero-length grams or
-    // allocate index values. It is intentionally treated as an inactive index.
-    ASSERT_EQ(0, writer->size());
+    // Do not silently write an empty index for malformed legacy metadata.
+    ASSERT_TRUE(status.is_invalid_argument()) << status;
+    ASSERT_EQ(nullptr, writer);
 }
 
 TEST_F(BloomFilterIndexReaderWriterTest, test_int) {


### PR DESCRIPTION
## Why I'm doing:

Materialized views created by affected older FE versions can persist an NGRAMBF index without its properties. The BE then receives `gram_num = 0`, and the ngram writer reads past the UTF-8 offset vector while building a segment, crashing the CN.

### Possible crash stack when `gram_num = 0`

For a non-empty VARCHAR value containing `N` UTF-8 characters, `get_utf8_index()` produces an offset vector with entries `[0, ..., N - 1]`. The old NGRAMBF writer loop permits `j == N` when `gram_num == 0`, then reads `index[N]` out of bounds. The invalid offset becomes the data pointer/length of an ngram `Slice`, and the subsequent value copy can fault in `memcpy`.

The affected write path is:

```
SegmentWriter::append_chunk
  -> ScalarColumnWriter::append
    -> NgramBloomFilterIndexWriterImpl<TYPE_VARCHAR>::add_values
      -> ScalarTypeInfoImpl<TYPE_CHAR>::deep_copy
        -> memcpy  // SIGSEGV
```

This is the same shape as the production CN crash during MV refresh. Spill/merge can be present in the stack because it is the segment-writing path, but it is not the source of the invalid memory access. A malformed legacy index can also reach the same zero-gram split loop during `ngram_search`; the read-side guard keeps that path from producing an out-of-bounds access as well.

## What I'm doing:

- Reject creation of an NGRAMBF writer with `gram_num = 0`, so a malformed legacy schema fails the write/refresh with `InvalidArgument` instead of silently producing an empty index or crashing the CN.
- Disable NGRAMBF pruning on the read side when its metadata has no gram number. The guard runs before the cached `NgramBloomFilterState`, so a legacy rowset cannot reuse ngrams cached from an earlier valid rowset.
- Add writer and reader regression coverage for legacy zero-gram metadata.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old policy, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
