### PR TITLE
[Enhancement] Add [merge_sort] window hint (backport #76903)

### DIFF
--- a/be/src/exec/analytic_node.cpp
+++ b/be/src/exec/analytic_node.cpp
@@ -97,10 +97,21 @@ pipeline::OpFactories AnalyticNode::decompose_to_pipeline(pipeline::PipelineBuil
     OpFactories ops_with_sink = _children[0]->decompose_to_pipeline(context);
     auto* upstream_source_op = context->source_operator(ops_with_sink);
     bool is_skewed = _tnode.analytic_node.__isset.is_skewed && _tnode.analytic_node.is_skewed;
+    bool force_merge_sort = _tnode.analytic_node.__isset.force_merge_sort && _tnode.analytic_node.force_merge_sort;
 
     if (_tnode.analytic_node.partition_exprs.empty()) {
         // analytic's dop must be 1 if with no partition clause
         ops_with_sink = context->maybe_interpolate_local_passthrough_exchange(runtime_state(), id(), ops_with_sink);
+    } else if (force_merge_sort) {
+        // force_merge_sort feeds the AnalyticNode through OrderedPartitionExchanger, which assumes a single,
+        // globally-ordered input stream (dop=1). When the upstream DOP is > 1 the data is already partitioned
+        // and sorting already happened. This can occur when there are multiple analytics with different frames
+        // but the same partitioning and order by clauses. So only interpolate when DOP == 1; otherwise run the
+        // analytic directly on the parallel streams, which is correct.
+        if (upstream_source_op->degree_of_parallelism() == 1) {
+            ops_with_sink = context->maybe_interpolate_local_ordered_partition_exchange(runtime_state(), id(),
+                                                                                    ops_with_sink, _partition_exprs);
+        }
     } else if (_use_hash_based_partition) {
         bool has_outer_join_child =
                 _tnode.analytic_node.__isset.has_outer_join_child && _tnode.analytic_node.has_outer_join_child;

--- a/be/src/exec/analytic_node.cpp
+++ b/be/src/exec/analytic_node.cpp
@@ -109,8 +109,8 @@ pipeline::OpFactories AnalyticNode::decompose_to_pipeline(pipeline::PipelineBuil
         // but the same partitioning and order by clauses. So only interpolate when DOP == 1; otherwise run the
         // analytic directly on the parallel streams, which is correct.
         if (upstream_source_op->degree_of_parallelism() == 1) {
-            ops_with_sink = context->maybe_interpolate_local_ordered_partition_exchange(runtime_state(), id(),
-                                                                                    ops_with_sink, _partition_exprs);
+            ops_with_sink = context->maybe_interpolate_local_ordered_partition_exchange(
+                    runtime_state(), id(), ops_with_sink, _partition_exprs);
         }
     } else if (_use_hash_based_partition) {
         bool has_outer_join_child =

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -74,6 +74,7 @@ set(EXEC_FILES
         ./exec/pipeline/sink/memory_scratch_sink_operator_test.cpp
         ./exec/pipeline/limit_operator_test.cpp
         ./exec/pipeline/nljoin_probe_operator_test.cpp
+        ./exec/pipeline/analytic_node_pipeline_test.cpp
         ./exec/pipeline/ordered_partition_exchanger_test.cpp
         ./exec/pipeline/mem_limited_chunk_queue_test.cpp
         ./exec/pipeline/exec_group_test.cpp

--- a/be/test/exec/pipeline/analytic_node_pipeline_test.cpp
+++ b/be/test/exec/pipeline/analytic_node_pipeline_test.cpp
@@ -1,0 +1,247 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <utility>
+
+#include "base/statusor.h"
+#include "base/testutil/assert.h"
+#include "base/uid_util.h"
+#include "common/config_exec_fwd.h"
+#include "exec/analytic_node.h"
+#include "exec/chunk_buffer_memory_manager.h"
+#include "exec/empty_set_node.h"
+#include "exec/exec_env.h"
+#include "exec/pipeline/exchange/local_exchange.h"
+#include "exec/pipeline/exchange/local_exchange_source_operator.h"
+#include "exec/pipeline/fragment_context.h"
+#include "exec/pipeline/pipeline_builder.h"
+#include "exec/pipeline/query_context.h"
+#include "exec/pipeline_node.h"
+#include "exec/runtime/fragment_context_manager.h"
+#include "exec/runtime/pipeline.h"
+#include "exec/runtime/query_context_manager.h"
+#include "gutil/casts.h"
+#include "runtime/descriptor_helper.h"
+#include "runtime/runtime_env.h"
+#include "runtime/runtime_state.h"
+#include "types/logical_type.h"
+
+namespace starrocks {
+namespace {
+
+constexpr size_t kPipelineDop = 3;
+
+TExpr make_slot_ref_expr(TTupleId tuple_id, TSlotId slot_id) {
+    TExprNode node;
+    node.__set_node_type(TExprNodeType::SLOT_REF);
+    node.__set_type(gen_type_desc(TPrimitiveType::INT));
+    node.__set_num_children(0);
+    node.__set_is_nullable(true);
+
+    TSlotRef slot_ref;
+    slot_ref.__set_tuple_id(tuple_id);
+    slot_ref.__set_slot_id(slot_id);
+    node.__set_slot_ref(slot_ref);
+
+    TExpr expr;
+    expr.nodes.emplace_back(std::move(node));
+    return expr;
+}
+
+TPlanNode make_base_plan_node(TPlanNodeType::type node_type, TPlanNodeId node_id, TTupleId tuple_id, int num_children) {
+    TPlanNode tnode;
+    tnode.__set_node_id(node_id);
+    tnode.__set_node_type(node_type);
+    tnode.__set_num_children(num_children);
+    tnode.__set_limit(-1);
+    tnode.row_tuples.push_back(tuple_id);
+    return tnode;
+}
+
+class FixedDopSourceNode final : public PipelineNode {
+public:
+    FixedDopSourceNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs, size_t dop)
+            : PipelineNode(pool, tnode, descs), _dop(dop) {}
+
+    StatusOr<pipeline::OpFactories> decompose_to_pipeline(pipeline::PipelineBuilderContext* context) override {
+        auto mem_mgr = std::make_shared<pipeline::ChunkBufferMemoryManager>(_dop, 1024 * 1024);
+        auto source = std::make_shared<pipeline::LocalExchangeSourceOperatorFactory>(context->next_operator_id(), id(),
+                                                                                     mem_mgr);
+        source->set_runtime_state(context->runtime_state());
+        source->set_degree_of_parallelism(_dop);
+        return pipeline::OpFactories{std::move(source)};
+    }
+
+private:
+    size_t _dop;
+};
+
+class AnalyticNodePipelineTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        _exec_env = ExecEnv::GetInstance();
+        _query_id = generate_uuid();
+        _fragment_id = generate_uuid();
+
+        ASSIGN_OR_ASSERT_FAIL(_query_ctx, _exec_env->query_context_mgr()->get_or_register(_query_id));
+        _query_ctx->set_query_id(_query_id);
+        _query_ctx->set_total_fragments(1);
+        _query_ctx->query_runtime_state().set_delivery_expire_seconds(60);
+        _query_ctx->query_runtime_state().set_query_expire_seconds(60);
+        _query_ctx->query_runtime_state().extend_delivery_lifetime();
+        _query_ctx->query_runtime_state().extend_query_lifetime();
+        _query_ctx->init_mem_tracker(RuntimeEnv::GetInstance()->query_pool_mem_tracker()->limit(),
+                                     RuntimeEnv::GetInstance()->query_pool_mem_tracker());
+
+        // FragmentContextManager::get() only returns an already-registered fragment (nullptr otherwise),
+        // so the fragment context has to be created and registered explicitly before it can be used.
+        _fragment_ctx = std::make_shared<pipeline::FragmentContext>();
+        _fragment_ctx->set_query_id(_query_id);
+        _fragment_ctx->set_fragment_instance_id(_fragment_id);
+        _fragment_ctx->set_runtime_state(
+                std::make_unique<RuntimeState>(_query_id, _fragment_id, _query_options, _query_globals,
+                                               &_exec_env->query_execution_services(), _exec_env));
+        ASSERT_OK(_query_ctx->fragment_mgr()->register_ctx(_fragment_id, _fragment_ctx));
+
+        _runtime_state = _fragment_ctx->runtime_state();
+        _runtime_state->set_chunk_size(config::vector_chunk_size);
+        _runtime_state->init_mem_trackers(_query_ctx->mem_tracker());
+        _query_ctx->attach_to_runtime_state(_runtime_state);
+        _runtime_state->set_fragment_ctx(_fragment_ctx.get(), &_fragment_ctx->fragment_runtime_state());
+        _runtime_state->set_fragment_dict_state(_fragment_ctx->dict_state());
+
+        TDescriptorTableBuilder desc_tbl_builder;
+        TTupleDescriptorBuilder tuple_desc_builder;
+        tuple_desc_builder.add_slot(
+                TSlotDescriptorBuilder().type(TYPE_INT).nullable(true).column_name("c1").column_pos(0).build());
+        tuple_desc_builder.build(&desc_tbl_builder);
+        TDescriptorTable thrift_desc_tbl = desc_tbl_builder.desc_tbl();
+        _tuple_id = thrift_desc_tbl.tupleDescriptors[0].id;
+        _slot_id = thrift_desc_tbl.slotDescriptors[0].id;
+
+        ASSERT_OK(DescriptorTbl::create(_runtime_state, _runtime_state->obj_pool(), thrift_desc_tbl, &_desc_tbl,
+                                        config::vector_chunk_size));
+        _runtime_state->set_desc_tbl(_desc_tbl);
+    }
+
+    void TearDown() override {
+        if (_query_ctx != nullptr) {
+            _query_ctx->fragment_mgr()->unregister(_fragment_id);
+            _fragment_ctx.reset();
+            _runtime_state = nullptr;
+            _query_ctx->count_down_fragment();
+        }
+    }
+
+protected:
+    TPlanNode make_analytic_plan_node(bool force_merge_sort) const {
+        TPlanNode tnode = make_base_plan_node(TPlanNodeType::ANALYTIC_EVAL_NODE, 2, _tuple_id, 1);
+        TExpr partition_expr = make_slot_ref_expr(_tuple_id, _slot_id);
+
+        tnode.analytic_node.__set_partition_exprs({partition_expr});
+        tnode.analytic_node.__set_order_by_exprs({partition_expr});
+        tnode.analytic_node.__set_analytic_functions({});
+        tnode.analytic_node.__set_intermediate_tuple_id(_tuple_id);
+        tnode.analytic_node.__set_output_tuple_id(_tuple_id);
+        tnode.analytic_node.__set_force_merge_sort(force_merge_sort);
+        return tnode;
+    }
+
+    pipeline::Pipelines decompose_analytic(bool force_merge_sort, pipeline::OpFactories* analytic_source_ops) {
+        TPlanNode child_tnode = make_base_plan_node(TPlanNodeType::EMPTY_SET_NODE, 1, _tuple_id, 0);
+        EmptySetNode child(_runtime_state->obj_pool(), child_tnode, *_desc_tbl);
+
+        TPlanNode analytic_tnode = make_analytic_plan_node(force_merge_sort);
+        AnalyticNode analytic(_runtime_state->obj_pool(), analytic_tnode, *_desc_tbl);
+        analytic.add_child(&child);
+        CHECK_OK(analytic.init(analytic_tnode, _runtime_state));
+
+        pipeline::PipelineBuilderContext context(_fragment_ctx.get(), kPipelineDop, kPipelineDop);
+        ASSIGN_OR_ABORT(*analytic_source_ops, analytic.decompose_to_pipeline(&context));
+        return context.pipelines();
+    }
+
+    pipeline::Pipelines decompose_analytic_with_child(ExecNode* child, bool force_merge_sort,
+                                                      pipeline::OpFactories* analytic_source_ops) {
+        TPlanNode analytic_tnode = make_analytic_plan_node(force_merge_sort);
+        AnalyticNode analytic(_runtime_state->obj_pool(), analytic_tnode, *_desc_tbl);
+        analytic.add_child(child);
+        CHECK_OK(analytic.init(analytic_tnode, _runtime_state));
+
+        pipeline::PipelineBuilderContext context(_fragment_ctx.get(), kPipelineDop, kPipelineDop);
+        ASSIGN_OR_ABORT(*analytic_source_ops, analytic.decompose_to_pipeline(&context));
+        return context.pipelines();
+    }
+
+    ExecEnv* _exec_env = nullptr;
+    TUniqueId _query_id;
+    TUniqueId _fragment_id;
+    TQueryOptions _query_options;
+    TQueryGlobals _query_globals;
+    pipeline::QueryContext* _query_ctx = nullptr;
+    pipeline::FragmentContextPtr _fragment_ctx = nullptr;
+    RuntimeState* _runtime_state = nullptr;
+    DescriptorTbl* _desc_tbl = nullptr;
+    TTupleId _tuple_id = 0;
+    TSlotId _slot_id = 0;
+};
+
+TEST_F(AnalyticNodePipelineTest, ForceMergeSortUsesOrderedPartitionExchange) {
+    pipeline::OpFactories analytic_source_ops;
+    auto pipelines = decompose_analytic(true, &analytic_source_ops);
+
+    ASSERT_EQ(2, pipelines.size());
+    auto* local_exchange_source =
+            down_cast<pipeline::LocalExchangeSourceOperatorFactory*>(pipelines.back()->source_operator_factory());
+    ASSERT_NE(nullptr, local_exchange_source->exchanger());
+    EXPECT_EQ("OrderedPartition", local_exchange_source->exchanger()->name());
+
+    ASSERT_EQ(1, analytic_source_ops.size());
+    auto* analytic_source = down_cast<pipeline::SourceOperatorFactory*>(analytic_source_ops.front().get());
+    EXPECT_EQ(kPipelineDop, analytic_source->degree_of_parallelism());
+}
+
+TEST_F(AnalyticNodePipelineTest, AnalyticWithoutForceMergeSortDoesNotUseOrderedPartitionExchangeWithoutForce) {
+    pipeline::OpFactories analytic_source_ops;
+    auto pipelines = decompose_analytic(false, &analytic_source_ops);
+
+    ASSERT_EQ(1, pipelines.size());
+    EXPECT_EQ("empty_set", pipelines.front()->source_operator_factory()->get_raw_name());
+
+    ASSERT_EQ(1, analytic_source_ops.size());
+    auto* analytic_source = down_cast<pipeline::SourceOperatorFactory*>(analytic_source_ops.front().get());
+    EXPECT_EQ(1, analytic_source->degree_of_parallelism());
+}
+
+TEST_F(AnalyticNodePipelineTest, ForceMergeSortSkipsOrderedPartitionExchangeWhenUpstreamParallel) {
+    TPlanNode child_tnode = make_base_plan_node(TPlanNodeType::EMPTY_SET_NODE, 1, _tuple_id, 0);
+    FixedDopSourceNode child(_runtime_state->obj_pool(), child_tnode, *_desc_tbl, kPipelineDop);
+
+    pipeline::OpFactories analytic_source_ops;
+    auto pipelines = decompose_analytic_with_child(&child, true, &analytic_source_ops);
+
+    ASSERT_EQ(1, pipelines.size());
+    auto* child_source =
+            down_cast<pipeline::LocalExchangeSourceOperatorFactory*>(pipelines.front()->source_operator_factory());
+    EXPECT_EQ(nullptr, child_source->exchanger());
+
+    ASSERT_EQ(1, analytic_source_ops.size());
+    auto* analytic_source = down_cast<pipeline::SourceOperatorFactory*>(analytic_source_ops.front().get());
+    EXPECT_EQ(kPipelineDop, analytic_source->degree_of_parallelism());
+}
+} // namespace
+} // namespace starrocks

--- a/be/test/exec/pipeline/analytic_node_pipeline_test.cpp
+++ b/be/test/exec/pipeline/analytic_node_pipeline_test.cpp
@@ -17,28 +17,24 @@
 #include <memory>
 #include <utility>
 
-#include "base/statusor.h"
-#include "base/testutil/assert.h"
-#include "base/uid_util.h"
-#include "common/config_exec_fwd.h"
+#include "common/config.h"
 #include "exec/analytic_node.h"
 #include "exec/chunk_buffer_memory_manager.h"
 #include "exec/empty_set_node.h"
-#include "exec/exec_env.h"
+#include "exec/exec_node.h"
 #include "exec/pipeline/exchange/local_exchange.h"
 #include "exec/pipeline/exchange/local_exchange_source_operator.h"
 #include "exec/pipeline/fragment_context.h"
+#include "exec/pipeline/pipeline.h"
 #include "exec/pipeline/pipeline_builder.h"
 #include "exec/pipeline/query_context.h"
-#include "exec/pipeline_node.h"
-#include "exec/runtime/fragment_context_manager.h"
-#include "exec/runtime/pipeline.h"
-#include "exec/runtime/query_context_manager.h"
 #include "gutil/casts.h"
 #include "runtime/descriptor_helper.h"
-#include "runtime/runtime_env.h"
+#include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
+#include "testutil/assert.h"
 #include "types/logical_type.h"
+#include "util/uid_util.h"
 
 namespace starrocks {
 namespace {
@@ -72,12 +68,12 @@ TPlanNode make_base_plan_node(TPlanNodeType::type node_type, TPlanNodeId node_id
     return tnode;
 }
 
-class FixedDopSourceNode final : public PipelineNode {
+class FixedDopSourceNode final : public ExecNode {
 public:
     FixedDopSourceNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs, size_t dop)
-            : PipelineNode(pool, tnode, descs), _dop(dop) {}
+            : ExecNode(pool, tnode, descs), _dop(dop) {}
 
-    StatusOr<pipeline::OpFactories> decompose_to_pipeline(pipeline::PipelineBuilderContext* context) override {
+    pipeline::OpFactories decompose_to_pipeline(pipeline::PipelineBuilderContext* context) override {
         auto mem_mgr = std::make_shared<pipeline::ChunkBufferMemoryManager>(_dop, 1024 * 1024);
         auto source = std::make_shared<pipeline::LocalExchangeSourceOperatorFactory>(context->next_operator_id(), id(),
                                                                                      mem_mgr);
@@ -97,32 +93,21 @@ public:
         _query_id = generate_uuid();
         _fragment_id = generate_uuid();
 
-        ASSIGN_OR_ASSERT_FAIL(_query_ctx, _exec_env->query_context_mgr()->get_or_register(_query_id));
+        _query_ctx = std::make_shared<pipeline::QueryContext>();
         _query_ctx->set_query_id(_query_id);
-        _query_ctx->set_total_fragments(1);
-        _query_ctx->query_runtime_state().set_delivery_expire_seconds(60);
-        _query_ctx->query_runtime_state().set_query_expire_seconds(60);
-        _query_ctx->query_runtime_state().extend_delivery_lifetime();
-        _query_ctx->query_runtime_state().extend_query_lifetime();
-        _query_ctx->init_mem_tracker(RuntimeEnv::GetInstance()->query_pool_mem_tracker()->limit(),
-                                     RuntimeEnv::GetInstance()->query_pool_mem_tracker());
+        _query_ctx->init_mem_tracker(-1, GlobalEnv::GetInstance()->process_mem_tracker());
 
-        // FragmentContextManager::get() only returns an already-registered fragment (nullptr otherwise),
-        // so the fragment context has to be created and registered explicitly before it can be used.
         _fragment_ctx = std::make_shared<pipeline::FragmentContext>();
         _fragment_ctx->set_query_id(_query_id);
         _fragment_ctx->set_fragment_instance_id(_fragment_id);
         _fragment_ctx->set_runtime_state(
-                std::make_unique<RuntimeState>(_query_id, _fragment_id, _query_options, _query_globals,
-                                               &_exec_env->query_execution_services(), _exec_env));
-        ASSERT_OK(_query_ctx->fragment_mgr()->register_ctx(_fragment_id, _fragment_ctx));
+                std::make_unique<RuntimeState>(_query_id, _fragment_id, _query_options, _query_globals, _exec_env));
 
         _runtime_state = _fragment_ctx->runtime_state();
         _runtime_state->set_chunk_size(config::vector_chunk_size);
         _runtime_state->init_mem_trackers(_query_ctx->mem_tracker());
-        _query_ctx->attach_to_runtime_state(_runtime_state);
-        _runtime_state->set_fragment_ctx(_fragment_ctx.get(), &_fragment_ctx->fragment_runtime_state());
-        _runtime_state->set_fragment_dict_state(_fragment_ctx->dict_state());
+        _runtime_state->set_query_ctx(_query_ctx.get());
+        _runtime_state->set_fragment_ctx(_fragment_ctx.get());
 
         TDescriptorTableBuilder desc_tbl_builder;
         TTupleDescriptorBuilder tuple_desc_builder;
@@ -136,15 +121,6 @@ public:
         ASSERT_OK(DescriptorTbl::create(_runtime_state, _runtime_state->obj_pool(), thrift_desc_tbl, &_desc_tbl,
                                         config::vector_chunk_size));
         _runtime_state->set_desc_tbl(_desc_tbl);
-    }
-
-    void TearDown() override {
-        if (_query_ctx != nullptr) {
-            _query_ctx->fragment_mgr()->unregister(_fragment_id);
-            _fragment_ctx.reset();
-            _runtime_state = nullptr;
-            _query_ctx->count_down_fragment();
-        }
     }
 
 protected:
@@ -170,8 +146,8 @@ protected:
         analytic.add_child(&child);
         CHECK_OK(analytic.init(analytic_tnode, _runtime_state));
 
-        pipeline::PipelineBuilderContext context(_fragment_ctx.get(), kPipelineDop, kPipelineDop);
-        ASSIGN_OR_ABORT(*analytic_source_ops, analytic.decompose_to_pipeline(&context));
+        pipeline::PipelineBuilderContext context(_fragment_ctx.get(), kPipelineDop, kPipelineDop, false);
+        *analytic_source_ops = analytic.decompose_to_pipeline(&context);
         return context.pipelines();
     }
 
@@ -182,8 +158,8 @@ protected:
         analytic.add_child(child);
         CHECK_OK(analytic.init(analytic_tnode, _runtime_state));
 
-        pipeline::PipelineBuilderContext context(_fragment_ctx.get(), kPipelineDop, kPipelineDop);
-        ASSIGN_OR_ABORT(*analytic_source_ops, analytic.decompose_to_pipeline(&context));
+        pipeline::PipelineBuilderContext context(_fragment_ctx.get(), kPipelineDop, kPipelineDop, false);
+        *analytic_source_ops = analytic.decompose_to_pipeline(&context);
         return context.pipelines();
     }
 
@@ -192,7 +168,7 @@ protected:
     TUniqueId _fragment_id;
     TQueryOptions _query_options;
     TQueryGlobals _query_globals;
-    pipeline::QueryContext* _query_ctx = nullptr;
+    std::shared_ptr<pipeline::QueryContext> _query_ctx;
     pipeline::FragmentContextPtr _fragment_ctx = nullptr;
     RuntimeState* _runtime_state = nullptr;
     DescriptorTbl* _desc_tbl = nullptr;

--- a/be/test/exec/pipeline/analytic_node_pipeline_test.cpp
+++ b/be/test/exec/pipeline/analytic_node_pipeline_test.cpp
@@ -143,7 +143,7 @@ protected:
 
         TPlanNode analytic_tnode = make_analytic_plan_node(force_merge_sort);
         AnalyticNode analytic(_runtime_state->obj_pool(), analytic_tnode, *_desc_tbl);
-        analytic.add_child(&child);
+        analytic.set_children({&child});
         CHECK_OK(analytic.init(analytic_tnode, _runtime_state));
 
         pipeline::PipelineBuilderContext context(_fragment_ctx.get(), kPipelineDop, kPipelineDop, false);
@@ -155,7 +155,7 @@ protected:
                                                       pipeline::OpFactories* analytic_source_ops) {
         TPlanNode analytic_tnode = make_analytic_plan_node(force_merge_sort);
         AnalyticNode analytic(_runtime_state->obj_pool(), analytic_tnode, *_desc_tbl);
-        analytic.add_child(child);
+        analytic.set_children({child});
         CHECK_OK(analytic.init(analytic_tnode, _runtime_state));
 
         pipeline::PipelineBuilderContext context(_fragment_ctx.get(), kPipelineDop, kPipelineDop, false);

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AnalyticExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AnalyticExpr.java
@@ -87,6 +87,7 @@ public class AnalyticExpr extends Expr {
 
     private boolean useHashBasedPartition;
     private boolean isSkewed;
+    private boolean forceMergeSort;
 
     // Skew hint with explicit column and values: [skew|t.column(value1, value2, ...)]
     private Expr skewColumn;
@@ -99,6 +100,7 @@ public class AnalyticExpr extends Expr {
     private static final String HINT_HASH = "hash";
     private static final String HINT_SKEW = "skewed";
     public static final String HINT_ANALYTIC_SKEW_EXPLICIT = "skew";
+    public static final String HINT_ANALYTIC_MERGE_SORT = "merge_sort";
 
     public static String LEAD = "LEAD";
     public static String LAG = "LAG";
@@ -150,8 +152,12 @@ public class AnalyticExpr extends Expr {
                     this.skewHint = hint;
                     this.skewColumn = skewColumn;
                     this.skewValues = skewValues;
+                } else if (HintNode.HINT_ANALYTIC_MERGE_SORT.equalsIgnoreCase(hint)) {
+                    this.skewHint = hint;
+                    this.forceMergeSort = true;
                 } else {
-                    Preconditions.checkState(false, "partition by hint can only be 'sort' or 'hash' or 'skew' or 'skewed'");
+                    Preconditions.checkState(false,
+                            "partition by hint can only be 'sort' or 'hash' or 'skew' or 'skewed' or 'merge_sort'");
                 }
             }
         }
@@ -177,6 +183,7 @@ public class AnalyticExpr extends Expr {
         skewHint = other.skewHint;
         useHashBasedPartition = other.useHashBasedPartition;
         isSkewed = other.isSkewed;
+        forceMergeSort = other.forceMergeSort;
         skewColumn = (other.skewColumn != null ? other.skewColumn.clone() : null);
         skewValues = Expr.cloneList(other.skewValues);
         sqlString = other.sqlString;
@@ -223,6 +230,10 @@ public class AnalyticExpr extends Expr {
         return skewValues;
     }
 
+    public boolean isForceMergeSort() {
+        return forceMergeSort;
+    }
+
     @Override
     public boolean equalsWithoutChild(Object obj) {
         if (!super.equalsWithoutChild(obj)) {
@@ -239,6 +250,7 @@ public class AnalyticExpr extends Expr {
                 Objects.equals(skewHint, o.skewHint) &&
                 Objects.equals(useHashBasedPartition, o.useHashBasedPartition) &&
                 Objects.equals(isSkewed, o.isSkewed) &&
+                Objects.equals(forceMergeSort, o.forceMergeSort) &&
                 Objects.equals(skewColumn, o.skewColumn) &&
                 Objects.equals(skewValues, o.skewValues) &&
                 Objects.equals(fnCall.getIgnoreNulls(), o.fnCall.getIgnoreNulls());
@@ -500,6 +512,6 @@ public class AnalyticExpr extends Expr {
         // so need to calculate super's hashCode.
         // field window is correlated with field resetWindow, so no need to add resetWindow when calculating hashCode.
         return Objects.hash(type, opcode, fnCall, partitionExprs, orderByElements, window, partitionHint, skewHint,
-                useHashBasedPartition, isSkewed, skewColumn, skewValues);
+                useHashBasedPartition, isSkewed, forceMergeSort, skewColumn, skewValues);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AnalyticExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AnalyticExpr.java
@@ -152,7 +152,7 @@ public class AnalyticExpr extends Expr {
                     this.skewHint = hint;
                     this.skewColumn = skewColumn;
                     this.skewValues = skewValues;
-                } else if (HintNode.HINT_ANALYTIC_MERGE_SORT.equalsIgnoreCase(hint)) {
+                } else if (HINT_ANALYTIC_MERGE_SORT.equalsIgnoreCase(hint)) {
                     this.skewHint = hint;
                     this.forceMergeSort = true;
                 } else {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/AnalyticEvalNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AnalyticEvalNode.java
@@ -73,6 +73,7 @@ public class AnalyticEvalNode extends PlanNode {
 
     private final boolean useHashBasedPartition;
     private final boolean isSkewed;
+    private final boolean forceMergeSort;
 
     // Physical tuples used/produced by this analytic node.
     private final TupleDescriptor intermediateTupleDesc;
@@ -90,6 +91,7 @@ public class AnalyticEvalNode extends PlanNode {
             AnalyticWindow analyticWindow,
             boolean useHashBasedPartition,
             boolean isSkewed,
+            boolean forceMergeSort,
             TupleDescriptor intermediateTupleDesc,
             TupleDescriptor outputTupleDesc,
             Expr partitionByEq, Expr orderByEq, TupleDescriptor bufferedTupleDesc) {
@@ -103,6 +105,7 @@ public class AnalyticEvalNode extends PlanNode {
         this.analyticWindow = analyticWindow;
         this.useHashBasedPartition = useHashBasedPartition;
         this.isSkewed = isSkewed;
+        this.forceMergeSort = forceMergeSort;
         this.intermediateTupleDesc = intermediateTupleDesc;
         this.outputTupleDesc = outputTupleDesc;
         this.partitionByEq = partitionByEq;
@@ -148,6 +151,7 @@ public class AnalyticEvalNode extends PlanNode {
                 .add("window", analyticWindow)
                 .add("useHashBasedPartition", useHashBasedPartition)
                 .add("isSkewed", isSkewed)
+                .add("forceMergeSort", forceMergeSort)
                 .add("intermediateTid", intermediateTupleDesc.getId())
                 .add("intermediateTid", outputTupleDesc.getId())
                 .add("outputTid", outputTupleDesc.getId())
@@ -215,6 +219,7 @@ public class AnalyticEvalNode extends PlanNode {
 
         msg.analytic_node.setUse_hash_based_partition(useHashBasedPartition);
         msg.analytic_node.setIs_skewed(isSkewed);
+        msg.analytic_node.setForce_merge_sort(forceMergeSort);
 
         if (bufferedTupleDesc != null) {
             msg.analytic_node.setBuffered_tuple_id(bufferedTupleDesc.getId().asInt());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyticAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyticAnalyzer.java
@@ -153,6 +153,23 @@ public class AnalyticAnalyzer {
             }
         }
 
+        if (analyticExpr.isForceMergeSort()) {
+            if (!AnalyticExpr.HINT_ANALYTIC_MERGE_SORT.equalsIgnoreCase(analyticExpr.getSkewHint()) || analyticExpr.isSkewed() ||
+                    analyticExpr.getPartitionHint() != null) {
+                throw new SemanticException("The merge_sort hint cannot be combined with any other hint",
+                        analyticExpr.getPos());
+            }
+            if (analyticExpr.getPartitionExprs().isEmpty()) {
+                throw new SemanticException("The merge_sort hint requires a PARTITION BY clause",
+                        analyticExpr.getPos());
+            }
+            if (analyticExpr.getOrderByElements().isEmpty()) {
+                throw new SemanticException(
+                        "The merge_sort hint requires an ORDER BY clause in the window specification",
+                        analyticExpr.getPos());
+            }
+        }
+
         if (analyticExpr.getWindow() != null) {
             if ((isRankingFn(analyticFunction.getFn()) || isCumeFn(analyticFunction.getFn()) ||
                     isOffsetFn(analyticFunction.getFn()) || isHllAggFn(analyticFunction.getFn()))) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/RequiredPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/RequiredPropertyDeriver.java
@@ -281,7 +281,9 @@ public class RequiredPropertyDeriver extends PropertyDeriverBase<Void, Expressio
         SortProperty sortProperty = SortProperty.createProperty(node.getEnforceOrderBy(), partitionColumnRefSet);
 
         DistributionProperty distributionProperty;
-        if (partitionColumnRefSet.isEmpty()) {
+        // forceMergeSort requires a single, globally-ordered input stream, so gather instead of
+        // hash-shuffling the partition keys.
+        if (partitionColumnRefSet.isEmpty() || node.isForceMergeSort()) {
             distributionProperty = DistributionProperty.createProperty(DistributionSpec.createGatherDistributionSpec());
         } else {
             // If scan tablet sum less than 1, no distribution property is required

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalWindowOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalWindowOperator.java
@@ -56,6 +56,13 @@ public class LogicalWindowOperator extends LogicalOperator {
     private boolean useHashBasedPartition;
     private boolean isSkewed;
 
+    /**
+     * Feed the AnalyticNode from a single globally-ordered stream (gather + merging exchange +
+     * ordered-partition local exchange) instead of hash-shuffling the partition keys. Set by the
+     * [merge_sort] hint.
+     */
+    private boolean forceMergeSort;
+
     // Skew hint with explicit column and values: [skew|t.column(value1, value2, ...)]
     private ScalarOperator skewColumn;
     private ImmutableList<ScalarOperator> skewValues;
@@ -71,6 +78,7 @@ public class LogicalWindowOperator extends LogicalOperator {
         this.enforceSortColumns = ImmutableList.of();
         this.useHashBasedPartition = false;
         this.isSkewed = false;
+        this.forceMergeSort = false;
         this.skewColumn = null;
         this.skewValues = ImmutableList.of();
     }
@@ -101,6 +109,10 @@ public class LogicalWindowOperator extends LogicalOperator {
 
     public boolean isSkewed() {
         return isSkewed;
+    }
+
+    public boolean isForceMergeSort() {
+        return forceMergeSort;
     }
 
     public ScalarOperator getSkewColumn() {
@@ -174,6 +186,7 @@ public class LogicalWindowOperator extends LogicalOperator {
                 && Objects.equals(analyticWindow, that.analyticWindow)
                 && Objects.equals(useHashBasedPartition, that.useHashBasedPartition)
                 && Objects.equals(isSkewed, that.isSkewed)
+                && Objects.equals(forceMergeSort, that.forceMergeSort)
                 && Objects.equals(skewColumn, that.skewColumn)
                 && Objects.equals(skewValues, that.skewValues)
                 && Objects.equals(inputIsBinary, that.inputIsBinary);
@@ -182,7 +195,7 @@ public class LogicalWindowOperator extends LogicalOperator {
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), windowCall, partitionExpressions, orderByElements, analyticWindow,
-                useHashBasedPartition, isSkewed, skewColumn, skewValues, inputIsBinary);
+                useHashBasedPartition, isSkewed, forceMergeSort, skewColumn, skewValues, inputIsBinary);
     }
 
     public static Builder builder() {
@@ -206,6 +219,7 @@ public class LogicalWindowOperator extends LogicalOperator {
             builder.enforceSortColumns = windowOperator.enforceSortColumns;
             builder.useHashBasedPartition = windowOperator.useHashBasedPartition;
             builder.isSkewed = windowOperator.isSkewed;
+            builder.forceMergeSort = windowOperator.forceMergeSort;
             builder.skewColumn = windowOperator.skewColumn;
             builder.skewValues = windowOperator.skewValues;
             return this;
@@ -243,6 +257,11 @@ public class LogicalWindowOperator extends LogicalOperator {
 
         public Builder setIsSkewed(boolean isSkewed) {
             builder.isSkewed = isSkewed;
+            return this;
+        }
+
+        public Builder setForceMergeSort(boolean forceMergeSort) {
+            builder.forceMergeSort = forceMergeSort;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalWindowOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalWindowOperator.java
@@ -43,6 +43,12 @@ public class PhysicalWindowOperator extends PhysicalOperator {
     private final boolean useHashBasedPartition;
     private final boolean isSkewed;
 
+    /**
+     * Feed the AnalyticNode from a single globally-ordered stream instead of hash-shuffling the
+     * partition keys. Set by the [merge_sort] hint.
+     */
+    private final boolean forceMergeSort;
+
     // Skew hint with explicit column and values: [skew|t.column(value1, value2, ...)]
     private final ScalarOperator skewColumn;
     private final List<ScalarOperator> skewValues;
@@ -60,6 +66,7 @@ public class PhysicalWindowOperator extends PhysicalOperator {
                                   boolean isSkewed,
                                   ScalarOperator skewColumn,
                                   List<ScalarOperator> skewValues,
+                                  boolean forceMergeSort,
                                   boolean inputIsBinary,
                                   long limit,
                                   ScalarOperator predicate,
@@ -74,6 +81,7 @@ public class PhysicalWindowOperator extends PhysicalOperator {
         this.isSkewed = isSkewed;
         this.skewColumn = skewColumn;
         this.skewValues = skewValues;
+        this.forceMergeSort = forceMergeSort;
         this.inputIsBinary = inputIsBinary;
         this.limit = limit;
         this.predicate = predicate;
@@ -114,6 +122,10 @@ public class PhysicalWindowOperator extends PhysicalOperator {
 
     public List<ScalarOperator> getSkewValues() {
         return skewValues;
+    }
+
+    public boolean isForceMergeSort() {
+        return forceMergeSort;
     }
 
     public boolean isInputIsBinary() {
@@ -159,6 +171,7 @@ public class PhysicalWindowOperator extends PhysicalOperator {
                 Objects.equals(analyticWindow, that.analyticWindow) &&
                 Objects.equals(useHashBasedPartition, that.useHashBasedPartition) &&
                 Objects.equals(isSkewed, that.isSkewed) &&
+                Objects.equals(forceMergeSort, that.forceMergeSort) &&
                 Objects.equals(skewColumn, that.skewColumn) &&
                 Objects.equals(skewValues, that.skewValues) &&
                 Objects.equals(inputIsBinary, that.inputIsBinary);
@@ -167,7 +180,7 @@ public class PhysicalWindowOperator extends PhysicalOperator {
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), analyticCall, partitionExpressions, orderByElements, analyticWindow,
-                useHashBasedPartition, isSkewed, skewColumn, skewValues, inputIsBinary);
+                useHashBasedPartition, isSkewed, forceMergeSort, skewColumn, skewValues, inputIsBinary);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/WindowImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/WindowImplementationRule.java
@@ -45,6 +45,7 @@ public class WindowImplementationRule extends ImplementationRule {
                 logical.isSkewed(),
                 logical.getSkewColumn(),
                 logical.getSkewValues(),
+                logical.isForceMergeSort(),
                 logical.isInputIsBinary(),
                 logical.getLimit(),
                 logical.getPredicate(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitWindowSkewToUnionRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitWindowSkewToUnionRule.java
@@ -131,10 +131,12 @@ public class SplitWindowSkewToUnionRule extends TransformationRule {
 
             // Rule only applies if there is exactly one partition expression,
             // and that expression is a direct ColumnReference (not a function or expression).
+            // An explicit [merge_sort] hint picks the merge-sort strategy instead, so leave it alone.
             return partitionExprs != null
                     && partitionExprs.size() == 1
                     && lwo.getOrderByElements() != null
-                    && !lwo.getOrderByElements().isEmpty();
+                    && !lwo.getOrderByElements().isEmpty()
+                    && !lwo.isForceMergeSort();
         }
         return false;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -409,6 +409,7 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
                 windowOp.isSkewed(),
                 windowOp.getSkewColumn(),
                 windowOp.getSkewValues(),
+                windowOp.isForceMergeSort(),
                 windowOp.isInputIsBinary(),
                 windowOp.getLimit(),
                 predicate,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
@@ -396,6 +396,9 @@ public class QueryTransformer {
                     windowOperator.setSkewColumn(rewriteOperator.getSkewColumn());
                     windowOperator.setSkewValues(rewriteOperator.getSkewValues());
                 }
+                if (rewriteOperator.isForceMergeSort()) {
+                    windowOperator.setForceMergeSort();
+                }
                 windowOperator.addFunction(analyticExpr);
             } else {
                 windowOperators.add(rewriteOperator);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/WindowTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/WindowTransformer.java
@@ -321,6 +321,7 @@ public class WindowTransformer {
                     .setEnforceSortColumns(sortEnforceProperty.stream().distinct().collect(Collectors.toList()))
                     .setUseHashBasedPartition(windowOperator.useHashBasedPartition)
                     .setIsSkewed(windowOperator.isSkewed)
+                    .setForceMergeSort(windowOperator.forceMergeSort)
                     .setSkewColumn(skewColumnOp)
                     .setSkewValues(skewValueOps)
                     .build());
@@ -557,6 +558,10 @@ public class WindowTransformer {
         // it will be also treated as the same window clause. So this field should not be involved in the equals and
         // hashCode method.
         private boolean isSkewed;
+        // Set by the [merge_sort] hint. Like isSkewed, it must stay out of equals/hashCode so that
+        // window functions sharing a window clause still merge into one WindowOperator when only
+        // some of them carry the hint.
+        private boolean forceMergeSort;
 
         // Skew hint with explicit column and values: [skew|t.column(value1, value2, ...)]
         private Expr skewColumn;
@@ -588,10 +593,12 @@ public class WindowTransformer {
                 this.isSkewed = analyticExpr.isSkewed();
                 this.skewColumn = analyticExpr.getSkewColumn();
                 this.skewValues = analyticExpr.getSkewValues();
+                this.forceMergeSort = analyticExpr.isForceMergeSort();
             } else {
                 this.isSkewed = false;
                 this.skewColumn = null;
                 this.skewValues = List.of();
+                this.forceMergeSort = false;
             }
         }
 
@@ -626,7 +633,15 @@ public class WindowTransformer {
         }
 
         public void setSkewed() {
-            isSkewed = true;
+            this.isSkewed = true;
+        }
+
+        public boolean isForceMergeSort() {
+            return forceMergeSort;
+        }
+
+        public void setForceMergeSort() {
+            this.forceMergeSort = true;
         }
 
         public void setSkewColumn(Expr skewColumn) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -3146,6 +3146,7 @@ public class PlanFragmentBuilder {
                     node.getAnalyticWindow(),
                     node.isUseHashBasedPartition(),
                     node.isSkewed(),
+                    node.isForceMergeSort(),
                     null, outputTupleDesc, null, null,
                     context.getDescTbl().createTupleDescriptor());
             analyticEvalNode.setSubstitutedPartitionExprs(partitionExprs);
@@ -3165,8 +3166,10 @@ public class PlanFragmentBuilder {
                 analyticEvalNode.getConjuncts()
                         .add(ScalarOperatorToExpr.buildExecExpression(predicate, formatterContext));
             }
+            // Both the skewed and the forceMergeSort paths make the AnalyticNode consume a single
+            // ordered stream via OrderedPartitionExchanger, so the child SortNode must merge.
             passPartitionByToSortNode(context, inputFragment.getPlanRoot(), analyticEvalNode.getPartitionExprs(),
-                    node.isSkewed());
+                    node.isSkewed() || node.isForceMergeSort());
 
             inputFragment.setPlanRoot(analyticEvalNode);
             return inputFragment;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowMergeSortHintTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowMergeSortHintTest.java
@@ -1,0 +1,174 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
+import com.starrocks.sql.optimizer.statistics.CachedStatisticStorage;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.statistics.StatisticStorage;
+import com.starrocks.statistic.StatisticsMetaManager;
+import com.starrocks.thrift.TExplainLevel;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+/**
+ * Plan-level coverage for the [merge_sort] window hint. The hint forces the analytic to consume a
+ * single globally-ordered stream, which shows up in the plan as a MERGING-EXCHANGE below ANALYTIC
+ * instead of a hash-partitioned EXCHANGE.
+ */
+class WindowMergeSortHintTest extends PlanTestBase {
+    private static final String TABLE_NAME = "merge_sort_hint_table";
+    private static final List<String> ALL_COLUMNS = List.of("p", "s", "x");
+    private static final String HINTED_SQL =
+            "select p, s, sum(x) over ([merge_sort] partition by s order by p) from " + TABLE_NAME;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        FeConstants.runningUnitTest = true;
+        Config.enable_sync_statistics_load = true;
+        connectContext.getGlobalStateMgr().setStatisticStorage(new CachedStatisticStorage());
+
+        starRocksAssert.withTable(
+                """
+                        CREATE TABLE `merge_sort_hint_table` (
+                          `p` int NULL,
+                          `s` int NULL,
+                          `x` int NULL
+                        ) ENGINE=OLAP
+                        DUPLICATE KEY(`p`, `s`, `x`)
+                        DISTRIBUTED BY HASH(`p`) BUCKETS 3
+                        PROPERTIES (
+                          "replication_num" = "1",
+                          "in_memory" = "false"
+                        );
+                        """
+        );
+
+        if (!starRocksAssert.databaseExist("_statistics_")) {
+            StatisticsMetaManager m = new StatisticsMetaManager();
+            m.createStatisticsTablesForTest();
+        }
+    }
+
+    @BeforeEach
+    @Override
+    public void setUp() {
+        super.setUp();
+        connectContext.getSessionVariable().setEnableSplitWindowSkewToUnion(false);
+        setTableStatistics(table(), 1000);
+    }
+
+    private OlapTable table() {
+        return getOlapTable(TABLE_NAME);
+    }
+
+    private StatisticStorage storage() {
+        return connectContext.getGlobalStateMgr().getStatisticStorage();
+    }
+
+    private String getCostPlan(String sql) throws Exception {
+        return getFragmentPlan(sql, TExplainLevel.COSTS, "");
+    }
+
+    private void refreshAndSetColumnStat(String column, ColumnStatistic stat) {
+        storage().refreshColumnStatistics(table(), ALL_COLUMNS, true);
+        storage().addColumnStatistic(table(), column, stat);
+        storage().getColumnStatistics(table(), ALL_COLUMNS);
+    }
+
+    private void setSkewedStatsForS() {
+        refreshAndSetColumnStat("s", ColumnStatistic.builder().setNullsFraction(0.3).build());
+    }
+
+    private void setNonSkewedStatsForS() {
+        refreshAndSetColumnStat("s", ColumnStatistic.builder().setNullsFraction(0.05).build());
+    }
+
+    private void assertMergeSortApplied(String plan) {
+        assertContains(plan, "ANALYTIC");
+        assertContains(plan, "MERGING-EXCHANGE");
+    }
+
+    @Test
+    void testUnhintedWindowKeepsShuffleDistribution() throws Exception {
+        setSkewedStatsForS();
+
+        String plan = getCostPlan("select p, s, sum(x) over (partition by s order by p) from " + TABLE_NAME);
+        assertContains(plan, "ANALYTIC");
+        assertNotContains(plan, "MERGING-EXCHANGE");
+    }
+
+    @Test
+    void testHintForcesMergeSortWithNonSkewedStats() throws Exception {
+        setNonSkewedStatsForS();
+
+        // The hint is unconditional: it does not consult statistics.
+        assertMergeSortApplied(getCostPlan(HINTED_SQL));
+    }
+
+    @Test
+    void testHintForcesMergeSortWithSkewedStats() throws Exception {
+        setSkewedStatsForS();
+
+        assertMergeSortApplied(getCostPlan(HINTED_SQL));
+    }
+
+    @Test
+    void testHintTakesPrecedenceOverSplitWindowSkewToUnion() throws Exception {
+        connectContext.getSessionVariable().setEnableSplitWindowSkewToUnion(true);
+        setSkewedStatsForS();
+
+        String plan = getCostPlan(HINTED_SQL);
+        assertMergeSortApplied(plan);
+        assertNotContains(plan, "UNION");
+    }
+
+    @Test
+    void testHintOnMultiColumnPartition() throws Exception {
+        setSkewedStatsForS();
+
+        String sql = "select p, s, sum(x) over ([merge_sort] partition by p, s order by x) from " + TABLE_NAME;
+        assertMergeSortApplied(getCostPlan(sql));
+    }
+
+    @Test
+    void testHintRequiresOnlyOneHint() {
+        setSkewedStatsForS();
+
+        starRocksAssert.query("select p, s, sum(x) over ([merge_sort,hash] partition by s) from " + TABLE_NAME)
+                .analysisError("The merge_sort hint cannot be combined with any other hint");
+
+        starRocksAssert.query("select p, s, sum(x) over ([merge_sort,skewed] partition by s) from " + TABLE_NAME)
+                .analysisError("The merge_sort hint cannot be combined with any other hint");
+
+        starRocksAssert.query("select p, s, sum(x) over ([merge_sort,skewed,hash] partition by s) from " + TABLE_NAME)
+                .analysisError("The merge_sort hint cannot be combined with any other hint");
+
+        starRocksAssert.query("select p, s, sum(x) over ([sort,merge_sort] partition by s) from " + TABLE_NAME)
+                .analysisError("The merge_sort hint cannot be combined with any other hint");
+    }
+
+    @Test
+    void testHintRequiresOrderBy() {
+        starRocksAssert.query("select p, s, sum(x) over ([merge_sort] partition by s) from " + TABLE_NAME)
+                .analysisError("The merge_sort hint requires an ORDER BY clause in the window specification.");
+    }
+}

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -1052,6 +1052,9 @@ struct TAnalyticNode {
   20: optional bool has_outer_join_child
   21: optional bool use_hash_based_partition
   22: optional bool is_skewed
+  // Feed the AnalyticNode from a single globally-ordered stream via an ordered-partition
+  // local exchange instead of hash-shuffling the partition keys.
+  23: optional bool force_merge_sort
 }
 
 struct TMergeNode {

--- a/test/sql/test_window_function/R/test_window_merge_sort_hint
+++ b/test/sql/test_window_function/R/test_window_merge_sort_hint
@@ -1,0 +1,122 @@
+-- name: test_window_merge_sort_hint
+DROP TABLE IF EXISTS window_merge_sort_t1;
+-- result:
+-- !result
+CREATE TABLE window_merge_sort_t1 (
+    p INT NULL,
+    s INT NULL,
+    x INT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(p, s, x)
+DISTRIBUTED BY HASH(p) BUCKETS 3
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO window_merge_sort_t1 VALUES
+    (1, 1, 1),
+    (2, 2, 2),
+    (3, 3, 3),
+    (NULL, NULL, 4),
+    (NULL, NULL, 5),
+    (NULL, NULL, 6),
+    (NULL, NULL, 7),
+    (NULL, NULL, 8),
+    (NULL, NULL, 9),
+    (NULL, NULL, 10),
+    (NULL, NULL, 11),
+    (NULL, NULL, 12),
+    (NULL, NULL, 13);
+-- result:
+-- !result
+SET enable_split_window_skew_to_union = false;
+-- result:
+-- !result
+function: assert_explain_not_contains('SELECT p, s, x, sum(x) OVER (PARTITION BY p, s ORDER BY x) FROM window_merge_sort_t1', 'MERGING-EXCHANGE')
+-- result:
+None
+-- !result
+SELECT p, s, x, running_sum
+FROM (
+    SELECT p, s, x, sum(x) OVER (PARTITION BY p, s ORDER BY x) AS running_sum
+    FROM window_merge_sort_t1
+) q
+ORDER BY p, s, x;
+-- result:
+None	None	4	4
+None	None	5	9
+None	None	6	15
+None	None	7	22
+None	None	8	30
+None	None	9	39
+None	None	10	49
+None	None	11	60
+None	None	12	72
+None	None	13	85
+1	1	1	1
+2	2	2	2
+3	3	3	3
+-- !result
+function: assert_explain_contains('SELECT p, s, x, sum(x) OVER ([merge_sort] PARTITION BY p, s ORDER BY x) FROM window_merge_sort_t1', 'MERGING-EXCHANGE', 'ANALYTIC')
+-- result:
+None
+-- !result
+SELECT p, s, x, running_sum
+FROM (
+    SELECT p, s, x, sum(x) OVER ([merge_sort] PARTITION BY p, s ORDER BY x) AS running_sum
+    FROM window_merge_sort_t1
+) q
+ORDER BY p, s, x;
+-- result:
+None	None	4	4
+None	None	5	9
+None	None	6	15
+None	None	7	22
+None	None	8	30
+None	None	9	39
+None	None	10	49
+None	None	11	60
+None	None	12	72
+None	None	13	85
+1	1	1	1
+2	2	2	2
+3	3	3	3
+-- !result
+SET pipeline_dop = 8;
+-- result:
+-- !result
+WITH baseline AS (
+    SELECT p, s, x, sum(x) OVER (PARTITION BY p, s ORDER BY x) AS rs FROM window_merge_sort_t1
+),
+hinted AS (
+    SELECT p, s, x, sum(x) OVER ([merge_sort] PARTITION BY p, s ORDER BY x) AS rs FROM window_merge_sort_t1
+)
+SELECT count(*) FROM baseline b JOIN hinted h ON (b.p <=> h.p) AND (b.s <=> h.s) AND b.x = h.x
+WHERE NOT (b.rs <=> h.rs);
+-- result:
+0
+-- !result
+WITH baseline AS (
+    SELECT p, s, x,
+        sum(x) OVER (PARTITION BY p, s ORDER BY x ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS f1,
+        sum(x) OVER (PARTITION BY p, s ORDER BY x) AS f2
+    FROM window_merge_sort_t1
+),
+hinted AS (
+    SELECT p, s, x,
+        sum(x) OVER (PARTITION BY p, s ORDER BY x ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS f1,
+        sum(x) OVER ([merge_sort] PARTITION BY p, s ORDER BY x) AS f2
+    FROM window_merge_sort_t1
+)
+SELECT count(*) FROM baseline b JOIN hinted h ON (b.p <=> h.p) AND (b.s <=> h.s) AND b.x = h.x
+WHERE NOT (b.f1 <=> h.f1) OR NOT (b.f2 <=> h.f2);
+-- result:
+0
+-- !result
+SET pipeline_dop = 0;
+-- result:
+-- !result
+DROP TABLE IF EXISTS window_merge_sort_t1;
+-- result:
+-- !result

--- a/test/sql/test_window_function/T/test_window_merge_sort_hint
+++ b/test/sql/test_window_function/T/test_window_merge_sort_hint
@@ -1,0 +1,80 @@
+-- name: test_window_merge_sort_hint
+DROP TABLE IF EXISTS window_merge_sort_t1;
+
+CREATE TABLE window_merge_sort_t1 (
+    p INT NULL,
+    s INT NULL,
+    x INT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(p, s, x)
+DISTRIBUTED BY HASH(p) BUCKETS 3
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO window_merge_sort_t1 VALUES
+    (1, 1, 1),
+    (2, 2, 2),
+    (3, 3, 3),
+    (NULL, NULL, 4),
+    (NULL, NULL, 5),
+    (NULL, NULL, 6),
+    (NULL, NULL, 7),
+    (NULL, NULL, 8),
+    (NULL, NULL, 9),
+    (NULL, NULL, 10),
+    (NULL, NULL, 11),
+    (NULL, NULL, 12),
+    (NULL, NULL, 13);
+
+SET enable_split_window_skew_to_union = false;
+
+function: assert_explain_not_contains('SELECT p, s, x, sum(x) OVER (PARTITION BY p, s ORDER BY x) FROM window_merge_sort_t1', 'MERGING-EXCHANGE')
+SELECT p, s, x, running_sum
+FROM (
+    SELECT p, s, x, sum(x) OVER (PARTITION BY p, s ORDER BY x) AS running_sum
+    FROM window_merge_sort_t1
+) q
+ORDER BY p, s, x;
+
+function: assert_explain_contains('SELECT p, s, x, sum(x) OVER ([merge_sort] PARTITION BY p, s ORDER BY x) FROM window_merge_sort_t1', 'MERGING-EXCHANGE', 'ANALYTIC')
+SELECT p, s, x, running_sum
+FROM (
+    SELECT p, s, x, sum(x) OVER ([merge_sort] PARTITION BY p, s ORDER BY x) AS running_sum
+    FROM window_merge_sort_t1
+) q
+ORDER BY p, s, x;
+
+-- Correctness at DOP > 1: the [merge_sort] hint must never change results. The BE only uses the
+-- ordered-partition exchange when its upstream is a single ordered stream (DOP == 1); otherwise it
+-- runs the analytic on the partition-sorted streams directly. The hot NULL partition is skewed.
+SET pipeline_dop = 8;
+
+-- A single hinted window must equal the unhinted baseline (expect 0 differing rows).
+WITH baseline AS (
+    SELECT p, s, x, sum(x) OVER (PARTITION BY p, s ORDER BY x) AS rs FROM window_merge_sort_t1
+),
+hinted AS (
+    SELECT p, s, x, sum(x) OVER ([merge_sort] PARTITION BY p, s ORDER BY x) AS rs FROM window_merge_sort_t1
+)
+SELECT count(*) FROM baseline b JOIN hinted h ON (b.p <=> h.p) AND (b.s <=> h.s) AND b.x = h.x
+WHERE NOT (b.rs <=> h.rs);
+
+-- Stacked windows sharing one SortGroup: hinting only the upper window must not change results.
+WITH baseline AS (
+    SELECT p, s, x,
+        sum(x) OVER (PARTITION BY p, s ORDER BY x ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS f1,
+        sum(x) OVER (PARTITION BY p, s ORDER BY x) AS f2
+    FROM window_merge_sort_t1
+),
+hinted AS (
+    SELECT p, s, x,
+        sum(x) OVER (PARTITION BY p, s ORDER BY x ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS f1,
+        sum(x) OVER ([merge_sort] PARTITION BY p, s ORDER BY x) AS f2
+    FROM window_merge_sort_t1
+)
+SELECT count(*) FROM baseline b JOIN hinted h ON (b.p <=> h.p) AND (b.s <=> h.s) AND b.x = h.x
+WHERE NOT (b.f1 <=> h.f1) OR NOT (b.f2 <=> h.f2);
+SET pipeline_dop = 0;
+
+DROP TABLE IF EXISTS window_merge_sort_t1;


### PR DESCRIPTION
Backport of #76903 to `branch-3.5-cc`.

Original commit: 30772bd263eeab1aff6f75bbb091155d5239c7e5
Original PR: https://github.com/StarRocks/starrocks/pull/76903

---

<!-- Original PR description below -->

## Why I'm doing:
Similar to `skew` hint, this PR adds another optimization for skewed window partitions. 

`skew` needs the exact skewed value, because it splits the input into skewed and non-skewed branches based on that value. 
This optimization avoids that requirement by forcing a sort-merge path before partitioning the data by the window partition expressions. After the merge sort, `local_ordered_partition_exchange` distributes partitions across multiple pipeline drivers on one node while preserving the required order and partition boundaries.

Its main advantage of this approach is that we can build a transformation rule (which is added in a follow-up PR) that can apply the skew hint even when there are multiple partition columns. 
```
  ANALYTIC        ← OrderedPartitionExchanger (intra-node)
  ↑
  MERGING-EXCHANGE(GATHER)    ← single global stream
  ↑
   SORT           ← inter-node gather, all data converges here
```

### How is it different from `skewed` optimization:
The skewed optimization is a similar option that is less aggressive. Instead of having a distributed sort of all data, data is first partitioned by p and then sorted by each backend. Once the data is partitioned each node adds a sort + gather and then uses the `local_ordered_partition_exchange` to distribute partitions across pipelines.
This optimization is useful if some partitions are slightly skewed but for large skew the new optimization is preferred.

## What I'm doing:
I am adding the hint `[merge_sort]` for analytic window functions. 
- Hint constant + parsing in `HintNode` / `AnalyticExpr`. `AnalyticAnalyzer` rejects the hint without `PARTITION BY` or `ORDER BY`.
- `forceMergeSort` threaded through `WindowTransformer` → `Logical`/`PhysicalWindowOperator` and both
  construction sites. 
- `RequiredPropertyDeriver` requires gather distribution when set. This is what produces the
  `MERGING-EXCHANGE`. 
- BE interpolates the ordered-partition exchange **only at upstream DOP 1**. When analytics with
  different frames share a SortGroup the input is already partitioned and sorted, and running on
  those parallel streams directly is correct.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
