### PR TITLE
[BugFix] Do not pick a DECOMMISSION replica as the load primary

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -1229,18 +1229,34 @@ public class OlapTableSink extends DataSink {
         }
 
         int lowUsageIndex = -1;
+        // Only used when every healthy candidate is in DECOMMISSION state.
+        int decommissionIndex = -1;
         for (int i = 0; i < replicas.size(); i++) {
             Replica replica = replicas.get(i);
             boolean isHealthy = !replica.getLastWriteFail()
                     && !infoService.getBackend(replica.getBackendId()).getLastWriteFail();
-            
+
             // The isAlive() flag indicates node availability during shutdown sequences.
             // For single-replica configurations, we bypass node status checks to maintain
             // loading operation continuity despite shutdown transitions.
             if (replicas.size() > 1) {
                 isHealthy = isHealthy && infoService.getBackend(replica.getBackendId()).isAlive();
             }
-            
+
+            // A replica in DECOMMISSION state is scheduled for deletion, so it is the one most
+            // likely to disappear while the load is still running. It has to stay a write target
+            // to make up the write quorum, but it should not become the primary: when its tablet
+            // is dropped mid-load, LocalTabletsChannel tolerates the resulting "Fail to get
+            // tablet" error only for a Secondary replica, while for a Primary one it aborts the
+            // whole tablet_writer_open and fails the entire load. Keeping it as the last resort
+            // degrades a mid-load deletion to a per-replica failure that the write quorum absorbs.
+            if (replica.getState() == Replica.ReplicaState.DECOMMISSION) {
+                if (decommissionIndex == -1 && isHealthy) {
+                    decommissionIndex = i;
+                }
+                continue;
+            }
+
             if (lowUsageIndex == -1 && isHealthy) {
                 lowUsageIndex = i;
             }
@@ -1251,7 +1267,7 @@ public class OlapTableSink extends DataSink {
                 lowUsageIndex = i;
             }
         }
