### PR TITLE
[UT] Pin how a batched IVM job merges its source window

### DIFF
--- a/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_mv_max_rows_per_refresh
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_with_iceberg_mv_max_rows_per_refresh
@@ -92,6 +92,29 @@ SELECT count(*) FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME
 -- result:
 3
 -- !result
+-- The IMV_SOURCE_* columns merge a batched job into one window: the first run's start and
+-- the last run's end. Asserted structurally -- the job's start must be the head of the run
+-- chain (a start that no run ends at) and its end the tail -- so the golden pins no snapshot
+-- id and does not depend on the second-granular CREATE_TIME ordering of the runs.
+WITH r AS (
+  SELECT regexp_extract(get_json_string(EXTRA_MESSAGE, '$.imvSourceVersionRange'), '"start": *"([0-9]+)"', 1) AS s,
+         regexp_extract(get_json_string(EXTRA_MESSAGE, '$.imvSourceVersionRange'), '"end": *"([0-9]+)"', 1) AS e
+  FROM information_schema.task_runs
+  WHERE TASK_NAME = '${TASK_NAME}' AND get_json_string(EXTRA_MESSAGE, '$.imvSourceVersionRange') != '{}'
+),
+j AS (
+  SELECT regexp_extract(IMV_SOURCE_VERSION_RANGE, '"start":"([0-9]+)"', 1) AS s,
+         regexp_extract(IMV_SOURCE_VERSION_RANGE, '"end":"([0-9]+)"', 1) AS e
+  FROM information_schema.materialized_view_refresh_jobs
+  WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_mv_batch' AND IMV_SOURCE_VERSION_RANGE IS NOT NULL
+)
+SELECT (SELECT count(*) FROM r) >= 2 AS batched,
+       (SELECT count(*) FROM j WHERE s IN (SELECT s FROM r) AND s NOT IN (SELECT e FROM r)) AS job_start_is_chain_head,
+       (SELECT count(*) FROM j WHERE e IN (SELECT e FROM r) AND e NOT IN (SELECT s FROM r)) AS job_end_is_chain_tail,
+       (SELECT count(*) FROM r a JOIN r b ON a.e = b.s) = (SELECT count(*) FROM r) - 1 AS runs_form_one_chain;
+-- result:
+1	1	1	1
+-- !result
 admin set frontend config ("mv_max_rows_per_refresh" = "100000000");
 -- result:
 -- !result

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_mv_max_rows_per_refresh
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_with_iceberg_mv_max_rows_per_refresh
@@ -56,6 +56,27 @@ SELECT k, v FROM test_mv_batch ORDER BY k;
 -- The delta was processed as multiple INCREMENTAL runs, not one.
 SELECT count(*) FROM information_schema.task_runs WHERE TASK_NAME = '${TASK_NAME}' AND STATE = 'SUCCESS' AND get_json_string(EXTRA_MESSAGE, '$.refreshMode') = 'INCREMENTAL';
 
+-- The IMV_SOURCE_* columns merge a batched job into one window: the first run's start and
+-- the last run's end. Asserted structurally -- the job's start must be the head of the run
+-- chain (a start that no run ends at) and its end the tail -- so the golden pins no snapshot
+-- id and does not depend on the second-granular CREATE_TIME ordering of the runs.
+WITH r AS (
+  SELECT regexp_extract(get_json_string(EXTRA_MESSAGE, '$.imvSourceVersionRange'), '"start": *"([0-9]+)"', 1) AS s,
+         regexp_extract(get_json_string(EXTRA_MESSAGE, '$.imvSourceVersionRange'), '"end": *"([0-9]+)"', 1) AS e
+  FROM information_schema.task_runs
+  WHERE TASK_NAME = '${TASK_NAME}' AND get_json_string(EXTRA_MESSAGE, '$.imvSourceVersionRange') != '{}'
+),
+j AS (
+  SELECT regexp_extract(IMV_SOURCE_VERSION_RANGE, '"start":"([0-9]+)"', 1) AS s,
+         regexp_extract(IMV_SOURCE_VERSION_RANGE, '"end":"([0-9]+)"', 1) AS e
+  FROM information_schema.materialized_view_refresh_jobs
+  WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME = 'test_mv_batch' AND IMV_SOURCE_VERSION_RANGE IS NOT NULL
+)
+SELECT (SELECT count(*) FROM r) >= 2 AS batched,
+       (SELECT count(*) FROM j WHERE s IN (SELECT s FROM r) AND s NOT IN (SELECT e FROM r)) AS job_start_is_chain_head,
+       (SELECT count(*) FROM j WHERE e IN (SELECT e FROM r) AND e NOT IN (SELECT s FROM r)) AS job_end_is_chain_tail,
+       (SELECT count(*) FROM r a JOIN r b ON a.e = b.s) = (SELECT count(*) FROM r) - 1 AS runs_form_one_chain;
+
 admin set frontend config ("mv_max_rows_per_refresh" = "100000000");
 drop materialized view test_mv_batch;
 drop catalog mv_iceberg_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

`information_schema.materialized_view_refresh_jobs` reports one row per refresh *job*, but an asynchronous IVM
refresh whose delta exceeds `mv_max_rows_per_refresh` runs as several task runs. `mergeRangeToJson()` folds
those runs into a single window per base table — the first run's `start` and the last run's `end`.

That merge had only ever been exercised by single-run jobs, where it is indistinguishable from copying the one
run's window. `test_ivm_with_iceberg_mv_max_rows_per_refresh` already drives a batched refresh and asserts that
the split happened and the data is correct, but it never looks at what the job row then reports.

Measured on a cluster, a batched job's runs chain and the job window spans them:

```
-- information_schema.task_runs, one job
INCREMENTAL  {"...t_multi": {"start": "8700639231683500626", "end": "1895318484918588397"}}
INCREMENTAL  {"...t_multi": {"start": "1895318484918588397", "end": "1631910195984958550"}}

-- information_schema.materialized_view_refresh_jobs, same job
IMV_SOURCE_VERSION_RANGE:   {"...t_multi":{"start":"8700639231683500626","end":"1631910195984958550"}}
IMV_SOURCE_TIMESTAMP_RANGE: {"...t_multi":{"start":"1785727605894","end":"1785727607520"}}
```

## What I'm doing:

Extended the existing case with one assertion over both surfaces, covering two distinct properties:

- **`mergeRangeToJson` itself** — the job's `start` must be the head of the run chain (a start that no run ends
  at) and its `end` the tail (an end that no run starts at), checked against the runs it folded.
- **the batching that makes that summary honest** — the runs must form one unbroken chain, as many joins as
  runs minus one. The merge keeps only the outer endpoints and discards the middle, so a gap between
  consecutive batches would make the column claim a wider range than the job actually consumed, and nothing in
  the job row would show it.

Both are written structurally rather than by pinning values, so the golden holds no snapshot id and survives
re-recording against another warehouse.

It also does not order the runs. `CREATE_TIME` is exposed with second granularity, and the batch runs of one
job can land in the same second — the merge itself sorts on `TaskRunStatus::getCreateTime`, the millisecond
field behind that column, so a test that ordered by the displayed value could disagree with the merge it is
checking.

Verified on a cluster running community `main`: the extended case passes (`Ran 1 test ... ok`), and the new
assertion has teeth — flipping its expected `1 1 1 1` to `0 0 0 0` fails the case with
`[exp]: ['0\t0\t0\t0'] [act]: ['1\t1\t1\t1']`.

No production code changes.

Fixes #issue: N/A — test coverage gap found while auditing MV refresh observability.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
