### PR TITLE
[Tool] cd-repo-sync: pin executor to [self-hosted, sync, ubuntu] runners

### DIFF
--- a/.github/workflows/cd-repo-sync.yml
+++ b/.github/workflows/cd-repo-sync.yml
@@ -45,7 +45,7 @@ jobs:
 
   pr-info:
     name: Add PR Information
-    runs-on: [self-hosted, sync]
+    runs-on: [self-hosted, sync, ubuntu]
     env:
       PR_ID: ${{ inputs.PR_ID }}
       SYNC_PAT: ${{ secrets.SYNC_PAT }}
@@ -63,7 +63,7 @@ jobs:
 
   cd-repo-sync-main:
     name: CD Repo Sync - main
-    runs-on: [self-hosted, sync]
+    runs-on: [self-hosted, sync, ubuntu]
     if: inputs.BRANCH == 'main'
     needs: pr-info
     env:


### PR DESCRIPTION
## Why I'm doing:

The CD→SR reverse-sync executor `cd-repo-sync.yml` uses `runs-on: [self-hosted, sync]`. That label set also matches **unprovisioned** sync runners (the existing `sr/runner:v1` containers) that lack `/var/lib/elastic-service`, so the executor fails at its first step (`cd /var/lib/elastic-service` → No such file or directory) and no sync PR is created.

## What I'm doing:

Two fully-provisioned SR sync runners were added (self-hosted, local, with `/var/lib/elastic-service` [reverse-sync tooling], `/var/lib/starrocks`, and the `celerdata-enterprise` source mirror). They carry an extra `ubuntu` label: `[self-hosted, Linux, X64, sync, ubuntu]`.

Pin the executor's two jobs to `runs-on: [self-hosted, sync, ubuntu]` so it only lands on those provisioned runners and never on the bare-`sync` ones. Routing only; no logic change.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5