### PR TITLE
[Doc] Catch absolute docs.starrocks.io links with Vale, and fix fence detection in the script rules

### DIFF
--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -11,6 +11,7 @@ mdx = md
 # off for _assets sub-directories.
 [*.md]
 BasedOnStyles = local
+local.AbsoluteDocsLink = NO
 local.BareAngleBrackets = NO
 local.FrontmatterDescription = NO
 local.FrontmatterDescriptionFluff = NO
@@ -18,6 +19,7 @@ local.FrontmatterDuplicateKey = NO
 
 [*.mdx]
 BasedOnStyles = local
+local.AbsoluteDocsLink = NO
 local.BareAngleBrackets = NO
 local.FrontmatterDescription = NO
 local.FrontmatterDescriptionFluff = NO
@@ -25,6 +27,7 @@ local.FrontmatterDuplicateKey = NO
 
 # **/ prefix makes these match from any working directory (repo root or docs/).
 [**/{en,zh,ja}/**/*.md]
+local.AbsoluteDocsLink = YES
 local.FrontmatterDescription = YES
 local.FrontmatterDescriptionFluff = YES
 local.FrontmatterDuplicateKey = YES
@@ -32,9 +35,17 @@ local.FrontmatterDuplicateKey = YES
 # MDX pages use the same YAML frontmatter and can hit the same Docusaurus/js-yaml
 # duplicated mapping key build failure, so enable the duplicate-key check there too.
 [**/{en,zh,ja}/**/*.mdx]
