### PR TITLE
Update post_deployment_setup.md

### DIFF
--- a/docs/en/deployment/post_deployment_setup.md
+++ b/docs/en/deployment/post_deployment_setup.md
@@ -48,12 +48,12 @@ The default value is `false`, which means no profile is required.
 Setting this variable to `true` can affect the concurrency of StarRocks. 
 
 #### Recommended value
-false
+true
 
 - Set `enable_profile` to `false` globally:
 
   ```SQL
-  SET GLOBAL enable_profile = false;
+  SET GLOBAL enable_profile = true;
   ```
 
 ### enable_pipeline_engine


### PR DESCRIPTION
The boolean switch that controls whether to send the profile of a query for analysis.  The default value is `false`, which means no profile is required.  Setting this variable to `true` can affect the concurrency of StarRocks.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:
 Doc

Does this PR entail a change in behavior?

- [x] No.

## Checklist:
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] This pr needs auto generate documentation


## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5