### PR TITLE
[BugFix] Stop strpos from indexing out of bounds on an INT32_MIN instance

### DIFF
--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -3025,8 +3025,14 @@ StatusOr<ColumnPtr> StringFunctions::strpos_instance(FunctionContext* context, c
                 from_index = pos + 1;
             }
 
-            int abs_instance = std::abs(instance_value);
-            if (abs_instance <= static_cast<int>(positions.size())) {
+            // Widened on purpose. instance_value is int32_t, so std::abs(INT32_MIN) is undefined and
+            // in practice yields INT32_MIN again -- still negative, because +2147483648 does not fit
+            // in an int32. The bounds check below then passes for a negative value, and
+            // positions.size() - abs_instance converts it to size_t, ADDING 2^31 instead of
+            // subtracting. With 4-byte elements that indexes 2^33 bytes past the vector, which is
+            // exactly the SIGSEGV @0x200000000 this was first reported as.
+            int64_t abs_instance = std::abs(static_cast<int64_t>(instance_value));
+            if (abs_instance <= static_cast<int64_t>(positions.size())) {
                 builder.append(positions[positions.size() - abs_instance] + 1);
             } else {
                 builder.append(0);

--- a/be/test/exprs/string_fn_test.cpp
+++ b/be/test/exprs/string_fn_test.cpp
@@ -16,7 +16,6 @@
 #include <gtest/gtest.h>
 
 #include <limits>
-
 #include <memory>
 #include <random>
 
@@ -3427,8 +3426,8 @@ PARALLEL_TEST(VecStringFunctionsTest, strposInstanceIntMinTest) {
     auto instance = Int32Column::create();
 
     // "aaa" contains "a" at 1, 2 and 3.
-    std::vector<int32_t> instances = {std::numeric_limits<int32_t>::min(), -4, -3, -1,
-                                      1, 3, std::numeric_limits<int32_t>::max()};
+    std::vector<int32_t> instances = {std::numeric_limits<int32_t>::min(), -4, -3, -1, 1, 3,
+                                      std::numeric_limits<int32_t>::max()};
     std::vector<int64_t> expected = {0, 0, 1, 3, 1, 3, 0};
 
     for (int32_t inst : instances) {

--- a/be/test/exprs/string_fn_test.cpp
+++ b/be/test/exprs/string_fn_test.cpp
@@ -15,6 +15,8 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include <limits>
+
 #include <memory>
 #include <random>
 
@@ -3405,6 +3407,44 @@ PARALLEL_TEST(VecStringFunctionsTest, strposTest) {
 
     for (size_t i = 0; i < haystacks.size(); ++i) {
         ASSERT_EQ(expected[i], v->get_data()[i]) << "Failed for input: " << haystacks[i] << ", " << needles[i];
+    }
+}
+
+PARALLEL_TEST(VecStringFunctionsTest, strposInstanceIntMinTest) {
+    // std::abs(INT32_MIN) is undefined and returns INT32_MIN again, so the old
+    // `int abs_instance = std::abs(instance_value)` stayed negative, passed the
+    // `abs_instance <= positions.size()` bounds check, and then indexed
+    // positions[positions.size() - abs_instance] -- a size_t subtraction that ADDS 2^31.
+    // With 4-byte elements that reads 2^33 bytes past the vector.
+    //
+    // The boundary either side of the occurrence count is asserted too: a fix that merely
+    // stops the crash but shifts the comparison by one would still pass on INT32_MIN alone.
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+
+    Columns columns;
+    auto haystack = BinaryColumn::create();
+    auto needle = BinaryColumn::create();
+    auto instance = Int32Column::create();
+
+    // "aaa" contains "a" at 1, 2 and 3.
+    std::vector<int32_t> instances = {std::numeric_limits<int32_t>::min(), -4, -3, -1,
+                                      1, 3, std::numeric_limits<int32_t>::max()};
+    std::vector<int64_t> expected = {0, 0, 1, 3, 1, 3, 0};
+
+    for (int32_t inst : instances) {
+        haystack->append("aaa");
+        needle->append("a");
+        instance->append(inst);
+    }
+    columns.emplace_back(haystack);
+    columns.emplace_back(needle);
+    columns.emplace_back(instance);
+
+    ColumnPtr result = StringFunctions::strpos_instance(ctx.get(), columns).value();
+    ASSERT_EQ(instances.size(), result->size());
+    auto v = ColumnHelper::cast_to<TYPE_BIGINT>(result);
+    for (size_t i = 0; i < instances.size(); ++i) {
+        ASSERT_EQ(expected[i], v->get_data()[i]) << "Failed for instance " << instances[i];
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:

```
start time: Tue Aug  4 01:01:31 AM UTC 2026, server uptime:  01:01:31 up 247 days, 19:11,  0 user,  load average: 205.90, 74.96, 42.06
Run with JEMALLOC_CONF: 'percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true,prof:true,prof_active:false'
WARNING: Logging before InitGoogleLogging() is written to STDERR
I20260804 01:01:31.055206 139828299428672 current_thread.cpp:56] [eBPF] tls_thread_status tpoff=-69744 query_id_offset=48 module_type_offset=140
Ignored unknown config: starlet_port
I20260804 01:01:31.064761 139828299428672 starrocks_main.cpp:201] file system provider registry init successfully
Built on a system without sched_getcpu() support. Performance may be impacted.fuzz RELEASE (build 069fa13 distro ubuntu arch x86_64)
query_id:019fcb69-390e-706c-bd3d-2228c2b26dd9, fragment_instance:019fcb69-390e-706c-bd3d-2228c2b26dda, plan_node_id:0
*** Aborted at 1785824098 (unix time) try "date -d @1785824098" if you are using GNU date ***
PC: @          0xdfaee60 starrocks::StringFunctions::strpos_instance(starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutP
tr<starrocks::Column> > > const&)
*** SIGSEGV (@0x200000000) received by PID 269911 (TID 0x7f2af28ef6c0) LWP(271417) from PID 0; stack trace: ***
    @     0x7f2c502c3ed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)
    @         0x1260d186 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f2c50267330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @          0xdfaee60 starrocks::StringFunctions::strpos_instance(starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutP
tr<starrocks::Column> > > const&)
    @          0x99ed33a std::_Function_handler<starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > (starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::C@
    @          0xddeadea starrocks::VectorizedFunctionCallExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
    @          0xcbbcc13 starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*)
    @          0xcbbd8cb starrocks::ExprContext::evaluate(starrocks::Chunk*, unsigned char*)
    @          0x978b182 starrocks::pipeline::ProjectOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @          0xade0caf starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0x9716596 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0xe7952fb starrocks::ThreadPool::dispatch_thread()
    @          0xe78c1af starrocks::Thread::supervise_thread(void*)
    @     0x7f2c502beaa4 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x9caa3)
    @     0x7f2c5034bc6c (/usr/lib/x86_64-linux-gnu/libc.so.6+0x129c6b)
```

strpos(haystack, needle, instance) with instance = -2147483648 read roughly 8GB past its position vector and killed the BE with SIGSEGV @0x200000000.

instance_value is int32_t, so std::abs(INT32_MIN) is undefined and in practice returns INT32_MIN -- still negative, because +2147483648 does not fit in an int32. The `abs_instance <= positions.size()` bounds check therefore passed for a negative value, and `positions[positions.size() - abs_instance]` converted the negative int to size_t, adding 2^31 rather than subtracting. positions holds ints, so 2^31 * 4 == 2^33 == 0x200000000, which is exactly the faulting address the crash reported.

Widening abs_instance to int64_t makes std::abs well defined for INT32_MIN and restores the intended comparison, so an out-of-range instance now falls to the existing "not found" branch and returns 0.

Found by an AST-mutation fuzzer replaying mutated queries against a live cluster; the mutator supplies INT32_MIN as a boundary literal.

The test pins the boundary either side of the occurrence count (-3 -> 1, -4 -> 0) as well as both int32 extremes, so a fix that stops the crash but shifts the comparison by one does not pass.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
