### PR TITLE
[Enhancement] Add PCU diagnostics for shared-nothing column mode partial update

### DIFF
--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -177,11 +177,60 @@ void ArrayColumn::fill_default(const Filter& filter) {
     update_rows(*default_column, indexes.data());
 }
 
+namespace {
+
+// [PCU_DIAG] The byte range `append()` copies is derived from offset arithmetic, so a wild
+// range can come from corrupt offsets just as easily as from a bad index. Report the first
+// anomaly only -- these run per update_rows() call and must not flood the log.
+void diag_check_array_offsets(const ArrayColumn& column, const char* tag) {
+    const auto& offsets = column.offsets().get_data();
+    if (offsets.empty()) {
+        LOG(ERROR) << "PCU_DIAG_A1: " << tag << " empty offsets";
+        return;
+    }
+    for (size_t i = 1; i < offsets.size(); i++) {
+        if (offsets[i] < offsets[i - 1]) {
+            LOG(ERROR) << "PCU_DIAG_A1: " << tag << " non-monotonic offsets row=" << i - 1
+                       << " off[i-1]=" << offsets[i - 1] << " off[i]=" << offsets[i]
+                       << " num_rows=" << offsets.size() - 1 << " elements=" << column.elements().size();
+            return;
+        }
+    }
+    const uint32_t span = offsets.back() - offsets.front();
+    LOG_IF(ERROR, span != column.elements().size())
+            << "PCU_DIAG_A1: " << tag << " elements size mismatch span=" << span
+            << " elements=" << column.elements().size() << " num_rows=" << offsets.size() - 1;
+}
+
+// [PCU_DIAG] The resize branch below computes an unsigned span between consecutive indexes,
+// so anything but a strictly increasing, in-range sequence underflows to ~SIZE_MAX.
+void diag_check_update_indexes(const uint32_t* indexes, size_t replace_num, size_t dst_rows) {
+    for (size_t i = 0; i < replace_num; ++i) {
+        if (indexes[i] >= dst_rows) {
+            LOG(ERROR) << "PCU_DIAG_A2: index out of bounds i=" << i << " indexes[i]=" << indexes[i]
+                       << " dst_rows=" << dst_rows << " replace_num=" << replace_num;
+            return;
+        }
+        if (i > 0 && indexes[i] <= indexes[i - 1]) {
+            LOG(ERROR) << "PCU_DIAG_A2: indexes not strictly increasing i=" << i << " indexes[i-1]=" << indexes[i - 1]
+                       << " indexes[i]=" << indexes[i] << " replace_num=" << replace_num;
+            return;
+        }
+    }
+}
+
+} // namespace
+
 void ArrayColumn::update_rows(const Column& src, const uint32_t* indexes) {
     const auto& array_column = down_cast<const ArrayColumn&>(src);
 
     const OffsetColumn& src_offsets = array_column.offsets();
     size_t replace_num = src.size();
+
+    diag_check_array_offsets(*this, "update_rows.dst");
+    diag_check_array_offsets(array_column, "update_rows.src");
+    diag_check_update_indexes(indexes, replace_num, _offsets->size() - 1);
+
     bool need_resize = false;
     for (size_t i = 0; i < replace_num; ++i) {
         if (_offsets->get_data()[indexes[i] + 1] - _offsets->get_data()[indexes[i]] !=
@@ -205,7 +254,13 @@ void ArrayColumn::update_rows(const Column& src, const uint32_t* indexes) {
         MutableColumnPtr new_array_column = clone_empty();
         size_t idx_begin = 0;
         for (size_t i = 0; i < replace_num; ++i) {
-            size_t count = indexes[i] - idx_begin;
+            // [PCU_DIAG] Clamp instead of underflowing: a ~SIZE_MAX count makes append() read a
+            // multi-hundred-MB phantom slice and segfault, which turns a committed rowset into a
+            // permanent apply crash loop. Skipping the copy corrupts this one row, not the process.
+            LOG_IF(ERROR, indexes[i] < idx_begin)
+                    << "PCU_DIAG_A3: update_rows count underflow clamped i=" << i << " indexes[i]=" << indexes[i]
+                    << " idx_begin=" << idx_begin << " replace_num=" << replace_num;
+            size_t count = (indexes[i] >= idx_begin) ? (indexes[i] - idx_begin) : 0;
             new_array_column->append(*this, idx_begin, count);
             new_array_column->append(src, i, 1);
             idx_begin = indexes[i] + 1;
@@ -214,6 +269,10 @@ void ArrayColumn::update_rows(const Column& src, const uint32_t* indexes) {
         if (remain_count > 0) {
             new_array_column->append(*this, idx_begin, remain_count);
         }
+        const auto* rebuilt = down_cast<const ArrayColumn*>(new_array_column.get());
+        LOG_IF(ERROR, rebuilt->offsets().size() != _offsets->size())
+                << "PCU_DIAG_A3: update_rows row count mismatch new=" << rebuilt->offsets().size()
+                << " old=" << _offsets->size() << " replace_num=" << replace_num;
         swap_column(*new_array_column.get());
     }
 }

--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -16,6 +16,7 @@
 
 #include <cstdint>
 
+#include "column/binary_column.h"
 #include "column/column_helper.h"
 #include "column/column_view/column_view.h"
 #include "column/fixed_length_column.h"
@@ -179,6 +180,32 @@ void ArrayColumn::fill_default(const Filter& filter) {
 
 namespace {
 
+// [PCU_DIAG] The elements of an ARRAY<STRING> are a BinaryColumn whose offsets are uint32 BYTE
+// offsets. Once the element bytes of one chunk pass UINT32_MAX they silently wrap, and every
+// later `append` derives its byte range from wrapped values -- which is how a legal count still
+// produces a multi-hundred-MB phantom slice. This is the offset set that actually overflows;
+// ArrayColumn's own offsets are element indexes and stay far below the limit.
+void diag_check_binary_offsets(const Column& column, const char* tag) {
+    const Column* inner = &column;
+    if (inner->is_nullable()) {
+        inner = down_cast<const NullableColumn*>(inner)->data_column().get();
+    }
+    if (!inner->is_binary()) {
+        return;
+    }
+    const auto& offsets = down_cast<const BinaryColumn*>(inner)->get_offset();
+    for (size_t i = 1; i < offsets.size(); i++) {
+        if (offsets[i] < offsets[i - 1]) {
+            LOG(ERROR) << "PCU_DIAG_A0: " << tag << " BYTE OFFSET WRAP (uint32 overflow) at element=" << i - 1
+                       << " off[i-1]=" << offsets[i - 1] << " off[i]=" << offsets[i]
+                       << " num_elements=" << offsets.size() - 1
+                       << " bytes=" << down_cast<const BinaryColumn*>(inner)->get_bytes().size()
+                       << " UINT32_MAX=" << UINT32_MAX;
+            return;
+        }
+    }
+}
+
 // [PCU_DIAG] The byte range `append()` copies is derived from offset arithmetic, so a wild
 // range can come from corrupt offsets just as easily as from a bad index. Report the first
 // anomaly only -- these run per update_rows() call and must not flood the log.
@@ -200,6 +227,7 @@ void diag_check_array_offsets(const ArrayColumn& column, const char* tag) {
     LOG_IF(ERROR, span != column.elements().size())
             << "PCU_DIAG_A1: " << tag << " elements size mismatch span=" << span
             << " elements=" << column.elements().size() << " num_rows=" << offsets.size() - 1;
+    diag_check_binary_offsets(column.elements(), tag);
 }
 
 // [PCU_DIAG] The resize branch below computes an unsigned span between consecutive indexes,

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -15,6 +15,7 @@
 #include "rowset_column_update_state.h"
 
 #include "column/array_column.h"
+#include "column/binary_column.h"
 #include "column/nullable_column.h"
 #include "common/tracer.h"
 #include "fs/fs_util.h"
@@ -87,6 +88,29 @@ static void diag_validate_chunk(const Chunk& chunk, const char* tag, int64_t tab
                 << "PCU_DIAG_C: " << tag << " array elements mismatch col=" << i << " span=" << span
                 << " elements=" << array->elements().size() << " tablet=" << tablet_id << " txn=" << txn_id
                 << " rssid=" << rssid << " upt_id=" << upt_id;
+        // The array's own offsets are element indexes and rarely get anywhere near UINT32_MAX.
+        // The offsets that actually overflow are the uint32 BYTE offsets of the element
+        // BinaryColumn, once one chunk holds more than 4 GiB of string data.
+        const Column* elements = &array->elements();
+        if (elements->is_nullable()) {
+            elements = down_cast<const NullableColumn*>(elements)->data_column().get();
+        }
+        if (!elements->is_binary()) {
+            continue;
+        }
+        const auto* binary = down_cast<const BinaryColumn*>(elements);
+        const auto& byte_offsets = binary->get_offset();
+        for (size_t e = 1; e < byte_offsets.size(); e++) {
+            if (byte_offsets[e] < byte_offsets[e - 1]) {
+                LOG(ERROR) << "PCU_DIAG_C: " << tag << " BYTE OFFSET WRAP (uint32 overflow) col=" << i
+                           << " element=" << e - 1 << " off[i-1]=" << byte_offsets[e - 1]
+                           << " off[i]=" << byte_offsets[e] << " num_elements=" << byte_offsets.size() - 1
+                           << " bytes=" << binary->get_bytes().size() << " UINT32_MAX=" << UINT32_MAX
+                           << " tablet=" << tablet_id << " txn=" << txn_id << " rssid=" << rssid
+                           << " upt_id=" << upt_id;
+                break;
+            }
+        }
     }
 }
 

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -14,6 +14,8 @@
 
 #include "rowset_column_update_state.h"
 
+#include "column/array_column.h"
+#include "column/nullable_column.h"
 #include "common/tracer.h"
 #include "fs/fs_util.h"
 #include "gutil/strings/substitute.h"
@@ -36,6 +38,58 @@
 #include "util/time.h"
 
 namespace starrocks {
+
+// [PCU_DIAG] Structural validation of a chunk on the column-mode partial update apply path.
+// `tag` says where the chunk came from, which is the whole point: the same segfault in
+// ArrayColumn::update_rows can originate from a corrupt .upt file, a corrupt source segment
+// (or its delta column groups), or a bad rowid mapping, and only the origin tells them apart.
+static void diag_validate_chunk(const Chunk& chunk, const char* tag, int64_t tablet_id, int64_t txn_id,
+                                uint32_t rssid, uint32_t upt_id) {
+    const size_t num_rows = chunk.num_rows();
+    for (size_t i = 0; i < chunk.num_columns(); i++) {
+        const Column* column = chunk.get_column_by_index(i).get();
+        if (column->size() != num_rows) {
+            LOG(ERROR) << "PCU_DIAG_C: " << tag << " column size mismatch col=" << i << " size=" << column->size()
+                       << " chunk_rows=" << num_rows << " tablet=" << tablet_id << " txn=" << txn_id
+                       << " rssid=" << rssid << " upt_id=" << upt_id;
+        }
+        if (column->is_nullable()) {
+            const auto* nullable = down_cast<const NullableColumn*>(column);
+            if (nullable->null_column()->size() != num_rows || nullable->data_column()->size() != num_rows) {
+                LOG(ERROR) << "PCU_DIAG_C: " << tag << " nullable sub-column size mismatch col=" << i
+                           << " null=" << nullable->null_column()->size()
+                           << " data=" << nullable->data_column()->size() << " chunk_rows=" << num_rows
+                           << " tablet=" << tablet_id << " txn=" << txn_id << " rssid=" << rssid
+                           << " upt_id=" << upt_id;
+            }
+            column = nullable->data_column().get();
+        }
+        if (!column->is_array()) {
+            continue;
+        }
+        const auto* array = down_cast<const ArrayColumn*>(column);
+        const auto& offsets = array->offsets().get_data();
+        if (offsets.size() != column->size() + 1) {
+            LOG(ERROR) << "PCU_DIAG_C: " << tag << " array offsets size mismatch col=" << i
+                       << " offsets=" << offsets.size() << " expected=" << column->size() + 1
+                       << " tablet=" << tablet_id << " txn=" << txn_id << " rssid=" << rssid << " upt_id=" << upt_id;
+            continue;
+        }
+        for (size_t r = 1; r < offsets.size(); r++) {
+            if (offsets[r] < offsets[r - 1]) {
+                LOG(ERROR) << "PCU_DIAG_C: " << tag << " array non-monotonic offsets col=" << i << " row=" << r - 1
+                           << " off[i-1]=" << offsets[r - 1] << " off[i]=" << offsets[r] << " tablet=" << tablet_id
+                           << " txn=" << txn_id << " rssid=" << rssid << " upt_id=" << upt_id;
+                break;
+            }
+        }
+        const uint32_t span = offsets.back() - offsets.front();
+        LOG_IF(ERROR, span != array->elements().size())
+                << "PCU_DIAG_C: " << tag << " array elements mismatch col=" << i << " span=" << span
+                << " elements=" << array->elements().size() << " tablet=" << tablet_id << " txn=" << txn_id
+                << " rssid=" << rssid << " upt_id=" << upt_id;
+    }
+}
 
 RowsetColumnUpdateState::RowsetColumnUpdateState() = default;
 
@@ -452,8 +506,12 @@ void split_rowid_pairs(const std::vector<RowidPairs>& rowid_pairs, std::vector<u
 Status RowsetColumnUpdateState::_update_source_chunk_by_upt(const UptidToRowidPairs& upt_id_to_rowid_pairs,
                                                             const Schema& partial_schema, Rowset* rowset,
                                                             OlapReaderStatistics* stats, MemTracker* tracker,
-                                                            StreamChunkContainer container) {
+                                                            StreamChunkContainer container, uint32_t rssid) {
     CHECK_MEM_LIMIT("RowsetColumnUpdateState::_update_source_chunk_by_upt");
+    const int64_t diag_txn_id = rowset->txn_id();
+    // [PCU_DIAG] The source chunk is shared across every upt file handled below, so validate it
+    // once here: if it already arrives corrupt, the fault is in the segment/DCG read, not in us.
+    diag_validate_chunk(*container.chunk_ptr, "source_chunk", _tablet_id, diag_txn_id, rssid, 0);
     // handle upt files one by one
     for (const auto& each : upt_id_to_rowid_pairs) {
         const uint32_t upt_id = each.first;
@@ -467,6 +525,9 @@ Status RowsetColumnUpdateState::_update_source_chunk_by_upt(const UptidToRowidPa
             }
         });
         RETURN_IF_ERROR(read_chunk_from_update_file(update_iterator, upt_chunk));
+        // [PCU_DIAG] The .upt content is persisted, so corruption here reproduces on every
+        // re-apply after restart -- exactly the deterministic crash loop we are chasing.
+        diag_validate_chunk(*upt_chunk, "upt_chunk", _tablet_id, diag_txn_id, rssid, upt_id);
         const size_t upt_chunk_size = upt_chunk->memory_usage();
         tracker->consume(upt_chunk_size);
         DeferOp tracker_defer([&]() { tracker->release(upt_chunk_size); });
@@ -476,12 +537,35 @@ Status RowsetColumnUpdateState::_update_source_chunk_by_upt(const UptidToRowidPa
         // split rowid_pairs into sorted_source_rowids and unsorted_upt_rowids
         split_rowid_pairs(each.second, &sorted_source_rowids, &unsorted_upt_rowids, &container);
         DCHECK(sorted_source_rowids.size() == unsorted_upt_rowids.size());
+        // [PCU_DIAG] The DCHECK above is compiled out in release, and std::is_sorted treats
+        // adjacent duplicates as sorted, so nothing enforces the strictly-increasing invariant
+        // that ArrayColumn::update_rows relies on. Report the first violation with full context.
+        for (size_t i = 1; i < sorted_source_rowids.size(); i++) {
+            if (sorted_source_rowids[i] == sorted_source_rowids[i - 1]) {
+                LOG(ERROR) << "PCU_DIAG_S2: duplicate source rowid=" << sorted_source_rowids[i]
+                           << " (container-relative, start_rowid=" << container.start_rowid << ")"
+                           << " upt_rowids=" << unsorted_upt_rowids[i - 1] << "," << unsorted_upt_rowids[i]
+                           << " at i=" << i << " total=" << sorted_source_rowids.size() << " tablet=" << _tablet_id
+                           << " txn=" << diag_txn_id << " rssid=" << rssid << " upt_id=" << upt_id;
+                break;
+            }
+        }
+        for (size_t i = 0; i < unsorted_upt_rowids.size(); i++) {
+            if (unsorted_upt_rowids[i] >= upt_chunk->num_rows()) {
+                LOG(ERROR) << "PCU_DIAG_S2: upt rowid out of range=" << unsorted_upt_rowids[i]
+                           << " upt_rows=" << upt_chunk->num_rows() << " at i=" << i << " tablet=" << _tablet_id
+                           << " txn=" << diag_txn_id << " rssid=" << rssid << " upt_id=" << upt_id;
+                break;
+            }
+        }
         // fetch upt rows from upt_chunk
         auto tmp_chunk = ChunkHelper::new_chunk(partial_schema, unsorted_upt_rowids.size());
         TRY_CATCH_BAD_ALLOC(
                 tmp_chunk->append_selective(*upt_chunk, unsorted_upt_rowids.data(), 0, unsorted_upt_rowids.size()));
+        diag_validate_chunk(*tmp_chunk, "selected_upt_chunk", _tablet_id, diag_txn_id, rssid, upt_id);
         // update source chunk use upt rows
         RETURN_IF_EXCEPTION(container.chunk_ptr->update_rows(*tmp_chunk, sorted_source_rowids.data()));
+        diag_validate_chunk(*container.chunk_ptr, "updated_source_chunk", _tablet_id, diag_txn_id, rssid, upt_id);
     }
     return Status::OK();
 }
@@ -805,7 +889,7 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
                         DeferOp tracker_defer([&]() { tracker->release(source_chunk_size); });
                         // 3.4 read from update segment and do update
                         RETURN_IF_ERROR(_update_source_chunk_by_upt(each.second, partial_schema, rowset, &stats,
-                                                                    tracker, container));
+                                                                    tracker, container, each.first));
                         padding_char_columns(partial_schema, partial_tschema, container.chunk_ptr);
                         RETURN_IF_ERROR(delta_column_group_writer->append_chunk(*container.chunk_ptr));
                         return Status::OK();

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -43,8 +43,8 @@ namespace starrocks {
 // `tag` says where the chunk came from, which is the whole point: the same segfault in
 // ArrayColumn::update_rows can originate from a corrupt .upt file, a corrupt source segment
 // (or its delta column groups), or a bad rowid mapping, and only the origin tells them apart.
-static void diag_validate_chunk(const Chunk& chunk, const char* tag, int64_t tablet_id, int64_t txn_id,
-                                uint32_t rssid, uint32_t upt_id) {
+static void diag_validate_chunk(const Chunk& chunk, const char* tag, int64_t tablet_id, int64_t txn_id, uint32_t rssid,
+                                uint32_t upt_id) {
     const size_t num_rows = chunk.num_rows();
     for (size_t i = 0; i < chunk.num_columns(); i++) {
         const Column* column = chunk.get_column_by_index(i).get();
@@ -57,10 +57,9 @@ static void diag_validate_chunk(const Chunk& chunk, const char* tag, int64_t tab
             const auto* nullable = down_cast<const NullableColumn*>(column);
             if (nullable->null_column()->size() != num_rows || nullable->data_column()->size() != num_rows) {
                 LOG(ERROR) << "PCU_DIAG_C: " << tag << " nullable sub-column size mismatch col=" << i
-                           << " null=" << nullable->null_column()->size()
-                           << " data=" << nullable->data_column()->size() << " chunk_rows=" << num_rows
-                           << " tablet=" << tablet_id << " txn=" << txn_id << " rssid=" << rssid
-                           << " upt_id=" << upt_id;
+                           << " null=" << nullable->null_column()->size() << " data=" << nullable->data_column()->size()
+                           << " chunk_rows=" << num_rows << " tablet=" << tablet_id << " txn=" << txn_id
+                           << " rssid=" << rssid << " upt_id=" << upt_id;
             }
             column = nullable->data_column().get();
         }
@@ -71,8 +70,8 @@ static void diag_validate_chunk(const Chunk& chunk, const char* tag, int64_t tab
         const auto& offsets = array->offsets().get_data();
         if (offsets.size() != column->size() + 1) {
             LOG(ERROR) << "PCU_DIAG_C: " << tag << " array offsets size mismatch col=" << i
-                       << " offsets=" << offsets.size() << " expected=" << column->size() + 1
-                       << " tablet=" << tablet_id << " txn=" << txn_id << " rssid=" << rssid << " upt_id=" << upt_id;
+                       << " offsets=" << offsets.size() << " expected=" << column->size() + 1 << " tablet=" << tablet_id
+                       << " txn=" << txn_id << " rssid=" << rssid << " upt_id=" << upt_id;
             continue;
         }
         for (size_t r = 1; r < offsets.size(); r++) {

--- a/be/src/storage/rowset_column_update_state.h
+++ b/be/src/storage/rowset_column_update_state.h
@@ -232,7 +232,7 @@ private:
 
     Status _update_source_chunk_by_upt(const UptidToRowidPairs& upt_id_to_rowid_pairs, const Schema& partial_schema,
                                        Rowset* rowset, OlapReaderStatistics* stats, MemTracker* tracker,
-                                       StreamChunkContainer container);
+                                       StreamChunkContainer container, uint32_t rssid);
 
 private:
     int64_t _tablet_id = 0;


### PR DESCRIPTION
## Why I'm doing:

Diagnostic build vehicle — **not for merge**.

Investigating a deterministic BE apply crash on branch-3.5 (shared-nothing, PK
table, column-mode partial update on `ARRAY<STRING>` columns). The segfault is
inside `ArrayColumn::update_rows` → `append` → `BinaryColumnBase::_append_binary_impl`
with a ~859MB phantom byte range, and it reproduces on every restart because the
offending rowset is already committed.

The existing PCU diagnostics (#71488) only instrument the lake path; this crash
is on the shared-nothing path.

## What I'm doing:

Adds `PCU_DIAG` logging to `be/src/column/array_column.cpp` and
`be/src/storage/rowset_column_update_state.cpp` to separate the possible origins
of the corruption (bad rowid mapping vs. already-corrupt `.upt` file vs.
already-corrupt source segment / delta column group), and clamps the `count`
underflow so the crash loop is interrupted rather than fatal.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
- [x] This is a backport pr

