### PR TITLE
[BugFix] Keep DateValue::weekday() in range for out-of-range julian values

### DIFF
--- a/be/src/types/date_value.cpp
+++ b/be/src/types/date_value.cpp
@@ -119,13 +119,17 @@ bool DateValue::from_string(const char* date_str, size_t len) {
 }
 
 int DateValue::weekday() const {
-    //  @info: _julian < 0 is impossible
-    //    int w = (_julian + 1) % 7;
-    //
-    //    if (w < 0) {
-    //        w += 7;
-    //    }
-    return (_julian + 1) % 7;
+    // `_julian` is positive for every date in the supported range, but this method must also
+    // tolerate out-of-range values: the vectorized function framework evaluates the data column
+    // of a NullableColumn as a whole, so the payload sitting under a null flag reaches here too
+    // and may hold an arbitrary int32. Signed `%` truncates towards zero, so `(_julian + 1) % 7`
+    // would return a negative value there and blow up the callers that use the result as an array
+    // index (`trunc_to_week()`, `day_name()`, `TimeFunctions::datetime_trunc_week`).
+    // Doing the arithmetic unsigned keeps the result in [0, 6] for every input, and is identical
+    // to the signed form for the whole valid julian range. It also makes the wrap-around at
+    // INT32_MAX well defined, and is one instruction cheaper than the signed modulo, which needs
+    // an extra sign fixup.
+    return static_cast<int>((static_cast<uint32_t>(_julian) + 1u) % 7u);
 }
 
 void DateValue::trunc_to_day() {}

--- a/be/test/types/date_value_test.cpp
+++ b/be/test/types/date_value_test.cpp
@@ -18,6 +18,7 @@
 #define private public
 
 #include <cstring>
+#include <limits>
 #include <type_traits>
 
 #include "types/date_value.h"
@@ -288,6 +289,22 @@ TEST(DateValueTest, weekday) {
     ASSERT_EQ(6, dv.weekday()); // Saturday
     dv.from_date(2020, 6, 7);
     ASSERT_EQ(0, dv.weekday()); // Sunday
+}
+
+// The vectorized function framework evaluates the data column of a NullableColumn as a whole, so
+// DateValue methods are fed the arbitrary payload sitting under the null flags as well. weekday()
+// must stay inside [0, 6] for any julian value, otherwise trunc_to_week() reads out of bounds.
+TEST(DateValueTest, weekday_out_of_range_julian) {
+    for (int32_t julian : {std::numeric_limits<int32_t>::min(), -100000000, -8, -7, -6, -5, -4, -3, -2, -1, 0,
+                           std::numeric_limits<int32_t>::max()}) {
+        DateValue dv{julian};
+        int weekday = dv.weekday();
+        ASSERT_GE(weekday, 0) << "julian=" << julian;
+        ASSERT_LE(weekday, 6) << "julian=" << julian;
+
+        // must not read out of bounds of the day-of-week table
+        dv.trunc_to_week();
+    }
 }
 
 TEST(DateValueTest, test_trunc_to_month) {


### PR DESCRIPTION
## Why I'm doing:

DateValue::trunc_to_week() indexes the 8-entry day_to_first[] table with weekday() + 1. weekday() computed (_julian + 1) % 7, and signed % truncates towards zero, so a negative _julian makes it return a negative index and read before the table. ASan pins it exactly:
```
==647729==ERROR: AddressSanitizer: global-buffer-overflow on address 0x00003fb2d07c at pc 0x00002dfa190c bp 0x732b3f4bea10 sp 0x732b3f4bea08
READ of size 4 at 0x00003fb2d07c thread T739
    #0 0x2dfa190b in starrocks::DateValue::trunc_to_week() ../../../src/types/date_value.cpp:147
    #1 0x2d142d89 in starrocks::DateValue starrocks::date_trunc_weekImpl::apply<starrocks::DateValue, starrocks::DateValue>(starrocks::DateValue const&) ../../../src/exprs/time_functions.cpp:3325
    #2 0x2d13a60e in starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> starrocks::UnaryFunction<starrocks::date_trunc_weekImpl>::evaluate<(starrocks::LogicalType)50, (starrocks::LogicalType)50>(starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> const&) ../../../src/exprs/unary_function.h:208
    #3 0x2d10a352 in starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> starrocks::UnpackConstColumnUnaryFunction<starrocks::UnaryFunction<starrocks::date_trunc_weekImpl> >::evaluate<(starrocks::LogicalType)50, (starrocks::LogicalType)50>(starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> const&) ../../../src/exprs/unary_function.h:257
    #4 0x2d0d7deb in starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> starrocks::DealNullableColumnUnaryFunction<starrocks::UnpackConstColumnUnaryFunction<starrocks::UnaryFunction<starrocks::date_trunc_weekImpl> > >::evaluate<(starrocks::LogicalType)50, (starrocks::LogicalType)50>(starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> const&) ../../../src/exprs/unary_function.h:292
    #5 0x2d055d37 in starrocks::TimeFunctions::date_trunc_week(starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&) ../../../src/exprs/time_functions.cpp:3328

```

i.e. day_to_first[-1], so weekday() had returned -2.

The removed comment claimed a negative _julian is impossible. It is not a safe assumption for this method: date_trunc_week reaches it through DealNullableColumnUnaryFunction, which evaluates the data column of a NullableColumn as a whole, so whatever sits under a null flag is passed to the function too and is not required to be a valid date. day_name() already guards against exactly this. TimeFunctions::datetime_trunc_week indexes the same table the same way and is fixed by the same change.

Do the arithmetic unsigned so the result stays in [0, 6] for every int32 input. It is identical to the signed form over the whole valid julian range (verified by exhaustive comparison), makes the wrap-around at INT32_MAX well defined, and generates one instruction less than the signed modulo, which needs an extra sign fixup.

Found by the SQL fuzzer, which hit it twice within 75 minutes on an ASan build, both times in the same round, on this statement:

    CREATE TABLE wkt (dt DATE, v INT) DUPLICATE KEY(dt)
    DISTRIBUTED BY HASH(dt) BUCKETS 1;
    INSERT INTO wkt VALUES ('2024-12-30',1),('2024-12-31',1),('2025-01-01',1);
    SELECT date_trunc('week', dt) AS wk, sum(v) AS s FROM wkt
    GROUP BY date_trunc('week', dt) ORDER BY wk ASC;

Note this does not reproduce on a freshly loaded table: both crashes happened after the fuzzer's writer phase had repeatedly run "INSERT INTO wkt SELECT * FROM wkt" concurrently with the readers, leaving the table with many rowsets. Which step then produces an out-of-range julian is not yet identified, so this change fixes the out-of-bounds read only -- it does not claim to fix whatever hands trunc_to_week an invalid date.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
