### PR TITLE
[BugFix] Do not use a global dictionary for aggregate-state columns 

### DIFF
--- a/be/src/exprs/agg/array_agg.h
+++ b/be/src/exprs/agg/array_agg.h
@@ -238,13 +238,41 @@ public:
     }
 
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
-        // Array element is nullable, so we need to extract the data from nullable column first
         const auto* input_column = down_cast<const ArrayColumn*>(column);
         auto offset_size = input_column->get_element_offset_size(row_num);
-        auto& array_element = down_cast<const NullableColumn&>(input_column->elements());
-
+        const auto& array_element = input_column->elements();
         const auto* element_data_column = ColumnHelper::get_data_column(&array_element);
-        size_t element_null_count = array_element.null_count(offset_size.first, offset_size.second);
+
+        // The offsets and the element column must agree on how many elements the array has.
+        // If they don't, the update() below indexes past the element column and hands the state
+        // a wild Slice.
+        if (UNLIKELY(offset_size.first + offset_size.second > element_data_column->size())) {
+            LOG_FIRST_N(ERROR, 20) << "array_agg merge: inconsistent array column"
+                                   << " row=" << row_num << " offset=" << offset_size.first
+                                   << " size=" << offset_size.second << " elements=" << element_data_column->size()
+                                   << " array_rows=" << input_column->size()
+                                   << " elem_nullable=" << array_element.is_nullable();
+            ctx->set_error("array_agg: corrupted array column (offsets exceed element column)");
+            return;
+        }
+
+        // update() reinterprets the element column as the column for LT. Nothing in the type
+        // system ties the two together -- a dictionary-encoded stand-in for a string column is
+        // an INT column -- so check rather than reinterpret.
+        if constexpr (lt_is_string_or_binary<LT>) {
+            if (UNLIKELY(!element_data_column->is_binary() && !element_data_column->is_large_binary())) {
+                LOG_FIRST_N(ERROR, 20) << "array_agg merge: array element column is " << element_data_column->get_name()
+                                       << ", expected a binary column for logical type " << static_cast<int>(LT);
+                ctx->set_error("array_agg: unexpected array element column type");
+                return;
+            }
+        }
+
+        // Array elements are normally nullable, but nothing in the type system guarantees it.
+        size_t element_null_count = array_element.is_nullable()
+                                            ? down_cast<const NullableColumn&>(array_element)
+                                                      .null_count(offset_size.first, offset_size.second)
+                                            : 0;
         DCHECK_LE(element_null_count, offset_size.second);
 
         this->data(state).update(ctx->mem_pool(), *element_data_column, offset_size.first,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
@@ -29,6 +29,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.AggregateType;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -971,6 +972,16 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
             for (ColumnRefOperator column : scanOperator.getColRefToColumnMetaMap().keySet()) {
                 // Condition 1:
                 if (!column.getType().isVarchar()) {
+                    continue;
+                }
+
+                // Condition 1.1: an aggregate-state column stores a serialized aggregate state, not
+                // the values its type describes. The BE reads it with an aggregate function built
+                // from the agg state descriptor and never looks at the column type, so it would
+                // decode the dictionary codes as if they were still the original values.
+                Column aggStateCheck = scanOperator.getColRefToColumnMetaMap().get(column);
+                if (aggStateCheck != null
+                        && aggStateCheck.getAggregationType() == AggregateType.AGG_STATE_UNION) {
                     continue;
                 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -34,6 +34,7 @@ import com.starrocks.common.util.UnionFind;
 import com.starrocks.connector.hive.HiveStorageFormat;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.AggregateType;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
@@ -1155,6 +1156,14 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 continue;
             }
 
+            // Condition 1.2: an aggregate-state column stores a serialized aggregate state, not the
+            // values its type describes. The BE reads it through the agg state descriptor rather than
+            // through the column type, so it would decode dictionary codes as if they were still the
+            // original values.
+            if (isAggStateColumn(scan, column)) {
+                continue;
+            }
+
             // If it's not an extended column, we have to check the cardinality of the column.
             // TODO(murphy) support collect cardinality of extended column
             if (!checkExtendedColumn(scan, column)) {
@@ -1198,6 +1207,11 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         }
 
         return info;
+    }
+
+    private boolean isAggStateColumn(PhysicalOlapScanOperator scan, ColumnRefOperator column) {
+        Column columnMeta = scan.getColRefToColumnMetaMap().get(column);
+        return columnMeta != null && columnMeta.getAggregationType() == AggregateType.AGG_STATE_UNION;
     }
 
     private boolean banArrayColumnWithPredicate(PhysicalScanOperator scan, ColumnRefOperator column) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollectorTest.java
@@ -18,6 +18,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnAccessPath;
 import com.starrocks.catalog.Table;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.ast.AggregateType;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -93,6 +94,55 @@ public class DecodeCollectorTest {
         Assertions.assertFalse(valid,
                 "checkComplexTypeInvalid should return false for renamed complex column when matching by ColumnId");
     }
+
+    /**
+     * An AGG_STATE_UNION column stores a serialized aggregate state rather than the values its
+     * type describes. The BE reads it through the agg state descriptor and never looks at the
+     * column type, so if it were dictionary encoded the reader would decode the dictionary codes
+     * as if they were still the original values and crash on the resulting wild pointers.
+     */
+    @Test
+    public void testAggStateColumnIsNotADictCandidate() throws Exception {
+        SessionVariable session = new SessionVariable();
+        DecodeCollector collector = new DecodeCollector(session, true);
+
+        ColumnRefOperator aggStateRef =
+                new ColumnRefOperator(1, TypeFactory.createVarcharType(100), "v_state", true);
+        Column aggStateCol = new Column("v_state", TypeFactory.createVarcharType(100), true, "");
+        aggStateCol.setAggregationType(AggregateType.AGG_STATE_UNION, false);
+
+        ColumnRefOperator plainRef =
+                new ColumnRefOperator(2, TypeFactory.createVarcharType(100), "v_plain", true);
+        Column plainCol = new Column("v_plain", TypeFactory.createVarcharType(100), true, "");
+
+        Table table = new Table(Table.TableType.OLAP) { };
+        table.setId(1L);
+        table.setName("t");
+
+        PhysicalOlapScanOperator scan = new PhysicalOlapScanOperator(
+                table,
+                Map.of(aggStateRef, aggStateCol, plainRef, plainCol),
+                null,
+                Operator.DEFAULT_LIMIT,
+                null,
+                0L,
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                null,
+                false,
+                null);
+
+        Method method = DecodeCollector.class.getDeclaredMethod(
+                "isAggStateColumn",
+                com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator.class,
+                ColumnRefOperator.class);
+        method.setAccessible(true);
+
+        Assertions.assertTrue((boolean) method.invoke(collector, scan, aggStateRef),
+                "an AGG_STATE_UNION column must never be offered as a global dictionary candidate");
+        Assertions.assertFalse((boolean) method.invoke(collector, scan, plainRef),
+                "an ordinary string column should still be a global dictionary candidate");
+    }
 }
