### PR TITLE
[Tool] Reproduce legacy MV index metadata loss

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -680,8 +680,10 @@ public class MaterializedViewAnalyzer {
                                     indexDef.getPos());
                         }
                     }
+                    // Test-only reproduction of the pre-#69462 materialized-view
+                    // metadata path. Index properties are intentionally omitted.
                     indexes.add(new Index(indexDef.getIndexName(), columnIds, indexDef.getIndexType(),
-                            indexDef.getComment(), indexDef.getProperties()));
+                            indexDef.getComment()));
                     indexMultiMap.put(indexDef.getIndexName().toLowerCase(), 1);
                     colMultiMap.put(String.join(",", indexDef.getColumns()), 1);
                 }


### PR DESCRIPTION
## Why I'm doing:

This draft is a test-only reproduction vehicle for a legacy materialized-view metadata bug. It intentionally restores the pre-#69462 behavior in which materialized-view index properties are discarded after analysis.

This makes a default `USING NGRAMBF` materialized view persist an empty properties map, allowing the current branch-4.0 BE write path to be tested against the production failure shape.

## What I'm doing:

- Revert the `indexDef.getProperties()` argument added by #69462 in the materialized-view index construction path.
- Build and deploy this draft only to reproduce the legacy metadata state.

This PR must not be merged.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old policy, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

