### PR TITLE
[BugFix] [Revert] Cache Iceberg REST vended-credential tables and keep their credentials fresh (backport #75431)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -27,7 +27,6 @@ import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.ConnectorViewDefinition;
 import com.starrocks.connector.PlanMode;
 import com.starrocks.connector.exception.StarRocksConnectorException;
-import com.starrocks.connector.iceberg.rest.IcebergRESTCatalog;
 import com.starrocks.mysql.MysqlCommand;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
@@ -79,9 +78,6 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     // Only emit the partition-load INFO line when a refresh exceeds this many partitions, so the log
     // remains useful for diagnosing slow loads on large tables without flooding for normal-sized ones.
     private static final int PARTITION_LOAD_LOG_THRESHOLD = 10000;
-    // REST tables embed short-lived vended credentials (~1h) in their FileIO; cap the table-cache TTL so an
-    // idle entry can't outlive its token. Provider-agnostic: bounds cache lifetime, no per-cloud expiry parse.
-    private static final long REST_TABLE_CACHE_MAX_TTL_SEC = 3000;
     private final String catalogName;
     private final IcebergCatalog delegate;
     private final com.github.benmanes.caffeine.cache.LoadingCache<IcebergTableName, Table> tables;
@@ -109,12 +105,8 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                 icebergProperties.getIcebergMetaCacheTtlSec(),
                 NEVER_CACHE,
                 enableCache ? DEFAULT_CACHE_NUM : NEVER_CACHE).build();
-        long tableCacheTtlSec = icebergProperties.getIcebergMetaCacheTtlSec();
-        if (delegate instanceof IcebergRESTCatalog) {
-            tableCacheTtlSec = Math.min(tableCacheTtlSec, REST_TABLE_CACHE_MAX_TTL_SEC);
-        }
         this.tables = newCacheBuilder(
-                tableCacheTtlSec,
+                icebergProperties.getIcebergMetaCacheTtlSec(),
                 icebergProperties.getIcebergTableCacheRefreshIntervalSec())
                 .executor(executorService)
                 .maximumWeight(tableCacheSize)