-
-

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityAggStateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityAggStateTest.java
@@ -1,0 +1,117 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.common.FeConstants;
+import com.starrocks.utframe.StarRocksAssert;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * An aggregate-state column stores a serialized aggregate state rather than the values its type
+ * describes. The BE reads it with an aggregate function built from the agg state descriptor and
+ * never looks at the column type, so it must never be dictionary encoded: it would decode the
+ * dictionary codes as if they were still the original values and read wild pointers out of the
+ * code buffer.
+ *
+ * There are two low cardinality implementations and they are mutually exclusive --
+ * AddDecodeNodeForDictStringRule bails out when low_cardinality_optimize_v2 is on and
+ * LowCardinalityRewriteRule bails out when it is off -- so both have to exclude these columns.
+ *
+ * The array queries reference the array as a whole: a bare "select col" is subfield pruned and is
+ * not a dictionary candidate either way, so it cannot tell the two cases apart.
+ */
+public class LowCardinalityAggStateTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withTable("CREATE TABLE `agg_state_dict_t` (\n" +
+                "  `k1` bigint,\n" +
+                "  `a_plain` array<varchar(100)> REPLACE,\n" +
+                "  `s_plain` varchar(100) REPLACE,\n" +
+                "  `v_state` array_agg_distinct(varchar(100)),\n" +
+                "  `s_state` max(varchar(20))\n" +
+                ") ENGINE=OLAP\n" +
+                "AGGREGATE KEY(`k1`)\n" +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 3\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");");
+
+        // the mock dict manager offers a dictionary for every column, so anything a collector is
+        // willing to encode shows up as INT / ARRAY<INT> in the plan
+        FeConstants.USE_MOCK_DICT_MANAGER = true;
+        connectContext.getSessionVariable().setEnableLowCardinalityOptimize(true);
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        FeConstants.USE_MOCK_DICT_MANAGER = false;
+        connectContext.getSessionVariable().setEnableLowCardinalityOptimize(false);
+        connectContext.getSessionVariable().setUseLowCardinalityOptimizeV2(true);
+    }
+
+    private void assertNotEncoded(String sql, String encodedType) throws Exception {
+        String plan = getVerboseExplain(sql);
+        Assertions.assertFalse(plan.contains(encodedType),
+                "aggregate-state column must not be dictionary encoded: " + sql + "\n" + plan);
+        Assertions.assertFalse(plan.contains("DictDecode"),
+                "aggregate-state column must not need a decode: " + sql + "\n" + plan);
+    }
+
+    private void assertEncoded(String sql, String encodedType) throws Exception {
+        String plan = getVerboseExplain(sql);
+        Assertions.assertTrue(plan.contains(encodedType),
+                "an ordinary string column should still be dictionary encoded: " + sql + "\n" + plan);
+    }
+
+    // ---------------------------------------------------------------- LowCardinalityRewriteRule
+
+    @Test
+    public void testAggStateColumnIsNotDictEncodedV2() throws Exception {
+        connectContext.getSessionVariable().setUseLowCardinalityOptimizeV2(true);
+        assertNotEncoded("select array_min(v_state) from agg_state_dict_t", "ARRAY<INT>");
+        assertNotEncoded("select k1 from agg_state_dict_t where v_state[0] = 'a'", "ARRAY<INT>");
+        assertNotEncoded("select k1, array_min(v_state) from agg_state_dict_t group by k1, v_state", "ARRAY<INT>");
+        assertNotEncoded("select max(s_state) from agg_state_dict_t", ", INT,");
+    }
+
+    @Test
+    public void testOrdinaryColumnIsStillDictEncodedV2() throws Exception {
+        connectContext.getSessionVariable().setUseLowCardinalityOptimizeV2(true);
+        assertEncoded("select array_min(a_plain) from agg_state_dict_t", "ARRAY<INT>");
+        assertEncoded("select k1 from agg_state_dict_t where a_plain[0] = 'a'", "ARRAY<INT>");
+        assertEncoded("select max(s_plain) from agg_state_dict_t", ", INT,");
+    }
+
+    // ------------------------------------------------------- AddDecodeNodeForDictStringRule (v1)
+
+    @Test
+    public void testAggStateColumnIsNotDictEncodedV1() throws Exception {
+        connectContext.getSessionVariable().setUseLowCardinalityOptimizeV2(false);
+        // v1 only ever picks scalar varchar columns, and the intermediate type of an
+        // aggregate-state column such as max(varchar) is exactly that
+        assertNotEncoded("select max(s_state) from agg_state_dict_t", ", INT,");
+        assertNotEncoded("select k1 from agg_state_dict_t where s_state = 'a'", ", INT,");
+    }
+
+    @Test
+    public void testOrdinaryColumnIsStillDictEncodedV1() throws Exception {
+        connectContext.getSessionVariable().setUseLowCardinalityOptimizeV2(false);
+        assertEncoded("select max(s_plain) from agg_state_dict_t", ", INT,");
+    }
+}

