### PR TITLE
[BugFix] Remove the global limit for streaming distinct

### DIFF
--- a/be/src/exec/aggregate/distinct_streaming_node.cpp
+++ b/be/src/exec/aggregate/distinct_streaming_node.cpp
@@ -73,10 +73,6 @@ StatusOr<pipeline::OpFactories> DistinctStreamingNode::decompose_to_pipeline(
                 context, id(), ops_with_sink, ops_with_source, operators_generator);
     }
     context->add_pipeline(ops_with_sink);
-    if (limit() != -1) {
-        ops_with_source.emplace_back(
-                std::make_shared<LimitOperatorFactory>(context->next_operator_id(), id(), limit()));
-    }
     ops_with_source =
             ::starrocks::pipeline::builder::maybe_interpolate_debug_ops(context, runtime_state(), _id, ops_with_source);
     return ops_with_source;


### PR DESCRIPTION
## Why I'm doing:

Imagine this scenario: `distinct -> limit -> sink`, running with parallelism (multiple driver-sequence instances of the streaming-distinct source operator).

`LimitOperatorFactory` holds a single `std::atomic<int64_t>` limit, passed by reference into every parallel `LimitOperator` instance it creates — i.e. one shared countdown across all parallel streaming-distinct instances. But each parallel instance builds its own independent hash set with no cross-instance dedup, and there may be non-overlapping distinct values across instances. Sharing the limit before the global merge phase means a fast instance can exhaust the shared countdown, silently truncating a slower sibling instance's genuinely-distinct rows before they ever reach the merge stage — producing fewer distinct rows than correct.

This is the same bug pattern already fixed for the plain group-by streaming aggregate in #66074 ("Remove the global limit for streaming aggregators"), which removed the identical `LimitOperatorFactory` insertion from `AggregateStreamingNode::decompose_to_pipeline`. That fix only touched `aggregate_streaming_node.cpp` and did not touch `distinct_streaming_node.cpp`, which has the same pattern and the same bug. #66109 (the companion FE-side fix for the same issue) also doesn't touch this file — it only changes plan-shape/limit-pushdown on the FE side.

The original issue #66012's repro (`SELECT DISTINCT xxx FROM table1 LIMIT 1000` returning fewer rows than exist) is against exactly this code path (`DistinctStreamingNode`, selected when `tnode.agg_node.aggregate_functions.size() == 0` in the streaming-preaggregation case), so it remains reproducible on current `main`.

## What I'm doing:

Remove the shared global `LimitOperatorFactory` insertion from `DistinctStreamingNode::decompose_to_pipeline`, mirroring #66074's fix for `AggregateStreamingNode`. The limit on streaming distinct aggregation only became reachable after the same optimization (#55455) that motivated the original #66074 fix, so removing it here is safe for the same reason.

Fixes #66012

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5