### PR TITLE
[BugFix] Refresh Iceberg native table before cast-on-string-partition metadata delete

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -621,6 +621,21 @@ public class IcebergMetadata implements ConnectorMetadata {
         DeleteFiles deleteFiles = nativeTbl.newDelete();
         String deleteDesc;
         if (residual.hasResidual()) {
+            // This branch enumerates the files to delete (and skips the commit when nothing matches) from
+            // nativeTbl, which is served from a cross-query cache and can lag the real table until the cache is
+            // next refreshed (lazily on access, or by the periodic background refresh controlled by
+            // background_refresh_metadata_interval_millis). Refresh so files appended by an external writer since
+            // the handle was cached are not silently left behind; the row-filter branch below needs no refresh
+            // because its DeleteFiles.commit() re-applies the filter against a refreshed snapshot internally.
+            try {
+                nativeTbl.refresh();
+            } catch (Exception e) {
+                ConnectorMetricsMgr.increaseDeleteTotalFail(ConnectorMetricsMgr.CONNECTOR_ICEBERG, e, deleteType);
+                ConnectorMetricsMgr.increaseDeleteDurationMs(ConnectorMetricsMgr.CONNECTOR_ICEBERG,
+                        System.currentTimeMillis() - startMs, deleteType);
+                throw new StarRocksConnectorException("Failed to refresh Iceberg table %s.%s before metadata delete: %s",
+                        dbName, tableName, e.getMessage());
+            }
             if (icebergTable.hasPartitionTransformedEvolution()) {
                 // Defensive: canDeleteUsingMetadata should have returned false; never silently mis-delete.
                 ConnectorMetricsMgr.increaseDeleteTotalFail(ConnectorMetricsMgr.CONNECTOR_ICEBERG,

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -3998,6 +3998,105 @@ public class IcebergMetadataTest extends TableTestBase {
     }
 
     @Test
+    public void testExecuteMetadataDeleteStringDatePartitionCastStaleHandle() throws Exception {
+        // The FE serves the native table from a cross-query cache, so executeMetadataDelete can run against a
+        // handle that lags behind the real table. The cast-on-string-partition branch enumerates the files to
+        // delete (and decides whether to commit at all) from that handle, so it must refresh first: otherwise a
+        // file appended by an external writer after the handle was cached is silently left behind while the
+        // DELETE reports success.
+        PartitionSpec spec = PartitionSpec.builderFor(SCHEMA_J).identity("k2").build();
+        TestTables.TestTable cachedHandle = create(SCHEMA_J, spec, "tbDeleteStrPartStale", 1);
+        cachedHandle.newFastAppend()
+                .appendFile(DataFiles.builder(spec).withPath("/path/to/stale-0608.parquet").withFileSizeInBytes(20)
+                        .withPartitionPath("k2=2020-06-08").withRecordCount(3).build())
+                .commit();
+        cachedHandle.refresh();
+
+        // An external writer appends the partition the DELETE targets; the cached handle does not see it.
+        TestTables.TestTable writerHandle = TestTables.load(tableDir, "tbDeleteStrPartStale");
+        writerHandle.newFastAppend()
+                .appendFile(DataFiles.builder(spec).withPath("/path/to/stale-0614.parquet").withFileSizeInBytes(20)
+                        .withPartitionPath("k2=2020-06-14").withRecordCount(4).build())
+                .commit();
+
+        List<Column> columns = Lists.newArrayList(
+                new Column("id", INT), new Column("k1", INT), new Column("k2", VARCHAR));
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", columns, cachedHandle, Maps.newHashMap());
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT,
+                new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG),
+                Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+
+        new MockUp<NodeMgr>() {
+            @Mock
+            public Frontend getMySelf() {
+                return new Frontend(FrontendNodeType.LEADER, "test-fe", "127.0.0.1", 9010);
+            }
+        };
+        new MockUp<Frontend>() {
+            @Mock
+            public String getFeVersion() {
+                return "test-version";
+            }
+        };
+
+        metadata.executeMetadataDelete(icebergTable, k2EqDate(2020, 6, 14), connectContext);
+
+        writerHandle.refresh();
+        List<FileScanTask> fileScanTasks = Lists.newArrayList(writerHandle.newScan().planFiles());
+        Assertions.assertEquals(1, fileScanTasks.size(),
+                "the externally appended 2020-06-14 file must be deleted despite the stale cached handle");
+        Assertions.assertEquals("PartitionData{k2=2020-06-08}", fileScanTasks.get(0).file().partition().toString(),
+                "only the pre-existing 2020-06-08 partition must remain");
+    }
+
+    @Test
+    public void testExecuteMetadataDeleteStringDatePartitionCastRefreshFailure() {
+        // If the pre-scan refresh in the residual branch fails (e.g. remote metadata unavailable), the delete
+        // must surface a StarRocksConnectorException carrying table context, consistent with the other failure
+        // paths in executeMetadataDelete, rather than propagating a raw Iceberg exception.
+        PartitionSpec spec = PartitionSpec.builderFor(SCHEMA_J).identity("k2").build();
+        TestTables.TestTable table = create(SCHEMA_J, spec, "tbDeleteStrPartRefreshFail", 1);
+        table.newFastAppend()
+                .appendFile(DataFiles.builder(spec).withPath("/path/to/rf-0614.parquet").withFileSizeInBytes(20)
+                        .withPartitionPath("k2=2020-06-14").withRecordCount(3).build())
+                .commit();
+
+        List<Column> columns = Lists.newArrayList(
+                new Column("id", INT), new Column("k1", INT), new Column("k2", VARCHAR));
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", columns, table, Maps.newHashMap());
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT,
+                new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG),
+                Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+
+        new MockUp<NodeMgr>() {
+            @Mock
+            public Frontend getMySelf() {
+                return new Frontend(FrontendNodeType.LEADER, "test-fe", "127.0.0.1", 9010);
+            }
+        };
+        new MockUp<Frontend>() {
+            @Mock
+            public String getFeVersion() {
+                return "test-version";
+            }
+        };
+        // Make the residual branch's pre-scan refresh fail.
+        new MockUp<BaseTable>() {
+            @Mock
+            public void refresh() {
+                throw new RuntimeException("mock metastore unavailable");
+            }
+        };
+
+        StarRocksConnectorException e = Assertions.assertThrows(StarRocksConnectorException.class,
+                () -> metadata.executeMetadataDelete(icebergTable, k2EqDate(2020, 6, 14), connectContext));
+        Assertions.assertTrue(e.getMessage().contains("Failed to refresh Iceberg table"),
+                "unexpected message: " + e.getMessage());
+    }
+
+    @Test
     public void testMetadataDeleteNodeExplainString() {
         // Test that IcebergMetadataDeleteNode generates correct EXPLAIN output
         mockedNativeTableB.newFastAppend().appendFile(FILE_B_1).appendFile(FILE_B_2).commit();


### PR DESCRIPTION
## Why I'm doing:

The cast-on-string-partition residual branch of `IcebergMetadata.executeMetadataDelete` enumerates the files to delete (and decides whether to skip the commit when nothing matches) directly from the `nativeTbl` handle. That handle is served from StarRocks' cross-query Iceberg metadata cache (`enable_iceberg_metadata_cache=true`), so it can lag the real table until the cache is next refreshed — lazily on access (`iceberg_table_cache_refresh_interval_sec`, default 60s, and only when a query happens to touch the entry), or by the periodic background refresh (`background_refresh_metadata_interval_millis`, default 10 min). When an external writer appends files matching the delete predicate after the handle was cached, the stale handle sees no matching partition, so the delete is silently skipped while reporting success — the matching files are left behind and the DELETE returns `Query OK` with no snapshot committed.

Unlike the row-filter branch, this branch cannot rely on `DeleteFiles.commit()` to catch the staleness: it makes the "which files / commit-or-skip" decision *before* committing, and when the decision is "nothing matched" no commit happens at all, so the internal refresh + CAS retry inside `commit()` never runs.

## What I'm doing:

Refresh the native table at the start of the residual branch, before enumerating candidate files, so the file scan and the no-match decision observe the latest snapshot. The row-filter branch is unchanged and needs no refresh, because its `DeleteFiles.commit()` re-applies the row filter against a refreshed snapshot internally.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
