### PR TITLE
[Tool] backport fan-out — ON HOLD (superseded by 决策10, do not merge)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,8 +35,9 @@ If yes, please specify the type of change:
   - [ ] This pr needs auto generate documentation
 - [ ] This is a backport pr
 
-## Bugfix cherry-pick branch check:
-- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
-  - [ ] 4.1
-  - [ ] 4.0
-  - [ ] 3.5
+## Backport:
+Backport targets are computed automatically from the PR type and per-branch metadata
+(`.github/.status` / `.github/.lts`): BugFix/Doc/UT → recent releases ∪ recent LTS,
+Enhancement → recent releases, others → none. No manual version checkboxes.
+- To exclude a branch: comment `/no-backport branch-X` before merge (`/no-backport` for none).
+- To add a branch beyond the computed set: comment `@Mergifyio backport branch-X` after merge.

--- a/.github/workflows/ci-merged.yml
+++ b/.github/workflows/ci-merged.yml
@@ -44,6 +44,29 @@ jobs:
         with:
           labels: ${{ matrix.version }}
 
+  # Backport fan-out engine — DRY-RUN shadow. Runs alongside the static `backport`
+  # job above and only PRINTS the computed target set (never posts @Mergifyio), for
+  # reconciliation against the manual matrix before cutover. continue-on-error so it
+  # can never affect the merge. Depends on ci-tool #4910/#4911 being on the runner.
+  backport-fanout-shadow:
+    name: Backport Fan-out (dry-run shadow)
+    runs-on: [ self-hosted, quick ]
+    if: >
+      github.event.pull_request.merged == true &&
+      github.base_ref == 'main' &&
+      github.repository == 'StarRocks/starrocks' &&
+      !contains(github.event.pull_request.title, 'cherry-pick') &&
+      !contains(github.event.pull_request.title, 'backport')
+    continue-on-error: true
+    env:
+      PR_NUMBER: ${{ github.event.number }}
+      GH_TOKEN: ${{ secrets.PAT }}
+    steps:
+      - name: fan-out dry-run
+        run: |
+          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
+          python3 lib/backport_fanout_run.py --repo ${GITHUB_REPOSITORY} --pr ${PR_NUMBER} --dry-run
+
   thirdparty-filter:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true

--- a/.github/workflows/ci-merged.yml
+++ b/.github/workflows/ci-merged.yml
@@ -15,41 +15,12 @@ env:
   PR_NUMBER: ${{ github.event.number }}
 
 jobs:
-  backport:
-    runs-on: ubuntu-latest
-    if: >
-      github.event.pull_request.merged == true &&
-      github.base_ref == 'main' && 
-      github.repository == 'StarRocks/starrocks' &&
-      !contains(github.event.pull_request.title, 'cherry-pick') &&
-      !contains(github.event.pull_request.title, 'backport')
-
-    strategy:
-      fail-fast: false
-      matrix:
-        version: ["4.1", "4.0", "3.5", "3.4", "3.3"]
-    env:
-      PR_NUMBER: ${{ github.event.number }}
-    steps:
-      - name: backport branch-${{ matrix.version }}
-        if: contains(github.event.pull_request.labels.*.name, matrix.version)
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: |
-            @Mergifyio backport branch-${{ matrix.version }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: actions-ecosystem/action-remove-labels@v1
-        if: contains(github.event.pull_request.labels.*.name, matrix.version)
-        with:
-          labels: ${{ matrix.version }}
-
-  # Backport fan-out engine — DRY-RUN shadow. Runs alongside the static `backport`
-  # job above and only PRINTS the computed target set (never posts @Mergifyio), for
-  # reconciliation against the manual matrix before cutover. continue-on-error so it
-  # can never affect the merge. Depends on ci-tool #4910/#4911 being on the runner.
-  backport-fanout-shadow:
-    name: Backport Fan-out (dry-run shadow)
+  # Backport fan-out engine (CUTOVER: real). Computes targets from PR type +
+  # .github/.status / .github/.lts + issue containment and posts `@Mergifyio backport
+  # branch-X`. Replaces the removed static version-matrix backport job (manual
+  # checkboxes -> auto). Requires ci-tool backport_fanout on /var/lib/ci-tool.
+  backport-fanout:
+    name: Backport Fan-out
     runs-on: [ self-hosted, quick ]
     if: >
       github.event.pull_request.merged == true &&
@@ -57,15 +28,14 @@ jobs:
       github.repository == 'StarRocks/starrocks' &&
       !contains(github.event.pull_request.title, 'cherry-pick') &&
       !contains(github.event.pull_request.title, 'backport')
-    continue-on-error: true
     env:
       PR_NUMBER: ${{ github.event.number }}
       GH_TOKEN: ${{ secrets.PAT }}
     steps:
-      - name: fan-out dry-run
+      - name: fan-out
         run: |
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
-          python3 lib/backport_fanout_run.py --repo ${GITHUB_REPOSITORY} --pr ${PR_NUMBER} --dry-run
+          python3 lib/backport_fanout_run.py --repo ${GITHUB_REPOSITORY} --pr ${PR_NUMBER} --no-dry-run
 
   thirdparty-filter:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## ⛔ ON HOLD — superseded by 决策10 (2026-08-04), DO NOT MERGE

老板拍板改用 **AI 二次判断 + 保留 checkbox** 模型(决策10):
- 自动 backport **仅 `[BugFix]`**;窗口(recent3∪recent2LTS)内每条分支由 **AI 判"是否真需要"**,与作者 **checkbox 对账**:勾∧AI需要→自动;任一分歧→通知人工。
- **checkbox / version matrix / 模板复选框全部保留** —— 本 PR 原本要删它们,方向相反,**作废**。

**本 PR 的旧内容(翻 real + 删 matrix + 删模板复选框)全部不再需要。**

正确路径:先建 ci-tool AI 组件(`backport_ai_judge`,`[self-hosted, ubuntu, ai]` 池)→ 再把本 PR **重写**为决策10-C 切换(保留 matrix/checkbox + 加 AI job + 对账 + 翻 real)。

详见设计文档 `docs/superpowers/specs/2026-08-03-backport-fanout-engine-design.md` 决策10 与「AI 二次判断」节。