### PR TITLE
[BugFix] Fix ordinal page index out-of-bounds step when reading past end of column

### DIFF
--- a/be/src/storage/lake/add_index_schema_change.cpp
+++ b/be/src/storage/lake/add_index_schema_change.cpp
@@ -463,11 +463,16 @@ Status AddIndexSchemaChange::build_bitmap_for_column(Segment* segment, const Tab
         col->reset_column();
         size_t n = kBatch;
         Status st = col_iter->next_batch(&n, col.get());
-        if (st.is_end_of_file() || n == 0) {
+        if (!st.ok() && !st.is_end_of_file()) return st;
+        if (n > 0) {
+            RETURN_IF_ERROR(feed_index_from_column(bitmap_writer.get(), *col, 0, n, type_size, char_pad_len));
+        }
+        // A short read is the iterator's end-of-column signal: it means the
+        // last data page was consumed by this call. Keep looping only on a
+        // full batch, so we never ask an exhausted iterator for more rows.
+        if (st.is_end_of_file() || n < kBatch) {
             break;
         }
-        if (!st.ok()) return st;
-        RETURN_IF_ERROR(feed_index_from_column(bitmap_writer.get(), *col, 0, n, type_size, char_pad_len));
     }
 
     // Final memory check: the loop-top check does not cover the last batch's

--- a/be/src/storage/rowset/ordinal_page_index.h
+++ b/be/src/storage/rowset/ordinal_page_index.h
@@ -145,7 +145,10 @@ public:
     OrdinalPageIndexIterator() = default;
     explicit OrdinalPageIndexIterator(OrdinalIndexReader* index) : _index(index), _cur_idx(0) {}
     OrdinalPageIndexIterator(OrdinalIndexReader* index, int cur_idx) : _index(index), _cur_idx(cur_idx) {}
-    bool valid() const { return _cur_idx < _index->_num_pages; }
+    // A default-constructed iterator (no index bound yet) is never valid.
+    bool valid() const { return _index != nullptr && _cur_idx < _index->_num_pages; }
+    // REQUIRES: valid(). Callers that may re-enter after exhaustion must test
+    // valid() first instead of relying on next() to saturate at the end.
     void next() {
         DCHECK_LT(_cur_idx, _index->_num_pages);
         _cur_idx++;

--- a/be/src/storage/rowset/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/scalar_column_iterator.cpp
@@ -413,6 +413,15 @@ Status ScalarColumnIterator::next_batch_with_filter(const SparseRange<>& range, 
 }
 
 Status ScalarColumnIterator::_load_next_page(bool* eos) {
+    // The page iterator is already past the last data page: a previous call
+    // consumed the final page and reported eos. Re-entering here is legal --
+    // a caller that got a short read may issue one more next_batch() -- so
+    // report eos again instead of stepping the ordinal page index out of
+    // bounds (DCHECK_LT in OrdinalPageIndexIterator::next()).
+    if (!_page_iter.valid()) {
+        *eos = true;
+        return Status::OK();
+    }
     _page_iter.next();
     if (!_page_iter.valid()) {
         *eos = true;

--- a/be/test/storage/rowset/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/column_reader_writer_test.cpp
@@ -916,6 +916,60 @@ TEST_F(ColumnReaderWriterTest, test_string_writer_finish_without_append) {
     ASSERT_OK(writer->finish());
 }
 
+// Reading past the end of a column must be idempotent.
+//
+// Before the fix this crashed with
+//   Check failed: _cur_idx < _index->_num_pages (1 vs. 1)
+// in OrdinalPageIndexIterator::next(). The call that consumes the last rows
+// returns a SHORT batch (n < requested) and, on its way out, already steps the
+// page iterator one past the last data page to detect eos. A caller that only
+// stops on n == 0 -- e.g. the lake ADD INDEX bitmap builder -- then issues one
+// more next_batch(), and _load_next_page() stepped the exhausted page iterator
+// again, tripping the DCHECK in debug/ASAN builds.
+TEST_F(ColumnReaderWriterTest, test_next_batch_after_eos_is_idempotent) {
+    // 100 rows: fewer than one batch, so the very first read is short and the
+    // column fits in a single data page (_num_pages == 1).
+    constexpr size_t kNumRows = 100;
+    constexpr size_t kBatch = 4096;
+
+    auto src = ChunkFactory::column_from_field_type(TYPE_INT, true);
+    for (size_t i = 0; i < kNumRows; ++i) {
+        src->append_datum(Datum(static_cast<int32_t>(i)));
+    }
+
+    const std::string fname = TEST_DIR + "/" + generate_uuid_string() + ".data";
+    auto segment = create_dummy_segment(fname);
+    ColumnMetaPB meta;
+    {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(fname));
+        ColumnWriterOptions writer_opts = make_writer_opts<TYPE_INT, DEFAULT_ENCODING, 2>(&meta);
+        TabletColumn column = make_tablet_column<TYPE_INT>();
+        ASSIGN_OR_ABORT(auto writer, ColumnWriter::create(writer_opts, &column, wfile.get()));
+        ASSERT_OK(writer->init());
+        ASSERT_OK(writer->append(*src));
+        flush_column_writer(writer.get());
+        ASSERT_OK(wfile->close());
+    }
+
+    auto iter = create_and_init_iterator(meta, segment.get(), fname);
+    ASSERT_OK(iter->seek_to_first());
+
+    // First read: short batch, all rows.
+    auto dst = ChunkFactory::column_from_field_type(TYPE_INT, true);
+    size_t n = kBatch;
+    ASSERT_OK(iter->next_batch(&n, dst.get()));
+    ASSERT_EQ(kNumRows, n);
+
+    // Every subsequent read must report zero rows instead of crashing.
+    for (int i = 0; i < 3; ++i) {
+        dst->reset_column();
+        n = kBatch;
+        ASSERT_OK(iter->next_batch(&n, dst.get()));
+        ASSERT_EQ(0U, n);
+        ASSERT_EQ(0U, dst->size());
+    }
+}
+
 // ---------------------------------------------------------------------------
 // IDG read-side probe tests (covers scalar_column_iterator.cpp lines 80-99,
 // the `_opts.idg_loader != nullptr` block in init() that flips


### PR DESCRIPTION
## Why I'm doing:

A BE/CN built with ASAN (or any DCHECK-enabled build) aborts during lake `ALTER TABLE ... ADD INDEX` (BITMAP):

```
F ordinal_page_index.h:150] Check failed: _cur_idx < _index->_num_pages (1 vs. 1)
    starrocks::OrdinalPageIndexIterator::next()
    starrocks::ScalarColumnIterator::_load_next_page(bool*)
    starrocks::ScalarColumnIterator::next_batch(unsigned long*, starrocks::Column*)
    starrocks::lake::AddIndexSchemaChange::build_bitmap_for_column(...)
    starrocks::lake::AddIndexSchemaChange::build_idg_for_segment(...)
    starrocks::lake::SegmentTaskRunner::submit(...)
```

`ScalarColumnIterator::next_batch()` detects end-of-column by stepping the ordinal
page index one past the last data page, and the call that consumes the final rows
returns a **short** batch (`0 < n < requested`) with `_cur_idx == _num_pages`
already. A caller that stops only on `n == 0` therefore issues one more
`next_batch()` against an exhausted iterator, and `_load_next_page()` stepped the
page iterator again — tripping the `DCHECK_LT` in `OrdinalPageIndexIterator::next()`.

The lake ADD INDEX bitmap builder is exactly such a caller, so **any** column whose
row count is not an exact multiple of the 4096-row build batch aborts the process.
Release builds are unaffected: the DCHECK compiles out, and the extra step leaves
the iterator invalid anyway, so the read still reports eos and returns 0 rows.

## What I'm doing:

Fixed on both sides of the contract:

- `ScalarColumnIterator::_load_next_page()` reports eos without advancing when the
  page iterator is already exhausted, so `next_batch()` after eos is well defined
  (returns 0 rows) for every caller, in every build type.
- `OrdinalPageIndexIterator::valid()` no longer dereferences a null index, so a
  default-constructed iterator is simply invalid instead of UB. The `DCHECK` in
  `next()` is kept — genuine misuse is still caught — and its precondition is
  documented.
- `AddIndexSchemaChange::build_bitmap_for_column()` treats a short read as
  end-of-column and stops there, instead of asking an exhausted iterator for more
  rows. (The bloom builder in the same file iterates per data-page row range and is
  already bounded; unchanged.)

Test: `ColumnReaderWriterTest.test_next_batch_after_eos_is_idempotent` writes a
100-row single-page column, takes the short first batch, then reads three more
times and asserts each returns 0 rows instead of crashing.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
