### PR TITLE
[BugFix] Fix no-executable-plan failure for GROUPING SETS aggregation joined on its group-by keys

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -17,7 +17,6 @@ package com.starrocks.sql.optimizer.cost;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.starrocks.catalog.FunctionSet;
 import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
@@ -57,9 +56,7 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
-import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.skew.DataSkew;
 import com.starrocks.sql.optimizer.skew.DataSkewInfo;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
@@ -653,20 +650,10 @@ public class CostModel {
                     // Don't limited to multi-stage aggregate node, refs: invalidOneStageAggCost
                     // split aggregate node lose distinct flag, check the group's origin
                     // aggregate
-                    LogicalAggregationOperator originAgg = group.getFirstLogicalExpression().getOp().cast();
-                    for (CallOperator callOperator : originAgg.getAggregations().values()) {
-                        if (callOperator.isDistinct()) {
-                            String fnName = callOperator.getFnName();
-                            List<ScalarOperator> children = callOperator.getChildren();
-                            if (children.size() > 1 || children.stream().anyMatch(c -> c.getType().isComplexType())
-                                    || FunctionSet.GROUP_CONCAT.equalsIgnoreCase(fnName)
-                                    || FunctionSet.AVG.equalsIgnoreCase(fnName)) {
-                                return Optional.empty();
-                            } else if (FunctionSet.ARRAY_AGG.equalsIgnoreCase(fnName) && (children.size() > 1
-                                    || children.get(0).getType().isDecimalOfAnyVersion())) {
-                                return Optional.empty();
-                            }
-                        }
+                    GroupExpression firstLogicalExpression = group.getFirstLogicalExpression();
+                    if (Utils.mustGenerateMultiStageAggregate(firstLogicalExpression.getOp(),
+                            firstLogicalExpression.inputAt(0).getFirstLogicalExpression().getOp())) {
+                        return Optional.empty();
                     }
                     return Optional.of(CostEstimate.infinite());
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsJoinAggPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsJoinAggPlanTest.java
@@ -1,0 +1,189 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.common.FeConstants;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+// An aggregation on top of a REPEAT node must be multi-stage, so invalidOneStageAggCost gives the
+// one-stage plan an infinite cost. When such an aggregation also consumes a shuffle it did not ask
+// for itself (source type is not SHUFFLE_AGG), redundantTwoStageAggCost used to give the two-stage
+// plan an infinite cost as well, assuming a one-stage alternative existed. With broadcast forbidden
+// by the row count limit, the group ended up with no viable plan and planning failed.
+public class GroupingSetsJoinAggPlanTest extends DistributedEnvPlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        DistributedEnvPlanTestBase.beforeClass();
+        FeConstants.runningUnitTest = true;
+    }
+
+    @AfterEach
+    public void after() {
+        connectContext.getSessionVariable().setBroadcastRowCountLimit(15000000);
+        connectContext.getSessionVariable().setNewPlanerAggStage(0);
+    }
+
+    // Plans the query with broadcast forbidden, and asserts the aggregation over REPEAT is planned
+    // as a multi-stage aggregation.
+    private void assertMultiStageAggOverRepeat(String sql) throws Exception {
+        connectContext.getSessionVariable().setBroadcastRowCountLimit(1);
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "REPEAT_NODE");
+        assertContains(plan, "AGGREGATE (merge finalize)");
+    }
+
+    @Test
+    public void testGroupingSetsAggUnderLeftJoin() throws Exception {
+        assertMultiStageAggOverRepeat("select a.k1, a.k2, a.s1, b.s2 from "
+                + " (select l_orderkey k1, coalesce(l_linenumber, 0) k2, sum(l_quantity) s1 from lineitem "
+                + "  group by grouping sets((l_orderkey, l_linenumber), (l_orderkey))) a "
+                + " left join (select o_orderkey k1, coalesce(o_custkey, 0) k2, sum(o_totalprice) s2 from orders "
+                + "  group by grouping sets((o_orderkey, o_custkey), (o_orderkey))) b "
+                + " on a.k1 = b.k1 and a.k2 = b.k2");
+    }
+
+    // The defect does not depend on the join type.
+    @Test
+    public void testGroupingSetsAggUnderInnerJoin() throws Exception {
+        assertMultiStageAggOverRepeat("select a.k1, a.k2, a.s1, b.s2 from "
+                + " (select l_orderkey k1, coalesce(l_linenumber, 0) k2, sum(l_quantity) s1 from lineitem "
+                + "  group by grouping sets((l_orderkey, l_linenumber), (l_orderkey))) a "
+                + " join (select o_orderkey k1, coalesce(o_custkey, 0) k2, sum(o_totalprice) s2 from orders "
+                + "  group by grouping sets((o_orderkey, o_custkey), (o_orderkey))) b "
+                + " on a.k1 = b.k1 and a.k2 = b.k2");
+    }
+
+    // Only one side aggregates: the aggregation is joined against a plain table.
+    @Test
+    public void testGroupingSetsAggJoinedWithTable() throws Exception {
+        assertMultiStageAggOverRepeat("select a.k1, a.k2, a.s1, o.o_totalprice from "
+                + " (select l_orderkey k1, coalesce(l_linenumber, 0) k2, sum(l_quantity) s1 from lineitem "
+                + "  group by grouping sets((l_orderkey, l_linenumber), (l_orderkey))) a "
+                + " left join orders o on a.k1 = o.o_orderkey and a.k2 = o.o_custkey");
+    }
+
+    // The aggregation's input distribution comes from a join below it, not from the table itself.
+    @Test
+    public void testGroupingSetsAggOverJoinInput() throws Exception {
+        assertMultiStageAggOverRepeat("select a.k1, a.k2, a.s1, b.s2 from "
+                + " (select k1, coalesce(k2, 0) k2, sum(v) s1 from "
+                + "   (select l_orderkey k1, o_custkey k2, l_quantity v from lineitem join orders "
+                + "     on l_orderkey = o_orderkey) t "
+                + "  group by grouping sets((k1, k2), (k1))) a "
+                + " left join (select o_orderkey k1, coalesce(o_custkey, 0) k2, sum(o_totalprice) s2 from orders "
+                + "  group by grouping sets((o_orderkey, o_custkey), (o_orderkey))) b "
+                + " on a.k1 = b.k1 and a.k2 = b.k2");
+    }
+
+    // Three aggregations joined together.
+    @Test
+    public void testGroupingSetsAggThreeWayJoin() throws Exception {
+        assertMultiStageAggOverRepeat("select a.k1, a.k2, a.s1, b.s2, c.s3 from "
+                + " (select l_orderkey k1, coalesce(l_linenumber, 0) k2, sum(l_quantity) s1 from lineitem "
+                + "  group by grouping sets((l_orderkey, l_linenumber), (l_orderkey))) a "
+                + " left join (select o_orderkey k1, coalesce(o_custkey, 0) k2, sum(o_totalprice) s2 from orders "
+                + "  group by grouping sets((o_orderkey, o_custkey), (o_orderkey))) b "
+                + " on a.k1 = b.k1 and a.k2 = b.k2 "
+                + " left join (select ps_partkey k1, coalesce(ps_suppkey, 0) k2, sum(ps_availqty) s3 from partsupp "
+                + "  group by grouping sets((ps_partkey, ps_suppkey), (ps_partkey))) c "
+                + " on a.k1 = c.k1 and a.k2 = c.k2");
+    }
+
+    // Shape of the reported query: several joins and a window function below the aggregation, one
+    // group-by key carried from the scan and one derived by an expression, and the outer join on
+    // both of them.
+    @Test
+    public void testGroupingSetsAggWithDerivedKeyAndWindow() throws Exception {
+        assertMultiStageAggOverRepeat("select t.k, t.seg, t.m, r.m2 from "
+                + " (select k, seg, sum(amt) m from "
+                + "   (select l_orderkey k, coalesce(substr(c_mktsegment, 1, 4), 'ALL') seg, "
+                + "           sum(l_extendedprice) over (partition by l_orderkey) amt "
+                + "    from lineitem join orders on l_orderkey = o_orderkey "
+                + "                  join customer on o_custkey = c_custkey) s "
+                + "  group by grouping sets((k, seg), (k))) t "
+                + " left join "
+                + " (select k, seg, sum(price) m2 from "
+                + "   (select o_orderkey k, coalesce(substr(c_mktsegment, 1, 4), 'ALL') seg, o_totalprice price "
+                + "    from orders join customer on o_custkey = c_custkey) s2 "
+                + "  group by grouping sets((k, seg), (k))) r "
+                + " on t.k = r.k and t.seg = r.seg");
+    }
+
+    // The join's distribution requirement reaches the aggregation through a window operator.
+    @Test
+    public void testGroupingSetsAggUnderWindowAndJoin() throws Exception {
+        assertMultiStageAggOverRepeat("select x.k1, x.w, b.s2 from "
+                + " (select k1, k2, sum(s1) over (partition by k1) w from "
+                + "   (select l_orderkey k1, coalesce(l_linenumber, 0) k2, sum(l_quantity) s1 from lineitem "
+                + "    group by grouping sets((l_orderkey, l_linenumber), (l_orderkey))) a) x "
+                + " left join (select o_orderkey k1, coalesce(o_custkey, 0) k2, sum(o_totalprice) s2 from orders "
+                + "  group by grouping sets((o_orderkey, o_custkey), (o_orderkey))) b "
+                + " on x.k1 = b.k1 and x.k2 = b.k2");
+    }
+
+    // A semi join above the aggregation pins the property the same way an outer join does.
+    @Test
+    public void testGroupingSetsAggUnderSemiJoin() throws Exception {
+        assertMultiStageAggOverRepeat("select k1, k2, s1 from "
+                + " (select l_orderkey k1, coalesce(l_linenumber, 0) k2, sum(l_quantity) s1 from lineitem "
+                + "  group by grouping sets((l_orderkey, l_linenumber), (l_orderkey))) a "
+                + " where exists (select 1 from "
+                + "   (select o_orderkey k1, coalesce(o_custkey, 0) k2 from orders "
+                + "    group by grouping sets((o_orderkey, o_custkey), (o_orderkey))) b "
+                + "  where a.k1 = b.k1 and a.k2 = b.k2)");
+    }
+
+    // The aggregation's input distribution is produced for a window operator below it, not by the
+    // table's own bucketing: lineitem is bucketed by l_orderkey while this query groups by l_partkey.
+    @Test
+    public void testGroupingSetsAggOverWindowDistribution() throws Exception {
+        assertMultiStageAggOverRepeat("select x.k1, x.s1, b.s2 from "
+                + " (select k1, coalesce(k2, 0) k2, sum(v) s1 from "
+                + "   (select l_partkey k1, l_suppkey k2, l_quantity v, "
+                + "           sum(l_extendedprice) over (partition by l_partkey) w from lineitem) t "
+                + "  group by grouping sets((k1, k2), (k1))) x "
+                + " left join (select ps_partkey k1, coalesce(ps_suppkey, 0) k2, sum(ps_availqty) s2 from partsupp "
+                + "  group by grouping sets((ps_partkey, ps_suppkey), (ps_partkey))) b "
+                + " on x.k1 = b.k1 and x.k2 = b.k2");
+    }
+
+    // The aggregation is produced by a CTE and consumed by the join.
+    @Test
+    public void testGroupingSetsAggInCte() throws Exception {
+        assertMultiStageAggOverRepeat("with c as "
+                + " (select l_orderkey k1, coalesce(l_linenumber, 0) k2, sum(l_quantity) s1 from lineitem "
+                + "  group by grouping sets((l_orderkey, l_linenumber), (l_orderkey))) "
+                + "select c.k1, c.s1, b.s2 from c "
+                + " left join (select o_orderkey k1, coalesce(o_custkey, 0) k2, sum(o_totalprice) s2 from orders "
+                + "  group by grouping sets((o_orderkey, o_custkey), (o_orderkey))) b "
+                + " on c.k1 = b.k1 and c.k2 = b.k2");
+    }
+
+    // An aggregation that can be one-stage keeps the redundant-two-stage penalty: its input is
+    // already distributed by the group-by key, so the local aggregation would save nothing.
+    @Test
+    public void testOneStageAggStillPreferred() throws Exception {
+        connectContext.getSessionVariable().setBroadcastRowCountLimit(1);
+        String plan = getFragmentPlan("select a.k1, a.s1, b.s2 from "
+                + " (select l_orderkey k1, sum(l_quantity) s1 from lineitem group by l_orderkey) a "
+                + " left join (select o_orderkey k1, sum(o_totalprice) s2 from orders group by o_orderkey) b "
+                + " on a.k1 = b.k1");
+        assertContains(plan, "AGGREGATE (update finalize)");
+        assertNotContains(plan, "AGGREGATE (merge finalize)");
+    }
+}

