### PR TITLE
[BugFix] Fix unsorted PK SST writer memory accounting

### DIFF
--- a/be/src/storage/lake/pk_tablet_unsort_sst_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_unsort_sst_writer.cpp
@@ -16,6 +16,7 @@
 
 #include <fmt/format.h>
 
+#include "base/string/string_util.h"
 #include "column/chunk.h"
 #include "common/config_cache_fwd.h"
 #include "common/config_primary_key_fwd.h"
@@ -61,7 +62,7 @@ Status PkTabletUnsortSSTWriter::reset_sst_writer(const std::shared_ptr<LocationP
     _deleted_rowids.clear();
     _delete_keys.reset();
     _intermediate_ssts.clear();
-    _map_mem_usage = 0;
+    _keys_heap_size = 0;
     _next_rowid = 0;
     return Status::OK();
 }
@@ -93,10 +94,9 @@ void PkTabletUnsortSSTWriter::reconcile_entry(std::string_view key, uint64_t ord
     // not allocate; only a first-seen key materializes the owning std::string on the emplace branch.
     auto it = _map.find(key);
     if (it == _map.end()) {
-        // Rough per-entry footprint: encoded key bytes + value + btree node overhead.
-        static constexpr size_t kBtreeEntryOverhead = 24;
-        _map_mem_usage += key.size() + sizeof(Entry) + kBtreeEntryOverhead;
-        _map.emplace(std::string(key), Entry{order, rowid});
+        auto [inserted_it, inserted] = _map.emplace(std::string(key), Entry{order, rowid});
+        DCHECK(inserted);
+        _keys_heap_size += is_string_heap_allocated(inserted_it->first) ? inserted_it->first.capacity() : 0;
     } else if (order > it->second.order) {
         if (it->second.rowid != kDeleteRowid) {
             _deleted_rowids.push_back(it->second.rowid);
@@ -179,7 +179,7 @@ bool PkTabletUnsortSSTWriter::is_map_full() const {
     // map keeps the writer's combined footprint near the bound instead of letting _map independently
     // pile another l0_max_mem_usage on top of the loser vector. (_delete_keys is filled only at flush,
     // never during append, so it is not part of the footprint at this spill check.)
-    const size_t mem_usage = _map_mem_usage + _deleted_rowids.size() * sizeof(uint32_t);
+    const size_t mem_usage = memory_usage();
     if (mem_usage >= static_cast<size_t>(config::l0_max_mem_usage)) {
         return true;
     }
@@ -191,6 +191,14 @@ bool PkTabletUnsortSSTWriter::is_map_full() const {
         return true;
     }
     return false;
+}
+
+size_t PkTabletUnsortSSTWriter::map_memory_usage() const {
+    return _keys_heap_size + _map.bytes_used();
+}
+
+size_t PkTabletUnsortSSTWriter::memory_usage() const {
+    return map_memory_usage() + _deleted_rowids.capacity() * sizeof(uint32_t);
 }
 
 Status PkTabletUnsortSSTWriter::flush_map_to_intermediate_sst() {
@@ -232,7 +240,7 @@ Status PkTabletUnsortSSTWriter::flush_map_to_intermediate_sst() {
     RETURN_IF_ERROR(wf->close());
     _intermediate_ssts.push_back({location, size, std::move(encryption_meta)});
     _map.clear();
-    _map_mem_usage = 0;
+    _keys_heap_size = 0;
     return Status::OK();
 }
 
@@ -378,7 +386,7 @@ StatusOr<std::pair<FileInfo, PersistentIndexSstableRangePB>> PkTabletUnsortSSTWr
     _wf.reset();
     _map.clear();
     _intermediate_ssts.clear();
-    _map_mem_usage = 0;
+    _keys_heap_size = 0;
     _next_rowid = 0;
     return std::make_pair(file_info, range_pb);
 }

--- a/be/src/storage/lake/pk_tablet_unsort_sst_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_unsort_sst_writer.cpp
@@ -41,6 +41,11 @@
 
 namespace starrocks::lake {
 
+PkTabletUnsortSSTWriter::PkTabletUnsortSSTWriter(TabletSchemaCSPtr tablet_schema_ptr, TabletManager* tablet_mgr,
+                                                 int64_t tablet_id)
+        : PkTabletSSTWriter(std::move(tablet_schema_ptr), tablet_mgr, tablet_id),
+          _map(std::less<>(), MapAllocator(&_map_node_bytes)) {}
+
 Status PkTabletUnsortSSTWriter::reset_sst_writer(const std::shared_ptr<LocationProvider>& location_provider,
                                                  const std::shared_ptr<FileSystem>& fs) {
     _location_provider = location_provider;
@@ -194,7 +199,8 @@ bool PkTabletUnsortSSTWriter::is_map_full() const {
 }
 
 size_t PkTabletUnsortSSTWriter::map_memory_usage() const {
-    return _keys_heap_size + _map.bytes_used();
+    DCHECK_GE(_map_node_bytes, 0);
+    return sizeof(_map) + static_cast<size_t>(_map_node_bytes) + _keys_heap_size;
 }
 
 size_t PkTabletUnsortSSTWriter::memory_usage() const {

--- a/be/src/storage/lake/pk_tablet_unsort_sst_writer.h
+++ b/be/src/storage/lake/pk_tablet_unsort_sst_writer.h
@@ -41,9 +41,10 @@ namespace starrocks::lake {
 // memory. At segment finalize the intermediate SSTs (plus the residual map) are k-way merged into the
 // single final SST; duplicate PKs across intermediates are resolved there (last-flushed wins) and the
 // losers appended to the delete vector.
-// Memory: the map is bounded by l0_max_mem_usage (100 MB default) before it spills, and each parallel
-// merge task owns its own writer (and map), so peak usage is up to l0_max_mem_usage x the number of
-// concurrent merge tasks before spilling kicks in. It is charged to the load-spill merge mem tracker.
+// Memory: the map and loser-rowid vector are charged by allocated capacity and trigger a map spill at
+// l0_max_mem_usage (100 MB default). Each parallel merge task owns its own writer, so peak usage scales
+// with the number of concurrent merge tasks. The loser-rowid vector must live until segment finalize
+// and is not released by a map spill. Writer memory is charged to the load-spill merge mem tracker.
 class PkTabletUnsortSSTWriter : public PkTabletSSTWriter {
 public:
     PkTabletUnsortSSTWriter(TabletSchemaCSPtr tablet_schema_ptr, TabletManager* tablet_mgr, int64_t tablet_id)
@@ -64,6 +65,9 @@ public:
     bool has_file_info() const override { return _wf != nullptr; }
     std::vector<uint32_t> take_deleted_rowids() override { return std::move(_deleted_rowids); }
     MutableColumnPtr take_delete_keys() override { return std::move(_delete_keys); }
+
+protected:
+    size_t memory_usage() const;
 
 private:
     // A row that has no segment position (a DELETE) stores this reserved rowid, matching the
@@ -105,6 +109,8 @@ private:
     void collect_delete_key(const Slice& key);
     // Whether `_map` has reached the memtable memory threshold and should be spilled to an SST.
     bool is_map_full() const;
+    // Memory owned by `_map`: allocated B-tree nodes plus heap allocations of non-SSO keys.
+    size_t map_memory_usage() const;
     // Spill the current `_map` to a new intermediate SST (storing order+rowid), then clear the map.
     Status flush_map_to_intermediate_sst();
     // K-way merge the intermediate SSTs into `builder` (the final SST), keeping the max-order entry
@@ -117,8 +123,9 @@ private:
     // moved out via take_delete_keys(). A map/merge key IS an encoded-PK slice, so it is appended
     // straight into this column (built from clone_empty_pk_column). nullptr until the first winner.
     MutableColumnPtr _delete_keys;
-    // Rough running estimate of `_map`'s memory footprint, compared against l0_*_mem_usage.
-    size_t _map_mem_usage = 0;
+    // Heap allocations owned by non-SSO strings in `_map`. The std::string objects themselves are
+    // stored in the B-tree nodes and are already included in `_map.bytes_used()`.
+    size_t _keys_heap_size = 0;
     std::vector<IntermediateSst> _intermediate_ssts;
     // Running rowid within the current segment (== rows appended so far); reset per segment.
     uint32_t _next_rowid = 0;

--- a/be/src/storage/lake/pk_tablet_unsort_sst_writer.h
+++ b/be/src/storage/lake/pk_tablet_unsort_sst_writer.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "base/phmap/btree.h"
+#include "runtime/memory/counting_allocator.h"
 #include "storage/lake/pk_tablet_sst_writer.h"
 #include "storage/sstable/table_builder.h"
 
@@ -47,8 +48,7 @@ namespace starrocks::lake {
 // and is not released by a map spill. Writer memory is charged to the load-spill merge mem tracker.
 class PkTabletUnsortSSTWriter : public PkTabletSSTWriter {
 public:
-    PkTabletUnsortSSTWriter(TabletSchemaCSPtr tablet_schema_ptr, TabletManager* tablet_mgr, int64_t tablet_id)
-            : PkTabletSSTWriter(std::move(tablet_schema_ptr), tablet_mgr, tablet_id) {}
+    PkTabletUnsortSSTWriter(TabletSchemaCSPtr tablet_schema_ptr, TabletManager* tablet_mgr, int64_t tablet_id);
     ~PkTabletUnsortSSTWriter() override = default;
     Status append_sst_record(const Chunk& data, const std::vector<uint64_t>* rssid_rowids = nullptr,
                              const std::vector<uint32_t>* column_indexes = nullptr) override;
@@ -83,6 +83,9 @@ private:
         uint64_t order;
         uint32_t rowid;
     };
+    using MapValue = std::pair<const std::string, Entry>;
+    using MapAllocator = STLCountingAllocator<MapValue>;
+    using Map = phmap::btree_map<std::string, Entry, std::less<>, MapAllocator>;
     // An intermediate SST spilled from `_map` when it got full. Its entries store both rowid and order
     // (order in the value's version field) so the final merge can pick the dedup winner across SSTs.
     struct IntermediateSst {
@@ -117,7 +120,10 @@ private:
     // per key and appending the losing rowids to `_deleted_rowids`.
     Status merge_intermediates_into(sstable::TableBuilder* builder);
 
-    phmap::btree_map<std::string, Entry, std::less<>> _map;
+    // Bytes allocated for B-tree nodes. MapAllocator maintains this counter incrementally, so
+    // checking the spill threshold does not have to traverse the whole tree.
+    int64_t _map_node_bytes = 0;
+    Map _map;
     std::vector<uint32_t> _deleted_rowids;
     // Encoded primary keys (del-file binary format) whose latest op is a DELETE, collected at flush and
     // moved out via take_delete_keys(). A map/merge key IS an encoded-PK slice, so it is appended

--- a/be/test/storage/lake/pk_tablet_sst_writer_test.cpp
+++ b/be/test/storage/lake/pk_tablet_sst_writer_test.cpp
@@ -1040,14 +1040,20 @@ TEST_F(PkTabletSSTWriterTest, test_unsort_sst_writer_memory_usage) {
         uint64_t order;
         uint32_t rowid;
     };
-    phmap::btree_map<std::string, ExpectedEntry, std::less<>> expected_map;
+    using ExpectedMapValue = std::pair<const std::string, ExpectedEntry>;
+    using ExpectedMapAllocator = STLCountingAllocator<ExpectedMapValue>;
+    using ExpectedMap = phmap::btree_map<std::string, ExpectedEntry, std::less<>, ExpectedMapAllocator>;
+    int64_t expected_map_node_bytes = 0;
+    ExpectedMap expected_map{std::less<>(), ExpectedMapAllocator(&expected_map_node_bytes)};
     size_t expected_keys_heap_size = 0;
     for (uint32_t i = 0; i < encoded_keys.size(); ++i) {
         auto [it, inserted] = expected_map.emplace(encoded_keys[i], ExpectedEntry{order[i], i});
         ASSERT_TRUE(inserted);
         expected_keys_heap_size += is_string_heap_allocated(it->first) ? it->first.capacity() : 0;
     }
-    const size_t expected_map_usage = expected_map.bytes_used() + expected_keys_heap_size;
+    EXPECT_EQ(expected_map.bytes_used(), sizeof(expected_map) + static_cast<size_t>(expected_map_node_bytes));
+    const size_t expected_map_usage =
+            sizeof(expected_map) + static_cast<size_t>(expected_map_node_bytes) + expected_keys_heap_size;
 
     ASSERT_OK(w->append_sst_record(chunk, &order));
     EXPECT_EQ(expected_map_usage, w->memory_usage());

--- a/be/test/storage/lake/pk_tablet_sst_writer_test.cpp
+++ b/be/test/storage/lake/pk_tablet_sst_writer_test.cpp
@@ -17,10 +17,12 @@
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <map>
 #include <random>
 #include <tuple>
 
+#include "base/string/string_util.h"
 #include "base/testutil/assert.h"
 #include "base/testutil/id_generator.h"
 #include "base/testutil/sync_point.h"
@@ -996,6 +998,85 @@ static Chunk make_kv_chunk(const std::shared_ptr<Schema>& schema,
         c1->append(v);
     }
     return Chunk({std::move(c0), std::move(c1)}, schema);
+}
+
+class TestPkTabletUnsortSSTWriter : public PkTabletUnsortSSTWriter {
+public:
+    using PkTabletUnsortSSTWriter::PkTabletUnsortSSTWriter;
+    using PkTabletUnsortSSTWriter::memory_usage;
+
+    StatusOr<std::vector<std::string>> encode_keys_for_test(const Chunk& data) {
+        Buffer<Slice> keys;
+        MutableColumnPtr owned_column;
+        ASSIGN_OR_RETURN(const Slice* encoded_keys, encode_pk_keys(data, &keys, &owned_column));
+        std::vector<std::string> result;
+        result.reserve(data.num_rows());
+        for (size_t i = 0; i < data.num_rows(); ++i) {
+            result.emplace_back(encoded_keys[i].data, encoded_keys[i].size);
+        }
+        return result;
+    }
+};
+
+TEST_F(PkTabletSSTWriterTest, test_unsort_sst_writer_memory_usage) {
+    const int64_t tablet_id = _tablet_metadata->id();
+    ConfigResetGuard<int64_t> max_mem_guard(&config::l0_max_mem_usage, std::numeric_limits<int64_t>::max());
+    auto lp = std::make_shared<FixedLocationProvider>(kTestDirectory);
+    auto w = std::make_unique<TestPkTabletUnsortSSTWriter>(_tablet_schema, _tablet_mgr.get(), tablet_id);
+    ASSERT_OK(w->reset_sst_writer(lp, _fs));
+
+    std::vector<std::pair<std::string, int>> rows;
+    for (int i = 0; i < 6; ++i) {
+        rows.emplace_back(std::string(20, static_cast<char>('a' + i)), i);
+    }
+    auto chunk = make_kv_chunk(_schema, rows);
+    ASSIGN_OR_ABORT(auto encoded_keys, w->encode_keys_for_test(chunk));
+    std::vector<uint64_t> order(chunk.num_rows());
+    for (uint32_t i = 0; i < chunk.num_rows(); ++i) {
+        order[i] = (static_cast<uint64_t>(1) << 32) | i;
+    }
+
+    struct ExpectedEntry {
+        uint64_t order;
+        uint32_t rowid;
+    };
+    phmap::btree_map<std::string, ExpectedEntry, std::less<>> expected_map;
+    size_t expected_keys_heap_size = 0;
+    for (uint32_t i = 0; i < encoded_keys.size(); ++i) {
+        auto [it, inserted] = expected_map.emplace(encoded_keys[i], ExpectedEntry{order[i], i});
+        ASSERT_TRUE(inserted);
+        expected_keys_heap_size += is_string_heap_allocated(it->first) ? it->first.capacity() : 0;
+    }
+    const size_t expected_map_usage = expected_map.bytes_used() + expected_keys_heap_size;
+
+    ASSERT_OK(w->append_sst_record(chunk, &order));
+    EXPECT_EQ(expected_map_usage, w->memory_usage());
+
+    // Duplicate keys do not grow the map. Verify that the separately-owned loser vector is charged
+    // by allocated capacity rather than logical size.
+    std::vector<std::pair<std::string, int>> duplicate_rows(9, rows.front());
+    auto duplicate_chunk = make_kv_chunk(_schema, duplicate_rows);
+    std::vector<uint64_t> duplicate_order(duplicate_chunk.num_rows());
+    for (uint32_t i = 0; i < duplicate_chunk.num_rows(); ++i) {
+        duplicate_order[i] = (static_cast<uint64_t>(2 + i) << 32) | i;
+    }
+    ASSERT_OK(w->append_sst_record(duplicate_chunk, &duplicate_order));
+    const size_t usage_with_deleted_rowids = w->memory_usage();
+    auto deleted_rowids = w->take_deleted_rowids();
+    ASSERT_EQ(duplicate_chunk.num_rows(), deleted_rowids.size());
+    ASSERT_GT(deleted_rowids.capacity(), deleted_rowids.size());
+    EXPECT_EQ(expected_map_usage + deleted_rowids.capacity() * sizeof(uint32_t), usage_with_deleted_rowids);
+    ASSIGN_OR_ABORT(auto first_flush_result, w->flush_sst_writer());
+    EXPECT_FALSE(first_flush_result.first.path.empty());
+
+    // The exact map footprint is also the spill boundary: reaching it must clear the in-memory map.
+    config::l0_max_mem_usage = static_cast<int64_t>(expected_map_usage);
+    auto spill_writer = std::make_unique<TestPkTabletUnsortSSTWriter>(_tablet_schema, _tablet_mgr.get(), tablet_id);
+    ASSERT_OK(spill_writer->reset_sst_writer(lp, _fs));
+    ASSERT_OK(spill_writer->append_sst_record(chunk, &order));
+    EXPECT_LT(spill_writer->memory_usage(), expected_map_usage);
+    ASSIGN_OR_ABORT(auto spill_flush_result, spill_writer->flush_sst_writer());
+    EXPECT_FALSE(spill_flush_result.first.path.empty());
 }
 
 TEST_F(PkTabletSSTWriterTest, test_unsort_sst_writer_basic_no_dup) {


### PR DESCRIPTION
## Why I'm doing:

`PkTabletUnsortSSTWriter` used a fixed per-entry estimate for its B-tree memory. That estimate did not reflect platform-dependent `std::string` storage, actual B-tree node allocation and occupancy, or heap capacity for encoded keys. The loser-rowid vector was also charged by logical size instead of allocated capacity. As a result, the writer could underestimate its retained memory and spill later than the configured L0 threshold.

## What I'm doing:

- Track B-tree node allocations incrementally with `STLCountingAllocator` and separately track heap allocations owned by non-SSO encoded keys, avoiding a recursive B-tree scan on each spill-threshold check.
- Charge `_deleted_rowids` by allocated capacity and reset the key-heap counter whenever the map is cleared.
- Add coverage for exact map accounting, loser-vector capacity, and the spill boundary.

The change has no user-facing API or configuration changes. It makes the existing `l0_max_mem_usage`/`l0_min_mem_usage` spill policy track allocated memory more accurately, so the unsorted PK SST writer may spill earlier when the old estimate undercounted.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Validation:

- [x] `git diff --check`
- [x] Changed files formatted with clang-format
- [x] `python3 build-support/check_be_module_boundaries.py --mode full`
- [ ] `PkTabletSSTWriterTest.test_unsort_sst_writer_memory_usage` — not run locally because `/opt/homebrew/opt/llvm` is unavailable
- [ ] TSP build — intentionally not submitted

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

Documentation is not required because this only corrects internal accounting for existing configuration thresholds.

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

This PR currently targets `main` only and is not intended for automatic backporting.
