### PR TITLE
[BugFix] Stop push-down-distinct-below-window leaving dropped columns in a projection

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownDistinctAggregateRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownDistinctAggregateRewriter.java
@@ -268,9 +268,7 @@ public class PushDownDistinctAggregateRewriter {
             if (ctx.groupBys.isEmpty() || ctx.aggregations.isEmpty()) {
                 return AggRewriteInfo.NOT_REWRITE;
             }
-            List<ColumnRefOperator> groupBys = ctx.groupBys.values().stream().map(ScalarOperator::getUsedColumns)
-                    .flatMap(colSet -> colSet.getStream().map(factory::getColumnRef)).distinct()
-                    .collect(Collectors.toList());
+            List<ColumnRefOperator> groupBys = pushDownGroupBys(ctx);
 
             LogicalScanOperator scanOp = optExpression.getOp().cast();
             ColumnRefSet scanOutputColRefSet = new ColumnRefSet(scanOp.getOutputColumns());
@@ -315,12 +313,48 @@ public class PushDownDistinctAggregateRewriter {
                 return AggRewriteInfo.NOT_REWRITE;
             }
 
+            // The aggregation pushed down below this projection replaces every aggregated argument column by
+            // the column holding the partial aggregate, so those argument columns are gone from the child
+            // output unless they are also grouping keys of the pushed-down aggregation.
+            ColumnRefSet survivingColumns = new ColumnRefSet(pushDownGroupBys(rewriteInfo.getCtx()));
+
+            // A column that survives as a grouping key must not be remapped inside an expression: the
+            // partial aggregate holds an aggregate over the whole group, not that column's own value, so
+            // reading it instead silently changes what the expression computes.
+            Map<ColumnRefOperator, ScalarOperator> droppedRemapping = Maps.newHashMap();
+            rewriteInfo.getRemapping().get().getRemapping().forEach((from, to) -> {
+                if (!survivingColumns.contains(from)) {
+                    droppedRemapping.put(from, to);
+                }
+            });
+            ReplaceColumnRefRewriter droppedReplacer = new ReplaceColumnRefRewriter(droppedRemapping, true);
+
             Map<ColumnRefOperator, ScalarOperator> newColumnRefMap = Maps.newHashMap();
             for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : projectOp.getColumnRefMap().entrySet()) {
-                newColumnRefMap.put((ColumnRefOperator) replacer.rewrite(entry.getKey()),
-                        replacer.rewrite(entry.getValue()));
+                ColumnRefOperator newKey = (ColumnRefOperator) replacer.rewrite(entry.getKey());
+                if (newKey.equals(entry.getKey())) {
+                    // This entry does not produce an aggregated argument, so the operators above consume
+                    // its expression as it is. Only columns the child no longer produces may be remapped
+                    // in it; everything else has to go on reading what it read before.
+                    newColumnRefMap.put(newKey, droppedReplacer.rewrite(entry.getValue()));
+                    continue;
+                }
+                // This entry produces an aggregated argument, which the pushed-down aggregation replaced
+                // by the partial aggregate column, so emit that column for the window to consume.
+                newColumnRefMap.put(newKey, replacer.rewrite(entry.getValue()));
+                // A remapped column that is still a grouping key is still produced by the child, and the
+                // operators above may read it, so it has to be emitted under its original name as well.
+                // A remapped column that is not, however, must not be kept: the projection would read a
+                // column its child no longer produces, which breaks statistics derivation and yields an
+                // invalid plan.
+                if (survivingColumns.contains(entry.getKey())) {
+                    newColumnRefMap.put(entry.getKey(), entry.getValue());
+                }
             }
+            projectOp.getColumnRefMap().clear();
             projectOp.getColumnRefMap().putAll(newColumnRefMap);
+            // The projection is mutated in place, so its cached row output info no longer describes it.
+            projectOp.clearRowOutputInfo();
             rewriteInfo.setOp(optExpression);
             return rewriteInfo;
         }
