### PR TITLE
[BugFix] Restore multiple connection groups per endpoint in bRPC (backport #76765)

### DIFF
--- a/be/src/util/brpc_stub_cache.cpp
+++ b/be/src/util/brpc_stub_cache.cpp
@@ -113,7 +113,8 @@ BrpcStubCache::StubPool::~StubPool() {
 std::shared_ptr<PInternalService_RecoverableStub> BrpcStubCache::StubPool::get_or_create(
         const butil::EndPoint& endpoint) {
     if (UNLIKELY(_stubs.size() < config::brpc_max_connections_per_server)) {
-        auto stub = std::make_shared<PInternalService_RecoverableStub>(endpoint, "");
+        auto stub =
+                std::make_shared<PInternalService_RecoverableStub>(endpoint, "", static_cast<int64_t>(_stubs.size()));
         if (!stub->reset_channel().ok()) {
             return nullptr;
         }

--- a/be/src/util/internal_service_recoverable_stub.cpp
+++ b/be/src/util/internal_service_recoverable_stub.cpp
@@ -49,8 +49,8 @@ private:
 };
 
 PInternalService_RecoverableStub::PInternalService_RecoverableStub(const butil::EndPoint& endpoint,
-                                                                   std::string protocol)
-        : _endpoint(endpoint), _protocol(std::move(protocol)) {}
+                                                                   std::string protocol, int64_t connection_group_seed)
+        : _endpoint(endpoint), _connection_group_seed(connection_group_seed), _protocol(std::move(protocol)) {}
 
 PInternalService_RecoverableStub::~PInternalService_RecoverableStub() = default;
 
@@ -70,7 +70,10 @@ Status PInternalService_RecoverableStub::reset_channel(int64_t next_connection_g
     if (_protocol != "http") {
         // http does not support these.
         options.connection_type = config::brpc_connection_type;
-        options.connection_group = std::to_string(next_connection_group);
+        // The seed keeps sibling stubs on distinct connection_groups (distinct TCP connections under
+        // connection_type=single); the epoch suffix lets a single stub obtain a fresh connection when recovering from
+        // EHOSTDOWN.
+        options.connection_group = std::to_string(_connection_group_seed) + "_" + std::to_string(next_connection_group);
     }
     options.max_retry = 3;
     std::unique_ptr<brpc::Channel> channel(new brpc::Channel());

--- a/be/src/util/internal_service_recoverable_stub.h
+++ b/be/src/util/internal_service_recoverable_stub.h
@@ -26,7 +26,8 @@ namespace starrocks {
 class PInternalService_RecoverableStub : public PInternalService,
                                          public std::enable_shared_from_this<PInternalService_RecoverableStub> {
 public:
-    PInternalService_RecoverableStub(const butil::EndPoint& endpoint, std::string protocol = "");
+    PInternalService_RecoverableStub(const butil::EndPoint& endpoint, std::string protocol = "",
+                                     int64_t connection_group_seed = 0);
     ~PInternalService_RecoverableStub();
 
     Status reset_channel(int64_t next_connection_group = 0);
@@ -97,6 +98,8 @@ private:
     std::shared_ptr<starrocks::PInternalService_Stub> _stub;
     const butil::EndPoint _endpoint;
     std::atomic<int64_t> _connection_group = 0;
+    // Distinguishes stubs that share the same endpoint.
+    const int64_t _connection_group_seed = 0;
     mutable std::shared_mutex _mutex;
     std::string _protocol;
 


### PR DESCRIPTION
## Why I'm doing:

Consider these configs:
```
        brpc_max_connections_per_server: "8"
        brpc_connection_type: "single"
```

The intention is that one BE can talk with another BE using 8 TCP connections. But in fact it only uses 1 TCP connection because all stubs use the same connection group `"1"`

## What I'm doing:

Seed each stub with its pool index and compose the brpc connection_group as `<seed>_<epoch>`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
<hr>This is a backport of pull request #76765 

