### PR TITLE
[BugFix] Rebuild the JSON key column when a set operation deserializes its keys

### DIFF
--- a/be/src/column/json_column.cpp
+++ b/be/src/column/json_column.cpp
@@ -109,6 +109,20 @@ const uint8_t* JsonColumn::deserialize_and_append(const uint8_t* data) {
     return data + size;
 }
 
+// ObjectColumn::deserialize_and_append_batch() is a DCHECK-only stub that silently degrades into a
+// no-op in release builds. Set operations (INTERSECT/EXCEPT) and the serialized-key aggregator use it
+// to rebuild a *non-nullable* key column out of the serialized keys, so falling back to that stub left
+// the JSON column empty while its sibling key columns held `chunk_size` rows. The resulting chunk is
+// inconsistent and reading it by Chunk::num_rows() (e.g. Chunk::bytes_usage()) walks off the end of the
+// JSON pool. The nullable case never hit this because it goes through
+// ColumnFactory::deserialize_and_append_batch_nullable(), which calls the per-row overload below.
+void JsonColumn::deserialize_and_append_batch(Buffer<Slice>& srcs, size_t chunk_size) {
+    DCHECK(!is_flat_json());
+    for (size_t i = 0; i < chunk_size; ++i) {
+        srcs[i].data = (char*)deserialize_and_append((uint8_t*)srcs[i].data);
+    }
+}
+
 uint32_t JsonColumn::serialize_size(size_t idx) const {
     return static_cast<uint32_t>(get_object(idx)->serialize_size());
 }

--- a/be/src/column/json_column.h
+++ b/be/src/column/json_column.h
@@ -55,6 +55,7 @@ public:
     bool is_json() const override { return true; }
 
     const uint8_t* deserialize_and_append(const uint8_t* pos) override;
+    void deserialize_and_append_batch(Buffer<Slice>& srcs, size_t chunk_size) override;
     uint32_t serialize_size(size_t idx) const override;
     uint32_t serialize(size_t idx, uint8_t* pos) const override;
     void serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,

--- a/be/src/column/object_column.cpp
+++ b/be/src/column/object_column.cpp
@@ -14,6 +14,8 @@
 
 #include "column/object_column.h"
 
+#include <stdexcept>
+
 #include "base/phmap/phmap.h"
 #include "column/mysql_row_buffer.h"
 #include "column/vectorized_fwd.h"
