### PR TITLE
[UT] Move PseudoCluster based scan limit test out of PartitionPruneRuleTest

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/OlapPartitionScanLimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/OlapPartitionScanLimitTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
-import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Statement;
 
 /**
@@ -47,34 +47,29 @@ public class OlapPartitionScanLimitTest {
                     "values('1','a','2024-09-20'),('2','a','2024-09-21')," +
                     "('3','a','2024-09-22'),('4','a','2024-09-23'),('5','a','2024-09-24')," +
                     "('6','a','2024-09-25'),('7','a','2024-09-26')");
-            //check default value 0
-            stmt.execute("select count(*) from olap_partition_scan_limit_test_table where ds>='2024-09-22';");
-            ResultSet rs = stmt.getResultSet();
-            Assertions.assertTrue(rs.next(), "count(*) must return exactly one row");
-            Assertions.assertEquals(5, rs.getInt(1));
-            //check set value -1
+            // The limit is enforced on the FE while planning, which is all this test can observe:
+            // PseudoBackend never produces result rows (QueryProgress#getFetchDataResult returns eos
+            // with no row batch), so a select always comes back empty here and the returned count
+            // cannot be asserted. What is asserted is whether the query is accepted or rejected.
+            String query = "select count(*) from olap_partition_scan_limit_test_table where ds>='2024-09-22';";
+
+            //check default value 0, means no limit
+            stmt.execute(query);
+            //check set value -1, means no limit
             stmt.execute("set scan_olap_partition_num_limit=-1;");
-            stmt.execute("select count(*) from olap_partition_scan_limit_test_table where ds>='2024-09-22';");
-            rs = stmt.getResultSet();
-            Assertions.assertTrue(rs.next(), "count(*) must return exactly one row");
-            Assertions.assertEquals(5, rs.getInt(1));
-            //check set value 3
+            stmt.execute(query);
+            //check set value 3, 5 partitions have to be scanned so the query must be rejected
             stmt.execute("set scan_olap_partition_num_limit=3;");
-            try {
-                stmt.execute("select count(*) from olap_partition_scan_limit_test_table where ds>='2024-09-22';");
-            } catch (Exception e) {
-                String exp = "Exceeded the limit of number of olap table partitions to be scanned. Number of partitions " +
-                        "allowed: 3, number of partitions to be scanned: 5. Please adjust the SQL or " +
-                        "change the limit by set variable scan_olap_partition_num_limit.";
-                Assertions.assertTrue(e.getMessage().contains(exp));
-            }
+            SQLException e = Assertions.assertThrows(SQLException.class, () -> stmt.execute(query));
+            String exp = "Exceeded the limit of number of olap table partitions to be scanned. Number of partitions " +
+                    "allowed: 3, number of partitions to be scanned: 5. Please adjust the SQL or " +
+                    "change the limit by set variable scan_olap_partition_num_limit.";
+            Assertions.assertTrue(e.getMessage().contains(exp), e.getMessage());
             //check set invalid value abc
-            try {
-                stmt.execute("set scan_olap_partition_num_limit=abc;");
-            } catch (Exception e) {
-                String exp = "Incorrect argument type to variable 'scan_olap_partition_num_limit'";
-                Assertions.assertTrue(e.getMessage().contains(exp));
-            }
+            e = Assertions.assertThrows(SQLException.class,
+                    () -> stmt.execute("set scan_olap_partition_num_limit=abc;"));
+            exp = "Incorrect argument type to variable 'scan_olap_partition_num_limit'";
+            Assertions.assertTrue(e.getMessage().contains(exp), e.getMessage());
         } finally {
             PseudoCluster.getInstance().shutdown(true);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/OlapPartitionScanLimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/OlapPartitionScanLimitTest.java
@@ -1,0 +1,86 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation;
+
+import com.starrocks.pseudocluster.PseudoCluster;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.Statement;
+
+/**
+ * Kept in a separate class from {@link PartitionPruneRuleTest}: PseudoCluster.shutdown() only removes
+ * the run dir, the pseudo FE/BE daemon threads keep running for the rest of the JVM's life. Those threads
+ * keep touching OlapTable, which collides with the JVM-wide class mocking done by the JMockit based tests
+ * in PartitionPruneRuleTest.
+ */
+public class OlapPartitionScanLimitTest {
+
+    @Test
+    public void testOlapPartitionScanLimit() throws Exception {
+        PseudoCluster.getOrCreateWithRandomPort(true, 1);
+        Connection connection = PseudoCluster.getInstance().getQueryConnection();
+        Statement stmt = connection.createStatement();
+        try {
+            stmt.execute("create database olap_partition_scan_limit_test_db");
+            stmt.execute("use olap_partition_scan_limit_test_db");
+            stmt.execute("CREATE TABLE olap_partition_scan_limit_test_table " +
+                    "(`a` varchar(65533),`b` varchar(65533),`ds` date) ENGINE=OLAP " +
+                    "DUPLICATE KEY(`a`) PARTITION BY RANGE(`ds`)" +
+                    "(START (\"2024-09-20\") END (\"2024-09-27\") EVERY (INTERVAL 1 DAY))" +
+                    "DISTRIBUTED BY HASH(`a`)" +
+                    "PROPERTIES (\"replication_num\" = \"1\")");
+            stmt.execute("insert into olap_partition_scan_limit_test_table(a,b,ds) " +
+                    "values('1','a','2024-09-20'),('2','a','2024-09-21')," +
+                    "('3','a','2024-09-22'),('4','a','2024-09-23'),('5','a','2024-09-24')," +
+                    "('6','a','2024-09-25'),('7','a','2024-09-26')");
+            //check default value 0
+            stmt.execute("select count(*) from olap_partition_scan_limit_test_table where ds>='2024-09-22';");
+            if (stmt.getResultSet().next()) {
+                int count = stmt.getResultSet().getInt(1);
+                Assertions.assertEquals(count, 5);
+            }
+            //check set value -1
+            stmt.execute("set scan_olap_partition_num_limit=-1;");
+            stmt.execute("select count(*) from olap_partition_scan_limit_test_table where ds>='2024-09-22';");
+            if (stmt.getResultSet().next()) {
+                int count = stmt.getResultSet().getInt(1);
+                Assertions.assertEquals(count, 5);
+            }
+            //check set value 3
+            stmt.execute("set scan_olap_partition_num_limit=3;");
+            try {
+                stmt.execute("select count(*) from olap_partition_scan_limit_test_table where ds>='2024-09-22';");
+            } catch (Exception e) {
+                String exp = "Exceeded the limit of number of olap table partitions to be scanned. Number of partitions " +
+                        "allowed: 3, number of partitions to be scanned: 5. Please adjust the SQL or " +
+                        "change the limit by set variable scan_olap_partition_num_limit.";
+                Assertions.assertTrue(e.getMessage().contains(exp));
+            }
+            //check set invalid value abc
+            try {
+                stmt.execute("set scan_olap_partition_num_limit=abc;");
+            } catch (Exception e) {
+                String exp = "Incorrect argument type to variable 'scan_olap_partition_num_limit'";
+                Assertions.assertTrue(e.getMessage().contains(exp));
+            }
+        } finally {
+            stmt.close();
+            connection.close();
+            PseudoCluster.getInstance().shutdown(true);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/OlapPartitionScanLimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/OlapPartitionScanLimitTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.Statement;
 
 /**
@@ -49,17 +50,15 @@ public class OlapPartitionScanLimitTest {
                     "('6','a','2024-09-25'),('7','a','2024-09-26')");
             //check default value 0
             stmt.execute("select count(*) from olap_partition_scan_limit_test_table where ds>='2024-09-22';");
-            if (stmt.getResultSet().next()) {
-                int count = stmt.getResultSet().getInt(1);
-                Assertions.assertEquals(count, 5);
-            }
+            ResultSet rs = stmt.getResultSet();
+            Assertions.assertTrue(rs.next(), "count(*) must return exactly one row");
+            Assertions.assertEquals(5, rs.getInt(1));
             //check set value -1
             stmt.execute("set scan_olap_partition_num_limit=-1;");
             stmt.execute("select count(*) from olap_partition_scan_limit_test_table where ds>='2024-09-22';");
-            if (stmt.getResultSet().next()) {
-                int count = stmt.getResultSet().getInt(1);
-                Assertions.assertEquals(count, 5);
-            }
+            rs = stmt.getResultSet();
+            Assertions.assertTrue(rs.next(), "count(*) must return exactly one row");
+            Assertions.assertEquals(5, rs.getInt(1));
             //check set value 3
             stmt.execute("set scan_olap_partition_num_limit=3;");
             try {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/OlapPartitionScanLimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/OlapPartitionScanLimitTest.java
@@ -34,8 +34,7 @@ public class OlapPartitionScanLimitTest {
     public void testOlapPartitionScanLimit() throws Exception {
         PseudoCluster.getOrCreateWithRandomPort(true, 1);
         Connection connection = PseudoCluster.getInstance().getQueryConnection();
-        Statement stmt = connection.createStatement();
-        try {
+        try (connection; Statement stmt = connection.createStatement()) {
             stmt.execute("create database olap_partition_scan_limit_test_db");
             stmt.execute("use olap_partition_scan_limit_test_db");
             stmt.execute("CREATE TABLE olap_partition_scan_limit_test_table " +
@@ -77,8 +76,6 @@ public class OlapPartitionScanLimitTest {
                 Assertions.assertTrue(e.getMessage().contains(exp));
             }
         } finally {
-            stmt.close();
-            connection.close();
             PseudoCluster.getInstance().shutdown(true);
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PartitionPruneRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PartitionPruneRuleTest.java
@@ -29,7 +29,6 @@ import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.FeConstants;
-import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.sql.ast.PartitionValue;
 import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.ast.expression.DateLiteral;
@@ -50,11 +49,8 @@ import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.StringType;
 import mockit.Expectations;
 import mockit.Mocked;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.sql.Connection;
-import java.sql.Statement;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
@@ -459,60 +455,4 @@ public class PartitionPruneRuleTest {
         long actual = selectPartitionIds.get(0);
         assertEquals(10001L, actual);
     }
-
-    @Test
-    public void testOlapPartitionScanLimit() throws Exception {
-        PseudoCluster.getOrCreateWithRandomPort(true, 1);
-        Connection connection = PseudoCluster.getInstance().getQueryConnection();
-        Statement stmt = connection.createStatement();
-        try {
-            stmt.execute("create database olap_partition_scan_limit_test_db");
-            stmt.execute("use olap_partition_scan_limit_test_db");
-            stmt.execute("CREATE TABLE olap_partition_scan_limit_test_table " +
-                    "(`a` varchar(65533),`b` varchar(65533),`ds` date) ENGINE=OLAP " +
-                    "DUPLICATE KEY(`a`) PARTITION BY RANGE(`ds`)" +
-                    "(START (\"2024-09-20\") END (\"2024-09-27\") EVERY (INTERVAL 1 DAY))" +
-                    "DISTRIBUTED BY HASH(`a`)" +
-                    "PROPERTIES (\"replication_num\" = \"1\")");
-            stmt.execute("insert into olap_partition_scan_limit_test_table(a,b,ds) " +
-                    "values('1','a','2024-09-20'),('2','a','2024-09-21')," +
-                    "('3','a','2024-09-22'),('4','a','2024-09-23'),('5','a','2024-09-24')," +
-                    "('6','a','2024-09-25'),('7','a','2024-09-26')");
-            //check default value 0
-            stmt.execute("select count(*) from olap_partition_scan_limit_test_table where ds>='2024-09-22';");
-            if (stmt.getResultSet().next()) {
-                int count = stmt.getResultSet().getInt(1);
-                Assertions.assertEquals(count, 5);
-            }
-            //check set value -1
-            stmt.execute("set scan_olap_partition_num_limit=-1;");
-            stmt.execute("select count(*) from olap_partition_scan_limit_test_table where ds>='2024-09-22';");
-            if (stmt.getResultSet().next()) {
-                int count = stmt.getResultSet().getInt(1);
-                Assertions.assertEquals(count, 5);
-            }
-            //check set value 3
-            stmt.execute("set scan_olap_partition_num_limit=3;");
-            try {
-                stmt.execute("select count(*) from olap_partition_scan_limit_test_table where ds>='2024-09-22';");
-            } catch (Exception e) {
-                String exp = "Exceeded the limit of number of olap table partitions to be scanned. Number of partitions " +
-                        "allowed: 3, number of partitions to be scanned: 5. Please adjust the SQL or " +
-                        "change the limit by set variable scan_olap_partition_num_limit.";
-                Assertions.assertTrue(e.getMessage().contains(exp));
-            }
-            //check set invalid value abc
-            try {
-                stmt.execute("set scan_olap_partition_num_limit=abc;");
-            } catch (Exception e) {
-                String exp = "Incorrect argument type to variable 'scan_olap_partition_num_limit'";
-                Assertions.assertTrue(e.getMessage().contains(exp));
-            }
-        } finally {
-            stmt.close();
-            connection.close();
-            PseudoCluster.getInstance().shutdown(true);
-        }
-    }
-
 }


### PR DESCRIPTION
## Why I'm doing:

```
 PartitionPruneRuleTest.transformForSingleItemListPartitionWithTemp(OlapTable, ListPartitionInfo)                                                                                                                                      
                                                                                                                                                                                                                                         
    java.util.ConcurrentModificationException                                                                                                                                                                                            
        at com.starrocks.sql.optimizer.rule.transformation.PartitionPruneRuleTest$4.<init>(PartitionPruneRuleTest.java:435)                                                                                                              
    java.util.ConcurrentModificationException                                                                                                                                                                                            
        at com.starrocks.sql.optimizer.rule.transformation.PartitionPruneRuleTest$4.<init>(PartitionPruneRuleTest.java:435)                                                                                                              
        at com.starrocks.sql.optimizer.rule.transformation.PartitionPruneRuleTest.transformForSingleItemListPartitionWithTemp(PartitionPruneRuleTest.java:409)                                                                           
        Suppressed: Missing 1 invocation to:                                                                                                                                                                                             
    com.starrocks.catalog.OlapTable#getPartitionInfo()                                                                                                                                                                                   
       on mock instance: com.starrocks.catalog.OlapTable@208e2b0                                                                                                                                                                         
        Caused by: Missing invocations                                                                                                                                                                                                   
            at com.starrocks.sql.optimizer.rule.transformation.PartitionPruneRuleTest$4.<init>(PartitionPruneRuleTest.java:411)                                                                                                          
            at com.starrocks.sql.optimizer.rule.transformation.PartitionPruneRuleTest.transformForSingleItemListPartitionWithTemp(PartitionPruneRuleTest.java:409)
```

PseudoCluster.shutdown() only deletes the run dir, so the pseudo FE/BE daemon threads keep running for the rest of the JVM's life and keep calling OlapTable methods. Surefire forks one JVM per test class, so those threads outlive testOlapPartitionScanLimit and run concurrently with the JMockit tests in the same class, whose @Mocked OlapTable redefines that class JVM-wide. The daemon calls then mutate JMockit's global record/replay state while the Expectations block is still recording, which fails with ConcurrentModificationException.

## What I'm doing:

Move the test into its own class so the JMockit tests run in a JVM without a live cluster.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
