### PR TITLE
[BugFix] Track percentile_cont merge exhaustion by position, not by value

### DIFF
--- a/be/src/exprs/agg/percentile_cont.h
+++ b/be/src/exprs/agg/percentile_cont.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <cstring>
 #include <limits>
 #include <type_traits>
@@ -67,6 +68,22 @@ struct PercentileState {
     double rate = 0.0;
 };
 
+// Merges the k already-sorted rows of `grid` with a loser tree and picks out the two elements
+// surrounding `goal`. Every row is laid out by merge() as
+//     [min_sentinel, payload (ascending) ..., max_sentinel]
+// so the payload occupies exactly the slots [1, size - 2].
+//
+// Neither the end of a row nor the tree's virtual leaf may be recognised by VALUE:
+//   * real data can be equal to RunTimeTypeLimits<LT>::min_value()/max_value() - for DATE those are
+//     the perfectly ordinary values '0000-01-01' and '9999-12-31' - so a payload element would be
+//     mistaken for the row's terminator, and
+//   * the virtual leaf k, which seeds the tree during the build, would then no longer be strictly
+//     better than every real leaf. It could stay behind in ls[] and later become ls[0], and the loop
+//     would index grid[k]/mp[k], i.e. one past the end of both vectors.
+// A row whose payload is empty (size == 2) has the same effect, because its only readable slot in
+// forward order is the max sentinel.
+// Both are therefore tracked by POSITION, not by value: `done[i]` records whether row i still has
+// payload left, and the virtual leaf is recognised by its index.
 template <LogicalType LT, typename CppType, bool reverse>
 void kWayMergeSort(const typename PercentileStateTypes<LT>::GridType& grid, std::vector<CppType>& b,
                    std::vector<int>& ls, std::vector<int>& mp, size_t goal, int k, CppType& junior_elm,
@@ -76,22 +93,36 @@ void kWayMergeSort(const typename PercentileStateTypes<LT>::GridType& grid, std:
     b.resize(k + 1);
     ls.resize(k);
     mp.resize(k);
+    // done[i]: row i has no payload element left. done[k] belongs to the virtual leaf.
+    std::vector<uint8_t> done(k + 1, 0);
+
     for (int i = 0; i < k; ++i) {
-        if constexpr (reverse) {
-            mp[i] = grid[i].size() - 2;
-        } else {
-            mp[i] = 1;
-        }
-    }
-    for (int i = 0; i < k; ++i) {
-        b[i] = grid[i][mp[i]];
-        if constexpr (reverse) {
-            mp[i]--;
-        } else {
-            mp[i]++;
-        }
+        DCHECK_GE(grid[i].size(), 2U);
+        const int last = static_cast<int>(grid[i].size()) - 1;
+        const int pos = reverse ? last - 1 : 1;
+        b[i] = grid[i][pos];
+        // pos lands on a sentinel exactly when the row carries no payload at all.
+        done[i] = reverse ? (pos <= 0) : (pos >= last);
+        mp[i] = reverse ? pos - 1 : pos + 1;
     }
     b[k] = reverse ? maxV : minV;
+    done[k] = 1;
+
+    // Whether leaf x must be stored as the loser of a node whose current loser is y.
+    // The virtual leaf k always wins and is never stored, so that after the build no node refers to
+    // it any more; exhausted rows always lose; only then are values compared.
+    auto loses = [&](int x, int y) {
+        if (y == k) return true;
+        if (x == k) return false;
+        if (done[x]) return true;
+        if (done[y]) return false;
+        if constexpr (reverse) {
+            return b[x] < b[y];
+        } else {
+            return b[x] > b[y];
+        }
+    };
+
     for (int i = 0; i < k; ++i) {
         ls[i] = k;
     }
@@ -100,11 +131,7 @@ void kWayMergeSort(const typename PercentileStateTypes<LT>::GridType& grid, std:
         int q = i;
         int t = (q + k) / 2;
         while (t > 0) {
-            if constexpr (reverse) {
-                if (b[q] < b[ls[t]]) {
-                    std::swap(q, ls[t]);
-                }
-            } else if (b[q] > b[ls[t]]) {
+            if (loses(q, ls[t])) {
                 std::swap(q, ls[t]);
             }
             t = t / 2;
@@ -112,11 +139,12 @@ void kWayMergeSort(const typename PercentileStateTypes<LT>::GridType& grid, std:
         ls[0] = q;
     }
 
-    CppType tp = reverse ? minV : maxV;
     size_t cnt = 0;
 
-    while (b[ls[0]] != tp) {
+    // done[k] == 1, so even a degenerate tree can only stop the merge, never read out of range.
+    while (!done[ls[0]]) {
         int q = ls[0];
+        DCHECK_LT(q, k);
         if (UNLIKELY(cnt >= goal)) {
             if (cnt == goal) {
                 if constexpr (reverse)
@@ -133,20 +161,17 @@ void kWayMergeSort(const typename PercentileStateTypes<LT>::GridType& grid, std:
             }
         }
         cnt++;
-        b[q] = grid[q][mp[q]];
+        // !done[q] guarantees mp[q] is still a valid index into the row.
+        const int pos = mp[q];
+        const int last = static_cast<int>(grid[q].size()) - 1;
+        DCHECK(pos >= 0 && pos <= last);
+        b[q] = grid[q][pos];
+        done[q] = reverse ? (pos <= 0) : (pos >= last);
+        mp[q] = reverse ? pos - 1 : pos + 1;
 
-        if constexpr (reverse) {
-            mp[q]--;
-        } else {
-            mp[q]++;
-        }
         int t = (q + k) / 2;
         while (t > 0) {
-            if constexpr (reverse) {
-                if (b[q] < b[ls[t]]) {
-                    std::swap(q, ls[t]);
-                }
-            } else if (b[q] > b[ls[t]]) {
+            if (loses(q, ls[t])) {
                 std::swap(q, ls[t]);
             }
             t = t / 2;

--- a/be/test/exprs/agg/aggregate_test.cpp
+++ b/be/test/exprs/agg/aggregate_test.cpp
@@ -1265,6 +1265,97 @@ TEST_F(AggregateTest, test_percentile_cont_2) {
     ASSERT_EQ(3, result_column->get_data()[0]);
 }
 
+// Builds one merge-phase (grid) row out of `values` and merges it into `state`, exactly like a
+// partial aggregate arriving from a local aggregation. `values` may be empty, which is what a
+// local aggregation instance that saw no input row produces.
+static void merge_date_percentile_partial(const AggregateFunction* func, FunctionContext* fn_ctx,
+                                          ManagedAggrState* into, const std::vector<DateValue>& values, double rate) {
+    auto partial = ManagedAggrState::create(fn_ctx, func);
+    auto data_column = DateColumn::create();
+    for (auto v : values) {
+        data_column->append(v);
+    }
+    auto rate_column = ColumnHelper::create_const_column<TYPE_DOUBLE>(rate, 1);
+    std::vector<const Column*> raw_columns = {data_column.get(), rate_column.get()};
+    if (!values.empty()) {
+        func->update_batch_single_state(fn_ctx, data_column->size(), raw_columns.data(), partial->state());
+    }
+    MutableColumnPtr serde_column = BinaryColumn::create();
+    func->serialize_to_column(fn_ctx, partial->state(), serde_column.get());
+    func->merge(fn_ctx, serde_column.get(), into->state(), 0);
+}
+
+// The merge phase of percentile_cont builds a loser tree over the partial states. Neither the end
+// of a partial nor the tree's virtual leaf may be detected by value: for DATE, min_value() and
+// max_value() are the ordinary dates '0000-01-01' and '9999-12-31', and an empty partial consists
+// of nothing but those two sentinels. Before the fix each of the cases below made ls[0] hold the
+// virtual leaf k, and the merge loop then read grid[k]/mp[k], one past the end of both vectors.
+TEST_F(AggregateTest, test_percentile_cont_date_merge_sentinel_values) {
+    std::vector<TypeDescriptor> arg_types = {TypeDescriptor::from_logical_type(TYPE_DATE),
+                                             TypeDescriptor::from_logical_type(TYPE_DOUBLE)};
+    auto return_type = TypeDescriptor::from_logical_type(TYPE_DATE);
+    std::unique_ptr<FunctionContext> local_ctx(FunctionContext::create_test_context(std::move(arg_types), return_type));
+    const AggregateFunction* func = get_aggregate_function("percentile_cont", TYPE_DATE, TYPE_DATE, false);
+    const DateValue kMax = DateValue::MAX_DATE_VALUE; // '9999-12-31', == RunTimeTypeLimits<TYPE_DATE>::max_value()
+    const DateValue kMin = DateValue::MIN_DATE_VALUE; // '0000-01-01', == RunTimeTypeLimits<TYPE_DATE>::min_value()
+
+    // reverse == true (rate > 0.5): every partial's largest element equals the max sentinel.
+    {
+        auto state = ManagedAggrState::create(ctx, func);
+        merge_date_percentile_partial(func, local_ctx.get(), state.get(),
+                                      {DateValue::create(2020, 1, 1), DateValue::create(2020, 1, 11), kMax}, 0.6);
+        merge_date_percentile_partial(func, local_ctx.get(), state.get(),
+                                      {DateValue::create(2020, 1, 2), DateValue::create(2020, 1, 12), kMax}, 0.6);
+        merge_date_percentile_partial(func, local_ctx.get(), state.get(),
+                                      {DateValue::create(2020, 1, 3), DateValue::create(2020, 1, 13), kMax}, 0.6);
+        auto result = DateColumn::create();
+        func->finalize_to_column(local_ctx.get(), state->state(), result.get());
+        // sorted: 01-01 01-02 01-03 01-11 01-12 01-13 max max max, u = 8 * 0.6 = 4.8
+        ASSERT_EQ(DateValue::create(2020, 1, 12), result->get_data()[0]);
+    }
+    // reverse == false (rate <= 0.5): every partial's smallest element equals the min sentinel.
+    {
+        auto state = ManagedAggrState::create(ctx, func);
+        merge_date_percentile_partial(func, local_ctx.get(), state.get(),
+                                      {kMin, DateValue::create(2020, 1, 2), DateValue::create(2020, 1, 11)}, 0.4);
+        merge_date_percentile_partial(func, local_ctx.get(), state.get(),
+                                      {kMin, DateValue::create(2020, 1, 3), DateValue::create(2020, 1, 12)}, 0.4);
+        merge_date_percentile_partial(func, local_ctx.get(), state.get(),
+                                      {kMin, DateValue::create(2020, 1, 4), DateValue::create(2020, 1, 13)}, 0.4);
+        auto result = DateColumn::create();
+        func->finalize_to_column(local_ctx.get(), state->state(), result.get());
+        // sorted: min min min 01-02 01-03 01-04 01-11 01-12 01-13, u = 8 * 0.4 = 3.2
+        ASSERT_EQ(DateValue::create(2020, 1, 2), result->get_data()[0]);
+    }
+}
+
+// A local aggregation instance that received no input row still emits one partial state, so the
+// merge phase can see a grid row with an empty payload next to non-empty ones.
+TEST_F(AggregateTest, test_percentile_cont_date_merge_empty_partial) {
+    std::vector<TypeDescriptor> arg_types = {TypeDescriptor::from_logical_type(TYPE_DATE),
+                                             TypeDescriptor::from_logical_type(TYPE_DOUBLE)};
+    auto return_type = TypeDescriptor::from_logical_type(TYPE_DATE);
+    std::unique_ptr<FunctionContext> local_ctx(FunctionContext::create_test_context(std::move(arg_types), return_type));
+    const AggregateFunction* func = get_aggregate_function("percentile_cont", TYPE_DATE, TYPE_DATE, false);
+
+    // The empty partial is merged first: an empty state carries rate 0, and merge() adopts the rate
+    // of whichever partial it saw last.
+    for (double rate : {0.4, 0.9}) {
+        auto state = ManagedAggrState::create(ctx, func);
+        merge_date_percentile_partial(func, local_ctx.get(), state.get(), {}, rate);
+        merge_date_percentile_partial(
+                func, local_ctx.get(), state.get(),
+                {DateValue::create(2020, 1, 1), DateValue::create(2020, 1, 2), DateValue::create(2020, 1, 3)}, rate);
+        merge_date_percentile_partial(
+                func, local_ctx.get(), state.get(),
+                {DateValue::create(2020, 1, 4), DateValue::create(2020, 1, 5), DateValue::create(2020, 1, 6)}, rate);
+        auto result = DateColumn::create();
+        func->finalize_to_column(local_ctx.get(), state->state(), result.get());
+        // sorted: 01-01 .. 01-06; rate 0.4 -> u = 2.0, rate 0.9 -> u = 4.5
+        ASSERT_EQ(rate == 0.4 ? DateValue::create(2020, 1, 3) : DateValue::create(2020, 1, 5), result->get_data()[0]);
+    }
+}
+
 TEST_F(AggregateTest, test_percentile_disc) {
     std::vector<TypeDescriptor> arg_types = {TypeDescriptor::from_logical_type(TYPE_DOUBLE),
                                              TypeDescriptor::from_logical_type(TYPE_DOUBLE)};


### PR DESCRIPTION
## Why I'm doing:

```
query_id:019fca49-a93d-7aa3-bf49-b5486bba9b37, fragment_instance:019fca49-a93d-7aa3-bf49-b5486bba9b38, plan_node_id:3
*** Aborted at 1785805252 (unix time) try "date -d @1785805252" if you are using GNU date ***
PC: @          0xc42046b void starrocks::kWayMergeSort<(starrocks::LogicalType)50, starrocks::DateValue, true>(starrocks::PercentileStateTypes<(starrocks::LogicalType)50>::GridType const&, std::vector<starrocks::DateValue, std::al
locator<starrocks::DateValue> >&, std::vector<int, @
*** SIGSEGV (@0xfffffffedcd13770) received by PID 216279 (TID 0x7fa1b24e36c0) LWP(217019) from PID 18446744073119283056; stack trace: ***
    @     0x7fa316a65ed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)
    @         0x1260d186 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7fa316a09330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @          0xc42046b void starrocks::kWayMergeSort<(starrocks::LogicalType)50, starrocks::DateValue, true>(starrocks::PercentileStateTypes<(starrocks::LogicalType)50>::GridType const&, std::vector<starrocks::DateValue, std::al
locator<starrocks::DateValue> >&, std::vector<int, @
    @          0xc425adb starrocks::PercentileContAggregateFunction<(starrocks::LogicalType)50>::finalize_to_column(starrocks::FunctionContext*, unsigned char const*, starrocks::Column*) const
    @          0xc396ef3 starrocks::NullableAggregateFunctionBase<starrocks::AggregateFunction const*, starrocks::NullableAggregateFunctionState<starrocks::PercentileState<(starrocks::LogicalType)50, int>, false>, false, true, sta
rrocks::AggNonNullPred<starrocks::PercentileState<(@
    @          0x93c4b83 starrocks::Aggregator::_finalize_to_chunk(unsigned char const*, std::vector<starrocks::Cow<starrocks::Column>::MutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::MutPtr<starrocks:
:Column> > >&)
    @          0x9485945 starrocks::Aggregator::convert_to_chunk_no_groupby(std::shared_ptr<starrocks::Chunk>*)
    @          0x98cf498 starrocks::pipeline::AggregateBlockingSourceOperator::pull_chunk(starrocks::RuntimeState*)
    @          0xaddf607 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0x9716596 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0xe7952fb starrocks::ThreadPool::dispatch_thread()
    @          0xe78c1af starrocks::Thread::supervise_thread(void*)
    @     0x7fa316a60aa4 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x9caa3)
    @     0x7fa316aedc6c (/usr/lib/x86_64-linux-gnu/libc.so.6+0x129c6b)
```

percentile_cont over a DATE column killed the BE with a heap-buffer-overflow in kWayMergeSort during finalize, whenever the data contained '0000-01-01' or '9999-12-31'.

The loser tree's virtual leaf b[k] was recognised by its VALUE -- max_value() when merging in reverse, min_value() when forward -- and the comparisons are strict. RunTimeTypeLimits<TYPE_DATE> returns MIN_DATE_VALUE / MAX_DATE_VALUE, which unlike the numeric_limits sentinels of INT or DOUBLE are perfectly ordinary storable dates. So real data can equal the sentinel, a real leaf then never displaces the virtual one, ls[t] == k survives the build and propagates to ls[0], and `while (b[ls[0]] != tp)` stays true because b[k] holds the opposite extreme from tp. The loop body then runs with q == k and indexes grid[k] and mp[k], one past the end of both.

The same state is reachable a second way: a partial aggregate that contributed no rows still serialises as a two-sentinel row, whose only readable slot ties with the virtual leaf on the forward path. The existing `if (rowsNum == 0)` guard only catches the case where every row is empty.

Row exhaustion and the virtual leaf are now both tracked by position: done[i] is set when a cursor reaches a sentinel slot, the comparator never stores the virtual leaf, and the loop ends on !done[ls[0]]. Since done[k] is set, a degenerate tree can now only stop the merge early instead of reading out of range. rowsNum, the goal computation and the tournament are unchanged.

Note this also silently corrupted results without crashing: a payload value equal to min_value()/max_value() terminated its row early, so a percentile over boundary dates could come back wrong with no error at all.

Found by an AST-mutation fuzzer replaying mutated queries against a live ASan cluster, which reported the overrun object as the 32-byte std::vector<int> that is mp, read at offset 0 past its end with k == 8.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