@@ -366,6 +400,16 @@ public class PushDownDistinctAggregateRewriter {
 
     public PreVisitor preVisitor = new PreVisitor();
     public PostVisitor postVisitor = new PostVisitor();
+
+    /**
+     * The grouping keys of the aggregation that is pushed down onto the scan, which together with the
+     * partial aggregate columns are the only columns that aggregation emits.
+     */
+    private List<ColumnRefOperator> pushDownGroupBys(AggregatePushDownContext ctx) {
+        return ctx.groupBys.values().stream().map(ScalarOperator::getUsedColumns)
+                .flatMap(colSet -> colSet.getStream().map(factory::getColumnRef)).distinct()
+                .collect(Collectors.toList());
+    }
 
     public static ColumnRefSet getReferencedColumnRef(Collection<ScalarOperator> operators) {
         ColumnRefSet refSet = new ColumnRefSet();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownDistinctAggregateRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownDistinctAggregateRewriter.java
@@ -268,9 +268,7 @@ public class PushDownDistinctAggregateRewriter {
             if (ctx.groupBys.isEmpty() || ctx.aggregations.isEmpty()) {
                 return AggRewriteInfo.NOT_REWRITE;
             }
-            List<ColumnRefOperator> groupBys = ctx.groupBys.values().stream().map(ScalarOperator::getUsedColumns)
-                    .flatMap(colSet -> colSet.getStream().map(factory::getColumnRef)).distinct()
-                    .collect(Collectors.toList());
+            List<ColumnRefOperator> groupBys = pushDownGroupBys(ctx);
 
             LogicalScanOperator scanOp = optExpression.getOp().cast();
             ColumnRefSet scanOutputColRefSet = new ColumnRefSet(scanOp.getOutputColumns());
@@ -315,12 +313,28 @@ public class PushDownDistinctAggregateRewriter {
                 return AggRewriteInfo.NOT_REWRITE;
             }
 
+            // The aggregation pushed down below this projection replaces every aggregated argument column by
+            // the column holding the partial aggregate, so those argument columns are gone from the child
+            // output unless they are also grouping keys of the pushed-down aggregation.
+            ColumnRefSet survivingColumns = new ColumnRefSet(pushDownGroupBys(rewriteInfo.getCtx()));
+
             Map<ColumnRefOperator, ScalarOperator> newColumnRefMap = Maps.newHashMap();
             for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : projectOp.getColumnRefMap().entrySet()) {
-                newColumnRefMap.put((ColumnRefOperator) replacer.rewrite(entry.getKey()),
-                        replacer.rewrite(entry.getValue()));
+                ColumnRefOperator newKey = (ColumnRefOperator) replacer.rewrite(entry.getKey());
+                newColumnRefMap.put(newKey, replacer.rewrite(entry.getValue()));
+                // A remapped column that is still a grouping key is still produced by the child, and the
+                // operators above may read it, so it has to be emitted under its original name as well.
+                // A remapped column that is not, however, must not be kept: the projection would read a
+                // column its child no longer produces, which breaks statistics derivation and yields an
+                // invalid plan.
+                if (!newKey.equals(entry.getKey()) && survivingColumns.contains(entry.getKey())) {
+                    newColumnRefMap.put(entry.getKey(), entry.getValue());
+                }
             }
+            projectOp.getColumnRefMap().clear();
             projectOp.getColumnRefMap().putAll(newColumnRefMap);
+            // The projection is mutated in place, so its cached row output info no longer describes it.
+            projectOp.clearRowOutputInfo();
             rewriteInfo.setOp(optExpression);
             return rewriteInfo;
         }
@@ -366,6 +380,16 @@ public class PushDownDistinctAggregateRewriter {
 
     public PreVisitor preVisitor = new PreVisitor();
     public PostVisitor postVisitor = new PostVisitor();
+
+    /**
+     * The grouping keys of the aggregation that is pushed down onto the scan, which together with the
+     * partial aggregate columns are the only columns that aggregation emits.
+     */
+    private List<ColumnRefOperator> pushDownGroupBys(AggregatePushDownContext ctx) {
+        return ctx.groupBys.values().stream().map(ScalarOperator::getUsedColumns)
+                .flatMap(colSet -> colSet.getStream().map(factory::getColumnRef)).distinct()
+                .collect(Collectors.toList());
+    }
 
     public static ColumnRefSet getReferencedColumnRef(Collection<ScalarOperator> operators) {
         ColumnRefSet refSet = new ColumnRefSet();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PushDownDistinctBelowWindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PushDownDistinctBelowWindowTest.java
@@ -1,0 +1,143 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.sql.common.StarRocksPlannerException;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.statistics.Statistics;
+import mockit.Invocation;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * PushDownDistinctAggregateRewriter pre-aggregates the argument of a window function below the window
+ * operator. The projections it rewrites on the way must not keep reading the argument column afterwards,
+ * because the aggregation it inserted no longer produces it.
+ * <p>
+ * The resulting invalid projection is not visible in the final plan -- the column pruning this rule
+ * schedules right after removes it -- but statistics derivation runs in between, in the
+ * Utils.calculateStatistics that pushDownAggregation reaches through logicalJoinReorder, and fails there
+ * with "missing statistic of col". That exception is swallowed, so these tests observe it at the throw
+ * site instead of expecting the query to fail.
+ */
+public class PushDownDistinctBelowWindowTest extends PlanTestBase {
+
+    private final List<String> missingStatistics = new ArrayList<>();
+
+    @BeforeEach
+    public void setUpPushDownDistinct() {
+        missingStatistics.clear();
+        // PlanTestBase turns aggregate push-down off, but the rewrite under test only runs together with
+        // it, and it is on by default in production.
+        connectContext.getSessionVariable().setCboPushDownAggregateMode(0);
+        new MockUp<Statistics>() {
+            @Mock
+            public ColumnStatistic getColumnStatistic(Invocation invocation, ColumnRefOperator column) {
+                try {
+                    return invocation.proceed(column);
+                } catch (StarRocksPlannerException e) {
+                    missingStatistics.add(e.getMessage());
+                    throw e;
+                }
+            }
+        };
+    }
+
+    @AfterEach
+    public void tearDownPushDownDistinct() {
+        connectContext.getSessionVariable().setCboPushDownAggregateMode(-1);
+    }
+
+    private void assertStatisticsDerived(String sql) throws Exception {
+        String plan = getFragmentPlan(sql);
+        assertTrue(missingStatistics.isEmpty(),
+                "statistics derivation failed with " + missingStatistics + " for: " + sql + "\n" + plan);
+    }
+
+    @Test
+    public void testWindowArgumentIsNotKeptInProjection() throws Exception {
+        assertStatisticsDerived("select distinct v1, sum(v3) over () from t0");
+        assertStatisticsDerived("select distinct sum(v3) over () as s, v1 from t0 order by 1 limit 30, 1");
+        assertStatisticsDerived("select distinct v1, v2, sum(v3) over (partition by v1 order by v2) from t0");
+        assertStatisticsDerived("select distinct v1, sum(v3) over () as s, sum(v2) over () as t from t0");
+        assertStatisticsDerived("select distinct t1a, sum(t1f) over (partition by t1b) from test_all_type");
+    }
+
+    /**
+     * Nothing but the window function is selected here, so the projection that reads the dropped column
+     * sits below the window and no window function is visible in it at all. This is the shape cluster
+     * fuzzing reports as
+     * "LogicalProjectOperator [1: c0, 3: c2, 15: sum] child size 1" over an aggregation of {c2, sum}.
+     */
+    @Test
+    public void testOnlyTheWindowFunctionIsSelected() throws Exception {
+        assertStatisticsDerived("select distinct sum(v1) over (partition by v3) from t0 limit 100");
+        assertStatisticsDerived("select distinct sum(v1) over (partition by v3) from t0");
+    }
+
+    /**
+     * The window argument is selected as well here, so it is a grouping key of the pushed-down
+     * aggregation and does stay available; the projection must keep emitting it.
+     */
+    @Test
+    public void testWindowArgumentThatIsAlsoSelectedIsKept() throws Exception {
+        assertStatisticsDerived("select distinct v1, v3, sum(v3) over () from t0");
+        assertStatisticsDerived("select distinct v1, v3, sum(v3) over (partition by v1) from t0");
+    }
+
+    /**
+     * A DISTINCT output that is an expression over the window argument makes that argument a grouping key
+     * of the pushed-down aggregation, so the child does still produce it and the expression has to go on
+     * reading it. Reading the partial aggregate instead computes over the whole group rather than over the
+     * row's own value, which changes the DISTINCT values without failing anything -- visible only when a
+     * grouping key covers more than one row, which no plan test can show.
+     */
+    @Test
+    public void testExpressionOverWindowArgumentKeepsReadingTheArgument() throws Exception {
+        assertProjectsExpression("select distinct v3 + 1, sum(v3) over () from t0", "3: v3 + 1");
+        assertProjectsExpression("select distinct v3 * 2, v1, sum(v3) over () from t0", "3: v3 * 2");
+        assertProjectsExpression("select distinct abs(v3), sum(v3) over (partition by v1) from t0",
+                "abs(3: v3)");
+        assertProjectsExpression("select distinct v1 + v3, sum(v3) over () from t0", "1: v1 + 3: v3");
+        assertProjectsExpression("select distinct v3, v3 + 1, sum(v3) over () from t0", "3: v3 + 1");
+    }
+
+    private void assertProjectsExpression(String sql, String expression) throws Exception {
+        String plan = getFragmentPlan(sql);
+        assertTrue(plan.contains(expression),
+                "expected the projection to go on computing " + expression + " for: " + sql + "\n" + plan);
+        assertTrue(plan.indexOf("ANALYTIC") < plan.lastIndexOf("AGGREGATE"),
+                "expected an aggregation below the analytic node for: " + sql + "\n" + plan);
+    }
+
+    /**
+     * The rewrite itself must still happen: an aggregation is inserted below the window function.
+     */
+    @Test
+    public void testDistinctIsStillPushedBelowWindow() throws Exception {
+        String plan = getFragmentPlan("select distinct v1, sum(v3) over () from t0");
+        assertTrue(plan.indexOf("ANALYTIC") < plan.lastIndexOf("AGGREGATE"),
+                "expected an aggregation below the analytic node:\n" + plan);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PushDownDistinctBelowWindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PushDownDistinctBelowWindowTest.java
@@ -1,0 +1,118 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.sql.common.StarRocksPlannerException;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.statistics.Statistics;
+import mockit.Invocation;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * PushDownDistinctAggregateRewriter pre-aggregates the argument of a window function below the window
+ * operator. The projections it rewrites on the way must not keep reading the argument column afterwards,
+ * because the aggregation it inserted no longer produces it.
+ * <p>
+ * The resulting invalid projection is not visible in the final plan -- the column pruning this rule
+ * schedules right after removes it -- but statistics derivation runs in between, in the
+ * Utils.calculateStatistics that pushDownAggregation reaches through logicalJoinReorder, and fails there
+ * with "missing statistic of col". That exception is swallowed, so these tests observe it at the throw
+ * site instead of expecting the query to fail.
+ */
+public class PushDownDistinctBelowWindowTest extends PlanTestBase {
+
+    private final List<String> missingStatistics = new ArrayList<>();
+
+    @BeforeEach
+    public void setUpPushDownDistinct() {
+        missingStatistics.clear();
+        // PlanTestBase turns aggregate push-down off, but the rewrite under test only runs together with
+        // it, and it is on by default in production.
+        connectContext.getSessionVariable().setCboPushDownAggregateMode(0);
+        new MockUp<Statistics>() {
+            @Mock
+            public ColumnStatistic getColumnStatistic(Invocation invocation, ColumnRefOperator column) {
+                try {
+                    return invocation.proceed(column);
+                } catch (StarRocksPlannerException e) {
+                    missingStatistics.add(e.getMessage());
+                    throw e;
+                }
+            }
+        };
+    }
+
+    @AfterEach
+    public void tearDownPushDownDistinct() {
+        connectContext.getSessionVariable().setCboPushDownAggregateMode(-1);
+    }
+
+    private void assertStatisticsDerived(String sql) throws Exception {
+        String plan = getFragmentPlan(sql);
+        assertTrue(missingStatistics.isEmpty(),
+                "statistics derivation failed with " + missingStatistics + " for: " + sql + "\n" + plan);
+    }
+
+    @Test
+    public void testWindowArgumentIsNotKeptInProjection() throws Exception {
+        assertStatisticsDerived("select distinct v1, sum(v3) over () from t0");
+        assertStatisticsDerived("select distinct sum(v3) over () as s, v1 from t0 order by 1 limit 30, 1");
+        assertStatisticsDerived("select distinct v1, v2, sum(v3) over (partition by v1 order by v2) from t0");
+        assertStatisticsDerived("select distinct v1, sum(v3) over () as s, sum(v2) over () as t from t0");
+        assertStatisticsDerived("select distinct t1a, sum(t1f) over (partition by t1b) from test_all_type");
+    }
+
+    /**
+     * Nothing but the window function is selected here, so the projection that reads the dropped column
+     * sits below the window and no window function is visible in it at all. This is the shape cluster
+     * fuzzing reports as
+     * "LogicalProjectOperator [1: c0, 3: c2, 15: sum] child size 1" over an aggregation of {c2, sum}.
+     */
+    @Test
+    public void testOnlyTheWindowFunctionIsSelected() throws Exception {
+        assertStatisticsDerived("select distinct sum(v1) over (partition by v3) from t0 limit 100");
+        assertStatisticsDerived("select distinct sum(v1) over (partition by v3) from t0");
+    }
+
+    /**
+     * The window argument is selected as well here, so it is a grouping key of the pushed-down
+     * aggregation and does stay available; the projection must keep emitting it.
+     */
+    @Test
+    public void testWindowArgumentThatIsAlsoSelectedIsKept() throws Exception {
+        assertStatisticsDerived("select distinct v1, v3, sum(v3) over () from t0");
+        assertStatisticsDerived("select distinct v1, v3, sum(v3) over (partition by v1) from t0");
+    }
+
+    /**
+     * The rewrite itself must still happen: an aggregation is inserted below the window function.
+     */
+    @Test
+    public void testDistinctIsStillPushedBelowWindow() throws Exception {
+        String plan = getFragmentPlan("select distinct v1, sum(v3) over () from t0");
+        assertTrue(plan.indexOf("ANALYTIC") < plan.lastIndexOf("AGGREGATE"),
+                "expected an aggregation below the analytic node:\n" + plan);
+    }
+}

--- a/test/sql/test_push_down_distinct_agg_across_window/R/test_push_down_distinct_below_window_join
+++ b/test/sql/test_push_down_distinct_agg_across_window/R/test_push_down_distinct_below_window_join
@@ -1,0 +1,111 @@
+-- name: test_push_down_distinct_below_window_join
+DROP TABLE if exists pdw_t0;
+-- result:
+-- !result
+DROP TABLE if exists pdw_t1;
+-- result:
+-- !result
+DROP TABLE if exists pdw_t2;
+-- result:
+-- !result
+CREATE TABLE pdw_t0 (v1 bigint, v2 bigint, v3 bigint)
+DUPLICATE KEY(v1)
+DISTRIBUTED BY HASH(v1) BUCKETS 3
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE pdw_t1 (v4 bigint, v5 bigint, v6 bigint)
+DUPLICATE KEY(v4)
+DISTRIBUTED BY HASH(v4) BUCKETS 3
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE pdw_t2 (v7 bigint, v8 bigint, v9 bigint)
+DUPLICATE KEY(v7)
+DISTRIBUTED BY HASH(v7) BUCKETS 3
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO pdw_t0 VALUES (1,10,100),(1,10,200),(2,20,300),(3,30,400);
+-- result:
+-- !result
+INSERT INTO pdw_t1 VALUES (1,11,111),(2,22,222),(4,44,444);
+-- result:
+-- !result
+INSERT INTO pdw_t2 VALUES (1,1,1),(2,2,2),(3,3,3);
+-- result:
+-- !result
+set cbo_push_down_distinct_below_window = true;
+-- result:
+-- !result
+set cbo_push_down_aggregate_mode = 0;
+-- result:
+-- !result
+set cbo_push_down_aggregate_on_broadcast_join = true;
+-- result:
+-- !result
+select count(*) from (select distinct v1, sum(v3) over () as s from pdw_t0) x join pdw_t1 on x.v1 = pdw_t1.v4 join pdw_t2 on pdw_t1.v4 = pdw_t2.v7;
+-- result:
+2
+-- !result
+select x.v1, x.s from (select distinct v1, sum(v3) over () as s from pdw_t0) x join pdw_t1 on x.v1 = pdw_t1.v4 order by 1,2;
+-- result:
+1	1000
+2	1000
+-- !result
+select count(*) from (select distinct sum(v1) over (partition by v3) as s from pdw_t0) x join pdw_t1 on x.s = pdw_t1.v4;
+-- result:
+2
+-- !result
+select count(*) from (select distinct v1, sum(v3) over (partition by v2) as s from pdw_t0) x join pdw_t1 on x.v1 = pdw_t1.v4 join pdw_t2 on pdw_t1.v4 = pdw_t2.v7;
+-- result:
+2
+-- !result
+select x.v1, x.s from (select distinct v1, sum(v3) over (partition by v2) as s from pdw_t0) x join pdw_t1 on x.v1 = pdw_t1.v4 join pdw_t2 on pdw_t1.v4 = pdw_t2.v7 order by 1,2;
+-- result:
+1	300
+2	300
+-- !result
+select x.v1, x.v3, x.s from (select distinct v1, v3, sum(v3) over () as s from pdw_t0) x join pdw_t1 on x.v1 = pdw_t1.v4 order by 1,2;
+-- result:
+1	100	1000
+1	200	1000
+2	300	1000
+-- !result
+DROP TABLE if exists pdw_t3;
+-- result:
+-- !result
+CREATE TABLE pdw_t3 (v1 bigint, v2 bigint, v3 bigint)
+DUPLICATE KEY(v1)
+DISTRIBUTED BY HASH(v1) BUCKETS 3
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO pdw_t3 VALUES (1,10,1),(1,10,1),(2,20,2);
+-- result:
+-- !result
+select e, s from (select distinct v3 + 1 as e, sum(v3) over () as s from pdw_t3) t order by 1,2;
+-- result:
+2	4
+3	4
+-- !result
+select e, v1, s from (select distinct v3 * 2 as e, v1, sum(v3) over () as s from pdw_t3) t order by 1,2;
+-- result:
+2	1	4
+4	2	4
+-- !result
+select e, s from (select distinct abs(v3) as e, sum(v3) over (partition by v1) as s from pdw_t3) t order by 1,2;
+-- result:
+1	2
+2	2
+-- !result
+select e, s from (select distinct v1 + v3 as e, sum(v3) over () as s from pdw_t3) t order by 1,2;
+-- result:
+2	4
+4	4
+-- !result
+select v3, e, s from (select distinct v3, v3 + 1 as e, sum(v3) over () as s from pdw_t3) t order by 1,2;
+-- result:
+1	2	4
+2	3	4
+-- !result

--- a/test/sql/test_push_down_distinct_agg_across_window/R/test_push_down_distinct_below_window_join
+++ b/test/sql/test_push_down_distinct_agg_across_window/R/test_push_down_distinct_below_window_join
@@ -1,0 +1,74 @@
+-- name: test_push_down_distinct_below_window_join
+DROP TABLE if exists pdw_t0;
+-- result:
+-- !result
+DROP TABLE if exists pdw_t1;
+-- result:
+-- !result
+DROP TABLE if exists pdw_t2;
+-- result:
+-- !result
+CREATE TABLE pdw_t0 (v1 bigint, v2 bigint, v3 bigint)
+DUPLICATE KEY(v1)
+DISTRIBUTED BY HASH(v1) BUCKETS 3
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE pdw_t1 (v4 bigint, v5 bigint, v6 bigint)
+DUPLICATE KEY(v4)
+DISTRIBUTED BY HASH(v4) BUCKETS 3
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE pdw_t2 (v7 bigint, v8 bigint, v9 bigint)
+DUPLICATE KEY(v7)
+DISTRIBUTED BY HASH(v7) BUCKETS 3
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO pdw_t0 VALUES (1,10,100),(1,10,200),(2,20,300),(3,30,400);
+-- result:
+-- !result
+INSERT INTO pdw_t1 VALUES (1,11,111),(2,22,222),(4,44,444);
+-- result:
+-- !result
+INSERT INTO pdw_t2 VALUES (1,1,1),(2,2,2),(3,3,3);
+-- result:
+-- !result
+set cbo_push_down_distinct_below_window = true;
+-- result:
+-- !result
+set cbo_push_down_aggregate_mode = 0;
+-- result:
+-- !result
+set cbo_push_down_aggregate_on_broadcast_join = true;
+-- result:
+-- !result
+select count(*) from (select distinct v1, sum(v3) over () as s from pdw_t0) x join pdw_t1 on x.v1 = pdw_t1.v4 join pdw_t2 on pdw_t1.v4 = pdw_t2.v7;
+-- result:
+2
+-- !result
+select x.v1, x.s from (select distinct v1, sum(v3) over () as s from pdw_t0) x join pdw_t1 on x.v1 = pdw_t1.v4 order by 1,2;
+-- result:
+1	1000
+2	1000
+-- !result
+select count(*) from (select distinct sum(v1) over (partition by v3) as s from pdw_t0) x join pdw_t1 on x.s = pdw_t1.v4;
+-- result:
+2
+-- !result
+select count(*) from (select distinct v1, sum(v3) over (partition by v2) as s from pdw_t0) x join pdw_t1 on x.v1 = pdw_t1.v4 join pdw_t2 on pdw_t1.v4 = pdw_t2.v7;
+-- result:
+2
+-- !result
+select x.v1, x.s from (select distinct v1, sum(v3) over (partition by v2) as s from pdw_t0) x join pdw_t1 on x.v1 = pdw_t1.v4 join pdw_t2 on pdw_t1.v4 = pdw_t2.v7 order by 1,2;
+-- result:
+1	300
+2	300
+-- !result
+select x.v1, x.v3, x.s from (select distinct v1, v3, sum(v3) over () as s from pdw_t0) x join pdw_t1 on x.v1 = pdw_t1.v4 order by 1,2;
+-- result:
+1	100	1000
+1	200	1000
+2	300	1000
+-- !result

--- a/test/sql/test_push_down_distinct_agg_across_window/T/test_push_down_distinct_below_window_join
+++ b/test/sql/test_push_down_distinct_agg_across_window/T/test_push_down_distinct_below_window_join
@@ -1,0 +1,55 @@
+-- name: test_push_down_distinct_below_window_join
+DROP TABLE if exists pdw_t0;
+DROP TABLE if exists pdw_t1;
+DROP TABLE if exists pdw_t2;
+CREATE TABLE pdw_t0 (v1 bigint, v2 bigint, v3 bigint)
+DUPLICATE KEY(v1)
+DISTRIBUTED BY HASH(v1) BUCKETS 3
+PROPERTIES("replication_num" = "1");
+CREATE TABLE pdw_t1 (v4 bigint, v5 bigint, v6 bigint)
+DUPLICATE KEY(v4)
+DISTRIBUTED BY HASH(v4) BUCKETS 3
+PROPERTIES("replication_num" = "1");
+CREATE TABLE pdw_t2 (v7 bigint, v8 bigint, v9 bigint)
+DUPLICATE KEY(v7)
+DISTRIBUTED BY HASH(v7) BUCKETS 3
+PROPERTIES("replication_num" = "1");
+INSERT INTO pdw_t0 VALUES (1,10,100),(1,10,200),(2,20,300),(3,30,400);
+INSERT INTO pdw_t1 VALUES (1,11,111),(2,22,222),(4,44,444);
+INSERT INTO pdw_t2 VALUES (1,1,1),(2,2,2),(3,3,3);
+set cbo_push_down_distinct_below_window = true;
+set cbo_push_down_aggregate_mode = 0;
+set cbo_push_down_aggregate_on_broadcast_join = true;
+-- SELECT DISTINCT over a window function is rewritten into an aggregation on top of the scan
+-- that pre-aggregates the window argument, so that argument column is no longer produced below
+-- the window. The projections the rewrite touches must stop reading it: a projection that reads
+-- a column its child does not produce breaks statistics derivation, and with a join in the query
+-- that derivation runs inside join reordering, where the failure is not swallowed and the query
+-- cannot be planned at all -- it fails with "missing statistic of col".
+select count(*) from (select distinct v1, sum(v3) over () as s from pdw_t0) x join pdw_t1 on x.v1 = pdw_t1.v4 join pdw_t2 on pdw_t1.v4 = pdw_t2.v7;
+select x.v1, x.s from (select distinct v1, sum(v3) over () as s from pdw_t0) x join pdw_t1 on x.v1 = pdw_t1.v4 order by 1,2;
+-- Only the window function is selected, so the projection that reads the dropped column sits
+-- below the window and no window function is visible in it at all.
+select count(*) from (select distinct sum(v1) over (partition by v3) as s from pdw_t0) x join pdw_t1 on x.s = pdw_t1.v4;
+-- The same with a PARTITION BY, whose key stays available while the argument does not.
+select count(*) from (select distinct v1, sum(v3) over (partition by v2) as s from pdw_t0) x join pdw_t1 on x.v1 = pdw_t1.v4 join pdw_t2 on pdw_t1.v4 = pdw_t2.v7;
+select x.v1, x.s from (select distinct v1, sum(v3) over (partition by v2) as s from pdw_t0) x join pdw_t1 on x.v1 = pdw_t1.v4 join pdw_t2 on pdw_t1.v4 = pdw_t2.v7 order by 1,2;
+-- The window argument is selected here as well, so it is a grouping key of the pushed-down
+-- aggregation and does stay available: the projection must keep emitting it.
+select x.v1, x.v3, x.s from (select distinct v1, v3, sum(v3) over () as s from pdw_t0) x join pdw_t1 on x.v1 = pdw_t1.v4 order by 1,2;
+-- A DISTINCT output that is an expression over the window argument makes that argument a grouping key
+-- of the pushed-down aggregation, so the child still produces it and the expression must go on reading
+-- it. Reading the partial aggregate instead yields an aggregate over the whole group rather than the
+-- column's own value, which silently changes the DISTINCT values -- and only when a grouping key covers
+-- more than one row, hence the duplicated row below.
+DROP TABLE if exists pdw_t3;
+CREATE TABLE pdw_t3 (v1 bigint, v2 bigint, v3 bigint)
+DUPLICATE KEY(v1)
+DISTRIBUTED BY HASH(v1) BUCKETS 3
+PROPERTIES("replication_num" = "1");
+INSERT INTO pdw_t3 VALUES (1,10,1),(1,10,1),(2,20,2);
+select e, s from (select distinct v3 + 1 as e, sum(v3) over () as s from pdw_t3) t order by 1,2;
+select e, v1, s from (select distinct v3 * 2 as e, v1, sum(v3) over () as s from pdw_t3) t order by 1,2;
+select e, s from (select distinct abs(v3) as e, sum(v3) over (partition by v1) as s from pdw_t3) t order by 1,2;
+select e, s from (select distinct v1 + v3 as e, sum(v3) over () as s from pdw_t3) t order by 1,2;
+select v3, e, s from (select distinct v3, v3 + 1 as e, sum(v3) over () as s from pdw_t3) t order by 1,2;

--- a/test/sql/test_push_down_distinct_agg_across_window/T/test_push_down_distinct_below_window_join
+++ b/test/sql/test_push_down_distinct_agg_across_window/T/test_push_down_distinct_below_window_join
@@ -1,0 +1,39 @@
+-- name: test_push_down_distinct_below_window_join
+DROP TABLE if exists pdw_t0;
+DROP TABLE if exists pdw_t1;
+DROP TABLE if exists pdw_t2;
+CREATE TABLE pdw_t0 (v1 bigint, v2 bigint, v3 bigint)
+DUPLICATE KEY(v1)
+DISTRIBUTED BY HASH(v1) BUCKETS 3
+PROPERTIES("replication_num" = "1");
+CREATE TABLE pdw_t1 (v4 bigint, v5 bigint, v6 bigint)
+DUPLICATE KEY(v4)
+DISTRIBUTED BY HASH(v4) BUCKETS 3
+PROPERTIES("replication_num" = "1");
+CREATE TABLE pdw_t2 (v7 bigint, v8 bigint, v9 bigint)
+DUPLICATE KEY(v7)
+DISTRIBUTED BY HASH(v7) BUCKETS 3
+PROPERTIES("replication_num" = "1");
+INSERT INTO pdw_t0 VALUES (1,10,100),(1,10,200),(2,20,300),(3,30,400);
+INSERT INTO pdw_t1 VALUES (1,11,111),(2,22,222),(4,44,444);
+INSERT INTO pdw_t2 VALUES (1,1,1),(2,2,2),(3,3,3);
+set cbo_push_down_distinct_below_window = true;
+set cbo_push_down_aggregate_mode = 0;
+set cbo_push_down_aggregate_on_broadcast_join = true;
+-- SELECT DISTINCT over a window function is rewritten into an aggregation on top of the scan
+-- that pre-aggregates the window argument, so that argument column is no longer produced below
+-- the window. The projections the rewrite touches must stop reading it: a projection that reads
+-- a column its child does not produce breaks statistics derivation, and with a join in the query
+-- that derivation runs inside join reordering, where the failure is not swallowed and the query
+-- cannot be planned at all -- it fails with "missing statistic of col".
+select count(*) from (select distinct v1, sum(v3) over () as s from pdw_t0) x join pdw_t1 on x.v1 = pdw_t1.v4 join pdw_t2 on pdw_t1.v4 = pdw_t2.v7;
+select x.v1, x.s from (select distinct v1, sum(v3) over () as s from pdw_t0) x join pdw_t1 on x.v1 = pdw_t1.v4 order by 1,2;
+-- Only the window function is selected, so the projection that reads the dropped column sits
+-- below the window and no window function is visible in it at all.
+select count(*) from (select distinct sum(v1) over (partition by v3) as s from pdw_t0) x join pdw_t1 on x.s = pdw_t1.v4;
+-- The same with a PARTITION BY, whose key stays available while the argument does not.
+select count(*) from (select distinct v1, sum(v3) over (partition by v2) as s from pdw_t0) x join pdw_t1 on x.v1 = pdw_t1.v4 join pdw_t2 on pdw_t1.v4 = pdw_t2.v7;
+select x.v1, x.s from (select distinct v1, sum(v3) over (partition by v2) as s from pdw_t0) x join pdw_t1 on x.v1 = pdw_t1.v4 join pdw_t2 on pdw_t1.v4 = pdw_t2.v7 order by 1,2;
+-- The window argument is selected here as well, so it is a grouping key of the pushed-down
+-- aggregation and does stay available: the projection must keep emitting it.
+select x.v1, x.v3, x.s from (select distinct v1, v3, sum(v3) over () as s from pdw_t0) x join pdw_t1 on x.v1 = pdw_t1.v4 order by 1,2;


### PR DESCRIPTION
## Why I'm doing:


PushDownDistinctAggregateRewriter turns

  select distinct a, sum(b) over (...) from t

into an aggregation on top of the scan that pre-aggregates b, so the window only has to process one row per group. That aggregation emits its grouping keys and the partial aggregate column, and nothing else: the argument column b is gone.

The rewriter rewrites the projections between the scan and the window through a remapping b -> partial_sum, but merged the rewritten entries into the existing column ref map with putAll instead of replacing it, so the entry for b survived next to the new one. The projection then reads a column its child no longer produces, which is what InputDependenciesChecker calls an invalid plan; statistics derivation trips over it first, in the Utils.calculateStatistics that pushDownAggregation runs right after this rewrite through logicalJoinReorder, and fails with the opaque

  only found column statistics: {1: v1, 5: sum}, but missing statistic of col: 3: v3.

That exception is swallowed there, so the query still plans -- the stale entry is removed by the column pruning this rule schedules afterwards -- but the whole subtree is left without derived statistics, and join reordering and aggregate push-down then choose a plan from statistics that were never computed. Reproduced by "select distinct v1, sum(v3) over () from t0"; a window function is not visible in the failing projection itself, which is the one below the window.

Keep an original entry only when its column is also a grouping key of the pushed-down aggregation, in which case the child does still produce it and the operators above may legitimately read it, as in
"select distinct v1, v3, sum(v3) over () from t0". Also drop the projection's cached row output info, which the in-place mutation invalidates.

The plan test observes the failure at the throw site, since Utils.calculateStatistics swallows it and the query still plans. The SQL test puts a join in the query instead: the same derivation then runs inside join reordering, through JoinOrder.calculateStatistics, which does not swallow it, so the query fails outright and the regression is visible end to end.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
