### PR TITLE
[BugFix] Fix IVM refresh with external authorization

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
@@ -594,8 +594,17 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
 
             try (Timer ignored = Tracers.watchScope("MVRefreshPlanner")) {
                 ctx.getSessionVariable().setEnableInsertSelectExternalAutoRefresh(false); //already refreshed before
-                ExecPlan execPlan = StatementPlanner.plan(insertStmt, ctx);
-                mvContext.setExecPlan(execPlan);
+                boolean previousBypassAuthorizerCheck = ctx.isBypassAuthorizerCheck();
+                try {
+                    // Match PCT by skipping authorization for the trusted refresh INSERT. External column authorization
+                    // launches an auxiliary optimizer before InsertPlanner has bound the IVM aggregate state columns
+                    // required by the rewrite.
+                    ctx.setBypassAuthorizerCheck(true);
+                    ExecPlan execPlan = StatementPlanner.plan(insertStmt, ctx);
+                    mvContext.setExecPlan(execPlan);
+                } finally {
+                    ctx.setBypassAuthorizerCheck(previousBypassAuthorizerCheck);
+                }
             }
             return insertStmt;
         } finally {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
@@ -15,6 +15,9 @@
 package com.starrocks.scheduler.mv.ivm;
 
 import com.google.common.collect.ImmutableList;
+import com.starrocks.authorization.AccessControlProvider;
+import com.starrocks.authorization.AccessController;
+import com.starrocks.authorization.AllowAllAccessController;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.IcebergTable;
@@ -29,6 +32,7 @@ import com.starrocks.common.tvr.TvrVersion;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.iceberg.MockIcebergMetadata;
 import com.starrocks.load.loadv2.IVMInsertLoadTxnCallback;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.scheduler.MVTaskRunProcessor;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.scheduler.TaskRun;
@@ -37,8 +41,11 @@ import com.starrocks.scheduler.mv.hybrid.MVHybridRefreshProcessor;
 import com.starrocks.scheduler.mv.pct.MVPCTRefreshProcessor;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.StatementPlanner;
+import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.KeysType;
+import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanTestBase;
@@ -53,6 +60,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 @TestMethodOrder(MethodName.class)
 public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase {
@@ -63,6 +72,70 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         starRocksAssert.useDatabase("test");
         starRocksAssert.withTable(cluster, "depts");
         starRocksAssert.withTable(cluster, "emps");
+    }
+
+    @Test
+    public void testExternalAuthorizationDoesNotReplanInternalIvmRefresh() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW `test`.`test_mv1` " +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES ('refresh_mode' = 'incremental')\n" +
+                "AS SELECT id, count(*) AS row_count " +
+                "FROM `iceberg0`.`unpartitioned_db`.`t0` GROUP BY id";
+        starRocksAssert.withMaterializedView(ddl);
+        MaterializedView mv = getMv("test_mv1");
+        seedTvrBaselineAtVersionZero(mv);
+
+        String catalog = MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME;
+        AccessControlProvider provider = Authorizer.getInstance();
+        AccessController previousController =
+                provider.catalogToAccessControl.put(catalog, new AllowAllAccessController());
+        try {
+            TaskRun taskRun = buildMVTaskRun(mv, "test");
+            ExecPlan execPlan = getMVRefreshExecPlan(taskRun);
+            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+            PlanTestBase.assertContains(plan, "state_union", "TABLE: test_mv1");
+            Assertions.assertFalse(taskRun.getRunCtx().isBypassAuthorizerCheck());
+        } finally {
+            if (previousController == null) {
+                provider.catalogToAccessControl.remove(catalog);
+            } else {
+                provider.catalogToAccessControl.put(catalog, previousController);
+            }
+            starRocksAssert.dropMaterializedView("test_mv1");
+        }
+    }
+
+    @Test
+    public void testPlannerFailureRestoresInternalAuthorizationBypass() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW `test`.`test_mv1` " +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES ('refresh_mode' = 'incremental')\n" +
+                "AS SELECT id, count(*) AS row_count " +
+                "FROM `iceberg0`.`unpartitioned_db`.`t0` GROUP BY id";
+        starRocksAssert.withMaterializedView(ddl);
+        MaterializedView mv = getMv("test_mv1");
+        seedTvrBaselineAtVersionZero(mv);
+
+        AtomicBoolean bypassDuringPlanning = new AtomicBoolean();
+        AtomicReference<ConnectContext> plannerContext = new AtomicReference<>();
+        new MockUp<StatementPlanner>() {
+            @Mock
+            public ExecPlan plan(StatementBase ignoredStmt, ConnectContext ctx) {
+                bypassDuringPlanning.set(ctx.isBypassAuthorizerCheck());
+                plannerContext.set(ctx);
+                throw new RuntimeException("mock planner failure");
+            }
+        };
+
+        try {
+            TaskRun taskRun = buildMVTaskRun(mv, "test");
+            Assertions.assertThrows(RuntimeException.class, () -> getMVRefreshExecPlan(taskRun));
+            Assertions.assertTrue(bypassDuringPlanning.get());
+            Assertions.assertSame(taskRun.getRunCtx(), plannerContext.get());
+            Assertions.assertFalse(plannerContext.get().isBypassAuthorizerCheck());
+        } finally {
+            starRocksAssert.dropMaterializedView("test_mv1");
+        }
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Ranger uses an external access controller, so `ColumnPrivilege` runs a separate optimizer to identify the columns that need authorization. During IVM refresh, that auxiliary optimizer inherits IVM mode before `InsertPlanner` has built the complete IVM target-output context. It therefore enters aggregate IVM rewrite without the state-column bindings required by `IvmDeltaAggregateRule`.

