### PR TITLE
[BugFix] Normalize scan heavy-expr result columns to the slot's nullability

### DIFF
--- a/be/src/exec/pipeline/scan/chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/chunk_source.cpp
@@ -17,6 +17,8 @@
 #include "base/failpoint/fail_point.h"
 #include "base/time/monotime.h"
 #include "base/utility/defer_op.h"
+#include "column/column_helper.h"
+#include "column/nullable_column.h"
 #include "compute_env/workgroup/scan_task_queue.h"
 #include "compute_env/workgroup/work_group.h"
 #include "exec/pipeline/scan/balanced_chunk_buffer.h"
@@ -87,8 +89,30 @@ Status ChunkSource::buffer_next_batch_chunks_blocking(RuntimeState* state, size_
                 auto* scan_op_factory = down_cast<ScanOperatorFactory*>(_scan_op->get_factory());
                 auto& slot_ids = scan_op_factory->scan_node()->get_heavy_expr_slot_ids();
                 auto& expr_ctxs = scan_op_factory->scan_node()->get_heavy_expr_ctxs();
+                const size_t num_rows = chunk->num_rows();
                 for (auto k = 0; k < slot_ids.size(); ++k) {
                     ASSIGN_OR_RETURN(auto col, expr_ctxs[k]->evaluate(chunk.get()));
+                    // The heavy expr result must follow the slot's declared type/nullability, the same
+                    // way ProjectOperator normalizes its own evaluated columns. Without this the column
+                    // implementation drifts across chunks -- a chunk whose rows all evaluate non-null
+                    // yields a bare BinaryColumn while the next one yields NullableColumn<BinaryColumn>.
+                    // ChunkPipelineAccumulator::push then appends one into the other, and
+                    // BinaryColumnBase::append reinterprets the source through a release-mode down_cast.
+                    const auto& type_desc = expr_ctxs[k]->root()->type();
+                    if (col->only_null()) {
+                        auto mutable_col = ColumnHelper::create_column(type_desc, true);
+                        mutable_col->append_nulls(num_rows);
+                        col = std::move(mutable_col);
+                    } else if (col->is_constant()) {
+                        MutableColumnPtr new_column = ColumnHelper::create_column(type_desc, false);
+                        auto* const_column = down_cast<const ConstColumn*>(col.get());
+                        new_column->append(*const_column->data_column(), 0, 1);
+                        new_column->assign(num_rows, 0);
+                        col = std::move(new_column);
+                    }
+                    if (expr_ctxs[k]->root()->is_nullable() && !col->is_nullable()) {
+                        col = NullableColumn::create(col, NullColumn::create(num_rows, 0));
+                    }
                     chunk->append_column(std::move(col), slot_ids[k]);
                 }
             }

