### PR TITLE
[BugFix] Fix IVM refresh with external authorization (backport #77210)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
@@ -588,8 +588,17 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
 
             try (Timer ignored = Tracers.watchScope("MVRefreshPlanner")) {
                 ctx.getSessionVariable().setEnableInsertSelectExternalAutoRefresh(false); //already refreshed before
-                ExecPlan execPlan = StatementPlanner.plan(insertStmt, ctx);
-                mvContext.setExecPlan(execPlan);
+                boolean previousBypassAuthorizerCheck = ctx.isBypassAuthorizerCheck();
+                try {
+                    // Match PCT by skipping authorization for the trusted refresh INSERT. External column authorization
+                    // launches an auxiliary optimizer before InsertPlanner has bound the IVM aggregate state columns
+                    // required by the rewrite.
+                    ctx.setBypassAuthorizerCheck(true);
+                    ExecPlan execPlan = StatementPlanner.plan(insertStmt, ctx);
+                    mvContext.setExecPlan(execPlan);
+                } finally {
+                    ctx.setBypassAuthorizerCheck(previousBypassAuthorizerCheck);
+                }
             }
             return insertStmt;
         } finally {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
@@ -15,6 +15,9 @@
 package com.starrocks.scheduler.mv.ivm;
 
 import com.google.common.collect.ImmutableList;
+import com.starrocks.authorization.AccessControlProvider;
+import com.starrocks.authorization.AccessController;
+import com.starrocks.authorization.AllowAllAccessController;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.IcebergTable;
@@ -28,6 +31,7 @@ import com.starrocks.common.tvr.TvrVersion;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.iceberg.MockIcebergMetadata;
 import com.starrocks.load.loadv2.IVMInsertLoadTxnCallback;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.scheduler.MVTaskRunProcessor;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.scheduler.TaskRun;
@@ -36,11 +40,16 @@ import com.starrocks.scheduler.mv.hybrid.MVHybridRefreshProcessor;
 import com.starrocks.scheduler.mv.pct.MVPCTRefreshProcessor;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.StatementPlanner;
+import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.sql.ast.KeysType;
+import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.thrift.TExplainLevel;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer.MethodName;
@@ -49,6 +58,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 @TestMethodOrder(MethodName.class)
 public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase {
@@ -59,6 +70,70 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         starRocksAssert.useDatabase("test");
         starRocksAssert.withTable(cluster, "depts");
         starRocksAssert.withTable(cluster, "emps");
+    }
+
+    @Test
+    public void testExternalAuthorizationDoesNotReplanInternalIvmRefresh() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW `test`.`test_mv1` " +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES ('refresh_mode' = 'incremental')\n" +
+                "AS SELECT id, count(*) AS row_count " +
+                "FROM `iceberg0`.`unpartitioned_db`.`t0` GROUP BY id";
+        starRocksAssert.withMaterializedView(ddl);
+        MaterializedView mv = getMv("test_mv1");
+        seedTvrBaselineAtVersionZero(mv);
+
+        String catalog = MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME;
+        AccessControlProvider provider = Authorizer.getInstance();
+        AccessController previousController =
+                provider.catalogToAccessControl.put(catalog, new AllowAllAccessController());
+        try {
+            TaskRun taskRun = buildMVTaskRun(mv, "test");
+            ExecPlan execPlan = getMVRefreshExecPlan(taskRun);
+            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+            PlanTestBase.assertContains(plan, "state_union", "TABLE: test_mv1");
+            Assertions.assertFalse(taskRun.getRunCtx().isBypassAuthorizerCheck());
+        } finally {
+            if (previousController == null) {
+                provider.catalogToAccessControl.remove(catalog);
+            } else {
+                provider.catalogToAccessControl.put(catalog, previousController);
+            }
+            starRocksAssert.dropMaterializedView("test_mv1");
+        }
+    }
+
+    @Test
+    public void testPlannerFailureRestoresInternalAuthorizationBypass() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW `test`.`test_mv1` " +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES ('refresh_mode' = 'incremental')\n" +
+                "AS SELECT id, count(*) AS row_count " +
+                "FROM `iceberg0`.`unpartitioned_db`.`t0` GROUP BY id";
+        starRocksAssert.withMaterializedView(ddl);
+        MaterializedView mv = getMv("test_mv1");
+        seedTvrBaselineAtVersionZero(mv);
+
+        AtomicBoolean bypassDuringPlanning = new AtomicBoolean();
+        AtomicReference<ConnectContext> plannerContext = new AtomicReference<>();
+        new MockUp<StatementPlanner>() {
+            @Mock
+            public ExecPlan plan(StatementBase ignoredStmt, ConnectContext ctx) {
+                bypassDuringPlanning.set(ctx.isBypassAuthorizerCheck());
+                plannerContext.set(ctx);
+                throw new RuntimeException("mock planner failure");
+            }
+        };
+
+        try {
+            TaskRun taskRun = buildMVTaskRun(mv, "test");
+            Assertions.assertThrows(RuntimeException.class, () -> getMVRefreshExecPlan(taskRun));
+            Assertions.assertTrue(bypassDuringPlanning.get());
+            Assertions.assertSame(taskRun.getRunCtx(), plannerContext.get());
+            Assertions.assertFalse(plannerContext.get().isBypassAuthorizerCheck());
+        } finally {
+            starRocksAssert.dropMaterializedView("test_mv1");
+        }
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

This manually backports #77210 to `branch-4.1` and supersedes the automatic backport #77253, whose test-file conflict resolution retained Git conflict markers.

Ranger uses an external access controller, so `ColumnPrivilege` runs a separate optimizer to identify the columns that need authorization. During IVM refresh, that auxiliary optimizer inherits IVM mode before `InsertPlanner` has built the complete IVM target-output context. It can therefore enter aggregate IVM rewrite without the state-column bindings required by `IvmDeltaAggregateRule`.

## What I'm doing:

- Temporarily bypass authorization while planning the trusted IVM refresh INSERT, and restore the previous bypass state in a `finally` block.
- Preserve user-facing MV refresh authorization; only duplicate authorization of the planner-generated internal INSERT is skipped.
- Backport the Iceberg aggregate IVM regression coverage for successful planning and planner-failure state restoration.
- Resolve the 4.1 test import conflict and include the JMockit imports required by the 4.1 test source.

Issue: N/A

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

## Validation

```text
./run-fe-ut.sh --test com.starrocks.scheduler.mv.ivm.IVMBasedMvRefreshProcessorIcebergTest -j 30
Tests run: 62, Failures: 0, Errors: 0, Skipped: 0

Checkstyle violations: 0
```

