### PR TITLE
[BugFix] Plan subqueries in a window's PARTITION BY/ORDER BY

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExprToThrift.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExprToThrift.java
@@ -431,7 +431,10 @@ public final class ExprToThrift {
 
         @Override
         public Void visitSubqueryExpr(Subquery node, TExprNode msg) {
-            return null;
+            // A subquery has to be rewritten into a join/apply by the optimizer. Serializing it would produce a
+            // TExprNode without a node_type, which the BE rejects with an unhelpful thrift error.
+            throw new StarRocksPlannerException(
+                    "Subquery needs to be rewritten before it can be sent to the backend.", ErrorType.INTERNAL_ERROR);
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
@@ -32,11 +32,15 @@ import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.TreeNode;
 import com.starrocks.sql.ast.expression.AnalyticExpr;
 import com.starrocks.sql.ast.expression.CloneExpr;
+import com.starrocks.sql.ast.expression.ExistsPredicate;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
+import com.starrocks.sql.ast.expression.InPredicate;
 import com.starrocks.sql.ast.expression.LimitElement;
+import com.starrocks.sql.ast.expression.MultiInPredicate;
 import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.sql.ast.expression.Subquery;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.SubqueryUtils;
 import com.starrocks.sql.optimizer.Utils;
@@ -359,6 +363,13 @@ public class QueryTransformer {
                     .stream().map(OrderByElement::getExpr).collect(Collectors.toList()));
         }
 
+        // PARTITION BY/ORDER BY of a window may contain subqueries. They have to be turned into Apply
+        // operators before the expressions below are translated, because that translation has no
+        // OptExprBuilder to plan them with: a scalar subquery would become a SubqueryOperator which no rule
+        // ever eliminates (and the FE would end up serializing a TExprNode without a node_type), and an
+        // IN/EXISTS subquery would dereference the null builder.
+        subOpt = windowSubquery(subOpt, projectExpressions);
+
         final ExpressionMapping expressionMapping = subOpt.getExpressionMapping();
         boolean allColumnRef = true;
         Map<Expr, ColumnRefOperator> tempMapping = new HashMap<>();
@@ -445,6 +456,67 @@ public class QueryTransformer {
         }
 
         return subOpt;
+    }
+
+    /**
+     * Plan every subquery used by a window's PARTITION BY/ORDER BY expressions into an Apply operator on top of
+     * subOpt, and record the resulting column reference in the expression mapping so that any later translation of
+     * the enclosing expression resolves it to that column instead of building a new SubqueryOperator.
+     */
+    private OptExprBuilder windowSubquery(OptExprBuilder subOpt, List<Expr> projectExpressions) {
+        for (Expr expression : projectExpressions) {
+            subOpt = windowSubquery(subOpt, expression);
+        }
+        return subOpt;
+    }
+
+    private OptExprBuilder windowSubquery(OptExprBuilder subOpt, Expr expression) {
+        if (subOpt.getExpressionMapping().get(expression) != null) {
+            return subOpt;
+        }
+
+        // Only the expression that consumes a subquery as a whole can be planned: a quantified/existential
+        // predicate becomes the Apply itself, so translating its Subquery child on its own would both lose the
+        // predicate and turn a multi-row subquery into a scalar one. Anything else is descended into, so that a
+        // subquery buried in e.g. abs((select ...)) still gets planned.
+        if (!ownsSubquery(expression)) {
+            for (Expr child : expression.getChildren()) {
+                subOpt = windowSubquery(subOpt, child);
+            }
+            return subOpt;
+        }
+
+        Map<ScalarOperator, SubqueryOperator> subqueryPlaceholders = Maps.newHashMap();
+        ScalarOperator scalarOperator = SqlToScalarOperatorTranslator.translate(expression,
+                subOpt.getExpressionMapping(), columnRefFactory, session, cteContext, subOpt,
+                subqueryPlaceholders, false);
+        Pair<ScalarOperator, OptExprBuilder> pair =
+                SubqueryUtils.rewriteScalarOperator(scalarOperator, subOpt, subqueryPlaceholders);
+        subOpt = pair.second;
+        if (!pair.first.isColumnRef()) {
+            throw new StarRocksPlannerException(
+                    "subquery in window partition by/order by is not supported", INTERNAL_ERROR);
+        }
+        subOpt.getExpressionMapping().put(expression, (ColumnRefOperator) pair.first);
+        return subOpt;
+    }
+
+    /**
+     * Whether the expression is the one SqlToScalarOperatorTranslator turns into an Apply, i.e. the ones whose
+     * visitor needs a non-null OptExprBuilder. Everything else treats a subquery as an ordinary child.
+     */
+    private static boolean ownsSubquery(Expr expression) {
+        if (expression instanceof Subquery) {
+            return true;
+        } else if (expression instanceof ExistsPredicate) {
+            return expression.getChild(0) instanceof Subquery;
+        } else if (expression instanceof MultiInPredicate) {
+            MultiInPredicate predicate = (MultiInPredicate) expression;
+            return predicate.getChild(predicate.getNumberOfColumns()) instanceof Subquery;
+        } else if (expression instanceof InPredicate) {
+            return expression.getChild(1) instanceof Subquery;
+        }
+        return false;
     }
 
     private OptExprBuilder limit(OptExprBuilder subOpt, LimitElement limit) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/ExprToThriftTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/ExprToThriftTest.java
