### PR TITLE
[BugFix] Share ownership of PassThroughChannel with its sink and receiver

### DIFF
--- a/be/src/compute_env/data_stream/local_pass_through_buffer.cpp
+++ b/be/src/compute_env/data_stream/local_pass_through_buffer.cpp
@@ -134,17 +134,17 @@ PassThroughChunkBuffer::~PassThroughChunkBuffer() {
         LOG(WARNING) << "PassThroughChunkBuffer reference leak detected! query_id=" << print_id(_query_id)
                      << ", _ref_count=" << _ref_count;
     }
-    for (auto& it : _key_to_channel) {
-        delete it.second;
-    }
+    // Channels are shared with the PassThroughContexts that resolved them; dropping the map only
+    // drops this buffer's reference. A channel still referenced by a sink or a receiver stays
+    // alive until that side is destroyed too.
     _key_to_channel.clear();
 }
 
-PassThroughChannel* PassThroughChunkBuffer::get_or_create_channel(const Key& key) {
+PassThroughChannelPtr PassThroughChunkBuffer::get_or_create_channel(const Key& key) {
     std::unique_lock lock(_mutex);
     auto it = _key_to_channel.find(key);
     if (it == _key_to_channel.end()) {
-        auto* channel = new PassThroughChannel();
+        auto channel = std::make_shared<PassThroughChannel>();
         _key_to_channel.emplace(key, channel);
         return channel;
     } else {
@@ -153,7 +153,13 @@ PassThroughChannel* PassThroughChunkBuffer::get_or_create_channel(const Key& key
 }
 
 void PassThroughContext::init() {
+    if (_channel != nullptr) {
+        return;
+    }
     _channel = _chunk_buffer->get_or_create_channel(PassThroughChunkBuffer::Key(_fragment_instance_id, _node_id));
+    // From here on the context owns the channel, so every later use of it is safe regardless of
+    // when the PassThroughChunkBuffer is released.
+    _chunk_buffer = nullptr;
 }
 
 void PassThroughContext::append_chunk(int sender_id, const Chunk* chunk, size_t chunk_size, int32_t driver_sequence) {

--- a/be/src/compute_env/data_stream/local_pass_through_buffer.h
+++ b/be/src/compute_env/data_stream/local_pass_through_buffer.h
@@ -14,6 +14,7 @@
 
 #pragma once
 #include <map>
+#include <memory>
 
 #include "base/hash/hash.h"
 #include "base/hash/hash_std.hpp"
@@ -28,6 +29,12 @@ namespace starrocks {
 // To manage pass through chunks between sink/sources in the same process.
 using ChunkUniquePtrVector = std::vector<std::pair<ChunkUniquePtr, int32_t>>;
 class PassThroughChannel;
+
+// A channel is shared by the local sink and the local receiver of one
+// [fragment_instance_id, dest_node_id] pair, and both of them keep using it while they are being
+// torn down. Ownership is therefore shared: the PassThroughChunkBuffer publishes the channel, but
+// it does not outlive every user of it. See PassThroughContext below.
+using PassThroughChannelPtr = std::shared_ptr<PassThroughChannel>;
 
 class PassThroughChunkBuffer {
 public:
@@ -44,7 +51,7 @@ public:
     };
     PassThroughChunkBuffer(const TUniqueId& query_id);
     ~PassThroughChunkBuffer();
-    PassThroughChannel* get_or_create_channel(const Key& key);
+    PassThroughChannelPtr get_or_create_channel(const Key& key);
     int ref() { return ++_ref_count; }
     int unref() {
         _ref_count -= 1;
@@ -54,7 +61,7 @@ public:
 private:
     std::mutex _mutex;
     const TUniqueId _query_id;
-    std::unordered_map<Key, PassThroughChannel*, KeyHash> _key_to_channel;
+    std::unordered_map<Key, PassThroughChannelPtr, KeyHash> _key_to_channel;
     int _ref_count{1};
 };
 
@@ -71,11 +78,16 @@ public:
     bool is_cancelled() const;
 
 private:
-    // hold this chunk buffer to avoid early deallocation.
+    // Only used by init(), which runs while the owning fragment still holds its
+    // PassThroughChunkBufferGuard. Never dereferenced afterwards.
     PassThroughChunkBuffer* _chunk_buffer;
     TUniqueId _fragment_instance_id;
     PlanNodeId _node_id;
-    PassThroughChannel* _channel = nullptr;
+    // Owning reference. The PassThroughChunkBuffer is released per fragment
+    // (FragmentContext::destroy_pass_through_chunk_buffer), which can happen before the pipelines
+    // that hold this context are torn down; keeping a strong reference here is what makes the
+    // channel outlive both the sink and the receiver instead of only the buffer.
+    PassThroughChannelPtr _channel;
 };
 
 class PassThroughChunkBufferManager {

--- a/be/test/compute_env/CMakeLists.txt
+++ b/be/test/compute_env/CMakeLists.txt
@@ -78,6 +78,7 @@ add_executable(compute_env_test
         load/time_bounded_stream_load_pipe_test.cpp
         load_path_state_helper_test.cpp
         load_path_mgr_test.cpp
+        local_pass_through_buffer_test.cpp
         profile_report_worker_test.cpp
         query/file_scan_split_context_test.cpp
         query/fragment_runtime_state_test.cpp

--- a/be/test/compute_env/local_pass_through_buffer_test.cpp
+++ b/be/test/compute_env/local_pass_through_buffer_test.cpp
@@ -1,0 +1,100 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "compute_env/data_stream/local_pass_through_buffer.h"
+
+#include <gtest/gtest.h>
+
+namespace starrocks {
+
+static TUniqueId make_id(int64_t hi, int64_t lo) {
+    TUniqueId id;
+    id.hi = hi;
+    id.lo = lo;
+    return id;
+}
+
+// A PassThroughContext must keep working after the query's PassThroughChunkBuffer is released.
+//
+// The buffer is refcounted per fragment and released by PassThroughChunkBufferGuard. Both
+// FragmentExecutor::_fail_cleanup() and FragmentContext::count_down_execution_group() drop that
+// reference *before* the fragment's pipelines are destroyed, and pipeline teardown runs
+// ~ExchangeSourceOperatorFactory -> DataStreamRecvr::close() -> PassThroughContext::set_cancelled().
+// If the context only held a raw pointer into the buffer, that is a use-after-free.
+TEST(LocalPassThroughBufferTest, context_outlives_chunk_buffer) {
+    PassThroughChunkBufferManager mgr;
+    const TUniqueId query_id = make_id(2023, 1121);
+    const TUniqueId fragment_instance_id = make_id(2023, 1122);
+    const PlanNodeId dest_node_id = 7;
+
+    mgr.open_fragment_instance(query_id);
+    PassThroughChunkBuffer* buffer = mgr.get(query_id);
+    ASSERT_NE(nullptr, buffer);
+
+    // The local sink and the local receiver of the same [instance, dest node] share one channel.
+    PassThroughContext recvr_ctx(buffer, fragment_instance_id, dest_node_id);
+    recvr_ctx.init();
+    PassThroughContext sink_ctx(buffer, fragment_instance_id, dest_node_id);
+    sink_ctx.init();
+
+    ASSERT_FALSE(recvr_ctx.is_cancelled());
+    ASSERT_FALSE(sink_ctx.is_cancelled());
+
+    // The fragment fails: the last reference to the query's buffer goes away, so the buffer and
+    // everything it published is destroyed, while the pipelines holding these contexts are not.
+    mgr.close_fragment_instance(query_id);
+    ASSERT_EQ(nullptr, mgr.get(query_id));
+
+    // Pipeline teardown happens afterwards and cancels the receiver.
+    recvr_ctx.set_cancelled();
+    EXPECT_TRUE(recvr_ctx.is_cancelled());
+    EXPECT_EQ(0, recvr_ctx.total_bytes());
+
+    // The sink still observes the cancellation through the same shared channel.
+    EXPECT_TRUE(sink_ctx.is_cancelled());
+    EXPECT_EQ(0, sink_ctx.total_bytes());
+}
+
+// Two fragments of the same query share the buffer; releasing one reference must not invalidate
+// the contexts resolved by the other, nor the channel identity they share.
+TEST(LocalPassThroughBufferTest, channel_shared_across_fragment_references) {
+    PassThroughChunkBufferManager mgr;
+    const TUniqueId query_id = make_id(2023, 2121);
+    const TUniqueId fragment_instance_id = make_id(2023, 2122);
+    const PlanNodeId dest_node_id = 9;
+
+    mgr.open_fragment_instance(query_id);
+    mgr.open_fragment_instance(query_id);
+    PassThroughChunkBuffer* buffer = mgr.get(query_id);
+    ASSERT_NE(nullptr, buffer);
+
+    PassThroughContext sink_ctx(buffer, fragment_instance_id, dest_node_id);
+    sink_ctx.init();
+
+    // The sender fragment finishes and drops its reference.
+    mgr.close_fragment_instance(query_id);
+    ASSERT_NE(nullptr, mgr.get(query_id));
+
+    PassThroughContext recvr_ctx(buffer, fragment_instance_id, dest_node_id);
+    recvr_ctx.init();
+
+    // The receiver fragment fails and drops the last reference.
+    mgr.close_fragment_instance(query_id);
+    ASSERT_EQ(nullptr, mgr.get(query_id));
+
+    sink_ctx.set_cancelled();
+    EXPECT_TRUE(recvr_ctx.is_cancelled());
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

```
==372390==ERROR: AddressSanitizer: heap-use-after-free on address 0x50b00068cb98
WRITE of size 1 at 0x50b00068cb98 thread T507
    #2 starrocks::PassThroughChannel::set_cancelled()   local_pass_through_buffer.cpp:115
    #3 starrocks::PassThroughContext::set_cancelled()   local_pass_through_buffer.cpp:180
    #4 starrocks::DataStreamRecvr::close()              data_stream_recvr.cpp:289
    #5 starrocks::pipeline::ExchangeSourceOperatorFactory::~ExchangeSourceOperatorFactory()
   ... starrocks::pipeline::Pipeline::~Pipeline()       pipeline.h:33

freed by thread T507 here:
    #1 starrocks::PassThroughChunkBuffer::~PassThroughChunkBuffer()
    #2 starrocks::PassThroughChunkBufferManager::close_fragment_instance()
    #3 starrocks::DataStreamMgr::destroy_pass_through_chunk_buffer()
    #4 starrocks::pipeline::PassThroughChunkBufferGuard::~PassThroughChunkBufferGuard()
                                                        fragment_context.cpp:77
    #8 starrocks::pipeline::FragmentContext::destroy_pass_through_chunk_buffer()
                                                        fragment_context.cpp:376
    #9 starrocks::orchestration::FragmentExecutor::_fail_cleanup(bool)
                                                        fragment_executor.cpp:1060

```

#76603 made DataStreamRecvr::close() and cancel_stream() write into the PassThroughChannel shared with the local sink, so the receiver is now cancelled during pipeline teardown. That write can land on freed memory.

PassThroughChannel is owned solely by the query's PassThroughChunkBuffer, whose lifetime is a refcount released per fragment by PassThroughChunkBufferGuard. Both FragmentExecutor::_fail_cleanup() and
FragmentContext::count_down_execution_group() drop that reference *before* the fragment's pipelines are destroyed. When it is the last reference, the buffer and all its channels are deleted while a DataStreamRecvr still holds a raw pointer into them; ~ExchangeSourceOperatorFactory then runs close() -> set_cancelled() and writes into the freed channel:

  WRITE of size 1
    PassThroughChannel::set_cancelled()
    PassThroughContext::set_cancelled()
    DataStreamRecvr::close()
    ~ExchangeSourceOperatorFactory()
  freed by
    ~PassThroughChunkBuffer()
    PassThroughChunkBufferManager::close_fragment_instance()
    FragmentContext::destroy_pass_through_chunk_buffer()
    FragmentExecutor::_fail_cleanup()

Rather than ordering the two teardown paths, give the channel the lifetime its users already assume: PassThroughChunkBuffer now publishes shared_ptr channels and PassThroughContext keeps a strong reference, so a channel outlives both the sink and the receiver regardless of when the buffer is released. init() also becomes idempotent and drops the buffer pointer once the channel is resolved, so no raw pointer into the buffer survives.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
