### PR TITLE
[BugFix] Validate static partition clause for Iceberg/Hive INSERT with a column list (backport #76659)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -181,6 +181,12 @@ public class InsertAnalyzer {
 
             PartitionNames targetPartitionNames = insertStmt.getTargetPartitionNames();
             List<String> tablePartitionColumnNames = table.getPartitionColumnNames();
+            // Always validate a static partition clause so a clause naming a non-partition or
+            // non-existent column is rejected instead of being silently ignored (issue #11350).
+            // This is independent of the target-list invariant below, so both run when both apply.
+            if (insertStmt.isStaticKeyPartitionInsert()) {
+                checkStaticKeyPartitionInsert(insertStmt, table, targetPartitionNames);
+            }
             if (insertStmt.getTargetColumnNames() != null) {
                 for (String partitionColName : tablePartitionColumnNames) {
                     // case-insensitive match. refer to AstBuilder#getColumnNames
@@ -188,8 +194,6 @@ public class InsertAnalyzer {
                         throw new SemanticException("Must include partition column %s", partitionColName);
                     }
                 }
-            } else if (insertStmt.isStaticKeyPartitionInsert()) {
-                checkStaticKeyPartitionInsert(insertStmt, table, targetPartitionNames);
             }
             if (!table.isIcebergTable()) {
                 List<Column> partitionColumns = tablePartitionColumnNames.stream()

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
@@ -34,6 +34,7 @@ import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Delegate;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -267,6 +268,129 @@ public class AnalyzeInsertTest {
         };
 
         analyzeSuccess("insert into iceberg_catalog.db.tbl select 1, 2, \"2023-01-01 12:34:45\"");
+    }
+
+    @Test
+    public void testInsertIntoNonExistentIcebergPartitionColumn(@Mocked IcebergTable icebergTable) {
+        MetadataMgr metadata = AnalyzeTestUtil.getConnectContext().getGlobalStateMgr().getMetadataMgr();
+
+        new MockUp<MetadataMgr>() {
+            @Mock
+            public Database getDb(String catalogName, String dbName) {
+                return new Database();
+            }
+        };
+
+        new MockUp<MetaUtils>() {
+            @Mock
+            public Table getSessionAwareTable(ConnectContext context, Database database, TableName tableName) {
+                return icebergTable;
+            }
+        };
+
+        new Expectations(metadata) {
+            {
+                metadata.getDb((ConnectContext) any, anyString, anyString);
+                minTimes = 0;
+                result = new Database();
+
+                icebergTable.supportInsert();
+                result = true;
+                minTimes = 0;
+
+                icebergTable.isIcebergTable();
+                result = true;
+                minTimes = 0;
+
+                // Non-partitioned table: no partition columns at all.
+                icebergTable.getPartitionColumnNames();
+                result = Lists.newArrayList();
+                minTimes = 0;
+
+                icebergTable.getBaseSchema();
+                result = ImmutableList.of(new Column("c1", Type.INT));
+                minTimes = 0;
+
+                icebergTable.getFullSchema();
+                result = ImmutableList.of(new Column("c1", Type.INT));
+                minTimes = 0;
+
+                icebergTable.getColumn(anyString);
+                result = new Column("c1", Type.INT);
+                minTimes = 0;
+            }
+        };
+
+        // A static partition clause naming a non-partition column must be rejected, not silently
+        // ignored, even when a target column list is present (issue #11350).
+        analyzeFail("insert into iceberg_catalog.db.tbl partition(nonexist_part_col='x') (c1) values (1)",
+                "Only 0 partition columns can be included in the partition clause");
+    }
+
+    @Test
+    public void testInsertIntoIcebergStaticPartitionWithColumnList(@Mocked IcebergTable icebergTable) {
+        MetadataMgr metadata = AnalyzeTestUtil.getConnectContext().getGlobalStateMgr().getMetadataMgr();
+
+        new MockUp<MetadataMgr>() {
+            @Mock
+            public Database getDb(String catalogName, String dbName) {
+                return new Database();
+            }
+        };
+
+        new MockUp<MetaUtils>() {
+            @Mock
+            public Table getSessionAwareTable(ConnectContext context, Database database, TableName tableName) {
+                return icebergTable;
+            }
+        };
+
+        Column c1 = new Column("c1", Type.INT, true);
+        Column p1 = new Column("p1", Type.INT, true);
+        new Expectations(metadata) {
+            {
+                metadata.getDb((ConnectContext) any, anyString, anyString);
+                minTimes = 0;
+                result = new Database();
+
+                icebergTable.supportInsert();
+                result = true;
+                minTimes = 0;
+
+                icebergTable.isIcebergTable();
+                result = true;
+                minTimes = 0;
+
+                icebergTable.getPartitionColumnNames();
+                result = Lists.newArrayList("p1");
+                minTimes = 0;
+
+                icebergTable.getBaseSchema();
+                result = ImmutableList.of(c1, p1);
+                minTimes = 0;
+
+                icebergTable.getFullSchema();
+                result = ImmutableList.of(c1, p1);
+                minTimes = 0;
+
+                icebergTable.getColumn(anyString);
+                result = new Delegate<Column>() {
+                    Column getColumn(String name) {
+                        return "p1".equalsIgnoreCase(name) ? p1 : c1;
+                    }
+                };
+                minTimes = 0;
+            }
+        };
+
+        // The target-list invariant still applies to a static partition insert: a column list that
+        // omits the partition column is rejected (partition columns must appear in the list).
+        analyzeFail("insert into iceberg_catalog.db.tbl partition(p1=111) (c1) values (1)",
+                "Must include partition column p1");
+
+        // A column list that includes the partition column stays accepted (the partition value is
+        // taken from the PARTITION clause; only the non-partition column is supplied by VALUES).
+        analyzeSuccess("insert into iceberg_catalog.db.tbl partition(p1=111) (c1, p1) values (1)");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

A static partition INSERT (`PARTITION(col=val)`) on an Iceberg/Hive table was only validated when no target column list was given. With a column list the analyzer took the target-column branch (`if (getTargetColumnNames() != null)`) and never reached `checkStaticKeyPartitionInsert` in the `else if`, so the static partition clause was never checked. As a result a clause naming a column that is not a partition column of the table — or a table with no partition columns at all — was silently ignored and the row was still inserted (StarRocks/StarRocksTest#11350).

## What I'm doing:

Validate the static partition clause independently of the target column list: run `checkStaticKeyPartitionInsert` whenever `isStaticKeyPartitionInsert()` is true, in its own `if` rather than an `else if`. The existing target-list invariant (when a column list is given it must include every partition column) is kept exactly as before in a separate `if`, and the column-count logic is unchanged. So every INSERT shape that was accepted before is still accepted, and a static partition clause naming a non-partition/non-existent column is now rejected with a clear error instead of being silently dropped.

Note on scope: making `INSERT ... PARTITION(p=v) (non_partition_cols)` (a column list that omits the partition columns, Spark-style) actually succeed is intentionally out of scope here — the sink/planner appends the static partition value at the end of the output columns, which is only correct when the partition columns are the trailing columns of the schema, and it does not exempt required partition columns from the column-permutation check. That is a separate enhancement tracked in a follow-up issue; this PR only stops the silent-accept bug without changing which shapes are accepted.

Fixes StarRocks/StarRocksTest#11350

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

