### PR TITLE
[BugFix] Reject an invalid default_mv_refresh_mode that makes MVs unqueryable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ConfigBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ConfigBase.java
@@ -38,6 +38,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.starrocks.authentication.SecurityIntegration;
 import com.starrocks.common.util.DateUtils;
+import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.Util;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.rpc.ThriftConnectionPool;
@@ -260,6 +261,14 @@ public class ConfigBase {
                     throw new InvalidConfException("'authentication_chain' configuration invalid, " +
                             "'native' must be in the list, and cannot have duplicates, current value: "
                             + confVal);
+                }
+                break;
+            case "default_mv_refresh_mode":
+                try {
+                    PropertyAnalyzer.parseRefreshMode(confVal);
+                } catch (IllegalArgumentException e) {
+                    throw new InvalidConfException("'default_mv_refresh_mode' configuration invalid, " +
+                            "only INCREMENTAL, PCT are supported, current value: " + confVal);
                 }
                 break;
             case "db_used_data_quota_update_interval_secs":

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -746,22 +746,31 @@ public class PropertyAnalyzer {
         String refreshMode = null;
         if (properties != null && properties.containsKey(PROPERTIES_MV_REFRESH_MODE)) {
             refreshMode = properties.get(PROPERTIES_MV_REFRESH_MODE);
-            MaterializedView.RefreshMode parsed;
-            try {
-                parsed = MaterializedView.RefreshMode.valueOf(refreshMode.toUpperCase());
-            } catch (IllegalArgumentException e) {
-                throw new IllegalArgumentException("Invalid refresh_mode: " + refreshMode +
-                        ". Only INCREMENTAL, PCT are supported.");
-            }
-            // AUTO is intentionally not exposed to users; the implementation is preserved
-            // internally for future revival.
-            if (parsed == MaterializedView.RefreshMode.AUTO) {
-                throw new IllegalArgumentException("Invalid refresh_mode: " + refreshMode +
-                        ". Only INCREMENTAL, PCT are supported.");
-            }
+            parseRefreshMode(refreshMode);
             properties.remove(PROPERTIES_MV_REFRESH_MODE);
         }
         return refreshMode;
+    }
+
+    /**
+     * Parse a user supplied refresh mode. Shared by the `refresh_mode` table property and the
+     * `default_mv_refresh_mode` FE config so every entry point accepts the same set of values.
+     */
+    public static MaterializedView.RefreshMode parseRefreshMode(String refreshMode) {
+        MaterializedView.RefreshMode parsed;
+        try {
+            parsed = MaterializedView.RefreshMode.valueOf(refreshMode.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid refresh_mode: " + refreshMode +
+                    ". Only INCREMENTAL, PCT are supported.");
+        }
+        // AUTO is intentionally not exposed to users; the implementation is preserved
+        // internally for future revival.
+        if (parsed == MaterializedView.RefreshMode.AUTO) {
+            throw new IllegalArgumentException("Invalid refresh_mode: " + refreshMode +
+                    ". Only INCREMENTAL, PCT are supported.");
+        }
+        return parsed;
     }
 
     public static List<TableName> analyzeExcludedTables(Map<String, String> properties,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
@@ -538,20 +538,11 @@ public class IVMAnalyzer {
         }
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_MV_REFRESH_MODE)) {
             String mode = properties.get(PropertyAnalyzer.PROPERTIES_MV_REFRESH_MODE);
-            MaterializedView.RefreshMode parsed;
             try {
-                parsed = MaterializedView.RefreshMode.valueOf(mode.toUpperCase());
+                return PropertyAnalyzer.parseRefreshMode(mode);
             } catch (IllegalArgumentException e) {
-                throw new SemanticException("Invalid refresh_mode: " + mode +
-                        ". Only INCREMENTAL, PCT are supported.");
+                throw new SemanticException(e.getMessage());
             }
-            // AUTO is intentionally not exposed to users; the implementation is preserved
-            // internally for future revival.
-            if (parsed == MaterializedView.RefreshMode.AUTO) {
-                throw new SemanticException("Invalid refresh_mode: " + mode +
-                        ". Only INCREMENTAL, PCT are supported.");
-            }
-            return parsed;
         } else {
             return MaterializedView.RefreshMode.PCT;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/common/ConfigTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/ConfigTest.java
@@ -141,6 +141,48 @@ public class ConfigTest {
         Assertions.assertEquals(99, Config.adaptive_choose_instances_threshold);
     }
 
+    @Test
+    public void testDefaultMvRefreshMode() throws Exception {
+        String origin = Config.default_mv_refresh_mode;
+        try {
+            Config.setMutableConfig("default_mv_refresh_mode", "pct", false, "");
+            Assertions.assertEquals("pct", Config.default_mv_refresh_mode);
+
+            Config.setMutableConfig("default_mv_refresh_mode", "INCREMENTAL", false, "");
+            Assertions.assertEquals("INCREMENTAL", Config.default_mv_refresh_mode);
+
+            // A typo has to be rejected here, not on every later read of the mv refresh mode
+            Assertions.assertThrows(DdlException.class, () ->
+                    Config.setMutableConfig("default_mv_refresh_mode", "incrementall", false, ""));
+            Assertions.assertThrows(DdlException.class, () ->
+                    Config.setMutableConfig("default_mv_refresh_mode", "", false, ""));
+            // AUTO is not exposed to users, same as the refresh_mode table property
+            Assertions.assertThrows(DdlException.class, () ->
+                    Config.setMutableConfig("default_mv_refresh_mode", "auto", false, ""));
+
+            Assertions.assertEquals("INCREMENTAL", Config.default_mv_refresh_mode);
+        } finally {
+            Config.default_mv_refresh_mode = origin;
+        }
+    }
+
+    @Test
+    public void testDefaultMvRefreshModeFromConfigFile() throws Exception {
+        String origin = Config.default_mv_refresh_mode;
+        try {
+            // ADMIN SET FRONTEND CONFIG ... PERSISTENT writes into fe.conf, so the value read back
+            // on the next startup has to go through the same validation
+            URL resource = getClass().getClassLoader()
+                    .getResource("conf/config_test_invalid_mv_refresh_mode.properties");
+            assert resource != null;
+            String confFile = Paths.get(resource.toURI()).toFile().getAbsolutePath();
+            Assertions.assertThrows(InvalidConfException.class, () -> config.init(confFile));
+            Assertions.assertEquals(origin, Config.default_mv_refresh_mode);
+        } finally {
+            Config.default_mv_refresh_mode = origin;
+        }
+    }
+
     private static class ConfigForArray extends ConfigBase {
 
         @ConfField(mutable = true)

--- a/fe/fe-core/src/test/resources/conf/config_test_invalid_mv_refresh_mode.properties
+++ b/fe/fe-core/src/test/resources/conf/config_test_invalid_mv_refresh_mode.properties
@@ -1,0 +1,1 @@
+default_mv_refresh_mode = incrementall


### PR DESCRIPTION
## Why I'm doing:

`default_mv_refresh_mode` is a mutable `String` FE config, the fallback for every materialized view
created without an explicit `refresh_mode`. Nothing validated it, so any string could be stored and
the failure only showed up later, wherever that mode is turned into an enum
(`MaterializedView#getRefreshMode` -> `TableProperty#getMvRefreshMode` -> `RefreshMode.valueOf`):

```sql
mysql> ADMIN SET FRONTEND CONFIG ('default_mv_refresh_mode' = 'incrementall');
Query OK

mysql> SELECT * FROM db1.mv_pct;
ERROR 1064 (HY000): No enum constant com.starrocks.catalog.MaterializedView.RefreshMode.INCREMENTALL
```

All seven callers of `getRefreshMode` are on user-facing paths. Reading such an MV, refreshing it,
querying `information_schema.materialized_view_refresh_jobs` and scraping FE metrics all fail like
that. `MvRewritePreprocessor`, `TextMatchBasedRewriteRule` and `ShowMaterializedViewStatus#of` catch
the exception instead, so query rewrite is lost with no error at all and `SHOW MATERIALIZED VIEWS`
returns a row carrying only the MV's id, database and name.

`auto` gets through as well. `AUTO` is a real enum constant that both existing entry points reject
for users, but set through the config it makes `isIncrementalOrAuto()` true for every MV without an
explicit `refresh_mode`, disabling query rewrite cluster-wide.

A restart makes it worse. `ADMIN SET ... PERSISTENT` writes the value into
`fe.conf`, and `TableProperty#gsonPostProcess` copies the config into each MV's own `mvRefreshMode`
on image load, so a value that only broke newly created MVs at runtime breaks every MV without an
explicit `refresh_mode` after the next startup.

## What I'm doing:

Fixes #77207

The rule for a valid refresh mode already existed, written twice, and the config path went through
neither copy. Extract it into `PropertyAnalyzer#parseRefreshMode`, call that from a new
`default_mv_refresh_mode` case in `ConfigBase#validateConfValue`, and replace the third copy in
`IVMAnalyzer#getRefreshMode` with the same call. No behavior or message changes, including the
`SemanticException` that `IVMAnalyzer` throws.

The case runs inside `parseAndValidateConfigField`, which both `setMutableConfig` and startup
(`init` -> `setFields` -> `setConfigField`) go through, so a value a previous version already
persisted into `fe.conf` is rejected at startup too:

```
Failed to set config 'default_mv_refresh_mode'. err: 'default_mv_refresh_mode' configuration invalid, only INCREMENTAL, PCT are supported, current value: incrementall
```

`auto` is rejected the same way. `pct` / `PCT` / `incremental` / `INCREMENTAL` keep working, still
stored as written and still matched case-insensitively.

Falling back to `PCT` on an unparseable value, the way `PartitionRefreshStrategy#of` does for
`default_mv_partition_refresh_strategy`, would not cover `auto`, which parses fine and is rejected
by an explicit rule rather than by `valueOf`. It would also swallow a typo that the per-MV
`refresh_mode` property rejects loudly. `default_mv_partition_refresh_strategy` itself is not part
of this bug, since `PartitionRefreshStrategy#of` already falls back instead of throwing.

`ConfigTest#testDefaultMvRefreshMode` covers the runtime path and
`ConfigTest#testDefaultMvRefreshModeFromConfigFile` loads a config file holding an invalid value,
which is the restart path. Both fail without the `ConfigBase` change, and the existing MV
refresh-mode suites pass unchanged.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

An FE whose `fe.conf` already contains an invalid `default_mv_refresh_mode` will now refuse to start
instead of starting with every materialized view broken. `conf/fe.conf` does not ship this key and
`ConfigBase#setFields` skips a key that is absent or empty, so a deployment that never set it cannot
be affected. The config was introduced in 4.1, so the exposure is a 4.1.0 or 4.1.1 cluster that
already persisted an invalid value through `ADMIN SET ... PERSISTENT`, and such a cluster is not
healthy today either, since every MV without an explicit `refresh_mode` is already unreadable on it.
The startup error names the config, the accepted values and the current value, so correcting
`fe.conf` is the whole fix. The bad value never reached MV metadata, so there is nothing to migrate.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

`refresh_mode` and `default_mv_refresh_mode` were introduced in 4.1, so 4.0 and 3.5 are not
affected. The cherry-pick onto `branch-4.1` applies without conflicts.

@Youngwb you filed #77207, could you take a look when you have a moment?