### PR TITLE
[BugFix] Bound and check chunk capacity on the data load and column mode partial update paths

### DIFF
--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -34,6 +34,7 @@
 #include "column/vectorized_fwd.h"
 #include "exprs/expr_context.h"
 #include "gutil/strings/fastmem.h"
+#include "gutil/strings/substitute.h"
 #include "runtime/chunk_accumulator.h"
 #include "storage/tablet_schema.h"
 #include "types/olap_type_infra.h"
@@ -152,6 +153,18 @@ void ChunkHelper::padding_char_column(const starrocks::TabletSchemaCSPtr& tschem
     } else {
         new_binary->swap_column(*column);
     }
+}
+
+Status ChunkHelper::reject_if_over_capacity(const Chunk& chunk, std::string_view what, int64_t tablet_id,
+                                            int64_t txn_id) {
+    Status st = chunk.capacity_limit_reached();
+    if (st.ok()) {
+        return st;
+    }
+    return Status::CapacityLimitExceed(
+            strings::Substitute("$0 is too large for tablet:$1 txn:$2, $3. Reduce the amount of data in a single "
+                                "statement.",
+                                std::string(what), tablet_id, txn_id, std::string(st.message())));
 }
 
 void ChunkHelper::padding_char_columns(const std::vector<size_t>& char_column_indexes, const Schema& schema,

--- a/be/src/storage/chunk_helper.h
+++ b/be/src/storage/chunk_helper.h
@@ -51,6 +51,17 @@ public:
 
     // Padding one char column
     static void padding_char_column(const starrocks::TabletSchemaCSPtr& tschema, const Field& field, Column* column);
+
+    // Returns CapacityLimitExceed when a column in `chunk` holds more than it can address. A
+    // BinaryColumn addresses its bytes with uint32 offsets, so past 4GB they wrap and stop
+    // describing its own buffer, and a wrap is not reliably an error: reading the offsets throws
+    // when the span it produces goes negative, reads out of bounds when it does not, and copies
+    // the right number of bytes from an address 2^32 too low when the span stays inside a single
+    // wrap segment. Worth calling wherever a chunk's offsets are about to be read and the caller
+    // would rather refuse the chunk than find out which of those happens. `what` names the chunk
+    // in the message; the limit itself comes from the column, and is read from its byte size
+    // rather than from the offsets, so it stays meaningful once they have wrapped.
+    static Status reject_if_over_capacity(const Chunk& chunk, std::string_view what, int64_t tablet_id, int64_t txn_id);
 };
 
 class ChunkPipelineAccumulator {

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -431,6 +431,10 @@ Status DeltaWriter::_check_partial_update_with_sort_key(const Chunk& chunk) {
 Status DeltaWriter::write(const Chunk& chunk, const uint32_t* indexes, uint32_t from, uint32_t size) {
     SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
     RETURN_IF_ERROR(_check_partial_update_with_sort_key(chunk));
+    // A column addresses its bytes with uint32 offsets, so a chunk wider than that cannot be
+    // carried through to apply. Fail the load here, where the statement can still be retried with
+    // less data per batch, rather than let it commit and leave apply to fail on every retry.
+    RETURN_IF_ERROR(ChunkHelper::reject_if_over_capacity(chunk, "load chunk", _opt.tablet_id, _opt.txn_id));
     ADD_COUNTER_RELAXED(_stats.write_count, 1);
     ADD_COUNTER_RELAXED(_stats.row_count, size);
     int64_t start_time = MonotonicNanos();

--- a/be/src/storage/lake/column_mode_partial_update_handler.cpp
+++ b/be/src/storage/lake/column_mode_partial_update_handler.cpp
@@ -204,7 +204,16 @@ StatusOr<ChunkPtr> ColumnModePartialUpdateHandler::_read_from_source_segment(con
         } else if (!st.ok()) {
             return st;
         } else {
+            // Check before appending from it: appending reads the source offsets, and reading
+            // offsets that have already wrapped is what throws or silently copies from the wrong
+            // address. Note this accumulator has no byte budget at all -- it is sized at the whole
+            // segment -- so the column limit is the only thing bounding it.
+            RETURN_IF_ERROR(ChunkHelper::reject_if_over_capacity(*tmp_chunk_ptr,
+                                                                 "column mode partial update source segment read batch",
+                                                                 params.tablet->id(), _txn_id));
             source_chunk_ptr->append(*tmp_chunk_ptr);
+            RETURN_IF_ERROR(ChunkHelper::reject_if_over_capacity(
+                    *source_chunk_ptr, "column mode partial update source chunk", params.tablet->id(), _txn_id));
         }
     }
     return source_chunk_ptr;
@@ -261,6 +270,10 @@ Status ColumnModePartialUpdateHandler::_update_source_chunk_by_upt(const UptidTo
             }
         });
         RETURN_IF_ERROR(read_chunk_from_update_file(segment_iters[upt_id], upt_chunk));
