### PR TITLE
[BugFix] Skip ranking window pre-agg when the windows are not in the same sort group

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/RankingWindowUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/RankingWindowUtils.java
@@ -84,9 +84,13 @@ public class RankingWindowUtils {
             }
         }
 
-        // same partition and without order by, so they are in same sort group and partition group, which means share the same sort Node and exchange Node
-        Preconditions.checkState(operator.getEnforceSortColumns().equals(rankRelatedOperator.getEnforceSortColumns()));
-        return true;
+        // The pre-Agg rewrite requires both operators to share the same sort Node and exchange Node,
+        // i.e. to belong to the same sort group. Having the same partition expressions is not enough:
+        // WindowTransformer groups window operators by an ORDERED prefix of their enforce-sort columns
+        // (isPrefixHyperSortSet), while the check above compares partition expressions as a SET, and a
+        // hash-partitioned window is never placed in a sort group at all. So two operators may reach
+        // this point with different enforce-sort columns, in which case the optimization must be skipped.
+        return operator.getEnforceSortColumns().equals(rankRelatedOperator.getEnforceSortColumns());
     }
 
     // This is similar to Splitting Aggregation into two phase Aggregation

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
@@ -1044,6 +1044,88 @@ public class WindowTest extends PlanTestBase {
         FeConstants.runningUnitTest = false;
     }
 
+    @Test
+    public void testRankingWindowPreAggNotInSameSortGroup() throws Exception {
+        FeConstants.runningUnitTest = true;
+        // The agg window and the rank window have the same partition expressions as a SET, but they do
+        // not share a sort group, so the pre-Agg optimization must be skipped instead of hitting an
+        // assertion. The plain rank push-down still applies, hence a PARTITION-TOP-N without pre agg.
+        // NOTE: the agg window has to be listed first, otherwise the rank window does not end up on
+        // top of it and neither push-down rule matches the plan shape.
+
+        // Partition expressions in a different order: WindowTransformer groups sort columns by an
+        // ordered prefix, so the two windows land in different sort groups.
+        {
+            String sql = "select * from (\n" +
+                    "    select *, " +
+                    "        sum(v3) over (partition by v3, v2) as _sum, " +
+                    "        row_number() over (partition by v2, v3 order by v1) as rk " +
+                    "    from t0\n" +
+                    ") sub_t0\n" +
+                    "where rk <= 4;";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  4:PARTITION-TOP-N\n" +
+                    "  |  partition by: 2: v2 , 3: v3 \n" +
+                    "  |  partition limit: 4\n" +
+                    "  |  order by: <slot 2> 2: v2 ASC, <slot 3> 3: v3 ASC, <slot 1> 1: v1 ASC\n" +
+                    "  |  offset: 0");
+            assertNotContains(plan, "pre agg functions");
+        }
+        // Same, through PushDownLimitRankingWindowRule.
+        {
+            String sql = "select * from (\n" +
+                    "    select *, " +
+                    "        sum(v3) over (partition by v3, v2) as _sum, " +
+                    "        row_number() over (partition by v2, v3 order by v1) as rk " +
+                    "    from t0\n" +
+                    ") sub_t0\n" +
+                    "order by rk limit 4;";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  4:PARTITION-TOP-N\n" +
+                    "  |  partition by: 2: v2 , 3: v3 \n" +
+                    "  |  partition limit: 4\n" +
+                    "  |  order by: <slot 2> 2: v2 ASC, <slot 3> 3: v3 ASC, <slot 1> 1: v1 ASC\n" +
+                    "  |  offset: 0");
+            assertNotContains(plan, "pre agg functions");
+        }
+        // A hash-partitioned window is never placed in a sort group at all.
+        {
+            String sql = "select * from (\n" +
+                    "    select *, " +
+                    "        sum(v3) over ([hash] partition by v3) as _sum, " +
+                    "        row_number() over (partition by v3 order by v2) as rk " +
+                    "    from t0\n" +
+                    ") sub_t0\n" +
+                    "where rk <= 4;";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  3:PARTITION-TOP-N\n" +
+                    "  |  partition by: 3: v3 \n" +
+                    "  |  partition limit: 4\n" +
+                    "  |  order by: <slot 3> 3: v3 ASC, <slot 2> 2: v2 ASC\n" +
+                    "  |  offset: 0");
+            assertNotContains(plan, "pre agg functions");
+        }
+        // The query reported in issue #76711: window_partition_mode=2 makes the agg window
+        // hash-partitioned while the rank window stays sort-based.
+        {
+            String sql = "select /*+ SET_VAR(window_partition_mode=2) */ * from (\n" +
+                    "    select *, " +
+                    "        sum(v3) over (partition by v3) as _sum, " +
+                    "        row_number() over (partition by v3 order by v2) as rk " +
+                    "    from t0\n" +
+                    ") sub_t0\n" +
+                    "where rk = 1;";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  3:PARTITION-TOP-N\n" +
+                    "  |  partition by: 3: v3 \n" +
+                    "  |  partition limit: 1\n" +
+                    "  |  order by: <slot 3> 3: v3 ASC, <slot 2> 2: v2 ASC\n" +
+                    "  |  offset: 0");
+            assertNotContains(plan, "pre agg functions");
+        }
+        FeConstants.runningUnitTest = false;
+    }
+
     // TODO:support this case later
     @Test
     public void testRankingWindowWithoutPartitionCanNotPushDown() throws Exception {


### PR DESCRIPTION
## Why I'm doing:

satisfyRankingPreAggOptimization asserted that the aggregate window and the rank-related window share the same enforce-sort columns, on the grounds that having the same partition expressions puts them in the same sort group. That inference does not hold: WindowTransformer forms sort groups from an ordered prefix of the enforce-sort columns while the partition check above compares partition expressions as a set, and a hash-partitioned window is never placed in a sort group at all. Two windows partitioned by the same columns written in a different order, or an aggregate window using hash-based partitioning, reach the assertion with different enforce-sort columns and fail the whole query with an IllegalStateException raised from the rule's check().

Sharing a sort group is a precondition of the pre-agg rewrite, not an invariant, so return it instead of asserting it. Both rules already handle a false result: check() falls into its case 2 branch and transform() re-evaluates the same predicate, so the plain rank push-down applies as designed.

## What I'm doing:

Fixes #76711

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
