### PR TITLE
[BugFix] Deduplicate source rowids in column partial updates

### DIFF
--- a/be/src/storage/lake/column_mode_partial_update_handler.cpp
+++ b/be/src/storage/lake/column_mode_partial_update_handler.cpp
@@ -268,7 +268,7 @@ Status ColumnModePartialUpdateHandler::_update_source_chunk_by_upt(const UptidTo
         std::vector<uint32_t> sorted_source_rowids;
         std::vector<uint32_t> unsorted_upt_rowids;
         // Sort source rowid -> upt rowid pairs by source rowid.
-        split_rowid_pairs(each.second, &sorted_source_rowids, &unsorted_upt_rowids, nullptr);
+        RETURN_IF_ERROR(split_rowid_pairs(each.second, &sorted_source_rowids, &unsorted_upt_rowids, nullptr));
         DCHECK(sorted_source_rowids.size() == unsorted_upt_rowids.size());
 
         // When condition update is enabled, compare the condition column value in

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -432,10 +432,15 @@ static Status read_chunk_from_update_file(const ChunkIteratorPtr& iter, const Ch
 // 1. sorted_source_rowids: sorted source rowids
 // 2. unsorted_upt_rowids: unsorted upt rowids
 // If container is not provided, we will just push back the rowids without alignment.
-void split_rowid_pairs(const std::vector<RowidPairs>& rowid_pairs, std::vector<uint32_t>* sorted_source_rowids,
-                       std::vector<uint32_t>* unsorted_upt_rowids, StreamChunkContainer* container) {
-    // rowid_pairs MUST be sorted already
-    DCHECK(std::is_sorted(rowid_pairs.begin(), rowid_pairs.end(), RowidPairsCompFn));
+Status split_rowid_pairs(const std::vector<RowidPairs>& rowid_pairs, std::vector<uint32_t>* sorted_source_rowids,
+                         std::vector<uint32_t>* unsorted_upt_rowids, StreamChunkContainer* container) {
+    for (size_t i = 1; i < rowid_pairs.size(); ++i) {
+        if (UNLIKELY(rowid_pairs[i - 1].first >= rowid_pairs[i].first)) {
+            return Status::Corruption(
+                    strings::Substitute("source rowids must be strictly increasing, previous:$0 current:$1",
+                                        rowid_pairs[i - 1].first, rowid_pairs[i].first));
+        }
+    }
     for (const auto& each : rowid_pairs) {
         if (container == nullptr) {
             // If container is not provided, we just push back the rowids.
@@ -452,6 +457,7 @@ void split_rowid_pairs(const std::vector<RowidPairs>& rowid_pairs, std::vector<u
             unsorted_upt_rowids->push_back(each.second);
         }
     }
+    return Status::OK();
 }
 
 // read from upt files and update rows in source chunk.
@@ -480,7 +486,7 @@ Status RowsetColumnUpdateState::_update_source_chunk_by_upt(const UptidToRowidPa
         std::vector<uint32_t> sorted_source_rowids;
         std::vector<uint32_t> unsorted_upt_rowids;
         // split rowid_pairs into sorted_source_rowids and unsorted_upt_rowids
-        split_rowid_pairs(each.second, &sorted_source_rowids, &unsorted_upt_rowids, &container);
+        RETURN_IF_ERROR(split_rowid_pairs(each.second, &sorted_source_rowids, &unsorted_upt_rowids, &container));
         DCHECK(sorted_source_rowids.size() == unsorted_upt_rowids.size());
         // fetch upt rows from upt_chunk
         auto tmp_chunk = ChunkFactory::new_chunk(partial_schema, unsorted_upt_rowids.size());

--- a/be/src/storage/rowset_column_update_state.h
+++ b/be/src/storage/rowset_column_update_state.h
@@ -110,6 +110,12 @@ struct ColumnPartialUpdateState {
             if (!std::is_sorted(each.second.begin(), each.second.end(), RowidPairsCompFn)) {
                 std::sort(each.second.begin(), each.second.end(), RowidPairsCompFn);
             }
+
+            // Column::update_rows requires source rowids to be strictly increasing. Keep one update row when
+            // duplicate source rowids are found.
+            each.second.erase(std::unique(each.second.begin(), each.second.end(),
+                                          [](const RowidPairs& a, const RowidPairs& b) { return a.first == b.first; }),
+                              each.second.end());
         }
 #ifndef BE_TEST
         src_rss_rowids.clear();
@@ -269,8 +275,8 @@ private:
     std::map<string, string> _column_to_expr_value;
 };
 
-void split_rowid_pairs(const std::vector<RowidPairs>& rowid_pairs, std::vector<uint32_t>* sorted_source_rowids,
-                       std::vector<uint32_t>* unsorted_upt_rowids, StreamChunkContainer* container);
+Status split_rowid_pairs(const std::vector<RowidPairs>& rowid_pairs, std::vector<uint32_t>* sorted_source_rowids,
+                         std::vector<uint32_t>* unsorted_upt_rowids, StreamChunkContainer* container);
 
 inline std::ostream& operator<<(std::ostream& os, const RowsetColumnUpdateState& o) {
     os << o.to_string();

--- a/be/test/storage/rowset_column_update_state_test.cpp
+++ b/be/test/storage/rowset_column_update_state_test.cpp
@@ -21,6 +21,8 @@
 #include <memory>
 
 #include "base/testutil/assert.h"
+#include "column/array_column.h"
+#include "column/binary_column.h"
 #include "column/chunk_factory.h"
 #include "column/datum_tuple.h"
 #include "fs/fs_memory.h"
@@ -245,6 +247,88 @@ static uint32_t find_upt_row_id(const ColumnPartialUpdateState& state, uint64_t 
         }
     }
     return m[src_rss_id];
+}
+
+TEST_F(RowsetColumnUpdateStateTest, deduplicate_source_rowids) {
+    ColumnPartialUpdateState state;
+    state.src_rss_rowids = {
+            (uint64_t{2} << 32) | 7, // update row 0
+            (uint64_t{1} << 32) | 9, // update row 1
+            (uint64_t{2} << 32) | 7, // duplicate source rowid
+            (uint64_t{2} << 32) | 3, // update row 3
+            (uint64_t{1} << 32) | 9, // duplicate source rowid
+            UINT64_MAX,              // update row 5 is an insert
+    };
+
+    state.build_rss_rowid_to_update_rowid(0);
+
+    const auto& rssid1 = state.rss_rowid_to_update_rowid.at(1);
+    ASSERT_EQ(1, rssid1.size());
+    EXPECT_EQ(9, rssid1[0].first);
+    EXPECT_TRUE(rssid1[0].second == 1 || rssid1[0].second == 4);
+
+    const auto& rssid2 = state.rss_rowid_to_update_rowid.at(2);
+    ASSERT_EQ(2, rssid2.size());
+    EXPECT_EQ(3, rssid2[0].first);
+    EXPECT_EQ(3, rssid2[0].second);
+    EXPECT_EQ(7, rssid2[1].first);
+    EXPECT_TRUE(rssid2[1].second == 0 || rssid2[1].second == 2);
+    EXPECT_EQ(std::vector<uint32_t>({5}), state.insert_rowids);
+    EXPECT_TRUE(is_rowid_pairs_ordered(state.rss_rowid_to_update_rowid));
+}
+
+TEST_F(RowsetColumnUpdateStateTest, split_rowid_pairs_validates_source_rowid_order) {
+    std::vector<uint32_t> source_rowids;
+    std::vector<uint32_t> upt_rowids;
+
+    auto st = split_rowid_pairs({{1, 0}, {1, 1}}, &source_rowids, &upt_rowids, nullptr);
+    EXPECT_TRUE(st.is_corruption()) << st;
+
+    st = split_rowid_pairs({{2, 0}, {1, 1}}, &source_rowids, &upt_rowids, nullptr);
+    EXPECT_TRUE(st.is_corruption()) << st;
+
+    StreamChunkContainer container{.start_rowid = 10, .end_rowid = 20};
+    st = split_rowid_pairs({{5, 0}, {12, 1}, {18, 2}, {25, 3}}, &source_rowids, &upt_rowids, &container);
+    ASSERT_TRUE(st.ok()) << st;
+    EXPECT_EQ(std::vector<uint32_t>({2, 8}), source_rowids);
+    EXPECT_EQ(std::vector<uint32_t>({1, 2}), upt_rowids);
+}
+
+TEST_F(RowsetColumnUpdateStateTest, deduplicate_variable_length_update_indexes) {
+    ColumnPartialUpdateState state;
+    state.src_rss_rowids = {0, 0};
+    state.build_rss_rowid_to_update_rowid(0);
+
+    std::vector<uint32_t> source_rowids;
+    std::vector<uint32_t> upt_rowids;
+    auto st = split_rowid_pairs(state.rss_rowid_to_update_rowid.at(0), &source_rowids, &upt_rowids, nullptr);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_EQ(std::vector<uint32_t>({0}), source_rowids);
+    ASSERT_EQ(1, upt_rowids.size());
+    ASSERT_LT(upt_rowids[0], 2);
+
+    auto source_binary = BinaryColumn::create();
+    source_binary->append_datum(Datum("old"));
+    auto upt_binary = BinaryColumn::create();
+    upt_binary->append_datum(Datum("first"));
+    upt_binary->append_datum(Datum("first"));
+    auto selected_binary = BinaryColumn::create();
+    selected_binary->append_selective(*upt_binary, upt_rowids.data(), 0, upt_rowids.size());
+    source_binary->update_rows(*selected_binary, source_rowids.data());
+    EXPECT_EQ("first", source_binary->get(0).get_slice());
+
+    auto source_array = ArrayColumn::create(BinaryColumn::create(), UInt32Column::create());
+    source_array->append_datum(Datum(DatumArray{Datum("old")}));
+    auto upt_array = ArrayColumn::create(BinaryColumn::create(), UInt32Column::create());
+    upt_array->append_datum(Datum(DatumArray{Datum("first")}));
+    upt_array->append_datum(Datum(DatumArray{Datum("first")}));
+    auto selected_array = ArrayColumn::create(BinaryColumn::create(), UInt32Column::create());
+    selected_array->append_selective(*upt_array, upt_rowids.data(), 0, upt_rowids.size());
+    source_array->update_rows(*selected_array, source_rowids.data());
+
+    const auto result = source_array->get(0).get_array();
+    ASSERT_EQ(1, result.size());
+    EXPECT_EQ("first", result[0].get_slice());
 }
 
 TEST_F(RowsetColumnUpdateStateTest, prepare_partial_update_states) {


### PR DESCRIPTION
## Why I'm doing:

Column-mode partial update apply sorts source-rowid/update-rowid pairs but does not deduplicate them. If multiple rows in one update file resolve to the same source rowid, `Column::update_rows` receives duplicate indexes even though variable-length column implementations require those indexes to be strictly increasing.

When VARCHAR or ARRAY updates take the resize path, the duplicate index causes an unsigned subtraction to underflow and can lead to an out-of-bounds append and a deterministic BE apply crash loop.

## What I'm doing:

- Deduplicate source rowids while building the apply mapping.
- Keep one update row for each source rowid without imposing first-write or last-write ordering semantics.
- Validate strict source-rowid ordering before calling `Chunk::update_rows`.
- Apply the validation to shared-nothing and shared-data column partial update paths.
- Add regression coverage for deduplication, invalid source-rowid ordering, and VARCHAR/ARRAY resize updates.

Issue: N/A

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5

## Validation:

- [ ] `git diff --check upstream/main...HEAD`
- [ ] Changed C++ files formatted with the repository clang-format configuration
- [ ] Local BE unit tests (not run per request; CI will validate the added tests)
