### PR TITLE
[BugFix] Fix out-of-range read and silent row loss in JsonColumn append

### DIFF
--- a/be/src/column/json_column.cpp
+++ b/be/src/column/json_column.cpp
@@ -19,6 +19,7 @@
 #include <sstream>
 
 #include "base/hash/hash_util.hpp"
+#include "column/flat_json/json_merger.h"
 #include "column/mysql_row_buffer.h"
 #include "column/nullable_column.h"
 #include "column/vectorized_fwd.h"
@@ -260,9 +261,8 @@ void JsonColumn::append_selective(const Column& src, const uint32_t* indexes, ui
         return;
     }
     const auto* other_json = down_cast<const JsonColumn*>(&src);
-    if (other_json->is_flat_json() && !is_flat_json()) {
+    if (other_json->is_flat_json() && !is_flat_json() && this->size() == 0) {
         // only hit in AggregateIterator (Aggregate mode in storage)
-        DCHECK_EQ(0, this->size());
         MutableColumns copy;
         copy.reserve(other_json->_flat_columns.size());
         for (const auto& col : other_json->_flat_columns) {
@@ -271,27 +271,25 @@ void JsonColumn::append_selective(const Column& src, const uint32_t* indexes, ui
         set_flat_columns(other_json->flat_column_paths(), other_json->flat_column_types(), std::move(copy));
     }
 
-    if (is_flat_json()) {
-        DCHECK(src.is_object());
-        DCHECK_EQ(_flat_column_paths.size(), other_json->_flat_column_paths.size());
-        DCHECK_EQ(_flat_column_paths.size(), other_json->_flat_column_types.size());
-        DCHECK_EQ(_flat_column_types.size(), other_json->_flat_column_paths.size());
-
-        DCHECK_EQ(_flat_columns.size(), other_json->_flat_columns.size());
-
-        for (size_t i = 0; i < _flat_column_paths.size(); i++) {
-            DCHECK_EQ(_flat_column_paths[i], other_json->_flat_column_paths[i]);
-            DCHECK_EQ(_flat_column_types[i], other_json->_flat_column_types[i]);
+    if (LIKELY(is_equallity_schema(other_json))) {
+        if (is_flat_json()) {
+            for (size_t i = 0; i < _flat_columns.size(); i++) {
+                _flat_columns[i]->append_selective(*other_json->get_flat_field(i), indexes, from, size);
+            }
+        } else {
+            SuperClass::append_selective(src, indexes, from, size);
         }
-
-        for (size_t i = 0; i < _flat_columns.size(); i++) {
-            _flat_columns[i]->append_selective(*other_json->get_flat_field(i), indexes, from, size);
-        }
-    } else {
-        DCHECK(!this->is_flat_json());
-        DCHECK(!other_json->is_flat_json());
-        SuperClass::append_selective(src, indexes, from, size);
+        return;
     }
+
+    // Appending nothing must not cost this column its flat representation.
+    if (size == 0) {
+        return;
+    }
+
+    ColumnPtr plain_src = other_json->unflatten();
+    _degrade_to_plain_json(*other_json);
+    SuperClass::append_selective(plain_src != nullptr ? *plain_src : src, indexes, from, size);
 }
 
 void JsonColumn::append_default(size_t count) {
@@ -342,35 +340,35 @@ void JsonColumn::append(const JsonValue& object) {
 
 void JsonColumn::append(const Column& src, size_t offset, size_t count) {
     const auto* other_json = down_cast<const JsonColumn*>(&src);
-    if (other_json->is_flat_json() && !is_flat_json()) {
+    if (other_json->is_flat_json() && !is_flat_json() && this->size() == 0) {
         // only hit in AggregateIterator (Aggregate mode in storage)
-        DCHECK_EQ(0, this->size());
         MutableColumns copy;
+        copy.reserve(other_json->_flat_columns.size());
         for (const auto& col : other_json->_flat_columns) {
             copy.emplace_back(col->clone_empty());
         }
         set_flat_columns(other_json->flat_column_paths(), other_json->flat_column_types(), std::move(copy));
     }
 
-    if (is_flat_json()) {
-        DCHECK(src.is_object());
-        DCHECK_EQ(_flat_column_paths.size(), other_json->_flat_column_paths.size());
-        DCHECK_EQ(_flat_column_paths.size(), other_json->_flat_column_types.size());
-        DCHECK_EQ(_flat_column_types.size(), other_json->_flat_column_paths.size());
-
-        DCHECK_EQ(_flat_columns.size(), other_json->_flat_columns.size());
-
-        for (size_t i = 0; i < _flat_column_paths.size(); i++) {
-            DCHECK_EQ(_flat_column_paths[i], other_json->_flat_column_paths[i]);
-            DCHECK_EQ(_flat_column_types[i], other_json->_flat_column_types[i]);
+    if (LIKELY(is_equallity_schema(other_json))) {
+        if (is_flat_json()) {
+            for (size_t i = 0; i < _flat_columns.size(); i++) {
+                _flat_columns[i]->append(*other_json->get_flat_field(i), offset, count);
+            }
+        } else {
+            SuperClass::append(src, offset, count);
         }
-
-        for (size_t i = 0; i < _flat_columns.size(); i++) {
-            _flat_columns[i]->append(*other_json->get_flat_field(i), offset, count);
-        }
-    } else {
-        SuperClass::append(src, offset, count);
+        return;
     }
+
+    // Appending nothing must not cost this column its flat representation.
+    if (count == 0) {
+        return;
+    }
+
+    ColumnPtr plain_src = other_json->unflatten();
+    _degrade_to_plain_json(*other_json);
+    SuperClass::append(plain_src != nullptr ? *plain_src : src, offset, count);
 }
 
 size_t JsonColumn::filter_range(const Filter& filter, size_t from, size_t to) {
@@ -485,6 +483,44 @@ bool JsonColumn::is_equallity_schema(const Column* other) const {
         return _flat_columns.size() == other_json->_flat_columns.size();
     }
     return !this->is_flat_json() && !other_json->is_flat_json();
+}
+
+ColumnPtr JsonColumn::unflatten() const {
+    if (!is_flat_json()) {
+        return nullptr;
+    }
+    JsonMerger merger(_flat_column_paths, _flat_column_types, has_remain());
+    // merge() keeps the result alive through the returned ColumnPtr, so it outlives `merger`.
+    return merger.merge(get_flat_fields());
+}
+
+void JsonColumn::_clear_flat_schema() {
+    _flat_columns.clear();
+    _flat_column_paths.clear();
+    _flat_column_types.clear();
+    _path_to_index.clear();
+}
+
+void JsonColumn::to_plain_json() {
+    if (!is_flat_json()) {
+        return;
+    }
+    // While a column is flat every row lives in the flat sub-columns, so the object storage
+    // of the base class must be empty and can simply take over the merged values. Report it
+    // in release builds too: silently ending up with more rows than the sub-columns held is
+    // far harder to diagnose than the mismatch itself.
+    LOG_IF(WARNING, BaseClass::size() != 0)
+            << "flat JSON column also holds " << BaseClass::size() << " plain rows, row count will not match";
+    DCHECK_EQ(0, BaseClass::size());
+    ColumnPtr plain = unflatten();
+    _clear_flat_schema();
+    SuperClass::append(*plain, 0, plain->size());
+}
+
+void JsonColumn::_degrade_to_plain_json(const JsonColumn& src) {
+    LOG_FIRST_N(WARNING, 10) << "flat JSON schema mismatch while appending, falling back to plain JSON. dest="
+                             << debug_flat_paths() << ", src=" << src.debug_flat_paths();
+    to_plain_json();
 }
 
 std::string JsonColumn::debug_flat_paths() const {

--- a/be/src/column/json_column.h
+++ b/be/src/column/json_column.h
@@ -142,6 +142,14 @@ public:
 
     bool is_equallity_schema(const Column* other) const;
 
+    // Materialize the flat sub-columns back into a plain (non-flat) JSON column.
+    // Returns nullptr when this column is not flat.
+    ColumnPtr unflatten() const;
+
+    // In-place unflatten(): keeps the same rows but stores them as plain JSON values and
+    // drops the flat sub-columns. No-op when this column is not flat.
+    void to_plain_json();
+
     std::string debug_flat_paths() const;
 
     void mutate_each_subcolumn() override {
@@ -151,6 +159,14 @@ public:
     }
 
 private:
+    // Flat-JSON schemas are decided per segment, so one scan can produce chunks whose JSON
+    // columns carry different flat schemas (or none at all). When that happens the flat
+    // fast-path of append()/append_selective() is not applicable: degrade this column to
+    // plain JSON, which can always represent whatever the source holds.
+    void _degrade_to_plain_json(const JsonColumn& src);
+
+    void _clear_flat_schema();
+
     // flat-columns[sub_columns, remain_column]
     std::vector<Column::WrappedPtr> _flat_columns;
 

--- a/be/test/column/json_column_test.cpp
+++ b/be/test/column/json_column_test.cpp
@@ -24,7 +24,9 @@
 #include "base/testutil/parallel_test.h"
 #include "column/column_builder.h"
 #include "column/column_helper.h"
+#include "column/flat_json/json_flattener.h"
 #include "column/mysql_row_buffer.h"
+#include "column/nullable_column.h"
 #include "column/runtime_type_traits.h"
 #include "column/vectorized_fwd.h"
 #include "gutil/casts.h"
@@ -491,6 +493,188 @@ PARALLEL_TEST(JsonConvertTest, convert_from_simdjson_big_integer) {
     ondemand::object double_overflow_obj = double_overflow_doc.get_object();
     auto double_overflow_json = JsonValue::from_simdjson(&double_overflow_obj);
     ASSERT_FALSE(double_overflow_json.ok());
+}
+
+// Flat-JSON schemas are decided per segment, so a single scan can hand the same JsonColumn
+// chunks with different flat schemas (or with no flat schema at all). The append paths must
+// reconcile that instead of indexing the flat sub-columns out of range.
+namespace {
+
+MutableColumnPtr make_plain_json(const std::vector<std::string>& jsons) {
+    auto column = JsonColumn::create();
+    for (const auto& str : jsons) {
+        JsonValue value;
+        CHECK(JsonValue::parse(str, &value).ok());
+        column->append(&value);
+    }
+    return column;
+}
+
+MutableColumnPtr make_flat_json(const std::vector<std::string>& jsons, const std::vector<std::string>& paths,
+                                const std::vector<LogicalType>& types, bool has_remain) {
+    auto plain = make_plain_json(jsons);
+    JsonFlattener flattener(paths, types, has_remain);
+    flattener.flatten(plain.get());
+
+    auto column = JsonColumn::create();
+    column->set_flat_columns(paths, types, flattener.mutable_result());
+    return column;
+}
+
+std::vector<std::string> dump_json(const Column& column) {
+    std::vector<std::string> result;
+    for (size_t i = 0; i < column.size(); i++) {
+        result.emplace_back(column.debug_item(i));
+    }
+    return result;
+}
+
+// The plain rendering of a (possibly flat) column, i.e. what a degraded destination must hold.
+std::vector<std::string> plain_dump(const MutableColumnPtr& column) {
+    auto* json = down_cast<JsonColumn*>(column.get());
+    auto plain = json->unflatten();
+    return plain != nullptr ? dump_json(*plain) : dump_json(*column);
+}
+
+} // namespace
+
+PARALLEL_TEST(JsonColumnTest, test_unflatten_roundtrip) {
+    auto flat = make_flat_json({R"({"a": 1, "b": "x"})", R"({"a": 2, "b": "y"})"}, {"a", "b"},
+                               {TYPE_BIGINT, TYPE_VARCHAR}, false);
+    auto* flat_ptr = down_cast<JsonColumn*>(flat.get());
+    ASSERT_TRUE(flat_ptr->is_flat_json());
+
+    auto plain = flat_ptr->unflatten();
+    ASSERT_TRUE(plain != nullptr);
+    ASSERT_FALSE(down_cast<const JsonColumn*>(plain.get())->is_flat_json());
+    ASSERT_EQ(2, plain->size());
+
+    flat_ptr->to_plain_json();
+    ASSERT_FALSE(flat_ptr->is_flat_json());
+    ASSERT_EQ(2, flat_ptr->size());
+    ASSERT_EQ(dump_json(*plain), dump_json(*flat_ptr));
+
+    // to_plain_json() on a plain column is a no-op
+    flat_ptr->to_plain_json();
+    ASSERT_EQ(2, flat_ptr->size());
+    ASSERT_TRUE(flat_ptr->unflatten() == nullptr);
+}
+
+PARALLEL_TEST(JsonColumnTest, test_append_keeps_flat_on_identical_schema) {
+    auto dst = make_flat_json({R"({"a": 1, "b": "x"})"}, {"a", "b"}, {TYPE_BIGINT, TYPE_VARCHAR}, false);
+    auto src = make_flat_json({R"({"a": 2, "b": "y"})"}, {"a", "b"}, {TYPE_BIGINT, TYPE_VARCHAR}, false);
+    auto* dst_ptr = down_cast<JsonColumn*>(dst.get());
+
+    dst_ptr->append(*src, 0, src->size());
+    ASSERT_TRUE(dst_ptr->is_flat_json());
+    ASSERT_EQ(2, dst_ptr->size());
+    dst_ptr->check_or_die();
+}
+
+PARALLEL_TEST(JsonColumnTest, test_append_narrower_flat_schema) {
+    auto dst = make_flat_json({R"({"a": 1, "b": "x"})"}, {"a", "b"}, {TYPE_BIGINT, TYPE_VARCHAR}, false);
+    // a second segment flattened only "a": appending it used to read _flat_columns out of range
+    auto src = make_flat_json({R"({"a": 2})", R"({"a": 3})"}, {"a"}, {TYPE_BIGINT}, false);
+    auto* dst_ptr = down_cast<JsonColumn*>(dst.get());
+    auto expected_head = plain_dump(dst);
+    auto expected_tail = plain_dump(src);
+
+    dst_ptr->append(*src, 0, src->size());
+    ASSERT_FALSE(dst_ptr->is_flat_json());
+    ASSERT_EQ(3, dst_ptr->size());
+    ASSERT_EQ(expected_head[0], dst_ptr->debug_item(0));
+    ASSERT_EQ(expected_tail[0], dst_ptr->debug_item(1));
+    ASSERT_EQ(expected_tail[1], dst_ptr->debug_item(2));
+}
+
+PARALLEL_TEST(JsonColumnTest, test_append_plain_source_into_flat_dest) {
+    auto dst = make_flat_json({R"({"a": 1, "b": "x"})"}, {"a", "b"}, {TYPE_BIGINT, TYPE_VARCHAR}, false);
+    auto src = make_plain_json({R"({"c": true})"});
+    auto* dst_ptr = down_cast<JsonColumn*>(dst.get());
+
+    dst_ptr->append(*src, 0, src->size());
+    ASSERT_FALSE(dst_ptr->is_flat_json());
+    ASSERT_EQ(2, dst_ptr->size());
+    ASSERT_EQ(src->debug_item(0), dst_ptr->debug_item(1));
+}
+
+PARALLEL_TEST(JsonColumnTest, test_append_flat_source_into_non_empty_plain_dest) {
+    auto dst = make_plain_json({R"({"c": true})"});
+    auto src = make_flat_json({R"({"a": 2})"}, {"a"}, {TYPE_BIGINT}, false);
+    auto* dst_ptr = down_cast<JsonColumn*>(dst.get());
+    auto expected_tail = plain_dump(src);
+
+    // the destination already has rows, so it must not adopt the source's flat schema
+    dst_ptr->append(*src, 0, src->size());
+    ASSERT_FALSE(dst_ptr->is_flat_json());
+    ASSERT_EQ(2, dst_ptr->size());
+    ASSERT_EQ(expected_tail[0], dst_ptr->debug_item(1));
+}
+
+PARALLEL_TEST(JsonColumnTest, test_append_selective_flat_schema_mismatch) {
+    auto dst = make_flat_json({R"({"a": 1, "b": "x"})"}, {"a", "b"}, {TYPE_BIGINT, TYPE_VARCHAR}, false);
+    auto src = make_flat_json({R"({"a": 2})", R"({"a": 3})", R"({"a": 4})"}, {"a"}, {TYPE_BIGINT}, false);
+    auto* dst_ptr = down_cast<JsonColumn*>(dst.get());
+    auto expected = plain_dump(src);
+
+    std::vector<uint32_t> indexes{2, 0};
+    dst_ptr->append_selective(*src, indexes.data(), 0, indexes.size());
+    ASSERT_FALSE(dst_ptr->is_flat_json());
+    ASSERT_EQ(3, dst_ptr->size());
+    ASSERT_EQ(expected[2], dst_ptr->debug_item(1));
+    ASSERT_EQ(expected[0], dst_ptr->debug_item(2));
+}
+
+PARALLEL_TEST(JsonColumnTest, test_append_with_remain_column) {
+    auto dst = make_flat_json({R"({"a": 1, "z": [1, 2]})"}, {"a"}, {TYPE_BIGINT}, true);
+    auto src = make_flat_json({R"({"a": 2, "b": "y", "z": {"k": 1}})"}, {"a", "b"}, {TYPE_BIGINT, TYPE_VARCHAR}, true);
+    auto* dst_ptr = down_cast<JsonColumn*>(dst.get());
+    ASSERT_TRUE(dst_ptr->has_remain());
+    auto expected_head = plain_dump(dst);
+    auto expected_tail = plain_dump(src);
+
+    // different schemas, both with a remain column: the merged values must survive
+    dst_ptr->append(*src, 0, src->size());
+    ASSERT_FALSE(dst_ptr->is_flat_json());
+    ASSERT_EQ(2, dst_ptr->size());
+    ASSERT_EQ(expected_head[0], dst_ptr->debug_item(0));
+    ASSERT_EQ(expected_tail[0], dst_ptr->debug_item(1));
+}
+
+PARALLEL_TEST(JsonColumnTest, test_empty_append_keeps_flat_schema) {
+    auto dst = make_flat_json({R"({"a": 1, "b": "x"})"}, {"a", "b"}, {TYPE_BIGINT, TYPE_VARCHAR}, false);
+    auto src = make_flat_json({R"({"a": 2})"}, {"a"}, {TYPE_BIGINT}, false);
+    auto* dst_ptr = down_cast<JsonColumn*>(dst.get());
+
+    dst_ptr->append(*src, 0, 0);
+    ASSERT_TRUE(dst_ptr->is_flat_json());
+    ASSERT_EQ(1, dst_ptr->size());
+
+    dst_ptr->append_selective(*src, nullptr, 0, 0);
+    ASSERT_TRUE(dst_ptr->is_flat_json());
+    ASSERT_EQ(1, dst_ptr->size());
+}
+
+PARALLEL_TEST(JsonColumnTest, test_nullable_wrapper_survives_degrade) {
+    // the flat sub-columns carry their own nulls; the outer null column must stay in sync
+    auto dst_data = make_flat_json({R"({"a": 1})", R"({"a": 2})"}, {"a"}, {TYPE_BIGINT}, false);
+    auto dst_nulls = NullColumn::create();
+    dst_nulls->append(0);
+    dst_nulls->append(1);
+    auto dst = NullableColumn::create(std::move(dst_data), std::move(dst_nulls));
+
+    auto src_data = make_flat_json({R"({"b": "y"})"}, {"b"}, {TYPE_VARCHAR}, false);
+    auto src_nulls = NullColumn::create();
+    src_nulls->append(0);
+    auto src = NullableColumn::create(std::move(src_data), std::move(src_nulls));
+
+    dst->append(*src, 0, 1);
+    ASSERT_EQ(3, dst->size());
+    dst->check_or_die();
+    ASSERT_FALSE(down_cast<const JsonColumn*>(dst->data_column().get())->is_flat_json());
+    ASSERT_FALSE(dst->is_null(0));
+    ASSERT_TRUE(dst->is_null(1));
+    ASSERT_FALSE(dst->is_null(2));
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

```
json_column.cpp:347] Check failed: 0 == this->size() (0 vs. 4)
  starrocks::JsonColumn::append(Column const&, size_t, size_t)
  <- starrocks::NullableColumn::append
  <- starrocks::Chunk::append(Chunk const&, size_t, size_t)
  <- starrocks::HeapMergeIterator::do_get_next(Chunk*)
  <- starrocks::AggregateIterator::do_get_next(Chunk*)
  <- starrocks::TabletReader::do_get_next(Chunk*)
```

Flat-JSON schemas are decided per segment, so a single scan can hand one JsonColumn chunks that are flattened along different paths, or not flattened at all. JsonColumn::append and append_selective only validated that with DCHECK/DCHECK_EQ, which compile out in release builds. Two separate defects follow from that.

1. Out-of-range read. After the (no-op) DCHECKs, the flat branch indexed _flat_columns and the source's flat fields by position, reading past the end of the source's vector whenever it had fewer -- or zero -- flat columns. This hits both when the destination is flat and the source is flat along fewer paths, and when the source is not flat at all, in which case the very first iteration indexes an empty vector.

2. Silent row loss. The branch that lets an empty destination adopt the source's flat schema was guarded only by DCHECK_EQ(0, this->size()), so in release builds it also fired on a destination that already held rows: it installed empty flat sub-columns on a non-empty column, after which size() reports the sub-columns' row count and the rows already sitting in the object pool become unreachable. That returns wrong results without any error -- arguably worse than the crash above.

Fix (1) by checking the schemas with the existing is_equallity_schema() instead. When they do not match, degrade the destination to plain JSON and append a materialized plain view of the source, which is always representable; every consumer of a JSON column already re-checks is_flat_json() per chunk, so a degraded column simply takes the plain path. An append of zero rows never degrades the destination.

Fix (2) by making the adoption conditional on this->size() == 0. The two fixes are not interchangeable: the schema check does not help defect 2, because adoption runs first and leaves both sides with an identical schema, so the check then passes and the rows are lost anyway; and the size() guard does not help defect 1, because adoption is skipped entirely in both of its cases.

Note on severity: this hardens validation that is a no-op in release builds. On current main the mismatch could not be reached from SQL -- 16 query shapes were tried against a cluster whose segments were verified (via meta_tool) to carry genuinely different flat schemas, covering DUP/AGG tables, ORDER BY, UNION ALL, INSERT SELECT, compaction, cross join, and both settings of enable_lazy_dynamic_flat_json. Obtaining a flat JsonColumn requires a ColumnAccessPath (the column is only used through subfields), and its sole consumer is then a json_query expression that immediately produces a plain column; passing the column through as an output slot instead widens the access path to the whole column, which makes the reader merge it back to plain. The FE additionally rejects JSON as a sort/group/join key. So this is defence in depth against a future plan shape, not a fix for a reachable crash.

Adds JsonColumn::unflatten()/to_plain_json() for the fallback and unit tests covering identical, narrower, absent, remain-carrying and per-row-selective source schemas, the non-empty destination, the zero-row append, and a nullable-wrapped degrade.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
