### PR TITLE
[Enhancement] Add configurable rollover file index and delete count for FE logs (backport #76760)

### DIFF
--- a/docs/en/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/en/administration/management/FE_parameters/log_server_meta.md
@@ -63,6 +63,15 @@ This topic introduces the following types of FE configurations:
 - Description: The retention period of audit log files. The default value `30d` specifies that each audit log file can be retained for 30 days. StarRocks checks each audit log file and deletes those that were generated 30 days ago.
 - Introduced in: -
 
+### `audit_log_delete_count`
+
+- Default: -1
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: A hard cap on the number of rolled `fe.audit.log` archives retained on disk, enforced by Log4j's `Delete` action via an `IfAccumulatedFileCount` condition. A value less than or equal to `0` disables the cap (retention governed only by `audit_log_delete_age`). When set to a positive value, an archive is deleted when it is older than `audit_log_delete_age` OR falls outside the newest `audit_log_delete_count` files. This is primarily useful together with `audit_log_roll_file_index = nomax` to bound disk usage.
+- Introduced in: -
+
 ### `audit_log_dir`
 
 - Default: `StarRocksFE.STARROCKS_HOME_DIR` + "/log"
@@ -97,6 +106,15 @@ This topic introduces the following types of FE configurations:
 - Unit: -
 - Is mutable: No
 - Description: The modules for which StarRocks generates audit log entries. By default, StarRocks generates audit logs for the `slow_query` module and the `query` module. The `connection` module is supported from v3.0. Separate the module names with a comma (,) and a space.
+- Introduced in: -
+
+### `audit_log_roll_file_index`
+
+- Default: min
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: The rollover file index strategy passed to Log4j's `DefaultRolloverStrategy` for `fe.audit.log`. Valid values are `min`, `max`, and `nomax`. With `min`, Log4j keeps at most `audit_log_roll_num` archives and, on each rollover, shifts the indexes so the newest archive is at the lowest index. With `max`, Log4j also keeps at most `audit_log_roll_num` archives but keeps the newest archive at the highest index. With `nomax`, Log4j appends monotonically increasing indexes without renaming existing archives; because `nomax` makes Log4j ignore the `max` (`audit_log_roll_num`) limit, set `audit_log_delete_count` to bound disk usage. An invalid value causes an IOException during logging initialization.
 - Introduced in: -
 
 ### `audit_log_roll_interval`
@@ -146,6 +164,15 @@ This topic introduces the following types of FE configurations:
 - Description: Controls how long FE big query log files (`fe.big_query.log.*`) are retained before automatic deletion. The value is passed to Log4j's deletion policy as the IfLastModified age — any rotated big query log whose last-modified time is older than this value will be removed. Supports suffixes include `d` (day), `h` (hour), `m` (minute), and `s` (second). Example: `7d` (7 days), `10h` (10 hours), `60m` (60 minutes), and `120s` (120 seconds). This item works together with `big_query_log_roll_interval` and `big_query_log_roll_num` to determine which files are kept or purged.
 - Introduced in: v3.2.0
 
+### `big_query_log_delete_count`
+
+- Default: -1
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: A hard cap on the number of rolled `fe.big_query.log` archives retained on disk, enforced by Log4j's `Delete` action via an `IfAccumulatedFileCount` condition. A value less than or equal to `0` disables the cap (retention governed only by `big_query_log_delete_age`). When set to a positive value, an archive is deleted when it is older than `big_query_log_delete_age` OR falls outside the newest `big_query_log_delete_count` files. This is primarily useful together with `big_query_log_roll_file_index = nomax` to bound disk usage.
+- Introduced in: -
+
 ### `big_query_log_dir`
 
 - Default: `Config.STARROCKS_HOME_DIR + "/log"`
@@ -163,6 +190,15 @@ This topic introduces the following types of FE configurations:
 - Is mutable: No
 - Description: List of module name suffixes that enable per-module big query logging. Typical values are logical component names. For example, the default `query` produces `big_query.query`.
 - Introduced in: v3.2.0
+
+### `big_query_log_roll_file_index`
+
+- Default: min
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: The rollover file index strategy passed to Log4j's `DefaultRolloverStrategy` for `fe.big_query.log`. Valid values are `min`, `max`, and `nomax`. With `min`, Log4j keeps at most `big_query_log_roll_num` archives and, on each rollover, shifts the indexes so the newest archive is at the lowest index. With `max`, Log4j also keeps at most `big_query_log_roll_num` archives but keeps the newest archive at the highest index. With `nomax`, Log4j appends monotonically increasing indexes without renaming existing archives; because `nomax` makes Log4j ignore the `max` (`big_query_log_roll_num`) limit, set `big_query_log_delete_count` to bound disk usage. An invalid value causes an IOException during logging initialization.
+- Introduced in: -
 
 ### `big_query_log_roll_interval`
 
@@ -191,6 +227,15 @@ This topic introduces the following types of FE configurations:
 - Description: The retention period of dump log files. The default value `7d` specifies that each dump log file can be retained for 7 days. StarRocks checks each dump log file and deletes those that were generated 7 days ago.
 - Introduced in: -
 
+### `dump_log_delete_count`
+
+- Default: -1
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: A hard cap on the number of rolled `fe.dump.log` archives retained on disk, enforced by Log4j's `Delete` action via an `IfAccumulatedFileCount` condition. A value less than or equal to `0` disables the cap (retention governed only by `dump_log_delete_age`). When set to a positive value, an archive is deleted when it is older than `dump_log_delete_age` OR falls outside the newest `dump_log_delete_count` files. This is primarily useful together with `dump_log_roll_file_index = nomax` to bound disk usage.
+- Introduced in: -
+
 ### `dump_log_dir`
 
 - Default: `StarRocksFE.STARROCKS_HOME_DIR` + "/log"
@@ -207,6 +252,15 @@ This topic introduces the following types of FE configurations:
 - Unit: -
 - Is mutable: No
 - Description: The modules for which StarRocks generates dump log entries. By default, StarRocks generates dump logs for the query module. Separate the module names with a comma (,) and a space.
+- Introduced in: -
+
+### `dump_log_roll_file_index`
+
+- Default: min
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: The rollover file index strategy passed to Log4j's `DefaultRolloverStrategy` for `fe.dump.log`. Valid values are `min`, `max`, and `nomax`. With `min`, Log4j keeps at most `dump_log_roll_num` archives and, on each rollover, shifts the indexes so the newest archive is at the lowest index. With `max`, Log4j also keeps at most `dump_log_roll_num` archives but keeps the newest archive at the highest index. With `nomax`, Log4j appends monotonically increasing indexes without renaming existing archives; because `nomax` makes Log4j ignore the `max` (`dump_log_roll_num`) limit, set `dump_log_delete_count` to bound disk usage. An invalid value causes an IOException during logging initialization.
 - Introduced in: -
 
 ### `dump_log_roll_interval`
@@ -274,6 +328,24 @@ This topic introduces the following types of FE configurations:
 - Description: When this item is set to `true`, the system replaces or hides sensitive SQL content before it is written to logs, query-detail records, and query profiles. Code paths that honor this configuration include ConnectProcessor.formatStmt (audit logs), StmtExecutor.addRunningQueryDetail (query details), SimpleExecutor.formatSQL (internal executor logs), and StmtExecutor.buildTopLevelProfile / processProfileAsync (the `Sql Statement` and `ExplainPlan` info-strings stored in a profile's `Summary` section). With the feature enabled, invalid SQLs may be replaced with a fixed desensitized message, credentials (user/password) are hidden, and the SQL formatter is required to produce a sanitized representation (it can also enable digest-style output). For the `ExplainPlan` field added by the `enable_explain_in_profile` session variable, this config also forces literal-digest rendering of the embedded `EXPLAIN COSTS` text, so the profile does not leak the literals that the persisted `Sql Statement` would have hidden. This reduces leakage of sensitive literals and credentials in audit/internal logs and profiles, but also means logs, query details, and profiles no longer contain the original full SQL text (which can affect replay or debugging).
 - Introduced in: -
 
+### `feature_log_delete_count`
+
+- Default: -1
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: A hard cap on the number of rolled `fe.features.log` archives retained on disk, enforced by Log4j's `Delete` action via an `IfAccumulatedFileCount` condition. A value less than or equal to `0` disables the cap (retention governed only by `feature_log_delete_age`). When set to a positive value, an archive is deleted when it is older than `feature_log_delete_age` OR falls outside the newest `feature_log_delete_count` files. This is primarily useful together with `feature_log_roll_file_index = nomax` to bound disk usage.
+- Introduced in: -
+
+### `feature_log_roll_file_index`
+
+- Default: min
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: The rollover file index strategy passed to Log4j's `DefaultRolloverStrategy` for `fe.features.log`. Valid values are `min`, `max`, and `nomax`. With `min`, Log4j keeps at most `feature_log_roll_num` archives and, on each rollover, shifts the indexes so the newest archive is at the lowest index. With `max`, Log4j also keeps at most `feature_log_roll_num` archives but keeps the newest archive at the highest index. With `nomax`, Log4j appends monotonically increasing indexes without renaming existing archives; because `nomax` makes Log4j ignore the `max` (`feature_log_roll_num`) limit, set `feature_log_delete_count` to bound disk usage. An invalid value causes an IOException during logging initialization.
+- Introduced in: -
+
 ### `internal_log_delete_age`
 
 - Default: 7d
@@ -282,6 +354,15 @@ This topic introduces the following types of FE configurations:
 - Is mutable: No
 - Description: Specifies the retention period for FE internal log files (written to `internal_log_dir`). The value is a duration string. Supported suffixes: `d` (day), `h` (hour), `m` (minute), `s` (second). Examples: `7d` (7 days), `10h` (10 hours), `60m` (60 minutes), `120s` (120 seconds). This item is substituted into the log4j configuration as the `<IfLastModified age="..."/>` predicate used by the RollingFile Delete policy. Files whose last-modified time is earlier than this duration will be removed during log rollover. Increase this value to free disk space sooner, or decrease it to retain internal materialized view or statistics logs longer.
 - Introduced in: v3.2.4
+
+### `internal_log_delete_count`
+
+- Default: -1
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: A hard cap on the number of rolled `fe.internal.log` archives retained on disk, enforced by Log4j's `Delete` action via an `IfAccumulatedFileCount` condition. A value less than or equal to `0` disables the cap (retention governed only by `internal_log_delete_age`). When set to a positive value, an archive is deleted when it is older than `internal_log_delete_age` OR falls outside the newest `internal_log_delete_count` files. This is primarily useful together with `internal_log_roll_file_index = nomax` to bound disk usage.
+- Introduced in: -
 
 ### `internal_log_dir`
 
@@ -309,6 +390,15 @@ This topic introduces the following types of FE configurations:
 - Is mutable: No
 - Description: A list of module identifiers that will receive dedicated internal logging. For each entry X, Log4j creates a logger named `internal.<X>` with level INFO and additivity="false". Those loggers are routed to the internal appender (written to `fe.internal.log`) or to console when `sys_log_to_console` is enabled. Use short names or package fragments as needed — the exact logger name becomes `internal.` + the configured string. Internal log file rotation and retention follow `internal_log_dir`, `internal_log_roll_num`, `internal_log_delete_age`, `internal_log_roll_interval`, and `log_roll_size_mb`. Adding a module causes its runtime messages to be separated into the internal logger stream for easier debugging and audit.
 - Introduced in: v3.2.4
+
+### `internal_log_roll_file_index`
+
+- Default: min
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: The rollover file index strategy passed to Log4j's `DefaultRolloverStrategy` for `fe.internal.log`. Valid values are `min`, `max`, and `nomax`. With `min`, Log4j keeps at most `internal_log_roll_num` archives and, on each rollover, shifts the indexes so the newest archive is at the lowest index. With `max`, Log4j also keeps at most `internal_log_roll_num` archives but keeps the newest archive at the highest index. With `nomax`, Log4j appends monotonically increasing indexes without renaming existing archives; because `nomax` makes Log4j ignore the `max` (`internal_log_roll_num`) limit, set `internal_log_delete_count` to bound disk usage. An invalid value causes an IOException during logging initialization.
+- Introduced in: -
 
 ### `internal_log_roll_interval`
 
@@ -400,6 +490,24 @@ This topic introduces the following types of FE configurations:
 - Description: The maximum size of a system log file or an audit log file.
 - Introduced in: -
 
+### `plan_log_delete_count`
+
+- Default: -1
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: A hard cap on the number of rolled `fe.plan.log` archives retained on disk, enforced by Log4j's `Delete` action via an `IfAccumulatedFileCount` condition. A value less than or equal to `0` disables the cap (retention governed only by `plan_log_delete_age`). When set to a positive value, an archive is deleted when it is older than `plan_log_delete_age` OR falls outside the newest `plan_log_delete_count` files. This is primarily useful together with `plan_log_roll_file_index = nomax` to bound disk usage.
+- Introduced in: -
+
+### `plan_log_roll_file_index`
+
+- Default: min
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: The rollover file index strategy passed to Log4j's `DefaultRolloverStrategy` for `fe.plan.log`. Valid values are `min`, `max`, and `nomax`. With `min`, Log4j keeps at most `plan_log_roll_num` archives and, on each rollover, shifts the indexes so the newest archive is at the lowest index. With `max`, Log4j also keeps at most `plan_log_roll_num` archives but keeps the newest archive at the highest index. With `nomax`, Log4j appends monotonically increasing indexes without renaming existing archives; because `nomax` makes Log4j ignore the `max` (`plan_log_roll_num`) limit, set `plan_log_delete_count` to bound disk usage. An invalid value causes an IOException during logging initialization.
+- Introduced in: -
+
 ### `proc_profile_file_retained_days`
 
 - Default: 1
@@ -427,6 +535,15 @@ This topic introduces the following types of FE configurations:
 - Description: Controls how long FE profile log files are retained before they are eligible for deletion. The value is injected into Log4j's `<IfLastModified age="..."/>` policy (via `Log4jConfig`) and is applied together with rotation settings such as `profile_log_roll_interval` and `profile_log_roll_num`. Supported suffixes: `d` (day), `h` (hour), `m` (minute), `s` (second). For example: `7d` (7 days), `10h` (10 hours), `60m` (60 minutes), `120s` (120 seconds).
 - Introduced in: v3.2.5
 
+### `profile_log_delete_count`
+
+- Default: -1
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: A hard cap on the number of rolled `fe.profile.log` archives retained on disk, enforced by Log4j's `Delete` action via an `IfAccumulatedFileCount` condition. A value less than or equal to `0` disables the cap (retention governed only by `profile_log_delete_age`). When set to a positive value, an archive is deleted when it is older than `profile_log_delete_age` OR falls outside the newest `profile_log_delete_count` files. This is primarily useful together with `profile_log_roll_file_index = nomax` to bound disk usage.
+- Introduced in: -
+
 ### `profile_log_dir`
 
 - Default: `Config.STARROCKS_HOME_DIR` + "/log"
@@ -445,6 +562,15 @@ This topic introduces the following types of FE configurations:
 - Description: Minimum query latency (in milliseconds) for a profile to be written to `fe.profile.log`. Only queries whose execution time is greater than or equal to this value are logged. Set to 0 to log all profiles (no threshold). Use a positive value to reduce log volume by logging only slower queries.
 - Introduced in: -
 
+
+### `profile_log_roll_file_index`
+
+- Default: min
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: The rollover file index strategy passed to Log4j's `DefaultRolloverStrategy` for `fe.profile.log`. Valid values are `min`, `max`, and `nomax`. With `min`, Log4j keeps at most `profile_log_roll_num` archives and, on each rollover, shifts the indexes so the newest archive is at the lowest index. With `max`, Log4j also keeps at most `profile_log_roll_num` archives but keeps the newest archive at the highest index. With `nomax`, Log4j appends monotonically increasing indexes without renaming existing archives; because `nomax` makes Log4j ignore the `max` (`profile_log_roll_num`) limit, set `profile_log_delete_count` to bound disk usage. An invalid value causes an IOException during logging initialization.
+- Introduced in: -
 
 ### `profile_log_roll_interval`
 
@@ -518,6 +644,15 @@ This topic introduces the following types of FE configurations:
 - Description: The retention period of system log files. The default value `7d` specifies that each system log file can be retained for 7 days. StarRocks checks each system log file and deletes those that were generated 7 days ago.
 - Introduced in: -
 
+### `sys_log_delete_count`
+
+- Default: -1
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: A hard cap on the number of rolled `fe.log` and `fe.warn.log` archives retained on disk, enforced by Log4j's `Delete` action via an `IfAccumulatedFileCount` condition. A value less than or equal to `0` disables the cap (retention governed only by `sys_log_delete_age`). When set to a positive value, an archive is deleted when it is older than `sys_log_delete_age` OR falls outside the newest `sys_log_delete_count` files. This is primarily useful together with `sys_log_roll_file_index = nomax` to bound disk usage.
+- Introduced in: -
+
 ### `sys_log_dir`
 
 - Default: `StarRocksFE.STARROCKS_HOME_DIR` + "/log"
@@ -570,6 +705,15 @@ This topic introduces the following types of FE configurations:
 - Unit: -
 - Is mutable: No
 - Description: The severity levels into which system log entries are classified. Valid values: `INFO`, `WARN`, `ERROR`, and `FATAL`.
+- Introduced in: -
+
+### `sys_log_roll_file_index`
+
+- Default: min
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: The rollover file index strategy passed to Log4j's `DefaultRolloverStrategy` for `fe.log` and `fe.warn.log`. Valid values are `min`, `max`, and `nomax`. With `min`, Log4j keeps at most `sys_log_roll_num` archives and, on each rollover, shifts the indexes so the newest archive is at the lowest index. With `max`, Log4j also keeps at most `sys_log_roll_num` archives but keeps the newest archive at the highest index. With `nomax`, Log4j appends monotonically increasing indexes without renaming existing archives; because `nomax` makes Log4j ignore the `max` (`sys_log_roll_num`) limit, set `sys_log_delete_count` to bound disk usage. An invalid value causes an IOException during logging initialization.
 - Introduced in: -
 
 ### `sys_log_roll_interval`

--- a/docs/en/administration/management/logs.md
+++ b/docs/en/administration/management/logs.md
@@ -15,6 +15,8 @@ The main FE logs include the startup process, cluster state changes, DML/DQL req
 - `sys_log_roll_num`: Controls the number of retained log files to prevent unlimited growth from consuming too much disk space. Default is 10
 - `sys_log_roll_interval`: Specifies the rotation frequency. Default is `DAY`, meaning logs are rotated daily
 - `sys_log_delete_age`: Controls how long to keep old log files before deletion. Default is 7 day
+- `sys_log_roll_file_index`: Rollover file index strategy (`min`, `max`, or `nomax`). Default is `min`
+- `sys_log_delete_count`: Hard cap on the number of retained rolled files, enforced by the Delete action. Default is `-1` (disabled).
 - `sys_log_roll_mode`: Log rotation mode. Default is `SIZE-MB-1024`, meaning a new log file will be created when the current one reaches 1024 MB. Together with sys_log_roll_interval, this indicates that FE logs can be rotated either daily or based on file size
 - `sys_log_enable_compress`: Controls whether log compression is enabled. Default is false, meaning compression is disabled
 
@@ -85,6 +87,8 @@ The purpose of `fe.profile.log` is to record detailed query execution informatio
 - `profile_log_roll_interval`: Specifies the rotation frequency. Default is DAY, meaning daily rotation. When rotation conditions are met, the latest 5 files are retained, and older files are deleted
 - `profile_log_delete_age`: Controls how long old files are kept before deletion. Default is 1 day
 - `profile_log_latency_threshold_ms`: Minimum query latency (in milliseconds) for a profile to be written the log. Default is 0, meaning all profiles are logged.
+- `profile_log_roll_file_index`: Rollover file index strategy (`min`, `max`, or `nomax`). Default is `min`
+- `profile_log_delete_count`: Hard cap on the number of retained rolled files, enforced by the Delete action. Default is `-1` (disabled).
 
 ### `fe.internal.log`
 
@@ -105,6 +109,8 @@ This log is especially useful for analyzing StarRocks’ internal statistics col
 - `internal_log_roll_num`: Number of files to retain. Default is 90
 - `internal_log_roll_interval`: Specifies the rotation frequency. Default is DAY, meaning daily rotation. When rotation conditions are met, the latest 90 files are retained, and older files are deleted
 - `internal_log_delete_age`: Controls how long old files are kept before deletion. Default is 7 days
+- `internal_log_roll_file_index`: Rollover file index strategy (`min`, `max`, or `nomax`). Default is `min`
+- `internal_log_delete_count`: Hard cap on the number of retained rolled files, enforced by the Delete action. Default is `-1` (disabled).
 
 ### `fe.audit.log`
 
@@ -121,6 +127,8 @@ This is StarRocks’ query audit log, which records detailed information about a
 - `audit_log_roll_num`: Number of files to retain. Default is 90
 - `audit_log_roll_interval`: Specifies the rotation frequency. Default is DAY, meaning daily rotation. When rotation conditions are met, the latest 90 files are retained, and older files are deleted
 - `audit_log_delete_age`: Controls how long old files are kept before deletion. Default is 7 days
+- `audit_log_roll_file_index`: Rollover file index strategy (`min`, `max`, or `nomax`). Default is `min`
+- `audit_log_delete_count`: Hard cap on the number of retained rolled files, enforced by the Delete action. Default is `-1` (disabled).
 - `audit_log_json_format`: Whether to log in JSON format. Default is false
 - `audit_log_enable_compress`: Whether compression is enabled
 
@@ -138,6 +146,8 @@ This is StarRocks’ dedicated Big Query log file, used to monitor and analyze q
 - `big_query_log_modules`: Types of internal log modules. Default is query
 - `big_query_log_roll_interval`: Specifies the rotation frequency. Default is DAY, meaning daily rotation. When rotation conditions are met, the latest 10 files are retained, and older files are deleted
 - `big_query_log_delete_age`: Controls how long old files are kept before deletion. Default is 7 days
+- `big_query_log_roll_file_index`: Rollover file index strategy (`min`, `max`, or `nomax`). Default is `min`
+- `big_query_log_delete_count`: Hard cap on the number of retained rolled files, enforced by the Delete action. Default is `-1` (disabled).
 
 ### `fe.dump.log`
 
@@ -159,6 +169,8 @@ SET enable_query_dump = true;
 - `dump_log_modules`: Types of internal log modules. Default is query
 - `dump_log_roll_interval`: Specifies the rotation frequency. Default is DAY, meaning daily rotation. When rotation conditions are met, the latest 10 files are retained, and older files are deleted
 - `dump_log_delete_age`: Controls how long old files are kept before deletion. Default is 7 days
+- `dump_log_roll_file_index`: Rollover file index strategy (`min`, `max`, or `nomax`). Default is `min`
+- `dump_log_delete_count`: Hard cap on the number of retained rolled files, enforced by the Delete action. Default is `-1` (disabled).
 
 ### `fe.features.log`
 This is StarRocks’ query plan feature log, used to collect and record feature information of query execution plans. It mainly serves machine learning and query optimization analysis. Key purposes include:
@@ -183,6 +195,8 @@ enable_query_cost_prediction = false  // Disabled by default
 - `feature_log_roll_num`: Number of files to retain. Default is 5
 - `feature_log_roll_interval`: Specifies the rotation frequency. Default is DAY, meaning daily rotation. When rotation conditions are met, the latest 5 files are retained, and older files are deleted
 - `feature_log_delete_age`: Controls how long old files are kept before deletion. Default is 3 days
+- `feature_log_roll_file_index`: Rollover file index strategy (`min`, `max`, or `nomax`). Default is `min`
+- `feature_log_delete_count`: Hard cap on the number of retained rolled files, enforced by the Delete action. Default is `-1` (disabled).
 - `feature_log_roll_size_mb`: Log rotation size. Default is 1024 MB, meaning a new file is created every 1 GB
 
 ## BE/CN Logging in detail

--- a/docs/ja/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/ja/administration/management/FE_parameters/log_server_meta.md
@@ -63,6 +63,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：監査ログファイルの保持期間。デフォルト値 `30d` は、各監査ログファイルが 30 日間保持できることを指定します。StarRocks は各監査ログファイルをチェックし、30 日以上前に生成されたファイルを削除します。
 - 導入時期：-
 
+### `audit_log_delete_count`
+
+- デフォルト：-1
+- タイプ：Int
+- 単位：-
+- 変更可能：No
+- 説明：ディスク上に保持される `fe.audit.log` のロールされたアーカイブ数の上限（ハードキャップ）。Log4j の `Delete` アクションが `IfAccumulatedFileCount` 条件を用いて適用します。`0` 以下の場合はキャップを無効化します（保持は `audit_log_delete_age` のみで制御）。正の値を設定すると、アーカイブは `audit_log_delete_age` より古い場合、または最新の `audit_log_delete_count` 個に含まれない場合に削除されます。主に `audit_log_roll_file_index = nomax` と併用してディスク使用量を制限するために使用します。
+- 導入時期：-
+
 ### `audit_log_dir`
 
 - デフォルト：`StarRocksFE.STARROCKS_HOME_DIR` + "/log"
@@ -97,6 +106,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 単位：-
 - 変更可能：No
 - 説明：StarRocks が監査ログエントリを生成するモジュール。デフォルトでは、StarRocks は `slow_query` モジュールと `query` モジュールの監査ログを生成します。`connection` モジュールは v3.0 以降でサポートされています。モジュール名をコンマ (,) とスペースで区切ります。
+- 導入時期：-
+
+### `audit_log_roll_file_index`
+
+- デフォルト：min
+- タイプ：String
+- 単位：-
+- 変更可能：No
+- 説明：Log4j の `DefaultRolloverStrategy` が `fe.audit.log` に使用するロールオーバーのファイルインデックス戦略。有効な値は `min`、`max`、`nomax` です。`min` の場合、Log4j は最大 `audit_log_roll_num` 個のアーカイブを保持し、ロールオーバーのたびにインデックスをシフトして最新のアーカイブを最小のインデックスに配置します。`max` の場合、Log4j も最大 `audit_log_roll_num` 個のアーカイブを保持しますが、最新のアーカイブを最大のインデックスに配置します。`nomax` の場合、Log4j はインデックスを単調増加させ、既存のアーカイブをリネームしません。`nomax` は Log4j に `max`（`audit_log_roll_num`）の上限を無視させるため、ディスク使用量を制限するには `audit_log_delete_count` を設定してください。無効な値はログ初期化時に IOException を発生させます。
 - 導入時期：-
 
 ### `audit_log_roll_interval`
@@ -137,6 +155,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：FE の大容量クエリログファイル (`fe.big_query.log.*`) が自動削除されるまでの保持期間を制御します。この値は、Log4j の削除ポリシーに IfLastModified age として渡されます。最終更新時刻がこの値よりも古いローテーションされた大容量クエリログは削除されます。`d` (日)、`h` (時間)、`m` (分)、`s` (秒) などの接尾辞をサポートしています。例: `7d` (7 日間)、`10h` (10 時間)、`60m` (60 分)、`120s` (120 秒)。この項目は `big_query_log_roll_interval` および `big_query_log_roll_num` と連携して、どのファイルを保持またはパージするかを決定します。
 - 導入時期：v3.2.0
 
+### `big_query_log_delete_count`
+
+- デフォルト：-1
+- タイプ：Int
+- 単位：-
+- 変更可能：No
+- 説明：ディスク上に保持される `fe.big_query.log` のロールされたアーカイブ数の上限（ハードキャップ）。Log4j の `Delete` アクションが `IfAccumulatedFileCount` 条件を用いて適用します。`0` 以下の場合はキャップを無効化します（保持は `big_query_log_delete_age` のみで制御）。正の値を設定すると、アーカイブは `big_query_log_delete_age` より古い場合、または最新の `big_query_log_delete_count` 個に含まれない場合に削除されます。主に `big_query_log_roll_file_index = nomax` と併用してディスク使用量を制限するために使用します。
+- 導入時期：-
+
 ### `big_query_log_dir`
 
 - デフォルト：`Config.STARROCKS_HOME_DIR + "/log"`
@@ -154,6 +181,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 変更可能：No
 - 説明：モジュールごとの大容量クエリロギングを有効にするモジュール名サフィックスのリスト。一般的な値は論理コンポーネント名です。たとえば、デフォルトの `query` は `big_query.query` を生成します。
 - 導入時期：v3.2.0
+
+### `big_query_log_roll_file_index`
+
+- デフォルト：min
+- タイプ：String
+- 単位：-
+- 変更可能：No
+- 説明：Log4j の `DefaultRolloverStrategy` が `fe.big_query.log` に使用するロールオーバーのファイルインデックス戦略。有効な値は `min`、`max`、`nomax` です。`min` の場合、Log4j は最大 `big_query_log_roll_num` 個のアーカイブを保持し、ロールオーバーのたびにインデックスをシフトして最新のアーカイブを最小のインデックスに配置します。`max` の場合、Log4j も最大 `big_query_log_roll_num` 個のアーカイブを保持しますが、最新のアーカイブを最大のインデックスに配置します。`nomax` の場合、Log4j はインデックスを単調増加させ、既存のアーカイブをリネームしません。`nomax` は Log4j に `max`（`big_query_log_roll_num`）の上限を無視させるため、ディスク使用量を制限するには `big_query_log_delete_count` を設定してください。無効な値はログ初期化時に IOException を発生させます。
+- 導入時期：-
 
 ### `big_query_log_roll_interval`
 
@@ -182,6 +218,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：ダンプログファイルの保持期間。デフォルト値 `7d` は、各ダンプログファイルが 7 日間保持できることを指定します。StarRocks は各ダンプログファイルをチェックし、7 日以上前に生成されたファイルを削除します。
 - 導入時期：-
 
+### `dump_log_delete_count`
+
+- デフォルト：-1
+- タイプ：Int
+- 単位：-
+- 変更可能：No
+- 説明：ディスク上に保持される `fe.dump.log` のロールされたアーカイブ数の上限（ハードキャップ）。Log4j の `Delete` アクションが `IfAccumulatedFileCount` 条件を用いて適用します。`0` 以下の場合はキャップを無効化します（保持は `dump_log_delete_age` のみで制御）。正の値を設定すると、アーカイブは `dump_log_delete_age` より古い場合、または最新の `dump_log_delete_count` 個に含まれない場合に削除されます。主に `dump_log_roll_file_index = nomax` と併用してディスク使用量を制限するために使用します。
+- 導入時期：-
+
 ### `dump_log_dir`
 
 - デフォルト：`StarRocksFE.STARROCKS_HOME_DIR` + "/log"
@@ -198,6 +243,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 単位：-
 - 変更可能：No
 - 説明：StarRocks がダンプログエントリを生成するモジュール。デフォルトでは、StarRocks はクエリモジュールのダンプログを生成します。モジュール名をコンマ (,) とスペースで区切ります。
+- 導入時期：-
+
+### `dump_log_roll_file_index`
+
+- デフォルト：min
+- タイプ：String
+- 単位：-
+- 変更可能：No
+- 説明：Log4j の `DefaultRolloverStrategy` が `fe.dump.log` に使用するロールオーバーのファイルインデックス戦略。有効な値は `min`、`max`、`nomax` です。`min` の場合、Log4j は最大 `dump_log_roll_num` 個のアーカイブを保持し、ロールオーバーのたびにインデックスをシフトして最新のアーカイブを最小のインデックスに配置します。`max` の場合、Log4j も最大 `dump_log_roll_num` 個のアーカイブを保持しますが、最新のアーカイブを最大のインデックスに配置します。`nomax` の場合、Log4j はインデックスを単調増加させ、既存のアーカイブをリネームしません。`nomax` は Log4j に `max`（`dump_log_roll_num`）の上限を無視させるため、ディスク使用量を制限するには `dump_log_delete_count` を設定してください。無効な値はログ初期化時に IOException を発生させます。
 - 導入時期：-
 
 ### `dump_log_roll_interval`
@@ -265,6 +319,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：この項目が `true` に設定されている場合、システムはログ、クエリ詳細レコード、およびクエリプロファイルに書き込まれる前に機密性の高い SQL コンテンツを置き換えるか隠します。この設定を尊重するコードパスには、ConnectProcessor.formatStmt (監査ログ)、StmtExecutor.addRunningQueryDetail (クエリ詳細)、SimpleExecutor.formatSQL (内部エクゼキュータログ)、および StmtExecutor.buildTopLevelProfile / processProfileAsync (プロファイルの `Summary` セクションに格納される `Sql Statement` および `ExplainPlan` info-string) が含まれます。この機能が有効になっている場合、無効な SQL は固定の非機密化メッセージに置き換えられる可能性があり、資格情報 (ユーザー/パスワード) は隠され、SQL フォーマッターはサニタイズされた表現を生成する必要があります (ダイジェスト形式の出力を有効にすることもできます)。セッション変数 `enable_explain_in_profile` によって追加される `ExplainPlan` フィールドについても、本設定により埋め込まれる `EXPLAIN COSTS` テキストのリテラルが強制的にダイジェスト化されるため、プロファイル内で `Sql Statement` が非機密化されているにもかかわらず `ExplainPlan` が元のリテラルを露出してしまうことを防ぎます。これにより、監査/内部ログおよびプロファイルでの機密リテラルや資格情報の漏洩が減少しますが、ログ、クエリ詳細、およびプロファイルに元の完全な SQL テキストが含まれなくなることになります (これは再生やデバッグに影響する可能性があります)。
 - 導入時期：-
 
+### `feature_log_delete_count`
+
+- デフォルト：-1
+- タイプ：Int
+- 単位：-
+- 変更可能：No
+- 説明：ディスク上に保持される `fe.features.log` のロールされたアーカイブ数の上限（ハードキャップ）。Log4j の `Delete` アクションが `IfAccumulatedFileCount` 条件を用いて適用します。`0` 以下の場合はキャップを無効化します（保持は `feature_log_delete_age` のみで制御）。正の値を設定すると、アーカイブは `feature_log_delete_age` より古い場合、または最新の `feature_log_delete_count` 個に含まれない場合に削除されます。主に `feature_log_roll_file_index = nomax` と併用してディスク使用量を制限するために使用します。
+- 導入時期：-
+
+### `feature_log_roll_file_index`
+
+- デフォルト：min
+- タイプ：String
+- 単位：-
+- 変更可能：No
+- 説明：Log4j の `DefaultRolloverStrategy` が `fe.features.log` に使用するロールオーバーのファイルインデックス戦略。有効な値は `min`、`max`、`nomax` です。`min` の場合、Log4j は最大 `feature_log_roll_num` 個のアーカイブを保持し、ロールオーバーのたびにインデックスをシフトして最新のアーカイブを最小のインデックスに配置します。`max` の場合、Log4j も最大 `feature_log_roll_num` 個のアーカイブを保持しますが、最新のアーカイブを最大のインデックスに配置します。`nomax` の場合、Log4j はインデックスを単調増加させ、既存のアーカイブをリネームしません。`nomax` は Log4j に `max`（`feature_log_roll_num`）の上限を無視させるため、ディスク使用量を制限するには `feature_log_delete_count` を設定してください。無効な値はログ初期化時に IOException を発生させます。
+- 導入時期：-
+
 ### `internal_log_delete_age`
 
 - デフォルト：7d
@@ -273,6 +345,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 変更可能：No
 - 説明：FE 内部ログファイル (`internal_log_dir` に書き込まれます) の保持期間を指定します。値は期間文字列です。サポートされている接尾辞: `d` (日)、`h` (時間)、`m` (分)、`s` (秒)。例: `7d` (7 日間)、`10h` (10 時間)、`60m` (60 分)、`120s` (120 秒)。この項目は、RollingFile Delete ポリシーで使用される `<IfLastModified age="..."/>` 述語として log4j 設定に代入されます。最終変更時刻がこの期間よりも古いファイルは、ログのロールオーバー中に削除されます。この値を増やすとディスク領域をより早く解放できます。減らすと内部マテリアライズドビューまたは統計ログをより長く保持できます。
 - 導入時期：v3.2.4
+
+### `internal_log_delete_count`
+
+- デフォルト：-1
+- タイプ：Int
+- 単位：-
+- 変更可能：No
+- 説明：ディスク上に保持される `fe.internal.log` のロールされたアーカイブ数の上限（ハードキャップ）。Log4j の `Delete` アクションが `IfAccumulatedFileCount` 条件を用いて適用します。`0` 以下の場合はキャップを無効化します（保持は `internal_log_delete_age` のみで制御）。正の値を設定すると、アーカイブは `internal_log_delete_age` より古い場合、または最新の `internal_log_delete_count` 個に含まれない場合に削除されます。主に `internal_log_roll_file_index = nomax` と併用してディスク使用量を制限するために使用します。
+- 導入時期：-
 
 ### `internal_log_dir`
 
@@ -300,6 +381,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 変更可能：No
 - 説明：専用の内部ロギングを受け取るモジュール識別子のリスト。各エントリ X について、Log4j はレベル INFO と additivity="false" の `internal.<X>` という名前のロガーを作成します。これらのロガーは、内部アペンダー ( `fe.internal.log` に書き込まれます) または `sys_log_to_console` が有効になっている場合はコンソールにルーティングされます。必要に応じて短い名前またはパッケージフラグメントを使用します。正確なロガー名は `internal.` + 構成された文字列になります。内部ログファイルのローテーションと保持は、`internal_log_dir`、`internal_log_roll_num`、`internal_log_delete_age`、`internal_log_roll_interval`、および `log_roll_size_mb` に従います。モジュールを追加すると、実行時メッセージが内部ロガーストリームに分離され、デバッグと監査が容易になります。
 - 導入時期：v3.2.4
+
+### `internal_log_roll_file_index`
+
+- デフォルト：min
+- タイプ：String
+- 単位：-
+- 変更可能：No
+- 説明：Log4j の `DefaultRolloverStrategy` が `fe.internal.log` に使用するロールオーバーのファイルインデックス戦略。有効な値は `min`、`max`、`nomax` です。`min` の場合、Log4j は最大 `internal_log_roll_num` 個のアーカイブを保持し、ロールオーバーのたびにインデックスをシフトして最新のアーカイブを最小のインデックスに配置します。`max` の場合、Log4j も最大 `internal_log_roll_num` 個のアーカイブを保持しますが、最新のアーカイブを最大のインデックスに配置します。`nomax` の場合、Log4j はインデックスを単調増加させ、既存のアーカイブをリネームしません。`nomax` は Log4j に `max`（`internal_log_roll_num`）の上限を無視させるため、ディスク使用量を制限するには `internal_log_delete_count` を設定してください。無効な値はログ初期化時に IOException を発生させます。
+- 導入時期：-
 
 ### `internal_log_roll_interval`
 
@@ -391,6 +481,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：システムログファイルまたは監査ログファイルの最大サイズ。
 - 導入時期：-
 
+### `plan_log_delete_count`
+
+- デフォルト：-1
+- タイプ：Int
+- 単位：-
+- 変更可能：No
+- 説明：ディスク上に保持される `fe.plan.log` のロールされたアーカイブ数の上限（ハードキャップ）。Log4j の `Delete` アクションが `IfAccumulatedFileCount` 条件を用いて適用します。`0` 以下の場合はキャップを無効化します（保持は `plan_log_delete_age` のみで制御）。正の値を設定すると、アーカイブは `plan_log_delete_age` より古い場合、または最新の `plan_log_delete_count` 個に含まれない場合に削除されます。主に `plan_log_roll_file_index = nomax` と併用してディスク使用量を制限するために使用します。
+- 導入時期：-
+
+### `plan_log_roll_file_index`
+
+- デフォルト：min
+- タイプ：String
+- 単位：-
+- 変更可能：No
+- 説明：Log4j の `DefaultRolloverStrategy` が `fe.plan.log` に使用するロールオーバーのファイルインデックス戦略。有効な値は `min`、`max`、`nomax` です。`min` の場合、Log4j は最大 `plan_log_roll_num` 個のアーカイブを保持し、ロールオーバーのたびにインデックスをシフトして最新のアーカイブを最小のインデックスに配置します。`max` の場合、Log4j も最大 `plan_log_roll_num` 個のアーカイブを保持しますが、最新のアーカイブを最大のインデックスに配置します。`nomax` の場合、Log4j はインデックスを単調増加させ、既存のアーカイブをリネームしません。`nomax` は Log4j に `max`（`plan_log_roll_num`）の上限を無視させるため、ディスク使用量を制限するには `plan_log_delete_count` を設定してください。無効な値はログ初期化時に IOException を発生させます。
+- 導入時期：-
+
 ### `proc_profile_file_retained_days`
 
 - デフォルト：1
@@ -418,6 +526,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：FE プロファイルログファイルが削除対象となるまでの保持期間を制御します。この値は Log4j の `<IfLastModified age="..."/>` ポリシー (`Log4jConfig` 経由) に注入され、`profile_log_roll_interval` や `profile_log_roll_num` などのローテーション設定と組み合わせて適用されます。サポートされる接尾辞: `d` (日)、`h` (時間)、`m` (分)、`s` (秒)。例: `7d` (7 日間)、`10h` (10 時間)、`60m` (60 分)、`120s` (120 秒)。
 - 導入時期：v3.2.5
 
+### `profile_log_delete_count`
+
+- デフォルト：-1
+- タイプ：Int
+- 単位：-
+- 変更可能：No
+- 説明：ディスク上に保持される `fe.profile.log` のロールされたアーカイブ数の上限（ハードキャップ）。Log4j の `Delete` アクションが `IfAccumulatedFileCount` 条件を用いて適用します。`0` 以下の場合はキャップを無効化します（保持は `profile_log_delete_age` のみで制御）。正の値を設定すると、アーカイブは `profile_log_delete_age` より古い場合、または最新の `profile_log_delete_count` 個に含まれない場合に削除されます。主に `profile_log_roll_file_index = nomax` と併用してディスク使用量を制限するために使用します。
+- 導入時期：-
+
 ### `profile_log_dir`
 
 - デフォルト：`Config.STARROCKS_HOME_DIR` + "/log"
@@ -435,6 +552,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 単位：Milliseconds
 - 変更可能：Yes
 - 説明：`fe.profile.log` に書き込むクエリの最小レイテンシ（ミリ秒）。実行時間がこの値以上の場合にのみ profile を記録します。0 に設定するとすべての profile を記録します（しきい値なし）。正の値に設定すると、遅いクエリのみを記録してログ量を削減できます。
+- 導入時期：-
+
+### `profile_log_roll_file_index`
+
+- デフォルト：min
+- タイプ：String
+- 単位：-
+- 変更可能：No
+- 説明：Log4j の `DefaultRolloverStrategy` が `fe.profile.log` に使用するロールオーバーのファイルインデックス戦略。有効な値は `min`、`max`、`nomax` です。`min` の場合、Log4j は最大 `profile_log_roll_num` 個のアーカイブを保持し、ロールオーバーのたびにインデックスをシフトして最新のアーカイブを最小のインデックスに配置します。`max` の場合、Log4j も最大 `profile_log_roll_num` 個のアーカイブを保持しますが、最新のアーカイブを最大のインデックスに配置します。`nomax` の場合、Log4j はインデックスを単調増加させ、既存のアーカイブをリネームしません。`nomax` は Log4j に `max`（`profile_log_roll_num`）の上限を無視させるため、ディスク使用量を制限するには `profile_log_delete_count` を設定してください。無効な値はログ初期化時に IOException を発生させます。
 - 導入時期：-
 
 ### `profile_log_roll_interval`
@@ -509,6 +635,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：システムログファイルの保持期間。デフォルト値 `7d` は、各システムログファイルが 7 日間保持できることを指定します。StarRocks は各システムログファイルをチェックし、7 日以上前に生成されたファイルを削除します。
 - 導入時期：-
 
+### `sys_log_delete_count`
+
+- デフォルト：-1
+- タイプ：Int
+- 単位：-
+- 変更可能：No
+- 説明：ディスク上に保持される `fe.log` および `fe.warn.log` のロールされたアーカイブ数の上限（ハードキャップ）。Log4j の `Delete` アクションが `IfAccumulatedFileCount` 条件を用いて適用します。`0` 以下の場合はキャップを無効化します（保持は `sys_log_delete_age` のみで制御）。正の値を設定すると、アーカイブは `sys_log_delete_age` より古い場合、または最新の `sys_log_delete_count` 個に含まれない場合に削除されます。主に `sys_log_roll_file_index = nomax` と併用してディスク使用量を制限するために使用します。
+- 導入時期：-
+
 ### `sys_log_dir`
 
 - デフォルト：`StarRocksFE.STARROCKS_HOME_DIR` + "/log"
@@ -561,6 +696,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 単位：-
 - 変更可能：No
 - 説明：システムログエントリが分類される重大度レベル。有効な値: `INFO`、`WARN`、`ERROR`、および `FATAL`。
+- 導入時期：-
+
+### `sys_log_roll_file_index`
+
+- デフォルト：min
+- タイプ：String
+- 単位：-
+- 変更可能：No
+- 説明：Log4j の `DefaultRolloverStrategy` が `fe.log` および `fe.warn.log` に使用するロールオーバーのファイルインデックス戦略。有効な値は `min`、`max`、`nomax` です。`min` の場合、Log4j は最大 `sys_log_roll_num` 個のアーカイブを保持し、ロールオーバーのたびにインデックスをシフトして最新のアーカイブを最小のインデックスに配置します。`max` の場合、Log4j も最大 `sys_log_roll_num` 個のアーカイブを保持しますが、最新のアーカイブを最大のインデックスに配置します。`nomax` の場合、Log4j はインデックスを単調増加させ、既存のアーカイブをリネームしません。`nomax` は Log4j に `max`（`sys_log_roll_num`）の上限を無視させるため、ディスク使用量を制限するには `sys_log_delete_count` を設定してください。無効な値はログ初期化時に IOException を発生させます。
 - 導入時期：-
 
 ### `sys_log_roll_interval`

--- a/docs/ja/administration/management/logs.md
+++ b/docs/ja/administration/management/logs.md
@@ -15,6 +15,8 @@ StarRocks をデプロイおよび運用する際、ログシステムを理解�
 - `sys_log_roll_num`: ログファイルの無制限な増加を防ぐために保持するログファイルの数を制御します。デフォルトは 10
 - `sys_log_roll_interval`: ローテーションの頻度を指定します。デフォルトは `DAY` で、ログは毎日ローテーションされます
 - `sys_log_delete_age`: 古いログファイルを削除するまでの保持期間を制御します。デフォルトは 7 日
+- `sys_log_roll_file_index`: ロールオーバーのファイルインデックス戦略（`min`、`max`、`nomax`）。デフォルトは `min`
+- `sys_log_delete_count`: ディスク上に保持されるロールされたアーカイブ数の上限。Delete アクションによって適用されます。デフォルトは `-1`（無効）。
 - `sys_log_roll_mode`: ログローテーションモード。デフォルトは `SIZE-MB-1024` で、現在のログファイルが 1024 MB に達すると新しいログファイルが作成されます。`sys_log_roll_interval` と組み合わせて、FE ログは日次またはファイルサイズに基づいてローテーションされることを示します
 - `sys_log_enable_compress`: ログ圧縮が有効かどうかを制御します。デフォルトは false で、圧縮は無効です
 
@@ -85,6 +87,8 @@ StarRocks をデプロイおよび運用する際、ログシステムを理解�
 - `profile_log_roll_interval`: ローテーションの頻度を指定します。デフォルトは DAY で、日次ローテーションを意味します。ローテーション条件が満たされると、最新の 5 ファイルが保持され、古いファイルは削除されます
 - `profile_log_delete_age`: 古いファイルを削除するまでの保持期間を制御します。デフォルトは 1 日
 - `profile_log_latency_threshold_ms`: プロファイルをログに書き込むための最小クエリレイテンシ（ミリ秒）。デフォルトは 0 で、すべてのプロファイルが記録されることを意味します
+- `profile_log_roll_file_index`: ロールオーバーのファイルインデックス戦略（`min`、`max`、`nomax`）。デフォルトは `min`
+- `profile_log_delete_count`: ディスク上に保持されるロールされたアーカイブ数の上限。Delete アクションによって適用されます。デフォルトは `-1`（無効）。
 
 ### `fe.internal.log`
 
@@ -105,6 +109,8 @@ StarRocks をデプロイおよび運用する際、ログシステムを理解�
 - `internal_log_roll_num`: 保持するファイルの数。デフォルトは 90
 - `internal_log_roll_interval`: ローテーションの頻度を指定します。デフォルトは DAY で、日次ローテーションを意味します。ローテーション条件が満たされると、最新の 90 ファイルが保持され、古いファイルは削除されます
 - `internal_log_delete_age`: 古いファイルを削除するまでの保持期間を制御します。デフォルトは 7 日
+- `internal_log_roll_file_index`: ロールオーバーのファイルインデックス戦略（`min`、`max`、`nomax`）。デフォルトは `min`
+- `internal_log_delete_count`: ディスク上に保持されるロールされたアーカイブ数の上限。Delete アクションによって適用されます。デフォルトは `-1`（無効）。
 
 ### `fe.audit.log`
 
@@ -121,6 +127,8 @@ StarRocks をデプロイおよび運用する際、ログシステムを理解�
 - `audit_log_roll_num`: 保持するファイルの数。デフォルトは 90
 - `audit_log_roll_interval`: ローテーションの頻度を指定します。デフォルトは DAY で、日次ローテーションを意味します。ローテーション条件が満たされると、最新の 90 ファイルが保持され、古いファイルは削除されます
 - `audit_log_delete_age`: 古いファイルを削除するまでの保持期間を制御します。デフォルトは 7 日
+- `audit_log_roll_file_index`: ロールオーバーのファイルインデックス戦略（`min`、`max`、`nomax`）。デフォルトは `min`
+- `audit_log_delete_count`: ディスク上に保持されるロールされたアーカイブ数の上限。Delete アクションによって適用されます。デフォルトは `-1`（無効）。
 - `audit_log_json_format`: JSON 形式でログを記録するかどうか。デフォルトは false
 - `audit_log_enable_compress`: 圧縮が有効かどうか
 
@@ -138,6 +146,8 @@ StarRocks をデプロイおよび運用する際、ログシステムを理解�
 - `big_query_log_modules`: 内部ログモジュールの種類。デフォルトは query
 - `big_query_log_roll_interval`: ローテーションの頻度を指定します。デフォルトは DAY で、日次ローテーションを意味します。ローテーション条件が満たされると、最新の 10 ファイルが保持され、古いファイルは削除されます
 - `big_query_log_delete_age`: 古いファイルを削除するまでの保持期間を制御します。デフォルトは 7 日
+- `big_query_log_roll_file_index`: ロールオーバーのファイルインデックス戦略（`min`、`max`、`nomax`）。デフォルトは `min`
+- `big_query_log_delete_count`: ディスク上に保持されるロールされたアーカイブ数の上限。Delete アクションによって適用されます。デフォルトは `-1`（無効）。
 
 ### `fe.dump.log`
 
@@ -159,6 +169,8 @@ SET enable_query_dump = true;
 - `dump_log_modules`: 内部ログモジュールの種類。デフォルトは query
 - `dump_log_roll_interval`: ローテーションの頻度を指定します。デフォルトは DAY で、日次ローテーションを意味します。ローテーション条件が満たされると、最新の 10 ファイルが保持され、古いファイルは削除されます
 - `dump_log_delete_age`: 古いファイルを削除するまでの保持期間を制御します。デフォルトは 7 日
+- `dump_log_roll_file_index`: ロールオーバーのファイルインデックス戦略（`min`、`max`、`nomax`）。デフォルトは `min`
+- `dump_log_delete_count`: ディスク上に保持されるロールされたアーカイブ数の上限。Delete アクションによって適用されます。デフォルトは `-1`（無効）。
 
 ### `fe.features.log`
 これは StarRocks のクエリプラン機能ログであり、クエリ実行プランの機能情報を収集および記録するために使用されます。主に機械学習とクエリ最適化分析に役立ちます。主な目的には以下が含まれます:
@@ -183,6 +195,8 @@ enable_query_cost_prediction = false  // デフォルトでは無効
 - `feature_log_roll_num`: 保持するファイルの数。デフォルトは 5
 - `feature_log_roll_interval`: ローテーションの頻度を指定します。デフォルトは DAY で、日次ローテーションを意味します。ローテーション条件が満たされると、最新の 5 ファイルが保持され、古いファイルは削除されます
 - `feature_log_delete_age`: 古いファイルを削除するまでの保持期間を制御します。デフォルトは 3 日
+- `feature_log_roll_file_index`: ロールオーバーのファイルインデックス戦略（`min`、`max`、`nomax`）。デフォルトは `min`
+- `feature_log_delete_count`: ディスク上に保持されるロールされたアーカイブ数の上限。Delete アクションによって適用されます。デフォルトは `-1`（無効）。
 - `feature_log_roll_size_mb`: ログローテーションサイズ。デフォルトは 1024 MB で、1 GB ごとに新しいファイルが作成されます
 
 ## BE/CN ロギングの詳細

--- a/docs/zh/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/zh/administration/management/FE_parameters/log_server_meta.md
@@ -63,6 +63,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 审计日志文件的保留期限。默认值 `30d` 指定每个审计日志文件可以保留 30 天。StarRocks 会检查每个审计日志文件，并删除 30 天前生成的那些。
 - 引入版本: -
 
+### `audit_log_delete_count`
+
+- 默认值: -1
+- 类型: Int
+- 单位: -
+- 是否可变: No
+- 描述: 磁盘上保留的 `fe.audit.log` 滚动归档文件数量的硬性上限，由 Log4j `Delete` 动作通过 `IfAccumulatedFileCount` 条件强制执行。小于或等于 `0` 时禁用该上限（仅由 `audit_log_delete_age` 控制保留）。设置为正值时，当某个归档文件早于 `audit_log_delete_age` 或不在最新的 `audit_log_delete_count` 个文件之内时会被删除。该参数主要与 `audit_log_roll_file_index = nomax` 配合使用以限制磁盘占用。
+- 引入版本: -
+
 ### `audit_log_dir`
 
 - 默认值: `StarRocksFE.STARROCKS_HOME_DIR` + "/log"
@@ -97,6 +106,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 单位: -
 - 是否可变: No
 - 描述: StarRocks 为其生成审计日志条目的模块。默认情况下，StarRocks 为 `slow_query` 模块和 `query` 模块生成审计日志。`connection` 模块从 v3.0 版本开始支持。模块名称用逗号 (,) 和空格分隔。
+- 引入版本: -
+
+### `audit_log_roll_file_index`
+
+- 默认值: min
+- 类型: String
+- 单位: -
+- 是否可变: No
+- 描述: Log4j `DefaultRolloverStrategy` 为 `fe.audit.log` 使用的滚动文件索引策略。有效值为 `min`、`max` 和 `nomax`。使用 `min` 时，Log4j 最多保留 `audit_log_roll_num` 个归档文件，并在每次轮转时移动索引，使最新归档位于最小索引处。使用 `max` 时，Log4j 同样最多保留 `audit_log_roll_num` 个归档文件，但将最新归档保留在最大索引处。使用 `nomax` 时，Log4j 会持续递增索引且不重命名已有归档；由于 `nomax` 会使 Log4j 忽略 `max`（即 `audit_log_roll_num`）限制，请设置 `audit_log_delete_count` 以限制磁盘占用。无效值会在日志初始化时抛出 IOException。
 - 引入版本: -
 
 ### `audit_log_roll_interval`
@@ -146,6 +164,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 控制 FE 大查询日志文件 (`fe.big_query.log.*`) 在自动删除前的保留时间。该值作为 IfLastModified age 传递给 Log4j 的删除策略 — 任何最后修改时间早于此值的轮转大查询日志都将被删除。支持的后缀包括 `d`（天）、`h`（小时）、`m`（分钟）和 `s`（秒）。示例：`7d`（7 天）、`10h`（10 小时）、`60m`（60 分钟）和 `120s`（120 秒）。此项与 `big_query_log_roll_interval` 和 `big_query_log_roll_num` 共同决定哪些文件被保留或清除。
 - 引入版本: v3.2.0
 
+### `big_query_log_delete_count`
+
+- 默认值: -1
+- 类型: Int
+- 单位: -
+- 是否可变: No
+- 描述: 磁盘上保留的 `fe.big_query.log` 滚动归档文件数量的硬性上限，由 Log4j `Delete` 动作通过 `IfAccumulatedFileCount` 条件强制执行。小于或等于 `0` 时禁用该上限（仅由 `big_query_log_delete_age` 控制保留）。设置为正值时，当某个归档文件早于 `big_query_log_delete_age` 或不在最新的 `big_query_log_delete_count` 个文件之内时会被删除。该参数主要与 `big_query_log_roll_file_index = nomax` 配合使用以限制磁盘占用。
+- 引入版本: -
+
 ### `big_query_log_dir`
 
 - 默认值: `Config.STARROCKS_HOME_DIR + "/log"`
@@ -163,6 +190,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 是否可变: No
 - 描述: 启用每个模块大查询日志记录的模块名称后缀列表。典型值是逻辑组件名称。例如，默认的 `query` 会生成 `big_query.query`。
 - 引入版本: v3.2.0
+
+### `big_query_log_roll_file_index`
+
+- 默认值: min
+- 类型: String
+- 单位: -
+- 是否可变: No
+- 描述: Log4j `DefaultRolloverStrategy` 为 `fe.big_query.log` 使用的滚动文件索引策略。有效值为 `min`、`max` 和 `nomax`。使用 `min` 时，Log4j 最多保留 `big_query_log_roll_num` 个归档文件，并在每次轮转时移动索引，使最新归档位于最小索引处。使用 `max` 时，Log4j 同样最多保留 `big_query_log_roll_num` 个归档文件，但将最新归档保留在最大索引处。使用 `nomax` 时，Log4j 会持续递增索引且不重命名已有归档；由于 `nomax` 会使 Log4j 忽略 `max`（即 `big_query_log_roll_num`）限制，请设置 `big_query_log_delete_count` 以限制磁盘占用。无效值会在日志初始化时抛出 IOException。
+- 引入版本: -
 
 ### `big_query_log_roll_interval`
 
@@ -191,6 +227,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: dump 日志文件的保留期限。默认值 `7d` 指定每个 dump 日志文件可以保留 7 天。StarRocks 会检查每个 dump 日志文件，并删除 7 天前生成的那些。
 - 引入版本: -
 
+### `dump_log_delete_count`
+
+- 默认值: -1
+- 类型: Int
+- 单位: -
+- 是否可变: No
+- 描述: 磁盘上保留的 `fe.dump.log` 滚动归档文件数量的硬性上限，由 Log4j `Delete` 动作通过 `IfAccumulatedFileCount` 条件强制执行。小于或等于 `0` 时禁用该上限（仅由 `dump_log_delete_age` 控制保留）。设置为正值时，当某个归档文件早于 `dump_log_delete_age` 或不在最新的 `dump_log_delete_count` 个文件之内时会被删除。该参数主要与 `dump_log_roll_file_index = nomax` 配合使用以限制磁盘占用。
+- 引入版本: -
+
 ### `dump_log_dir`
 
 - 默认值: `StarRocksFE.STARROCKS_HOME_DIR` + "/log"
@@ -207,6 +252,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 单位: -
 - 是否可变: No
 - 描述: StarRocks 为其生成 dump 日志条目的模块。默认情况下，StarRocks 为 query 模块生成 dump 日志。模块名称用逗号 (,) 和空格分隔。
+- 引入版本: -
+
+### `dump_log_roll_file_index`
+
+- 默认值: min
+- 类型: String
+- 单位: -
+- 是否可变: No
+- 描述: Log4j `DefaultRolloverStrategy` 为 `fe.dump.log` 使用的滚动文件索引策略。有效值为 `min`、`max` 和 `nomax`。使用 `min` 时，Log4j 最多保留 `dump_log_roll_num` 个归档文件，并在每次轮转时移动索引，使最新归档位于最小索引处。使用 `max` 时，Log4j 同样最多保留 `dump_log_roll_num` 个归档文件，但将最新归档保留在最大索引处。使用 `nomax` 时，Log4j 会持续递增索引且不重命名已有归档；由于 `nomax` 会使 Log4j 忽略 `max`（即 `dump_log_roll_num`）限制，请设置 `dump_log_delete_count` 以限制磁盘占用。无效值会在日志初始化时抛出 IOException。
 - 引入版本: -
 
 ### `dump_log_roll_interval`
@@ -274,6 +328,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 当此项设置为 `true` 时，系统会在将敏感 SQL 内容写入日志、查询详细记录以及查询 profile 之前替换或隐藏这些内容。遵循此配置的代码路径包括 ConnectProcessor.formatStmt（审计日志）、StmtExecutor.addRunningQueryDetail（查询详细信息）、SimpleExecutor.formatSQL（内部执行器日志），以及 StmtExecutor.buildTopLevelProfile / processProfileAsync（profile 的 `Summary` 段中的 `Sql Statement` 与 `ExplainPlan` info-string）。启用此功能后，无效的 SQL 可能会被替换为固定的脱敏消息，凭据（用户/密码）将被隐藏，并且 SQL 格式化程序必须生成 sanitized 表示（它还可以启用摘要式输出）。对于通过会话变量 `enable_explain_in_profile` 加入的 `ExplainPlan` 字段，此配置还会强制对嵌入的 `EXPLAIN COSTS` 文本启用文字（literal）摘要渲染，从而避免 profile 中的 `Sql Statement` 已被脱敏但 `ExplainPlan` 仍然暴露原始字面量。这减少了审计/内部日志和 profile 中敏感字面量和凭据的泄露，但也意味着日志、查询详细信息和 profile 不再包含原始完整 SQL 文本（这可能会影响回放或调试）。
 - 引入版本: -
 
+### `feature_log_delete_count`
+
+- 默认值: -1
+- 类型: Int
+- 单位: -
+- 是否可变: No
+- 描述: 磁盘上保留的 `fe.features.log` 滚动归档文件数量的硬性上限，由 Log4j `Delete` 动作通过 `IfAccumulatedFileCount` 条件强制执行。小于或等于 `0` 时禁用该上限（仅由 `feature_log_delete_age` 控制保留）。设置为正值时，当某个归档文件早于 `feature_log_delete_age` 或不在最新的 `feature_log_delete_count` 个文件之内时会被删除。该参数主要与 `feature_log_roll_file_index = nomax` 配合使用以限制磁盘占用。
+- 引入版本: -
+
+### `feature_log_roll_file_index`
+
+- 默认值: min
+- 类型: String
+- 单位: -
+- 是否可变: No
+- 描述: Log4j `DefaultRolloverStrategy` 为 `fe.features.log` 使用的滚动文件索引策略。有效值为 `min`、`max` 和 `nomax`。使用 `min` 时，Log4j 最多保留 `feature_log_roll_num` 个归档文件，并在每次轮转时移动索引，使最新归档位于最小索引处。使用 `max` 时，Log4j 同样最多保留 `feature_log_roll_num` 个归档文件，但将最新归档保留在最大索引处。使用 `nomax` 时，Log4j 会持续递增索引且不重命名已有归档；由于 `nomax` 会使 Log4j 忽略 `max`（即 `feature_log_roll_num`）限制，请设置 `feature_log_delete_count` 以限制磁盘占用。无效值会在日志初始化时抛出 IOException。
+- 引入版本: -
+
 ### `internal_log_delete_age`
 
 - 默认值: 7d
@@ -282,6 +354,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 是否可变: No
 - 描述: 指定 FE 内部日志文件（写入 `internal_log_dir`）的保留期限。该值是一个持续时间字符串。支持的后缀：`d`（天）、`h`（小时）、`m`（分钟）、`s`（秒）。示例：`7d`（7 天）、`10h`（10 小时）、`60m`（60 分钟）、`120s`（120 秒）。此项作为 `<IfLastModified age="..."/>` 谓词替换到 Log4j 配置中，该谓词由 RollingFile Delete 策略使用。最后修改时间早于此持续时间的文件将在日志轮转期间删除。增加此值可更快释放磁盘空间，或减少此值可更长时间保留内部物化视图或统计信息日志。
 - 引入版本: v3.2.4
+
+### `internal_log_delete_count`
+
+- 默认值: -1
+- 类型: Int
+- 单位: -
+- 是否可变: No
+- 描述: 磁盘上保留的 `fe.internal.log` 滚动归档文件数量的硬性上限，由 Log4j `Delete` 动作通过 `IfAccumulatedFileCount` 条件强制执行。小于或等于 `0` 时禁用该上限（仅由 `internal_log_delete_age` 控制保留）。设置为正值时，当某个归档文件早于 `internal_log_delete_age` 或不在最新的 `internal_log_delete_count` 个文件之内时会被删除。该参数主要与 `internal_log_roll_file_index = nomax` 配合使用以限制磁盘占用。
+- 引入版本: -
 
 ### `internal_log_dir`
 
@@ -309,6 +390,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 是否可变: No
 - 描述: 将接收专用内部日志记录的模块标识符列表。对于每个条目 X，Log4j 将创建一个名为 `internal.<X>` 的日志记录器，其级别为 INFO，并且 additivity="false"。这些日志记录器被路由到内部 appender（写入 `fe.internal.log`），或者在 `sys_log_to_console` 启用时路由到控制台。根据需要使用短名称或包片段 — 确切的日志记录器名称变为 `internal.` + 配置的字符串。内部日志文件轮转和保留遵循 `internal_log_dir`、`internal_log_roll_num`、`internal_log_delete_age`、`internal_log_roll_interval` 和 `log_roll_size_mb`。添加模块会导致其运行时消息分离到内部日志记录器流中，以便于调试和审计。
 - 引入版本: v3.2.4
+
+### `internal_log_roll_file_index`
+
+- 默认值: min
+- 类型: String
+- 单位: -
+- 是否可变: No
+- 描述: Log4j `DefaultRolloverStrategy` 为 `fe.internal.log` 使用的滚动文件索引策略。有效值为 `min`、`max` 和 `nomax`。使用 `min` 时，Log4j 最多保留 `internal_log_roll_num` 个归档文件，并在每次轮转时移动索引，使最新归档位于最小索引处。使用 `max` 时，Log4j 同样最多保留 `internal_log_roll_num` 个归档文件，但将最新归档保留在最大索引处。使用 `nomax` 时，Log4j 会持续递增索引且不重命名已有归档；由于 `nomax` 会使 Log4j 忽略 `max`（即 `internal_log_roll_num`）限制，请设置 `internal_log_delete_count` 以限制磁盘占用。无效值会在日志初始化时抛出 IOException。
+- 引入版本: -
 
 ### `internal_log_roll_interval`
 
@@ -400,6 +490,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 系统日志文件或审计日志文件的最大大小。
 - 引入版本: -
 
+### `plan_log_delete_count`
+
+- 默认值: -1
+- 类型: Int
+- 单位: -
+- 是否可变: No
+- 描述: 磁盘上保留的 `fe.plan.log` 滚动归档文件数量的硬性上限，由 Log4j `Delete` 动作通过 `IfAccumulatedFileCount` 条件强制执行。小于或等于 `0` 时禁用该上限（仅由 `plan_log_delete_age` 控制保留）。设置为正值时，当某个归档文件早于 `plan_log_delete_age` 或不在最新的 `plan_log_delete_count` 个文件之内时会被删除。该参数主要与 `plan_log_roll_file_index = nomax` 配合使用以限制磁盘占用。
+- 引入版本: -
+
+### `plan_log_roll_file_index`
+
+- 默认值: min
+- 类型: String
+- 单位: -
+- 是否可变: No
+- 描述: Log4j `DefaultRolloverStrategy` 为 `fe.plan.log` 使用的滚动文件索引策略。有效值为 `min`、`max` 和 `nomax`。使用 `min` 时，Log4j 最多保留 `plan_log_roll_num` 个归档文件，并在每次轮转时移动索引，使最新归档位于最小索引处。使用 `max` 时，Log4j 同样最多保留 `plan_log_roll_num` 个归档文件，但将最新归档保留在最大索引处。使用 `nomax` 时，Log4j 会持续递增索引且不重命名已有归档；由于 `nomax` 会使 Log4j 忽略 `max`（即 `plan_log_roll_num`）限制，请设置 `plan_log_delete_count` 以限制磁盘占用。无效值会在日志初始化时抛出 IOException。
+- 引入版本: -
+
 ### `proc_profile_file_retained_days`
 
 - 默认值: 1
@@ -427,6 +535,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 控制 FE profile 日志文件在符合删除条件之前保留多长时间。该值注入到 Log4j 的 `<IfLastModified age="..."/>` 策略（通过 `Log4jConfig`）中，并与轮转设置（如 `profile_log_roll_interval` 和 `profile_log_roll_num`）一起应用。支持的后缀：`d`（天）、`h`（小时）、`m`（分钟）、`s`（秒）。例如：`7d`（7 天）、`10h`（10 小时）、`60m`（60 分钟）、`120s`（120 秒）。
 - 引入版本: v3.2.5
 
+### `profile_log_delete_count`
+
+- 默认值: -1
+- 类型: Int
+- 单位: -
+- 是否可变: No
+- 描述: 磁盘上保留的 `fe.profile.log` 滚动归档文件数量的硬性上限，由 Log4j `Delete` 动作通过 `IfAccumulatedFileCount` 条件强制执行。小于或等于 `0` 时禁用该上限（仅由 `profile_log_delete_age` 控制保留）。设置为正值时，当某个归档文件早于 `profile_log_delete_age` 或不在最新的 `profile_log_delete_count` 个文件之内时会被删除。该参数主要与 `profile_log_roll_file_index = nomax` 配合使用以限制磁盘占用。
+- 引入版本: -
+
 ### `profile_log_dir`
 
 - 默认值: `Config.STARROCKS_HOME_DIR` + "/log"
@@ -444,6 +561,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 是否动态：是
 - 描述：写入 `fe.profile.log` 的查询最小延迟（毫秒）。仅当查询执行时间大于或等于该值时才记录 profile。设为 0 表示记录所有 profile（无阈值）。设为正数可仅记录较慢的查询以降低日志量。
 - 引入版本：-
+
+### `profile_log_roll_file_index`
+
+- 默认值: min
+- 类型: String
+- 单位: -
+- 是否可变: No
+- 描述: Log4j `DefaultRolloverStrategy` 为 `fe.profile.log` 使用的滚动文件索引策略。有效值为 `min`、`max` 和 `nomax`。使用 `min` 时，Log4j 最多保留 `profile_log_roll_num` 个归档文件，并在每次轮转时移动索引，使最新归档位于最小索引处。使用 `max` 时，Log4j 同样最多保留 `profile_log_roll_num` 个归档文件，但将最新归档保留在最大索引处。使用 `nomax` 时，Log4j 会持续递增索引且不重命名已有归档；由于 `nomax` 会使 Log4j 忽略 `max`（即 `profile_log_roll_num`）限制，请设置 `profile_log_delete_count` 以限制磁盘占用。无效值会在日志初始化时抛出 IOException。
+- 引入版本: -
 
 ### `profile_log_roll_interval`
 
@@ -517,6 +643,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 系统日志文件的保留期限。默认值 `7d` 指定每个系统日志文件可以保留 7 天。StarRocks 会检查每个系统日志文件，并删除 7 天前生成的那些。
 - 引入版本: -
 
+### `sys_log_delete_count`
+
+- 默认值: -1
+- 类型: Int
+- 单位: -
+- 是否可变: No
+- 描述: 磁盘上保留的 `fe.log` 和 `fe.warn.log` 滚动归档文件数量的硬性上限，由 Log4j `Delete` 动作通过 `IfAccumulatedFileCount` 条件强制执行。小于或等于 `0` 时禁用该上限（仅由 `sys_log_delete_age` 控制保留）。设置为正值时，当某个归档文件早于 `sys_log_delete_age` 或不在最新的 `sys_log_delete_count` 个文件之内时会被删除。该参数主要与 `sys_log_roll_file_index = nomax` 配合使用以限制磁盘占用。
+- 引入版本: -
+
 ### `sys_log_dir`
 
 - 默认值: `StarRocksFE.STARROCKS_HOME_DIR` + "/log"
@@ -569,6 +704,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 单位: -
 - 是否可变: No
 - 描述: 系统日志条目分类的严重性级别。有效值：`INFO`、`WARN`、`ERROR` 和 `FATAL`。
+- 引入版本: -
+
+### `sys_log_roll_file_index`
+
+- 默认值: min
+- 类型: String
+- 单位: -
+- 是否可变: No
+- 描述: Log4j `DefaultRolloverStrategy` 为 `fe.log` 和 `fe.warn.log` 使用的滚动文件索引策略。有效值为 `min`、`max` 和 `nomax`。使用 `min` 时，Log4j 最多保留 `sys_log_roll_num` 个归档文件，并在每次轮转时移动索引，使最新归档位于最小索引处。使用 `max` 时，Log4j 同样最多保留 `sys_log_roll_num` 个归档文件，但将最新归档保留在最大索引处。使用 `nomax` 时，Log4j 会持续递增索引且不重命名已有归档；由于 `nomax` 会使 Log4j 忽略 `max`（即 `sys_log_roll_num`）限制，请设置 `sys_log_delete_count` 以限制磁盘占用。无效值会在日志初始化时抛出 IOException。
 - 引入版本: -
 
 ### `sys_log_roll_interval`

--- a/docs/zh/administration/management/logs.md
+++ b/docs/zh/administration/management/logs.md
@@ -20,6 +20,8 @@ keywords: ['shen ji ri zhi']
 - `sys_log_roll_num`: 控制保留的日志文件数量，以防止无限增长消耗过多磁盘空间。默认是10
 - `sys_log_roll_interval`: 指定轮换频率。默认是`DAY`，意味着日志每天轮换
 - `sys_log_delete_age`: 控制旧日志文件在删除前保留的时间。默认是7天
+- `sys_log_roll_file_index`: 滚动文件索引策略（`min`、`max` 或 `nomax`）。默认是 `min`
+- `sys_log_delete_count`: 磁盘上保留的滚动归档文件数量的硬性上限，由 Delete 动作强制执行。默认是 `-1`（禁用）。
 - `sys_log_roll_mode`: 日志轮换模式。默认是`SIZE-MB-1024`，意味着当前日志文件达到1024 MB时将创建新文件。与sys_log_roll_interval结合使用，表示FE日志可以按天或文件大小轮换
 - `sys_log_enable_compress`: 控制是否启用日志压缩。默认是false，意味着压缩未启用
 
@@ -90,6 +92,8 @@ keywords: ['shen ji ri zhi']
 - `profile_log_roll_interval`: 指定轮换频率。默认是DAY，意味着每天轮换。当满足轮换条件时，保留最新的5个文件，删除旧文件
 - `profile_log_delete_age`: 控制旧文件在删除前保留的时间。默认是1天
 - `profile_log_latency_threshold_ms`: 将 profile 写入日志所需的最小查询延迟（毫秒）。默认是 0，表示记录所有 profile
+- `profile_log_roll_file_index`: 滚动文件索引策略（`min`、`max` 或 `nomax`）。默认是 `min`
+- `profile_log_delete_count`: 磁盘上保留的滚动归档文件数量的硬性上限，由 Delete 动作强制执行。默认是 `-1`（禁用）。
 
 ### `fe.internal.log`
 
@@ -110,6 +114,8 @@ keywords: ['shen ji ri zhi']
 - `internal_log_roll_num`: 保留的文件数量。默认是90
 - `internal_log_roll_interval`: 指定轮换频率。默认是DAY，意味着每天轮换。当满足轮换条件时，保留最新的90个文件，删除旧文件
 - `internal_log_delete_age`: 控制旧文件在删除前保留的时间。默认是7天
+- `internal_log_roll_file_index`: 滚动文件索引策略（`min`、`max` 或 `nomax`）。默认是 `min`
+- `internal_log_delete_count`: 磁盘上保留的滚动归档文件数量的硬性上限，由 Delete 动作强制执行。默认是 `-1`（禁用）。
 
 ### `fe.audit.log`
 
@@ -126,6 +132,8 @@ keywords: ['shen ji ri zhi']
 - `audit_log_roll_num`: 保留的文件数量。默认是90
 - `audit_log_roll_interval`: 指定轮换频率。默认是DAY，意味着每天轮换。当满足轮换条件时，保留最新的90个文件，删除旧文件
 - `audit_log_delete_age`: 控制旧文件在删除前保留的时间。默认是7天
+- `audit_log_roll_file_index`: 滚动文件索引策略（`min`、`max` 或 `nomax`）。默认是 `min`
+- `audit_log_delete_count`: 磁盘上保留的滚动归档文件数量的硬性上限，由 Delete 动作强制执行。默认是 `-1`（禁用）。
 - `audit_log_json_format`: 是否以JSON格式记录。默认是false
 - `audit_log_enable_compress`: 是否启用压缩
 
@@ -143,6 +151,8 @@ keywords: ['shen ji ri zhi']
 - `big_query_log_modules`: 内部日志模块类型。默认是query
 - `big_query_log_roll_interval`: 指定轮换频率。默认是DAY，意味着每天轮换。当满足轮换条件时，保留最新的10个文件，删除旧文件
 - `big_query_log_delete_age`: 控制旧文件在删除前保留的时间。默认是7天
+- `big_query_log_roll_file_index`: 滚动文件索引策略（`min`、`max` 或 `nomax`）。默认是 `min`
+- `big_query_log_delete_count`: 磁盘上保留的滚动归档文件数量的硬性上限，由 Delete 动作强制执行。默认是 `-1`（禁用）。
 
 ### `fe.dump.log`
 
@@ -164,6 +174,8 @@ SET enable_query_dump = true;
 - `dump_log_modules`: 内部日志模块类型。默认是query
 - `dump_log_roll_interval`: 指定轮换频率。默认是DAY，意味着每天轮换。当满足轮换条件时，保留最新的10个文件，删除旧文件
 - `dump_log_delete_age`: 控制旧文件在删除前保留的时间。默认是7天
+- `dump_log_roll_file_index`: 滚动文件索引策略（`min`、`max` 或 `nomax`）。默认是 `min`
+- `dump_log_delete_count`: 磁盘上保留的滚动归档文件数量的硬性上限，由 Delete 动作强制执行。默认是 `-1`（禁用）。
 
 ### `fe.features.log`
 这是StarRocks的查询计划特征日志，用于收集和记录查询执行计划的特征信息。主要服务于机器学习和查询优化分析。关键目的包括：
@@ -188,6 +200,8 @@ enable_query_cost_prediction = false  // 默认禁用
 - `feature_log_roll_num`: 保留的文件数量。默认是5
 - `feature_log_roll_interval`: 指定轮换频率。默认是DAY，意味着每天轮换。当满足轮换条件时，保留最新的5个文件，删除旧文件
 - `feature_log_delete_age`: 控制旧文件在删除前保留的时间。默认是3天
+- `feature_log_roll_file_index`: 滚动文件索引策略（`min`、`max` 或 `nomax`）。默认是 `min`
+- `feature_log_delete_count`: 磁盘上保留的滚动归档文件数量的硬性上限，由 Delete 动作强制执行。默认是 `-1`（禁用）。
 - `feature_log_roll_size_mb`: 日志轮换大小。默认是1024 MB，意味着每1 GB创建一个新文件
 
 ## BE/CN日志详解

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -83,6 +83,14 @@ public class Config extends ConfigBase {
      * 60m     60 mins
      * 120s    120 seconds
      * <p>
+     * sys_log_roll_file_index:
+     * Rollover file index strategy for fe.log/fe.warn.log: min, max, or nomax.
+     * Default 'min'. With 'nomax' set sys_log_delete_count to bound disk usage.
+     * <p>
+     * sys_log_delete_count:
+     * Hard cap on the number of retained rolled fe.log/fe.warn.log files (counted separately), enforced by the Delete
+     * action. <= 0 disables the cap.
+     * <p>
      * sys_log_enable_compress:
      *      default is false. if true, then compress fe.log & fe.warn.log by gzip
      */
@@ -98,6 +106,10 @@ public class Config extends ConfigBase {
     public static String sys_log_roll_interval = "DAY";
     @ConfField
     public static String sys_log_delete_age = "7d";
+    @ConfField
+    public static String sys_log_roll_file_index = "min";
+    @ConfField
+    public static int sys_log_delete_count = -1;
     @Deprecated
     @ConfField
     public static String sys_log_roll_mode = "SIZE-MB-1024";
@@ -149,6 +161,14 @@ public class Config extends ConfigBase {
      * 60m     60 mins
      * 120s    120 seconds
      * <p>
+     * audit_log_roll_file_index:
+     * Rollover file index strategy for fe.audit.log: min, max, or nomax.
+     * Default 'min'. With 'nomax' set audit_log_delete_count to bound disk usage.
+     * <p>
+     * audit_log_delete_count:
+     * Hard cap on the number of retained rolled fe.audit.log files, enforced by the Delete action.
+     * <= 0 disables the cap.
+     * <p>
      * audit_log_enable_compress:
      *      default is false. if true, then compress fe.audit.log by gzip
      */
@@ -168,6 +188,10 @@ public class Config extends ConfigBase {
     public static String audit_log_roll_interval = "DAY";
     @ConfField
     public static String audit_log_delete_age = "30d";
+    @ConfField
+    public static String audit_log_roll_file_index = "min";
+    @ConfField
+    public static int audit_log_delete_count = -1;
     @ConfField(mutable = true)
     public static boolean audit_log_json_format = false;
     @ConfField
@@ -191,6 +215,14 @@ public class Config extends ConfigBase {
     /*
      * internal log:
      * This specifies FE MV/Statistics log dir.
+     * <p>
+     * internal_log_roll_file_index:
+     * Rollover file index strategy for fe.internal.log: min, max, or nomax.
+     * Default 'min'. With 'nomax' set internal_log_delete_count to bound disk usage.
+     * <p>
+     * internal_log_delete_count:
+     * Hard cap on the number of retained rolled fe.internal.log files, enforced by the Delete action.
+     * <= 0 disables the cap.
      */
     @ConfField
     public static String internal_log_dir = StarRocksFE.STARROCKS_HOME_DIR + "/log";
@@ -202,6 +234,10 @@ public class Config extends ConfigBase {
     public static String internal_log_roll_interval = "DAY";
     @ConfField
     public static String internal_log_delete_age = "7d";
+    @ConfField
+    public static String internal_log_roll_file_index = "min";
+    @ConfField
+    public static int internal_log_delete_count = -1;
     @ConfField
     public static boolean internal_log_json_format = false;
 
@@ -224,6 +260,14 @@ public class Config extends ConfigBase {
      * 10h     10 hours
      * 60m     60 mins
      * 120s    120 seconds
+     * <p>
+     * dump_log_roll_file_index:
+     * Rollover file index strategy for fe.dump.log: min, max, or nomax.
+     * Default 'min'. With 'nomax' set dump_log_delete_count to bound disk usage.
+     * <p>
+     * dump_log_delete_count:
+     * Hard cap on the number of retained rolled fe.dump.log files, enforced by the Delete action.
+     * <= 0 disables the cap.
      */
     @ConfField
     public static int dump_log_roll_num = 10;
@@ -233,6 +277,10 @@ public class Config extends ConfigBase {
     public static String dump_log_roll_interval = "DAY";
     @ConfField
     public static String dump_log_delete_age = "7d";
+    @ConfField
+    public static String dump_log_roll_file_index = "min";
+    @ConfField
+    public static int dump_log_delete_count = -1;
 
     /**
      * plan_log_roll_num:
@@ -250,6 +298,14 @@ public class Config extends ConfigBase {
      * 10h     10 hours
      * 60m     60 mins
      * 120s    120 seconds
+     * <p>
+     * plan_log_roll_file_index:
+     * Rollover file index strategy for fe.plan.log: min, max, or nomax.
+     * Default 'min'. With 'nomax' set plan_log_delete_count to bound disk usage.
+     * <p>
+     * plan_log_delete_count:
+     * Hard cap on the number of retained rolled fe.plan.log files, enforced by the Delete action.
+     * <= 0 disables the cap.
      */
     @ConfField
     public static int plan_log_roll_num = 10;
@@ -257,6 +313,10 @@ public class Config extends ConfigBase {
     public static String plan_log_roll_interval = "DAY";
     @ConfField
     public static String plan_log_delete_age = "7d";
+    @ConfField
+    public static String plan_log_roll_file_index = "min";
+    @ConfField
+    public static int plan_log_delete_count = -1;
 
     /**
      * big_query_log_dir:
@@ -286,6 +346,14 @@ public class Config extends ConfigBase {
      * 10h     10 hours
      * 60m     60 mins
      * 120s    120 seconds
+     * <p>
+     * big_query_log_roll_file_index:
+     * Rollover file index strategy for fe.big_query.log: min, max, or nomax.
+     * Default 'min'. With 'nomax' set big_query_log_delete_count to bound disk usage.
+     * <p>
+     * big_query_log_delete_count:
+     * Hard cap on the number of retained rolled fe.big_query.log files, enforced by the Delete action.
+     * <= 0 disables the cap.
      */
     @ConfField
     public static String big_query_log_dir = StarRocksFE.STARROCKS_HOME_DIR + "/log";
@@ -297,6 +365,10 @@ public class Config extends ConfigBase {
     public static String big_query_log_roll_interval = "DAY";
     @ConfField
     public static String big_query_log_delete_age = "7d";
+    @ConfField
+    public static String big_query_log_roll_file_index = "min";
+    @ConfField
+    public static int big_query_log_delete_count = -1;
 
     /**
      * profile_log_dir:
@@ -316,6 +388,14 @@ public class Config extends ConfigBase {
      * 10h     10 hours
      * 60m     60 minutes
      * 120s    120 seconds
+     * <p>
+     * profile_log_roll_file_index:
+     * Rollover file index strategy for fe.profile.log: min, max, or nomax.
+     * Default 'min'. With 'nomax' set profile_log_delete_count to bound disk usage.
+     * <p>
+     * profile_log_delete_count:
+     * Hard cap on the number of retained rolled fe.profile.log files, enforced by the Delete action.
+     * <= 0 disables the cap.
      */
     @ConfField
     public static boolean enable_profile_log = true;
@@ -330,6 +410,10 @@ public class Config extends ConfigBase {
     public static String profile_log_roll_interval = "DAY";
     @ConfField
     public static String profile_log_delete_age = "1d";
+    @ConfField
+    public static String profile_log_roll_file_index = "min";
+    @ConfField
+    public static int profile_log_delete_count = -1;
     @ConfField
     public static int profile_log_roll_size_mb = 1024; // 1 GB in MB
 
@@ -2871,6 +2955,10 @@ public class Config extends ConfigBase {
     public static String feature_log_roll_interval = "DAY";
     @ConfField
     public static String feature_log_delete_age = "3d";
+    @ConfField
+    public static String feature_log_roll_file_index = "min";
+    @ConfField
+    public static int feature_log_delete_count = -1;
     @ConfField
     public static int feature_log_roll_num = 5;
     @ConfField

--- a/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
@@ -56,6 +56,7 @@ import java.util.Set;
 // don't use trace. use INFO, WARN, ERROR, FATAL
 public class Log4jConfig extends XmlConfiguration {
     private static final Set<String> DEBUG_LEVELS = ImmutableSet.of("FATAL", "ERROR", "WARN", "INFO", "DEBUG");
+    private static final Set<String> VALID_FILE_INDEXES = ImmutableSet.of("min", "max", "nomax");
 
     private static final String APPENDER_TEMPLATE = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
             "\n" +
@@ -70,10 +71,9 @@ public class Log4jConfig extends XmlConfiguration {
             "        <TimeBasedTriggeringPolicy/>\n" +
             "        <SizeBasedTriggeringPolicy size=\"${sys_roll_maxsize}MB\"/>\n" +
             "      </Policies>\n" +
-            "      <DefaultRolloverStrategy max=\"${sys_roll_num}\" fileIndex=\"min\">\n" +
+            "      <DefaultRolloverStrategy max=\"${sys_roll_num}\" fileIndex=\"${sys_roll_file_index}\">\n" +
             "        <Delete basePath=\"${sys_log_dir}/\" maxDepth=\"1\" followLinks=\"true\">\n" +
-            "          <IfFileName glob=\"fe.log.*\" />\n" +
-            "          <IfLastModified age=\"${sys_log_delete_age}\" />\n" +
+            "${sys_delete_conditions}" +
             "        </Delete>\n" +
             "      </DefaultRolloverStrategy>\n" +
             "    </RollingFile>\n" +
@@ -83,10 +83,9 @@ public class Log4jConfig extends XmlConfiguration {
             "        <TimeBasedTriggeringPolicy/>\n" +
             "        <SizeBasedTriggeringPolicy size=\"${sys_roll_maxsize}MB\"/>\n" +
             "      </Policies>\n" +
-            "      <DefaultRolloverStrategy max=\"${sys_roll_num}\" fileIndex=\"min\">\n" +
+            "      <DefaultRolloverStrategy max=\"${sys_roll_num}\" fileIndex=\"${sys_roll_file_index}\">\n" +
             "        <Delete basePath=\"${sys_log_dir}/\" maxDepth=\"1\" followLinks=\"true\">\n" +
-            "          <IfFileName glob=\"fe.warn.log.*\" />\n" +
-            "          <IfLastModified age=\"${sys_log_delete_age}\" />\n" +
+            "${sys_wf_delete_conditions}" +
             "        </Delete>\n" +
             "      </DefaultRolloverStrategy>\n" +
             "    </RollingFile>\n" +
@@ -96,10 +95,9 @@ public class Log4jConfig extends XmlConfiguration {
             "        <TimeBasedTriggeringPolicy/>\n" +
             "        <SizeBasedTriggeringPolicy size=\"${audit_roll_maxsize}MB\"/>\n" +
             "      </Policies>\n" +
-            "      <DefaultRolloverStrategy max=\"${audit_roll_num}\" fileIndex=\"min\">\n" +
+            "      <DefaultRolloverStrategy max=\"${audit_roll_num}\" fileIndex=\"${audit_roll_file_index}\">\n" +
             "        <Delete basePath=\"${audit_log_dir}/\" maxDepth=\"1\" followLinks=\"true\">\n" +
-            "          <IfFileName glob=\"fe.audit.log.*\" />\n" +
-            "          <IfLastModified age=\"${audit_log_delete_age}\" />\n" +
+            "${audit_delete_conditions}" +
             "        </Delete>\n" +
             "      </DefaultRolloverStrategy>\n" +
             "    </RollingFile>\n" +
@@ -109,10 +107,9 @@ public class Log4jConfig extends XmlConfiguration {
             "        <TimeBasedTriggeringPolicy/>\n" +
             "        <SizeBasedTriggeringPolicy size=\"${dump_roll_maxsize}MB\"/>\n" +
             "      </Policies>\n" +
-            "      <DefaultRolloverStrategy max=\"${dump_roll_num}\" fileIndex=\"min\">\n" +
+            "      <DefaultRolloverStrategy max=\"${dump_roll_num}\" fileIndex=\"${dump_roll_file_index}\">\n" +
             "        <Delete basePath=\"${dump_log_dir}/\" maxDepth=\"1\" followLinks=\"true\">\n" +
-            "          <IfFileName glob=\"fe.dump.log.*\" />\n" +
-            "          <IfLastModified age=\"${dump_log_delete_age}\" />\n" +
+            "${dump_delete_conditions}" +
             "        </Delete>\n" +
             "      </DefaultRolloverStrategy>\n" +
             "    </RollingFile>\n" +
@@ -122,10 +119,9 @@ public class Log4jConfig extends XmlConfiguration {
             "        <TimeBasedTriggeringPolicy/>\n" +
             "        <SizeBasedTriggeringPolicy size=\"${big_query_roll_maxsize}MB\"/>\n" +
             "      </Policies>\n" +
-            "      <DefaultRolloverStrategy max=\"${big_query_log_roll_num}\" fileIndex=\"min\">\n" +
+            "      <DefaultRolloverStrategy max=\"${big_query_log_roll_num}\" fileIndex=\"${big_query_roll_file_index}\">\n" +
             "        <Delete basePath=\"${big_query_log_dir}/\" maxDepth=\"1\" followLinks=\"true\">\n" +
-            "          <IfFileName glob=\"fe.big_query.log.*\" />\n" +
-            "          <IfLastModified age=\"${big_query_log_delete_age}\" />\n" +
+            "${big_query_delete_conditions}" +
             "        </Delete>\n" +
             "      </DefaultRolloverStrategy>\n" +
             "    </RollingFile>\n" +
@@ -136,10 +132,9 @@ public class Log4jConfig extends XmlConfiguration {
             "        <TimeBasedTriggeringPolicy/>\n" +
             "        <SizeBasedTriggeringPolicy size=\"${profile_log_roll_size_mb}MB\"/>\n" +
             "      </Policies>\n" +
-            "      <DefaultRolloverStrategy max=\"${profile_log_roll_num}\" fileIndex=\"min\">\n" +
+            "      <DefaultRolloverStrategy max=\"${profile_log_roll_num}\" fileIndex=\"${profile_roll_file_index}\">\n" +
             "        <Delete basePath=\"${profile_log_dir}/\" maxDepth=\"1\" followLinks=\"true\">\n" +
-            "          <IfFileName glob=\"fe.profile.log.*\" />\n" +
-            "          <IfLastModified age=\"${profile_log_delete_age}\" />\n" +
+            "${profile_delete_conditions}" +
             "        </Delete>\n" +
             "      </DefaultRolloverStrategy>\n" +
             "    </RollingFile>\n" +
@@ -151,10 +146,9 @@ public class Log4jConfig extends XmlConfiguration {
             "        <TimeBasedTriggeringPolicy/>\n" +
             "        <SizeBasedTriggeringPolicy size=\"${feature_log_roll_size_mb}MB\"/>\n" +
             "      </Policies>\n" +
-            "      <DefaultRolloverStrategy max=\"${feature_log_roll_num}\" fileIndex=\"min\">\n" +
+            "      <DefaultRolloverStrategy max=\"${feature_log_roll_num}\" fileIndex=\"${feature_roll_file_index}\">\n" +
             "        <Delete basePath=\"${feature_log_dir}/\" maxDepth=\"1\" followLinks=\"true\">\n" +
-            "          <IfFileName glob=\"fe.features.log.*\" />\n" +
-            "          <IfLastModified age=\"${feature_log_delete_age}\" />\n" +
+            "${feature_delete_conditions}" +
             "        </Delete>\n" +
             "      </DefaultRolloverStrategy>\n" +
             "    </RollingFile>\n" +
@@ -165,10 +159,9 @@ public class Log4jConfig extends XmlConfiguration {
             "        <TimeBasedTriggeringPolicy/>\n" +
             "        <SizeBasedTriggeringPolicy size=\"${internal_roll_maxsize}MB\"/>\n" +
             "      </Policies>\n" +
-            "      <DefaultRolloverStrategy max=\"${internal_log_roll_num}\" fileIndex=\"min\">\n" +
+            "      <DefaultRolloverStrategy max=\"${internal_log_roll_num}\" fileIndex=\"${internal_roll_file_index}\">\n" +
             "        <Delete basePath=\"${internal_log_dir}/\" maxDepth=\"1\" followLinks=\"true\">\n" +
-            "          <IfFileName glob=\"fe.internal.log.*\" />\n" +
-            "          <IfLastModified age=\"${internal_log_delete_age}\" />\n" +
+            "${internal_delete_conditions}" +
             "        </Delete>\n" +
             "      </DefaultRolloverStrategy>\n" +
             "    </RollingFile>\n" +
@@ -179,10 +172,9 @@ public class Log4jConfig extends XmlConfiguration {
             "        <TimeBasedTriggeringPolicy/>\n" +
             "        <SizeBasedTriggeringPolicy size=\"${plan_roll_maxsize}MB\"/>\n" +
             "      </Policies>\n" +
-            "      <DefaultRolloverStrategy max=\"${plan_roll_num}\" fileIndex=\"min\">\n" +
+            "      <DefaultRolloverStrategy max=\"${plan_roll_num}\" fileIndex=\"${plan_roll_file_index}\">\n" +
             "        <Delete basePath=\"${plan_log_dir}/\" maxDepth=\"1\" followLinks=\"true\">\n" +
-            "          <IfFileName glob=\"fe.plan.log.*\" />\n" +
-            "          <IfLastModified age=\"${plan_log_delete_age}\" />\n" +
+            "${plan_delete_conditions}" +
             "        </Delete>\n" +
             "      </DefaultRolloverStrategy>\n" +
             "    </RollingFile>\n" +
@@ -254,6 +246,12 @@ public class Log4jConfig extends XmlConfiguration {
         properties.put("sys_log_delete_age", String.valueOf(Config.sys_log_delete_age));
         properties.put("sys_log_level", sysLogLevel);
         properties.put("sys_file_pattern", getIntervalPattern("sys_log_roll_interval", Config.sys_log_roll_interval));
+        properties.put("sys_roll_file_index",
+                validateFileIndex("sys_log_roll_file_index", Config.sys_log_roll_file_index));
+        properties.put("sys_delete_conditions",
+                buildDeleteConditions("fe.log.*", String.valueOf(Config.sys_log_delete_age), Config.sys_log_delete_count));
+        properties.put("sys_wf_delete_conditions",
+                buildDeleteConditions("fe.warn.log.*", String.valueOf(Config.sys_log_delete_age), Config.sys_log_delete_count));
         properties.put("sys_file_postfix", compressSysLog ? ".gz" : "");
         properties.put("audit_file_postfix", compressAuditLog ? ".gz" : "");
 
@@ -264,6 +262,11 @@ public class Log4jConfig extends XmlConfiguration {
         properties.put("audit_log_delete_age", String.valueOf(Config.audit_log_delete_age));
         properties.put("audit_file_pattern",
                 getIntervalPattern("audit_log_roll_interval", Config.audit_log_roll_interval));
+        properties.put("audit_roll_file_index",
+                validateFileIndex("audit_log_roll_file_index", Config.audit_log_roll_file_index));
+        properties.put("audit_delete_conditions",
+                buildDeleteConditions("fe.audit.log.*", String.valueOf(Config.audit_log_delete_age),
+                        Config.audit_log_delete_count));
 
         // dump log config — always co-located with fe.log (sys_log_dir)
         properties.put("dump_log_dir", Config.sys_log_dir);
@@ -272,6 +275,11 @@ public class Log4jConfig extends XmlConfiguration {
         properties.put("dump_log_delete_age", String.valueOf(Config.dump_log_delete_age));
         properties.put("dump_file_pattern",
                 getIntervalPattern("dump_log_roll_interval", Config.dump_log_roll_interval));
+        properties.put("dump_roll_file_index",
+                validateFileIndex("dump_log_roll_file_index", Config.dump_log_roll_file_index));
+        properties.put("dump_delete_conditions",
+                buildDeleteConditions("fe.dump.log.*", String.valueOf(Config.dump_log_delete_age),
+                        Config.dump_log_delete_count));
 
         // big query log config
         properties.put("big_query_log_dir", Config.big_query_log_dir);
@@ -280,6 +288,11 @@ public class Log4jConfig extends XmlConfiguration {
         properties.put("big_query_log_delete_age", String.valueOf(Config.big_query_log_delete_age));
         properties.put("big_query_file_pattern",
                 getIntervalPattern("big_query_log_roll_interval", Config.big_query_log_roll_interval));
+        properties.put("big_query_roll_file_index",
+                validateFileIndex("big_query_log_roll_file_index", Config.big_query_log_roll_file_index));
+        properties.put("big_query_delete_conditions",
+                buildDeleteConditions("fe.big_query.log.*", String.valueOf(Config.big_query_log_delete_age),
+                        Config.big_query_log_delete_count));
 
         // profile log config
         properties.put("profile_log_dir", Config.profile_log_dir);
@@ -288,6 +301,11 @@ public class Log4jConfig extends XmlConfiguration {
         properties.put("profile_log_delete_age", String.valueOf(Config.profile_log_delete_age));
         properties.put("profile_file_pattern",
                 getIntervalPattern("profile_log_roll_interval", Config.profile_log_roll_interval));
+        properties.put("profile_roll_file_index",
+                validateFileIndex("profile_log_roll_file_index", Config.profile_log_roll_file_index));
+        properties.put("profile_delete_conditions",
+                buildDeleteConditions("fe.profile.log.*", String.valueOf(Config.profile_log_delete_age),
+                        Config.profile_log_delete_count));
 
         // feature log config
         properties.put("feature_log_dir", Config.feature_log_dir);
@@ -296,6 +314,11 @@ public class Log4jConfig extends XmlConfiguration {
         properties.put("feature_log_delete_age", String.valueOf(Config.feature_log_delete_age));
         properties.put("feature_file_pattern",
                 getIntervalPattern("feature_log_roll_interval", Config.feature_log_roll_interval));
+        properties.put("feature_roll_file_index",
+                validateFileIndex("feature_log_roll_file_index", Config.feature_log_roll_file_index));
+        properties.put("feature_delete_conditions",
+                buildDeleteConditions("fe.features.log.*", String.valueOf(Config.feature_log_delete_age),
+                        Config.feature_log_delete_count));
 
         // internal log config
         properties.put("internal_log_dir", Config.internal_log_dir);
@@ -304,6 +327,11 @@ public class Log4jConfig extends XmlConfiguration {
         properties.put("internal_log_delete_age", String.valueOf(Config.internal_log_delete_age));
         properties.put("internal_file_pattern",
                 getIntervalPattern("big_query_log_roll_interval", Config.internal_log_roll_interval));
+        properties.put("internal_roll_file_index",
+                validateFileIndex("internal_log_roll_file_index", Config.internal_log_roll_file_index));
+        properties.put("internal_delete_conditions",
+                buildDeleteConditions("fe.internal.log.*", String.valueOf(Config.internal_log_delete_age),
+                        Config.internal_log_delete_count));
 
         // plan log config — always co-located with fe.log (sys_log_dir)
         properties.put("plan_log_dir", Config.sys_log_dir);
@@ -312,6 +340,11 @@ public class Log4jConfig extends XmlConfiguration {
         properties.put("plan_log_delete_age", String.valueOf(Config.plan_log_delete_age));
         properties.put("plan_file_pattern",
                 getIntervalPattern("plan_log_roll_interval", Config.plan_log_roll_interval));
+        properties.put("plan_roll_file_index",
+                validateFileIndex("plan_log_roll_file_index", Config.plan_log_roll_file_index));
+        properties.put("plan_delete_conditions",
+                buildDeleteConditions("fe.plan.log.*", String.valueOf(Config.plan_log_delete_age),
+                        Config.plan_log_delete_count));
 
         // appender layout
         final String jsonLoggingConfValue = "json";
@@ -416,6 +449,33 @@ public class Log4jConfig extends XmlConfiguration {
         newXmlConfTemplate = newXmlConfTemplate.replaceAll("<!--REPLACED BY AUDIT AND VERBOSE MODULE NAMES-->",
                 sb.toString());
         return newXmlConfTemplate;
+    }
+
+    private static String validateFileIndex(String name, String fileIndex) throws IOException {
+        if (fileIndex == null) {
+            throw new IOException(name + " config error: " + fileIndex + ", must be one of min/max/nomax");
+        }
+        String normalized = StringUtils.lowerCase(fileIndex.trim());
+        if (!VALID_FILE_INDEXES.contains(normalized)) {
+            throw new IOException(name + " config error: " + fileIndex + ", must be one of min/max/nomax");
+        }
+        return normalized;
+    }
+
+    private static String buildDeleteConditions(String glob, String deleteAge, int deleteCount) {
+        StringBuilder sb = new StringBuilder();
+        if (deleteCount > 0) {
+            sb.append("          <IfFileName glob=\"").append(glob).append("\">\n");
+            sb.append("            <IfAny>\n");
+            sb.append("              <IfLastModified age=\"").append(deleteAge).append("\" />\n");
+            sb.append("              <IfAccumulatedFileCount exceeds=\"").append(deleteCount).append("\" />\n");
+            sb.append("            </IfAny>\n");
+            sb.append("          </IfFileName>\n");
+        } else {
+            sb.append("          <IfFileName glob=\"").append(glob).append("\" />\n");
+            sb.append("          <IfLastModified age=\"").append(deleteAge).append("\" />\n");
+        }
+        return sb.toString();
     }
 
     private static String getIntervalPattern(String name, String config) throws IOException {

--- a/fe/fe-core/src/test/java/com/starrocks/common/Log4jConfigTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/Log4jConfigTest.java
@@ -121,4 +121,42 @@ public class Log4jConfigTest {
         Assertions.assertEquals("main", jsonObject.get("thread.name").getAsString());
         Assertions.assertEquals(logMessage, jsonObject.get("message").getAsString());
     }
+
+    @Test
+    public void testRolloverFileIndexAndDeleteCount() throws IOException {
+        Config.sys_log_format = "plaintext";
+        String oldFileIndex = Config.profile_log_roll_file_index;
+        int oldDeleteCount = Config.profile_log_delete_count;
+        try {
+            // default: preserve historical behavior (min file index, no accumulated-count cap)
+            Config.profile_log_roll_file_index = "min";
+            Config.profile_log_delete_count = -1;
+            String xmlConfig = Log4jConfig.generateActiveLog4jXmlConfig();
+            Assertions.assertTrue(xmlConfig.contains("<DefaultRolloverStrategy max=\"5\" fileIndex=\"min\">"));
+            Assertions.assertTrue(xmlConfig.contains("<IfFileName glob=\"fe.profile.log.*\" />"));
+            Assertions.assertFalse(xmlConfig.contains("<IfAccumulatedFileCount"),
+                    "no accumulated-count cap should be emitted when delete_count <= 0");
+
+            // opt-in: nomax file index with a hard retention cap
+            Config.profile_log_roll_file_index = "nomax";
+            Config.profile_log_delete_count = 3;
+            xmlConfig = Log4jConfig.generateActiveLog4jXmlConfig();
+            Assertions.assertTrue(xmlConfig.contains("fileIndex=\"nomax\""));
+            Assertions.assertTrue(xmlConfig.contains("<IfAccumulatedFileCount exceeds=\"3\" />"));
+            Assertions.assertTrue(xmlConfig.contains("<IfAny>"));
+
+            // invalid file index is rejected
+            Config.profile_log_roll_file_index = "bogus";
+            Config.profile_log_delete_count = -1;
+            try {
+                Log4jConfig.generateActiveLog4jXmlConfig();
+                Assertions.fail("Expected IOException for invalid fileIndex");
+            } catch (IOException e) {
+                Assertions.assertTrue(e.getMessage().contains("profile_log_roll_file_index config error"));
+            }
+        } finally {
+            Config.profile_log_roll_file_index = oldFileIndex;
+            Config.profile_log_delete_count = oldDeleteCount;
+        }
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

Today it's hardcoded to use the `min` strategy: https://logging.apache.org/log4j/2.x/manual/appenders/rolling-file.html#RolloverStrategy-index

We want to use the `nomax` strategy where the file index monotonically increase. It's more friendly to a companion program which watches the file system change and uploads log files to an object store for backups.


## What I'm doing:

Introduce two new FE configs per log type: `*_log_roll_file_index` (min/max/nomax) and `*_log_delete_count`. These allow tuning Log4j's DefaultRolloverStrategy fileIndex and enforcing a hard cap on the number of retained rolled archives via an IfAccumulatedFileCount condition.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr
<hr>This is a backport of pull request #76760 