### PR TITLE
[BugFix] Fix Thrift client leak after cache invalidation

### DIFF
--- a/be/src/common/util/thrift_client_cache.cpp
+++ b/be/src/common/util/thrift_client_cache.cpp
@@ -41,6 +41,7 @@
 
 #include "base/hash/hash_std.hpp"
 #include "base/network/network_util.h"
+#include "base/utility/defer_op.h"
 #include "common/config_rpc_client_fwd.h"
 #include "common/logging.h"
 #include "gen_cpp/FrontendService.h"
@@ -159,48 +160,59 @@ void ClientCacheHelper::release_client(void** client_key) {
     DCHECK(*client_key != nullptr) << "Trying to release NULL client";
     std::lock_guard<std::mutex> lock(_lock);
 
-    auto client_map_entry = _client_map.find(*client_key);
-    if (client_map_entry == _client_map.end()) {
+    void* key = *client_key;
+    DeferOp release([&]() {
+        if (_metrics_enabled) {
+            _used_clients->increment(-1);
+        }
         *client_key = nullptr;
+    });
+
+    auto client_map_entry = _client_map.find(key);
+    if (client_map_entry == _client_map.end()) {
+        // No current path removes a checked-out client while its caller still has a
+        // non-null key. Keep this branch defensive in case a future path does so.
+        _clients_to_evict.erase(key);
         return;
     }
 
     ThriftClientImpl* info = client_map_entry->second;
     auto iter = _client_cache.find(make_network_address(info->ipaddress(), info->port()));
-    if (iter == _client_cache.end()) {
-        *client_key = nullptr;
+    if (_clients_to_evict.find(key) != _clients_to_evict.end() || iter == _client_cache.end()) {
+        _evict_client(key, info);
         return;
     }
 
     if (_max_cache_size_per_host >= 0 && iter->second.size() >= _max_cache_size_per_host) {
         // cache of this host is full, close this client connection and remove if from _client_map
-        _evict_client(*client_key, info);
+        _evict_client(key, info);
     } else {
-        iter->second.push_back(*client_key);
+        iter->second.push_back(key);
     }
-
-    if (_metrics_enabled) {
-        _used_clients->increment(-1);
-    }
-
-    *client_key = nullptr;
 }
 
 void ClientCacheHelper::close_connections(const TNetworkAddress& hostport) {
     std::lock_guard<std::mutex> lock(_lock);
     auto cache_entry = _client_cache.find(hostport);
-    if (cache_entry == _client_cache.end()) {
-        return;
+    if (cache_entry != _client_cache.end()) {
+        auto& client_keys = cache_entry->second;
+        for (void* client_key : client_keys) {
+            auto client_map_entry = _client_map.find(client_key);
+            DCHECK(client_map_entry != _client_map.end());
+            ThriftClientImpl* info = client_map_entry->second;
+            _evict_client(client_key, info);
+        }
+        _client_cache.erase(cache_entry);
     }
 
-    auto& client_keys = cache_entry->second;
-    for (void* client_key : client_keys) {
-        auto client_map_entry = _client_map.find(client_key);
-        DCHECK(client_map_entry != _client_map.end());
-        ThriftClientImpl* info = client_map_entry->second;
-        _evict_client(client_key, info);
+    // Checked-out clients cannot be closed here because their callers still hold the
+    // interface pointer. Mark them so release_client() closes them on return. This also
+    // prevents an old client from entering a cache entry recreated after this call.
+    for (const auto& [client_key, client] : _client_map) {
+        if (client->ipaddress() == hostport.hostname && client->port() == hostport.port) {
+            _clients_to_evict.insert(client_key);
+        }
     }
-    _client_cache.erase(cache_entry);
 }
 
 std::string ClientCacheHelper::debug_string() {
@@ -235,6 +247,9 @@ void ClientCacheHelper::init_metrics(MetricRegistry* metrics, const std::string&
 
 void ClientCacheHelper::_evict_client(void* client_key, ThriftClientImpl* client) {
     client->close();
+    // Clear the eviction mark before deleting: the set is keyed by the raw iface pointer,
+    // so a stale mark plus address reuse would evict a newly created client.
+    _clients_to_evict.erase(client_key);
     _client_map.erase(client_key);
     delete client;
 

--- a/be/src/common/util/thrift_client_cache.h
+++ b/be/src/common/util/thrift_client_cache.h
@@ -39,6 +39,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "base/hash/hash_std.hpp"
@@ -90,11 +91,12 @@ public:
     // created.
     Status reopen_client(const client_factory& factory_method, void** client_key, int timeout_ms);
 
-    // Return a client to the cache, without closing it, and set *client_key to NULL.
+    // Return a client to the cache, or close it if it was invalidated, and set
+    // *client_key to NULL.
     void release_client(void** client_key);
 
-    // Close all connections to a host (e.g., in case of failure) so that on their
-    // next use they will have to be Reopen'ed.
+    // Close idle connections to a host and mark checked-out connections so they are
+    // closed when released.
     void close_connections(const TNetworkAddress& address);
 
     std::string debug_string();
@@ -121,6 +123,10 @@ private:
     // Map from client key back to its associated ThriftClientImpl transport
     typedef std::unordered_map<void*, ThriftClientImpl*> ClientMap;
     ClientMap _client_map;
+
+    // Clients that were checked out when close_connections() invalidated their host.
+    // They must be evicted instead of returned to a newly-created cache entry.
+    std::unordered_set<void*> _clients_to_evict;
 
     // MetricRegistry
     bool _metrics_enabled{false};
@@ -229,9 +235,8 @@ public:
         _client_cache_helper.init_metrics(metrics, key_prefix);
     }
 
-    // Close all clients connected to the supplied address, (e.g., in
-    // case of failure) so that on their next use they will have to be
-    // Reopen'ed.
+    // Close idle clients connected to the supplied address and mark checked-out
+    // clients so they are closed when released.
     void close_connections(const TNetworkAddress& hostport) { return _client_cache_helper.close_connections(hostport); }
 
 private:

--- a/be/test/common/thrift_client_test.cpp
+++ b/be/test/common/thrift_client_test.cpp
@@ -23,7 +23,9 @@
 #include <memory>
 #include <thread>
 
+#include "base/network/network_util.h"
 #include "base/testutil/assert.h"
+#include "common/util/thrift_client_cache.h"
 #include "gen_cpp/FrontendService.h"
 
 namespace starrocks {
@@ -80,19 +82,155 @@ void MockedFrontendService::init() {
     sleep(1);
 }
 
-TEST(ThriftClientTest, test_open_close_and_reopen) {
-    MockedFrontendService service;
-    service.init();
+class ThriftClientTest : public testing::Test {
+protected:
+    static void SetUpTestSuite() {
+        _service = std::make_unique<MockedFrontendService>();
+        _service->init();
+        _other_service = std::make_unique<MockedFrontendService>();
+        _other_service->init();
+    }
+
+    static void TearDownTestSuite() {
+        _other_service.reset();
+        _service.reset();
+    }
+
+    static MockedFrontendService* service() { return _service.get(); }
+    static MockedFrontendService* other_service() { return _other_service.get(); }
+
+private:
+    static std::unique_ptr<MockedFrontendService> _service;
+    static std::unique_ptr<MockedFrontendService> _other_service;
+};
+
+std::unique_ptr<MockedFrontendService> ThriftClientTest::_service;
+std::unique_ptr<MockedFrontendService> ThriftClientTest::_other_service;
+
+TEST_F(ThriftClientTest, test_open_close_and_reopen) {
     TGetProfileResponse rep;
     TGetProfileRequest req;
 
-    ThriftClient<FrontendServiceClient> client("127.0.0.1", service.get_port());
+    ThriftClient<FrontendServiceClient> client("127.0.0.1", service()->get_port());
     ASSERT_OK(client.open());
     client.iface()->getQueryProfile(rep, req);
 
     client.close();
     ASSERT_OK(client.open_with_retry(3, 100));
     client.iface()->getQueryProfile(rep, req);
+}
+
+TEST_F(ThriftClientTest, release_client_after_close_connections) {
+    FrontendServiceClientCache client_cache(10);
+    MetricRegistry metrics("test");
+    client_cache.init_metrics(&metrics, "frontend");
+    auto address = make_network_address("127.0.0.1", service()->get_port());
+    auto labels = MetricLabels().add("name", "frontend");
+    auto* opened_clients = dynamic_cast<IntGauge*>(metrics.get_metric("thrift_opened_clients", labels));
+    auto* used_clients = dynamic_cast<IntGauge*>(metrics.get_metric("thrift_used_clients", labels));
+    ASSERT_NE(nullptr, opened_clients);
+    ASSERT_NE(nullptr, used_clients);
+
+    {
+        Status status;
+        FrontendServiceConnection client(&client_cache, address, 1000, &status);
+        ASSERT_OK(status);
+        ASSERT_EQ(1, opened_clients->value());
+        ASSERT_EQ(1, used_clients->value());
+
+        client_cache.close_connections(address);
+        ASSERT_EQ(1, client_cache._client_cache_helper._client_map.size());
+        ASSERT_EQ(1, client_cache._client_cache_helper._clients_to_evict.size());
+    }
+
+    EXPECT_TRUE(client_cache._client_cache_helper._client_map.empty());
+    EXPECT_TRUE(client_cache._client_cache_helper._clients_to_evict.empty());
+    EXPECT_EQ(0, opened_clients->value());
+    EXPECT_EQ(0, used_clients->value());
+}
+
+TEST_F(ThriftClientTest, invalidated_client_does_not_enter_recreated_cache) {
+    FrontendServiceClientCache client_cache(10);
+    MetricRegistry metrics("test");
+    client_cache.init_metrics(&metrics, "frontend");
+    auto address = make_network_address("127.0.0.1", service()->get_port());
+    auto labels = MetricLabels().add("name", "frontend");
+    auto* opened_clients = dynamic_cast<IntGauge*>(metrics.get_metric("thrift_opened_clients", labels));
+    auto* used_clients = dynamic_cast<IntGauge*>(metrics.get_metric("thrift_used_clients", labels));
+    ASSERT_NE(nullptr, opened_clients);
+    ASSERT_NE(nullptr, used_clients);
+
+    Status old_status;
+    auto old_client = std::make_unique<FrontendServiceConnection>(&client_cache, address, 1000, &old_status);
+    ASSERT_OK(old_status);
+    client_cache.close_connections(address);
+
+    {
+        Status new_status;
+        FrontendServiceConnection new_client(&client_cache, address, 1000, &new_status);
+        ASSERT_OK(new_status);
+        ASSERT_EQ(2, opened_clients->value());
+        ASSERT_EQ(2, used_clients->value());
+
+        old_client.reset();
+        EXPECT_EQ(1, client_cache._client_cache_helper._client_map.size());
+        EXPECT_TRUE(client_cache._client_cache_helper._clients_to_evict.empty());
+        EXPECT_EQ(1, opened_clients->value());
+        EXPECT_EQ(1, used_clients->value());
+    }
+
+    EXPECT_EQ(1, client_cache._client_cache_helper._client_map.size());
+    EXPECT_EQ(1, opened_clients->value());
+    EXPECT_EQ(0, used_clients->value());
+
+    client_cache.close_connections(address);
+    EXPECT_TRUE(client_cache._client_cache_helper._client_map.empty());
+    EXPECT_EQ(0, opened_clients->value());
+    EXPECT_EQ(0, used_clients->value());
+}
+
+TEST_F(ThriftClientTest, close_connections_only_invalidates_matching_host) {
+    FrontendServiceClientCache client_cache(10);
+    MetricRegistry metrics("test");
+    client_cache.init_metrics(&metrics, "frontend");
+    auto address = make_network_address("127.0.0.1", service()->get_port());
+    auto other_address = make_network_address("127.0.0.1", other_service()->get_port());
+    auto labels = MetricLabels().add("name", "frontend");
+    auto* opened_clients = dynamic_cast<IntGauge*>(metrics.get_metric("thrift_opened_clients", labels));
+    auto* used_clients = dynamic_cast<IntGauge*>(metrics.get_metric("thrift_used_clients", labels));
+    ASSERT_NE(nullptr, opened_clients);
+    ASSERT_NE(nullptr, used_clients);
+
+    Status status;
+    auto client = std::make_unique<FrontendServiceConnection>(&client_cache, address, 1000, &status);
+    ASSERT_OK(status);
+    Status other_status;
+    auto other_client = std::make_unique<FrontendServiceConnection>(&client_cache, other_address, 1000, &other_status);
+    ASSERT_OK(other_status);
+    void* client_key = client->get();
+    void* other_client_key = other_client->get();
+
+    client_cache.close_connections(address);
+    ASSERT_EQ(1, client_cache._client_cache_helper._clients_to_evict.size());
+    EXPECT_NE(client_cache._client_cache_helper._clients_to_evict.end(),
+              client_cache._client_cache_helper._clients_to_evict.find(client_key));
+    EXPECT_EQ(client_cache._client_cache_helper._clients_to_evict.end(),
+              client_cache._client_cache_helper._clients_to_evict.find(other_client_key));
+
+    client.reset();
+    EXPECT_EQ(1, client_cache._client_cache_helper._client_map.size());
+    EXPECT_TRUE(client_cache._client_cache_helper._clients_to_evict.empty());
+
+    other_client.reset();
+    auto cache_entry = client_cache._client_cache_helper._client_cache.find(other_address);
+    ASSERT_NE(client_cache._client_cache_helper._client_cache.end(), cache_entry);
+    EXPECT_EQ(1, cache_entry->second.size());
+    EXPECT_EQ(1, opened_clients->value());
+    EXPECT_EQ(0, used_clients->value());
+
+    client_cache.close_connections(other_address);
+    EXPECT_TRUE(client_cache._client_cache_helper._client_map.empty());
+    EXPECT_EQ(0, opened_clients->value());
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

When a Thrift connection attempt fails, `ThriftRpcHelper` calls `close_connections()` for the target host. The cache closes idle clients and erases the host entry, but clients already checked out by concurrent RPCs remain in `_client_map`.

When those clients are released, `release_client()` currently returns early because the host cache entry no longer exists. It neither closes nor deletes the underlying transport and also skips updating the opened/used client metrics. If the peer has closed the socket, these leaked clients remain in `CLOSE_WAIT` until the BE process exits. In monitoring, both `thrift_used_clients` and `thrift_opened_clients` can therefore drift upward permanently.

There is also a timing-dependent stale-client path: if a new cache entry for the same host is created before an invalidated checked-out client is returned, the old client can enter the new cache generation. A later checkout normally detects and removes it through `is_active()`, but only if the host is used again. Explicit eviction makes host invalidation deterministic.

## What I'm doing:

- Mark checked-out clients for eviction when their host connections are invalidated.
- Evict invalidated clients when they are released instead of returning them to the cache.
- Evict clients when their host cache entry is missing, closing the previous leak path.
- Update `thrift_used_clients` exactly once on every release path.
- Add regression coverage for release after `close_connections()`, cache recreation before release, and isolation between two different hosts.

This prevents stale FE Thrift connections from accumulating file descriptors and remaining in `CLOSE_WAIT` after connection failures.

Fixes no public issue.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: after a connection failure invalidates host H, all currently checked-out clients to H, including otherwise healthy connections, are closed on release instead of being recycled. This follows the existing policy of flushing the host's idle pool on any connection failure.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Validation:

- `git diff --check`
- BE unit tests were added but not run locally because the requested workflow skips local compilation. The PR must wait for the GitHub BE UT check to pass.

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5

Manual backports are expected for 4.1, 4.0, and 3.5 because the implementation and test files use different paths on those branches.
