### PR TITLE
[BugFix] Reflect TIME and VARIANT columns instead of returning NullType

### DIFF
--- a/contrib/starrocks-python-client/CHANGES.md
+++ b/contrib/starrocks-python-client/CHANGES.md
@@ -3,6 +3,10 @@ Version history
 
 **Unreleased**
 
+**1.3.5**
+
+- Reflect `TIME` and `VARIANT` columns instead of returning `NullType` (#77259 by @rad-pat)
+
 **1.3.4**
 
 - Add `to_diff_tuple` for Alembic alter operations (#70146 by @arvindKandpal-ksolves)

--- a/contrib/starrocks-python-client/CHANGES.md
+++ b/contrib/starrocks-python-client/CHANGES.md
@@ -3,8 +3,6 @@ Version history
 
 **Unreleased**
 
-**1.3.5**
-
 - Reflect `TIME` and `VARIANT` columns instead of returning `NullType` (#77259 by @rad-pat)
 
 **1.3.4**

--- a/contrib/starrocks-python-client/starrocks/__init__.py
+++ b/contrib/starrocks-python-client/starrocks/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.4"
+__version__ = "1.3.5"
 
 # import it to import some internal alembic packages implicitly
 # but, it's not needed if users only want to use SQLAlchemy rather than Alembic
@@ -39,9 +39,11 @@ from .datatype import (
     SMALLINT,
     STRING,
     STRUCT,
+    TIME,
     TINYINT,
     VARBINARY,
     VARCHAR,
+    VARIANT,
 )
 from .sql.dml import (
     AmazonS3,
@@ -67,10 +69,10 @@ from .sql.dml import (
 __all__ = (
     "BOOLEAN", "TINYINT", "SMALLINT", "INTEGER", "BIGINT", "LARGEINT",
     "DECIMAL", "DOUBLE", "FLOAT",
-    "DATETIME", "DATE",
+    "DATETIME", "DATE", "TIME",
     "CHAR", "VARCHAR", "STRING", "BINARY", "VARBINARY",
     "HLL", "BITMAP", "PERCENTILE",
-    "ARRAY", "MAP", "STRUCT", "JSON",
+    "ARRAY", "MAP", "STRUCT", "JSON", "VARIANT",
 
     "InsertIntoFiles",
     "FilesTarget",

--- a/contrib/starrocks-python-client/starrocks/__init__.py
+++ b/contrib/starrocks-python-client/starrocks/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.5"
+__version__ = "1.3.4"
 
 # import it to import some internal alembic packages implicitly
 # but, it's not needed if users only want to use SQLAlchemy rather than Alembic

--- a/contrib/starrocks-python-client/starrocks/datatype.py
+++ b/contrib/starrocks-python-client/starrocks/datatype.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from decimal import Decimal
 from inspect import isclass
 import json
@@ -102,8 +102,51 @@ class DATETIME(mysql_types.DATETIME):
 
         return process
 
+
 class TIME(mysql_types.TIME):
+    """StarRocks ``TIME``, a signed duration rather than a time of day.
+
+    StarRocks holds a TIME as a signed number of seconds and renders it as
+    ``[-]HH:MM:SS`` with no day part, so the hour field is unbounded and may be
+    negative: ``timediff('1000-01-02 01:01:01', '1000-01-01 01:01:01')`` is
+    ``24:00:00``, and reversing the arguments gives ``-24:00:00``.
+
+    Values are therefore returned as :class:`datetime.timedelta`, which spans
+    that whole range. :class:`sqlalchemy.dialects.mysql.TIME` instead maps the
+    driver's ``timedelta`` onto :class:`datetime.time` and drops
+    ``timedelta.days`` in the process, turning ``24:00:00`` into ``00:00:00``
+    and ``-00:00:01`` into ``23:59:59``. Past 999 hours the value never reaches
+    that processor at all -- PyMySQL's parser allows at most three hour digits
+    and hands back the undecoded string, which then raises ``AttributeError``.
+    """
+
     __visit_name__ = "TIME"
+
+    _reg = re.compile(r"(-)?(\d+):(\d{1,2}):(\d{1,2})(?:\.(\d{1,6}))?$")
+
+    @property
+    def python_type(self) -> Type[timedelta]:
+        return timedelta
+
+    def result_processor(self, dialect: Dialect, coltype: object):
+        def process(value: Any) -> Optional[timedelta]:
+            if value is None or isinstance(value, timedelta):
+                return value
+            if isinstance(value, (bytes, bytearray)):
+                value = value.decode("ascii")
+            m = self._reg.match(value)
+            if not m:
+                raise ValueError("could not parse %r as a time value" % (value,))
+            sign, hours, minutes, seconds, fraction = m.groups()
+            elapsed = timedelta(
+                hours=int(hours),
+                minutes=int(minutes),
+                seconds=int(seconds),
+                microseconds=int((fraction or "").ljust(6, "0")),
+            )
+            return -elapsed if sign else elapsed
+
+        return process
 
 
 class DATE(sqltypes.DATE):

--- a/contrib/starrocks-python-client/starrocks/datatype.py
+++ b/contrib/starrocks-python-client/starrocks/datatype.py
@@ -20,6 +20,7 @@ import json
 import re
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
 
+from sqlalchemy import func
 import sqlalchemy.dialects.mysql.types as mysql_types
 from sqlalchemy.engine import Dialect
 from sqlalchemy.sql import sqltypes
@@ -100,6 +101,10 @@ class DATETIME(mysql_types.DATETIME):
                 return value
 
         return process
+
+class TIME(mysql_types.TIME):
+    __visit_name__ = "TIME"
+
 
 class DATE(sqltypes.DATE):
     __visit_name__ = "DATE"
@@ -362,3 +367,40 @@ class STRUCT(StructuredType):
 
 class JSON(sqltypes.JSON):
     __visit_name__ = "JSON"
+
+
+class VARIANT(sqltypes.TypeEngine):
+    """Semi-structured type, available from StarRocks 4.1.
+
+    Supported on Iceberg catalog tables (Iceberg format-version 3), where it
+    maps to Iceberg's ``variant`` type.
+
+    A bound value is serialised to JSON text and parsed back into a VARIANT
+    server-side by ``PARSE_JSON``. That round trip is the reason this does not
+    subclass :class:`sqlalchemy.types.JSON`: JSON suppresses ``bind_expression``
+    on INSERT, so the text would reach the column as a ``VARCHAR`` bind and
+    StarRocks would store the whole document as a VARIANT *string* — indexing
+    into it then yields NULL and reading it back returns JSON text rather than
+    the original structure.
+    """
+
+    __visit_name__ = "VARIANT"
+
+    def bind_expression(self, bindparam):
+        return func.parse_json(bindparam)
+
+    def bind_processor(self, dialect: Dialect):
+        def process(value: Any) -> Optional[str]:
+            return None if value is None else json.dumps(value)
+
+        return process
+
+    def result_processor(self, dialect: Dialect, coltype: object):
+        def process(value: Any) -> Any:
+            if value is None:
+                return None
+            if isinstance(value, (bytes, bytearray)):
+                value = value.decode("utf-8")
+            return json.loads(value)
+
+        return process

--- a/contrib/starrocks-python-client/starrocks/dialect.py
+++ b/contrib/starrocks-python-client/starrocks/dialect.py
@@ -88,9 +88,11 @@ from .datatype import (
     SMALLINT,
     STRING,
     STRUCT,
+    TIME,
     TINYINT,
     VARBINARY,
     VARCHAR,
+    VARIANT,
 )
 from .engine.interfaces import ReflectedMVState, ReflectedState, ReflectedViewState
 from .reflection import StarRocksInspector, StarRocksTableDefinitionParser
@@ -160,10 +162,12 @@ ischema_names = {
     "char": CHAR,
     "string": STRING,
     "json": JSON,
+    "variant": VARIANT,
     # === Date and time ===
     "date": DATE,
     "datetime": DATETIME,
     "timestamp": DATETIME,
+    "time": TIME,
     # == binary ==
     "binary": BINARY,
     "varbinary": VARBINARY,
@@ -252,6 +256,9 @@ class StarRocksTypeCompiler(MySQLTypeCompiler):
 
     def visit_BITMAP(self, type_, **kw):
         return "BITMAP"
+
+    def visit_VARIANT(self, type_, **kw):
+        return "VARIANT"
 
     def visit_BLOB(self, type_, **kw):
         return "BINARY"

--- a/contrib/starrocks-python-client/starrocks/dialect.py
+++ b/contrib/starrocks-python-client/starrocks/dialect.py
@@ -184,6 +184,7 @@ colspecs = base_colspecs | {
     sqltypes.Date: DATE,
     sqltypes.DateTime: DATETIME,
     sqltypes.DECIMAL: DECIMAL,
+    sqltypes.Time: TIME,
 }
 
 class StarRocksTypeCompiler(MySQLTypeCompiler):

--- a/contrib/starrocks-python-client/test/unit/test_reflect_time_and_variant.py
+++ b/contrib/starrocks-python-client/test/unit/test_reflect_time_and_variant.py
@@ -1,0 +1,99 @@
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""TIME and VARIANT columns reflect to real types rather than NullType.
+
+Neither was in ``ischema_names``, so reflecting either column raised inside
+``parse_data_type``; ``_parse_column_type`` swallowed that and returned
+``NullType``, whose ``compile()`` raises ``CompileError``. Any caller that
+compiles a reflected column — comparing a table against its declared shape,
+for instance — therefore failed on a table that had itself created happily.
+"""
+
+import pytest
+from sqlalchemy import Column, MetaData, Table
+from sqlalchemy.sql import sqltypes
+
+from starrocks.datatype import TIME, VARIANT
+from starrocks.dialect import StarRocksDialect
+from starrocks.drivers.parsers import parse_data_type
+
+
+@pytest.fixture(name="dialect")
+def dialect_fixture():
+    return StarRocksDialect()
+
+
+@pytest.mark.parametrize(
+    "type_string, expected_type, expected_ddl",
+    [
+        # information_schema.columns reports TIME upper case, unlike every
+        # other type; the parser lowercases before the lookup.
+        ("TIME", TIME, "TIME"),
+        ("time", TIME, "TIME"),
+        ("variant", VARIANT, "VARIANT"),
+        ("VARIANT", VARIANT, "VARIANT"),
+    ],
+)
+def test_reflected_type_compiles_back(type_string, expected_type, expected_ddl, dialect):
+    parsed = parse_data_type(type_string)
+    instance = parsed() if isinstance(parsed, type) else parsed
+
+    assert isinstance(instance, expected_type)
+    assert instance.compile(dialect) == expected_ddl
+
+
+@pytest.mark.parametrize("type_string", ["TIME", "variant"])
+def test_reflected_type_is_not_nulltype(type_string):
+    """NullType is what made this fail: it cannot generate DDL."""
+    parsed = parse_data_type(type_string)
+    instance = parsed() if isinstance(parsed, type) else parsed
+
+    assert not isinstance(instance, sqltypes.NullType)
+
+
+def test_variant_insert_parses_json_server_side(dialect):
+    """The bound value must reach the column through PARSE_JSON.
+
+    Without this, the JSON text arrives as a VARCHAR bind and StarRocks stores
+    the whole document as a VARIANT *string*: indexing into it yields NULL and
+    reading it back returns text instead of the original structure. Note this
+    is why VARIANT does not subclass sqltypes.JSON, which suppresses
+    bind_expression on INSERT -- so asserting on the compiled statement is what
+    catches a regression here; processors alone would still look correct.
+    """
+    table = Table("t", MetaData(), Column("j", VARIANT()))
+    compiled = str(table.insert().values(j={"a": 1}).compile(dialect=dialect))
+
+    assert "parse_json(" in compiled.lower()
+
+
+def test_variant_round_trips_json_values(dialect):
+    value = {"a": 1, "b": "x", "nested": [1, 2]}
+    bind = VARIANT().bind_processor(dialect)
+    result = VARIANT().result_processor(dialect, None)
+
+    assert result(bind(value)) == value
+
+
+def test_variant_decodes_bytes_from_the_driver(dialect):
+    """pymysql hands the column back as bytes."""
+    result = VARIANT().result_processor(dialect, None)
+
+    assert result(b'{"a": 1}') == {"a": 1}
+
+
+def test_variant_passes_null_through(dialect):
+    assert VARIANT().bind_processor(dialect)(None) is None
+    assert VARIANT().result_processor(dialect, None)(None) is None

--- a/contrib/starrocks-python-client/test/unit/test_reflect_time_and_variant.py
+++ b/contrib/starrocks-python-client/test/unit/test_reflect_time_and_variant.py
@@ -21,6 +21,8 @@ compiles a reflected column — comparing a table against its declared shape,
 for instance — therefore failed on a table that had itself created happily.
 """
 
+from datetime import timedelta
+
 import pytest
 from sqlalchemy import Column, MetaData, Table
 from sqlalchemy.sql import sqltypes
@@ -61,6 +63,68 @@ def test_reflected_type_is_not_nulltype(type_string):
     instance = parsed() if isinstance(parsed, type) else parsed
 
     assert not isinstance(instance, sqltypes.NullType)
+
+
+@pytest.mark.parametrize(
+    "wire_value, expected",
+    [
+        ("12:34:56", timedelta(hours=12, minutes=34, seconds=56)),
+        # timediff('1000-01-02 01:01:01', '1000-01-01 01:01:01'). A time-of-day
+        # processor drops timedelta.days here and reports 00:00:00.
+        ("24:00:00", timedelta(hours=24)),
+        ("-24:00:00", timedelta(hours=-24)),
+        # The sign is what gets lost on this one -- it reads back as 23:59:59.
+        ("-00:00:01", timedelta(seconds=-1)),
+        # Past 999 hours PyMySQL stops parsing and hands the string through, so
+        # anything expecting a timedelta from the driver raises AttributeError.
+        ("78883632:00:00", timedelta(hours=78883632)),
+        ("-78883632:00:01", -timedelta(hours=78883632, seconds=1)),
+        ("00:00:00.123456", timedelta(microseconds=123456)),
+        ("-00:00:00.5", timedelta(microseconds=-500000)),
+    ],
+)
+def test_time_preserves_signed_and_multi_day_durations(wire_value, expected, dialect):
+    """StarRocks TIME is a signed duration, not a time of day.
+
+    It is held as a signed number of seconds and rendered as ``[-]HH:MM:SS``
+    with no day part, so ``timediff`` legitimately produces ``24:00:00`` and
+    ``-78883632:00:01``. Reflecting such a column as a time-of-day type
+    silently truncates every one of these.
+    """
+    result = TIME().result_processor(dialect, None)
+
+    assert result(wire_value) == expected
+
+
+def test_time_accepts_the_drivers_timedelta_unchanged(dialect):
+    """PyMySQL decodes TIME within its range for us; keep the full duration."""
+    result = TIME().result_processor(dialect, None)
+
+    assert result(timedelta(days=1)) == timedelta(hours=24)
+
+
+def test_time_decodes_bytes_from_the_driver(dialect):
+    result = TIME().result_processor(dialect, None)
+
+    assert result(b"24:00:00") == timedelta(hours=24)
+
+
+def test_time_passes_null_through(dialect):
+    assert TIME().result_processor(dialect, None)(None) is None
+
+
+def test_time_rejects_an_unparseable_value(dialect):
+    result = TIME().result_processor(dialect, None)
+
+    with pytest.raises(ValueError):
+        result("not a time")
+
+
+def test_generic_time_column_uses_the_starrocks_type(dialect):
+    """A declared sqlalchemy.Time must not fall back to the MySQL processor."""
+    column = Column("c", sqltypes.Time())
+
+    assert isinstance(column.type.dialect_impl(dialect), TIME)
 
 
 def test_variant_insert_parses_json_server_side(dialect):


### PR DESCRIPTION
## Why I'm doing:

`TIME` and `VARIANT` are not registered in `ischema_names`, so reflecting a column of either type raises inside `parse_data_type`. `_parse_column_type` catches that and falls back to `NullType`, whose `compile()` raises `CompileError`.

The result is a table that creates and queries perfectly well but cannot be reflected — so anything that compiles a reflected column (comparing a table against its declared shape, autogenerating a migration, `CREATE TABLE LIKE`) fails on the *second* run, having succeeded on the first. It surfaces only as a warning plus an unrelated-looking error:

```
Could not parse type string 'TIME' for column 'c'. Error: Unsupported data type: TIME
SAWarning: Did not recognize type 'TIME' of column 'c'
...
CompileError: Can't generate DDL for NullType(); did you forget to specify a type on this Column?
```

Reproduced against StarRocks 4.1.3 with an Iceberg REST catalog (Lakekeeper 0.12.4):

- a `TIME` column accepts `CREATE TABLE`, stores Iceberg's `time` primitive, and round-trips `'12:34:56'` through INSERT/SELECT
- a `VARIANT` column does the same with `PARSE_JSON(...)` on a format-version 3 table, storing Iceberg's `variant`

Both work end to end at the engine level. Only the dialect's reflection was missing.

## What I'm doing:

- add `TIME` and `VARIANT` to `datatype.py`, each with a result processor that preserves the value's full range
- map `sqltypes.Time` to the StarRocks `TIME` in the dialect's `colspecs`, alongside the existing `Date` and `DateTime` entries
- register `"time"` and `"variant"` in `ischema_names`, and export both
- add `visit_VARIANT` to the type compiler; `TIME` needs no renderer, it inherits `visit_TIME` from `MySQLTypeCompiler`
- add unit tests covering both, parameterised over both spellings and over the full signed multi-day `TIME` range
- changelog entry under **Unreleased** (no version bump -- that lands in a separate release PR)

Three details worth a reviewer's eye:

1. `information_schema.columns.COLUMN_TYPE` reports this one type as upper-case `TIME`, where every other type comes back lower-case. `DataTypeTransformer.simple_type` lowercases before the lookup, so the lower-case key is the correct one and both spellings resolve — the tests pin both so a future change to that lowercasing can't silently regress it.
2. StarRocks `TIME` is a signed *duration*, not a time of day: `time_str_from_double` holds it as a signed double of seconds and formats it `[-]HH:MM:SS` with an `int64_t` hour and no day part, so `timediff` legitimately yields `24:00:00`, `78883632:00:00` and `-78883632:00:01` (pinned in `SelectConstTest#testExecuteInFe`). Inheriting `mysql_types.TIME` folded the driver's `timedelta` into a `datetime.time` and dropped `timedelta.days`, and past 999 hours PyMySQL's parser gives up and returns the raw string. `TIME` therefore returns `datetime.timedelta` — `datetime.time` cannot represent either case.
3. `VARIANT` is StarRocks 4.1+ and is supported on Iceberg catalog tables at format-version 3. It is a distinct type from `JSON` — `JSON` has no Iceberg mapping (`Unsupported primitive column type JSON`), so the two cannot share an entry.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

A column that previously reflected as `NullType` now reflects as `TIME` or `VARIANT`. Both `ischema_names` keys are new, so no existing reflection mapping is altered.

The one pre-existing mapping this does change is `sqltypes.Time`, which the MySQL `colspecs` pointed at `mysql.TIME`. A `Time` column now yields `datetime.timedelta` instead of `datetime.time`, which is the only Python type that can carry the values StarRocks produces — `24:00:00` previously read back as `00:00:00`, `-00:00:01` as `23:59:59`, and anything past 999 hours raised `AttributeError`. The compliance suite is unaffected: `requirements.py` already has `time` and `time_microseconds` closed.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Testing

- `test/unit/` — 550 passed, 1 pre-existing failure (`test_sql_canonical.py::test_arithmetic_paren_is_significant`, reproduces unchanged on `main`; looks like a local SQLGlot version difference)
- SQLAlchemy compliance suite (`test/test_suite.py`) against StarRocks 4.1.3, run both with and without this change:

  | | `main` | this PR |
  |---|---|---|
  | default catalog | 664 passed / 730 skipped / 18 errors | 664 passed / 730 skipped / 18 errors |
  | iceberg catalog | 7 failed / 47 passed / 493 errors | 6 failed / 48 passed / 494 errors |

  Default catalog is identical — no regression. The 18 errors are pre-existing teardown races (`TRUNCATE` colliding with an in-flight schema change). On the Iceberg catalog nothing is newly broken; the single differing test is one of those teardown flakes.

  For context on the Iceberg column: almost all of those errors are `This connector doesn't support alter table`, which the compliance suite's fixtures depend on, and the remaining failures are `test_string_length_reflection` — Iceberg stores `string` without a length, so a `VARCHAR(52)` reflects back as `VARCHAR(1073741824)` (`CATALOG_MAX_VARCHAR_LENGTH`). Both are independent of this change and present on `main`.


