### PR TITLE
[BugFix] Do not allow null buckets/mcv in Histogram (backport #77024)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkew.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkew.java
@@ -101,7 +101,7 @@ public class DataSkew {
 
         final var mcv = histogram.getMCV();
 
-        if (mcv == null) {
+        if (mcv.isEmpty()) {
             return new McvSkewInfo(false, AdditionalInfo.NO_MCV);
         }
 
@@ -209,7 +209,7 @@ public class DataSkew {
     }
 
     public static long getOverlappingMcvRowCount(Map<String, Long> mcvs, Map<String, Long> otherMcvs) {
-        if (mcvs == null || mcvs.isEmpty() || otherMcvs == null || otherMcvs.isEmpty()) {
+        if (mcvs.isEmpty() || otherMcvs.isEmpty()) {
             return 0;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 import static java.lang.Double.NEGATIVE_INFINITY;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.statistics;
 
 import com.starrocks.analysis.BinaryType;
@@ -31,6 +30,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
@@ -227,7 +228,7 @@ public class BinaryPredicateStatisticCalculator {
             ColumnStatistic estimatedColumnStatistic = ColumnStatistic.buildFrom(columnStatistic).setNullsFraction(0).build();
             double rowCount = Math.max(0.0, statistics.getOutputRowCount() * (1 - columnStatistic.getNullsFraction())
                     - estimateColumnEqualToConstant(columnRefOperator, columnStatistic, constant, statistics)
-                            .getOutputRowCount());
+                    .getOutputRowCount());
 
             return columnRefOperator.map(operator -> Statistics.buildFrom(statistics)
                             .setOutputRowCount(rowCount).addColumnStatistic(operator, estimatedColumnStatistic).build())
@@ -480,10 +481,6 @@ public class BinaryPredicateStatisticCalculator {
 
     private static void estimateMcvToBucket(Map<String, Long> leftMcv, Map<String, Long> estimatedMcv,
                                             Histogram rightHistogram, double distinctValuesCount, Type dataType) {
-        if (rightHistogram.getBuckets() == null) {
-            return;
-        }
-
         for (Map.Entry<String, Long> entry : leftMcv.entrySet()) {
             if (estimatedMcv.containsKey(entry.getKey())) {
                 continue;
@@ -501,17 +498,18 @@ public class BinaryPredicateStatisticCalculator {
         }
     }
 
+    @Nonnull
     private static List<Bucket> estimateBucketToBucket(Histogram leftHistogram, double leftColumnDistinctValue, Type dataTypeLeft,
                                                        Histogram rightHistogram, double rightColumnDistinctValue,
                                                        Type dataTypeRight) {
         if (leftHistogram == null || rightHistogram == null) {
-            return null;
+            return List.of();
         }
 
         List<Bucket> leftBuckets = leftHistogram.getBuckets();
         List<Bucket> rightBuckets = rightHistogram.getBuckets();
-        if (leftBuckets == null || leftBuckets.isEmpty() || rightBuckets == null || rightBuckets.isEmpty()) {
-            return null;
+        if (leftBuckets.isEmpty() || rightBuckets.isEmpty()) {
+            return List.of();
         }
 
         // Assume the distinct values are uniformly distributed.
@@ -653,8 +651,8 @@ public class BinaryPredicateStatisticCalculator {
     }
 
     public static Optional<Histogram> updateHistWithLessThan(ColumnStatistic columnStatistic,
-                                                   Optional<ConstantOperator> constant,
-                                                   boolean containUpper) {
+                                                             Optional<ConstantOperator> constant,
+                                                             boolean containUpper) {
         if (columnStatistic.getHistogram() == null || !constant.isPresent()) {
             return Optional.empty();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -208,7 +208,7 @@ public class ExpressionStatisticCalculator {
 
             if (!childStat.isUnknown() && childStat.getHistogram() != null && child.getType().isBoolean()) {
                 Map<String, Long> mcv = childStat.getHistogram().getMCV();
-                if (mcv != null && (!mcv.isEmpty())) {
+                if (!mcv.isEmpty()) {
                     String trueKey = booleanToMcvValue(true);
                     String falseKey = booleanToMcvValue(false);
 
@@ -1085,7 +1085,7 @@ public class ExpressionStatisticCalculator {
         private Histogram transformHistogramForDateTrunc(String fmtString, ColumnStatistic dateStatistic,
                                                          Type resultType) {
             final var histogram = dateStatistic.getHistogram();
-            if (histogram == null || histogram.getMCV() == null || histogram.getMCV().isEmpty()) {
+            if (histogram == null || histogram.getMCV().isEmpty()) {
                 return null;
             }
 
@@ -1183,7 +1183,7 @@ public class ExpressionStatisticCalculator {
                     // If condition MCVs are available, use branch row weights and collapse
                     // stats to the surviving branch when one side is unreachable.
                     final var conditionHistogram = condStat.getHistogram();
-                    if (conditionHistogram != null && conditionHistogram.getMCV() != null) {
+                    if (conditionHistogram != null) {
                         final var conditionMcv = conditionHistogram.getMCV();
                         final long trueRows = conditionMcv.getOrDefault(booleanToMcvValue(true), 0L);
                         final long falseRows = conditionMcv.getOrDefault(booleanToMcvValue(false), 0L);
@@ -1250,7 +1250,7 @@ public class ExpressionStatisticCalculator {
         private Histogram buildIfMcv(ColumnStatistic condStat,
                                      ColumnStatistic thenStat,
                                      ColumnStatistic elseStat) {
-            if (condStat.getHistogram() == null || condStat.getHistogram().getMCV() == null) {
+            if (condStat.getHistogram() == null) {
                 return null;
             }
 
@@ -1259,8 +1259,8 @@ public class ExpressionStatisticCalculator {
             long trueRows = conditionMcv.getOrDefault(booleanToMcvValue(true), 0L);
             long falseRows = conditionMcv.getOrDefault(booleanToMcvValue(false), 0L);
 
-            final boolean thenHasHist = thenStat.getHistogram() != null && thenStat.getHistogram().getMCV() != null;
-            final boolean elseHasHist = elseStat.getHistogram() != null && elseStat.getHistogram().getMCV() != null;
+            final boolean thenHasHist = thenStat.getHistogram() != null;
+            final boolean elseHasHist = elseStat.getHistogram() != null;
 
             // If neither branch has a histogram, nothing to propagate.
             if (!thenHasHist && !elseHasHist) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Histogram.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Histogram.java
@@ -21,6 +21,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nonnull;
 
 public class Histogram {
 
@@ -28,26 +29,25 @@ public class Histogram {
     private final Map<String, Long> mcv;
 
     public Histogram(List<Bucket> buckets, Map<String, Long> mcv) {
-        this.buckets = buckets;
-        this.mcv = mcv;
-
+        this.buckets = buckets == null ? List.of() : buckets;
+        this.mcv = mcv == null ? Map.of() : mcv;
     }
 
     public long getTotalRows() {
         long totalRows = 0;
-        if (buckets != null && !buckets.isEmpty()) {
+        if (!buckets.isEmpty()) {
             totalRows += buckets.get(buckets.size() - 1).getCount();
         }
-        if (mcv != null) {
-            totalRows += mcv.values().stream().reduce(Long::sum).orElse(0L);
-        }
+        totalRows += mcv.values().stream().reduce(Long::sum).orElse(0L);
         return Math.max(1, totalRows);
     }
 
+    @Nonnull
     public List<Bucket> getBuckets() {
         return buckets;
     }
 
+    @Nonnull
     public Map<String, Long> getMCV() {
         return mcv;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateUtils.java
@@ -96,8 +96,7 @@ public class StatisticsEstimateUtils {
         }
 
         // Neither side has buckets
-        boolean noBuckets = (left == null || left.getBuckets() == null || left.getBuckets().isEmpty())
-                && (right == null || right.getBuckets() == null || right.getBuckets().isEmpty());
+        boolean noBuckets = (left == null || left.getBuckets().isEmpty()) && (right == null || right.getBuckets().isEmpty());
 
         // The merged MCV rows account for at least 50% of the total rows.
         final double totalRowCount = leftRowCount + rightRowCount;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
@@ -519,21 +519,21 @@ public class HistogramStatisticsTest {
         mcvLeft = new HashMap<>();
         mcvLeft.put("10", 300L);
         mcvLeft.put("22", 100L);
-        histogramLeft = new Histogram(null, mcvLeft);
+        histogramLeft = new Histogram(List.of(), mcvLeft);
         columnStatisticLeft = new ColumnStatistic(1, 50, 0, 4, 500,
                 histogramLeft, ColumnStatistic.StatisticType.ESTIMATE);
 
         mcvRight = new HashMap<>();
         mcvRight.put("22", 80L);
         mcvRight.put("9", 50L);
-        histogramRight = new Histogram(null, mcvRight);
+        histogramRight = new Histogram(List.of(), mcvRight);
         columnStatisticRight = new ColumnStatistic(1, 50, 0, 4, 500,
                 histogramRight, ColumnStatistic.StatisticType.ESTIMATE);
 
         Optional<Histogram> exist = BinaryPredicateStatisticCalculator.updateHistWithJoin(columnStatisticLeft, Type.BIGINT,
                 columnStatisticRight, Type.BIGINT);
         Assertions.assertTrue(exist.isPresent());
-        Assertions.assertNull(exist.get().getBuckets());
+        Assertions.assertTrue(exist.get().getBuckets().isEmpty());
         Assertions.assertEquals(exist.get().getMCV().size(), 1);
         Assertions.assertEquals(exist.get().getMCV().get("22").longValue(), 100 * 80);
 


### PR DESCRIPTION
Backport of #77024 to `branch-3.5-cc`.

Original commit: 2c110bbc3e649c2b1282f794333140dcc32b891f
Original PR: https://github.com/StarRocks/starrocks/pull/77024

---

<!-- Original PR description below -->

## Why I'm doing:
We see regularly stack traces like these in the optimizer which leads to having no stats:
```java
Failed to calculate statistics for expression ...
java.lang.NullPointerException: Cannot invoke "java.util.List.size()" because the return value of "com.starrocks.sql.optimizer.statistics.Histogram.getBuckets()" is null
	at com.starrocks.sql.optimizer.statistics.BinaryPredicateStatisticCalculator.estimateColumnEqualToConstant(BinaryPredicateStatisticCalculator.java:138) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.BinaryPredicateStatisticCalculator.estimateColumnToConstantComparison(BinaryPredicateStatisticCalculator.java:49) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.PredicateStatisticsCalculator$BaseCalculatingVisitor.visitBinaryPredicate(PredicateStatisticsCalculator.java:332) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.PredicateStatisticsCalculator$BaseCalculatingVisitor.visitBinaryPredicate(PredicateStatisticsCalculator.java:71) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator.accept(BinaryPredicateOperator.java:81) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.PredicateStatisticsCalculator.statisticsCalculate(PredicateStatisticsCalculator.java:54) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.ExpressionStatisticCalculator$ExpressionStatisticVisitor.visitBinaryPredicate(ExpressionStatisticCalculator.java:315) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.ExpressionStatisticCalculator$ExpressionStatisticVisitor.visitBinaryPredicate(ExpressionStatisticCalculator.java:84) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator.accept(BinaryPredicateOperator.java:81) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.ExpressionStatisticCalculator$ExpressionStatisticVisitor.lambda$visitCall$5(ExpressionStatisticCalculator.java:516) ~[starrocks-fe.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[?:?]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921) ~[?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682) ~[?:?]
	at com.starrocks.sql.optimizer.statistics.ExpressionStatisticCalculator$ExpressionStatisticVisitor.visitCall(ExpressionStatisticCalculator.java:516) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.ExpressionStatisticCalculator$ExpressionStatisticVisitor.visitCall(ExpressionStatisticCalculator.java:84) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.scalar.CallOperator.accept(CallOperator.java:263) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.ExpressionStatisticCalculator.calculate(ExpressionStatisticCalculator.java:78) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.ExpressionStatisticCalculator.calculate(ExpressionStatisticCalculator.java:70) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.computeProjectNode(StatisticsCalculator.java:992) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.visitLogicalProject(StatisticsCalculator.java:962) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.visitLogicalProject(StatisticsCalculator.java:193) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator.accept(LogicalProjectOperator.java:110) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.estimatorStats(StatisticsCalculator.java:220) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:890) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:879) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:879) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:879) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:879) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:879) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:879) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:879) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:879) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:879) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.QueryOptimizer.logicalRuleRewrite(QueryOptimizer.java:531) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.QueryOptimizer.rewriteAndValidatePlan(QueryOptimizer.java:782) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.QueryOptimizer.optimizeByCost(QueryOptimizer.java:245) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.QueryOptimizer.optimize(QueryOptimizer.java:201) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.UpdatePlanner.plan(UpdatePlanner.java:104) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:160) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:107) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.StmtExecutor.generateExecPlan(StmtExecutor.java:651) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:761) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.ConnectProcessor.doProxyExecute(ConnectProcessor.java:1145) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.ConnectProcessor.proxyExecute(ConnectProcessor.java:1072) ~[starrocks-fe.jar:?]
	at com.starrocks.service.FrontendServiceImpl.forward(FrontendServiceImpl.java:1142) ~[starrocks-fe.jar:?]
	at com.starrocks.thrift.FrontendService$Processor$forward.getResult(FrontendService.java:5948) ~[starrocks-fe.jar:?]
	at com.starrocks.thrift.FrontendService$Processor$forward.getResult(FrontendService.java:5920) ~[starrocks-fe.jar:?]
	at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:40) ~[libthrift-0.23.0.jar:0.23.0]
	at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:41) ~[libthrift-0.23.0.jar:0.23.0]
	at com.starrocks.common.SRTThreadPoolServer$WorkerProcess.run(SRTThreadPoolServer.java:313) ~[starrocks-fe.jar:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
	at java.lang.Thread.run(Thread.java:840) ~[?:?]
```

The underlying issue is that a `Histogram` object with `null` buckets (instead of an empty list) is created. 

## What I'm doing:
This PR makes the histogram class safer (if there is an input null `buckets`), it will be converted to an empty list. Similarly for `mcv`. Additionally, the now unnecessary null handling is removed for all the callers.
This also fixes the one caller where we could definitely pass in `null` buckets to use empty collections instead.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
