### PR TITLE
[BugFix] Fix cache select crash after read schema reorder

### DIFF
--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2837,12 +2837,22 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
         }
         _context->_read_chunk->reset();
         Chunk* chunk = _context->_read_chunk.get();
-        size_t column_index = 0;
         for (size_t cid = 0; cid < _column_iterators.size(); ++cid) {
             if (_column_iterators[cid] == nullptr) {
                 continue;
             }
-            auto* col = chunk->get_column_raw_ptr_by_index(column_index++);
+            // The read chunk is built from `_context->_read_schema`, which may be reordered
+            // (predicate columns moved to the front by `reorder_schema` for late-materialization
+            // / low-cardinality handling). Its positional order therefore does NOT match the
+            // ascending-cid order of `_column_iterators`. Look up the scratch destination column
+            // by column id so the iterator and its `dst` stay type-aligned; pairing a complex-type
+            // iterator (array/map/struct/json) with a scalar column otherwise reinterprets the
+            // column and crashes inside `get_io_range_vec` (e.g. ArrayColumnIterator reading
+            // `offsets->get_data().back()` on a mistyped column).
+            if (!chunk->is_cid_exist(cid)) {
+                continue;
+            }
+            auto* col = chunk->get_column_raw_ptr_by_id(cid);
             if (!_scan_range.empty()) {
                 RETURN_IF_ERROR(_column_iterators[cid]->seek_to_ordinal(_scan_range.begin()));
             }

--- a/test/sql/test_cacheselect/R/test_shared_data_cache_select
+++ b/test/sql/test_cacheselect/R/test_shared_data_cache_select
@@ -22,6 +22,60 @@ CACHE SELECT c1, c2, c3 FROM t1 WHERE c3 >= utc_timestamp() - INTERVAL 2 month ;
 -- result:
 [REGEX].*
 -- !result
+CREATE TABLE t2 (
+    k1 int NOT NULL,
+    v_arr array<bigint> NOT NULL,
+    v_map map<int, string> NOT NULL,
+    dtm int NOT NULL
+)
+DUPLICATE KEY(k1)
+PARTITION BY RANGE(dtm) (PARTITION p20260630 VALUES [("20260630"), ("20260701")))
+DISTRIBUTED BY HASH(k1) BUCKETS 1;
+-- result:
+-- !result
+INSERT INTO t2
+SELECT generate_series, [generate_series, generate_series * 2], map{generate_series: 'v'}, 20260630
+FROM TABLE(generate_series(1, 1000));
+-- result:
+-- !result
+CACHE SELECT * FROM t2 WHERE dtm = 20260630;
+-- result:
+[REGEX].*
+-- !result
 DROP DATABASE cache_select_db_${uuid0} FORCE;
+-- result:
+-- !result
+-- name: test_shared_data_cache_select_array_reorder @cloud
+CREATE DATABASE cache_select_array_crash_${uuid0};
+-- result:
+-- !result
+USE cache_select_array_crash_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t_array (
+    c1  INT NOT NULL,
+    arr ARRAY<BIGINT> NOT NULL,
+    c3  DATETIME NOT NULL
+)
+PARTITION BY date_trunc('month', c3)
+DISTRIBUTED BY HASH(c1)
+BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t_array VALUES
+    (1, [10, 11], '2025-12-24 00:00:00'),
+    (2, [20, 21, 22], '2025-12-25 00:00:00');
+-- result:
+-- !result
+CACHE SELECT c1, arr, c3
+FROM t_array
+WHERE c3 >= '2025-12-23 00:00:00';
+-- result:
+[REGEX].*
+-- !result
+DROP DATABASE cache_select_array_crash_${uuid0} FORCE;
 -- result:
 -- !result

--- a/test/sql/test_cacheselect/T/test_shared_data_cache_select
+++ b/test/sql/test_cacheselect/T/test_shared_data_cache_select
@@ -16,5 +16,54 @@ FROM
 
 CACHE SELECT c1, c2, c3 FROM t1 WHERE c3 >= utc_timestamp() - INTERVAL 2 month ;
 
+-- CACHE SELECT over a table with complex-type columns while a predicate on a
+-- subset of columns reorders the read schema. The reorder must not misalign the
+-- per-column scratch buffer used by get_io_range_vec, otherwise the array/map
+-- iterator is paired with a scalar column and the CN crashes.
+CREATE TABLE t2 (
+    k1 int NOT NULL,
+    v_arr array<bigint> NOT NULL,
+    v_map map<int, string> NOT NULL,
+    dtm int NOT NULL
+)
+DUPLICATE KEY(k1)
+PARTITION BY RANGE(dtm) (PARTITION p20260630 VALUES [("20260630"), ("20260701")))
+DISTRIBUTED BY HASH(k1) BUCKETS 1;
+
+INSERT INTO t2
+SELECT generate_series, [generate_series, generate_series * 2], map{generate_series: 'v'}, 20260630
+FROM TABLE(generate_series(1, 1000));
+
+CACHE SELECT * FROM t2 WHERE dtm = 20260630;
+
 -- clean up
 DROP DATABASE cache_select_db_${uuid0} FORCE;
+
+-- name: test_shared_data_cache_select_array_reorder @cloud
+
+CREATE DATABASE cache_select_array_crash_${uuid0};
+USE cache_select_array_crash_${uuid0};
+
+CREATE TABLE t_array (
+    c1  INT NOT NULL,
+    arr ARRAY<BIGINT> NOT NULL,
+    c3  DATETIME NOT NULL
+)
+PARTITION BY date_trunc('month', c3)
+DISTRIBUTED BY HASH(c1)
+BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO t_array VALUES
+    (1, [10, 11], '2025-12-24 00:00:00'),
+    (2, [20, 21, 22], '2025-12-25 00:00:00');
+
+-- Buggy CN should crash in ArrayColumnIterator::get_io_range_vec().
+-- Fixed CN should execute successfully.
+CACHE SELECT c1, arr, c3
+FROM t_array
+WHERE c3 >= '2025-12-23 00:00:00';
+
+DROP DATABASE cache_select_array_crash_${uuid0} FORCE;


### PR DESCRIPTION
## Why I'm doing:
CACHE SELECT may crash the CN when the read schema contains complex-type columns and is reordered for predicate evaluation.

The cache-select path iterates column iterators by column ID but previously selected destination columns by their positional index in the reordered chunk. This could pair an iterator with a column of a different type—for example, pairing an ArrayColumnIterator with a scalar column—and trigger an assertion failure in ArrayColumnIterator::get_io_range_vec().

cn crash:
```c++
main ASAN (build 2686c18 distro ubuntu arch x86_64)
query_id:019fc778-9fa9-71ce-a893-efd0396f17e0, fragment_instance:019fc778-9fa9-71ce-a893-efd0396f17e1, plan_node_id:0
*** Aborted at 1785757999 (unix time) try "date -d @1785757999" if you are using GNU date ***
PC: @     0x7f4fd6e9ec0c pthread_kill
*** SIGABRT (@0x737f) received by PID 29567 (TID 0x7f4d0c3ca6c0) LWP(30196) from PID 29567; stack trace: ***
    @         0x333e3607 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7f4fd6ea1fb3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1fb2)
    @         0x333e2e06 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f4fd6e45330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @     0x7f4fd6e9ec0c pthread_kill
    @     0x7f4fd6e4527e gsignal
    @     0x7f4fd6e288ff abort
    @     0x7f4fd6e2881b (/usr/lib/x86_64-linux-gnu/libc.so.6+0x2881a)
    @     0x7f4fd6e3b517 __assert_fail
    @         0x1f6e2e5f starrocks::ArrayColumn* down_cast<starrocks::ArrayColumn*, starrocks::Column>(starrocks::Column*)
    @         0x21302db9 starrocks::unpack_array_column(starrocks::Column*)
    @         0x2130952a starrocks::ArrayColumnIterator::get_io_range_vec(starrocks::SparseRange<unsigned int> const&, starrocks::Column*)
    @         0x21a93e19 starrocks::SegmentIterator::_do_get_next(starrocks::Chunk*, std::vector<unsigned int, std::allocator<unsigned int> >*)
    @         0x21a91ba4 starrocks::SegmentIterator::do_get_next(starrocks::Chunk*)
    @         0x1d12c783 starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x24b545bb starrocks::ProjectionIterator::do_get_next(starrocks::Chunk*)
    @         0x1d12c783 starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x245c449c starrocks::TimedChunkIterator::do_get_next(starrocks::Chunk*)
    @         0x1d12c783 starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x2291972a starrocks::lake::TabletReader::do_get_next(starrocks::Chunk*)
    @         0x1d12c783 starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x1f455c59 starrocks::connector::LakeDataSource::get_next(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)
    @         0x1eb6303d starrocks::pipeline::ConnectorChunkSource::_read_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)::{lambda()#2}::operator()() const
    @         0x1eb64715 starrocks::pipeline::ConnectorChunkSource::_read_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)
    @         0x1eadc724 starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking(starrocks::RuntimeState*, unsigned long, starrocks::workgroup::WorkGroup const*)
    @         0x1eac0292 auto starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}::operator()<starrocks::workgroup::YieldContext>(starrocks::workgroup::YieldContext&) const
    @         0x1eac79b1 void std::__invoke_impl<void, starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}&, starrocks::workgroup::YieldContext&>(std::__invoke_other, starrocks::pipeline::ScanOperator::_trigger_next_scan(starro@
    @         0x1eac7608 std::enable_if<is_invocable_r_v<void, starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}&, starrocks::workgroup::YieldContext&>, void>::type std::__invoke_r<void, starrocks::pipeline::ScanOperator::_tr@
    @         0x1eac7017 std::_Function_handler<void (starrocks::workgroup::YieldContext&), starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}>::_M_invoke(std::_Any_data const&, starrocks::workgroup::YieldContext&)
    @         0x1f1adef7 std::function<void (starrocks::workgroup::YieldContext&)>::operator()(starrocks::workgroup::YieldContext&) const
    @         0x1f1ad017 starrocks::workgroup::ScanTask::run()
    @         0x23c43bb5 starrocks::workgroup::ScanExecutor::worker_thread()
```

## What I'm doing:
- Look up the destination column by column ID instead of its positional index, ensuring each column iterator receives a type-compatible column after schema reordering.
- Skip column IDs that are not present in the read chunk.
- Add a shared-data regression test covering CACHE SELECT on an ARRAY column with a predicate that reorders the read schema.
- Verify that the query completes successfully and the CN no longer crashes.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
