### PR TITLE
[BugFix] Honor Lake scan cache policy in GLM lookup

### DIFF
--- a/be/src/connector/lake/lake_connector.cpp
+++ b/be/src/connector/lake/lake_connector.cpp
@@ -589,6 +589,7 @@ Status LakeDataSource::init_tablet_reader(RuntimeState* runtime_state, bool use_
 
     bool enable_glm = thrift_lake_scan_node.__isset.enable_global_late_materialization &&
                       thrift_lake_scan_node.enable_global_late_materialization;
+    LakeScanLazyMaterializationContext* glm_ctx = nullptr;
     if (enable_glm) {
         auto* glm_mgr = runtime_state->query_runtime_state()->global_late_materialization_ctx_mgr();
         auto* obj_pool = runtime_state->query_runtime_state()->object_pool();
@@ -596,11 +597,8 @@ Status LakeDataSource::init_tablet_reader(RuntimeState* runtime_state, bool use_
             auto* ctx = obj_pool->add(new LakeScanLazyMaterializationContext());
             return ctx;
         };
-        auto* glm_ctx =
-                (LakeScanLazyMaterializationContext*)glm_mgr->get_or_create_ctx(_provider->_plan_node_id, creator);
+        glm_ctx = (LakeScanLazyMaterializationContext*)glm_mgr->get_or_create_ctx(_provider->_plan_node_id, creator);
         glm_ctx->set_scan_node(thrift_lake_scan_node);
-        int64_t version = strtoul(_scan_range.version.c_str(), nullptr, 10);
-        glm_ctx->capture_rowsets(_scan_range.tablet_id, version, _morsel->rowsets());
     }
 
     RETURN_IF_ERROR(_extend_schema_by_access_paths());
@@ -615,6 +613,14 @@ Status LakeDataSource::init_tablet_reader(RuntimeState* runtime_state, bool use_
     }
     RETURN_IF_ERROR(init_unused_output_columns(thrift_lake_scan_node.unused_output_column_name));
     RETURN_IF_ERROR(init_reader_params(_scanner_ranges));
+    if (glm_ctx != nullptr) {
+        int64_t version = strtoul(_scan_range.version.c_str(), nullptr, 10);
+        glm_ctx->capture_rowsets(_scan_range.tablet_id, version, _morsel->rowsets(),
+                                 LakeScanCacheOptions{.use_page_cache = _params.use_page_cache,
+                                                      .fill_data_cache = _params.lake_io_opts.fill_data_cache,
+                                                      .fill_metadata_cache = _params.lake_io_opts.fill_metadata_cache,
+                                                      .skip_disk_cache = _params.lake_io_opts.skip_disk_cache});
+    }
 
     // Setup SST warmup callback for CACHE SELECT on PK tables
     if (_params.lake_io_opts.cache_file_only && _slots != nullptr &&

--- a/be/src/connector/lake/lake_global_late_materialization_context.cpp
+++ b/be/src/connector/lake/lake_global_late_materialization_context.cpp
@@ -74,7 +74,8 @@ lake::RowsetPtr LakeScanLazyMaterializationContext::get_rowset(const std::vector
 }
 
 void LakeScanLazyMaterializationContext::capture_rowsets(int32_t tablet_id, int64_t version,
-                                                         const std::vector<BaseRowsetSharedPtr>& rowsets) {
+                                                         const std::vector<BaseRowsetSharedPtr>& rowsets,
+                                                         LakeScanCacheOptions cache_options) {
     std::unique_lock lock(_mutex);
     std::vector<lake::RowsetPtr> lake_rowsets;
     lake_rowsets.reserve(rowsets.size());
@@ -86,6 +87,7 @@ void LakeScanLazyMaterializationContext::capture_rowsets(int32_t tablet_id, int6
     }
     _rowsets[tablet_id] = std::move(lake_rowsets);
     _versions[tablet_id] = version;
+    _cache_options[tablet_id] = cache_options;
 }
 
 void LakeScanLazyMaterializationContext::set_scan_node(const TLakeScanNode& node) {

--- a/be/src/connector/lake/lake_global_late_materialization_context.h
+++ b/be/src/connector/lake/lake_global_late_materialization_context.h
@@ -26,9 +26,17 @@
 
 namespace starrocks {
 
+struct LakeScanCacheOptions {
+    bool use_page_cache = false;
+    bool fill_data_cache = false;
+    bool fill_metadata_cache = false;
+    bool skip_disk_cache = false;
+};
+
 class LakeScanLazyMaterializationContext : public GlobalLateMaterilizationContext {
 public:
-    void capture_rowsets(int32_t tablet_id, int64_t version, const std::vector<BaseRowsetSharedPtr>& rowsets);
+    void capture_rowsets(int32_t tablet_id, int64_t version, const std::vector<BaseRowsetSharedPtr>& rowsets,
+                         LakeScanCacheOptions cache_options);
 
     lake::RowsetPtr get_rowset(int32_t tablet_id, int32_t dynamic_rssid, int32_t* segment_idx) const;
     lake::RowsetPtr get_rowset(const std::vector<lake::RowsetPtr>& rowsets, int32_t drssid, int32_t* segment_idx) const;
@@ -38,6 +46,11 @@ public:
         return _versions.at(tablet_id);
     }
 
+    LakeScanCacheOptions get_cache_options(int32_t tablet_id) const {
+        std::shared_lock lock(_mutex);
+        return _cache_options.at(tablet_id);
+    }
+
     const TLakeScanNode& scan_node() const { return *_thrift_lake_scan_node; }
     void set_scan_node(const TLakeScanNode& node);
 
@@ -45,6 +58,7 @@ private:
     mutable std::shared_mutex _mutex;
     std::unordered_map<int32_t, std::vector<lake::RowsetPtr>> _rowsets;
     std::unordered_map<int32_t, int64_t> _versions;
+    std::unordered_map<int32_t, LakeScanCacheOptions> _cache_options;
     std::optional<TLakeScanNode> _thrift_lake_scan_node;
 };
 

--- a/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
+++ b/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
@@ -170,6 +170,7 @@ private:
     LakeScanLazyMaterializationContext* _glm_ctx = nullptr;
     std::vector<lake::RowsetPtr> _rowsets;
     bool _use_page_cache = false;
+    LakeIOOptions _lake_io_opts;
 };
 
 Status OlapScanTabletAdaptor::init(int64_t tablet_id) {
@@ -222,8 +223,8 @@ Status OlapScanTabletAdaptor::init_read_columns(const std::vector<SlotDescriptor
     return init_read_schema(_tablet_schema, slots, &_read_schema);
 }
 
-auto OlapScanTabletAdaptor::get_iterator(int64_t rssid, SparseRange<rowid_t> row_id_range)
-        -> StatusOr<ChunkIteratorPtr> {
+auto OlapScanTabletAdaptor::get_iterator(int64_t rssid,
+                                         SparseRange<rowid_t> row_id_range) -> StatusOr<ChunkIteratorPtr> {
     RowsetSharedPtr target;
     int32_t segment_id;
 
@@ -272,7 +273,11 @@ Status LakeScanTabletAdaptor::init(int64_t tablet_id) {
 }
 
 Status LakeScanTabletAdaptor::init_schema(RuntimeState* state) {
-    _use_page_cache = state->use_page_cache();
+    const auto cache_options = _glm_ctx->get_cache_options(_tablet_id);
+    _use_page_cache = state->use_page_cache() && cache_options.use_page_cache;
+    _lake_io_opts.fill_data_cache = cache_options.fill_data_cache;
+    _lake_io_opts.fill_metadata_cache = cache_options.fill_metadata_cache;
+    _lake_io_opts.skip_disk_cache = cache_options.skip_disk_cache;
     auto* tablet_mgr = StorageEnv::GetInstance()->lake_tablet_manager();
     const auto& lake_scan_node = _glm_ctx->scan_node();
 
@@ -320,8 +325,8 @@ Status LakeScanTabletAdaptor::init_read_columns(const std::vector<SlotDescriptor
     return init_read_schema(_tablet_schema, slots, &_read_schema);
 }
 
-auto LakeScanTabletAdaptor::get_iterator(int64_t rssid, SparseRange<rowid_t> row_id_range)
-        -> StatusOr<ChunkIteratorPtr> {
+auto LakeScanTabletAdaptor::get_iterator(int64_t rssid,
+                                         SparseRange<rowid_t> row_id_range) -> StatusOr<ChunkIteratorPtr> {
     if (rssid < 0 || rssid > std::numeric_limits<uint32_t>::max()) {
         return Status::InternalError(fmt::format("invalid lake rssid:{}", rssid));
     }
@@ -343,7 +348,7 @@ auto LakeScanTabletAdaptor::get_iterator(int64_t rssid, SparseRange<rowid_t> row
         return Status::InternalError(fmt::format("not found lake rssid:{} in tablet_id:{}", rssid, _tablet_id));
     }
 
-    ASSIGN_OR_RETURN(auto segments, target->segments(true));
+    ASSIGN_OR_RETURN(auto segments, target->segments(_lake_io_opts));
     if (target_segment_idx < 0 || target_segment_idx >= segments.size()) {
         return Status::InternalError(
                 fmt::format("invalid segment index:{} for lake rssid:{}", target_segment_idx, rssid));
@@ -355,12 +360,9 @@ auto LakeScanTabletAdaptor::get_iterator(int64_t rssid, SparseRange<rowid_t> row
     RowsetReadOptions rs_opts;
     rs_opts.rowid_range_option = std::make_shared<RowidRangeOption>();
     rs_opts.profile = nullptr;
-    // Honor the same page-cache policy as the normal scan (RuntimeState::use_page_cache(),
-    // which already respects the disable_storage_page_cache config and the session var).
-    // Otherwise the lookup bypasses StoragePageCache and re-decompresses every fetched
-    // column page per row locator. See lake_connector.cpp. Data-cache (fill_data_cache)
-    // is left at its default so the lookup does not override the scan's per-range policy.
+    // Honor both the query-level page-cache setting and this tablet's scan-range cache policy.
     rs_opts.use_page_cache = _use_page_cache;
+    rs_opts.lake_io_opts = _lake_io_opts;
     rs_opts.stats = &_stats;
     rs_opts.global_dictmaps = _global_dicts;
     rs_opts.column_access_paths = &_column_access_paths;

--- a/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
+++ b/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
@@ -223,8 +223,8 @@ Status OlapScanTabletAdaptor::init_read_columns(const std::vector<SlotDescriptor
     return init_read_schema(_tablet_schema, slots, &_read_schema);
 }
 
-auto OlapScanTabletAdaptor::get_iterator(int64_t rssid,
-                                         SparseRange<rowid_t> row_id_range) -> StatusOr<ChunkIteratorPtr> {
+auto OlapScanTabletAdaptor::get_iterator(int64_t rssid, SparseRange<rowid_t> row_id_range)
+        -> StatusOr<ChunkIteratorPtr> {
     RowsetSharedPtr target;
     int32_t segment_id;
 
@@ -325,8 +325,8 @@ Status LakeScanTabletAdaptor::init_read_columns(const std::vector<SlotDescriptor
     return init_read_schema(_tablet_schema, slots, &_read_schema);
 }
 
-auto LakeScanTabletAdaptor::get_iterator(int64_t rssid,
-                                         SparseRange<rowid_t> row_id_range) -> StatusOr<ChunkIteratorPtr> {
+auto LakeScanTabletAdaptor::get_iterator(int64_t rssid, SparseRange<rowid_t> row_id_range)
+        -> StatusOr<ChunkIteratorPtr> {
     if (rssid < 0 || rssid > std::numeric_limits<uint32_t>::max()) {
         return Status::InternalError(fmt::format("invalid lake rssid:{}", rssid));
     }

--- a/be/test/connector/lake/lake_data_source_test.cpp
+++ b/be/test/connector/lake/lake_data_source_test.cpp
@@ -28,12 +28,16 @@
 #include "column/vectorized_fwd.h"
 #include "common/config_exec_fwd.h"
 #include "common/config_scan_io_fwd.h"
+#include "common/config_storage_fwd.h"
 #include "common/logging.h"
 #include "common/object_pool.h"
 #include "common/runtime_profile.h"
 #include "compute_env/global_dict/fragment_dict_state.h"
 #include "compute_env/query/fragment_runtime_state.h"
+#include "compute_env/query/global_late_materialization_context.h"
+#include "compute_env/query/query_runtime_state.h"
 #include "connector/lake/lake_connector.h"
+#include "connector/lake/lake_global_late_materialization_context.h"
 #include "exec_primitive/pipeline/scan/scan_morsel.h"
 #include "exec_primitive/runtime_filter/runtime_filter_probe.h"
 #include "fs/fs_factory.h"
@@ -1583,6 +1587,244 @@ TEST_F(LakeDataSourceTest, disable_runtime_filter_dependent_cache_is_flag_only) 
     EXPECT_EQ(borrowed_range->span_size(), 50u);
     EXPECT_FALSE(state.seek_ranges_rowid_bounds.empty());
     EXPECT_EQ(borrowed_bounds->size(), 1u);
+}
+
+// A Lake scan resolves its cache policy from BOTH the query options and each TInternalScanRange
+// (fill_data_cache / skip_page_cache / skip_disk_cache), and the GLM lookup that later re-reads the
+// late-materialized columns of the very same tablet must reuse that resolved policy. So the capture
+// has to run AFTER init_reader_params() folded the scan range into _params: capturing earlier (as the
+// pre-fix code did, right where the context is created) records nothing but default-constructed flags
+// and lets the lookup populate caches the scan range explicitly disabled.
+TEST_F(LakeDataSourceTest, glm_capture_carries_resolved_scan_range_cache_policy) {
+    const bool saved_disable_page_cache = config::disable_storage_page_cache;
+    config::disable_storage_page_cache = false;
+    DeferOp restore_config([&]() { config::disable_storage_page_cache = saved_disable_page_cache; });
+
+    create_rowsets_for_testing(_tablet_metadata.get(), 2);
+
+    // A second tablet (same schema and rowsets, different id) so two scan ranges of ONE scan node can
+    // carry different cache policies through the single GLM context they share.
+    TabletMetadata second_metadata = *_tablet_metadata;
+    second_metadata.set_id(next_id());
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(second_metadata));
+
+    TLakeScanNode lake_scan_node;
+    lake_scan_node.__set_tuple_id(0);
+    lake_scan_node.__set_enable_global_late_materialization(true);
+    TPlanNode plan_node;
+    plan_node.__set_node_id(0);
+    plan_node.__set_lake_scan_node(lake_scan_node);
+
+    auto runtime_state = create_runtime_state_for_test();
+    TDescriptorTableBuilder desc_tbl_builder;
+    TSlotDescriptorBuilder slot_desc_builder;
+    auto slot0 = slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c0").column_pos(0).nullable(true).build();
+    auto slot1 = slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c1").column_pos(1).nullable(true).build();
+    TTupleDescriptorBuilder tuple_desc_builder;
+    tuple_desc_builder.add_slot(slot0);
+    tuple_desc_builder.add_slot(slot1);
+    tuple_desc_builder.build(&desc_tbl_builder);
+    DescriptorTbl* desc_tbl = nullptr;
+    CHECK(DescriptorTbl::create(runtime_state.get(), runtime_state->obj_pool(), desc_tbl_builder.desc_tbl(), &desc_tbl,
+                                config::vector_chunk_size)
+                  .ok());
+    runtime_state->set_desc_tbl(desc_tbl);
+
+    TTableDescriptor tdesc;
+    tdesc.__set_id(0);
+    tdesc.__set_tableType(TTableType::OLAP_TABLE);
+    tdesc.__set_tableName("test_table");
+    tdesc.__set_dbName("test_db");
+    auto* table_desc = runtime_state->obj_pool()->add(new OlapTableDescriptor(tdesc));
+    desc_tbl->get_tuple_descriptor(0)->set_table_desc(table_desc);
+
+    // GLM needs the query-scoped context manager + object pool off the QueryRuntimeState.
+    GlobalLateMaterilizationContextMgr glm_mgr;
+    pipeline::QueryRuntimeState query_runtime_state;
+    query_runtime_state.set_object_pool(runtime_state->obj_pool());
+    query_runtime_state.set_global_late_materialization_ctx_mgr(&glm_mgr);
+    runtime_state->set_query_runtime_state(&query_runtime_state);
+
+    connector::LakeDataSourceProvider provider(plan_node);
+    provider.set_lake_tablet_manager(_tablet_mgr);
+    RuntimeProfile parent_profile("LakeDataSourceTest");
+
+    auto glm_ctx = [&]() {
+        return static_cast<LakeScanLazyMaterializationContext*>(glm_mgr.get_ctx(plan_node.node_id));
+    };
+
+    struct Resolved {
+        LakeScanCacheOptions from_params; // what the scan itself resolved for this tablet
+        LakeScanCacheOptions captured;    // what the GLM context handed to the lookup
+    };
+
+    // Open one scan range with the given per-range cache flags and report both views of the policy.
+    auto scan_tablet = [&](const TabletMetadata& metadata, bool fill_data_cache, bool skip_page_cache,
+                           bool skip_disk_cache) -> Resolved {
+        TInternalScanRange internal_scan_range;
+        internal_scan_range.__set_tablet_id(metadata.id());
+        internal_scan_range.__set_version(std::to_string(metadata.version()));
+        internal_scan_range.__set_fill_data_cache(fill_data_cache);
+        internal_scan_range.__set_skip_page_cache(skip_page_cache);
+        internal_scan_range.__set_skip_disk_cache(skip_disk_cache);
+        TScanRange scan_range;
+        scan_range.__set_internal_scan_range(internal_scan_range);
+
+        auto tablet = _tablet_mgr->get_tablet(metadata.id(), metadata.version());
+        CHECK(tablet.ok()) << tablet.status();
+        std::vector<BaseRowsetSharedPtr> base_rowsets;
+        for (auto& rs : tablet->get_rowsets()) {
+            base_rowsets.emplace_back(rs);
+        }
+        pipeline::ScanMorsel morsel(plan_node.node_id, scan_range);
+        morsel.set_rowsets(base_rowsets);
+
+        connector::LakeDataSource ds(&provider, scan_range);
+        ds.set_runtime_profile(&parent_profile);
+        ds.set_morsel(&morsel);
+        DeferOp close_guard([&]() { ds.close(runtime_state.get()); });
+        CHECK_OK(ds.open(runtime_state.get()));
+
+        const auto& params = ds.TEST_params();
+        auto* ctx = glm_ctx();
+        CHECK(ctx != nullptr);
+        return Resolved{.from_params = {.use_page_cache = params.use_page_cache,
+                                        .fill_data_cache = params.lake_io_opts.fill_data_cache,
+                                        .fill_metadata_cache = params.lake_io_opts.fill_metadata_cache,
+                                        .skip_disk_cache = params.lake_io_opts.skip_disk_cache},
+                        .captured = ctx->get_cache_options(static_cast<int32_t>(metadata.id()))};
+    };
+
+    // The lookup must see exactly what the scan resolved -- no field silently dropped or defaulted.
+    auto expect_matches_scan = [](const Resolved& r) {
+        EXPECT_EQ(r.from_params.use_page_cache, r.captured.use_page_cache);
+        EXPECT_EQ(r.from_params.fill_data_cache, r.captured.fill_data_cache);
+        EXPECT_EQ(r.from_params.fill_metadata_cache, r.captured.fill_metadata_cache);
+        EXPECT_EQ(r.from_params.skip_disk_cache, r.captured.skip_disk_cache);
+    };
+
+    // (1) Permissive range: caches stay enabled end to end.
+    {
+        auto r = scan_tablet(*_tablet_metadata, /*fill_data_cache=*/true, /*skip_page_cache=*/false,
+                             /*skip_disk_cache=*/false);
+        EXPECT_TRUE(r.captured.use_page_cache);
+        EXPECT_TRUE(r.captured.fill_data_cache);
+        EXPECT_FALSE(r.captured.skip_disk_cache);
+        // fill_metadata_cache is NOT derived from the scan range; it keeps TabletReaderParams' default
+        // (true), which is what the pre-fix `segments(true)` already gave the lookup. Pinned here so
+        // narrowing the captured policy never silently stops filling the segment metacache.
+        EXPECT_TRUE(r.captured.fill_metadata_cache);
+        expect_matches_scan(r);
+    }
+
+    // (2) skip_page_cache on the range: the lookup must not touch the page cache even though the
+    //     query-level setting still allows it. This is precisely the flag the pre-fix code dropped.
+    {
+        auto r = scan_tablet(*_tablet_metadata, /*fill_data_cache=*/true, /*skip_page_cache=*/true,
+                             /*skip_disk_cache=*/false);
+        EXPECT_TRUE(runtime_state->use_page_cache()); // query level still says "yes"
+        EXPECT_FALSE(r.captured.use_page_cache);
+        EXPECT_TRUE(r.captured.fill_data_cache);
+        expect_matches_scan(r);
+    }
+
+    // (3) Data cache off + disk cache skipped: both must reach the lookup, and fill_data_cache=false
+    //     also turns the page cache off (that is how the scan derives _params.use_page_cache).
+    {
+        auto r = scan_tablet(*_tablet_metadata, /*fill_data_cache=*/false, /*skip_page_cache=*/false,
+                             /*skip_disk_cache=*/true);
+        EXPECT_FALSE(r.captured.use_page_cache);
+        EXPECT_FALSE(r.captured.fill_data_cache);
+        EXPECT_TRUE(r.captured.skip_disk_cache);
+        expect_matches_scan(r);
+    }
+
+    // (4) Two tablets of the same scan node with opposite policies: the shared context must keep them
+    //     apart, so the second (restrictive) range cannot relax the first one's policy.
+    {
+        (void)scan_tablet(*_tablet_metadata, /*fill_data_cache=*/true, /*skip_page_cache=*/false,
+                          /*skip_disk_cache=*/false);
+        (void)scan_tablet(second_metadata, /*fill_data_cache=*/false, /*skip_page_cache=*/true,
+                          /*skip_disk_cache=*/true);
+
+        auto* ctx = glm_ctx();
+        ASSERT_NE(nullptr, ctx);
+        auto permissive = ctx->get_cache_options(static_cast<int32_t>(_tablet_metadata->id()));
+        auto restrictive = ctx->get_cache_options(static_cast<int32_t>(second_metadata.id()));
+
+        EXPECT_TRUE(permissive.use_page_cache);
+        EXPECT_TRUE(permissive.fill_data_cache);
+        EXPECT_FALSE(permissive.skip_disk_cache);
+
+        EXPECT_FALSE(restrictive.use_page_cache);
+        EXPECT_FALSE(restrictive.fill_data_cache);
+        EXPECT_TRUE(restrictive.skip_disk_cache);
+    }
+}
+
+// Without enable_global_late_materialization the scan must not create a GLM context at all -- the
+// per-tablet cache policy is only recorded for the lookup path that actually consumes it.
+TEST_F(LakeDataSourceTest, no_glm_context_when_late_materialization_disabled) {
+    create_rowsets_for_testing(_tablet_metadata.get(), 2);
+
+    TPlanNode plan_node = create_lake_plan_node();
+    plan_node.__set_node_id(0);
+
+    auto runtime_state = create_runtime_state_for_test();
+    TDescriptorTableBuilder desc_tbl_builder;
+    TSlotDescriptorBuilder slot_desc_builder;
+    auto slot0 = slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c0").column_pos(0).nullable(true).build();
+    auto slot1 = slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c1").column_pos(1).nullable(true).build();
+    TTupleDescriptorBuilder tuple_desc_builder;
+    tuple_desc_builder.add_slot(slot0);
+    tuple_desc_builder.add_slot(slot1);
+    tuple_desc_builder.build(&desc_tbl_builder);
+    DescriptorTbl* desc_tbl = nullptr;
+    CHECK(DescriptorTbl::create(runtime_state.get(), runtime_state->obj_pool(), desc_tbl_builder.desc_tbl(), &desc_tbl,
+                                config::vector_chunk_size)
+                  .ok());
+    runtime_state->set_desc_tbl(desc_tbl);
+
+    TTableDescriptor tdesc;
+    tdesc.__set_id(0);
+    tdesc.__set_tableType(TTableType::OLAP_TABLE);
+    tdesc.__set_tableName("test_table");
+    tdesc.__set_dbName("test_db");
+    auto* table_desc = runtime_state->obj_pool()->add(new OlapTableDescriptor(tdesc));
+    desc_tbl->get_tuple_descriptor(0)->set_table_desc(table_desc);
+
+    GlobalLateMaterilizationContextMgr glm_mgr;
+    pipeline::QueryRuntimeState query_runtime_state;
+    query_runtime_state.set_object_pool(runtime_state->obj_pool());
+    query_runtime_state.set_global_late_materialization_ctx_mgr(&glm_mgr);
+    runtime_state->set_query_runtime_state(&query_runtime_state);
+
+    TInternalScanRange internal_scan_range;
+    internal_scan_range.__set_tablet_id(_tablet_metadata->id());
+    internal_scan_range.__set_version(std::to_string(_tablet_metadata->version()));
+    TScanRange scan_range;
+    scan_range.__set_internal_scan_range(internal_scan_range);
+
+    connector::LakeDataSourceProvider provider(plan_node);
+    provider.set_lake_tablet_manager(_tablet_mgr);
+
+    ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id(), _tablet_metadata->version()));
+    std::vector<BaseRowsetSharedPtr> base_rowsets;
+    for (auto& rs : tablet.get_rowsets()) {
+        base_rowsets.emplace_back(rs);
+    }
+    pipeline::ScanMorsel morsel(plan_node.node_id, scan_range);
+    morsel.set_rowsets(base_rowsets);
+
+    connector::LakeDataSource ds(&provider, scan_range);
+    RuntimeProfile parent_profile("LakeDataSourceTest");
+    ds.set_runtime_profile(&parent_profile);
+    ds.set_morsel(&morsel);
+    DeferOp close_guard([&]() { ds.close(runtime_state.get()); });
+    ASSERT_OK(ds.open(runtime_state.get()));
+
+    // get_ctx() DCHECKs on an unknown scan node id, so assert on the map itself.
+    EXPECT_TRUE(glm_mgr._ctx_map.empty());
 }
 
 } // namespace starrocks::lake

--- a/be/test/connector/lake/lake_global_late_materialization_context_test.cpp
+++ b/be/test/connector/lake/lake_global_late_materialization_context_test.cpp
@@ -80,16 +80,39 @@ TEST(LakeScanLazyMaterializationContextTest, CaptureRowsetsStoresVersion) {
     LakeScanLazyMaterializationContext ctx;
     ObjectPool pool;
     auto rowset = make_lake_rowset(2, &pool);
-    ctx.capture_rowsets(100, 42, as_base({rowset}));
+    ctx.capture_rowsets(100, 42, as_base({rowset}), {});
     EXPECT_EQ(42, ctx.get_rowsets_version(100));
+}
+
+TEST(LakeScanLazyMaterializationContextTest, CacheOptionsIsolatedPerTablet) {
+    LakeScanLazyMaterializationContext ctx;
+    ObjectPool pool;
+    ctx.capture_rowsets(
+            1, 10, as_base({make_lake_rowset(1, &pool)}),
+            {.use_page_cache = false, .fill_data_cache = false, .fill_metadata_cache = true, .skip_disk_cache = true});
+    ctx.capture_rowsets(
+            2, 20, as_base({make_lake_rowset(1, &pool)}),
+            {.use_page_cache = true, .fill_data_cache = true, .fill_metadata_cache = false, .skip_disk_cache = false});
+
+    auto tablet1_options = ctx.get_cache_options(1);
+    EXPECT_FALSE(tablet1_options.use_page_cache);
+    EXPECT_FALSE(tablet1_options.fill_data_cache);
+    EXPECT_TRUE(tablet1_options.fill_metadata_cache);
+    EXPECT_TRUE(tablet1_options.skip_disk_cache);
+
+    auto tablet2_options = ctx.get_cache_options(2);
+    EXPECT_TRUE(tablet2_options.use_page_cache);
+    EXPECT_TRUE(tablet2_options.fill_data_cache);
+    EXPECT_FALSE(tablet2_options.fill_metadata_cache);
+    EXPECT_FALSE(tablet2_options.skip_disk_cache);
 }
 
 TEST(LakeScanLazyMaterializationContextTest, VersionsIsolatedPerTablet) {
     LakeScanLazyMaterializationContext ctx;
     ObjectPool pool;
-    ctx.capture_rowsets(1, 10, as_base({make_lake_rowset(1, &pool)}));
-    ctx.capture_rowsets(2, 20, as_base({make_lake_rowset(1, &pool)}));
-    ctx.capture_rowsets(3, 30, as_base({make_lake_rowset(1, &pool)}));
+    ctx.capture_rowsets(1, 10, as_base({make_lake_rowset(1, &pool)}), {});
+    ctx.capture_rowsets(2, 20, as_base({make_lake_rowset(1, &pool)}), {});
+    ctx.capture_rowsets(3, 30, as_base({make_lake_rowset(1, &pool)}), {});
 
     EXPECT_EQ(10, ctx.get_rowsets_version(1));
     EXPECT_EQ(20, ctx.get_rowsets_version(2));
@@ -100,7 +123,7 @@ TEST(LakeScanLazyMaterializationContextTest, GetRowsetFirstSegment) {
     LakeScanLazyMaterializationContext ctx;
     ObjectPool pool;
     auto rowset = make_lake_rowset(2, &pool);
-    ctx.capture_rowsets(100, 1, as_base({rowset}));
+    ctx.capture_rowsets(100, 1, as_base({rowset}), {});
 
     int32_t segment_idx = -1;
     auto result = ctx.get_rowset(100, 0, &segment_idx);
@@ -120,7 +143,7 @@ TEST(LakeScanLazyMaterializationContextTest, GetRowsetSparseSegmentIdx) {
     ObjectPool pool;
     // rowset id=1000, kept segments segment_idx {1, 2} (low-key segment 0 dropped by the split).
     auto rs = make_lake_rowset_with_seg_idxs(1000, {1, 2}, &pool);
-    ctx.capture_rowsets(7, /*version=*/1, as_base({rs}));
+    ctx.capture_rowsets(7, /*version=*/1, as_base({rs}), {});
 
     int32_t seg_idx = -1;
     // rssid id+1 -> physical position 0.
@@ -150,7 +173,7 @@ TEST(LakeScanLazyMaterializationContextTest, GetRowsetMixedDenseAndSparse) {
     ObjectPool pool;
     auto dense = make_lake_rowset_with_seg_idxs(2000, {0, 1}, &pool);  // span [2000, 2002)
     auto sparse = make_lake_rowset_with_seg_idxs(3000, {2, 3}, &pool); // span [3000, 3004)
-    ctx.capture_rowsets(9, /*version=*/1, as_base({dense, sparse}));
+    ctx.capture_rowsets(9, /*version=*/1, as_base({dense, sparse}), {});
 
     int32_t seg_idx = -1;
     EXPECT_EQ(dense.get(), ctx.get_rowset(9, 2000, &seg_idx).get());

--- a/be/test/exec/pipeline/glm_manager_tablet_adaptor_test.cpp
+++ b/be/test/exec/pipeline/glm_manager_tablet_adaptor_test.cpp
@@ -17,18 +17,41 @@
 #include <string>
 #include <vector>
 
+#include "base/testutil/assert.h"
+#include "base/testutil/id_generator.h"
+#include "base/testutil/sync_point.h"
+#include "base/utility/defer_op.h"
+#include "column/chunk.h"
+#include "column/fixed_length_column.h"
 #include "common/config_exec_fwd.h"
+#include "common/config_storage_fwd.h"
 #include "common/object_pool.h"
 #include "compute_env/global_dict/fragment_dict_state.h"
 #include "connector/lake/lake_global_late_materialization_context.h"
 #include "exec/pipeline/lookup/tablet_adaptor.h"
 #include "exec/pipeline/scan/glm_manager.h"
+#include "fs/fs_util.h"
 #include "gtest/gtest.h"
 #include "runtime/descriptor_helper.h"
 #include "runtime/runtime_state.h"
+#include "storage/chunk_helper.h"
+#include "storage/lake/filenames.h"
+#include "storage/lake/fixed_location_provider.h"
+#include "storage/lake/join_path.h"
+#include "storage/lake/location_provider.h"
+#include "storage/lake/rowset.h"
+#include "storage/lake/tablet.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_metadata.h"
+#include "storage/lake/tablet_writer.h"
+#include "storage/lake/versioned_tablet.h"
+#include "storage/options.h"
+#include "storage/rowset/base_rowset.h"
 #include "storage/rowset/rowset.h"
 #include "storage/rowset/rowset_meta.h"
+#include "storage/rowset/segment_options.h"
 #include "storage/storage_engine.h"
+#include "storage/storage_env.h"
 #include "storage/tablet.h"
 #include "storage/tablet_manager.h"
 #include "storage/tablet_schema.h"
@@ -290,6 +313,201 @@ TEST(LakeScanTabletAdaptorTest, InvalidRssid) {
     auto iter_or = adaptor->get_iterator(-1, std::move(rowids));
     ASSERT_FALSE(iter_or.ok());
     ASSERT_TRUE(iter_or.status().is_internal_error());
+}
+
+// The GLM lookup re-reads columns of a tablet a Lake scan already scanned, so it must apply the cache
+// policy that scan resolved for that tablet -- both when loading segments and when reading rowsets.
+// Before the fix the adaptor only kept the query-level page-cache setting and loaded segments with a
+// hardcoded `segments(true)`, so fill_data_cache / skip_page_cache / skip_disk_cache from the scan
+// range were silently ignored and the lookup could populate caches the query explicitly disabled.
+//
+// The assertions below read the SegmentReadOptions that the lookup's RowsetReadOptions produce, via the
+// `Rowset::read::seg_options` sync point at the end of the chain
+// (LakeScanCacheOptions -> LakeIOOptions -> RowsetReadOptions -> SegmentReadOptions).
+class LakeScanTabletAdaptorCacheTest : public testing::Test {
+public:
+    void SetUp() override {
+        _tablet_mgr = StorageEnv::GetInstance()->lake_tablet_manager();
+        ASSERT_NE(nullptr, _tablet_mgr);
+        _location_provider = std::make_shared<lake::FixedLocationProvider>(kRootLocation);
+        _backup_location_provider = _tablet_mgr->TEST_set_location_provider(_location_provider);
+        for (const std::string dir :
+             {lake::kSegmentDirectoryName, lake::kMetadataDirectoryName, lake::kTxnLogDirectoryName}) {
+            ASSERT_OK(FileSystem::Default()->create_dir_recursive(lake::join_path(kRootLocation, dir)));
+        }
+
+        _tablet_id = next_id();
+        TabletMetadata metadata;
+        metadata.set_id(_tablet_id);
+        metadata.set_version(1);
+        auto* schema = metadata.mutable_schema();
+        schema->set_id(next_id());
+        schema->set_num_short_key_columns(1);
+        schema->set_keys_type(DUP_KEYS);
+        schema->set_num_rows_per_row_block(65535);
+        auto* c0 = schema->add_column();
+        c0->set_unique_id(0);
+        c0->set_name("c0");
+        c0->set_type("INT");
+        c0->set_is_key(true);
+        c0->set_is_nullable(false);
+        auto* c1 = schema->add_column();
+        c1->set_unique_id(1);
+        c1->set_name("c1");
+        c1->set_type("INT");
+        c1->set_is_key(false);
+        c1->set_is_nullable(false);
+        ASSERT_OK(_tablet_mgr->put_tablet_metadata(metadata));
+
+        // One rowset with one real segment, so get_iterator() actually loads a footer and reads.
+        auto tablet_schema = TabletSchema::create(*schema);
+        auto chunk_schema = std::make_shared<starrocks::Schema>(ChunkHelper::convert_schema(tablet_schema));
+        std::vector<int> keys{1, 2, 3, 4, 5};
+        std::vector<int> values{10, 20, 30, 40, 50};
+        auto key_column = Int32Column::create();
+        auto value_column = Int32Column::create();
+        key_column->append_numbers(keys.data(), keys.size() * sizeof(int));
+        value_column->append_numbers(values.data(), values.size() * sizeof(int));
+        Chunk chunk({std::move(key_column), std::move(value_column)}, chunk_schema);
+
+        ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_id));
+        ASSIGN_OR_ABORT(auto writer, tablet.new_writer(lake::kHorizontal, next_id()));
+        ASSERT_OK(writer->open());
+        ASSERT_OK(writer->write(chunk));
+        ASSERT_OK(writer->finish());
+        ASSERT_EQ(1, static_cast<int>(writer->segments().size()));
+        auto* rowset = metadata.add_rowsets();
+        rowset->set_overlapped(false);
+        rowset->set_id(kRowsetId);
+        rowset->set_num_rows(static_cast<int64_t>(keys.size()));
+        for (const auto& file : writer->segments()) {
+            rowset->add_segment_metas()->set_filename(file.path);
+        }
+        writer->close();
+
+        metadata.set_version(kVersion);
+        ASSERT_OK(_tablet_mgr->put_tablet_metadata(metadata));
+    }
+
+    void TearDown() override {
+        (void)_tablet_mgr->TEST_set_location_provider(_backup_location_provider);
+        (void)fs::remove_all(kRootLocation);
+    }
+
+protected:
+    struct ObservedOptions {
+        bool seen = false;
+        bool use_page_cache = false;
+        LakeIOOptions lake_io_opts;
+    };
+
+    // Drive the lookup adaptor over the single captured segment and report the read options it built.
+    ObservedOptions run_lookup(const LakeScanCacheOptions& cache_options, bool query_use_page_cache) {
+        // starrocks_test shares one process: pin the global so a sibling test cannot flip the expectation.
+        const bool saved_disable_page_cache = config::disable_storage_page_cache;
+        config::disable_storage_page_cache = false;
+        DeferOp restore_config([&]() { config::disable_storage_page_cache = saved_disable_page_cache; });
+
+        LakeScanLazyMaterializationContext ctx;
+        TLakeScanNode scan_node;
+        ctx.set_scan_node(scan_node);
+
+        auto tablet = _tablet_mgr->get_tablet(_tablet_id, kVersion);
+        CHECK(tablet.ok()) << tablet.status();
+        std::vector<BaseRowsetSharedPtr> rowsets;
+        for (auto& rs : tablet->get_rowsets()) {
+            rowsets.emplace_back(rs);
+        }
+        CHECK_EQ(1, static_cast<int>(rowsets.size()));
+        ctx.capture_rowsets(static_cast<int32_t>(_tablet_id), kVersion, rowsets, cache_options);
+
+        TQueryOptions query_options;
+        query_options.__set_use_page_cache(query_use_page_cache);
+        RuntimeState state(TUniqueId(), query_options, TQueryGlobals(), nullptr);
+        FragmentDictState dict_state;
+        state.set_fragment_dict_state(&dict_state);
+        ObjectPool pool;
+        auto slots = create_slots(&state, &pool, {"c0"});
+        CHECK(!slots.empty());
+
+        auto adaptor_or = create_look_up_tablet_adaptor(RowPositionDescriptor::Type::LAKE_SCAN);
+        CHECK(adaptor_or.ok());
+        auto adaptor = std::move(adaptor_or.value());
+        CHECK_OK(adaptor->capture(&ctx));
+        CHECK_OK(adaptor->init(_tablet_id));
+        CHECK_OK(adaptor->init_schema(&state));
+        CHECK_OK(adaptor->init_access_path(&state, &pool));
+        CHECK_OK(adaptor->init_global_dicts(&state, &pool, slots));
+        CHECK_OK(adaptor->init_read_columns(slots));
+
+        ObservedOptions observed;
+        SyncPoint::GetInstance()->EnableProcessing();
+        DeferOp sync_point_guard([]() {
+            SyncPoint::GetInstance()->ClearAllCallBacks();
+            SyncPoint::GetInstance()->DisableProcessing();
+        });
+        SyncPoint::GetInstance()->SetCallBack("Rowset::read::seg_options", [&](void* arg) {
+            const auto* seg_options = static_cast<const SegmentReadOptions*>(arg);
+            observed.seen = true;
+            observed.use_page_cache = seg_options->use_page_cache;
+            observed.lake_io_opts = seg_options->lake_io_opts;
+        });
+
+        SparseRange<rowid_t> row_id_range;
+        row_id_range.add(Range<rowid_t>(0, 1));
+        // rssid == rowset id + segment_idx; the single segment has segment_idx 0.
+        auto iter_or = adaptor->get_iterator(kRowsetId, std::move(row_id_range));
+        CHECK(iter_or.ok()) << iter_or.status();
+        CHECK(iter_or.value() != nullptr);
+        iter_or.value()->close();
+        return observed;
+    }
+
+    constexpr static const char* const kRootLocation = "./lake_scan_tablet_adaptor_cache_test";
+    constexpr static int64_t kVersion = 2;
+    constexpr static uint32_t kRowsetId = 1;
+
+    lake::TabletManager* _tablet_mgr = nullptr;
+    std::shared_ptr<lake::LocationProvider> _location_provider;
+    std::shared_ptr<lake::LocationProvider> _backup_location_provider;
+    int64_t _tablet_id = 0;
+};
+
+// A permissive scan range: everything the scan enabled must reach the lookup's reads.
+TEST_F(LakeScanTabletAdaptorCacheTest, PermissivePolicyIsHonored) {
+    auto observed = run_lookup(
+            {.use_page_cache = true, .fill_data_cache = true, .fill_metadata_cache = true, .skip_disk_cache = false},
+            /*query_use_page_cache=*/true);
+    ASSERT_TRUE(observed.seen);
+    EXPECT_TRUE(observed.use_page_cache);
+    EXPECT_TRUE(observed.lake_io_opts.fill_data_cache);
+    EXPECT_TRUE(observed.lake_io_opts.fill_metadata_cache);
+    EXPECT_FALSE(observed.lake_io_opts.skip_disk_cache);
+}
+
+// The scan range said "skip the page cache" (and don't fill either cache): the lookup must obey even
+// though the query-level page-cache setting is still on. Pre-fix this read came back with
+// use_page_cache=true and fill_data_cache=true (from the hardcoded `segments(true)`).
+TEST_F(LakeScanTabletAdaptorCacheTest, RestrictiveScanRangePolicyIsHonored) {
+    auto observed = run_lookup(
+            {.use_page_cache = false, .fill_data_cache = false, .fill_metadata_cache = false, .skip_disk_cache = true},
+            /*query_use_page_cache=*/true);
+    ASSERT_TRUE(observed.seen);
+    EXPECT_FALSE(observed.use_page_cache);
+    EXPECT_FALSE(observed.lake_io_opts.fill_data_cache);
+    EXPECT_FALSE(observed.lake_io_opts.fill_metadata_cache);
+    EXPECT_TRUE(observed.lake_io_opts.skip_disk_cache);
+}
+
+// The two page-cache inputs are ANDed: a query that turned the page cache off keeps it off even when
+// the captured scan-range policy allows it. Data/disk cache flags come from the scan range alone.
+TEST_F(LakeScanTabletAdaptorCacheTest, QueryLevelPageCacheOffWins) {
+    auto observed = run_lookup(
+            {.use_page_cache = true, .fill_data_cache = true, .fill_metadata_cache = true, .skip_disk_cache = false},
+            /*query_use_page_cache=*/false);
+    ASSERT_TRUE(observed.seen);
+    EXPECT_FALSE(observed.use_page_cache);
+    EXPECT_TRUE(observed.lake_io_opts.fill_data_cache);
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

Lake scans derive their cache policy from both query options and each
`TInternalScanRange`. The GLM lookup path only retained the query-level page
cache setting; it lost `fill_data_cache`, `skip_page_cache`, and
`skip_disk_cache`, and loaded segments with `segments(true)`. As a result,
late-materialized Lake columns could access or populate caches even when the
scan range explicitly disabled them.

## What I'm doing:

Carry the resolved cache policy per tablet through
`LakeScanLazyMaterializationContext`, then apply it to both segment loading and
rowset reads in `LakeScanTabletAdaptor`. The query-level page-cache setting is
still combined with the captured scan-range policy. A regression test verifies
that cache options are retained independently for different tablets.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.2
  - [ ] 4.1
  - [ ] 4.0