+        // A whole .upt file lands in one chunk, because the upt rowids below index into it. Check
+        // before append_selective() reads its offsets.
+        RETURN_IF_ERROR(ChunkHelper::reject_if_over_capacity(*upt_chunk, "column mode partial update upt file chunk",
+                                                             _rowset_ptr->tablet_id(), _txn_id));
         const size_t upt_chunk_size = upt_chunk->memory_usage();
         _tracker->consume(upt_chunk_size);
         DeferOp tracker_defer([&]() { _tracker->release(upt_chunk_size); });
@@ -302,6 +315,11 @@ Status ColumnModePartialUpdateHandler::_update_source_chunk_by_upt(const UptidTo
         TRY_CATCH_BAD_ALLOC(
                 tmp_chunk->append_selective(*upt_chunk, unsorted_upt_rowids.data(), 0, unsorted_upt_rowids.size()));
         RETURN_IF_EXCEPTION((*source_chunk)->update_rows(*tmp_chunk, sorted_source_rowids.data()));
+        // The merge writes values wider than the ones it replaces, so the result can be over the
+        // limit even though both inputs were under it, and the next .upt file in this loop reads
+        // these offsets again.
+        RETURN_IF_ERROR(ChunkHelper::reject_if_over_capacity(
+                **source_chunk, "column mode partial update merged source chunk", _rowset_ptr->tablet_id(), _txn_id));
     }
     return Status::OK();
 }
@@ -497,6 +515,16 @@ Status ColumnModePartialUpdateHandler::execute(const RowsetUpdateStateParams& pa
                 }
 
                 padding_char_columns(partial_schema, partial_tschema, source_chunk_ptr.get());