@@ -185,10 +185,12 @@ public class ExprToThriftTest {
                     StarRocksPlannerException.class));
             cases.add(exceptionCase("ArrowExpr", ExprCaseFactory::buildArrowExpr,
                     StarRocksPlannerException.class));
+            // A subquery has to be rewritten into a join/apply by the optimizer. Serializing one used to
+            // produce a TExprNode without a node_type, which the BE rejects with an unhelpful thrift error.
+            cases.add(exceptionCase("Subquery", ExprCaseFactory::buildSubquery,
+                    StarRocksPlannerException.class));
 
             // Miscellaneous
-            cases.add(nodeCase("Subquery", ExprCaseFactory::buildSubquery, null,
-                    node -> Assertions.assertFalse(node.isSetNode_type())));
             cases.add(nodeCase("DefaultValueExpr", ExprCaseFactory::buildDefaultValueExpr, null,
                     node -> Assertions.assertFalse(node.isSetNode_type())));
             cases.add(exceptionCase("IntervalLiteral", ExprCaseFactory::buildIntervalLiteral,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
@@ -77,6 +77,44 @@ public class WindowTest extends PlanTestBase {
     }
 
     @Test
+    public void testSubqueryInWindowPartitionByAndOrderBy() throws Exception {
+        // The subquery has to be planned as an Apply/join below the window. Leaving it as a SubqueryOperator
+        // makes the FE emit a TExprNode without a node_type, which the BE rejects.
+        String sql = "select dense_rank() over (order by abs((select max(v1) from t0)))";
+        assertNotContains(getThriftPlan(sql), "node_type:null");
+        assertContains(getFragmentPlan(sql), "ANALYTIC\n" +
+                "  |  functions: [, dense_rank(), ]\n" +
+                "  |  order by: 8: abs ASC");
+
+        sql = "select dense_rank() over (partition by (select max(v1) from t0)) from t1";
+        assertNotContains(getThriftPlan(sql), "node_type:null");
+        assertContains(getFragmentPlan(sql), "partition by: 8: max");
+
+        // A subquery used directly as the order by expression used to fail analysis with
+        // "slot type shouldn't be invalid", because it was translated to an INVALID-typed operator.
+        sql = "select row_number() over (order by (select max(v1) from t0)) from t1";
+        assertNotContains(getThriftPlan(sql), "node_type:null");
+        assertContains(getFragmentPlan(sql), "order by: 8: max ASC");
+    }
+
+    @Test
+    public void testQuantifiedSubqueryInWindowPartitionByAndOrderBy() throws Exception {
+        // A quantified/existential subquery is planned together with its predicate, because that predicate is
+        // what becomes the Apply. Planning its Subquery child on its own dereferenced a null OptExprBuilder.
+        String sql = "select row_number() over (partition by v4 in (select v1 from t0) order by v4) from t1";
+        assertNotContains(getThriftPlan(sql), "node_type:null");
+        assertContains(getFragmentPlan(sql), "ANALYTIC");
+
+        sql = "select row_number() over (order by v4 not in (select v1 from t0)) from t1";
+        assertNotContains(getThriftPlan(sql), "node_type:null");
+        assertContains(getFragmentPlan(sql), "ANALYTIC");
+
+        sql = "select row_number() over (partition by exists (select v1 from t0) order by v4) from t1";
+        assertNotContains(getThriftPlan(sql), "node_type:null");
+        assertContains(getFragmentPlan(sql), "ANALYTIC");
+    }
+
+    @Test
     public void testPruneWindowColumn() throws Exception {
         String sql = "select sum(t1c) from (select t1c, lag(id_datetime, 1, '2020-01-01') over( partition by t1c)" +
                 "from test_all_type) a ;";

--- a/test/sql/test_window_function/R/test_window_partition_order_by_subquery
+++ b/test/sql/test_window_function/R/test_window_partition_order_by_subquery
@@ -1,0 +1,104 @@
+-- name: test_window_partition_order_by_subquery
+CREATE TABLE `t0` (
+  `v1` int(11) NULL,
+  `v2` int(11) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 3
+PROPERTIES (
+  "replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `t1` (
+  `k1` int(11) NULL,
+  `k2` int(11) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+PROPERTIES (
+  "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO `t0` (v1, v2) VALUES (1, 10), (2, 20), (3, 30);
+-- result:
+-- !result
+INSERT INTO `t1` (k1, k2) VALUES (1, 100), (2, 200), (3, 300);
+-- result:
+-- !result
+select k1, dense_rank() over (order by abs((select max(v1) from t0))) as r from t1 order by k1;
+-- result:
+1	1
+2	1
+3	1
+-- !result
+select k1, count(1) over (order by (select max(v1) from t0)) as c from t1 order by k1;
+-- result:
+1	3
+2	3
+3	3
+-- !result
+select k1, dense_rank() over (partition by (select max(v1) from t0) order by k1) as r from t1 order by k1;
+-- result:
+1	1
+2	2
+3	3
+-- !result
+select k1,
+       sum(k2) over (partition by (select min(v1) from t0) order by k1 + (select count(*) from t0)) as s
+from t1 order by k1;
+-- result:
+1	100
+2	300
+3	600
+-- !result
+select k1, k2 + (select max(v2) from t0) as e,
+       row_number() over (partition by (select max(v1) from t0) order by k1 desc) as rn
+from t1 order by k1;
+-- result:
+1	130	3
+2	230	2
+3	330	1
+-- !result
+select k1, dense_rank() over (partition by k1 in (select v1 from t0 where v1 <= 2) order by k1) as r
+from t1 order by k1;
+-- result:
+1	1
+2	2
+3	1
+-- !result
+select k1, count(1) over (order by k1 in (select v1 from t0 where v1 <= 2)) as c from t1 order by k1;
+-- result:
+1	3
+2	3
+3	1
+-- !result
+select k1, count(1) over (order by k1 not in (select v1 from t0 where v1 <= 2)) as c from t1 order by k1;
+-- result:
+1	2
+2	2
+3	3
+-- !result
+select k1, dense_rank() over (partition by exists (select v1 from t0 where v1 > 100) order by k1) as r
+from t1 order by k1;
+-- result:
+1	1
+2	2
+3	3
+-- !result
+select k1, dense_rank() over (partition by exists (select 1 from t0 where t0.v1 = t1.k1 and t0.v2 >= 20)
+                              order by k1) as r
+from t1 order by k1;
+-- result:
+1	1
+2	1
+3	2
+-- !result
+select k1, count(1) over (order by (k1 in (select v1 from t0 where v1 <= 2)) or k1 = 3) as c
+from t1 order by k1;
+-- result:
+1	3
+2	3
+3	3
+-- !result

--- a/test/sql/test_window_function/T/test_window_partition_order_by_subquery
+++ b/test/sql/test_window_function/T/test_window_partition_order_by_subquery
@@ -1,0 +1,64 @@
+-- name: test_window_partition_order_by_subquery
+CREATE TABLE `t0` (
+  `v1` int(11) NULL,
+  `v2` int(11) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 3
+PROPERTIES (
+  "replication_num" = "1"
+);
+
+CREATE TABLE `t1` (
+  `k1` int(11) NULL,
+  `k2` int(11) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+PROPERTIES (
+  "replication_num" = "1"
+);
+
+INSERT INTO `t0` (v1, v2) VALUES (1, 10), (2, 20), (3, 30);
+INSERT INTO `t1` (k1, k2) VALUES (1, 100), (2, 200), (3, 300);
+
+-- A scalar subquery nested inside the window's ORDER BY expression. It has to be planned as an
+-- Apply below the window, otherwise the FE emits a TExprNode without a node_type and the BE
+-- rejects the fragment with "Required field 'node_type' was not present!".
+select k1, dense_rank() over (order by abs((select max(v1) from t0))) as r from t1 order by k1;
+
+-- The same subquery used directly as the window's ORDER BY expression. This used to fail
+-- analysis with "slot type shouldn't be invalid".
+select k1, count(1) over (order by (select max(v1) from t0)) as c from t1 order by k1;
+
+-- Scalar subquery as the window's PARTITION BY expression.
+select k1, dense_rank() over (partition by (select max(v1) from t0) order by k1) as r from t1 order by k1;
+
+-- Subqueries in both PARTITION BY and ORDER BY, plus one nested in an expression.
+select k1,
+       sum(k2) over (partition by (select min(v1) from t0) order by k1 + (select count(*) from t0)) as s
+from t1 order by k1;
+
+-- The window's subquery may also appear in the select list and in an aggregate below the window.
+select k1, k2 + (select max(v2) from t0) as e,
+       row_number() over (partition by (select max(v1) from t0) order by k1 desc) as rn
+from t1 order by k1;
+
+-- A quantified or existential subquery has to be planned together with its predicate: that predicate is
+-- what becomes the Apply. Planning its Subquery child on its own used to dereference a null
+-- OptExprBuilder ("Cannot invoke OptExprBuilder.getExpressionMapping() because this.builder is null").
+select k1, dense_rank() over (partition by k1 in (select v1 from t0 where v1 <= 2) order by k1) as r
+from t1 order by k1;
+select k1, count(1) over (order by k1 in (select v1 from t0 where v1 <= 2)) as c from t1 order by k1;
+select k1, count(1) over (order by k1 not in (select v1 from t0 where v1 <= 2)) as c from t1 order by k1;
+select k1, dense_rank() over (partition by exists (select v1 from t0 where v1 > 100) order by k1) as r
+from t1 order by k1;
+
+-- Correlated existential subquery in a window's PARTITION BY.
+select k1, dense_rank() over (partition by exists (select 1 from t0 where t0.v1 = t1.k1 and t0.v2 >= 20)
+                              order by k1) as r
+from t1 order by k1;
+
+-- A quantified subquery nested inside a larger window expression.
+select k1, count(1) over (order by (k1 in (select v1 from t0 where v1 <= 2)) or k1 = 3) as c
+from t1 order by k1;


### PR DESCRIPTION
## Why I'm doing:

reported by fuzzer

```
  com.starrocks.sql.analyzer.SemanticException: Getting analyzing error. Detail message: slot type shouldn't be invalid.
        at com.starrocks.planner.SlotDescriptor.setType(SlotDescriptor.java:144)
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.buildProjectNode(PlanFragmentBuilder.java:779)
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.visit(PlanFragmentBuilder.java:556)
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.visitPhysicalTopN(PlanFragmentBuilder.java:2921)
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.visitPhysicalTopN(PlanFragmentBuilder.java:445)
        at com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator.accept(PhysicalTopNOperator.java:181)
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.visit(PlanFragmentBuilder.java:552)
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.visitPhysicalTopN(PlanFragmentBuilder.java:2921)
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.visitPhysicalTopN(PlanFragmentBuilder.java:445)
        at com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator.accept(PhysicalTopNOperator.java:181)
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.visit(PlanFragmentBuilder.java:552)
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.visitPhysicalAnalytic(PlanFragmentBuilder.java:3493)
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.visitPhysicalAnalytic(PlanFragmentBuilder.java:445)
        at com.starrocks.sql.optimizer.operator.physical.PhysicalWindowOperator.accept(PhysicalWindowOperator.java:154)
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.visit(PlanFragmentBuilder.java:552)
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.translate(PlanFragmentBuilder.java:458)
        at com.starrocks.sql.plan.PlanFragmentBuilder.createPhysicalPlan(PlanFragmentBuilder.java:285)
        at com.starrocks.sql.StatementPlanner.createQueryPlanWithReTry(StatementPlanner.java:438)
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:160)
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:112)
        at com.starrocks.utframe.UtFrameUtils.buildPlan(UtFrameUtils.java:609)
        at com.starrocks.utframe.UtFrameUtils.getPlanAndFragment(UtFrameUtils.java:667)
        at com.starrocks.sql.plan.PlanTestNoneDBBase.getFragmentPlan(PlanTestNoneDBBase.java:286)

```

QueryTransformer.window() translated the partition-by and order-by expressions of an analytic function with the subquery-unaware overload of SqlToScalarOperatorTranslator.translate(). With a null OptExprBuilder, visitSubqueryExpr() falls back to the "set @var = (select ...)" path and returns a bare SubqueryOperator typed INVALID. Nothing ever rewrites that operator into an Apply, so it reached ScalarOperatorToExpr, which turned it back into a Subquery expr, and the FE serialized a TExprNode with no node_type. The BE then rejected the fragment with

    Required field 'node_type' was not present!
      Struct: TExprNode(node_type:null, ...)

A subquery used directly as the window's order-by expression failed earlier with "slot type shouldn't be invalid" for the same reason.

Plan those subqueries into Apply operators before the window's project is built, and map each Subquery expr to the apply's output column so later translations resolve it. Also make ExprToThrift reject a Subquery instead of emitting an incomplete node, so any remaining leak fails in the FE with a readable message rather than as a thrift error on the way to the BE.

Minimal repro:
    select dense_rank() over (order by abs((select max(v1) from t0)));

The SQL test test_window_partition_order_by_subquery covers the end-to-end path: without the fix its first statement fails on the backend with the thrift error above and the remaining four fail in the frontend with "slot type shouldn't be invalid".

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
