### PR TITLE
[BugFix] Stop generate_series from crashing on an untypeable step count 

### DIFF
--- a/be/src/exprs/table_function/generate_series.h
+++ b/be/src/exprs/table_function/generate_series.h
@@ -136,7 +136,7 @@ public:
                 size_t count;
                 if constexpr (sizeof(UnsignedType) >= sizeof(size_t)) {
                     count = (steps_left >= static_cast<UnsignedType>(room)) ? room
-                                                                           : static_cast<size_t>(steps_left) + 1;
+                                                                            : static_cast<size_t>(steps_left) + 1;
                 } else {
                     count = std::min<size_t>(static_cast<size_t>(steps_left) + 1, room);
                 }

--- a/be/src/exprs/table_function/generate_series.h
+++ b/be/src/exprs/table_function/generate_series.h
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include <algorithm>
+#include <type_traits>
+
 #include "column/column_builder.h"
 #include "column/column_viewer.h"
 #include "column/runtime_type_traits.h"
@@ -100,9 +103,42 @@ public:
                     continue;
                 }
 
-                auto count = (stop - current) / step + 1;
-                if (count > max_chunk_size - res->size()) {
-                    count = max_chunk_size - res->size();
+                // The number of values still to emit for this row is `(stop - current) / step + 1`,
+                // but neither the subtraction nor the division is safe in NumericType:
+                //   * `stop - current` overflows whenever the two ends are further apart than the
+                //     type range (e.g. `current = -1, stop = INT32_MAX`), which is undefined
+                //     behaviour and yields a garbage count;
+                //   * `<type>::min() / -1` is not representable. For INT and BIGINT the division
+                //     traps with SIGFPE on x86 and takes the BE down, e.g. INT columns feeding
+                //     `generate_series(0, -2147483648, -1)`; for LARGEINT the __int128 division
+                //     helper returns min() instead, and the resulting negative count skips the fill
+                //     loop and hands back uninitialized memory. (TINYINT and SMALLINT escape only
+                //     because their operands are promoted to `int` before the division.)
+                // Both operands come from input columns, so the offending values can only be known
+                // at runtime and cannot be rejected by constant-time analysis in the FE.
+                //
+                // Compute the distance and the step magnitude as unsigned values instead: unsigned
+                // arithmetic is defined to wrap, so it represents the whole two's-complement span
+                // exactly, and then clamp to the room left in the output chunk.
+                using UnsignedType = std::make_unsigned_t<NumericType>;
+                const auto u_current = static_cast<UnsignedType>(current);
+                const auto u_stop = static_cast<UnsignedType>(stop);
+                const UnsignedType span = (step > 0) ? static_cast<UnsignedType>(u_stop - u_current)
+                                                     : static_cast<UnsignedType>(u_current - u_stop);
+                const UnsignedType abs_step =
+                        (step > 0) ? static_cast<UnsignedType>(step)
+                                   : static_cast<UnsignedType>(UnsignedType{0} - static_cast<UnsignedType>(step));
+                // Values left after `current` itself; `+ 1` is applied below, after clamping, so it
+                // can never overflow UnsignedType.
+                const UnsignedType steps_left = span / abs_step;
+                const size_t room = static_cast<size_t>(max_chunk_size) - res->size();
+
+                size_t count;
+                if constexpr (sizeof(UnsignedType) >= sizeof(size_t)) {
+                    count = (steps_left >= static_cast<UnsignedType>(room)) ? room
+                                                                           : static_cast<size_t>(steps_left) + 1;
+                } else {
+                    count = std::min<size_t>(static_cast<size_t>(steps_left) + 1, room);
                 }
 
                 bool overflow = false;

--- a/be/test/exprs/CMakeLists.txt
+++ b/be/test/exprs/CMakeLists.txt
@@ -70,6 +70,7 @@ set(EXPR_TEST_FILES
     decimal_cast_expr_time_test.cpp
     encryption_functions_test.cpp
     function_call_expr_test.cpp
+    generate_series_core_test.cpp
     if_expr_test.cpp
     json_each_core_test.cpp
     like_test.cpp

--- a/be/test/exprs/generate_series_core_test.cpp
+++ b/be/test/exprs/generate_series_core_test.cpp
@@ -37,8 +37,8 @@ protected:
 
     // Runs one `process()` batch of generate_series(start, stop[, step]) over a single input row.
     template <LogicalType Type>
-    Result<Type> run_one_batch(RunTimeCppType<Type> start, RunTimeCppType<Type> stop,
-                               const RunTimeCppType<Type>* step, int chunk_size) {
+    Result<Type> run_one_batch(RunTimeCppType<Type> start, RunTimeCppType<Type> stop, const RunTimeCppType<Type>* step,
+                               int chunk_size) {
         GenerateSeries<Type> function;
         TableFunctionState* state = nullptr;
         CHECK(function.init(TFunction(), &state).ok());

--- a/be/test/exprs/generate_series_core_test.cpp
+++ b/be/test/exprs/generate_series_core_test.cpp
@@ -1,0 +1,194 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <vector>
+
+#include "base/testutil/assert.h"
+#include "column/column_helper.h"
+#include "exprs/table_function/generate_series.h"
+#include "gen_cpp/Types_types.h"
+#include "runtime/runtime_state.h"
+
+namespace starrocks {
+
+class GenerateSeriesCoreTest : public ::testing::Test {
+protected:
+    template <LogicalType Type>
+    struct Result {
+        std::vector<RunTimeCppType<Type>> values;
+        std::vector<uint32_t> offsets;
+        size_t processed_rows = 0;
+        Status status;
+    };
+
+    // Runs one `process()` batch of generate_series(start, stop[, step]) over a single input row.
+    template <LogicalType Type>
+    Result<Type> run_one_batch(RunTimeCppType<Type> start, RunTimeCppType<Type> stop,
+                               const RunTimeCppType<Type>* step, int chunk_size) {
+        GenerateSeries<Type> function;
+        TableFunctionState* state = nullptr;
+        CHECK(function.init(TFunction(), &state).ok());
+        CHECK(state != nullptr);
+        CHECK(function.prepare(state).ok());
+
+        RuntimeState runtime_state;
+        runtime_state.set_chunk_size(chunk_size);
+        CHECK(function.open(&runtime_state, state).ok());
+
+        Columns input_columns;
+        auto start_column = RunTimeColumnType<Type>::create();
+        start_column->append(start);
+        input_columns.emplace_back(std::move(start_column));
+        auto stop_column = RunTimeColumnType<Type>::create();
+        stop_column->append(stop);
+        input_columns.emplace_back(std::move(stop_column));
+        if (step != nullptr) {
+            auto step_column = RunTimeColumnType<Type>::create();
+            step_column->append(*step);
+            input_columns.emplace_back(std::move(step_column));
+        }
+        state->set_params(std::move(input_columns));
+
+        auto [result_columns, offset_column] = function.process(&runtime_state, state);
+
+        Result<Type> result;
+        result.status = state->status();
+        result.processed_rows = state->processed_rows();
+        if (!result_columns.empty()) {
+            auto column = ColumnHelper::cast_to<Type>(result_columns[0]);
+            result.values.assign(column->immutable_data().begin(), column->immutable_data().end());
+        }
+        if (offset_column != nullptr) {
+            result.offsets.assign(offset_column->immutable_data().begin(), offset_column->immutable_data().end());
+        }
+        CHECK(function.close(&runtime_state, state).ok());
+        return result;
+    }
+
+    template <LogicalType Type>
+    Result<Type> run_one_batch(RunTimeCppType<Type> start, RunTimeCppType<Type> stop, RunTimeCppType<Type> step,
+                               int chunk_size) {
+        return run_one_batch<Type>(start, stop, &step, chunk_size);
+    }
+};
+
+TEST_F(GenerateSeriesCoreTest, basic_ascending) {
+    auto result = run_one_batch<TYPE_INT>(1, 5, 1, 4096);
+    ASSERT_OK(result.status);
+    EXPECT_EQ(std::vector<int32_t>({1, 2, 3, 4, 5}), result.values);
+    EXPECT_EQ(std::vector<uint32_t>({0, 5}), result.offsets);
+    EXPECT_EQ(1, result.processed_rows);
+}
+
+TEST_F(GenerateSeriesCoreTest, basic_descending) {
+    auto result = run_one_batch<TYPE_INT>(5, 1, -2, 4096);
+    ASSERT_OK(result.status);
+    EXPECT_EQ(std::vector<int32_t>({5, 3, 1}), result.values);
+    EXPECT_EQ(std::vector<uint32_t>({0, 3}), result.offsets);
+    EXPECT_EQ(1, result.processed_rows);
+}
+
+TEST_F(GenerateSeriesCoreTest, zero_step_is_rejected) {
+    auto result = run_one_batch<TYPE_INT>(1, 5, 0, 4096);
+    ASSERT_FALSE(result.status.ok());
+}
+
+// `(stop - current) / step` used to be evaluated in the argument type. With `step == -1` and a
+// distance of exactly `numeric_limits<T>::min()` the quotient is not representable, so the idiv
+// raised SIGFPE and killed the BE inside GenerateSeries<TYPE_INT>::process().
+// Before the fix this test died with "AddressSanitizer: FPE" at generate_series.h:103.
+TEST_F(GenerateSeriesCoreTest, int_min_distance_with_minus_one_step) {
+    constexpr int32_t kIntMin = std::numeric_limits<int32_t>::min();
+    auto result = run_one_batch<TYPE_INT>(0, kIntMin, -1, 16);
+    ASSERT_OK(result.status);
+    ASSERT_EQ(16, result.values.size());
+    for (int32_t i = 0; i < 16; ++i) {
+        EXPECT_EQ(-i, result.values[i]);
+    }
+    EXPECT_EQ(std::vector<uint32_t>({0, 16}), result.offsets);
+    // The row is not exhausted yet, so it must be resumed on the next call.
+    EXPECT_EQ(0, result.processed_rows);
+}
+
+// TINYINT and SMALLINT escaped the trap because their operands are promoted to `int` before the
+// division. Pinned down so a future rewrite cannot regress the narrow types either.
+TEST_F(GenerateSeriesCoreTest, tinyint_min_distance_with_minus_one_step) {
+    constexpr int8_t kTinyMin = std::numeric_limits<int8_t>::min();
+    auto result = run_one_batch<TYPE_TINYINT>(0, kTinyMin, -1, 4096);
+    ASSERT_OK(result.status);
+    ASSERT_EQ(129, result.values.size());
+    for (int i = 0; i < 129; ++i) {
+        EXPECT_EQ(static_cast<int8_t>(-i), result.values[i]);
+    }
+    EXPECT_EQ(std::vector<uint32_t>({0, 129}), result.offsets);
+    EXPECT_EQ(1, result.processed_rows);
+}
+
+// Before the fix: same SIGFPE as the INT case.
+TEST_F(GenerateSeriesCoreTest, bigint_min_distance_with_minus_one_step) {
+    constexpr int64_t kBigMin = std::numeric_limits<int64_t>::min();
+    auto result = run_one_batch<TYPE_BIGINT>(0, kBigMin, -1, 8);
+    ASSERT_OK(result.status);
+    ASSERT_EQ(8, result.values.size());
+    for (int64_t i = 0; i < 8; ++i) {
+        EXPECT_EQ(-i, result.values[i]);
+    }
+    EXPECT_EQ(0, result.processed_rows);
+}
+
+// __int128 division does not trap, so before the fix this one did not crash: the negative count
+// skipped the fill loop entirely and the test read uninitialized column memory instead.
+TEST_F(GenerateSeriesCoreTest, largeint_min_distance_with_minus_one_step) {
+    constexpr __int128 kLargeMin = std::numeric_limits<__int128>::min();
+    auto result = run_one_batch<TYPE_LARGEINT>(static_cast<__int128>(0), kLargeMin, static_cast<__int128>(-1), 8);
+    ASSERT_OK(result.status);
+    ASSERT_EQ(8, result.values.size());
+    for (int i = 0; i < 8; ++i) {
+        EXPECT_EQ(static_cast<__int128>(-i), result.values[i]);
+    }
+    EXPECT_EQ(0, result.processed_rows);
+}
+
+// `stop - current` overflows the argument type here; the resulting garbage count used to feed the
+// chunk-size clamp. The series itself is well-defined and must simply be produced in batches.
+TEST_F(GenerateSeriesCoreTest, distance_overflows_argument_type) {
+    constexpr int32_t kIntMax = std::numeric_limits<int32_t>::max();
+    auto result = run_one_batch<TYPE_INT>(-1, kIntMax, 1, 16);
+    ASSERT_OK(result.status);
+    ASSERT_EQ(16, result.values.size());
+    for (int32_t i = 0; i < 16; ++i) {
+        EXPECT_EQ(i - 1, result.values[i]);
+    }
+    EXPECT_EQ(0, result.processed_rows);
+}
+
+// A single row that fits exactly in the chunk must be reported as fully consumed.
+TEST_F(GenerateSeriesCoreTest, row_exactly_fills_chunk) {
+    auto result = run_one_batch<TYPE_INT>(1, 16, 1, 16);
+    ASSERT_OK(result.status);
+    ASSERT_EQ(16, result.values.size());
+    EXPECT_EQ(1, result.processed_rows);
+}
+
+TEST_F(GenerateSeriesCoreTest, implicit_step) {
+    auto result = run_one_batch<TYPE_INT>(3, 6, nullptr, 4096);
+    ASSERT_OK(result.status);
+    EXPECT_EQ(std::vector<int32_t>({3, 4, 5, 6}), result.values);
+    EXPECT_EQ(1, result.processed_rows);
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

  select * from table(generate_series(cast(0 as int), cast(-2147483648 as int), cast(-1 as int))) limit 3;
```
*** Aborted at 1785688476 (unix time) try "date -d @1785688476" if you are using GNU date ***
PC: @         0x2cefc62c starrocks::GenerateSeries<(starrocks::LogicalType)5>::process(starrocks::RuntimeState*, starrocks::TableFunctionState*) const
*** SIGFPE (@0x2cefc62c) received by PID 578333 (TID 0x7f547107f640) LWP(579047) from PID 753911340; stack trace: ***
    @         0x32c9ff07 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7f5739d96ea8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ea7)
    @         0x32c9f706 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f5739d3f520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @         0x2cefc62c starrocks::GenerateSeries<(starrocks::LogicalType)5>::process(starrocks::RuntimeState*, starrocks::TableFunctionState*) const
    @         0x1eb0ec86 starrocks::pipeline::TableFunctionOperator::_process_table_function(starrocks::RuntimeState*)
    @         0x1eb0ca79 starrocks::pipeline::TableFunctionOperator::pull_chunk(starrocks::RuntimeState*)
    @         0x234e95f4 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @         0x1e47fa3d starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @         0x1e47ddea starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}::operator()() const
    @         0x1e4859a6 void std::__invoke_impl<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(std::__invoke_other, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&)
    @         0x1e4850ec std::enable_if<is_invocable_r_v<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>, void>::type std::__invoke_r<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(starrocks::pipeline::GlobalDriver@
    @         0x1e484bbc std::_Function_handler<void (), starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}>::_M_invoke(std::_Any_data const&)
    @         0x1c988924 std::function<void ()>::operator()() const
    @         0x2e156ae2 starrocks::FunctionRunnable::run()
    @         0x2e1508e8 starrocks::ThreadPool::dispatch_thread()
    @         0x2e171d82 void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @         0x2e170720 std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @         0x2e16f194 void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>)
    @         0x2e16d7f0 void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>()
    @         0x2e16ba76 void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&)
    @         0x2e169379 std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPool:@
    @         0x2e164c0f std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&)
    @         0x1c988924 std::function<void ()>::operator()() const
    @         0x2e136b49 starrocks::Thread::supervise_thread(void*)
    @         0x1c7e9616 asan_thread_start(void*)
    @     0x7f5739d91a83 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94a82)
    @     0x7f5739e23890 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x12688f)

```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
