### PR TITLE
[BugFix] Decide property satisfaction once when enforcing it

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/EnforceAndCostTask.java
@@ -348,10 +348,21 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
         setSatisfiedPropertyWithCost(outputProperty, childrenOutputProperties);
         PhysicalPropertySet requiredProperty = context.getRequiredProperty();
         recordPlanEnumInfo(groupExpression, outputProperty, childrenOutputProperties);
+        // Whether a property is satisfied is not a pure function: HashDistributionSpec.isSatisfy() asks
+        // ColocateTableIndex whether the colocate group is stable, and ColocateTableBalancer flips that
+        // state concurrently with planning. Decide once here and hand the answer to enforceProperty(),
+        // otherwise a flip between the two questions leaves enforceProperty() with nothing to enforce
+        // and it returns null. Deciding once also keeps the plan on the safe side of the race: whatever
+        // this thread observed first is what the whole decision is built on.
+        boolean satisfyOrderProperty =
+                outputProperty.getSortProperty().isSatisfy(requiredProperty.getSortProperty());
+        boolean satisfyDistributionProperty =
+                outputProperty.getDistributionProperty().isSatisfy(requiredProperty.getDistributionProperty());
         // Enforce property if outputProperty doesn't satisfy context requiredProperty
-        if (!outputProperty.isSatisfy(requiredProperty)) {
+        if (!satisfyOrderProperty || !satisfyDistributionProperty) {
             // Enforce the property to meet the required property
-            PhysicalPropertySet enforcedProperty = enforceProperty(outputProperty, requiredProperty);
+            PhysicalPropertySet enforcedProperty =
+                    enforceProperty(outputProperty, requiredProperty, satisfyOrderProperty, satisfyDistributionProperty);
 
             // enforcedProperty is superset of requiredProperty
             if (!enforcedProperty.equals(requiredProperty)) {
@@ -468,13 +479,14 @@ public class EnforceAndCostTask extends OptimizerTask implements Cloneable {
         setPropertyWithCost(groupExpression, requiredProperty, requiredProperty, childrenOutputProperties);
     }
 
+    // satisfyOrderProperty/satisfyDistributionProperty are decided by the caller and passed in on
+    // purpose: re-asking here could give a different answer (see recordCostsAndEnforce) and leave
+    // every branch below unmatched. The caller only calls this when at least one of them is false,
+    // so the branches are exhaustive and the result is never null.
     private PhysicalPropertySet enforceProperty(PhysicalPropertySet outputProperty,
-                                                PhysicalPropertySet requiredProperty) {
-        boolean satisfyOrderProperty =
-                outputProperty.getSortProperty().isSatisfy(requiredProperty.getSortProperty());
-        boolean satisfyDistributionProperty =
-                outputProperty.getDistributionProperty().isSatisfy(requiredProperty.getDistributionProperty());
-
+                                                PhysicalPropertySet requiredProperty,
+                                                boolean satisfyOrderProperty,
+                                                boolean satisfyDistributionProperty) {
         PhysicalPropertySet enforcedProperty = null;
         if (!satisfyDistributionProperty && satisfyOrderProperty) {
             if (requiredProperty.getSortProperty().isEmpty()) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/task/EnforcePropertyColocateRaceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/task/EnforcePropertyColocateRaceTest.java
@@ -1,0 +1,84 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.task;
+
+import com.starrocks.catalog.ColocateTableIndex;
+import com.starrocks.common.FeConstants;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+// Whether a physical property is satisfied is not a pure function: HashDistributionSpec.isSatisfy()
+// asks ColocateTableIndex whether the colocate group is stable, and the ColocateTableBalancer daemon
+// flips that state concurrently. EnforceAndCostTask used to ask twice -- once to decide that the
+// property needs enforcing, once inside enforceProperty() to pick the enforcer -- so a flip between
+// the two made enforceProperty() fall through all of its branches and return null, and the caller
+// dereferenced it.
+public class EnforcePropertyColocateRaceTest {
+    private static ConnectContext ctx;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        UtFrameUtils.addMockBackend(10002);
+        UtFrameUtils.addMockBackend(10003);
+        ctx = UtFrameUtils.createDefaultCtx();
+        ctx.getSessionVariable().setOptimizerExecuteTimeout(30000);
+        FeConstants.runningUnitTest = true;
+        StarRocksAssert starRocksAssert = new StarRocksAssert(ctx);
+        starRocksAssert.withDatabase("colocate_race_db").useDatabase("colocate_race_db");
+        starRocksAssert.withTable("" +
+                "CREATE TABLE t1 (\n" +
+                "dt DATE NOT NULL,\n" +
+                "c1 INT NOT NULL,\n" +
+                "v1 BIGINT NOT NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(dt, c1)\n" +
+                "PARTITION BY RANGE(dt) (\n" +
+                "  START (\"2022-01-01\") END (\"2022-02-01\") EVERY (INTERVAL 1 day))\n" +
+                "DISTRIBUTED BY HASH(c1) BUCKETS 4\n" +
+                "PROPERTIES(\"replication_num\" = \"1\", \"colocate_with\" = \"cg_colocate_race\");");
+    }
+
+    @Test
+    public void testPlanningSurvivesColocateGroupFlippingStability() throws Exception {
+        // Every other question about the group's stability gets the opposite answer, which is what a
+        // balancer running concurrently with the optimizer looks like from the planner's side.
+        AtomicInteger calls = new AtomicInteger();
+        new MockUp<ColocateTableIndex>() {
+            @Mock
+            public boolean isGroupUnstable(ColocateTableIndex.GroupId groupId) {
+                return calls.getAndIncrement() % 2 == 0;
+            }
+        };
+
+        String sql = "select count(*), sum(s), min(s), max(s) from " +
+                "(select c1, sum(v1) s from t1 group by c1 limit 10) x";
+        // The plan itself is whatever the flipping answers make it; all that matters is that
+        // planning completes instead of dereferencing a null enforced property.
+        for (int i = 0; i < 16; i++) {
+            final int round = i;
+            Assertions.assertDoesNotThrow(() -> UtFrameUtils.getPlanAndFragment(ctx, sql),
+                    "planning must not fail when the colocate group's stability flips, round " + round);
+        }
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Planning a query over a colocate table could fail with

  NullPointerException: Cannot invoke "PhysicalPropertySet.equals(Object)"
  because "enforcedProperty" is null

Whether a physical property is satisfied is not a pure function. HashDistributionSpec.isSatisfy() asks ColocateTableIndex whether the colocate group is stable, and the ColocateTableBalancer daemon flips that state while the optimizer runs. recordCostsAndEnforce() asked twice: once through PhysicalPropertySet.isSatisfy() to decide that the property needs enforcing, and once again inside enforceProperty(), which re-derives the same two component answers to pick an enforcer. enforceProperty() has a branch for "distribution unsatisfied", one for "order unsatisfied" and one for both, so a flip to "everything is satisfied" between the two questions leaves all of them unmatched and returns null, which the caller then dereferences.

This is easy to hit right after a colocate table is created on a multi-BE cluster, while the balancer is still working on the fresh group.

Decide the two component answers once in the caller and pass them down. The branches are then exhaustive by construction -- the caller only enforces when at least one of them is false -- and the whole decision is built on what this thread observed first, rather than on two observations that can disagree.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
