### PR TITLE
[BugFix] Stop the query cache from storing incomplete per-tablet results

### DIFF
--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -562,6 +562,7 @@ public:
     void convert_hash_set_to_chunk(int32_t chunk_size, ChunkPtr* chunk);
 
     bool is_pre_cache() { return _aggr_mode == AM_BLOCKING_PRE_CACHE || _aggr_mode == AM_STREAMING_PRE_CACHE; }
+    AggrMode aggr_mode() const { return _aggr_mode; }
     MutableColumns create_group_by_columns(size_t num_rows) const { return _create_group_by_columns(num_rows); }
 
 protected:

--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
@@ -40,10 +40,19 @@ Status AggregateBlockingSinkOperator::prepare_local_state(RuntimeState* state) {
     RETURN_IF_ERROR(_aggregator->prepare(state, _unique_metrics.get()));
     RETURN_IF_ERROR(_aggregator->open(state));
 
-    _agg_group_by_with_limit = (!_aggregator->is_none_group_by_exprs() &&     // has group by keys
-                                _aggregator->limit() != -1 &&                 // has limit
-                                _aggregator->conjunct_ctxs().empty() &&       // no 'having' clause
-                                _aggregator->get_aggr_phase() == AggrPhase2); // phase 2, keep it to make things safe
+    // The limit optimization drops rows whose group-by key is not already in the hash map once the
+    // limit is reached. That is only sound because a key reaches exactly one hash map: the input is
+    // partitioned by the group-by key, so a key dropped here has no rows anywhere else. The query
+    // cache breaks that premise -- it decomposes this aggregation into one lane per tablet, each lane
+    // with its own Aggregator, while the shared limit countdown lives on the factory and is consumed
+    // once per (lane, key). A key can then survive in one tablet and be dropped in another, and the
+    // truncated per-tablet result is populated into the cache as if it were complete. So keep the
+    // optimization off for an aggregation that the query cache has decomposed.
+    _agg_group_by_with_limit = (!_aggregator->is_none_group_by_exprs() &&      // has group by keys
+                                _aggregator->limit() != -1 &&                  // has limit
+                                _aggregator->conjunct_ctxs().empty() &&        // no 'having' clause
+                                _aggregator->get_aggr_phase() == AggrPhase2 && // phase 2, keep it to make things safe
+                                _aggregator->aggr_mode() == AM_DEFAULT);       // not decomposed by the query cache
     return Status::OK();
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.IdGenerator;
 import com.starrocks.common.Pair;
+import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.UnionFind;
 import com.starrocks.planner.expression.ExprToNormalFormVisitor;
 import com.starrocks.planner.expression.ExprToThrift;
@@ -53,6 +54,7 @@ import org.apache.thrift.TSerializer;
 import org.apache.thrift.protocol.TCompactProtocol;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -304,6 +306,13 @@ public class FragmentNormalizer {
         return exprList.stream().map(this::normalizeExpr).collect(Collectors.toList());
     }
 
+    // The time zone the BE will evaluate this plan with, normalized the same way
+    // CoordinatorPreprocessor.genQueryGlobals() normalizes it before putting it into TQueryGlobals.
+    private String getNormalizedTimeZone() {
+        String timezone = execPlan.getConnectContext().getSessionVariable().getTimeZone();
+        return "CST".equals(timezone) ? TimeUtils.DEFAULT_TIME_ZONE : timezone;
+    }
+
     public boolean computeDigest(PlanNode cachePointNode) {
         try {
             if (uncacheable || selectedRangeMap.isEmpty()) {
@@ -319,6 +328,12 @@ public class FragmentNormalizer {
             for (TGlobalDict dict : dicts) {
                 digest.update(serializer.serialize(dict));
             }
+            // Session variables that change how expressions are evaluated on the BE are not part of the
+            // plan, so semantically-equivalent plans evaluated under different variables would otherwise
+            // share cache entries. time_zone is such a variable: from_unixtime/unix_timestamp/convert_tz
+            // are evaluated against RuntimeState::timezone, so two sessions that only differ in time_zone
+            // must not reuse each other's per-tablet results.
+            digest.update(getNormalizedTimeZone().getBytes(StandardCharsets.UTF_8));
 
             List<SlotId> slotIds = cachePointNode.getOutputSlotIds(execPlan.getDescTbl());
             List<Integer> remappedSlotIds = remapSlotIds(slotIds);
@@ -774,6 +789,22 @@ public class FragmentNormalizer {
 
         // Not cacheable unless Aggregation node is found
         if (firstAggNode == null) {
+            return false;
+        }
+
+        // Not cacheable if an AggregationNode of the leftmost path builds runtime filters itself
+        // (AGG_IN_FILTER/TOPN_FILTER). Such a filter probes the OlapScanNode that feeds the cache
+        // interpolation point, so the per-tablet results that get populated only contain the rows that
+        // survived it. Its content is decided at run time -- it depends on which tablets this instance
+        // happened to scan, in which order, and which of them were served from the cache -- so unlike a
+        // JoinNode's runtime filter, whose build side is packed into the digest together with the data
+        // versions of its OlapScanNodes, there is nothing here that could be packed into the cache key.
+        // A populated entry would therefore not be a function of the cache key, and would produce wrong
+        // results as soon as it is read back by a query that needs the rows the filter dropped.
+        boolean aggBuildsRuntimeFilters = leftNodesTopDown.stream()
+                .filter(node -> node instanceof AggregationNode)
+                .anyMatch(node -> !((AggregationNode) node).getBuildRuntimeFilters().isEmpty());
+        if (aggBuildsRuntimeFilters) {
             return false;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheRuntimeFilterAndTimeZoneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheRuntimeFilterAndTimeZoneTest.java
@@ -1,0 +1,131 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.common.FeConstants;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.thrift.TCacheParam;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+// Guards the two cache-key invariants that the query cache relies on:
+// 1. nothing below the cache interpolation point may filter rows by something that is decided at
+//    run time and is absent from the cache key (a runtime filter built by the aggregation itself);
+// 2. session variables that change how the BE evaluates the plan must be part of the digest.
+public class QueryCacheRuntimeFilterAndTimeZoneTest {
+    private static ConnectContext ctx;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        ctx = UtFrameUtils.createDefaultCtx();
+        ctx.getSessionVariable().setEnableQueryCache(true);
+        ctx.getSessionVariable().setOptimizerExecuteTimeout(30000);
+        ctx.getSessionVariable().setEnableRewriteSimpleAggToMetaScan(false);
+        FeConstants.runningUnitTest = true;
+        StarRocksAssert starRocksAssert = new StarRocksAssert(ctx);
+        starRocksAssert.withDatabase("qc_rf_db").useDatabase("qc_rf_db");
+        // colocate, so that an aggregation carrying a LIMIT stays in the scan fragment and builds a
+        // *local* AGG_IN_FILTER -- the shape the alien-GRF check does not catch.
+        starRocksAssert.withTable("" +
+                "CREATE TABLE t1(\n" +
+                "dt DATE NOT NULL,\n" +
+                "c1 INT NOT NULL,\n" +
+                "ts BIGINT NOT NULL,\n" +
+                "v1 BIGINT NOT NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`dt`, `c1`)\n" +
+                "PARTITION BY RANGE(dt) (\n" +
+                "  START (\"2022-01-01\") END (\"2022-03-01\") EVERY (INTERVAL 1 day))\n" +
+                "DISTRIBUTED BY HASH(`c1`) BUCKETS 10\n" +
+                "PROPERTIES(\"replication_num\" = \"1\", \"colocate_with\" = \"cg_qc_rf\");");
+        // non-colocate, so that `group by ... order by ... limit` is planned as a two-phase aggregation
+        // and PushDownTopNToPreAggRule can attach the TopN to the local (pre-cache) aggregation.
+        starRocksAssert.withTable("" +
+                "CREATE TABLE t2(\n" +
+                "dt DATE NOT NULL,\n" +
+                "c1 INT NOT NULL,\n" +
+                "ts BIGINT NOT NULL,\n" +
+                "v1 BIGINT NOT NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`dt`, `c1`)\n" +
+                "PARTITION BY RANGE(dt) (\n" +
+                "  START (\"2022-01-01\") END (\"2022-03-01\") EVERY (INTERVAL 1 day))\n" +
+                "DISTRIBUTED BY HASH(`c1`) BUCKETS 10\n" +
+                "PROPERTIES(\"replication_num\" = \"1\");");
+    }
+
+    private Optional<TCacheParam> cacheParamOf(String sql) throws Exception {
+        ExecPlan plan = UtFrameUtils.getPlanAndFragment(ctx, sql).second;
+        return plan.getFragments().stream().map(PlanFragment::getCacheParam)
+                .filter(java.util.Objects::nonNull).findFirst();
+    }
+
+    @Test
+    public void testAggBuiltRuntimeFilterDisablesQueryCache() throws Exception {
+        // baseline: the very same aggregation without a LIMIT builds no runtime filter and is cacheable.
+        Assertions.assertTrue(cacheParamOf(
+                        "select c1, sum(v1) from t1 where dt between '2022-01-01' and '2022-02-01' group by c1")
+                .isPresent(), "an aggregation that builds no runtime filter must stay cacheable");
+
+        // AGG_IN_FILTER: `group by ... limit n` makes the aggregation build an IN filter that probes
+        // the scan feeding the cache point.
+        Assertions.assertFalse(cacheParamOf(
+                        "select c1, sum(v1) from t1 where dt between '2022-01-01' and '2022-02-01' " +
+                                "group by c1 limit 10")
+                .isPresent(), "an aggregation building an AGG_IN_FILTER must not be cached");
+
+        Assertions.assertTrue(cacheParamOf(
+                        "select c1, sum(v1) from t2 where dt between '2022-01-01' and '2022-02-01' group by c1")
+                .isPresent(), "the two-phase baseline must stay cacheable");
+        // The other filter an aggregation can build, TOPN_FILTER, goes through the very same branch.
+        // It is not asserted here because PushDownTopNToPreAggRule needs table statistics this test
+        // environment does not have; it is covered end-to-end by
+        // test/sql/test_query_cache/T/test_query_cache_topn_filter_stale_entry.
+    }
+
+
+    @Test
+    public void testTimeZoneIsPartOfTheDigest() throws Exception {
+        String sql = "select from_unixtime(ts) h, count(*) from t1 " +
+                "where dt between '2022-01-01' and '2022-02-01' group by h";
+        String originalTimeZone = ctx.getSessionVariable().getTimeZone();
+        try {
+            ctx.getSessionVariable().setTimeZone("Asia/Shanghai");
+            TCacheParam shanghai = cacheParamOf(sql).orElseThrow(() -> new AssertionError("expected a cached plan"));
+            byte[] shanghaiDigest = shanghai.getDigest();
+
+            ctx.getSessionVariable().setTimeZone("UTC");
+            TCacheParam utc = cacheParamOf(sql).orElseThrow(() -> new AssertionError("expected a cached plan"));
+
+            Assertions.assertFalse(java.util.Arrays.equals(shanghaiDigest, utc.getDigest()),
+                    "plans evaluated under different time zones must not share a cache key");
+
+            // ... and the digest is still stable for a fixed time zone.
+            ctx.getSessionVariable().setTimeZone("Asia/Shanghai");
+            TCacheParam shanghaiAgain = cacheParamOf(sql).orElseThrow(() -> new AssertionError("expected a plan"));
+            Assertions.assertArrayEquals(shanghaiDigest, shanghaiAgain.getDigest(),
+                    "the digest must stay stable for a fixed time zone");
+        } finally {
+            ctx.getSessionVariable().setTimeZone(originalTimeZone);
+        }
+    }
+}

--- a/test/sql/test_query_cache/R/test_query_cache_agg_limit_truncation
+++ b/test/sql/test_query_cache/R/test_query_cache_agg_limit_truncation
@@ -1,0 +1,75 @@
+-- name: test_query_cache_agg_limit_truncation
+CREATE TABLE t1 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1", "colocate_with" = "cg1_${uuid0}");
+-- result:
+-- !result
+INSERT INTO t1
+SELECT date_add('2022-01-01', interval (generate_series % 31) day), generate_series % 4 + 1, 1
+FROM TABLE(generate_series(1, 124));
+-- result:
+-- !result
+set pipeline_dop = 1;
+-- result:
+-- !result
+set query_cache_hot_partition_num = 100;
+-- result:
+-- !result
+set enable_query_cache = false;
+-- result:
+-- !result
+select count(*), sum(s), min(s), max(s) from (select c1, sum(v1) s from t1 group by c1 limit 10) x;
+-- result:
+4	124	31	31
+-- !result
+set enable_query_cache = true;
+-- result:
+-- !result
+select count(*), sum(s), min(s), max(s) from (select c1, sum(v1) s from t1 group by c1 limit 10) x;
+-- result:
+4	124	31	31
+-- !result
+select count(*), sum(s), min(s), max(s) from (select c1, sum(v1) s from t1 group by c1 limit 10) x;
+-- result:
+4	124	31	31
+-- !result
+CREATE TABLE t2 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1", "colocate_with" = "cg2_${uuid0}");
+-- result:
+-- !result
+INSERT INTO t2
+SELECT date_add('2022-01-01', interval (generate_series % 31) day), generate_series % 4 + 1, 1
+FROM TABLE(generate_series(1, 124));
+-- result:
+-- !result
+set enable_query_cache = true;
+-- result:
+-- !result
+select count(*), sum(s), min(s), max(s) from (select c1, sum(v1) s from t2 where dt >= '2022-01-01' group by c1 limit 40) x;
+-- result:
+4	124	31	31
+-- !result
+select count(*), sum(s), min(s), max(s) from (select c1, sum(v1) s from t2 where dt >= '2022-01-27' group by c1 limit 40) x;
+-- result:
+4	20	5	5
+-- !result
+set enable_query_cache = false;
+-- result:
+-- !result
+select count(*), sum(s), min(s), max(s) from (select c1, sum(v1) s from t2 where dt >= '2022-01-27' group by c1 limit 40) x;
+-- result:
+4	20	5	5
+-- !result

--- a/test/sql/test_query_cache/R/test_query_cache_time_zone
+++ b/test/sql/test_query_cache/R/test_query_cache_time_zone
@@ -1,0 +1,55 @@
+-- name: test_query_cache_time_zone
+CREATE TABLE days (d int) DUPLICATE KEY(d) DISTRIBUTED BY HASH(d) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO days SELECT generate_series FROM TABLE(generate_series(0, 30));
+-- result:
+-- !result
+CREATE TABLE t1 (
+  dt date NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, ts)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(ts) BUCKETS 4
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t1 SELECT date_add('2022-01-01', interval d day), 1640995200 + d * 3600, 1 FROM days;
+-- result:
+-- !result
+set enable_query_cache = true;
+-- result:
+-- !result
+set query_cache_hot_partition_num = 100;
+-- result:
+-- !result
+set time_zone = 'Asia/Shanghai';
+-- result:
+-- !result
+select from_unixtime(ts, '%Y-%m-%d %H') h, count(*) from t1 group by h order by h limit 3;
+-- result:
+2022-01-01 08	1
+2022-01-01 09	1
+2022-01-01 10	1
+-- !result
+set time_zone = 'UTC';
+-- result:
+-- !result
+select from_unixtime(ts, '%Y-%m-%d %H') h, count(*) from t1 group by h order by h limit 3;
+-- result:
+2022-01-01 00	1
+2022-01-01 01	1
+2022-01-01 02	1
+-- !result
+set time_zone = 'Asia/Shanghai';
+-- result:
+-- !result
+select from_unixtime(ts, '%Y-%m-%d %H') h, count(*) from t1 group by h order by h limit 3;
+-- result:
+2022-01-01 08	1
+2022-01-01 09	1
+2022-01-01 10	1
+-- !result

--- a/test/sql/test_query_cache/R/test_query_cache_topn_filter_stale_entry
+++ b/test/sql/test_query_cache/R/test_query_cache_topn_filter_stale_entry
@@ -1,0 +1,65 @@
+-- name: test_query_cache_topn_filter_stale_entry
+CREATE TABLE days (d int) DUPLICATE KEY(d) DISTRIBUTED BY HASH(d) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE ks (k int) DUPLICATE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO days SELECT generate_series FROM TABLE(generate_series(0, 30));
+-- result:
+-- !result
+INSERT INTO ks SELECT generate_series FROM TABLE(generate_series(1, 40));
+-- result:
+-- !result
+CREATE TABLE t1 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t1 SELECT date_add('2022-01-01', interval d day), if(d < 5, k, k + 99), 1 FROM days, ks;
+-- result:
+-- !result
+set enable_query_cache = true;
+-- result:
+-- !result
+set query_cache_hot_partition_num = 100;
+-- result:
+-- !result
+select count(*), sum(s), min(s), max(s) from (select c1, sum(v1) s from t1 group by c1 order by c1 limit 10) x;
+-- result:
+10	50	5	5
+-- !result
+alter table t1 drop partition p20220101;
+-- result:
+-- !result
+alter table t1 drop partition p20220102;
+-- result:
+-- !result
+alter table t1 drop partition p20220103;
+-- result:
+-- !result
+alter table t1 drop partition p20220104;
+-- result:
+-- !result
+alter table t1 drop partition p20220105;
+-- result:
+-- !result
+select count(*), sum(s), min(s), max(s) from (select c1, sum(v1) s from t1 group by c1 order by c1 limit 10) x;
+-- result:
+10	260	26	26
+-- !result
+set enable_query_cache = false;
+-- result:
+-- !result
+select count(*), sum(s), min(s), max(s) from (select c1, sum(v1) s from t1 group by c1 order by c1 limit 10) x;
+-- result:
+10	260	26	26
+-- !result

--- a/test/sql/test_query_cache/T/test_query_cache_agg_limit_truncation
+++ b/test/sql/test_query_cache/T/test_query_cache_agg_limit_truncation
@@ -1,0 +1,63 @@
+-- name: test_query_cache_agg_limit_truncation
+-- An aggregation that carries a LIMIT truncates its hash map once the shared limit
+-- countdown (Aggregator::_build_hash_map_with_shared_limit) is exhausted: rows whose
+-- group key is not already in the hash map are dropped. Without the query cache that
+-- is safe, because every key belongs to exactly one hash map. The query cache splits
+-- the very same aggregation into one lane per tablet, so the countdown is consumed
+-- once per (lane, key) instead of once per key, keys survive in some tablets and are
+-- dropped in others, and those truncated per-tablet results are populated into the
+-- cache as if they were the complete aggregate of the tablet.
+CREATE TABLE t1 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1", "colocate_with" = "cg1_${uuid0}");
+
+-- 4 distinct keys x 31 daily partitions x 1 row each: every key's true sum is 31,
+-- and every key lives in 31 different tablets (one per partition).
+INSERT INTO t1
+SELECT date_add('2022-01-01', interval (generate_series % 31) day), generate_series % 4 + 1, 1
+FROM TABLE(generate_series(1, 124));
+
+-- A colocate table keeps the LIMIT-carrying aggregation in the scan fragment, and
+-- pipeline_dop=1 keeps the BE from interpolating a local shuffle in front of it,
+-- which is what allows the cache operator to be interpolated on top of it.
+set pipeline_dop = 1;
+set query_cache_hot_partition_num = 100;
+
+-- LIMIT 10 is larger than the 4 groups that exist, so LIMIT may not drop anything
+-- and the result is fully deterministic: 4 groups, every sum 31.
+set enable_query_cache = false;
+select count(*), sum(s), min(s), max(s) from (select c1, sum(v1) s from t1 group by c1 limit 10) x;
+set enable_query_cache = true;
+select count(*), sum(s), min(s), max(s) from (select c1, sum(v1) s from t1 group by c1 limit 10) x;
+select count(*), sum(s), min(s), max(s) from (select c1, sum(v1) s from t1 group by c1 limit 10) x;
+
+-- The entries populated above outlive the query: the partition-range predicate is
+-- stripped from the cache digest and encoded per tablet, so a query over a narrower
+-- range reuses them. On a cold cache the narrow query below is exact (5 partitions x
+-- 4 keys = 20 insertions, well under LIMIT 40), so anything but 4/20/5/5 is the
+-- poisoned entries left behind by the wide query talking.
+CREATE TABLE t2 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1", "colocate_with" = "cg2_${uuid0}");
+
+INSERT INTO t2
+SELECT date_add('2022-01-01', interval (generate_series % 31) day), generate_series % 4 + 1, 1
+FROM TABLE(generate_series(1, 124));
+
+set enable_query_cache = true;
+select count(*), sum(s), min(s), max(s) from (select c1, sum(v1) s from t2 where dt >= '2022-01-01' group by c1 limit 40) x;
+select count(*), sum(s), min(s), max(s) from (select c1, sum(v1) s from t2 where dt >= '2022-01-27' group by c1 limit 40) x;
+set enable_query_cache = false;
+select count(*), sum(s), min(s), max(s) from (select c1, sum(v1) s from t2 where dt >= '2022-01-27' group by c1 limit 40) x;

--- a/test/sql/test_query_cache/T/test_query_cache_time_zone
+++ b/test/sql/test_query_cache/T/test_query_cache_time_zone
@@ -1,0 +1,30 @@
+-- name: test_query_cache_time_zone
+-- The cache digest is computed from the plan only, while from_unixtime/unix_timestamp/convert_tz
+-- are evaluated on the BE against the session time zone. Two runs that differ only in time_zone
+-- must therefore not share per-tablet entries.
+CREATE TABLE days (d int) DUPLICATE KEY(d) DISTRIBUTED BY HASH(d) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+INSERT INTO days SELECT generate_series FROM TABLE(generate_series(0, 30));
+
+CREATE TABLE t1 (
+  dt date NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, ts)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(ts) BUCKETS 4
+PROPERTIES("replication_num" = "1");
+
+-- one row per day, one hour apart, starting at 1640995200 = 2022-01-01 00:00:00 UTC
+INSERT INTO t1 SELECT date_add('2022-01-01', interval d day), 1640995200 + d * 3600, 1 FROM days;
+
+set enable_query_cache = true;
+set query_cache_hot_partition_num = 100;
+
+set time_zone = 'Asia/Shanghai';
+select from_unixtime(ts, '%Y-%m-%d %H') h, count(*) from t1 group by h order by h limit 3;
+set time_zone = 'UTC';
+select from_unixtime(ts, '%Y-%m-%d %H') h, count(*) from t1 group by h order by h limit 3;
+set time_zone = 'Asia/Shanghai';
+select from_unixtime(ts, '%Y-%m-%d %H') h, count(*) from t1 group by h order by h limit 3;

--- a/test/sql/test_query_cache/T/test_query_cache_topn_filter_stale_entry
+++ b/test/sql/test_query_cache/T/test_query_cache_topn_filter_stale_entry
@@ -1,0 +1,45 @@
+-- name: test_query_cache_topn_filter_stale_entry
+-- PushDownTopNToPreAggRule attaches the TopN of `group by k order by k limit n` to the local
+-- aggregation, which is exactly where the query cache interpolates its cache operator. The
+-- aggregation then builds a TOPN_FILTER that probes the scan feeding it, so the per-tablet results
+-- that get populated only hold the rows below the boundary that filter happened to reach. The
+-- boundary is a property of the whole query's data scope, not of the tablet, and it is not part of
+-- the cache key -- so the entries are only accidentally safe while every later reader's scope is a
+-- superset of the writer's. Dropping the partitions that held the small keys narrows the scope,
+-- and the surviving tablets keep their version and their region, hence their entries are reused.
+CREATE TABLE days (d int) DUPLICATE KEY(d) DISTRIBUTED BY HASH(d) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+CREATE TABLE ks (k int) DUPLICATE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+INSERT INTO days SELECT generate_series FROM TABLE(generate_series(0, 30));
+INSERT INTO ks SELECT generate_series FROM TABLE(generate_series(1, 40));
+
+CREATE TABLE t1 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1");
+
+-- the first 5 days hold the small keys 1..40, the remaining 26 days hold the large keys 100..139
+INSERT INTO t1 SELECT date_add('2022-01-01', interval d day), if(d < 5, k, k + 99), 1 FROM days, ks;
+
+set enable_query_cache = true;
+set query_cache_hot_partition_num = 100;
+
+-- top-10 by key is 1..10, each present in the 5 small-key partitions
+select count(*), sum(s), min(s), max(s) from (select c1, sum(v1) s from t1 group by c1 order by c1 limit 10) x;
+
+alter table t1 drop partition p20220101;
+alter table t1 drop partition p20220102;
+alter table t1 drop partition p20220103;
+alter table t1 drop partition p20220104;
+alter table t1 drop partition p20220105;
+
+-- top-10 by key is now 100..109, each present in the 26 remaining partitions
+select count(*), sum(s), min(s), max(s) from (select c1, sum(v1) s from t1 group by c1 order by c1 limit 10) x;
+set enable_query_cache = false;
+select count(*), sum(s), min(s), max(s) from (select c1, sum(v1) s from t1 group by c1 order by c1 limit 10) x;


### PR DESCRIPTION
## Why I'm doing:

A query cache entry is keyed by the plan digest plus the tablet's id, version and partition region, so it is only correct if its content is a function of exactly those. Three paths broke that invariant and returned wrong results.

An aggregation that carries a LIMIT truncates its hash map once the limit is reached, dropping rows whose key is not already in the map. That is sound because the input is partitioned by the group-by key, so a dropped key has no rows anywhere else. The query cache decomposes the very same aggregation into one lane per tablet, each with its own Aggregator, while the shared limit countdown lives on the factory and is consumed once per (lane, key). A key then survives in one tablet and is dropped in another, and the truncated per-tablet result is populated as if it were complete. Keep the optimization off for an aggregation the query cache has decomposed.

An aggregation can also build a runtime filter itself: AGG_IN_FILTER from a LIMIT, TOPN_FILTER from PushDownTopNToPreAggRule. Both probe the scan that feeds the cache interpolation point, so the populated results only hold the rows that survived them, and their content depends on which tablets this instance scanned, in which order, and which were served from the cache. Unlike a JoinNode's runtime filter -- whose build side is packed into the digest together with the data versions of its OlapScanNodes -- there is nothing here that could be packed into the cache key, so such a fragment must not be cached at all. Both filters are local, so the alien-GRF check never saw them.

Finally, time_zone reaches expression evaluation through RuntimeState, while the digest is computed from the plan alone, so two sessions differing only in time_zone shared entries and read back each other's shifted groups. Mix the time zone into the digest, normalized the way genQueryGlobals() normalizes it.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
