### PR TITLE
[BugFix] Do not allow null buckets/mcv in Histogram

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkew.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkew.java
@@ -111,7 +111,7 @@ public class DataSkew {
 
         final var mcv = histogram.getMCV();
 
-        if (mcv == null) {
+        if (mcv.isEmpty()) {
             return new McvSkewInfo(false, AdditionalInfo.NO_MCV);
         }
 
@@ -258,7 +258,7 @@ public class DataSkew {
     }
 
     public static long getOverlappingMcvRowCount(Map<String, Long> mcvs, Map<String, Long> otherMcvs) {
-        if (mcvs == null || mcvs.isEmpty() || otherMcvs == null || otherMcvs.isEmpty()) {
+        if (mcvs.isEmpty() || otherMcvs.isEmpty()) {
             return 0;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.statistics;
 
 import com.starrocks.qe.ConnectContext;
@@ -33,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
@@ -229,7 +229,7 @@ public class BinaryPredicateStatisticCalculator {
             ColumnStatistic estimatedColumnStatistic = ColumnStatistic.buildFrom(columnStatistic).setNullsFraction(0).build();
             double rowCount = Math.max(0.0, statistics.getOutputRowCount() * (1 - columnStatistic.getNullsFraction())
                     - estimateColumnEqualToConstant(columnRefOperator, columnStatistic, constant, statistics)
-                            .getOutputRowCount());
+                    .getOutputRowCount());
 
             return columnRefOperator.map(operator -> Statistics.buildFrom(statistics)
                             .setOutputRowCount(rowCount).addColumnStatistic(operator, estimatedColumnStatistic).build())
@@ -311,7 +311,7 @@ public class BinaryPredicateStatisticCalculator {
             ColumnStatistic finalNewEstimateColumnStatistics = adjustColumnStatisticsMinMax(
                     newEstimateColumnStatistics, constant, statistics, columnRefOperator, false);
             return columnRefOperator.map(operator -> Statistics.buildFrom(statistics).setOutputRowCount(rowCount)
-                                    .addColumnStatistic(operator, finalNewEstimateColumnStatistics).build())
+                            .addColumnStatistic(operator, finalNewEstimateColumnStatistics).build())
                     .orElseGet(() -> statistics.withOutputRowCount(rowCount));
         }
     }
@@ -487,10 +487,6 @@ public class BinaryPredicateStatisticCalculator {
 
     private static void estimateMcvToBucket(Map<String, Long> leftMcv, Map<String, Long> estimatedMcv,
                                             Histogram rightHistogram, double distinctValuesCount, Type dataType) {
-        if (rightHistogram.getBuckets() == null) {
-            return;
-        }
-
         for (Map.Entry<String, Long> entry : leftMcv.entrySet()) {
             if (estimatedMcv.containsKey(entry.getKey())) {
                 continue;
@@ -508,11 +504,12 @@ public class BinaryPredicateStatisticCalculator {
         }
     }
 
+    @Nonnull
     private static List<Bucket> estimateBucketToBucket(Histogram leftHistogram, double leftColumnDistinctValue, Type dataTypeLeft,
                                                        Histogram rightHistogram, double rightColumnDistinctValue,
                                                        Type dataTypeRight) {
         if (leftHistogram == null || rightHistogram == null) {
-            return null;
+            return List.of();
         }
 
         // Intersecting two such placeholders bucket degenerate zero-count bucket that collapses the estimate to ~1/(L*R),
@@ -521,7 +518,7 @@ public class BinaryPredicateStatisticCalculator {
         List<Bucket> leftBuckets = withFiniteBounds(leftHistogram.getBuckets());
         List<Bucket> rightBuckets = withFiniteBounds(rightHistogram.getBuckets());
         if (leftBuckets.isEmpty() || rightBuckets.isEmpty()) {
-            return null;
+            return List.of();
         }
 
         // Assume the distinct values are uniformly distributed.
@@ -680,8 +677,8 @@ public class BinaryPredicateStatisticCalculator {
     }
 
     public static Optional<Histogram> updateHistWithLessThan(ColumnStatistic columnStatistic,
-                                                   Optional<ConstantOperator> constant,
-                                                   boolean containUpper) {
+                                                             Optional<ConstantOperator> constant,
+                                                             boolean containUpper) {
         if (columnStatistic.getHistogram() == null || !constant.isPresent()) {
             return Optional.empty();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
@@ -595,10 +595,7 @@ public class BinaryPredicateStatisticCalculator {
         return mergedBuckets;
     }
 
-    private static List<Bucket> withFiniteBounds(List<Bucket> buckets) {
-        if (buckets == null) {
-            return List.of();
-        }
+    private static List<Bucket> withFiniteBounds(@Nonnull List<Bucket> buckets) {
         return buckets.stream()
                 .filter(b -> Double.isFinite(b.getLower()) && Double.isFinite(b.getUpper()))
                 .collect(Collectors.toList());
@@ -609,7 +606,7 @@ public class BinaryPredicateStatisticCalculator {
     // histogram fully described by MCVs is legitimately complete, not a placeholder.
     private static boolean hasOnlyNonFiniteBuckets(Histogram histogram) {
         List<Bucket> buckets = histogram.getBuckets();
-        return buckets != null && !buckets.isEmpty() && withFiniteBounds(buckets).isEmpty();
+        return !buckets.isEmpty() && withFiniteBounds(buckets).isEmpty();
     }
 
     private static Optional<StatisticRangeValues> computeBucketIntersection(Bucket leftBucket, Bucket rightBucket) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -1215,7 +1215,7 @@ public class ExpressionStatisticCalculator {
         private Histogram transformHistogramForDateTrunc(String fmtString, ColumnStatistic dateStatistic,
                                                          Type resultType) {
             final var histogram = dateStatistic.getHistogram();
-            if (histogram == null || histogram.getMCV() == null || histogram.getMCV().isEmpty()) {
+            if (histogram == null || histogram.getMCV().isEmpty()) {
                 return null;
             }
 
@@ -1383,7 +1383,7 @@ public class ExpressionStatisticCalculator {
         private Histogram buildIfMcv(ColumnStatistic condStat,
                                      ColumnStatistic thenStat,
                                      ColumnStatistic elseStat) {
-            if (condStat.getHistogram() == null || condStat.getHistogram().getMCV() == null) {
+            if (condStat.getHistogram() == null) {
                 return null;
             }
 
@@ -1483,7 +1483,7 @@ public class ExpressionStatisticCalculator {
          */
         private Optional<Histogram> transformHistogramForUnary(CallOperator callOperator, ColumnStatistic childStats) {
             Histogram childHist = childStats == null ? null : childStats.getHistogram();
-            if (childHist == null || childHist.getMCV() == null || childHist.getMCV().isEmpty()) {
+            if (childHist == null || childHist.getMCV().isEmpty()) {
                 return Optional.empty();
             }
 
@@ -1612,7 +1612,7 @@ public class ExpressionStatisticCalculator {
             ConstantOperator constOp = constOpOpt.get();
             ColumnStatistic baseStats = leftIsConst ? rightStats : leftStats;
             Histogram baseHist = baseStats == null ? null : baseStats.getHistogram();
-            if (baseHist == null || baseHist.getMCV() == null || baseHist.getMCV().isEmpty()) {
+            if (baseHist == null || baseHist.getMCV().isEmpty()) {
                 return Optional.empty();
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -212,7 +212,7 @@ public class ExpressionStatisticCalculator {
 
             if (!childStat.isUnknown() && childStat.getHistogram() != null && child.getType().isBoolean()) {
                 Map<String, Long> mcv = childStat.getHistogram().getMCV();
-                if (mcv != null && (!mcv.isEmpty())) {
+                if (!mcv.isEmpty()) {
                     String trueKey = booleanToMcvValue(true);
                     String falseKey = booleanToMcvValue(false);
 
@@ -1129,7 +1129,7 @@ public class ExpressionStatisticCalculator {
             for (ColumnStatistic input : inputs) {
                 final double nullsFraction = input.getNullsFraction();
                 final var histogram = input.getHistogram();
-                if (nullsFraction < 1 && histogram != null && histogram.getMCV() != null) {
+                if (nullsFraction < 1 && histogram != null) {
                     for (final var entry : histogram.getMCV().entrySet().stream()
                             .sorted((a, b) -> {
                                 int cmp = Long.compare(b.getValue(), a.getValue());
@@ -1315,7 +1315,7 @@ public class ExpressionStatisticCalculator {
                     // If condition MCVs are available, use branch row weights and collapse
                     // stats to the surviving branch when one side is unreachable.
                     final var conditionHistogram = condStat.getHistogram();
-                    if (conditionHistogram != null && conditionHistogram.getMCV() != null) {
+                    if (conditionHistogram != null) {
                         final var conditionMcv = conditionHistogram.getMCV();
                         final long trueRows = conditionMcv.getOrDefault(booleanToMcvValue(true), 0L);
                         final long falseRows = conditionMcv.getOrDefault(booleanToMcvValue(false), 0L);
@@ -1392,8 +1392,8 @@ public class ExpressionStatisticCalculator {
             long trueRows = conditionMcv.getOrDefault(booleanToMcvValue(true), 0L);
             long falseRows = conditionMcv.getOrDefault(booleanToMcvValue(false), 0L);
 
-            final boolean thenHasHist = thenStat.getHistogram() != null && thenStat.getHistogram().getMCV() != null;
-            final boolean elseHasHist = elseStat.getHistogram() != null && elseStat.getHistogram().getMCV() != null;
+            final boolean thenHasHist = thenStat.getHistogram() != null;
+            final boolean elseHasHist = elseStat.getHistogram() != null;
 
             // If neither branch has a histogram, nothing to propagate.
             if (!thenHasHist && !elseHasHist) {
@@ -1509,7 +1509,7 @@ public class ExpressionStatisticCalculator {
             //     - if buckets are all <= 0: y = -x (monotonic decreasing) => [l,u] -> [-u,-l], reverse order
             //     - if buckets cross 0: non-monotonic => fail closed (Optional.empty()) to avoid inconsistent histogram
             List<Bucket> newBuckets = childHist.getBuckets();
-            if (newBuckets != null && !newBuckets.isEmpty()) {
+            if (!newBuckets.isEmpty()) {
                 boolean needNegateBuckets = FunctionSet.NEGATIVE.equalsIgnoreCase(fn);
                 if (FunctionSet.ABS.equalsIgnoreCase(fn)) {
                     boolean allNonNegative = newBuckets.stream().allMatch(b -> b.getLower() >= 0);
@@ -1657,16 +1657,14 @@ public class ExpressionStatisticCalculator {
                     final double bucketShift = FunctionSet.SUBTRACT.equalsIgnoreCase(callOperator.getFnName())
                             ? -deltaOpt.getAsDouble()
                             : deltaOpt.getAsDouble();
-                    if (baseHist.getBuckets() != null) {
-                        newBuckets = baseHist.getBuckets().stream()
-                                .map(b -> new Bucket(b.getLower() + bucketShift, b.getUpper() + bucketShift,
-                                        b.getCount(), b.getUpperRepeats()))
-                                .collect(Collectors.toList());
-                    }
+                    newBuckets = baseHist.getBuckets().stream()
+                            .map(b -> new Bucket(b.getLower() + bucketShift, b.getUpper() + bucketShift,
+                                    b.getCount(), b.getUpperRepeats()))
+                            .collect(Collectors.toList());
                 }
             } else {
                 OptionalDouble cOpt = ConstantOperatorUtils.doubleValueFromConstant(constOp);
-                if (cOpt.isPresent() && baseHist.getBuckets() != null && !baseHist.getBuckets().isEmpty()) {
+                if (cOpt.isPresent() && !baseHist.getBuckets().isEmpty()) {
                     final double cDouble = cOpt.getAsDouble();
                     final List<Bucket> baseBuckets = baseHist.getBuckets();
                     long prevCum = 0L;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Histogram.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Histogram.java
@@ -21,6 +21,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nonnull;
 
 public class Histogram {
 
@@ -28,26 +29,25 @@ public class Histogram {
     private final Map<String, Long> mcv;
 
     public Histogram(List<Bucket> buckets, Map<String, Long> mcv) {
-        this.buckets = buckets;
-        this.mcv = mcv;
-
+        this.buckets = buckets == null ? List.of() : buckets;
+        this.mcv = mcv == null ? Map.of() : mcv;
     }
 
     public long getTotalRows() {
         long totalRows = 0;
-        if (buckets != null && !buckets.isEmpty()) {
+        if (!buckets.isEmpty()) {
             totalRows += buckets.get(buckets.size() - 1).getCount();
         }
-        if (mcv != null) {
-            totalRows += mcv.values().stream().reduce(Long::sum).orElse(0L);
-        }
+        totalRows += mcv.values().stream().reduce(Long::sum).orElse(0L);
         return Math.max(1, totalRows);
     }
 
+    @Nonnull
     public List<Bucket> getBuckets() {
         return buckets;
     }
 
+    @Nonnull
     public Map<String, Long> getMCV() {
         return mcv;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/HistogramUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/HistogramUtils.java
@@ -105,27 +105,23 @@ public class HistogramUtils {
         JsonObject root = new JsonObject();
 
         JsonArray bucketsArray = new JsonArray();
-        if (histogram.getBuckets() != null) {
-            for (Bucket bucket : histogram.getBuckets()) {
-                JsonArray bucketArray = new JsonArray();
-                bucketArray.add(Double.toString(bucket.getLower()));
-                bucketArray.add(Double.toString(bucket.getUpper()));
-                bucketArray.add(Long.toString(bucket.getCount()));
-                bucketArray.add(Long.toString(bucket.getUpperRepeats()));
-                bucket.getDistinctCount().ifPresent(distinctCount -> bucketArray.add(Long.toString(distinctCount)));
-                bucketsArray.add(bucketArray);
-            }
+        for (Bucket bucket : histogram.getBuckets()) {
+            JsonArray bucketArray = new JsonArray();
+            bucketArray.add(Double.toString(bucket.getLower()));
+            bucketArray.add(Double.toString(bucket.getUpper()));
+            bucketArray.add(Long.toString(bucket.getCount()));
+            bucketArray.add(Long.toString(bucket.getUpperRepeats()));
+            bucket.getDistinctCount().ifPresent(distinctCount -> bucketArray.add(Long.toString(distinctCount)));
+            bucketsArray.add(bucketArray);
         }
         root.add("buckets", bucketsArray);
 
         JsonArray mcvArray = new JsonArray();
-        if (histogram.getMCV() != null) {
-            for (Map.Entry<String, Long> entry : histogram.getMCV().entrySet()) {
-                JsonArray mcvEntry = new JsonArray();
-                mcvEntry.add(entry.getKey());
-                mcvEntry.add(Long.toString(entry.getValue()));
-                mcvArray.add(mcvEntry);
-            }
+        for (Map.Entry<String, Long> entry : histogram.getMCV().entrySet()) {
+            JsonArray mcvEntry = new JsonArray();
+            mcvEntry.add(entry.getKey());
+            mcvEntry.add(Long.toString(entry.getValue()));
+            mcvArray.add(mcvEntry);
         }
         root.add("mcv", mcvArray);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateUtils.java
@@ -96,8 +96,7 @@ public class StatisticsEstimateUtils {
         }
 
         // Neither side has buckets
-        boolean noBuckets = (left == null || left.getBuckets() == null || left.getBuckets().isEmpty())
-                && (right == null || right.getBuckets() == null || right.getBuckets().isEmpty());
+        boolean noBuckets = (left == null || left.getBuckets().isEmpty()) && (right == null || right.getBuckets().isEmpty());
 
         // The merged MCV rows account for at least 50% of the total rows.
         final double totalRowCount = leftRowCount + rightRowCount;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
@@ -24,7 +24,6 @@ import com.starrocks.type.BooleanType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.VarcharType;
 import com.starrocks.utframe.UtFrameUtils;
-import org.apache.commons.collections.CollectionUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -635,7 +634,7 @@ public class HistogramStatisticsTest {
         Optional<Histogram> exist = BinaryPredicateStatisticCalculator.updateHistWithJoin(
                 columnStatisticLeft, IntegerType.BIGINT, columnStatisticRight, IntegerType.BIGINT);
         Assertions.assertTrue(exist.isPresent());
-        Assertions.assertTrue(CollectionUtils.isEmpty(exist.get().getBuckets()));
+        Assertions.assertTrue(exist.get().getBuckets().isEmpty());
         Assertions.assertEquals(exist.get().getMCV().size(), 1);
         Assertions.assertEquals(exist.get().getMCV().get("22").longValue(), 100 * 80);
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
@@ -24,6 +24,7 @@ import com.starrocks.type.BooleanType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.VarcharType;
 import com.starrocks.utframe.UtFrameUtils;
+import org.apache.commons.collections.CollectionUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -620,21 +621,21 @@ public class HistogramStatisticsTest {
         mcvLeft = new HashMap<>();
         mcvLeft.put("10", 300L);
         mcvLeft.put("22", 100L);
-        histogramLeft = new Histogram(null, mcvLeft);
+        histogramLeft = new Histogram(List.of(), mcvLeft);
         columnStatisticLeft = new ColumnStatistic(1, 50, 0, 4, 500,
                 histogramLeft, ColumnStatistic.StatisticType.ESTIMATE);
 
         mcvRight = new HashMap<>();
         mcvRight.put("22", 80L);
         mcvRight.put("9", 50L);
-        histogramRight = new Histogram(null, mcvRight);
+        histogramRight = new Histogram(List.of(), mcvRight);
         columnStatisticRight = new ColumnStatistic(1, 50, 0, 4, 500,
                 histogramRight, ColumnStatistic.StatisticType.ESTIMATE);
 
         Optional<Histogram> exist = BinaryPredicateStatisticCalculator.updateHistWithJoin(
                 columnStatisticLeft, IntegerType.BIGINT, columnStatisticRight, IntegerType.BIGINT);
         Assertions.assertTrue(exist.isPresent());
-        Assertions.assertNull(exist.get().getBuckets());
+        Assertions.assertTrue(CollectionUtils.isEmpty(exist.get().getBuckets()));
         Assertions.assertEquals(exist.get().getMCV().size(), 1);
         Assertions.assertEquals(exist.get().getMCV().get("22").longValue(), 100 * 80);
 


### PR DESCRIPTION
## Why I'm doing:
We see regularly stack traces like these in the optimizer which leads to having no stats:
```java
Failed to calculate statistics for expression ...
java.lang.NullPointerException: Cannot invoke "java.util.List.size()" because the return value of "com.starrocks.sql.optimizer.statistics.Histogram.getBuckets()" is null
	at com.starrocks.sql.optimizer.statistics.BinaryPredicateStatisticCalculator.estimateColumnEqualToConstant(BinaryPredicateStatisticCalculator.java:138) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.BinaryPredicateStatisticCalculator.estimateColumnToConstantComparison(BinaryPredicateStatisticCalculator.java:49) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.PredicateStatisticsCalculator$BaseCalculatingVisitor.visitBinaryPredicate(PredicateStatisticsCalculator.java:332) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.PredicateStatisticsCalculator$BaseCalculatingVisitor.visitBinaryPredicate(PredicateStatisticsCalculator.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator.accept(BinaryPredicateOperator.java:81) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.PredicateStatisticsCalculator.statisticsCalculate(PredicateStatisticsCalculator.java:54) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.ExpressionStatisticCalculator$ExpressionStatisticVisitor.visitBinaryPredicate(ExpressionStatisticCalculator.java:315) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.ExpressionStatisticCalculator$ExpressionStatisticVisitor.visitBinaryPredicate(ExpressionStatisticCalculator.java:84) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator.accept(BinaryPredicateOperator.java:81) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.ExpressionStatisticCalculator$ExpressionStatisticVisitor.lambda$visitCall$5(ExpressionStatisticCalculator.java:516) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[?:?]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921) ~[?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682) ~[?:?]
	at com.starrocks.sql.optimizer.statistics.ExpressionStatisticCalculator$ExpressionStatisticVisitor.visitCall(ExpressionStatisticCalculator.java:516) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.ExpressionStatisticCalculator$ExpressionStatisticVisitor.visitCall(ExpressionStatisticCalculator.java:84) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CallOperator.accept(CallOperator.java:263) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.ExpressionStatisticCalculator.calculate(ExpressionStatisticCalculator.java:78) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.ExpressionStatisticCalculator.calculate(ExpressionStatisticCalculator.java:70) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.computeProjectNode(StatisticsCalculator.java:992) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.visitLogicalProject(StatisticsCalculator.java:962) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.visitLogicalProject(StatisticsCalculator.java:193) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator.accept(LogicalProjectOperator.java:110) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.estimatorStats(StatisticsCalculator.java:220) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:890) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:879) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:879) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:879) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:879) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:879) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:879) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:879) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:879) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:879) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.QueryOptimizer.logicalRuleRewrite(QueryOptimizer.java:531) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.QueryOptimizer.rewriteAndValidatePlan(QueryOptimizer.java:782) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.QueryOptimizer.optimizeByCost(QueryOptimizer.java:245) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.QueryOptimizer.optimize(QueryOptimizer.java:201) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.UpdatePlanner.plan(UpdatePlanner.java:104) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:160) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:107) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.StmtExecutor.generateExecPlan(StmtExecutor.java:651) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:761) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.ConnectProcessor.doProxyExecute(ConnectProcessor.java:1145) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.ConnectProcessor.proxyExecute(ConnectProcessor.java:1072) ~[starrocks-fe.jar:?]
	at com.starrocks.service.FrontendServiceImpl.forward(FrontendServiceImpl.java:1142) ~[starrocks-fe.jar:?]
	at com.starrocks.thrift.FrontendService$Processor$forward.getResult(FrontendService.java:5948) ~[starrocks-fe.jar:?]
	at com.starrocks.thrift.FrontendService$Processor$forward.getResult(FrontendService.java:5920) ~[starrocks-fe.jar:?]
	at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:40) ~[libthrift-0.23.0.jar:0.23.0]
	at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:41) ~[libthrift-0.23.0.jar:0.23.0]
	at com.starrocks.common.SRTThreadPoolServer$WorkerProcess.run(SRTThreadPoolServer.java:313) ~[starrocks-fe.jar:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
	at java.lang.Thread.run(Thread.java:840) ~[?:?]
```

The underlying issue is that a `Histogram` object with `null` buckets (instead of an empty list) is created. 

## What I'm doing:
This PR makes the histogram class safer (if there is an input null `buckets`), it will be converted to an empty list. Similarly for `mcv`. Additionally, the now unnecessary null handling is removed for all the callers.
This also fixes the one caller where we could definitely pass in `null` buckets to use empty collections instead.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
