### PR TITLE
[Refactor] Rename TSortNode.analytic_partition_skewed to analytic_need_merge (backport #76899)

### DIFF
--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -266,7 +266,7 @@ Status TopNNode::_consume_chunks(RuntimeState* state, ExecNode* child) {
 
 template <class ContextFactory, class SinkFactory, class SourceFactory>
 std::vector<std::shared_ptr<pipeline::OperatorFactory>> TopNNode::_decompose_to_pipeline(
-        pipeline::PipelineBuilderContext* context, bool is_partition_topn, bool is_partition_skewed, bool need_merge,
+        pipeline::PipelineBuilderContext* context, bool is_partition_topn, bool analytic_need_merge, bool need_merge,
         bool enable_parallel_merge, bool is_per_pipeline) {
     using namespace pipeline;
 
@@ -284,7 +284,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory>> TopNNode::_decompose_to_
     } else if (need_merge) {
         if (enable_parallel_merge) {
             ops_sink_with_sort = context->maybe_interpolate_local_passthrough_exchange(
-                    runtime_state(), id(), ops_sink_with_sort, context->degree_of_parallelism(), is_partition_skewed);
+                    runtime_state(), id(), ops_sink_with_sort, context->degree_of_parallelism(), analytic_need_merge);
         }
     } else if (!is_per_pipeline) {
         // prepend local shuffle to PartitionSortSinkOperator
@@ -388,9 +388,8 @@ pipeline::OpFactories TopNNode::decompose_to_pipeline(pipeline::PipelineBuilderC
     bool is_per_pipeline = _tnode.sort_node.__isset.per_pipeline && _tnode.sort_node.per_pipeline;
     // need_merge = true means gather is needed for multiple streams of data
     // need_merge = false means gather is no longer needed
-    bool is_partition_skewed =
-            _tnode.sort_node.__isset.analytic_partition_skewed && _tnode.sort_node.analytic_partition_skewed;
-    bool need_merge = !is_per_pipeline && (_analytic_partition_exprs.empty() || is_partition_skewed);
+    bool analytic_need_merge = _tnode.sort_node.__isset.analytic_need_merge && _tnode.sort_node.analytic_need_merge;
+    bool need_merge = !is_per_pipeline && (_analytic_partition_exprs.empty() || analytic_need_merge);
     bool enable_parallel_merge = _tnode.sort_node.__isset.enable_parallel_merge &&
                                  _tnode.sort_node.enable_parallel_merge &&
                                  !_sort_exec_exprs.lhs_ordering_expr_ctxs().empty();
@@ -401,7 +400,7 @@ pipeline::OpFactories TopNNode::decompose_to_pipeline(pipeline::PipelineBuilderC
         operators_source_with_sort =
                 _decompose_to_pipeline<LocalPartitionTopnContextFactory, LocalPartitionTopnSinkOperatorFactory,
                                        LocalPartitionTopnSourceOperatorFactory>(context, is_partition_topn,
-                                                                                is_partition_skewed, need_merge,
+                                                                                analytic_need_merge, need_merge,
                                                                                 enable_parallel_merge, is_per_pipeline);
     } else {
         if (runtime_state()->enable_spill() && runtime_state()->enable_sort_spill() && _limit < 0) {
@@ -409,13 +408,13 @@ pipeline::OpFactories TopNNode::decompose_to_pipeline(pipeline::PipelineBuilderC
                 operators_source_with_sort =
                         _decompose_to_pipeline<SortContextFactory, SpillablePartitionSortSinkOperatorFactory,
                                                LocalParallelMergeSortSourceOperatorFactory>(
-                                context, is_partition_topn, is_partition_skewed, need_merge, enable_parallel_merge,
+                                context, is_partition_topn, analytic_need_merge, need_merge, enable_parallel_merge,
                                 is_per_pipeline);
             } else {
                 operators_source_with_sort =
                         _decompose_to_pipeline<SortContextFactory, SpillablePartitionSortSinkOperatorFactory,
                                                LocalMergeSortSourceOperatorFactory>(
-                                context, is_partition_topn, is_partition_skewed, need_merge, enable_parallel_merge,
+                                context, is_partition_topn, analytic_need_merge, need_merge, enable_parallel_merge,
                                 is_per_pipeline);
             }
         } else {
@@ -423,13 +422,13 @@ pipeline::OpFactories TopNNode::decompose_to_pipeline(pipeline::PipelineBuilderC
                 operators_source_with_sort =
                         _decompose_to_pipeline<SortContextFactory, PartitionSortSinkOperatorFactory,
                                                LocalParallelMergeSortSourceOperatorFactory>(
-                                context, is_partition_topn, is_partition_skewed, need_merge, enable_parallel_merge,
+                                context, is_partition_topn, analytic_need_merge, need_merge, enable_parallel_merge,
                                 is_per_pipeline);
             } else {
                 operators_source_with_sort =
                         _decompose_to_pipeline<SortContextFactory, PartitionSortSinkOperatorFactory,
                                                LocalMergeSortSourceOperatorFactory>(
-                                context, is_partition_topn, is_partition_skewed, need_merge, enable_parallel_merge,
+                                context, is_partition_topn, analytic_need_merge, need_merge, enable_parallel_merge,
                                 is_per_pipeline);
             }
         }

--- a/be/src/exec/topn_node.h
+++ b/be/src/exec/topn_node.h
@@ -44,7 +44,7 @@ public:
 private:
     template <class ContextFactory, class SinkFactory, class SourceFactory>
     std::vector<std::shared_ptr<pipeline::OperatorFactory>> _decompose_to_pipeline(
-            pipeline::PipelineBuilderContext* context, bool is_partition_topn, bool is_partition_skewed,
+            pipeline::PipelineBuilderContext* context, bool is_partition_topn, bool analytic_need_merge,
             bool is_merging, bool enable_parallel_merge, bool is_per_pipeline);
 
     Status _consume_chunks(RuntimeState* state, ExecNode* child);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
@@ -84,7 +84,11 @@ public class SortNode extends PlanNode implements RuntimeFilterBuildNode {
     // also added to TopNNode to hint that local shuffle operator is prepended to TopNNode in
     // order to eliminate merging operation in pipeline execution engine.
     private List<Expr> analyticPartitionExprs = Collections.emptyList();
-    private boolean analyticPartitionSkewed = false;
+
+    // When true, forces the SortNode to produce a single merged output stream instead of
+    // partition-sorted streams. Required when the downstream AnalyticNode consumes a single,
+    // globally-ordered input (currently the skewed-partition path).
+    private boolean analyticNeedsMerge = false;
 
     // info_.sortTupleSlotExprs_ substituted with the outputSmap_ for materialized slots in init().
     public List<Expr> resolvedTupleExprs;
@@ -102,8 +106,8 @@ public class SortNode extends PlanNode implements RuntimeFilterBuildNode {
         this.analyticPartitionExprs = exprs;
     }
 
-    public void setAnalyticPartitionSkewed(boolean isSkewed) {
-        analyticPartitionSkewed = isSkewed;
+    public void setAnalyticNeedsMerge(boolean needsMerge) {
+        analyticNeedsMerge = needsMerge;
     }
 
     private DataPartition inputPartition;
@@ -256,7 +260,7 @@ public class SortNode extends PlanNode implements RuntimeFilterBuildNode {
         msg.sort_node.setIs_asc_order(info.getIsAscOrder());
         msg.sort_node.setNulls_first(info.getNullsFirst());
         msg.sort_node.setAnalytic_partition_exprs(Expr.treesToThrift(analyticPartitionExprs));
-        msg.sort_node.setAnalytic_partition_skewed(analyticPartitionSkewed);
+        msg.sort_node.setAnalytic_need_merge(analyticNeedsMerge);
         if (info.getSortTupleSlotExprs() != null) {
             msg.sort_node.setSort_tuple_slot_exprs(Expr.treesToThrift(info.getSortTupleSlotExprs()));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -3176,9 +3176,13 @@ public class PlanFragmentBuilder {
          * In new planner.
          * Add partition exprs of AnalyticEvalNode to SortNode, it is used in pipeline execution engine
          * to eliminate time-consuming LocalMergeSortSourceOperator and parallelize AnalyticNode.
+         *
+         * @param needsMerge when true, forces the SortNode to produce a single merged output stream
+         *                   instead of partition-sorted streams, because the downstream AnalyticNode
+         *                   consumes a single globally-ordered input.
          */
         private static void passPartitionByToSortNode(ExecPlan context, PlanNode childRoot, List<Expr> partitionExprs,
-                                                      boolean isSkewed) {
+                                                      boolean needsMerge) {
             SortNode sortNode = null;
             if (childRoot instanceof SortNode) {
                 sortNode = (SortNode) childRoot;
@@ -3210,7 +3214,7 @@ public class PlanFragmentBuilder {
 
             if (sortNode != null) {
                 // If the data is skewed, we prefer to perform the standard sort-merge process to enhance performance.
-                sortNode.setAnalyticPartitionSkewed(isSkewed);
+                sortNode.setAnalyticNeedsMerge(needsMerge);
             }
         }
 

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -950,7 +950,7 @@ struct TSortNode {
   28: optional i64 max_buffered_bytes;
   29: optional bool late_materialization;
   30: optional bool enable_parallel_merge;
-  31: optional bool analytic_partition_skewed;
+  31: optional bool analytic_need_merge;
   32: optional list<Exprs.TExpr> pre_agg_exprs;
   33: optional list<Types.TSlotId> pre_agg_output_slot_id;
   34: optional bool pre_agg_insert_local_shuffle;


### PR DESCRIPTION
Backport of #76899 to `branch-3.5-cc`.

Original commit: 1dd025c8ec8a18dec23d62f5c3441fa3aa047a22
Original PR: https://github.com/StarRocks/starrocks/pull/76899

---

<!-- Original PR description below -->

## Why I'm doing:
The flag tells the BE's `TopNNode` to emit one merged stream instead of partition-sorted streams. It
happens to be set only on the skewed path today, but the condition it expresses is "the downstream
AnalyticNode needs one globally-ordered input", not "the data is skewed". A follow-up PR adds a
second rule to set it.

## What I'm doing:

Rename `TSortNode.analytic_partition_skewed` to `analytic_need_merge`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
