### PR TITLE
[Tool] ci-merged: add backport fan-out dry-run shadow job

### DIFF
--- a/.github/workflows/ci-merged.yml
+++ b/.github/workflows/ci-merged.yml
@@ -44,6 +44,29 @@ jobs:
         with:
           labels: ${{ matrix.version }}
 
+  # Backport fan-out engine — DRY-RUN shadow. Runs alongside the static `backport`
+  # job above and only PRINTS the computed target set (never posts @Mergifyio), for
+  # reconciliation against the manual matrix before cutover. continue-on-error so it
+  # can never affect the merge. Depends on ci-tool #4910/#4911 being on the runner.
+  backport-fanout-shadow:
+    name: Backport Fan-out (dry-run shadow)
+    runs-on: [ self-hosted, quick ]
+    if: >
+      github.event.pull_request.merged == true &&
+      github.base_ref == 'main' &&
+      github.repository == 'StarRocks/starrocks' &&
+      !contains(github.event.pull_request.title, 'cherry-pick') &&
+      !contains(github.event.pull_request.title, 'backport')
+    continue-on-error: true
+    env:
+      PR_NUMBER: ${{ github.event.number }}
+      GH_TOKEN: ${{ secrets.PAT }}
+    steps:
+      - name: fan-out dry-run
+        run: |
+          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
+          python3 lib/backport_fanout_run.py --repo ${GITHUB_REPOSITORY} --pr ${PR_NUMBER} --dry-run
+
   thirdparty-filter:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true


### PR DESCRIPTION
## Why I'm doing:
Roll out the CelerData-first backport fan-out engine in **dry-run shadow** — compute the target
branch set from PR type + `.status`/`.lts` metadata and print it, alongside the existing static-matrix
`backport` job, to reconcile "engine set vs manual-label set" before cutover.

## What I'm doing:
Add a `backport-fanout-shadow` job to `ci-merged.yml` (same merge-to-main + non-backport/cherry-pick
guards as `backport`). It runs `backport_fanout_run.py --dry-run`, which only **prints** the computed
targets — never posts `@Mergifyio`. `continue-on-error: true` so it can never affect the merge; the
static `backport` job is unchanged and still does the real backport. Depends on ci-tool #4910 (core) +
#4911 (glue) on the runner's `/var/lib/ci-tool`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4