### PR TITLE
[BugFix] Check the status before unwrapping a StatusOr

### DIFF
--- a/be/src/connector/file/file_chunk_sink.cpp
+++ b/be/src/connector/file/file_chunk_sink.cpp
@@ -58,8 +58,8 @@ StatusOr<std::unique_ptr<ConnectorSink>> FileChunkSinkProvider::create_sink(int3
     if (runtime_state == nullptr) {
         return Status::InternalError("FileChunkSinkContext requires runtime_state");
     }
-    std::shared_ptr<FileSystem> fs =
-            FileSystemFactory::CreateUniqueFromString(ctx->path, FSOptions(&ctx->cloud_conf)).value();
+    ASSIGN_OR_RETURN(std::shared_ptr<FileSystem> fs,
+                     FileSystemFactory::CreateUniqueFromString(ctx->path, FSOptions(&ctx->cloud_conf)));
     auto column_evaluators = ColumnEvaluator::clone(ctx->column_evaluators);
 
     auto normalized_format = normalize_format_name(ctx->format);

--- a/be/src/connector/hive/hive_chunk_sink.cpp
+++ b/be/src/connector/hive/hive_chunk_sink.cpp
@@ -64,8 +64,8 @@ StatusOr<std::unique_ptr<ConnectorSink>> HiveChunkSinkProvider::create_sink(int3
     if (runtime_state == nullptr) {
         return Status::InternalError("HiveChunkSinkContext requires runtime_state");
     }
-    std::shared_ptr<FileSystem> fs =
-            FileSystemFactory::CreateUniqueFromString(ctx->path, FSOptions(&ctx->cloud_conf)).value(); // must succeed
+    ASSIGN_OR_RETURN(std::shared_ptr<FileSystem> fs,
+                     FileSystemFactory::CreateUniqueFromString(ctx->path, FSOptions(&ctx->cloud_conf)));
     auto data_column_evaluators = ColumnEvaluator::clone(ctx->data_column_evaluators);
     auto location_provider = std::make_shared<connector::LocationProvider>(
             ctx->path, print_id(runtime_state->query_id()), runtime_state->be_number(), driver_id,

--- a/be/src/connector/hive/scanner/cache_select_scanner.cpp
+++ b/be/src/connector/hive/scanner/cache_select_scanner.cpp
@@ -77,8 +77,9 @@ Status CacheSelectScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* ch
 }
 
 Status CacheSelectScanner::_fetch_orc() {
-    std::unique_ptr<ORCHdfsFileStream> input_stream = std::make_unique<ORCHdfsFileStream>(
-            _file.get(), _file->get_size().value(), _shared_buffered_input_stream.get());
+    ASSIGN_OR_RETURN(const int64_t file_size, _file->get_size());
+    std::unique_ptr<ORCHdfsFileStream> input_stream =
+            std::make_unique<ORCHdfsFileStream>(_file.get(), file_size, _shared_buffered_input_stream.get());
     input_stream->set_app_stats(&_app_stats);
 
     std::unique_ptr<orc::Reader> reader;
@@ -181,10 +182,11 @@ Status CacheSelectScanner::_fetch_orc() {
 }
 
 Status CacheSelectScanner::_fetch_parquet() {
+    ASSIGN_OR_RETURN(const int64_t file_size, _file->get_size());
     // create file reader
-    std::shared_ptr<parquet::FileReader> reader = std::make_shared<parquet::FileReader>(
-            4096, _file.get(), _file->get_size().value(), _scanner_ctx->datacache_options,
-            _shared_buffered_input_stream.get(), nullptr);
+    std::shared_ptr<parquet::FileReader> reader =
+            std::make_shared<parquet::FileReader>(4096, _file.get(), file_size, _scanner_ctx->datacache_options,
+                                                  _shared_buffered_input_stream.get(), nullptr);
 
     RETURN_IF_ERROR(reader->init(&_scanner_ctx->format_scan_context));
 

--- a/be/src/connector/hive/scanner/hdfs_scanner_orc.cpp
+++ b/be/src/connector/hive/scanner/hdfs_scanner_orc.cpp
@@ -483,8 +483,9 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
     // create wrapped input stream.
     RETURN_IF_ERROR(open_random_access_file());
     if (_input_stream == nullptr) {
-        _input_stream = std::make_unique<ORCHdfsFileStream>(_file.get(), _file->get_size().value(),
-                                                            _shared_buffered_input_stream.get());
+        ASSIGN_OR_RETURN(const int64_t file_size, _file->get_size());
+        _input_stream =
+                std::make_unique<ORCHdfsFileStream>(_file.get(), file_size, _shared_buffered_input_stream.get());
         _input_stream->set_lazy_column_coalesce_counter(_scanner_ctx->format_scan_context.lazy_column_coalesce_counter);
         _input_stream->set_app_stats(&_app_stats);
     }

--- a/be/src/connector/hive/scanner/hdfs_scanner_parquet.cpp
+++ b/be/src/connector/hive/scanner/hdfs_scanner_parquet.cpp
@@ -273,8 +273,9 @@ void HdfsParquetScanner::do_update_counter(HdfsScannerProfile* profile) {
 
 Status HdfsParquetScanner::do_open(RuntimeState* runtime_state) {
     RETURN_IF_ERROR(open_random_access_file());
+    ASSIGN_OR_RETURN(const int64_t file_size, _file->get_size());
     // create file reader
-    _reader = std::make_shared<parquet::FileReader>(runtime_state->chunk_size(), _file.get(), _file->get_size().value(),
+    _reader = std::make_shared<parquet::FileReader>(runtime_state->chunk_size(), _file.get(), file_size,
                                                     _scanner_ctx->datacache_options,
                                                     _shared_buffered_input_stream.get(), _skip_rows_ctx);
     SCOPED_RAW_TIMER(&_app_stats.reader_init_ns);

--- a/be/src/connector/iceberg/iceberg_chunk_sink.cpp
+++ b/be/src/connector/iceberg/iceberg_chunk_sink.cpp
@@ -96,8 +96,8 @@ StatusOr<std::unique_ptr<ConnectorSink>> IcebergChunkSinkProvider::create_sink(i
     if (runtime_state == nullptr) {
         return Status::InternalError("IcebergChunkSinkContext requires runtime_state");
     }
-    std::shared_ptr<FileSystem> fs =
-            FileSystemFactory::CreateUniqueFromString(ctx->path, FSOptions(&ctx->cloud_conf)).value();
+    ASSIGN_OR_RETURN(std::shared_ptr<FileSystem> fs,
+                     FileSystemFactory::CreateUniqueFromString(ctx->path, FSOptions(&ctx->cloud_conf)));
     auto column_evaluators = std::make_shared<std::vector<std::unique_ptr<ColumnEvaluator>>>(
             ColumnEvaluator::clone(ctx->column_evaluators));
     auto location_provider = std::make_shared<connector::LocationProvider>(

--- a/be/src/connector/iceberg/iceberg_delete_sink.cpp
+++ b/be/src/connector/iceberg/iceberg_delete_sink.cpp
@@ -241,8 +241,8 @@ StatusOr<std::unique_ptr<ConnectorSink>> IcebergDeleteSinkProvider::create_sink(
     }
 
     // Create filesystem
-    std::shared_ptr<FileSystem> fs =
-            FileSystemFactory::CreateUniqueFromString(ctx->path, FSOptions(&ctx->cloud_configuration)).value();
+    ASSIGN_OR_RETURN(std::shared_ptr<FileSystem> fs,
+                     FileSystemFactory::CreateUniqueFromString(ctx->path, FSOptions(&ctx->cloud_configuration)));
 
     // For delete files, we only need file_path and row_position columns
     std::vector<std::string> column_names = {"file_path", "pos"};

--- a/be/src/exec/pipeline/lookup_request.cpp
+++ b/be/src/exec/pipeline/lookup_request.cpp
@@ -747,7 +747,7 @@ auto NativeLookUpTask::_build_row_id_range(RuntimeState* state, const Columns& r
     std::vector<RowLocatorTuple> locators;
 
     if (num_rows == 0) {
-        return Status::OK();
+        return locators;
     }
 
     int64_t cur_tablet = tablet_ids[0];

--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -645,7 +645,7 @@ StatusOr<ColumnPtr> JsonFunctions::_full_json_exists(FunctionContext* context, c
             VLOG(2) << "parse json path failed: " << path_str;
             continue;
         }
-        VLOG(2) << "json_exists for  " << path_str << " of " << json_value->to_string().value();
+        VLOG(2) << "json_exists for  " << path_str << " of " << json_value->to_string_uncheck();
         vpack::Builder builder;
         vpack::Slice slice = JsonPath::extract(json_value, *jsonpath.value(), &builder);
         result.append(!slice.isNone());
@@ -756,12 +756,12 @@ StatusOr<ColumnPtr> JsonFunctions::json_object(FunctionContext* context, const C
                 DCHECK(field_name != nullptr);
 
                 if (!field_name_slice.isString()) {
-                    VLOG(2) << "nonstring json field name" << field_name->to_string().value();
+                    VLOG(2) << "nonstring json field name" << field_name->to_string_uncheck();
                     ok = false;
                     break;
                 }
                 if (field_name_slice.stringRef().length() == 0) {
-                    VLOG(2) << "json field name could not be empty string" << field_name->to_string().value();
+                    VLOG(2) << "json field name could not be empty string" << field_name->to_string_uncheck();
                     ok = false;
                     break;
                 }
@@ -770,7 +770,7 @@ StatusOr<ColumnPtr> JsonFunctions::json_object(FunctionContext* context, const C
                     DCHECK(field_value != nullptr);
                     builder.add(field_name->to_vslice().stringRef(), field_value->to_vslice());
                 } else {
-                    VLOG(2) << "field value not exists, patch a null value" << field_name->to_string().value();
+                    VLOG(2) << "field value not exists, patch a null value" << field_name->to_string_uncheck();
                     builder.add(field_name->to_vslice().stringRef(), vpack::Value(vpack::ValueType::Null));
                 }
                 ok = true;

--- a/be/src/exprs/map_functions.cpp
+++ b/be/src/exprs/map_functions.cpp
@@ -340,7 +340,7 @@ StatusOr<ColumnPtr> MapFunctions::distinct_map_keys(FunctionContext* context, co
     auto values = col_map->values_column();
     if (values->is_map()) {
         const Columns map_values = {std::move(values)};
-        values = distinct_map_keys(context, map_values).value();
+        ASSIGN_OR_RETURN(values, distinct_map_keys(context, map_values));
     }
 
     Filter filter(keys->size(), 1);

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -985,7 +985,7 @@ Status OrcChunkReader::_add_conjunct(const Expr* conjunct,
         orc::TruthValue val = orc::TruthValue::NO;
         if (node_type == TExprNodeType::BOOL_LITERAL) {
             Expr* literal = const_cast<Expr*>(conjunct);
-            auto ptr = literal->evaluate_checked(nullptr, nullptr).value();
+            ASSIGN_OR_RETURN(auto ptr, literal->evaluate_checked(nullptr, nullptr));
             const Datum& datum = ptr->get(0);
             if (datum.get_int8()) {
                 val = orc::TruthValue::YES;

--- a/be/src/storage/lake/pk_tablet_sst_writer.h
+++ b/be/src/storage/lake/pk_tablet_sst_writer.h
@@ -55,7 +55,12 @@ public:
                                     const std::shared_ptr<FileSystem>& fs) {
         return Status::OK();
     }
-    virtual StatusOr<std::pair<FileInfo, PersistentIndexSstableRangePB>> flush_sst_writer() { return Status::OK(); }
+    // Only meaningful for writers that actually produce an SST; callers must gate the call on
+    // has_file_info(), which is false here, so the default is unreachable. Never return Status::OK()
+    // from a StatusOr: it is rewritten into an opaque InternalError instead of carrying a value.
+    virtual StatusOr<std::pair<FileInfo, PersistentIndexSstableRangePB>> flush_sst_writer() {
+        return Status::NotSupported("flush_sst_writer() called on a writer that produces no SST file");
+    }
     virtual bool has_file_info() const { return false; }
     // Rowids (within the just-flushed segment) that lost primary-key dedup and must be masked by a
     // delete vector at publish. Non-empty only for the unsort writer; the caller moves them out once


### PR DESCRIPTION
## Why I'm doing:

StatusOr::value() throws BadStatusOrAccess when the status is not OK, so an
unchecked unwrap converts a recoverable error into an exception that escapes
into the pipeline. Every call site changed here already sits in a function
returning Status or StatusOr, so propagating the error costs one
ASSIGN_OR_RETURN and no signature change.

FileSystemFactory::CreateUniqueFromString is the notable one: the four call
sites run inside XxxSinkProvider::create_sink, which itself returns
StatusOr<std::unique_ptr<ConnectorSink>>, and an unsupported scheme or a
malformed cloud configuration is a reachable failure. OrcChunkReader and
MapFunctions::distinct_map_keys follow the same shape.

The scanner get_size() calls cannot fail today: create_random_access_file
always installs a SharedBufferedInputStream carrying the already-known file
size, and its get_size() is a plain member read. Converting them means the
code no longer depends on that wrapper-chain invariant to stay correct.

json_functions only wants a JsonValue for a VLOG(2) line and should not fail
the query to produce one, so those switch to the non-failing
JsonValue::to_string_uncheck().

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