-        return lowUsageIndex;
+        return lowUsageIndex != -1 ? lowUsageIndex : decommissionIndex;
     }
 
     private static boolean canUseColocateMVIndex(OlapTable table) {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -1047,6 +1047,63 @@ public class OlapTableSinkTest {
     }
 
     @Test
+    public void testFindPrimaryReplicaSkipDecommission() throws StarRocksException {
+        Backend be1 = new Backend(2001L, "127.0.0.1", 9050);
+        Backend be2 = new Backend(2002L, "127.0.0.2", 9050);
+        Backend be3 = new Backend(2003L, "127.0.0.3", 9050);
+        be1.setAlive(true);
+        be2.setAlive(true);
+        be3.setAlive(true);
+
+        Map<Long, Backend> idToBackendRef = new HashMap<>();
+        idToBackendRef.put(be1.getId(), be1);
+        idToBackendRef.put(be2.getId(), be2);
+        idToBackendRef.put(be3.getId(), be3);
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public Backend getBackend(long backendId) {
+                return idToBackendRef.get(backendId);
+            }
+        };
+
+        //be1 hosts the fewest primaries, so without the DECOMMISSION check it would be selected
+        Map<Long, Long> bePrimaryMap = new HashMap<>();
+        bePrimaryMap.put(be1.getId(), 0L);
+        bePrimaryMap.put(be2.getId(), 1L);
+        bePrimaryMap.put(be3.getId(), 2L);
+
+        OlapTable olapTable = new OlapTable();
+        SystemInfoService infoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+        MaterializedIndex index = new MaterializedIndex(1L, MaterializedIndex.IndexState.NORMAL);
+        List<Long> selectedBackedIds = Lists.newArrayList();
+
+        //1.a replica being decommissioned must not be selected while other candidates exist
+        Replica decommissioned = new Replica(55L, be1.getId(), Replica.ReplicaState.DECOMMISSION, 1, 0);
+        Replica normal1 = new Replica(66L, be2.getId(), Replica.ReplicaState.NORMAL, 1, 0);
+        Replica normal2 = new Replica(77L, be3.getId(), Replica.ReplicaState.NORMAL, 1, 0);
+        decommissioned.setLastWriteFail(false);
+        normal1.setLastWriteFail(false);
+        normal2.setLastWriteFail(false);
+        List<Replica> replicaList = new ArrayList<>();
+        replicaList.add(decommissioned);
+        replicaList.add(normal1);
+        replicaList.add(normal2);
+
+        int lowUsageIndex1 = OlapTableSink.findPrimaryReplica(olapTable, bePrimaryMap, infoService,
+                index, selectedBackedIds, replicaList);
+        Assertions.assertEquals(normal1.getId(), replicaList.get(lowUsageIndex1).getId());
+        Assertions.assertEquals(be2.getId(), replicaList.get(lowUsageIndex1).getBackendId());
+
+        //2.fall back to the decommissioned replica when it is the only candidate
+        List<Replica> onlyDecommissionedList = new ArrayList<>();
+        onlyDecommissionedList.add(decommissioned);
+
+        int lowUsageIndex2 = OlapTableSink.findPrimaryReplica(olapTable, bePrimaryMap, infoService,
+                index, selectedBackedIds, onlyDecommissionedList);
+        Assertions.assertEquals(decommissioned.getId(), onlyDecommissionedList.get(lowUsageIndex2).getId());
+    }
+
+    @Test
     public void testCreateLocationWithSharedDataMode(@Mocked GlobalStateMgr globalStateMgr) throws Exception {
         SystemInfoService sysInfoService = new SystemInfoService();
         MockedWarehouseManager warehouseManager = new MockedWarehouseManager();


### PR DESCRIPTION
## Why I'm doing:

Since #60224, a replica in `DECOMMISSION` state is deliberately kept as a load target: while the newly cloned replica is still in version-miss state, the decommissioning replica is what makes up the write quorum. That part is intentional and this PR does not change it.

What #60224 did not account for is that `findPrimaryReplica()` never looks at the replica state. It only filters on `lastWriteFail` and backend liveness, and then picks the candidate with the fewest primaries assigned. A `DECOMMISSION` replica frequently wins that contest — it is being decommissioned precisely because its backend is being drained, so it tends to have the lowest primary count.

Electing it as the primary is the worst possible choice, because it is by definition the replica most likely to disappear while the load is still running:

1. `TabletScheduler` only waits (`isPreviousTransactionsFinished`) for the transactions that were already running at the moment the replica was marked `DECOMMISSION`. A transaction whose plan is built afterwards still targets the replica but is not covered by that watermark, so the tablet can be dropped in the middle of the load.
2. When the tablet is gone, `DeltaWriter` fails with `Fail to get tablet, perhaps this table is doing schema change, or it has already been deleted.`
3. `LocalTabletsChannel::_open_all_writers()` tolerates that error **only for a `Secondary` replica** — it records the tablet in `failed_tablet_ids` and lets the write quorum absorb it. For a `Primary` replica it returns the status directly, aborting the whole `tablet_writer_open` and failing the entire load:

```cpp
} else {
    if (options.replica_state == Secondary) {
        failed_tablet_ids.emplace_back(tablet.tablet_id());
    } else {
        return res.status();     // whole load fails
    }
}
```

So the same event — a decommissioning replica being deleted mid-load — is a harmless per-replica failure when that replica is a Secondary, and a full load failure when it happens to be the Primary. Users hit this as loads failing with `Fail to get tablet ... tablet_id=xxx` during a backend decommission.

## What I'm doing:

Keep the `DECOMMISSION` replica as a write target (the quorum contribution from #60224 is preserved), but do not let it become the primary unless there is no other healthy candidate.

`findPrimaryReplica()` now skips `DECOMMISSION` replicas in the main selection loop, remembering the first healthy one separately, and returns it only as a last resort. Behavior is therefore unchanged for tablets without a decommissioning replica, and unchanged for tablets where *every* candidate is decommissioning.

This does not make the mid-load deletion impossible — it degrades it from a whole-load failure into a single-replica failure that the write quorum can absorb.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
