### PR TITLE
[Enhancement] Add Config Option to Designate Schema for Temp Views

### DIFF
--- a/contrib/starrocks-python-client/CHANGES.md
+++ b/contrib/starrocks-python-client/CHANGES.md
@@ -3,6 +3,13 @@ Version history
 
 **Unreleased**
 
+- Add the `starrocks_temp_view_schema` Alembic option (`context.configure(...)`) to designate
+  the schema in which the transient view used to canonicalize view/MV definitions is created.
+  Lets a locked-down migration user be granted the required privileges on a single schema
+  (e.g. the same one as `version_table_schema`) instead of on every schema that holds a view.
+  Also logs (DEBUG) when the temp view cannot be created, so the AST/regex fallback is no
+  longer silent.
+
 **1.3.4**
 
 - Add `to_diff_tuple` for Alembic alter operations (#70146 by @arvindKandpal-ksolves)

--- a/contrib/starrocks-python-client/CHANGES.md
+++ b/contrib/starrocks-python-client/CHANGES.md
@@ -7,8 +7,6 @@ Version history
   the schema in which the transient view used to canonicalize view/MV definitions is created.
   Lets a locked-down migration user be granted the required privileges on a single schema
   (e.g. the same one as `version_table_schema`) instead of on every schema that holds a view.
-  Also logs (DEBUG) when the temp view cannot be created, so the AST/regex fallback is no
-  longer silent.
 
 **1.3.4**
 

--- a/contrib/starrocks-python-client/docs/usage_guide/alembic.md
+++ b/contrib/starrocks-python-client/docs/usage_guide/alembic.md
@@ -157,10 +157,7 @@ schema and grant the required privileges only there.
 ```python
 # alembic/env.py
 context.configure(
-    connection=connection,
-    target_metadata=target_metadata,
-    render_item=render_column_type,
-    include_object=include_object_for_view_mv,
+    # ... your existing parameters (render_item, include_object, etc.) ...
     starrocks_temp_view_schema="__alembic_canon__",  # host the transient comparison view here
 )
 ```

--- a/contrib/starrocks-python-client/docs/usage_guide/alembic.md
+++ b/contrib/starrocks-python-client/docs/usage_guide/alembic.md
@@ -143,8 +143,8 @@ def run_migrations_online() -> None:
 ### Advanced: Choosing the canonicalization schema for view/MV comparison
 
 On StarRocks versions before 4.0.6 a view/MV definition is stored in the engine's own
-canonical form, which differs textually from the SQL you wrote in your model (dropped
-`col AS col` aliases, added parentheses, `LEFT OUTER JOIN LATERAL unnest`, etc.). To avoid
+canonical form, which could differ textually from the SQL in the model (dropped
+`col AS col` aliases, added parentheses, etc.) but the same semantically. To avoid
 reporting a phantom change on every autogenerate, the dialect canonicalizes your model's
 definition by round-tripping it through a **temporary view** and comparing the engine's
 stored form of both sides.

--- a/contrib/starrocks-python-client/docs/usage_guide/alembic.md
+++ b/contrib/starrocks-python-client/docs/usage_guide/alembic.md
@@ -152,8 +152,7 @@ stored form of both sides.
 By default that temporary view is created in the schema of the object being compared, so
 the migration user needs privileges to create views in every schema that contains a view or
 MV. If your user is locked down, set `starrocks_temp_view_schema` to a single dedicated
-schema (for example the same one as your `version_table_schema`) and grant the required
-privileges only there:
+schema and grant the required privileges only there.
 
 ```python
 # alembic/env.py
@@ -162,17 +161,16 @@ context.configure(
     target_metadata=target_metadata,
     render_item=render_column_type,
     include_object=include_object_for_view_mv,
-    version_table_schema="migrations",
-    starrocks_temp_view_schema="migrations",  # host the transient comparison view here
+    starrocks_temp_view_schema="__alembic_canon__",  # host the transient comparison view here
 )
 ```
 
 Grant the migration user, on that one schema, the privileges needed for the
-create → read-back → drop round-trip:
+create → read-back → drop round-trip (`CREATE VIEW` alone is not enough):
 
 ```sql
-GRANT CREATE VIEW ON DATABASE migrations TO '<user>';
-GRANT SELECT, DROP ON ALL VIEWS IN DATABASE migrations TO '<user>';
+GRANT CREATE VIEW ON DATABASE __alembic_canon__ TO '<user>';
+GRANT SELECT, DROP ON ALL VIEWS IN DATABASE __alembic_canon__ TO '<user>';
 ```
 
 When `starrocks_temp_view_schema` is unset the previous behaviour is unchanged (the temp

--- a/contrib/starrocks-python-client/docs/usage_guide/alembic.md
+++ b/contrib/starrocks-python-client/docs/usage_guide/alembic.md
@@ -140,6 +140,46 @@ def run_migrations_online() -> None:
         ...
 ```
 
+### Advanced: Choosing the canonicalization schema for view/MV comparison
+
+On StarRocks versions before 4.0.6 a view/MV definition is stored in the engine's own
+canonical form, which differs textually from the SQL you wrote in your model (dropped
+`col AS col` aliases, added parentheses, `LEFT OUTER JOIN LATERAL unnest`, etc.). To avoid
+reporting a phantom change on every autogenerate, the dialect canonicalizes your model's
+definition by round-tripping it through a **temporary view** and comparing the engine's
+stored form of both sides.
+
+By default that temporary view is created in the schema of the object being compared, so
+the migration user needs privileges to create views in every schema that contains a view or
+MV. If your user is locked down, set `starrocks_temp_view_schema` to a single dedicated
+schema (for example the same one as your `version_table_schema`) and grant the required
+privileges only there:
+
+```python
+# alembic/env.py
+context.configure(
+    connection=connection,
+    target_metadata=target_metadata,
+    render_item=render_column_type,
+    include_object=include_object_for_view_mv,
+    version_table_schema="migrations",
+    starrocks_temp_view_schema="migrations",  # host the transient comparison view here
+)
+```
+
+Grant the migration user, on that one schema, the privileges needed for the
+create → read-back → drop round-trip:
+
+```sql
+GRANT CREATE VIEW ON DATABASE migrations TO '<user>';
+GRANT SELECT, DROP ON ALL VIEWS IN DATABASE migrations TO '<user>';
+```
+
+When `starrocks_temp_view_schema` is unset the previous behaviour is unchanged (the temp
+view is created in the compared object's own schema). If the temporary view cannot be
+created (missing privilege, or a referenced object that does not exist yet), the comparison
+logs a DEBUG message and falls back to in-process AST/regex normalization.
+
 ### Advanced: Custom Object Filtering
 
 If you need to add custom filtering logic to control which database objects Alembic should process during autogeneration (e.g., excluding temporary tables, test tables, or certain schemas), you can use the `combine_include_object` helper function.

--- a/contrib/starrocks-python-client/starrocks/alembic/compare.py
+++ b/contrib/starrocks-python-client/starrocks/alembic/compare.py
@@ -565,13 +565,15 @@ def _get_canonical_sql_via_temp_view(conn, schema: str, sql: str) -> Optional[st
         ).fetchone()
         return row[0] if row else None
     except Exception as e:
-        # Expected when the migration user cannot CREATE VIEW in ``schema`` (or a
-        # referenced object is missing); logged so the fallback is diagnosable rather
-        # than silent. Set ``starrocks_temp_view_schema`` to a schema the user can write.
+        # Expected when the migration user lacks privileges on ``schema`` (or a referenced
+        # object is missing); logged so the fallback is diagnosable rather than silent. The
+        # round-trip needs create + read-back + drop, so all three privileges are required.
         logger.debug(
             "Temp-view canonicalization could not create %s (falling back to AST/regex "
-            "normalization); grant CREATE VIEW on schema %r or set %s: %s",
-            quoted, schema, TEMP_VIEW_SCHEMA_OPT, e,
+            "normalization). Grant the migration user privileges on schema %r with "
+            "`GRANT CREATE VIEW ON DATABASE %s; GRANT SELECT, DROP ON ALL VIEWS IN DATABASE %s;`, "
+            "or set %s to a schema it can already write to. Error: %s",
+            quoted, schema, schema, schema, TEMP_VIEW_SCHEMA_OPT, e,
         )
         return None
     finally:

--- a/contrib/starrocks-python-client/starrocks/alembic/compare.py
+++ b/contrib/starrocks-python-client/starrocks/alembic/compare.py
@@ -70,6 +70,10 @@ logger = logging.getLogger(__name__)
 
 INTEGER_VISIT_NAMES_WITH_DISPLAY_WIDTH = {"TINYINT", "SMALLINT", "INTEGER", "BIGINT", "LARGEINT"}
 
+# ``context.configure()`` option: schema to host the transient view/MV canonicalization
+# view. When unset, it is created in the compared object's own schema (the prior default).
+TEMP_VIEW_SCHEMA_OPT = "starrocks_temp_view_schema"
+
 
 def _is_integer_with_display_width(type_obj: sqltypes.TypeEngine) -> bool:
     visit_name = getattr(type_obj, "__visit_name__", None)
@@ -535,18 +539,8 @@ def compare_view(
 
         logger.debug(f"Detected changed view attributes ({', '.join(changed_attrs)}) on {view_fqn!r}")
 
-# Alembic ``context.configure()`` option naming the schema in which the transient view
-# used to canonicalize view/MV definitions is created. Setting it lets a locked-down
-# migration user be granted ``CREATE VIEW`` on a single schema (e.g. the same one as
-# ``version_table_schema``) instead of on every schema that contains a view. When unset,
-# the temp view is created in the schema of the object being compared (the prior default).
-TEMP_VIEW_SCHEMA_OPT = "starrocks_temp_view_schema"
-
-
 def _configured_temp_view_schema(autogen_context) -> Optional[str]:
-    """Return the schema configured via
-    ``context.configure(starrocks_temp_view_schema=...)``, or ``None`` when it is not set
-    (callers then default to the compared object's own schema)."""
+    """Return the schema configured by user, or ``None`` when it is not set"""
     migration_context = getattr(autogen_context, "migration_context", None)
     opts = getattr(migration_context, "opts", None) or {}
     return opts.get(TEMP_VIEW_SCHEMA_OPT) or None
@@ -554,9 +548,6 @@ def _configured_temp_view_schema(autogen_context) -> Optional[str]:
 
 def _get_canonical_sql_via_temp_view(conn, schema: str, sql: str) -> Optional[str]:
     """Canonicalize SQL by round-tripping it through a temporary VIEW.
-
-    ``schema`` is the schema in which the transient view is created and read back; it may
-    differ from the compared object's schema when ``starrocks_temp_view_schema`` is set.
 
     Returns the reflected canonical SQL, or ``None`` if the temp VIEW could not be
     created (e.g. a referenced table does not exist yet in this migration, or the

--- a/contrib/starrocks-python-client/starrocks/alembic/compare.py
+++ b/contrib/starrocks-python-client/starrocks/alembic/compare.py
@@ -505,10 +505,12 @@ def compare_view(
     # Compare each view attribute using dedicated functions
     # Order: definition+columns -> comment -> security
     resolved_schema = schema or autogen_context.dialect.default_schema_name
+    temp_view_schema = _configured_temp_view_schema(autogen_context) or resolved_schema
     definition_changed = _compare_view_definition_and_columns(
         alter_view_op, view_fqn, conn_view, metadata_view,
         conn=autogen_context.connection,
         schema=resolved_schema,
+        temp_view_schema=temp_view_schema,
     )
     comment_changed = _compare_view_comment(
         alter_view_op, view_fqn, conn_view, metadata_view
@@ -533,12 +535,33 @@ def compare_view(
 
         logger.debug(f"Detected changed view attributes ({', '.join(changed_attrs)}) on {view_fqn!r}")
 
+# Alembic ``context.configure()`` option naming the schema in which the transient view
+# used to canonicalize view/MV definitions is created. Setting it lets a locked-down
+# migration user be granted ``CREATE VIEW`` on a single schema (e.g. the same one as
+# ``version_table_schema``) instead of on every schema that contains a view. When unset,
+# the temp view is created in the schema of the object being compared (the prior default).
+TEMP_VIEW_SCHEMA_OPT = "starrocks_temp_view_schema"
+
+
+def _configured_temp_view_schema(autogen_context) -> Optional[str]:
+    """Return the schema configured via
+    ``context.configure(starrocks_temp_view_schema=...)``, or ``None`` when it is not set
+    (callers then default to the compared object's own schema)."""
+    migration_context = getattr(autogen_context, "migration_context", None)
+    opts = getattr(migration_context, "opts", None) or {}
+    return opts.get(TEMP_VIEW_SCHEMA_OPT) or None
+
+
 def _get_canonical_sql_via_temp_view(conn, schema: str, sql: str) -> Optional[str]:
     """Canonicalize SQL by round-tripping it through a temporary VIEW.
 
+    ``schema`` is the schema in which the transient view is created and read back; it may
+    differ from the compared object's schema when ``starrocks_temp_view_schema`` is set.
+
     Returns the reflected canonical SQL, or ``None`` if the temp VIEW could not be
-    created (e.g. a referenced table does not exist yet in this migration), in which
-    case the caller falls back to the regex-based normalizer.
+    created (e.g. a referenced table does not exist yet in this migration, or the
+    migration user lacks ``CREATE VIEW`` on ``schema``), in which case the caller falls
+    back to the regex-based normalizer.
     """
     temp_name = f"_alembic_cmp_{uuid.uuid4().hex[:12]}"
     quoted = f"`{schema}`.`{temp_name}`"
@@ -550,7 +573,15 @@ def _get_canonical_sql_via_temp_view(conn, schema: str, sql: str) -> Optional[st
             (schema, temp_name),
         ).fetchone()
         return row[0] if row else None
-    except Exception:
+    except Exception as e:
+        # Expected when the migration user cannot CREATE VIEW in ``schema`` (or a
+        # referenced object is missing); logged so the fallback is diagnosable rather
+        # than silent. Set ``starrocks_temp_view_schema`` to a schema the user can write.
+        logger.debug(
+            "Temp-view canonicalization could not create %s (falling back to AST/regex "
+            "normalization); grant CREATE VIEW on schema %r or set %s: %s",
+            quoted, schema, TEMP_VIEW_SCHEMA_OPT, e,
+        )
         return None
     finally:
         try:
@@ -585,6 +616,7 @@ def _compare_view_definition_and_columns(
     metadata_view: View,
     conn=None,
     schema: Optional[str] = None,
+    temp_view_schema: Optional[str] = None,
 ) -> bool:
     """
     Compare view definition and columns, and update AlterViewOp if changed.
@@ -610,11 +642,12 @@ def _compare_view_definition_and_columns(
     logger.debug("Compare view definition: conn_definition=%s, meta_definition=%s", conn_definition, meta_definition)
 
     if conn is not None and schema is not None:
-        canonical_meta = _get_canonical_sql_via_temp_view(conn, schema, meta_definition)
+        host_schema = temp_view_schema or schema
+        canonical_meta = _get_canonical_sql_via_temp_view(conn, host_schema, meta_definition)
         if canonical_meta is not None:
             conn_def_norm = TableAttributeNormalizer.normalize_sql(conn_definition)
             meta_def_norm = TableAttributeNormalizer.normalize_sql(canonical_meta)
-            logger.debug("View definition comparison via temp-view canonicalization.")
+            logger.debug("View definition comparison via temp-view canonicalization (temp schema %r).", host_schema)
         else:
             logger.debug("Temp-view canonicalization failed for %r; falling back to AST/regex normalizer.", view_fqn)
             conn_def_norm, meta_def_norm = _normalize_definitions_for_compare(conn_definition, meta_definition)
@@ -1029,6 +1062,7 @@ def _compare_mv_definition(
     conn_mv: Union[MaterializedView, Table],
     metadata_mv: Union[MaterializedView, Table],
     conn=None,
+    temp_view_schema: Optional[str] = None,
 ) -> None:
     """
     Compare MV definition and raise error if changed.
@@ -1043,8 +1077,9 @@ def _compare_mv_definition(
 
     # Preferred path: canonicalize both sides through temporary VIEWs.
     if conn is not None and schema is not None:  # schema is already resolved by _compare_mv
-        canonical_conn = _get_canonical_sql_via_temp_view(conn, schema, conn_def_raw)
-        canonical_meta = _get_canonical_sql_via_temp_view(conn, schema, meta_def_raw)
+        host_schema = temp_view_schema or schema
+        canonical_conn = _get_canonical_sql_via_temp_view(conn, host_schema, conn_def_raw)
+        canonical_meta = _get_canonical_sql_via_temp_view(conn, host_schema, meta_def_raw)
         if canonical_conn is not None and canonical_meta is not None:
             conn_def_norm = TableAttributeNormalizer.normalize_sql(canonical_conn)
             meta_def_norm = TableAttributeNormalizer.normalize_sql(canonical_meta)
@@ -1241,8 +1276,9 @@ def _compare_mv(
     # Order: immutable attributes first (will raise error if changed), then mutable attributes
     # Immutable attributes (will raise NotImplementedError if changed):
     resolved_schema = schema or autogen_context.dialect.default_schema_name
+    temp_view_schema = _configured_temp_view_schema(autogen_context) or resolved_schema
     _compare_mv_definition(upgrade_ops.ops, resolved_schema, mv_name, conn_mv, metadata_mv,
-                           conn=autogen_context.connection)
+                           conn=autogen_context.connection, temp_view_schema=temp_view_schema)
     _compare_table_partition(
         upgrade_ops.ops,
         schema,

--- a/contrib/starrocks-python-client/test/unit/test_temp_view_schema_config.py
+++ b/contrib/starrocks-python-client/test/unit/test_temp_view_schema_config.py
@@ -1,0 +1,121 @@
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ``starrocks_temp_view_schema`` Alembic option: the schema in which the
+transient canonicalization view is created for view/MV definition comparison."""
+
+from types import SimpleNamespace
+
+from sqlalchemy import MetaData
+
+from starrocks.alembic import compare
+from starrocks.alembic.compare import (
+    TEMP_VIEW_SCHEMA_OPT,
+    _compare_view_definition_and_columns,
+    _configured_temp_view_schema,
+    _get_canonical_sql_via_temp_view,
+)
+from starrocks.alembic.ops import AlterViewOp
+from starrocks.sql.schema import View
+
+
+def _autogen_context(opts):
+    """Minimal stand-in exposing ``migration_context.opts`` like Alembic's AutogenContext."""
+    return SimpleNamespace(migration_context=SimpleNamespace(opts=opts))
+
+
+class TestConfiguredTempViewSchema:
+    def test_returns_configured_value(self):
+        ctx = _autogen_context({TEMP_VIEW_SCHEMA_OPT: "migrations"})
+        assert _configured_temp_view_schema(ctx) == "migrations"
+
+    def test_none_when_unset(self):
+        assert _configured_temp_view_schema(_autogen_context({})) is None
+
+    def test_empty_string_treated_as_unset(self):
+        assert _configured_temp_view_schema(_autogen_context({TEMP_VIEW_SCHEMA_OPT: ""})) is None
+
+    def test_missing_migration_context(self):
+        assert _configured_temp_view_schema(SimpleNamespace()) is None
+
+
+class _FakeResult:
+    def __init__(self, row):
+        self._row = row
+
+    def fetchone(self):
+        return self._row
+
+
+class _FakeConn:
+    """Records exec_driver_sql calls and returns a canned reflected definition."""
+
+    def __init__(self, reflected_definition):
+        self.calls = []
+        self._reflected = reflected_definition
+
+    def exec_driver_sql(self, sql, params=None):
+        self.calls.append((sql, params))
+        if sql.strip().upper().startswith("SELECT VIEW_DEFINITION"):
+            return _FakeResult((self._reflected,))
+        return _FakeResult(None)
+
+
+class TestTempViewHostSchema:
+    def test_temp_view_created_and_read_in_given_schema(self):
+        conn = _FakeConn("SELECT a FROM t")
+        result = _get_canonical_sql_via_temp_view(conn, "locked_schema", "SELECT a FROM t")
+        assert result == "SELECT a FROM t"
+        create = conn.calls[0][0]
+        assert "CREATE OR REPLACE VIEW `locked_schema`.`_alembic_cmp_" in create
+        # read-back filters information_schema.views on the same schema
+        read = conn.calls[1]
+        assert read[1][0] == "locked_schema"
+        # temp view dropped from the same schema
+        assert any("DROP VIEW IF EXISTS `locked_schema`.`_alembic_cmp_" in c[0] for c in conn.calls)
+
+
+class TestViewCompareRoutesToConfiguredSchema:
+    def test_temp_view_schema_overrides_object_schema(self, monkeypatch):
+        captured = {}
+
+        def fake_temp_view(conn, schema, sql):
+            captured["schema"] = schema
+            return sql  # canonical form == input, so no phantom delta
+
+        monkeypatch.setattr(compare, "_get_canonical_sql_via_temp_view", fake_temp_view)
+
+        md = MetaData()
+        conn_view = View("v", md, definition="SELECT a FROM t")
+        meta_view = View("v", MetaData(), definition="SELECT a FROM t")
+        changed = _compare_view_definition_and_columns(
+            AlterViewOp(view_name="v", schema="app"),
+            "app.v", conn_view, meta_view,
+            conn=object(), schema="app", temp_view_schema="locked_schema",
+        )
+        assert changed is False
+        assert captured["schema"] == "locked_schema"
+
+    def test_defaults_to_object_schema_when_unset(self, monkeypatch):
+        captured = {}
+        monkeypatch.setattr(compare, "_get_canonical_sql_via_temp_view",
+                            lambda conn, schema, sql: captured.setdefault("schema", schema) or sql)
+        conn_view = View("v", MetaData(), definition="SELECT a FROM t")
+        meta_view = View("v", MetaData(), definition="SELECT a FROM t")
+        _compare_view_definition_and_columns(
+            AlterViewOp(view_name="v", schema="app"),
+            "app.v", conn_view, meta_view,
+            conn=object(), schema="app",  # temp_view_schema not passed
+        )
+        assert captured["schema"] == "app"

--- a/docs/en/integrations/starrocks_sqlalchemy.md
+++ b/docs/en/integrations/starrocks_sqlalchemy.md
@@ -293,6 +293,32 @@ This enables Alembic’s **autogenerate** to work properly.
                 context.run_migrations()
     ```
 
+### Choosing the canonicalization schema for view/MV comparison
+
+On StarRocks versions before 4.0.6, a view or materialized-view definition is stored in the engine's own canonical form, which can differ textually from the SQL in your model (dropped `col AS col` aliases, added parentheses, and similar) while remaining semantically identical. To avoid reporting a phantom change on every autogenerate, the dialect canonicalizes your model's definition by round-tripping it through a **temporary view** and comparing the engine's stored form of both sides.
+
+By default that temporary view is created in the schema of the object being compared, so the migration user needs privileges to create views in every schema that contains a view or MV. If your user is locked down, set `starrocks_temp_view_schema` to a single dedicated schema and grant the required privileges only there. A `__…__` style name (for example `__alembic_canon__`) makes the schema's purpose clear; it can be any schema the user can write to, including an existing one such as your `version_table_schema`:
+
+```python
+# env.py — in both run_migrations_offline() and run_migrations_online()
+context.configure(
+    connection=connection,
+    target_metadata=target_metadata,
+    render_item=render_column_type,
+    include_object=include_object_for_view_mv,
+    starrocks_temp_view_schema="__alembic_canon__",  # host the transient comparison view here
+)
+```
+
+Grant the migration user, on that one schema, the privileges needed for the create → read-back → drop round-trip (`CREATE VIEW` alone is not enough):
+
+```sql
+GRANT CREATE VIEW ON DATABASE __alembic_canon__ TO '<user>';
+GRANT SELECT, DROP ON ALL VIEWS IN DATABASE __alembic_canon__ TO '<user>';
+```
+
+When `starrocks_temp_view_schema` is unset, behavior is unchanged (the temporary view is created in the compared object's own schema). If the temporary view cannot be created (missing privilege, or a referenced object that does not exist yet), the comparison logs a DEBUG message and falls back to in-process AST/regex normalization.
+
 ### Generating migrations automatically
 
 ```bash

--- a/docs/en/integrations/starrocks_sqlalchemy.md
+++ b/docs/en/integrations/starrocks_sqlalchemy.md
@@ -300,12 +300,9 @@ On StarRocks versions before 4.0.6, a view or materialized-view definition is st
 By default that temporary view is created in the schema of the object being compared, so the migration user needs privileges to create views in every schema that contains a view or MV. If your user is locked down, set `starrocks_temp_view_schema` to a single dedicated schema and grant the required privileges only there. A `__…__` style name (for example `__alembic_canon__`) makes the schema's purpose clear; it can be any schema the user can write to, including an existing one such as your `version_table_schema`:
 
 ```python
-# env.py — in both run_migrations_offline() and run_migrations_online()
+# env.py
 context.configure(
-    connection=connection,
-    target_metadata=target_metadata,
-    render_item=render_column_type,
-    include_object=include_object_for_view_mv,
+    # ... your existing parameters (render_item, include_object, etc.) ...
     starrocks_temp_view_schema="__alembic_canon__",  # host the transient comparison view here
 )
 ```

--- a/docs/ja/integrations/starrocks_sqlalchemy.md
+++ b/docs/ja/integrations/starrocks_sqlalchemy.md
@@ -300,12 +300,9 @@ StarRocks SQLAlchemy ダイアレクトは以下を完全にサポートしま�
 デフォルトでは、この一時ビューは比較対象オブジェクトのスキーマに作成されるため、移行ユーザーはビュー/MV を含むすべてのスキーマでビューを作成する権限が必要です。ユーザーの権限が制限されている場合は、`starrocks_temp_view_schema` を専用のスキーマ 1 つに設定し、そのスキーマにのみ必要な権限を付与してください。`__…__` 形式の名前（例: `__alembic_canon__`）を使うとスキーマの用途が明確になります。ユーザーが書き込めるスキーマであれば何でもよく、既存のスキーマ（`version_table_schema` など）を再利用することもできます:
 
 ```python
-# env.py — run_migrations_offline() と run_migrations_online() の両方で設定
+# env.py
 context.configure(
-    connection=connection,
-    target_metadata=target_metadata,
-    render_item=render_column_type,
-    include_object=include_object_for_view_mv,
+    # ... 既存のパラメータ（render_item、include_object など）...
     starrocks_temp_view_schema="__alembic_canon__",  # 一時比較ビューをここに作成
 )
 ```

--- a/docs/ja/integrations/starrocks_sqlalchemy.md
+++ b/docs/ja/integrations/starrocks_sqlalchemy.md
@@ -293,6 +293,32 @@ StarRocks SQLAlchemy ダイアレクトは以下を完全にサポートしま�
                 context.run_migrations()
     ```
 
+### ビュー/マテリアライズドビュー比較のための正規化スキーマの選択
+
+4.0.6 より前の StarRocks では、ビューまたはマテリアライズドビューの定義はエンジン独自の正規化された形式で保存されます。これはモデル内の SQL とテキスト上は異なる場合があります（`col AS col` エイリアスの削除、括弧の追加など）が、意味的には同一です。自動生成のたびに誤った変更が報告されるのを避けるため、方言はモデル定義を**一時ビューを経由して往復**させ、両者のエンジン保存形式を比較することで正規化します。
+
+デフォルトでは、この一時ビューは比較対象オブジェクトのスキーマに作成されるため、移行ユーザーはビュー/MV を含むすべてのスキーマでビューを作成する権限が必要です。ユーザーの権限が制限されている場合は、`starrocks_temp_view_schema` を専用のスキーマ 1 つに設定し、そのスキーマにのみ必要な権限を付与してください。`__…__` 形式の名前（例: `__alembic_canon__`）を使うとスキーマの用途が明確になります。ユーザーが書き込めるスキーマであれば何でもよく、既存のスキーマ（`version_table_schema` など）を再利用することもできます:
+
+```python
+# env.py — run_migrations_offline() と run_migrations_online() の両方で設定
+context.configure(
+    connection=connection,
+    target_metadata=target_metadata,
+    render_item=render_column_type,
+    include_object=include_object_for_view_mv,
+    starrocks_temp_view_schema="__alembic_canon__",  # 一時比較ビューをここに作成
+)
+```
+
+「作成 → 読み戻し → 削除」の往復に必要な権限を、そのスキーマ 1 つに対して移行ユーザーへ付与します（`CREATE VIEW` だけでは不十分です）:
+
+```sql
+GRANT CREATE VIEW ON DATABASE __alembic_canon__ TO '<user>';
+GRANT SELECT, DROP ON ALL VIEWS IN DATABASE __alembic_canon__ TO '<user>';
+```
+
+`starrocks_temp_view_schema` を設定しない場合、動作は変わりません（一時ビューは比較対象オブジェクトのスキーマに作成されます）。一時ビューを作成できない場合（権限不足、またはこの移行時点で参照先オブジェクトが存在しない場合）、比較は DEBUG ログを出力し、プロセス内の AST/正規表現による正規化にフォールバックします。
+
 ### マイグレーションの自動生成
 
 ```bash

--- a/docs/zh/integrations/starrocks_sqlalchemy.md
+++ b/docs/zh/integrations/starrocks_sqlalchemy.md
@@ -300,12 +300,9 @@ StarRocks SQLAlchemy 方言提供对以下功能的全面支持：
 默认情况下，该临时视图会创建在被比较对象所在的 schema 中，因此迁移用户需要在每个包含视图或物化视图的 schema 中都具备创建视图的权限。如果您的用户权限受限，可以将 `starrocks_temp_view_schema` 设置为一个专用的 schema，并只在该 schema 上授予所需权限。使用 `__…__` 风格的名称（例如 `__alembic_canon__`）可以让该 schema 的用途更清晰；它可以是用户有写入权限的任意 schema，也可以复用现有的 schema（例如您的 `version_table_schema`）：
 
 ```python
-# env.py —— 在 run_migrations_offline() 和 run_migrations_online() 中均需配置
+# env.py
 context.configure(
-    connection=connection,
-    target_metadata=target_metadata,
-    render_item=render_column_type,
-    include_object=include_object_for_view_mv,
+    # ... 您已有的参数（render_item、include_object 等）...
     starrocks_temp_view_schema="__alembic_canon__",  # 在此 schema 中创建临时比较视图
 )
 ```

--- a/docs/zh/integrations/starrocks_sqlalchemy.md
+++ b/docs/zh/integrations/starrocks_sqlalchemy.md
@@ -293,6 +293,32 @@ StarRocks SQLAlchemy 方言提供对以下功能的全面支持：
                 context.run_migrations()
     ```
 
+### 选择用于视图/物化视图比较的规范化 schema
+
+在 4.0.6 之前的 StarRocks 版本中，视图或物化视图的定义会以引擎自身的规范化形式存储，这可能与模型中的 SQL 在文本上有所不同（例如去掉了 `col AS col` 别名、添加了括号等），但语义完全相同。为避免每次自动生成时都报告虚假的变更，方言会将模型定义**往返经过一个临时视图**，并比较两侧在引擎中存储的形式，以此进行规范化。
+
+默认情况下，该临时视图会创建在被比较对象所在的 schema 中，因此迁移用户需要在每个包含视图或物化视图的 schema 中都具备创建视图的权限。如果您的用户权限受限，可以将 `starrocks_temp_view_schema` 设置为一个专用的 schema，并只在该 schema 上授予所需权限。使用 `__…__` 风格的名称（例如 `__alembic_canon__`）可以让该 schema 的用途更清晰；它可以是用户有写入权限的任意 schema，也可以复用现有的 schema（例如您的 `version_table_schema`）：
+
+```python
+# env.py —— 在 run_migrations_offline() 和 run_migrations_online() 中均需配置
+context.configure(
+    connection=connection,
+    target_metadata=target_metadata,
+    render_item=render_column_type,
+    include_object=include_object_for_view_mv,
+    starrocks_temp_view_schema="__alembic_canon__",  # 在此 schema 中创建临时比较视图
+)
+```
+
+在该 schema 上为迁移用户授予“创建 → 回读 → 删除”整个往返所需的权限（仅有 `CREATE VIEW` 是不够的）：
+
+```sql
+GRANT CREATE VIEW ON DATABASE __alembic_canon__ TO '<user>';
+GRANT SELECT, DROP ON ALL VIEWS IN DATABASE __alembic_canon__ TO '<user>';
+```
+
+当未设置 `starrocks_temp_view_schema` 时，行为保持不变（临时视图仍创建在被比较对象所在的 schema 中）。如果临时视图无法创建（缺少权限，或引用的对象在本次迁移中尚不存在），比较会记录一条 DEBUG 日志，并回退到进程内的 AST/正则规范化。
+
 ### 自动生成迁移
 
 ```bash


### PR DESCRIPTION
## Why I'm doing:
The view/MV definition comparison introduced in #75984 canonicalizes definitions by round-tripping them through a temporary view created in the compared object's own schema, which forces locked-down migration users to hold view-creation/deletion privileges across every schema that contains a view or MV.
## What I'm doing:
Adding a `starrocks_temp_view_schema` Alembic `context.configure()` option that routes those temporary comparison views into a single designated schema (e.g. the same one as version_table_schema), so the migration user only needs the create/read/drop privileges there.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5