--- a/test/sql/test_grouping_sets/R/test_grouping_sets_join_agg
+++ b/test/sql/test_grouping_sets/R/test_grouping_sets_join_agg
@@ -1,0 +1,48 @@
+-- name: test_grouping_sets_join_agg
+DROP TABLE IF EXISTS t_gs_join_l_${uuid0};
+-- result:
+-- !result
+DROP TABLE IF EXISTS t_gs_join_r_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t_gs_join_l_${uuid0} (k1 INT NOT NULL, k2 INT NOT NULL, v1 BIGINT)
+DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 3 PROPERTIES('replication_num'='1');
+-- result:
+-- !result
+CREATE TABLE t_gs_join_r_${uuid0} (k1 INT NOT NULL, k2 INT NOT NULL, v2 BIGINT)
+DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 3 PROPERTIES('replication_num'='1');
+-- result:
+-- !result
+INSERT INTO t_gs_join_l_${uuid0} VALUES (1, 10, 100), (1, 20, 200), (2, 10, 300), (2, 30, 400);
+-- result:
+-- !result
+INSERT INTO t_gs_join_r_${uuid0} VALUES (1, 10, 1000), (2, 10, 2000), (2, 30, 3000);
+-- result:
+-- !result
+SET broadcast_row_limit = 1;
+-- result:
+-- !result
+SELECT a.k1, a.gk, a.s1, b.s2
+FROM (SELECT k1, coalesce(k2, -1) AS gk, sum(v1) AS s1 FROM t_gs_join_l_${uuid0}
+      GROUP BY GROUPING SETS((k1, k2), (k1))) a
+LEFT JOIN (SELECT k1, coalesce(k2, -1) AS gk, sum(v2) AS s2 FROM t_gs_join_r_${uuid0}
+      GROUP BY GROUPING SETS((k1, k2), (k1))) b
+ON a.k1 = b.k1 AND a.gk = b.gk
+ORDER BY 1, 2, 3;
+-- result:
+1	-1	300	1000
+1	10	100	1000
+1	20	200	None
+2	-1	700	5000
+2	10	300	2000
+2	30	400	3000
+-- !result
+SET broadcast_row_limit = 15000000;
+-- result:
+-- !result
+DROP TABLE t_gs_join_l_${uuid0};
+-- result:
+-- !result
+DROP TABLE t_gs_join_r_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_grouping_sets/T/test_grouping_sets_join_agg
+++ b/test/sql/test_grouping_sets/T/test_grouping_sets_join_agg
@@ -1,0 +1,20 @@
+-- name: test_grouping_sets_join_agg
+DROP TABLE IF EXISTS t_gs_join_l_${uuid0};
+DROP TABLE IF EXISTS t_gs_join_r_${uuid0};
+CREATE TABLE t_gs_join_l_${uuid0} (k1 INT NOT NULL, k2 INT NOT NULL, v1 BIGINT)
+DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 3 PROPERTIES('replication_num'='1');
+CREATE TABLE t_gs_join_r_${uuid0} (k1 INT NOT NULL, k2 INT NOT NULL, v2 BIGINT)
+DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 3 PROPERTIES('replication_num'='1');
+INSERT INTO t_gs_join_l_${uuid0} VALUES (1, 10, 100), (1, 20, 200), (2, 10, 300), (2, 30, 400);
+INSERT INTO t_gs_join_r_${uuid0} VALUES (1, 10, 1000), (2, 10, 2000), (2, 30, 3000);
+SET broadcast_row_limit = 1;
+SELECT a.k1, a.gk, a.s1, b.s2
+FROM (SELECT k1, coalesce(k2, -1) AS gk, sum(v1) AS s1 FROM t_gs_join_l_${uuid0}
+      GROUP BY GROUPING SETS((k1, k2), (k1))) a
+LEFT JOIN (SELECT k1, coalesce(k2, -1) AS gk, sum(v2) AS s2 FROM t_gs_join_r_${uuid0}
+      GROUP BY GROUPING SETS((k1, k2), (k1))) b
+ON a.k1 = b.k1 AND a.gk = b.gk
+ORDER BY 1, 2, 3;
+SET broadcast_row_limit = 15000000;
+DROP TABLE t_gs_join_l_${uuid0};
+DROP TABLE t_gs_join_r_${uuid0};


