### PR TITLE
[Enhancement] Revert Support ANALYZE SAMPLE TABLE PREDICATE COLUMNS for external tables (#77278)

### DIFF
--- a/docs/en/using_starrocks/Cost_based_optimizer.md
+++ b/docs/en/using_starrocks/Cost_based_optimizer.md
@@ -248,7 +248,7 @@ Parameter description:
 - The type of the column from which to collect statistics:
   - `col_name`: Columns from which to collect statistics. Separate multiple columns with commas (`,`). If this parameter is not specified, the entire table is collected.
   - `ALL COLUMNS`: Collect statistics from all columns. Supported since v3.5.0.
-  - `PREDICATE COLUMNS`: Collect statistics from only Predicate Columns. Supported for native tables since v3.5.0 and for analyzable external tables, including Hive, Iceberg, Hudi, ODPS, Delta Lake, and Paimon, since v4.1.4.
+  - `PREDICATE COLUMNS`: Collect statistics from only Predicate Columns. Supported since v3.5.0.
   - `MULTIPLE COLUMNS`: Collects joint statistics from the specified multiple columns. Currently, only manual synchronous collection of multiple columns is supported. The number of columns for manual statistics collection cannot exceed `statistics_max_multi_column_combined_num`, the default value is `10`. Supported since v3.5.0.
 
 - `WITH SYNC | ASYNC MODE`: whether to run the manual collection task in synchronous or asynchronous mode. Synchronous collection is used by default if you do not specify this parameter.

--- a/docs/ja/using_starrocks/Cost_based_optimizer.md
+++ b/docs/ja/using_starrocks/Cost_based_optimizer.md
@@ -250,7 +250,7 @@ ANALYZE [FULL|SAMPLE] TABLE tbl_name
 - 統計情報を収集するカラムの型：
   - `col_name`： 統計情報を収集する列。複数の列はカンマ (`,`) で区切る。このパラメータが指定されない場合は、テーブル全体が収集される。
   - `ALL COLUMNS`： すべての列から統計情報を収集する。v3.5.0 からサポートされている。
-  - `PREDICATE COLUMNS`：Predicate Column のみから統計情報を収集する。ネイティブテーブルでは v3.5.0 から、Hive、Iceberg、Hudi、ODPS、Delta Lake、Paimon を含む分析可能な外部テーブルでは v4.1.4 からサポートされている。
+  - `PREDICATE COLUMNS`：Predicate Column のみから統計情報を収集する。v3.5.0 からサポート。
   - `MULTIPLE COLUMNS`：指定した複数の列から共同の統計情報を収集する。現在のところ、複数列の手動同期収集のみがサポートされている。手動で統計情報を収集する列の数は `statistics_max_multi_column_combined_num` を超えることはできず、デフォルト値は `10` である。v3.5.0 からサポートされている。
 
 - `WITH SYNC | ASYNC MODE`: 手動収集タスクを同期モードまたは非同期モードで実行するかどうか。指定しない場合、デフォルトで同期収集が使用されます。

--- a/docs/zh/using_starrocks/Cost_based_optimizer.md
+++ b/docs/zh/using_starrocks/Cost_based_optimizer.md
@@ -244,7 +244,7 @@ ANALYZE [FULL|SAMPLE] TABLE tbl_name
 - 采集列类型：
   - `col_name`: 要采集统计信息的列，多列使用逗号分隔。如果不指定，表示采集整张表的信息。
   - `ALL COLUMNS`：对所有列进行采集。自 v3.5.0 起支持。
-  - `PREDICATE COLUMNS`：仅对 Predicate Column 进行采集。原生表自 v3.5.0 起支持，可分析的外部表（包括 Hive、Iceberg、Hudi、ODPS、Delta Lake 和 Paimon）自 v4.1.4 起支持。
+  - `PREDICATE COLUMNS`：仅对 Predicate Column 进行采集。自 v3.5.0 起支持。
   - `MULTIPLE COLUMNS`：对指定的多个列进行联合统计信息进行采集。当前多列联合统计信息仅支持手动同步采集。当前手动采集多列联合统计信息的列数不能超过 `statistics_max_multi_column_combined_num`, 默认值为 `10`。自 v3.5.0 起支持。
 
 - `PROPERTIES`: 采集任务的自定义参数。如果不配置，则采用 `fe.conf` 中的默认配置。

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
@@ -51,7 +51,6 @@ import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.statistic.StatsConstants;
 import com.starrocks.statistic.columns.ColumnUsage;
-import com.starrocks.statistic.columns.ExternalColumnUsage;
 import com.starrocks.statistic.columns.PredicateColumnsMgr;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
@@ -211,34 +210,20 @@ public class AnalyzeStmtAnalyzer {
             // ANALYZE TABLE xxx PREDICATE COLUMNS
             if (statement.isUsePredicateColumns()) {
                 // check if the table type is supported
-                if (!analyzeTable.isNativeTableOrMaterializedView() && !analyzeTable.isAnalyzableExternalTable()) {
-                    throw new SemanticException("Only analyzable table can support ANALYZE PREDICATE COLUMNS");
+                if (!analyzeTable.isNativeTableOrMaterializedView()) {
+                    throw new SemanticException("Only OLAP table can support ANALYZE PREDICATE COLUMNS");
                 }
 
                 List<String> targetColumns = Lists.newArrayList();
 
-                if (analyzeTable.isNativeTableOrMaterializedView()) {
-                    TableName tableNameForPredicate = new TableName(tableRef.getCatalogName(), tableRef.getDbName(),
-                            tableRef.getTableName(), tableRef.getPos());
-                    List<ColumnUsage> predicateColumns =
-                            PredicateColumnsMgr.getInstance().queryPredicateColumns(tableNameForPredicate);
-                    for (ColumnUsage col : ListUtils.emptyIfNull(predicateColumns)) {
-                        Column realColumn = analyzeTable.getColumnByUniqueId(col.getColumnFullId().getColumnUniqueId());
-                        if (realColumn != null) {
-                            targetColumns.add(realColumn.getName());
-                        }
-                    }
-                } else {
-                    for (ExternalColumnUsage col : ListUtils.emptyIfNull(
-                            PredicateColumnsMgr.getInstance().queryExternalPredicateColumns(analyzeTable))) {
-                        Column realColumn = analyzeTable.getColumn(col.getColumnName());
-                        if (realColumn != null) {
-                            targetColumns.add(realColumn.getName());
-                        }
-                    }
-                    if (targetColumns.isEmpty()) {
-                        throw new SemanticException("No predicate columns found for external table '%s'",
-                                analyzeTable.getName());
+                TableName tableNameForPredicate = new TableName(tableRef.getCatalogName(), tableRef.getDbName(),
+                        tableRef.getTableName(), tableRef.getPos());
+                List<ColumnUsage> predicateColumns =
+                        PredicateColumnsMgr.getInstance().queryPredicateColumns(tableNameForPredicate);
+                for (ColumnUsage col : ListUtils.emptyIfNull(predicateColumns)) {
+                    Column realColumn = analyzeTable.getColumnByUniqueId(col.getColumnFullId().getColumnUniqueId());
+                    if (realColumn != null) {
+                        targetColumns.add(realColumn.getName());
                     }
                 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
@@ -66,9 +66,6 @@ import com.starrocks.statistic.StatisticSQLBuilder;
 import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.statistic.StatisticsMetaManager;
 import com.starrocks.statistic.StatsConstants;
-import com.starrocks.statistic.columns.ColumnUsage;
-import com.starrocks.statistic.columns.ExternalColumnUsage;
-import com.starrocks.statistic.columns.PredicateColumnsMgr;
 import com.starrocks.statistic.columns.PredicateColumnsStorage;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
@@ -203,37 +200,6 @@ public class AnalyzeStmtTest {
         sql = "analyze table hive0.tpch.customer(C_NAME, C_PHONE)";
         analyzeStmt = (AnalyzeStmt) analyzeSuccess(sql);
         Assertions.assertEquals("[c_name, c_phone]", analyzeStmt.getColumnNames().toString());
-    }
-
-    @Test
-    public void testAnalyzeExternalPredicateColumns() {
-        new MockUp<PredicateColumnsMgr>() {
-            @Mock
-            public List<ExternalColumnUsage> queryExternalPredicateColumns(Table table) {
-                return List.of(new ExternalColumnUsage("table-hash", table.getCatalogName(),
-                        table.getCatalogDBName(), table.getCatalogTableName(), "c_name",
-                        ColumnUsage.UseCase.PREDICATE));
-            }
-        };
-
-        AnalyzeStmt analyzeStmt = (AnalyzeStmt) analyzeSuccess(
-                "analyze sample table hive0.tpch.customer predicate columns");
-        Assertions.assertTrue(analyzeStmt.isExternal());
-        Assertions.assertTrue(analyzeStmt.isSample());
-        Assertions.assertEquals(List.of("c_name"), analyzeStmt.getColumnNames());
-    }
-
-    @Test
-    public void testAnalyzeExternalPredicateColumnsWithoutUsage() {
-        new MockUp<PredicateColumnsMgr>() {
-            @Mock
-            public List<ExternalColumnUsage> queryExternalPredicateColumns(Table table) {
-                return List.of();
-            }
-        };
-
-        analyzeFail("analyze sample table hive0.tpch.customer predicate columns",
-                "No predicate columns found for external table 'customer'");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

#77278 merged `[Enhancement] Support ANALYZE SAMPLE TABLE PREDICATE COLUMNS for external tables` into `branch-4.1.4`, but this enhancement should not ship in 4.1.4. This PR reverts it from the release branch.

## What I'm doing:

Revert #77278 (merge commit `590d34399bd036c557c917a6cace2efe64f09a83`) on `branch-4.1.4`. It is the exact inverse of the original change (5 files, +13/-62): `AnalyzeStmtAnalyzer.java`, `AnalyzeStmtTest.java`, and the en/ja/zh `Cost_based_optimizer.md` docs.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4