### PR TITLE
[UT] Cover the explicit-transaction db binding restore on registration failure

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
@@ -185,7 +185,15 @@ public class TransactionStmtExecutor {
                 transactionState.setDbId(database.getId());
                 DatabaseTransactionMgr databaseTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
                         .getDatabaseTransactionMgr(database.getId());
-                databaseTransactionMgr.upsertTransactionState(transactionState);
+                try {
+                    databaseTransactionMgr.upsertTransactionState(transactionState);
+                } catch (Exception e) {
+                    // Registration failed (e.g. running-txn limit, duplicate label, quota). Undo the db binding
+                    // so a later statement re-attempts registration instead of skipping it (getDbId() != 0) and
+                    // then failing COMMIT against a transaction the DatabaseTransactionMgr never registered.
+                    transactionState.setDbId(0);
+                    throw e;
+                }
             }
 
             if (database.getId() != transactionState.getDbId()) {

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/ExplicitTxnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/ExplicitTxnTest.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReportException;
@@ -309,6 +310,82 @@ public class ExplicitTxnTest {
             Assertions.assertEquals(ErrorCode.ERR_TXN_IMPORT_SAME_TABLE, e.getErrorCode());
         }
         Assertions.assertEquals(1, activationCount.get());
+    }
+
+    @Test
+    public void testRejectedFirstStatementDoesNotStrandTransaction() throws IOException, DdlException {
+        // A rejected first DML of an explicit transaction must not leave the transaction bound to a
+        // database it was never registered in. registerExplicitTransactionState sets dbId before the
+        // fallible upsert and restores it on failure; without that restore, getDbId() stays non-zero,
+        // every later statement skips registration, and COMMIT then fails against a transaction the
+        // DatabaseTransactionMgr never registered. Nothing else covers that restore, so this pins it.
+        new MockUp<DefaultCoordinator>() {
+            @Mock
+            public void exec() throws StarRocksException, RpcException, InterruptedException {
+            }
+
+            @Mock
+            public boolean join(int timeoutSecond) {
+                return true;
+            }
+
+            @Mock
+            public boolean isDone() {
+                return true;
+            }
+
+            @Mock
+            public Status getExecStatus() {
+                return Status.OK;
+            }
+
+            @Mock
+            public Map<String, String> getLoadCounters() {
+                Map<String, String> counters = new HashMap<String, String>();
+                counters.put(LoadEtlTask.DPP_NORMAL_ALL, "0");
+                counters.put(LoadEtlTask.DPP_ABNORMAL_ALL, "0");
+                counters.put(LoadJob.LOADED_BYTES, "0");
+                return counters;
+            }
+        };
+
+        ConnectContext context = new ConnectContext();
+        context.setThreadLocalInfo();
+        context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+
+        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable("db1", "tbl1");
+
+        context.setQualifiedUser("u1");
+        context.setCurrentUserIdentity(new UserIdentity("u1", "%"));
+        context.setExecutionId(new TUniqueId(6, 7));
+        context.setLastQueryId(new UUID(8L, 9L));
+
+        TransactionStmtExecutor.beginStmt(context, new BeginStmt(NodePosition.ZERO));
+
+        String sql = "insert into db1.tbl1 values(1,2,3)";
+        DmlStmt stmt = (DmlStmt) SqlParser.parseSingleStatement(sql, context.getSessionVariable().getSqlMode());
+        Analyzer.analyze(stmt, context);
+
+        ExplicitTxnState explicitTxnState = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                .getExplicitTxnState(context.getTxnId());
+        TransactionState transactionState = explicitTxnState.getTransactionState();
+        // Precondition: an explicit txn is not bound to a db until its first DML registers it.
+        Assertions.assertEquals(0, transactionState.getDbId());
+
+        int savedPerDb = Config.max_running_txn_num_per_db;
+        try {
+            // Force the first-DML registration (upsertTransactionState) to be rejected.
+            Config.max_running_txn_num_per_db = 0;
+            TransactionStmtExecutor.loadData(database, olapTable, new ExecPlan(), stmt, stmt.getOrigStmt(), context);
+        } finally {
+            Config.max_running_txn_num_per_db = savedPerDb;
+        }
+
+        Assertions.assertTrue(context.getState().isError());
+        // The rejected first statement must leave the txn unbound (dbId reset), so a later statement can
+        // re-attempt registration instead of silently skipping it forever.
+        Assertions.assertEquals(0, transactionState.getDbId());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/ExplicitTxnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/ExplicitTxnTest.java
@@ -18,6 +18,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MockedLocalMetaStore;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.UserIdentity;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReportException;
@@ -240,6 +241,81 @@ public class ExplicitTxnTest {
         } catch (ErrorReportException e) {
             Assertions.assertEquals(ErrorCode.ERR_TXN_IMPORT_SAME_TABLE, e.getErrorCode());
         }
+    }
+
+    @Test
+    public void testRejectedFirstStatementDoesNotStrandTransaction() throws IOException, DdlException {
+        // A rejected first DML of an explicit transaction must not leave the transaction bound to a
+        // database it was never registered in. setDbId() runs before the fallible upsert; if the reject
+        // does not undo it, getDbId() stays non-zero, every later statement skips registration, and COMMIT
+        // then fails against a transaction the DatabaseTransactionMgr never registered.
+        new MockUp<DefaultCoordinator>() {
+            @Mock
+            public void exec() throws StarRocksException, RpcException, InterruptedException {
+            }
+
+            @Mock
+            public boolean join(int timeoutSecond) {
+                return true;
+            }
+
+            @Mock
+            public boolean isDone() {
+                return true;
+            }
+
+            @Mock
+            public Status getExecStatus() {
+                return Status.OK;
+            }
+
+            @Mock
+            public Map<String, String> getLoadCounters() {
+                Map<String, String> counters = new HashMap<String, String>();
+                counters.put(LoadEtlTask.DPP_NORMAL_ALL, "0");
+                counters.put(LoadEtlTask.DPP_ABNORMAL_ALL, "0");
+                counters.put(LoadJob.LOADED_BYTES, "0");
+                return counters;
+            }
+        };
+
+        ConnectContext context = new ConnectContext();
+        context.setThreadLocalInfo();
+        context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+
+        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable("db1", "tbl1");
+
+        context.setQualifiedUser("u1");
+        context.setCurrentUserIdentity(new UserIdentity("u1", "%"));
+        context.setExecutionId(new TUniqueId(6, 7));
+        context.setLastQueryId(new UUID(8L, 9L));
+
+        TransactionStmtExecutor.beginStmt(context, new BeginStmt(NodePosition.ZERO));
+
+        String sql = "insert into db1.tbl1 values(1,2,3)";
+        DmlStmt stmt = (DmlStmt) SqlParser.parseSingleStatement(sql, context.getSessionVariable().getSqlMode());
+        Analyzer.analyze(stmt, context);
+
+        ExplicitTxnState explicitTxnState = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                .getExplicitTxnState(context.getTxnId());
+        TransactionState transactionState = explicitTxnState.getTransactionState();
+        // Precondition: an explicit txn is not bound to a db until its first DML registers it.
+        Assertions.assertEquals(0, transactionState.getDbId());
+
+        int savedPerDb = Config.max_running_txn_num_per_db;
+        try {
+            // Force the first-DML registration (upsertTransactionState) to be rejected.
+            Config.max_running_txn_num_per_db = 0;
+            TransactionStmtExecutor.loadData(database, olapTable, new ExecPlan(), stmt, stmt.getOrigStmt(), context);
+        } finally {
+            Config.max_running_txn_num_per_db = savedPerDb;
+        }
+
+        Assertions.assertTrue(context.getState().isError());
+        // The rejected first statement must leave the txn unbound (dbId reset), so a later statement can
+        // re-attempt registration instead of silently skipping it forever.
+        Assertions.assertEquals(0, transactionState.getDbId());
     }
 
     @Test


