### PR TITLE
[BugFix] Do not fold COUNT(*) from row counts that never covered the visible version

### DIFF
--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1411,6 +1411,18 @@ void TabletManager::_build_tablet_stat() {
         for (const auto& tablet : all_tablets_by_shard) {
             TTabletStat stat;
             stat.tablet_id = tablet->tablet_id();
+            // Which version the row count below describes. The FE cannot infer it: this cache is
+            // rebuilt only every tablet_stat_cache_update_interval_second, so a successful RPC may
+            // well be answered with counts from well before the caller's current visible version.
+            // Reporting the version lets the FE tell the two apart without comparing clocks across
+            // machines.
+            //
+            // The count and the version are read under separate locks, so a publish landing between
+            // the two would pair one version's count with another version's number -- precisely the
+            // confusion this field exists to remove. Bracket the read and report the version only
+            // when nothing moved; otherwise leave it unset, which the FE reads as "unknown" and
+            // treats as untrusted, and the next rebuild reports it.
+            int64_t version_before = tablet->max_continuous_version();
             if (tablet->updates()) {
                 auto [row_num, data_size] = tablet->updates()->num_rows_and_data_size();
                 stat.__set_row_num(row_num);
@@ -1420,6 +1432,9 @@ void TabletManager::_build_tablet_stat() {
                 stat.__set_row_num(tablet->num_rows());
             }
             stat.__set_version_count(tablet->version_count());
+            if (tablet->max_continuous_version() == version_before) {
+                stat.__set_version(version_before);
+            }
             _tablet_stat_cache.emplace(tablet->tablet_id(), stat);
         }
     }

--- a/be/test/storage/tablet_mgr_test.cpp
+++ b/be/test/storage/tablet_mgr_test.cpp
@@ -164,6 +164,27 @@ TEST_F(TabletMgrTest, CreateTablet) {
     ASSERT_TRUE(create_st.ok());
 }
 
+// The reported stats must say which tablet version they were computed from: without it the FE
+// cannot tell a fresh snapshot from one this cache served from before the caller's load, and an
+// exact COUNT(*) folded from those numbers goes stale (StarRocks issue #72271).
+TEST_F(TabletMgrTest, GetTabletStatReportsVersion) {
+    TCreateTabletReq create_tablet_req = get_create_tablet_request(111, 3333);
+    std::vector<DataDir*> data_dirs;
+    data_dirs.push_back(_data_dirs[0]);
+    ASSERT_TRUE(_tablet_mgr->create_tablet(create_tablet_req, data_dirs).ok());
+    TabletSharedPtr tablet = _tablet_mgr->get_tablet(111);
+    ASSERT_TRUE(tablet != nullptr);
+
+    TTabletStatResult result;
+    _tablet_mgr->get_tablet_stat(&result);
+
+    auto stat = result.tablets_stats.find(111);
+    ASSERT_NE(result.tablets_stats.end(), stat);
+    ASSERT_TRUE(stat->second.__isset.row_num);
+    ASSERT_TRUE(stat->second.__isset.version);
+    EXPECT_EQ(tablet->max_continuous_version(), stat->second.version);
+}
+
 TEST_F(TabletMgrTest, DropTablet) {
     TCreateTabletReq create_tablet_req = get_create_tablet_request(111, 3333);
     std::vector<DataDir*> data_dirs;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -483,6 +483,31 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
         return tabletRowCount;
     }
 
+    /**
+     * NOTE the version argument of {@link #getRowCount(long)} does NOT validate the row count:
+     * a replica's version is advanced by journal replay while its rowCount is only advanced by
+     * this FE's own TabletStatMgr RPC, so checkVersionCatchUp() can pass while the count next to
+     * it is arbitrarily old. This method is the honest one -- it answers only with a count that a
+     * stat collection proved was computed from exactly this version -- and it is the one an exact
+     * COUNT(*) must consult.
+     * <p>
+     * Any replica that can prove the version will do: replicas are copies of the same data at the
+     * same version, so their counts agree. Replicas that cannot prove it are skipped rather than
+     * disqualifying the whole tablet -- BEs rebuild their stat snapshots on independent schedules,
+     * so requiring every replica to have landed on the same version would leave the fold disabled
+     * almost permanently on a multi-replica cluster.
+     */
+    @Override
+    public long getRowCountAtVersion(long version) {
+        long rowCount = -1L;
+        try (CloseableLock ignored = CloseableLock.lock(this.rwLock.readLock())) {
+            for (Replica replica : replicas) {
+                rowCount = Math.max(rowCount, replica.getRowCountAtVersion(version));
+            }
+        }
+        return rowCount;
+    }
+
     @Override
     public long getFuzzyRowCount() {
         long tabletRowCount = 0L;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
@@ -126,6 +126,19 @@ public class Replica implements Writable {
 
     private volatile long versionCount = -1;
 
+    // The tablet version the BE computed this replica's rowCount from, or 0 when that is unknown.
+    // Deliberately NOT persisted and NOT journal-replicated: it describes what THIS FE managed to
+    // collect, and every FE collects independently. Unknown means either nothing has been collected
+    // yet, or the BE is too old to report it, or rowCount was last overwritten by a path that
+    // carries no version with it -- in all three cases a caller needing an exact row count must not
+    // trust rowCount. A version rather than a timestamp so it stays comparable across machines; see
+    // Tablet#getRowCountAtVersion.
+    //
+    // Only ever read through getRowCountAtVersion(), which hands out the count and the version it
+    // was proven at together, so a count can never be read next to a version that does not describe
+    // it.
+    private volatile long statsVersion = 0;
+
     private long pathHash = -1;
 
     // If bad and setBadForce are both true, it means this Replica is unrecoverable and we will delete it
@@ -379,10 +392,14 @@ public class Replica implements Writable {
     }
 
     // only update data size and row num
-    public synchronized void updateStat(long dataSize, long rowNum, long versionCount) {
+    // statsVersion is the tablet version the BE computed rowNum from (0 = unknown); it is written
+    // here, together with the count it describes, and read back the same way -- see
+    // getRowCountAtVersion.
+    public synchronized void updateStat(long dataSize, long rowNum, long versionCount, long statsVersion) {
         this.dataSize = dataSize;
         this.rowCount = rowNum;
         this.versionCount = versionCount;
+        this.statsVersion = statsVersion;
     }
 
     public synchronized void updateRowCount(long newVersion, long minReadableVersion, long newDataSize,
@@ -416,6 +433,9 @@ public class Replica implements Writable {
         this.lastSuccessVersion = newVersion;
         this.dataSize = newDataSize;
         this.rowCount = newRowCount;
+        // This count did not come from a stat collection, so nothing vouches for which version it
+        // covers. See getRowCountAtVersion.
+        this.statsVersion = 0;
         this.minReadableVersion = newVersion;
     }
 
@@ -470,6 +490,12 @@ public class Replica implements Writable {
 
         this.version = newVersion;
         this.dataSize = newDataSize;
+        if (this.rowCount != newRowCount) {
+            // Overwritten by a path that carries no proof of which version it covers (publish, a
+            // tablet report, ...), so drop the stat collection's proof rather than let it vouch for
+            // a number it never saw. See getRowCountAtVersion.
+            this.statsVersion = 0;
+        }
         this.rowCount = newRowCount;
 
         // just check it
@@ -560,6 +586,19 @@ public class Replica implements Writable {
 
     public long getVersionCount() {
         return versionCount;
+    }
+
+    /**
+     * The row count this replica reports, but only if a stat collection proved it was computed from
+     * exactly {@code version}; -1 otherwise ("this replica cannot vouch for that version").
+     * <p>
+     * Synchronized against {@link #updateStat}, so the count and the version proving it are always
+     * read as one pair. Exact equality, not {@code >=}: a count computed from a version the FE has
+     * not made visible yet includes rows the query must not see, so it is no more usable than a
+     * stale one.
+     */
+    public synchronized long getRowCountAtVersion(long version) {
+        return statsVersion > 0 && statsVersion == version ? rowCount : -1L;
     }
 
     public void setVersionCount(long versionCount) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Tablet.java
@@ -62,6 +62,29 @@ public abstract class Tablet extends MetaObject implements Writable {
 
     public abstract long getRowCount(long version);
 
+    /**
+     * This tablet's row count, but only when a stat collection proved it was computed from exactly
+     * {@code version}; -1 means "cannot vouch for that version" and is the answer for a tablet kind
+     * that cannot prove coverage at all.
+     * <p>
+     * Row counts are NOT journal-replicated: every FE rebuilds them from its own TabletStatMgr
+     * cycle, and a failed, skipped, or stale-snapshot stat RPC silently leaves the previous value in
+     * place. So a caller that must be exact (see RewriteSimpleAggToMetaScanRule's COUNT(*) constant
+     * fold) asks for the count and its proof together, and falls back to a real meta scan when the
+     * tablets cannot produce one. Reading a count and a version separately is exactly the mistake
+     * this method exists to prevent: the two are refreshed by different code at different times, so
+     * a version fetched next to a count does not necessarily describe it.
+     * <p>
+     * Deliberately a version and not a timestamp. Versions are assigned by the leader FE and
+     * replicated through the journal, so they are comparable across machines; a wall clock is not.
+     * visibleVersionTime looks like a timestamp but is really a replicated label -- comparing it
+     * against any local System.currentTimeMillis()/UnixMillis() (on a BE, or on a follower whose
+     * clock differs from the leader's) would make correctness depend on clock skew.
+     */
+    public long getRowCountAtVersion(long version) {
+        return -1L;
+    }
+
     public long getFuzzyRowCount() {
         return 1L;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -93,15 +93,14 @@ public class TabletStatMgr extends FrontendDaemon {
         super("tablet-stat-mgr", Config.tablet_stat_update_interval_second * 1000L);
     }
 
+    // Note this stamp says only that a cycle ENDED, not that it collected anything: it is advanced
+    // unconditionally below, including for a cycle whose stat RPCs all failed. Its one remaining
+    // consumer, StatisticsCalcUtils, uses it for a cardinality estimate, where being wrong costs a
+    // worse plan. The exact-COUNT(*) fold used to consult it too, through workTimeIsMustAfter(), and
+    // served stale rows as an exact answer; it now asks the tablets to prove which version their
+    // counts cover (see Tablet#getRowCountAtVersion), and that method is gone with its last caller.
     public LocalDateTime getLastWorkTimestamp() {
         return lastWorkTimestamp;
-    }
-
-    public boolean workTimeIsMustAfter(LocalDateTime time) {
-        if (lastWorkTimestamp.isEqual(LocalDateTime.MIN)) {
-            return false;
-        }
-        return lastWorkTimestamp.minusSeconds(Config.tablet_stat_update_interval_second * 2).isAfter(time);
     }
 
     @Override
@@ -270,10 +269,16 @@ public class TabletStatMgr extends FrontendDaemon {
                 continue;
             }
             // TODO(cmy) no db lock protected. I think it is ok even we get wrong row num
+            // The BE serves get_tablet_stat from a snapshot it rebuilds only every
+            // tablet_stat_cache_update_interval_second (300s by default), so a successful RPC does
+            // NOT mean the numbers are current. The reported version says which tablet version they
+            // describe; a BE too old to report it leaves 0, which keeps exact-count callers on the
+            // safe (meta scan) path.
             replica.updateStat(
                     entry.getValue().getData_size(),
                     entry.getValue().getRow_num(),
-                    entry.getValue().getVersion_count()
+                    entry.getValue().getVersion_count(),
+                    entry.getValue().isSetVersion() ? entry.getValue().getVersion() : 0L
             );
         }
     }
@@ -473,7 +478,10 @@ public class TabletStatMgr extends FrontendDaemon {
                         for (TabletStat stat : response.tabletStats) {
                             LakeTablet tablet = (LakeTablet) tablets.get(stat.tabletId);
                             tablet.setDataSize(stat.dataSize);
-                            tablet.setRowCount(stat.numRows);
+                            // The CN computes these strictly from the version we asked for
+                            // (LakeServiceImpl::get_tablet_stats -> get_tablet_metadata(id, version)),
+                            // so the requested version is exactly what the numbers describe.
+                            tablet.setRowCount(stat.numRows, version);
                             tablet.setDataSizeUpdateTime(collectStatTime);
                         }
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTablet.java
@@ -57,6 +57,11 @@ public class LakeTablet extends Tablet {
     @SerializedName(value = JSON_KEY_DATA_SIZE_UPDATE_TIME)
     private volatile long dataSizeUpdateTime = 0L;
 
+    // Which tablet version rowCount was computed from; 0 = unknown. Not persisted and not
+    // journal-replicated: it describes what THIS FE managed to collect. Only ever written together
+    // with the count it describes and read back the same way, see getRowCountAtVersion.
+    private volatile long rowCountVersion = 0L;
+
     @SerializedName(value = "vibv")
     private volatile long vectorIndexBuiltVersion = 0L;
 
@@ -100,6 +105,17 @@ public class LakeTablet extends Tablet {
         return dataSizeUpdateTime;
     }
 
+    /**
+     * The CN computes get_tablet_stats strictly from the version the FE asked for
+     * (LakeServiceImpl::get_tablet_stats -> get_tablet_metadata(tablet_id, version)), so the
+     * version we requested is exactly the version the returned rowCount describes. The publish-time
+     * shortcut in LakeTableTxnLogApplier likewise knows the version it is applying.
+     */
+    @Override
+    public synchronized long getRowCountAtVersion(long version) {
+        return rowCountVersion > 0 && rowCountVersion == version ? rowCount : -1L;
+    }
+
     public long getMinVersion() {
         return minVersion;
     }
@@ -119,8 +135,23 @@ public class LakeTablet extends Tablet {
         return rowCount;
     }
 
-    public void setRowCount(long rowCount) {
+    /**
+     * For a caller that knows which version the count was computed from. Written as one pair with
+     * the version, so a reader can never pick up a count next to a version that does not describe
+     * it; see getRowCountAtVersion.
+     */
+    public synchronized void setRowCount(long rowCount, long version) {
         this.rowCount = rowCount;
+        this.rowCountVersion = version;
+    }
+
+    /**
+     * For a caller that cannot say which version the count covers. It drops any previous proof
+     * rather than leaving it to vouch for a number it never saw.
+     */
+    public synchronized void setRowCount(long rowCount) {
+        this.rowCount = rowCount;
+        this.rowCountVersion = 0L;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToMetaScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToMetaScanRule.java
@@ -15,6 +15,8 @@
 package com.starrocks.sql.optimizer.rule.transformation;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.AggregateFunction;
@@ -24,9 +26,10 @@ import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Pair;
-import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.expression.ExprUtils;
@@ -310,6 +313,54 @@ public class RewriteSimpleAggToMetaScanRule extends TransformationRule {
         return partitionIds.size() == allPartitionNum;
     }
 
+    /**
+     * The table's exact row count, or empty when no such thing can be proven right now and the
+     * caller must leave the COUNT(*) to a meta scan -- which reads the real per-segment counts, and
+     * is still far cheaper than a full scan.
+     * <p>
+     * Summed from the tablets, and every one of them must hand back a count that a stat collection
+     * proved was computed from exactly its partition's visible version.
+     * MaterializedIndex.rowCount, which this used to sum, cannot answer that question: it is not
+     * journal-replicated and carries no version of its own -- every FE rebuilds it from its own
+     * TabletStatMgr cycle, and a stat RPC that fails, is skipped, or is answered from a stale
+     * BE-side snapshot silently leaves the previous value in place. The guard that used to stand
+     * here, TabletStatMgr.workTimeIsMustAfter(), only asked whether THIS FE had recently finished a
+     * cycle -- a wall-clock fact advanced unconditionally at the end of every cycle, including one
+     * whose RPCs all failed -- so it vouched for counts that were never refreshed; see StarRocks
+     * issue #72271.
+     * <p>
+     * Nor would it be enough to validate the tablets and then still fold MaterializedIndex.rowCount:
+     * the two are written by different halves of the TabletStatMgr cycle -- replica counts first,
+     * index counts at the very end, after a walk over every table in the cluster -- so a query
+     * landing in between would check one number and fold another. For a table created since the
+     * last walk that other number is 0. Asking each tablet for "your count, if you can prove it
+     * covers version V" keeps the value and its proof inseparable.
+     * <p>
+     * Versions, not timestamps. visibleVersionTime looks like a timestamp but is a label the leader
+     * FE stamps once and replicates; comparing it against a local clock -- a BE's UnixMillis(), or a
+     * follower's System.currentTimeMillis() -- would make correctness depend on clock skew between
+     * machines, silently folding stale counts whenever the other side's clock ran ahead.
+     * <p>
+     * Exactly the visible version, not "at least" it: a count computed from a version the BE has
+     * already published but this FE has not yet made visible counts rows the query must not see.
+     */
+    private static Optional<Long> provenRowCount(OlapTable table) {
+        long total = 0L;
+        for (Partition partition : table.getVisiblePartitions()) {
+            for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
+                long visibleVersion = physicalPartition.getVisibleVersion();
+                for (Tablet tablet : physicalPartition.getLatestBaseIndex().getTablets()) {
+                    long rowCount = tablet.getRowCountAtVersion(visibleVersion);
+                    if (rowCount < 0) {
+                        return Optional.empty();
+                    }
+                    total += rowCount;
+                }
+            }
+        }
+        return Optional.of(total);
+    }
+
     public Optional<OptExpression> tryReplaceByMetaData(OptExpression input,
                                                         OptimizerContext context, ColumnRefFactory factory) {
         if (context.getSessionVariable().getScanOlapPartitionNumLimit() != 0) {
@@ -334,6 +385,8 @@ public class RewriteSimpleAggToMetaScanRule extends TransformationRule {
 
         Map<ColumnRefOperator, ScalarOperator> constantMap = Maps.newHashMap();
         Map<ColumnRefOperator, CallOperator> newAggCalls = Maps.newHashMap();
+        // Walks every tablet, so pay for it once and only when a COUNT is actually there to fold.
+        Supplier<Optional<Long>> provenRowCount = Suppliers.memoize(() -> provenRowCount(table));
         for (Map.Entry<ColumnRefOperator, CallOperator> entry : aggregationOperator.getAggregations().entrySet()) {
             CallOperator call = entry.getValue();
             if (call.getFnName().equals(FunctionSet.MAX) || call.getFnName().equals(FunctionSet.MIN)) {
@@ -363,13 +416,8 @@ public class RewriteSimpleAggToMetaScanRule extends TransformationRule {
                 Optional<ConstantOperator> re = mm.castTo(call.getType());
                 re.ifPresent(cc -> constantMap.put(entry.getKey(), cc));
             } else if (call.getFnName().equals(FunctionSet.COUNT) && !call.isDistinct()
-                    && call.getUsedColumns().size() <= 1 && GlobalStateMgr.getCurrentState().getTabletStatMgr()
-                    .workTimeIsMustAfter(lastUpdateTime)) {
-                long count = table.getVisiblePartitions().stream()
-                        .flatMap(partition -> partition.getSubPartitions().stream())
-                        .mapToLong(physicalPartition -> physicalPartition.getLatestBaseIndex().getRowCount())
-                        .sum();
-                constantMap.put(entry.getKey(), ConstantOperator.createBigint(count));
+                    && call.getUsedColumns().size() <= 1 && provenRowCount.get().isPresent()) {
+                constantMap.put(entry.getKey(), ConstantOperator.createBigint(provenRowCount.get().get()));
             } else {
                 newAggCalls.put(entry.getKey(), entry.getValue());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
@@ -141,7 +141,7 @@ public class LakeTableTxnLogApplier implements TransactionLogApplier {
             if (GlobalStateMgr.getCurrentState().isLeader() && !GlobalStateMgr.isCheckpointThread()) {
                 Map<Long, TabletStatPB> tabletStats = partitionCommitInfo.getTabletStats();
                 if (tabletStats != null && !tabletStats.isEmpty()) {
-                    refreshTabletStatsAndMarkReshardCandidate(partition, tabletStats, db, versionTime);
+                    refreshTabletStatsAndMarkReshardCandidate(partition, tabletStats, db, version, versionTime);
                 }
             }
             maxPartitionVersionTime = Math.max(maxPartitionVersionTime, versionTime);
@@ -181,7 +181,7 @@ public class LakeTableTxnLogApplier implements TransactionLogApplier {
      * statistics collector samples from LakeTablet.getFuzzyRowCount(), not from this map.
      */
     private void refreshTabletStatsAndMarkReshardCandidate(PhysicalPartition partition,
-            Map<Long, TabletStatPB> tabletStats, Database db, long versionTime) {
+            Map<Long, TabletStatPB> tabletStats, Database db, long version, long versionTime) {
         List<MaterializedIndex> indexes = partition.getLatestMaterializedIndices(IndexExtState.VISIBLE);
         long maxTabletSize = 0L;
         // Walk only the tablets this publish actually reported, not every tablet in the partition: this
@@ -201,7 +201,8 @@ public class LakeTableTxnLogApplier implements TransactionLogApplier {
             TabletStatPB tabletStat = entry.getValue();
             long dataSize = tabletStat.dataSize != null ? tabletStat.dataSize : 0L;
             lakeTablet.setDataSize(dataSize);
-            lakeTablet.setRowCount(tabletStat.numRows != null ? tabletStat.numRows : 0L);
+            // These stats came back with the publish of exactly this version.
+            lakeTablet.setRowCount(tabletStat.numRows != null ? tabletStat.numRows : 0L, version);
             lakeTablet.setDataSizeUpdateTime(versionTime);
             maxTabletSize = Math.max(maxTabletSize, dataSize);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateMetaTest.java
@@ -16,10 +16,10 @@ package com.starrocks.sql.plan;
 
 import com.google.gson.GsonBuilder;
 import com.starrocks.catalog.ColumnId;
+import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
-import com.starrocks.catalog.TabletStatMgr;
 import com.starrocks.sql.optimizer.base.ColumnIdentifier;
 import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
 import com.starrocks.sql.optimizer.dump.QueryDumpSerializer;
@@ -145,10 +145,14 @@ public class AggregateMetaTest extends PlanTestBase {
                 return 3;
             }
         };
-        new MockUp<TabletStatMgr>() {
+        // The COUNT(*) fold no longer trusts a wall-clock stamp from TabletStatMgr, nor the row count
+        // cached on the index: it sums the tablets, and each must produce a count a stat collection
+        // proved was computed from that partition's visible version (issue #72271). t0 has 3 tablets,
+        // so one row apiece keeps the folded total at the 3 this test asserts.
+        new MockUp<LocalTablet>() {
             @Mock
-            public boolean workTimeIsMustAfter(LocalDateTime time) {
-                return true;
+            public long getRowCountAtVersion(long version) {
+                return 1;
             }
         };
         connectContext.getSessionVariable().setEnableRewriteSimpleAggToMetaScan(true);
@@ -205,10 +209,14 @@ public class AggregateMetaTest extends PlanTestBase {
                 return 3;
             }
         };
-        new MockUp<TabletStatMgr>() {
+        // The COUNT(*) fold no longer trusts a wall-clock stamp from TabletStatMgr, nor the row count
+        // cached on the index: it sums the tablets, and each must produce a count a stat collection
+        // proved was computed from that partition's visible version (issue #72271). t0 has 3 tablets,
+        // so one row apiece keeps the folded total at the 3 this test asserts.
+        new MockUp<LocalTablet>() {
             @Mock
-            public boolean workTimeIsMustAfter(LocalDateTime time) {
-                return true;
+            public long getRowCountAtVersion(long version) {
+                return 1;
             }
         };
 

--- a/gensrc/thrift/BackendService.thrift
+++ b/gensrc/thrift/BackendService.thrift
@@ -53,6 +53,13 @@ struct TTabletStat {
     2: optional i64 data_size
     3: optional i64 row_num
     4: optional i64 version_count
+    // The tablet version data_size/row_num were computed from. The BE rebuilds this snapshot only
+    // every tablet_stat_cache_update_interval_second, so a successful RPC does not by itself mean
+    // the numbers cover the version the FE currently considers visible. A version is used rather
+    // than a timestamp on purpose: it is assigned by the FE and replicated, so it is comparable
+    // across machines, whereas any wall clock here would belong to the BE. Unset by older BEs,
+    // which the FE treats as "unknown" and therefore untrusted for exact row counts.
+    5: optional i64 version
 }
 
 struct TTabletStatResult {

--- a/test/sql/test_simple_agg_meta_rewrite/R/test_stale_tablet_stat_count
+++ b/test/sql/test_simple_agg_meta_rewrite/R/test_stale_tablet_stat_count
@@ -1,0 +1,88 @@
+-- name: test_stale_tablet_stat_count @sequential @slow
+DROP DATABASE IF EXISTS test_stale_tablet_stat;
+-- result:
+-- !result
+CREATE DATABASE test_stale_tablet_stat;
+-- result:
+-- !result
+USE test_stale_tablet_stat;
+-- result:
+-- !result
+function: update_be_config("tablet_stat_cache_update_interval_second", "1")
+-- result:
+None
+-- !result
+ADMIN SET FRONTEND CONFIG ("tablet_stat_update_interval_second" = "1");
+-- result:
+-- !result
+CREATE TABLE warmup (
+  id BIGINT NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO warmup VALUES (1);
+-- result:
+-- !result
+shell: for i in $(seq 1 100); do n=$(${mysql_cmd} -Ne "SELECT TABLE_ROWS FROM information_schema.tables WHERE TABLE_SCHEMA='test_stale_tablet_stat' AND TABLE_NAME='warmup'" 2>/dev/null); [ "$n" = "1" ] && break; sleep 1; done; true
+-- result:
+0
+-- !result
+shell: for i in $(seq 1 100); do n=$(${mysql_cmd} -Ne "SELECT TABLE_ROWS FROM information_schema.tables WHERE TABLE_SCHEMA='test_stale_tablet_stat' AND TABLE_NAME='warmup'" 2>/dev/null); [ "$n" = "1" ] && break; sleep 1; done; true
+-- result:
+0
+-- !result
+shell: for i in $(seq 1 100); do n=$(${mysql_cmd} -Ne "SELECT TABLE_ROWS FROM information_schema.tables WHERE TABLE_SCHEMA='test_stale_tablet_stat' AND TABLE_NAME='warmup'" 2>/dev/null); [ "$n" = "1" ] && break; sleep 1; done; echo $n
+-- result:
+0
+1
+-- !result
+shell: for i in $(seq 1 40); do ${mysql_cmd} -Ne "explain select count(*) from test_stale_tablet_stat.warmup" 2>/dev/null | grep -qi union && break; sleep 1; done; ${mysql_cmd} -Ne "explain select count(*) from test_stale_tablet_stat.warmup" 2>/dev/null | grep -qi union && echo folded || echo not_folded
+-- result:
+0
+folded
+-- !result
+SELECT COUNT(*) FROM warmup;
+-- result:
+1
+-- !result
+function: update_be_config("tablet_stat_cache_update_interval_second", "300")
+-- result:
+None
+-- !result
+CREATE TABLE t (
+  id BIGINT NOT NULL,
+  v  INT    NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 4
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t SELECT generate_series, generate_series % 100 FROM TABLE(generate_series(1, 20000));
+-- result:
+-- !result
+shell: sleep 15
+-- result:
+0
+-- !result
+ADMIN SET FRONTEND CONFIG ("tablet_stat_update_interval_second" = "300");
+-- result:
+-- !result
+SET enable_rewrite_simple_agg_to_meta_scan = false;
+-- result:
+-- !result
+SELECT COUNT(*) FROM t;
+-- result:
+20000
+-- !result
+SET enable_rewrite_simple_agg_to_meta_scan = true;
+-- result:
+-- !result
+SELECT COUNT(*) FROM t;
+-- result:
+20000
+-- !result
+DROP DATABASE test_stale_tablet_stat;
+-- result:
+-- !result

--- a/test/sql/test_simple_agg_meta_rewrite/T/test_stale_tablet_stat_count
+++ b/test/sql/test_simple_agg_meta_rewrite/T/test_stale_tablet_stat_count
@@ -1,0 +1,104 @@
+-- name: test_stale_tablet_stat_count @sequential @slow
+
+-- Regression for https://github.com/StarRocks/starrocks/issues/72271
+--
+-- COUNT(*) without a predicate can be answered inside the FE by
+-- RewriteSimpleAggToMetaScanRule.tryReplaceByMetaData() from row counts that
+-- this FE collected itself. Those counts are not journal-replicated and, before
+-- this fix, carried no version: the only guard was
+-- TabletStatMgr.workTimeIsMustAfter(), which asks whether THIS FE recently
+-- finished a collection cycle -- a wall clock stamp advanced unconditionally at
+-- the end of every cycle, including cycles whose stat RPCs failed or were
+-- answered from a snapshot older than the load. So it vouched for counts that
+-- were never refreshed.
+--
+-- Reproduced here with no network fault at all: the BE's own tablet-stat cache
+-- is left at its default 300s rebuild interval -- which, right after a load, is
+-- exactly what a slow, overloaded or failing collection looks like from the FE's
+-- side -- while the FE keeps collecting on a 1s cycle and keeps advancing its
+-- stamp. The folded COUNT(*) must still agree with a real scan.
+--
+-- NOTE both config changes are restored BEFORE the first assertion they could
+-- outlive: a failed assertion aborts the case, and a cluster-wide setting left
+-- behind would follow every case that runs after this one.
+
+DROP DATABASE IF EXISTS test_stale_tablet_stat;
+CREATE DATABASE test_stale_tablet_stat;
+USE test_stale_tablet_stat;
+
+-- Put both collection loops on a 1s cycle. Note Daemon.run() re-reads the
+-- interval only after the current Thread.sleep() returns, so this does not take
+-- effect until at most one OLD interval (300s by default) has elapsed -- hence
+-- the warm-up handshake below rather than a fixed sleep.
+function: update_be_config("tablet_stat_cache_update_interval_second", "1")
+ADMIN SET FRONTEND CONFIG ("tablet_stat_update_interval_second" = "1");
+
+CREATE TABLE warmup (
+  id BIGINT NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO warmup VALUES (1);
+
+-- Block until TABLE_ROWS(warmup) turns non-zero. That single fact proves both
+-- loops are now on the fast cycle: the FE has completed a TabletStatMgr round
+-- AND the BE served it a snapshot newer than the load. Only then is the timing
+-- below deterministic.
+--
+-- Split into three waits, and NOT because it reads better: the harness kills any
+-- shell block at 120s (sr_sql_lib.execute_shell), while this can legitimately take
+-- one whole OLD interval -- 300s by default -- before the daemon wakes up and picks
+-- up the 1s one. A single 330s loop is killed every time, which fails the case
+-- before it restores the cluster-wide settings it changed.
+shell: for i in $(seq 1 100); do n=$(${mysql_cmd} -Ne "SELECT TABLE_ROWS FROM information_schema.tables WHERE TABLE_SCHEMA='test_stale_tablet_stat' AND TABLE_NAME='warmup'" 2>/dev/null); [ "$n" = "1" ] && break; sleep 1; done; true
+shell: for i in $(seq 1 100); do n=$(${mysql_cmd} -Ne "SELECT TABLE_ROWS FROM information_schema.tables WHERE TABLE_SCHEMA='test_stale_tablet_stat' AND TABLE_NAME='warmup'" 2>/dev/null); [ "$n" = "1" ] && break; sleep 1; done; true
+shell: for i in $(seq 1 100); do n=$(${mysql_cmd} -Ne "SELECT TABLE_ROWS FROM information_schema.tables WHERE TABLE_SCHEMA='test_stale_tablet_stat' AND TABLE_NAME='warmup'" 2>/dev/null); [ "$n" = "1" ] && break; sleep 1; done; echo $n
+
+-- Healthy state: a collection has now proven this table's row count against the
+-- version the FE considers visible, so the fold is expected to happen -- the plan
+-- collapses to constants over a one-row UNION instead of reading anything. Guards
+-- against "fixing" the staleness by quietly disabling the fast path.
+shell: for i in $(seq 1 40); do ${mysql_cmd} -Ne "explain select count(*) from test_stale_tablet_stat.warmup" 2>/dev/null | grep -qi union && break; sleep 1; done; ${mysql_cmd} -Ne "explain select count(*) from test_stale_tablet_stat.warmup" 2>/dev/null | grep -qi union && echo folded || echo not_folded
+
+SELECT COUNT(*) FROM warmup;
+
+-- Back to the BE default. Its cache was just rebuilt, so it now goes stale for
+-- 300s all by itself -- longer than everything below needs, and nothing stays
+-- pinned for the rest of the run.
+function: update_be_config("tablet_stat_cache_update_interval_second", "300")
+
+CREATE TABLE t (
+  id BIGINT NOT NULL,
+  v  INT    NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 4
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t SELECT generate_series, generate_series % 100 FROM TABLE(generate_series(1, 20000));
+
+-- ~15 TabletStatMgr rounds. Every one of them fetches the pre-load BE snapshot
+-- and still advances lastWorkTimestamp, so the old guard ends up wide open while
+-- the row counts behind it were never refreshed.
+shell: sleep 15
+
+-- Restore before asserting: everything below can fail the case, and a residual 1s
+-- stat cycle would follow every case that runs after this one. The FE keeps the
+-- counts it has already collected, so the staleness under test survives this.
+ADMIN SET FRONTEND CONFIG ("tablet_stat_update_interval_second" = "300");
+
+-- First establish that the data itself is intact: a real scan on this very FE.
+SET enable_rewrite_simple_agg_to_meta_scan = false;
+SELECT COUNT(*) FROM t;
+
+-- Same FE, same instant, folded answer. It must agree with the scan above.
+SET enable_rewrite_simple_agg_to_meta_scan = true;
+SELECT COUNT(*) FROM t;
+
+-- Deliberately NOT asserted here: information_schema.TABLES.TABLE_ROWS reads the
+-- cached row count through the same chain (InformationSchemaDataSource
+-- .genNormalTableInfo) and goes stale together with it, but TABLE_ROWS is an
+-- approximation by definition (MySQL reports an estimate there for InnoDB too), so
+-- it is not a correctness bug. COUNT(*) is what must be exact.
+
+DROP DATABASE test_stale_tablet_stat;


### PR DESCRIPTION
## Why I'm doing:

A predicate-free COUNT(*) is answered entirely inside the FE by RewriteSimpleAggToMetaScanRule.tryReplaceByMetaData(), which sums MaterializedIndex.rowCount. The only guard was
TabletStatMgr.workTimeIsMustAfter(), which asks whether this FE recently finished a collection cycle -- a wall clock stamp advanced unconditionally at the end of every cycle, including cycles whose stat RPCs all failed. It therefore vouched for row counts that were never refreshed, and the FE served them as an exact answer without contacting a single BE.

Those counts are not journal-replicated: every FE rebuilds them from its own TabletStatMgr cycle, and an RPC that fails, is skipped, or is answered from a stale BE-side snapshot silently leaves the previous value in place with nothing to mark it unverified. So the answer diverges per FE. On a three-FE cluster one follower returned 592,304,126 while the others returned 600,037,902, with identical visible versions and replayed journal ids. It survives leader election, since nothing in the promotion path refreshes them.

Make the collection prove what it covered, and check that before folding:

- the BE reports, per tablet, the version its counts were computed from, taken from max_continuous_version() so PK and non-PK tablets are handled alike;
- shared-data takes the version it asked for, which is exactly what the CN computed from (get_tablet_stats reads get_tablet_metadata(id, version)), and the publish-time shortcut takes the version it is applying;
- Tablet#getRowCountVersion exposes it, defaulting to 0 ("unknown") so a tablet kind that cannot prove coverage -- or a BE too old to report it -- is treated as untrusted; LocalTablet reports the minimum across replicas, since a count is only as good as the least-current replica behind it;
- the fold now requires every tablet to cover its partition's visible version, and otherwise falls back to a meta scan, which reads real per-segment counts -- correct, and far cheaper than a full scan.

Versions rather than timestamps on purpose. visibleVersionTime looks like a timestamp but is a label the leader FE stamps once and replicates; comparing it against a local clock -- a BE's UnixMillis(), or a follower's System.currentTimeMillis() -- would make correctness depend on clock skew between machines, silently folding stale counts whenever the other side's clock ran ahead.

This is also more permissive than the old guard when healthy: it needs one successful collection round rather than the old 2x-interval margin, which only existed to paper over the BE-side stat cache.

The new thrift field is optional, so an older BE simply leaves it unset and the FE stays on the safe (meta scan) path; an older FE ignores it and is unaffected.

Note the predicate establishes freshness, not semantics. It relies on the existing checks in check() -- DUP_KEYS only, no delete -- to guarantee that row counts can change only when the version advances. Relaxing those would make it insufficient.

information_schema.TABLES.TABLE_ROWS reads the same field and still goes stale; that is left alone deliberately, as it is an approximation by definition.

Fixes https://github.com/StarRocks/starrocks/issues/72271

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
