### PR TITLE
[BugFix] Fix bucket pruning for expr partition table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
@@ -181,6 +181,13 @@ public class ColumnFilterConverter {
         if (predicate == null) {
             return;
         }
+        List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);
+        if (conjuncts.size() > 1) {
+            for (ScalarOperator conjunct : conjuncts) {
+                convertColumnFilterWithoutExpr(conjunct, result, table);
+            }
+            return;
+        }
         if (predicate.getChildren().size() <= 0) {
             return;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -61,6 +61,20 @@ public class PartitionPruneTest extends PlanTestBase {
                 + "\"in_memory\" = \"false\"\n"
                 + ");");
 
+        starRocksAssert.withTable("CREATE TABLE `expr_partition_bucket_prune` (\n"
+                + "  `ts` bigint NOT NULL COMMENT \"\",\n"
+                + "  `country` varchar(64) NOT NULL COMMENT \"\",\n"
+                + "  `os` varchar(64) NOT NULL COMMENT \"\",\n"
+                + "  `device_id` varchar(128) NOT NULL COMMENT \"\"\n"
+                + ") ENGINE=OLAP\n"
+                + "DUPLICATE KEY(`ts`, `country`, `os`, `device_id`)\n"
+                + "PARTITION BY RANGE(from_unixtime(`ts`))\n"
+                + "(PARTITION p20240612 VALUES [('2024-06-12 00:00:00'), ('2024-06-13 00:00:00')))\n"
+                + "DISTRIBUTED BY HASH(`country`, `os`) BUCKETS 4\n"
+                + "PROPERTIES (\n"
+                + "\"replication_num\" = \"1\"\n"
+                + ");");
+
         starRocksAssert.withTable("CREATE TABLE `ptest_case` (\n"
                 + "  `k1` int(11) NOT NULL COMMENT \"\",\n"
                 + "  `d2` date    NULL COMMENT \"\",\n"
@@ -190,6 +204,14 @@ public class PartitionPruneTest extends PlanTestBase {
                 "     PREDICATES: 2: d2 = '2020-07-01'\n" +
                 "     partitions=1/4\n" +
                 "     rollup: ptest"));
+    }
+
+    @Test
+    public void testBucketPruneOnExprPartitionTableWithAndPredicate() throws Exception {
+        String plan = getFragmentPlan("select device_id from expr_partition_bucket_prune partition(p20240612) "
+                + "where country = 'JOR' and os = 'Ios' and device_id > '8A49A522'");
+        assertContains(plan, "partitions=1/1");
+        assertContains(plan, "tabletRatio=1/4");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Expression partition tables may fail to prune hash buckets when the original scan predicate is an AND compound predicate.

## What I'm doing:

Split AND predicates before converting filters in `convertColumnFilterWithoutExpr()`, and add a regression test.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