@@ -147,7 +139,14 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                     @Override
                     public Table reload(IcebergTableName key, Table oldValue) {
                         try {
-                            return delegate.getTable(key.dbName, key.tableName);
+                            BaseTable updateTable =
+                                    (BaseTable) delegate.getTable(key.dbName, key.tableName);
+                            TableOperations newOps = updateTable.operations();
+                            TableOperations oldOps = ((BaseTable) oldValue).operations();
+                            if (oldOps.current().metadataFileLocation().equals(newOps.current().metadataFileLocation())) {
+                                return oldValue;
+                            }
+                            return updateTable;
                         } catch (Exception e) {
                             LOG.warn("refresh table {}.{} failed", key.dbName, key.tableName, e);
                             return oldValue;
@@ -274,7 +273,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     public Table getTable(String dbName, String tableName) throws StarRocksConnectorException {
         IcebergTableName icebergTableName = new IcebergTableName(dbName, tableName);
 
-        if (!icebergProperties.isEnableIcebergMetadataCache()) {
+        if (!icebergProperties.isEnableIcebergMetadataCache() || delegate.isVendedCredentialsEnabled()) {
             return delegate.getTable(dbName, tableName);
         }
 
@@ -408,10 +407,6 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                         dbName, tableName, currentLocation, updateLocation);
                 refreshTable(currentTable, updateTable, dbName, tableName, executorService);
                 LOG.info("Finished to refresh iceberg table {}.{}", dbName, tableName);
-            } else {
-                // Metadata unchanged keeps the partition/file caches valid; still swap in the reloaded
-                // table so the cache stops serving the old (expiring) vended FileIO token.
-                tables.put(icebergTableName, updateTable);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -253,6 +253,17 @@ public interface IcebergCatalog extends MemoryTrackable {
                 srScanContext);
     }
 
+    /**
+     * Check if this catalog uses vended credentials for table access.
+     * When vended credentials are used, caching tables may cause issues
+     * because credentials expire before the cache TTL.
+     *
+     * @return true if vended credentials are enabled
+     */
+    default boolean isVendedCredentialsEnabled() {
+        return false;
+    }
+
     default String defaultTableLocation(Namespace ns, String tableName) {
         Map<String, String> properties = loadNamespaceMetadata(ns);
         String databaseLocation = properties.get(LOCATION_PROPERTY);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -82,6 +82,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     private final boolean nestedNamespaceEnabled;
     private final boolean authRecoveryEnabled;
     private long lastAuthRecoveryMillis;
+    private final boolean enableVendedCredentials;
 
 
     public IcebergRESTCatalog(String name, Configuration conf, Map<String, String> properties) {
@@ -100,7 +101,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         copiedProperties.put(CatalogProperties.FILE_IO_IMPL, IcebergCachingFileIO.class.getName());
         copiedProperties.put(CatalogProperties.METRICS_REPORTER_IMPL, IcebergMetricsReporter.class.getName());
 
-        boolean enableVendedCredentials =
+        this.enableVendedCredentials =
                 Boolean.parseBoolean(copiedProperties.getOrDefault(KEY_VENDED_CREDENTIALS_ENABLED, "true"));
         if (enableVendedCredentials) {
             copiedProperties.put("header.X-Iceberg-Access-Delegation", "vended-credentials");
@@ -134,6 +135,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         this.nestedNamespaceEnabled = false;
         this.restCatalogProperties = Maps.newHashMap();
         this.authRecoveryEnabled = false;
+        this.enableVendedCredentials = false;
     }
 
     @Override
@@ -472,5 +474,10 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             // start the cooldown from completion so a slow rebuild doesn't immediately admit another
             lastAuthRecoveryMillis = System.currentTimeMillis();
         }
+    }
+
+    @Override
+    public boolean isVendedCredentialsEnabled() {
+        return enableVendedCredentials;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
@@ -57,7 +57,6 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.starrocks.connector.iceberg.IcebergCatalogProperties.HIVE_METASTORE_URIS;
@@ -300,111 +299,63 @@ public class CachingIcebergCatalogTest {
     }
 
     @Test
-    public void testRestCatalogWithoutAuthTokenUsesCache(@Mocked IcebergRESTCatalog restCatalog) {
-        // A REST catalog (including one with vended credentials) is served from the cache: the delegate
-        // is hit once and the second getTable() is a cache hit. Guards the revert of the #69434 bypass.
-        Table nativeTable = createBaseTableWithManifests(1, 1);
+    public void testGetTableBypassCacheWhenVendedCredentialsEnabled(@Mocked IcebergRESTCatalog restCatalog) {
+        // When vended credentials is enabled, caching should be bypassed to avoid
+        // using expired credentials.
+        ConnectContext ctx = new ConnectContext();
+        Table nativeTable1 = createBaseTableWithManifests(1, 1);
+        Table nativeTable2 = createBaseTableWithManifests(1, 1);
+
         new Expectations() {
             {
+                restCatalog.isVendedCredentialsEnabled();
+                result = true;
+                minTimes = 0;
+
                 restCatalog.getTable("db4", "tbl4");
-                result = nativeTable;
-                times = 1;
+                result = nativeTable1;
+                result = nativeTable2;
             }
         };
 
         CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(CATALOG_NAME, restCatalog,
                 DEFAULT_CATALOG_PROPERTIES, Executors.newSingleThreadExecutor());
 
-        Assertions.assertSame(nativeTable, cachingIcebergCatalog.getTable("db4", "tbl4"));
-        Assertions.assertSame(nativeTable, cachingIcebergCatalog.getTable("db4", "tbl4"));
+        Table result1 = cachingIcebergCatalog.getTable("db4", "tbl4");
+        Table result2 = cachingIcebergCatalog.getTable("db4", "tbl4");
+
+        // Should return different instances (no caching)
+        Assertions.assertSame(nativeTable1, result1);
+        Assertions.assertSame(nativeTable2, result2);
     }
 
     @Test
-    public void testReloadReturnsFreshTableWhenMetadataUnchanged(@Mocked IcebergCatalog delegate) throws Exception {
-        Table oldTable = createBaseTableWithManifests(1, 1);
-        Table freshTable = createBaseTableWithManifests(1, 1);
-        // Identical metadata location on both: the removed short-circuit would have returned oldValue here,
-        // so this asserts the fresh (renewed-credential) table is installed regardless of metadata equality.
-        String sharedLocation = "s3://bucket/metadata/v1.metadata.json";
-        Mockito.when(((BaseTable) oldTable).operations().current().metadataFileLocation()).thenReturn(sharedLocation);
-        Mockito.when(((BaseTable) freshTable).operations().current().metadataFileLocation()).thenReturn(sharedLocation);
+    public void testGetTableWithCacheWhenVendedCredentialsDisabled(@Mocked IcebergRESTCatalog restCatalog) {
+        // When vended credentials is disabled, normal caching should work.
+        ConnectContext ctx = new ConnectContext();
+        Table nativeTable = createBaseTableWithManifests(1, 1);
 
-        AtomicInteger calls = new AtomicInteger();
         new Expectations() {
             {
-                delegate.getTable("db1", "t1");
-                result = new Delegate<Table>() {
-                    Table get(String db, String tbl) {
-                        return calls.getAndIncrement() == 0 ? oldTable : freshTable;
-                    }
-                };
+                restCatalog.isVendedCredentialsEnabled();
+                result = false;
+                minTimes = 0;
+
+                restCatalog.getTable("db5", "tbl5");
+                result = nativeTable;
             }
         };
 
-        ExecutorService refreshExecutor = Executors.newSingleThreadExecutor();
-        CachingIcebergCatalog catalog = new CachingIcebergCatalog(CATALOG_NAME, delegate,
-                DEFAULT_CATALOG_PROPERTIES, refreshExecutor);
-        LoadingCache<IcebergTableName, Table> tableCache = Deencapsulation.getField(catalog, "tables");
-        IcebergTableName key = new IcebergTableName("db1", "t1");
-
-        Assertions.assertSame(oldTable, catalog.getTable("db1", "t1"));
-        tableCache.refresh(key);
-        // refresh dispatches reload() onto refreshExecutor; this FIFO barrier returns once it has run.
-        refreshExecutor.submit(() -> { }).get();
-        Assertions.assertSame(freshTable, tableCache.getIfPresent(key));
-    }
-
-    @Test
-    public void testRefreshTableRenewsCredentialsWhenMetadataUnchanged(@Mocked IcebergCatalog delegate) {
-        Table cachedTable = createBaseTableWithManifests(1, 1);
-        Table reloadedTable = createBaseTableWithManifests(1, 1);
-        // Identical metadata location: no snapshot change, so the background refresh keeps the
-        // partition/file caches but must still swap in the reloaded table to pick up renewed credentials.
-        String sharedLocation = "s3://bucket/metadata/v1.metadata.json";
-        Mockito.when(((BaseTable) cachedTable).operations().current().metadataFileLocation()).thenReturn(sharedLocation);
-        Mockito.when(((BaseTable) reloadedTable).operations().current().metadataFileLocation()).thenReturn(sharedLocation);
-
-        AtomicInteger calls = new AtomicInteger();
-        new Expectations() {
-            {
-                delegate.getTable("db1", "t1");
-                result = new Delegate<Table>() {
-                    Table get(String db, String tbl) {
-                        return calls.getAndIncrement() == 0 ? cachedTable : reloadedTable;
-                    }
-                };
-            }
-        };
-
-        ExecutorService executor = Executors.newSingleThreadExecutor();
-        CachingIcebergCatalog catalog = new CachingIcebergCatalog(CATALOG_NAME, delegate,
-                DEFAULT_CATALOG_PROPERTIES, executor);
-        LoadingCache<IcebergTableName, Table> tableCache = Deencapsulation.getField(catalog, "tables");
-        IcebergTableName key = new IcebergTableName("db1", "t1");
-
-        Assertions.assertSame(cachedTable, catalog.getTable("db1", "t1"));
-        catalog.refreshTable("db1", "t1", executor);
-        Assertions.assertSame(reloadedTable, tableCache.getIfPresent(key));
-    }
-
-    @Test
-    public void testRestTableCacheTtlIsCapped(@Mocked IcebergRESTCatalog restCatalog,
-                                              @Mocked IcebergCatalog hiveCatalog) {
-        // REST catalog: the table cache hard-expiry is capped regardless of the (default 24h) meta cache
-        // TTL, so an idle vended-credential entry cannot outlive its token.
-        CachingIcebergCatalog restCaching = new CachingIcebergCatalog(CATALOG_NAME, restCatalog,
+        CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(CATALOG_NAME, restCatalog,
                 DEFAULT_CATALOG_PROPERTIES, Executors.newSingleThreadExecutor());
-        LoadingCache<IcebergTableName, Table> restCache = Deencapsulation.getField(restCaching, "tables");
-        long restTtl = restCache.policy().expireAfterWrite().get().getExpiresAfter(TimeUnit.SECONDS);
-        Assertions.assertTrue(restTtl <= 3000, "REST table cache TTL must be capped, was " + restTtl);
 
-        // Non-REST catalog: TTL stays at the configured meta cache TTL (no credential to protect).
-        CachingIcebergCatalog hiveCaching = new CachingIcebergCatalog(CATALOG_NAME, hiveCatalog,
-                DEFAULT_CATALOG_PROPERTIES, Executors.newSingleThreadExecutor());
-        LoadingCache<IcebergTableName, Table> hiveCache = Deencapsulation.getField(hiveCaching, "tables");
-        long hiveTtl = hiveCache.policy().expireAfterWrite().get().getExpiresAfter(TimeUnit.SECONDS);
-        Assertions.assertEquals(DEFAULT_CATALOG_PROPERTIES.getIcebergMetaCacheTtlSec(), hiveTtl,
-                "non-REST table cache TTL must equal the configured meta cache TTL");
+        Table result1 = cachingIcebergCatalog.getTable("db5", "tbl5");
+        Table result2 = cachingIcebergCatalog.getTable("db5", "tbl5");
+
+        // Should return the same instance (cached)
+        Assertions.assertSame(nativeTable, result1);
+        Assertions.assertSame(nativeTable, result2);
+        Assertions.assertSame(result1, result2);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

On `branch-3.5`, `InsertPlanner.plan()` calls `refreshExternalTable()` **while the planner already
holds a READ lock on the INSERT target table** (`PlannerMetaLocker` takes `IS` on the database plus
`READ` on the tables of the whole statement). Publishing a transaction on that table needs a `WRITE`
lock on the same table (`DatabaseTransactionMgr.finishTransaction` →
`tryLockTablesWithIntensiveDbLock(..., LockType.WRITE, 1000ms)`), so any blocking connector I/O
inside that window is converted directly into transaction visibility delay.

`CachingIcebergCatalog.refreshTable()` only issues a REST `loadTable` when the table is **already in
the table cache**:

```java
if (tables.getIfPresent(icebergTableName) == null) {
    partitionCache.invalidate(icebergTableName);          // no network call
} else {
    BaseTable updateTable = (BaseTable) delegate.getTable(dbName, tableName);   // synchronous REST
```

#75431 / #75643 removed the vended-credential cache bypass, so Iceberg REST tables started entering
that cache — and the forced INSERT refresh started taking the second branch. The number of REST calls
per statement did not change, but their position did: before #75643 the `loadTable` happened during
SELECT analysis, which `InsertAnalyzer.analyzeWithDeferredLock` performs **before** the lock is taken;
after it, an additional `loadTable` runs **inside** the lock.

A production 3.5.20 cluster with a slow Iceberg REST catalog saw `INSERT OVERWRITE` transactions stay
`COMMITTED` but not `VISIBLE` for ~11s. Of the publish-blocking slow-lock snapshots sampled over three
hours, 98.6% had a lock owner performing an Iceberg metadata refresh; measured lock holds reached
10.2–15.7s.

The underlying defect is that the refresh performs blocking connector I/O inside a lock that protects
partition versions — something the external-table refresh does not touch at all. #73391 fixes this
properly by moving the refresh before lock acquisition, but it is released on 4.1.1+ only and builds
on #68467, which `branch-3.5` also does not have.

This is therefore proposed for `branch-3.5` only. `main` and `branch-4.1` already carry #73391, so
caching REST tables there is safe and should stay.

Note on the alternative: #76969 backported #73391 to `branch-3.5` and was reverted by #76991, because
#73391 never selected 3.5 in its cherry-pick list and the conflict resolution pulled in unrelated
files. Re-backporting #73391 to 3.5 on its own remains the better long-term fix, but it also needs
#68467 (the pre-lock external-table resolution it builds on), which `branch-3.5` does not have either.
This revert is the smaller, self-contained step that removes the blocking I/O from the lock in the
meantime; it does not preclude that backport, and becomes unnecessary once it lands.

## What I'm doing:

Reverting 7d7d385ccb4 (backport #75431, PR #75643) on `branch-3.5`, restoring the cache bypass for
Iceberg REST catalogs with vended credentials enabled. This returns `branch-3.5` to the 3.5.16–3.5.19
shape, in which `refreshTable()` finds no cached table and takes the "invalidate the partition cache
only" branch, leaving no REST call inside the lock.

The cost is exactly what #75431 set out to remove: REST tables are not cached, so table metadata is
re-fetched from the REST service on every access. That is the behaviour 3.5.16–3.5.19 shipped with,
and it is preferable to blocking transaction publication until #68467 + #73391 can be backported.

`IcebergRESTCatalog.java` conflicted with the OAuth session self-heal added later by #76519. That code
is kept in full; only the vended-credential members (`enableVendedCredentials`,
`isVendedCredentialsEnabled()`) were restored. One trailing whitespace the revert would have brought
back was dropped.

`CachingIcebergCatalogTest` is reverted along with it and passes 12/12. No new test cases were added,
so the test-coverage box below is left unchecked; coverage is restored to its pre-#75431 state.
`mvn checkstyle:check -pl fe-core` passes.

Fixes #issue: N/A — no public issue; found while investigating a production transaction-visibility
report.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
