### PR TITLE
[Doc] Document vector index parameters and configurations

### DIFF
--- a/docs/en/administration/management/BE_parameters/query_loading.md
+++ b/docs/en/administration/management/BE_parameters/query_loading.md
@@ -674,6 +674,42 @@ This topic introduces the following types of BE configurations:
 - Description: Fraction of the BE process memory reserved for update-related memory and caches. During startup `RuntimeEnv` computes the `MemTracker` for updates as process_mem_limit * clamp(update_memory_limit_percent, 0, 100) / 100. `UpdateManager` also uses this percentage to size its primary-index/index-cache capacity (index cache capacity = RuntimeEnv::process_mem_limit * update_memory_limit_percent / 100). The HTTP config update logic registers a callback that calls `update_primary_index_memory_limit` on the update managers, so changes would be applied to the update subsystem if the config were changed. Increasing this value gives more memory to update/primary-index paths (reducing memory available for other pools); decreasing it reduces update memory and cache capacity. Values are clamped to the range 0–100.
 - Introduced in: v3.2.0
 
+### enable_vector_index_block_cache
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether to cache IVFPQ indexes by inverted-list block. When enabled, StarRocks loads and caches only the IVFPQ blocks needed by a query. When disabled, it caches the whole IVFPQ index file. This configuration does not change HNSW caching.
+- Introduced in: -
+
+### config_vector_index_build_concurrency
+
+- Default: 8
+- Type: Int
+- Unit: Threads
+- Is mutable: Yes
+- Description: Number of OpenMP threads used by each vector index build. StarRocks clamps the effective value to at least `1`. Together with `vector_index_build_max_cpu_ratio`, this item also determines the size of the asynchronous vector index build thread pool.
+- Introduced in: -
+
+### config_vector_index_default_build_threshold
+
+- Default: 10000
+- Type: Int
+- Unit: Rows
+- Is mutable: Yes
+- Description: Default minimum number of rows in a Segment required to build a vector index. The index property `index_build_threshold` overrides this value. For IVFPQ, the effective threshold is at least `nlist` so that the index has enough rows for training.
+- Introduced in: -
+
+### vector_index_build_max_cpu_ratio
+
+- Default: 0.5
+- Type: Double
+- Unit: Ratio
+- Is mutable: Yes
+- Description: Target fraction of BE/CN CPU cores available to asynchronous vector index builds. The build CPU budget is `max(2, floor(cpu_cores * value))`, and the build pool size is derived from this budget and `config_vector_index_build_concurrency`. Because the minimum budget is `2`, small machines or small ratios can exceed the configured fraction.
+- Introduced in: -
+
 ### enable_vector_adaptive_search
 
 - Default: true
@@ -716,6 +752,24 @@ This topic introduces the following types of BE configurations:
 - Unit: -
 - Is mutable: Yes
 - Description: Upper bound on the adaptive `ef_search` multiplier. Caps the worst-case CPU and latency cost of the scaling formula even on extremely large segments. Effective only when `enable_vector_adaptive_search` is true.
+- Introduced in: -
+
+### vector_index_brute_selectivity_threshold
+
+- Default: 0.01
+- Type: Double
+- Unit: Ratio
+- Is mutable: Yes
+- Description: Selectivity threshold for routing a vector query with residual scalar filters to exact scoring instead of a filtered HNSW traversal. If the matched rows are no more than this fraction of the Segment, StarRocks scores the filtered candidates directly. Set to `0` to disable this ratio check. The separate short circuit for a candidate count no greater than the query `k` remains enabled.
+- Introduced in: -
+
+### vector_index_build_flush_threshold_rows
+
+- Default: 262144
+- Type: Int
+- Unit: Rows
+- Is mutable: Yes
+- Description: Maximum rows held in each vector index builder's staging buffer before the rows are added to the in-memory index. This bounds the staging-buffer memory used when building HNSW Flat indexes, but does not limit the trained index itself. Set to `0` to disable intermediate flushing and buffer the whole Segment.
 - Introduced in: -
 
 ### vector_chunk_size

--- a/docs/en/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/en/administration/management/FE_parameters/shared_lake_other.md
@@ -654,6 +654,15 @@ This topic introduces the following types of FE configurations:
 - Description: When this item is set to `true`, the system allows Lake tables to use the combined transaction log path for relevant transactions. Available for shared-data clusters only.
 - Introduced in: v3.3.7, v3.4.0, v3.5.0
 
+### `lake_vector_index_build_warehouse`
+
+- Default: `default_warehouse`
+- Type: String
+- Unit: -
+- Is mutable: Yes
+- Description: Warehouse used to run asynchronous vector index build tasks in shared-data clusters. Set this item to a non-default warehouse name to isolate vector index builds from query and load workloads. If the configured warehouse is `default_warehouse`, empty, missing, or unavailable, StarRocks uses the table's recorded background warehouse and finally falls back to the default warehouse.
+- Introduced in: v4.2.0
+
 ### `lake_vi_build_load_tail_delay_ms`
 
 - Default: 300000

