### PR TITLE
[BugFix] Reject SELECT DISTINCT ordering by a column the DISTINCT drops

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
@@ -146,6 +146,9 @@ public class SelectAnalyzer {
             if (!orderByElements.isEmpty()) {
                 new AggregationAnalyzer(session, analyzeState, groupByExpressions, sourceScope, sourceAndOutputScope)
                         .verify(orderByExpressions);
+                if (selectList.isDistinct()) {
+                    verifyDistinctOrderBy(orderByExpressions, outputExpressions, analyzeState, sourceAndOutputScope);
+                }
             }
         }
 
@@ -363,6 +366,74 @@ public class SelectAnalyzer {
         analyzeState.setOutputExprInOrderByScope(outputExprInOrderByScope);
         analyzeState.setOutputScope(new Scope(RelationId.anonymous(), new RelationFields(outputFields.build())));
         return outputExpressions;
+    }
+
+    /**
+     * SELECT DISTINCT is evaluated on top of the aggregation, and it only emits the select-list
+     * expressions. An ORDER BY may therefore only reference those; a GROUP BY key that is not
+     * selected is no longer available once DISTINCT has been applied, and picking one of the rows
+     * that DISTINCT collapsed would be arbitrary anyway. MySQL and PostgreSQL both reject such
+     * queries. Without this check the transformer still builds a plan whose projection above the
+     * DISTINCT aggregation reads a column that aggregation does not output, which fails much later
+     * with an opaque "missing statistic of col" planner error.
+     * <p>
+     * The equivalent check for {@code SELECT DISTINCT} without GROUP BY is already covered by
+     * {@link AggregationAnalyzer}, but only when the ONLY_FULL_GROUP_BY sql mode is set, so this
+     * check is deliberately independent of the sql mode.
+     */
+    private void verifyDistinctOrderBy(List<Expr> orderByExpressions, List<Expr> outputExpressions,
+                                       AnalyzeState analyzeState, Scope orderByScope) {
+        // The fields the select list reads. An ORDER BY slot bound to one of them refers to the same
+        // column even when the two SlotRefs disagree on qualification, as in
+        // "select distinct t.a as b from t order by a".
+        Set<FieldId> outputFields = outputExpressions.stream()
+                .map(analyzeState.getColumnReferences()::get)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        for (Expr orderByExpression : orderByExpressions) {
+            Expr uncovered = findExprNotEmittedByDistinct(orderByExpression, outputExpressions, outputFields,
+                    analyzeState, orderByScope);
+            if (uncovered != null) {
+                throw new SemanticException("for SELECT DISTINCT, ORDER BY expressions must appear in select list",
+                        uncovered.getPos());
+            }
+        }
+    }
+
+    /**
+     * Returns the first sub-expression of {@code expr} that the DISTINCT output cannot provide, or
+     * null when the whole expression can be computed from it.
+     */
+    private Expr findExprNotEmittedByDistinct(Expr expr, List<Expr> outputExpressions, Set<FieldId> outputFields,
+                                              AnalyzeState analyzeState, Scope orderByScope) {
+        if (outputExpressions.stream().anyMatch(expr::equals)) {
+            return null;
+        }
+        if (expr instanceof SlotRef) {
+            SlotRef slotRef = (SlotRef) expr;
+            if (slotRef.isFromLambda()) {
+                return null;
+            }
+            FieldId fieldId = analyzeState.getColumnReferences().get(expr);
+            if (fieldId == null) {
+                return null;
+            }
+            // Slots bound to the order-by scope itself resolve to a select-list item, e.g. an alias.
+            if (Objects.equals(fieldId.getRelationId(), orderByScope.getRelationId())) {
+                return null;
+            }
+            return outputFields.contains(fieldId) ? null : expr;
+        }
+        // Only a column reference can make an expression un-computable from the DISTINCT output;
+        // everything else (literals, functions, casts, ...) is fine as long as its children are.
+        for (Expr child : expr.getChildren()) {
+            Expr uncovered = findExprNotEmittedByDistinct(child, outputExpressions, outputFields, analyzeState,
+                    orderByScope);
+            if (uncovered != null) {
+                return uncovered;
+            }
+        }
+        return null;
     }
 
     private List<OrderByElement> expandOrderByAll(OrderByElement orderByElement,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDistinctOrderByTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDistinctOrderByTest.java
@@ -1,0 +1,93 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SqlModeHelper;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeFail;
+import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeSuccess;
+
+/**
+ * SELECT DISTINCT only emits the select-list expressions, so an ORDER BY that references anything
+ * else cannot be evaluated above it. Such queries used to be accepted by the analyzer and then blew
+ * up deep in the optimizer with "only found column statistics: {...}, but missing statistic of col".
+ */
+public class AnalyzeDistinctOrderByTest {
+    private static final String ERR = "for SELECT DISTINCT, ORDER BY expressions must appear in select list";
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        AnalyzeTestUtil.init();
+    }
+
+    @Test
+    public void testOrderByGroupByKeyNotInSelectList() {
+        // the group by key is dropped by the DISTINCT, so it cannot be an ordering key
+        analyzeFail("select distinct sum(v2) from t0 group by v1 order by v1", ERR);
+        analyzeFail("select distinct sum(v2) from t0 group by v1 order by v1 + 1", ERR);
+        analyzeFail("select distinct sum(v2) from t0 group by v1 having sum(v2) > 1 order by v1", ERR);
+        analyzeFail("select distinct v1 + v2 as e from t0 group by v1, v2 order by v1", ERR);
+        analyzeFail("select distinct v1 + v2 as e from t0 group by grouping sets((v1, v2), (v1)) order by v1", ERR);
+        // the shape reported by the SQL fuzzer
+        analyzeFail("select ((abs(result.co - 120)) / 120) < 0.00001 from (" +
+                "select distinct covar_samp(t0.v2, t0.v3) as co from t0 " +
+                "group by t0.v1 order by t0.v1 asc limit 1, 1) result", ERR);
+    }
+
+    @Test
+    public void testOrderByIsCheckedRegardlessOfSqlMode() {
+        ConnectContext ctx = AnalyzeTestUtil.getConnectContext();
+        long sqlMode = ctx.getSessionVariable().getSqlMode();
+        try {
+            ctx.getSessionVariable().setSqlMode(sqlMode & ~SqlModeHelper.MODE_ONLY_FULL_GROUP_BY);
+            analyzeFail("select distinct sum(v2) from t0 group by v1 order by v1", ERR);
+            analyzeFail("select distinct v1 from t0 order by v2", ERR);
+        } finally {
+            ctx.getSessionVariable().setSqlMode(sqlMode);
+        }
+    }
+
+    @Test
+    public void testOrderByCoveredByDistinctOutputIsAccepted() {
+        analyzeSuccess("select distinct v1, sum(v2) from t0 group by v1 order by v1");
+        analyzeSuccess("select distinct sum(v2) as s from t0 group by v1 order by s");
+        analyzeSuccess("select distinct sum(v2) from t0 group by v1 order by 'x'");
+        analyzeSuccess("select distinct v1, v2 from t0 group by grouping sets((v1), (v2)) order by v1 + v2");
+        analyzeSuccess("select distinct v1, v2 from t0 group by rollup(v1, v2) order by v1 + v2");
+        analyzeSuccess("select distinct v1 from t0 order by v1");
+        analyzeSuccess("select distinct v1 from t0 order by abs(v1) desc");
+    }
+
+    @Test
+    public void testOrderByReferringToSelectListThroughAnAliasIsAccepted() {
+        analyzeSuccess("select distinct v1 as b from t0 order by v1");
+        analyzeSuccess("select distinct v1 as b from t0 order by b");
+        analyzeSuccess("select distinct v1 from t0 order by t0.v1");
+        analyzeSuccess("select distinct t0.v1 from t0 order by v1");
+        analyzeSuccess("select distinct v1 + 1 from t0 order by v1 + 1");
+        analyzeSuccess("select distinct v1 from t0 order by v1 + 1");
+        analyzeSuccess("select distinct v1 as a, v2 as b from t0 order by v1 + v2");
+        analyzeSuccess("select distinct abs(v1) as b from t0 order by abs(v1)");
+        // still rejected: v2 is not part of the DISTINCT output. Under ONLY_FULL_GROUP_BY the
+        // pre-existing AggregationAnalyzer check refuses it first, so it keeps its own message.
+        analyzeFail("select distinct v1 as b from t0 order by v2",
+                "must be an aggregate expression or appear in GROUP BY clause");
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

SELECT DISTINCT is applied on top of the aggregation and emits only the select-list expressions, but the analyzer let ORDER BY reference any GROUP BY key: AggregationAnalyzer.isGroupingKey accepts a grouping key, which is correct for the pre-DISTINCT aggregation and wrong for what DISTINCT outputs.

QueryTransformer then projects the ordering column below the DISTINCT (projectForOrder), rebuilds the aggregation in distinct() with only the select-list columns as group keys -- dropping that column -- and immediately projects concat(orderByExpressions, outputExpression) back on top of it. The resulting projection reads a column its child no longer produces, which is what InputDependenciesChecker calls an invalid plan, but statistics derivation trips over it first and fails with the opaque

  only found column statistics: {4: sum}, but missing statistic of col: 1: no.

Absent statistics are not involved: an uncollected column yields a ColumnStatistic.unknown() entry, never a missing map key, so a missing key means the node genuinely does not output that column. On the memo path the exception aborts planning; under Utils.calculateStatistics it is swallowed and leaves a null Statistics behind for the parent node to dereference.

Verify in the analyzer instead that every ORDER BY expression is computable from the DISTINCT output, and reject with the error MySQL and PostgreSQL also raise. Ordering by an alias, an ordinal, a constant, or an expression over select-list columns keeps working; a differently qualified reference to a selected column is matched by FieldId so it is not rejected on spelling alone. The equivalent check already existed for SELECT DISTINCT without GROUP BY but only under the ONLY_FULL_GROUP_BY sql mode, so the new check is sql-mode independent.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
