### PR TITLE
[Enhancement] Only fetch the archives a targeted thirdparty build needs

### DIFF
--- a/thirdparty/build-thirdparty-darwin.sh
+++ b/thirdparty/build-thirdparty-darwin.sh
@@ -62,6 +62,11 @@ Usage: $0 [options...] [packages...]
     --clean                Clean extracted source before building
     --continue <package>   Continue building from specified package
     -h, --help             Show this help message
+
+  Notes:
+    When packages are given (also with --continue), only the archives those
+    packages are built from are downloaded, unpacked and patched. A full build
+    still processes every archive.
 EOF
 }
 
@@ -3006,6 +3011,14 @@ if [[ "${CONTINUE}" -eq 1 ]] && ([[ -z "${start_package}" ]] || [[ "${#packages[
 fi
 if [[ "${CONTINUE}" -eq 1 ]]; then
     validate_requested_package "${start_package}"
+fi
+
+# A partial build only needs its own archives, so limit the download/unpack/patch
+# pass accordingly. Must happen before packages defaults to the full list below.
+if [[ "${#packages[@]}" -ne 0 ]]; then
+    starrocks_restrict_archives "${packages[@]}"
+elif [[ "${CONTINUE}" -eq 1 ]]; then
+    starrocks_restrict_archives_from "${start_package}"
 fi
 
 if [[ "${#packages[@]}" -eq 0 ]]; then

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -54,6 +54,13 @@ if [ ! -f ${TP_DIR}/vars.sh ]; then
 fi
 . ${TP_DIR}/vars.sh
 
+if [[ ! -f "${TP_DIR}/package-manifest.sh" ]]; then
+    echo "package-manifest.sh is missing".
+    exit 1
+fi
+. "${TP_DIR}/package-manifest.sh"
+starrocks_set_default_packages "${MACHINE_TYPE}"
+
 # Check args
 usage() {
     echo "
@@ -68,6 +75,11 @@ Usage: $0 [options...] [packages...]
     --clean                Clean extracted source before building
     --continue <package>   Continue building from specified package
     -h, --help             Show this help message
+
+  Notes:
+    When packages are given (also with --continue), only the archives those
+    packages are built from are downloaded, unpacked and patched. A full build
+    still processes every archive.
 
   Examples:
     # Build all packages with default parallelism
@@ -221,7 +233,13 @@ if [[ "${CLEAN}" -eq 1 ]]; then
     clean_sources
 fi
 
-# Download thirdparties.
+# Download thirdparties. A partial build only needs its own archives, so limit
+# the download/unpack/patch pass accordingly.
+if [[ "${#packages[@]}" -ne 0 ]]; then
+    starrocks_restrict_archives "${packages[@]}"
+elif [[ "${CONTINUE}" -eq 1 ]]; then
+    starrocks_restrict_archives_from "${start_package}"
+fi
 ${TP_DIR}/download-thirdparty.sh
 
 # set COMPILER
@@ -1770,13 +1788,6 @@ export GLOBAL_CXXFLAGS="-O3 -fno-omit-frame-pointer -Wno-class-memaccess -fPIC -
 export CPPFLAGS=$GLOBAL_CPPFLAGS
 export CXXFLAGS=$GLOBAL_CXXFLAGS
 export CFLAGS=$GLOBAL_CFLAGS
-
-if [[ ! -f "${TP_DIR}/package-manifest.sh" ]]; then
-    echo "package-manifest.sh is missing".
-    exit 1
-fi
-. "${TP_DIR}/package-manifest.sh"
-starrocks_set_default_packages "${MACHINE_TYPE}"
 
 # Initialize packages array - if none specified, build all
 if [[ "${#packages[@]}" -eq 0 ]]; then

--- a/thirdparty/package-manifest.sh
+++ b/thirdparty/package-manifest.sh
@@ -125,3 +125,135 @@ starrocks_set_default_packages() {
         starrocks_filter_default_packages "${DARWIN_UNSUPPORTED_PACKAGES:-}"
     fi
 }
+
+# Print the packages of the default order starting from the given one, i.e. the
+# packages a `--continue <package>` run is going to build.
+starrocks_packages_from() {
+    local start="$1"
+    local package
+    local found=0
+
+    for package in "${STARROCKS_THIRDPARTY_ALL_PACKAGES[@]}"; do
+        if [[ "${package}" == "${start}" ]]; then
+            found=1
+        fi
+        if [[ "${found}" -eq 1 ]]; then
+            echo "${package}"
+        fi
+    done
+}
+
+# Print the archive keys the body of build_<name> refers to, following the calls
+# it makes to other build_* helpers. An archive is referenced either through its
+# extracted directory (X_SOURCE) or through the archive file itself (X_NAME, e.g.
+# the ARROW_*_URL pointers build_arrow hands to arrow's bundled builds).
+# Recursion is guarded by _starrocks_scanned_functions.
+_starrocks_scan_build_function() {
+    local name="$1"
+    local body
+    local callee
+
+    case " ${_starrocks_scanned_functions} " in
+    *" ${name} "*)
+        return 0
+        ;;
+    esac
+    _starrocks_scanned_functions="${_starrocks_scanned_functions} ${name}"
+
+    body="$(awk -v fn="build_${name}()" '
+            index($0, fn) == 1 { inside = 1; next }
+            inside && $0 == "}" { inside = 0 }
+            inside { print }
+        ' "${_starrocks_build_scripts[@]}")"
+    if [[ -z "${body}" ]]; then
+        return 0
+    fi
+
+    printf '%s\n' "${body}" \
+        | grep -oE '[A-Z][A-Z0-9_]*_(SOURCE|NAME)([^A-Z0-9_]|$)' \
+        | sed -E 's/_(SOURCE|NAME).*$//'
+
+    for callee in $(printf '%s\n' "${body}" \
+        | grep -oE '(^|[^A-Za-z0-9_])build_[a-z0-9_]+' \
+        | grep -oE 'build_[a-z0-9_]+' | sed 's/^build_//' | sort -u); do
+        _starrocks_scan_build_function "${callee}"
+    done
+}
+
+# Map package names to the archive keys of vars.sh, so that building a subset of
+# the packages does not have to download, unpack and patch everything else.
+#
+# The mapping is derived from the build scripts instead of being hardcoded here:
+# whatever archives the body of build_<package> refers to, directly or through the
+# helpers it calls, are the archives that package is built from. Keys that vars.sh
+# does not declare in TP_ARCHIVES are dropped, and a package that resolves to
+# nothing fails the whole call, so callers can fall back to downloading everything.
+starrocks_package_archives() {
+    local script
+    local package
+    local key
+    local resolved
+    local keys=""
+
+    _starrocks_build_scripts=()
+    for script in "${TP_DIR}/build-thirdparty.sh" "${TP_DIR}/build-thirdparty-darwin.sh"; do
+        if [[ -f "${script}" ]]; then
+            _starrocks_build_scripts+=("${script}")
+        fi
+    done
+    if [[ "${#_starrocks_build_scripts[@]}" -eq 0 ]]; then
+        return 1
+    fi
+
+    for package in "$@"; do
+        resolved=""
+        _starrocks_scanned_functions=""
+        for key in $(_starrocks_scan_build_function "${package}" | sort -u); do
+            if [[ " ${TP_ARCHIVES} " == *" ${key} "* ]]; then
+                resolved="${resolved} ${key}"
+            fi
+        done
+        if [[ -z "${resolved}" ]]; then
+            return 1
+        fi
+        keys="${keys}${resolved}"
+    done
+
+    echo ${keys} | tr ' ' '\n' | sort -u | tr '\n' ' '
+}
+
+# Narrow the download/unpack/patch pass down to the archives the given packages
+# need. A STARROCKS_THIRDPARTY_ARCHIVES coming from the environment always wins.
+starrocks_restrict_archives() {
+    local archives
+
+    if [[ -n "${STARROCKS_THIRDPARTY_ARCHIVES:-}" ]] || [[ "$#" -eq 0 ]]; then
+        return 0
+    fi
+
+    if archives="$(starrocks_package_archives "$@")" && [[ -n "${archives}" ]]; then
+        export STARROCKS_THIRDPARTY_ARCHIVES="${archives}"
+        echo "Thirdparty archives needed by [$*]: ${archives}"
+    else
+        echo "Warning: cannot resolve the archives of [$*], downloading all archives"
+    fi
+
+    return 0
+}
+
+# The --continue <package> variant of the above: restrict to the archives of that
+# package and of the ones built after it. An unknown package name resolves to no
+# packages at all, which is reported instead of silently leaving the download
+# unfiltered.
+starrocks_restrict_archives_from() {
+    local start="$1"
+    local from
+
+    from="$(starrocks_packages_from "${start}")"
+    if [[ -z "${from}" ]]; then
+        echo "Warning: unknown package [${start}] for --continue, downloading all archives"
+        return 0
+    fi
+
+    starrocks_restrict_archives ${from}
+}


### PR DESCRIPTION
> Rebased onto main now that #77320 has merged. Patching narrows down on its
> own thanks to that fix; this PR is the download side.

## Why I'm doing:

`./build-thirdparty.sh jemalloc` builds only jemalloc, but it still downloads
every thirdparty archive: `build-thirdparty.sh` calls `download-thirdparty.sh`
unconditionally, and that script always walks the full `TP_ARCHIVES` list of
vars.sh. On a fresh source tree, building one library means fetching, md5
checking, unpacking and patching all ~75 archives first.

The package selection only reaches the build loop at the end of the script.

## What I'm doing:

Compute the archives the requested packages are actually built from and pass
them to `download-thirdparty.sh` via `STARROCKS_THIRDPARTY_ARCHIVES`:

```
$ ./build-thirdparty.sh jemalloc
Thirdparty archives needed by [jemalloc]: JEMALLOC
```

The package to archive mapping is not hardcoded: `starrocks_package_archives`
in package-manifest.sh scans the build scripts for the archives a package refers
to. An archive is referenced either as an extracted directory (`X_SOURCE`) or as
the archive file itself (`X_NAME`), and the reference may live in a `build_*`
helper the package calls, so helper calls are followed transitively.

That keeps the mapping correct when packages are added, renamed or bumped, and it
catches the non-obvious cases a hand written table would miss:

```
protobuf   -> GTEST PROTOBUF      # build_protobuf untars the gtest source
kerberos   -> KRB5
hadoop_src -> HADOOPSRC
breakpad   -> BREAK_PAD
grpc       -> ABSL CARES GRPC
rocksdb    -> ROCKSDB ZSTD        # Darwin's build_rocksdb calls build_zstd
arrow      -> ARROW BROTLI FLATBUFFERS GLOG LZ4 SNAPPY THRIFT ZLIB ZSTD
                                  # build_arrow points ARROW_*_URL at these
                                  # tarballs for its bundled builds
```

Rules:

- packages given on the command line: only their archives;
- `--continue <package>`: the archives of that package and everything after it
  in the default order;
- no packages (full build): no filtering, unchanged behavior;
- `STARROCKS_THIRDPARTY_ARCHIVES` set in the environment: always wins;
- a package that cannot be resolved (typo, unknown name): a warning and a
  fallback to downloading everything, so a partial download can never silently
  break the build.

Patching narrows down on its own, since #77320 makes every patch block guard on
its source directory.

`package-manifest.sh` is now sourced right after `vars.sh` in
`build-thirdparty.sh` (it was sourced at the very end of the file) because the
package list is needed before the download step, which matches how
`build-thirdparty-darwin.sh` is already structured. The build loop is unchanged.

## Verification

All 75 (x86_64) and 73 (aarch64) default packages resolve to a non empty, valid
archive set. Against a sandbox thirdparty tree that only has
`src/jemalloc-5.3.0`, running the real scripts:

| command | archives processed |
|---|---|
| `build-thirdparty.sh jemalloc` | `JEMALLOC` |
| `build-thirdparty.sh openssl curl protobuf` | `CURL GTEST OPENSSL PROTOBUF` |
| `build-thirdparty.sh arrow` | `ARROW BROTLI FLATBUFFERS GLOG LZ4 SNAPPY THRIFT ZLIB ZSTD` |
| `build-thirdparty.sh --continue xxhash` | `BENCHGEN BLAKE3 BREAK_PAD LIBDEFLATE PPROF XXHASH` |
| `build-thirdparty.sh` (full) | no filtering, all archives |
| `STARROCKS_THIRDPARTY_ARCHIVES=JEMALLOC ... rocksdb` | `JEMALLOC` (env wins) |
| `build-thirdparty.sh not_a_package` | warning, all archives |

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

A partial `build-thirdparty.sh <package>` run no longer downloads the archives it
does not need. Full builds are unaffected.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