--- a/docs/en/sql-reference/System_variable.md
+++ b/docs/en/sql-reference/System_variable.md
@@ -190,6 +190,13 @@ The variables are described **in alphabetical order**. Variables with the `globa
 
 If you want to activate the roles assigned to you in a session, use the [SET ROLE](sql-statements/account-management/SET_DEFAULT_ROLE.md) command.
 
+### ann_params
+
+* **Description**: Specifies query-time parameters for approximate nearest neighbor (ANN) vector index searches. The value is a JSON object string whose keys and values are strings. HNSW supports `efsearch`; IVFPQ supports `nprobe`, `max_codes`, `scan_table_threshold`, `polysemous_ht`, and `range_search_confidence`. You can set the variable for a session or a single statement, for example `SET ann_params = '{"efsearch":"256"}'` or `SET_VAR (ann_params='{"efsearch":"256"}')`.
+* **Default**: `""`
+* **Data type**: String
+* **Scope**: Session
+
 ### array_low_cardinality_optimize
 
 * **Scope**: Session
@@ -1186,6 +1193,13 @@ The following variables tune the back-pressure behavior and only take effect whe
 * **Data Type**: boolean
 * **Introduced in**: v3.2.4
 
+### enable_vector_index_refine
+
+* **Description**: Whether to recompute exact distances from the original vectors and rerank candidates returned by a quantized vector index. This variable applies to IVFPQ and HNSW indexes using the `sq4`, `sq8`, or `pq` quantizer. It has no effect on unquantized HNSW indexes (`quantizer = flat`). Enabling it can improve result accuracy but increases I/O and computation. Use `EXPLAIN` and check `Refine: ON/OFF` to confirm whether refinement is active.
+* **Default**: `false`
+* **Data type**: Boolean
+* **Scope**: Session
+
 ### enable_view_based_mv_rewrite
 
 * **Description**: Whether to enable query rewrite for logical view-based materialized views. If this item is set to `true`, the logical view is used as a unified node to rewrite the queries against itself for better performance. If this item is set to `false`, the system transcribes the queries against logical views into queries against physical tables or materialized views and then rewrites them.
@@ -1322,6 +1336,13 @@ Used for MySQL client compatibility. No practical usage.
 * **Default**: `false`
 * **Data Type**: boolean
 * **Introduced in**: v3.3.0, v3.4.0, v3.5.0
+
+### k_factor
+
+* **Description**: Multiplies the query `LIMIT` to determine how many vector index candidates each Segment returns. Values greater than `1` can improve recall after candidates from multiple Segments are merged, but increase index, memory, and downstream processing costs. The final candidate count is clamped to at least `1`.
+* **Default**: `1`
+* **Data type**: Double
+* **Scope**: Session
 
 ### lake_bucket_assign_mode
 
@@ -1600,6 +1621,13 @@ Used for compatibility with MySQL JDBC versions 8.0.16 and above. No practical u
   * `never`: Never cache the data.
 * **Default**: auto
 * **Introduced in**: v3.3.2
+
+### pq_refine_factor
+
+* **Description**: Additional candidate multiplier for a vector range search when `enable_vector_index_refine` is enabled. It is applied after `k_factor`. Increasing it can improve recall before exact-distance reranking, but increases index, I/O, and distance-computation costs.
+* **Default**: `1`
+* **Data type**: Double
+* **Scope**: Session
 
 ### query_cache_agg_cardinality_limit
 

--- a/docs/en/table_design/indexes/vector_index.md
+++ b/docs/en/table_design/indexes/vector_index.md
@@ -92,8 +92,9 @@ This tutorial creates vector indexes while creating tables. You can also append 
             "dim"="5", 
             "metric_type" = "l2_distance", 
             "is_vector_normed" = "false", 
-            "nbits" = "16", 
-            "nlist" = "40"
+            "nbits" = "8",
+            "nlist" = "40",
+            "M_IVFPQ" = "1"
         )
     ) ENGINE=OLAP
     DUPLICATE KEY(id)
@@ -136,9 +137,17 @@ This tutorial creates vector indexes while creating tables. You can also append 
 
 ##### index_build_threshold
 
-- **Default**: 10000 (determined by the BE configuration item `config_vector_index_default_build_threshold`)
+- **Default**: 10000 (determined by the BE configuration item [`config_vector_index_default_build_threshold`](../../administration/management/BE_parameters/query_loading.md#config_vector_index_default_build_threshold))
 - **Required**: No
 - **Description**: Row-count threshold that triggers the vector index build. If the number of rows written is smaller than this threshold, the vector index is not built and searches fall back to brute-force scan. It must be an integer greater than or equal to `1`. For IVFPQ indexes, the value must also be greater than or equal to `nlist`, because IVFPQ k-means training requires at least `nlist` vectors. DDL statements that violate this constraint are rejected.
+
+##### index_build_mode
+
+- **Default**: `sync`
+- **Required**: No
+- **Description**: Index build mode for shared-data clusters. Valid values:
+  - `sync`: Builds the index during data writes. Queries can use the index immediately, at the cost of higher load latency.
+  - `async`: Builds the index in the background after the write finishes. Until the build completes, queries over the affected segments automatically fall back to brute-force search. Use [`lake_vector_index_build_warehouse`](../../administration/management/FE_parameters/shared_lake_other.md#lake_vector_index_build_warehouse) to select the build warehouse and [`lake_vi_build_load_tail_delay_ms`](../../administration/management/FE_parameters/shared_lake_other.md#lake_vi_build_load_tail_delay_ms) to control load-tail dispatch delay.
 
 ##### M
 
@@ -175,9 +184,9 @@ This tutorial creates vector indexes while creating tables. You can also append 
 
 ##### nbits
 
-- **Default**: 16
+- **Default**: 8
 - **Required**: No
-- **Description**: IVFPQ-specific parameter. Precision of Product Quantization (PQ).  It must be the multiplier of `8`. With IVFPQ, each vector is divided into multiple subvectors, and then each subvector is quantized. `Nbits` defines the precision of quantization, that is, how many binary digits each subvector is quantized into. The larger the value of `nbits`, the higher the quantization precision, but the higher storage and computation costs.
+- **Description**: IVFPQ-specific parameter. Number of bits used by Product Quantization (PQ). Currently, only `8` is supported.
 
 ##### nlist
 
@@ -187,8 +196,9 @@ This tutorial creates vector indexes while creating tables. You can also append 
 
 ##### M_IVFPQ
 
+- **Default**: N/A
 - **Required**: Yes
-- **Description**: IVFPQ-specific parameter. Number of the subvectors the original vector will be split into. The IVFPQ index will divide a `dim`-dimensional vector into `M_IVFPQ` equal-length subvectors. Therefore, it must be a factor of the value of `dim`.
+- **Description**: IVFPQ-specific parameter. Number of the subvectors the original vector will be split into. The IVFPQ index will divide a `dim`-dimensional vector into `M_IVFPQ` equal-length subvectors. Therefore, it must be a factor of the value of `dim`. The SQL property name is `M_IVFPQ`; `M` is a different, HNSW-only property.
 
 #### Append vector index
 
@@ -204,8 +214,9 @@ USING VECTOR (
     "metric_type" = "l2_distance", 
     "is_vector_normed" = "false",  
     "dim"="5", 
-    "nlist" = "256", 
-    "nbits"="10"
+    "nlist" = "256",
+    "nbits" = "8",
+    "M_IVFPQ" = "1"
 );
 
 ALTER TABLE ivfpq 
@@ -215,8 +226,9 @@ USING VECTOR (
     "metric_type" = "l2_distance", 
     "is_vector_normed" = "false", 
     "dim"="5", 
-    "nlist" = "256", 
-    "nbits"="10"
+    "nlist" = "256",
+    "nbits" = "8",
+    "M_IVFPQ" = "1"
 );
 ```
 
@@ -309,8 +321,9 @@ CREATE TABLE test_hnsw (
         "index_type" = "hnsw",
         "metric_type" = "l2_distance", 
         "is_vector_normed" = "false", 
-        "M" = "512", 
-        "dim"="5")
+        "M" = "512",
+        "dim" = "5",
+        "index_build_threshold" = "1")
 ) ENGINE=OLAP
 DUPLICATE KEY(id)
 DISTRIBUTED BY HASH(id) BUCKETS 1;
@@ -326,10 +339,11 @@ CREATE TABLE test_ivfpq (
         "index_type" = "ivfpq",
         "metric_type" = "l2_distance", 
         "is_vector_normed" = "false", 
-        "nlist" = "256", 
-        "nbits"="8",
-        "dim"="5",
-        "M_IVFPQ"="1")
+        "nlist" = "1",
+        "nbits" = "8",
+        "dim" = "5",
+        "M_IVFPQ" = "1",
+        "index_build_threshold" = "1")
 ) ENGINE=OLAP
 DUPLICATE KEY(id)
 DISTRIBUTED BY HASH(id) BUCKETS 1;
@@ -401,7 +415,7 @@ LIMIT 1;
 
 Parameter tuning is essential in vector search, as it affects both performance and accuracy. It is recommended to tune the search paramters on a small dataset and move to large datasets only when expected recall and latency are achieved.
 
