### PR TITLE
[BugFix] Read constant arguments at index 0 in encode_fingerprint_sha256

### DIFF
--- a/be/src/exprs/encryption_functions.cpp
+++ b/be/src/exprs/encryption_functions.cpp
@@ -819,21 +819,24 @@ struct EncodeColumnToDigest {
     using CppType = RunTimeCppType<LT>;
     using ColumnType = RunTimeColumnType<LT>;
 
-    static void encode(const Column* data_col, const NullColumn* null_col, size_t chunk_size,
+    // `is_const` marks a constant argument, whose unwrapped data column holds exactly one element
+    // that logically repeats for every row. Such a column must always be read at index 0.
+    static void encode(const Column* data_col, const NullColumn* null_col, size_t chunk_size, bool is_const,
                        std::vector<SHA256Digest>& digests) {
         if constexpr (lt_is_string<LT> || lt_is_binary<LT>) {
             // String/Binary types
             auto* col = data_col ? down_cast<const ColumnType*>(data_col) : nullptr;
             const uint8_t* null_data = null_col ? null_col->immutable_data().data() : nullptr;
             for (size_t row = 0; row < chunk_size; row++) {
-                if (null_data && null_data[row]) {
+                const size_t idx = is_const ? 0 : row;
+                if (null_data && null_data[idx]) {
                     uint8_t marker = static_cast<uint8_t>(RowFingerprintValueType::Null);
                     digests[row].update(&marker, 1);
                 } else {
                     DCHECK(col != nullptr);
                     uint8_t marker = static_cast<uint8_t>(RowFingerprintValueType::String);
                     digests[row].update(&marker, 1);
-                    Slice value = col->get_slice(row);
+                    Slice value = col->get_slice(idx);
                     digests[row].update(value.data, value.size);
                 }
             }
@@ -864,13 +867,14 @@ struct EncodeColumnToDigest {
             uint8_t marker = static_cast<uint8_t>(marker_type);
             const auto* null_data = null_col ? null_col->immutable_data().data() : nullptr;
             for (size_t row = 0; row < chunk_size; row++) {
-                if (null_data && null_data[row]) {
+                const size_t idx = is_const ? 0 : row;
+                if (null_data && null_data[idx]) {
                     uint8_t null_marker = static_cast<uint8_t>(RowFingerprintValueType::Null);
                     digests[row].update(&null_marker, 1);
                 } else {
                     DCHECK(data != nullptr);
                     digests[row].update(&marker, 1);
-                    digests[row].update(&data[row], sizeof(CppType));
+                    digests[row].update(&data[idx], sizeof(CppType));
                 }
             }
         } else if (LT == TYPE_NULL) {
@@ -884,7 +888,8 @@ struct EncodeColumnToDigest {
             auto* col = data_col ? down_cast<const ColumnType*>(data_col) : nullptr;
             const auto* null_data = null_col ? null_col->immutable_data().data() : nullptr;
             for (size_t row = 0; row < chunk_size; row++) {
-                if (null_data && null_data[row]) {
+                const size_t idx = is_const ? 0 : row;
+                if (null_data && null_data[idx]) {
                     uint8_t marker = static_cast<uint8_t>(RowFingerprintValueType::Null);
                     digests[row].update(&marker, 1);
                 } else {
@@ -892,7 +897,7 @@ struct EncodeColumnToDigest {
                     uint8_t marker = static_cast<uint8_t>(RowFingerprintValueType::String);
                     digests[row].update(&marker, 1);
                     // Convert the value to string and encode
-                    std::string str_value = col->debug_item(row);
+                    std::string str_value = col->debug_item(idx);
                     digests[row].update(str_value.data(), str_value.size());
                 }
             }
@@ -901,6 +906,8 @@ struct EncodeColumnToDigest {
 };
 
 StatusOr<ColumnPtr> EncryptionFunctions::encode_fingerprint_sha256(FunctionContext* ctx, const Columns& columns) {
+    RETURN_IF(columns.empty(), Status::InvalidArgument("encode_fingerprint_sha256 requires at least 1 argument"));
+
     size_t chunk_size = columns[0]->size();
     std::vector<SHA256Digest> digests(chunk_size);
 
@@ -917,6 +924,9 @@ StatusOr<ColumnPtr> EncryptionFunctions::encode_fingerprint_sha256(FunctionConte
             }
             continue;
         }
+        // A constant argument keeps its single value in a one-element data column while reporting
+        // `chunk_size` rows, so every row must read index 0 instead of its own row index.
+        const bool is_const = col->is_constant();
         const Column* data_col = ColumnHelper::get_data_column(col.get());
         const NullColumn* null_col = ColumnHelper::get_null_column(col.get());
 
@@ -930,7 +940,7 @@ StatusOr<ColumnPtr> EncryptionFunctions::encode_fingerprint_sha256(FunctionConte
 
         // Use type dispatch to call the appropriate template specialization
         type_dispatch_filter(type, false, [&]<LogicalType LT>() -> bool {
-            EncodeColumnToDigest<LT>::encode(data_col, null_col, chunk_size, digests);
+            EncodeColumnToDigest<LT>::encode(data_col, null_col, chunk_size, is_const, digests);
             return true;
         });
     }

--- a/be/test/exprs/encryption_functions_test.cpp
+++ b/be/test/exprs/encryption_functions_test.cpp
@@ -2653,4 +2653,113 @@ TEST_F(EncryptionFunctionsTest, encode_fingerprint_sha256_type_markers) {
     }
 }
 
+// A constant argument arrives as a ConstColumn whose inner data column holds a SINGLE row, while
+// the function still has to emit `chunk_size` digests. Reading the inner column with the loop's row
+// index walks off the end of it. Encoding a const argument must be identical to encoding the same
+// value materialised once per row.
+TEST_F(EncryptionFunctionsTest, encode_fingerprint_sha256_const_arg_matches_materialized) {
+    constexpr size_t kNumRows = 4;
+    auto return_type = TypeDescriptor::from_logical_type(TYPE_VARBINARY);
+    std::vector<FunctionContext::TypeDesc> arg_types = {TypeDescriptor::from_logical_type(TYPE_INT),
+                                                        TypeDescriptor::from_logical_type(TYPE_VARCHAR),
+                                                        TypeDescriptor::from_logical_type(TYPE_BIGINT)};
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context(std::move(arg_types), return_type));
+
+    const std::string const_str = "starrocks";
+    constexpr int64_t const_bigint = 1234567890123LL;
+
+    auto make_varying = []() {
+        auto col = Int32Column::create();
+        for (size_t i = 0; i < kNumRows; i++) {
+            col->append(static_cast<int32_t>(i));
+        }
+        return col;
+    };
+
+    // Reference: every argument materialised for all rows.
+    Columns materialized;
+    materialized.emplace_back(make_varying());
+    {
+        auto str_col = BinaryColumn::create();
+        auto big_col = Int64Column::create();
+        for (size_t i = 0; i < kNumRows; i++) {
+            str_col->append(const_str);
+            big_col->append(const_bigint);
+        }
+        materialized.emplace_back(std::move(str_col));
+        materialized.emplace_back(std::move(big_col));
+    }
+    ColumnPtr expected = EncryptionFunctions::encode_fingerprint_sha256(ctx.get(), materialized).value();
+    ASSERT_EQ(kNumRows, expected->size());
+
+    // Same values, but the last two arguments are constants (what a SQL literal produces).
+    Columns with_consts;
+    with_consts.emplace_back(make_varying());
+    with_consts.emplace_back(ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice(const_str), kNumRows));
+    with_consts.emplace_back(ColumnHelper::create_const_column<TYPE_BIGINT>(const_bigint, kNumRows));
+
+    ColumnPtr actual = EncryptionFunctions::encode_fingerprint_sha256(ctx.get(), with_consts).value();
+    ASSERT_EQ(kNumRows, actual->size());
+
+    for (size_t row = 0; row < kNumRows; row++) {
+        EXPECT_EQ(expected->get(row).get_slice(), actual->get(row).get_slice()) << "row " << row;
+    }
+}
+
+// All arguments constant over a multi-row chunk: every row must get the same, correct digest.
+TEST_F(EncryptionFunctionsTest, encode_fingerprint_sha256_all_const_args) {
+    constexpr size_t kNumRows = 8;
+    auto return_type = TypeDescriptor::from_logical_type(TYPE_VARBINARY);
+    std::vector<FunctionContext::TypeDesc> arg_types = {TypeDescriptor::from_logical_type(TYPE_VARCHAR)};
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context(std::move(arg_types), return_type));
+
+    const std::string const_str = "starrocks";
+
+    // Single-row reference value.
+    Columns one_row;
+    {
+        auto col = BinaryColumn::create();
+        col->append(const_str);
+        one_row.emplace_back(std::move(col));
+    }
+    ColumnPtr expected = EncryptionFunctions::encode_fingerprint_sha256(ctx.get(), one_row).value();
+
+    Columns const_cols;
+    const_cols.emplace_back(ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice(const_str), kNumRows));
+    ColumnPtr actual = EncryptionFunctions::encode_fingerprint_sha256(ctx.get(), const_cols).value();
+    ASSERT_EQ(kNumRows, actual->size());
+
+    for (size_t row = 0; row < kNumRows; row++) {
+        EXPECT_EQ(expected->get(0).get_slice(), actual->get(row).get_slice()) << "row " << row;
+    }
+}
+
+// A const NULL argument mixed with a const non-null argument over a multi-row chunk.
+TEST_F(EncryptionFunctionsTest, encode_fingerprint_sha256_const_null_and_const_value) {
+    constexpr size_t kNumRows = 4;
+    auto return_type = TypeDescriptor::from_logical_type(TYPE_VARBINARY);
+    std::vector<FunctionContext::TypeDesc> arg_types = {TypeDescriptor::from_logical_type(TYPE_INT),
+                                                        TypeDescriptor::from_logical_type(TYPE_VARCHAR),
+                                                        TypeDescriptor::from_logical_type(TYPE_VARCHAR)};
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context(std::move(arg_types), return_type));
+
+    auto varying = Int32Column::create();
+    for (size_t i = 0; i < kNumRows; i++) {
+        varying->append(static_cast<int32_t>(i));
+    }
+
+    Columns columns;
+    columns.emplace_back(std::move(varying));
+    columns.emplace_back(ColumnHelper::create_const_null_column(kNumRows));
+    columns.emplace_back(ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("abc"), kNumRows));
+
+    ColumnPtr result = EncryptionFunctions::encode_fingerprint_sha256(ctx.get(), columns).value();
+    ASSERT_EQ(kNumRows, result->size());
+    for (size_t row = 0; row < kNumRows; row++) {
+        EXPECT_EQ(32, result->get(row).get_slice().size);
+    }
+    // The varying first argument must still differentiate the rows.
+    EXPECT_NE(result->get(0).get_slice(), result->get(1).get_slice());
+}
+
 } // namespace starrocks

--- a/test/sql/test_function/R/test_encode_fingerprint_sha256_const
+++ b/test/sql/test_function/R/test_encode_fingerprint_sha256_const
@@ -1,0 +1,45 @@
+-- name: test_encode_fingerprint_sha256_const_arg @sequential
+CREATE TABLE t_fp_const (k INT, v INT)
+  DUPLICATE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1
+  PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_fp_const SELECT generate_series, generate_series FROM TABLE(generate_series(1, 5000));
+-- result:
+-- !result
+SELECT count(encode_fingerprint_sha256(v, 'x')) FROM t_fp_const;
+-- result:
+5000
+-- !result
+SELECT count(encode_fingerprint_sha256(v, 7)) FROM t_fp_const;
+-- result:
+5000
+-- !result
+SELECT count(encode_fingerprint_sha256('x', v)) FROM t_fp_const;
+-- result:
+5000
+-- !result
+SELECT count(encode_fingerprint_sha256(v, k, 'x', 7)) FROM t_fp_const;
+-- result:
+5000
+-- !result
+SELECT count(*) FROM t_fp_const WHERE encode_fingerprint_sha256(v, CAST(k AS INT)) = encode_fingerprint_sha256(v, k);
+-- result:
+5000
+-- !result
+SELECT count(*) FROM t_fp_const WHERE k = 7 AND encode_fingerprint_sha256(v, CAST(7 AS INT)) = encode_fingerprint_sha256(v, k);
+-- result:
+1
+-- !result
+SELECT DISTINCT length(encode_fingerprint_sha256(v, 'x')) FROM t_fp_const;
+-- result:
+32
+-- !result
+SELECT count(encode_fingerprint_sha256(v, CAST(NULL AS INT))) FROM t_fp_const;
+-- result:
+5000
+-- !result
+SELECT count(*) FROM t_fp_const;
+-- result:
+5000
+-- !result

--- a/test/sql/test_function/T/test_encode_fingerprint_sha256_const
+++ b/test/sql/test_function/T/test_encode_fingerprint_sha256_const
@@ -1,0 +1,33 @@
+-- name: test_encode_fingerprint_sha256_const_arg @sequential
+-- Regression: a constant argument reaches the BE as a ConstColumn reporting chunk_size
+-- rows over an inner data column holding exactly one element. get_data_column() strips
+-- the ConstColumn and returns that one-element column, which was then indexed by the
+-- per-row loop counter. For a string argument this handed a wild pointer and a huge
+-- length to SHA256_Update, crashing the BE (SIGSEGV). The fix reads constant arguments
+-- at index 0.
+--
+-- Three conditions are all required: a chunk of more than one row, at least one constant
+-- argument, and at least one non-constant argument. An all-constant call is folded in the
+-- FE and never reaches the BE, which is why the existing single-row tests never tripped it.
+CREATE TABLE t_fp_const (k INT, v INT)
+  DUPLICATE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1
+  PROPERTIES("replication_num" = "1");
+INSERT INTO t_fp_const SELECT generate_series, generate_series FROM TABLE(generate_series(1, 5000));
+-- a constant string argument over a multi-row chunk must not crash the BE
+SELECT count(encode_fingerprint_sha256(v, 'x')) FROM t_fp_const;
+-- a constant integer argument, and a constant in first position
+SELECT count(encode_fingerprint_sha256(v, 7)) FROM t_fp_const;
+SELECT count(encode_fingerprint_sha256('x', v)) FROM t_fp_const;
+-- several constants mixed with non-constants
+SELECT count(encode_fingerprint_sha256(v, k, 'x', 7)) FROM t_fp_const;
+-- The digest of a constant argument must equal the digest of the same value materialised,
+-- which is what reading index 0 rather than the row index restores. The cast matters: a bare
+-- literal 7 is not an INT, and the argument's type is part of the digest.
+SELECT count(*) FROM t_fp_const WHERE encode_fingerprint_sha256(v, CAST(k AS INT)) = encode_fingerprint_sha256(v, k);
+SELECT count(*) FROM t_fp_const WHERE k = 7 AND encode_fingerprint_sha256(v, CAST(7 AS INT)) = encode_fingerprint_sha256(v, k);
+-- every row still yields a 32-byte digest
+SELECT DISTINCT length(encode_fingerprint_sha256(v, 'x')) FROM t_fp_const;
+-- the existing only-null guard is unaffected
+SELECT count(encode_fingerprint_sha256(v, CAST(NULL AS INT))) FROM t_fp_const;
+-- BE must still be serving queries
+SELECT count(*) FROM t_fp_const;


### PR DESCRIPTION
## Why I'm doing:

```
  CREATE TABLE t_fp (k INT, v INT) DUPLICATE KEY(k)
  DISTRIBUTED BY HASH(k) BUCKETS 1 PROPERTIES("replication_num"="1");
  INSERT INTO t_fp SELECT generate_series, generate_series FROM TABLE(generate_series(1, 5000));

  select count(encode_fingerprint_sha256(v, 'x')) from t_fp;
```

```
==602836==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x50200088e878 at pc 0x00001d13cb83 bp 0x7fa930890820 sp 0x7fa930890818
READ of size 4 at 0x50200088e878 thread T676
    #0 0x1d13cb82 in starrocks::Slice starrocks::BinaryColumnBase<unsigned int>::get_slice(unsigned long) const::{lambda(auto:1 const&)#1}::operator()<std::vector<unsigned int, starrocks::ColumnAllocator<unsigned int> > >(std::vec
tor<unsigned int, starrocks::ColumnAllocator<unsigned int> > const&) const be/src/column/binary_column.h:216
    #1 0x1d1319ef in decltype(auto) starrocks::AdaptiveOffsets::visit_storage<starrocks::BinaryColumnBase<unsigned int>::get_slice(unsigned long) const::{lambda(auto:1 const&)#1}>(starrocks::BinaryColumnBase<unsigned int>::get_sli
ce(unsigned long) const::{lambda(auto:1 const&)#1}&&) const be/src/column/adaptive_offsets.h:290
    #2 0x1d1319ef in starrocks::BinaryColumnBase<unsigned int>::get_slice(unsigned long) const be/src/column/binary_column.h:214
    #3 0x2c9f3b35 in starrocks::EncodeColumnToDigest<(starrocks::LogicalType)17>::encode(starrocks::Column const*, starrocks::FixedLengthColumn<unsigned char> const*, unsigned long, std::vector<starrocks::SHA256Digest, std::alloca
tor<starrocks::SHA256Digest> >&) be/src/exprs/encryption_functions.cpp:836
    #4 0x2c9e9b28 in operator()<(starrocks::LogicalType)17> be/src/exprs/encryption_functions.cpp:933
    #5 0x2c9e422e in type_dispatch_filter<starrocks::EncryptionFunctions::encode_fingerprint_sha256(starrocks::FunctionContext*, const starrocks::Columns&)::<lambda()>, bool> be/src/types/logical_type_infra.h:295
    #6 0x2c9e4b12 in starrocks::EncryptionFunctions::encode_fingerprint_sha256(starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Colum
n>::ImmutPtr<starrocks::Column> > > const&) be/src/exprs/encryption_functions.cpp:932

```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
