### PR TITLE
[Tool] cd-sync: carry source PR body via BODY_FILE in reverse executor

### DIFF
--- a/.github/workflows/cd-repo-sync.yml
+++ b/.github/workflows/cd-repo-sync.yml
@@ -152,7 +152,10 @@ jobs:
           PR_LABEL: sync,cd-sync,${{ steps.cherry-pick.outputs.LABEL }}${{ steps.cherry-pick.outputs.CONFLICT_LABEL }}
           HEAD: ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.PR_ID }}
           TITLE: "${{ needs.pr-info.outputs.title }}(cd-sync #${{ inputs.PR_ID }})"
-          BODY: "Reverse sync of ${{ inputs.SOURCE_REPO }}#${{ inputs.PR_ID }} (commit ${{ inputs.COMMIT_ID }})."
+          # Mirror the forward flow (repo-sync.yml): carry the source PR's full body
+          # (official template, all sections) via the file get_pr_info.py wrote in the
+          # pr-info job, plus any conflict info run_cherry_pick.sh prepended to it.
+          BODY_FILE: /var/local/env/body/${{ github.repository }}/${{ inputs.PR_ID }}.txt
           REVIEWER: ${{ needs.pr-info.outputs.assignees }}
           BASE: ${{ inputs.BRANCH }}
         run: |


### PR DESCRIPTION
## Why I'm doing:

The CD→SR reverse-sync executor (`cd-repo-sync.yml`) created SR PRs with a one-line
body (`Reverse sync of ...#N (commit ...)`), dropping the source PR's full description.
The forward flow (`repo-sync.yml`) already carries the source PR's complete body: its
`pr-info` job runs `get_pr_info.py`, which writes the source PR body to
`/var/local/env/body/<repo>/<PR_ID>.txt`, and the create-PR step passes it via
`BODY_FILE`. The reverse executor's `pr-info` job writes the same file (its
`get_pr_info.sh` honors `SOURCE_REPO`), but the create-PR step ignored it and used an
inline `BODY:` string instead.

## What I'm doing:

Align the reverse executor with the forward flow: replace the inline `BODY:` in the
"Create pull request" step with `BODY_FILE: /var/local/env/body/${{ github.repository }}/${{ inputs.PR_ID }}.txt`.
The synced SR PR now carries the source PR's full body (official template, all
sections), plus any conflict info `run_cherry_pick.sh` prepends to the same file.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
