### PR TITLE
[BugFix] Reject tokenize and ngram_search constant arguments that crash the BE

### DIFF
--- a/be/src/exprs/function_call_expr.cpp
+++ b/be/src/exprs/function_call_expr.cpp
@@ -325,13 +325,21 @@ bool VectorizedFunctionCallExpr::split_normal_string_to_ngram(const Slice& needl
     size_t index_gram_num = reader_options.index_gram_num;
     bool index_case_sensitive = reader_options.index_case_sensitive;
 
-    auto gram_num_column = fn_ctx->get_constant_column(2);
-    if (gram_num_column != nullptr) {
+    // Defence in depth: the FE analyzer already requires a positive integer literal here.
+    // get_const_value() casts the constant's data column straight to an Int32Column, so a
+    // non-constant or NULL gram_num would be a wild read rather than a skipped optimization.
+    // Note this runs during index evaluation in the storage layer, before the function itself is
+    // ever evaluated, so ngram_search_prepare()'s own guard does not protect it.
+    if (fn_ctx->is_notnull_constant_column(2)) {
+        auto gram_num_column = fn_ctx->get_constant_column(2);
         size_t predicate_gram_num = ColumnHelper::get_const_value<TYPE_INT>(gram_num_column);
         // case like ngram_search(col,"needle", 5) when col has a 4gram bloom filter, don't use this index
         if (index_gram_num != predicate_gram_num) {
             return false;
         }
+    } else {
+        // gram_num is not a usable constant: the index cannot be matched against it.
+        return false;
     }
 
     // if ngram bloom filter is case_sensitive,but function is case insensitive

--- a/be/src/exprs/gin_functions.cpp
+++ b/be/src/exprs/gin_functions.cpp
@@ -58,8 +58,12 @@ Status GinFunctions::tokenize_prepare(FunctionContext* context, FunctionContext:
         return Status::OK();
     }
 
+    // Defence in depth: the FE analyzer already requires a string literal here. get_const_value()
+    // casts the constant's data column straight to a BinaryColumn, so a non-constant or NULL
+    // argument would be a wild read rather than an error.
+    RETURN_IF(!context->is_notnull_constant_column(0),
+              Status::InvalidArgument("Tokenize function requires a non-null constant string parameter"));
     auto column = context->get_constant_column(0);
-    RETURN_IF(column == nullptr, Status::InvalidArgument("Tokenize function requires constant parameter"));
     auto method = ColumnHelper::get_const_value<TYPE_VARCHAR>(column);
     if (method != "english" && method != "standard" && method != "chinese") {
         return Status::NotSupported("Unknown method '" + method.to_string() +
@@ -80,8 +84,9 @@ StatusOr<ColumnPtr> GinFunctions::tokenize(FunctionContext* context, const starr
         return Status::InvalidArgument("Tokenize function only call by tokenize('<index_type>', str_column)");
     }
 
+    RETURN_IF(!context->is_notnull_constant_column(0),
+              Status::InvalidArgument("Tokenize function requires a non-null constant string parameter"));
     auto method_column = context->get_constant_column(0);
-    RETURN_IF(method_column == nullptr, Status::InvalidArgument("Tokenize function requires constant parameter"));
     auto method = ColumnHelper::get_const_value<TYPE_VARCHAR>(method_column);
 
     auto* ts = context->get_or_create_thread_state<GinTokenizeThreadState>([&]() {

--- a/be/src/exprs/ngram.cpp
+++ b/be/src/exprs/ngram.cpp
@@ -79,7 +79,13 @@ public:
         // Defence in depth: the FE analyzer already requires a positive integer literal here, and
         // get_const_value() casts the data column straight to an Int32Column, so anything else
         // would be a wild read rather than an error.
-        if (!context->is_notnull_constant_column(2)) {
+        //
+        // Test what get_const_value actually needs -- a ConstColumn over a non-nullable column -- rather
+        // than asking the FunctionContext whether it registered a constant. Those are not the same thing:
+        // a caller can hand over a perfectly good ConstColumn without registering it, which is exactly
+        // what the non-constant-needle tests do, and keying off the registry rejected all of them.
+        if (!gram_num_column->is_constant() ||
+            down_cast<const ConstColumn*>(gram_num_column.get())->data_column()->is_nullable()) {
             return Status::InvalidArgument("ngram search's third parameter must be a non-null constant integer");
         }
         int gram_num = ColumnHelper::get_const_value<TYPE_INT>(gram_num_column);

--- a/be/src/exprs/ngram.cpp
+++ b/be/src/exprs/ngram.cpp
@@ -76,6 +76,12 @@ public:
         const auto& needle_column = columns[1];
         const auto& gram_num_column = columns[2];
 
+        // Defence in depth: the FE analyzer already requires a positive integer literal here, and
+        // get_const_value() casts the data column straight to an Int32Column, so anything else
+        // would be a wild read rather than an error.
+        if (!context->is_notnull_constant_column(2)) {
+            return Status::InvalidArgument("ngram search's third parameter must be a non-null constant integer");
+        }
         int gram_num = ColumnHelper::get_const_value<TYPE_INT>(gram_num_column);
         if (gram_num <= 0) {
             return Status::NotSupported("ngram search's third parameter must be a positive number");

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -591,6 +591,11 @@ public class FunctionSet {
     public static final String NGRAM_SEARCH = "ngram_search";
     public static final String NGRAM_SEARCH_CASE_INSENSITIVE = "ngram_search_case_insensitive";
 
+    public static final String TOKENIZE = "tokenize";
+    // Tokenizers GinFunctions::tokenize() implements on the BE. Matching is case-sensitive there.
+    public static final Set<String> SUPPORTED_TOKENIZERS =
+            ImmutableSet.of("english", "standard", "chinese");
+
     // JSON functions
     public static final Function JSON_QUERY_FUNC = new Function(
             new FunctionName(JSON_QUERY), new Type[] {JsonType.JSON, VarcharType.VARCHAR}, JsonType.JSON, false);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -169,10 +169,42 @@ public class FunctionAnalyzer {
                         functionCallExpr.getPos());
             }
 
-            if (!functionCallExpr.getChild(2).isConstant()) {
+            // gram_num is read on the BE as a raw non-nullable INT constant column, with no type or
+            // null check. It is read twice: by ngram_search itself, and -- more dangerously -- by
+            // VectorizedFunctionCallExpr::split_normal_string_to_ngram() while evaluating an NGRAMBF
+            // index in the storage layer, which is reached before ordinary expression evaluation.
+            // "constant" alone is not enough there: a constant of another type (e.g. a JSON
+            // expression) or a constant NULL is a ConstColumn over something that is not an
+            // Int32Column, and reading it crashes the BE. Require a positive integer constant.
+            Expr gramNumExpr = functionCallExpr.getChild(2);
+            Optional<Long> gramNum = extractIntegerValue(gramNumExpr);
+            if (!gramNum.isPresent() || gramNum.get() <= 0 || gramNum.get() > Integer.MAX_VALUE) {
                 throw new SemanticException(
-                        fnName + " function 's third parameter must be constant",
-                        functionCallExpr.getPos());
+                        fnName + " function 's third parameter must be a constant positive integer",
+                        gramNumExpr.getPos());
+            }
+        }
+
+        // tokenize(tokenizer_name, content): the tokenizer name is read on the BE at prepare time as
+        // a raw non-nullable VARCHAR constant column, with no type or null check. A constant of
+        // another type -- e.g. cast('english' as time), which the FE cannot fold and so cannot see
+        // is NULL -- reaches the BE as a constant of the wrong shape and crashes it. Require a
+        // string literal naming one of the tokenizers the BE implements. A NULL constant stays
+        // legal: FoldConstantsRule rewrites the whole call to NULL, so it never reaches the BE.
+        if (fnName.equals(FunctionSet.TOKENIZE) && functionCallExpr.hasChild(0)) {
+            Expr tokenizerExpr = functionCallExpr.getChild(0);
+            Expr unwrapped = unwrapConstantString(tokenizerExpr);
+            if (unwrapped instanceof StringLiteral) {
+                String tokenizer = ((StringLiteral) unwrapped).getValue();
+                if (!FunctionSet.SUPPORTED_TOKENIZERS.contains(tokenizer)) {
+                    throw new SemanticException(
+                            "Unknown tokenizer '" + tokenizer + "'. Supported tokenizers are: " +
+                                    String.join(", ", FunctionSet.SUPPORTED_TOKENIZERS), tokenizerExpr.getPos());
+                }
+            } else if (!(unwrapped instanceof NullLiteral)) {
+                throw new SemanticException(
+                        "tokenize function 's first parameter (tokenizer_name) must be a constant string, one of: " +
+                                String.join(", ", FunctionSet.SUPPORTED_TOKENIZERS), tokenizerExpr.getPos());
             }
         }
         Function fn = functionCallExpr.getFn();
@@ -738,6 +770,25 @@ public class FunctionAnalyzer {
         }
 
         return Optional.empty();
+    }
+
+    /**
+     * Peel user variables and casts to a string type off an expression, so that a constant string
+     * argument can be recognised through e.g. cast('english' as varchar). A cast to a non-string
+     * type is deliberately not peeled: cast('english' as time) is not a constant string, even
+     * though the FE will later wrap it in an implicit cast back to VARCHAR -- its value is whatever
+     * the inner cast produces, which the FE cannot fold and which is NULL at runtime.
+     */
+    private static Expr unwrapConstantString(Expr expr) {
+        if (expr instanceof UserVariableExpr) {
+            return unwrapConstantString(((UserVariableExpr) expr).getValue());
+        }
+
+        if (expr instanceof CastExpr && expr.getType().isStringType()) {
+            return unwrapConstantString(expr.getChild(0));
+        }
+
+        return expr;
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
@@ -625,6 +625,36 @@ public class AnalyzeExprTest {
         analyzeSuccess("select ngram_search(ta, ta, 4) from tall;");
         // non-constant gram_num is still rejected
         analyzeFail("select ngram_search(ta, ta, tc) from tall;");
+        // gram_num must be a positive integer constant: a constant expression of some other type is
+        // not enough. The BE reads it as a raw INT const column (including from the ngram bloom
+        // filter path in the storage layer), so a JSON/NULL constant used to crash the BE.
+        analyzeFail("select ngram_search(ta, 'aabaa', json_query(cast(4 as json), '$.a')) from tall;");
+        analyzeFail("select ngram_search(ta, 'aabaa', null) from tall;");
+        analyzeFail("select ngram_search(ta, 'aabaa', cast(null as int)) from tall;");
+        analyzeFail("select ngram_search(ta, 'aabaa', 0) from tall;");
+        analyzeFail("select ngram_search(ta, 'aabaa', -1) from tall;");
+        analyzeSuccess("select ngram_search(ta, 'aabaa', cast(4 as int)) from tall;");
+    }
+
+    @Test
+    public void testTokenize() {
+        analyzeSuccess("select tokenize('english', 'Today is saturday')");
+        analyzeSuccess("select tokenize('standard', 'Today is saturday')");
+        analyzeSuccess("select tokenize('chinese', '中华人民共和国')");
+        // The tokenizer name is read by the BE as a raw VARCHAR const column at prepare time, so a
+        // constant of any other type (or NULL) used to crash the BE.
+        analyzeFail("select tokenize(cast('english' as time), 'Today is saturday')");
+        analyzeFail("select tokenize(cast('english' as int), 'Today is saturday')");
+        analyzeFail("select tokenize(json_query(cast(4 as json), '$.a'), 'Today is saturday')");
+        // a NULL tokenizer is still accepted: the whole call folds to NULL and never reaches the BE
+        analyzeSuccess("select tokenize(null, 'Today is saturday')");
+        analyzeSuccess("select tokenize(cast(null as varchar), 'Today is saturday')");
+        // a cast to a string type over a string literal is still a constant string
+        analyzeSuccess("select tokenize(cast('english' as varchar), 'Today is saturday')");
+        // unknown tokenizer
+        analyzeFail("select tokenize('nosuchtokenizer', 'Today is saturday')");
+        // non-constant tokenizer name
+        analyzeFail("select tokenize(ta, ta) from tall");
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstArrayFunctionFoldingTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstArrayFunctionFoldingTest.java
@@ -152,7 +152,9 @@ public class ConstArrayFunctionFoldingTest extends PlanTestBase {
                 "SELECT 'distinct_map_keys' as func_name, distinct_map_keys(NULL) as result;",
                 "SELECT 'cardinality' as func_name, cardinality(NULL) as result;",
                 "SELECT 'tokenize' as func_name, tokenize(NULL, ' ') as result;",
-                "SELECT 'tokenize' as func_name, tokenize('hello world', NULL) as result;"};
+                // The tokenizer name must now name a tokenizer the BE implements; what this case
+                // covers is the NULL content folding to NULL, so use a real tokenizer for it.
+                "SELECT 'tokenize' as func_name, tokenize('english', NULL) as result;"};
         for (String q : queryList) {
             System.out.println(q);
             String plan = getFragmentPlan(q);

--- a/test/sql/test_string_functions/R/test_string_functions
+++ b/test/sql/test_string_functions/R/test_string_functions
@@ -507,11 +507,11 @@ select ngram_search("000073a7-274f-46bf-bfaf-678868cc26cd",rowkey,4) from string
 -- !result
 select ngram_search("chi","chi",0);
 -- result:
-[REGEX].*ngram search's third parameter must be a positive number.*
+[REGEX].*third parameter must be a constant positive integer.*
 -- !result
 select ngram_search("chi","chi",-1);
 -- result:
-[REGEX].*ngram search's third parameter must be a positive number.*
+[REGEX].*third parameter must be a constant positive integer.*
 -- !result
 select ngram_search(date('2020-06-23'), "2020", 4);
 -- result:


### PR DESCRIPTION
## Why I'm doing:

ngram:
```
CREATE DATABASE IF NOT EXISTS ngrepro;
  USE ngrepro;

  CREATE TABLE ngram_index_case_in_sensitive(
      timestamp DATETIME NOT NULL,
      Username  STRING,
      price     INT NULL
  ) PROPERTIES ("replication_num" = "1");

  INSERT INTO ngram_index_case_in_sensitive VALUES ('2023-01-01', "aAbac", 3);
  INSERT INTO ngram_index_case_in_sensitive VALUES ('2023-01-01', "AaBAa", 3);

  ALTER TABLE ngram_index_case_in_sensitive ADD INDEX idx_name1(Username)
    USING NGRAMBF ('gram_num' = "4", "bloom_filter_fpp" = "0.01");
  DROP INDEX idx_name1 ON ngram_index_case_in_sensitive;
  ALTER TABLE ngram_index_case_in_sensitive ADD INDEX idx_name1(Username)
    USING NGRAMBF ('gram_num' = "4", "bloom_filter_fpp" = "0.05", "case_sensitive" = "false");

  -- must way index build finished.
  SHOW ALTER TABLE COLUMN FROM ngrepro;   

  SELECT ngram_search(Username, 'aabaa', json_query(CAST(4 AS JSON), '$.a')) AS order_col
  FROM ngram_index_case_in_sensitive
  ORDER BY order_col DESC;

```

```
*** Aborted at 1785687546 (unix time) try "date -d @1785687546" if you are using GNU date ***
PC: @     0x7fbddb3719bc pthread_kill
*** SIGABRT (@0x3eb0007bfbe) received by PID 507838 (TID 0x7fbab63b0640) LWP(508636) from PID 507838; stack trace: ***
    @         0x32c9ff07 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7fbddb374ea8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ea7)
    @         0x32c9f706 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7fbddb31d520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @     0x7fbddb3719bc pthread_kill
    @     0x7fbddb31d476 raise
    @     0x7fbddb3037f3 abort
    @         0x1cafbe14 starrocks::failure_function()
    @         0x32c9381d google::LogMessage::Fail()
    @         0x32c94904 google::LogMessageFatal::~LogMessageFatal()
    @         0x1e08ce62 starrocks::RunTimeTypeTraits<(starrocks::LogicalType)5>::ColumnType const* starrocks::ColumnHelper::cast_to_raw<(starrocks::LogicalType)5>(starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> const&)
    @         0x1edd91f1 starrocks::RunTimeTypeTraits<(starrocks::LogicalType)5>::CppType starrocks::ColumnHelper::get_const_value<(starrocks::LogicalType)5>(starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> const&)
    @         0x2ca0ad10 starrocks::VectorizedFunctionCallExpr::split_normal_string_to_ngram(starrocks::Slice const&, starrocks::FunctionContext*, starrocks::NgramBloomFilterReaderOptions const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<c@
    @         0x2ca09f80 starrocks::VectorizedFunctionCallExpr::ngram_bloom_filter(starrocks::ExprContext*, starrocks::BloomFilter const*, starrocks::NgramBloomFilterReaderOptions const&) const
    @         0x2a4ad8a1 starrocks::Expr::ngram_bloom_filter(starrocks::ExprContext*, starrocks::BloomFilter const*, starrocks::NgramBloomFilterReaderOptions const&) const
    @         0x2a4a673f starrocks::ExprContext::ngram_bloom_filter(starrocks::BloomFilter const*, starrocks::NgramBloomFilterReaderOptions const&)
    @         0x241496f3 starrocks::ColumnExprPredicate::ngram_bloom_filter(starrocks::BloomFilter const*, starrocks::NgramBloomFilterReaderOptions const&) const
    @         0x20e2a252 starrocks::ColumnReader::bloom_filter<false>(std::vector<starrocks::ColumnPredicate const*, std::allocator<starrocks::ColumnPredicate const*> > const&, starrocks::SparseRange<unsigned int>*, starrocks::IndexReadOptions const&)::{lambda(starrocks::ColumnPre@
    @         0x20e3e3c0 bool std::__invoke_impl<bool, starrocks::ColumnReader::bloom_filter<false>(std::vector<starrocks::ColumnPredicate const*, std::allocator<starrocks::ColumnPredicate const*> > const&, starrocks::SparseRange<unsigned int>*, starrocks::IndexReadOptions const&)@
    @         0x20e3b391 std::__invoke_result<starrocks::ColumnReader::bloom_filter<false>(std::vector<starrocks::ColumnPredicate const*, std::allocator<starrocks::ColumnPredicate const*> > const&, starrocks::SparseRange<unsigned int>*, starrocks::IndexReadOptions const&)::{lambda@
    @         0x20e3531c bool std::ranges::__any_of_fn::operator()<__gnu_cxx::__normal_iterator<starrocks::ColumnPredicate const* const*, std::vector<starrocks::ColumnPredicate const*, std::allocator<starrocks::ColumnPredicate const*> > >, __gnu_cxx::__normal_iterator<starrocks::C@
    @         0x20e2a40c bool std::ranges::__any_of_fn::operator()<std::vector<starrocks::ColumnPredicate const*, std::allocator<starrocks::ColumnPredicate const*> > const&, std::identity, starrocks::ColumnReader::bloom_filter<false>(std::vector<starrocks::ColumnPredicate const*, @
    @         0x20e2c45c starrocks::Status starrocks::ColumnReader::bloom_filter<false>(std::vector<starrocks::ColumnPredicate const*, std::allocator<starrocks::ColumnPredicate const*> > const&, starrocks::SparseRange<unsigned int>*, starrocks::IndexReadOptions const&)
    @         0x20e0fd07 starrocks::ColumnReader::ngram_bloom_filter(std::vector<starrocks::ColumnPredicate const*, std::allocator<starrocks::ColumnPredicate const*> > const&, starrocks::SparseRange<unsigned int>*, starrocks::IndexReadOptions const&)
    @         0x21154ede starrocks::ScalarColumnIterator::get_row_ranges_by_bloom_filter(std::vector<starrocks::ColumnPredicate const*, std::allocator<starrocks::ColumnPredicate const*> > const&, starrocks::SparseRange<unsigned int>*)
    @         0x21657b54 starrocks::BloomFilterEvaluator::operator()(starrocks::PredicateCompoundNode<(starrocks::CompoundNodeType)0> const&, starrocks::SparseRange<unsigned int>&)
    @         0x21658ad6 auto starrocks::PredicateNodeFactory<starrocks::PredicateCompoundNode<(starrocks::CompoundNodeType)0> >::visit<starrocks::BloomFilterEvaluator, starrocks::SparseRange<unsigned int>&>(starrocks::BloomFilterEvaluator&&, starrocks::SparseRange<unsigned int>&)@
    @         0x21658b2f auto starrocks::PredicateTree::visit<starrocks::BloomFilterEvaluator, starrocks::SparseRange<unsigned int>&>(starrocks::BloomFilterEvaluator&&, starrocks::SparseRange<unsigned int>&)
    @         0x2162f321 starrocks::SegmentIterator::_get_row_ranges_by_bloom_filter()
    @         0x215f1659 starrocks::SegmentIterator::_init_scan_range_and_context()
    @         0x215f0b70 starrocks::SegmentIterator::_init_internal()
    @         0x215ef48f starrocks::SegmentIterator::_init()

```

function tokenize:
select tokenize(cast('english' as time), 'Today is saturday')
```
*** SIGABRT (@0x3eb00271079) received by PID 2560121 (TID 0x7fa377908640) LWP(2561468) from PID 2560121; stack trace: ***
    @         0x32c9ff07 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7fa4719ecea8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ea7)
    @         0x32c9f706 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7fa471995520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @     0x7fa4719e99bc pthread_kill
    @     0x7fa471995476 raise
    @     0x7fa47197b7f3 abort
    @         0x1cafbe14 starrocks::failure_function()
    @         0x32c9381d google::LogMessage::Fail()
    @         0x32c94904 google::LogMessageFatal::~LogMessageFatal()
    @         0x1e7fa292 starrocks::RunTimeTypeTraits<(starrocks::LogicalType)17>::ColumnType const* starrocks::ColumnHelper::cast_to_raw<(starrocks::LogicalType)17>(starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> const&)
    @         0x1edd9356 starrocks::RunTimeTypeTraits<(starrocks::LogicalType)17>::CppType starrocks::ColumnHelper::get_const_value<(starrocks::LogicalType)17>(starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> const&)
    @         0x2ca2ba41 starrocks::GinFunctions::tokenize_prepare(starrocks::FunctionContext*, starrocks::FunctionContext::FunctionStateScope)
    @         0x1eddd21e starrocks::Status std::__invoke_impl<starrocks::Status, starrocks::Status (*&)(starrocks::FunctionContext*, starrocks::FunctionContext::FunctionStateScope), starrocks::FunctionContext*, starrocks::FunctionContext::FunctionStateScope>(std::__invoke_other, s@
    @         0x1eddc58b std::enable_if<is_invocable_r_v<starrocks::Status, starrocks::Status (*&)(starrocks::FunctionContext*, starrocks::FunctionContext::FunctionStateScope), starrocks::FunctionContext*, starrocks::FunctionContext::FunctionStateScope>, starrocks::Status>::type s@
    @         0x1eddb929 std::_Function_handler<starrocks::Status (starrocks::FunctionContext*, starrocks::FunctionContext::FunctionStateScope), starrocks::Status (*)(starrocks::FunctionContext*, starrocks::FunctionContext::FunctionStateScope)>::_M_invoke(std::_Any_data const&, st@
    @         0x2ca0d9e8 std::function<starrocks::Status (starrocks::FunctionContext*, starrocks::FunctionContext::FunctionStateScope)>::operator()(starrocks::FunctionContext*, starrocks::FunctionContext::FunctionStateScope) const
    @         0x2ca07c3a starrocks::VectorizedFunctionCallExpr::open(starrocks::RuntimeState*, starrocks::ExprContext*, starrocks::FunctionContext::FunctionStateScope)
    @         0x2a4a3556 starrocks::ExprContext::open(starrocks::RuntimeState*)

```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