--- a/test/sql/test_agg_state/R/test_agg_state_low_cardinality_dict.sql
+++ b/test/sql/test_agg_state/R/test_agg_state_low_cardinality_dict.sql
@@ -1,0 +1,81 @@
+-- name: test_agg_state_low_cardinality_dict
+-- An aggregate-state column stores a serialized aggregate state, not the values its type
+-- describes. The BE reads it through the agg state descriptor and never looks at the column
+-- type, so it must never be dictionary encoded.
+--
+-- Getting the FE to offer a dictionary for such a column takes a specific sequence: several
+-- loads, a compaction so the column is written as one dictionary encoded segment, then more
+-- loads so the storage layer still has to merge at read time. The predicate below is what
+-- keeps the column dictionary encoded; reading it through array_agg_distinct_merge would put
+-- it on the decode side instead and would prove nothing.
+CREATE TABLE `t_src` (
+  `id` bigint,
+  `k1` bigint,
+  `s` varchar(100)
+) DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 4
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into t_src select gs, gs % 2000, concat('v', gs % 3) from (select generate_series as gs from TABLE(generate_series(0, 49999))) g;
+-- result:
+-- !result
+CREATE TABLE `t_state` (
+  `k1` bigint,
+  `v_str` array_agg_distinct(varchar(100))
+) DISTRIBUTED BY HASH(`k1`) BUCKETS 4
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into t_state select k1, array_agg_distinct_state(s) from t_src;
+-- result:
+-- !result
+insert into t_state select k1, array_agg_distinct_state(s) from t_src;
+-- result:
+-- !result
+insert into t_state select k1, array_agg_distinct_state(s) from t_src;
+-- result:
+-- !result
+insert into t_state select k1, array_agg_distinct_state(s) from t_src;
+-- result:
+-- !result
+insert into t_state select k1, array_agg_distinct_state(s) from t_src;
+-- result:
+-- !result
+insert into t_state select k1, array_agg_distinct_state(s) from t_src;
+-- result:
+-- !result
+[UC] alter table t_state compact;
+[UC] analyze full table t_src;
+[UC] analyze full table t_state;
+function: wait_global_dict_ready('s', 't_src')
+-- result:
+
+-- !result
+insert into t_state select k1, array_agg_distinct_state(s) from t_src;
+-- result:
+-- !result
+insert into t_state select k1, array_agg_distinct_state(s) from t_src;
+-- result:
+-- !result
+insert into t_state select k1, array_agg_distinct_state(s) from t_src;
+-- result:
+-- !result
+select count(*) from t_state;
+-- result:
+2000
+-- !result
+select count(*) from t_state where v_str[1] = 'v0' or v_str[2] = 'v0' or v_str[3] = 'v0';
+-- result:
+2000
+-- !result
+select count(*) from t_state where v_str[1] = 'nope';
+-- result:
+0
+-- !result
+select k1, array_sort(v_str) from t_state order by k1 limit 3;
+-- result:
+0	["v0","v1","v2"]
+1	["v0","v1","v2"]
+2	["v0","v1","v2"]
+-- !result

