### PR TITLE
[BugFix] Resolve config yaml path against cwd, not __dirname

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -399,7 +399,8 @@ public class StatisticExecutor {
             String sql = "select cast(" + StatsConstants.STATISTIC_DICT_VERSION + " as Int), " +
                     "cast(" + version + " as bigint), " +
                     "dict_merge(" + StatisticUtils.quoting(columnName) + ", " +
-                    CacheDictManager.LOW_CARDINALITY_THRESHOLD + ") as _dict_merge_" + columnName +
+                    CacheDictManager.LOW_CARDINALITY_THRESHOLD + ") as " +
+                    StatisticUtils.quoting("_dict_merge_" + columnName) +
                     " from " + StatisticUtils.quoting(catalogName, db.getOriginName(), table.getName()) + " [_META_]";
             return executeStatisticDQLWithoutContext(sql);
         } else {
@@ -429,7 +430,8 @@ public class StatisticExecutor {
         String sql = "select cast(" + StatsConstants.STATISTIC_DICT_VERSION + " as Int), " +
                 "cast(" + version + " as bigint), " +
                 "dict_merge(" + columnRef + ", " +
-                CacheDictManager.LOW_CARDINALITY_THRESHOLD + ") as _dict_merge_" + columnAlias +
+                CacheDictManager.LOW_CARDINALITY_THRESHOLD + ") as " +
+                StatisticUtils.quoting("_dict_merge_" + columnAlias) +
                 " from " + StatisticUtils.quoting(catalogName, db.getOriginName(), table.getName()) + " [_META_]";
 
         return executeStatisticDQLWithoutContext(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticExecutorTest.java
@@ -16,8 +16,11 @@ package com.starrocks.statistic;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.Pair;
+import com.starrocks.common.Status;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.plan.PlanTestBase;
@@ -58,5 +61,38 @@ public class StatisticExecutorTest extends PlanTestBase {
         List<TStatisticData> stats = statisticExecutor.queryStatisticSync(
                 StatisticUtils.buildConnectContext(), null, 1000L, Lists.newArrayList("foo", "bar"));
         Assertions.assertEquals(0, stats.size());
+    }
+
+    // Regression test for https://github.com/StarRocks/starrocks/issues/77044
+    // dict_merge()'s generated alias must be quoted, otherwise columns whose name contains
+    // characters that are invalid in an unquoted identifier (e.g. `#os`) produce a SQL statement
+    // that fails to parse, so the column is never marked as NO_DICT_STRING and low-cardinality
+    // dict collection is retried indefinitely.
+    @Test
+    public void testDictSyncSpecialCharColumn() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE `t_dict_special_char` (\n" +
+                "  `id` int NULL,\n" +
+                "  `#os` varchar(32) NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`id`)\n" +
+                "DISTRIBUTED BY HASH(`id`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\"\n" +
+                ");");
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "t_dict_special_char");
+        ColumnId columnId = table.getColumn("#os").getColumnId();
+
+        Pair<List<TStatisticData>, Status> result =
+                StatisticExecutor.queryDictSync(db.getId(), table.getId(), columnId);
+
+        // Before the fix, the generated "as _dict_merge_#os" alias fails to parse and
+        // queryDictSync would throw a ParsingException instead of returning here.
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.second.ok(), "expected dict_merge query on a special-char column to " +
+                "parse and execute successfully, got status: " + result.second);
     }
 }


### PR DESCRIPTION
## Why I'm doing:
Columns with special characters in their name (e.g. `#os`, `#distinct_id` — common in ThinkingData-style event schemas) cause the low-cardinality dict collection query to fail with a `ParsingException` in `StatisticExecutor.queryDictSync()` / `queryDictSyncForJson()`. The generated `dict_merge(...)` alias is built as `"_dict_merge_" + columnName` and concatenated **unquoted** into the SQL string, so for a column like `#os` the alias becomes `_dict_merge_#os`, which the lexer chokes on (`#` isn't valid in an unquoted identifier).

Because the query fails to parse on the FE, it never reaches BE, so the column is never added to `NO_DICT_STRING_COLUMNS`. This means every subsequent query re-triggers the async dict load — causing constant retries, `fe.warn.log` spam, and permanent loss of the low-cardinality optimization for that column.

## What I'm doing:
Quote the generated `dict_merge` alias using `StatisticUtils.quoting(...)`, consistent with how the column reference and table reference are already quoted in the same statement. Applied to both call sites:
- `StatisticExecutor.queryDictSync()`
- `StatisticExecutor.queryDictSyncForJson()`

Added a regression test (`StatisticExecutorTest#testDictSyncSpecialCharColumn`) that creates a table with a `#os` column and verifies `queryDictSync` completes successfully instead of throwing a parse error.

Fixes #77044

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?
- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:
- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

(Columns with special characters in their names will now correctly participate in low-cardinality dict optimization instead of silently failing every time.)

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5