+                // Padding grows CHAR values to their declared length, so it can carry a chunk that
+                // was under the limit at the end of the merge over it.
+                st = ChunkHelper::reject_if_over_capacity(*source_chunk_ptr,
+                                                          "column mode partial update padded source chunk",
+                                                          params.tablet->id(), _txn_id);
+                if (!st.ok()) {
+                    std::lock_guard<std::mutex> l(result_mutex);
+                    shared_status.update(st);
+                    return;
+                }
 
                 // 3.5 write delta column group (.col file with UUID name, no collision)
                 auto writer_or = _prepare_delta_column_group_writer(params, partial_tschema);

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -684,6 +684,10 @@ Status DeltaWriterImpl::check_partial_update_with_sort_key(const Chunk& chunk) {
 
 Status DeltaWriterImpl::write(const Chunk& chunk, const uint32_t* indexes, uint32_t indexes_size) {
     SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
+    // A column addresses its bytes with uint32 offsets, so a chunk wider than that cannot be
+    // carried through to apply. Fail the load here, where the statement can still be retried with
+    // less data per batch, rather than let it commit and leave apply to fail on every retry.
+    RETURN_IF_ERROR(ChunkHelper::reject_if_over_capacity(chunk, "load chunk", _tablet_id, _txn_id));
 
     // Fast-fail if writer has been cancelled.
     auto cancel_st = current_cancel_status();

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -232,6 +232,17 @@ StatusOr<bool> MemTable::insert(const Chunk& chunk, const uint32_t* indexes, uin
         }
     }
 
+    // The buffer accumulates across inserts and is only measured against its budget afterwards, so
+    // it can end up holding more than a column can address with uint32 offsets even when every
+    // chunk that went into it was fine on its own. Everything downstream -- the flushed segment and
+    // the apply that reads it back -- inherits the wrapped offsets, so stop here instead.
+    if (auto st = _chunk->capacity_limit_reached(); !st.ok()) {
+        return Status::CapacityLimitExceed(fmt::format(
+                "memtable of tablet {} is too large to flush: {}. Reduce the number of rows per batch, or the size "
+                "of the string/array values in it.",
+                _tablet_id, st.message()));
+    }
+
     if (chunk.has_rows()) {
         _chunk_memory_usage += chunk.memory_usage() * size / chunk.num_rows();
         _chunk_bytes_usage += _chunk->bytes_usage(cur_row_count, size);

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -352,6 +352,25 @@ static Status read_from_source_segment_and_update(
     TRY_CATCH_BAD_ALLOC(source_chunk_ptr = ChunkFactory::new_chunk(schema, config::vector_chunk_size));
     TRY_CATCH_BAD_ALLOC(tmp_chunk_ptr = ChunkFactory::new_chunk(schema, config::vector_chunk_size));
     uint32_t start_rowid = 0;
+    // Accumulated rather than re-measured: bytes_usage() is O(1) for a binary column but walks every
+    // element of an object-backed one -- JSON, BITMAP, HLL -- so asking the whole accumulator after each
+    // batch would cost O(rows^2 / vector_chunk_size) on those schemas. Appending adds exactly the
+    // batch's bytes, so a running total is exact, not an estimate.
+    int64_t source_chunk_bytes = 0;
+    auto emit_container = [&](bool print_log) {
+        // Because we will handle columns group by group (define by config::vertical_compaction_max_columns_per_group),
+        // so use `upt_memory_usage_per_row` to estimate source chunk future memory cost will be overvalued.
+        // But it's better to be overvalued than undervalued.
+        StreamChunkContainer container = {
+                .chunk_ptr = source_chunk_ptr.get(),
+                .start_rowid = start_rowid,
+                .end_rowid = start_rowid + static_cast<uint32_t>(source_chunk_ptr->num_rows())};
+        RETURN_IF_ERROR(update_func(container, print_log, upt_memory_usage_per_row));
+        start_rowid += static_cast<uint32_t>(source_chunk_ptr->num_rows());
+        source_chunk_ptr->reset();
+        source_chunk_bytes = 0;
+        return Status::OK();
+    };
     while (true) {
         tmp_chunk_ptr->reset();
         auto st = seg_iter->get_next(tmp_chunk_ptr.get());
@@ -360,32 +379,43 @@ static Status read_from_source_segment_and_update(
         } else if (!st.ok()) {
             return st;
         } else {
-            source_chunk_ptr->append(*tmp_chunk_ptr);
+            // Batches are sized in rows, so a segment of wide rows can hand back more than a column
+            // can address in a single get_next(). Check before appending from it: appending reads
+            // the source offsets, and reading wrapped offsets is what throws or silently copies
+            // from the wrong address.
+            RETURN_IF_ERROR(ChunkHelper::reject_if_over_capacity(*tmp_chunk_ptr,
+                                                                 "column mode partial update source segment read batch",
+                                                                 tablet->tablet_id(), rowset->txn_id()));
             // Avoid too many memory usage and Column overflow, we will limit source chunk's size.
-            if (source_chunk_ptr->num_rows() >= INT32_MAX ||
-                (int64_t)source_chunk_ptr->num_rows() * upt_memory_usage_per_row >
-                        config::partial_update_memory_limit_per_worker) {
-                // Because we will handle columns group by group (define by config::vertical_compaction_max_columns_per_group),
-                // so use `upt_memory_usage_per_row` to estimate source chunk future memory cost will be overvalued.
-                // But it's better to be overvalued than undervalued.
-                StreamChunkContainer container = {
-                        .chunk_ptr = source_chunk_ptr.get(),
-                        .start_rowid = start_rowid,
-                        .end_rowid = start_rowid + static_cast<uint32_t>(source_chunk_ptr->num_rows())};
-                RETURN_IF_ERROR(update_func(container, true /*print log*/, upt_memory_usage_per_row));
-                start_rowid += static_cast<uint32_t>(source_chunk_ptr->num_rows());
-                source_chunk_ptr->reset();
+            // Decide before copying rather than after. The check used to run once the batch was
+            // already in, so a batch of wide rows was resident twice -- itself and its copy in the
+            // accumulator -- before anything could give, and the budget could only be honoured a
+            // whole batch late.
+            // `upt_memory_usage_per_row` covers only the half update_rows() is about to merge in:
+            // it is the per-row size of the .upt, which holds the new values of the rows this
+            // transaction updates, while the accumulator holds the old values of every row in the
+            // segment. Sizing the accumulator by that alone made the bound collapse whenever the
+            // update shrinks values or touches few rows -- and vanish entirely for a rowset with no
+            // recorded num_rows_upt, where the estimate is 0. Add what it actually holds.
+            const int64_t batch_bytes = (int64_t)tmp_chunk_ptr->bytes_usage();
+            const int64_t rows_after = (int64_t)source_chunk_ptr->num_rows() + (int64_t)tmp_chunk_ptr->num_rows();
+            if (!source_chunk_ptr->is_empty() &&
+                (rows_after >= INT32_MAX || source_chunk_bytes + batch_bytes + rows_after * upt_memory_usage_per_row >
+                                                    config::partial_update_memory_limit_per_worker)) {
+                RETURN_IF_ERROR(emit_container(true /*print log*/));
             }
+            // A batch that is over the budget on its own still goes in whole -- splitting it is not
+            // worth the complexity here, and the capacity check below is what stops it if it is
+            // also more than a column can address.
+            source_chunk_ptr->append(*tmp_chunk_ptr);
+            source_chunk_bytes += batch_bytes;
+            RETURN_IF_ERROR(ChunkHelper::reject_if_over_capacity(*source_chunk_ptr,
+                                                                 "column mode partial update source chunk",
+                                                                 tablet->tablet_id(), rowset->txn_id()));
         }
     }
     if (!source_chunk_ptr->is_empty()) {
-        StreamChunkContainer container = {
-                .chunk_ptr = source_chunk_ptr.get(),
-                .start_rowid = start_rowid,
-                .end_rowid = start_rowid + static_cast<uint32_t>(source_chunk_ptr->num_rows())};
-        RETURN_IF_ERROR(update_func(container, false /*print log*/, upt_memory_usage_per_row));
-        start_rowid += static_cast<uint32_t>(source_chunk_ptr->num_rows());
-        source_chunk_ptr->reset();
+        RETURN_IF_ERROR(emit_container(false /*print log*/));
     }
     return Status::OK();
 }
@@ -473,6 +503,11 @@ Status RowsetColumnUpdateState::_update_source_chunk_by_upt(const UptidToRowidPa
             }
         });
         RETURN_IF_ERROR(read_chunk_from_update_file(update_iterator, upt_chunk));
+        // A whole .upt file lands in one chunk, because the upt rowids below index into it, so
+        // unlike the source read it cannot be split. Check before append_selective() reads its
+        // offsets.
+        RETURN_IF_ERROR(ChunkHelper::reject_if_over_capacity(*upt_chunk, "column mode partial update upt file chunk",
+                                                             _tablet_id, rowset->txn_id()));
         const size_t upt_chunk_size = upt_chunk->memory_usage();
         tracker->consume(upt_chunk_size);
         DeferOp tracker_defer([&]() { tracker->release(upt_chunk_size); });
@@ -488,6 +523,11 @@ Status RowsetColumnUpdateState::_update_source_chunk_by_upt(const UptidToRowidPa
                 tmp_chunk->append_selective(*upt_chunk, unsorted_upt_rowids.data(), 0, unsorted_upt_rowids.size()));
         // update source chunk use upt rows
         RETURN_IF_EXCEPTION(container.chunk_ptr->update_rows(*tmp_chunk, sorted_source_rowids.data()));
+        // The merge writes values wider than the ones it replaces, so the result can be over the
+        // limit even though both inputs were under it. The container is also reused by the next
+        // .upt file in this loop, which reads its offsets again.
+        RETURN_IF_ERROR(ChunkHelper::reject_if_over_capacity(
+                *container.chunk_ptr, "column mode partial update merged source chunk", _tablet_id, rowset->txn_id()));
     }
     return Status::OK();
 }
