### PR TITLE
[BugFix] Collect UKFK constraints unconditionally in join reorder

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinOrder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinOrder.java
@@ -371,8 +371,12 @@ public abstract class JoinOrder {
         UKFKConstraints.JoinProperty joinProperty = null;
         SessionVariable sessionVariable = ConnectContext.get().getSessionVariable();
         if (sessionVariable.isEnableUKFKJoinReorder()) {
-            UKFKConstraintsCollector.collectColumnConstraints(leftExprInfo.expr);
-            UKFKConstraintsCollector.collectColumnConstraints(rightExprInfo.expr);
+            // enable_ukfk_join_reorder is an independent switch from enable_ukfk_opt, so the constraints have to be
+            // collected unconditionally here. collectColumnConstraints() is a no-op when enable_ukfk_opt is off,
+            // which would leave both children without constraints and make buildJoinColumnConstraint dereference
+            // null. EliminateAggRule uses the force variant for the same reason.
+            UKFKConstraintsCollector.collectColumnConstraintsForce(leftExprInfo.expr);
+            UKFKConstraintsCollector.collectColumnConstraintsForce(rightExprInfo.expr);
             UKFKConstraints constraint = UKFKConstraintsCollector.buildJoinColumnConstraint(newJoin,
                     newJoin.getJoinType(), newJoin.getOnPredicate(), leftExprInfo.expr, rightExprInfo.expr);
             joinProperty = constraint.getJoinProperty();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/UKFKJoinReorderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/UKFKJoinReorderTest.java
@@ -1,0 +1,87 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.qe.SessionVariable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * enable_ukfk_join_reorder is an independent switch from enable_ukfk_opt. Turning only the former on used to make
+ * JoinOrder.buildJoinExpr dereference UK/FK constraints that UKFKConstraintsCollector had refused to collect
+ * (the collector short-circuits on enable_ukfk_opt), so every join under an aggregate died with
+ * NullPointerException: Cannot read field "uniqueKeys" because "other" is null.
+ */
+public class UKFKJoinReorderTest extends PlanTestBase {
+    private boolean prevUKFKJoinReorder;
+    private boolean prevUKFKOpt;
+    private int prevPushDownAggregateMode;
+
+    @BeforeEach
+    public void setUp() {
+        SessionVariable sv = connectContext.getSessionVariable();
+        prevUKFKJoinReorder = sv.isEnableUKFKJoinReorder();
+        prevUKFKOpt = sv.isEnableUKFKOpt();
+        prevPushDownAggregateMode = sv.getCboPushDownAggregateMode();
+        // PlanTestBase disables aggregate push-down, but ReorderJoinRule is only reached from
+        // QueryOptimizer.pushDownAggregation, so restore the production default here.
+        sv.setCboPushDownAggregateMode(0);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        SessionVariable sv = connectContext.getSessionVariable();
+        sv.setEnableUKFKJoinReorder(prevUKFKJoinReorder);
+        sv.setEnableUKFKOpt(prevUKFKOpt);
+        sv.setCboPushDownAggregateMode(prevPushDownAggregateMode);
+    }
+
+    @Test
+    public void testJoinReorderWithoutUKFKOpt() throws Exception {
+        SessionVariable sv = connectContext.getSessionVariable();
+        sv.setEnableUKFKJoinReorder(true);
+        // Left at its default on purpose: this is the combination that used to crash.
+        sv.setEnableUKFKOpt(false);
+
+        // Cross join: no equal-on predicate, so the collector fails while inheriting relaxed unique keys.
+        String plan = getFragmentPlan("select count(1) from t0 a, t0 b");
+        assertContains(plan, "CROSS JOIN");
+
+        plan = getFragmentPlan("select count(1) from t0 a, t0 b, t0 c");
+        assertContains(plan, "CROSS JOIN");
+
+        // Inner join: there is an equal-on predicate, so the collector fails earlier, while looking the
+        // unique constraint of the left child up.
+        plan = getFragmentPlan("select count(1) from t0 a join t0 b on a.v1 = b.v1");
+        assertContains(plan, "JOIN");
+
+        plan = getFragmentPlan("select count(1) from t0 a join t0 b on a.v1 = b.v1 join t0 c on b.v2 = c.v2");
+        assertContains(plan, "JOIN");
+    }
+
+    @Test
+    public void testJoinReorderWithUKFKOpt() throws Exception {
+        SessionVariable sv = connectContext.getSessionVariable();
+        sv.setEnableUKFKJoinReorder(true);
+        sv.setEnableUKFKOpt(true);
+
+        String plan = getFragmentPlan("select count(1) from t0 a, t0 b");
+        assertContains(plan, "CROSS JOIN");
+
+        plan = getFragmentPlan("select count(1) from t0 a join t0 b on a.v1 = b.v1");
+        assertContains(plan, "JOIN");
+    }
+}

--- a/test/sql/test_ukfk_constraints/R/test_ukfk_join_reorder_only
+++ b/test/sql/test_ukfk_constraints/R/test_ukfk_join_reorder_only
@@ -1,0 +1,99 @@
+-- name: test_ukfk_join_reorder_only
+-- enable_ukfk_join_reorder is an independent switch from enable_ukfk_opt, but JoinOrder.buildJoinExpr used to
+-- collect the UK/FK constraints through a helper that short-circuits on enable_ukfk_opt. Turning only the former
+-- on therefore left both join children without constraints, and buildJoinColumnConstraint dereferenced null, so
+-- any join below an aggregate failed with an internal NullPointerException. enable_ukfk_join_reorder is off by
+-- default, which is exactly why this needs to be set explicitly here.
+CREATE TABLE t_jr (
+  c0 int(11) NULL,
+  c1 int(11) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(c0)
+DISTRIBUTED BY HASH(c0) BUCKETS 1
+PROPERTIES (
+ "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t_jr VALUES (1, 1), (2, 2);
+-- result:
+-- !result
+-- A table without any declared unique key is not what triggers this; a table with one fails the same way.
+CREATE TABLE t_jr_pk (
+  c0 int(11) NOT NULL,
+  c1 int(11) NULL
+) ENGINE=OLAP
+PRIMARY KEY(c0)
+DISTRIBUTED BY HASH(c0) BUCKETS 1
+PROPERTIES (
+ "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t_jr_pk VALUES (1, 1), (2, 2);
+-- result:
+-- !result
+-- enable_ukfk_opt deliberately keeps its default value (false) here.
+set enable_ukfk_join_reorder = true;
+-- result:
+-- !result
+SELECT count(1) FROM t_jr a, t_jr b;
+-- result:
+4
+-- !result
+SELECT count(1) FROM t_jr a, t_jr b, t_jr c;
+-- result:
+8
+-- !result
+SELECT count(1) FROM t_jr, t_jr_pk;
+-- result:
+4
+-- !result
+SELECT count(1) FROM t_jr_pk a, t_jr_pk b, t_jr_pk c;
+-- result:
+8
+-- !result
+SELECT count(1) FROM t_jr a JOIN t_jr b ON a.c0 = b.c0;
+-- result:
+2
+-- !result
+SELECT count(1) FROM t_jr a JOIN t_jr b ON a.c0 = b.c0 JOIN t_jr c ON b.c1 = c.c1;
+-- result:
+2
+-- !result
+SELECT sum(a.c0) FROM t_jr a JOIN t_jr b ON a.c0 = b.c0 LEFT JOIN t_jr c ON b.c1 = c.c1;
+-- result:
+3
+-- !result
+-- The same queries must keep working when both switches are on.
+set enable_ukfk_opt = true;
+-- result:
+-- !result
+SELECT count(1) FROM t_jr a, t_jr b;
+-- result:
+4
+-- !result
+SELECT count(1) FROM t_jr a, t_jr b, t_jr c;
+-- result:
+8
+-- !result
+SELECT count(1) FROM t_jr, t_jr_pk;
+-- result:
+4
+-- !result
+SELECT count(1) FROM t_jr_pk a, t_jr_pk b, t_jr_pk c;
+-- result:
+8
+-- !result
+SELECT count(1) FROM t_jr a JOIN t_jr b ON a.c0 = b.c0;
+-- result:
+2
+-- !result
+SELECT count(1) FROM t_jr a JOIN t_jr b ON a.c0 = b.c0 JOIN t_jr c ON b.c1 = c.c1;
+-- result:
+2
+-- !result
+SELECT sum(a.c0) FROM t_jr a JOIN t_jr b ON a.c0 = b.c0 LEFT JOIN t_jr c ON b.c1 = c.c1;
+-- result:
+3
+-- !result

--- a/test/sql/test_ukfk_constraints/T/test_ukfk_join_reorder_only
+++ b/test/sql/test_ukfk_constraints/T/test_ukfk_join_reorder_only
@@ -1,0 +1,52 @@
+-- name: test_ukfk_join_reorder_only
+-- enable_ukfk_join_reorder is an independent switch from enable_ukfk_opt, but JoinOrder.buildJoinExpr used to
+-- collect the UK/FK constraints through a helper that short-circuits on enable_ukfk_opt. Turning only the former
+-- on therefore left both join children without constraints, and buildJoinColumnConstraint dereferenced null, so
+-- any join below an aggregate failed with an internal NullPointerException. enable_ukfk_join_reorder is off by
+-- default, which is exactly why this needs to be set explicitly here.
+CREATE TABLE t_jr (
+  c0 int(11) NULL,
+  c1 int(11) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(c0)
+DISTRIBUTED BY HASH(c0) BUCKETS 1
+PROPERTIES (
+ "replication_num" = "1"
+);
+
+INSERT INTO t_jr VALUES (1, 1), (2, 2);
+
+-- A table without any declared unique key is not what triggers this; a table with one fails the same way.
+CREATE TABLE t_jr_pk (
+  c0 int(11) NOT NULL,
+  c1 int(11) NULL
+) ENGINE=OLAP
+PRIMARY KEY(c0)
+DISTRIBUTED BY HASH(c0) BUCKETS 1
+PROPERTIES (
+ "replication_num" = "1"
+);
+
+INSERT INTO t_jr_pk VALUES (1, 1), (2, 2);
+
+-- enable_ukfk_opt deliberately keeps its default value (false) here.
+set enable_ukfk_join_reorder = true;
+
+SELECT count(1) FROM t_jr a, t_jr b;
+SELECT count(1) FROM t_jr a, t_jr b, t_jr c;
+SELECT count(1) FROM t_jr, t_jr_pk;
+SELECT count(1) FROM t_jr_pk a, t_jr_pk b, t_jr_pk c;
+SELECT count(1) FROM t_jr a JOIN t_jr b ON a.c0 = b.c0;
+SELECT count(1) FROM t_jr a JOIN t_jr b ON a.c0 = b.c0 JOIN t_jr c ON b.c1 = c.c1;
+SELECT sum(a.c0) FROM t_jr a JOIN t_jr b ON a.c0 = b.c0 LEFT JOIN t_jr c ON b.c1 = c.c1;
+
+-- The same queries must keep working when both switches are on.
+set enable_ukfk_opt = true;
+
+SELECT count(1) FROM t_jr a, t_jr b;
+SELECT count(1) FROM t_jr a, t_jr b, t_jr c;
+SELECT count(1) FROM t_jr, t_jr_pk;
+SELECT count(1) FROM t_jr_pk a, t_jr_pk b, t_jr_pk c;
+SELECT count(1) FROM t_jr a JOIN t_jr b ON a.c0 = b.c0;
+SELECT count(1) FROM t_jr a JOIN t_jr b ON a.c0 = b.c0 JOIN t_jr c ON b.c1 = c.c1;
+SELECT sum(a.c0) FROM t_jr a JOIN t_jr b ON a.c0 = b.c0 LEFT JOIN t_jr c ON b.c1 = c.c1;


### PR DESCRIPTION

## Why I'm doing:

  create table t1 (c0 int, c1 int) duplicate key(c0) distributed by hash(c0) buckets 1;
  insert into t1 values (1,1),(2,2);
  set enable_ukfk_join_reorder = true;
  set cbo_push_down_aggregate_mode = 0;
  select count(1) from t1 a, t1 b, t1 c; 
```
 java.lang.NullPointerException: Cannot read field "uniqueKeys" because "other" is null
        at com.starrocks.sql.optimizer.operator.UKFKConstraints.inheritRelaxedUniqueKey(UKFKConstraints.java:106)
        at com.starrocks.sql.optimizer.UKFKConstraintsCollector.buildJoinColumnConstraint(UKFKConstraintsCollector.java:343)
        at com.starrocks.sql.optimizer.rule.join.JoinOrder.buildJoinExpr(JoinOrder.java:376)
        at com.starrocks.sql.optimizer.rule.join.JoinReorderLeftDeep.enumerate(JoinReorderLeftDeep.java:91)
        at com.starrocks.sql.optimizer.rule.join.JoinOrder.reorder(JoinOrder.java:231)
        at com.starrocks.sql.optimizer.rule.join.ReorderJoinRule.enumerate(ReorderJoinRule.java:106)
        at com.starrocks.sql.optimizer.rule.join.ReorderJoinRule.rewrite(ReorderJoinRule.java:211)
        at com.starrocks.sql.optimizer.QueryOptimizer.logicalJoinReorder(QueryOptimizer.java:903)
        at com.starrocks.sql.optimizer.QueryOptimizer.pushDownAggregation(QueryOptimizer.java:857)
        at com.starrocks.sql.optimizer.QueryOptimizer.logicalRuleRewrite(QueryOptimizer.java:697)
        at com.starrocks.sql.optimizer.QueryOptimizer.rewriteAndValidatePlan(QueryOptimizer.java:829)
        at com.starrocks.sql.optimizer.QueryOptimizer.optimizeByCost(QueryOptimizer.java:260)
        at com.starrocks.sql.optimizer.QueryOptimizer.optimize(QueryOptimizer.java:216)
        at com.starrocks.sql.StatementPlanner.createQueryPlanWithReTry(StatementPlanner.java:423)
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:156)
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:110)
        at com.starrocks.qe.StmtExecutor.generateExecPlan(StmtExecutor.java:856)
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:1026)
        at com.starrocks.qe.ConnectProcessor.executeStmtWithAudit(ConnectProcessor.java:601)
        at com.starrocks.qe.ConnectProcessor.runWithStmtParserStageRetry(ConnectProcessor.java:633)
        at com.starrocks.qe.ConnectProcessor.executeQueryAttempt(ConnectProcessor.java:747)
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:675)
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:989)
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:1379)
        at com.starrocks.mysql.nio.MySQLReadListener.handleRequest(MySQLReadListener.java:152)
        at com.starrocks.mysql.nio.MySQLReadListener.lambda$handleEvent$0(MySQLReadListener.java:92)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:840)

```

enable_ukfk_join_reorder and enable_ukfk_opt are two independent session variables, but JoinOrder.buildJoinExpr gated on the former while collecting the constraints through UKFKConstraintsCollector.collectColumnConstraints(), which short-circuits on the latter. With only enable_ukfk_join_reorder set, neither join child got an UKFKConstraints attached and the immediately following buildJoinColumnConstraint() dereferenced null:

  java.lang.NullPointerException: Cannot read field "uniqueKeys" because "other" is null
    at UKFKConstraints.inheritRelaxedUniqueKey(UKFKConstraints.java:106)
    at UKFKConstraintsCollector.buildJoinColumnConstraint(UKFKConstraintsCollector.java:343)
    at JoinOrder.buildJoinExpr(JoinOrder.java:376)

Any join below an aggregate failed, because ReorderJoinRule is reached from QueryOptimizer.pushDownAggregation. A two-table cross join was enough:

  set enable_ukfk_join_reorder = true;
  select count(1) from t1 a, t1 b;

Use collectColumnConstraintsForce() instead, the same way EliminateAggRule already does for its own independently gated feature. Nothing changes unless enable_ukfk_join_reorder is on, where the previous behaviour was a hard failure.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
