### PR TITLE
[Enhancement] Include primary key value in key size exceed error message

### DIFF
--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -15,6 +15,7 @@
 #include "storage/memtable.h"
 
 #include <memory>
+#include <sstream>
 
 #include "base/time/time.h"
 #include "column/binary_column.h"
@@ -299,14 +300,18 @@ Status MemTable::finalize() {
             _chunk_bytes_usage = 0;
 
             _result_chunk = _aggregator->aggregate_result();
-            if (_keys_type == PRIMARY_KEYS &&
-                PrimaryKeyEncoder::encode_exceed_limit(*_vectorized_schema, *_result_chunk.get(), 0,
-                                                       _result_chunk->num_rows(), config::primary_key_limit_size,
-                                                       _pk_encoding_type)) {
-                _aggregator.reset();
-                _aggregator_memory_usage = 0;
-                _aggregator_bytes_usage = 0;
-                return Status::Cancelled(kPrimaryKeySizeExceedError);
+            if (_keys_type == PRIMARY_KEYS) {
+                auto exceed_idx = PrimaryKeyEncoder::find_first_exceed_limit_index(
+                        *_vectorized_schema, *_result_chunk.get(), 0, _result_chunk->num_rows(),
+                        config::primary_key_limit_size, _pk_encoding_type);
+                if (exceed_idx >= 0) {
+                    _aggregator.reset();
+                    _aggregator_memory_usage = 0;
+                    _aggregator_bytes_usage = 0;
+                    return Status::Cancelled(fmt::format("{} key: {}, tablet: {}, limit: {}",
+                                                         kPrimaryKeySizeExceedError, _debug_primary_key_row(exceed_idx),
+                                                         _tablet_id, config::primary_key_limit_size));
+                }
             }
             if (_has_op_slot && !_sink->keep_op_column()) {
                 // TODO(cbl): mem_tracker
@@ -408,6 +413,28 @@ Status MemTable::flush(SegmentPB* seg_info, bool eos, int64_t* flush_data_size, 
             << "io time: " << _stats.io_time_ns / 1000 << "us, memory bytes: " << _stats.flush_memory_size
             << ", disk bytes: " << _stats.flush_disk_size;
     return Status::OK();
+}
+
+std::string MemTable::_debug_primary_key_row(size_t row_idx) const {
+    DCHECK(_result_chunk != nullptr);
+    std::stringstream os;
+    os << "[";
+    int ncol = _vectorized_schema->num_key_fields();
+    for (int i = 0; i < ncol; ++i) {
+        if (i > 0) {
+            os << ", ";
+        }
+        std::string item = _result_chunk->get_column_by_index(i)->debug_item(row_idx);
+        // cap each key value to avoid log explosion on very long keys
+        constexpr size_t kMaxValueLen = 200;
+        if (item.size() > kMaxValueLen) {
+            item.resize(kMaxValueLen);
+            item.append("...");
+        }
+        os << _vectorized_schema->field(i)->name() << "=" << item;
+    }
+    os << "]";
+    return os.str();
 }
 
 Status MemTable::_merge() {

--- a/be/src/storage/memtable.h
+++ b/be/src/storage/memtable.h
@@ -131,6 +131,8 @@ private:
 
     Status _split_upserts_deletes(ChunkPtr& src, ChunkPtr* upserts, MutableColumnPtr* deletes);
 
+    // Formats the key-column values of the given row for error reporting.
+    std::string _debug_primary_key_row(size_t row_idx) const;
     ChunkPtr _chunk;
     ChunkPtr _result_chunk;
 

--- a/be/src/storage_primitive/primary_key_encoder.cpp
+++ b/be/src/storage_primitive/primary_key_encoder.cpp
@@ -539,15 +539,20 @@ void PrimaryKeyEncoder::encode_selective(const Schema& schema, const Chunk& chun
     }
 }
 
-bool PrimaryKeyEncoder::encode_exceed_limit(const Schema& schema, const Chunk& chunk, size_t offset, size_t len,
-                                            const size_t limit_size, PrimaryKeyEncodingType encoding_type) {
+int64_t PrimaryKeyEncoder::find_first_exceed_limit_index(const Schema& schema, const Chunk& chunk, size_t offset,
+                                                         size_t len, const size_t limit_size,
+                                                         PrimaryKeyEncodingType encoding_type) {
+    if (len == 0) {
+        return -1;
+    }
+
     int ncol = schema.num_key_fields();
     if (ncol == 1 && encoding_type == PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1) {
         if (schema.field(0)->type()->type() == TYPE_VARCHAR) {
             const auto& keys = GetContainer<TYPE_VARCHAR>::get_data(chunk.get_column_by_index(0));
             for (size_t i = 0; i < len; i++) {
                 if (keys[offset + i].size > limit_size) {
-                    return true;
+                    return offset + i;
                 }
             }
         }
@@ -566,7 +571,7 @@ bool PrimaryKeyEncoder::encode_exceed_limit(const Schema& schema, const Chunk& c
                 size += TypeUtils::estimate_field_size(t, 0);
             }
             if (size > limit_size) {
-                return true;
+                return offset;
             }
         }
 
@@ -584,12 +589,12 @@ bool PrimaryKeyEncoder::encode_exceed_limit(const Schema& schema, const Chunk& c
                 }
             }
             if (size > limit_size) {
-                return true;
+                return offset + i;
             }
         }
     }
 
-    return false;
+    return -1;
 }
 
 template <LogicalType LT>

--- a/be/src/storage_primitive/primary_key_encoder.h
+++ b/be/src/storage_primitive/primary_key_encoder.h
@@ -174,8 +174,10 @@ public:
     static void encode_selective(const Schema& schema, const Chunk& chunk, const uint32_t* indexes, size_t len,
                                  Column* dest, PrimaryKeyEncodingType encoding_type);
 
-    static bool encode_exceed_limit(const Schema& schema, const Chunk& chunk, size_t offset, size_t len,
-                                    size_t limit_size, PrimaryKeyEncodingType encoding_type);
+    // Returns the row index of the first key whose encoded size exceeds limit_size,
+    // or -1 if none. The row index is used to report which row caused the failure.
+    static int64_t find_first_exceed_limit_index(const Schema& schema, const Chunk& chunk, size_t offset, size_t len,
+                                                 size_t limit_size, PrimaryKeyEncodingType encoding_type);
 
     static Status decode(const Schema& schema, const Column& keys, size_t offset, size_t len, Chunk* dest,
                          PrimaryKeyEncodingType encoding_type, std::vector<uint8_t>* value_encode_flags = nullptr);

--- a/be/test/storage/primary_key_encoder_test.cpp
+++ b/be/test/storage/primary_key_encoder_test.cpp
@@ -212,6 +212,13 @@ TEST(PrimaryKeyEncoderTest, testDecodeCompositeWithSkipFlag) {
 
 TEST(PrimaryKeyEncoderTest, testEncodeCompositeLimit) {
     {
+        auto sc = create_key_schema({TYPE_INT, TYPE_INT});
+        auto pchunk = ChunkFactory::new_chunk(*sc, 0);
+        EXPECT_EQ(-1, PrimaryKeyEncoder::find_first_exceed_limit_index(*sc, *pchunk, 0, 0, 1,
+                                                                       PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
+    }
+
+    {
         auto sc = create_key_schema({TYPE_INT, TYPE_VARCHAR, TYPE_SMALLINT, TYPE_BOOLEAN});
         const int n = 1;
         auto pchunk = ChunkFactory::new_chunk(*sc, n);
@@ -226,10 +233,10 @@ TEST(PrimaryKeyEncoderTest, testEncodeCompositeLimit) {
         pchunk->columns()[2]->as_mutable_ptr()->append_datum(tmp);
         tmp.set_uint8(1);
         pchunk->columns()[3]->as_mutable_ptr()->append_datum(tmp);
-        EXPECT_TRUE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 10,
-                                                           PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
-        EXPECT_FALSE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 128,
-                                                            PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
+        EXPECT_EQ(0, PrimaryKeyEncoder::find_first_exceed_limit_index(*sc, *pchunk, 0, n, 10,
+                                                                      PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
+        EXPECT_EQ(-1, PrimaryKeyEncoder::find_first_exceed_limit_index(*sc, *pchunk, 0, n, 128,
+                                                                       PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
     }
 
     {
@@ -247,8 +254,8 @@ TEST(PrimaryKeyEncoderTest, testEncodeCompositeLimit) {
         pchunk->columns()[2]->as_mutable_ptr()->append_datum(tmp);
         tmp.set_uint8(1);
         pchunk->columns()[3]->as_mutable_ptr()->append_datum(tmp);
-        EXPECT_TRUE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 128,
-                                                           PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
+        EXPECT_EQ(0, PrimaryKeyEncoder::find_first_exceed_limit_index(*sc, *pchunk, 0, n, 128,
+                                                                      PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
     }
 }
 
@@ -266,8 +273,10 @@ TEST(PrimaryKeyEncoderTest, testEncodeVarcharLimit) {
                  "00000000000000000000000000000000000";
         tmp.set_slice(tmpstr);
         pchunk->columns()[0]->as_mutable_ptr()->append_datum(tmp);
-        EXPECT_TRUE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 128,
-                                                           PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
+        EXPECT_EQ(1, PrimaryKeyEncoder::find_first_exceed_limit_index(*sc, *pchunk, 0, n, 128,
+                                                                      PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
+        EXPECT_EQ(1, PrimaryKeyEncoder::find_first_exceed_limit_index(*sc, *pchunk, 1, 1, 128,
+                                                                      PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
     }
     {
         auto pchunk = ChunkFactory::new_chunk(*sc, n);
@@ -278,8 +287,8 @@ TEST(PrimaryKeyEncoderTest, testEncodeVarcharLimit) {
         tmpstr = "slice00000000000000000000000000000000000";
         tmp.set_slice(tmpstr);
         pchunk->columns()[0]->as_mutable_ptr()->append_datum(tmp);
-        EXPECT_FALSE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 128,
-                                                            PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
+        EXPECT_EQ(-1, PrimaryKeyEncoder::find_first_exceed_limit_index(*sc, *pchunk, 0, n, 128,
+                                                                       PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
     }
 }
 
@@ -712,10 +721,10 @@ TEST(PrimaryKeyEncoderTest, testV2EncodeExceedLimitForComposite) {
     pchunk->columns()[2]->as_mutable_ptr()->append_datum(d);
 
     // 4 (int) + 100 (varchar) + 1 (escape for \0) + 2 (separator) + 2 (smallint) = 109
-    EXPECT_FALSE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 128,
-                                                        PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2));
-    EXPECT_TRUE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 10,
-                                                       PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2));
+    EXPECT_EQ(-1, PrimaryKeyEncoder::find_first_exceed_limit_index(*sc, *pchunk, 0, n, 128,
+                                                                   PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2));
+    EXPECT_EQ(0, PrimaryKeyEncoder::find_first_exceed_limit_index(*sc, *pchunk, 0, n, 10,
+                                                                  PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2));
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

If primary key exceed config::primary_key_limit_size, the error message is `primary key size exceed the limit.`, this message doesn't reveal the key values

## What I'm doing:

Add key values to message for help user locate which key exceed the limit.

`ERROR 5609 (22000): 127.0.0.1: primary key size exceed the limit. key: [id='ERROR 1064 (HY000): Insert has filtered data, txn_id = 192033, tracking sql = select tracking_log from information
_schema. Load_tracking_Logs where job_id=203063', pt=2025-12-121, tablet: 203054, Limit: 128`

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
