### PR TITLE
[Enhancement] Remove the enable_experimental_vector FE config

### DIFF
--- a/docs/en/table_design/indexes/vector_index.md
+++ b/docs/en/table_design/indexes/vector_index.md
@@ -47,18 +47,6 @@ HNSW offers both efficiency and precision, making it adaptable to various data a
 
 Each table supports only one vector index.
 
-### Prerequisites
-
-Before creating vector indexes, you must enable it by setting the FE configuration item `enable_experimental_vector` to `true`.
-
-Execute the following statement to enable it dynamically:
-
-```SQL
-ADMIN SET FRONTEND CONFIG ("enable_experimental_vector" = "true");
-```
-
-To enable it permanently, you must add `enable_experimental_vector = true` to the FE configuration file `fe.conf` and restart FE.
-
 ### Create vector index
 
 This tutorial creates vector indexes while creating tables. You can also append vector indexes to an existing table. See [Append vector index](#append-vector-index) for detailed instructions.
@@ -258,8 +246,6 @@ ALTER TABLE ivfpq DROP INDEX ivfpq_vector;
 ```
 
 ### Perform ANNS with vector indexes
-
-Before running a vector search, make sure the FE configuration item `enable_experimental_vector` is set to `true`.
 
 #### Requirements for vector index-based queries
 

--- a/docs/ja/table_design/indexes/vector_index.md
+++ b/docs/ja/table_design/indexes/vector_index.md
@@ -47,18 +47,6 @@ HNSW は効率性と精度の両方を提供し、さまざまなデータとク
 
 各テーブルは 1 つのベクターインデックスのみをサポートします。
 
-### 前提条件
-
-ベクターインデックスを作成する前に、FE 設定項目 `enable_experimental_vector` を `true` に設定して有効にする必要があります。
-
-次のステートメントを実行して動的に有効にします。
-
-```SQL
-ADMIN SET FRONTEND CONFIG ("enable_experimental_vector" = "true");
-```
-
-永続的に有効にするには、FE 設定ファイル `fe.conf` に `enable_experimental_vector = true` を追加し、FE を再起動する必要があります。
-
 ### ベクターインデックスの作成
 
 このチュートリアルでは、テーブルを作成しながらベクターインデックスを作成します。既存のテーブルにベクターインデックスを追加することもできます。詳細な手順については、[Append vector index](#append-vector-index) を参照してください。
@@ -259,8 +247,6 @@ ALTER TABLE ivfpq DROP INDEX ivfpq_vector;
 ```
 
 ### ベクターインデックスを使用した ANNS の実行
-
-ベクター検索を実行する前に、FE 設定項目 `enable_experimental_vector` が `true` に設定されていることを確認してください。
 
 #### ベクターインデックスベースのクエリの要件
 

--- a/docs/zh/table_design/indexes/vector_index.md
+++ b/docs/zh/table_design/indexes/vector_index.md
@@ -47,18 +47,6 @@ HNSW提供了效率和精度的平衡，使其适应各种数据和查询分布�
 
 每个表仅支持一个向量索引。
 
-### 前提条件
-
-在创建向量索引之前，必须通过设置FE配置项`enable_experimental_vector`为`true`来启用它。
-
-执行以下语句以动态启用：
-
-```SQL
-ADMIN SET FRONTEND CONFIG ("enable_experimental_vector" = "true");
-```
-
-要永久启用它，必须将`enable_experimental_vector = true`添加到FE配置文件`fe.conf`中并重启FE。
-
 ### 创建向量索引
 
 本教程在创建表时创建向量索引。您也可以将向量索引附加到现有表中。有关详细说明，请参见[附加向量索引](#append-vector-index)。
@@ -258,8 +246,6 @@ ALTER TABLE ivfpq DROP INDEX ivfpq_vector;
 ```
 
 ### 使用向量索引执行ANNS
-
-在运行向量搜索之前，请确保FE配置项`enable_experimental_vector`设置为`true`。
 
 #### 基于向量索引的查询要求
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3473,9 +3473,6 @@ public class Config extends ConfigBase {
     public static boolean enable_experimental_gin = false;
 
     @ConfField(mutable = true)
-    public static boolean enable_experimental_vector = false;
-
-    @ConfField(mutable = true)
     public static boolean enable_experimental_mv = true;
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -81,6 +81,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.service.FrontendOptions;
+import com.starrocks.sql.ast.IndexDef;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.TableSampleClause;
 import com.starrocks.sql.ast.expression.Expr;
@@ -916,7 +917,11 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
             output.append(prefix).append("SORT COLUMN: ").append(sortColumn).append("\n");
         }
 
-        if (Config.enable_experimental_vector) {
+        // Only report the ANN state for tables that actually carry a vector index, so plans of
+        // ordinary tables stay unchanged.
+        boolean hasVectorIndex = olapTable.getIndexes().stream()
+                .anyMatch(idx -> idx.getIndexType() == IndexDef.IndexType.VECTOR);
+        if (hasVectorIndex) {
             if (vectorSearchOptions != null && vectorSearchOptions.isEnableUseANN()) {
                 output.append(vectorSearchOptions.getExplainString(prefix));
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/IndexAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/IndexAnalyzer.java
@@ -265,11 +265,6 @@ public class IndexAnalyzer {
 
     // VectorIndexUtil methods
     public static void checkVectorIndexValid(Column column, Map<String, String> properties, KeysType keysType) {
-        if (!Config.enable_experimental_vector) {
-            throw new SemanticException(
-                    "The vector index is disabled, enable it by setting FE config `enable_experimental_vector` to true");
-        }
-
         if (column.isAllowNull()) {
             throw new SemanticException("The vector index can only build on non-nullable column");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteToVectorPlanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteToVectorPlanRule.java
@@ -19,7 +19,6 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Index;
 import com.starrocks.catalog.OlapTable;
-import com.starrocks.common.Config;
 import com.starrocks.common.VectorIndexParams;
 import com.starrocks.common.VectorSearchOptions;
 import com.starrocks.sql.analyzer.SemanticException;
@@ -67,10 +66,6 @@ public class RewriteToVectorPlanRule extends TransformationRule {
 
     @Override
     public boolean check(OptExpression input, OptimizerContext context) {
-        if (!Config.enable_experimental_vector) {
-            return false;
-        }
-
         LogicalTopNOperator topNOp = (LogicalTopNOperator) input.getOp();
         LogicalOlapScanOperator scanOp = (LogicalOlapScanOperator) input.getInputs().get(0).getOp();
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAddVectorIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAddVectorIndexTest.java
@@ -22,7 +22,6 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletMeta;
-import com.starrocks.common.Config;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.LakeTablet;
@@ -55,7 +54,6 @@ public class LakeTableAddVectorIndexTest {
 
     @BeforeAll
     public static void setUp() throws Exception {
-        Config.enable_experimental_vector = true;
         UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
         connectContext = UtFrameUtils.createDefaultCtx();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/VectorIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/VectorIndexTest.java
@@ -18,7 +18,6 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Index;
 import com.starrocks.catalog.IndexParams.IndexParamItem;
-import com.starrocks.common.Config;
 import com.starrocks.common.VectorIndexParams;
 import com.starrocks.common.VectorIndexParams.CommonIndexParamKey;
 import com.starrocks.common.VectorIndexParams.IndexParamsKey;
@@ -54,7 +53,6 @@ public class VectorIndexTest extends PlanTestBase {
 
     @BeforeAll
     public static void beforeClass() throws Exception {
-        Config.enable_experimental_vector = true;
         PlanTestBase.beforeClass();
         starRocksAssert.withTable("CREATE TABLE `test_index_tbl` (\n" +
                 "  `f1` int NOT NULL COMMENT \"\",\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/planner/VectorIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/VectorIndexTest.java
@@ -35,7 +35,6 @@
 package com.starrocks.planner;
 
 import com.starrocks.catalog.OlapTable;
-import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.plan.PlanTestBase;
@@ -50,7 +49,6 @@ public class VectorIndexTest extends PlanTestBase {
     @BeforeAll
     public static void beforeClass() throws Exception {
         PlanTestBase.beforeClass();
-        Config.enable_experimental_vector = true;
         FeConstants.enablePruneEmptyOutputScan = false;
         starRocksAssert.withTable("CREATE TABLE test.test_cosine ("
                 + " c0 INT,"
@@ -555,9 +553,10 @@ public class VectorIndexTest extends PlanTestBase {
         assertContains(plan, "  13:OlapScanNode\n" +
                 "     table: test_cosine, rollup: test_cosine\n" +
                 "     VECTORINDEX: OFF");
+        // A table without a vector index reports no VECTORINDEX state at all.
         assertContains(plan, "  25:OlapScanNode\n" +
                 "     table: test_no_vector_index, rollup: test_no_vector_index\n" +
-                "     VECTORINDEX: OFF");
+                "     preAggregation: on");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/service/LakeInformationSchemaDataSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/LakeInformationSchemaDataSourceTest.java
@@ -21,7 +21,6 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.UserIdentity;
-import com.starrocks.common.Config;
 import com.starrocks.common.PatternMatcher;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.vector.VectorIndexBuildScheduler;
@@ -201,55 +200,49 @@ public class LakeInformationSchemaDataSourceTest {
      */
     @Test
     public void testGetLakePartitionsMetaAsyncVectorIndexBuiltVersion() throws Exception {
-        boolean prevEnableExperimentalVector = Config.enable_experimental_vector;
-        Config.enable_experimental_vector = true;
-        try {
-            starRocksAssert.withEnableMV().withDatabase("db_vi_meta").useDatabase("db_vi_meta");
+        starRocksAssert.withEnableMV().withDatabase("db_vi_meta").useDatabase("db_vi_meta");
 
-            String createTblStmtStr = "CREATE TABLE db_vi_meta.vi_table (" +
-                    " c0 INT," +
-                    " c1 array<float> NOT NULL," +
-                    " INDEX index_vector1 (c1) USING VECTOR ('metric_type' = 'cosine_similarity', " +
-                    "'is_vector_normed' = 'false', 'M' = '512', 'index_type' = 'hnsw', 'dim' = '5', " +
-                    "'index_build_mode' = 'async')) " +
-                    "DUPLICATE KEY(c0) " +
-                    "DISTRIBUTED BY HASH(c0) BUCKETS 3 " +
-                    "PROPERTIES ('replication_num' = '1');";
-            starRocksAssert.withTable(createTblStmtStr);
+        String createTblStmtStr = "CREATE TABLE db_vi_meta.vi_table (" +
+                " c0 INT," +
+                " c1 array<float> NOT NULL," +
+                " INDEX index_vector1 (c1) USING VECTOR ('metric_type' = 'cosine_similarity', " +
+                "'is_vector_normed' = 'false', 'M' = '512', 'index_type' = 'hnsw', 'dim' = '5', " +
+                "'index_build_mode' = 'async')) " +
+                "DUPLICATE KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 3 " +
+                "PROPERTIES ('replication_num' = '1');";
+        starRocksAssert.withTable(createTblStmtStr);
 
-            OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .getTable("db_vi_meta", "vi_table");
-            Assertions.assertTrue(VectorIndexBuildScheduler.hasAsyncVectorIndex(table));
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable("db_vi_meta", "vi_table");
+        Assertions.assertTrue(VectorIndexBuildScheduler.hasAsyncVectorIndex(table));
 
-            // Stamp distinct built versions on the base-index tablets so the span becomes [3, 7].
-            long[] versions = {3L, 5L, 7L};
-            for (PhysicalPartition partition : table.getPhysicalPartitions()) {
-                MaterializedIndex baseIndex = partition.getIndex(table.getBaseIndexMetaId());
-                int i = 0;
-                for (Tablet tablet : baseIndex.getTablets()) {
-                    ((LakeTablet) tablet).setVectorIndexBuiltVersion(versions[i % versions.length]);
-                    i++;
-                }
+        // Stamp distinct built versions on the base-index tablets so the span becomes [3, 7].
+        long[] versions = {3L, 5L, 7L};
+        for (PhysicalPartition partition : table.getPhysicalPartitions()) {
+            MaterializedIndex baseIndex = partition.getIndex(table.getBaseIndexMetaId());
+            int i = 0;
+            for (Tablet tablet : baseIndex.getTablets()) {
+                ((LakeTablet) tablet).setVectorIndexBuiltVersion(versions[i % versions.length]);
+                i++;
             }
-
-            FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
-            TGetPartitionsMetaRequest req = new TGetPartitionsMetaRequest();
-            TAuthInfo authInfo = new TAuthInfo();
-            authInfo.setPattern("db_vi_meta");
-            authInfo.setUser("root");
-            authInfo.setUser_ip("%");
-            req.setAuth_info(authInfo);
-            TGetPartitionsMetaResponse response = impl.getPartitionsMeta(req);
-
-            TPartitionMetaInfo partitionMeta = response.getPartitions_meta_infos().stream()
-                    .filter(t -> t.getTable_name().equals("vi_table")).findFirst().orElse(null);
-            Assertions.assertNotNull(partitionMeta);
-            Assertions.assertTrue(partitionMeta.isSetMin_vi_built_version());
-            Assertions.assertEquals(3L, partitionMeta.getMin_vi_built_version());
-            Assertions.assertEquals(7L, partitionMeta.getMax_vi_built_version());
-        } finally {
-            Config.enable_experimental_vector = prevEnableExperimentalVector;
         }
+
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+        TGetPartitionsMetaRequest req = new TGetPartitionsMetaRequest();
+        TAuthInfo authInfo = new TAuthInfo();
+        authInfo.setPattern("db_vi_meta");
+        authInfo.setUser("root");
+        authInfo.setUser_ip("%");
+        req.setAuth_info(authInfo);
+        TGetPartitionsMetaResponse response = impl.getPartitionsMeta(req);
+
+        TPartitionMetaInfo partitionMeta = response.getPartitions_meta_infos().stream()
+                .filter(t -> t.getTable_name().equals("vi_table")).findFirst().orElse(null);
+        Assertions.assertNotNull(partitionMeta);
+        Assertions.assertTrue(partitionMeta.isSetMin_vi_built_version());
+        Assertions.assertEquals(3L, partitionMeta.getMin_vi_built_version());
+        Assertions.assertEquals(7L, partitionMeta.getMax_vi_built_version());
     }
 
     /**
@@ -258,46 +251,40 @@ public class LakeInformationSchemaDataSourceTest {
      */
     @Test
     public void testGetLakePartitionsMetaSyncVectorIndexBuiltVersion() throws Exception {
-        boolean prevEnableExperimentalVector = Config.enable_experimental_vector;
-        Config.enable_experimental_vector = true;
-        try {
-            starRocksAssert.withEnableMV().withDatabase("db_vi_sync").useDatabase("db_vi_sync");
+        starRocksAssert.withEnableMV().withDatabase("db_vi_sync").useDatabase("db_vi_sync");
 
-            String createTblStmtStr = "CREATE TABLE db_vi_sync.vi_sync_table (" +
-                    " c0 INT," +
-                    " c1 array<float> NOT NULL," +
-                    " INDEX index_vector1 (c1) USING VECTOR ('metric_type' = 'cosine_similarity', " +
-                    "'is_vector_normed' = 'false', 'M' = '512', 'index_type' = 'hnsw', 'dim' = '5', " +
-                    "'index_build_mode' = 'sync')) " +
-                    "DUPLICATE KEY(c0) " +
-                    "DISTRIBUTED BY HASH(c0) BUCKETS 3 " +
-                    "PROPERTIES ('replication_num' = '1');";
-            starRocksAssert.withTable(createTblStmtStr);
+        String createTblStmtStr = "CREATE TABLE db_vi_sync.vi_sync_table (" +
+                " c0 INT," +
+                " c1 array<float> NOT NULL," +
+                " INDEX index_vector1 (c1) USING VECTOR ('metric_type' = 'cosine_similarity', " +
+                "'is_vector_normed' = 'false', 'M' = '512', 'index_type' = 'hnsw', 'dim' = '5', " +
+                "'index_build_mode' = 'sync')) " +
+                "DUPLICATE KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 3 " +
+                "PROPERTIES ('replication_num' = '1');";
+        starRocksAssert.withTable(createTblStmtStr);
 
-            OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .getTable("db_vi_sync", "vi_sync_table");
-            Assertions.assertFalse(VectorIndexBuildScheduler.hasAsyncVectorIndex(table));
-            Assertions.assertTrue(VectorIndexBuildScheduler.hasVectorIndex(table));
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable("db_vi_sync", "vi_sync_table");
+        Assertions.assertFalse(VectorIndexBuildScheduler.hasAsyncVectorIndex(table));
+        Assertions.assertTrue(VectorIndexBuildScheduler.hasVectorIndex(table));
 
-            FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
-            TGetPartitionsMetaRequest req = new TGetPartitionsMetaRequest();
-            TAuthInfo authInfo = new TAuthInfo();
-            authInfo.setPattern("db_vi_sync");
-            authInfo.setUser("root");
-            authInfo.setUser_ip("%");
-            req.setAuth_info(authInfo);
-            TGetPartitionsMetaResponse response = impl.getPartitionsMeta(req);
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+        TGetPartitionsMetaRequest req = new TGetPartitionsMetaRequest();
+        TAuthInfo authInfo = new TAuthInfo();
+        authInfo.setPattern("db_vi_sync");
+        authInfo.setUser("root");
+        authInfo.setUser_ip("%");
+        req.setAuth_info(authInfo);
+        TGetPartitionsMetaResponse response = impl.getPartitionsMeta(req);
 
-            TPartitionMetaInfo partitionMeta = response.getPartitions_meta_infos().stream()
-                    .filter(t -> t.getTable_name().equals("vi_sync_table")).findFirst().orElse(null);
-            Assertions.assertNotNull(partitionMeta);
-            Assertions.assertTrue(partitionMeta.isSetMin_vi_built_version());
-            // Sync index is always current as of the visible version.
-            Assertions.assertEquals(partitionMeta.getVisible_version(), partitionMeta.getMin_vi_built_version());
-            Assertions.assertEquals(partitionMeta.getVisible_version(), partitionMeta.getMax_vi_built_version());
-        } finally {
-            Config.enable_experimental_vector = prevEnableExperimentalVector;
-        }
+        TPartitionMetaInfo partitionMeta = response.getPartitions_meta_infos().stream()
+                .filter(t -> t.getTable_name().equals("vi_sync_table")).findFirst().orElse(null);
+        Assertions.assertNotNull(partitionMeta);
+        Assertions.assertTrue(partitionMeta.isSetMin_vi_built_version());
+        // Sync index is always current as of the visible version.
+        Assertions.assertEquals(partitionMeta.getVisible_version(), partitionMeta.getMin_vi_built_version());
+        Assertions.assertEquals(partitionMeta.getVisible_version(), partitionMeta.getMax_vi_built_version());
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeVectorIndexDMLTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeVectorIndexDMLTest.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.sql.analyzer;
 
-import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.StmtExecutor;
@@ -40,8 +39,6 @@ public class AnalyzeVectorIndexDMLTest {
         UtFrameUtils.addMockBackend(10002);
         UtFrameUtils.addMockBackend(10003);
         connectContext = AnalyzeTestUtil.getConnectContext();
-
-        Config.enable_experimental_vector = true;
     }
 
     @Test

--- a/test/sql/test_vector_index/R/test_shared_data_add_vector_index
+++ b/test/sql/test_vector_index/R/test_shared_data_add_vector_index
@@ -1,7 +1,4 @@
 -- name: test_shared_data_add_vector_index_sync @cloud
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
--- result:
--- !result
 create database db_sd_vidx_sync_${uuid0};
 -- result:
 -- !result
@@ -44,9 +41,6 @@ drop database db_sd_vidx_sync_${uuid0} force;
 -- result:
 -- !result
 -- name: test_shared_data_add_vector_index_async @cloud
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
--- result:
--- !result
 create database db_sd_vidx_async_${uuid0};
 -- result:
 -- !result
@@ -78,9 +72,6 @@ drop database db_sd_vidx_async_${uuid0} force;
 -- result:
 -- !result
 -- name: test_shared_data_add_vector_index_rollback @cloud
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
--- result:
--- !result
 create database db_sd_vidx_rb_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_vector_index/R/test_shared_data_pk_partial_update_vector_index
+++ b/test/sql/test_vector_index/R/test_shared_data_pk_partial_update_vector_index
@@ -1,7 +1,4 @@
 -- name: test_sd_pk_partial_update_vector_index_sync @cloud
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
--- result:
--- !result
 create database db_sd_pk_pu_vidx_sync_${uuid0};
 -- result:
 -- !result
@@ -59,9 +56,6 @@ drop database db_sd_pk_pu_vidx_sync_${uuid0} force;
 -- result:
 -- !result
 -- name: test_sd_pk_partial_update_vector_index_async @cloud
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
--- result:
--- !result
 create database db_sd_pk_pu_vidx_async_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_vector_index/R/test_vector_filter_strategy
+++ b/test/sql/test_vector_index/R/test_vector_filter_strategy
@@ -1,7 +1,4 @@
 -- name: test_vector_filter_strategy @sequential @native
-ADMIN SET FRONTEND CONFIG ("enable_experimental_vector" = "true");
--- result:
--- !result
 ADMIN SET FRONTEND CONFIG ("enable_experimental_gin" = "true");
 -- result:
 -- !result
@@ -139,8 +136,5 @@ DROP TABLE vt_pk;
 -- result:
 -- !result
 ADMIN SET FRONTEND CONFIG ("enable_experimental_gin" = "false");
--- result:
--- !result
-ADMIN SET FRONTEND CONFIG ("enable_experimental_vector" = "false");
 -- result:
 -- !result

--- a/test/sql/test_vector_index/R/test_vector_index
+++ b/test/sql/test_vector_index/R/test_vector_index
@@ -1,7 +1,4 @@
 -- name: test_create_vector_index @sequential @native
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
--- result:
--- !result
 CREATE TABLE `t_test_vector_table` (
   `id` bigint(20) NOT NULL COMMENT "",
   `vector1` ARRAY<FLOAT> NOT NULL COMMENT "",
@@ -57,14 +54,8 @@ None
 DROP TABLE t_test_vector_table;
 -- result:
 -- !result
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "false");
--- result:
--- !result
 
 -- name: test_vector_index @sequential @native
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
--- result:
--- !result
 CREATE TABLE `t_test_vector_table` (
   `id` bigint(20) NOT NULL COMMENT "",
   `vector1` ARRAY<FLOAT> NOT NULL COMMENT "",
@@ -103,6 +94,3 @@ DROP TABLE t_test_vector_table;
 -- result:
 -- !result
 
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "false");
--- result:
--- !result

--- a/test/sql/test_vector_index/R/test_vector_index_cache
+++ b/test/sql/test_vector_index/R/test_vector_index_cache
@@ -1,7 +1,4 @@
 -- name: test_vector_index_cache @sequential
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
--- result:
--- !result
 update information_schema.be_configs set value = "20%" where name = "vector_query_cache_capacity";
 -- result:
 -- !result
@@ -87,8 +84,5 @@ update information_schema.be_configs set value = "20%" where name = "vector_quer
 -- result:
 -- !result
 DROP TABLE t_vi_cache;
--- result:
--- !result
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "false");
 -- result:
 -- !result

--- a/test/sql/test_vector_index/R/test_vector_index_hnsw
+++ b/test/sql/test_vector_index/R/test_vector_index_hnsw
@@ -1,7 +1,4 @@
 -- name: test_vector_index_hnsw @sequential @native
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
--- result:
--- !result
 CREATE TABLE __row_util_base (
   k1 bigint NULL
 ) ENGINE=OLAP
@@ -333,9 +330,6 @@ order by dis, id limit 10;
 29	[9,9,9,9,9]	[9,9,9,9,9]	29	320.0
 30	[10,10,10,10,10]	[10,10,10,10,10]	30	405.0
 -- !result
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "false");
--- result:
--- !result
 with w1 as (
     select *, approx_l2_distance(v1, [1, 1, 1, 1, 1]) as dis from t2
 )
@@ -478,7 +472,4 @@ with w1 as (
 18	[10000,10001,10002,10003,10004]	[10000,10001,10002,10003,10004]	18	0.0
 19	[10000,10001,10002,10003,10004]	[10000,10001,10002,10003,10004]	19	0.0
 20	[10000,10001,10002,10003,10004]	[10000,10001,10002,10003,10004]	20	0.0
--- !result
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "false");
--- result:
 -- !result

--- a/test/sql/test_vector_index/R/test_vector_index_insert
+++ b/test/sql/test_vector_index/R/test_vector_index_insert
@@ -1,7 +1,4 @@
 -- name: test_vector_index_insert @sequential @native
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
--- result:
--- !result
 CREATE TABLE t1 (
     id bigint(20) NOT NULL,
     v1 ARRAY<FLOAT> NOT NULL,
@@ -164,7 +161,4 @@ select * from t2 order by id, v1, v2;
 3	[0.33686078,0.42107597,0.50529116,null,0.67372155]	[0.33686078,0.42107597,0.50529116,null,0.67372155]
 4	[0.33686078,0.42107597,0.50529116,null,0.67372155]	None
 4	[0.33686078,0.42107597,0.50529116,null,0.67372155]	None
--- !result
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "false");
--- result:
 -- !result

--- a/test/sql/test_vector_index/R/test_vector_index_ivfpq
+++ b/test/sql/test_vector_index/R/test_vector_index_ivfpq
@@ -1,7 +1,4 @@
 -- name: test_vector_index_ivfpq @sequential @native
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
--- result:
--- !result
 SET enable_vector_index_refine = true;
 -- result:
 -- !result
@@ -361,9 +358,6 @@ order by dis, id limit 10;
 29	[9,9,9,9]	[9,9,9,9]	29	256.0
 30	[10,10,10,10]	[10,10,10,10]	30	324.0
 -- !result
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "false");
--- result:
--- !result
 with w1 as (
     select *, approx_l2_distance(v1, [1, 1, 1, 1]) as dis from t1
 )
@@ -507,7 +501,4 @@ with w1 as (
 18	[10000,10001,10002,10003]	[10000,10001,10002,10003]	18	0.0
 19	[10000,10001,10002,10003]	[10000,10001,10002,10003]	19	0.0
 20	[10000,10001,10002,10003]	[10000,10001,10002,10003]	20	0.0
--- !result
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "false");
--- result:
 -- !result

--- a/test/sql/test_vector_index/R/test_vector_index_refine
+++ b/test/sql/test_vector_index/R/test_vector_index_refine
@@ -1,7 +1,4 @@
 -- name: test_vector_index_refine @sequential @native
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
--- result:
--- !result
 CREATE TABLE __refine_rows (
   k1 bigint NULL
 ) ENGINE=OLAP
@@ -197,8 +194,5 @@ DROP TABLE IF EXISTS t_novi;
 -- result:
 -- !result
 DROP TABLE IF EXISTS __refine_rows;
--- result:
--- !result
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "false");
 -- result:
 -- !result

--- a/test/sql/test_vector_index/T/test_shared_data_add_vector_index
+++ b/test/sql/test_vector_index/T/test_shared_data_add_vector_index
@@ -1,5 +1,4 @@
 -- name: test_shared_data_add_vector_index_sync @cloud
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
 create database db_sd_vidx_sync_${uuid0};
 use db_sd_vidx_sync_${uuid0};
 CREATE TABLE t_sync (id BIGINT NOT NULL, v ARRAY<FLOAT> NOT NULL) DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1");
@@ -14,7 +13,6 @@ select id from t_sync order by approx_l2_distance([0.9,0.1,0,0], v) limit 1;
 drop database db_sd_vidx_sync_${uuid0} force;
 
 -- name: test_shared_data_add_vector_index_async @cloud
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
 create database db_sd_vidx_async_${uuid0};
 use db_sd_vidx_async_${uuid0};
 CREATE TABLE t_async (id BIGINT NOT NULL, v ARRAY<FLOAT> NOT NULL) DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1");
@@ -26,7 +24,6 @@ select id from t_async order by approx_l2_distance([1,0,0,0], v) limit 1;
 drop database db_sd_vidx_async_${uuid0} force;
 
 -- name: test_shared_data_add_vector_index_rollback @cloud
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
 create database db_sd_vidx_rb_${uuid0};
 use db_sd_vidx_rb_${uuid0};
 CREATE TABLE t_rb (id BIGINT NOT NULL, v ARRAY<FLOAT> NOT NULL) DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1");

--- a/test/sql/test_vector_index/T/test_shared_data_pk_partial_update_vector_index
+++ b/test/sql/test_vector_index/T/test_shared_data_pk_partial_update_vector_index
@@ -1,5 +1,4 @@
 -- name: test_sd_pk_partial_update_vector_index_sync @cloud
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
 create database db_sd_pk_pu_vidx_sync_${uuid0};
 use db_sd_pk_pu_vidx_sync_${uuid0};
 CREATE TABLE t (
@@ -26,7 +25,6 @@ select id, val from t order by approx_l2_distance([0,1,0,0], v) limit 1;
 drop database db_sd_pk_pu_vidx_sync_${uuid0} force;
 
 -- name: test_sd_pk_partial_update_vector_index_async @cloud
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
 create database db_sd_pk_pu_vidx_async_${uuid0};
 use db_sd_pk_pu_vidx_async_${uuid0};
 CREATE TABLE t (

--- a/test/sql/test_vector_index/T/test_vector_filter_strategy
+++ b/test/sql/test_vector_index/T/test_vector_filter_strategy
@@ -9,7 +9,6 @@
 --   which is not rewritten) -- checked via assert_equal_result. PRE-vs-BRUTE is
 --   a BE-runtime choice not visible in EXPLAIN (always VECTORINDEX: ON).
 -- ===========================================================================
-ADMIN SET FRONTEND CONFIG ("enable_experimental_vector" = "true");
 ADMIN SET FRONTEND CONFIG ("enable_experimental_gin" = "true");
 
 CREATE TABLE vt (
@@ -121,4 +120,3 @@ function: assert_equal_result("select id from vt_pk where cat < 5 order by appro
 DROP TABLE vt_pk;
 
 ADMIN SET FRONTEND CONFIG ("enable_experimental_gin" = "false");
-ADMIN SET FRONTEND CONFIG ("enable_experimental_vector" = "false");

--- a/test/sql/test_vector_index/T/test_vector_index
+++ b/test/sql/test_vector_index/T/test_vector_index
@@ -1,5 +1,4 @@
 -- name: test_create_vector_index @sequential @native
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
 
 CREATE TABLE `t_test_vector_table` (
   `id` bigint(20) NOT NULL COMMENT "",
@@ -26,11 +25,9 @@ ALTER TABLE t_test_vector_table drop index index_vector2;
 
 DROP TABLE t_test_vector_table;
 
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "false");
 
 -- name: test_vector_index @sequential @native
 
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
 
 CREATE TABLE `t_test_vector_table` (
   `id` bigint(20) NOT NULL COMMENT "",
@@ -54,4 +51,3 @@ select * from (select id, approx_l2_distance([1,1,1,1,1], vector1) score from t_
 DROP TABLE t_test_vector_table;
 
 
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "false");

--- a/test/sql/test_vector_index/T/test_vector_index_cache
+++ b/test/sql/test_vector_index/T/test_vector_index_cache
@@ -9,7 +9,6 @@
 -- These paths are end-to-end-only; unit tests can drive isolated pieces but
 -- can't reach init_searcher's happy path without spinning up the BE.
 
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
 
 -- ---- vector_query_cache_capacity runtime config (config_update_hooks callback) ----
 
@@ -94,4 +93,3 @@ select count(*) from (
 update information_schema.be_configs set value = "20%" where name = "vector_query_cache_capacity";
 DROP TABLE t_vi_cache;
 
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "false");

--- a/test/sql/test_vector_index/T/test_vector_index_hnsw
+++ b/test/sql/test_vector_index/T/test_vector_index_hnsw
@@ -1,6 +1,5 @@
 -- name: test_vector_index_hnsw @sequential @native
 
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
 
 
 
@@ -180,7 +179,6 @@ with w1 as (
 select * from w1 
 order by dis, id limit 10;
 
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "false");
 
 -- basic queries.
 
@@ -246,4 +244,3 @@ with w1 as (
 ) select * from w2 order by dis, id;
 
 
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "false");

--- a/test/sql/test_vector_index/T/test_vector_index_hnsw_lazymat
+++ b/test/sql/test_vector_index/T/test_vector_index_hnsw_lazymat
@@ -3,7 +3,6 @@
 -- HNSW vector queries under global lazy-materialization: SELECT id only (prune),
 -- SELECT with v (defer + fetch K survivors), predicate + ANN (eager), IVFPQ (eager).
 
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
 
 -- IVFPQ is quantized; refine so its embedding stays eager and distances are exact (the eager check below).
 SET enable_vector_index_refine = true;
@@ -82,4 +81,3 @@ order by d, id limit 2;
 
 drop table lm_ivfpq;
 
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "false");

--- a/test/sql/test_vector_index/T/test_vector_index_hnsw_quantizer
+++ b/test/sql/test_vector_index/T/test_vector_index_hnsw_quantizer
@@ -1,6 +1,5 @@
 -- name: test_vector_index_hnsw_quantizer @sequential @native
 
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
 
 -- =====================================================================
 -- HNSW + quantizer DDL: SQ4 / SQ8 / PQ acceptance and rejection.

--- a/test/sql/test_vector_index/T/test_vector_index_insert
+++ b/test/sql/test_vector_index/T/test_vector_index_insert
@@ -1,6 +1,5 @@
 -- name: test_vector_index_insert @sequential @native
 
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
 
 CREATE TABLE t1 (
     id bigint(20) NOT NULL,
@@ -117,4 +116,3 @@ insert into t2 select id, v2, v1 from t2;
 select * from t2 order by id, v1, v2;
 
 
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "false");

--- a/test/sql/test_vector_index/T/test_vector_index_ivfpq
+++ b/test/sql/test_vector_index/T/test_vector_index_ivfpq
@@ -1,6 +1,5 @@
 -- name: test_vector_index_ivfpq @sequential @native
 
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
 
 -- IVFPQ is a quantized index; turn refine on so distances are recomputed exactly and the
 -- distance-range filter is rechecked on the exact distance (results are exact and stable).
@@ -206,7 +205,6 @@ with w1 as (
 select * from w1 
 order by dis, id limit 10;
 
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "false");
 
 -- basic queries.
 
@@ -272,4 +270,3 @@ with w1 as (
 ) select * from w2 order by dis, id;
 
 
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "false");

--- a/test/sql/test_vector_index/T/test_vector_index_refine
+++ b/test/sql/test_vector_index/T/test_vector_index_refine
@@ -1,6 +1,5 @@
 -- name: test_vector_index_refine @sequential @native
 
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "true");
 
 -- =====================================================================
 -- Quantized vector index + enable_vector_index_refine on/off.
@@ -126,4 +125,3 @@ DROP TABLE IF EXISTS t_hnsw_flat;
 DROP TABLE IF EXISTS t_novi;
 DROP TABLE IF EXISTS __refine_rows;
 
-ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = "false");


### PR DESCRIPTION
## Why I'm doing:

The vector index is no longer an experimental feature, but it is still gated behind the
FE config `enable_experimental_vector` (default `false`). Users therefore have to flip an
FE config before they can create a vector index or get an ANN plan, which is pure friction
for a supported feature.

## What I'm doing:

Remove `Config.enable_experimental_vector` and its three gates:

- `IndexAnalyzer.checkVectorIndexValid()`: vector index DDL is no longer rejected with
  "The vector index is disabled, enable it by setting FE config ... to true".
- `RewriteToVectorPlanRule.check()`: the ANN rewrite is always considered.
- `OlapScanNode` explain: report the `VECTORINDEX: ON/OFF` state only for tables that
  actually carry a vector index. Dropping the gate unconditionally would add a meaningless
  `VECTORINDEX: OFF` line to every OLAP scan; keying it on the presence of a vector index
  keeps the plans of ordinary tables byte-identical to today's output.

Tests drop the now-invalid `Config.enable_experimental_vector = true` setup, and the vector
SQL tests drop the `ADMIN SET FRONTEND CONFIG("enable_experimental_vector" = ...)`
statements, which would otherwise fail against a config that no longer exists.

Note on release branches: `branch-4.2` has not been cut yet, so merging into `main` is what
ships this in 4.2; no cherry-pick is needed. The config still exists in 4.1 and earlier, where
it must stay for compatibility, so nothing is backported.

User documentation is updated in the same PR: `docs/en|zh|ja/table_design/indexes/vector_index.md`
told users to run `ADMIN SET FRONTEND CONFIG ("enable_experimental_vector" = "true")`, which would
now fail with `ERROR_CONFIG_NOT_EXIST`, so the prerequisite section and the search-time reminder are
removed in all three languages.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.2
  - [ ] 4.1
  - [ ] 4.0