### PR TITLE
[Enhancement] Support lake batch publish for multi-table transactions

### DIFF
--- a/docs/en/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/en/administration/management/FE_parameters/shared_lake_other.md
@@ -627,6 +627,15 @@ This topic introduces the following types of FE configurations:
 - Description: When enabled, PublishVersionDaemon batches ready transactions for the same Lake (shared-data) table/partition and publishes their versions together instead of issuing per-transaction publishes. In RunMode shared-data, the daemon calls getReadyPublishTransactionsBatch() and uses publishVersionForLakeTableBatch(...) to perform grouped publish operations (reducing RPCs and improving throughput). When disabled, the daemon falls back to per-transaction publishing via publishVersionForLakeTable(...). The implementation coordinates in-flight work using internal sets to avoid duplicate publishes when the switch is toggled and is affected by the thread pool sizing via `lake_publish_version_max_threads`.
 - Introduced in: v3.2.0
 
+### `lake_enable_batch_publish_multi_table`
+
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether to allow batch publish to group consecutive multi-table transactions into one publish operation. This benefits workloads that commit small atomic transactions spanning the same group of tables at a high rate (for example, CDC pipelines fanning out to multiple tables), where per-transaction publishing serializes on the shared table dependency chain and inflates the commit-to-visible latency. Effective only when `lake_enable_batch_publish_version` is `true`. Enable this parameter only after all FE nodes are upgraded to a version that supports it: an FE follower running an older version that replays a multi-table transaction batch applies the visible log of the first table only.
+- Introduced in: v4.1.5
+
 ### `lake_enable_tablet_creation_optimization`
 
 - Default: false

--- a/docs/ja/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/management/FE_parameters/shared_lake_other.md
@@ -649,6 +649,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：有効にすると、PublishVersionDaemon は同じ Lake (共有データ) テーブル/パーティションの準備完了トランザクションをバッチ処理し、トランザクションごとの公開を発行するのではなく、まとめてバージョンを公開します。RunMode shared-data では、デーモンは getReadyPublishTransactionsBatch() を呼び出し、publishVersionForLakeTableBatch(...) を使用してグループ化された公開操作を実行します (RPC を削減し、スループットを向上させます)。無効の場合、デーモンは publishVersionForLakeTable(...) を介してトランザクションごとの公開にフォールバックします。実装は、スイッチが切り替えられたときに重複公開を避けるために内部セットを使用して進行中の作業を調整し、`lake_publish_version_max_threads` を介したスレッドプールサイズ設定の影響を受けます。
 - 導入時期：v3.2.0
 
+### `lake_enable_batch_publish_multi_table`
+
+- デフォルト：false
+- タイプ：Boolean
+- 単位：-
+- 変更可能：Yes
+- 説明：バッチ発行 (Batch Publish) が連続する複数テーブルトランザクションを 1 回の発行操作にまとめることを許可するかどうか。同じテーブル群にまたがる小さなアトミックトランザクションを高頻度でコミットするワークロード（例えば、複数のテーブルに書き込む CDC パイプライン）に有効です。このようなワークロードでは、トランザクションごとの発行が共有テーブルの依存チェーン上で直列化され、コミットから可視化までのレイテンシーが増大します。`lake_enable_batch_publish_version` が `true` の場合にのみ有効です。すべての FE ノードがこの機能をサポートするバージョンにアップグレードされた後にのみ、このパラメータを有効にしてください。旧バージョンで動作している FE Follower が複数テーブルのトランザクションバッチをリプレイすると、最初のテーブルの Visible Log のみが適用されます。
+- 導入時期：v4.1.5
+
 ### `lake_enable_tablet_creation_optimization`
 
 - デフォルト：false

--- a/docs/zh/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/management/FE_parameters/shared_lake_other.md
@@ -636,6 +636,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 启用后，PublishVersionDaemon 会为同一个 Lake（存算分离）表/分区批处理就绪事务，并将其版本一起发布，而不是为每个事务单独发布。在 RunMode shared-data 中，守护进程调用 getReadyPublishTransactionsBatch() 并使用 publishVersionForLakeTableBatch(...) 执行分组发布操作（减少 RPC 并提高吞吐量）。禁用时，守护进程回退到通过 publishVersionForLakeTable(...) 进行的逐事务发布。实现通过内部集合协调进行中的工作，以避免在切换开关时重复发布，并且受 `lake_publish_version_max_threads` 的线程池大小影响。
 - 引入版本: v3.2.0
 
+### `lake_enable_batch_publish_multi_table`
+
+- 默认值: false
+- 类型: Boolean
+- 单位: -
+- 是否可变: Yes
+- 描述: 是否允许批量发布（Batch Publish）将连续的多表事务合并为一次发布操作。该功能适用于以较高频率提交小型原子多表事务的负载（例如同时写入多张表的 CDC 数据管道）。在此类负载下，逐事务发布会在共享表的依赖链上串行执行，从而显著增加事务从提交到可见的延迟。仅当 `lake_enable_batch_publish_version` 为 `true` 时生效。请在所有 FE 节点都升级到支持该功能的版本之后再开启此参数：运行旧版本的 FE Follower 在回放多表事务批次时只会应用其中第一张表的 Visible Log。
+- 引入版本: v4.1.5
+
 ### `lake_enable_tablet_creation_optimization`
 
 - 默认值: false

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1236,6 +1236,11 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int lake_batch_publish_min_version_num = 1;
 
+    @ConfField(mutable = true, comment = "Allow batching consecutive multi-table transactions into one publish. " +
+            "Effective only when lake_enable_batch_publish_version is true. Enable this only after all FE nodes " +
+            "are upgraded to a version that supports it.")
+    public static boolean lake_enable_batch_publish_multi_table = false;
+
     @ConfField(mutable = true)
     public static boolean lake_use_combined_txn_log = false;
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/PartitionPublishVersionData.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/PartitionPublishVersionData.java
@@ -38,6 +38,10 @@ public class PartitionPublishVersionData {
         this.partitionId = partitionId;
     }
 
