### PR TITLE
[BugFix] Don't penalize two-stage aggregation as redundant when aggregation must be multi-stage (backport #77296)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -17,7 +17,6 @@ package com.starrocks.sql.optimizer.cost;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.starrocks.catalog.FunctionSet;
 import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
@@ -56,8 +55,6 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
-import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.sql.optimizer.statistics.StatisticsEstimateCoefficient;
@@ -535,20 +532,10 @@ public class CostModel {
                     // Don't limited to multi-stage aggregate node, refs: invalidOneStageAggCost
                     // split aggregate node lose distinct flag, check the group's origin
                     // aggregate
-                    LogicalAggregationOperator originAgg = group.getFirstLogicalExpression().getOp().cast();
-                    for (CallOperator callOperator : originAgg.getAggregations().values()) {
-                        if (callOperator.isDistinct()) {
-                            String fnName = callOperator.getFnName();
-                            List<ScalarOperator> children = callOperator.getChildren();
-                            if (children.size() > 1 || children.stream().anyMatch(c -> c.getType().isComplexType())
-                                    || FunctionSet.GROUP_CONCAT.equalsIgnoreCase(fnName)
-                                    || FunctionSet.AVG.equalsIgnoreCase(fnName)) {
-                                return Optional.empty();
-                            } else if (FunctionSet.ARRAY_AGG.equalsIgnoreCase(fnName) && (children.size() > 1
-                                    || children.get(0).getType().isDecimalOfAnyVersion())) {
-                                return Optional.empty();
-                            }
-                        }
+                    GroupExpression firstLogicalExpression = group.getFirstLogicalExpression();
+                    if (Utils.mustGenerateMultiStageAggregate(firstLogicalExpression.getOp(),
+                            firstLogicalExpression.inputAt(0).getFirstLogicalExpression().getOp())) {
+                        return Optional.empty();
                     }
                     return Optional.of(CostEstimate.infinite());
                 }


### PR DESCRIPTION
## Why I'm doing:

A production query joining two GROUPING SETS aggregations on derived keys fails at planning with `no executable plan for this sql`:

```sql
from   ( ... group by grouping sets((k1, k2, ...), (k1, k2, ..., k3)) ) a
left join ( ... large table ... group by grouping sets((c1, c2, c3), (c1, c2)) ) b
  on  a.k1 = b.c1 and a.k2 = b.c2 and a.k3 = b.c3   -- join keys are derived (cast/coalesce) from group-by columns
```

Two cost rules collide on this aggregation:

1. It sits above REPEAT, so it **must** be multi-stage: `invalidOneStageAggCost` rejects the one-stage candidate with an infinite cost (BE hard constraint, correct).
2. Its input distribution is reused from the shuffle produced by the join subtree below (property pass-through), so the input source is `SHUFFLE_JOIN`. `redundantTwoStageAggCost` then rejects the **two-stage** candidate with an infinite cost too, assuming a one-stage alternative exists — without verifying that assumption.

With both candidates infinite and the parent join's broadcast alternative forbidden by the row-count limit (both sides far above `broadcast_row_limit`), the group has no viable plan and the failure cascades to the root. The same query plans fine on 3.3, which never produces the "two-stage aggregation consuming a SHUFFLE_JOIN-sourced input" shape. No session variable works around it.

## What I'm doing:

In `redundantTwoStageAggCost`, verify the premise before applying the penalty: if the aggregation must be multi-stage, a one-stage plan can never exist, so the two-stage plan is not redundant and must not be penalized.

- The check reuses `Utils.mustGenerateMultiStageAggregate` — the same authority `invalidOneStageAggCost` uses — so the two rules cannot disagree.
- It is evaluated on the **group's origin logical aggregation and its origin input**, because the split aggregate node loses the distinct flag and its direct child is the local aggregation instead of the real input (e.g. REPEAT).
- This replaces the previous hand-written distinct exemption list, which was a strict subset of `mustGenerateMultiStageAggregate` (it covered the distinct cases but missed REPEAT). Behavior for aggregations that can be one-stage is unchanged.

## Verification

Verified by replaying the production query dump on a 3.5 build: deterministic `no executable plan` failure before the fix, valid plan (two-stage aggregation over REPEAT, shuffle join) after; the production dump contains customer schemas so it is not included here — a sanitized regression test will follow in a separate PR. Neighborhood regression green on the same build: full ReplayFromDumpTest, AggregateTest, DistinctAggTest, GroupingSetTest.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: the redundant-two-stage-aggregation penalty no longer misfires on must-multi-stage aggregations; queries that previously failed with "no executable plan" now plan normally

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