--- a/test/sql/test_push_down_heavy_exprs/R/test_push_down_heavy_exprs_nullability
+++ b/test/sql/test_push_down_heavy_exprs/R/test_push_down_heavy_exprs_nullability
@@ -1,0 +1,88 @@
+-- name: test_push_down_heavy_exprs_nullability
+-- Regression test for the scan heavy-expr result column not following the slot's
+-- nullability. Loading in 20 small batches leaves one rowset per insert in a single
+-- tablet, so the scan emits partial chunks that ChunkPipelineAccumulator appends
+-- together instead of swapping out. The odd batches carry one row whose value has no
+-- date, so nullif() produces a NULL there and the expression evaluates to a
+-- NullableColumn, while the even batches evaluate to a bare BinaryColumn. Appending
+-- one into the other used to either crash the BE in BinaryColumnBase::append or
+-- silently return a NULL min(). Pushing the expression down must give the same answer
+-- as evaluating it above the scan.
+
+create table t_heavy (
+  id bigint,
+  flag varchar(10),
+  s varchar(1000)
+) duplicate key(id)
+distributed by hash(id) buckets 1
+properties("replication_num"="1");
+-- result:
+-- !result
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, concat('a/b/c/2026-07-15/part-', cast(g as string)) from (select generate_series as g from table(generate_series(1, 200))) t;
+-- result:
+-- !result
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, case when g % 200 = 1 then concat('a/b/c/no-date-', cast(g as string)) else concat('a/b/c/2026-07-15/part-', cast(g as string)) end from (select generate_series as g from table(generate_series(201, 400))) t;
+-- result:
+-- !result
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, concat('a/b/c/2026-07-15/part-', cast(g as string)) from (select generate_series as g from table(generate_series(401, 600))) t;
+-- result:
+-- !result
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, case when g % 200 = 1 then concat('a/b/c/no-date-', cast(g as string)) else concat('a/b/c/2026-07-15/part-', cast(g as string)) end from (select generate_series as g from table(generate_series(601, 800))) t;
+-- result:
+-- !result
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, concat('a/b/c/2026-07-15/part-', cast(g as string)) from (select generate_series as g from table(generate_series(801, 1000))) t;
+-- result:
+-- !result
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, case when g % 200 = 1 then concat('a/b/c/no-date-', cast(g as string)) else concat('a/b/c/2026-07-15/part-', cast(g as string)) end from (select generate_series as g from table(generate_series(1001, 1200))) t;
+-- result:
+-- !result
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, concat('a/b/c/2026-07-15/part-', cast(g as string)) from (select generate_series as g from table(generate_series(1201, 1400))) t;
+-- result:
+-- !result
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, case when g % 200 = 1 then concat('a/b/c/no-date-', cast(g as string)) else concat('a/b/c/2026-07-15/part-', cast(g as string)) end from (select generate_series as g from table(generate_series(1401, 1600))) t;
+-- result:
+-- !result
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, concat('a/b/c/2026-07-15/part-', cast(g as string)) from (select generate_series as g from table(generate_series(1601, 1800))) t;
+-- result:
+-- !result
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, case when g % 200 = 1 then concat('a/b/c/no-date-', cast(g as string)) else concat('a/b/c/2026-07-15/part-', cast(g as string)) end from (select generate_series as g from table(generate_series(1801, 2000))) t;
+-- result:
+-- !result
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, concat('a/b/c/2026-07-15/part-', cast(g as string)) from (select generate_series as g from table(generate_series(2001, 2200))) t;
+-- result:
+-- !result
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, case when g % 200 = 1 then concat('a/b/c/no-date-', cast(g as string)) else concat('a/b/c/2026-07-15/part-', cast(g as string)) end from (select generate_series as g from table(generate_series(2201, 2400))) t;
+-- result:
+-- !result
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, concat('a/b/c/2026-07-15/part-', cast(g as string)) from (select generate_series as g from table(generate_series(2401, 2600))) t;
+-- result:
+-- !result
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, case when g % 200 = 1 then concat('a/b/c/no-date-', cast(g as string)) else concat('a/b/c/2026-07-15/part-', cast(g as string)) end from (select generate_series as g from table(generate_series(2601, 2800))) t;
+-- result:
+-- !result
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, concat('a/b/c/2026-07-15/part-', cast(g as string)) from (select generate_series as g from table(generate_series(2801, 3000))) t;
+-- result:
+-- !result
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, case when g % 200 = 1 then concat('a/b/c/no-date-', cast(g as string)) else concat('a/b/c/2026-07-15/part-', cast(g as string)) end from (select generate_series as g from table(generate_series(3001, 3200))) t;
+-- result:
+-- !result
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, concat('a/b/c/2026-07-15/part-', cast(g as string)) from (select generate_series as g from table(generate_series(3201, 3400))) t;
+-- result:
+-- !result
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, case when g % 200 = 1 then concat('a/b/c/no-date-', cast(g as string)) else concat('a/b/c/2026-07-15/part-', cast(g as string)) end from (select generate_series as g from table(generate_series(3401, 3600))) t;
+-- result:
+-- !result
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, concat('a/b/c/2026-07-15/part-', cast(g as string)) from (select generate_series as g from table(generate_series(3601, 3800))) t;
+-- result:
+-- !result
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, case when g % 200 = 1 then concat('a/b/c/no-date-', cast(g as string)) else concat('a/b/c/2026-07-15/part-', cast(g as string)) end from (select generate_series as g from table(generate_series(3801, 4000))) t;
+-- result:
+-- !result
+select /*+SET_VAR(push_down_heavy_exprs=true)*/ substr(s, 1, 6) as p, min(nullif(regexp_extract(s, '(\\d\\d\\d\\d-\\d\\d-\\d\\d)', 1), '')) as k from t_heavy where flag = 'y' group by p;
+-- result:
+a/b/c/	2026-07-15
+-- !result
+select /*+SET_VAR(push_down_heavy_exprs=false)*/ substr(s, 1, 6) as p, min(nullif(regexp_extract(s, '(\\d\\d\\d\\d-\\d\\d-\\d\\d)', 1), '')) as k from t_heavy where flag = 'y' group by p;
+-- result:
+a/b/c/	2026-07-15
+-- !result