@@ -227,7 +229,11 @@ bool ObjectColumn<T>::deserialize_and_append(const Slice& src) {
 
 template <typename T>
 void ObjectColumn<T>::deserialize_and_append_batch(Buffer<Slice>& srcs, size_t chunk_size) {
+    // NOTE: never degrade this into a silent no-op. The callers (set operations and the serialized-key
+    // aggregator) assume `chunk_size` rows have been appended, and returning without appending anything
+    // produces a chunk whose columns disagree on their size, which corrupts every later reader.
     DCHECK(false) << "Don't support object column deserialize and append";
+    throw std::runtime_error("ObjectColumn::deserialize_and_append_batch() is not supported");
 }
 
 template <typename T>

--- a/be/test/column/json_column_test.cpp
+++ b/be/test/column/json_column_test.cpp
@@ -677,4 +677,73 @@ PARALLEL_TEST(JsonColumnTest, test_nullable_wrapper_survives_degrade) {
     ASSERT_FALSE(dst->is_null(2));
 }
 
+// Regression test for the crash in
+//   ObjectColumn<JsonValue>::byte_size() <- Chunk::bytes_usage() <- PipelineDriver::process().
+//
+// INTERSECT/EXCEPT rebuild their output rows by serializing every key column into one row-major
+// buffer and then deserializing that buffer back into freshly created destination columns
+// (IntersectHashSet::deserialize_to_columns / ExceptHashSet::deserialize_to_columns). When the key
+// expression is non-nullable the destination is a bare JsonColumn, which used to inherit
+// ObjectColumn::deserialize_and_append_batch() - a DCHECK-only stub that appends nothing in a
+// release build. The JSON column then stayed empty while the sibling key column held `chunk_size`
+// rows, and the first reader that trusted Chunk::num_rows() walked off the end of the JSON pool.
+//
+// This reproduces that flow without a cluster: it must leave every destination column with the
+// same number of rows, and the JSON values must round-trip.
+// NOLINTNEXTLINE
+PARALLEL_TEST(JsonColumnTest, test_deserialize_and_append_batch_set_operation_keys) {
+    constexpr size_t kChunkSize = 4;
+
+    // The two key columns of `SELECT v1, js FROM js7 INTERSECT ...`, both NOT NULL.
+    auto src_int = Int32Column::create();
+    auto src_json = JsonColumn::create();
+    std::vector<std::string> json_strs = {R"({"a": 1})", R"({"b": [1, 2, 3]})", R"("plain string")", R"(42)"};
+    for (size_t i = 0; i < kChunkSize; ++i) {
+        src_int->append(static_cast<int32_t>(i));
+        ASSIGN_OR_ABORT(auto json, JsonValue::parse(json_strs[i]));
+        src_json->append(std::move(json));
+    }
+
+    // 1. Serialize the keys exactly like IntersectHashSet::_serialize_columns() does for
+    //    non-nullable key columns: a leading null byte followed by the value.
+    uint32_t max_one_row_size = 0;
+    max_one_row_size += src_int->max_one_element_serialize_size() + sizeof(bool);
+    max_one_row_size += src_json->max_one_element_serialize_size() + sizeof(bool);
+
+    std::vector<uint8_t> buffer(max_one_row_size * kChunkSize, 0);
+    Buffer<uint32_t> slice_sizes(kChunkSize, 0);
+    src_int->serialize_batch_with_null_masks(buffer.data(), slice_sizes, kChunkSize, max_one_row_size, nullptr, false);
+    src_json->serialize_batch_with_null_masks(buffer.data(), slice_sizes, kChunkSize, max_one_row_size, nullptr, false);
+
+    Buffer<Slice> keys(kChunkSize);
+    for (size_t i = 0; i < kChunkSize; ++i) {
+        keys[i] = Slice(reinterpret_cast<char*>(buffer.data()) + i * max_one_row_size, slice_sizes[i]);
+    }
+
+    // 2. Rebuild the destination columns the way *HashSet::deserialize_to_columns() does. Both
+    //    destinations are non-nullable, so the serialized null byte is skipped by hand.
+    MutableColumns dst_columns;
+    dst_columns.emplace_back(Int32Column::create());
+    dst_columns.emplace_back(JsonColumn::create());
+    for (auto& dst_column : dst_columns) {
+        for (auto& key : keys) {
+            key.data += sizeof(bool);
+        }
+        dst_column->deserialize_and_append_batch(keys, kChunkSize);
+    }
+
+    // 3. A chunk built out of these columns must be self consistent: every column has to report
+    //    the same size, otherwise Chunk::num_rows() lies about the JSON column and any range
+    //    accessor (Chunk::bytes_usage() -> ObjectColumn::byte_size(0, num_rows)) reads out of bounds.
+    ASSERT_EQ(kChunkSize, dst_columns[0]->size());
+    ASSERT_EQ(kChunkSize, dst_columns[1]->size());
+    ASSERT_EQ(dst_columns[0]->size(), dst_columns[1]->size());
+
+    auto* dst_json = down_cast<JsonColumn*>(dst_columns[1].get());
+    ASSERT_EQ(src_json->byte_size(0, kChunkSize), dst_json->byte_size(0, kChunkSize));
+    for (size_t i = 0; i < kChunkSize; ++i) {
+        ASSERT_EQ(0, src_json->get_object(i)->compare(*dst_json->get_object(i))) << "row " << i;
+    }
+}
+
 } // namespace starrocks

