### PR TITLE
[BugFix] Do not journal an insert overwrite failure for a dropped table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -453,6 +453,13 @@ public class InsertOverwriteJobRunner {
 
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null || !db.isExist()) {
+            if (isReplay) {
+                // the database was dropped by a journal entry replayed before this one, so
+                // there is nothing left to clean up; throwing here would exit the FE
+                LOG.warn("database id:{} does not exist when replaying insert overwrite job:{} to FAILED, skip gc",
+                        dbId, job.getJobId());
+                return;
+            }
             // the dynamic overwrite transaction needs only dbId and txnId to abort;
             // clean it up even when the database is gone, otherwise it lingers until
             // the transaction timeout checker reaps it. Skip on replay: the transaction
@@ -464,6 +471,15 @@ public class InsertOverwriteJobRunner {
         }
         Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (table == null) {
+            if (isReplay) {
+                // the table was dropped by a journal entry replayed before this one, so
+                // there is nothing left to clean up. Only a FAILED entry written before the
+                // race below was fixed can be ordered after the drop, but replaying it must
+                // not be fatal: throwing here fails the replay and exits the FE.
+                LOG.warn("table:{} does not exist in database:{} when replaying insert overwrite job:{} to FAILED, "
+                        + "skip gc", tableId, db.getFullName(), job.getJobId());
+                return;
+            }
             if (!isReplay) {
                 abortDynamicOverwriteTxnQuietly();
             }
@@ -492,6 +508,15 @@ public class InsertOverwriteJobRunner {
             throw new DmlException("insert overwrite commit failed because locking db:%s failed", dbId);
         }
         try {
+            // Re-check the table under the WRITE lock, the way doCommit() does: a concurrent
+            // DROP TABLE may have removed it while gc() was waiting for the lock, and the
+            // reference resolved before the lock must not be used then. Failing here also
+            // skips the state change logged below, so that no FAILED entry is ever written
+            // for an already dropped table - such an entry kills every FE that replays it.
+            if (GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId) == null) {
+                throw new DmlException("table:%d does not exist in database:%s", tableId, db.getFullName());
+            }
+
             // Drop temp partitions by partition IDs (for non-dynamic overwrite)
             if (job.getTmpPartitionIds() != null) {
                 for (long pid : job.getTmpPartitionIds()) {

--- a/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerEditLogTest.java
@@ -30,6 +30,8 @@ import com.starrocks.catalog.TableProperty;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.Config;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.persist.InsertOverwriteStateChangeInfo;
 import com.starrocks.persist.OperationType;
 import com.starrocks.server.GlobalStateMgr;
@@ -51,6 +53,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -209,6 +212,91 @@ public class InsertOverwriteJobRunnerEditLogTest {
         // marking precedes the failing statistics collection, so it must have happened
         Assertions.assertTrue(GlobalStateMgr.getCurrentState().getTabletInvertedIndex()
                 .tabletForceDelete(sourceTabletId, BACKEND_ID));
+    }
+
+    @Test
+    public void testGcWritesNoFailedJournalWhenTableDroppedDuringLockWait() throws Exception {
+        InsertOverwriteJob job = new InsertOverwriteJob(2010L, db.getId(), table.getId(),
+                Lists.newArrayList(sourcePartitionId), false);
+        job.setJobState(InsertOverwriteJobState.OVERWRITE_FAILED);
+        job.setTmpPartitionIds(Lists.newArrayList(tempPartitionId));
+        InsertOverwriteJobRunner runner = new InsertOverwriteJobRunner(job);
+
+        // hold the table WRITE lock so that gc() passes its pre-lock existence check and
+        // parks on the lock, then drop the table while it waits — exactly the interleaving
+        // of a concurrent DROP TABLE winning the race against gc()
+        Locker blocker = new Locker();
+        Assertions.assertTrue(blocker.lockTableAndCheckDbExist(db, tableId, LockType.WRITE));
+        AtomicReference<Throwable> gcFailure = new AtomicReference<>();
+        Thread gcThread = new Thread(() -> {
+            try {
+                runner.testGc(false);
+            } catch (Throwable t) {
+                gcFailure.set(t);
+            }
+        });
+        try {
+            gcThread.start();
+            long deadlineMs = System.currentTimeMillis() + 30_000;
+            while (gcThread.isAlive() && gcThread.getState() != Thread.State.WAITING
+                    && gcThread.getState() != Thread.State.TIMED_WAITING) {
+                Assertions.assertTrue(System.currentTimeMillis() < deadlineMs,
+                        "gc() never parked on the table WRITE lock");
+                Thread.sleep(10);
+            }
+            db.dropTable(TABLE_NAME);
+        } finally {
+            blocker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.WRITE);
+        }
+        gcThread.join(60_000);
+        Assertions.assertFalse(gcThread.isAlive());
+        Assertions.assertNull(gcFailure.get());
+
+        // the cleanup must not have run through the reference resolved before the lock:
+        // the dropped table's tablets must not be marked for force delete
+        Assertions.assertFalse(GlobalStateMgr.getCurrentState().getTabletInvertedIndex()
+                .tabletForceDelete(tempTabletId, BACKEND_ID));
+
+        // and no FAILED entry may be journaled for the dropped table: ordered after the
+        // DROP TABLE entry, it would kill every FE that replays it
+        Exception e = Assertions.assertThrows(Exception.class, () -> UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_INSERT_OVERWRITE_STATE_CHANGE));
+        Assertions.assertTrue(e.getMessage().contains("queue is empty"), e.getMessage());
+    }
+
+    @Test
+    public void testReplayFailedStateChangeToleratesDroppedTable() {
+        // the journal stream can legally contain "DROP TABLE t" followed by an
+        // OVERWRITE_FAILED state change for t (see the test above). Replay must treat
+        // the missing table as "nothing left to clean up" instead of failing, which
+        // would make every replaying FE exit.
+        InsertOverwriteJob job = new InsertOverwriteJob(2011L, db.getId(), table.getId(),
+                Lists.newArrayList(sourcePartitionId), false);
+        job.setJobState(InsertOverwriteJobState.OVERWRITE_RUNNING);
+        InsertOverwriteStateChangeInfo info = new InsertOverwriteStateChangeInfo(2011L,
+                InsertOverwriteJobState.OVERWRITE_RUNNING, InsertOverwriteJobState.OVERWRITE_FAILED,
+                Lists.newArrayList(sourcePartitionId), null, Lists.newArrayList(tempPartitionId), -1L);
+
+        db.dropTable(TABLE_NAME);
+
+        InsertOverwriteJobRunner runner = new InsertOverwriteJobRunner(job);
+        Assertions.assertDoesNotThrow(() -> runner.replayStateChange(info));
+        Assertions.assertEquals(InsertOverwriteJobState.OVERWRITE_FAILED, job.getJobState());
+    }
+
+    @Test
+    public void testReplayFailedStateChangeToleratesDroppedDb() {
+        long droppedDbId = GlobalStateMgr.getCurrentState().getNextId();
+        InsertOverwriteJob job = new InsertOverwriteJob(2012L, droppedDbId, table.getId(),
+                Lists.newArrayList(sourcePartitionId), false);
+        job.setJobState(InsertOverwriteJobState.OVERWRITE_RUNNING);
+        InsertOverwriteStateChangeInfo info = new InsertOverwriteStateChangeInfo(2012L,
+                InsertOverwriteJobState.OVERWRITE_RUNNING, InsertOverwriteJobState.OVERWRITE_FAILED,
+                Lists.newArrayList(sourcePartitionId), null, Lists.newArrayList(tempPartitionId), -1L);
+
+        InsertOverwriteJobRunner runner = new InsertOverwriteJobRunner(job);
+        Assertions.assertDoesNotThrow(() -> runner.replayStateChange(info));
+        Assertions.assertEquals(InsertOverwriteJobState.OVERWRITE_FAILED, job.getJobState());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

`InsertOverwriteJobRunner.gc()` resolves the target table **before** acquiring the table WRITE lock. A concurrent `DROP TABLE` can remove the table while `gc()` is waiting for the lock (for example, while a newly elected leader is cancelling the unfinished overwrite jobs it took over and drop statements are running in parallel). `gc()` then continues with the reference resolved earlier and logs the `OVERWRITE_FAILED` state change **after** the drop-table entry has already been journaled.

That journal order crashes every FE that replays it: replay routes through `gc(true)`, which throws `DmlException("table:xxx does not exist")`, the exception is wrapped into `JournalInconsistentException: failed to load journal type 10096`, and the replayer exits. Followers die on real-time replay, the old leader dies on restart replay, and the new leader dies when the checkpoint thread replays the entry — the whole cluster cannot start until the bad journal id is configured into `metadata_journal_skip_bad_journal_ids` on every FE. This was hit in production on 3.5.15.

`doCommit()` is not affected: it resolves the table and logs the state change under the same table WRITE lock, so a drop cannot interleave between the two. `gc()` was the only phase resolving the table outside the lock.

## What I'm doing:

Fix the TOCTOU race on both sides. The change is purely additive:

1. **Re-check the table under the WRITE lock (writer side), the way `doCommit()` already does.** If the table is gone, `gc()` fails there, which also skips the state change logged further down — so no `OVERWRITE_FAILED` entry is ever written for a dropped table. This is exactly what the already existing pre-lock check does when the table is dropped before `gc()` starts, so both paths now behave the same instead of the in-lock case inventing a third behavior. The dynamic overwrite transaction is still aborted after the lock is released.
2. **Tolerate a missing db/table on replay.** On the replay path, a missing database or table means the corresponding drop entry was replayed before this one, so there is nothing left to clean up: warn and return instead of throwing and exiting the FE. Only an entry journaled before fix 1 can be ordered that way, and this keeps clusters that already carry such an entry startable without `metadata_journal_skip_bad_journal_ids`. It also matters for rolling upgrades: with fix 1 in place, a new leader never emits an entry that an FE still running the old code cannot apply.

The race only exists on the leader: replay is single threaded and returns early when the table is already missing, so the in-lock re-check can never fire during replay.

New tests (verified red before the fix, green after):
- a race test that holds the table WRITE lock, lets `gc()` park on it, drops the table, then releases the lock, and verifies that `gc()` neither cleans up through the reference resolved before the lock nor journals a FAILED entry;
- replaying `OVERWRITE_FAILED` tolerates a dropped table;
- replaying `OVERWRITE_FAILED` tolerates a dropped database.

`branch-4.0` and `branch-3.5` have the same code and will be backported manually after this PR merges.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
