### PR TITLE
[BugFix] Do not share one Hadoop FileSystem across Iceberg catalogs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
@@ -87,6 +87,7 @@ import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -215,6 +216,7 @@ public class IcebergCachingFileIO implements FileIO, HadoopConfigurable {
     public Configuration buildConfFromProperties(Map<String, String> properties, String path) throws StarRocksException {
         // build Hadoop configuration from properties for HadoopFileIO
         Configuration copied = new Configuration(conf.get());
+        disableSharedFileSystemCache(copied, path);
         for (Map.Entry<String, String> entry : properties.entrySet()) {
             if (entry.getKey().startsWith(ADLS_SAS_TOKEN) && entry.getKey().endsWith(ADLS_ENDPOINT)) {
                 // Handle Azure ADLS SAS token
@@ -239,7 +241,6 @@ public class IcebergCachingFileIO implements FileIO, HadoopConfigurable {
                         GCPCloudConfigurationProvider.ACCESS_TOKEN_PROVIDER_IMPL);
                 copied.set(GCPCloudConfigurationProvider.LEGACY_ACCESS_TOKEN_PROVIDER_IMPL_KEY,
                         GCPCloudConfigurationProvider.ACCESS_TOKEN_PROVIDER_IMPL);
-                copied.set(GCPCloudConfigurationProvider.DISABLE_FS_CACHE_KEY, "true");
                 // The base conf may carry catalog-level impersonation, which gcs-connector would apply
                 // on top of the vended token; vended tokens typically lack IAM impersonation permission.
                 copied.unset(GCPCloudConfigurationProvider.IMPERSONATION_SERVICE_ACCOUNT_KEY);
@@ -250,7 +251,27 @@ public class IcebergCachingFileIO implements FileIO, HadoopConfigurable {
                 return copied;
             }
         }
-        return conf.get();
+        return copied;
+    }
+
+    // GCSFileIO/ADLSFileIO are absent from the FE classpath, so ResolvingFileIO falls back to
+    // HadoopFileIO, whose FileSystem cache key is (scheme, authority, ugi) and excludes the
+    // Configuration holding the credential — one shared instance would serve every catalog on a bucket
+    // with whichever credential created it first. Kept to Azure and GCS deliberately: bypassing the
+    // cache leaks an unclosed FileSystem per call, so other schemes wait for a credential-keyed cache.
+    private static final Set<String> SCHEMES_REQUIRING_FS_ISOLATION =
+            Set.of("gs", "abfs", "abfss", "wasb", "wasbs", "adl");
+
+    private static void disableSharedFileSystemCache(Configuration conf, String path) {
+        String scheme = new Path(path).toUri().getScheme();
+        if (scheme == null) {
+            // FileSystem.get() resolves a scheme-less path through fs.defaultFS and only then consults
+            // the flag, so the flag has to be keyed on the default scheme rather than skipped.
+            scheme = FileSystem.getDefaultUri(conf).getScheme();
+        }
+        if (scheme != null && SCHEMES_REQUIRING_FS_ISOLATION.contains(scheme)) {
+            conf.setBoolean(String.format("fs.%s.impl.disable.cache", scheme), true);
+        }
     }
 
     private static class CacheEntry {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIOTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIOTest.java
@@ -130,6 +130,82 @@ public class IcebergCachingFileIOTest {
     }
 
     @Test
+    public void testDisableSharedFileSystemCache() throws StarRocksException {
+        Map<String, String> vended = new HashMap<>();
+        vended.put(ADLS_SAS_TOKEN + "account." + ADLS_ENDPOINT, "sas_token");
+
+        // vended-credentials-enabled=false yields no credential properties at all, so it matches none
+        // of the branches in buildConfFromProperties. That is the path that failed in production.
+        Map<String, String> noCredential = new HashMap<>();
+
+        Assertions.assertTrue(buildConf(vended, "abfss://c@a.dfs.core.windows.net/p")
+                .getBoolean("fs.abfss.impl.disable.cache", false));
+        Assertions.assertTrue(buildConf(noCredential, "abfss://c@a.dfs.core.windows.net/p")
+                .getBoolean("fs.abfss.impl.disable.cache", false));
+        Assertions.assertTrue(buildConf(noCredential, "abfs://c@a.dfs.core.windows.net/p")
+                .getBoolean("fs.abfs.impl.disable.cache", false));
+        Assertions.assertTrue(buildConf(noCredential, "wasbs://c@a.blob.core.windows.net/p")
+                .getBoolean("fs.wasbs.impl.disable.cache", false));
+        Assertions.assertTrue(buildConf(noCredential, "gs://bucket/p")
+                .getBoolean("fs.gs.impl.disable.cache", false));
+        Assertions.assertTrue(buildConf(noCredential, "adl://a.azuredatalakestore.net/p")
+                .getBoolean("fs.adl.impl.disable.cache", false));
+
+        // s3* is served by S3FileIO and never reaches HadoopFileIO. oss/cosn do reach it and do carry
+        // their credential in the Configuration, but bypassing the cache leaks an unclosed FileSystem
+        // per call - enough to exhaust FE threads on an oss-backed workload - so they are left alone
+        // until the cache can be keyed on the credential instead.
+        Assertions.assertFalse(buildConf(noCredential, "s3a://bucket/p")
+                .getBoolean("fs.s3a.impl.disable.cache", false));
+        Assertions.assertFalse(buildConf(noCredential, "oss://bucket/p")
+                .getBoolean("fs.oss.impl.disable.cache", false));
+        Assertions.assertFalse(buildConf(noCredential, "cosn://bucket/p")
+                .getBoolean("fs.cosn.impl.disable.cache", false));
+        Assertions.assertFalse(buildConf(noCredential, "hdfs://nn/p")
+                .getBoolean("fs.hdfs.impl.disable.cache", false));
+    }
+
+    @Test
+    public void testSchemeLessPathUsesDefaultFs() throws StarRocksException {
+        // Hadoop's Path keeps a scheme-less location as-is, so getScheme() is null. FileSystem.get()
+        // resolves such a path through fs.defaultFS and consults the flag only after that, so the flag
+        // has to follow the default scheme.
+        String schemeLess = "/warehouse/db/t/metadata/v1.metadata.json";
+
+        Assertions.assertFalse(buildConf(new HashMap<>(), schemeLess)
+                .getBoolean("fs.file.impl.disable.cache", false));
+
+        IcebergCachingFileIO onAzureDefaultFs = new IcebergCachingFileIO();
+        Configuration baseConf = new Configuration();
+        baseConf.set("fs.defaultFS", "abfss://c@a.dfs.core.windows.net");
+        onAzureDefaultFs.setConf(baseConf);
+
+        Assertions.assertTrue(onAzureDefaultFs.buildConfFromProperties(new HashMap<>(), schemeLess)
+                .getBoolean("fs.abfss.impl.disable.cache", false));
+    }
+
+    @Test
+    public void testFallThroughConfKeepsBaseValues() throws StarRocksException {
+        IcebergCachingFileIO cachingFileIO = new IcebergCachingFileIO();
+        Configuration baseConf = new Configuration();
+        baseConf.set("fs.azure.account.auth.type.account.dfs.core.windows.net", "OAuth");
+        cachingFileIO.setConf(baseConf);
+
+        Configuration configuration =
+                cachingFileIO.buildConfFromProperties(new HashMap<>(), "abfss://c@account.dfs.core.windows.net/p");
+
+        Assertions.assertEquals("OAuth",
+                configuration.get("fs.azure.account.auth.type.account.dfs.core.windows.net"));
+        Assertions.assertTrue(configuration.getBoolean("fs.abfss.impl.disable.cache", false));
+    }
+
+    private static Configuration buildConf(Map<String, String> properties, String path) throws StarRocksException {
+        IcebergCachingFileIO cachingFileIO = new IcebergCachingFileIO();
+        cachingFileIO.setConf(new Configuration());
+        return cachingFileIO.buildConfFromProperties(properties, path);
+    }
+
+    @Test
     public void testBuildGCSConfFromProperties() throws StarRocksException {
         Map<String, String> properties = new HashMap<>();
         String accessToken = "access_token";


### PR DESCRIPTION
## Why I'm doing:

`GCSFileIO` and `ADLSFileIO` are not on the FE classpath, so `ResolvingFileIO` falls back to `HadoopFileIO` for `gs://`, `abfs(s)://`, `wasb(s)://` and `adl://`. `HadoopFileIO` resolves the filesystem through `Path.getFileSystem(conf)` → `FileSystem.get(uri, conf)`, and Hadoop keys its process-wide `FileSystem` cache on `(scheme, authority, ugi)` only:

```java
// hadoop-common, FileSystem$Cache$Key
final String scheme;
final String authority;
final UserGroupInformation ugi;
final long unique;   // always 0 on the FileSystem.get() path
```

The `Configuration` that carries the credential is not part of the key, and ABFS reads the credential exactly once, in `AzureBlobFileSystem.initialize()`. So within one FE process every catalog pointing at the same bucket/container shares a single `FileSystem` instance, permanently bound to whichever credential created it first. Later catalogs' credential configuration is discarded, and an expiring token is never replaced.

`IcebergCachingFileIO.buildConfFromProperties()` carefully translates the vended `adls.sas-token.*` / `gcs.oauth2.token` properties into Hadoop keys on every call, but that work is thrown away as soon as a cached instance exists.

Observed on an Iceberg REST catalog over ADLS Gen2:

- Catalogs configured with `vended-credentials-enabled=false` were sending a vended SAS. With that setting FE never sends the `X-Iceberg-Access-Delegation` header, so the catalog cannot obtain one — it came from another catalog's cached filesystem.
- Three differently-configured catalogs were sending a **byte-identical** SAS (same `st`/`se`). Independently vended tokens would each differ.
- That shared SAS had expired **six days** before the failing requests.
- Managed identity was discarded silently, because the cached instance had been built with `auth.type=SAS`.

Failures surfaced as `403 AuthenticationFailed` from ADLS, both on the metadata read path (`HadoopInputFile.lazyStat()` → `Failed to get status for file: ...`) and on the uncommitted-file cleanup path.

## What I'm doing:

Set `fs.<scheme>.impl.disable.cache` for `gs`, `abfs`, `abfss`, `wasb`, `wasbs` and `adl`, so each operation builds its `FileSystem` from the credential of the catalog actually making the call.

Three details matter:

1. **The switch is set before the property loop, not inside a branch.** A catalog authenticating without vended credentials matches none of the branches in `buildConfFromProperties`, so a per-branch switch would miss exactly the configuration that failed here. The fall-through `return` had to change from `conf.get()` to `copied` for the same reason.
2. **The GCS inline switch is folded into the same place.** It previously only applied when a vended access token was present, so GCS catalogs authenticating another way had the same defect.
3. **A scheme-less location follows `fs.defaultFS`.** Hadoop's `Path` keeps such a location as-is, so `getScheme()` is null — and `Set.contains(null)` throws. Skipping it is not right either: `FileSystem.get()` short-circuits when both scheme and authority are absent, recurses through `fs.defaultFS`, and consults the flag only on that second pass. So a catalog whose `fs.defaultFS` is `abfss://…` would still share a cached filesystem. The flag is therefore keyed on the default scheme when the path has none.

### Why the scope stops at Azure and GCS

Bypassing the cache means every call constructs a `FileSystem` that nobody closes — `createFileSystem()` does not register it, so `FileSystem.closeAll()` cannot reach it either — and each instance holds client thread pools.

`oss` and `cosn` carry their credential in the `Configuration` the same way (`AliyunCloudCredential` maps `fs.oss.impl` to `S3AFileSystem`, `TencentCloudCredential` sets `fs.cosn.userinfo.*`), and an earlier revision of this PR covered them. That revision exhausted FE threads during SQL-Tester on the oss-backed test corpus:

```
java.lang.OutOfMemoryError: unable to create native thread:
possibly out of memory or process/resource limits reached
```

Seven cases failed, every one of them Iceberg or IVM-on-Iceberg. So the leak is measured, not hypothetical. Isolating those schemes safely needs a cache keyed on the credential — the shape `HdfsFsManager` already uses for its own filesystems — which cannot be threaded through Iceberg's `HadoopFileIO`, since it calls `Path.getFileSystem(conf)` internally. That is left as follow-up work; the tests assert the current exclusion so the decision is not silently reversed.

`s3*` is unaffected either way: `iceberg-aws` is bundled, so S3 is served by `S3FileIO` and never reaches `HadoopFileIO`.

Not addressed here, filed separately: `IcebergRESTCatalog.deleteUncommittedDataFiles` builds its filesystem from the catalog-level `Configuration`, which never carries vended credentials. Disabling the cache there would turn "sometimes succeeds with another catalog's credential" into "always fails", so the right fix is to delete through the table's own `FileIO`, which is a signature change.

Fixes #issue: N/A — reported through support, no upstream issue filed yet.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

`fs.gs.impl.disable.cache` now applies to every `gs://` catalog, not only to catalogs using a vended access token. This is the intended correctness fix — a GCS catalog using a service account key collides with other catalogs on the same bucket in exactly the same way — but it does extend the leak described above from vended GCS to all GCS. Operators on GCS-backed Iceberg should watch FE thread count after upgrading.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

Tests: `IcebergCachingFileIOTest` — 11/11 pass, checkstyle clean.

The new assertions were checked against baselines to confirm they can fail:

- With `disableSharedFileSystemCache()` removed entirely: `testDisableSharedFileSystemCache`, `testFallThroughConfKeepsBaseValues` and the pre-existing `testBuildGCSConfFromProperties` all fail. The last one is deliberate evidence that the shared helper takes over the GCS responsibility rather than duplicating it.
- Without `adl` in the set, `testDisableSharedFileSystemCache` fails.
- Without any handling of the null scheme, `testSchemeLessPathUsesDefaultFs` errors with `NullPointerException`.
- With the null scheme skipped rather than resolved through `fs.defaultFS`, `testSchemeLessPathUsesDefaultFs` fails on the `abfss` default-FS case, and nothing else does.

**Not verified at runtime.** This has not been exercised against a live ADLS or GCS deployment, and CI cannot do it either: `test/sql` uses only `oss://`, `s3://` and `hdfs://`, none of which this change touches. CI can show that nothing else broke; it cannot show that the fix works.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