### PR DESCRIPTION
> **Test only.** No production code changes. This PR originally carried the fix as well, but the same behavior landed on `main` independently via #78625, which moved the explicit-transaction db binding out of `TransactionStmtExecutor` and into `GlobalTransactionMgr.registerExplicitTransactionState` and wrote the same restore-on-failure there. What remains here is the regression test, because nothing currently pins that restore.

## Why I'm doing:

An explicit `BEGIN ... COMMIT` transaction is bound to a database on its first DML. `GlobalTransactionMgr.registerExplicitTransactionState` remembers the original `dbId`, sets the new one, calls `upsertTransactionState`, and restores the original if that registration is rejected (running-txn limit, duplicate label, quota).

That restore is load-bearing. Without it the transaction is left half-bound: `getDbId() != 0`, so every later statement skips the registration block entirely, yet the transaction was never put into `idToRunningTransactionState`. On `COMMIT`, `getTransactionState` returns null and the commit fails with a misleading error, after the client already saw later statements report success.

No test asserts that restore today. `registerExplicitTransactionState` is a small `synchronized` method that has already been refactored once, and the restore is three lines inside a `catch` that is easy to drop while changing something else nearby. If it is dropped, nothing fails.

The path is also more reachable than it looks. It is rare under the per-database cap `max_running_txn_num_per_db` (default 1000), but it becomes routine for anyone using `max_running_txn_num_per_table` (#76919) to isolate a hot table, where a per-table reject is expected behavior rather than an exceptional one.

## What I'm doing:

Adding one regression test to `ExplicitTxnTest`. It drives a genuinely rejected first DML through `TransactionStmtExecutor.loadData` by setting `max_running_txn_num_per_db` to 0, rather than mocking the rejection, and asserts the transaction is left unbound so a later statement can re-attempt registration. It fails if the restore is removed.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

No backports. The test asserts behavior introduced on `main` by #78625, so it would not compile or pass on branches that do not carry that change.