@@ -816,6 +856,11 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
                         RETURN_IF_ERROR(_update_source_chunk_by_upt(each.second, partial_schema, rowset, &stats,
                                                                     tracker, container));
                         padding_char_columns(partial_schema, partial_tschema, container.chunk_ptr);
+                        // Padding grows CHAR values to their declared length, so it can carry a
+                        // container that was under the limit at the end of the merge over it.
+                        RETURN_IF_ERROR(ChunkHelper::reject_if_over_capacity(
+                                *container.chunk_ptr, "column mode partial update padded source chunk",
+                                tablet->tablet_id(), rowset->txn_id()));
                         RETURN_IF_ERROR(delta_column_group_writer->append_chunk(*container.chunk_ptr));
                         return Status::OK();
                     }));

--- a/be/test/storage/chunk_helper_test.cpp
+++ b/be/test/storage/chunk_helper_test.cpp
@@ -18,10 +18,13 @@
 #include <string_view>
 #include <vector>
 
+#include "base/testutil/assert.h"
+#include "column/array_column.h"
 #include "column/binary_column.h"
 #include "column/chunk.h"
 #include "column/column.h"
 #include "column/column_helper.h"
+#include "column/fixed_length_column.h"
 #include "column/nullable_column.h"
 #include "column/vectorized_fwd.h"
 #include "gtest/gtest.h"
