### PR TITLE
[BugFix] Sort only the sort tuple in TopNNode, not the window pre-agg tuple

### DIFF
--- a/be/src/exec/chunks_sorter.cpp
+++ b/be/src/exec/chunks_sorter.cpp
@@ -58,6 +58,19 @@ void ChunksSorter::setup_runtime(RuntimeState* state, RuntimeProfile* profile, M
     profile->add_info_string("UseGermanString", is_use_german_string() ? "True" : "False");
 }
 
+// TODO: take the materialized slot ids directly instead of a RecordDescriptor.
+//
+// The only thing read out of `materialized_record_desc` below is `slot->id()` -- the slot types and
+// nullability come from `order_by_types`. Passing a whole descriptor is therefore over-general, and
+// it is what let a caller hand over a record that was not the sort tuple (the window pre-agg plan
+// gives the sort node a second tuple), which this function cannot detect beyond a DCHECK.
+//
+// The pre-aggregation half of the same node already does it the narrow way: it gets its output slot
+// ids straight off the thrift plan as `TSortNode.pre_agg_output_slot_id` and never consults a tuple
+// descriptor. Sending the sort tuple's materialized slot ids the same way would make the two halves
+// symmetric and let TopNNode::_materialized_record_descriptor, this parameter and the DCHECK below
+// all disappear. It needs a thrift field plus FE changes, so it is deliberately not part of the fix
+// for the crash.
 StatusOr<ChunkPtr> ChunksSorter::materialize_chunk_before_sort(Chunk* chunk,
                                                                const RecordDescriptor& materialized_record_desc,
                                                                const SortExecExprs& sort_exec_exprs,
@@ -69,6 +82,10 @@ StatusOr<ChunkPtr> ChunksSorter::materialize_chunk_before_sort(Chunk* chunk,
     auto slots_in_record_descriptor = materialized_record_desc.slots();
     const auto& slots_in_sort_exprs = sort_exec_exprs.sort_tuple_slot_expr_ctxs();
 
+    // One slot per sort-tuple expression: the expressions supply the values, the descriptor supplies
+    // the slot ids they are keyed by, and the two are paired POSITIONALLY below. This holds only if
+    // the caller passes the sort tuple ALONE -- passing a sort node's whole record, which may also
+    // carry the window pre-agg tuple, breaks it. See TopNNode::_materialized_record_descriptor.
     DCHECK_EQ(materialized_record_desc.num_slots(), slots_in_sort_exprs.size());
 
     auto slot_iter = slots_in_record_descriptor.begin();

--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -47,6 +47,10 @@ TopNNode::TopNNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl
         : PipelineNode(pool, tnode, descs), _tnode(tnode) {
     _sort_keys = tnode.sort_node.__isset.sql_sort_keys ? tnode.sort_node.sql_sort_keys : "NONE";
     _offset = tnode.sort_node.__isset.offset ? tnode.sort_node.offset : 0;
+    // row_tuples[0] is the sort tuple: the FE appends the optional pre-agg tuple after it.
+    if (!tnode.row_tuples.empty()) {
+        _materialized_record_descriptor = RecordDescriptor(descs.get_tuple_descriptor(tnode.row_tuples[0]));
+    }
 }
 
 TopNNode::~TopNNode() {
@@ -102,7 +106,11 @@ Status TopNNode::init(const TPlanNode& tnode, RuntimeState* state) {
 
     DCHECK_EQ(_conjuncts.size(), 0) << "TopNNode should never have predicates to evaluate.";
     _abort_on_default_limit_exceeded = tnode.sort_node.is_default_limit;
-    DCHECK(_tuple_ids.size() == 1) << "TopNNode should only have one tuple id.";
+    // NOT "exactly one tuple": a window pre-aggregation plan legitimately gives this node two --
+    // the sort tuple and the pre-agg tuple (SortNode.java appends the latter when
+    // enable_push_down_pre_agg_with_rank turns a ranking predicate into a PARTITION-TOP-N).
+    // What must hold is that there IS a sort tuple, and it is the first one.
+    DCHECK(!_tuple_ids.empty()) << "TopNNode must have a sort tuple.";
 
     bool all_slot_ref = true;
     std::unordered_set<SlotId> early_materialized_slots;
@@ -124,7 +132,7 @@ Status TopNNode::init(const TPlanNode& tnode, RuntimeState* state) {
     // but if c0 is tinyint, the byte width of the element of c0 is 1, obviously permuting ordinal column costs more.
     // The permutation cost is proportion of the total size of bytes of the elements of non-group-by columns.
     int materialized_cost = 0;
-    for (auto* slot : _record_descriptor.slots()) {
+    for (auto* slot : _materialized_record_descriptor.slots()) {
         if (early_materialized_slots.count(slot->id())) {
             continue;
         }
@@ -232,12 +240,13 @@ StatusOr<pipeline::OpFactories> TopNNode::_decompose_to_pipeline(pipeline::Pipel
         max_buffered_rows = _tnode.sort_node.max_buffered_rows;
     }
 
-    // The record produced by TopNNode is the record materialized before sorting.
-    sink_operator = std::make_shared<SinkFactory>(context->next_operator_id(), id(), context_factory, _sort_exec_exprs,
-                                                  _is_asc_order, _is_null_first, _sort_keys, _offset, _limit,
-                                                  _tnode.sort_node.topn_type, _order_by_types, _record_descriptor,
-                                                  _analytic_partition_exprs, max_buffered_rows, max_buffered_bytes,
-                                                  _early_materialized_slots, spill_channel_factory);
+    // The sink materializes and sorts the SORT TUPLE, which is not necessarily the whole record
+    // this node produces -- see _materialized_record_descriptor.
+    sink_operator = std::make_shared<SinkFactory>(
+            context->next_operator_id(), id(), context_factory, _sort_exec_exprs, _is_asc_order, _is_null_first,
+            _sort_keys, _offset, _limit, _tnode.sort_node.topn_type, _order_by_types, _materialized_record_descriptor,
+            _analytic_partition_exprs, max_buffered_rows, max_buffered_bytes, _early_materialized_slots,
+            spill_channel_factory);
 
     // Initialize OperatorFactory's fields involving runtime filters.
     pipeline::init_runtime_filter_for_operator(*this, sink_operator.get(), context, rc_rf_probe_collector);
@@ -248,7 +257,7 @@ StatusOr<pipeline::OpFactories> TopNNode::_decompose_to_pipeline(pipeline::Pipel
     source_operator = std::make_shared<SourceFactory>(context->next_operator_id(), id(), context_factory);
     if constexpr (std::is_same_v<LocalParallelMergeSortSourceOperatorFactory, SourceFactory>) {
         down_cast<LocalParallelMergeSortSourceOperatorFactory*>(source_operator.get())
-                ->set_record_desc(_record_descriptor);
+                ->set_record_desc(_materialized_record_descriptor);
         down_cast<LocalParallelMergeSortSourceOperatorFactory*>(source_operator.get())->set_is_gathered(need_merge);
         if (_tnode.sort_node.__isset.parallel_merge_late_materialize_mode) {
             down_cast<LocalParallelMergeSortSourceOperatorFactory*>(source_operator.get())

--- a/be/src/exec/topn_node.h
+++ b/be/src/exec/topn_node.h
@@ -54,6 +54,20 @@ private:
 
     // _sort_exec_exprs contains the ordering expressions
     SortExecExprs _sort_exec_exprs;
+
+    // The record that is materialized and sorted: the SORT TUPLE alone.
+    //
+    // This is NOT the node's own record (ExecNode::_record_descriptor). A window pre-aggregation
+    // plan gives the sort node a SECOND tuple -- the pre-agg tuple, appended after the sort tuple
+    // by SortNode's constructor on the FE side -- which this node PRODUCES but does not materialize
+    // before sorting. Conflating the two makes the sorter's slot list longer than its list of
+    // sort-tuple expressions, and charges the late-materialization estimate for slots that are
+    // never permuted.
+    //
+    // TODO: this exists only to carry slot ids; see the TODO on
+    // ChunksSorter::materialize_chunk_before_sort for how to remove it entirely.
+    RecordDescriptor _materialized_record_descriptor;
+
     std::vector<SlotId> _early_materialized_slots{};
     std::vector<bool> _is_asc_order;
     std::vector<bool> _is_null_first;

--- a/test/sql/test_topn_window_pre_agg/R/test_topn_window_pre_agg.sql
+++ b/test/sql/test_topn_window_pre_agg/R/test_topn_window_pre_agg.sql
@@ -1,0 +1,61 @@
+-- name: test_topn_window_pre_agg
+DROP TABLE IF EXISTS t_topn_pre_agg;
+-- result:
+-- !result
+CREATE TABLE t_topn_pre_agg (
+  g INT NOT NULL,
+  k INT NOT NULL,
+  v INT NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(g, k)
+DISTRIBUTED BY HASH(g) BUCKETS 3
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_topn_pre_agg (g, k, v) VALUES
+  (1, 1, 10), (1, 2, 20), (1, 3, 30),
+  (2, 1, 100), (2, 2, 200),
+  (3, 1, 5), (3, 2, 6), (3, 3, 7), (3, 4, 8);
+-- result:
+-- !result
+function: assert_explain_contains('SELECT * FROM (SELECT g, k, v, row_number() OVER (PARTITION BY g ORDER BY k) AS rn, sum(v) OVER (PARTITION BY g) AS s FROM t_topn_pre_agg) x WHERE rn <= 2 ORDER BY g, k', 'PARTITION-TOP-N')
+-- result:
+None
+-- !result
+function: assert_explain_contains('SELECT * FROM (SELECT g, k, v, row_number() OVER (PARTITION BY g ORDER BY k) AS rn, sum(v) OVER (PARTITION BY g) AS s FROM t_topn_pre_agg) x WHERE rn <= 2 ORDER BY g, k', 'pre agg functions')
+-- result:
+None
+-- !result
+SELECT * FROM (SELECT g, k, v, row_number() OVER (PARTITION BY g ORDER BY k) AS rn, sum(v) OVER (PARTITION BY g) AS s FROM t_topn_pre_agg) x WHERE rn <= 2 ORDER BY g, k;
+-- result:
+1	1	10	1	60
+1	2	20	2	60
+2	1	100	1	300
+2	2	200	2	300
+3	1	5	1	26
+3	2	6	2	26
+-- !result
+set enable_push_down_pre_agg_with_rank = false;
+-- result:
+-- !result
+SELECT * FROM (SELECT g, k, v, row_number() OVER (PARTITION BY g ORDER BY k) AS rn, sum(v) OVER (PARTITION BY g) AS s FROM t_topn_pre_agg) x WHERE rn <= 2 ORDER BY g, k;
+-- result:
+1	1	10	1	60
+1	2	20	2	60
+2	1	100	1	300
+2	2	200	2	300
+3	1	5	1	26
+3	2	6	2	26
+-- !result
+set enable_push_down_pre_agg_with_rank = true;
+-- result:
+-- !result
+SELECT g, count(*) AS n, max(s) AS total FROM (SELECT g, row_number() OVER (PARTITION BY g ORDER BY v) AS rn, sum(v) OVER (PARTITION BY g) AS s FROM t_topn_pre_agg) x WHERE rn <= 2 GROUP BY g ORDER BY g;
+-- result:
+1	2	60
+2	2	300
+3	2	26
+-- !result
+DROP TABLE t_topn_pre_agg;
+-- result:
+-- !result

--- a/test/sql/test_topn_window_pre_agg/T/test_topn_window_pre_agg.sql
+++ b/test/sql/test_topn_window_pre_agg/T/test_topn_window_pre_agg.sql
@@ -1,0 +1,47 @@
+-- name: test_topn_window_pre_agg
+-- A ranking window filtered by `rn <= k`, sitting on a second window with the SAME PARTITION BY, no
+-- ORDER BY and a single-argument plain aggregate, is turned into a PARTITION-TOP-N whose pre-agg
+-- calls are pushed into it (enable_push_down_pre_agg_with_rank, on by default).
+--
+-- The FE gives that SORT node TWO tuples -- the sort tuple and the pre-agg tuple. The BE asserted it
+-- had exactly one and aborted in TopNNode::init, before executing a single row, so every plan of this
+-- shape killed a debug/ASan backend. There was no test over this path, which is how the assertion
+-- shipped.
+DROP TABLE IF EXISTS t_topn_pre_agg;
+
+CREATE TABLE t_topn_pre_agg (
+  g INT NOT NULL,
+  k INT NOT NULL,
+  v INT NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(g, k)
+DISTRIBUTED BY HASH(g) BUCKETS 3
+PROPERTIES("replication_num" = "1");
+
+-- k is unique within each g, so row_number() is deterministic and the expected output is stable.
+INSERT INTO t_topn_pre_agg (g, k, v) VALUES
+  (1, 1, 10), (1, 2, 20), (1, 3, 30),
+  (2, 1, 100), (2, 2, 200),
+  (3, 1, 5), (3, 2, 6), (3, 3, 7), (3, 4, 8);
+
+-- Assert the plan is the one that used to crash. Without this, a planner change could stop producing
+-- the pre-agg PARTITION-TOP-N and the test would keep passing while covering nothing at all.
+function: assert_explain_contains('SELECT * FROM (SELECT g, k, v, row_number() OVER (PARTITION BY g ORDER BY k) AS rn, sum(v) OVER (PARTITION BY g) AS s FROM t_topn_pre_agg) x WHERE rn <= 2 ORDER BY g, k', 'PARTITION-TOP-N')
+function: assert_explain_contains('SELECT * FROM (SELECT g, k, v, row_number() OVER (PARTITION BY g ORDER BY k) AS rn, sum(v) OVER (PARTITION BY g) AS s FROM t_topn_pre_agg) x WHERE rn <= 2 ORDER BY g, k', 'pre agg functions')
+
+-- Aborts a debug/ASan BE before the fix.
+SELECT * FROM (SELECT g, k, v, row_number() OVER (PARTITION BY g ORDER BY k) AS rn, sum(v) OVER (PARTITION BY g) AS s FROM t_topn_pre_agg) x WHERE rn <= 2 ORDER BY g, k;
+
+-- The optimization must not change the answer: same rows with the pre-agg push-down turned off.
+set enable_push_down_pre_agg_with_rank = false;
+
+SELECT * FROM (SELECT g, k, v, row_number() OVER (PARTITION BY g ORDER BY k) AS rn, sum(v) OVER (PARTITION BY g) AS s FROM t_topn_pre_agg) x WHERE rn <= 2 ORDER BY g, k;
+
+set enable_push_down_pre_agg_with_rank = true;
+
+-- A partition whose rows all tie on the ranking key still has a deterministic row COUNT, and the
+-- pre-agg result is order-independent, so this stays stable while exercising the same node with a
+-- non-unique sort key.
+SELECT g, count(*) AS n, max(s) AS total FROM (SELECT g, row_number() OVER (PARTITION BY g ORDER BY v) AS rn, sum(v) OVER (PARTITION BY g) AS s FROM t_topn_pre_agg) x WHERE rn <= 2 GROUP BY g ORDER BY g;
+
+DROP TABLE t_topn_pre_agg;


### PR DESCRIPTION
## Why I'm doing:

```
query_id:019fd070-818e-77ca-8307-deb690bdb698, fragment_instance:019fd070-818e-77ca-8307-deb690bdb69a, plan_node_id:-1
[1785908462.81][thread: 124163307792064] je_mallctl execute purge success
[1785908462.81][thread: 124163307792064] je_mallctl execute dontdump success
*** Aborted at 1785908462 (unix time) try "date -d @1785908462" if you are using GNU date ***
PC: @     0x70ef14ea0b2c pthread_kill
*** SIGABRT (@0x21695d) received by PID 2189661 (TID 0x70ed05dae6c0) LWP(2190503) from PID 2189661; stack trace: ***
    @         0x32ddc347 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x70ef14ea3ed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)
    @         0x32ddbb46 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x70ef14e47330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @     0x70ef14ea0b2c pthread_kill
    @     0x70ef14e4727e gsignal
    @     0x70ef14e2a8ff abort
    @         0x1cc06548 starrocks::failure_function()
    @         0x32dcfc5d google::LogMessage::Fail()
    @         0x32dd0d44 google::LogMessageFatal::~LogMessageFatal()
    @         0x1e36013b starrocks::StatusOr<std::vector<std::shared_ptr<starrocks::pipeline::OperatorFactory>, std::allocator<std::shared_ptr<starrocks::pipeline::OperatorFactory> > > > starrocks::HashJoinNode::_decompose_to_pipe
line<starrocks::pipeline::HashJoinerFactory, starro@
    @         0x1e353e94 starrocks::HashJoinNode::decompose_to_pipeline(starrocks::pipeline::PipelineBuilderContext*)
    @         0x1e3bf82a starrocks::StatusOr<std::vector<std::shared_ptr<starrocks::pipeline::OperatorFactory>, std::allocator<std::shared_ptr<starrocks::pipeline::OperatorFactory> > > > starrocks::TopNNode::_decompose_to_pipeline
<starrocks::pipeline::SortContextFactory, starrocks@
    @         0x1e3b5321 starrocks::TopNNode::decompose_to_pipeline(starrocks::pipeline::PipelineBuilderContext*)
```

A window pre-aggregation plan legitimately gives the sort node TWO tuples: the sort tuple, and the pre-agg tuple that SortNode appends when enable_push_down_pre_agg_with_rank turns a ranking predicate into a PARTITION-TOP-N. #76928 replaced "materialize tuple_descriptors()[0]" with an assertion that the node has exactly one tuple, so every plan of that shape aborted a debug/ASan backend inside TopNNode::init -- during plan-tree construction, before executing a single row.

Restore the distinction the assertion collapsed: the record materialized before sorting is the sort tuple alone. That also fixes a release-visible defect, since the late-materialization cost estimate was being charged for pre-agg slots that are never permuted.

Add the SQL test this path never had. It asserts the plan shape as well as the result, so a planner change cannot silently stop covering the case, and it cross-checks the answer with the optimization turned off.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