### Reproduction with an Iceberg table

Configure an Iceberg catalog to use an external access controller such as Ranger. Create an aggregate incremental MV over the Iceberg table:

```sql
CREATE MATERIALIZED VIEW `test`.`test_mv1`
REFRESH DEFERRED MANUAL
PROPERTIES ("refresh_mode" = "incremental")
AS
SELECT id, COUNT(*) AS row_count
FROM `iceberg0`.`unpartitioned_db`.`t0`
GROUP BY id;
```

After the initial refresh establishes the TVR baseline, commit a new Iceberg snapshot and refresh the MV again:

```sql
REFRESH MATERIALIZED VIEW `test`.`test_mv1` WITH SYNC MODE;
```

The refresh fails during planning:

```text
com.starrocks.sql.common.DmlException:
Failed to get MV refresh explain for task: mv-10023,
error: IVM aggregate state-column binding is missing for MV test_mv1
Caused by: java.lang.IllegalStateException:
IVM aggregate state-column binding is missing for MV test_mv1
    at com.starrocks.sql.optimizer.rule.ivm.IvmDeltaAggregateRule.transform(...)
    at com.starrocks.sql.optimizer.rule.ivm.IvmRewriter.rewrite(...)
    at com.starrocks.authorization.ColumnPrivilege.check(...)
    at com.starrocks.sql.analyzer.Authorizer.check(...)
    at com.starrocks.sql.StatementPlanner.plan(...)
    at com.starrocks.scheduler.mv.ivm.MVIVMRefreshProcessor.prepareRefreshPlan(...)
```

## What I'm doing:

- Temporarily bypass authorization while planning the trusted IVM refresh INSERT, and restore the previous bypass state in a `finally` block.
- Document why this aligns with PCT and why the authorization optimizer is currently unsafe for IVM rewrite.
- Add an FE regression test using an Iceberg table, an aggregate incremental MV, and an external access controller.
- Verify that refresh produces the aggregate state plan and restores the authorization bypass state on both success and planner failure.

The user-facing MV refresh authorization remains at the MV level; this only skips duplicate authorization of the planner-generated internal INSERT.

Issue: N/A

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

## Validation

```text
./build.sh --fe --without-java-ext --enable-shared-data --with-compress-debug-symbol OFF -j 30
Successfully build StarRocks Frontend

./run-fe-ut.sh --test com.starrocks.scheduler.mv.ivm.IVMBasedMvRefreshProcessorIcebergTest -j 30
Tests run: 64, Failures: 0, Errors: 0, Skipped: 0

Checkstyle violations: 0
```
