### PR TITLE
[Enhancement] Stream source segments for lake column updates

### DIFF
--- a/be/src/storage/lake/column_mode_partial_update_handler.cpp
+++ b/be/src/storage/lake/column_mode_partial_update_handler.cpp
@@ -14,8 +14,11 @@
 
 #include "storage/lake/column_mode_partial_update_handler.h"
 
+#include <climits>
+
 #include "base/debug/trace.h"
 #include "base/phmap/phmap.h"
+#include "base/testutil/sync_point.h"
 #include "base/time/time.h"
 #include "base/utility/defer_op.h"
 #include "column/chunk_factory.h"
@@ -157,8 +160,9 @@ StatusOr<std::unique_ptr<SegmentWriter>> ColumnModePartialUpdateHandler::_prepar
     return std::move(segment_writer);
 }
 
-StatusOr<ChunkPtr> ColumnModePartialUpdateHandler::_read_from_source_segment(const RowsetUpdateStateParams& params,
-                                                                             const Schema& schema, uint32_t rssid) {
+Status ColumnModePartialUpdateHandler::_read_from_source_segment_and_update(
+        const RowsetUpdateStateParams& params, const Schema& schema, uint32_t rssid,
+        const std::function<Status(StreamChunkContainer)>& update_func) {
     TRACE_COUNTER_SCOPE_LATENCY_US("pcu_read_from_source_us");
     OlapReaderStatistics stats;
     size_t footer_size_hint = 16 * 1024;
@@ -193,9 +197,28 @@ StatusOr<ChunkPtr> ColumnModePartialUpdateHandler::_read_from_source_segment(con
     seg_options.tablet_schema = params.tablet_schema;
     // not use delvec loader
     seg_options.dcg_loader = std::make_shared<LakeDeltaColumnGroupLoader>(params.metadata);
+    seg_options.chunk_size = config::vector_chunk_size;
     ASSIGN_OR_RETURN(auto seg_iter, segment->new_iterator(schema, seg_options));
-    auto source_chunk_ptr = ChunkFactory::new_chunk(schema, segment->num_rows());
-    auto tmp_chunk_ptr = ChunkFactory::new_chunk(schema, 1024);
+    auto source_chunk_ptr = ChunkFactory::new_chunk(schema, config::vector_chunk_size);
+    auto tmp_chunk_ptr = ChunkFactory::new_chunk(schema, config::vector_chunk_size);
+    const int64_t upt_memory_usage_per_row = RowsetColumnUpdateState::calc_upt_memory_usage_per_row(_rowset_ptr.get());
+    uint32_t start_rowid = 0;
+    // Accumulate the source bytes incrementally. bytes_usage() may walk every value for
+    // object-backed columns, while appending a batch adds exactly that batch's bytes.
+    int64_t source_chunk_bytes = 0;
+    auto emit_container = [&]() {
+        StreamChunkContainer container = {
+                .chunk_ptr = source_chunk_ptr.get(),
+                .start_rowid = start_rowid,
+                .end_rowid = start_rowid + static_cast<uint32_t>(source_chunk_ptr->num_rows())};
+        TEST_SYNC_POINT_CALLBACK("ColumnModePartialUpdateHandler::_read_from_source_segment_and_update:emit",
+                                 &container);
+        RETURN_IF_ERROR(update_func(container));
+        start_rowid += static_cast<uint32_t>(source_chunk_ptr->num_rows());
+        source_chunk_ptr->reset();
+        source_chunk_bytes = 0;
+        return Status::OK();
+    };
     while (true) {
         tmp_chunk_ptr->reset();
         auto st = seg_iter->get_next(tmp_chunk_ptr.get());
@@ -211,12 +234,26 @@ StatusOr<ChunkPtr> ColumnModePartialUpdateHandler::_read_from_source_segment(con
             RETURN_IF_ERROR(ChunkHelper::reject_if_over_capacity(*tmp_chunk_ptr,
                                                                  "column mode partial update source segment read batch",
                                                                  params.tablet->id(), _txn_id));
+            const int64_t batch_bytes = static_cast<int64_t>(tmp_chunk_ptr->bytes_usage());
+            const int64_t rows_after = static_cast<int64_t>(source_chunk_ptr->num_rows()) +
+                                       static_cast<int64_t>(tmp_chunk_ptr->num_rows());
+            if (!source_chunk_ptr->is_empty() &&
+                (rows_after >= INT32_MAX || source_chunk_bytes + batch_bytes + rows_after * upt_memory_usage_per_row >
+                                                    config::partial_update_memory_limit_per_worker)) {
+                RETURN_IF_ERROR(emit_container());
+            }
+            // Keep an oversized iterator batch intact. The capacity check below remains the hard
+            // safety bound, while the memory limit controls accumulation across batches.
             source_chunk_ptr->append(*tmp_chunk_ptr);
+            source_chunk_bytes += batch_bytes;
             RETURN_IF_ERROR(ChunkHelper::reject_if_over_capacity(
                     *source_chunk_ptr, "column mode partial update source chunk", params.tablet->id(), _txn_id));
         }
     }
-    return source_chunk_ptr;
+    if (!source_chunk_ptr->is_empty()) {
+        RETURN_IF_ERROR(emit_container());
+    }
+    return Status::OK();
 }
 
 static Status read_chunk_from_update_file(const ChunkIteratorPtr& iter, const ChunkUniquePtr& result_chunk) {
@@ -242,7 +279,8 @@ static Status read_chunk_from_update_file(const ChunkIteratorPtr& iter, const Ch
 // win, matching the existing upsert/row-mode condition-update semantics (see
 // UpdateManager::_process_single_chunk_update_with_condition).
 Status ColumnModePartialUpdateHandler::_update_source_chunk_by_upt(const UptidToRowidPairs& upt_id_to_rowid_pairs,
-                                                                   const Schema& partial_schema, ChunkPtr* source_chunk,
+                                                                   const Schema& partial_schema,
+                                                                   StreamChunkContainer container,
                                                                    int32_t condition_idx_in_partial_schema) {
     TRACE_COUNTER_SCOPE_LATENCY_US("pcu_update_source_by_upt_us");
     // build iterators
@@ -280,15 +318,15 @@ Status ColumnModePartialUpdateHandler::_update_source_chunk_by_upt(const UptidTo
         // 2. update source chunk
         std::vector<uint32_t> sorted_source_rowids;
         std::vector<uint32_t> unsorted_upt_rowids;
-        // Sort source rowid -> upt rowid pairs by source rowid.
-        split_rowid_pairs(each.second, &sorted_source_rowids, &unsorted_upt_rowids, nullptr);
+        // Keep only source rowids in this streamed chunk and align them to the chunk's rowid base.
+        split_rowid_pairs(each.second, &sorted_source_rowids, &unsorted_upt_rowids, &container);
         DCHECK(sorted_source_rowids.size() == unsorted_upt_rowids.size());
 
         // When condition update is enabled, compare the condition column value in
         // source chunk vs upt chunk and keep winners (old <= new); equal values let
         // the new row win, matching the upsert path.
         if (condition_idx_in_partial_schema >= 0) {
-            const auto& source_cond = (*source_chunk)->get_column_by_index(condition_idx_in_partial_schema);
+            const auto& source_cond = container.chunk_ptr->get_column_by_index(condition_idx_in_partial_schema);
             const auto& upt_cond = upt_chunk->get_column_by_index(condition_idx_in_partial_schema);
             const size_t original_size = sorted_source_rowids.size();
             std::vector<uint32_t> filtered_source_rowids;
@@ -314,12 +352,13 @@ Status ColumnModePartialUpdateHandler::_update_source_chunk_by_upt(const UptidTo
         auto tmp_chunk = ChunkFactory::new_chunk(partial_schema, unsorted_upt_rowids.size());
         TRY_CATCH_BAD_ALLOC(
                 tmp_chunk->append_selective(*upt_chunk, unsorted_upt_rowids.data(), 0, unsorted_upt_rowids.size()));
-        RETURN_IF_EXCEPTION((*source_chunk)->update_rows(*tmp_chunk, sorted_source_rowids.data()));
+        RETURN_IF_EXCEPTION(container.chunk_ptr->update_rows(*tmp_chunk, sorted_source_rowids.data()));
         // The merge writes values wider than the ones it replaces, so the result can be over the
         // limit even though both inputs were under it, and the next .upt file in this loop reads
         // these offsets again.
-        RETURN_IF_ERROR(ChunkHelper::reject_if_over_capacity(
-                **source_chunk, "column mode partial update merged source chunk", _rowset_ptr->tablet_id(), _txn_id));
+        RETURN_IF_ERROR(ChunkHelper::reject_if_over_capacity(*container.chunk_ptr,
+                                                             "column mode partial update merged source chunk",
+                                                             _rowset_ptr->tablet_id(), _txn_id));
     }
     return Status::OK();
 }
@@ -493,40 +532,7 @@ Status ColumnModePartialUpdateHandler::execute(const RowsetUpdateStateParams& pa
                          upt_pairs_ptr, condition_idx_in_partial_schema, &dcg_column_ids,
                          &dcg_column_file_with_encryption_metas, &dcg_column_file_sizes, &result_mutex,
                          &shared_status]() {
-                // 3.3 read from source segment
-                auto source_chunk_or = _read_from_source_segment(params, partial_schema, rssid);
-                if (!source_chunk_or.ok()) {
-                    std::lock_guard<std::mutex> l(result_mutex);
-                    shared_status.update(source_chunk_or.status());
-                    return;
-                }
-                auto source_chunk_ptr = std::move(source_chunk_or.value());
-                const size_t source_chunk_size = source_chunk_ptr->memory_usage();
-                _tracker->consume(source_chunk_size);
-                DeferOp tracker_defer([&]() { _tracker->release(source_chunk_size); });
-
-                // 3.4 read from update segment and apply updates
-                auto st = _update_source_chunk_by_upt(*upt_pairs_ptr, partial_schema, &source_chunk_ptr,
-                                                      condition_idx_in_partial_schema);
-                if (!st.ok()) {
-                    std::lock_guard<std::mutex> l(result_mutex);
-                    shared_status.update(st);
-                    return;
-                }
-
-                padding_char_columns(partial_schema, partial_tschema, source_chunk_ptr.get());
-                // Padding grows CHAR values to their declared length, so it can carry a chunk that
-                // was under the limit at the end of the merge over it.
-                st = ChunkHelper::reject_if_over_capacity(*source_chunk_ptr,
-                                                          "column mode partial update padded source chunk",
-                                                          params.tablet->id(), _txn_id);
-                if (!st.ok()) {
-                    std::lock_guard<std::mutex> l(result_mutex);
-                    shared_status.update(st);
-                    return;
-                }
-
-                // 3.5 write delta column group (.col file with UUID name, no collision)
+                // 3.3 prepare one DCG writer, then stream source-segment chunks through update and append.
                 auto writer_or = _prepare_delta_column_group_writer(params, partial_tschema);
                 if (!writer_or.ok()) {
                     std::lock_guard<std::mutex> l(result_mutex);
@@ -534,14 +540,34 @@ Status ColumnModePartialUpdateHandler::execute(const RowsetUpdateStateParams& pa
                     return;
                 }
                 auto delta_column_group_writer = std::move(writer_or.value());
+                auto st = _read_from_source_segment_and_update(
+                        params, partial_schema, rssid, [&](StreamChunkContainer container) {
+                            const size_t source_chunk_size = container.chunk_ptr->memory_usage();
+                            _tracker->consume(source_chunk_size);
+                            DeferOp tracker_defer([&]() { _tracker->release(source_chunk_size); });
+
+                            // 3.4 read from update segments and apply rows in this source range.
+                            RETURN_IF_ERROR(_update_source_chunk_by_upt(*upt_pairs_ptr, partial_schema, container,
+                                                                        condition_idx_in_partial_schema));
+                            padding_char_columns(partial_schema, partial_tschema, container.chunk_ptr);
+                            RETURN_IF_ERROR(ChunkHelper::reject_if_over_capacity(
+                                    *container.chunk_ptr, "column mode partial update padded source chunk",
+                                    params.tablet->id(), _txn_id));
+
+                            // 3.5 append this bounded source range to the same DCG file.
+                            RETURN_IF_ERROR(delta_column_group_writer->append_chunk(*container.chunk_ptr));
+                            return Status::OK();
+                        });
+                if (!st.ok()) {
+                    std::lock_guard<std::mutex> l(result_mutex);
+                    shared_status.update(st);
+                    return;
+                }
 
                 uint64_t segment_file_size = 0;
                 uint64_t index_size = 0;
                 uint64_t footer_position = 0;
-                st = delta_column_group_writer->append_chunk(*source_chunk_ptr);
-                if (st.ok()) {
-                    st = delta_column_group_writer->finalize(&segment_file_size, &index_size, &footer_position);
-                }
+                st = delta_column_group_writer->finalize(&segment_file_size, &index_size, &footer_position);
 
                 // 3.6 collect results under lock
                 std::lock_guard<std::mutex> l(result_mutex);

--- a/be/src/storage/lake/column_mode_partial_update_handler.cpp
+++ b/be/src/storage/lake/column_mode_partial_update_handler.cpp
@@ -41,6 +41,7 @@
 #include "storage/lake/meta_file.h"
 #include "storage/lake/update_manager.h"
 #include "storage/rowset/column_iterator.h"
+#include "storage/rowset/column_reader.h"
 #include "storage/rowset/default_value_column_iterator.h"
 #include "storage/rowset/rowset.h"
 #include "storage/rowset/rowset_options.h"
@@ -91,6 +92,8 @@ Status ColumnModePartialUpdateHandler::_load_update_state(const RowsetUpdateStat
         return Status::OK();
     }
 
+    ASSIGN_OR_RETURN(_upt_memory_usage_per_row, _calc_upt_memory_usage_per_row(*params.tablet_schema));
+
     // Build PK schema
     vector<uint32_t> pk_columns;
     pk_columns.reserve(params.tablet_schema->num_key_columns());
@@ -134,6 +137,41 @@ Status ColumnModePartialUpdateHandler::_load_update_state(const RowsetUpdateStat
     }
 
     return Status::OK();
+}
+
+StatusOr<int64_t> ColumnModePartialUpdateHandler::_calc_upt_memory_usage_per_row(const TabletSchema& tablet_schema) {
+    // RowsetMetadataPB only exposes compressed file sizes. The segment footer's per-column
+    // total_mem_footprint is accumulated from Column::byte_size() by SegmentWriter, which matches
+    // the total_update_row_size accounting used by the shared-nothing update rowset writer.
+    LakeIOOptions lake_io_opts{.fill_data_cache = false, .fill_metadata_cache = true};
+    ASSIGN_OR_RETURN(auto segments, _rowset_ptr->segments(lake_io_opts));
+
+    int64_t total_update_row_size = 0;
+    int64_t num_rows_upt = 0;
+    for (const auto& segment : segments) {
+        if (segment == nullptr) {
+            continue;
+        }
+        num_rows_upt += segment->num_rows();
+        // Sum every column that is actually present in the partial-update segment, including PK
+        // columns. This intentionally retains the conservative shared-nothing accounting even when
+        // the source segment is processed one update-column group at a time.
+        for (size_t cid = 0; cid < tablet_schema.num_columns(); ++cid) {
+            const auto* column_reader = segment->column_with_uid(tablet_schema.column(cid).unique_id());
+            if (column_reader == nullptr) {
+                continue;
+            }
+            const uint64_t column_size = column_reader->total_mem_footprint();
+            if (column_size > static_cast<uint64_t>(INT64_MAX - total_update_row_size)) {
+                return Status::Corruption("partial update row memory footprint overflows int64");
+            }
+            total_update_row_size += static_cast<int64_t>(column_size);
+        }
+    }
+
+    int64_t result = RowsetColumnUpdateState::calc_upt_memory_usage_per_row(total_update_row_size, num_rows_upt);
+    TEST_SYNC_POINT_CALLBACK("ColumnModePartialUpdateHandler::_calc_upt_memory_usage_per_row", &result);
+    return result;
 }
 
 // this function build delta writer for delta column group's file.(end with `.col`)
@@ -201,7 +239,6 @@ Status ColumnModePartialUpdateHandler::_read_from_source_segment_and_update(
     ASSIGN_OR_RETURN(auto seg_iter, segment->new_iterator(schema, seg_options));
     auto source_chunk_ptr = ChunkFactory::new_chunk(schema, config::vector_chunk_size);
     auto tmp_chunk_ptr = ChunkFactory::new_chunk(schema, config::vector_chunk_size);
-    const int64_t upt_memory_usage_per_row = RowsetColumnUpdateState::calc_upt_memory_usage_per_row(_rowset_ptr.get());
     uint32_t start_rowid = 0;
     // Accumulate the source bytes incrementally. bytes_usage() may walk every value for
     // object-backed columns, while appending a batch adds exactly that batch's bytes.
@@ -238,7 +275,7 @@ Status ColumnModePartialUpdateHandler::_read_from_source_segment_and_update(
             const int64_t rows_after = static_cast<int64_t>(source_chunk_ptr->num_rows()) +
                                        static_cast<int64_t>(tmp_chunk_ptr->num_rows());
             if (!source_chunk_ptr->is_empty() &&
-                (rows_after >= INT32_MAX || source_chunk_bytes + batch_bytes + rows_after * upt_memory_usage_per_row >
+                (rows_after >= INT32_MAX || source_chunk_bytes + batch_bytes + rows_after * _upt_memory_usage_per_row >
                                                     config::partial_update_memory_limit_per_worker)) {
                 RETURN_IF_ERROR(emit_container());
             }

--- a/be/src/storage/lake/column_mode_partial_update_handler.h
+++ b/be/src/storage/lake/column_mode_partial_update_handler.h
@@ -44,6 +44,7 @@ public:
 
 private:
     Status _load_update_state(const RowsetUpdateStateParams& params);
+    StatusOr<int64_t> _calc_upt_memory_usage_per_row(const TabletSchema& tablet_schema);
     StatusOr<std::unique_ptr<SegmentWriter>> _prepare_delta_column_group_writer(
             const RowsetUpdateStateParams& params, const std::shared_ptr<TabletSchema>& tschema);
     Status _update_source_chunk_by_upt(const UptidToRowidPairs& upt_id_to_rowid_pairs, const Schema& partial_schema,
@@ -75,6 +76,7 @@ private:
     // `_rowset_meta_ptr` contains full life cycle rowset meta in `_rowset_ptr`.
     RowsetMetadataUniquePtr _rowset_meta_ptr;
     std::unique_ptr<Rowset> _rowset_ptr;
+    int64_t _upt_memory_usage_per_row = 0;
 };
 
 class CompactionUpdateConflictChecker {

--- a/be/src/storage/lake/column_mode_partial_update_handler.h
+++ b/be/src/storage/lake/column_mode_partial_update_handler.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <functional>
+
 #include "storage/lake/rowset_update_state.h"
 #include "storage/lake/tablet_metadata.h"
 #include "storage/rowset_column_update_state.h"
@@ -45,9 +47,10 @@ private:
     StatusOr<std::unique_ptr<SegmentWriter>> _prepare_delta_column_group_writer(
             const RowsetUpdateStateParams& params, const std::shared_ptr<TabletSchema>& tschema);
     Status _update_source_chunk_by_upt(const UptidToRowidPairs& upt_id_to_rowid_pairs, const Schema& partial_schema,
-                                       ChunkPtr* source_chunk, int32_t condition_idx_in_partial_schema);
-    StatusOr<ChunkPtr> _read_from_source_segment(const RowsetUpdateStateParams& params, const Schema& schema,
-                                                 uint32_t rssid);
+                                       StreamChunkContainer container, int32_t condition_idx_in_partial_schema);
+    Status _read_from_source_segment_and_update(const RowsetUpdateStateParams& params, const Schema& schema,
+                                                uint32_t rssid,
+                                                const std::function<Status(StreamChunkContainer)>& update_func);
     // Resolve txn_meta.merge_condition() to a column id in `tschema`.
     // Returns -1 when no condition is set, or an error when the named column is missing from the schema.
     static StatusOr<int32_t> _resolve_condition_cid(const RowsetTxnMetaPB& txn_meta, const TabletSchema& tschema);

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -311,11 +311,15 @@ Status RowsetColumnUpdateState::_finalize_partial_update_state(Tablet* tablet, R
     return Status::OK();
 }
 
-int64_t RowsetColumnUpdateState::calc_upt_memory_usage_per_row(Rowset* rowset) {
+int64_t RowsetColumnUpdateState::calc_upt_memory_usage_per_row(int64_t total_update_row_size, int64_t num_rows_upt) {
     // `num_rows_upt` could be zero after upgrade from old version,
     // then we will return zero and no limit.
-    if ((rowset->num_rows_upt()) <= 0) return 0;
-    return rowset->total_update_row_size() / rowset->num_rows_upt();
+    if (num_rows_upt <= 0) return 0;
+    return total_update_row_size / num_rows_upt;
+}
+
+int64_t RowsetColumnUpdateState::calc_upt_memory_usage_per_row(Rowset* rowset) {
+    return calc_upt_memory_usage_per_row(rowset->total_update_row_size(), rowset->num_rows_upt());
 }
 
 // Read chunk from source segment file and call `update_func` to update it.

--- a/be/src/storage/rowset_column_update_state.h
+++ b/be/src/storage/rowset_column_update_state.h
@@ -187,6 +187,7 @@ public:
     // For UT test now
     const std::vector<BatchPKsPtr>& upserts() const { return _upserts; }
 
+    static int64_t calc_upt_memory_usage_per_row(int64_t total_update_row_size, int64_t num_rows_upt);
     static int64_t calc_upt_memory_usage_per_row(Rowset* rowset);
 
 private:

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -329,9 +329,12 @@ TEST_P(LakePartialUpdateTest, test_column_mode_partial_update_streams_source_seg
     delta_writer->close();
 
     ConfigResetGuard<int32_t> chunk_size_guard(&config::vector_chunk_size, 4);
-    ConfigResetGuard<int64_t> memory_limit_guard(&config::partial_update_memory_limit_per_worker, 0);
+    ConfigResetGuard<int64_t> memory_limit_guard(&config::partial_update_memory_limit_per_worker, 80);
     ConfigResetGuard<bool> parallel_guard(&config::enable_pk_index_parallel_execution, false);
+    int64_t upt_memory_usage_per_row = 0;
     std::vector<std::pair<uint32_t, uint32_t>> emitted_ranges;
+    SyncPoint::GetInstance()->SetCallBack("ColumnModePartialUpdateHandler::_calc_upt_memory_usage_per_row",
+                                          [&](void* arg) { upt_memory_usage_per_row = *static_cast<int64_t*>(arg); });
     SyncPoint::GetInstance()->SetCallBack("ColumnModePartialUpdateHandler::_read_from_source_segment_and_update:emit",
                                           [&](void* arg) {
                                               const auto* container = static_cast<StreamChunkContainer*>(arg);
@@ -339,12 +342,14 @@ TEST_P(LakePartialUpdateTest, test_column_mode_partial_update_streams_source_seg
                                           });
     SyncPoint::GetInstance()->EnableProcessing();
     DeferOp sync_point_guard([&]() {
+        SyncPoint::GetInstance()->ClearCallBack("ColumnModePartialUpdateHandler::_calc_upt_memory_usage_per_row");
         SyncPoint::GetInstance()->ClearCallBack(
                 "ColumnModePartialUpdateHandler::_read_from_source_segment_and_update:emit");
         SyncPoint::GetInstance()->DisableProcessing();
     });
 
     ASSERT_OK(publish_single_version(tablet_id, ++version, txn_id).status());
+    EXPECT_GE(upt_memory_usage_per_row, static_cast<int64_t>(sizeof(int32_t) * 2));
     EXPECT_EQ((std::vector<std::pair<uint32_t, uint32_t>>{{0, 4}, {4, 8}, {8, 12}}), emitted_ranges);
     EXPECT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return c0 * 5 == c1 && c0 * 4 == c2; }));
 }

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -34,6 +34,7 @@
 #include "common/logging.h"
 #include "platform/key_cache.h"
 #include "storage/chunk_helper.h"
+#include "storage/lake/column_mode_partial_update_handler.h"
 #include "storage/lake/delta_writer.h"
 #include "storage/lake/meta_file.h"
 #include "storage/lake/tablet_manager.h"
@@ -280,6 +281,72 @@ TEST_P(LakePartialUpdateTest, test_write) {
     if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
         check_local_persistent_index_meta(tablet_id, version);
     }
+}
+
+TEST_P(LakePartialUpdateTest, test_column_mode_partial_update_streams_source_segment) {
+    if (GetParam().partial_update_mode != PartialUpdateMode::COLUMN_UPDATE_MODE) {
+        GTEST_SKIP() << "Only column mode reads source segments while generating DCGs";
+    }
+
+    auto chunk_full = generate_data(kChunkSize, 0, false, 3);
+    auto chunk_partial = generate_data(kChunkSize, 0, true, 5);
+    std::vector<uint32_t> indexes(kChunkSize);
+    std::iota(indexes.begin(), indexes.end(), 0);
+
+    auto version = 1;
+    const auto tablet_id = _tablet_metadata->id();
+    {
+        const auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_full, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, ++version, txn_id).status());
+    }
+
+    const auto txn_id = next_id();
+    ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                               .set_tablet_manager(_tablet_mgr.get())
+                                               .set_tablet_id(tablet_id)
+                                               .set_txn_id(txn_id)
+                                               .set_partition_id(_partition_id)
+                                               .set_mem_tracker(_mem_tracker.get())
+                                               .set_schema_id(_tablet_schema->id())
+                                               .set_slot_descriptors(&_slot_pointers)
+                                               .set_partial_update_mode(PartialUpdateMode::COLUMN_UPDATE_MODE)
+                                               .build());
+    ASSERT_OK(delta_writer->open());
+    ASSERT_OK(delta_writer->write(chunk_partial, indexes.data(), indexes.size()));
+    ASSERT_OK(delta_writer->finish_with_txnlog());
+    delta_writer->close();
+
+    ConfigResetGuard<int32_t> chunk_size_guard(&config::vector_chunk_size, 4);
+    ConfigResetGuard<int64_t> memory_limit_guard(&config::partial_update_memory_limit_per_worker, 0);
+    ConfigResetGuard<bool> parallel_guard(&config::enable_pk_index_parallel_execution, false);
+    std::vector<std::pair<uint32_t, uint32_t>> emitted_ranges;
+    SyncPoint::GetInstance()->SetCallBack("ColumnModePartialUpdateHandler::_read_from_source_segment_and_update:emit",
+                                          [&](void* arg) {
+                                              const auto* container = static_cast<StreamChunkContainer*>(arg);
+                                              emitted_ranges.emplace_back(container->start_rowid, container->end_rowid);
+                                          });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp sync_point_guard([&]() {
+        SyncPoint::GetInstance()->ClearCallBack(
+                "ColumnModePartialUpdateHandler::_read_from_source_segment_and_update:emit");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    ASSERT_OK(publish_single_version(tablet_id, ++version, txn_id).status());
+    EXPECT_EQ((std::vector<std::pair<uint32_t, uint32_t>>{{0, 4}, {4, 8}, {8, 12}}), emitted_ranges);
+    EXPECT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return c0 * 5 == c1 && c0 * 4 == c2; }));
 }
 
 // Regression test: when a partial update orphans a bundled segment, the orphan_files entry must be


### PR DESCRIPTION
## Why I'm doing:

In shared-nothing storage, column-mode partial updates already stream source segments in bounded chunks before merging update rows. The shared-data path still accumulated an entire source segment, so a large or wide segment could cause excessive per-worker memory usage and column-capacity pressure during publish.

## What I'm doing:

- Stream shared-data source segment reads using `vector_chunk_size`.
- Flush each accumulated source range before its source bytes plus estimated update bytes exceed `partial_update_memory_limit_per_worker`.
- Estimate Lake update-row memory from the update segments' column-level `total_mem_footprint` values instead of compressed `RowsetMetadataPB.data_size`.
- Reuse the shared-nothing `total_update_row_size / num_rows_upt` calculation through a common overload.
- Align source rowids to each streamed range, then apply condition filtering, merge updates, pad CHAR columns, and append every range to the same DCG writer.
- Add a regression test that validates the footer-derived estimate, forces three source ranges, verifies their rowid boundaries, and checks the published values.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: the existing per-worker partial-update memory limit now also bounds shared-data source segment accumulation
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Validation:

- `python3 build-support/check_be_module_boundaries.py --mode changed --base upstream/main --enforce-baseline-shrink`
- `python3 build-support/render_be_agents.py --check`
- clang-format and `git diff --check`
- Local BE UT/build is unavailable because this checkout has no installed third-party dependency tree
- TSP BE build submission is unavailable because no TSP API token is configured
- GitHub BE BUILD, BE UT, BE Architecture, Clang-Format, DCO, title, and module-risk checks passed

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