@@ -137,6 +140,42 @@ TEST_F(ChunkHelperTest, PaddingNullableCharColumnCopiesAllRowsWhenNullsAreSparse
     expect_padded_char_column(
             *data_column, {padded_char("a", 4), padded_char("bc", 4), padded_char("def", 4), padded_char("nullv", 4),
                            padded_char("wxyzq", 4), padded_char("m", 4), padded_char("no", 4), padded_char("pqrs", 4)});
+}
+
+static ChunkPtr make_string_chunk(const std::vector<std::string>& values) {
+    // One row per value, and one array element per row, so that every invariant Chunk and its
+    // columns assert on lines up: each column's size equals the chunk's row count, the array's last
+    // offset equals its element count, and each null column matches the column it annotates.
+    const size_t rows = values.size();
+    auto binary = BinaryColumn::create();
+    auto elements = BinaryColumn::create();
+    auto offsets = UInt32Column::create();
+    offsets->append(0);
+    for (size_t i = 0; i < rows; i++) {
+        binary->append(Slice(values[i]));
+        elements->append(Slice(values[i]));
+        offsets->append(static_cast<uint32_t>(i + 1));
+    }
+    // ArrayColumn requires its elements to be nullable.
+    auto array = ArrayColumn::create(NullableColumn::create(std::move(elements), NullColumn::create(rows, 0)),
+                                     std::move(offsets));
+
+    auto chunk = std::make_shared<Chunk>();
+    chunk->append_column(std::move(binary), 0);
+    chunk->append_column(NullableColumn::create(std::move(array), NullColumn::create(rows, 0)), 1);
+    return chunk;
+}
+
+TEST_F(ChunkHelperTest, reject_if_over_capacity_accepts_an_ordinary_chunk) {
+    auto chunk = make_string_chunk({"alpha", "beta", "gamma"});
+    // Covers the nested case too: the array column has to be walked down to the binary column
+    // holding its elements. On this branch those offsets are AdaptiveOffsets and the byte limb
+    // is MAX_LARGE_CAPACITY_LIMIT, so this check only fires on a genuinely unaddressable chunk;
+    // it is here to keep the path in step with branch-3.5-cc, where the same offsets are uint32.
+    ASSERT_OK(ChunkHelper::reject_if_over_capacity(*chunk, "source chunk", 10001, 4242));
+
+    Chunk empty;
+    ASSERT_OK(ChunkHelper::reject_if_over_capacity(empty, "source chunk", 10001, 4242));
 }
 
 class ChunkPipelineAccumulatorTest : public ::testing::Test {

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -1378,6 +1378,58 @@ TEST_P(RowsetColumnPartialUpdateTest, partial_update_with_source_chunk_limit) {
     final_check(tablet, rowsets);
 }
 
+TEST_P(RowsetColumnPartialUpdateTest, partial_update_source_chunk_limit_counts_source_bytes) {
+    const int N = 100;
+    auto tablet = create_tablet(rand(), rand());
+    ASSERT_EQ(1, tablet->updates()->version_history_count());
+
+    std::vector<int64_t> keys(2 * N);
+    std::vector<int64_t> partial_keys(N);
+    for (int i = 0; i < 2 * N; i++) {
+        keys[i] = i;
+        if (i % 2 == 0) {
+            partial_keys[i / 2] = i;
+        }
+    }
+    auto v1_func = [](int64_t k1) { return (int16_t)(k1 % 100 + 3); };
+    auto v2_func = [](int64_t k1) { return (int32_t)(k1 % 1000 + 4); };
+    std::vector<RowsetSharedPtr> rowsets;
+    rowsets.reserve(12);
+    for (int i = 0; i < 10; i++) {
+        rowsets.emplace_back(create_rowset(tablet, keys));
+    }
+    std::vector<std::shared_ptr<TabletSchema>> partial_schemas;
+    for (int i = 0; i < 2; i++) {
+        std::vector<int32_t> column_indexes = {0, (i % 2) + 1};
+        partial_schemas.push_back(TabletSchema::create(tablet->tablet_schema(), column_indexes));
+        rowsets.emplace_back(create_partial_rowset(tablet, partial_keys, column_indexes, v1_func, v2_func,
+                                                   partial_schemas[i], 1, PartialUpdateMode::COLUMN_UPDATE_MODE, true));
+    }
+
+    int64_t old_vector_chunk_size = config::vector_chunk_size;
+    int64_t old_limit = config::partial_update_memory_limit_per_worker;
+    config::vector_chunk_size = 10;
+    // Sized so that only the source half of the bound can reach it. The accumulator holds 2 * N
+    // rows and the old bound was rows * upt_memory_usage_per_row, which for this schema stays well
+    // under this budget for the whole segment -- so before the fix the segment was never split and
+    // the budget was, in effect, not applied at all. Adding the accumulator's own bytes_usage()
+    // takes the sum past it partway through, so the segment now arrives in several containers and
+    // the rowid bookkeeping across those boundaries is what this checks.
+    config::partial_update_memory_limit_per_worker = 4096;
+    int64_t version = 1;
+    commit_rowsets(tablet, rowsets, version);
+    ASSERT_TRUE(check_tablet(tablet, version, 2 * N, [](int64_t k1, int64_t v1, int32_t v2, int32_t v3) {
+        if (k1 % 2 == 0) {
+            return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 4) == v2;
+        } else {
+            return (int16_t)(k1 % 100 + 1) == v1 && (int32_t)(k1 % 1000 + 2) == v2;
+        }
+    }));
+    config::vector_chunk_size = old_vector_chunk_size;
+    config::partial_update_memory_limit_per_worker = old_limit;
+    final_check(tablet, rowsets);
+}
+
 TEST_P(RowsetColumnPartialUpdateTest, partial_update_with_fast_schema_evolution) {
     config::enable_light_pk_compaction_publish = false;
     const int N = 100;


### PR DESCRIPTION
## Why I'm doing:

Both the data load path and the column mode partial update path can build a chunk whose `ARRAY` or string column holds more than the column can address. Nothing on either path is sized in bytes — load chunks, source read batches and `.upt` files are all sized in rows — so an `ARRAY<STRING>` of a few hundred thousand elements per row, or a plain string column of a few hundred KB per row, gets there without anything complaining, and the offsets stop describing the buffer they belong to.

The accumulator in `read_from_source_segment_and_update()` gets there the most easily, because the bound meant to stop it does not measure it:

```cpp
source_chunk_ptr->append(*tmp_chunk_ptr);
if (source_chunk_ptr->num_rows() >= INT32_MAX ||
    (int64_t)source_chunk_ptr->num_rows() * upt_memory_usage_per_row >
            config::partial_update_memory_limit_per_worker) {
```

`upt_memory_usage_per_row` is `total_update_row_size / num_rows_upt` — the per-row size of the **`.upt`**, which holds the *new* values of the rows this transaction updates. The accumulator holds something else: the *old* values of **every** row in the segment. Those are different populations, and the estimate is wrong in the direction that matters:

- an update that **shrinks** values, or touches a small fraction of rows, collapses the estimate and leaves the accumulator with no effective bound;
- for a rowset with no recorded `num_rows_upt` (`calc_upt_memory_usage_per_row()` returns 0) the byte term is `num_rows * 0` and **never fires at all**;
- it is consulted only *after* a whole batch has been copied in, so the batch and its copy are both resident before anything can flush, and the limit can only be honoured a whole batch late.

So `partial_update_memory_limit_per_worker` does not bound this path today.

## What I'm doing:

**1. Bound the accumulator by what it holds.** Add its own byte usage to the sum, decide *before* copying the batch in rather than after, and leave `upt_memory_usage_per_row` covering the half `update_rows()` is about to merge in. The emit block becomes a lambda so the in-loop and tail flushes share it.

The total is accumulated rather than recomputed: `Chunk::bytes_usage()` is `O(1)` for a binary column but walks every element of an object-backed one (JSON, BITMAP, HLL, PERCENTILE), so re-measuring the whole accumulator after each batch would cost `O(rows² / vector_chunk_size)` on those schemas. Appending adds exactly the batch's bytes, so a running total is exact.

A batch that is over the budget on its own still goes in whole; splitting it is not worth the complexity here, and (2) is what stops it if it is also more than a column can address.

**2. Add `ChunkHelper::reject_if_over_capacity()`** and call it on each chunk before its offsets are read: the source read batch, the accumulator, the `.upt` file chunk, the merge result, and again after `padding_char_columns()`, which grows CHAR values to their declared length after the merge has already been checked. It returns `CapacityLimitExceed`. The limit comes from the column rather than a constant, and it is read from the column's byte size rather than from the offsets, so it stays meaningful once those have wrapped.

Both handlers are covered: `storage/rowset_column_update_state.cpp` and `storage/lake/column_mode_partial_update_handler.cpp`. The shared-data one reads a whole segment into a single chunk with no byte budget at all, so there (1) has no counterpart to correct and the column limit is the only bound.

**3. Fail the load rather than the apply where possible**: the same helper on the incoming chunk in both `DeltaWriter::write()` implementations, and on the buffer in `MemTable::insert()`, which they share and which also covers the schema change path that builds its own memtable. A load that fails can be retried with less data per batch; one that commits leaves apply to fail on every retry, with the tablet unusable in between.

On `main` the checks in (2) and (3) do not reject anything the branch can represent: `BinaryColumnBase::Offsets` is `AdaptiveOffsets` (#74838) and promotes to 64-bit, so the byte limb is `MAX_LARGE_CAPACITY_LIMIT`. They are guards there, and they keep this path identical to the maintenance branches where the same offsets are still `uint32`.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

`partial_update_memory_limit_per_worker` now bounds the accumulator on this path, which it did not before, so a column mode partial update over wide values emits sooner and holds less memory; results are unchanged. A load or an update whose chunks exceed what a column can address now fails with `CapacityLimitExceed` instead of writing offsets that no longer describe their buffer.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
