### PR TITLE
[BugFix][CVE-2025-55163] Align all io.grpc artifacts via grpc-bom so grpc-netty matches grpc-core

### DIFF
--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -53,7 +53,7 @@ subprojects {
         set("dnsjava.version", "3.6.3")
         set("fastutil.version", "8.5.15")
         set("gcs.connector.version", "hadoop3-2.2.26")
-        set("grpc.version", "1.63.0")
+        set("grpc.version", "1.75.0")
         set("hadoop.version", "3.4.3")
         set("hbase.version", "2.6.2")
         set("hikaricp.version", "7.0.2")
@@ -90,6 +90,11 @@ subprojects {
         implementation(platform("io.opentelemetry:opentelemetry-bom:1.14.0"))
         implementation(platform("software.amazon.awssdk:bom:${project.ext["aws-v2-sdk.version"]}"))
         implementation(platform("io.netty:netty-bom:${project.ext["io.netty.version"]}"))
+        // Mirrors the grpc-bom import in fe/pom.xml. Added by hand because
+        // build-support/sync_pom_to_gradle.py skips `<type>pom</type>` entries
+        // ("Skip BOMs ... as they are handled with platform()"), so an import-scope
+        // BOM cannot reach this file through the `dependency sync` markers below.
+        implementation(platform("io.grpc:grpc-bom:${project.ext["grpc.version"]}"))
         // Enforce the same JUnit 5 versions as Maven (via `junit.version`) across all FE subprojects.
         testImplementation(enforcedPlatform("org.junit:junit-bom:${project.ext["junit.version"]}"))
 
@@ -159,11 +164,6 @@ subprojects {
             implementation("io.airlift:security:202")
             implementation("io.delta:delta-kernel-api:${project.ext["delta-kernel.version"]}")
             implementation("io.delta:delta-kernel-defaults:${project.ext["delta-kernel.version"]}")
-            implementation("io.grpc:grpc-api:${project.ext["grpc.version"]}")
-            implementation("io.grpc:grpc-core:${project.ext["grpc.version"]}")
-            implementation("io.grpc:grpc-netty-shaded:${project.ext["grpc.version"]}")
-            implementation("io.grpc:grpc-protobuf:${project.ext["grpc.version"]}")
-            implementation("io.grpc:grpc-stub:${project.ext["grpc.version"]}")
             implementation("io.netty:netty-all:${project.ext["io.netty.version"]}")
             implementation("io.netty:netty-handler:${project.ext["io.netty.version"]}")
             implementation("io.trino.hive:hive-apache:${project.ext["hive-apache.version"]}")

--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -53,7 +53,7 @@ subprojects {
         set("dnsjava.version", "3.6.3")
         set("fastutil.version", "8.5.15")
         set("gcs.connector.version", "hadoop3-2.2.26")
-        set("grpc.version", "1.75.0")
+        set("grpc.version", "1.76.0")
         set("hadoop.version", "3.4.3")
         set("hbase.version", "2.6.2")
         set("hikaricp.version", "7.0.2")

--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -53,7 +53,7 @@ subprojects {
         set("dnsjava.version", "3.6.3")
         set("fastutil.version", "8.5.15")
         set("gcs.connector.version", "hadoop3-2.2.26")
-        set("grpc.version", "1.63.0")
+        set("grpc.version", "1.75.0")
         set("hadoop.version", "3.4.3")
         set("hbase.version", "2.6.2")
         set("hikaricp.version", "7.0.2")
@@ -89,6 +89,11 @@ subprojects {
         implementation(platform("io.opentelemetry:opentelemetry-bom:1.14.0"))
         implementation(platform("software.amazon.awssdk:bom:${project.ext["aws-v2-sdk.version"]}"))
         implementation(platform("io.netty:netty-bom:${project.ext["io.netty.version"]}"))
+        // Mirrors the grpc-bom import in fe/pom.xml. Added by hand because
+        // build-support/sync_pom_to_gradle.py skips `<type>pom</type>` entries
+        // ("Skip BOMs ... as they are handled with platform()"), so an import-scope
+        // BOM cannot reach this file through the `dependency sync` markers below.
+        implementation(platform("io.grpc:grpc-bom:${project.ext["grpc.version"]}"))
         // Enforce the same JUnit 5 versions as Maven (via `junit.version`) across all FE subprojects.
         testImplementation(enforcedPlatform("org.junit:junit-bom:${project.ext["junit.version"]}"))
 
@@ -158,11 +163,6 @@ subprojects {
             implementation("io.airlift:security:202")
             implementation("io.delta:delta-kernel-api:${project.ext["delta-kernel.version"]}")
             implementation("io.delta:delta-kernel-defaults:${project.ext["delta-kernel.version"]}")
-            implementation("io.grpc:grpc-api:${project.ext["grpc.version"]}")
-            implementation("io.grpc:grpc-core:${project.ext["grpc.version"]}")
-            implementation("io.grpc:grpc-netty-shaded:${project.ext["grpc.version"]}")
-            implementation("io.grpc:grpc-protobuf:${project.ext["grpc.version"]}")
-            implementation("io.grpc:grpc-stub:${project.ext["grpc.version"]}")
             implementation("io.netty:netty-all:${project.ext["io.netty.version"]}")
             implementation("io.netty:netty-handler:${project.ext["io.netty.version"]}")
             implementation("io.trino.hive:hive-apache:${project.ext["hive-apache.version"]}")

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -70,7 +70,7 @@ under the License.
         <hikaricp.version>7.0.2</hikaricp.version>
         <kafka-clients.version>3.9.1</kafka-clients.version>
         <arrow.version>18.0.0</arrow.version>
-        <grpc.version>1.75.0</grpc.version>
+        <grpc.version>1.76.0</grpc.version>
         <io.netty.version>4.1.136.Final</io.netty.version>
         <puppycrawl.version>10.21.1</puppycrawl.version>
         <aws-v2-sdk.version>2.42.1</aws-v2-sdk.version>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -69,7 +69,7 @@ under the License.
         <hikaricp.version>7.0.2</hikaricp.version>
         <kafka-clients.version>3.9.1</kafka-clients.version>
         <arrow.version>18.0.0</arrow.version>
-        <grpc.version>1.63.0</grpc.version>
+        <grpc.version>1.75.0</grpc.version>
         <io.netty.version>4.1.136.Final</io.netty.version>
         <puppycrawl.version>10.21.1</puppycrawl.version>
         <aws-v2-sdk.version>2.42.1</aws-v2-sdk.version>
@@ -1359,34 +1359,17 @@ under the License.
                 <version>${odps.version}</version>
             </dependency>
 
+            <!-- Import the gRPC BOM instead of pinning artifacts individually. Individual
+                 <dependency> entries only govern the artifacts they name, so io.grpc artifacts
+                 that arrive transitively are left unmanaged: arrow flight-core brings in
+                 io.grpc:grpc-netty at its own version, which then runs against a grpc-core
+                 pinned here. The BOM covers direct and transitive io.grpc artifacts alike. -->
             <dependency>
                 <groupId>io.grpc</groupId>
-                <artifactId>grpc-api</artifactId>
+                <artifactId>grpc-bom</artifactId>
                 <version>${grpc.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-netty-shaded</artifactId>
-                <version>${grpc.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-protobuf</artifactId>
-                <version>${grpc.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-stub</artifactId>
-                <version>${grpc.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-core</artifactId>
-                <version>${grpc.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -70,7 +70,7 @@ under the License.
         <hikaricp.version>7.0.2</hikaricp.version>
         <kafka-clients.version>3.9.1</kafka-clients.version>
         <arrow.version>18.0.0</arrow.version>
-        <grpc.version>1.63.0</grpc.version>
+        <grpc.version>1.75.0</grpc.version>
         <io.netty.version>4.1.136.Final</io.netty.version>
         <puppycrawl.version>10.21.1</puppycrawl.version>
         <aws-v2-sdk.version>2.42.1</aws-v2-sdk.version>
@@ -1361,34 +1361,17 @@ under the License.
                 <version>${odps.version}</version>
             </dependency>
 
+            <!-- Import the gRPC BOM instead of pinning artifacts individually. Individual
+                 <dependency> entries only govern the artifacts they name, so io.grpc artifacts
+                 that arrive transitively are left unmanaged: arrow flight-core brings in
+                 io.grpc:grpc-netty at its own version, which then runs against a grpc-core
+                 pinned here. The BOM covers direct and transitive io.grpc artifacts alike. -->
             <dependency>
                 <groupId>io.grpc</groupId>
-                <artifactId>grpc-api</artifactId>
+                <artifactId>grpc-bom</artifactId>
                 <version>${grpc.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-netty-shaded</artifactId>
-                <version>${grpc.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-protobuf</artifactId>
-                <version>${grpc.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-stub</artifactId>
-                <version>${grpc.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-core</artifactId>
-                <version>${grpc.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -24,8 +24,6 @@ scan:
     - "**/gcs-connector-hadoop3-2.2.26-shaded.jar"
     # parquet hadoop bundle
     - "**/parquet-hadoop-bundle-1.15.2.jar"
-    # io.grpc:grpc-netty-shaded (grpc-netty-shaded-1.63.0.jar) CVE-2025-55163
-    - "**/grpc-netty-shaded-1.63.0.jar"
     # from java extension
     - "**/parquet-jackson-1.15.2.jar"
     # from fe


### PR DESCRIPTION
## Why I'm doing:

There is one root cause behind two separate symptoms, and I think a single change closes both.

### Symptom 1 — the `NoSuchMethodError` in #74577

`fe/pom.xml` manages five `io.grpc` artifacts at `${grpc.version}` = `1.63.0`, but **not** `grpc-netty`. `flight-core:18.0.0` brings `grpc-netty` in transitively at Arrow's own `dep.grpc-bom.version` of `1.65.0`, and because it isn't managed, it stays there. I resolved the graph rather than reasoning from the POMs — `mvn dependency:tree` on `fe-core`, JDK 17 / Maven 3.9:

```
[fe-core] +- org.apache.arrow:flight-core:jar:18.0.0:compile
          |  +- io.grpc:grpc-netty:jar:1.65.0:compile
          |  |  +- (io.grpc:grpc-api:jar:1.63.0:compile  - version managed from 1.65.0; ...)
          |  |  +- (io.grpc:grpc-core:jar:1.63.0:runtime - version managed from 1.65.0; ...)
          |  |  \- (io.grpc:grpc-util:jar:1.65.0:runtime - omitted for conflict with 1.63.0)
```

So a 1.65.0 transport runs against a 1.63.0 core — exactly the mechanism the reporter of #74577 identified. gRPC publishes `grpc-bom` precisely to prevent this; individual `<dependency>` entries cannot govern an artifact that arrives transitively.

### Symptom 2 — a HIGH CVE that is currently suppressed rather than fixed

`trivy.yaml` skips one jar with a comment naming the CVE:

```yaml
    # io.grpc:grpc-netty-shaded (grpc-netty-shaded-1.63.0.jar) CVE-2025-55163
    - "**/grpc-netty-shaded-1.63.0.jar"
```

I understand why that entry exists — #69863 says it plainly: *"add bundle jars that has CVEs into skip list, can't do anything for now."* That's a reasonable call for a shaded bundle you can't reach. My point is narrow: **for this particular jar, "can't do anything" is no longer true**, because the fix rides along with the version alignment above.

`fe/pom.xml:73` already pins the unshaded Netty to `4.1.136.Final`, which is patched. But `netty-bom` cannot reach the copy relocated inside `grpc-netty-shaded` under `io.grpc.netty.shaded.io.netty.*` — that copy is whatever the gRPC release bundled. I downloaded each candidate jar from Maven Central and read its own embedded version metadata:

| grpc-netty-shaded | bundled Netty | CVE-2025-55163 |
|---|---|---|
| 1.63.0 – 1.66.0 | 4.1.100.Final | affected |
| 1.67.1 – 1.74.0 | 4.1.110.Final | affected |
| **1.75.0**, 1.76.0 | **4.1.124.Final** | fixed |
| 1.83.1 (latest) | 4.2.15.Final | fixed |

CVE-2025-55163 is the Netty "MadeYouReset" HTTP/2 issue — CVSS v3.1 7.5 / v4.0 8.2, CWE-770 — fixed in Netty 4.1.124.Final and 4.2.4.Final. The jar shipped today (`sha256 4d170c599e47214f35c8955cda3edd7cdb8171229b45795d4d61eb43dfa76402`) reports `netty-transport-native-epoll.version=4.1.100.Final` and carries 282 shaded HTTP/2 codec classes.

I picked **1.75.0** because it is the *lowest* version satisfying both constraints at once — at or above Arrow's 1.65.0, and at or above the Netty fix line.

### Where the shaded jar is actually used

I initially assumed this jar might be dead weight, since there is no `import io.grpc` anywhere in the Java sources. The dependency tree shows otherwise, and I'd rather correct myself in public than quietly:

```
[fe-core] +- com.starrocks:starclient:jar:4.2-rc2:compile
          |  +- com.starrocks:starcommon:jar:4.2-rc2:compile
          |  |  +- (io.grpc:grpc-netty-shaded:jar:1.63.0:runtime - version managed from 1.58.0; ...)
          +- com.starrocks:starmanager:jar:4.2-rc2:compile
             +- (io.grpc:grpc-netty-shaded:jar:1.63.0:runtime - version managed from 1.58.0; ...)
```

So the shaded transport is on the runtime path via the StarMgr clients, matching what the reporter of #74577 said. Those artifacts ask for 1.58.0 and are already managed *up* to 1.63.0 today, so moving them again is not a new kind of change — but it is a further one, and it's the part I'd most want your eyes on.

## What I'm doing:

Importing `io.grpc:grpc-bom` into `fe/pom.xml`'s `dependencyManagement` at 1.75.0 in place of the five individual version pins, so every `io.grpc` artifact — direct and transitive — resolves to one version. Removing the now-unnecessary `grpc-netty-shaded-1.63.0.jar` entry from `trivy.yaml`.

The five `<dependency>` entries in `fe/fe-core/pom.xml` are untouched: they carry no `<version>`, so they pick it up from the BOM.

**I re-ran the same resolution against this branch to confirm the change does what I claim:**

```
io.grpc:grpc-api:jar:1.75.0            io.grpc:grpc-netty:jar:1.75.0
io.grpc:grpc-context:jar:1.75.0        io.grpc:grpc-protobuf:jar:1.75.0
io.grpc:grpc-core:jar:1.75.0           io.grpc:grpc-protobuf-lite:jar:1.75.0
io.grpc:grpc-netty-shaded:jar:1.75.0   io.grpc:grpc-stub:jar:1.75.0
                                       io.grpc:grpc-util:jar:1.75.0
```

No `io.grpc` artifact resolves to any other version, and `omitted for conflict` drops to **0**. The line that carried the bug now reads:

```
|  +- io.grpc:grpc-netty:jar:1.75.0:compile (version managed from 1.65.0)
```

Fixes #74577

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

*(#74577 reports the same skew on main, branch-3.5, branch-4.0 and branch-4.1 — I've left the backport labels unticked because that's your call, not mine.)*

---

## What I verified, and what I did not — please weigh this

**Verified, against `bdf38028ad481d1e50d326b190bdf4e24d715dc8`:**
- the resolved graph before and after this change, via `mvn dependency:tree` in a `maven:3.9-eclipse-temurin-17` container
- `grpc-netty-shaded` reaching the graph through `starclient`, `starcommon` and `starmanager`
- the bundled-Netty version of every grpc release in the table, read from each jar's own `META-INF/…netty.versions.properties`
- CVE-2025-55163's severity, CWE and fix versions, read from NVD

**NOT verified — the part I cannot do from outside:**
- **I have not built the FE or run its test suite**, so I cannot tell you 1.63.0 → 1.75.0 is behaviourally clean. It is a twelve-minor-version move, and dependency resolution succeeding is not the same as the code working.
- I have not exercised Arrow Flight SQL or the FE↔StarMgr path against the new version.
- I have not reproduced the `NoSuchMethodError` myself — I'm relying on #74577 for that, and on the tree above for the mechanism.

If the jump is too large to take in one step, I'd genuinely rather you said so than have this merged on my assurance. I'm happy to reduce it to managing `grpc-netty` at 1.65.0 — fixing #74577 only — and leave the CVE for a separate change.

*Disclosure: I use AI tooling to help me read code at this scale. Every version, checksum and tree line above I reproduced myself; both dependency resolutions were run in a container and the full output is available if useful.*
