### PR TITLE
[BugFix] Apply the GROUP BY rules to every child of an expression

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
@@ -163,7 +163,9 @@ public class AggregationAnalyzer {
 
         @Override
         public Boolean visitArithmeticExpr(ArithmeticExpr node, Void context) {
-            return visit(node.getChild(0)) && visit(node.getChild(1));
+            // Not every arithmetic operator is binary: BITNOT is unary, and TreeNode.getChild(1) returns
+            // null there rather than throwing, so asking for it used to NPE inside visit().
+            return node.getChildren().stream().allMatch(this::visit);
         }
 
         @Override
@@ -192,7 +194,11 @@ public class AggregationAnalyzer {
 
         @Override
         public Boolean visitCollectionElementExpr(CollectionElementExpr node, Void context) {
-            return visit(node.getChild(0));
+            // The subscript is an ordinary expression and has to satisfy the same grouping rules as the
+            // collection itself. Only checking the collection lets a bare column slip through, e.g.
+            // `SELECT map_agg(k, v)[c] FROM t`, and the planner then fails much later with an
+            // unactionable "Invalid plan" from the input-dependency checker.
+            return node.getChildren().stream().allMatch(this::visit);
         }
 
         @Override
@@ -299,12 +305,13 @@ public class AggregationAnalyzer {
 
         @Override
         public Boolean visitLikePredicate(LikePredicate node, Void context) {
-            return visit(node.getChild(0));
+            // The pattern only has to be a string expression, not a literal, so it can carry a bare column.
+            return node.getChildren().stream().allMatch(this::visit);
         }
 
         @Override
         public Boolean visitMatchExpr(MatchExpr node, Void context) {
-            return visit(node.getChild(0));
+            return node.getChildren().stream().allMatch(this::visit);
         }
 
         @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
@@ -82,6 +82,43 @@ public class AnalyzeAggregateTest {
     }
 
     @Test
+    public void testCollectionSubscriptIsSubjectToGroupBy() {
+        // The subscript of a collection element is an ordinary expression: a bare column there is no more
+        // legal than anywhere else. It used to slip past this check and blow up later in the optimizer
+        // with an unactionable "Invalid plan:".
+        analyzeFail("select map_agg(v1, v2)[v3] from t0",
+                "must be an aggregate expression or appear in GROUP BY clause");
+        analyzeFail("select map_agg(v1, v2)[v3] from t0 group by v1",
+                "must be an aggregate expression or appear in GROUP BY clause");
+
+        analyzeSuccess("select map_agg(v1, v2)[1] from t0");
+        analyzeSuccess("select map_agg(v1, v2)[v3] from t0 group by v3");
+
+        // The same rule has to hold wherever the check runs, not only in the select list.
+        analyzeFail("select v1 from t0 group by v1 having map_agg(v1, v2)[v3] = 'x'",
+                "must be an aggregate expression or appear in GROUP BY clause");
+        analyzeFail("select map_agg(v1, v2)[v3] from t0 order by map_agg(v1, v2)[v3]",
+                "must be an aggregate expression or appear in GROUP BY clause");
+    }
+
+    @Test
+    public void testEveryChildIsSubjectToGroupBy() {
+        // Several visitors used to look at only some of their children, so a bare column in the other ones
+        // reached the optimizer, which rejected its own plan with an unactionable "Invalid plan:".
+
+        // The LIKE pattern only has to be a string expression, so it can be a column.
+        analyzeFail("select max(ta) like ta from tall",
+                "must be an aggregate expression or appear in GROUP BY clause");
+        analyzeSuccess("select max(ta) like ta from tall group by ta");
+        analyzeSuccess("select max(ta) like 'a%' from tall");
+
+        // BITNOT is a unary ArithmeticExpr: asking for a second child yields null, which used to NPE.
+        analyzeSuccess("select ~v1, count(*) from t0 group by v1");
+        analyzeFail("select ~v1, count(*) from t0",
+                "must be an aggregate expression or appear in GROUP BY clause");
+    }
+
+    @Test
     public void testGrouping() {
         analyzeFail("select grouping(foo) from t0 group by grouping sets((v1), (v2))",
                 "cannot be resolved");


### PR DESCRIPTION
## Why I'm doing:

```
USE repro_aggchild;
CREATE TABLE t (k INT, s VARCHAR(16))
DUPLICATE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1
PROPERTIES("replication_num" = "1");
INSERT INTO t VALUES (1, 'a'), (2, 'b');


mysql> SELECT max(s) LIKE s FROM t;
ERROR 1064 (HY000): Invalid plan:

PhysicalHashAggregate {type=GLOBAL, groupBy=[], partitionBy=[] ,aggregations={10: max=max(2: s)}projection=[11: expr->10: max LIKE 2: s]}
->  PhysicalOlapScanOperator {table=3894531, selectedPartitionId=[3894530], selectedIndexMetaId=3894532, outputColumns=[2: s], prunedPartitionPredicates=[], limit=-1}
Input dependency cols check failed. 
The projection required cols {2} cannot obtain from original input cols {10}.
mysql> SELECT ~k, count(*) FROM t GROUP BY k;
ERROR 1064 (HY000): Unknown error


mysql> SELECT map_agg(k, s)[k] FROM t;
ERROR 1064 (HY000): Invalid plan:
PhysicalHashAggregate {type=GLOBAL, groupBy=[], partitionBy=[] ,aggregations={10: map_agg=map_agg(1: k, 2: s)}projection=[11: expr->10: map_agg,1: k]}
->  PhysicalOlapScanOperator {table=3894531, selectedPartitionId=[3894530], selectedIndexMetaId=3894532, outputColumns=[1: k, 2: s], prunedPartitionPredicates=[], limit=-1}
Input dependency cols check failed. 
The projection required cols {1} cannot obtain from original input cols {10}.

```

AggregationAnalyzer.VerifyExpressionVisitor is where ONLY_FULL_GROUP_BY is enforced, but several of its visitors looked at only some of their children, so a bare column in the others was never checked:

    SELECT map_agg(k, v)[c] FROM t;   -- the subscript
    SELECT max(s) LIKE s FROM t;      -- the LIKE pattern

Both pass analysis. The projection then requires a column the aggregate does not output, and the optimizer rejects its own plan with an unactionable "Invalid plan:" from the input-dependency checker.

visitArithmeticExpr was worse than incomplete: it asked for getChild(1) unconditionally, but BITNOT is unary and TreeNode.getChild returns null rather than throwing when the index is out of range. So an ordinary

    SELECT ~c, count(*) FROM t GROUP BY c;

died with a NullPointerException out of the analyzer.

Visit every child in all of them, which is what visitArrowExpr and visitInPredicate already do. visitMatchExpr has the same shape and is only unreachable because the analyzer currently forces a string literal on the right, so fix it too rather than leave the trap armed.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
