### PR TITLE
[Enhancement] Trace the throw site of BadStatusOrAccess by default

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1868,7 +1868,14 @@ CONF_mInt64(send_channel_buffer_limit, "67108864");
 // 2, print exceptions' stack whose prefix is not in the black list
 // other value means the default value
 CONF_Int32(exception_stack_level, "1");
-CONF_String(exception_stack_white_list, "std::");
+// `starrocks::BadStatusOrAccess` comes from an unguarded StatusOr::value() and is caught nowhere,
+// so every occurrence is a bug. The stack recorded at the throw site is the only way to locate it:
+// by the time a catch handler runs the throwing frames are already unwound, so a stack taken there
+// only shows the catch site.
+// Keep it an exact type rather than a bare `starrocks::` prefix, which would also match
+// starrocks::RuntimeException. That one exists specifically to opt out of this stack printing (see
+// be/src/runtime/exception.h) because it is thrown per row on hot paths such as cast failures.
+CONF_String(exception_stack_white_list, "std::,starrocks::BadStatusOrAccess");
 CONF_String(exception_stack_black_list, "apache::thrift::,ue2::,arangodb::");
 
 // PK table's tabletmeta object size may got very large(lot's of edit versions), so it may not fit into block cache

--- a/be/src/common/config_diagnostic_fwd.h
+++ b/be/src/common/config_diagnostic_fwd.h
@@ -82,7 +82,14 @@ CONF_String(jaeger_endpoint, "");
 // other value means the default value
 CONF_Int32(exception_stack_level, "1");
 
-CONF_String(exception_stack_white_list, "std::");
+// `starrocks::BadStatusOrAccess` comes from an unguarded StatusOr::value() and is caught nowhere,
+// so every occurrence is a bug. The stack recorded at the throw site is the only way to locate it:
+// by the time a catch handler runs the throwing frames are already unwound, so a stack taken there
+// only shows the catch site.
+// Keep it an exact type rather than a bare `starrocks::` prefix, which would also match
+// starrocks::RuntimeException. That one exists specifically to opt out of this stack printing (see
+// be/src/runtime/exception.h) because it is thrown per row on hot paths such as cast failures.
+CONF_String(exception_stack_white_list, "std::,starrocks::BadStatusOrAccess");
 
 CONF_String(exception_stack_black_list, "apache::thrift::,ue2::,arangodb::");
 


### PR DESCRIPTION
## Why I'm doing:

BadStatusOrAccess is thrown by an unguarded StatusOr::value() and is caught nowhere in the codebase, so every occurrence is a bug. Identifying it requires the stack at the throw site: __cxa_throw is already wrapped to capture one, but the white list only covers `std::` by default, so starrocks::BadStatusOrAccess was silently skipped. The only trace left then comes from the catch handler, by which point the throwing frames are unwound and the stack shows the catch site alone -- which is what happened on a CN that lost its whole connector-scan thread pool to escaped BadStatusOrAccess, leaving no way to identify the offending .value().

Keep it an exact type rather than a bare `starrocks::` prefix: that prefix would also match starrocks::RuntimeException, which exists specifically to opt out of this stack printing because it is thrown per row on hot paths such as cast failures.

Verified end to end on a live BE: with an unguarded value() injected into ProjectOperator::push_chunk, the query logs the throwing frame (ProjectOperator::push_chunk -> PipelineDriver::process -> _worker_thread) along with the query id, where previously only the catch handler's own frames survived.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
