### PR TITLE
[BugFix] Preserve inputIsBinary when copying logical window operators

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalWindowOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalWindowOperator.java
@@ -222,6 +222,7 @@ public class LogicalWindowOperator extends LogicalOperator {
             builder.forceMergeSort = windowOperator.forceMergeSort;
             builder.skewColumn = windowOperator.skewColumn;
             builder.skewValues = windowOperator.skewValues;
+            builder.inputIsBinary = windowOperator.inputIsBinary;
             return this;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/operator/LogicalWindowOperatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/operator/LogicalWindowOperatorTest.java
@@ -1,0 +1,36 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.operator.operator;
+
+import com.starrocks.sql.optimizer.operator.logical.LogicalWindowOperator;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LogicalWindowOperatorTest {
+
+    @Test
+    void testWithOperatorCopiesInputIsBinary() {
+        LogicalWindowOperator original = LogicalWindowOperator.builder()
+                .setInputIsBinary(true)
+                .build();
+
+        LogicalWindowOperator copy = LogicalWindowOperator.builder()
+                .withOperator(original)
+                .build();
+
+        assertTrue(copy.isInputIsBinary());
+    }
+}


### PR DESCRIPTION
<!-- PR title: [BugFix] Preserve inputIsBinary when copying logical window operators -->

## Why I'm doing:

`LogicalWindowOperator.Builder.withOperator` copied the other window properties but omitted
`inputIsBinary`. Optimizer rules that rebuild a logical window operator could therefore reset
the flag to `false` and lose the binary-input merge behavior selected by ranking-window
pre-aggregation.

## What I'm doing:

- Copy `inputIsBinary` in `LogicalWindowOperator.Builder.withOperator`.
- Add a regression test that rebuilds an operator with `inputIsBinary` enabled and verifies
  that the copied operator retains the flag.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: preserve binary-input merge behavior when optimizer rules copy logical window operators

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