+    public long getTableId() {
+        return tableId;
+    }
+
     public long getPartitionId() {
         return partitionId;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -997,9 +997,16 @@ public class DatabaseTransactionMgr {
         try {
             List<Long> txnIds = transactionGraph.getTxnsWithoutDependency();
             for (long txnId : txnIds) {
-                List<Long> txnsWithDependency = transactionGraph.getTxnsWithTxnDependencyBatch(
-                        Config.lake_batch_publish_min_version_num,
-                        Config.lake_batch_publish_max_version_num, txnId);
+                List<Long> txnsWithDependency;
+                if (Config.lake_enable_batch_publish_multi_table) {
+                    txnsWithDependency = transactionGraph.getTxnsWithTxnDependencyBatchMultiTable(
+                            Config.lake_batch_publish_min_version_num,
+                            Config.lake_batch_publish_max_version_num, txnId);
+                } else {
+                    txnsWithDependency = transactionGraph.getTxnsWithTxnDependencyBatch(
+                            Config.lake_batch_publish_min_version_num,
+                            Config.lake_batch_publish_max_version_num, txnId);
+                }
                 List<TransactionState> states = txnsWithDependency.stream().map(idToRunningTransactionState::get)
                         .filter(Objects::nonNull)
                         .collect(Collectors.toList());
@@ -1011,22 +1018,21 @@ public class DatabaseTransactionMgr {
                     continue;
                 }
 
-                // Only single table transactions will be batched together.
-                Preconditions.checkState(states.get(0).getTableIdList().size() == 1);
+                // Without lake_enable_batch_publish_multi_table only single table transactions are
+                // batched together. With it, txns whose dependencies are all inside the batch are
+                // grouped regardless of table set, so the checks below iterate each txn's own
+                // table list.
 
-                long tableId = states.get(0).getTableIdList().get(0);
-
-                // Cut the batch whenever a per-partition invariant breaks: version must stay
+                // Cut the batch whenever a per-(table, partition) invariant breaks: version must stay
                 // consecutive (schema change can occupy a version) and the loaded materialized-index
                 // id snapshot must stay identical (so a SplitTabletJob window does not let one batch
                 // mix old + new tablet ids and produce overlapping PublishTabletInfo tasks on BE).
+                // Partition ids are globally unique, so one map keyed by partition id covers all tables.
                 Map<Long, PartitionCommitState> partitionCommitStates = new HashMap<>();
 
                 outerLoop:
                 for (int i = 0; i < states.size(); i++) {
                     TransactionState state = states.get(i);
-                    TableCommitInfo tableInfo = state.getTableCommitInfo(tableId);
-                    // TableCommitInfo could be null if the table has been dropped before this transaction is committed.
                     // Handle special transaction types separately to prevent batching:
                     // 1. Replication transactions: may have non-consecutive versions
                     // 2. DELETE transactions: each delete predicate needs its own version
@@ -1036,30 +1042,39 @@ public class DatabaseTransactionMgr {
                     //    checkTxnStateBatchConsistent() would otherwise see the sentinel version).
                     // e.g. assume there are 4 txns in `states`: <txn_normal_0, txn_rep_0, txn_normal_1, txn_normal_2>
                     // 3 txn batch will be generated as: <txn_normal_0>, <txn_rep_0>, <txn_normal_1, txn_normal_2>
-                    if (tableInfo == null
-                            || state.getSourceType() == TransactionState.LoadJobSourceType.REPLICATION
+                    if (state.getSourceType() == TransactionState.LoadJobSourceType.REPLICATION
                             || state.getSourceType() == TransactionState.LoadJobSourceType.DELETE
                             || state.isShadowRewrite()) {
                         states = states.subList(0, Math.max(i, 1));
                         break;
                     }
 
-                    Map<Long, PartitionCommitInfo> partitionInfoMap = tableInfo.getIdToPartitionCommitInfo();
-                    for (Map.Entry<Long, PartitionCommitInfo> item : partitionInfoMap.entrySet()) {
-                        PartitionCommitInfo currTxnInfo = item.getValue();
-                        PartitionCommitState previousCommitState = partitionCommitStates.get(item.getKey());
-                        List<Long> currentLoadedIndexIds =
-                                state.getPartitionLoadedIndexIdsWithoutLock(tableId, item.getKey());
-                        if (previousCommitState != null
-                                && (previousCommitState.version() + 1 != currTxnInfo.getVersion()
-                                        || !Objects.equals(previousCommitState.loadedIndexIds(),
-                                                currentLoadedIndexIds))) {
-                            assert i > 0;
-                            states = states.subList(0, i);
+                    for (Long tableId : state.getTableIdList()) {
+                        TableCommitInfo tableInfo = state.getTableCommitInfo(tableId);
+                        // TableCommitInfo could be null if the table has been dropped
+                        // before this transaction is committed.
+                        if (tableInfo == null) {
+                            states = states.subList(0, Math.max(i, 1));
                             break outerLoop;
                         }
-                        partitionCommitStates.put(item.getKey(),
-                                new PartitionCommitState(currTxnInfo.getVersion(), currentLoadedIndexIds));
+
+                        Map<Long, PartitionCommitInfo> partitionInfoMap = tableInfo.getIdToPartitionCommitInfo();
+                        for (Map.Entry<Long, PartitionCommitInfo> item : partitionInfoMap.entrySet()) {
+                            PartitionCommitInfo currTxnInfo = item.getValue();
+                            PartitionCommitState previousCommitState = partitionCommitStates.get(item.getKey());
+                            List<Long> currentLoadedIndexIds =
+                                    state.getPartitionLoadedIndexIdsWithoutLock(tableId, item.getKey());
+                            if (previousCommitState != null
+                                    && (previousCommitState.version() + 1 != currTxnInfo.getVersion()
+                                            || !Objects.equals(previousCommitState.loadedIndexIds(),
+                                                    currentLoadedIndexIds))) {
+                                assert i > 0;
+                                states = states.subList(0, i);
+                                break outerLoop;
+                            }
+                            partitionCommitStates.put(item.getKey(),
+                                    new PartitionCommitState(currTxnInfo.getVersion(), currentLoadedIndexIds));
+                        }
                     }
                 }
 
@@ -2161,13 +2176,16 @@ public class DatabaseTransactionMgr {
 
     // the write lock of database has been hold
     private boolean updateCatalogAfterVisibleBatch(TransactionStateBatch transactionStateBatch, Database db) {
-        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .getTable(db.getId(), transactionStateBatch.getTableId());
-        if (table == null) {
-            return true;
+        // one applier per table; a single-table batch loops exactly once
+        for (Long tableId : transactionStateBatch.getTableIdList()) {
+            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getId(), tableId);
+            if (table == null) {
+                continue;
+            }
+            TransactionLogApplier applier = txnLogApplierFactory.create(table);
+            ((LakeTableTxnLogApplier) applier).applyVisibleLogBatch(transactionStateBatch, db);
         }
-        TransactionLogApplier applier = txnLogApplierFactory.create(table);
-        ((LakeTableTxnLogApplier) applier).applyVisibleLogBatch(transactionStateBatch, db);
         return true;
     }
 
@@ -2290,10 +2308,9 @@ public class DatabaseTransactionMgr {
     public void replayUpsertTransactionStateBatch(TransactionStateBatch transactionStateBatch) {
         // Locks are held to ensure that updates of visible version in the same batch are atomic,
         // so that intermediate versions cannot be seen.
+        List<Long> tableIdList = transactionStateBatch.getTableIdList();
         Locker locker = new Locker();
-        locker.lockTablesWithIntensiveDbLock(transactionStateBatch.getDbId(),
-                List.of(transactionStateBatch.getTableId()),
-                LockType.WRITE);
+        locker.lockTablesWithIntensiveDbLock(transactionStateBatch.getDbId(), tableIdList, LockType.WRITE);
         writeLock();
 
         try {
@@ -2308,8 +2325,7 @@ public class DatabaseTransactionMgr {
             unprotectSetTransactionStateBatch(transactionStateBatch);
         } finally {
             writeUnlock();
-            locker.unLockTablesWithIntensiveDbLock(transactionStateBatch.getDbId(),
-                    List.of(transactionStateBatch.getTableId()), LockType.WRITE);
+            locker.unLockTablesWithIntensiveDbLock(transactionStateBatch.getDbId(), tableIdList, LockType.WRITE);
         }
     }
 
@@ -2432,15 +2448,20 @@ public class DatabaseTransactionMgr {
     }
 
     private boolean isTxnStateBatchConsistent(Database db, TransactionStateBatch stateBatch) {
+        // Partition ids are globally unique, so one version map covers all tables of the batch.
         Map<Long, PartitionCommitInfo> versions = new HashMap<>();
         List<TransactionState> states = stateBatch.getTransactionStates();
-        long tableId = stateBatch.getTableId();
-        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .getTable(db.getId(), tableId);
-        if (table != null) {
-            for (int i = 0; i < states.size(); i++) {
-                TransactionState state = states.get(i);
-                TableCommitInfo tableInfo = state.getTableCommitInfo(tableId);
+        Map<Long, Table> tableCache = new HashMap<>();
+        for (int i = 0; i < states.size(); i++) {
+            TransactionState state = states.get(i);
+            for (TableCommitInfo tableInfo : state.getIdToTableCommitInfos().values()) {
+                long tableId = tableInfo.getTableId();
+                Table table = tableCache.computeIfAbsent(tableId,
+                        id -> GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), id));
+                if (table == null) {
+                    // table has been dropped
+                    continue;
+                }
 
                 Map<Long, PartitionCommitInfo> partitionInfoMap = tableInfo.getIdToPartitionCommitInfo();
                 for (Map.Entry<Long, PartitionCommitInfo> item : partitionInfoMap.entrySet()) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
@@ -214,7 +214,11 @@ public class LakeTableTxnLogApplier implements TransactionLogApplier {
 
     public void applyVisibleLogBatch(TransactionStateBatch txnStateBatch, Database db) {
         for (TransactionState txnState : txnStateBatch.getTransactionStates()) {
-            TableCommitInfo tableCommitInfo = txnState.getTableCommitInfo(txnStateBatch.getTableId());
+            TableCommitInfo tableCommitInfo = txnState.getTableCommitInfo(table.getId());
+            if (tableCommitInfo == null) {
+                // in a multi-table batch this txn does not write this applier's table
+                continue;
+            }
             applyVisibleLog(txnState, tableCommitInfo, db);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -89,7 +89,6 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
@@ -523,8 +522,12 @@ public class PublishVersionDaemon extends LeaderDaemon {
                     future.thenRun(() -> tableIdList.forEach(publishingLakeTransactionsBatchTableId::remove));
                 }
             } else {
-                long tableId = txnStateBatch.getTableId();
-                if (!publishingLakeTransactionsBatchTableId.contains(tableId)) {
+                // A single-table batch involves exactly one table; a multi-table batch
+                // (lake_enable_batch_publish_multi_table) involves the union of its
+                // transactions' tables. Every involved table must be free before this batch
+                // may start, so that two in-flight publishes never share a table.
+                List<Long> batchTableIdList = txnStateBatch.getTableIdList();
+                if (batchTableIdList.stream().noneMatch(publishingLakeTransactionsBatchTableId::contains)) {
                     // When the `enable_lake_batch_publish_version` switch is just set to true,
                     // it is possible that the result of publish task
                     // sent by `publishVersionForLakeTable` has not been returned,
@@ -543,10 +546,10 @@ public class PublishVersionDaemon extends LeaderDaemon {
                     if (needWait) {
                         continue;
                     }
-                    publishingLakeTransactionsBatchTableId.add(tableId);
+                    publishingLakeTransactionsBatchTableId.addAll(batchTableIdList);
 
                     CompletableFuture<Void> future = publishLakeTransactionBatchAsync(txnStateBatch);
-                    future.thenRun(() -> publishingLakeTransactionsBatchTableId.remove(tableId));
+                    future.thenRun(() -> batchTableIdList.forEach(publishingLakeTransactionsBatchTableId::remove));
                 }
             }
         }
@@ -864,48 +867,54 @@ public class PublishVersionDaemon extends LeaderDaemon {
         }
 
         long dbId = txnStateBatch.getDbId();
-        long tableId = txnStateBatch.getTableId();
+        List<Long> tableIdList = txnStateBatch.getTableIdList();
         List<TransactionState> states = txnStateBatch.getTransactionStates();
 
-        // Step 1: Collect first version per partition across the batch
-        // partitionId -> firstVersion (from the earliest txn in the batch that touches it)
-        Map<Long, Long> partitionFirstVersions = new LinkedHashMap<>();
+        // Step 1: Collect first version per (table, partition) across the batch
+        // tableId -> partitionId -> firstVersion (from the earliest txn in the batch that touches it)
+        Map<Long, Map<Long, Long>> tableToPartitionFirstVersions = new LinkedHashMap<>();
         for (TransactionState state : states) {
-            TableCommitInfo tableCommitInfo = state.getTableCommitInfo(tableId);
-            if (tableCommitInfo == null) {
-                continue;
-            }
-            for (Map.Entry<Long, PartitionCommitInfo> entry :
-                    tableCommitInfo.getIdToPartitionCommitInfo().entrySet()) {
-                partitionFirstVersions.putIfAbsent(entry.getKey(), entry.getValue().getVersion());
+            for (Long tableId : state.getTableIdList()) {
+                TableCommitInfo tableCommitInfo = state.getTableCommitInfo(tableId);
+                if (tableCommitInfo == null) {
+                    continue;
+                }
+                Map<Long, Long> partitionFirstVersions =
+                        tableToPartitionFirstVersions.computeIfAbsent(tableId, k -> new LinkedHashMap<>());
+                for (Map.Entry<Long, PartitionCommitInfo> entry :
+                        tableCommitInfo.getIdToPartitionCommitInfo().entrySet()) {
+                    partitionFirstVersions.putIfAbsent(entry.getKey(), entry.getValue().getVersion());
+                }
             }
         }
 
-        // Step 2: Check each partition's first version against visibleVersion
+        // Step 2: Check each partition's first version against visibleVersion.
+        // Partition ids are globally unique, so one gap set covers all tables.
         Set<Long> gapPartitions = new HashSet<>();
-        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState()
-                .getLocalMetastore().getTable(dbId, tableId);
-        if (table == null) {
-            return txnStateBatch;
-        }
-
         Locker locker = new Locker();
-        locker.lockTablesWithIntensiveDbLock(dbId, List.of(tableId), LockType.READ);
+        locker.lockTablesWithIntensiveDbLock(dbId, tableIdList, LockType.READ);
         try {
-            for (Map.Entry<Long, Long> entry : partitionFirstVersions.entrySet()) {
-                long partitionId = entry.getKey();
-                long firstVersion = entry.getValue();
-                PhysicalPartition partition = table.getPhysicalPartition(partitionId);
-                if (partition != null
-                        && partition.getVisibleVersion() + 1 != firstVersion
-                        // REPLICATION txns may have non-consecutive versions, skip check
-                        && states.get(0).getSourceType()
-                                != TransactionState.LoadJobSourceType.REPLICATION) {
-                    gapPartitions.add(partitionId);
+            for (Map.Entry<Long, Map<Long, Long>> tableEntry : tableToPartitionFirstVersions.entrySet()) {
+                OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState()
+                        .getLocalMetastore().getTable(dbId, tableEntry.getKey());
+                if (table == null) {
+                    continue; // table has been dropped
+                }
+                for (Map.Entry<Long, Long> entry : tableEntry.getValue().entrySet()) {
+                    long partitionId = entry.getKey();
+                    long firstVersion = entry.getValue();
+                    PhysicalPartition partition = table.getPhysicalPartition(partitionId);
+                    if (partition != null
+                            && partition.getVisibleVersion() + 1 != firstVersion
+                            // REPLICATION txns may have non-consecutive versions, skip check
+                            && states.get(0).getSourceType()
+                                    != TransactionState.LoadJobSourceType.REPLICATION) {
+                        gapPartitions.add(partitionId);
+                    }
                 }
             }
         } finally {
-            locker.unLockTablesWithIntensiveDbLock(dbId, List.of(tableId), LockType.READ);
+            locker.unLockTablesWithIntensiveDbLock(dbId, tableIdList, LockType.READ);
         }
 
         if (gapPartitions.isEmpty()) {
@@ -914,8 +923,12 @@ public class PublishVersionDaemon extends LeaderDaemon {
 
         // Step 3: Find the first transaction that touches any gap-affected partition
         for (int i = 0; i < states.size(); i++) {
-            TableCommitInfo tableCommitInfo = states.get(i).getTableCommitInfo(tableId);
-            if (tableCommitInfo != null) {
+            TransactionState state = states.get(i);
+            for (Long tableId : state.getTableIdList()) {
+                TableCommitInfo tableCommitInfo = state.getTableCommitInfo(tableId);
+                if (tableCommitInfo == null) {
+                    continue;
+                }
                 for (long partitionId : tableCommitInfo.getIdToPartitionCommitInfo().keySet()) {
                     if (gapPartitions.contains(partitionId)) {
                         if (i == 0) {
@@ -944,27 +957,30 @@ public class PublishVersionDaemon extends LeaderDaemon {
     private CompletableFuture<Void> publishLakeTransactionBatchAsync(TransactionStateBatch txnStateBatch) {
         GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
         assert txnStateBatch.size() > 1;
-        // pick up all tableCommitInfo
-        // only one table,if batch has multi transactionState for now,
-        // the batch only has one transactionState for multi table.
+        // Pick up all tableCommitInfos of every txn in the batch. Without
+        // lake_enable_batch_publish_multi_table all txns share one table; with it table sets
+        // may differ across txns. Publish stays per (table, partition):
+        // partition ids are globally unique, so the map below is keyed by partition id alone.
         long dbId = txnStateBatch.getDbId();
-        long tableId = txnStateBatch.getTableId();
         List<TransactionState> states = txnStateBatch.getTransactionStates();
         Map<Long, PartitionPublishVersionData> publishVersionDataMap = new HashMap<>();
 
         states.forEach(state -> state.setHasSendTask(true));
         for (TransactionState state : states) {
-            TableCommitInfo tableCommitInfo = Objects.requireNonNull(state.getTableCommitInfo(tableId));
-            Map<Long, PartitionCommitInfo> partitionCommitInfoMap = tableCommitInfo.getIdToPartitionCommitInfo();
-            for (Long partitionId : partitionCommitInfoMap.keySet()) {
-                if (!publishVersionDataMap.containsKey(partitionId)) {
-                    publishVersionDataMap.put(partitionId, new PartitionPublishVersionData(tableId, partitionId));
+            for (TableCommitInfo tableCommitInfo : state.getIdToTableCommitInfos().values()) {
+                long tableId = tableCommitInfo.getTableId();
+                Map<Long, PartitionCommitInfo> partitionCommitInfoMap = tableCommitInfo.getIdToPartitionCommitInfo();
+                for (Long partitionId : partitionCommitInfoMap.keySet()) {
+                    if (!publishVersionDataMap.containsKey(partitionId)) {
+                        publishVersionDataMap.put(partitionId, new PartitionPublishVersionData(tableId, partitionId));
+                    }
+                    PartitionPublishVersionData publishVersionData = publishVersionDataMap.get(partitionId);
+                    publishVersionData.addTransaction(state);
                 }
-                PartitionPublishVersionData publishVersionData = publishVersionDataMap.get(partitionId);
-                publishVersionData.addTransaction(state);
             }
         }
-        LOG.info("start publish lake batch db:{} table:{} txns:{}", dbId, tableId,
+        LOG.info("start publish lake batch db:{} tables:{} txns:{}", dbId,
+                StringUtils.join(txnStateBatch.getTableIdList(), ","),
                 StringUtils.join(states.stream().map(TransactionState::getTransactionId).toArray(), ","));
 
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
@@ -986,7 +1002,8 @@ public class PublishVersionDaemon extends LeaderDaemon {
 
         for (PartitionPublishVersionData publishVersionData : publishVersionDataMap.values()) {
             CompletableFuture<Boolean> future = CompletableFuture.supplyAsync(() -> {
-                boolean success = publishPartitionBatch(db, tableId, publishVersionData, txnStateBatch);
+                boolean success = publishPartitionBatch(db, publishVersionData.getTableId(),
+                        publishVersionData, txnStateBatch);
                 long versionTime = success ? System.currentTimeMillis() : -System.currentTimeMillis();
                 for (PartitionCommitInfo commitInfo : publishVersionData.getPartitionCommitInfos()) {
                     commitInfo.setVersionTime(versionTime);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionGraph.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionGraph.java
@@ -19,6 +19,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -175,6 +176,56 @@ public class TransactionGraph {
                     node = null;
                 }
             }
+        }
+        return txns.size() >= minBatchSize ? txns : new ArrayList<>();
+    }
+
+    /**
+     * Batch selection that also allows multi-table transactions. The batch is a dependency
+     * chain: starting from a dependency-free head transaction, it is extended with a
+     * successor of the current tail whose dependencies are all inside the batch. Because a
+     * successor of the tail depends on the tail directly, every transaction in the batch
+     * transitively depends on all transactions before it -- it would have to wait for them
+     * even without batching, so grouping them costs nothing. Transactions that are
+     * independent of the chain tail (parallel branches hanging off an earlier transaction)
+     * are never batched: batch visibility is all-or-nothing, and batching them would couple
+     * transactions that could otherwise publish in parallel.
+     *
+     * The returned list is in chain (hence topological) order, so any prefix cut downstream
+     * stays dependency-closed and per-partition commit versions appear in consecutive order.
+     *
+     * The size of ins of node with txnId must be zero.
+     */
+    public List<Long> getTxnsWithTxnDependencyBatchMultiTable(int minBatchSize, int maxBatchSize, long txnId) {
+        List<Long> txns = new ArrayList<>();
+        Node head = nodes.get(txnId);
+        if (head == null) {
+            return txns;
+        }
+        Set<Node> inBatch = new HashSet<>();
+        txns.add(head.txnId);
+        inBatch.add(head);
+        Node current = head;
+        while (txns.size() < maxBatchSize && current.outs != null) {
+            Node nextInChain = null;
+            List<Node> successors = current.outs.stream()
+                    .sorted(Comparator.comparingLong(n -> n.txnId))
+                    .collect(Collectors.toList());
+            for (Node next : successors) {
+                // A successor of the tail depends on the tail, and joins only when it has
+                // no dependency outside the batch: publishing it here would otherwise jump
+                // over a txn that has to become visible first.
+                if (next.ins == null || inBatch.containsAll(next.ins)) {
+                    nextInChain = next;
+                    break;
+                }
+            }
+            if (nextInChain == null) {
+                break;
+            }
+            txns.add(nextInChain.txnId);
+            inBatch.add(nextInChain);
+            current = nextInChain;
         }
         return txns.size() >= minBatchSize ? txns : new ArrayList<>();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStateBatch.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStateBatch.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -64,9 +65,10 @@ public class TransactionStateBatch implements Writable {
     // the partitionId will not be the same,
     // and transactionStates is read-only which will not be changed
     public void setCompactionScore(long tableId, long partitionId, Quantiles quantiles) {
+        // commitInfo can be null in a multi-table batch when a txn does not write this table
         this.transactionStates.stream()
                 .map(transactionState -> transactionState.getTableCommitInfo(tableId))
-                .filter(commitInfo -> commitInfo.getPartitionCommitInfo(partitionId) != null)
+                .filter(commitInfo -> commitInfo != null && commitInfo.getPartitionCommitInfo(partitionId) != null)
                 .forEach(commitInfo -> commitInfo.getPartitionCommitInfo(partitionId).setCompactionScore(quantiles));
     }
 
@@ -144,14 +146,15 @@ public class TransactionStateBatch implements Writable {
         return transactionStates.stream().map(TransactionState::getTransactionId).collect(Collectors.toList());
     }
 
-    // all transactionState in batch have the same table and return the tableId
-    public long getTableId() {
-        if (!transactionStates.isEmpty()) {
-            List<Long> tableIdList = transactionStates.get(0).getTableIdList();
-            assert tableIdList.size() == 1;
-            return tableIdList.get(0);
+    // Union of table ids across all transactions in the batch, in first-appearance order.
+    // For a single-table batch this is a singleton list; for a multi-table batch
+    // (lake_enable_batch_publish_multi_table) table sets may differ across transactions.
+    public List<Long> getTableIdList() {
+        Set<Long> tableIds = new LinkedHashSet<>();
+        for (TransactionState state : transactionStates) {
+            tableIds.addAll(state.getTableIdList());
         }
-        return -1;
+        return new ArrayList<>(tableIds);
     }
 
     public long size() {

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
@@ -45,6 +45,7 @@ import com.starrocks.catalog.FakeGlobalStateMgr;
 import com.starrocks.catalog.GlobalStateMgrTestUtil;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndex.IndexState;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
@@ -63,6 +64,7 @@ import com.starrocks.common.StarRocksException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.StringUtils;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
@@ -955,6 +957,102 @@ public class DatabaseTransactionMgrTest {
                 fakeEditLog.getTransaction(txnId8)));
         slaveTransMgr.replayUpsertTransactionStateBatch(replayStateBatch);
         assertEquals(4, masterDbTransMgr.getFinishedTxnNums());
+    }
+
+    private static TransactionState makeVisibleBatchTxn(long txnId, List<Long> tableIds) {
+        return new TransactionState(GlobalStateMgrTestUtil.testDbId1, tableIds, txnId,
+                "replay_mt_" + txnId, UUIDUtil.genTUniqueId(),
+                TransactionState.LoadJobSourceType.FRONTEND,
+                new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE, "localfe"),
+                -1, 60 * 1000L);
+    }
+
+    private static void addCommitInfo(TransactionState txn, long tableId, long physicalPartitionId,
+                                      long version, long versionTime) {
+        TableCommitInfo tableCommitInfo = txn.getTableCommitInfo(tableId);
+        if (tableCommitInfo == null) {
+            tableCommitInfo = new TableCommitInfo(tableId);
+            txn.putIdToTableCommitInfo(tableId, tableCommitInfo);
+        }
+        tableCommitInfo.addPartitionCommitInfo(new PartitionCommitInfo(physicalPartitionId, version, versionTime));
+    }
+
+    @Test
+    public void testReplayMultiTableTransactionStateBatch() throws StarRocksException {
+        long table2Id = 20000L;
+        long partition2Id = 20001L;
+
+        // Register a second lake-style table into the slave catalog only: replay is a
+        // follower-side path and must apply the visible logs of every table in the batch.
+        FakeGlobalStateMgr.setGlobalStateMgr(slaveGlobalStateMgr);
+        MaterializedIndex index2 = new MaterializedIndex(table2Id, IndexState.NORMAL);
+        RandomDistributionInfo distributionInfo = new RandomDistributionInfo(10);
+        Partition partition2 = new Partition(partition2Id, partition2Id + 100, "testTable2",
+                index2, distributionInfo);
+        partition2.getDefaultPhysicalPartition().updateVisibleVersion(GlobalStateMgrTestUtil.testStartVersion);
+        partition2.getDefaultPhysicalPartition().setNextVersion(GlobalStateMgrTestUtil.testStartVersion + 1);
+        List<Column> columns = new ArrayList<>();
+        Column k1 = new Column("k1", IntegerType.INT);
+        k1.setIsKey(true);
+        columns.add(k1);
+        columns.add(new Column("v", FloatType.DOUBLE, false, AggregateType.SUM, "0", ""));
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setDataProperty(partition2Id, DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(partition2Id, (short) 3);
+        OlapTable table2 = new OlapTable(table2Id, "testTable2", columns, KeysType.AGG_KEYS,
+                partitionInfo, distributionInfo);
+        table2.addPartition(partition2);
+        table2.setIndexMeta(table2Id, "testTable2", columns, 0, GlobalStateMgrTestUtil.testSchemaHash1,
+                (short) 1, TStorageType.COLUMN, KeysType.AGG_KEYS);
+        table2.setBaseIndexMetaId(table2Id);
+        Database slaveDb = slaveGlobalStateMgr.getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDbId1);
+        slaveDb.registerTableUnlocked(table2);
+
+        OlapTable slaveTable1 = (OlapTable) slaveGlobalStateMgr.getLocalMetastore()
+                .getTable(slaveDb.getId(), GlobalStateMgrTestUtil.testTableId1);
+        PhysicalPartition slaveT1Partition = slaveTable1.getPartition(GlobalStateMgrTestUtil.testPartition1)
+                .getDefaultPhysicalPartition();
+        PhysicalPartition slaveT2Partition = partition2.getDefaultPhysicalPartition();
+        long t1BaseVersion = slaveT1Partition.getVisibleVersion();
+        long t2BaseVersion = slaveT2Partition.getVisibleVersion();
+
+        // txnA and txnB write both tables, txnC writes only table1 (a subset of the head set)
+        long versionTime = System.currentTimeMillis();
+        List<Long> bothTables = Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1, table2Id);
+        TransactionState txnA = makeVisibleBatchTxn(9001L, bothTables);
+        addCommitInfo(txnA, GlobalStateMgrTestUtil.testTableId1, slaveT1Partition.getId(),
+                t1BaseVersion + 1, versionTime);
+        addCommitInfo(txnA, table2Id, slaveT2Partition.getId(), t2BaseVersion + 1, versionTime);
+        TransactionState txnB = makeVisibleBatchTxn(9002L, bothTables);
+        addCommitInfo(txnB, GlobalStateMgrTestUtil.testTableId1, slaveT1Partition.getId(),
+                t1BaseVersion + 2, versionTime);
+        addCommitInfo(txnB, table2Id, slaveT2Partition.getId(), t2BaseVersion + 2, versionTime);
+        TransactionState txnC = makeVisibleBatchTxn(9003L,
+                Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1));
+        addCommitInfo(txnC, GlobalStateMgrTestUtil.testTableId1, slaveT1Partition.getId(),
+                t1BaseVersion + 3, versionTime);
+
+        TransactionStateBatch stateBatch = new TransactionStateBatch(Lists.newArrayList(txnA, txnB, txnC));
+        stateBatch.setTransactionVisibleInfo();
+
+        new MockUp<Table>() {
+            @Mock
+            public boolean isCloudNativeTableOrMaterializedView() {
+                return true;
+            }
+        };
+
+        slaveTransMgr.replayUpsertTransactionStateBatch(stateBatch);
+
+        // both tables' visible versions advanced; table2 only by the two txns that write it
+        assertEquals(t1BaseVersion + 3, slaveT1Partition.getVisibleVersion());
+        assertEquals(t2BaseVersion + 2, slaveT2Partition.getVisibleVersion());
+
+        DatabaseTransactionMgr slaveDbTransMgr =
+                slaveTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1);
+        assertEquals(TransactionStatus.VISIBLE, slaveDbTransMgr.getTransactionState(9001L).getTransactionStatus());
+        assertEquals(TransactionStatus.VISIBLE, slaveDbTransMgr.getTransactionState(9002L).getTransactionStatus());
+        assertEquals(TransactionStatus.VISIBLE, slaveDbTransMgr.getTransactionState(9003L).getTransactionStatus());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
@@ -48,6 +48,7 @@ import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import com.starrocks.warehouse.cngroup.WarehouseComputeResourceProvider;
+import mockit.Invocation;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.logging.log4j.LogManager;
@@ -271,6 +272,213 @@ public class LakePublishBatchTest {
 
         PublishVersionDaemon publishVersionDaemon = new PublishVersionDaemon();
         awaitPublish(publishVersionDaemon, waiter1, waiter2, waiter3, waiter4);
+    }
+
+    @Test
+    public void testMultiTableBatchPublish() throws Exception {
+        boolean oldMultiTable = Config.lake_enable_batch_publish_multi_table;
+        Config.lake_enable_batch_publish_multi_table = true;
+        try {
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
+            Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), TABLE_AGG_OFF);
+            Table table2 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), TABLE_AGG_ON);
+
+            // every txn commits the same tablets so per-partition versions stay consecutive
+            List<TabletCommitInfo> bothTableTablets = Lists.newArrayList();
+            List<TabletCommitInfo> table1Tablets = Lists.newArrayList();
+            for (Table table : Lists.newArrayList(table1, table2)) {
+                for (Partition partition : table.getPartitions()) {
+                    MaterializedIndex baseIndex = partition.getDefaultPhysicalPartition().getLatestBaseIndex();
+                    for (Long tabletId : baseIndex.getTabletIdsInOrder()) {
+                        for (Long backendId : GlobalStateMgr.getCurrentState().getNodeMgr()
+                                .getClusterInfo().getBackendIds()) {
+                            TabletCommitInfo tabletCommitInfo = new TabletCommitInfo(tabletId, backendId);
+                            bothTableTablets.add(tabletCommitInfo);
+                            if (table == table1) {
+                                table1Tablets.add(tabletCommitInfo);
+                            }
+                        }
+                    }
+                }
+            }
+
+            GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+            List<Long> bothTableIds = Lists.newArrayList(table1.getId(), table2.getId());
+
+            long transactionId1 = globalTransactionMgr.beginTransaction(db.getId(), bothTableIds,
+                    "multi_table_batch_1_" + UUIDUtil.genUUID(), transactionSource,
+                    TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+            VisibleStateWaiter waiter1 = globalTransactionMgr.commitTransaction(db.getId(), transactionId1,
+                    bothTableTablets, Lists.newArrayList(), null);
+
+            long transactionId2 = globalTransactionMgr.beginTransaction(db.getId(), bothTableIds,
+                    "multi_table_batch_2_" + UUIDUtil.genUUID(), transactionSource,
+                    TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+            VisibleStateWaiter waiter2 = globalTransactionMgr.commitTransaction(db.getId(), transactionId2,
+                    bothTableTablets, Lists.newArrayList(), null);
+
+            // a txn writing only a subset of the head txn's tables joins the same batch
+            long transactionId3 = globalTransactionMgr.beginTransaction(db.getId(),
+                    Lists.newArrayList(table1.getId()),
+                    "multi_table_batch_3_" + UUIDUtil.genUUID(), transactionSource,
+                    TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+            VisibleStateWaiter waiter3 = globalTransactionMgr.commitTransaction(db.getId(), transactionId3,
+                    table1Tablets, Lists.newArrayList(), null);
+
+            long transactionId4 = globalTransactionMgr.beginTransaction(db.getId(), bothTableIds,
+                    "multi_table_batch_4_" + UUIDUtil.genUUID(), transactionSource,
+                    TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+            VisibleStateWaiter waiter4 = globalTransactionMgr.commitTransaction(db.getId(), transactionId4,
+                    bothTableTablets, Lists.newArrayList(), null);
+
+            // the head-gated selection groups all four txns into one multi-table batch
+            List<TransactionStateBatch> batches = globalTransactionMgr.getReadyPublishTransactionsBatch();
+            TransactionStateBatch multiTableBatch = batches.stream()
+                    .filter(batch -> batch.getTxnIds().contains(transactionId1))
+                    .findFirst().orElse(null);
+            assertNotNull(multiTableBatch);
+            assertEquals(Lists.newArrayList(transactionId1, transactionId2, transactionId3, transactionId4),
+                    multiTableBatch.getTxnIds());
+            assertEquals(bothTableIds, multiTableBatch.getTableIdList());
+
+            PublishVersionDaemon publishVersionDaemon = new PublishVersionDaemon();
+            awaitPublish(publishVersionDaemon, waiter1, waiter2, waiter3, waiter4);
+        } finally {
+            Config.lake_enable_batch_publish_multi_table = oldMultiTable;
+        }
+    }
+
+    @Test
+    public void testTrimBatchAtVersionGapMultiTable() throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
+        Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), TABLE_AGG_OFF);
+        Table table2 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), TABLE_AGG_ON);
+        List<Long> bothTableIds = Lists.newArrayList(table1.getId(), table2.getId());
+
+        Partition t1Part = Lists.newArrayList(table1.getPartitions()).get(0);
+        List<Partition> t2Parts = Lists.newArrayList(table2.getPartitions());
+        Partition t2PartNoGap = t2Parts.get(0);
+        Partition t2PartWithGap = t2Parts.get(2);
+
+        List<TabletCommitInfo> tabletsNoGap = getPartitionTabletCommitInfos(t1Part);
+        tabletsNoGap.addAll(getPartitionTabletCommitInfos(t2PartNoGap));
+        List<TabletCommitInfo> tabletsWithGap = getPartitionTabletCommitInfos(t1Part);
+        tabletsWithGap.addAll(getPartitionTabletCommitInfos(t2PartWithGap));
+
+        GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+
+        // txn1 and txn2 write both tables but avoid the gap partition of table2
+        long txnId1 = globalTransactionMgr.beginTransaction(db.getId(), bothTableIds,
+                "trim_mt_1_" + UUIDUtil.genUUID(), transactionSource,
+                TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+        VisibleStateWaiter waiter1 = globalTransactionMgr.commitTransaction(
+                db.getId(), txnId1, tabletsNoGap, Lists.newArrayList(), null);
+
+        long txnId2 = globalTransactionMgr.beginTransaction(db.getId(), bothTableIds,
+                "trim_mt_2_" + UUIDUtil.genUUID(), transactionSource,
+                TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+        VisibleStateWaiter waiter2 = globalTransactionMgr.commitTransaction(
+                db.getId(), txnId2, tabletsNoGap, Lists.newArrayList(), null);
+
+        // Create a version gap on the second table's partition
+        // (simulates SplitTabletJob.updateNextVersions)
+        PhysicalPartition physWithGap = t2PartWithGap.getDefaultPhysicalPartition();
+        physWithGap.setNextVersion(physWithGap.getNextVersion() + 1);
+
+        // txn3 writes both tables and touches the gap partition of table2
+        long txnId3 = globalTransactionMgr.beginTransaction(db.getId(), bothTableIds,
+                "trim_mt_3_" + UUIDUtil.genUUID(), transactionSource,
+                TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+        VisibleStateWaiter waiter3 = globalTransactionMgr.commitTransaction(
+                db.getId(), txnId3, tabletsWithGap, Lists.newArrayList(), null);
+
+        DatabaseTransactionMgr dbTxnMgr = globalTransactionMgr.getDatabaseTransactionMgr(db.getId());
+        TransactionStateBatch batch = new TransactionStateBatch(Lists.newArrayList(
+                dbTxnMgr.getTransactionState(txnId1),
+                dbTxnMgr.getTransactionState(txnId2),
+                dbTxnMgr.getTransactionState(txnId3)));
+
+        // The gap lives on the second table of the batch; the batch must still be
+        // trimmed right before the first txn touching the gap partition
+        PublishVersionDaemon daemon = new PublishVersionDaemon();
+        TransactionStateBatch trimmed = daemon.trimBatchAtVersionGap(batch);
+        assertNotNull(trimmed);
+        assertEquals(2, trimmed.size());
+        assertEquals(txnId1, trimmed.getTransactionStates().get(0).getTransactionId());
+        assertEquals(txnId2, trimmed.getTransactionStates().get(1).getTransactionId());
+
+        // Cleanup: fill the phantom version gap and publish all transactions
+        physWithGap.updateVisibleVersion(physWithGap.getVisibleVersion() + 1);
+        awaitPublish(daemon, waiter1, waiter2, waiter3);
+    }
+
+    @Test
+    public void testMultiTableBatchPublishTableDropped() throws Exception {
+        boolean oldMultiTable = Config.lake_enable_batch_publish_multi_table;
+        Config.lake_enable_batch_publish_multi_table = true;
+        try {
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
+            Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), TABLE_AGG_OFF);
+            Table table2 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), TABLE_AGG_ON);
+            List<Long> bothTableIds = Lists.newArrayList(table1.getId(), table2.getId());
+
+            List<TabletCommitInfo> bothTableTablets = Lists.newArrayList();
+            for (Table table : Lists.newArrayList(table1, table2)) {
+                for (Partition partition : table.getPartitions()) {
+                    bothTableTablets.addAll(getPartitionTabletCommitInfos(partition));
+                }
+            }
+
+            GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+
+            long txnId1 = globalTransactionMgr.beginTransaction(db.getId(), bothTableIds,
+                    "mt_dropped_1_" + UUIDUtil.genUUID(), transactionSource,
+                    TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+            VisibleStateWaiter waiter1 = globalTransactionMgr.commitTransaction(
+                    db.getId(), txnId1, bothTableTablets, Lists.newArrayList(), null);
+
+            long txnId2 = globalTransactionMgr.beginTransaction(db.getId(), bothTableIds,
+                    "mt_dropped_2_" + UUIDUtil.genUUID(), transactionSource,
+                    TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+            VisibleStateWaiter waiter2 = globalTransactionMgr.commitTransaction(
+                    db.getId(), txnId2, bothTableTablets, Lists.newArrayList(), null);
+
+            // Drop table2 after commit: publish, trim and visibility must skip it and
+            // still make the whole batch VISIBLE
+            long droppedTableId = table2.getId();
+            try {
+                new MockUp<LocalMetastore>() {
+                    @Mock
+                    public Table getTable(Invocation invocation, Long dbId, Long tableId) {
+                        if (tableId == droppedTableId) {
+                            return null;
+                        }
+                        return invocation.proceed(dbId, tableId);
+                    }
+                };
+
+                PublishVersionDaemon publishVersionDaemon = new PublishVersionDaemon();
+                awaitPublish(publishVersionDaemon, waiter1, waiter2);
+            } finally {
+                // The "dropped" table's committed versions were skipped, leaving
+                // nextVersion ahead of visibleVersion. The suite shares one cluster,
+                // so close the gap or every later publish on this table stalls.
+                for (Partition partition : table2.getPartitions()) {
+                    PhysicalPartition physicalPartition = partition.getDefaultPhysicalPartition();
+                    if (physicalPartition.getVisibleVersion() < physicalPartition.getNextVersion() - 1) {
+                        physicalPartition.updateVisibleVersion(physicalPartition.getNextVersion() - 1);
+                    }
+                }
+            }
+        } finally {
+            Config.lake_enable_batch_publish_multi_table = oldMultiTable;
+        }
     }
 
     //    @ParameterizedTest
@@ -599,7 +807,7 @@ public class LakePublishBatchTest {
             long myTableId = table.getId();
             TransactionStateBatch readyStateBatch = null;
             for (TransactionStateBatch batch : globalTransactionMgr.getReadyPublishTransactionsBatch()) {
-                if (batch.getTableId() == myTableId) {
+                if (batch.getTableIdList().contains(myTableId)) {
                     readyStateBatch = batch;
                     break;
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionGraphTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionGraphTest.java
@@ -203,6 +203,66 @@ public class TransactionGraphTest {
     }
 
     @Test
+    public void testGetTxnsWithTxnDependencyBatchMultiTable() {
+        // CDC-like chain: every txn writes the same multi-table set
+        TransactionGraph graph = new TransactionGraph();
+        for (int i = 1; i <= 6; i++) {
+            graph.add(i, Lists.newArrayList(1L, 2L, 3L));
+        }
+        List<Long> batch = graph.getTxnsWithTxnDependencyBatchMultiTable(1, 10, 1);
+        assertEquals(Lists.newArrayList(1L, 2L, 3L, 4L, 5L, 6L), batch);
+        // maxBatchSize caps the batch
+        batch = graph.getTxnsWithTxnDependencyBatchMultiTable(1, 4, 1);
+        assertEquals(Lists.newArrayList(1L, 2L, 3L, 4L), batch);
+
+        // diamond: txn1 {1,2} -> txn2 {1} / txn3 {2} -> txn4 {1,2}.
+        // txn2 and txn3 are independent of each other, so only one of them may chain onto
+        // txn1; the other is left out to publish in parallel after the batch finishes.
+        TransactionGraph graph2 = new TransactionGraph();
+        graph2.add(1, Lists.newArrayList(1L, 2L));
+        graph2.add(2, Lists.newArrayList(1L));
+        graph2.add(3, Lists.newArrayList(2L));
+        graph2.add(4, Lists.newArrayList(1L, 2L));
+        batch = graph2.getTxnsWithTxnDependencyBatchMultiTable(1, 10, 1);
+        assertEquals(Lists.newArrayList(1L, 2L), batch);
+
+        // a txn introducing a new table still joins when it extends the chain; a txn
+        // independent of the chain tail does not, even though its dependencies are in
+        // the batch
+        TransactionGraph graph3 = new TransactionGraph();
+        graph3.add(1, Lists.newArrayList(1L, 2L));
+        graph3.add(2, Lists.newArrayList(1L, 3L)); // table 3 is new, depends on txn1 only
+        graph3.add(3, Lists.newArrayList(2L));     // depends on txn1 only, independent of txn2
+        graph3.add(4, Lists.newArrayList(1L));     // depends on txn2, extends the chain
+        batch = graph3.getTxnsWithTxnDependencyBatchMultiTable(1, 10, 1);
+        assertEquals(Lists.newArrayList(1L, 2L, 4L), batch);
+
+        // single-table head: a multi-table successor joins as well
+        TransactionGraph graph4 = new TransactionGraph();
+        graph4.add(1, Lists.newArrayList(1L));
+        graph4.add(2, Lists.newArrayList(1L));
+        graph4.add(3, Lists.newArrayList(1L, 2L));
+        batch = graph4.getTxnsWithTxnDependencyBatchMultiTable(1, 10, 1);
+        assertEquals(Lists.newArrayList(1L, 2L, 3L), batch);
+
+        // minBatchSize not reached -> empty result
+        batch = graph4.getTxnsWithTxnDependencyBatchMultiTable(4, 10, 1);
+        assertEquals(0, batch.size());
+
+        // a txn depending on another dependency-free head outside the batch must not join:
+        // publishing it in this batch would jump over that txn
+        TransactionGraph graph5 = new TransactionGraph();
+        graph5.add(1, Lists.newArrayList(9L));     // independent head on table 9
+        graph5.add(2, Lists.newArrayList(1L, 2L)); // head of the walk
+        graph5.add(3, Lists.newArrayList(2L, 9L)); // depends on txn2 AND txn1 (outside)
+        batch = graph5.getTxnsWithTxnDependencyBatchMultiTable(1, 10, 2);
+        assertEquals(Lists.newArrayList(2L), batch);
+        // walking from txn1 must not pull txn3 either (txn2 outside that batch)
+        batch = graph5.getTxnsWithTxnDependencyBatchMultiTable(1, 10, 1);
+        assertEquals(Lists.newArrayList(1L), batch);
+    }
+
+    @Test
     public void testPrintGraph() {
         TransactionGraph graph = new TransactionGraph();
         graph.add(1, Lists.newArrayList(1L));


### PR DESCRIPTION
Multi-table transactions were excluded from lake batch publish: TransactionGraph.getTxnsWithTxnDependencyBatch returns any txn writing more than one table as a singleton, so workloads committing atomic multi-table txns (e.g. CDC micro-batches fanning out to many tables) publish one txn at a time. Because every txn chains on the previous writer of each table it touches, the whole stream serializes into one dependency chain and "wait for publish" grows with the backlog depth (observed ~1.5s avg with ~4s spikes at ~3 txn/s over 3 hot tables).

Add an opt-in batch mode for multi-table txns, gated by a new mutable FE config lake_enable_batch_publish_multi_table (default false):

- TransactionGraph.getTxnsWithTxnDependencyBatchMultiTable: the batch is a dependency chain. Starting from a dependency-free head txn, it is extended with a successor of the current tail whose dependencies are all inside the batch. Every txn in the batch therefore transitively depends on all txns before it -- it would have to wait for them even without batching, so grouping it costs nothing. Transactions independent of the chain tail (parallel branches hanging off an earlier txn) are never batched: batch visibility is all-or-nothing, and batching them would couple txns that could otherwise publish in parallel.
- getReadyToPublishTxnListBatch validates version contiguity and loaded-index-id snapshots per (table, partition) across all tables of the batch.
- Publish execution stays per (table, partition): publishLakeTransactionBatchAsync builds PartitionPublishVersionData from each txn's own TableCommitInfos; trimBatchAtVersionGap checks gaps per table; the in-flight mutual exclusion covers the batch's whole table set.
- Visibility and replay iterate the batch's table set: updateCatalogAfterVisibleBatch, replayUpsertTransactionStateBatch, isTxnStateBatchConsistent, and applyVisibleLogBatch (which skips txns that do not write the applier's table).

The edit-log serialization of TransactionStateBatch is unchanged. Enable the config only after all FE nodes are upgraded: a follower replaying a multi-table batch with old code applies only the first table's visible log.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5