### PR DESCRIPTION
Why I'm doing:
The following query fails at planning with no executable plan for this sql — two GROUPING SETS aggregations joined on their group-by keys:

```
from   ( ... group by grouping sets((k1, k2), (k1)) ) a
left join ( ... group by grouping sets((c1, c2), (c1)) ) b
  on a.k1 = b.c1 and a.k2 = b.c2
```

Two cost rules together reject both physical implementations of the same aggregation:

The aggregation sits above REPEAT, so it must be multi-stage: invalidOneStageAggCost gives the one-stage candidate an infinite cost (a BE hard constraint — correct).
Its input is a shuffle it did not request itself (source type is not SHUFFLE_AGG), so redundantTwoStageAggCost treats the two-stage plan as redundant and gives it an infinite cost too — assuming a one-stage alternative exists, without verifying that premise.
The outer left join enumerates two alternatives, broadcast and shuffle. The broadcast alternative is enumerated first and requires no particular distribution from the aggregation subtree, so solving the group for that property already records a best plan for it; when the shuffle alternative is then enumerated and requires the aggregation to be distributed by the join keys, the same group is solved again under a new property, existBestPlan is already true, and the penalty above is triggered — yet those recorded plans belong to a different required property and are no alternative for this one. The broadcast alternative itself is excluded because the right-hand input's row count exceeds broadcast_row_limit: with both routes gone at once, the group has no viable plan under this property and the failure cascades to the root.

Why it planned on 3.3: its cardinality estimates for the two sides of this join differ from 3.5's, so the broadcast alternative passed the row-count check — the 3.3 plan indeed uses LEFT OUTER JOIN (BROADCAST), and the mis-penalized shuffle route was never taken.

## What I'm doing:

In redundantTwoStageAggCost, check the premise before applying the penalty: if the aggregation must be multi-stage, no one-stage plan can exist, so the two-stage plan is not redundant and is left alone.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5