-Search parameters are passed through hints in SQL statements.
+Search parameters are passed through the [`ann_params`](../../sql-reference/System_variable.md#ann_params) session variable or hints in SQL statements.
 
 ##### For HNSW index
 
@@ -409,7 +423,7 @@ Before proceeding, make sure the vector column is built with the HNSW index.
 
 ```SQL
 SELECT 
-    /*+ SET_VAR (ann_params='{efsearch=256}') */ 
+    /*+ SET_VAR (ann_params='{"efsearch":"256"}') */
     id, approx_l2_distance([1,1,1,1,1], vector) 
 FROM test_hnsw 
 WHERE id = 1 
@@ -421,7 +435,7 @@ LIMIT 1;
 
 ###### efsearch
 
-- **Default**: 16
+- **Default**: 40
 - **Required**: No
 - **Description**: Parameter that controls precision-speed tradeoff. During a hierarchical graph structure search, this parameter controls the size of the candidate list during the search. The larger the value of `efsearch`, the higher the accuracy, but the lower the speed.
 
@@ -431,7 +445,7 @@ Before proceeding, make sure the vector column is built with the IVFPQ index.
 
 ```SQL
 SELECT 
-    /*+ SET_VAR (ann_params='{nprobe=256,max_codes=0,scan_table_threshold=0,polysemous_ht=0,range_search_confidence=0.1}') */
+    /*+ SET_VAR (ann_params='{"nprobe":"256","max_codes":"0","scan_table_threshold":"0","polysemous_ht":"0","range_search_confidence":"0.1"}') */
     id, approx_l2_distance([1,1,1,1,1], vector) 
 FROM test_ivfpq 
 ORDER BY approx_l2_distance([1,1,1,1,1], vector) 
@@ -469,6 +483,24 @@ LIMIT 1;
 - **Default**: 0.1
 - **Required**: No
 - **Description**: Confidence of approximate range searches. Value range: [0, 1]. Setting it to `1` produces the most accurate results.
+
+#### Tune candidate count and result refinement
+
+The following session variables control the number of candidates returned by the index and whether StarRocks recomputes their exact distances:
+
+- [`k_factor`](../../sql-reference/System_variable.md#k_factor), default `1`: Multiplies `LIMIT` to determine the number of candidates requested from each segment. A larger value can improve recall after results from multiple segments are merged, but increases CPU, memory, and downstream work.
+- [`enable_vector_index_refine`](../../sql-reference/System_variable.md#enable_vector_index_refine), default `false`: For IVFPQ and HNSW indexes using the `sq4`, `sq8`, or `pq` quantizer, recomputes exact distances from the original vectors and reranks the candidates. It has no effect on unquantized HNSW indexes (`quantizer = flat`).
+- [`pq_refine_factor`](../../sql-reference/System_variable.md#pq_refine_factor), default `1`: For a range search with exact-distance refinement enabled, further multiplies the candidate count after `k_factor` is applied.
+
+For example:
+
+```SQL
+SET enable_vector_index_refine = true;
+SET k_factor = 2;
+SET pq_refine_factor = 2;
+```
+
+Higher candidate multipliers generally improve recall at the cost of more index, I/O, and distance-computation work. Use `EXPLAIN` and check `Refine: ON/OFF` to verify whether exact-distance refinement is active.
 
 #### Calculate approximate recall
 

--- a/docs/ja/administration/management/BE_parameters/query_loading.md
+++ b/docs/ja/administration/management/BE_parameters/query_loading.md
@@ -657,6 +657,105 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 説明: BEプロセスメモリのうち、更新関連のメモリとキャッシュに予約される割合。起動時に `RuntimeEnv` は、更新用の `MemTracker` を process_mem_limit * clamp(update_memory_limit_percent, 0, 100) / 100 として計算します。`UpdateManager` もこの割合を使用して、プライマリインデックス/インデックスキャッシュの容量を決定します（インデックスキャッシュ容量 = RuntimeEnv::process_mem_limit * update_memory_limit_percent / 100）。HTTP設定更新ロジックは、更新マネージャーで `update_primary_index_memory_limit` を呼び出すコールバックを登録するため、設定が変更された場合、更新サブシステムに変更が適用されます。この値を増やすと、更新/プライマリインデックスパスにより多くのメモリが割り当てられ（他のプールで利用可能なメモリが減少します）、減らすと更新メモリとキャッシュ容量が減少します。値は0〜100の範囲にクランプされます。
 - 導入バージョン: v3.2.0
 
+### enable_vector_index_block_cache
+
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: はい
+- 説明: IVFPQ インデックスをインバーテッドリストの Block 単位でキャッシュするかどうかを指定します。有効にすると、StarRocks はクエリに必要な IVFPQ Block のみをロードしてキャッシュします。無効にすると、IVFPQ インデックスファイル全体をキャッシュします。HNSW のキャッシュ方式には影響しません。
+- 導入バージョン: -
+
+### config_vector_index_build_concurrency
+
+- デフォルト: 8
+- タイプ: Int
+- 単位: スレッド
+- 変更可能: はい
+- 説明: 各ベクターインデックス構築で使用する OpenMP スレッド数です。StarRocks は実効値を少なくとも `1` に調整します。`vector_index_build_max_cpu_ratio` とともに、非同期ベクターインデックス構築スレッドプールのサイズも決定します。
+- 導入バージョン: -
+
+### config_vector_index_default_build_threshold
+
+- デフォルト: 10000
+- タイプ: Int
+- 単位: 行
+- 変更可能: はい
+- 説明: ベクターインデックスを構築するために必要な Segment のデフォルト最小行数です。インデックスプロパティ `index_build_threshold` はこの値を上書きします。IVFPQ では、トレーニングに十分な行数を確保するため、実効しきい値は少なくとも `nlist` になります。
+- 導入バージョン: -
+
+### vector_index_build_max_cpu_ratio
+
+- デフォルト: 0.5
+- タイプ: Double
+- 単位: 比率
+- 変更可能: はい
+- 説明: 非同期ベクターインデックス構築で使用できる BE/CN CPU コアの目標比率です。構築 CPU 予算は `max(2, floor(cpu_cores * value))` で、構築プールのサイズはこの予算と `config_vector_index_build_concurrency` から決まります。最小予算が `2` のため、小規模なマシンや小さい比率では実効値が設定比率を超える場合があります。
+- 導入バージョン: -
+
+### enable_vector_adaptive_search
+
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: はい
+- 説明: HNSW ベクターインデックスの適応型 `ef_search` スケーリングを有効にするマスタースイッチです。有効にすると、BE は Segment の行数に基づいて実効 `ef_search` を調整し、Compaction により Segment が大きくなった場合の再現率低下を抑えます。`false` にすると、ユーザーが指定した `ef_search` をそのまま使用します。
+- 導入バージョン: -
+
+### vector_query_cache_capacity
+
+- デフォルト: `20%`
+- タイプ: String
+- 単位: バイト、単位サフィックス（`K`/`M`/`G`/`T`）または BE `mem_limit` に対する割合（`%`）
+- 変更可能: はい
+- 説明: StarRocks が管理するベクターインデックスキャッシュの総容量です。同じ LRU で HNSW のインデックス全体と、`enable_vector_index_block_cache=true` の場合の IVF-PQ のリスト単位 Block を管理します。絶対バイト数（`4294967296`）、単位付きの値（`4G`、`512M`）、または BE プロセスメモリ上限に対する割合（`20%`）を指定できます。BE 起動時と HTTP `/api/update_config` による更新時に適用されます。**v4.2.0 での動作変更：** 以前のバージョンは絶対バイト数のみを受け付け、デフォルトは 512 MB でした。この設定を明示的に上書きせずにアップグレードすると、キャッシュサイズは BE メモリの 20% に変更されます。
+- 導入バージョン: v3.4.0
+
+### vector_adaptive_ef_alpha
+
+- デフォルト: 1.0
+- タイプ: Double
+- 単位: -
+- 変更可能: はい
+- 説明: 適応型 `ef_search` の増加率です。スケーリング係数は `1 + alpha * log2(segment_rows / vector_adaptive_ef_baseline_rows)` です。値を大きくすると再現率をより積極的に高めますが、クエリごとの CPU コストが増加します。`enable_vector_adaptive_search=true` かつ `segment_rows > vector_adaptive_ef_baseline_rows` の場合のみ有効です。
+- 導入バージョン: -
+
+### vector_adaptive_ef_baseline_rows
+
+- デフォルト: 300000
+- タイプ: Int
+- 単位: 行
+- 変更可能: はい
+- 説明: 適応型 `ef_search` を拡大しない Segment 行数の基準値です。この値以下の Segment は指定された `ef_search` を使用し、この値を超える Segment は大きな HNSW グラフを補うため実効 `ef_search` が増加します。`enable_vector_adaptive_search=true` の場合のみ有効です。
+- 導入バージョン: -
+
+### vector_adaptive_ef_cap
+
+- デフォルト: 8.0
+- タイプ: Double
+- 単位: -
+- 変更可能: はい
+- 説明: 適応型 `ef_search` の倍率上限です。非常に大きな Segment でもスケーリング係数をこの値以下に抑え、CPU とレイテンシーの増加を制限します。`enable_vector_adaptive_search=true` の場合のみ有効です。
+- 導入バージョン: -
+
+### vector_index_brute_selectivity_threshold
+
+- デフォルト: 0.01
+- タイプ: Double
+- 単位: 比率
+- 変更可能: はい
+- 説明: 残余スカラーフィルターを持つベクタークエリを、フィルター付き HNSW 探索から正確なスコア計算へ切り替える選択率しきい値です。一致行数が Segment 全体のこの割合以下の場合、StarRocks はフィルター後の候補を直接スコアリングします。`0` に設定すると比率判定を無効にします。候補数がクエリの `k` 以下の場合の独立したショートサーキットは引き続き有効です。
+- 導入バージョン: -
+
+### vector_index_build_flush_threshold_rows
+
+- デフォルト: 262144
+- タイプ: Int
+- 単位: 行
+- 変更可能: はい
+- 説明: 各ベクターインデックスビルダーのステージングバッファが、行をメモリ内インデックスへ追加する前に保持する最大行数です。HNSW Flat 構築時のステージングバッファメモリを制限しますが、トレーニング済みインデックス自体のサイズは制限しません。`0` に設定すると中間 Flush を無効にし、Segment 全体をバッファします。
+- 導入バージョン: -
+
 ### vector_chunk_size
 
 - デフォルト: 4096

--- a/docs/ja/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/management/FE_parameters/shared_lake_other.md
@@ -676,6 +676,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：この項目が `true` に設定されている場合、システムは Lake テーブルが関連トランザクションの結合トランザクションログパスを使用することを許可します。共有データクラスターでのみ利用可能です。
 - 導入時期：v3.3.7, v3.4.0, v3.5.0
 
+### `lake_vector_index_build_warehouse`
+
+- デフォルト：`default_warehouse`
+- タイプ：String
+- 単位：-
+- 変更可能：はい
+- 説明：共有データクラスタで非同期ベクターインデックス構築タスクを実行する Warehouse です。デフォルト以外の Warehouse 名を指定すると、ベクターインデックス構築をクエリおよびロードのワークロードから分離できます。`default_warehouse`、空の値、存在しない Warehouse、または利用できない Warehouse が指定された場合、StarRocks はテーブルに記録されたバックグラウンド Warehouse を使用し、最後にデフォルト Warehouse へフォールバックします。
+- 導入時期：v4.2.0
+
+### `lake_vi_build_load_tail_delay_ms`
+
+- デフォルト：300000
+- タイプ：Long
+- 単位：ミリ秒
+- 変更可能：はい
+- 説明：最新の保留バージョンがロードのみで、保留中の Compaction 生成物を含まない Tablet について、非同期ベクターインデックス構築をディスパッチするまでの遅延時間です。この期間内に新しい Compaction が到着した場合、そのバージョンを末尾とまとめて構築し、間もなく Compaction される Rowset に対する不要な構築を回避します。Compaction 生成物は常に直ちにディスパッチされます。非同期ベクターインデックスを持つ共有データテーブルでのみ有効です。
+- 導入時期：v4.2.0
+
 ### `lake_repair_metadata_fetch_max_version_batch_size`
 
 - デフォルト: 160

--- a/docs/ja/sql-reference/System_variable.md
+++ b/docs/ja/sql-reference/System_variable.md
@@ -189,6 +189,13 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 
 セッションで割り当てられたロールをアクティブにしたい場合は、[SET ROLE](sql-statements/account-management/SET_DEFAULT_ROLE.md) コマンドを使用してください。
 
+### ann_params
+
+* **説明**: 近似最近傍（ANN）ベクターインデックス検索のクエリパラメータを指定します。値は、キーと値がともに文字列である JSON オブジェクト文字列です。HNSW は `efsearch`、IVFPQ は `nprobe`、`max_codes`、`scan_table_threshold`、`polysemous_ht`、`range_search_confidence` をサポートします。セッションまたは単一ステートメントに設定できます。例：`SET ann_params = '{"efsearch":"256"}'` または `SET_VAR (ann_params='{"efsearch":"256"}')`。
+* **デフォルト**: `""`
+* **データ型**: String
+* **スコープ**: Session
+
 ### array_low_cardinality_optimize
 
 * **スコープ**: Session
@@ -956,6 +963,13 @@ StarRocks は 2 種類の RF を提供します：ローカル RF とグロー�
 * **データタイプ**: boolean
 * **導入バージョン**: v3.2.4
 
+### enable_vector_index_refine
+
+* **説明**: 量子化ベクターインデックスが返した候補について、元のベクトルから正確な距離を再計算し、再順位付けするかどうかを指定します。IVFPQ、および `sq4`、`sq8`、`pq` 量子化器を使用する HNSW インデックスに適用されます。量子化されていない HNSW インデックス（`quantizer = flat`）には影響しません。有効にすると結果の精度が向上する可能性がありますが、I/O と計算コストが増加します。`EXPLAIN` の `Refine: ON/OFF` で有効かどうかを確認できます。
+* **デフォルト**: `false`
+* **データ型**: Boolean
+* **スコープ**: Session
+
 ### enable_view_based_mv_rewrite
 
 * **説明**: ビューに基づくマテリアライズドビューのクエリ書き換えを有効にするかどうか。この項目が `true` に設定されている場合、ビューは統一されたノードとして使用され、クエリのパフォーマンスを向上させるために自身に対するクエリを書き換えます。この項目が `false` に設定されている場合、システムはビューに対するクエリを物理テーブルまたはマテリアライズドビューに対するクエリに書き換えます。
@@ -1076,6 +1090,13 @@ MySQL クライアント互換性のために使用されます。実際の用�
 * **デフォルト**: 1
 * **データ型**: Int
 * **導入バージョン**: -
+
+### k_factor
+
+* **説明**: クエリの `LIMIT` にこの値を掛け、各 Segment が返すベクターインデックス候補数を決定します。`1` より大きい値は、複数 Segment の候補をマージした後の再現率を向上させる可能性がありますが、インデックス検索、メモリ、および後続処理のコストが増加します。最終的な候補数は少なくとも `1` に調整されます。
+* **デフォルト**: `1`
+* **データ型**: Double
+* **スコープ**: Session
 
 ### lake_bucket_assign_mode
 
@@ -1318,6 +1339,13 @@ MySQL JDBC バージョン 8.0.16 以降との互換性のために使用され�
   * `never`: データをキャッシュしません。
 * **デフォルト**: auto
 * **導入バージョン**: v3.3.2
+
+### pq_refine_factor
+
+* **説明**: `enable_vector_index_refine` を有効にしたベクター範囲検索で使用する追加の候補倍率です。`k_factor` の後に適用されます。値を大きくすると、正確な距離による再順位付け前の再現率が向上する可能性がありますが、インデックス検索、I/O、および距離計算のコストが増加します。
+* **デフォルト**: `1`
+* **データ型**: Double
+* **スコープ**: Session
 
 ### query_cache_agg_cardinality_limit
 

--- a/docs/ja/table_design/indexes/vector_index.md
+++ b/docs/ja/table_design/indexes/vector_index.md
@@ -92,8 +92,9 @@ ADMIN SET FRONTEND CONFIG ("enable_experimental_vector" = "true");
             "dim"="5", 
             "metric_type" = "l2_distance", 
             "is_vector_normed" = "false", 
-            "nbits" = "16", 
-            "nlist" = "40"
+            "nbits" = "8",
+            "nlist" = "40",
+            "M_IVFPQ" = "1"
         )
     ) ENGINE=OLAP
     DUPLICATE KEY(id)
@@ -136,9 +137,17 @@ ADMIN SET FRONTEND CONFIG ("enable_experimental_vector" = "true");
 
 ##### index_build_threshold
 
-- **デフォルト**: 10000（BE 設定項目 `config_vector_index_default_build_threshold` により決定）
+- **デフォルト**: 10000（BE 設定項目 [`config_vector_index_default_build_threshold`](../../administration/management/BE_parameters/query_loading.md#config_vector_index_default_build_threshold) により決定）
 - **必須**: いいえ
 - **説明**: ベクトルインデックスの構築をトリガーする行数のしきい値。書き込まれた行数がこのしきい値未満の場合、インデックスは構築されず、検索はブルートフォーススキャンにフォールバックします。`1` 以上の整数である必要があります。IVFPQ インデックスの場合、IVFPQ の k-means 学習には少なくとも `nlist` 件のベクトルが必要なため、この値は `nlist` 以上である必要もあります。この制約に違反する DDL 文は拒否されます。
+
+##### index_build_mode
+
+- **デフォルト**: `sync`
+- **必須**: いいえ
+- **説明**: 共有データクラスタでのインデックス構築方式です。有効な値：
+  - `sync`：データ書き込み時に同期してインデックスを構築します。クエリはすぐにインデックスを使用できますが、ロード遅延が増加します。
+  - `async`：書き込み完了後にバックグラウンドでインデックスを構築します。構築が完了するまで、該当 Segment のクエリは自動的にブルートフォース検索へフォールバックします。[`lake_vector_index_build_warehouse`](../../administration/management/FE_parameters/shared_lake_other.md#lake_vector_index_build_warehouse) で構築 Warehouse を選択し、[`lake_vi_build_load_tail_delay_ms`](../../administration/management/FE_parameters/shared_lake_other.md#lake_vi_build_load_tail_delay_ms) でロード末尾のディスパッチ遅延を制御できます。
 
 ##### M
 
@@ -176,9 +185,9 @@ ADMIN SET FRONTEND CONFIG ("enable_experimental_vector" = "true");
 
 ##### nbits
 
-- **デフォルト**: 16
+- **デフォルト**: 8
 - **必須**: いいえ
-- **説明**: IVFPQ 固有のパラメータ。プロダクト量子化 (PQ) の精度。`8` の倍数である必要があります。IVFPQ では、各ベクトルが複数のサブベクトルに分割され、各サブベクトルが量子化されます。`Nbits` は量子化の精度を定義し、各サブベクトルが何ビットに量子化されるかを示します。`nbits` の値が大きいほど、量子化の精度が高くなりますが、ストレージと計算コストも増加します。
+- **説明**: IVFPQ 固有のパラメータ。プロダクト量子化 (PQ) で使用するビット数です。現在は `8` のみサポートされています。
 
 ##### nlist
 
@@ -188,8 +197,9 @@ ADMIN SET FRONTEND CONFIG ("enable_experimental_vector" = "true");
 
 ##### M_IVFPQ
 
+- **デフォルト**: N/A
 - **必須**: はい
-- **説明**: IVFPQ 固有のパラメータ。元のベクトルが分割されるサブベクトルの数。IVFPQ インデックスは、`dim` 次元のベクトルを `M_IVFPQ` 等長のサブベクトルに分割します。したがって、`dim` の値の因数である必要があります。
+- **説明**: IVFPQ 固有のパラメータ。元のベクトルが分割されるサブベクトルの数。IVFPQ インデックスは、`dim` 次元のベクトルを `M_IVFPQ` 個の等長サブベクトルに分割するため、`M_IVFPQ` は `dim` を割り切る必要があります。SQL プロパティ名は `M_IVFPQ` です。`M` は HNSW 専用の別のプロパティです。
 
 #### ベクターインデックスの追加
 
@@ -205,8 +215,9 @@ USING VECTOR (
     "metric_type" = "l2_distance", 
     "is_vector_normed" = "false",  
     "dim"="5", 
-    "nlist" = "256", 
-    "nbits"="10"
+    "nlist" = "256",
+    "nbits" = "8",
+    "M_IVFPQ" = "1"
 );
 
 ALTER TABLE ivfpq 
@@ -216,8 +227,9 @@ USING VECTOR (
     "metric_type" = "l2_distance", 
     "is_vector_normed" = "false", 
     "dim"="5", 
-    "nlist" = "256", 
-    "nbits"="10"
+    "nlist" = "256",
+    "nbits" = "8",
+    "M_IVFPQ" = "1"
 );
 ```
 
@@ -310,8 +322,9 @@ CREATE TABLE test_hnsw (
         "index_type" = "hnsw",
         "metric_type" = "l2_distance", 
         "is_vector_normed" = "false", 
-        "M" = "512", 
-        "dim"="5")
+        "M" = "512",
+        "dim" = "5",
+        "index_build_threshold" = "1")
 ) ENGINE=OLAP
 DUPLICATE KEY(id)
 DISTRIBUTED BY HASH(id) BUCKETS 1;
@@ -327,10 +340,11 @@ CREATE TABLE test_ivfpq (
         "index_type" = "ivfpq",
         "metric_type" = "l2_distance", 
         "is_vector_normed" = "false", 
-        "nlist" = "256", 
-        "nbits"="8",
-        "dim"="5",
-        "M_IVFPQ"="1")
+        "nlist" = "1",
+        "nbits" = "8",
+        "dim" = "5",
+        "M_IVFPQ" = "1",
+        "index_build_threshold" = "1")
 ) ENGINE=OLAP
 DUPLICATE KEY(id)
 DISTRIBUTED BY HASH(id) BUCKETS 1;
@@ -402,7 +416,7 @@ LIMIT 1;
 
 パラメータの調整はベクター検索において重要であり、パフォーマンスと精度の両方に影響を与えます。小さなデータセットで検索パラメータを調整し、期待されるリコールと遅延が達成された場合にのみ大規模なデータセットに移行することをお勧めします。
 
-検索パラメータは SQL ステートメント内のヒントを通じて渡されます。
+検索パラメータは [`ann_params`](../../sql-reference/System_variable.md#ann_params) セッション変数、または SQL ステートメント内のヒントを通じて渡されます。
 
 ##### HNSW インデックスの場合
 
@@ -410,7 +424,7 @@ LIMIT 1;
 
 ```SQL
 SELECT 
-    /*+ SET_VAR (ann_params='{efsearch=256}') */ 
+    /*+ SET_VAR (ann_params='{"efsearch":"256"}') */
     id, approx_l2_distance([1,1,1,1,1], vector) 
 FROM test_hnsw 
 WHERE id = 1 
@@ -422,7 +436,7 @@ LIMIT 1;
 
 ###### efsearch
 
-- **デフォルト**: 16
+- **デフォルト**: 40
 - **必須**: いいえ
 - **説明**: 精度と速度のトレードオフを制御するパラメータ。階層的なグラフ構造の検索中に、このパラメータは検索中の候補リストのサイズを制御します。`efsearch` の値が大きいほど、精度が高くなりますが、速度が低下します。
 
@@ -432,7 +446,7 @@ LIMIT 1;
 
 ```SQL
 SELECT 
-    /*+ SET_VAR (ann_params='{nprobe=256,max_codes=0,scan_table_threshold=0,polysemous_ht=0,range_search_confidence=0.1}') */ 
+    /*+ SET_VAR (ann_params='{"nprobe":"256","max_codes":"0","scan_table_threshold":"0","polysemous_ht":"0","range_search_confidence":"0.1"}') */
     id, approx_l2_distance([1,1,1,1,1], vector) 
 FROM test_ivfpq 
 ORDER BY approx_l2_distance([1,1,1,1,1], vector) 
@@ -470,6 +484,24 @@ LIMIT 1;
 - **デフォルト**: 0.1
 - **必須**: いいえ
 - **説明**: 近似範囲検索の信頼度。値の範囲: [0, 1]。`1` に設定すると、最も正確な結果が得られます。
+
+#### 候補数と結果のリファインを調整する
+
+次のセッション変数は、インデックスが返す候補数と、StarRocks が候補の正確な距離を再計算するかどうかを制御します。
+
+- [`k_factor`](../../sql-reference/System_variable.md#k_factor)、デフォルト `1`：`LIMIT` にこの値を掛け、各 Segment に要求する候補数を決定します。値を大きくすると、複数 Segment の結果をマージした後の再現率が向上する可能性がありますが、CPU、メモリ、および後続処理のコストが増加します。
+- [`enable_vector_index_refine`](../../sql-reference/System_variable.md#enable_vector_index_refine)、デフォルト `false`：IVFPQ、および `sq4`、`sq8`、`pq` 量子化器を使用する HNSW インデックスについて、元のベクトルから正確な距離を再計算し、候補を再順位付けします。量子化されていない HNSW インデックス（`quantizer = flat`）には影響しません。
+- [`pq_refine_factor`](../../sql-reference/System_variable.md#pq_refine_factor)、デフォルト `1`：正確な距離によるリファインを有効にした範囲検索で、`k_factor` の適用後に候補数をさらに増やします。
+
+例：
+
+```SQL
+SET enable_vector_index_refine = true;
+SET k_factor = 2;
+SET pq_refine_factor = 2;
+```
+
+候補倍率を大きくすると一般に再現率は向上しますが、インデックス検索、I/O、および距離計算のコストも増加します。`EXPLAIN` の `Refine: ON/OFF` で、正確な距離によるリファインが有効かどうかを確認できます。
 
 #### 近似リコールの計算
 

--- a/docs/zh/administration/management/BE_parameters/query_loading.md
+++ b/docs/zh/administration/management/BE_parameters/query_loading.md
@@ -671,6 +671,42 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 描述：BE 进程内存中为更新相关内存和缓存保留的比例。在启动期间，`RuntimeEnv` 将更新的 `MemTracker` 计算为 process_mem_limit * clamp(update_memory_limit_percent, 0, 100) / 100。`UpdateManager` 也使用该百分比来确定其 primary-index/index-cache 的容量（index cache capacity = RuntimeEnv::process_mem_limit * update_memory_limit_percent / 100）。HTTP 配置更新逻辑会注册一个回调，在配置更改时调用 update managers 的 `update_primary_index_memory_limit`，因此配置更改会应用到更新子系统。增加此值会为更新/primary-index 路径分配更多内存（减少其他内存池可用内存）；减少它会降低更新内存和缓存容量。值会被限定在 0–100 范围内。
 - 引入版本：v3.2.0
 
+### enable_vector_index_block_cache
+
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：是否按倒排列表 Block 缓存 IVFPQ 索引。开启后，StarRocks 仅加载并缓存查询需要的 IVFPQ Block；关闭后缓存整个 IVFPQ 索引文件。该配置不改变 HNSW 的缓存方式。
+- 引入版本：-
+
+### config_vector_index_build_concurrency
+
+- 默认值：8
+- 类型：Int
+- 单位：线程
+- 是否动态：是
+- 描述：每个向量索引构建任务使用的 OpenMP 线程数。StarRocks 会将实际值限制为至少 `1`。该配置还会与 `vector_index_build_max_cpu_ratio` 一起决定异步向量索引构建线程池的大小。
+- 引入版本：-
+
+### config_vector_index_default_build_threshold
+
+- 默认值：10000
+- 类型：Int
+- 单位：行
+- 是否动态：是
+- 描述：构建向量索引所需的默认 Segment 最小行数。索引属性 `index_build_threshold` 可以覆盖该值。对于 IVFPQ，有效阈值至少为 `nlist`，以确保索引训练有足够的数据。
+- 引入版本：-
+
+### vector_index_build_max_cpu_ratio
+
+- 默认值：0.5
+- 类型：Double
+- 单位：比例
+- 是否动态：是
+- 描述：异步向量索引构建可使用的 BE/CN CPU 核数目标比例。构建 CPU 预算为 `max(2, floor(cpu_cores * value))`，构建线程池大小由该预算和 `config_vector_index_build_concurrency` 共同决定。由于最小预算为 `2`，小规格机器或较小的比例可能使实际值超过配置比例。
+- 引入版本：-
+
 ### enable_vector_adaptive_search
 
 - 默认值：true
@@ -713,6 +749,24 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 单位：-
 - 是否动态：是
 - 描述：自适应 `ef_search` 倍率上限。即使 segment 极大也将放大倍率限制在该上限内，避免 CPU 与延迟在极端情况下失控。仅在 `enable_vector_adaptive_search=true` 时生效。
+- 引入版本：-
+
+### vector_index_brute_selectivity_threshold
+
+- 默认值：0.01
+- 类型：Double
+- 单位：比例
+- 是否动态：是
+- 描述：带残余标量过滤条件的向量查询从过滤式 HNSW 遍历切换为精确计算的选择率阈值。如果匹配行数不超过 Segment 总行数的该比例，StarRocks 会直接对过滤后的候选项计算距离。设置为 `0` 可禁用该比例判断；候选数量不大于查询 `k` 时的独立短路仍然生效。
+- 引入版本：-
+
+### vector_index_build_flush_threshold_rows
+
+- 默认值：262144
+- 类型：Int
+- 单位：行
+- 是否动态：是
+- 描述：每个向量索引构建器的暂存 Buffer 在将数据加入内存索引前最多保留的行数。该配置可以限制构建 HNSW Flat 索引时的暂存 Buffer 内存，但不限制训练后索引本身的大小。设置为 `0` 可禁用中间 Flush，并缓存整个 Segment。
 - 引入版本：-
 
 ### vector_chunk_size

--- a/docs/zh/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/management/FE_parameters/shared_lake_other.md
@@ -663,6 +663,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 当此项设置为 `true` 时，系统允许 Lake 表使用组合事务日志路径进行相关事务。仅适用于存算分离集群。
 - 引入版本: v3.3.7, v3.4.0, v3.5.0
 
+### `lake_vector_index_build_warehouse`
+
+- 默认值：`default_warehouse`
+- 类型：String
+- 单位：-
+- 是否动态：是
+- 描述：存算分离集群中用于执行异步向量索引构建任务的 Warehouse。将该配置设置为非默认 Warehouse 名称，可以隔离向量索引构建与查询、导入负载。如果配置为 `default_warehouse`、空值，或指定的 Warehouse 不存在或不可用，StarRocks 会使用表记录的后台 Warehouse，最后回退到默认 Warehouse。
+- 引入版本：v4.2.0
+
 ### `lake_vi_build_load_tail_delay_ms`
 
 - 默认值：300000

--- a/docs/zh/sql-reference/System_variable.md
+++ b/docs/zh/sql-reference/System_variable.md
@@ -186,6 +186,13 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 
 如果要在当前会话中激活一个角色，可以使用 [SET ROLE](sql-statements/account-management/SET_ROLE.md)。
 
+### ann_params
+
+* **描述**：指定近似最近邻（ANN）向量索引检索的查询参数。取值是键和值均为字符串的 JSON 对象字符串。HNSW 支持 `efsearch`；IVFPQ 支持 `nprobe`、`max_codes`、`scan_table_threshold`、`polysemous_ht` 和 `range_search_confidence`。可以在会话或单条语句中设置，例如 `SET ann_params = '{"efsearch":"256"}'` 或 `SET_VAR (ann_params='{"efsearch":"256"}')`。
+* **默认值**：`""`
+* **数据类型**：String
+* **作用域**：Session
+
 ### array_low_cardinality_optimize
 
 * **作用域**: Session
@@ -978,6 +985,13 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 * **数据类型**: boolean
 * **引入版本**: v3.2.4
 
+### enable_vector_index_refine
+
+* **描述**：是否基于原始向量重新计算量化向量索引返回候选项的精确距离，并重新排序。该变量适用于 IVFPQ 以及使用 `sq4`、`sq8` 或 `pq` 量化器的 HNSW 索引；对未量化的 HNSW 索引（`quantizer = flat`）无效。开启后可以提高结果准确性，但会增加 I/O 和计算开销。可以通过 `EXPLAIN` 中的 `Refine: ON/OFF` 确认是否生效。
+* **默认值**：`false`
+* **数据类型**：Boolean
+* **作用域**：Session
+
 ### enable_view_based_mv_rewrite
 
 * 描述：是否为基于逻辑视图创建的物化视图启用查询改写。如果此项设置为 `true`，则逻辑视图被用作统一节点进行查询改写，从而获得更好的性能。如果此项设置为 `false`，则系统将针对逻辑视图的查询展开变为针对物理表或物化视图的查询，然后进行改写。
@@ -1110,6 +1124,13 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 * 默认值：1
 * 数据类型：Int
 * 引入版本：-
+
+### k_factor
+
+* **描述**：将查询的 `LIMIT` 乘以该值，得到每个 Segment 返回的向量索引候选数量。大于 `1` 的值可以提高多个 Segment 候选结果合并后的召回率，但会增加索引检索、内存和下游处理开销。最终候选数量至少为 `1`。
+* **默认值**：`1`
+* **数据类型**：Double
+* **作用域**：Session
 
 ### lake_bucket_assign_mode
 
@@ -1365,6 +1386,13 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
   * `never` 永不缓存数据。
 * 默认值：auto
 * 引入版本：v3.3.2
+
+### pq_refine_factor
+
+* **描述**：启用 `enable_vector_index_refine` 后，向量范围查询使用的额外候选倍率。该值在 `k_factor` 之后生效。增大该值可以在精确距离重排前提高召回率，但会增加索引检索、I/O 和距离计算开销。
+* **默认值**：`1`
+* **数据类型**：Double
+* **作用域**：Session
 
 ### query_cache_agg_cardinality_limit
 

--- a/docs/zh/table_design/indexes/vector_index.md
+++ b/docs/zh/table_design/indexes/vector_index.md
@@ -92,8 +92,9 @@ ADMIN SET FRONTEND CONFIG ("enable_experimental_vector" = "true");
             "dim"="5", 
             "metric_type" = "l2_distance", 
             "is_vector_normed" = "false", 
-            "nbits" = "16", 
-            "nlist" = "40"
+            "nbits" = "8",
+            "nlist" = "40",
+            "M_IVFPQ" = "1"
         )
     ) ENGINE=OLAP
     DUPLICATE KEY(id)
@@ -136,9 +137,17 @@ ADMIN SET FRONTEND CONFIG ("enable_experimental_vector" = "true");
 
 ##### index_build_threshold
 
-- **默认值**: 10000（由 BE 配置项 `config_vector_index_default_build_threshold` 决定）
+- **默认值**: 10000（由 BE 配置项 [`config_vector_index_default_build_threshold`](../../administration/management/BE_parameters/query_loading.md#config_vector_index_default_build_threshold) 决定）
 - **必需**: 否
 - **描述**: 触发向量索引构建的行数阈值。写入的数据行数低于该阈值时不构建索引，查询回退到暴力检索。取值必须为大于等于 `1` 的整数。对于 IVFPQ 索引，该值还必须大于等于 `nlist`，因为 IVFPQ 的 k-means 训练至少需要 `nlist` 条向量。违反该约束的 DDL 语句会被拒绝。
+
+##### index_build_mode
+
+- **默认值**: `sync`
+- **必需**: 否
+- **描述**: 存算分离集群中的索引构建方式。有效值：
+  - `sync`：在数据写入时同步构建索引。查询可立即使用索引，但导入延迟较高。
+  - `async`：数据写入完成后由后台任务构建索引。在构建完成前，涉及相应 Segment 的查询自动回退到暴力检索。可以通过 [`lake_vector_index_build_warehouse`](../../administration/management/FE_parameters/shared_lake_other.md#lake_vector_index_build_warehouse) 选择构建 Warehouse，并通过 [`lake_vi_build_load_tail_delay_ms`](../../administration/management/FE_parameters/shared_lake_other.md#lake_vi_build_load_tail_delay_ms) 控制 Load Tail 的调度延迟。
 
 ##### M
 
@@ -175,9 +184,9 @@ ADMIN SET FRONTEND CONFIG ("enable_experimental_vector" = "true");
 
 ##### nbits
 
-- **默认值**: 16
+- **默认值**: 8
 - **必需**: 否
-- **描述**: IVFPQ特定参数。乘积量化（PQ）的精度。必须是`8`的倍数。在IVFPQ中，每个向量被分割为多个子向量，然后每个子向量被量化。`Nbits`定义了量化的精度，即每个子向量被量化为多少个二进制位。`nbits`的值越大，量化精度越高，但存储和计算成本也越高。
+- **描述**: IVFPQ 特定参数。乘积量化（PQ）使用的位数，当前仅支持 `8`。
 
 ##### nlist
 
@@ -187,8 +196,9 @@ ADMIN SET FRONTEND CONFIG ("enable_experimental_vector" = "true");
 
 ##### M_IVFPQ
 
+- **默认值**: N/A
 - **必需**: 是
-- **描述**: IVFPQ特定参数。原始向量将被分割成的子向量数量。IVFPQ索引将一个`dim`维向量分割成`M_IVFPQ`个等长的子向量。因此，它必须是`dim`值的因数。
+- **描述**: IVFPQ 特定参数。原始向量将被分割成的子向量数量。IVFPQ 索引将一个 `dim` 维向量分割成 `M_IVFPQ` 个等长的子向量，因此 `M_IVFPQ` 必须能整除 `dim`。SQL 属性名是 `M_IVFPQ`；`M` 是另一个仅适用于 HNSW 的属性。
 
 #### 附加向量索引
 
@@ -204,8 +214,9 @@ USING VECTOR (
     "metric_type" = "l2_distance", 
     "is_vector_normed" = "false",  
     "dim"="5", 
-    "nlist" = "256", 
-    "nbits"="10"
+    "nlist" = "256",
+    "nbits" = "8",
+    "M_IVFPQ" = "1"
 );
 
 ALTER TABLE ivfpq 
@@ -215,8 +226,9 @@ USING VECTOR (
     "metric_type" = "l2_distance", 
     "is_vector_normed" = "false", 
     "dim"="5", 
-    "nlist" = "256", 
-    "nbits"="10"
+    "nlist" = "256",
+    "nbits" = "8",
+    "M_IVFPQ" = "1"
 );
 ```
 
@@ -309,8 +321,9 @@ CREATE TABLE test_hnsw (
         "index_type" = "hnsw",
         "metric_type" = "l2_distance", 
         "is_vector_normed" = "false", 
-        "M" = "512", 
-        "dim"="5")
+        "M" = "512",
+        "dim" = "5",
+        "index_build_threshold" = "1")
 ) ENGINE=OLAP
 DUPLICATE KEY(id)
 DISTRIBUTED BY HASH(id) BUCKETS 1;
@@ -326,10 +339,11 @@ CREATE TABLE test_ivfpq (
         "index_type" = "ivfpq",
         "metric_type" = "l2_distance", 
         "is_vector_normed" = "false", 
-        "nlist" = "256", 
-        "nbits"="8",
-        "dim"="5",
-        "M_IVFPQ"="1")
+        "nlist" = "1",
+        "nbits" = "8",
+        "dim" = "5",
+        "M_IVFPQ" = "1",
+        "index_build_threshold" = "1")
 ) ENGINE=OLAP
 DUPLICATE KEY(id)
 DISTRIBUTED BY HASH(id) BUCKETS 1;
