### PR TITLE
[BugFix] Do not re-append a constant aggregated value to the merge phase args

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
@@ -89,9 +89,25 @@ public abstract class SplitAggregateRule extends TransformationRule {
     // We should also pass the const args to merge phase aggregator for performance.
     // For example, for intersect_count(user_id, dt, '20191111'),
     // We should pass '20191111' to update and merge phase aggregator in BE both.
+    //
+    // The aggregated value (argument 0) is skipped: in the merge phase it is already replaced by
+    // the intermediate column, so appending its constant again shifts every following const arg
+    // one slot to the right. BE reads these const args positionally -- approx_top_k reads arg 1/2
+    // as k/counter_num, histogram reads 1/2/3, group_concat reads 1 as the separator -- so
+    //     approx_top_k(cast(1 as tinyint), 3, 10)
+    // would otherwise plan as approx_top_k(<intermediate>, 1, 3, 10) and make BE read the TINYINT
+    // value column as k, aborting on the type mismatch.
+    //
+    // window_funnel is the exception: its argument 0 is the window_size PARAMETER, not the
+    // aggregated value, and BE reads it back in the merge phase from slot 1 precisely because it
+    // is re-appended here (see the layout comment in be/src/exprs/agg/window_funnel.h).
     protected static void appendConstantColumns(List<ScalarOperator> arguments, CallOperator aggregation) {
-        if (aggregation.getChildren().size() > 1) {
-            aggregation.getChildren().stream().filter(ScalarOperator::isConstant).forEach(arguments::add);
+        List<ScalarOperator> children = aggregation.getChildren();
+        int from = FunctionSet.WINDOW_FUNNEL.equalsIgnoreCase(aggregation.getFnName()) ? 0 : 1;
+        for (int i = from; i < children.size(); i++) {
+            if (children.get(i).isConstant()) {
+                arguments.add(children.get(i));
+            }
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -2851,6 +2851,17 @@ public class AggregateTest extends PlanTestBase {
             getFragmentPlan(sql);
         }
         {
+            // A constant aggregated value must not be re-appended to the merge phase args: BE reads
+            // the const args positionally, so approx_top_k(<intermediate>, 1, 3, 10) would make it
+            // read the TINYINT literal 1 as k and abort on the type mismatch.
+            String sql = "select /*+SET_VAR(new_planner_agg_stage=2)*/ L_RETURNFLAG, "
+                    + "approx_top_k(cast(1 as tinyint), 3, 10) from lineitem group by L_RETURNFLAG";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "(merge finalize)");
+            assertContains(plan, ": approx_top_k, 3, 10)");
+            assertNotContains(plan, ": approx_top_k, 1, 3, 10)");
+        }
+        {
             Exception exception = Assertions.assertThrows(SemanticException.class, () -> {
                 String sql = "select approx_top_k(L_LINENUMBER, '111') from lineitem";
                 getFragmentPlan(sql);
@@ -3349,8 +3360,10 @@ public class AggregateTest extends PlanTestBase {
             // distinct group_concat cannot merge two phase agg to one phase agg.
             sql = "select group_concat(distinct 1,2 order by 1,2) from t0 group by v1 order by 1;";
             plan = getFragmentPlan(sql);
+            // '1' is the aggregated value, so it is not re-appended to the merge phase args --
+            // only the remaining constant args ('2' and the separator) are carried over.
             assertContains(plan, "  2:AGGREGATE (merge finalize)\n" +
-                    "  |  output: group_concat(4: group_concat, '1', '2', ',')\n" +
+                    "  |  output: group_concat(4: group_concat, '2', ',')\n" +
                     "  |  group by: 1: v1\n" +
                     "  |  \n" +
                     "  1:AGGREGATE (update serialize)\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistinctAggTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistinctAggTest.java
@@ -76,7 +76,8 @@ public class DistinctAggTest extends PlanTestBase {
         sql = "select count(distinct 1, 2, 3, 4) from t0 group by v2";
         plan = getFragmentPlan(sql);
         assertContains(plan, "3:AGGREGATE (merge finalize)\n" +
-                "  |  output: multi_distinct_count(4: count, 1, 2, 3, 4)");
+                // The aggregated value (the leading constant 1) is not re-appended to the merge args.
+                "  |  output: multi_distinct_count(4: count, 2, 3, 4)");
 
         sql = "select count(distinct v3, 1) from t0 group by v2";
         plan = getFragmentPlan(sql);
@@ -199,7 +200,8 @@ public class DistinctAggTest extends PlanTestBase {
         argumentsList.add(Arguments.of("select group_concat(distinct 1), array_agg(distinct 2), sum(v3) from t0 " +
                         "group by v2, v3",
                 "3:AGGREGATE (merge finalize)\n" +
-                        "  |  output: group_concat(4: group_concat, '1', ','), array_agg_distinct(5: array_agg), sum(6: sum)"));
+                        // '1' is the aggregated value, so only the separator is carried into merge.
+                        "  |  output: group_concat(4: group_concat, ','), array_agg_distinct(5: array_agg), sum(6: sum)"));
 
         return argumentsList.stream();
     }

--- a/test/sql/test_agg_function/R/test_approx_top_k
+++ b/test/sql/test_agg_function/R/test_approx_top_k
@@ -1528,3 +1528,42 @@ SELECT approx_top_k(1);
 -- result:
 [{"item":1,"count":1}]
 -- !result
+-- name: test_approx_top_k_const_first_arg
+CREATE TABLE `t_const_first_arg` (
+  `c_id` INT(11) NOT NULL,
+  `c_grp` TINYINT NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c_id`)
+DISTRIBUTED BY HASH(`c_id`) BUCKETS 4
+PROPERTIES (
+ "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO `t_const_first_arg` VALUES (1,1),(2,2),(3,1),(4,2),(5,3),(6,3),(7,1),(8,2);
+-- result:
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ c_grp, APPROX_TOP_K(CAST(1 AS TINYINT), 3, 10) FROM t_const_first_arg GROUP BY c_grp ORDER BY c_grp;
+-- result:
+1	[{"item":1,"count":3}]
+2	[{"item":1,"count":3}]
+3	[{"item":1,"count":2}]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ c_grp, APPROX_TOP_K(CAST(1 AS TINYINT), 3) FROM t_const_first_arg GROUP BY c_grp ORDER BY c_grp;
+-- result:
+1	[{"item":1,"count":3}]
+2	[{"item":1,"count":3}]
+3	[{"item":1,"count":2}]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ c_grp, APPROX_TOP_K(CAST(1 AS TINYINT)) FROM t_const_first_arg GROUP BY c_grp ORDER BY c_grp;
+-- result:
+1	[{"item":1,"count":3}]
+2	[{"item":1,"count":3}]
+3	[{"item":1,"count":2}]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ c_grp, APPROX_TOP_K('a', 3, 10) FROM t_const_first_arg GROUP BY c_grp ORDER BY c_grp;
+-- result:
+1	[{"item":"a","count":3}]
+2	[{"item":"a","count":3}]
+3	[{"item":"a","count":2}]
+-- !result

--- a/test/sql/test_agg_function/T/test_approx_top_k
+++ b/test/sql/test_agg_function/T/test_approx_top_k
@@ -514,3 +514,19 @@ SELECT L_RETURNFLAG, APPROX_TOP_K(L_LINENUMBER, 20) FROM lineitem GROUP BY L_RET
 SELECT approx_top_k(col1) FROM (VALUES (1)) AS tmp(col1);
 SELECT approx_top_k(col1) FROM (VALUES (1),(1),(1),(1),(1),(1)) AS tmp(col1);
 SELECT approx_top_k(1);
+
+-- name: test_approx_top_k_const_first_arg
+CREATE TABLE `t_const_first_arg` (
+  `c_id` INT(11) NOT NULL,
+  `c_grp` TINYINT NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c_id`)
+DISTRIBUTED BY HASH(`c_id`) BUCKETS 4
+PROPERTIES (
+ "replication_num" = "1"
+);
+INSERT INTO `t_const_first_arg` VALUES (1,1),(2,2),(3,1),(4,2),(5,3),(6,3),(7,1),(8,2);
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ c_grp, APPROX_TOP_K(CAST(1 AS TINYINT), 3, 10) FROM t_const_first_arg GROUP BY c_grp ORDER BY c_grp;
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ c_grp, APPROX_TOP_K(CAST(1 AS TINYINT), 3) FROM t_const_first_arg GROUP BY c_grp ORDER BY c_grp;
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ c_grp, APPROX_TOP_K(CAST(1 AS TINYINT)) FROM t_const_first_arg GROUP BY c_grp ORDER BY c_grp;
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ c_grp, APPROX_TOP_K('a', 3, 10) FROM t_const_first_arg GROUP BY c_grp ORDER BY c_grp;


### PR DESCRIPTION
## Why I'm doing:

SplitAggregateRule.appendConstantColumns carries an aggregate call constant arguments into the merge phase behind the intermediate column. It appended every constant child, including argument 0 -- which the merge phase has already replaced by the intermediate column. When the aggregated value itself is constant, that shifts every following const arg one slot to the right, and BE reads those args positionally: approx_top_k reads 1/2 as k/counter_num, histogram reads 1/2/3, group_concat reads 1 as the separator.

  SELECT v, approx_top_k(cast(1 as tinyint), 3, 10) FROM t GROUP BY v

planned the merge phase as approx_top_k(<intermediate>, 1, 3, 10), so BE read the TINYINT value column as k and aborted:

  Check failed: raw_column_ptr Cast failed for column:
    (expected type: 5, actual type: integral-1)
  ColumnHelper::cast_to_raw<TYPE_INT> <- get_const_value<TYPE_INT>
    <- ApproxTopKAggregateFunction<TYPE_TINYINT>::get_k_and_counter_num
    <- init_state_if_necessary <- merge

In release builds the unchecked down_cast reinterprets the int8 payload as an int32 instead, giving a garbage k/counter_num. group_concat silently used the wrong separator for the same reason.

Skip argument 0, except for window_funnel: its argument 0 is the window_size PARAMETER rather than the aggregated value, and BE reads it back from the merge phase precisely because it is re-appended here (see the layout comment in be/src/exprs/agg/window_funnel.h).

Adds a two-phase plan assertion and a SQL regression case with a constant first argument, and updates the group_concat plan pinned by testPruneAggregateNode.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
