### PR TITLE
[Tool] Add 30-minute timeout to Teardown jobs

### DIFF
--- a/.github/workflows/ci-pipeline-branch.yml
+++ b/.github/workflows/ci-pipeline-branch.yml
@@ -547,6 +547,7 @@ jobs:
   Teardown:
     runs-on: [self-hosted, normal]
     name: Teardown
+    timeout-minutes: 30
     needs: [fe-ut, be-ut]
     if: always()
     env:

--- a/.github/workflows/ci-pipeline-branch.yml
+++ b/.github/workflows/ci-pipeline-branch.yml
@@ -547,7 +547,6 @@ jobs:
   Teardown:
     runs-on: [self-hosted, normal]
     name: Teardown
-    timeout-minutes: 30
     needs: [fe-ut, be-ut]
     if: always()
     env:
@@ -562,6 +561,7 @@ jobs:
           echo ${GITHUB_SHA} > head_sha.txt
 
       - name: Upload the PR number
+        timeout-minutes: 5
         uses: actions/upload-artifact@v6
         with:
           name: pr_num
@@ -570,6 +570,7 @@ jobs:
           overwrite: true
 
       - name: Upload the PR HEAD REF
+        timeout-minutes: 5
         uses: actions/upload-artifact@v6
         with:
           name: head_sha

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1448,7 +1448,6 @@ jobs:
   Teardown:
     runs-on: [self-hosted, quick]
     name: Teardown
-    timeout-minutes: 30
     needs:
       - deploy
       - SQL-Tester
@@ -1468,6 +1467,7 @@ jobs:
           echo $PR_NUMBER > pr_num.txt
 
       - name: Upload the PR number
+        timeout-minutes: 5
         uses: actions/upload-artifact@v6
         with:
           name: pr_num
@@ -1478,6 +1478,7 @@ jobs:
       - name: Backup SR Info
         if: needs.deploy.outputs.deploy_conf_file != ''
         id: backup
+        timeout-minutes: 20
         run: |
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
           ./bin/backup_log_cores.sh \
@@ -1490,12 +1491,14 @@ jobs:
 
       - name: Clean ECS
         if: steps.backup.outcome == 'success'
+        timeout-minutes: 10
         run: |
           cd ci-tool && source lib/init.sh
           ./bin/elastic-cluster.sh --delete
 
       - name: clean ECI
         if: always() && needs.SQL-Tester.outputs.MYSQL_ECI_ID != ''
+        timeout-minutes: 5
         run: |
           eci rm ${{ needs.SQL-Tester.outputs.MYSQL_ECI_ID }}
 

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1448,6 +1448,7 @@ jobs:
   Teardown:
     runs-on: [self-hosted, quick]
     name: Teardown
+    timeout-minutes: 30
     needs:
       - deploy
       - SQL-Tester

--- a/.github/workflows/inspection-pipeline.yml
+++ b/.github/workflows/inspection-pipeline.yml
@@ -665,6 +665,7 @@ jobs:
   Teardown:
     runs-on: [self-hosted, normal]
     name: Teardown
+    timeout-minutes: 30
     needs:
       - info
       - be-ut

--- a/.github/workflows/inspection-pipeline.yml
+++ b/.github/workflows/inspection-pipeline.yml
@@ -665,7 +665,6 @@ jobs:
   Teardown:
     runs-on: [self-hosted, normal]
     name: Teardown
-    timeout-minutes: 30
     needs:
       - info
       - be-ut
@@ -692,11 +691,13 @@ jobs:
       BE_UT_LINUX: ${{ needs.info.outputs.BE_UT_LINUX }}
     steps:
       - name: init
+        timeout-minutes: 10
         run: |
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull
 
       - name: save unstable cases
         if: always() && (github.event_name == 'schedule' || (github.event_name != 'schedule' && env.BRANCH != 'main'))
+        timeout-minutes: 15
         run: |
           cd ci-tool && source lib/init.sh
           ./bin/save_unstable_cases.sh


### PR DESCRIPTION
## Why I'm doing:

The `Teardown` jobs in `ci-pipeline.yml`, `ci-pipeline-branch.yml`, and `inspection-pipeline.yml` have no `timeout-minutes`, so they inherit the GitHub default of 6 hours.

When the `actions/upload-artifact` step (uploading the tiny `pr_num.txt`) wedges on a single self-hosted runner's network path to the artifact backend, the step has no step-level timeout and hangs indefinitely. This blocks the downstream `Clean ECS` / `clean ECI` steps, so the ECS cluster and ECI containers are never torn down and keep billing hourly. Observed a real occurrence stuck for ~4 hours on one `quick`-pool runner before manual `force-cancel`.

## What I'm doing:

Add `timeout-minutes: 30` to the three `Teardown` jobs so a wedged runner fails the job within 30 minutes (instead of 6 hours), after which a re-run can complete the cleanup.

Sizing: over 41 recent `CI PIPELINE` Teardown runs, median ~2.1 min, p95 ~3.6 min, max ~11.3 min. 30 min is ~2.7x the observed max — comfortable headroom for a legitimately slow teardown (large log/core backup + ECS delete) while still bounding a hang.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