@@ -401,7 +415,7 @@ LIMIT 1;
 
 参数调优在向量搜索中至关重要，因为它影响性能和准确性。建议在小数据集上调优搜索参数，并在达到预期的召回率和延迟后再转向大数据集。
 
-搜索参数通过SQL语句中的提示传递。
+搜索参数可以通过 [`ann_params`](../../sql-reference/System_variable.md#ann_params) 会话变量或 SQL 语句中的 Hint 传递。
 
 ##### 对于HNSW索引
 
@@ -409,7 +423,7 @@ LIMIT 1;
 
 ```SQL
 SELECT 
-    /*+ SET_VAR (ann_params='{efsearch=256}') */ 
+    /*+ SET_VAR (ann_params='{"efsearch":"256"}') */
     id, approx_l2_distance([1,1,1,1,1], vector) 
 FROM test_hnsw 
 WHERE id = 1 
@@ -421,7 +435,7 @@ LIMIT 1;
 
 ###### efsearch
 
-- **默认值**: 16
+- **默认值**: 40
 - **必需**: 否
 - **描述**: 控制精度-速度权衡的参数。在分层图结构搜索中，此参数控制搜索期间候选列表的大小。`efsearch`的值越大，准确性越高，但速度越慢。
 
@@ -431,7 +445,7 @@ LIMIT 1;
 
 ```SQL
 SELECT 
-    /*+ SET_VAR (ann_params='{nprobe=256,max_codes=0,scan_table_threshold=0,polysemous_ht=0,range_search_confidence=0.1}') */ 
+    /*+ SET_VAR (ann_params='{"nprobe":"256","max_codes":"0","scan_table_threshold":"0","polysemous_ht":"0","range_search_confidence":"0.1"}') */
     id, approx_l2_distance([1,1,1,1,1], vector) 
 FROM test_ivfpq 
 ORDER BY approx_l2_distance([1,1,1,1,1], vector) 
@@ -469,6 +483,24 @@ LIMIT 1;
 - **默认值**: 0.1
 - **必需**: 否
 - **描述**: 近似范围搜索的置信度。值范围：[0, 1]。将其设置为`1`可产生最准确的结果。
+
+#### 调整候选数量和结果精排
+
+以下会话变量控制索引返回的候选数量，以及 StarRocks 是否重新计算候选项的精确距离：
+
+- [`k_factor`](../../sql-reference/System_variable.md#k_factor)，默认值为 `1`：将 `LIMIT` 乘以该值，得到每个 Segment 请求的候选数量。增大该值可以提高多个 Segment 合并结果后的召回率，但会增加 CPU、内存和下游处理开销。
+- [`enable_vector_index_refine`](../../sql-reference/System_variable.md#enable_vector_index_refine)，默认值为 `false`：对于 IVFPQ 以及使用 `sq4`、`sq8` 或 `pq` 量化器的 HNSW 索引，基于原始向量重新计算精确距离并对候选项重排。该变量对未量化的 HNSW 索引（`quantizer = flat`）无效。
+- [`pq_refine_factor`](../../sql-reference/System_variable.md#pq_refine_factor)，默认值为 `1`：在启用精确距离精排的范围查询中，在 `k_factor` 的基础上进一步放大候选数量。
+
+例如：
+
+```SQL
+SET enable_vector_index_refine = true;
+SET k_factor = 2;
+SET pq_refine_factor = 2;
+```
+
+候选倍率越大，通常召回率越高，但索引检索、I/O 和距离计算开销也越大。可以通过 `EXPLAIN` 中的 `Refine: ON/OFF` 确认是否启用了精确距离精排。
 
 #### 计算近似召回率
 


### PR DESCRIPTION
## Why I'm doing:

The vector index implementation exposes DDL, search, session, BE, and FE parameters that were missing from the documentation or only partially documented. Some existing defaults and SQL examples were also inconsistent with the current validation and BE behavior.

## What I'm doing:

- Synchronize the vector index documentation in English, Chinese, and Japanese.
- Document `index_build_mode`, asynchronous build controls, candidate expansion, and exact-distance refinement.
- Add reference entries for all four vector search session variables, all 11 vector-index-specific BE configurations, and the two asynchronous-build FE configurations.
- Clarify that IVFPQ requires the SQL property `M_IVFPQ`, while `M` is HNSW-only.
- Correct the IVFPQ `nbits` default and constraint, the HNSW `efsearch` default, `ann_params` JSON syntax, and invalid IVFPQ examples.

Validation:

```text
git diff --check
parameter-to-document coverage check: 20 DDL/search parameters, 4 session variables, 11 BE configurations, and 2 FE configurations in each language
DISABLE_VERSIONING=true npm run build (English, Chinese, and Japanese)
rendered-page checks for all modified reference pages in all three locales
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.2
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5