### PR TITLE
[BugFix] Fix DML with shadow generated columns during online optimize

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/MergePartitionJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/MergePartitionJob.java
@@ -541,7 +541,9 @@ public class MergePartitionJob extends AlterJobV2 implements GsonPostProcessable
             Collection<String> sourcePartitionNames = tempPartitionNameToSourcePartitionNames.get(tmpPartitionName);
             final String finalPartitionName = tmpPartitionName;
             String rewriteSql = "insert into " + ParseUtil.backquote(tableName) + " TEMPORARY PARTITION ("
-                        + ParseUtil.backquote(finalPartitionName) + ") select " + Joiner.on(", ").join(finalTableColumnNames)
+                        + ParseUtil.backquote(finalPartitionName) + ") ("
+                        + Joiner.on(", ").join(finalTableColumnNames) + ") select "
+                        + Joiner.on(", ").join(finalTableColumnNames)
                         + " from " + ParseUtil.backquote(tableName) + " partition ("
                         + Joiner.on(", ").join(sourcePartitionNames.stream()
                             .map(name -> ParseUtil.backquote(name))

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
@@ -333,7 +333,8 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
             String partitionName = partitionNames.get(i);
             String rewriteSql = "insert into " + ParseUtil.backquote(dbName) + "."
                         + ParseUtil.backquote(tableName) + " TEMPORARY PARTITION ("
-                        + ParseUtil.backquote(tmpPartitionName) + ") select " + Joiner.on(", ").join(tableColumnNames)
+                        + ParseUtil.backquote(tmpPartitionName) + ") (" + Joiner.on(", ").join(tableColumnNames)
+                        + ") select " + Joiner.on(", ").join(tableColumnNames)
                         + " from " + ParseUtil.backquote(dbName) + "." + ParseUtil.backquote(tableName)
                         + " partition (" + ParseUtil.backquote(partitionName) + ")";
             String taskName = getName() + "_" + tmpPartitionName;
@@ -941,8 +942,8 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
         if (context == null) {
             context = buildConnectContext();
         }
-        boolean originalOnlineOptimizeRewrite = context.isOnlineOptimizeRewrite();
-        context.setOnlineOptimizeRewrite(true);
+        boolean originalOptimizeRewrite = context.isOptimizeRewrite();
+        context.setOptimizeRewrite(true);
         try (var scope = context.bindScope()) {
             StatementBase parsedStmt = SqlParser.parseOneWithStarRocksDialect(sql, context.getSessionVariable());
             if (parsedStmt instanceof InsertStmt) {
@@ -968,7 +969,7 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
                 throw new AlterCancelException(context.getState().getErrorMessage());
             }
         } finally {
-            context.setOnlineOptimizeRewrite(originalOnlineOptimizeRewrite);
+            context.setOptimizeRewrite(originalOptimizeRewrite);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
@@ -944,7 +944,9 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
         try (var scope = context.bindScope()) {
             StatementBase parsedStmt = SqlParser.parseOneWithStarRocksDialect(sql, context.getSessionVariable());
             if (parsedStmt instanceof InsertStmt) {
-                ((InsertStmt) parsedStmt).setIsVersionOverwrite(true);
+                InsertStmt insertStmt = (InsertStmt) parsedStmt;
+                insertStmt.setIsVersionOverwrite(true);
+                insertStmt.setOnlineOptimizeRewrite(true);
             }
             StmtExecutor executor = StmtExecutor.newInternalExecutor(context, parsedStmt);
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
@@ -941,12 +941,13 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
         if (context == null) {
             context = buildConnectContext();
         }
+        boolean originalOnlineOptimizeRewrite = context.isOnlineOptimizeRewrite();
+        context.setOnlineOptimizeRewrite(true);
         try (var scope = context.bindScope()) {
             StatementBase parsedStmt = SqlParser.parseOneWithStarRocksDialect(sql, context.getSessionVariable());
             if (parsedStmt instanceof InsertStmt) {
                 InsertStmt insertStmt = (InsertStmt) parsedStmt;
                 insertStmt.setIsVersionOverwrite(true);
-                insertStmt.setOnlineOptimizeRewrite(true);
             }
             StmtExecutor executor = StmtExecutor.newInternalExecutor(context, parsedStmt);
 
@@ -966,6 +967,8 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
                         context.getState().getErrorMessage(), DebugUtil.printId(context.getQueryId()), sql);
                 throw new AlterCancelException(context.getState().getErrorMessage());
             }
+        } finally {
+            context.setOnlineOptimizeRewrite(originalOnlineOptimizeRewrite);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeJobV2.java
@@ -316,7 +316,8 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
             String tmpPartitionName = tmpPartitionNames.get(i);
             String partitionName = partitionNames.get(i);
             String rewriteSql = "insert into " + ParseUtil.backquote(tableName) + " TEMPORARY PARTITION ("
-                    + ParseUtil.backquote(tmpPartitionName) + ") select " + Joiner.on(", ").join(tableColumnNames)
+                    + ParseUtil.backquote(tmpPartitionName) + ") (" + Joiner.on(", ").join(tableColumnNames)
+                    + ") select " + Joiner.on(", ").join(tableColumnNames)
                     + " from " + ParseUtil.backquote(tableName) + " partition (" + ParseUtil.backquote(partitionName) + ")";
             String taskName = getName() + "_" + tmpPartitionName;
             OptimizeTask rewriteTask = TaskBuilder.buildOptimizeTask(taskName, properties, rewriteSql, dbName, warehouseId);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -292,9 +292,9 @@ public class ConnectContext {
     // Track if current write is CTAS (Create Table As Select)
     private boolean isCTAS = false;
 
-    // An OnlineOptimizeJobV2 rewrite copies logical rows into a temporary partition and must not
+    // An optimize rewrite copies logical rows into a temporary partition and must not
     // include unrelated schema-change shadow columns in its sink tuple.
-    private boolean onlineOptimizeRewrite = false;
+    private boolean optimizeRewrite = false;
 
     // Per-physical-partition read-version override: if set, OlapScanNode uses the mapped version
     // instead of physicalPartition.getVisibleVersion() for each entry in this map.
@@ -309,12 +309,12 @@ public class ConnectContext {
         return scanVersionOverride;
     }
 
-    public void setOnlineOptimizeRewrite(boolean onlineOptimizeRewrite) {
-        this.onlineOptimizeRewrite = onlineOptimizeRewrite;
+    public void setOptimizeRewrite(boolean optimizeRewrite) {
+        this.optimizeRewrite = optimizeRewrite;
     }
 
-    public boolean isOnlineOptimizeRewrite() {
-        return onlineOptimizeRewrite;
+    public boolean isOptimizeRewrite() {
+        return optimizeRewrite;
     }
 
     public void setTxnId(long txnId) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -292,6 +292,10 @@ public class ConnectContext {
     // Track if current write is CTAS (Create Table As Select)
     private boolean isCTAS = false;
 
+    // An OnlineOptimizeJobV2 rewrite copies logical rows into a temporary partition and must not
+    // include unrelated schema-change shadow columns in its sink tuple.
+    private boolean onlineOptimizeRewrite = false;
+
     // Per-physical-partition read-version override: if set, OlapScanNode uses the mapped version
     // instead of physicalPartition.getVisibleVersion() for each entry in this map.
     // Null means no override (normal visible-version path).
@@ -303,6 +307,14 @@ public class ConnectContext {
 
     public Map<Long, Long> getScanVersionOverride() {
         return scanVersionOverride;
+    }
+
+    public void setOnlineOptimizeRewrite(boolean onlineOptimizeRewrite) {
+        this.onlineOptimizeRewrite = onlineOptimizeRewrite;
+    }
+
+    public boolean isOnlineOptimizeRewrite() {
+        return onlineOptimizeRewrite;
     }
 
     public void setTxnId(long txnId) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.alter.AlterMVJobExecutor;
+import com.starrocks.alter.OptimizeTask;
 import com.starrocks.authentication.AuthenticationMgr;
 import com.starrocks.authorization.PrivilegeBuiltinConstants;
 import com.starrocks.authorization.PrivilegeException;
@@ -306,6 +307,12 @@ public class TaskRun implements Comparable<TaskRun> {
         context.setIsLastStmt(true);
         context.setMultiStmt(false);
         context.resetSessionVariable();
+        if (task instanceof OptimizeTask) {
+            // OptimizeJobV2 executes its rewrite through a new task-run context, so the
+            // submitter's ConnectContext marker cannot reach the planner. Restore the marker
+            // from the task type before parsing and planning the internal INSERT.
+            context.setOptimizeRewrite(true);
+        }
         // Preserve critical session variables from parent context if available
         // This ensures that settings like enableSingleNodeSchedule are inherited
         if (parentRunCtx != null && parentRunCtx.getSessionVariable() != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -285,9 +285,11 @@ public class InsertPlanner {
             outputBaseSchema = targetTable.getBaseSchema();
             // Online OPTIMIZE rewrites a temporary partition and does not perform a schema change.
             // Exclude stale schema-change shadow columns from the sink while retaining derived columns
-            // of normal synchronous materialized views, which are also kept in fullSchema.
+            // of normal synchronous materialized views, which are also kept in fullSchema. A completed
+            // OPTIMIZE may also leave same-named generated-column entries in fullSchema, so only emit the
+            // first occurrence of each logical column.
             outputFullSchema = session.isOnlineOptimizeRewrite()
-                    ? targetTable.getFullSchema().stream().filter(column -> !column.isShadowColumn()).toList()
+                    ? getOnlineOptimizeOutputFullSchema(targetTable)
                     : targetTable.getFullSchema();
         }
 
@@ -593,6 +595,18 @@ public class InsertPlanner {
         }
         throw new StarRocksPlannerException(String.format("failed to generate plan for the statement after %dms",
                 watch.elapsed(TimeUnit.MILLISECONDS)), ErrorType.INTERNAL_ERROR);
+    }
+
+    private List<Column> getOnlineOptimizeOutputFullSchema(Table targetTable) {
+        List<Column> outputSchema = new ArrayList<>();
+        Set<String> outputColumnNames = new HashSet<>();
+        for (Column column : targetTable.getFullSchema()) {
+            if (!column.isShadowColumn()
+                    && outputColumnNames.add(column.getName().toLowerCase(Locale.ROOT))) {
+                outputSchema.add(column);
+            }
+        }
+        return outputSchema;
     }
 
     private ExecPlan buildExecPlan(InsertStmt insertStmt, ConnectContext session, List<ColumnRefOperator> outputColumns,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -286,7 +286,7 @@ public class InsertPlanner {
             // Online OPTIMIZE rewrites a temporary partition and does not perform a schema change.
             // Exclude stale schema-change shadow columns from the sink while retaining derived columns
             // of normal synchronous materialized views, which are also kept in fullSchema.
-            outputFullSchema = insertStmt.isOnlineOptimizeRewrite()
+            outputFullSchema = session.isOnlineOptimizeRewrite()
                     ? targetTable.getFullSchema().stream().filter(column -> !column.isShadowColumn()).toList()
                     : targetTable.getFullSchema();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -288,8 +288,8 @@ public class InsertPlanner {
             // of normal synchronous materialized views, which are also kept in fullSchema. A completed
             // OPTIMIZE may also leave same-named generated-column entries in fullSchema, so only emit one
             // occurrence of each logical column and prefer the committed base-schema definition.
-            outputFullSchema = session.isOnlineOptimizeRewrite()
-                    ? getOnlineOptimizeOutputFullSchema(targetTable)
+            outputFullSchema = session.isOptimizeRewrite()
+                    ? getOptimizeOutputFullSchema(targetTable)
                     : targetTable.getFullSchema();
         }
 
@@ -597,7 +597,7 @@ public class InsertPlanner {
                 watch.elapsed(TimeUnit.MILLISECONDS)), ErrorType.INTERNAL_ERROR);
     }
 
-    private List<Column> getOnlineOptimizeOutputFullSchema(Table targetTable) {
+    private List<Column> getOptimizeOutputFullSchema(Table targetTable) {
         List<Column> outputSchema = new ArrayList<>(targetTable.getBaseSchema());
         Set<String> outputColumnNames = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
         targetTable.getBaseSchema().stream().map(Column::getName).forEach(outputColumnNames::add);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -283,11 +283,12 @@ public class InsertPlanner {
             inferOutputSchemaForPartialUpdate(insertStmt);
         } else {
             outputBaseSchema = targetTable.getBaseSchema();
-            // Online OPTIMIZE rewrites a temporary partition with the logical table schema. It does
-            // not perform a schema change, so stale shadow columns in fullSchema must not become sink
-            // slots: the rewrite SELECT and generated-column expansion are defined over baseSchema.
+            // Online OPTIMIZE rewrites a temporary partition and does not perform a schema change.
+            // Exclude stale schema-change shadow columns from the sink while retaining derived columns
+            // of normal synchronous materialized views, which are also kept in fullSchema.
             outputFullSchema = insertStmt.isOnlineOptimizeRewrite()
-                    ? outputBaseSchema : targetTable.getFullSchema();
+                    ? targetTable.getFullSchema().stream().filter(column -> !column.isShadowColumn()).toList()
+                    : targetTable.getFullSchema();
         }
 
         if (targetTable.isIcebergTable()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -283,7 +283,11 @@ public class InsertPlanner {
             inferOutputSchemaForPartialUpdate(insertStmt);
         } else {
             outputBaseSchema = targetTable.getBaseSchema();
-            outputFullSchema = targetTable.getFullSchema();
+            // Online OPTIMIZE rewrites a temporary partition with the logical table schema. It does
+            // not perform a schema change, so stale shadow columns in fullSchema must not become sink
+            // slots: the rewrite SELECT and generated-column expansion are defined over baseSchema.
+            outputFullSchema = insertStmt.isOnlineOptimizeRewrite()
+                    ? outputBaseSchema : targetTable.getFullSchema();
         }
 
         if (targetTable.isIcebergTable()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -286,8 +286,8 @@ public class InsertPlanner {
             // Online OPTIMIZE rewrites a temporary partition and does not perform a schema change.
             // Exclude stale schema-change shadow columns from the sink while retaining derived columns
             // of normal synchronous materialized views, which are also kept in fullSchema. A completed
-            // OPTIMIZE may also leave same-named generated-column entries in fullSchema, so only emit the
-            // first occurrence of each logical column.
+            // OPTIMIZE may also leave same-named generated-column entries in fullSchema, so only emit one
+            // occurrence of each logical column and prefer the committed base-schema definition.
             outputFullSchema = session.isOnlineOptimizeRewrite()
                     ? getOnlineOptimizeOutputFullSchema(targetTable)
                     : targetTable.getFullSchema();
@@ -598,11 +598,11 @@ public class InsertPlanner {
     }
 
     private List<Column> getOnlineOptimizeOutputFullSchema(Table targetTable) {
-        List<Column> outputSchema = new ArrayList<>();
-        Set<String> outputColumnNames = new HashSet<>();
+        List<Column> outputSchema = new ArrayList<>(targetTable.getBaseSchema());
+        Set<String> outputColumnNames = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
+        targetTable.getBaseSchema().stream().map(Column::getName).forEach(outputColumnNames::add);
         for (Column column : targetTable.getFullSchema()) {
-            if (!column.isShadowColumn()
-                    && outputColumnNames.add(column.getName().toLowerCase(Locale.ROOT))) {
+            if (!column.isShadowColumn() && outputColumnNames.add(column.getName())) {
                 outputSchema.add(column);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
@@ -162,12 +162,16 @@ public class UpdatePlanner {
         DescriptorTable descriptorTable = execPlan.getDescTbl();
         TupleDescriptor olapTuple = descriptorTable.createTupleDescriptor();
         long tableId = targetTable.getId();
+        OlapTable olapTable = (OlapTable) targetTable;
 
         List<Pair<Integer, ColumnDict>> globalDicts = Lists.newArrayList();
-        // UpdateAnalyzer builds the update output from the base schema. Keep the sink tuple
-        // aligned with that output instead of including shadow columns from an in-progress
-        // schema change in the full schema.
-        for (Column column : targetTable.getBaseSchema()) {
+        // Online OPTIMIZE does not write schema-change shadow indexes, so its unrelated shadow
+        // columns must not become sink slots. A real schema change still needs the full schema so
+        // concurrent writes can target its shadow indexes.
+        List<Column> outputSchema = olapTable.getState() == OlapTable.OlapTableState.OPTIMIZE
+                ? targetTable.getFullSchema().stream().filter(column -> !column.isShadowColumn()).toList()
+                : targetTable.getFullSchema();
+        for (Column column : outputSchema) {
             if (updateStmt.usePartialUpdate() && !column.isGeneratedColumn() &&
                     !updateStmt.isAssignmentColumn(column.getName()) && !column.isKey()) {
                 continue;
@@ -186,7 +190,6 @@ public class UpdatePlanner {
         }
         olapTuple.computeMemLayout();
 
-        OlapTable olapTable = (OlapTable) targetTable;
         List<Long> partitionIds = Lists.newArrayList();
         for (Partition partition : olapTable.getPartitions()) {
             partitionIds.add(partition.getId());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
@@ -165,12 +165,13 @@ public class UpdatePlanner {
         OlapTable olapTable = (OlapTable) targetTable;
 
         List<Pair<Integer, ColumnDict>> globalDicts = Lists.newArrayList();
-        // Only a real schema change needs shadow columns so concurrent writes can target its shadow
-        // indexes. Online OPTIMIZE may leave obsolete shadow generated columns in fullSchema even
-        // after the table returns to NORMAL, but its rewritten tablets do not contain those columns.
+        // UpdateAnalyzer builds the output expressions from baseSchema. Only a real schema change
+        // needs fullSchema so concurrent writes can target its shadow indexes. Online OPTIMIZE can
+        // leave duplicate generated-column entries in fullSchema, including entries without the
+        // shadow-name prefix, so filtering by Column.isShadowColumn() is not sufficient here.
         List<Column> outputSchema = olapTable.getState() == OlapTable.OlapTableState.SCHEMA_CHANGE
                 ? targetTable.getFullSchema()
-                : targetTable.getFullSchema().stream().filter(column -> !column.isShadowColumn()).toList();
+                : targetTable.getBaseSchema();
         for (Column column : outputSchema) {
             if (updateStmt.usePartialUpdate() && !column.isGeneratedColumn() &&
                     !updateStmt.isAssignmentColumn(column.getName()) && !column.isKey()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
@@ -165,12 +165,12 @@ public class UpdatePlanner {
         OlapTable olapTable = (OlapTable) targetTable;
 
         List<Pair<Integer, ColumnDict>> globalDicts = Lists.newArrayList();
-        // Online OPTIMIZE does not write schema-change shadow indexes, so its unrelated shadow
-        // columns must not become sink slots. A real schema change still needs the full schema so
-        // concurrent writes can target its shadow indexes.
-        List<Column> outputSchema = olapTable.getState() == OlapTable.OlapTableState.OPTIMIZE
-                ? targetTable.getFullSchema().stream().filter(column -> !column.isShadowColumn()).toList()
-                : targetTable.getFullSchema();
+        // Only a real schema change needs shadow columns so concurrent writes can target its shadow
+        // indexes. Online OPTIMIZE may leave obsolete shadow generated columns in fullSchema even
+        // after the table returns to NORMAL, but its rewritten tablets do not contain those columns.
+        List<Column> outputSchema = olapTable.getState() == OlapTable.OlapTableState.SCHEMA_CHANGE
+                ? targetTable.getFullSchema()
+                : targetTable.getFullSchema().stream().filter(column -> !column.isShadowColumn()).toList();
         for (Column column : outputSchema) {
             if (updateStmt.usePartialUpdate() && !column.isGeneratedColumn() &&
                     !updateStmt.isAssignmentColumn(column.getName()) && !column.isKey()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
@@ -164,7 +164,10 @@ public class UpdatePlanner {
         long tableId = targetTable.getId();
 
         List<Pair<Integer, ColumnDict>> globalDicts = Lists.newArrayList();
-        for (Column column : targetTable.getFullSchema()) {
+        // UpdateAnalyzer builds the update output from the base schema. Keep the sink tuple
+        // aligned with that output instead of including shadow columns from an in-progress
+        // schema change in the full schema.
+        for (Column column : targetTable.getBaseSchema()) {
             if (updateStmt.usePartialUpdate() && !column.isGeneratedColumn() &&
                     !updateStmt.isAssignmentColumn(column.getName()) && !column.isKey()) {
                 continue;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
@@ -96,11 +96,6 @@ public class InsertStmt extends DmlStmt {
 
     private boolean isVersionOverwrite = false;
 
-    // An OnlineOptimizeJobV2 rewrite copies logical base rows into a temporary partition. Unlike a
-    // schema-change rewrite, it must not include unrelated shadow columns that may still be present
-    // in the table's full schema.
-    private boolean isOnlineOptimizeRewrite = false;
-
     private boolean isShadowRewrite = false;
     private Long targetWriteIndexId = null;
     // For a shadow-rewrite INSERT: the watershed txn id the converted op_schema_change log must be
@@ -216,14 +211,6 @@ public class InsertStmt extends DmlStmt {
 
     public boolean isVersionOverwrite() {
         return isVersionOverwrite;
-    }
-
-    public void setOnlineOptimizeRewrite(boolean onlineOptimizeRewrite) {
-        isOnlineOptimizeRewrite = onlineOptimizeRewrite;
-    }
-
-    public boolean isOnlineOptimizeRewrite() {
-        return isOnlineOptimizeRewrite;
     }
 
     public void setShadowRewrite(boolean isShadowRewrite) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
@@ -96,6 +96,11 @@ public class InsertStmt extends DmlStmt {
 
     private boolean isVersionOverwrite = false;
 
+    // An OnlineOptimizeJobV2 rewrite copies logical base rows into a temporary partition. Unlike a
+    // schema-change rewrite, it must not include unrelated shadow columns that may still be present
+    // in the table's full schema.
+    private boolean isOnlineOptimizeRewrite = false;
+
     private boolean isShadowRewrite = false;
     private Long targetWriteIndexId = null;
     // For a shadow-rewrite INSERT: the watershed txn id the converted op_schema_change log must be
@@ -211,6 +216,14 @@ public class InsertStmt extends DmlStmt {
 
     public boolean isVersionOverwrite() {
         return isVersionOverwrite;
+    }
+
+    public void setOnlineOptimizeRewrite(boolean onlineOptimizeRewrite) {
+        isOnlineOptimizeRewrite = onlineOptimizeRewrite;
+    }
+
+    public boolean isOnlineOptimizeRewrite() {
+        return isOnlineOptimizeRewrite;
     }
 
     public void setShadowRewrite(boolean isShadowRewrite) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/OnlineOptimizeJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/OnlineOptimizeJobV2Test.java
@@ -41,6 +41,7 @@ import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class OnlineOptimizeJobV2Test extends DDLTestBase {
     private AlterTableStmt alterTableStmt;
@@ -98,7 +99,13 @@ public class OnlineOptimizeJobV2Test extends DDLTestBase {
 
         // runRunningJob
         List<OptimizeTask> optimizeTasks = optimizeJob.getOptimizeTasks();
+        String rewriteColumns = olapTable.getBaseSchema().stream()
+                .filter(column -> !column.isGeneratedColumn())
+                .map(column -> "`" + column.getName() + "`")
+                .collect(Collectors.joining(", "));
         for (OptimizeTask optimizeTask : optimizeTasks) {
+            Assertions.assertTrue(optimizeTask.getDefinition()
+                    .contains(") (" + rewriteColumns + ") select " + rewriteColumns + " from "));
             optimizeTask.setOptimizeTaskState(Constants.TaskRunState.SUCCESS);
         }
         optimizeJob.runRunningJob();

--- a/fe/fe-core/src/test/java/com/starrocks/alter/OptimizeJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/OptimizeJobV2Test.java
@@ -44,6 +44,7 @@ import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class OptimizeJobV2Test extends DDLTestBase {
     private static final String TEST_FILE_NAME = OptimizeJobV2Test.class.getCanonicalName();
@@ -172,8 +173,14 @@ public class OptimizeJobV2Test extends DDLTestBase {
 
         // runRunningJob
         List<OptimizeTask> optimizeTasks = optimizeJob.getOptimizeTasks();
+        String rewriteColumns = olapTable.getBaseSchema().stream()
+                .filter(column -> !column.isGeneratedColumn())
+                .map(column -> "`" + column.getName() + "`")
+                .collect(Collectors.joining(", "));
         for (int i = 0; i < optimizeTasks.size(); ++i) {
             OptimizeTask optimizeTask = optimizeTasks.get(i);
+            Assertions.assertTrue(optimizeTask.getDefinition()
+                    .contains(") (" + rewriteColumns + ") select " + rewriteColumns + " from "));
             removeTaskFromScheduler(optimizeTask);
             TaskRunStatus taskRunStatus = new TaskRunStatus();
             taskRunStatus.setTaskName(optimizeTask.getName());

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/SqlTaskRunProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/SqlTaskRunProcessorTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.scheduler;
 
+import com.starrocks.alter.OptimizeTask;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.sql.ast.StatementBase;
@@ -33,6 +34,24 @@ import java.util.UUID;
  * and that TaskRunContext propagates the remote host:port from the submitter.
  */
 public class SqlTaskRunProcessorTest {
+
+    @Test
+    public void testOptimizeTaskMarksRewriteContext() {
+        OptimizeTask task = new OptimizeTask("optimize-rewrite");
+        task.setSource(Constants.TaskSource.INSERT);
+        task.setCatalogName("internal");
+        task.setDbName("db1");
+        task.setDefinition("INSERT INTO t SELECT 1");
+
+        TaskRun taskRun = new TaskRun();
+        taskRun.setTask(task);
+        taskRun.setConnectContext(new ConnectContext(null));
+        taskRun.setProperties(new java.util.HashMap<>());
+        taskRun.initStatus(UUID.randomUUID().toString(), System.currentTimeMillis());
+
+        TaskRunContext context = taskRun.buildTaskRunContext();
+        Assertions.assertTrue(context.getCtx().isOptimizeRewrite());
+    }
 
     @Test
     public void testAuditClientIpSetForSubmitTaskInsert(@Mocked StatementBase mockStmt,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -35,7 +35,10 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.InsertPlanner;
 import com.starrocks.sql.StatementPlanner;
+import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.AstToSQLBuilder;
+import com.starrocks.sql.analyzer.PlannerMetaLocker;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.IcebergRewriteStmt;
 import com.starrocks.sql.ast.InsertStmt;
@@ -110,26 +113,38 @@ public class InsertPlanTest extends PlanTestBase {
                 schemaWithStaleGeneratedColumns.add(shadowColumn);
             }
         }
-        table.setNewFullSchema(schemaWithStaleGeneratedColumns);
 
+        String sql = "insert into insert_online_optimize_shadow_generated_column (pk, v, tags) " +
+                "select pk, v, tags from insert_online_optimize_shadow_generated_column";
+        InsertStmt insertStmt = (InsertStmt) SqlParser.parse(sql, connectContext.getSessionVariable().getSqlMode())
+                .get(0);
+        boolean originalOnlineOptimizeRewrite = connectContext.isOnlineOptimizeRewrite();
+        connectContext.setOnlineOptimizeRewrite(true);
         try {
-            String sql = "insert into insert_online_optimize_shadow_generated_column (pk, v, tags) " +
-                    "select pk, v, tags from insert_online_optimize_shadow_generated_column";
-            InsertStmt insertStmt = (InsertStmt) SqlParser.parse(sql, connectContext.getSessionVariable().getSqlMode())
-                    .get(0);
-            boolean originalOnlineOptimizeRewrite = connectContext.isOnlineOptimizeRewrite();
-            connectContext.setOnlineOptimizeRewrite(true);
+            connectContext.setQueryId(UUIDUtil.genUUID());
+            connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
+            connectContext.setDumpInfo(new QueryDumpInfo(connectContext));
+            connectContext.getDumpInfo().setOriginStmt(sql);
+            Analyzer.analyze(insertStmt, connectContext);
+            AnalyzerUtils.collectAllDatabase(connectContext, insertStmt);
+
+            // Simulate fullSchema changing after analysis but before sink planning, as can happen when
+            // an online optimize job publishes or cleans up a shadow schema concurrently with DML.
+            table.setNewFullSchema(schemaWithStaleGeneratedColumns);
+            PlannerMetaLocker locker = new PlannerMetaLocker(connectContext, insertStmt);
+            StatementPlanner.lock(locker);
             try {
-                ExecPlan execPlan = getInsertExecPlanObject(insertStmt, sql);
+                ExecPlan execPlan = new InsertPlanner(locker, true).plan(insertStmt, connectContext);
                 OlapTableSink sink = (OlapTableSink) execPlan.getFragments().get(0).getSink();
                 Assertions.assertEquals(originalFullSchema.size(), sink.getTupleDescriptor().getSlots().size());
                 Assertions.assertEquals(execPlan.getOutputExprs().size(), sink.getTupleDescriptor().getSlots().size());
                 Assertions.assertTrue(sink.getTupleDescriptor().getSlots().stream()
                         .noneMatch(slot -> slot.getColumn().isShadowColumn()));
             } finally {
-                connectContext.setOnlineOptimizeRewrite(originalOnlineOptimizeRewrite);
+                StatementPlanner.unLock(locker);
             }
         } finally {
+            connectContext.setOnlineOptimizeRewrite(originalOnlineOptimizeRewrite);
             table.setNewFullSchema(originalFullSchema);
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -97,19 +97,20 @@ public class InsertPlanTest extends PlanTestBase {
     }
 
     @Test
-    public void testOnlineOptimizeRewriteUsesBaseSchemaWithShadowGeneratedColumns() throws Exception {
+    public void testOnlineOptimizeRewriteExcludesStaleGeneratedColumns() throws Exception {
         OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
                 .getDb(connectContext.getDatabase()).getTable("insert_online_optimize_shadow_generated_column");
         List<Column> originalFullSchema = table.getFullSchema();
-        List<Column> schemaWithShadowGeneratedColumns = new ArrayList<>(originalFullSchema);
+        List<Column> schemaWithStaleGeneratedColumns = new ArrayList<>(originalFullSchema);
         for (Column column : table.getBaseSchema()) {
             if (column.isGeneratedColumn()) {
+                schemaWithStaleGeneratedColumns.add(column.deepCopy());
                 Column shadowColumn = column.deepCopy();
                 shadowColumn.setName(SchemaChangeHandler.SHADOW_NAME_PREFIX + column.getName());
-                schemaWithShadowGeneratedColumns.add(shadowColumn);
+                schemaWithStaleGeneratedColumns.add(shadowColumn);
             }
         }
-        table.setNewFullSchema(schemaWithShadowGeneratedColumns);
+        table.setNewFullSchema(schemaWithStaleGeneratedColumns);
 
         try {
             String sql = "insert into insert_online_optimize_shadow_generated_column (pk, v, tags) " +
@@ -121,8 +122,10 @@ public class InsertPlanTest extends PlanTestBase {
             try {
                 ExecPlan execPlan = getInsertExecPlanObject(insertStmt, sql);
                 OlapTableSink sink = (OlapTableSink) execPlan.getFragments().get(0).getSink();
-                Assertions.assertEquals(table.getBaseSchema().size(), sink.getTupleDescriptor().getSlots().size());
+                Assertions.assertEquals(originalFullSchema.size(), sink.getTupleDescriptor().getSlots().size());
                 Assertions.assertEquals(execPlan.getOutputExprs().size(), sink.getTupleDescriptor().getSlots().size());
+                Assertions.assertTrue(sink.getTupleDescriptor().getSlots().stream()
+                        .noneMatch(slot -> slot.getColumn().isShadowColumn()));
             } finally {
                 connectContext.setOnlineOptimizeRewrite(originalOnlineOptimizeRewrite);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -118,8 +118,8 @@ public class InsertPlanTest extends PlanTestBase {
                 "select pk, v, tags from insert_online_optimize_shadow_generated_column";
         InsertStmt insertStmt = (InsertStmt) SqlParser.parse(sql, connectContext.getSessionVariable().getSqlMode())
                 .get(0);
-        boolean originalOnlineOptimizeRewrite = connectContext.isOnlineOptimizeRewrite();
-        connectContext.setOnlineOptimizeRewrite(true);
+        boolean originalOptimizeRewrite = connectContext.isOptimizeRewrite();
+        connectContext.setOptimizeRewrite(true);
         try {
             connectContext.setQueryId(UUIDUtil.genUUID());
             connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
@@ -144,7 +144,7 @@ public class InsertPlanTest extends PlanTestBase {
                 StatementPlanner.unLock(locker);
             }
         } finally {
-            connectContext.setOnlineOptimizeRewrite(originalOnlineOptimizeRewrite);
+            connectContext.setOptimizeRewrite(originalOptimizeRewrite);
             table.setNewFullSchema(originalFullSchema);
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -15,10 +15,12 @@
 package com.starrocks.sql.plan;
 
 import com.google.common.collect.Lists;
+import com.starrocks.alter.SchemaChangeHandler;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.TableName;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
@@ -82,6 +84,45 @@ public class InsertPlanTest extends PlanTestBase {
                 "DUPLICATE KEY(id)\n" +
                 "DISTRIBUTED BY HASH(id) BUCKETS 1\n" +
                 "PROPERTIES ('replication_num' = '1');");
+        starRocksAssert.withTable("CREATE TABLE insert_online_optimize_shadow_generated_column (\n" +
+                "  pk bigint NOT NULL,\n" +
+                "  v int NOT NULL,\n" +
+                "  tags json NULL,\n" +
+                "  g varchar(32) NULL AS get_json_string(tags, '$.vendorId')\n" +
+                ") ENGINE=OLAP\n" +
+                "PRIMARY KEY (pk)\n" +
+                "DISTRIBUTED BY HASH (pk) BUCKETS 1\n" +
+                "PROPERTIES ('replication_num' = '1');");
+    }
+
+    @Test
+    public void testOnlineOptimizeRewriteUsesBaseSchemaWithShadowGeneratedColumns() throws Exception {
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getDb(connectContext.getDatabase()).getTable("insert_online_optimize_shadow_generated_column");
+        List<Column> originalFullSchema = table.getFullSchema();
+        List<Column> schemaWithShadowGeneratedColumns = new ArrayList<>(originalFullSchema);
+        for (Column column : table.getBaseSchema()) {
+            if (column.isGeneratedColumn()) {
+                Column shadowColumn = column.deepCopy();
+                shadowColumn.setName(SchemaChangeHandler.SHADOW_NAME_PREFIX + column.getName());
+                schemaWithShadowGeneratedColumns.add(shadowColumn);
+            }
+        }
+        table.setNewFullSchema(schemaWithShadowGeneratedColumns);
+
+        try {
+            String sql = "insert into insert_online_optimize_shadow_generated_column (pk, v, tags) " +
+                    "select pk, v, tags from insert_online_optimize_shadow_generated_column";
+            InsertStmt insertStmt = (InsertStmt) SqlParser.parse(sql, connectContext.getSessionVariable().getSqlMode())
+                    .get(0);
+            insertStmt.setOnlineOptimizeRewrite(true);
+            ExecPlan execPlan = getInsertExecPlanObject(insertStmt, sql);
+            OlapTableSink sink = (OlapTableSink) execPlan.getFragments().get(0).getSink();
+            Assertions.assertEquals(table.getBaseSchema().size(), sink.getTupleDescriptor().getSlots().size());
+            Assertions.assertEquals(execPlan.getOutputExprs().size(), sink.getTupleDescriptor().getSlots().size());
+        } finally {
+            table.setNewFullSchema(originalFullSchema);
+        }
     }
 
     @Test
@@ -430,12 +471,15 @@ public class InsertPlanTest extends PlanTestBase {
     }
 
     private static String getInsertExecPlan(StatementBase statementBase, String originStmt) throws Exception {
+        return getInsertExecPlanObject(statementBase, originStmt).getExplainString(TExplainLevel.NORMAL);
+    }
+
+    private static ExecPlan getInsertExecPlanObject(StatementBase statementBase, String originStmt) throws Exception {
         connectContext.setQueryId(UUIDUtil.genUUID());
         connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
         connectContext.setDumpInfo(new QueryDumpInfo(connectContext));
         connectContext.getDumpInfo().setOriginStmt(originStmt);
-        ExecPlan execPlan = new StatementPlanner().plan(statementBase, connectContext);
-        return execPlan.getExplainString(TExplainLevel.NORMAL);
+        return new StatementPlanner().plan(statementBase, connectContext);
     }
 
     public static void containsKeywords(String plan, String... keywords) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -31,6 +31,7 @@ import com.starrocks.planner.OlapTableSink;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.InsertPlanner;
 import com.starrocks.sql.StatementPlanner;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -116,11 +116,16 @@ public class InsertPlanTest extends PlanTestBase {
                     "select pk, v, tags from insert_online_optimize_shadow_generated_column";
             InsertStmt insertStmt = (InsertStmt) SqlParser.parse(sql, connectContext.getSessionVariable().getSqlMode())
                     .get(0);
-            insertStmt.setOnlineOptimizeRewrite(true);
-            ExecPlan execPlan = getInsertExecPlanObject(insertStmt, sql);
-            OlapTableSink sink = (OlapTableSink) execPlan.getFragments().get(0).getSink();
-            Assertions.assertEquals(table.getBaseSchema().size(), sink.getTupleDescriptor().getSlots().size());
-            Assertions.assertEquals(execPlan.getOutputExprs().size(), sink.getTupleDescriptor().getSlots().size());
+            boolean originalOnlineOptimizeRewrite = connectContext.isOnlineOptimizeRewrite();
+            connectContext.setOnlineOptimizeRewrite(true);
+            try {
+                ExecPlan execPlan = getInsertExecPlanObject(insertStmt, sql);
+                OlapTableSink sink = (OlapTableSink) execPlan.getFragments().get(0).getSink();
+                Assertions.assertEquals(table.getBaseSchema().size(), sink.getTupleDescriptor().getSlots().size());
+                Assertions.assertEquals(execPlan.getOutputExprs().size(), sink.getTupleDescriptor().getSlots().size());
+            } finally {
+                connectContext.setOnlineOptimizeRewrite(originalOnlineOptimizeRewrite);
+            }
         } finally {
             table.setNewFullSchema(originalFullSchema);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java
@@ -107,10 +107,11 @@ public class UpdatePlanTest extends PlanTestBase {
     }
 
     @Test
-    public void testUpdateSinkUsesBaseSchemaWithShadowGeneratedColumns() throws Exception {
+    public void testUpdateSinkExcludesShadowColumnsDuringOptimize() throws Exception {
         OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
                 .getDb(connectContext.getDatabase()).getTable("update_shadow_generated_column");
         List<Column> originalFullSchema = table.getFullSchema();
+        OlapTable.OlapTableState originalState = table.getState();
         List<Column> schemaWithShadowGeneratedColumns = new ArrayList<>(originalFullSchema);
         for (Column column : table.getBaseSchema()) {
             if (column.isGeneratedColumn()) {
@@ -120,6 +121,7 @@ public class UpdatePlanTest extends PlanTestBase {
             }
         }
         table.setNewFullSchema(schemaWithShadowGeneratedColumns);
+        table.setState(OlapTable.OlapTableState.OPTIMIZE);
 
         try {
             ExecPlan execPlan = getUpdateExecPlanObject(
@@ -127,6 +129,37 @@ public class UpdatePlanTest extends PlanTestBase {
             OlapTableSink sink = (OlapTableSink) execPlan.getFragments().get(0).getSink();
             assertEquals(execPlan.getOutputExprs().size(), sink.getTupleDescriptor().getSlots().size());
         } finally {
+            table.setState(originalState);
+            table.setNewFullSchema(originalFullSchema);
+        }
+    }
+
+    @Test
+    public void testUpdateSinkPreservesShadowColumnsDuringSchemaChange() throws Exception {
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getDb(connectContext.getDatabase()).getTable("update_shadow_generated_column");
+        List<Column> originalFullSchema = table.getFullSchema();
+        OlapTable.OlapTableState originalState = table.getState();
+        List<Column> schemaWithShadowGeneratedColumns = new ArrayList<>(originalFullSchema);
+        for (Column column : table.getBaseSchema()) {
+            if (column.isGeneratedColumn()) {
+                Column shadowColumn = column.deepCopy();
+                shadowColumn.setName(SchemaChangeHandler.SHADOW_NAME_PREFIX + column.getName());
+                schemaWithShadowGeneratedColumns.add(shadowColumn);
+            }
+        }
+        table.setNewFullSchema(schemaWithShadowGeneratedColumns);
+        table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
+
+        try {
+            ExecPlan execPlan = getUpdateExecPlanObject(
+                    "update update_shadow_generated_column set v = 2 where pk = 1");
+            OlapTableSink sink = (OlapTableSink) execPlan.getFragments().get(0).getSink();
+            assertEquals(schemaWithShadowGeneratedColumns.size(), sink.getTupleDescriptor().getSlots().size());
+            Assertions.assertTrue(sink.getTupleDescriptor().getSlots().stream()
+                    .anyMatch(slot -> slot.getColumn().isShadowColumn()));
+        } finally {
+            table.setState(originalState);
             table.setNewFullSchema(originalFullSchema);
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java
@@ -107,20 +107,18 @@ public class UpdatePlanTest extends PlanTestBase {
     }
 
     @Test
-    public void testUpdateSinkExcludesStaleShadowColumnsOutsideSchemaChange() throws Exception {
+    public void testUpdateSinkExcludesStaleGeneratedColumnsOutsideSchemaChange() throws Exception {
         OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
                 .getDb(connectContext.getDatabase()).getTable("update_shadow_generated_column");
         List<Column> originalFullSchema = table.getFullSchema();
         OlapTable.OlapTableState originalState = table.getState();
-        List<Column> schemaWithShadowGeneratedColumns = new ArrayList<>(originalFullSchema);
+        List<Column> schemaWithStaleGeneratedColumns = new ArrayList<>(originalFullSchema);
         for (Column column : table.getBaseSchema()) {
             if (column.isGeneratedColumn()) {
-                Column shadowColumn = column.deepCopy();
-                shadowColumn.setName(SchemaChangeHandler.SHADOW_NAME_PREFIX + column.getName());
-                schemaWithShadowGeneratedColumns.add(shadowColumn);
+                schemaWithStaleGeneratedColumns.add(column.deepCopy());
             }
         }
-        table.setNewFullSchema(schemaWithShadowGeneratedColumns);
+        table.setNewFullSchema(schemaWithStaleGeneratedColumns);
 
         try {
             for (OlapTable.OlapTableState state :

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java
@@ -70,7 +70,7 @@ public class UpdatePlanTest extends PlanTestBase {
         starRocksAssert.withTable("CREATE TABLE update_shadow_generated_column (\n" +
                 "  pk bigint NOT NULL,\n" +
                 "  v int NOT NULL,\n" +
-                "  g int NULL AS (v + 1)\n" +
+                "  g bigint NULL AS (v + 1)\n" +
                 ") ENGINE=OLAP\n" +
                 "PRIMARY KEY (pk)\n" +
                 "DISTRIBUTED BY HASH (pk) BUCKETS 1\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java
@@ -14,8 +14,10 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.alter.SchemaChangeHandler;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergMetadata;
@@ -23,6 +25,7 @@ import com.starrocks.connector.iceberg.MockIcebergMetadata;
 import com.starrocks.planner.DescriptorTable;
 import com.starrocks.planner.IcebergRowDeltaSink;
 import com.starrocks.planner.IcebergScanNode;
+import com.starrocks.planner.OlapTableSink;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.PlanNode;
 import com.starrocks.planner.ProjectNode;
@@ -48,6 +51,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -63,6 +67,14 @@ public class UpdatePlanTest extends PlanTestBase {
     public static void beforeClass() throws Exception {
         PlanTestBase.beforeClass();
         ConnectorPlanTestBase.mockCatalog(connectContext, MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME);
+        starRocksAssert.withTable("CREATE TABLE update_shadow_generated_column (\n" +
+                "  pk bigint NOT NULL,\n" +
+                "  v int NOT NULL,\n" +
+                "  g int NULL AS (v + 1)\n" +
+                ") ENGINE=OLAP\n" +
+                "PRIMARY KEY (pk)\n" +
+                "DISTRIBUTED BY HASH (pk) BUCKETS 1\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");");
     }
 
     @Test
@@ -92,6 +104,31 @@ public class UpdatePlanTest extends PlanTestBase {
         testExplain("explain verbose update tprimary set v2 = v2 + 1 where v1 = 'aaa'");
         testExplain("explain costs update tprimary set v2 = v2 + 1 where v1 = 'aaa'");
         connectContext.getSessionVariable().setPartialUpdateMode(oldVal);
+    }
+
+    @Test
+    public void testUpdateSinkUsesBaseSchemaWithShadowGeneratedColumns() throws Exception {
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getDb(connectContext.getDatabase()).getTable("update_shadow_generated_column");
+        List<Column> originalFullSchema = table.getFullSchema();
+        List<Column> schemaWithShadowGeneratedColumns = new ArrayList<>(originalFullSchema);
+        for (Column column : table.getBaseSchema()) {
+            if (column.isGeneratedColumn()) {
+                Column shadowColumn = column.deepCopy();
+                shadowColumn.setName(SchemaChangeHandler.SHADOW_NAME_PREFIX + column.getName());
+                schemaWithShadowGeneratedColumns.add(shadowColumn);
+            }
+        }
+        table.setNewFullSchema(schemaWithShadowGeneratedColumns);
+
+        try {
+            ExecPlan execPlan = getUpdateExecPlanObject(
+                    "update update_shadow_generated_column set v = 2 where pk = 1");
+            OlapTableSink sink = (OlapTableSink) execPlan.getFragments().get(0).getSink();
+            assertEquals(execPlan.getOutputExprs().size(), sink.getTupleDescriptor().getSlots().size());
+        } finally {
+            table.setNewFullSchema(originalFullSchema);
+        }
     }
 
     @Test
@@ -186,6 +223,10 @@ public class UpdatePlanTest extends PlanTestBase {
     }
 
     private static String getUpdateExecPlan(String originStmt) throws Exception {
+        return getUpdateExecPlanObject(originStmt).getExplainString(TExplainLevel.NORMAL);
+    }
+
+    private static ExecPlan getUpdateExecPlanObject(String originStmt) throws Exception {
         connectContext.setQueryId(UUIDUtil.genUUID());
         connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
         connectContext.setDumpInfo(new QueryDumpInfo(connectContext));
@@ -193,10 +234,7 @@ public class UpdatePlanTest extends PlanTestBase {
                 com.starrocks.sql.parser.SqlParser.parse(originStmt, connectContext.getSessionVariable().getSqlMode())
                         .get(0);
         connectContext.getDumpInfo().setOriginStmt(originStmt);
-        ExecPlan execPlan = new StatementPlanner().plan(statementBase, connectContext);
-
-        String ret = execPlan.getExplainString(TExplainLevel.NORMAL);
-        return ret;
+        return new StatementPlanner().plan(statementBase, connectContext);
     }
 
     private static ExecPlan getIcebergUpdateExecPlan(String originStmt) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java
@@ -107,7 +107,7 @@ public class UpdatePlanTest extends PlanTestBase {
     }
 
     @Test
-    public void testUpdateSinkExcludesShadowColumnsDuringOptimize() throws Exception {
+    public void testUpdateSinkExcludesStaleShadowColumnsOutsideSchemaChange() throws Exception {
         OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
                 .getDb(connectContext.getDatabase()).getTable("update_shadow_generated_column");
         List<Column> originalFullSchema = table.getFullSchema();
@@ -121,13 +121,16 @@ public class UpdatePlanTest extends PlanTestBase {
             }
         }
         table.setNewFullSchema(schemaWithShadowGeneratedColumns);
-        table.setState(OlapTable.OlapTableState.OPTIMIZE);
 
         try {
-            ExecPlan execPlan = getUpdateExecPlanObject(
-                    "update update_shadow_generated_column set v = 2 where pk = 1");
-            OlapTableSink sink = (OlapTableSink) execPlan.getFragments().get(0).getSink();
-            assertEquals(execPlan.getOutputExprs().size(), sink.getTupleDescriptor().getSlots().size());
+            for (OlapTable.OlapTableState state :
+                    List.of(OlapTable.OlapTableState.OPTIMIZE, OlapTable.OlapTableState.NORMAL)) {
+                table.setState(state);
+                ExecPlan execPlan = getUpdateExecPlanObject(
+                        "update update_shadow_generated_column set v = 2 where pk = 1");
+                OlapTableSink sink = (OlapTableSink) execPlan.getFragments().get(0).getSink();
+                assertEquals(execPlan.getOutputExprs().size(), sink.getTupleDescriptor().getSlots().size());
+            }
         } finally {
             table.setState(originalState);
             table.setNewFullSchema(originalFullSchema);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java
@@ -36,7 +36,10 @@ import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.IcebergPlannerUtils;
 import com.starrocks.sql.StatementPlanner;
+import com.starrocks.sql.UpdatePlanner;
+import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.UpdateStmt;
 import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
 import com.starrocks.thrift.TDataSink;
 import com.starrocks.thrift.TDataSinkType;
@@ -118,14 +121,23 @@ public class UpdatePlanTest extends PlanTestBase {
                 schemaWithStaleGeneratedColumns.add(column.deepCopy());
             }
         }
-        table.setNewFullSchema(schemaWithStaleGeneratedColumns);
-
         try {
             for (OlapTable.OlapTableState state :
                     List.of(OlapTable.OlapTableState.OPTIMIZE, OlapTable.OlapTableState.NORMAL)) {
                 table.setState(state);
-                ExecPlan execPlan = getUpdateExecPlanObject(
-                        "update update_shadow_generated_column set v = 2 where pk = 1");
+                table.setNewFullSchema(originalFullSchema);
+                String sql = "update update_shadow_generated_column set v = 2 where pk = 1";
+                connectContext.setQueryId(UUIDUtil.genUUID());
+                connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
+                connectContext.setDumpInfo(new QueryDumpInfo(connectContext));
+                connectContext.getDumpInfo().setOriginStmt(sql);
+                UpdateStmt updateStmt = (UpdateStmt) com.starrocks.sql.parser.SqlParser
+                        .parse(sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+                Analyzer.analyze(updateStmt, connectContext);
+
+                // Simulate a stale fullSchema becoming visible between analysis and sink planning.
+                table.setNewFullSchema(schemaWithStaleGeneratedColumns);
+                ExecPlan execPlan = new UpdatePlanner().plan(updateStmt, connectContext);
                 OlapTableSink sink = (OlapTableSink) execPlan.getFragments().get(0).getSink();
                 assertEquals(execPlan.getOutputExprs().size(), sink.getTupleDescriptor().getSlots().size());
             }


### PR DESCRIPTION
## Why I'm doing:

A primary-key table with generated columns can retain stale or duplicate generated-column entries in its full schema during or after an online bucket rewrite. UpdateAnalyzer produces expressions for the logical base schema, while the UPDATE sink previously used the full schema. The extra entries make the expression and sink-slot counts differ and cause "number of exprs is not same with slots backend".

The internal INSERT used by an optimize rewrite has the same schema-alignment requirement. Shared-data tables execute this INSERT through OptimizeJobV2 and an asynchronous OptimizeTask, whose fresh ConnectContext did not inherit the direct online-optimize marker.

## What I'm doing:

- Build UPDATE sink slots from the base schema in NORMAL/OPTIMIZE state, while retaining the full schema for a live SCHEMA_CHANGE and its shadow indexes.
- Mark both direct online-optimize rewrites and asynchronous OptimizeTask runs as optimize rewrites.
- Add explicit non-generated target-column lists to optimize and merge-partition internal INSERT SQL.
- Build optimize INSERT sink schemas base-first, remove stale/duplicate shadow entries, and preserve unique non-shadow full-schema columns.
- Add planner, optimize-job, and task-run regression tests for generated columns, stale full-schema entries, task context propagation, and production rewrite SQL.

TSP validation on build 2942 (starrocks-471da9d.tar.gz):

- Loaded 8,000,001 rows; both generated columns were non-null for all rows.
- Ran 160 original UPDATE statements while a 4-to-9 bucket optimize job traversed PENDING, WAITING_TXN, and RUNNING; all UPDATEs succeeded.
- Concurrent ingestion changed the source partition version, so the existing optimize safety logic skipped replacing that partition.
- Retried 4-to-9 without concurrent writes; both internal optimize tasks succeeded, the actual partition changed to 9 buckets, and a post-finish UPDATE succeeded.
- CN "number of exprs is not same with slots" count remained 0; FE optimize-task failure count remained 0.

Related issue: N/A

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