--- a/test/sql/test_push_down_heavy_exprs/T/test_push_down_heavy_exprs_nullability
+++ b/test/sql/test_push_down_heavy_exprs/T/test_push_down_heavy_exprs_nullability
@@ -1,0 +1,40 @@
+-- name: test_push_down_heavy_exprs_nullability
+-- Regression test for the scan heavy-expr result column not following the slot's
+-- nullability. Loading in 20 small batches leaves one rowset per insert in a single
+-- tablet, so the scan emits partial chunks that ChunkPipelineAccumulator appends
+-- together instead of swapping out. The odd batches carry one row whose value has no
+-- date, so nullif() produces a NULL there and the expression evaluates to a
+-- NullableColumn, while the even batches evaluate to a bare BinaryColumn. Appending
+-- one into the other used to either crash the BE in BinaryColumnBase::append or
+-- silently return a NULL min(). Pushing the expression down must give the same answer
+-- as evaluating it above the scan.
+
+create table t_heavy (
+  id bigint,
+  flag varchar(10),
+  s varchar(1000)
+) duplicate key(id)
+distributed by hash(id) buckets 1
+properties("replication_num"="1");
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, concat('a/b/c/2026-07-15/part-', cast(g as string)) from (select generate_series as g from table(generate_series(1, 200))) t;
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, case when g % 200 = 1 then concat('a/b/c/no-date-', cast(g as string)) else concat('a/b/c/2026-07-15/part-', cast(g as string)) end from (select generate_series as g from table(generate_series(201, 400))) t;
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, concat('a/b/c/2026-07-15/part-', cast(g as string)) from (select generate_series as g from table(generate_series(401, 600))) t;
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, case when g % 200 = 1 then concat('a/b/c/no-date-', cast(g as string)) else concat('a/b/c/2026-07-15/part-', cast(g as string)) end from (select generate_series as g from table(generate_series(601, 800))) t;
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, concat('a/b/c/2026-07-15/part-', cast(g as string)) from (select generate_series as g from table(generate_series(801, 1000))) t;
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, case when g % 200 = 1 then concat('a/b/c/no-date-', cast(g as string)) else concat('a/b/c/2026-07-15/part-', cast(g as string)) end from (select generate_series as g from table(generate_series(1001, 1200))) t;
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, concat('a/b/c/2026-07-15/part-', cast(g as string)) from (select generate_series as g from table(generate_series(1201, 1400))) t;
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, case when g % 200 = 1 then concat('a/b/c/no-date-', cast(g as string)) else concat('a/b/c/2026-07-15/part-', cast(g as string)) end from (select generate_series as g from table(generate_series(1401, 1600))) t;
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, concat('a/b/c/2026-07-15/part-', cast(g as string)) from (select generate_series as g from table(generate_series(1601, 1800))) t;
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, case when g % 200 = 1 then concat('a/b/c/no-date-', cast(g as string)) else concat('a/b/c/2026-07-15/part-', cast(g as string)) end from (select generate_series as g from table(generate_series(1801, 2000))) t;
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, concat('a/b/c/2026-07-15/part-', cast(g as string)) from (select generate_series as g from table(generate_series(2001, 2200))) t;
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, case when g % 200 = 1 then concat('a/b/c/no-date-', cast(g as string)) else concat('a/b/c/2026-07-15/part-', cast(g as string)) end from (select generate_series as g from table(generate_series(2201, 2400))) t;
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, concat('a/b/c/2026-07-15/part-', cast(g as string)) from (select generate_series as g from table(generate_series(2401, 2600))) t;
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, case when g % 200 = 1 then concat('a/b/c/no-date-', cast(g as string)) else concat('a/b/c/2026-07-15/part-', cast(g as string)) end from (select generate_series as g from table(generate_series(2601, 2800))) t;
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, concat('a/b/c/2026-07-15/part-', cast(g as string)) from (select generate_series as g from table(generate_series(2801, 3000))) t;
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, case when g % 200 = 1 then concat('a/b/c/no-date-', cast(g as string)) else concat('a/b/c/2026-07-15/part-', cast(g as string)) end from (select generate_series as g from table(generate_series(3001, 3200))) t;
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, concat('a/b/c/2026-07-15/part-', cast(g as string)) from (select generate_series as g from table(generate_series(3201, 3400))) t;
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, case when g % 200 = 1 then concat('a/b/c/no-date-', cast(g as string)) else concat('a/b/c/2026-07-15/part-', cast(g as string)) end from (select generate_series as g from table(generate_series(3401, 3600))) t;
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, concat('a/b/c/2026-07-15/part-', cast(g as string)) from (select generate_series as g from table(generate_series(3601, 3800))) t;
+insert into t_heavy select g, case when g % 97 = 0 then 'n' else 'y' end, case when g % 200 = 1 then concat('a/b/c/no-date-', cast(g as string)) else concat('a/b/c/2026-07-15/part-', cast(g as string)) end from (select generate_series as g from table(generate_series(3801, 4000))) t;
+select /*+SET_VAR(push_down_heavy_exprs=true)*/ substr(s, 1, 6) as p, min(nullif(regexp_extract(s, '(\\d\\d\\d\\d-\\d\\d-\\d\\d)', 1), '')) as k from t_heavy where flag = 'y' group by p;
+select /*+SET_VAR(push_down_heavy_exprs=false)*/ substr(s, 1, 6) as p, min(nullif(regexp_extract(s, '(\\d\\d\\d\\d-\\d\\d-\\d\\d)', 1), '')) as k from t_heavy where flag = 'y' group by p;


