### PR TITLE
[BugFix] Keep Set operators out of colocate exec groups to avoid a hang

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -3820,10 +3820,6 @@ public class PlanFragmentBuilder {
             }
 
             ExecGroup execGroup = execGroups.newExecGroup();
-            // TODO(by satanson): only all children of Set operator are colocate branch, we turn on execGroup.
-            //  if colocate set operator has bucket-shuffle branch, BE need tackle this situation to avoid
-            //  query hanging forever.
-            boolean canExecGroup = true;
             Optional<List<BucketProperty>> extractedBP = extractBucketProperties(inputFragments);
             for (int i = 0; i < optExpr.arity(); ++i) {
                 PlanFragment inputFragment = inputFragments.get(i);
@@ -3832,9 +3828,19 @@ public class PlanFragmentBuilder {
                 setOperationFragment.mergeQueryDictExprs(inputFragment.getQueryGlobalDictExprs());
                 setOperationFragment.mergeQueryGlobalDicts(inputFragment.getQueryGlobalDicts());
                 ExecGroup inputExecGroup = inputExecGroups.get(i);
+                // This branch's exec group is about to disappear -- merged into the Set operator's
+                // group below (which we then disable), or simply dropped when the branch sits
+                // behind an exchange. Runtime filters built inside the branch were stamped with
+                // build_from_group_execution back when that group was still colocate
+                // (RuntimeFilterPushDownContext stamps it as the join is built), and merge() copies
+                // only node ids -- so nothing would ever clear the flag. The BE would keep treating
+                // those probes as group-colocate filters and refuse to push them down, even though
+                // no colocate TExecGroup is emitted for them any more. disableColocateGroup() drops
+                // that metadata; it walks only this group's own node ids, so a colocate group
+                // elsewhere in the plan is left untouched.
+                inputExecGroup.disableColocateGroup(inputFragment.getPlanRoot());
                 execGroups.remove(inputExecGroup);
                 if (inputFragment.getPlanRoot() instanceof ExchangeNode) {
-                    canExecGroup = false;
                     if (isColocate) {
                         inputFragment.getChildren().forEach(fragment -> {
                             fragment.setOutputPartition(
@@ -3852,11 +3858,30 @@ public class PlanFragmentBuilder {
             execGroup.add(setOperationNode);
 
             setOperationNode.setColocate(isColocate);
-            if (canExecGroup && isColocate && ConnectContext.get().getSessionVariable().isEnableGroupExecution()) {
-                execGroup.setColocateGroup();
-            } else {
-                execGroup.disableColocateGroup(setOperationNode);
-            }
+            // Never run a Set operator inside a colocate exec group: it hangs forever.
+            //
+            // A colocate Set operator carries localPartitionByExprs, so on the BE
+            // UnionNode::decompose_to_pipeline routes each branch through
+            // maybe_interpolate_local_bucket_shuffle_exchange, which returns early -- without
+            // interpolating a grouped exchange -- whenever the branch source reports
+            // could_local_shuffle() == false. A group-execution scan always reports false. The
+            // branch pipelines therefore stay in the colocate exec group but are terminated by a
+            // plain LocalExchangeSink instead of a GroupedExecutionSink.
+            //
+            // ColocateExecutionGroup submits its logical bucket groups in waves of physical dop
+            // and the only thing that advances a wave is
+            // GroupedExecutionSinkOperator::set_finishing() -> submit_next_driver(). With no
+            // grouped sink on those pipelines, the groups beyond the first wave are never
+            // submitted, the gather exchanger never sees all sinkers finish, and every downstream
+            // driver stays INPUT_EMPTY forever. Reproduces whenever
+            // bucket groups >= 2 * physical dop (e.g. INSERT INTO, whose sink fragment dop is
+            // forced down in InsertPlanner).
+            //
+            // Group execution buys nothing for this shape anyway -- the gather exchanger at the
+            // Set operator collapses logical dop back to physical dop, so the per-group agg/join
+            // benefit is already lost -- hence disabling it outright rather than teaching the BE
+            // to split the group here.
+            execGroup.disableColocateGroup(setOperationNode);
             currentExecGroup = execGroup;
             return setOperationFragment;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupExecutionPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupExecutionPlanTest.java
@@ -250,4 +250,36 @@ public class GroupExecutionPlanTest extends PlanTestBase {
         }
     }
 
+    // A colocate Set operator must never be put into a colocate exec group: on the BE its branches
+    // keep a plain LocalExchangeSink instead of a GroupedExecutionSink, so nothing ever advances
+    // ColocateExecutionGroup past its first wave of bucket groups and the query hangs forever
+    // (reproduces as soon as bucket groups >= 2 * physical dop).
+    @Test
+    public void colocateSetOperatorIsNotGroupExecution() throws Exception {
+        FeConstants.runningUnitTest = true;
+        Config.show_execution_groups = true;
+        boolean enableGroupExecution = connectContext.getSessionVariable().isEnableGroupExecution();
+        connectContext.getSessionVariable().setEnableGroupExecution(true);
+        try {
+            List<String> querys = Lists.newArrayList();
+            // union/intersect/except on the full bucket key => colocate set operator, no exchange branch
+            querys.add("select k1,k2 from colocate1 l union select k1,k2 from colocate2 r");
+            querys.add("select k1,k2 from colocate1 l intersect select k1,k2 from colocate2 r");
+            querys.add("select k1,k2 from colocate1 l except select k1,k2 from colocate2 r");
+
+            for (String sql : querys) {
+                String thriftPlan = getThriftPlan(sql);
+                // guard: these really are the colocate flavour of the Set operator, which is the
+                // shape that used to turn the colocate exec group on
+                assertContains(thriftPlan, "local_partition_by_exprs");
+                assertNotContains(thriftPlan, "build_from_group_execution:true");
+
+                assertNotContains(getFragmentPlan(sql), "colocate exec groups:");
+            }
+        } finally {
+            FeConstants.runningUnitTest = false;
+            connectContext.getSessionVariable().setEnableGroupExecution(enableGroupExecution);
+        }
+    }
+
 }

--- a/test/sql/test_group_execution/R/test_group_execution_colocate_set
+++ b/test/sql/test_group_execution/R/test_group_execution_colocate_set
@@ -1,0 +1,73 @@
+-- name: test_group_execution_colocate_set
+set enable_group_execution = true;
+-- result:
+-- !result
+set group_execution_min_scan_rows = 1;
+-- result:
+-- !result
+set pipeline_dop = 2;
+-- result:
+-- !result
+CREATE TABLE `wid_info` (
+  `wid` varchar(64) NULL COMMENT "",
+  `a1` array<varchar(64)> NULL COMMENT "",
+  `a2` array<varchar(64)> NULL COMMENT "",
+  `st` varchar(8) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`wid`)
+DISTRIBUTED BY HASH(`wid`) BUCKETS 32
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `offline_uid` (
+  `user_id` varchar(200) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`user_id`)
+DISTRIBUTED BY HASH(`user_id`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into wid_info SELECT concat('w', generate_series), [concat('u', generate_series % 500)], [concat('u', generate_series % 300)], '1' FROM TABLE(generate_series(1, 20000));
+-- result:
+-- !result
+insert into offline_uid SELECT concat('u', generate_series) FROM TABLE(generate_series(1, 300));
+-- result:
+-- !result
+function: assert_explain_not_contains('select wid, unnest as uid from wid_info, unnest(a1) union select wid, unnest as uid from wid_info, unnest(a2)', 'colocate exec groups')
+-- result:
+None
+-- !result
+select count(*) from (select a.wid from (select wid, unnest as uid from wid_info, unnest(a1) where st = 1 and unnest is not null union select wid, unnest as uid from wid_info, unnest(a2) where st = 1 and unnest is not null) a join (select trim(user_id) as uid from offline_uid group by 1) b on a.uid = b.uid group by a.wid) t;
+-- result:
+19974
+-- !result
+CREATE TABLE `wid_profile` (
+  `seg_id` bigint(20) NULL COMMENT "",
+  `wid` varchar(64) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`seg_id`)
+DISTRIBUTED BY HASH(`seg_id`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into wid_profile select 1, a.wid from (select wid, unnest as uid from wid_info, unnest(a1) where st = 1 and unnest is not null union select wid, unnest as uid from wid_info, unnest(a2) where st = 1 and unnest is not null) a join (select trim(user_id) as uid from offline_uid group by 1) b on a.uid = b.uid group by a.wid;
+-- result:
+-- !result
+select count(*) from wid_profile;
+-- result:
+19974
+-- !result
+select count(*) from (select wid, unnest as uid from wid_info, unnest(a1) where unnest is not null intersect select wid, unnest as uid from wid_info, unnest(a2) where unnest is not null) t;
+-- result:
+4199
+-- !result
+select count(*) from (select wid, unnest as uid from wid_info, unnest(a1) where unnest is not null except select wid, unnest as uid from wid_info, unnest(a2) where unnest is not null) t;
+-- result:
+15801
+-- !result

--- a/test/sql/test_group_execution/T/test_group_execution_colocate_set
+++ b/test/sql/test_group_execution/T/test_group_execution_colocate_set
@@ -1,0 +1,59 @@
+-- name: test_group_execution_colocate_set
+
+-- A colocate Set operator must never be placed inside a colocate exec group.
+-- On the BE its branches keep a plain LocalExchangeSink instead of a GroupedExecutionSink,
+-- so nothing ever advances ColocateExecutionGroup past its first wave of bucket groups and
+-- the query hangs forever. Reproduces as soon as bucket groups >= 2 * physical dop.
+set enable_group_execution = true;
+-- force logical dop > physical dop, so the exec group needs more than one wave on small data
+set group_execution_min_scan_rows = 1;
+set pipeline_dop = 2;
+
+CREATE TABLE `wid_info` (
+  `wid` varchar(64) NULL COMMENT "",
+  `a1` array<varchar(64)> NULL COMMENT "",
+  `a2` array<varchar(64)> NULL COMMENT "",
+  `st` varchar(8) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`wid`)
+DISTRIBUTED BY HASH(`wid`) BUCKETS 32
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `offline_uid` (
+  `user_id` varchar(200) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`user_id`)
+DISTRIBUTED BY HASH(`user_id`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into wid_info SELECT concat('w', generate_series), [concat('u', generate_series % 500)], [concat('u', generate_series % 300)], '1' FROM TABLE(generate_series(1, 20000));
+insert into offline_uid SELECT concat('u', generate_series) FROM TABLE(generate_series(1, 300));
+
+-- the Set operator itself must stay out of the colocate exec group
+function: assert_explain_not_contains('select wid, unnest as uid from wid_info, unnest(a1) union select wid, unnest as uid from wid_info, unnest(a2)', 'colocate exec groups')
+
+-- and the query must actually finish (it hung forever before the fix)
+select count(*) from (select a.wid from (select wid, unnest as uid from wid_info, unnest(a1) where st = 1 and unnest is not null union select wid, unnest as uid from wid_info, unnest(a2) where st = 1 and unnest is not null) a join (select trim(user_id) as uid from offline_uid group by 1) b on a.uid = b.uid group by a.wid) t;
+
+-- same shape behind an OLAP table sink: INSERT forces the sink fragment dop down, which is how
+-- this was originally hit in production (plain SELECT happened to get one wave and survived)
+CREATE TABLE `wid_profile` (
+  `seg_id` bigint(20) NULL COMMENT "",
+  `wid` varchar(64) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`seg_id`)
+DISTRIBUTED BY HASH(`seg_id`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into wid_profile select 1, a.wid from (select wid, unnest as uid from wid_info, unnest(a1) where st = 1 and unnest is not null union select wid, unnest as uid from wid_info, unnest(a2) where st = 1 and unnest is not null) a join (select trim(user_id) as uid from offline_uid group by 1) b on a.uid = b.uid group by a.wid;
+select count(*) from wid_profile;
+
+-- intersect / except take the same colocate path
+select count(*) from (select wid, unnest as uid from wid_info, unnest(a1) where unnest is not null intersect select wid, unnest as uid from wid_info, unnest(a2) where unnest is not null) t;
+select count(*) from (select wid, unnest as uid from wid_info, unnest(a1) where unnest is not null except select wid, unnest as uid from wid_info, unnest(a2) where unnest is not null) t;

--- a/test/sql/test_iceberg/R/test_iceberg_bucket_aware_execution
+++ b/test/sql/test_iceberg/R/test_iceberg_bucket_aware_execution
@@ -81,11 +81,11 @@ function: assert_explain_not_contains('select trip_id, trip_distance, RANK() ove
 -- result:
 None
 -- !result
-function: assert_explain_contains('select * from iceberg_sql_test_${uuid0}.iceberg_bucket_db.taxis_1bucket_big except select * from iceberg_sql_test_${uuid0}.iceberg_bucket_db.taxis_1bucket_1', 'colocate')
+function: assert_explain_not_contains('select * from iceberg_sql_test_${uuid0}.iceberg_bucket_db.taxis_1bucket_big except select * from iceberg_sql_test_${uuid0}.iceberg_bucket_db.taxis_1bucket_1', 'BUCKET_SHUFFLE_HASH_PARTITIONED')
 -- result:
 None
 -- !result
-function: assert_explain_contains('select * from iceberg_sql_test_${uuid0}.iceberg_bucket_db.taxis_1bucket_big except select * from iceberg_sql_test_${uuid0}.iceberg_bucket_db.taxis_1bucket_2', 'colocate')
+function: assert_explain_not_contains('select * from iceberg_sql_test_${uuid0}.iceberg_bucket_db.taxis_1bucket_big except select * from iceberg_sql_test_${uuid0}.iceberg_bucket_db.taxis_1bucket_2', 'BUCKET_SHUFFLE_HASH_PARTITIONED')
 -- result:
 None
 -- !result

--- a/test/sql/test_iceberg/T/test_iceberg_bucket_aware_execution
+++ b/test/sql/test_iceberg/T/test_iceberg_bucket_aware_execution
@@ -36,8 +36,8 @@ function: assert_explain_contains('select sum(a.trip_distance), a.trip_id from i
 function: assert_explain_not_contains('select trip_id, trip_distance, RANK() over (partition by trip_id order by trip_distance desc) as rank from iceberg_sql_test_${uuid0}.iceberg_bucket_db.taxis_bucket_analytic', '1:EXCHANGE')
 
 -- #### colocate/bucket set operation
-function: assert_explain_contains('select * from iceberg_sql_test_${uuid0}.iceberg_bucket_db.taxis_1bucket_big except select * from iceberg_sql_test_${uuid0}.iceberg_bucket_db.taxis_1bucket_1', 'colocate')
-function: assert_explain_contains('select * from iceberg_sql_test_${uuid0}.iceberg_bucket_db.taxis_1bucket_big except select * from iceberg_sql_test_${uuid0}.iceberg_bucket_db.taxis_1bucket_2', 'colocate')
+function: assert_explain_not_contains('select * from iceberg_sql_test_${uuid0}.iceberg_bucket_db.taxis_1bucket_big except select * from iceberg_sql_test_${uuid0}.iceberg_bucket_db.taxis_1bucket_1', 'BUCKET_SHUFFLE_HASH_PARTITIONED')
+function: assert_explain_not_contains('select * from iceberg_sql_test_${uuid0}.iceberg_bucket_db.taxis_1bucket_big except select * from iceberg_sql_test_${uuid0}.iceberg_bucket_db.taxis_1bucket_2', 'BUCKET_SHUFFLE_HASH_PARTITIONED')
 function: assert_explain_contains('select * from iceberg_sql_test_${uuid0}.iceberg_bucket_db.taxis_1bucket_big except select * from iceberg_sql_test_${uuid0}.iceberg_bucket_db.taxis_no_bucket', 'BUCKET_SHUFFLE_HASH_PARTITIONED')
 
 -- #### bucket num not match


### PR DESCRIPTION
## Why I'm doing:

A colocate Set operator carries localPartitionByExprs, so on the BE UnionNode::decompose_to_pipeline routes each branch through maybe_interpolate_local_bucket_shuffle_exchange, which returns early -- without interpolating a grouped exchange -- whenever the branch source reports could_local_shuffle() == false. A group-execution scan always reports false, so the branch pipelines stay in the colocate exec group but are terminated by a plain LocalExchangeSink instead of a GroupedExecutionSink.

ColocateExecutionGroup submits its logical bucket groups in waves of physical dop, and the only thing that advances a wave is
GroupedExecutionSinkOperator::set_finishing() -> submit_next_driver(). With no grouped sink on those pipelines, the bucket groups beyond the first wave are never submitted, the gather exchanger never sees all sinkers finish, and every downstream driver stays INPUT_EMPTY forever.

This reproduces whenever bucket groups >= 2 * physical dop. INSERT INTO hits it easily because InsertPlanner forces the sink fragment dop down (to parallel_exec_instance_num, default 1), while a plain SELECT often keeps a dop large enough for the logical dop to collapse into a single wave and survive.

Never turn the colocate exec group on for a Set operator, as the TODO on that code already suggested. Group execution degenerates there anyway -- the gather exchanger collapses logical dop back to physical dop, so the per-group agg/join benefit is already lost -- and other fragments in the same query keep their exec groups.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