--- a/test/sql/test_agg_state/T/test_agg_state_low_cardinality_dict.sql
+++ b/test/sql/test_agg_state/T/test_agg_state_low_cardinality_dict.sql
@@ -1,0 +1,40 @@
+-- name: test_agg_state_low_cardinality_dict
+-- An aggregate-state column stores a serialized aggregate state, not the values its type
+-- describes. The BE reads it through the agg state descriptor and never looks at the column
+-- type, so it must never be dictionary encoded.
+--
+-- Getting the FE to offer a dictionary for such a column takes a specific sequence: several
+-- loads, a compaction so the column is written as one dictionary encoded segment, then more
+-- loads so the storage layer still has to merge at read time. The predicate below is what
+-- keeps the column dictionary encoded; reading it through array_agg_distinct_merge would put
+-- it on the decode side instead and would prove nothing.
+CREATE TABLE `t_src` (
+  `id` bigint,
+  `k1` bigint,
+  `s` varchar(100)
+) DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 4
+PROPERTIES ("replication_num" = "1");
+insert into t_src select gs, gs % 2000, concat('v', gs % 3) from (select generate_series as gs from TABLE(generate_series(0, 49999))) g;
+CREATE TABLE `t_state` (
+  `k1` bigint,
+  `v_str` array_agg_distinct(varchar(100))
+) DISTRIBUTED BY HASH(`k1`) BUCKETS 4
+PROPERTIES ("replication_num" = "1");
+insert into t_state select k1, array_agg_distinct_state(s) from t_src;
+insert into t_state select k1, array_agg_distinct_state(s) from t_src;
+insert into t_state select k1, array_agg_distinct_state(s) from t_src;
+insert into t_state select k1, array_agg_distinct_state(s) from t_src;
+insert into t_state select k1, array_agg_distinct_state(s) from t_src;
+insert into t_state select k1, array_agg_distinct_state(s) from t_src;
+[UC] alter table t_state compact;
+[UC] analyze full table t_src;
+[UC] analyze full table t_state;
+function: wait_global_dict_ready('s', 't_src')
+insert into t_state select k1, array_agg_distinct_state(s) from t_src;
+insert into t_state select k1, array_agg_distinct_state(s) from t_src;
+insert into t_state select k1, array_agg_distinct_state(s) from t_src;
+select count(*) from t_state;
+select count(*) from t_state where v_str[1] = 'v0' or v_str[2] = 'v0' or v_str[3] = 'v0';
+select count(*) from t_state where v_str[1] = 'nope';
+select k1, array_sort(v_str) from t_state order by k1 limit 3;


