### PR TITLE
[Tool] ci-merged: add checkbox x AI-affected backport reconcile dry-run shadow

### DIFF
--- a/.github/workflows/ci-merged.yml
+++ b/.github/workflows/ci-merged.yml
@@ -67,6 +67,37 @@ jobs:
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
           python3 lib/backport_fanout_run.py --repo ${GITHUB_REPOSITORY} --pr ${PR_NUMBER} --dry-run
 
+  # Decision-10 phase B shadow: checkbox x AI-affected reconciliation, DRY-RUN.
+  # Runs on [self-hosted, ubuntu, ai] — that pool has BOTH /var/lib/ci-tool AND
+  # `claude` + the github-bugfix-versions plugin (see bugfix-version-index.yml).
+  # `claude` returns this [BugFix]'s affected release lines (branches still
+  # carrying the bug); backport_reconcile.py then prints the matrix (window /
+  # affected / checked / auto / notify) and posts NOTHING. continue-on-error so
+  # it can never affect the merge. Needs ci-tool #4934 on the runner.
+  backport-reconcile-shadow:
+    name: Backport Reconcile (dry-run shadow)
+    runs-on: [ self-hosted, ubuntu, ai ]
+    if: >
+      github.event.pull_request.merged == true &&
+      github.base_ref == 'main' &&
+      github.repository == 'StarRocks/starrocks' &&
+      startsWith(github.event.pull_request.title, '[BugFix]') &&
+      !contains(github.event.pull_request.title, '(sync #') &&
+      !contains(github.event.pull_request.labels.*.name, 'sync') &&
+      !contains(github.head_ref, '-sync-') &&
+      !contains(github.event.pull_request.title, 'cherry-pick') &&
+      !contains(github.event.pull_request.title, 'backport')
+    continue-on-error: true
+    env:
+      PR_NUMBER: ${{ github.event.number }}
+      GH_TOKEN: ${{ secrets.PAT }}
+      GITHUB_TOKEN: ${{ secrets.PAT }}
+    steps:
+      - name: reconcile dry-run (checkbox x AI affected)
+        run: |
+          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
+          ./bin/backport_reconcile.sh --repo ${GITHUB_REPOSITORY} --pr ${PR_NUMBER} --dry-run
+
   thirdparty-filter:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true


### PR DESCRIPTION
## Why I'm doing:

Decision-10 phase B: measure the agreement between the author's backport **checkbox**
and the AI's **affected release lines** (from the `github-bugfix-versions` plugin)
before enabling auto-backport — without changing any behavior yet.

## What I'm doing:

Add a `backport-reconcile-shadow` job to `ci-merged.yml`, on `[self-hosted, ubuntu, ai]`
(that pool has both `/var/lib/ci-tool` and `claude` + the `github-bugfix-versions`
plugin, per `bugfix-version-index.yml`). For a `[BugFix]` merged to main:
1. `claude` returns the affected release lines (branches still carrying the bug) as JSON;
2. `backport_reconcile.py` (ci-tool #4934) prints the matrix — window / affected / checked
   / **auto** (checked and affected) / **notify** (disagreement) — and **posts nothing**.

**DRY-RUN + `continue-on-error`** so it can never affect the merge. Validated end-to-end
locally: #77049 (main-only -> affected `[]`, no-op), #76702 (bug in 4.1/4.0/3.5 ->
affected `[4.1,4.0,3.5]`, matches its real backports), and the disagreement -> notify path.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4