### PR TITLE
[BugFix] Bound the Teradata and Joda datetime parsers to the input string

### DIFF
--- a/be/src/types/datetime_value.cpp
+++ b/be/src/types/datetime_value.cpp
@@ -426,7 +426,7 @@ bool JodaFormat::prepare(std::string_view format) {
         }
         default: {
             _token_parsers.emplace_back([&, ch](JodaRuntimeState* state, const char* val_end) {
-                if (ch != **(state->valptr)) {
+                if (*(state->valptr) >= val_end || ch != **(state->valptr)) {
                     return false;
                 }
                 *(state->valptr) += 1;
@@ -2483,7 +2483,7 @@ bool TeradataFormat::prepare(std::string_view format) {
             //  - / , . ; :	Punctuation characters are ignored
             auto ignored_char = *ptr;
             _token_parsers.emplace_back([&, ignored_char](TeradataRuntimeState* state, const char* val_end) {
-                if (**(state->valptr) != ignored_char) {
+                if (*(state->valptr) >= val_end || **(state->valptr) != ignored_char) {
                     return false;
                 }
                 *(state->valptr) += 1;
@@ -2547,11 +2547,11 @@ bool TeradataFormat::prepare(std::string_view format) {
             next_ch_ptr++;
             ptr++;
             _token_parsers.emplace_back([&](TeradataRuntimeState* state, const char* val_end) {
-                if (**(state->valptr) != 'a') {
+                if (*(state->valptr) >= val_end || **(state->valptr) != 'a') {
                     return false;
                 }
                 *(state->valptr) += 1;
-                if (**(state->valptr) != 'm') {
+                if (*(state->valptr) >= val_end || **(state->valptr) != 'm') {
                     return false;
                 }
                 *(state->valptr) += 1;
@@ -2570,11 +2570,11 @@ bool TeradataFormat::prepare(std::string_view format) {
             next_ch_ptr++;
             ptr++;
             _token_parsers.emplace_back([&](TeradataRuntimeState* state, const char* val_end) {
-                if (**(state->valptr) != 'p') {
+                if (*(state->valptr) >= val_end || **(state->valptr) != 'p') {
                     return false;
                 }
                 *(state->valptr) += 1;
-                if (**(state->valptr) != 'm') {
+                if (*(state->valptr) >= val_end || **(state->valptr) != 'm') {
                     return false;
                 }
                 *(state->valptr) += 1;

--- a/be/test/types/datetime_value_test.cpp
+++ b/be/test/types/datetime_value_test.cpp
@@ -1549,4 +1549,60 @@ INSTANTIATE_TEST_SUITE_P(
                 // clang-format: on
                 ));
 
+// A value that runs out before the format does must be rejected, not read past its end.
+// The literal-character, am and pm parsers used to dereference the read cursor without
+// consulting val_end, so an empty value crashed the backend on the very first token.
+TEST_F(DateTimeValueTest, teradata_parse_truncated_value) {
+    auto parse = [](std::string_view format, std::string_view value) {
+        TeradataFormat tera;
+        EXPECT_TRUE(tera.prepare(format)) << "format=" << format;
+        DateTimeValue datetime;
+        return tera.parse(value, &datetime);
+    };
+
+    // Empty value, format starting with a punctuation literal.
+    EXPECT_FALSE(parse(";yyyy", ""));
+    EXPECT_FALSE(parse("-yyyy", ""));
+    EXPECT_FALSE(parse(" yyyy", ""));
+    // An empty string_view built from a null pointer takes the same path.
+    EXPECT_FALSE(parse(";yyyy", std::string_view()));
+
+    // Value exhausted midway through the format.
+    EXPECT_FALSE(parse("yyyy/mm/dd", "1988"));
+    EXPECT_FALSE(parse("yyyy/mm/dd", "1988/04/"));
+    EXPECT_FALSE(parse(";yyyy", ";"));
+
+    // am/pm with the value ending inside the marker.
+    EXPECT_FALSE(parse("yyyy/mm/dd hh am", "1988/04/08 02 "));
+    EXPECT_FALSE(parse("yyyy/mm/dd hh am", "1988/04/08 02 a"));
+    EXPECT_FALSE(parse("yyyy/mm/dd hh pm", "1988/04/08 02 p"));
+
+    // Complete values still parse.
+    EXPECT_TRUE(parse(";yyyy", ";1988"));
+    EXPECT_TRUE(parse("yyyy/mm/dd", "1988/04/08"));
+    EXPECT_TRUE(parse("yyyy/mm/dd hh am", "1988/04/08 02 am"));
+    EXPECT_TRUE(parse("yyyy/mm/dd hh pm", "1988/04/08 02 pm"));
+}
+
+TEST_F(DateTimeValueTest, joda_parse_truncated_value) {
+    auto parse = [](std::string_view format, std::string_view value) {
+        joda::JodaFormat joda;
+        EXPECT_TRUE(joda.prepare(format)) << "format=" << format;
+        DateTimeValue datetime;
+        return joda.parse(value, &datetime);
+    };
+
+    EXPECT_FALSE(parse(";yyyy", ""));
+    EXPECT_FALSE(parse("-yyyy", ""));
+    EXPECT_FALSE(parse(";yyyy", std::string_view()));
+
+    EXPECT_FALSE(parse("yyyy-MM-dd", "2024"));
+    EXPECT_FALSE(parse("yyyy-MM-dd", "2024-04-"));
+    EXPECT_FALSE(parse("yyyy-MM-dd HH:mm:ss", "2024-04-01"));
+
+    EXPECT_TRUE(parse(";yyyy", ";2024"));
+    EXPECT_TRUE(parse("yyyy-MM-dd", "2024-04-01"));
+    EXPECT_TRUE(parse("yyyy-MM-dd HH:mm:ss", "2024-04-01 01:02:03"));
+}
+
 } // namespace starrocks

--- a/test/sql/test_time_fn/R/test_to_date
+++ b/test/sql/test_time_fn/R/test_to_date
@@ -107,6 +107,70 @@ select to_tera_timestamp("1988/04/08 02 pm:3:4","yyyy/mm/dd hh am:mi:ss");
 -- result:
 None
 -- !result
+select to_tera_date("", ";yyyy");
+-- result:
+None
+-- !result
+select to_tera_timestamp("", ";yyyy");
+-- result:
+None
+-- !result
+select to_tera_timestamp("", "-yyyy");
+-- result:
+None
+-- !result
+select to_tera_timestamp("", " yyyy");
+-- result:
+None
+-- !result
+select to_tera_timestamp(";", ";yyyy");
+-- result:
+None
+-- !result
+select to_tera_timestamp("1988", "yyyy/mm/dd");
+-- result:
+None
+-- !result
+select to_tera_timestamp("1988/04/", "yyyy/mm/dd");
+-- result:
+None
+-- !result
+select to_tera_timestamp("1988/04/08 02 ", "yyyy/mm/dd hh am");
+-- result:
+None
+-- !result
+select to_tera_timestamp("1988/04/08 02 a", "yyyy/mm/dd hh am");
+-- result:
+None
+-- !result
+select to_tera_timestamp("1988/04/08 02 p", "yyyy/mm/dd hh pm");
+-- result:
+None
+-- !result
+select str_to_jodatime("", ";yyyy");
+-- result:
+None
+-- !result
+select str_to_jodatime("", "-yyyy");
+-- result:
+None
+-- !result
+select str_to_jodatime(";", ";yyyy");
+-- result:
+None
+-- !result
+select str_to_jodatime("2024", "yyyy-MM-dd");
+-- result:
+None
+-- !result
+select str_to_jodatime("2024-04-", "yyyy-MM-dd");
+-- result:
+None
+-- !result
+select str_to_jodatime("2024-04-01", "yyyy-MM-dd HH:mm:ss");
+-- result:
+None
+-- !result
 CREATE TABLE IF NOT EXISTS `to_tera_date_test` (
   `d1` DATE,
   `d2` VARCHAR(1024)

--- a/test/sql/test_time_fn/T/test_to_date
+++ b/test/sql/test_time_fn/T/test_to_date
@@ -32,6 +32,25 @@ select to_tera_date("1988/04/08","xyz/mm/dd");
 select to_tera_timestamp("1988/04/0800 02 pm:3:4","yyyy/mm/dd hh am:mi:ss");
 select to_tera_timestamp("1988/04/08 02 pm:3:4","yyyy/mm/dd hh am:mi:ss");
 
+-- test_to_tera_date_short_input
+-- A value shorter than the format must yield NULL, not read past the end of the string.
+select to_tera_date("", ";yyyy");
+select to_tera_timestamp("", ";yyyy");
+select to_tera_timestamp("", "-yyyy");
+select to_tera_timestamp("", " yyyy");
+select to_tera_timestamp(";", ";yyyy");
+select to_tera_timestamp("1988", "yyyy/mm/dd");
+select to_tera_timestamp("1988/04/", "yyyy/mm/dd");
+select to_tera_timestamp("1988/04/08 02 ", "yyyy/mm/dd hh am");
+select to_tera_timestamp("1988/04/08 02 a", "yyyy/mm/dd hh am");
+select to_tera_timestamp("1988/04/08 02 p", "yyyy/mm/dd hh pm");
+select str_to_jodatime("", ";yyyy");
+select str_to_jodatime("", "-yyyy");
+select str_to_jodatime(";", ";yyyy");
+select str_to_jodatime("2024", "yyyy-MM-dd");
+select str_to_jodatime("2024-04-", "yyyy-MM-dd");
+select str_to_jodatime("2024-04-01", "yyyy-MM-dd HH:mm:ss");
+
 -- test_to_tera_date_from_table
 CREATE TABLE IF NOT EXISTS `to_tera_date_test` (
   `d1` DATE,


### PR DESCRIPTION
## Why I'm doing:

```
query_id:019fc062-f347-7e8c-a4bc-32ce71161e65, fragment_instance:019fc062-f347-7e8c-a4bc-32ce71161e66, plan_node_id:0
*** Aborted at 1785639138 (unix time) try "date -d @1785639138" if you are using GNU date ***
PC: @          0xe686c5f std::_Function_handler<bool (starrocks::joda::JodaRuntimeState*, char const*), starrocks::joda::JodaFormat::prepare(std::basic_string_view<char, std::char_traits<char> >)::{lambda(starrocks::joda::JodaRuntimeState*, char const*)#18}>::_M_invoke(std::_Any_d@
*** SIGSEGV (@0x0) received by PID 3452126 (TID 0x74dfc23fc6c0) LWP(3452908) from PID 0; stack trace: ***
    @     0x74e189d06ed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)
    @         0x12621d06 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x74e189caa330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @          0xe686c5f std::_Function_handler<bool (starrocks::joda::JodaRuntimeState*, char const*), starrocks::joda::JodaFormat::prepare(std::basic_string_view<char, std::char_traits<char> >)::{lambda(starrocks::joda::JodaRuntimeState*, char const*)#18}>::_M_invoke(std::_Any_d@
    @          0xe68a9a5 starrocks::joda::JodaFormat::parse(std::basic_string_view<char, std::char_traits<char> >, starrocks::DateTimeValue*)
    @          0xe05a3ab starrocks::TimeFunctions::parse_jodatime(starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&)
    @          0x99ee33a std::_Function_handler<starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > (starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::C@
    @          0xddffd2a starrocks::VectorizedFunctionCallExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
    @          0xcbd1793 starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*)
    @          0xcbd244b starrocks::ExprContext::evaluate(starrocks::Chunk*, unsigned char*)
    @          0x978c182 starrocks::pipeline::ProjectOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @          0xade1caf starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0x9717596 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0xe7a9e7b starrocks::ThreadPool::dispatch_thread()
    @          0xe7a0d2f starrocks::Thread::supervise_thread(void*)
    @     0x74e189d01aa4 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x9caa3)
    @     0x74e189d8ea64 __clone

```

TeradataFormat::parse and JodaFormat::parse hand every token parser a val_end, and the literal-character parsers never look at it. They dereference the read cursor directly:

    if (**(state->valptr) != ignored_char) { ... }

For an empty input the cursor is the empty string's data pointer, which is null, so the very first token parser dereferences null and the BE dies with SIGSEGV at address 0. Reaching it only needs the format to begin with a literal character, because the numeric parsers go through str_to_int64 and fail safely:

    select to_tera_timestamp('', ';yyyy')
    select str_to_jodatime('', ';yyyy')

Both crash a release BE. A user needs no privileges and no table to do this; the fuzzer found it as a plain one-line SELECT over two constants.

Bound each cursor read by val_end. A parser that runs out of input now returns false, which is the same answer it already gives for input that does not match, so a short or empty value yields NULL instead of killing the backend. This covers the Teradata punctuation, am and pm parsers and the Joda literal-character parser -- every place that read through the cursor without checking it first.

Covered by two new gtest cases in datetime_value_test.cpp that exercise the empty, null-data and mid-format-truncated value for both parsers -- both segfault without this change -- and by SQL cases in test_time_fn/test_to_date that assert NULL for to_tera_date, to_tera_timestamp and str_to_jodatime on short input.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
