### PR TITLE
[BugFix] Stop corr/covar_pop/covar_samp from crashing on a folded constant argument

### DIFF
--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -890,8 +890,12 @@ Status Aggregator::evaluate_agg_input_column(Chunk* chunk, std::vector<ExprConte
                     ColumnHelper::unpack_and_duplicate_const_column(chunk->num_rows(), std::move(col));
         } else {
             // if function has at least two argument, unpack const column selectively
-            // for function like corr, FE forbid second args to be const, we will always unpack const column for it
             // for function like percentile_disc, the second args is const, do not unpack it
+            // NOTE: an argument that the analyzer saw as non-constant can still be constant here,
+            // because the optimizer folds constants after analysis. Every aggregate function that
+            // reads an argument other than the first one must therefore cope with a const column
+            // (see `GetContainer` / `ColumnHelper::get_data_column`), it cannot assume the column
+            // has the concrete type of its argument.
             if (agg_expr_ctxs[j]->root()->is_constant()) {
                 _agg_input_columns[i][j] = std::move(col);
             } else {

--- a/be/src/exprs/agg/covariance.h
+++ b/be/src/exprs/agg/covariance.h
@@ -15,6 +15,7 @@
 
 #include <cmath>
 
+#include "column/column_helper.h"
 #include "column/runtime_type_traits.h"
 #include "exprs/agg/aggregate.h"
 #include "exprs/function_context.h"
@@ -69,16 +70,18 @@ public:
                 size_t row_num) const override {
         DCHECK(ctx->get_num_args() == 2);
 
-        const auto* column0 = down_cast<const InputColumnType*>(columns[0]);
-        const auto* column1 = down_cast<const InputColumnType*>(columns[1]);
-
+        // An argument may still be a constant column here: the analyzer only rejects arguments
+        // that are already constant in the AST, but the optimizer can fold one into a literal
+        // afterwards (e.g. `covar_samp(a, b)` over an inlined one-row subquery), and the
+        // aggregator keeps constant arguments other than the first one packed as ConstColumn.
+        // GetContainer unwraps const/nullable wrappers and picks the right row index.
         this->data(state).count += 1;
 
         double oldMeanX = this->data(state).meanX;
-        InputCppType rowX = column0->immutable_data()[row_num];
+        InputCppType rowX = GetContainer<LT>::get_data(columns[0], row_num);
 
         double oldMeanY = this->data(state).meanY;
-        InputCppType rowY = column1->immutable_data()[row_num];
+        InputCppType rowY = GetContainer<LT>::get_data(columns[1], row_num);
 
         double newMeanX = (oldMeanX + (rowX - oldMeanX) / this->data(state).count);
         double newMeanY = (oldMeanY + (rowY - oldMeanY) / this->data(state).count);
@@ -174,19 +177,20 @@ public:
         auto& offsets = dst_column->get_offset();
         offsets.resize(chunk_size + 1);
 
-        const auto* src_column0 = down_cast<const InputColumnType*>(src[0].get());
-        const auto* src_column1 = down_cast<const InputColumnType*>(src[1].get());
+        // `src` may hold constant columns, see the comment in `update`.
+        const bool src0_is_const = src[0]->is_constant();
+        const bool src1_is_const = src[1]->is_constant();
 
         double meanX = {};
         double meanY = {};
         double c2 = 0;
 
         int64_t count = 1;
-        const auto src0_data = src_column0->immutable_data();
-        const auto src1_data = src_column1->immutable_data();
+        const auto src0_data = GetContainer<LT>::get_data(src[0]);
+        const auto src1_data = GetContainer<LT>::get_data(src[1]);
         for (size_t i = 0; i < chunk_size; ++i) {
-            meanX = static_cast<double>(src0_data[i]);
-            meanY = static_cast<double>(src1_data[i]);
+            meanX = static_cast<double>(src0_data[src0_is_const ? 0 : i]);
+            meanY = static_cast<double>(src1_data[src1_is_const ? 0 : i]);
             memcpy(bytes.data() + old_size, &meanX, sizeof(double));
             memcpy(bytes.data() + old_size + sizeof(double), &meanY, sizeof(double));
             memcpy(bytes.data() + old_size + sizeof(double) * 2, &c2, sizeof(double));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -690,7 +690,7 @@ public class FunctionAnalyzer {
                 throw new SemanticException(fnName + " function should have two args", functionCallExpr.getPos());
             }
             if (functionCallExpr.getChild(0).isConstant() || functionCallExpr.getChild(1).isConstant()) {
-                throw new SemanticException(fnName + " function 's args must be constant");
+                throw new SemanticException(fnName + " function 's args must not be constant");
             }
         }
 

--- a/test/sql/test_agg_function/R/test_corvariance_constant_args
+++ b/test/sql/test_agg_function/R/test_corvariance_constant_args
@@ -1,0 +1,34 @@
+-- name: test_corvariance_constant_args
+select covar_samp(a, b) from (select 1 as a, 10 as b) t;
+-- result:
+None
+-- !result
+select covar_pop(a, b) from (select 1 as a, 10 as b) t;
+-- result:
+0.0
+-- !result
+select corr(a, b) from (select 1 as a, 10 as b) t;
+-- result:
+None
+-- !result
+with w1 as (select t.column_0 as c1, t.column_1 as c2 from (values(1, 10)) t(column_0, column_1))
+select round(covar_samp(w1.c1, w1.c2), 3) from w1;
+-- result:
+None
+-- !result
+select round(covar_pop(k, c), 3) from (select k, 1 as c from (values(2), (3), (4)) t(k)) s;
+-- result:
+0.0
+-- !result
+select round(covar_samp(k, c), 3) from (select k, 1 as c from (values(2), (3), (4)) t(k)) s;
+-- result:
+0.0
+-- !result
+select round(covar_samp(a, b), 3) from (select 1.5 as a, 2.5 as b) t;
+-- result:
+None
+-- !result
+select round(covar_pop(a, b), 3) from (select cast(1 as double) as a, cast(10 as double) as b) t;
+-- result:
+0.0
+-- !result

--- a/test/sql/test_agg_function/T/test_corvariance_constant_args
+++ b/test/sql/test_agg_function/T/test_corvariance_constant_args
@@ -1,0 +1,15 @@
+-- name: test_corvariance_constant_args
+-- The analyzer rejects corr/covar_pop/covar_samp arguments that are already constant in the
+-- AST, but the optimizer can fold an argument into a literal afterwards. Such an argument
+-- reaches the BE as a constant column, which used to be read as a plain typed column.
+select covar_samp(a, b) from (select 1 as a, 10 as b) t;
+select covar_pop(a, b) from (select 1 as a, 10 as b) t;
+select corr(a, b) from (select 1 as a, 10 as b) t;
+with w1 as (select t.column_0 as c1, t.column_1 as c2 from (values(1, 10)) t(column_0, column_1))
+select round(covar_samp(w1.c1, w1.c2), 3) from w1;
+-- Only the second argument is folded into a constant, over a multi-row input.
+select round(covar_pop(k, c), 3) from (select k, 1 as c from (values(2), (3), (4)) t(k)) s;
+select round(covar_samp(k, c), 3) from (select k, 1 as c from (values(2), (3), (4)) t(k)) s;
+-- Non-integer input types.
+select round(covar_samp(a, b), 3) from (select 1.5 as a, 2.5 as b) t;
+select round(covar_pop(a, b), 3) from (select cast(1 as double) as a, cast(10 as double) as b) t;


### PR DESCRIPTION


The analyzer rejects corr/covar_* arguments that are already constant in the AST, but the optimizer folds constants after analysis, so an argument can still reach the BE as a literal. `select covar_samp(a, b) from (select 1 as a, 10 as b) t` plans as `covar_samp[(1, 10); args: TINYINT,TINYINT]`.

Aggregator::evaluate_agg_input_column keeps a constant argument other than the first one packed as a ConstColumn, and CorVarianceBaseAggregateFunction::update down_cast it straight to the argument's typed column. Under NDEBUG down_cast is a bare static_cast, so update() reads the ContainerResource/Buffer fields of a fixed-length column out of the much smaller ConstColumn object; those bytes are normally zero, immutable_data() then returns an empty span and indexing it dereferences a null pointer:
```
*** Aborted at 1785760557 (unix time) try "date -d @1785760557" if you are using GNU date ***
PC: @          0xc8a2d7e starrocks::CorVarianceBaseAggregateFunction<(starrocks::LogicalType)1, false, signed char>::update(starrocks::FunctionContext*, starrocks::Column const**, unsigned char*, unsigned long) const
*** SIGSEGV (@0x0) received by PID 2218189 (TID 0x7d30747ee6c0) LWP(2221063) from PID 0; stack trace: ***
    @     0x7d31f0ce7ed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)
    @         0x12621d06 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7d31f0c8b330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @          0xc8a2d7e starrocks::CorVarianceBaseAggregateFunction<(starrocks::LogicalType)1, false, signed char>::update(starrocks::FunctionContext*, starrocks::Column const**, unsigned char*, unsigned long) const
    @          0xc8cec13 starrocks::NullableAggregateFunctionVariadic<starrocks::NullableAggregateFunctionState<starrocks::CovarianceCorelationAggregateState<false>, false>, starrocks::CorVarianceAggregateFunction<(starrocks::LogicalType)1, true, signed char>::AggNullPred>::update@
    @          0x94a911e starrocks::Aggregator::compute_single_agg_state(starrocks::Chunk*, unsigned long)
    @          0x98d5f26 starrocks::pipeline::AggregateBlockingSinkOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @          0xade1caf starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0x9717596 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0xe7a9e7b starrocks::ThreadPool::dispatch_thread()
    @          0xe7a0d2f starrocks::Thread::supervise_thread(void*)
    @     0x7d31f0ce2aa4 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x9caa3)
    @     0x7d31f0d6fa64 __clone

```

Read both arguments through GetContainer, which unwraps const/nullable wrappers and clamps the row index the same way max_by/min_by already do, and handle constant sources in convert_to_serialize_format too. Also correct the analyzer guard's message, which claimed the arguments "must be constant" while rejecting exactly that.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
