### PR TITLE
[BugFix] Keep storage-filled __ROW_ID__ out of the MV DDL column list

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -916,18 +916,23 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     }
 
     /**
-     * Backtick-quoted schema columns in <strong>query projection order</strong>, excluding
-     * columns the storage engine fills in itself (AUTO_INCREMENT / generated). Sort-key
-     * reorder may permute schema order; the INSERT column list must still match the query's
-     * SELECT order so values line up correctly.
+     * Schema columns in <strong>query projection order</strong>, excluding columns the storage
+     * engine fills in itself (AUTO_INCREMENT / generated). Sort-key reorder may permute schema
+     * order; a column list paired with the defined query must follow the query's SELECT order
+     * so values line up correctly.
      */
-    private String queryProducedColumnList() {
+    private List<Column> queryProducedColumns() {
         // getOrderedOutputColumns(true) returns query-output-order columns, already excluding
         // generated (via baseSchemaWithoutGeneratedColumn) and AUTO_INCREMENT columns (which
         // are marked NO_QUERY_OUTPUT in queryOutputIndices). Defensive !isAutoIncrement
         // filter covers the identity-queryOutputIndices edge case.
         return getOrderedOutputColumns(true).stream()
                 .filter(col -> !col.isAutoIncrement())
+                .collect(Collectors.toList());
+    }
+
+    private String queryProducedColumnList() {
+        return queryProducedColumns().stream()
                 .map(col -> "`" + col.getName() + "`")
                 .collect(Collectors.joining(", "));
     }
@@ -1959,19 +1964,11 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         sb.append("CREATE MATERIALIZED VIEW `").append(getName()).append("` (");
         List<String> colDef = Lists.newArrayList();
 
-        // NOTE: only output non-generated columns.
-        // Start with query-output order (preserves user's ORDER BY reorder effect), then
-        // append schema columns not produced by the query (e.g. AUTO_INCREMENT __ROW_ID__
-        // on non-aggregate IVM). Match the pre-existing behavior of showing hidden columns
-        // like __ROW_ID__ / __AGG_STATE__ in the DDL.
-        List<Column> orderedColumns = new ArrayList<>(getOrderedOutputColumns(true));
-        Set<String> alreadyIncluded = orderedColumns.stream()
-                .map(Column::getName)
-                .collect(Collectors.toSet());
-        getBaseSchemaWithoutGeneratedColumn().stream()
-                .filter(col -> !alreadyIncluded.contains(col.getName()))
-                .forEach(orderedColumns::add);
-        for (Column column : orderedColumns) {
+        // NOTE: only output non-generated columns, in query-output order.
+        // ALTER ... ACTIVE re-analyzes this DDL, and the analyzer requires one listed column per
+        // query output field, then re-appends storage-filled ones (AUTO_INCREMENT __ROW_ID__ on
+        // non-aggregate IVM) itself — listing those here breaks the round trip.
+        for (Column column : queryProducedColumns()) {
             StringBuilder colSb = new StringBuilder();
             // Since mv supports complex expressions as the output column, add `` to support to replay it.
             colSb.append("`" + column.getName() + "`");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -604,8 +604,17 @@ public class MaterializedViewAnalyzer {
                 if (colWithComments.size() != relationFields.size()) {
                     ErrorReport.reportSemanticException(ErrorCode.ERR_VIEW_WRONG_LIST);
                 }
-                for (ColWithComment colWithComment : colWithComments) {
-                    FeNameFormat.checkColumnName(colWithComment.getColName());
+                for (int i = 0; i < colWithComments.size(); ++i) {
+                    String colName = colWithComments.get(i).getColName();
+                    // An IVM MV's re-parsed DDL lists the internal columns this analyzer generated
+                    // (__ROW_ID__, __AGG_STATE_*), whose names may hold characters a user-typed name
+                    // may not -- e.g. __AGG_STATE_count(*). Exempt only a name identical to the one
+                    // generated for that position, so a user-authored name is still checked.
+                    if (rowIdStrategy != null && IvmOpUtils.isIvmInternalColumn(colName)
+                            && colName.equals(columnNames.get(i))) {
+                        continue;
+                    }
+                    FeNameFormat.checkColumnName(colName);
                 }
             }
             List<Column> mvColumns = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/common/IvmOpUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/common/IvmOpUtils.java
@@ -66,6 +66,11 @@ public class IvmOpUtils {
     private IvmOpUtils() {
     }
 
+    /** Columns IVM derives for itself, as opposed to the ones the user's projection asks for. */
+    public static boolean isIvmInternalColumn(String columnName) {
+        return COLUMN_ROW_ID.equalsIgnoreCase(columnName) || columnName.startsWith(COLUMN_AGG_STATE_PREFIX);
+    }
+
     public static String getIvmAggStateColumnName(FunctionCallExpr functionCallExpr) {
         // agg_state column name is like __AGG_STATE_<agg_func_name>
         String exprFuncName = AstToStringBuilder.getAliasName(functionCallExpr, false, false);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -860,6 +861,30 @@ public class IVMAnalyzerTest extends MVIVMIcebergTestBase {
     }
 
     /**
+     * Column identity across an ACTIVE round trip: a positional mis-bind of the DDL column list
+     * would rename columns without changing their count.
+     */
+    private static String schemaFingerprint(MaterializedView mv) {
+        return mv.getBaseSchema().stream()
+                .map(col -> String.format("%s|%s|key=%s|agg=%s|hidden=%s|auto=%s|null=%s",
+                        col.getName(), col.getType().toSql(), col.isKey(), col.getAggregationType(),
+                        col.isHidden(), col.isAutoIncrement(), col.isAllowNull()))
+                .collect(Collectors.joining("\n"));
+    }
+
+    private void assertActiveRoundTripKeepsSchema(String mvName) throws Exception {
+        MaterializedView mv = getMv("test", mvName);
+        String before = schemaFingerprint(mv);
+
+        starRocksAssert.ddl("ALTER MATERIALIZED VIEW " + mvName + " INACTIVE");
+        assertFalse(mv.isActive());
+        starRocksAssert.ddl("ALTER MATERIALIZED VIEW " + mvName + " ACTIVE");
+        assertTrue(mv.isActive(), "inactive reason: " + mv.getInactiveReason());
+
+        assertEquals(before, schemaFingerprint(getMv("test", mvName)));
+    }
+
+    /**
      * The DDL rendered by {@code SHOW CREATE MATERIALIZED VIEW} is re-analyzed by
      * {@code ALTER MATERIALIZED VIEW ... ACTIVE}, so its column list must pair with the
      * defined query: no AUTO_INCREMENT {@code __ROW_ID__}, which the analyzer re-appends.
@@ -871,17 +896,13 @@ public class IVMAnalyzerTest extends MVIVMIcebergTestBase {
                 + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
                 + "AS SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0`";
         starRocksAssert.withMaterializedView(ddl, () -> {
-            MaterializedView mv = getMv("test", "mv_active_nonagg");
-            String createSql = mv.getMaterializedViewDdlStmt(false);
+            String createSql = getMv("test", "mv_active_nonagg").getMaterializedViewDdlStmt(false);
             assertTrue(createSql.contains("(`id`, `data`, `date`)"),
                     "AUTO_INCREMENT __ROW_ID__ must NOT be in the DDL column list, got: " + createSql);
 
-            starRocksAssert.ddl("ALTER MATERIALIZED VIEW mv_active_nonagg INACTIVE");
-            assertFalse(mv.isActive());
-            starRocksAssert.ddl("ALTER MATERIALIZED VIEW mv_active_nonagg ACTIVE");
-            assertTrue(mv.isActive(), "inactive reason: " + mv.getInactiveReason());
+            assertActiveRoundTripKeepsSchema("mv_active_nonagg");
 
-            Column rowIdCol = mv.getColumn(IvmOpUtils.COLUMN_ROW_ID);
+            Column rowIdCol = getMv("test", "mv_active_nonagg").getColumn(IvmOpUtils.COLUMN_ROW_ID);
             assertNotNull(rowIdCol, "__ROW_ID__ must survive the active round trip");
             assertTrue(rowIdCol.isAutoIncrement());
         });
@@ -895,33 +916,66 @@ public class IVMAnalyzerTest extends MVIVMIcebergTestBase {
                 + "PARTITION BY date "
                 + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
                 + "AS SELECT id, data, date FROM `iceberg0`.`partitioned_db`.`t2` WHERE id > 1";
-        starRocksAssert.withMaterializedView(ddl, () -> {
-            MaterializedView mv = getMv("test", "mv_active_nonagg_part");
-            starRocksAssert.ddl("ALTER MATERIALIZED VIEW mv_active_nonagg_part INACTIVE");
-            starRocksAssert.ddl("ALTER MATERIALIZED VIEW mv_active_nonagg_part ACTIVE");
-            assertTrue(mv.isActive(), "inactive reason: " + mv.getInactiveReason());
-        });
+        starRocksAssert.withMaterializedView(ddl, () ->
+                assertActiveRoundTripKeepsSchema("mv_active_nonagg_part"));
     }
 
     /**
      * An aggregate MV's {@code __ROW_ID__} and {@code __AGG_STATE_*} columns are produced by the
-     * rewritten query, so they stay in the DDL column list and the analyzer regenerates them.
+     * rewritten query, so they stay in the DDL column list and the analyzer regenerates them --
+     * in the same order, or the positional bind would swap column names.
      */
     @Test
     public void testAlterActiveRoundTripForQueryComputedRowId() throws Exception {
         String ddl = "CREATE MATERIALIZED VIEW mv_active_agg "
-                + "REFRESH DEFERRED MANUAL "
+                + "REFRESH DEFERRED MANUAL ORDER BY (id) "
                 + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
-                + "AS SELECT id, SUM(c1) AS s FROM `iceberg0`.`unpartitioned_db`.`t_numeric` GROUP BY id";
+                + "AS SELECT SUM(c2) AS s2, c1, id, MAX(c1) AS mx "
+                + "FROM `iceberg0`.`unpartitioned_db`.`t_numeric` GROUP BY id, c1";
         starRocksAssert.withMaterializedView(ddl, () -> {
-            MaterializedView mv = getMv("test", "mv_active_agg");
-            String createSql = mv.getMaterializedViewDdlStmt(false);
+            String createSql = getMv("test", "mv_active_agg").getMaterializedViewDdlStmt(false);
             assertTrue(createSql.contains("`" + IvmOpUtils.COLUMN_ROW_ID + "`"),
                     "QUERY_COMPUTED __ROW_ID__ must stay in the DDL column list, got: " + createSql);
 
-            starRocksAssert.ddl("ALTER MATERIALIZED VIEW mv_active_agg INACTIVE");
-            starRocksAssert.ddl("ALTER MATERIALIZED VIEW mv_active_agg ACTIVE");
-            assertTrue(mv.isActive(), "inactive reason: " + mv.getInactiveReason());
+            assertActiveRoundTripKeepsSchema("mv_active_agg");
+        });
+    }
+
+    /**
+     * The exemption above is positional, not prefix-based: a user-authored name that merely
+     * looks like a state column stays subject to the normal column-name rules -- otherwise it
+     * would smuggle in forbidden characters and become a hidden column.
+     */
+    @Test
+    public void testUserAuthoredStateLikeColumnNameStillRejected() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW mv_fake_state_name (`a`, `__AGG_STATE_bad=x`, `c`, `d`) "
+                + "REFRESH DEFERRED MANUAL PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT id, SUM(c1) FROM `iceberg0`.`unpartitioned_db`.`t_numeric` GROUP BY id";
+        CreateMaterializedViewStatement stmt = parseMvDdl(ddl);
+        Exception ex = assertThrows(Exception.class, () -> Analyzer.analyze(stmt, connectContext),
+                "a user-authored __AGG_STATE_* name must still be format-checked");
+        assertTrue(ex.getMessage().contains("Incorrect column name '__AGG_STATE_bad=x'"),
+                "error must name the rejected column, got: " + ex.getMessage());
+    }
+
+    /**
+     * {@code count(*)} names its state column {@code __AGG_STATE_count(*)}, which
+     * {@link com.starrocks.sql.analyzer.FeNameFormat} rejects for a user-authored column in
+     * shared-nothing mode. Re-analysis must not apply that check to IVM's own columns.
+     */
+    @Test
+    public void testAlterActiveRoundTripForStateColumnWithIllegalUserName() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW mv_active_agg_count_star "
+                + "REFRESH DEFERRED MANUAL "
+                + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT id, SUM(c1) AS s, COUNT(*) AS c "
+                + "FROM `iceberg0`.`unpartitioned_db`.`t_numeric` GROUP BY id";
+        starRocksAssert.withMaterializedView(ddl, () -> {
+            String createSql = getMv("test", "mv_active_agg_count_star").getMaterializedViewDdlStmt(false);
+            assertTrue(createSql.contains("`__AGG_STATE_count(*)`"),
+                    "expected the count(*) state column in the DDL column list, got: " + createSql);
+
+            assertActiveRoundTripKeepsSchema("mv_active_agg_count_star");
         });
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
@@ -860,6 +860,72 @@ public class IVMAnalyzerTest extends MVIVMIcebergTestBase {
     }
 
     /**
+     * The DDL rendered by {@code SHOW CREATE MATERIALIZED VIEW} is re-analyzed by
+     * {@code ALTER MATERIALIZED VIEW ... ACTIVE}, so its column list must pair with the
+     * defined query: no AUTO_INCREMENT {@code __ROW_ID__}, which the analyzer re-appends.
+     */
+    @Test
+    public void testAlterActiveRoundTripForAutoIncrementRowId() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW mv_active_nonagg "
+                + "REFRESH DEFERRED MANUAL "
+                + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT id, data, date FROM `iceberg0`.`unpartitioned_db`.`t0`";
+        starRocksAssert.withMaterializedView(ddl, () -> {
+            MaterializedView mv = getMv("test", "mv_active_nonagg");
+            String createSql = mv.getMaterializedViewDdlStmt(false);
+            assertTrue(createSql.contains("(`id`, `data`, `date`)"),
+                    "AUTO_INCREMENT __ROW_ID__ must NOT be in the DDL column list, got: " + createSql);
+
+            starRocksAssert.ddl("ALTER MATERIALIZED VIEW mv_active_nonagg INACTIVE");
+            assertFalse(mv.isActive());
+            starRocksAssert.ddl("ALTER MATERIALIZED VIEW mv_active_nonagg ACTIVE");
+            assertTrue(mv.isActive(), "inactive reason: " + mv.getInactiveReason());
+
+            Column rowIdCol = mv.getColumn(IvmOpUtils.COLUMN_ROW_ID);
+            assertNotNull(rowIdCol, "__ROW_ID__ must survive the active round trip");
+            assertTrue(rowIdCol.isAutoIncrement());
+        });
+    }
+
+    /** Same round trip with a partition column, which adds a PARTITION BY clause to the DDL. */
+    @Test
+    public void testAlterActiveRoundTripForPartitionedAutoIncrementRowId() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW mv_active_nonagg_part "
+                + "REFRESH DEFERRED MANUAL "
+                + "PARTITION BY date "
+                + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT id, data, date FROM `iceberg0`.`partitioned_db`.`t2` WHERE id > 1";
+        starRocksAssert.withMaterializedView(ddl, () -> {
+            MaterializedView mv = getMv("test", "mv_active_nonagg_part");
+            starRocksAssert.ddl("ALTER MATERIALIZED VIEW mv_active_nonagg_part INACTIVE");
+            starRocksAssert.ddl("ALTER MATERIALIZED VIEW mv_active_nonagg_part ACTIVE");
+            assertTrue(mv.isActive(), "inactive reason: " + mv.getInactiveReason());
+        });
+    }
+
+    /**
+     * An aggregate MV's {@code __ROW_ID__} and {@code __AGG_STATE_*} columns are produced by the
+     * rewritten query, so they stay in the DDL column list and the analyzer regenerates them.
+     */
+    @Test
+    public void testAlterActiveRoundTripForQueryComputedRowId() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW mv_active_agg "
+                + "REFRESH DEFERRED MANUAL "
+                + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT id, SUM(c1) AS s FROM `iceberg0`.`unpartitioned_db`.`t_numeric` GROUP BY id";
+        starRocksAssert.withMaterializedView(ddl, () -> {
+            MaterializedView mv = getMv("test", "mv_active_agg");
+            String createSql = mv.getMaterializedViewDdlStmt(false);
+            assertTrue(createSql.contains("`" + IvmOpUtils.COLUMN_ROW_ID + "`"),
+                    "QUERY_COMPUTED __ROW_ID__ must stay in the DDL column list, got: " + createSql);
+
+            starRocksAssert.ddl("ALTER MATERIALIZED VIEW mv_active_agg INACTIVE");
+            starRocksAssert.ddl("ALTER MATERIALIZED VIEW mv_active_agg ACTIVE");
+            assertTrue(mv.isActive(), "inactive reason: " + mv.getInactiveReason());
+        });
+    }
+
+    /**
      * Aggregate incremental MV (QUERY_COMPUTED): the INSERT uses positional form because the
      * schema has no AUTO_INCREMENT columns (contrast the non-agg case, which needs an explicit
      * column list to omit the storage-filled __ROW_ID__).

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_alter_active_round_trip
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_alter_active_round_trip
@@ -30,6 +30,15 @@ insert into t1 values
   ('c', 3, '2023-12-03');
 -- result:
 -- !result
+create table t2 (
+  col_int int,
+  tag string
+);
+-- result:
+-- !result
+insert into t2 values (1, 'x'), (2, 'y'), (3, 'z'), (4, 'w');
+-- result:
+-- !result
 set catalog default_catalog;
 -- result:
 -- !result
@@ -42,7 +51,82 @@ use db_${uuid0};
 set enable_materialized_view_rewrite = false;
 -- result:
 -- !result
-CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+CREATE MATERIALIZED VIEW test_pct_scan PARTITION BY dt
+REFRESH DEFERRED MANUAL
+AS SELECT col_str, col_int, dt FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE col_int > 1;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_pct_scan WITH SYNC MODE;
+SELECT col_str, col_int, dt FROM test_pct_scan ORDER BY col_int;
+-- result:
+b	2	2023-12-02
+c	3	2023-12-03
+-- !result
+ALTER MATERIALIZED VIEW test_pct_scan INACTIVE;
+-- result:
+-- !result
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_pct_scan';
+-- result:
+false
+-- !result
+ALTER MATERIALIZED VIEW test_pct_scan ACTIVE;
+-- result:
+-- !result
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_pct_scan';
+-- result:
+true	
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('d', 4, '2023-12-04');
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_pct_scan WITH SYNC MODE;
+SELECT col_str, col_int, dt FROM test_pct_scan ORDER BY col_int;
+-- result:
+b	2	2023-12-02
+c	3	2023-12-03
+d	4	2023-12-04
+-- !result
+drop materialized view test_pct_scan;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_pct_agg
+REFRESH DEFERRED MANUAL
+AS SELECT dt, SUM(col_int) AS s, COUNT(*) AS c FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_pct_agg WITH SYNC MODE;
+SELECT dt, s, c FROM test_pct_agg ORDER BY dt;
+-- result:
+2023-12-01	1	1
+2023-12-02	2	1
+2023-12-03	3	1
+2023-12-04	4	1
+-- !result
+ALTER MATERIALIZED VIEW test_pct_agg INACTIVE;
+-- result:
+-- !result
+ALTER MATERIALIZED VIEW test_pct_agg ACTIVE;
+-- result:
+-- !result
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_pct_agg';
+-- result:
+true	
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('e', 5, '2023-12-04');
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_pct_agg WITH SYNC MODE;
+SELECT dt, s, c FROM test_pct_agg ORDER BY dt;
+-- result:
+2023-12-01	1	1
+2023-12-02	2	1
+2023-12-03	3	1
+2023-12-04	9	2
+-- !result
+drop materialized view test_pct_agg;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_ivm_scan PARTITION BY dt
 REFRESH DEFERRED MANUAL
 properties
 (
@@ -51,85 +135,143 @@ properties
 AS SELECT col_str, col_int, dt FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE col_int > 1;
 -- result:
 -- !result
-REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
-SELECT col_str, col_int, dt FROM test_mv1 ORDER BY col_int;
--- result:
-b	2	2023-12-02
-c	3	2023-12-03
--- !result
-ALTER MATERIALIZED VIEW test_mv1 INACTIVE;
--- result:
--- !result
-SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_mv1';
--- result:
-false
--- !result
-ALTER MATERIALIZED VIEW test_mv1 ACTIVE;
--- result:
--- !result
-SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_mv1';
--- result:
-true	
--- !result
-insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('d', 4, '2023-12-04');
--- result:
--- !result
-REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
-SELECT col_str, col_int, dt FROM test_mv1 ORDER BY col_int;
+REFRESH MATERIALIZED VIEW test_ivm_scan WITH SYNC MODE;
+SELECT col_str, col_int, dt FROM test_ivm_scan ORDER BY col_int;
 -- result:
 b	2	2023-12-02
 c	3	2023-12-03
 d	4	2023-12-04
+e	5	2023-12-04
 -- !result
-drop materialized view test_mv1;
+ALTER MATERIALIZED VIEW test_ivm_scan INACTIVE;
 -- result:
 -- !result
-CREATE MATERIALIZED VIEW test_mv2
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_ivm_scan';
+-- result:
+false
+-- !result
+ALTER MATERIALIZED VIEW test_ivm_scan ACTIVE;
+-- result:
+-- !result
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_ivm_scan';
+-- result:
+true	
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('f', 6, '2023-12-05');
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_ivm_scan WITH SYNC MODE;
+SELECT col_str, col_int, dt FROM test_ivm_scan ORDER BY col_int;
+-- result:
+b	2	2023-12-02
+c	3	2023-12-03
+d	4	2023-12-04
+e	5	2023-12-04
+f	6	2023-12-05
+-- !result
+drop materialized view test_ivm_scan;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_ivm_agg
 REFRESH DEFERRED MANUAL
 properties
 (
     "refresh_mode" = "incremental"
 )
-AS SELECT dt, SUM(col_int) AS s, COUNT(*) AS c FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;
+AS SELECT dt, SUM(col_int) AS s, COUNT(*) AS c, MAX(col_str) AS mx
+   FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;
 -- result:
 -- !result
-REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
-SELECT dt, s, c FROM test_mv2 ORDER BY dt;
+REFRESH MATERIALIZED VIEW test_ivm_agg WITH SYNC MODE;
+SELECT dt, s, c, mx FROM test_ivm_agg ORDER BY dt;
 -- result:
-2023-12-01	1	1
-2023-12-02	2	1
-2023-12-03	3	1
-2023-12-04	4	1
+2023-12-01	1	1	a
+2023-12-02	2	1	b
+2023-12-03	3	1	c
+2023-12-04	9	2	e
+2023-12-05	6	1	f
 -- !result
-ALTER MATERIALIZED VIEW test_mv2 INACTIVE;
+ALTER MATERIALIZED VIEW test_ivm_agg INACTIVE;
 -- result:
 -- !result
-SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_mv2';
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_ivm_agg';
 -- result:
 false
 -- !result
-ALTER MATERIALIZED VIEW test_mv2 ACTIVE;
+ALTER MATERIALIZED VIEW test_ivm_agg ACTIVE;
 -- result:
 -- !result
-SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_mv2';
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_ivm_agg';
 -- result:
 true	
 -- !result
-insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('e', 5, '2023-12-04');
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('g', 7, '2023-12-05');
 -- result:
 -- !result
-REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
-SELECT dt, s, c FROM test_mv2 ORDER BY dt;
+REFRESH MATERIALIZED VIEW test_ivm_agg WITH SYNC MODE;
+SELECT dt, s, c, mx FROM test_ivm_agg ORDER BY dt;
 -- result:
-2023-12-01	1	1
-2023-12-02	2	1
-2023-12-03	3	1
-2023-12-04	9	2
+2023-12-01	1	1	a
+2023-12-02	2	1	b
+2023-12-03	3	1	c
+2023-12-04	9	2	e
+2023-12-05	13	2	g
 -- !result
-drop materialized view test_mv2;
+drop materialized view test_ivm_agg;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_ivm_join
+REFRESH DEFERRED MANUAL
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS SELECT t1.col_str, t1.col_int, t2.tag
+   FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 t1
+   JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 t2 ON t1.col_int = t2.col_int;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_ivm_join WITH SYNC MODE;
+SELECT col_str, col_int, tag FROM test_ivm_join ORDER BY col_int;
+-- result:
+a	1	x
+b	2	y
+c	3	z
+d	4	w
+-- !result
+ALTER MATERIALIZED VIEW test_ivm_join INACTIVE;
+-- result:
+-- !result
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_ivm_join';
+-- result:
+false
+-- !result
+ALTER MATERIALIZED VIEW test_ivm_join ACTIVE;
+-- result:
+-- !result
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_ivm_join';
+-- result:
+true	
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 values (6, 'v');
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_ivm_join WITH SYNC MODE;
+SELECT col_str, col_int, tag FROM test_ivm_join ORDER BY col_int;
+-- result:
+a	1	x
+b	2	y
+c	3	z
+d	4	w
+f	6	v
+-- !result
+drop materialized view test_ivm_join;
 -- result:
 -- !result
 drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 force;
 -- result:
 -- !result
 drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_alter_active_round_trip
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_alter_active_round_trip
@@ -1,0 +1,143 @@
+-- name: test_ivm_alter_active_round_trip
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_ice_db_${uuid0};
+-- result:
+-- !result
+use mv_ice_db_${uuid0};
+-- result:
+-- !result
+create table t1 (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt);
+-- result:
+-- !result
+insert into t1 values
+  ('a', 1, '2023-12-01'),
+  ('b', 2, '2023-12-02'),
+  ('c', 3, '2023-12-03');
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+set enable_materialized_view_rewrite = false;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS SELECT col_str, col_int, dt FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE col_int > 1;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT col_str, col_int, dt FROM test_mv1 ORDER BY col_int;
+-- result:
+b	2	2023-12-02
+c	3	2023-12-03
+-- !result
+ALTER MATERIALIZED VIEW test_mv1 INACTIVE;
+-- result:
+-- !result
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_mv1';
+-- result:
+false
+-- !result
+ALTER MATERIALIZED VIEW test_mv1 ACTIVE;
+-- result:
+-- !result
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_mv1';
+-- result:
+true	
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('d', 4, '2023-12-04');
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT col_str, col_int, dt FROM test_mv1 ORDER BY col_int;
+-- result:
+b	2	2023-12-02
+c	3	2023-12-03
+d	4	2023-12-04
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv2
+REFRESH DEFERRED MANUAL
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS SELECT dt, SUM(col_int) AS s, COUNT(*) AS c FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+SELECT dt, s, c FROM test_mv2 ORDER BY dt;
+-- result:
+2023-12-01	1	1
+2023-12-02	2	1
+2023-12-03	3	1
+2023-12-04	4	1
+-- !result
+ALTER MATERIALIZED VIEW test_mv2 INACTIVE;
+-- result:
+-- !result
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_mv2';
+-- result:
+false
+-- !result
+ALTER MATERIALIZED VIEW test_mv2 ACTIVE;
+-- result:
+-- !result
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_mv2';
+-- result:
+true	
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('e', 5, '2023-12-04');
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+SELECT dt, s, c FROM test_mv2 ORDER BY dt;
+-- result:
+2023-12-01	1	1
+2023-12-02	2	1
+2023-12-03	3	1
+2023-12-04	9	2
+-- !result
+drop materialized view test_mv2;
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+-- result:
+-- !result
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+-- result:
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result
+drop catalog mv_iceberg_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_alter_active_round_trip
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_alter_active_round_trip
@@ -18,6 +18,11 @@ insert into t1 values
   ('a', 1, '2023-12-01'),
   ('b', 2, '2023-12-02'),
   ('c', 3, '2023-12-03');
+create table t2 (
+  col_int int,
+  tag string
+);
+insert into t2 values (1, 'x'), (2, 'y'), (3, 'z'), (4, 'w');
 
 set catalog default_catalog;
 create database db_${uuid0};
@@ -25,55 +30,110 @@ use db_${uuid0};
 set enable_materialized_view_rewrite = false;
 
 -- ==============================================================
--- Case 1: non-aggregate IVM MV, whose __ROW_ID__ is AUTO_INCREMENT and
--- therefore absent from the defined query
+-- Case 1: PCT MV, partitioned projection. Control group: PCT has no __ROW_ID__,
+-- so the round trip must behave exactly as before.
 -- ==============================================================
-CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+CREATE MATERIALIZED VIEW test_pct_scan PARTITION BY dt
+REFRESH DEFERRED MANUAL
+AS SELECT col_str, col_int, dt FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE col_int > 1;
+REFRESH MATERIALIZED VIEW test_pct_scan WITH SYNC MODE;
+SELECT col_str, col_int, dt FROM test_pct_scan ORDER BY col_int;
+ALTER MATERIALIZED VIEW test_pct_scan INACTIVE;
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_pct_scan';
+ALTER MATERIALIZED VIEW test_pct_scan ACTIVE;
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_pct_scan';
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('d', 4, '2023-12-04');
+REFRESH MATERIALIZED VIEW test_pct_scan WITH SYNC MODE;
+SELECT col_str, col_int, dt FROM test_pct_scan ORDER BY col_int;
+drop materialized view test_pct_scan;
+
+-- ==============================================================
+-- Case 2: PCT MV, aggregate
+-- ==============================================================
+CREATE MATERIALIZED VIEW test_pct_agg
+REFRESH DEFERRED MANUAL
+AS SELECT dt, SUM(col_int) AS s, COUNT(*) AS c FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;
+REFRESH MATERIALIZED VIEW test_pct_agg WITH SYNC MODE;
+SELECT dt, s, c FROM test_pct_agg ORDER BY dt;
+ALTER MATERIALIZED VIEW test_pct_agg INACTIVE;
+ALTER MATERIALIZED VIEW test_pct_agg ACTIVE;
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_pct_agg';
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('e', 5, '2023-12-04');
+REFRESH MATERIALIZED VIEW test_pct_agg WITH SYNC MODE;
+SELECT dt, s, c FROM test_pct_agg ORDER BY dt;
+drop materialized view test_pct_agg;
+
+-- ==============================================================
+-- Case 3: IVM projection, whose __ROW_ID__ is AUTO_INCREMENT and therefore
+-- absent from the defined query
+-- ==============================================================
+CREATE MATERIALIZED VIEW test_ivm_scan PARTITION BY dt
 REFRESH DEFERRED MANUAL
 properties
 (
     "refresh_mode" = "incremental"
 )
 AS SELECT col_str, col_int, dt FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE col_int > 1;
-REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
-SELECT col_str, col_int, dt FROM test_mv1 ORDER BY col_int;
-
-ALTER MATERIALIZED VIEW test_mv1 INACTIVE;
-SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_mv1';
-ALTER MATERIALIZED VIEW test_mv1 ACTIVE;
-SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_mv1';
-
--- incremental refresh must keep working after the MV is re-activated
-insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('d', 4, '2023-12-04');
-REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
-SELECT col_str, col_int, dt FROM test_mv1 ORDER BY col_int;
-drop materialized view test_mv1;
+REFRESH MATERIALIZED VIEW test_ivm_scan WITH SYNC MODE;
+SELECT col_str, col_int, dt FROM test_ivm_scan ORDER BY col_int;
+ALTER MATERIALIZED VIEW test_ivm_scan INACTIVE;
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_ivm_scan';
+ALTER MATERIALIZED VIEW test_ivm_scan ACTIVE;
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_ivm_scan';
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('f', 6, '2023-12-05');
+REFRESH MATERIALIZED VIEW test_ivm_scan WITH SYNC MODE;
+SELECT col_str, col_int, dt FROM test_ivm_scan ORDER BY col_int;
+drop materialized view test_ivm_scan;
 
 -- ==============================================================
--- Case 2: aggregate IVM MV, whose __ROW_ID__ / __AGG_STATE_* columns are
--- produced by the rewritten query
+-- Case 4: IVM aggregate. __ROW_ID__ and __AGG_STATE_* are produced by the
+-- rewritten query; count(*) names a state column that is not a legal
+-- user-authored column name.
 -- ==============================================================
-CREATE MATERIALIZED VIEW test_mv2
+CREATE MATERIALIZED VIEW test_ivm_agg
 REFRESH DEFERRED MANUAL
 properties
 (
     "refresh_mode" = "incremental"
 )
-AS SELECT dt, SUM(col_int) AS s, COUNT(*) AS c FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;
-REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
-SELECT dt, s, c FROM test_mv2 ORDER BY dt;
+AS SELECT dt, SUM(col_int) AS s, COUNT(*) AS c, MAX(col_str) AS mx
+   FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;
+REFRESH MATERIALIZED VIEW test_ivm_agg WITH SYNC MODE;
+SELECT dt, s, c, mx FROM test_ivm_agg ORDER BY dt;
+ALTER MATERIALIZED VIEW test_ivm_agg INACTIVE;
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_ivm_agg';
+ALTER MATERIALIZED VIEW test_ivm_agg ACTIVE;
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_ivm_agg';
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('g', 7, '2023-12-05');
+REFRESH MATERIALIZED VIEW test_ivm_agg WITH SYNC MODE;
+SELECT dt, s, c, mx FROM test_ivm_agg ORDER BY dt;
+drop materialized view test_ivm_agg;
 
-ALTER MATERIALIZED VIEW test_mv2 INACTIVE;
-SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_mv2';
-ALTER MATERIALIZED VIEW test_mv2 ACTIVE;
-SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_mv2';
-
-insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('e', 5, '2023-12-04');
-REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
-SELECT dt, s, c FROM test_mv2 ORDER BY dt;
-drop materialized view test_mv2;
+-- ==============================================================
+-- Case 5: IVM join — two base tables must both survive re-binding on ACTIVE
+-- ==============================================================
+CREATE MATERIALIZED VIEW test_ivm_join
+REFRESH DEFERRED MANUAL
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS SELECT t1.col_str, t1.col_int, t2.tag
+   FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 t1
+   JOIN mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 t2 ON t1.col_int = t2.col_int;
+REFRESH MATERIALIZED VIEW test_ivm_join WITH SYNC MODE;
+SELECT col_str, col_int, tag FROM test_ivm_join ORDER BY col_int;
+ALTER MATERIALIZED VIEW test_ivm_join INACTIVE;
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_ivm_join';
+ALTER MATERIALIZED VIEW test_ivm_join ACTIVE;
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_ivm_join';
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 values (6, 'v');
+REFRESH MATERIALIZED VIEW test_ivm_join WITH SYNC MODE;
+SELECT col_str, col_int, tag FROM test_ivm_join ORDER BY col_int;
+drop materialized view test_ivm_join;
 
 drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t2 force;
 drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
 drop database db_${uuid0} force;
 drop catalog mv_iceberg_${uuid0};

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_alter_active_round_trip
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_alter_active_round_trip
@@ -1,0 +1,79 @@
+-- name: test_ivm_alter_active_round_trip
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog mv_iceberg_${uuid0};
+create database mv_ice_db_${uuid0};
+use mv_ice_db_${uuid0};
+create table t1 (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt);
+insert into t1 values
+  ('a', 1, '2023-12-01'),
+  ('b', 2, '2023-12-02'),
+  ('c', 3, '2023-12-03');
+
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+set enable_materialized_view_rewrite = false;
+
+-- ==============================================================
+-- Case 1: non-aggregate IVM MV, whose __ROW_ID__ is AUTO_INCREMENT and
+-- therefore absent from the defined query
+-- ==============================================================
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt
+REFRESH DEFERRED MANUAL
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS SELECT col_str, col_int, dt FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 WHERE col_int > 1;
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT col_str, col_int, dt FROM test_mv1 ORDER BY col_int;
+
+ALTER MATERIALIZED VIEW test_mv1 INACTIVE;
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_mv1';
+ALTER MATERIALIZED VIEW test_mv1 ACTIVE;
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_mv1';
+
+-- incremental refresh must keep working after the MV is re-activated
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('d', 4, '2023-12-04');
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT col_str, col_int, dt FROM test_mv1 ORDER BY col_int;
+drop materialized view test_mv1;
+
+-- ==============================================================
+-- Case 2: aggregate IVM MV, whose __ROW_ID__ / __AGG_STATE_* columns are
+-- produced by the rewritten query
+-- ==============================================================
+CREATE MATERIALIZED VIEW test_mv2
+REFRESH DEFERRED MANUAL
+properties
+(
+    "refresh_mode" = "incremental"
+)
+AS SELECT dt, SUM(col_int) AS s, COUNT(*) AS c FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY dt;
+REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+SELECT dt, s, c FROM test_mv2 ORDER BY dt;
+
+ALTER MATERIALIZED VIEW test_mv2 INACTIVE;
+SELECT IS_ACTIVE FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_mv2';
+ALTER MATERIALIZED VIEW test_mv2 ACTIVE;
+SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_mv2';
+
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('e', 5, '2023-12-04');
+REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+SELECT dt, s, c FROM test_mv2 ORDER BY dt;
+drop materialized view test_mv2;
+
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+drop database db_${uuid0} force;
+drop catalog mv_iceberg_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

`ALTER MATERIALIZED VIEW ... ACTIVE` fails for every non-aggregate INCREMENTAL (IVM) materialized view, so once such an MV goes inactive it can never be re-activated:

```sql
CREATE MATERIALIZED VIEW ivm_scan
PARTITION BY dt
REFRESH DEFERRED MANUAL
PROPERTIES ("refresh_mode" = "incremental")
AS SELECT id, v1, v2, dt FROM iceberg_catalog.db.t1 WHERE id > 1;

ALTER MATERIALIZED VIEW ivm_scan INACTIVE;
ALTER MATERIALIZED VIEW ivm_scan ACTIVE;
-- ERROR 1064 (HY000): Getting analyzing error. Detail message:
--   Can not active materialized view [ivm_scan] because analyze materialized view define sql:
--
--   CREATE MATERIALIZED VIEW `ivm_scan` (`id`, `v1`, `v2`, `dt`, `__ROW_ID__`)
--   ...
--   AS SELECT id, v1, v2, dt FROM ...;
--
--   Cause an error: View's SELECT and view's field list have different column counts.
```

`ACTIVE` re-analyzes the DDL rendered by `getMaterializedViewDdlStmt()`. Since #72011 that DDL appends schema columns the defined query does not produce, so the MV lists its `AUTO_INCREMENT __ROW_ID__` next to a `SELECT` that never outputs it. `MaterializedViewAnalyzer.genMaterializedViewColumns` requires one listed column per query output field and appends `__ROW_ID__` only *afterwards*, so the re-parse trips `ERR_VIEW_WRONG_LIST` before it gets there.

The same DDL is also not executable when copied out of `SHOW CREATE MATERIALIZED VIEW`.

### Second defect on the same round trip

An aggregate IVM MV names its hidden state columns after the aggregate expression, so `count(*)` yields `__AGG_STATE_count(*)`. Re-analysis ran every listed column name through `FeNameFormat.checkColumnName`, whose shared-nothing regex forbids `*`, `=`, `<`, `>` and `!`:

```
Cause an error: Incorrect column name '__AGG_STATE_count(*)'.
```

So an aggregate IVM MV with `count(*)` — a very common shape — could not be re-activated either. Only shared-data mode's laxer regex (`^[^\0]{1,1024}$`) let it through, which is why a cluster e2e passes while the shared-nothing FE unit test does not. These names are generated by the analyzer, not typed by a user, so the user-facing name format should not apply to them.

PCT MVs are unaffected by both: they have neither `__ROW_ID__` nor state columns. Aggregate IVM MVs escape the first defect — their `__ROW_ID__` (`encode(group_by_keys)`) and `__AGG_STATE_*` columns *are* produced by the rewritten query, so the counts match — but hit the second one as soon as an aggregate's name carries a character the column-name regex rejects.

Between them, no incremental MV shape survives `INACTIVE` -> `ACTIVE` in shared-nothing mode; in shared-data mode the non-aggregate shape fails. This is why system tests that pick one of `{pct, incremental} x {scan, agg}` at random looked flaky.

## What I'm doing:

1. Render the DDL column list from the query-produced columns only, reusing the helper the IVM `INSERT` path already relies on (`queryProducedColumns()`, extracted from `queryProducedColumnList()`). Storage-filled columns are re-appended by the analyzer itself, so leaving them out is what makes the DDL round-trip.
2. Exempt IVM's own columns from `FeNameFormat.checkColumnName`, which validates *user-authored* names. The exemption is positional: a listed name is exempt only when it equals the name generated for that output position. Trusting the `__AGG_STATE` prefix alone is not enough — a user-authored entry such as `(a, __AGG_STATE_bad=x, c, d)` would bypass the check, and schema generation marks any prefixed name hidden, so it would also silently hide the user's column.

Tests:

- `IVMAnalyzerTest` — four pins for the `INACTIVE` -> `ACTIVE` round trip: non-aggregate (unpartitioned and partitioned), aggregate (multi-key, `ORDER BY`, reversed projection), and aggregate with `count(*)`. Each asserts the full per-column schema is unchanged across the round trip, not just that the MV came back active — a positional mis-bind of the column list would rename columns without changing their count. Plus `testUserAuthoredStateLikeColumnNameStillRejected` for the exemption boundary.
- `test/sql/test_materialized_view_ivm/{T,R}/test_ivm_alter_active_round_trip` — e2e over Iceberg base tables covering PCT projection, PCT aggregate, IVM projection (partitioned), IVM aggregate with `count(*)`, and IVM join. Every case inserts into the base table after re-activation and refreshes, so the golden pins that the resumed refresh still produces correct data.

### Known limitation, deliberately not closed here

The positional exemption can still be bypassed if a user writes *both* an explicit column list and a matching `SELECT` alias in the same slot: `(a, __AGG_STATE_bad=x, c, d)` over `SELECT id AS __AGG_STATE_bad=x, SUM(c1) ... GROUP BY id`. Closing it requires threading which output slots the IVM rewrite synthesized from `IVMAnalyzer` down to schema generation, i.e. a new field on `CreateMaterializedViewStatement`. I implemented that, measured what it buys, and reverted it:

- the forbidden characters exist because BE encodes shared-nothing DELETE predicates as a flat `column<op>value` string and re-parses them with a regex whose column-name group is the same character class (`be/src/storage/delete_handler.cpp`), and `DeleteAnalyzer` rejects `DELETE` on a materialized view outright — so an MV column name never reaches that parser;
- the end state it admits (a forbidden character plus the hidden flag) is already reachable without any column list at all, on a plain PCT MV — see the next section — so the narrow path grants nothing new.

### Out of scope, found while probing

When no explicit column list is given, MV column names taken from `SELECT` aliases are never format-checked at all. On current main, `CREATE MATERIALIZED VIEW m REFRESH DEFERRED MANUAL AS SELECT id AS \`b=c\`, data FROM t` is accepted in shared-nothing mode, and an alias starting with `__AGG_STATE` additionally becomes a hidden column. That predates this PR and is not IVM-specific (a plain PCT MV reproduces it), so it is left for a separate change rather than widening this bugfix.

Fixes #issue: N/A — reported by an internal system test run; no public issue.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

`SHOW CREATE MATERIALIZED VIEW` on a non-aggregate incremental MV no longer lists the hidden `AUTO_INCREMENT __ROW_ID__` column, which also makes its output executable again.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