--- a/test/sql/test_set_operation/R/test_intersect_json_not_null
+++ b/test/sql/test_set_operation/R/test_intersect_json_not_null
@@ -1,0 +1,32 @@
+-- name: test_set_operation_with_non_nullable_json
+create table t1 (
+  `k` int not null,
+  `j` json not null
+) duplicate key(`k`)
+distributed by hash(`k`) buckets 1
+properties('replication_num'='1');
+-- result:
+-- !result
+create table t2 (
+  `k` int not null,
+  `j` json not null
+) duplicate key(`k`)
+distributed by hash(`k`) buckets 1
+properties('replication_num'='1');
+-- result:
+-- !result
+insert into t1 values (1, parse_json('{"a": 1}')), (2, parse_json('{"b": 2}')), (3, parse_json('[1, 2, 3]'));
+-- result:
+-- !result
+insert into t2 values (1, parse_json('{"a": 1}')), (2, parse_json('{"c": 3}')), (3, parse_json('[1, 2, 3]'));
+-- result:
+-- !result
+select k, j from t1 intersect select k, j from t2 order by k;
+-- result:
+1	{"a": 1}
+3	[1, 2, 3]
+-- !result
+select k, j from t1 except select k, j from t2 order by k;
+-- result:
+2	{"b": 2}
+-- !result

--- a/test/sql/test_set_operation/T/test_intersect_json_not_null
+++ b/test/sql/test_set_operation/T/test_intersect_json_not_null
@@ -1,0 +1,27 @@
+-- name: test_set_operation_with_non_nullable_json
+-- A set operation rebuilds its output rows by deserializing the serialized hash-set keys into
+-- freshly created destination columns. The destination is a bare JsonColumn only when the key
+-- expression is non-nullable, which is why the existing json coverage (a `json null` column) never
+-- reached this path.
+--
+-- Two properties of this case are load-bearing, so do not "simplify" them away:
+--   * `j` must be NOT NULL. A nullable key routes through
+--     ColumnFactory::deserialize_and_append_batch_nullable(), which was always correct.
+--   * `j` must not be the first output column. Chunk::num_rows() reports the first column's size,
+--     so a chunk holding only the (empty) JSON column reports zero rows and nothing overruns.
+create table t1 (
+  `k` int not null,
+  `j` json not null
+) duplicate key(`k`)
+distributed by hash(`k`) buckets 1
+properties('replication_num'='1');
+create table t2 (
+  `k` int not null,
+  `j` json not null
+) duplicate key(`k`)
+distributed by hash(`k`) buckets 1
+properties('replication_num'='1');
+insert into t1 values (1, parse_json('{"a": 1}')), (2, parse_json('{"b": 2}')), (3, parse_json('[1, 2, 3]'));
+insert into t2 values (1, parse_json('{"a": 1}')), (2, parse_json('{"c": 3}')), (3, parse_json('[1, 2, 3]'));
+select k, j from t1 intersect select k, j from t2 order by k;
+select k, j from t1 except select k, j from t2 order by k;


### PR DESCRIPTION
## Why I'm doing:

```
    @         0x1cafbe14 starrocks::failure_function()
    @         0x32c9381d google::LogMessage::Fail()
    @         0x32c94904 google::LogMessageFatal::~LogMessageFatal()
    @         0x2d7f961e starrocks::ObjectColumn<starrocks::JsonValue>::deserialize_and_append_batch(std::vector<starrocks::Slice, starrocks::ColumnAllocator<starrocks::Slice> >&, unsigned long)
    @         0x1eb8d37a starrocks::IntersectHashSet<phmap::flat_hash_set<starrocks::IntersectSliceFlag, starrocks::IntersectSliceFlagHash, starrocks::IntersectSliceFlagEqual, std::allocator<starrocks::IntersectSliceFlag> > >::deserialize_to_columns(std::vector<starrocks::Slice, s@
    @         0x1eb8a04a starrocks::pipeline::IntersectContext::pull_chunk(starrocks::RuntimeState*)
    @         0x1eb99ddc starrocks::pipeline::IntersectOutputSourceOperator::pull_chunk(starrocks::RuntimeState*)
    @         0x234e95f4 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @         0x1e47fa3d starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @         0x1e47ddea starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}::operator()() const

```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
