### PR TITLE
[BugFix] Fix NPE in PrepareCollectMetaTask when the optimizer has no query id

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/PrepareCollectMetaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/PrepareCollectMetaTask.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer.task;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.MetaPreparationItem;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -27,6 +28,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -60,7 +62,12 @@ public class PrepareCollectMetaTask extends OptimizerTask {
         }
 
         int threadPoolSize = context.getOptimizerContext().getSessionVariable().getPrepareMetadataPoolSize();
-        String queryId = context.getOptimizerContext().getQueryId().toString();
+        // The optimizer is not always driven by a real query: background callers such as the mv plan cache
+        // builder (CachingMvPlanContextBuilder) and schema change threads run it on a synthetic ConnectContext
+        // that never gets a query id. Fall back to a freshly generated one so that the query-level connector
+        // metadata cache still gets a private key instead of throwing a NPE here.
+        UUID contextQueryId = context.getOptimizerContext().getQueryId();
+        String queryId = (contextQueryId != null ? contextQueryId : UUIDUtil.genUUID()).toString();
         ExecutorService executorService = Executors.newFixedThreadPool(threadPoolSize,
                 new ThreadFactoryBuilder().setNameFormat(String.format("prepare-metadata-%s", queryId)).build());
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/PrepareCollectMetaTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/PrepareCollectMetaTaskTest.java
@@ -60,9 +60,11 @@ public class PrepareCollectMetaTaskTest {
         ConnectContext.remove();
     }
 
-    @Test
-    public void testForkJoinMergeEndToEnd() throws Exception {
-
+    /**
+     * A join over two iceberg scans: two scan operators sharing one op type is what makes
+     * PrepareCollectMetaTask actually do work instead of returning early.
+     */
+    private static OptExpression buildTwoIcebergScanPlan() {
         List<Column> columns = Lists.newArrayList(new Column("c1", IntegerType.INT));
         IcebergTable tbl1 = new IcebergTable(1L, "t1", "default_catalog", "default_catalog",
                 "db", "t1", "", columns, null, Maps.newHashMap());
@@ -74,9 +76,15 @@ public class PrepareCollectMetaTaskTest {
         LogicalIcebergScanOperator scan2 = new LogicalIcebergScanOperator.Builder()
                 .setTable(tbl2).setColRefToColumnMetaMap(Maps.newHashMap()).build();
 
-        OptExpression planTree = OptExpression.create(new LogicalJoinOperator(),
+        return OptExpression.create(new LogicalJoinOperator(),
                 OptExpression.create(scan1),
                 OptExpression.create(scan2));
+    }
+
+    @Test
+    public void testForkJoinMergeEndToEnd() throws Exception {
+
+        OptExpression planTree = buildTwoIcebergScanPlan();
 
         // Mock MetadataMgr.prepareMetadata to return true (no actual connector work)
         new MockUp<MetadataMgr>() {
@@ -119,5 +127,61 @@ public class PrepareCollectMetaTaskTest {
         String output = Tracers.printScopeTimer();
         Assertions.assertTrue(output.contains("EXTERNAL.parallel_prepare_metadata"),
                 "Expected outer scope in output:\n" + output);
+    }
+
+    /**
+     * Background callers - the mv plan cache builder and schema change threads - optimize on a
+     * synthetic ConnectContext that never gets a query id, so OptimizerContext#getQueryId is null.
+     * That must not blow up the whole plan build.
+     */
+    @Test
+    public void testExecuteWithoutQueryId() throws Exception {
+
+        OptExpression planTree = buildTwoIcebergScanPlan();
+
+        List<String> capturedQueryIds = Lists.newArrayList();
+        new MockUp<MetadataMgr>() {
+            @Mock
+            public boolean prepareMetadata(String queryId, String catalogName,
+                                           MetaPreparationItem item, Tracers tracers,
+                                           ConnectContext connectContext) {
+                synchronized (capturedQueryIds) {
+                    capturedQueryIds.add(queryId);
+                }
+                return true;
+            }
+        };
+
+        ConnectContext ctx = ConnectContext.get();
+        ctx.getSessionVariable().setPrepareMetadataPoolSize(4);
+
+        new MockUp<OptimizerContext>() {
+            @Mock
+            public void $init(ConnectContext cc) {}
+
+            @Mock
+            public SessionVariable getSessionVariable() {
+                return ctx.getSessionVariable();
+            }
+
+            @Mock
+            public UUID getQueryId() {
+                return null;
+            }
+        };
+
+        OptimizerContext optimizerCtx = new OptimizerContext(ctx);
+        TaskContext taskCtx = new TaskContext(optimizerCtx,
+                new PhysicalPropertySet(), new ColumnRefSet(), 0);
+
+        Assertions.assertDoesNotThrow(() -> new PrepareCollectMetaTask(taskCtx, planTree).execute());
+
+        // Both scans must still be prepared, under one generated id per optimizer run so that the
+        // query level connector metadata cache gets a private key rather than a shared constant.
+        Assertions.assertEquals(2, capturedQueryIds.size());
+        String generated = capturedQueryIds.get(0);
+        Assertions.assertNotNull(generated);
+        Assertions.assertEquals(generated, capturedQueryIds.get(1));
+        Assertions.assertDoesNotThrow(() -> UUID.fromString(generated));
     }
 }


### PR DESCRIPTION
## Why I'm doing:

PrepareCollectMetaTask dereferences OptimizerContext#getQueryId() unconditionally. That id comes from the ConnectContext, and the optimizer is not always driven by a real query: CachingMvPlanContextBuilder builds mv plan contexts on its own thread pool, where ConnectContext.get() is null and MvPlanContextBuilder falls back to a synthetic `new ConnectContext()` that never gets a query id assigned. Schema change threads reach the optimizer the same way.

The task only runs when a plan holds more than one scan of the same type over tables that support pre-collecting metadata, which today means iceberg tables, so any materialized view defined over two or more iceberg tables fails to build a plan context at all:

```
  java.lang.NullPointerException: Cannot invoke "java.util.UUID.toString()"
  because the return value of "OptimizerContext.getQueryId()" is null
      at PrepareCollectMetaTask.execute(PrepareCollectMetaTask.java:63)
      at QueryOptimizer.prepareMetaOnlyOnce(QueryOptimizer.java:1141)
      ...
      at CachingMvPlanContextBuilder.loadMvPlanContext(...)
```

MvPlanContextBuilder swallows the exception and caches an empty plan list, so those materialized views silently stop taking part in query rewrite and get rebuilt over and over as the plan cache evicts them.

Generate a fresh id when the context has none. The id is not decorative: it also keys MetadataMgr#metadataCacheByQueryId, so a shared constant would make concurrent background builds collide on one query-level connector metadata entry. That cache is bounded by size and expires after access, so a per-invocation id does not leak.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