### PR DESCRIPTION
## Why I'm doing:

```
query_id:019fca41-68e9-73ca-9fdf-fcf08f0720e3, fragment_instance:019fca41-68e9-73ca-9fdf-fcf08f0720f4, plan_node_id:0
*** Aborted at 1785804714 (unix time) try “date -d @1785804714” if you are using GNU date ***
PC: @          0xa90a6e4 starrocks::BinaryColumnBase<unsigned int>::append(starrocks::Column const&, unsigned long, unsigned long)
*** SIGSEGV (@0x0) received by PID 2218619 (TID 0xfe22c90ed440) LWP(2219490) from PID 0; stack trace: ***
    @     0xfe235b92aaac (/usr/lib/aarch64-linux-gnu/libc.so.6+0x8aaab)
    @         0x1386fe24 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0xfe235d0e1a60 ([vdso]+0xa5f)
    @          0xa90a6e4 starrocks::BinaryColumnBase<unsigned int>::append(starrocks::Column const&, unsigned long, unsigned long)
    @          0xa919f9c starrocks::Chunk::append(starrocks::Chunk const&, unsigned long, unsigned long)
    @          0xf7fa08c starrocks::ChunkPipelineAccumulator::push(std::shared_ptr<starrocks::Chunk> const&)
    @          0xe86a5bc starrocks::pipeline::ChunkAccumulateOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @          0xcf8b78c starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0xe4b6ed8 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
```

The heavy expression evaluated in ChunkSource::buffer_next_batch_chunks_blocking is appended to the chunk exactly as ExprContext::evaluate returns it. Since ColumnBuilder::build() only wraps the result in a NullableColumn when that batch actually produced a NULL, the same slot alternates between a bare BinaryColumn and a NullableColumn<BinaryColumn> from one chunk to the next.

ChunkPipelineAccumulator::push only compares the column count and the JSON schema before doing _in_chunk->append(*chunk), so a NullableColumn can be appended into a bare BinaryColumn. BinaryColumnBase::append then reinterprets the source through a down_cast that is unchecked in release builds, reading the offsets buffer out of the NullableColumn's members and dereferencing a null pointer.

Apply the same normalization ProjectOperator already performs on its own evaluated columns: unfold only-null/const results and follow the slot's is_nullable flag.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