+local.AbsoluteDocsLink = YES
 local.FrontmatterDuplicateKey = YES
 
 [**/{en,zh,ja}/_assets/**]
 local.FrontmatterDescription = NO
 local.FrontmatterDescriptionFluff = NO
 local.FrontmatterDuplicateKey = NO
+
+# Historical release notes link to doc pages using the absolute paths those
+# pages had at release time. They are a record of what shipped, not live
+# navigation, so rewriting them to relative links would be wrong — and many
+# targets no longer exist at all.
+[**/{en,zh,ja}/release_notes/**]
+local.AbsoluteDocsLink = NO

--- a/docs/en/sql-reference/template_for_config.md
+++ b/docs/en/sql-reference/template_for_config.md
@@ -5,7 +5,7 @@ unlisted: true
 
 # Template for writing FE/BE parameters and variables
 
-> When you add, modify, or delete an FE/BE parameter or a variable in code, do remember to update documentation: [FE configuration](https://docs.starrocks.io/docs/administration/management/FE_configuration/), [BE configuration](https://docs.starrocks.io/docs/administration/management/BE_configuration/), [System variables](https://docs.starrocks.io/docs/reference/System_variable/).
+> When you add, modify, or delete an FE/BE parameter or a variable in code, do remember to update documentation: [FE configuration](../administration/management/FE_configuration.md), [BE configuration](../administration/management/BE_configuration.md), [System variables](./System_variable.md).
 
 The parameter or variable description usually contains the following fields:
 

--- a/docs/styles/config/scripts/AbsoluteDocsLink.tengo
+++ b/docs/styles/config/scripts/AbsoluteDocsLink.tengo
@@ -1,0 +1,63 @@
+// AbsoluteDocsLink.tengo
+//
+// Detect absolute https://docs.starrocks.io/... links to documentation pages,
+// outside code blocks.
+//
+// Docusaurus classifies a fully-qualified URL as an EXTERNAL link even when it
+// points back at our own site, so `onBrokenLinks: 'throw'` never validates it.
+// A relative link is checked at build time and fails the build when its target
+// moves; an absolute one silently rots.
+//
+//   Bad:  [System variables](https://docs.starrocks.io/docs/sql-reference/System_variable/)
+//   Good: [System variables](../sql-reference/System_variable.md)
+//
+// Also caught, because both are always wrong:
+//   - /en/docs/...  the en locale is the default and has NO path prefix
+//   - /zh/docs/..., /ja/docs/... from an English page — a cross-locale link
+//     that sends readers into another language's docs
+//
+// NOT caught (these have no relative equivalent and are legitimate):
+//   - https://docs.starrocks.io/join/          static page, not a doc route
+//   - https://docs.starrocks.io/releasenotes/  separate plugin instance
+//
+// Historical release notes are exempt via .vale.ini — they record the paths
+// that existed at release time.
+//
+// Code regions excluded from flagging:
+//   - Backtick fenced code blocks:  ```[lang]\n...\n```
+//   - Tilde fenced code blocks:     ~~~[lang]\n...\n~~~
+//   - Inline code spans:            `...`
+
+text := import("text")
+
+code_regions := []
+
+for groups in text.re_find("(?s)```[^\n]*\n.*?\n[ \t]*```[ \t]*(?:\n|$)", scope, -1) {
+    m := groups[0]
+    code_regions = append(code_regions, [m.begin, m.end])
+}
+
+for groups in text.re_find("(?s)~~~[^\n]*\n.*?\n[ \t]*~~~[ \t]*(?:\n|$)", scope, -1) {
+    m := groups[0]
+    code_regions = append(code_regions, [m.begin, m.end])
+}
+
+for groups in text.re_find("`+[^`\n]+`+", scope, -1) {
+    m := groups[0]
+    code_regions = append(code_regions, [m.begin, m.end])
+}
+
+matches := []
+for groups in text.re_find(`\]\(https://docs\.starrocks\.io/(?:en/|zh/|ja/)?docs/[^)]*\)`, scope, -1) {
+    hit := groups[0]
+    inside := false
+    for r in code_regions {
+        if hit.begin >= r[0] && hit.begin < r[1] {
+            inside = true
+            break
+        }
+    }
+    if !inside {
+        matches = append(matches, {begin: hit.begin, end: hit.end})
+    }
+}

--- a/docs/styles/config/scripts/BackslashEscape.tengo
+++ b/docs/styles/config/scripts/BackslashEscape.tengo
@@ -22,14 +22,39 @@ text := import("text")
 
 code_regions := []
 
-for groups in text.re_find("(?s)```[^\n]*\n.*?\n[ \t]*```[ \t]*(?:\n|$)", scope, -1) {
-    m := groups[0]
-    code_regions = append(code_regions, [m.begin, m.end])
+// Fenced code blocks, scanned line by line.
+//
+// CommonMark requires a closing fence to use the same character as the opening
+// fence AND to be at least as long. RE2 has no backreferences, so a regex
+// cannot express that: a ``` line nested inside a ```` block closed it early,
+// and every fence after it was then inverted — content inside code read as
+// prose and got flagged.
+fence_offset := 0
+in_fence := false
+fence_char := ""
+fence_len := 0
+fence_start := 0
+
+for fence_line in text.split(scope, "\n") {
+    fence_hits := text.re_find("^[ \t]*(`{3,}|~{3,})", fence_line, 1)
+    if !is_undefined(fence_hits) {
+        fence_token := fence_hits[0][1].text
+        if !in_fence {
+            in_fence = true
+            fence_char = fence_token[0:1]
+            fence_len = len(fence_token)
+            fence_start = fence_offset
+        } else if fence_token[0:1] == fence_char && len(fence_token) >= fence_len {
+            in_fence = false
+            code_regions = append(code_regions, [fence_start, fence_offset + len(fence_line) + 1])
+        }
+    }
+    fence_offset += len(fence_line) + 1
 }
 
-for groups in text.re_find("(?s)~~~[^\n]*\n.*?\n[ \t]*~~~[ \t]*(?:\n|$)", scope, -1) {
-    m := groups[0]
-    code_regions = append(code_regions, [m.begin, m.end])
+// An unterminated fence runs to the end of the document.
+if in_fence {
+    code_regions = append(code_regions, [fence_start, len(scope)])
 }
 
 for groups in text.re_find("`+[^`\n]+`+", scope, -1) {

--- a/docs/styles/config/scripts/BareAngleBrackets.tengo
+++ b/docs/styles/config/scripts/BareAngleBrackets.tengo
@@ -19,14 +19,39 @@ text := import("text")
 
 code_regions := []
 
-for groups in text.re_find("(?s)```[^\n]*\n.*?\n[ \t]*```[ \t]*(?:\n|$)", scope, -1) {
-    m := groups[0]
-    code_regions = append(code_regions, [m.begin, m.end])
+// Fenced code blocks, scanned line by line.
+//
+// CommonMark requires a closing fence to use the same character as the opening
+// fence AND to be at least as long. RE2 has no backreferences, so a regex
+// cannot express that: a ``` line nested inside a ```` block closed it early,
+// and every fence after it was then inverted — content inside code read as
+// prose and got flagged.
+fence_offset := 0
+in_fence := false
+fence_char := ""
+fence_len := 0
+fence_start := 0
+
+for fence_line in text.split(scope, "\n") {
+    fence_hits := text.re_find("^[ \t]*(`{3,}|~{3,})", fence_line, 1)
+    if !is_undefined(fence_hits) {
+        fence_token := fence_hits[0][1].text
+        if !in_fence {
+            in_fence = true
+            fence_char = fence_token[0:1]
+            fence_len = len(fence_token)
+            fence_start = fence_offset
+        } else if fence_token[0:1] == fence_char && len(fence_token) >= fence_len {
+            in_fence = false
+            code_regions = append(code_regions, [fence_start, fence_offset + len(fence_line) + 1])
+        }
+    }
+    fence_offset += len(fence_line) + 1
 }
 
-for groups in text.re_find("(?s)~~~[^\n]*\n.*?\n[ \t]*~~~[ \t]*(?:\n|$)", scope, -1) {
-    m := groups[0]
-    code_regions = append(code_regions, [m.begin, m.end])
+// An unterminated fence runs to the end of the document.
+if in_fence {
+    code_regions = append(code_regions, [fence_start, len(scope)])
 }
 
 for groups in text.re_find("`+[^`\n]+`+", scope, -1) {

--- a/docs/styles/config/scripts/HTMLComment.tengo
+++ b/docs/styles/config/scripts/HTMLComment.tengo
@@ -18,18 +18,39 @@ text := import("text")
 // Build the list of byte-offset ranges [begin, end] for all code regions.
 code_regions := []
 
-// Backtick fenced code blocks.
-// Closing fence: optional leading whitespace, ```, optional trailing whitespace,
-// then newline or end of string.
-for groups in text.re_find("(?s)```[^\n]*\n.*?\n[ \t]*```[ \t]*(?:\n|$)", scope, -1) {
-    m := groups[0]
-    code_regions = append(code_regions, [m.begin, m.end])
+// Fenced code blocks, scanned line by line.
+//
+// CommonMark requires a closing fence to use the same character as the opening
+// fence AND to be at least as long. RE2 has no backreferences, so a regex
+// cannot express that: a ``` line nested inside a ```` block closed it early,
+// and every fence after it was then inverted — content inside code read as
+// prose and got flagged.
+fence_offset := 0
+in_fence := false
+fence_char := ""
+fence_len := 0
+fence_start := 0
+
+for fence_line in text.split(scope, "\n") {
+    fence_hits := text.re_find("^[ \t]*(`{3,}|~{3,})", fence_line, 1)
+    if !is_undefined(fence_hits) {
+        fence_token := fence_hits[0][1].text
+        if !in_fence {
+            in_fence = true
+            fence_char = fence_token[0:1]
+            fence_len = len(fence_token)
+            fence_start = fence_offset
+        } else if fence_token[0:1] == fence_char && len(fence_token) >= fence_len {
+            in_fence = false
+            code_regions = append(code_regions, [fence_start, fence_offset + len(fence_line) + 1])
+        }
+    }
+    fence_offset += len(fence_line) + 1
 }
 
-// Tilde fenced code blocks (same structure, different fence character).
-for groups in text.re_find("(?s)~~~[^\n]*\n.*?\n[ \t]*~~~[ \t]*(?:\n|$)", scope, -1) {
-    m := groups[0]
-    code_regions = append(code_regions, [m.begin, m.end])
+// An unterminated fence runs to the end of the document.
+if in_fence {
+    code_regions = append(code_regions, [fence_start, len(scope)])
 }
 
 // Inline code spans (single or multiple backticks, no newlines inside).

--- a/docs/styles/config/scripts/HtmlCodeTag.tengo
+++ b/docs/styles/config/scripts/HtmlCodeTag.tengo
@@ -18,14 +18,39 @@ text := import("text")
 
 code_regions := []
 
-for groups in text.re_find("(?s)```[^\n]*\n.*?\n[ \t]*```[ \t]*(?:\n|$)", scope, -1) {
-    m := groups[0]
-    code_regions = append(code_regions, [m.begin, m.end])
+// Fenced code blocks, scanned line by line.
+//
+// CommonMark requires a closing fence to use the same character as the opening
+// fence AND to be at least as long. RE2 has no backreferences, so a regex
+// cannot express that: a ``` line nested inside a ```` block closed it early,
+// and every fence after it was then inverted — content inside code read as
+// prose and got flagged.
+fence_offset := 0
+in_fence := false
+fence_char := ""
+fence_len := 0
+fence_start := 0
+
+for fence_line in text.split(scope, "\n") {
+    fence_hits := text.re_find("^[ \t]*(`{3,}|~{3,})", fence_line, 1)
+    if !is_undefined(fence_hits) {
+        fence_token := fence_hits[0][1].text
+        if !in_fence {
+            in_fence = true
+            fence_char = fence_token[0:1]
+            fence_len = len(fence_token)
+            fence_start = fence_offset
+        } else if fence_token[0:1] == fence_char && len(fence_token) >= fence_len {
+            in_fence = false
+            code_regions = append(code_regions, [fence_start, fence_offset + len(fence_line) + 1])
+        }
+    }
+    fence_offset += len(fence_line) + 1
 }
 
-for groups in text.re_find("(?s)~~~[^\n]*\n.*?\n[ \t]*~~~[ \t]*(?:\n|$)", scope, -1) {
-    m := groups[0]
-    code_regions = append(code_regions, [m.begin, m.end])
+// An unterminated fence runs to the end of the document.
+if in_fence {
+    code_regions = append(code_regions, [fence_start, len(scope)])
 }
 
 for groups in text.re_find("`+[^`\n]+`+", scope, -1) {

--- a/docs/styles/config/scripts/HtmlEntities.tengo
+++ b/docs/styles/config/scripts/HtmlEntities.tengo
@@ -23,14 +23,39 @@ text := import("text")
 
 code_regions := []
 
-for groups in text.re_find("(?s)```[^\n]*\n.*?\n[ \t]*```[ \t]*(?:\n|$)", scope, -1) {
-    m := groups[0]
-    code_regions = append(code_regions, [m.begin, m.end])
+// Fenced code blocks, scanned line by line.
+//
+// CommonMark requires a closing fence to use the same character as the opening
+// fence AND to be at least as long. RE2 has no backreferences, so a regex
+// cannot express that: a ``` line nested inside a ```` block closed it early,
+// and every fence after it was then inverted — content inside code read as
+// prose and got flagged.
+fence_offset := 0
+in_fence := false
+fence_char := ""
+fence_len := 0
+fence_start := 0
+
+for fence_line in text.split(scope, "\n") {
+    fence_hits := text.re_find("^[ \t]*(`{3,}|~{3,})", fence_line, 1)
+    if !is_undefined(fence_hits) {
+        fence_token := fence_hits[0][1].text
+        if !in_fence {
+            in_fence = true
+            fence_char = fence_token[0:1]
+            fence_len = len(fence_token)
+            fence_start = fence_offset
+        } else if fence_token[0:1] == fence_char && len(fence_token) >= fence_len {
+            in_fence = false
+            code_regions = append(code_regions, [fence_start, fence_offset + len(fence_line) + 1])
+        }
+    }
+    fence_offset += len(fence_line) + 1
 }
 
-for groups in text.re_find("(?s)~~~[^\n]*\n.*?\n[ \t]*~~~[ \t]*(?:\n|$)", scope, -1) {
-    m := groups[0]
-    code_regions = append(code_regions, [m.begin, m.end])
+// An unterminated fence runs to the end of the document.
+if in_fence {
+    code_regions = append(code_regions, [fence_start, len(scope)])
 }
 
 for groups in text.re_find("`+[^`\n]+`+", scope, -1) {

--- a/docs/styles/config/scripts/JsxCloserNeedsBlankLine.tengo
+++ b/docs/styles/config/scripts/JsxCloserNeedsBlankLine.tengo
@@ -34,14 +34,39 @@ text := import("text")
 
 code_regions := []
 
-for groups in text.re_find("(?s)```[^\n]*\n.*?\n[ \t]*```[ \t]*(?:\n|$)", scope, -1) {
-    m := groups[0]
-    code_regions = append(code_regions, [m.begin, m.end])
+// Fenced code blocks, scanned line by line.
+//
+// CommonMark requires a closing fence to use the same character as the opening
+// fence AND to be at least as long. RE2 has no backreferences, so a regex
+// cannot express that: a ``` line nested inside a ```` block closed it early,
+// and every fence after it was then inverted — content inside code read as
+// prose and got flagged.
+fence_offset := 0
+in_fence := false
+fence_char := ""
+fence_len := 0
+fence_start := 0
+
+for fence_line in text.split(scope, "\n") {
+    fence_hits := text.re_find("^[ \t]*(`{3,}|~{3,})", fence_line, 1)
+    if !is_undefined(fence_hits) {
+        fence_token := fence_hits[0][1].text
+        if !in_fence {
+            in_fence = true
+            fence_char = fence_token[0:1]
+            fence_len = len(fence_token)
+            fence_start = fence_offset
+        } else if fence_token[0:1] == fence_char && len(fence_token) >= fence_len {
+            in_fence = false
+            code_regions = append(code_regions, [fence_start, fence_offset + len(fence_line) + 1])
+        }
+    }
+    fence_offset += len(fence_line) + 1
 }
 
-for groups in text.re_find("(?s)~~~[^\n]*\n.*?\n[ \t]*~~~[ \t]*(?:\n|$)", scope, -1) {
-    m := groups[0]
-    code_regions = append(code_regions, [m.begin, m.end])
+// An unterminated fence runs to the end of the document.
+if in_fence {
+    code_regions = append(code_regions, [fence_start, len(scope)])
 }
 
 // Capture the preceding line and the closer separately so we can inspect the

--- a/docs/styles/local/AbsoluteDocsLink.yml
+++ b/docs/styles/local/AbsoluteDocsLink.yml
@@ -1,0 +1,6 @@
+extends: script
+message: "Use a relative Markdown link instead of '%s' — e.g. [System variables](../sql-reference/System_variable.md). Docusaurus treats an absolute docs.starrocks.io URL as an external link, so onBrokenLinks never checks it and it rots silently when the page moves."
+level: error
+scope: raw
+link: https://docusaurus.io/docs/api/docusaurus-config#onBrokenLinks
+script: AbsoluteDocsLink.tengo


### PR DESCRIPTION
## Why

`onBrokenLinks: 'throw'` does not see absolute self-links. Docusaurus classifies a fully-qualified `https://docs.starrocks.io/...` URL as **external**, so it is never validated — while a relative link is checked at build time and fails the build when its target moves.

That is how `sql-reference/template_for_config.md` — the page teaching contributors how to write config docs — ended up linking to `/docs/reference/System_variable/`, a tree renamed to `/docs/sql-reference/` long ago, with every check green.

## 1. New Vale rule: `AbsoluteDocsLink`

Flags `](https://docs.starrocks.io/[en|zh|ja/]docs/...)`, including two forms that are always wrong:

- **`/en/docs/...`** — en is the default locale and has no path prefix, so the URL is dead. One live page does this today.
- **`/zh/docs/...` or `/ja/docs/...` from an English page** — a cross-locale link that drops readers into another language.

**Not** flagged, having no relative equivalent: `https://docs.starrocks.io/join/` (a static page) and `/releasenotes/` (a separate plugin instance). Links inside fenced code blocks and inline code spans are skipped.

### `release_notes/` is exempt

Those record the paths pages had at release time — many targets no longer exist, and rewriting them to relative links would misrepresent what shipped. They are **1260 of the 1357** absolute links in the tree, and that exemption is what makes the rule viable at `level: error`.

### Existing backlog

**25 en, 27 zh, 25 ja across 33 files.** None of it breaks CI now: `ci-vale.yml` lints changed files only, so a contributor sees it when they touch one of those files.

The one scope call worth a second opinion: I did **not** exempt `ecosystem_release/`. Those are connector changelogs, but unlike doc release notes they link to *current* pages that still resolve, so relative is correct. They are 14 of the 25 en violations — one line in `.vale.ini` if you disagree.

## 2. Fix fence detection in all six script rules

While writing the rule I found the same latent bug in every existing script. They locate fenced regions with:

```
(?s)```[^\n]*\n.*?\n[ \t]*```[ \t]*(?:\n|$)
```

CommonMark requires a closing fence to use the same character **and** be at least as long as the opening one. RE2 has no backreferences, so a regex cannot express that. A ` ``` ` line nested inside a ` ```` ` block ends the region early, and because that inverts every fence after it, prose rules then run over content still inside code.

This produces **error-level false positives**, not just missed detections. Reproduced with an HTML comment inside a ` ```` ` block flagged as prose — enough to fail CI on a legitimate page:

````markdown
Example of a fenced block inside documentation:

```sql
SELECT 1;
```

<!-- flagged as prose before this fix -->
````

Reachable today: six files use 4-backtick fences, and `zh/sql-reference/sql-statements/table_bucket_part_index/SHOW_ALTER.md` closes a 3-backtick fence with a 4-backtick one, which the old regex cannot match at all.

Replaced with a line scan tracking fence character and length, closing only on a same-character fence of equal or greater length. Unterminated fences now correctly run to end of document.

Affects `BackslashEscape`, `BareAngleBrackets`, `HTMLComment`, `HtmlCodeTag`, `HtmlEntities`, `JsxCloserNeedsBlankLine`. All but `BareAngleBrackets` are enabled by default; that one is `= NO` in `.vale.ini` but fixed for consistency.

## 3. Fix the template's links

All three links in `template_for_config.md` converted to relative form, so `onBrokenLinks` now checks them. The other two (FE/BE configuration) resolved correctly but were equally unvalidated.

## Verification

- **Rule:** fixture covering same-locale, `/en/docs/`, and cross-locale (all flagged); `/join/`, `/releasenotes/`, relative links, `www.starrocks.io`, and links in inline code and fenced blocks (all silent). Exactly 3 of 9 cases flagged, as designed.
- **Fence fix, no regressions:** en 22, zh 13, ja 12 alerts before and after, measured by stashing and restoring the change. Zero corpus change — a latent fix, not a behavior change.
- **Fence fix, works both ways:** the false-positive fixture is now clean; a genuine HTML comment in prose still errors.
- **This PR's own files pass:** `template_for_config.md` is clean, so the Vale job will not fail on the PR that adds the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)