### PR DESCRIPTION
## Why I'm doing:

```
starrocks_be: be/src/gutil/casts.h:78: To down_cast(From*) [with To = const starrocks::BinaryColumnBase<unsigned int>*; From = const starrocks::Column]: Assertion `f == NULL || dynamic_cast<To>(f) != NULL' failed.
starrocks_be: be/src/gutil/casts.h:78: To down_cast(From*) [with To = const starrocks::BinaryColumnBase<unsigned int>*; From = const starrocks::Column]: Assertion `f == NULL || dynamic_cast<To>(f) != NULL' failed.
PC: @     0x7f18733679bc pthread_kill
*** SIGABRT (@0x3eb003bee47) received by PID 3927623 (TID 0x7f1527e98640) LWP(3928479) from PID 3927623; stack trace: ***
starrocks_be: be/src/gutil/casts.h:78: To down_cast(From*) [with To = const starrocks::BinaryColumnBase<unsigned int>*; From = const starrocks::Column]: Assertion `f == NULL || dynamic_cast<To>(f) != NULL' failed.
    @         0x32c9ff07 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7f187336aea8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ea7)
    @         0x32c9f706 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f1873313520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @     0x7f18733679bc pthread_kill
    @     0x7f1873313476 raise
    @     0x7f18732f97f3 abort
    @     0x7f18732f971b (/usr/lib/x86_64-linux-gnu/libc.so.6+0x2871a)
    @     0x7f187330ae96 __assert_fail
    @         0x1d1317c4 starrocks::BinaryColumnBase<unsigned int> const* down_cast<starrocks::BinaryColumnBase<unsigned int> const*, starrocks::Column const>(starrocks::Column const*)
    @         0x1de76def starrocks::GetContainer<(starrocks::LogicalType)17>::get_data(starrocks::Column const*)
    @         0x25b617f2 starrocks::ArrayAggAggregateState<(starrocks::LogicalType)17, true, phmap::flat_hash_set<starrocks::SliceWithHash, starrocks::HashOnSliceWithHash, starrocks::EqualOnSliceWithHash, std::allocator<starrocks::SliceWithHash> >, int>::update(starrocks::MemPool*@
    @         0x25a335a0 starrocks::ArrayAggAggregateFunctionBase<(starrocks::LogicalType)17, true, starrocks::ArrayAggAggregateState, phmap::flat_hash_set<starrocks::SliceWithHash, starrocks::HashOnSliceWithHash, starrocks::EqualOnSliceWithHash, std::allocator<starrocks::SliceWit@
    @         0x254d1a08 starrocks::NullableAggregateFunctionBase<starrocks::AggregateFunction const*, starrocks::NullableAggregateFunctionState<starrocks::ArrayAggAggregateState<(starrocks::LogicalType)17, true, phmap::flat_hash_set<starrocks::SliceWithHash, starrocks::HashOnSlic@
    @         0x240e615c starrocks::AggStateUnion::merge(starrocks::FunctionContext*, starrocks::Column const*, unsigned char*, unsigned long) const
    @         0x241295a8 starrocks::AggregateFunctionBatchHelper<starrocks::AggStateUnionState, starrocks::AggStateUnion>::merge_batch_single_state(starrocks::FunctionContext*, unsigned char*, starrocks::Column const*, unsigned long, unsigned long) const
    @         0x240e9e8c starrocks::AggFuncBasedValueAggregator::aggregate_batch_impl(int, int, starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> const&)
    @         0x240ea083 starrocks::AggFuncBasedValueAggregator::aggregate_values(int, int, unsigned int const*, bool)
    @         0x240d5f8d starrocks::ChunkAggregator::aggregate()
    @         0x240cc7a4 starrocks::AggregateIterator::do_get_next(starrocks::Chunk*, std::vector<starrocks::RowSourceMask, std::allocator<starrocks::RowSourceMask> >*)
    @         0x240cf4e1 starrocks::AggregateIterator::do_get_next(starrocks::Chunk*)
    @         0x1ccb18a3 starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x240dba0a starrocks::TimedChunkIterator::do_get_next(starrocks::Chunk*)
    @         0x1ccb18a3 starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x21e1cf2a starrocks::TabletReader::do_get_next(starrocks::Chunk*)
    @         0x1ccb18a3 starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x2466bb29 starrocks::ProjectionIterator::do_get_next(starrocks::Chunk*)
    @         0x1ccb18a3 starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x1e684435 starrocks::pipeline::OlapChunkSource::_read_chunk_from_storage(starrocks::RuntimeState*, starrocks::Chunk*)
    @         0x1e682d47 starrocks::pipeline::OlapChunkSource::_read_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)
    @         0x1e662860 starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking(starrocks::RuntimeState*, unsigned long, starrocks::workgroup::WorkGroup const*)
    @         0x1e6463ce auto starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}::operator()<starrocks::workgroup::YieldContext>(starrocks::workgroup::YieldContext&) const
