### PR TITLE
[Tool] Restore TLS certificate verification for thirdparty downloads, and fetch lzo over https

### DIFF
--- a/nix/thirdparty-archives.nix
+++ b/nix/thirdparty-archives.nix
@@ -245,7 +245,7 @@ let
       sha256 = "12zlqlp7j3fri1bvwfpz7637cvf6iv7mq18j54imxcs48y814xak";
     };
     "lzo-2.10.tar.gz" = {
-      url = "http://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz";
+      url = "https://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz";
       md5 = "39d3f3f9c55c87b1e5d6888e1420f4b5";
       sha256 = "0wm04519pd3g8hqpjqhfr72q8qmbiwqaxcs3cndny9h86aa95y60";
     };

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -109,7 +109,7 @@ download_func() {
             rm -f "$DESC_DIR/$FILENAME"
         else
             echo "Downloading $FILENAME from $DOWNLOAD_URL to $DESC_DIR"
-            wget --progress=dot:mega --tries=3 --no-check-certificate $DOWNLOAD_URL -O $DESC_DIR/$FILENAME
+            wget --progress=dot:mega --tries=3 $DOWNLOAD_URL -O $DESC_DIR/$FILENAME
             if [ "$?"x == "0"x ]; then
                 if md5sum_func $FILENAME $DESC_DIR $MD5SUM; then
                     SUCCESS=1

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -383,7 +383,7 @@ SERDES_SOURCE="libserdes-7.3.1"
 SERDES_MD5SUM="61012487a8845f37540710ac4ac2f7ab"
 
 # lzo
-LZO2_DOWNLOAD="http://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz"
+LZO2_DOWNLOAD="https://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz"
 LZO2_NAME=lzo-2.10.tar.gz
 LZO2_SOURCE=lzo-2.10
 LZO2_MD5SUM="39d3f3f9c55c87b1e5d6888e1420f4b5"


### PR DESCRIPTION
## Why I'm doing:

`thirdparty/download-thirdparty.sh:112` is the single download path used for every third-party source archive — 69 of them by my count in `thirdparty/vars.sh`, including OpenSSL, Thrift, Protobuf, Boost and libevent. It passes `--no-check-certificate`, which turns off verification of the server's TLS certificate. The effect is that the `https://` in those 69 URLs authenticates nothing: `wget` will accept any certificate from anything that answers on that address.

I want to be fair about how much this actually matters, because I don't think it's an open door. Every archive is checked against an MD5 recorded in `vars.sh` (`download-thirdparty.sh:103` and `:114` calling `md5sum_func`). MD5 is broken for *collision* resistance but not for *second-preimage* resistance, so producing a malicious file that matches the MD5 of a fixed upstream tarball is not something anyone can do today. **That MD5 pin is doing real work and I'm not suggesting otherwise.**

The narrower point is that the flag buys nothing the pin doesn't already provide, while giving up transport authentication — so a misconfigured proxy or a hostile endpoint gets contacted and its response written to disk before any check runs. Removing it costs nothing and restores a layer.

I did wonder whether the flag was added because some upstream host has a certificate that fails to validate. The 69 URLs resolve to 10 distinct hosts; I connected to each with verification **on** and every TLS handshake succeeded:

```
archive.apache.org  archives.boost.io  blitiri.com.ar  cdn-thirdparty.starrocks.com
curl.se  fossies.org  github.com  web.mit.edu  www.colm.net     (+ www.oberhumer.com over http)
```

(`cdn-thirdparty.starrocks.com` answers `403` to a bare `HEAD /` — that's an application-level response, the handshake itself was fine.)

I can only speak for today and from my vantage point, though. If the flag was added because of a specific host that breaks inside your build network — a TLS-intercepting proxy would do it — I'd rather be told than guess, and a targeted exception for that one host would still leave the other nine verified.

The second line is smaller: `vars.sh:386` fetches lzo over plain `http://`. It's the only non-HTTPS entry of the 69. I checked that the HTTPS URL serves exactly the same bytes:

```
http://www.oberhumer.com/.../lzo-2.10.tar.gz    600622 bytes  md5 39d3f3f9c55c87b1e5d6888e1420f4b5
https://www.oberhumer.com/.../lzo-2.10.tar.gz   600622 bytes  md5 39d3f3f9c55c87b1e5d6888e1420f4b5
```

and that this matches `LZO2_MD5SUM` at `vars.sh:389` exactly, so the change is byte-neutral.

## What I'm doing:

Removing `--no-check-certificate` from the single `wget` in `download-thirdparty.sh`, and switching the one `http://` source URL to `https://`.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] This is a backport pr

---

**What I verified, and what I did not.** Verified against `bdf38028ad481d1e50d326b190bdf4e24d715dc8`: that `download-thirdparty.sh:112` is the only `wget` in the download path and is reached by all 69 `*_DOWNLOAD` entries; and both lzo URLs returning 600622 bytes with the md5 that matches `vars.sh:389`. Not verified: that no upstream host presents a certificate that fails validation *inside your build environment*. That is the one thing that could make this fail, and it is exactly what the `Thirdparty Info` check would surface.

*Disclosure: I use AI tooling to help me read code at this scale. The URLs, byte counts and checksums above I reproduced myself.*
