### PR TITLE
[BugFix] Stop count() over an array of decimal from producing an INVALID type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
@@ -462,13 +462,19 @@ public class DecimalV3FunctionAnalyzer {
         }
 
         Function newFn = fn;
-        if (DECIMAL_AGG_FUNCTION_SAME_TYPE.contains(fnName) || DECIMAL_AGG_FUNCTION_WIDER_TYPE.contains(fnName)) {
+        // The widening rewriting has something to do only when the aggregated argument is itself a decimal.
+        // count(array<decimal(10,2)>) reaches this method only because argumentTypeContainDecimalV3 also
+        // matches an ARRAY whose *item* type is decimal, and there is no decimal to widen. Leave the resolved
+        // builtin alone, exactly as count(array<int>) does - it never enters this method at all.
+        boolean sameTypeAgg = DECIMAL_AGG_FUNCTION_SAME_TYPE.contains(fnName);
+        boolean widerTypeAgg = DECIMAL_AGG_FUNCTION_WIDER_TYPE.contains(fnName) && argumentTypes[0].isDecimalV3();
+        if (sameTypeAgg || widerTypeAgg) {
             Type commonType = InvalidType.INVALID;
             if (FunctionSet.HISTOGRAM.equals(fnName) || FunctionSet.HISTOGRAM_HLL_NDV.equals(fnName)) {
                 commonType = VarcharType.VARCHAR;
-            } else if (DECIMAL_AGG_FUNCTION_SAME_TYPE.contains(fnName)) {
+            } else if (sameTypeAgg) {
                 commonType = argumentTypes[0];
-            } else if (DECIMAL_AGG_FUNCTION_WIDER_TYPE.contains(fnName) && argumentTypes[0].isDecimalV3()) {
+            } else {
                 ScalarType argScalarType = (ScalarType) argumentTypes[0];
                 int precision;
                 if (argScalarType.isDecimal256()) {
@@ -485,6 +491,12 @@ public class DecimalV3FunctionAnalyzer {
                 commonType = TypeFactory.createDecimalV3Type(commonPrimitiveType, precision, scale);
 
             }
+
+            // The entry condition is exactly the union of the cases above, so one of them always assigned a
+            // type; for the same-type case its validity comes from the builtin having matched at all. An
+            // INVALID one used to reach the plan and surface much later as "slot type shouldn't be invalid".
+            Preconditions.checkState(commonType.isValid(),
+                    "decimalv3 rewriting produced no common type for %s", fnName);
 
             Type argType = argumentTypes[0];
             // stddev/variance always use decimal128(38,9) to computing result.

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecimalTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecimalTypeTest.java
@@ -228,6 +228,31 @@ public class DecimalTypeTest extends PlanTestBase {
     }
 
     @Test
+    public void testCountOverArrayOfDecimal() throws Exception {
+        // count() is routed through the decimalv3 rewriting because the ARRAY's item type is decimal,
+        // but there is nothing to widen, and the rewriting used to leave the return type INVALID.
+        // That surfaced as "slot type shouldn't be invalid" while building the fragment.
+        starRocksAssert.withTable("CREATE TABLE arr_dec (" +
+                "k INT NULL," +
+                "a32 ARRAY<DECIMAL32(4, 2)> NULL," +
+                "a64 ARRAY<DECIMAL64(10, 2)> NULL," +
+                "a128 ARRAY<DECIMAL128(30, 2)> NULL) " +
+                "DUPLICATE KEY (k) " +
+                "DISTRIBUTED BY HASH (k) " +
+                "properties(\"replication_num\"=\"1\") ;");
+        try {
+            for (String col : new String[] {"a32", "a64", "a128"}) {
+                assertContains(getVerboseExplain("select count(" + col + ") from arr_dec"),
+                        "aggregate: count", "result: BIGINT;");
+                assertContains(getVerboseExplain("select k, count(" + col + ") from arr_dec group by k"),
+                        "aggregate: count", "result: BIGINT;");
+            }
+        } finally {
+            starRocksAssert.dropTable("arr_dec");
+        }
+    }
+
+    @Test
     public void testDecimalV2ArraySlice() throws Exception {
         try {
             Config.enable_decimal_v3 = false;

--- a/test/sql/test_decimal/R/test_count_over_array_of_decimal
+++ b/test/sql/test_decimal/R/test_count_over_array_of_decimal
@@ -1,0 +1,55 @@
+-- name: test_count_over_array_of_decimal
+CREATE TABLE `t_arr_dec` (
+  `k` int(11) NULL,
+  `a32` ARRAY<DECIMAL32(4, 2)> NULL,
+  `a64` ARRAY<DECIMAL64(10, 2)> NULL,
+  `a128` ARRAY<DECIMAL128(30, 2)> NULL,
+  `d64` DECIMAL64(10, 2) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 3
+PROPERTIES (
+  "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t_arr_dec VALUES
+  (1, [1.10, 2.20], [1.10, 2.20], [1.10, 2.20], 1.10),
+  (1, [], [], [], 2.20),
+  (2, NULL, NULL, NULL, NULL),
+  (2, [3.30], [3.30], [3.30], 3.30);
+-- result:
+-- !result
+select count(a32), count(a64), count(a128) from t_arr_dec;
+-- result:
+3	3	3
+-- !result
+select k, count(a32), count(a64), count(a128) from t_arr_dec group by k order by k;
+-- result:
+1	2	2	2
+2	1	1	1
+-- !result
+select count(a64) from t_arr_dec where a64 is not null;
+-- result:
+3
+-- !result
+select count(a64) from (select a64 from t_arr_dec) t;
+-- result:
+3
+-- !result
+select k, count(a64) over (partition by k) as c from t_arr_dec order by k, c;
+-- result:
+1	2
+1	2
+2	1
+2	1
+-- !result
+select count(d64), sum(d64), avg(d64) from t_arr_dec;
+-- result:
+3	6.60	2.20000000
+-- !result
+select k, count(d64), sum(d64) from t_arr_dec group by k order by k;
+-- result:
+1	2	3.30
+2	1	3.30
+-- !result

--- a/test/sql/test_decimal/T/test_count_over_array_of_decimal
+++ b/test/sql/test_decimal/T/test_count_over_array_of_decimal
@@ -1,0 +1,33 @@
+-- name: test_count_over_array_of_decimal
+CREATE TABLE `t_arr_dec` (
+  `k` int(11) NULL,
+  `a32` ARRAY<DECIMAL32(4, 2)> NULL,
+  `a64` ARRAY<DECIMAL64(10, 2)> NULL,
+  `a128` ARRAY<DECIMAL128(30, 2)> NULL,
+  `d64` DECIMAL64(10, 2) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 3
+PROPERTIES (
+  "replication_num" = "1"
+);
+
+INSERT INTO t_arr_dec VALUES
+  (1, [1.10, 2.20], [1.10, 2.20], [1.10, 2.20], 1.10),
+  (1, [], [], [], 2.20),
+  (2, NULL, NULL, NULL, NULL),
+  (2, [3.30], [3.30], [3.30], 3.30);
+
+-- count() over an ARRAY is routed through the decimalv3 rewriting because the item type is
+-- decimal, even though there is nothing to widen. The rewritten function used to keep an
+-- INVALID return type, which only surfaced while building the fragment as the unrelated-looking
+-- "Getting analyzing error. Detail message: slot type shouldn't be invalid.".
+select count(a32), count(a64), count(a128) from t_arr_dec;
+select k, count(a32), count(a64), count(a128) from t_arr_dec group by k order by k;
+select count(a64) from t_arr_dec where a64 is not null;
+select count(a64) from (select a64 from t_arr_dec) t;
+select k, count(a64) over (partition by k) as c from t_arr_dec order by k, c;
+
+-- The widening rewriting itself must keep working for an argument that really is a decimal.
+select count(d64), sum(d64), avg(d64) from t_arr_dec;
+select k, count(d64), sum(d64) from t_arr_dec group by k order by k;


### PR DESCRIPTION
## Why I'm doing:

```
mysql> select count(a32), count(a64), count(a128) from t_arr_dec;
ERROR 1064 (HY000): Getting analyzing error. Detail message: slot type shouldn't be invalid.
```

An aggregate whose argument merely contains a decimal is routed through the decimalv3 rewriting: argumentTypeContainDecimalV3 also matches when an ARRAY's item type is decimal. In the widening branch commonType is only computed when argumentTypes[0] is itself decimalv3, so for count(array<decimal(10,2)>) it stayed InvalidType.INVALID and rectifyAggregationFunction stamped it on the function as its return type.

Nothing rejected that type until the fragment was built, where it surfaced as the unrelated-looking "slot type shouldn't be invalid" from SlotDescriptor.setType. Fall back to the return type of the matched builtin when there is nothing to widen.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