```

An AGG_STATE_UNION column stores a serialized aggregate state, not the values its
type describes. The BE reads it with an aggregate function built from the agg state
descriptor and never looks at the column type, so when the low cardinality
optimization picked such a column the storage layer rewrote it to ARRAY<INT>
dictionary codes while the reader still decoded it as ARRAY<VARCHAR>:

  ArrayAggAggregateState<TYPE_VARCHAR, true, ...>::update
  ArrayAggAggregateFunctionBase<TYPE_VARCHAR, true, ...>::merge
  AggStateUnion::merge
  AggFuncBasedValueAggregator::aggregate_values
  ChunkAggregator::aggregate
  AggregateIterator::do_get_next

down_cast is a plain static_cast in a release build, so get_slice() read the int
buffer as the binary column bytes and offsets and returned a Slice pointing at a
dictionary code, and the BE died hashing it.

Stop offering these columns as global dictionary candidates so the FE and the BE
agree they are never encoded. Doing this on the BE alone is not enough: the FE has
already planned the downstream types as INT, so the exchange sender and receiver
then disagree and the BE fails a NullableColumn size check instead.

The merge path of array_agg also rejects an element column that is not the type it
expects rather than reinterpreting it, and no longer assumes the element column is
nullable. That is a safety net, not the fix.

LowCardinalityAggStateTest was checked against a build with the exclusion disabled:
all three query shapes report ARRAY<INT> for the aggregate-state column without it.
A SQL level test is not included on purpose: whether the FE has collected a global
dictionary for such a column is not something a regression test can force, so the
test would have been permanently green.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
