### PR TITLE
[Feature] Persist per-partition LAST_ACCESS_TIME across FE restart/failover

### DIFF
--- a/docs/en/administration/configuration/FE_parameters/log_server_meta.md
+++ b/docs/en/administration/configuration/FE_parameters/log_server_meta.md
@@ -1519,11 +1519,20 @@ This topic introduces the following types of FE configurations:
 
 ### `enable_collect_partition_access_time`
 
-- Default: true
+- Default: false
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
 - Description: Whether to collect and expose the per-partition `LAST_ACCESS_TIME` (the last time a partition was scanned by a user query) in `SHOW PARTITIONS` and `information_schema.partitions_meta`. When disabled, the access time is neither recorded nor aggregated across FEs, and the `LAST_ACCESS_TIME` column shows `NULL`. This does not affect `LAST_UPDATE_TIME`.
+- Introduced in: v4.2.0
+
+### `partition_access_time_flush_interval_sec`
+
+- Default: 600
+- Type: Int
+- Unit: Seconds
+- Is mutable: Yes
+- Description: The interval at which each FE flushes its own collected per-partition `LAST_ACCESS_TIME` to the internal `_statistics_.partition_access_time` table for durability across restart/failover. Only effective when `enable_collect_partition_access_time` is `true`.
 - Introduced in: v4.2.0
 
 ### `enable_show_materialized_views_include_all_task_runs`

--- a/docs/ja/administration/configuration/FE_parameters/log_server_meta.md
+++ b/docs/ja/administration/configuration/FE_parameters/log_server_meta.md
@@ -1510,11 +1510,20 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ### `enable_collect_partition_access_time`
 
-- デフォルト：true
+- デフォルト：false
 - タイプ：Boolean
 - 単位：-
 - 変更可能：Yes
 - 説明：`SHOW PARTITIONS` および `information_schema.partitions_meta` で、パーティションごとの `LAST_ACCESS_TIME`（パーティションがユーザークエリによって最後にスキャンされた時刻）を収集して公開するかどうかを制御します。無効にすると、アクセス時刻は記録されず、FE 間で集約もされず、`LAST_ACCESS_TIME` 列は `NULL` を表示します。この項目は `LAST_UPDATE_TIME` には影響しません。
+- 導入時期：v4.2.0
+
+### `partition_access_time_flush_interval_sec`
+
+- デフォルト：600
+- タイプ：Int
+- 単位：秒
+- 変更可能：Yes
+- 説明：各 FE が自身で収集したパーティションごとの `LAST_ACCESS_TIME` を、再起動やフェイルオーバーをまたいで永続化するために内部テーブル `_statistics_.partition_access_time` にフラッシュする間隔です。`enable_collect_partition_access_time` が `true` の場合のみ有効です。
 - 導入時期：v4.2.0
 
 ### `enable_show_materialized_views_include_all_task_runs`

--- a/docs/zh/administration/configuration/FE_parameters/log_server_meta.md
+++ b/docs/zh/administration/configuration/FE_parameters/log_server_meta.md
@@ -1518,11 +1518,20 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ### `enable_collect_partition_access_time`
 
-- 默认值: true
+- 默认值: false
 - 类型: Boolean
 - 单位: -
 - 是否可变: Yes
 - 描述: 是否采集并展示每个分区的 `LAST_ACCESS_TIME`（分区最近一次被用户查询扫描的时间），展示在 `SHOW PARTITIONS` 和 `information_schema.partitions_meta` 中。禁用后，访问时间既不会被记录，也不会跨 FE 聚合，`LAST_ACCESS_TIME` 列显示为 `NULL`。此项不影响 `LAST_UPDATE_TIME`。
+- 引入版本: v4.2.0
+
+### `partition_access_time_flush_interval_sec`
+
+- 默认值: 600
+- 类型: Int
+- 单位: 秒
+- 是否可变: Yes
+- 描述: 每个 FE 将各自采集到的每个分区的 `LAST_ACCESS_TIME` 刷新到内部表 `_statistics_.partition_access_time` 的时间间隔，用于在 FE 重启或 Failover 后保证数据持久化。仅当 `enable_collect_partition_access_time` 为 `true` 时生效。
 - 引入版本: v4.2.0
 
 ### `enable_show_materialized_views_include_all_task_runs`

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionAccessTimeEntry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionAccessTimeEntry.java
@@ -1,0 +1,50 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+/**
+ * One partition's durable access-time record, flushed from each FE's own in-memory map into the internal
+ * {@code _statistics_.partition_access_time} table (MAX-aggregated across FEs). An in-process data carrier
+ * between {@link PartitionAccessTimeMgr}, {@link PartitionAccessTimeStore} and {@link PartitionAccessTimePersister}.
+ */
+public class PartitionAccessTimeEntry {
+    private final long dbId;
+    private final long tableId;
+    private final long partitionId;
+    private final long accessTimeMs;
+
+    public PartitionAccessTimeEntry(long dbId, long tableId, long partitionId, long accessTimeMs) {
+        this.dbId = dbId;
+        this.tableId = tableId;
+        this.partitionId = partitionId;
+        this.accessTimeMs = accessTimeMs;
+    }
+
+    public long getDbId() {
+        return dbId;
+    }
+
+    public long getTableId() {
+        return tableId;
+    }
+
+    public long getPartitionId() {
+        return partitionId;
+    }
+
+    public long getAccessTimeMs() {
+        return accessTimeMs;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionAccessTimeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionAccessTimeMgr.java
@@ -41,21 +41,17 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Tracks the last time each partition was scanned by a user query (lastAccessTime).
  * <p>
- * Pure in-memory: the timestamps live in {@link #partitionAccessTimes} on this FE and are NOT persisted
- * (no {@code @SerializedName}, no edit log), so they reset on FE restart/failover. Keyed by
- * {@code dbId -> tableId -> (logicalPartitionId -> ms)}; all three ids are globally unique. The query hot path
- * records with a single lock-free, catalog-free {@code merge} (monotonic max) via {@link #recordAccess},
- * and reads are lock-free too: the read path just snapshots the relevant tables' inner maps without
- * touching the catalog or walking the partition structure.
+ * In-memory, keyed by {@code dbId -> tableId -> (logicalPartitionId -> ms)} (all three ids are globally
+ * unique). The query hot path records with a single lock-free, catalog-free {@code merge} (monotonic max)
+ * via {@link #recordAccess}, and reads are lock-free too: the read path just snapshots the relevant tables'
+ * inner maps without touching the catalog.
  * <p>
- * A cluster-consistent value is assembled entirely inside {@link #getAccessTimes}: each FE only records the
- * queries it coordinates, so it folds this FE's own records together with the other FEs' (a best-effort
- * cross-FE RPC that lands in each peer's {@link #getLocalAccessTimes}), all keyed by logical partition id,
- * and raises {@link ErrorCode#ERR_GET_PARTITION_ACCESS_TIME} when there is nothing to show and every peer
- * failed. The read paths (SHOW PARTITIONS and information_schema.partitions_meta) just call it and map each
- * logical timestamp onto its physical sub-partition rows using the logical parent already in scope during
- * their {@code for (logical) for (physical)} row-building loop -- no reverse lookup, and no lock is needed
- * for the access-time column.
+ * Durability across restart/failover is provided out-of-band by {@link PartitionAccessTimePersister}, which
+ * runs only on the leader.
+ * <p>
+ * The read paths (SHOW PARTITIONS and information_schema.partitions_meta) just call {@link #getAccessTimes}
+ * and map each logical timestamp onto its physical sub-partition rows using the logical parent already in
+ * scope during their {@code for (logical) for (physical)} row-building loop.
  */
 public class PartitionAccessTimeMgr {
     private static final Logger LOG = LogManager.getLogger(PartitionAccessTimeMgr.class);
@@ -95,6 +91,10 @@ public class PartitionAccessTimeMgr {
     /**
      * Cluster-aggregated access times for a batch of tables (logicalPartitionId -&gt; ms), keyed by logical
      * partition id across all tables (ids are globally unique).
+     * <p>
+     * Assembled purely from memory -- this FE's own records plus a best-effort RPC to every alive peer's
+     * {@link #getLocalAccessTimes}; the leader's reply carries the full persisted baseline, so no FE ever
+     * queries the internal table on this path.
      * <p>
      * When the merged result is empty AND every peer we actually contacted failed, an empty result would be
      * indistinguishable from "genuinely never accessed", so this raises {@link ErrorCode#ERR_GET_PARTITION_ACCESS_TIME}
@@ -180,5 +180,88 @@ public class PartitionAccessTimeMgr {
         }
         ConcurrentHashMap<Long, Long> perTable = perDb.get(tableId);
         return perTable == null ? 0L : perTable.getOrDefault(logicalPartitionId, 0L);
+    }
+
+    /**
+     * Max-merge flat entries into the map without clearing anything. The leader uses this both to fold each
+     * drained follower's increment into its authoritative map and to seed that map from the persisted table
+     * when it becomes leader. Uses the same lock-free {@code merge(max)} as {@link #recordAccess}.
+     */
+    public void mergeEntries(List<PartitionAccessTimeEntry> entries) {
+        if (entries == null) {
+            return;
+        }
+        for (PartitionAccessTimeEntry e : entries) {
+            partitionAccessTimes
+                    .computeIfAbsent(e.getDbId(), k -> new ConcurrentHashMap<>())
+                    .computeIfAbsent(e.getTableId(), k -> new ConcurrentHashMap<>())
+                    .merge(e.getPartitionId(), e.getAccessTimeMs(), Math::max);
+        }
+    }
+
+    /**
+     * Snapshot the map entries whose access time is greater than or equal to {@code sinceInclusiveMs} (no clear).
+     * The leader flush uses this with the last persisted max time to persist the increment. The boundary is
+     * inclusive so a record whose ts equals the watermark but was not in the batch that advanced it is still
+     * persisted; re-persisting an already-stored boundary entry is harmless under the table's MAX aggregate.
+     * Weakly consistent iteration over the concurrent map -- safe against a concurrent {@link #recordAccess}.
+     */
+    public List<PartitionAccessTimeEntry> snapshotSince(long sinceInclusiveMs) {
+        List<PartitionAccessTimeEntry> out = new ArrayList<>();
+        for (Map.Entry<Long, ConcurrentHashMap<Long, ConcurrentHashMap<Long, Long>>> dbE : partitionAccessTimes.entrySet()) {
+            for (Map.Entry<Long, ConcurrentHashMap<Long, Long>> tblE : dbE.getValue().entrySet()) {
+                for (Map.Entry<Long, Long> pE : tblE.getValue().entrySet()) {
+                    if (pE.getValue() >= sinceInclusiveMs) {
+                        out.add(new PartitionAccessTimeEntry(dbE.getKey(), tblE.getKey(), pE.getKey(), pE.getValue()));
+                    }
+                }
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Snapshot every {@code (dbId, tableId, logicalPartitionId)} key currently in the map (no clear). The
+     * leader cleanup walks these to find rows whose partition was dropped from the live catalog.
+     */
+    public List<long[]> collectAllKeys() {
+        List<long[]> out = new ArrayList<>();
+        for (Map.Entry<Long, ConcurrentHashMap<Long, ConcurrentHashMap<Long, Long>>> dbE : partitionAccessTimes.entrySet()) {
+            for (Map.Entry<Long, ConcurrentHashMap<Long, Long>> tblE : dbE.getValue().entrySet()) {
+                for (Long pid : tblE.getValue().keySet()) {
+                    out.add(new long[] {dbE.getKey(), tblE.getKey(), pid});
+                }
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Remove the given {@code (dbId, tableId, logicalPartitionId)} keys from the map (leader cleanup, in step
+     * with the corresponding table DELETE). Empty inner maps are trimmed. A concurrent {@link #recordAccess}
+     * that re-adds a just-dropped partition is harmless -- the next cleanup cycle prunes it again.
+     */
+    public void removePartitions(Collection<long[]> keys) {
+        if (keys == null) {
+            return;
+        }
+        for (long[] key : keys) {
+            if (key.length < 3) {
+                continue;
+            }
+            long dbId = key[0];
+            long tableId = key[1];
+            ConcurrentHashMap<Long, ConcurrentHashMap<Long, Long>> perDb = partitionAccessTimes.get(dbId);
+            if (perDb == null) {
+                continue;
+            }
+            ConcurrentHashMap<Long, Long> perTable = perDb.get(tableId);
+            if (perTable == null) {
+                continue;
+            }
+            perTable.remove(key[2]);
+            perDb.computeIfPresent(tableId, (k, v) -> v.isEmpty() ? null : v);
+            partitionAccessTimes.computeIfPresent(dbId, (k, v) -> v.isEmpty() ? null : v);
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionAccessTimePersister.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionAccessTimePersister.java
@@ -1,0 +1,266 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.starrocks.common.Config;
+import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.statistic.StatsConstants;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Daemon that runs on <b>every</b> FE and gives per-partition {@code LAST_ACCESS_TIME} durability across
+ * restart/failover.
+ * <ul>
+ *   <li><b>Flush</b> (every FE, every cycle) -- persists this FE's own in-memory increment (entries at or newer
+ *       than its last persisted watermark) into {@code _statistics_.partition_access_time}. The table is an
+ *       aggregate table keyed on (db, table, partition) with a {@code MAX} timestamp, so blind per-FE INSERTs
+ *       merge into the newest value with no cross-FE coordination.</li>
+ *   <li><b>Baseline load</b> (leader only) -- while this FE is the leader it loads the whole table into its
+ *       in-memory map once ({@link #loadBaseline()}); that copy is the historical baseline the read path serves
+ *       (reads merge every FE's map over the {@code getPartitionAccessTimes} RPC). Followers do not load it, and
+ *       the load is re-armed whenever this FE is not leader so a promotion reloads a fresh baseline.</li>
+ *   <li><b>Memory cleanup</b> (every FE, rate-limited) -- evicts from this FE's own map the partitions that no
+ *       longer resolve anywhere ({@link #cleanupMemory()}); it never touches the table.</li>
+ *   <li><b>Table cleanup</b> (leader only, rate-limited) -- full-scans the table and deletes rows whose partition
+ *       is gone ({@link #cleanupTable()}).</li>
+ * </ul>
+ * Everything is gated by {@link Config#enable_collect_partition_access_time}; the cycle is skipped until
+ * {@code StatisticsMetaManager} has created the table.
+ */
+public class PartitionAccessTimePersister extends FrontendDaemon {
+    private static final Logger LOG = LogManager.getLogger(PartitionAccessTimePersister.class);
+
+    // Run the (full-scan) cleanup only once per this many cycles -- ~12h at the default 600s flush interval.
+    @VisibleForTesting
+    static final long CLEANUP_EVERY_N_CYCLES = 72;
+
+    private final PartitionAccessTimeStore store;
+
+    // Leader-only: whether this FE (as leader) has loaded the persisted baseline into memory. Forced false while
+    // not leader so a promotion reloads. Touched only from the single daemon worker thread.
+    private boolean baselineLoaded = false;
+
+    // Max access time this FE has already persisted; the flush persists only entries at or newer than this.
+    // Advanced only after a successful upsert. Touched only from the single daemon worker thread.
+    private long lastPersistedMaxTs = 0;
+
+    // Cycle counter that rate-limits cleanup; only touched from the single daemon worker thread.
+    private long flushCycles = 0;
+
+    public PartitionAccessTimePersister() {
+        this(new PartitionAccessTimeStore());
+    }
+
+    @VisibleForTesting
+    PartitionAccessTimePersister(PartitionAccessTimeStore store) {
+        super("partition-access-time-persister", intervalMs());
+        this.store = store;
+    }
+
+    @Override
+    protected void runAfterCatalogReady() {
+        if (!Config.enable_collect_partition_access_time) {
+            return;
+        }
+        // StatisticsMetaManager creates the table on its own loop; resume next cycle once it exists.
+        if (!tableExists()) {
+            return;
+        }
+        // Pick up the mutable flush interval each cycle (mirrors LoadsHistorySyncer).
+        setInterval(intervalMs());
+
+        boolean isLeader = GlobalStateMgr.getCurrentState().isLeader();
+        // Only the leader seeds its map from the table (the read path's baseline). Re-arm the load whenever this
+        // FE is not leader, so a later promotion rebuilds a fresh baseline instead of trusting a stale one.
+        if (!isLeader) {
+            baselineLoaded = false;
+        } else if (!baselineLoaded) {
+            loadBaseline();
+        }
+
+        // Every FE persists its own recorded increment; the table's MAX aggregate merges all FEs.
+        flushOnce();
+
+        if (flushCycles++ % CLEANUP_EVERY_N_CYCLES == 0) {
+            // Every FE trims its own memory; only the leader GCs the shared table.
+            cleanupMemory();
+            if (isLeader) {
+                cleanupTable();
+            }
+        }
+    }
+
+    // Flush interval in ms, clamped to >= 1s so a misconfigured 0/negative value can't turn the daemon into a
+    // busy loop (Daemon.run sleeps for getInterval() between cycles).
+    private static long intervalMs() {
+        return Math.max(1, Config.partition_access_time_flush_interval_sec) * 1000L;
+    }
+
+    /**
+     * Seed this (leader) FE's in-memory map from the persisted table exactly once per leadership term, and set the
+     * watermark to the max timestamp loaded so the first flush does not re-insert the whole baseline. On failure
+     * the map is left as-is and the load is retried next cycle (do not start from an empty baseline).
+     */
+    @VisibleForTesting
+    void loadBaseline() {
+        try {
+            List<PartitionAccessTimeEntry> baseline = store.loadAll();
+            GlobalStateMgr.getCurrentState().getPartitionAccessTimeMgr().mergeEntries(baseline);
+            long max = 0;
+            for (PartitionAccessTimeEntry e : baseline) {
+                max = Math.max(max, e.getAccessTimeMs());
+            }
+            lastPersistedMaxTs = max;
+            baselineLoaded = true;
+            LOG.info("loaded {} persisted partition access time rows into memory (watermark={})",
+                    baseline.size(), max);
+        } catch (Exception e) {
+            LOG.warn("failed to load partition access time baseline, will retry next cycle: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Persist this FE's own increment -- the map entries at or newer than its last persisted watermark. The
+     * boundary is inclusive so an entry whose ts equals the watermark but was not in the batch that advanced it is
+     * still persisted (a harmless re-write under the table's MAX aggregate, which also merges every FE's writes).
+     * Nothing is drained from memory here; the read path keeps serving from it.
+     */
+    @VisibleForTesting
+    void flushOnce() {
+        PartitionAccessTimeMgr mgr = GlobalStateMgr.getCurrentState().getPartitionAccessTimeMgr();
+        List<PartitionAccessTimeEntry> increment = mgr.snapshotSince(lastPersistedMaxTs);
+        if (increment.isEmpty()) {
+            return;
+        }
+        try {
+            store.upsert(increment);
+            // Advance the watermark only after the persist succeeds, so a failure retries the same increment.
+            long max = lastPersistedMaxTs;
+            for (PartitionAccessTimeEntry e : increment) {
+                max = Math.max(max, e.getAccessTimeMs());
+            }
+            lastPersistedMaxTs = max;
+        } catch (Exception e) {
+            LOG.warn("failed to persist partition access times, will retry next cycle: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Evict from THIS FE's in-memory map the partitions that no longer resolve anywhere (live catalog or recycle
+     * bin). Runs on every FE against its own map and never touches the table (that is the leader's job in
+     * {@link #cleanupTable()}); it just keeps memory from growing without bound as partitions are dropped.
+     */
+    @VisibleForTesting
+    void cleanupMemory() {
+        PartitionAccessTimeMgr mgr = GlobalStateMgr.getCurrentState().getPartitionAccessTimeMgr();
+        List<long[]> droppedKeys = new ArrayList<>();
+        for (long[] key : mgr.collectAllKeys()) {
+            if (key.length < 3) {
+                continue;
+            }
+            if (!partitionExists(key[0], key[1], key[2])) {
+                droppedKeys.add(key);
+            }
+        }
+        if (!droppedKeys.isEmpty()) {
+            mgr.removePartitions(droppedKeys);
+        }
+    }
+
+    /**
+     * Leader-only: delete persisted rows whose partition no longer resolves anywhere. A full {@code SELECT} of the
+     * table ({@link PartitionAccessTimeStore#loadAll()}) is the authoritative row set -- the in-memory map only
+     * holds this FE's own writes plus the baseline, not every FE's, so it is not a superset of the table. Re-checks
+     * leadership immediately before the {@code DELETE} so a demotion landing mid-scan cannot delete under a
+     * leadership this FE has already lost. A failed load/delete just retries next cleanup (best-effort GC).
+     */
+    @VisibleForTesting
+    void cleanupTable() {
+        List<PartitionAccessTimeEntry> persisted;
+        try {
+            persisted = store.loadAll();
+        } catch (Exception e) {
+            LOG.warn("failed to load persisted partition access times for cleanup, will retry next cycle: {}",
+                    e.getMessage());
+            return;
+        }
+        List<Long> droppedPartitionIds = new ArrayList<>();
+        for (PartitionAccessTimeEntry e : persisted) {
+            if (!partitionExists(e.getDbId(), e.getTableId(), e.getPartitionId())) {
+                droppedPartitionIds.add(e.getPartitionId());
+            }
+        }
+        if (droppedPartitionIds.isEmpty()) {
+            return;
+        }
+        if (!GlobalStateMgr.getCurrentState().isLeader()) {
+            return;
+        }
+        try {
+            store.deleteByPartitionIds(droppedPartitionIds);
+        } catch (Exception e) {
+            LOG.warn("failed to delete dropped partition access time rows, will retry next cycle: {}",
+                    e.getMessage());
+        }
+    }
+
+    /**
+     * Whether the {@code (db, table, partition)} still resolves to an existing partition -- either live in the
+     * catalog or recoverable from the {@link CatalogRecycleBin}. Only a clear absence of the exact partition from
+     * every layer prunes the row, so a {@code RECOVER PARTITION}/{@code TABLE}/{@code DATABASE} keeps its persisted
+     * access times, while a partition that is truly gone (e.g. individually dropped and GC'd before its table was
+     * dropped) is not kept forever as an orphan.
+     *
+     * <p>Follows the statistics-cleanup convention of not taking a DB/table metadata lock ("statistics job doesn't
+     * lock DB, partition may be dropped, skip it" -- e.g. {@code FullStatisticsCollectJob}, {@code MetaQueryJob}): a
+     * point lookup racing a concurrent drop/create only yields a stale answer, and a spurious prune of a still-live
+     * partition self-heals (its next scan re-records and re-persists the access time).
+     */
+    @VisibleForTesting
+    boolean partitionExists(long dbId, long tableId, long partitionId) {
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Database db = metastore.getDbIncludeRecycleBin(dbId);
+        if (db == null) {
+            return false;
+        }
+        Table table = metastore.getTableIncludeRecycleBin(db, tableId);
+        if (table == null) {
+            return false;
+        }
+        if (!(table instanceof OlapTable)) {
+            // An unexpected non-OlapTable type keeps the row defensively (prune only on clear absence).
+            return true;
+        }
+        return metastore.getPartitionIncludeRecycleBin((OlapTable) table, partitionId) != null;
+    }
+
+    /** Whether {@code _statistics_.partition_access_time} exists yet (mirrors {@code StatisticsMetaManager}). */
+    @VisibleForTesting
+    boolean tableExists() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(StatsConstants.STATISTICS_DB_NAME);
+        if (db == null) {
+            return false;
+        }
+        return GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), StatsConstants.PARTITION_ACCESS_TIME_TABLE_NAME) != null;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionAccessTimeStore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionAccessTimeStore.java
@@ -1,0 +1,129 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonParser;
+import com.starrocks.common.Config;
+import com.starrocks.qe.SimpleExecutor;
+import com.starrocks.statistic.StatsConstants;
+import com.starrocks.thrift.TResultBatch;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.StringJoiner;
+
+/**
+ * All SQL against the internal {@code _statistics_.partition_access_time} table lives here.
+ * <p>The table is a pure durability record: the leader flushes increments into it and loads it back into the
+ * authoritative in-memory map once, when it becomes leader. The read hot path never queries it (see
+ * {@link PartitionAccessTimeMgr}).
+ */
+public class PartitionAccessTimeStore {
+    private static final Logger LOG = LogManager.getLogger(PartitionAccessTimeStore.class);
+    private static final String TABLE =
+            StatsConstants.STATISTICS_DB_NAME + "." + StatsConstants.PARTITION_ACCESS_TIME_TABLE_NAME;
+    private static final String LOAD_ALL_SQL =
+            "SELECT db_id, table_id, partition_id, last_access_time_ms FROM " + TABLE;
+
+    public static String buildUpsertSql(List<PartitionAccessTimeEntry> entries) {
+        StringJoiner values = new StringJoiner(", ");
+        for (PartitionAccessTimeEntry e : entries) {
+            values.add("(" + e.getDbId() + ", " + e.getTableId() + ", "
+                    + e.getPartitionId() + ", " + e.getAccessTimeMs() + ")");
+        }
+        return "INSERT INTO " + TABLE + " VALUES " + values;
+    }
+
+    public static String buildDeleteByPartitionIdsSql(Collection<Long> partitionIds) {
+        return "DELETE FROM " + TABLE + " WHERE partition_id IN (" + join(partitionIds) + ")";
+    }
+
+    private static String join(Collection<Long> ids) {
+        StringJoiner j = new StringJoiner(", ");
+        for (Long id : ids) {
+            j.add(String.valueOf(id));
+        }
+        return j.toString();
+    }
+
+    public void upsert(List<PartitionAccessTimeEntry> entries) {
+        if (entries == null || entries.isEmpty()) {
+            return;
+        }
+        // An INSERT ... VALUES row list is capped by the parser at Config.expr_children_limit rows
+        // (insertRowsExceedLimit). Chunk with the same /2 margin the statistics cleanup uses so a large flush
+        // never trips the cap.
+        int chunkSize = Math.max(1, Config.expr_children_limit / 2);
+        for (List<PartitionAccessTimeEntry> chunk : ListUtils.partition(entries, chunkSize)) {
+            SimpleExecutor.getRepoExecutor().executeDML(buildUpsertSql(chunk));
+        }
+    }
+
+    public void deleteByPartitionIds(Collection<Long> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return;
+        }
+        int chunkSize = Math.max(1, Math.min(Config.expr_children_limit / 2, Config.max_allowed_in_element_num_of_delete));
+        for (List<Long> chunk : ListUtils.partition(new ArrayList<>(ids), chunkSize)) {
+            SimpleExecutor.getRepoExecutor().executeDML(buildDeleteByPartitionIdsSql(chunk));
+        }
+    }
+
+    /**
+     * The full persisted baseline as flat entries. The leader loads this once into memory when it becomes
+     * leader. Propagates a query failure so the caller can retry the one-time load next cycle rather than
+     * start from an empty baseline.
+     */
+    public List<PartitionAccessTimeEntry> loadAll() {
+        return parseEntries(SimpleExecutor.getRepoExecutor().executeDQL(LOAD_ALL_SQL));
+    }
+
+    /**
+     * Decode rows shaped like {@code (db_id, table_id, partition_id, last_access_time_ms)} into flat entries.
+     * <p>The repo executor runs with {@code TResultSinkType.HTTP_PROTOCAL}, so each row is a JSON document of
+     * the form {@code {"data": [col1, col2, ...]}} carried as a single buffer inside
+     * {@link TResultBatch#getRows()}; this mirrors the decode idiom used by {@code TaskRunStatus#fromResultBatch}
+     * and {@code PipeFileRecord#fromResultBatch}.
+     */
+    private static List<PartitionAccessTimeEntry> parseEntries(List<TResultBatch> batches) {
+        List<PartitionAccessTimeEntry> out = new ArrayList<>();
+        for (TResultBatch batch : ListUtils.emptyIfNull(batches)) {
+            for (ByteBuffer buffer : batch.getRows()) {
+                try {
+                    ByteBuf copied = Unpooled.copiedBuffer(buffer);
+                    String jsonString = copied.toString(Charset.defaultCharset());
+                    JsonArray data = JsonParser.parseString(jsonString).getAsJsonObject().get("data").getAsJsonArray();
+                    out.add(new PartitionAccessTimeEntry(
+                            data.get(0).getAsLong(),
+                            data.get(1).getAsLong(),
+                            data.get(2).getAsLong(),
+                            data.get(3).getAsLong()));
+                } catch (Exception e) {
+                    LOG.warn("failed to parse partition access time row: {}", e.getMessage());
+                }
+            }
+        }
+        return out;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -4735,7 +4735,12 @@ public class Config extends ConfigBase {
             "(the last time a partition was scanned by a user query) in SHOW PARTITIONS and " +
             "information_schema.partitions_meta. When disabled, the access time is neither recorded nor aggregated " +
             "across FEs and the LAST_ACCESS_TIME column shows NULL.")
-    public static boolean enable_collect_partition_access_time = true;
+    public static boolean enable_collect_partition_access_time = false;
+
+    @ConfField(mutable = true, comment = "Interval in seconds at which each FE flushes its own collected " +
+            "per-partition LAST_ACCESS_TIME to the internal _statistics_.partition_access_time table for " +
+            "durability across restart/failover. Only effective when enable_collect_partition_access_time is true.")
+    public static int partition_access_time_flush_interval_sec = 600;
 
     @ConfField(mutable = false)
     public static int max_spm_cache_baseline_size = 1000;

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -69,6 +69,7 @@ import com.starrocks.catalog.GlobalFunctionMgr;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MetaReplayState;
 import com.starrocks.catalog.PartitionAccessTimeMgr;
+import com.starrocks.catalog.PartitionAccessTimePersister;
 import com.starrocks.catalog.RefreshDictionaryCacheTaskDaemon;
 import com.starrocks.catalog.ResourceGroupMgr;
 import com.starrocks.catalog.ResourceMgr;
@@ -414,6 +415,7 @@ public class GlobalStateMgr {
     private final TabletStatMgr tabletStatMgr;
 
     private final PartitionAccessTimeMgr partitionAccessTimeMgr;
+    private final PartitionAccessTimePersister partitionAccessTimePersister;
 
     private AuthenticationMgr authenticationMgr;
     private AuthorizationMgr authorizationMgr;
@@ -762,6 +764,7 @@ public class GlobalStateMgr {
         this.globalTransactionMgr = new GlobalTransactionMgr(this);
         this.tabletStatMgr = new TabletStatMgr();
         this.partitionAccessTimeMgr = new PartitionAccessTimeMgr();
+        this.partitionAccessTimePersister = new PartitionAccessTimePersister();
         this.authenticationMgr = new AuthenticationMgr();
         this.domainResolver = new DomainResolver(authenticationMgr);
         this.authorizationMgr = new AuthorizationMgr(new DefaultAuthorizationProvider());
@@ -1938,6 +1941,9 @@ public class GlobalStateMgr {
 
         portConnectivityChecker.start();
         tabletStatMgr.start();
+        // Runs on every FE: each flushes its own recorded partition access times; the leader additionally
+        // loads the read-path baseline and GCs the internal table.
+        partitionAccessTimePersister.start();
         // load and export job label cleaner thread
         labelCleaner.start();
         // ES state store

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -33,6 +33,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.ast.AddColumnClause;
+import com.starrocks.sql.ast.AggregateType;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.CreateDbStmt;
@@ -65,6 +66,7 @@ import static com.starrocks.statistic.StatsConstants.EXTERNAL_HISTOGRAM_STATISTI
 import static com.starrocks.statistic.StatsConstants.FULL_STATISTICS_TABLE_NAME;
 import static com.starrocks.statistic.StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME;
 import static com.starrocks.statistic.StatsConstants.MULTI_COLUMN_STATISTICS_TABLE_NAME;
+import static com.starrocks.statistic.StatsConstants.PARTITION_ACCESS_TIME_TABLE_NAME;
 import static com.starrocks.statistic.StatsConstants.QUERY_HISTORY_TABLE_NAME;
 import static com.starrocks.statistic.StatsConstants.SAMPLE_STATISTICS_TABLE_NAME;
 import static com.starrocks.statistic.StatsConstants.SPM_BASELINE_TABLE_NAME;
@@ -146,6 +148,10 @@ public class StatisticsMetaManager extends LeaderDaemon {
 
     private static final List<String> MULTI_COLUMN_STATISTICS_KEY_COLUMNS = ImmutableList.of(
             "table_id", "column_ids"
+    );
+
+    private static final List<String> PARTITION_ACCESS_TIME_KEY_COLUMNS = ImmutableList.of(
+            "db_id", "table_id", "partition_id"
     );
 
     private boolean createSampleStatisticsTable(ConnectContext context) {
@@ -432,6 +438,43 @@ public class StatisticsMetaManager extends LeaderDaemon {
         return checkTableExist(QUERY_HISTORY_TABLE_NAME);
     }
 
+    private boolean createPartitionAccessTimeTable(ConnectContext context) {
+        LOG.info("create {} table start", PARTITION_ACCESS_TIME_TABLE_NAME);
+        // Aggregate table with last_access_time_ms MAX-aggregated: the periodic flush is a blind INSERT, so
+        // letting the storage engine keep the larger value on write makes the persisted timestamp monotonic --
+        // a late/stale batch from a rejoining FE can never move it backwards. Works in both run modes.
+        KeysType keysType = KeysType.AGG_KEYS;
+        Map<String, String> properties = Maps.newHashMap();
+        try {
+            List<ColumnDef> columns = ImmutableList.of(
+                    new ColumnDef("db_id", new TypeDef(BIGINT)),
+                    new ColumnDef("table_id", new TypeDef(BIGINT)),
+                    new ColumnDef("partition_id", new TypeDef(BIGINT)),
+                    new ColumnDef("last_access_time_ms", new TypeDef(BIGINT), false, AggregateType.MAX, null,
+                            false, ColumnDef.DefaultValueDef.NOT_SET, "")
+            );
+
+            int defaultReplicationNum = AutoInferUtil.calDefaultReplicationNum();
+            properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Integer.toString(defaultReplicationNum));
+            QualifiedName qualifiedName =
+                    QualifiedName.of(Arrays.asList(STATISTICS_DB_NAME, PARTITION_ACCESS_TIME_TABLE_NAME));
+            TableRef tableRef = new TableRef(qualifiedName, null, NodePosition.ZERO);
+            CreateTableStmt stmt = new CreateTableStmt(false, false,
+                    tableRef, columns, EngineType.defaultEngine().name(),
+                    new KeysDesc(keysType, PARTITION_ACCESS_TIME_KEY_COLUMNS), null,
+                    new HashDistributionDesc(10, PARTITION_ACCESS_TIME_KEY_COLUMNS),
+                    properties, null, "");
+
+            Analyzer.analyze(stmt, context);
+            GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(stmt);
+        } catch (StarRocksException e) {
+            LOG.warn("Failed to create {} table", PARTITION_ACCESS_TIME_TABLE_NAME, e);
+            return false;
+        }
+        LOG.info("create {} table done", PARTITION_ACCESS_TIME_TABLE_NAME);
+        return checkTableExist(PARTITION_ACCESS_TIME_TABLE_NAME);
+    }
+
     private void refreshAnalyzeJob() {
         for (Map.Entry<Long, BasicStatsMeta> entry :
                 GlobalStateMgr.getCurrentState().getAnalyzeMgr().getBasicStatsMetaMap().entrySet()) {
@@ -476,6 +519,8 @@ public class StatisticsMetaManager extends LeaderDaemon {
                 return createSPMBaselinesTable(context);
             } else if (QUERY_HISTORY_TABLE_NAME.equals(tableName)) {
                 return createQueryHistoryTable(context);
+            } else if (PARTITION_ACCESS_TIME_TABLE_NAME.equals(tableName)) {
+                return createPartitionAccessTimeTable(context);
             } else {
                 throw new StarRocksPlannerException("Error table name " + tableName, ErrorType.INTERNAL_ERROR);
             }
@@ -597,6 +642,7 @@ public class StatisticsMetaManager extends LeaderDaemon {
         refreshStatisticsTable(MULTI_COLUMN_STATISTICS_TABLE_NAME);
         refreshStatisticsTable(SPM_BASELINE_TABLE_NAME);
         refreshStatisticsTable(QUERY_HISTORY_TABLE_NAME);
+        refreshStatisticsTable(PARTITION_ACCESS_TIME_TABLE_NAME);
         if (isStopRequested()) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
@@ -110,6 +110,9 @@ public class StatsConstants {
     public static final String SPM_BASELINE_TABLE_NAME = "spm_baselines";
     public static final String QUERY_HISTORY_TABLE_NAME = "query_history";
 
+    // Durable per-partition LAST_ACCESS_TIME table
+    public static final String PARTITION_ACCESS_TIME_TABLE_NAME = "partition_access_time";
+
     /**
      * Deprecated stats properties
      */
@@ -138,7 +141,8 @@ public class StatsConstants {
             EXTERNAL_FULL_STATISTICS_TABLE_NAME,
             MULTI_COLUMN_STATISTICS_TABLE_NAME,
             HISTOGRAM_STATISTICS_TABLE_NAME,
-            EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME
+            EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME,
+            PARTITION_ACCESS_TIME_TABLE_NAME
     );
 
     public enum AnalyzeType {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/PartitionAccessTimeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/PartitionAccessTimeMgrTest.java
@@ -84,6 +84,77 @@ public class PartitionAccessTimeMgrTest {
         // Must not throw on a null / empty id collection, and must not create an entry.
         mgr.recordAccess(DB_ID, TABLE_ID, null);
         mgr.recordAccess(DB_ID, TABLE_ID, Lists.newArrayList());
+        mgr.mergeEntries(null);
+        mgr.removePartitions(null);
         Assertions.assertTrue(mgr.getLocalAccessTimes(refs(DB_ID, TABLE_ID)).isEmpty());
+        Assertions.assertTrue(mgr.collectAllKeys().isEmpty());
+    }
+
+    @Test
+    public void testMergeEntriesMaxMergesWithoutClearing() {
+        PartitionAccessTimeMgr mgr = new PartitionAccessTimeMgr();
+        mgr.mergeEntries(Lists.newArrayList(
+                new PartitionAccessTimeEntry(DB_ID, TABLE_ID, 100L, 500L),
+                new PartitionAccessTimeEntry(DB_ID, TABLE_ID, 200L, 20L)));
+        // A lower ts for an existing key does not move it backwards; a higher one wins.
+        mgr.mergeEntries(Lists.newArrayList(
+                new PartitionAccessTimeEntry(DB_ID, TABLE_ID, 100L, 400L),
+                new PartitionAccessTimeEntry(DB_ID, TABLE_ID, 200L, 999L)));
+        Assertions.assertEquals(500L, mgr.getLastAccessTime(DB_ID, TABLE_ID, 100L));
+        Assertions.assertEquals(999L, mgr.getLastAccessTime(DB_ID, TABLE_ID, 200L));
+        // mergeEntries leaves the map populated (it is a max-merge, never a drain).
+        Assertions.assertEquals(2, mgr.getLocalAccessTimes(refs(DB_ID, TABLE_ID)).size());
+    }
+
+    @Test
+    public void testSnapshotSinceIsInclusiveAndDoesNotClear() {
+        PartitionAccessTimeMgr mgr = new PartitionAccessTimeMgr();
+        mgr.mergeEntries(Lists.newArrayList(
+                new PartitionAccessTimeEntry(DB_ID, TABLE_ID, 100L, 40L),
+                new PartitionAccessTimeEntry(DB_ID, TABLE_ID, 200L, 50L),
+                new PartitionAccessTimeEntry(DB_ID, TABLE_ID, 300L, 60L)));
+        // Inclusive boundary: >= 50 returns the 50 and 60 entries; the 40 entry is excluded.
+        List<PartitionAccessTimeEntry> newer = mgr.snapshotSince(50L);
+        List<Long> ids = Lists.newArrayList();
+        for (PartitionAccessTimeEntry e : newer) {
+            ids.add(e.getPartitionId());
+        }
+        Assertions.assertEquals(2, ids.size());
+        Assertions.assertTrue(ids.contains(200L) && ids.contains(300L));
+        // A watermark below every entry returns them all; the snapshot never clears the map.
+        Assertions.assertEquals(3, mgr.snapshotSince(0L).size());
+        Assertions.assertEquals(60L, mgr.getLastAccessTime(DB_ID, TABLE_ID, 300L));
+    }
+
+    @Test
+    public void testCollectAllKeysAndRemovePartitions() {
+        PartitionAccessTimeMgr mgr = new PartitionAccessTimeMgr();
+        mgr.mergeEntries(Lists.newArrayList(
+                new PartitionAccessTimeEntry(DB_ID, TABLE_ID, 100L, 10L),
+                new PartitionAccessTimeEntry(DB_ID, TABLE_ID, 200L, 20L)));
+        Assertions.assertEquals(2, mgr.collectAllKeys().size());
+
+        // Removing one key drops it from the map (and trims the now-smaller table map) but keeps the other.
+        mgr.removePartitions(Lists.newArrayList(new long[] {DB_ID, TABLE_ID, 200L}));
+        Assertions.assertEquals(0L, mgr.getLastAccessTime(DB_ID, TABLE_ID, 200L));
+        Assertions.assertEquals(10L, mgr.getLastAccessTime(DB_ID, TABLE_ID, 100L));
+        List<long[]> remaining = mgr.collectAllKeys();
+        Assertions.assertEquals(1, remaining.size());
+        Assertions.assertArrayEquals(new long[] {DB_ID, TABLE_ID, 100L}, remaining.get(0));
+
+        // Removing the last key trims the whole table/db entry.
+        mgr.removePartitions(Lists.newArrayList(new long[] {DB_ID, TABLE_ID, 100L}));
+        Assertions.assertTrue(mgr.collectAllKeys().isEmpty());
+        Assertions.assertTrue(mgr.getLocalAccessTimes(refs(DB_ID, TABLE_ID)).isEmpty());
+    }
+
+    @Test
+    public void testGetAccessTimesReturnsMemoryWithoutQueryingTable() {
+        PartitionAccessTimeMgr mgr = new PartitionAccessTimeMgr();
+        // Single-FE test env: getSelfNode() is null (no cluster bootstrap), so remote collection is skipped and
+        // the read is served purely from memory -- the redesign removed the internal-table SELECT entirely.
+        mgr.mergeEntries(Lists.newArrayList(new PartitionAccessTimeEntry(DB_ID, TABLE_ID, 100L, 777L)));
+        Map<Long, Long> res = mgr.getAccessTimes(DB_ID, TABLE_ID);
+        Assertions.assertEquals(777L, res.get(100L));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/PartitionAccessTimePersisterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/PartitionAccessTimePersisterTest.java
@@ -1,0 +1,510 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.Config;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import mockit.Delegate;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Plain unit tests for the all-FE persister: each FE flushes its own in-memory increment; the leader additionally
+ * loads the read-path baseline and GCs the internal table. {@code GlobalStateMgr} and {@link PartitionAccessTimeStore}
+ * are stubbed with JMockit, so no running cluster / {@code UtFrameUtils} setup is required. Each test drives a real
+ * {@link PartitionAccessTimeMgr} so the flush/cleanup exercise the actual in-memory merge/scan logic.
+ */
+public class PartitionAccessTimePersisterTest {
+
+    private static final long DB = 1L;
+    private static final long TBL = 2L;
+
+    // Wire GlobalStateMgr.getCurrentState() -> {this FE's map manager, isLeader}.
+    private void stubGlobalState(GlobalStateMgr globalStateMgr, PartitionAccessTimeMgr mgr, boolean isLeader) {
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                minTimes = 0;
+                globalStateMgr.getPartitionAccessTimeMgr();
+                result = mgr;
+                minTimes = 0;
+                globalStateMgr.isLeader();
+                result = isLeader;
+                minTimes = 0;
+            }
+        };
+    }
+
+    // Each FE persists its own increment: the entries at or newer than its watermark, straight from its own map.
+    @Test
+    public void testFlushPersistsOwnIncrement(@Mocked GlobalStateMgr globalStateMgr) {
+        List<PartitionAccessTimeEntry> upserted = new ArrayList<>();
+        PartitionAccessTimeMgr mgr = new PartitionAccessTimeMgr();
+        mgr.recordAccess(DB, TBL, Lists.newArrayList(100L)); // this FE's own record, ts = now (> watermark 0)
+        stubGlobalState(globalStateMgr, mgr, true);
+        new MockUp<PartitionAccessTimeStore>() {
+            @Mock
+            public void upsert(List<PartitionAccessTimeEntry> entries) {
+                upserted.addAll(entries);
+            }
+        };
+
+        PartitionAccessTimePersister persister = new PartitionAccessTimePersister(new PartitionAccessTimeStore());
+        persister.flushOnce();
+
+        Assertions.assertEquals(1, upserted.size());
+        Assertions.assertEquals(100L, upserted.get(0).getPartitionId());
+        // Nothing is drained from memory: the read path keeps serving from it.
+        Assertions.assertTrue(mgr.getLastAccessTime(DB, TBL, 100L) > 0);
+    }
+
+    // A failed persist is swallowed and the map is left intact, so the next cycle retries the same increment
+    // (the watermark was not advanced).
+    @Test
+    public void testFailedPersistKeepsMemory(@Mocked GlobalStateMgr globalStateMgr) {
+        PartitionAccessTimeMgr mgr = new PartitionAccessTimeMgr();
+        mgr.recordAccess(DB, TBL, Lists.newArrayList(100L));
+        stubGlobalState(globalStateMgr, mgr, true);
+        new MockUp<PartitionAccessTimeStore>() {
+            @Mock
+            public void upsert(List<PartitionAccessTimeEntry> entries) {
+                throw new RuntimeException("table gone");
+            }
+        };
+
+        PartitionAccessTimePersister persister = new PartitionAccessTimePersister(new PartitionAccessTimeStore());
+        Assertions.assertDoesNotThrow(persister::flushOnce);
+        Assertions.assertTrue(mgr.getLastAccessTime(DB, TBL, 100L) > 0);
+    }
+
+    // Nothing at or newer than the watermark: upsert is not called at all.
+    @Test
+    public void testEmptyIncrementSkipsUpsert(@Mocked GlobalStateMgr globalStateMgr) {
+        boolean[] upsertCalled = {false};
+        PartitionAccessTimeMgr mgr = new PartitionAccessTimeMgr(); // empty map
+        stubGlobalState(globalStateMgr, mgr, true);
+        new MockUp<PartitionAccessTimeStore>() {
+            @Mock
+            public void upsert(List<PartitionAccessTimeEntry> entries) {
+                upsertCalled[0] = true;
+            }
+        };
+
+        PartitionAccessTimePersister persister = new PartitionAccessTimePersister(new PartitionAccessTimeStore());
+        persister.flushOnce();
+
+        Assertions.assertFalse(upsertCalled[0]);
+    }
+
+    // With the inclusive watermark (>=), an entry whose ts equals the persisted max is re-persisted rather than
+    // lost: the second flush with no newer records still re-persists the boundary entry (idempotent under the
+    // table's MAX aggregate).
+    @Test
+    public void testWatermarkBoundaryEntryIsRepersisted(@Mocked GlobalStateMgr globalStateMgr) {
+        int[] upsertCalls = {0};
+        PartitionAccessTimeMgr mgr = new PartitionAccessTimeMgr();
+        mgr.mergeEntries(Lists.newArrayList(new PartitionAccessTimeEntry(DB, TBL, 100L, 500L)));
+        stubGlobalState(globalStateMgr, mgr, true);
+        new MockUp<PartitionAccessTimeStore>() {
+            @Mock
+            public void upsert(List<PartitionAccessTimeEntry> entries) {
+                upsertCalls[0]++;
+            }
+        };
+
+        PartitionAccessTimePersister persister = new PartitionAccessTimePersister(new PartitionAccessTimeStore());
+        persister.flushOnce(); // persists {100@500}, advances watermark to 500
+        persister.flushOnce(); // {100@500} is >= watermark 500 => re-persisted (inclusive boundary)
+
+        Assertions.assertEquals(2, upsertCalls[0]);
+    }
+
+    // The leader loads the persisted table into its map and sets the watermark to the max loaded ts, so the very
+    // next flush re-persists only the boundary entry, not the whole baseline.
+    @Test
+    public void testLoadBaselineSeedsMapAndSetsWatermark(@Mocked GlobalStateMgr globalStateMgr) {
+        List<PartitionAccessTimeEntry> upserted = new ArrayList<>();
+        int[] upsertCalls = {0};
+        PartitionAccessTimeMgr mgr = new PartitionAccessTimeMgr();
+        stubGlobalState(globalStateMgr, mgr, true);
+        new MockUp<PartitionAccessTimeStore>() {
+            @Mock
+            public List<PartitionAccessTimeEntry> loadAll() {
+                return Lists.newArrayList(
+                        new PartitionAccessTimeEntry(DB, TBL, 100L, 500L),
+                        new PartitionAccessTimeEntry(DB, TBL, 200L, 700L));
+            }
+
+            @Mock
+            public void upsert(List<PartitionAccessTimeEntry> entries) {
+                upsertCalls[0]++;
+                upserted.addAll(entries);
+            }
+        };
+
+        PartitionAccessTimePersister persister = new PartitionAccessTimePersister(new PartitionAccessTimeStore());
+        persister.loadBaseline();
+        // Baseline is now in memory (serves reads without a table query on the leader).
+        Assertions.assertEquals(500L, mgr.getLastAccessTime(DB, TBL, 100L));
+        Assertions.assertEquals(700L, mgr.getLastAccessTime(DB, TBL, 200L));
+
+        // Watermark == max loaded ts (700). A flush with no new records must not re-insert the WHOLE baseline: the
+        // inclusive snapshot re-persists only the boundary entry (partition 200); the older 100@500 stays below.
+        persister.flushOnce();
+        Assertions.assertEquals(1, upsertCalls[0]);
+        Assertions.assertEquals(1, upserted.size());
+        Assertions.assertEquals(200L, upserted.get(0).getPartitionId());
+        Assertions.assertEquals(700L, upserted.get(0).getAccessTimeMs());
+    }
+
+    // cleanupMemory evicts only the dropped partitions from THIS FE's own map, and never touches the table.
+    @Test
+    public void testCleanupMemoryEvictsDroppedFromMemoryOnly(@Mocked GlobalStateMgr globalStateMgr) {
+        boolean[] deleted = {false};
+        PartitionAccessTimeMgr mgr = new PartitionAccessTimeMgr();
+        mgr.mergeEntries(Lists.newArrayList(
+                new PartitionAccessTimeEntry(DB, TBL, 100L, 10L),
+                new PartitionAccessTimeEntry(DB, TBL, 200L, 20L)));
+        stubGlobalState(globalStateMgr, mgr, false); // runs on any FE
+        new MockUp<PartitionAccessTimeStore>() {
+            @Mock
+            public void deleteByPartitionIds(Collection<Long> ids) {
+                deleted[0] = true;
+            }
+        };
+        new MockUp<PartitionAccessTimePersister>() {
+            @Mock
+            boolean partitionExists(long dbId, long tableId, long partitionId) {
+                return partitionId == 100L; // 100 is live, 200 was dropped
+            }
+        };
+
+        PartitionAccessTimePersister persister = new PartitionAccessTimePersister(new PartitionAccessTimeStore());
+        persister.cleanupMemory();
+
+        Assertions.assertEquals(0L, mgr.getLastAccessTime(DB, TBL, 200L)); // dropped evicted from memory
+        Assertions.assertEquals(10L, mgr.getLastAccessTime(DB, TBL, 100L)); // live kept
+        Assertions.assertFalse(deleted[0]); // cleanupMemory never issues a table DELETE
+    }
+
+    // cleanupTable (leader-only) uses a full SELECT of the table as the authoritative row set and deletes only the
+    // rows whose partition no longer resolves -- independent of what is in this FE's memory.
+    @Test
+    public void testCleanupTableDeletesDroppedFromFullScan(@Mocked GlobalStateMgr globalStateMgr) {
+        List<Long> deleted = new ArrayList<>();
+        PartitionAccessTimeMgr mgr = new PartitionAccessTimeMgr(); // empty: cleanupTable reads the table, not memory
+        stubGlobalState(globalStateMgr, mgr, true); // leader
+        new MockUp<PartitionAccessTimeStore>() {
+            @Mock
+            public List<PartitionAccessTimeEntry> loadAll() {
+                return Lists.newArrayList(
+                        new PartitionAccessTimeEntry(DB, TBL, 100L, 10L),
+                        new PartitionAccessTimeEntry(DB, TBL, 200L, 20L));
+            }
+
+            @Mock
+            public void deleteByPartitionIds(Collection<Long> ids) {
+                deleted.addAll(ids);
+            }
+        };
+        new MockUp<PartitionAccessTimePersister>() {
+            @Mock
+            boolean partitionExists(long dbId, long tableId, long partitionId) {
+                return partitionId == 100L; // 100 live, 200 dropped
+            }
+        };
+
+        PartitionAccessTimePersister persister = new PartitionAccessTimePersister(new PartitionAccessTimeStore());
+        persister.cleanupTable();
+
+        Assertions.assertEquals(Lists.newArrayList(200L), deleted);
+    }
+
+    // cleanupTable re-checks leadership right before the DELETE: a demotion landing mid-scan aborts it (so a stale
+    // leader cannot delete under a leadership it has already lost).
+    @Test
+    public void testCleanupTableSkipsDeleteWhenNotLeader(@Mocked GlobalStateMgr globalStateMgr) {
+        boolean[] deleted = {false};
+        PartitionAccessTimeMgr mgr = new PartitionAccessTimeMgr();
+        stubGlobalState(globalStateMgr, mgr, false); // not (or no longer) leader
+        new MockUp<PartitionAccessTimeStore>() {
+            @Mock
+            public List<PartitionAccessTimeEntry> loadAll() {
+                return Lists.newArrayList(new PartitionAccessTimeEntry(DB, TBL, 200L, 20L));
+            }
+
+            @Mock
+            public void deleteByPartitionIds(Collection<Long> ids) {
+                deleted[0] = true;
+            }
+        };
+        new MockUp<PartitionAccessTimePersister>() {
+            @Mock
+            boolean partitionExists(long dbId, long tableId, long partitionId) {
+                return false; // dropped -> would be deleted if leadership still held
+            }
+        };
+
+        PartitionAccessTimePersister persister = new PartitionAccessTimePersister(new PartitionAccessTimeStore());
+        persister.cleanupTable();
+
+        Assertions.assertFalse(deleted[0]);
+    }
+
+    // A follower still flushes its own increment, but does neither the baseline load nor the table cleanup (both
+    // read the table via loadAll) -- those are leader-only.
+    @Test
+    public void testFollowerFlushesButSkipsLeaderOnlyWork(@Mocked GlobalStateMgr globalStateMgr) {
+        boolean[] loadAllCalled = {false};
+        boolean[] upserted = {false};
+        PartitionAccessTimeMgr mgr = new PartitionAccessTimeMgr();
+        mgr.recordAccess(DB, TBL, Lists.newArrayList(100L));
+        stubGlobalState(globalStateMgr, mgr, false); // follower
+        boolean saved = Config.enable_collect_partition_access_time;
+        Config.enable_collect_partition_access_time = true;
+        try {
+            new MockUp<PartitionAccessTimeStore>() {
+                @Mock
+                public List<PartitionAccessTimeEntry> loadAll() {
+                    loadAllCalled[0] = true;
+                    return Lists.newArrayList();
+                }
+
+                @Mock
+                public void upsert(List<PartitionAccessTimeEntry> entries) {
+                    upserted[0] = true;
+                }
+            };
+            new MockUp<PartitionAccessTimePersister>() {
+                @Mock
+                boolean tableExists() {
+                    return true;
+                }
+
+                @Mock
+                boolean partitionExists(long dbId, long tableId, long partitionId) {
+                    return true; // nothing to evict, keeps cleanupMemory from touching the metastore mocks
+                }
+            };
+
+            PartitionAccessTimePersister persister = new PartitionAccessTimePersister(new PartitionAccessTimeStore());
+            persister.runAfterCatalogReady();
+
+            Assertions.assertTrue(upserted[0], "follower still flushes its own increment");
+            Assertions.assertFalse(loadAllCalled[0], "follower does neither loadBaseline nor table cleanup");
+        } finally {
+            Config.enable_collect_partition_access_time = saved;
+        }
+    }
+
+    // The baseline load is leader-only and re-armed on demotion: an FE that leads, is demoted, then leads again
+    // reloads the baseline on re-promotion. Observed via store.loadAll(): exactly once per leadership term.
+    @Test
+    public void testBaselineReloadsWhenLeadershipIsRegained(@Mocked GlobalStateMgr globalStateMgr) {
+        int[] loadAllCalls = {0};
+        boolean[] leader = {true};
+        PartitionAccessTimeMgr mgr = new PartitionAccessTimeMgr();
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                minTimes = 0;
+                globalStateMgr.getPartitionAccessTimeMgr();
+                result = mgr;
+                minTimes = 0;
+                globalStateMgr.isLeader();
+                result = new Delegate<Boolean>() {
+                    boolean isLeader() {
+                        return leader[0];
+                    }
+                };
+                minTimes = 0;
+            }
+        };
+        boolean saved = Config.enable_collect_partition_access_time;
+        Config.enable_collect_partition_access_time = true;
+        try {
+            new MockUp<PartitionAccessTimeStore>() {
+                @Mock
+                public List<PartitionAccessTimeEntry> loadAll() {
+                    loadAllCalls[0]++;
+                    return Lists.newArrayList(new PartitionAccessTimeEntry(DB, TBL, 100L, 500L));
+                }
+            };
+            // Only loadBaseline reaches store.loadAll(); flush/cleanup are stubbed away so the count is unambiguous.
+            new MockUp<PartitionAccessTimePersister>() {
+                @Mock
+                boolean tableExists() {
+                    return true;
+                }
+
+                @Mock
+                void flushOnce() {
+                }
+
+                @Mock
+                void cleanupMemory() {
+                }
+
+                @Mock
+                void cleanupTable() {
+                }
+            };
+
+            PartitionAccessTimePersister persister = new PartitionAccessTimePersister(new PartitionAccessTimeStore());
+            persister.runAfterCatalogReady(); // leader: loads the baseline
+            persister.runAfterCatalogReady(); // leader, already loaded: no reload
+            Assertions.assertEquals(1, loadAllCalls[0]);
+
+            leader[0] = false;
+            persister.runAfterCatalogReady(); // follower: re-arm, no load
+            Assertions.assertEquals(1, loadAllCalls[0]);
+
+            leader[0] = true;
+            persister.runAfterCatalogReady(); // leader again: reload
+            Assertions.assertEquals(2, loadAllCalls[0]);
+        } finally {
+            Config.enable_collect_partition_access_time = saved;
+        }
+    }
+
+    // Cleanup is rate-limited: it runs on the first cycle, then only once every CLEANUP_EVERY_N_CYCLES cycles.
+    @Test
+    public void testCleanupIsRateLimitedAcrossCycles(@Mocked GlobalStateMgr globalStateMgr) {
+        int[] memCalls = {0};
+        int[] tableCalls = {0};
+        PartitionAccessTimeMgr mgr = new PartitionAccessTimeMgr();
+        stubGlobalState(globalStateMgr, mgr, true); // leader, so cleanupTable is eligible
+        boolean saved = Config.enable_collect_partition_access_time;
+        Config.enable_collect_partition_access_time = true;
+        try {
+            new MockUp<PartitionAccessTimePersister>() {
+                @Mock
+                boolean tableExists() {
+                    return true;
+                }
+
+                @Mock
+                void loadBaseline() {
+                }
+
+                @Mock
+                void flushOnce() {
+                }
+
+                @Mock
+                void cleanupMemory() {
+                    memCalls[0]++;
+                }
+
+                @Mock
+                void cleanupTable() {
+                    tableCalls[0]++;
+                }
+            };
+
+            PartitionAccessTimePersister persister = new PartitionAccessTimePersister(new PartitionAccessTimeStore());
+            persister.runAfterCatalogReady(); // cycle 0: cleanup runs
+            persister.runAfterCatalogReady(); // cycle 1: gated, no cleanup
+            Assertions.assertEquals(1, memCalls[0]);
+            Assertions.assertEquals(1, tableCalls[0]);
+        } finally {
+            Config.enable_collect_partition_access_time = saved;
+        }
+    }
+
+    // partitionExists resolves db -> table -> partition through LocalMetastore's *IncludeRecycleBin helpers (each
+    // folds "live or recycle bin" into one lookup) and prunes only when the partition is absent from every layer.
+    // Distinct ids per case so the mocked lookups don't collide.
+    @Test
+    public void testPartitionExistsHonorsRecycleBin(@Mocked GlobalStateMgr globalStateMgr,
+                                                    @Mocked LocalMetastore localMetastore,
+                                                    @Mocked OlapTable olapTable,
+                                                    @Mocked Partition partition,
+                                                    @Mocked Database database) {
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                minTimes = 0;
+                globalStateMgr.getLocalMetastore();
+                result = localMetastore;
+                minTimes = 0;
+                // db DB resolves (live or recycled) for cases A, B, E, F; db 555 resolves (recycled) for D.
+                localMetastore.getDbIncludeRecycleBin(DB);
+                result = database;
+                minTimes = 0;
+                localMetastore.getDbIncludeRecycleBin(555L);
+                result = database;
+                minTimes = 0;
+                // A/B) table TBL live: partition 100 live, partition 200 sits in the partition recycle bin.
+                localMetastore.getTableIncludeRecycleBin(database, TBL);
+                result = olapTable;
+                minTimes = 0;
+                localMetastore.getPartitionIncludeRecycleBin(olapTable, 100L);
+                result = partition;
+                minTimes = 0;
+                localMetastore.getPartitionIncludeRecycleBin(olapTable, 200L);
+                result = partition;
+                minTimes = 0;
+                // C) table 888 DROP'd: partition 300 rides inside the recycled table.
+                localMetastore.getTableIncludeRecycleBin(database, 888L);
+                result = olapTable;
+                minTimes = 0;
+                localMetastore.getPartitionIncludeRecycleBin(olapTable, 300L);
+                result = partition;
+                minTimes = 0;
+                // D) database 555 DROP'd: descend db -> table 100 -> partition 400.
+                localMetastore.getTableIncludeRecycleBin(database, 100L);
+                result = olapTable;
+                minTimes = 0;
+                localMetastore.getPartitionIncludeRecycleBin(olapTable, 400L);
+                result = partition;
+                minTimes = 0;
+                // E) table 999 gone from every layer.
+                localMetastore.getTableIncludeRecycleBin(database, 999L);
+                result = null;
+                minTimes = 0;
+                // F) orphan: table 666 is in the recycle bin but no longer holds partition 600 (it was DROP'd and
+                // GC'd before the table was dropped) -- the precise descent prunes it instead of keeping it forever.
+                localMetastore.getTableIncludeRecycleBin(database, 666L);
+                result = olapTable;
+                minTimes = 0;
+                localMetastore.getPartitionIncludeRecycleBin(olapTable, 600L);
+                result = null;
+                minTimes = 0;
+            }
+        };
+
+        PartitionAccessTimePersister persister = new PartitionAccessTimePersister(new PartitionAccessTimeStore());
+        Assertions.assertTrue(persister.partitionExists(DB, TBL, 100L));    // A) live table, live partition
+        Assertions.assertTrue(persister.partitionExists(DB, TBL, 200L));    // B) live table, DROP PARTITION in bin
+        Assertions.assertTrue(persister.partitionExists(DB, 888L, 300L));   // C) DROP TABLE, partition inside it
+        Assertions.assertTrue(persister.partitionExists(555L, 100L, 400L)); // D) DROP DATABASE, descend to partition
+        Assertions.assertFalse(persister.partitionExists(DB, 999L, 500L));  // E) gone from every layer -> prune
+        Assertions.assertFalse(persister.partitionExists(DB, 666L, 600L));  // F) orphan: table in bin, partition not
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/PartitionAccessTimeStoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/PartitionAccessTimeStoreTest.java
@@ -1,0 +1,156 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.Config;
+import com.starrocks.qe.SimpleExecutor;
+import com.starrocks.thrift.TResultBatch;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class PartitionAccessTimeStoreTest {
+
+    @Test
+    public void testBuildUpsertSql() {
+        String sql = PartitionAccessTimeStore.buildUpsertSql(
+                Lists.newArrayList(new PartitionAccessTimeEntry(1, 2, 3, 111L), new PartitionAccessTimeEntry(1, 2, 4, 222L)));
+        Assertions.assertTrue(sql.startsWith("INSERT INTO _statistics_.partition_access_time"));
+        Assertions.assertTrue(sql.contains("(1, 2, 3, 111)"));
+        Assertions.assertTrue(sql.contains("(1, 2, 4, 222)"));
+    }
+
+    @Test
+    public void testBuildDeleteByPartitionIdsSql() {
+        String sql = PartitionAccessTimeStore.buildDeleteByPartitionIdsSql(Arrays.asList(5L, 6L));
+        Assertions.assertTrue(sql.startsWith("DELETE FROM _statistics_.partition_access_time"));
+        Assertions.assertTrue(sql.contains("partition_id IN (5, 6)"));
+    }
+
+    // The repo executor returns each row as a JSON {"data":[...]} buffer (HTTP_PROTOCAL sink).
+    private static ByteBuffer jsonRow(String json) {
+        return ByteBuffer.wrap(json.getBytes(Charset.defaultCharset()));
+    }
+
+    @Test
+    public void testLoadAllDecodesJsonRows() {
+        new MockUp<SimpleExecutor>() {
+            @Mock
+            public List<TResultBatch> executeDQL(String sql) {
+                TResultBatch batch = new TResultBatch();
+                batch.setRows(Lists.newArrayList(
+                        jsonRow("{\"data\": [1, 2, 100, 111]}"),
+                        jsonRow("{\"data\": [1, 2, 300, 222]}")));
+                return Lists.newArrayList(batch);
+            }
+        };
+        List<PartitionAccessTimeEntry> all = new PartitionAccessTimeStore().loadAll();
+        Assertions.assertEquals(2, all.size());
+        Assertions.assertEquals(1L, all.get(0).getDbId());
+        Assertions.assertEquals(2L, all.get(0).getTableId());
+        Assertions.assertEquals(100L, all.get(0).getPartitionId());
+        Assertions.assertEquals(111L, all.get(0).getAccessTimeMs());
+        Assertions.assertEquals(300L, all.get(1).getPartitionId());
+        Assertions.assertEquals(222L, all.get(1).getAccessTimeMs());
+    }
+
+    @Test
+    public void testLoadAllPropagatesQueryFailure() {
+        new MockUp<SimpleExecutor>() {
+            @Mock
+            public List<TResultBatch> executeDQL(String sql) {
+                throw new RuntimeException("table gone");
+            }
+        };
+        // loadAll must NOT swallow the failure -- the caller (persister) needs to know so it retries the
+        // one-time baseline load next cycle rather than starting from an empty map.
+        Assertions.assertThrows(RuntimeException.class, () -> new PartitionAccessTimeStore().loadAll());
+    }
+
+    @Test
+    public void testUpsertChunksWithinExprChildrenLimit() {
+        // Read the real chunk size (don't mutate the global expr_children_limit -- the SQL parser reads it, so
+        // lowering it could disturb a concurrently-running test). One entry past a single chunk => exactly 2
+        // INSERTs, proving a large flush is split and never trips the parser's INSERT row-count cap.
+        List<String> sqls = new ArrayList<>();
+        new MockUp<SimpleExecutor>() {
+            @Mock
+            public void executeDML(String sql) {
+                sqls.add(sql);
+            }
+        };
+        int chunkSize = Math.max(1, Config.expr_children_limit / 2);
+        List<PartitionAccessTimeEntry> entries = new ArrayList<>();
+        for (int i = 0; i < chunkSize + 1; i++) {
+            entries.add(new PartitionAccessTimeEntry(1, 1, i, 10));
+        }
+        new PartitionAccessTimeStore().upsert(entries);
+        Assertions.assertEquals(2, sqls.size());
+    }
+
+    @Test
+    public void testDeleteChunksWithinExprChildrenLimit() {
+        // Same chunking as upsert: one id past a single chunk => exactly 2 DELETEs, so a large cleanup never
+        // trips the parser's IN-list cap. Reads the real chunk size without mutating the global config.
+        List<String> sqls = new ArrayList<>();
+        new MockUp<SimpleExecutor>() {
+            @Mock
+            public void executeDML(String sql) {
+                sqls.add(sql);
+            }
+        };
+        int chunkSize = Math.max(1, Config.expr_children_limit / 2);
+        List<Long> ids = new ArrayList<>();
+        for (int i = 0; i < chunkSize + 1; i++) {
+            ids.add((long) i);
+        }
+        new PartitionAccessTimeStore().deleteByPartitionIds(ids);
+        Assertions.assertEquals(2, sqls.size());
+    }
+
+    @Test
+    public void testDeleteChunksWithinDeleteInListCap() {
+        // When the delete-specific cap is smaller than expr_children_limit/2, chunking must respect it, otherwise
+        // DeleteAnalyzer rejects the oversized DELETE and dropped-partition rows accumulate forever.
+        int savedDeleteCap = Config.max_allowed_in_element_num_of_delete;
+        Config.max_allowed_in_element_num_of_delete = 3;
+        List<String> sqls = new ArrayList<>();
+        try {
+            new MockUp<SimpleExecutor>() {
+                @Mock
+                public void executeDML(String sql) {
+                    sqls.add(sql);
+                }
+            };
+            List<Long> ids = new ArrayList<>();
+            for (int i = 0; i < 7; i++) {
+                ids.add((long) i);
+            }
+            new PartitionAccessTimeStore().deleteByPartitionIds(ids);
+            // 7 ids capped at 3 per DELETE => ceil(7/3) = 3 statements.
+            Assertions.assertEquals(3, sqls.size());
+        } finally {
+            Config.max_allowed_in_element_num_of_delete = savedDeleteCap;
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/load/ExportJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/ExportJobTest.java
@@ -241,35 +241,41 @@ public class ExportJobTest {
     public void testGenScanNodeRecordsPartitionAccess(@Mocked GlobalStateMgr globalStateMgr,
                                                        @Mocked Table table,
                                                        @Mocked OlapScanNode scanNode) {
-        long dbId = 777L;
-        long tableId = 555L;
-        PartitionAccessTimeMgr accessTimeMgr = new PartitionAccessTimeMgr();
-        new Expectations() {
-            {
-                table.getType();
-                result = Table.TableType.OLAP;
-                table.getId();
-                result = tableId;
-                GlobalStateMgr.getCurrentState().getPartitionAccessTimeMgr();
-                result = accessTimeMgr;
-                // computePartitionInfo() has resolved these data-bearing logical partition ids.
-                scanNode.getSelectedPartitionIds();
-                result = Lists.newArrayList(100L, 200L);
-            }
-        };
+        boolean saved = Config.enable_collect_partition_access_time;
+        Config.enable_collect_partition_access_time = true;
+        try {
+            long dbId = 777L;
+            long tableId = 555L;
+            PartitionAccessTimeMgr accessTimeMgr = new PartitionAccessTimeMgr();
+            new Expectations() {
+                {
+                    table.getType();
+                    result = Table.TableType.OLAP;
+                    table.getId();
+                    result = tableId;
+                    GlobalStateMgr.getCurrentState().getPartitionAccessTimeMgr();
+                    result = accessTimeMgr;
+                    // computePartitionInfo() has resolved these data-bearing logical partition ids.
+                    scanNode.getSelectedPartitionIds();
+                    result = Lists.newArrayList(100L, 200L);
+                }
+            };
 
-        ExportJob job = new ExportJob(0, UUIDUtil.genUUID());
-        Deencapsulation.setField(job, "exportTable", table);
-        Deencapsulation.setField(job, "exportTupleDesc", new TupleDescriptor(new TupleId(0)));
-        Deencapsulation.setField(job, "dbId", dbId);
+            ExportJob job = new ExportJob(0, UUIDUtil.genUUID());
+            Deencapsulation.setField(job, "exportTable", table);
+            Deencapsulation.setField(job, "exportTupleDesc", new TupleDescriptor(new TupleId(0)));
+            Deencapsulation.setField(job, "dbId", dbId);
 
-        long before = System.currentTimeMillis();
-        Deencapsulation.invoke(job, "genScanNode");
+            long before = System.currentTimeMillis();
+            Deencapsulation.invoke(job, "genScanNode");
 
-        // genScanNode records the export scan as a user access for exactly the selected partitions.
-        Assertions.assertTrue(accessTimeMgr.getLastAccessTime(dbId, tableId, 100L) >= before);
-        Assertions.assertTrue(accessTimeMgr.getLastAccessTime(dbId, tableId, 200L) >= before);
-        Assertions.assertEquals(0L, accessTimeMgr.getLastAccessTime(dbId, tableId, 300L));
+            // genScanNode records the export scan as a user access for exactly the selected partitions.
+            Assertions.assertTrue(accessTimeMgr.getLastAccessTime(dbId, tableId, 100L) >= before);
+            Assertions.assertTrue(accessTimeMgr.getLastAccessTime(dbId, tableId, 200L) >= before);
+            Assertions.assertEquals(0L, accessTimeMgr.getLastAccessTime(dbId, tableId, 300L));
+        } finally {
+            Config.enable_collect_partition_access_time = saved;
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -2465,42 +2465,49 @@ public class FrontendServiceImplTest {
 
     @Test
     public void testGetPartitionAccessTimes() throws Exception {
-        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
-        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .getTable(db.getFullName(), "site_access_auto");
+        boolean saved = Config.enable_collect_partition_access_time;
+        Config.enable_collect_partition_access_time = true;
+        try {
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+            OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), "site_access_auto");
 
-        // Record a query access on every (logical) partition of the table on this (local) FE.
-        List<Long> partitionIds = table.getPartitions().stream()
-                .map(Partition::getId).collect(Collectors.toList());
-        GlobalStateMgr.getCurrentState().getPartitionAccessTimeMgr()
-                .recordAccess(db.getId(), table.getId(), partitionIds);
+            // Record a query access on every (logical) partition of the table on this (local) FE.
+            List<Long> partitionIds = table.getPartitions().stream()
+                    .map(Partition::getId).collect(Collectors.toList());
+            GlobalStateMgr.getCurrentState().getPartitionAccessTimeMgr()
+                    .recordAccess(db.getId(), table.getId(), partitionIds);
 
-        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+            FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
 
-        // Batch request carrying this table; the handler is lock-free and returns logicalPartitionId -> ms.
-        TGetPartitionAccessTimesRequest request = new TGetPartitionAccessTimesRequest();
-        TPartitionAccessTimeTableRef ref = new TPartitionAccessTimeTableRef();
-        ref.setDb_id(db.getId());
-        ref.setTable_id(table.getId());
-        request.setTables(Lists.newArrayList(ref));
+            // Batch request carrying this table; the handler is lock-free and returns logicalPartitionId -> ms.
+            TGetPartitionAccessTimesRequest request = new TGetPartitionAccessTimesRequest();
+            TPartitionAccessTimeTableRef ref = new TPartitionAccessTimeTableRef();
+            ref.setDb_id(db.getId());
+            ref.setTable_id(table.getId());
+            request.setTables(Lists.newArrayList(ref));
 
-        TGetPartitionAccessTimesResponse response = impl.getPartitionAccessTimes(request);
-        Assertions.assertEquals(TStatusCode.OK, response.getStatus().getStatus_code());
-        Map<Long, Long> accessTimes = response.getPartition_id_to_access_time_ms();
-        Assertions.assertNotNull(accessTimes);
-        Assertions.assertEquals(partitionIds.size(), accessTimes.size());
-        for (Long pid : partitionIds) {
-            Assertions.assertTrue(accessTimes.getOrDefault(pid, 0L) > 0);
+            TGetPartitionAccessTimesResponse response = impl.getPartitionAccessTimes(request);
+            Assertions.assertEquals(TStatusCode.OK, response.getStatus().getStatus_code());
+            Map<Long, Long> accessTimes = response.getPartition_id_to_access_time_ms();
+            Assertions.assertNotNull(accessTimes);
+            Assertions.assertEquals(partitionIds.size(), accessTimes.size());
+            for (Long pid : partitionIds) {
+                Assertions.assertTrue(accessTimes.getOrDefault(pid, 0L) > 0);
+            }
+
+            // A table absent on this FE (bogus id) must not fail: the lock-free snapshot returns empty.
+            TGetPartitionAccessTimesRequest missingReq = new TGetPartitionAccessTimesRequest();
+            TPartitionAccessTimeTableRef missingRef = new TPartitionAccessTimeTableRef();
+            missingRef.setDb_id(db.getId());
+            missingRef.setTable_id(-1L);
+            missingReq.setTables(Lists.newArrayList(missingRef));
+            TGetPartitionAccessTimesResponse missingResp = impl.getPartitionAccessTimes(missingReq);
+            Assertions.assertEquals(TStatusCode.OK, missingResp.getStatus().getStatus_code());
+            Assertions.assertTrue(missingResp.getPartition_id_to_access_time_ms().isEmpty());
+        } finally {
+            Config.enable_collect_partition_access_time = saved;
         }
-
-        // A table absent on this FE (bogus id) must not fail: the lock-free snapshot returns empty.
-        TGetPartitionAccessTimesRequest missingReq = new TGetPartitionAccessTimesRequest();
-        TPartitionAccessTimeTableRef missingRef = new TPartitionAccessTimeTableRef();
-        missingRef.setDb_id(db.getId());
-        missingRef.setTable_id(-1L);
-        missingReq.setTables(Lists.newArrayList(missingRef));
-        TGetPartitionAccessTimesResponse missingResp = impl.getPartitionAccessTimes(missingReq);
-        Assertions.assertEquals(TStatusCode.OK, missingResp.getStatus().getStatus_code());
-        Assertions.assertTrue(missingResp.getPartition_id_to_access_time_ms().isEmpty());
     }
+
 }


### PR DESCRIPTION
## Why I'm doing:

`LAST_ACCESS_TIME` (per-partition last query scan time, exposed via `SHOW PARTITIONS` and `information_schema.partitions_meta`) was in-memory only in v1 (#76637): it reset on FE restart/failover, so operators lost the signal exactly when they most need it (post-restart cold/hot tiering and cache-warmup decisions). This PR implements the v2 durability that #76680 lists as future work.

## What I'm doing:

A `PartitionAccessTimePersister` daemon runs on **every** FE. The internal table `_statistics_.partition_access_time` is a `MAX`-aggregate durability record; the read hot path is served from memory.

- **Per-FE flush.** Every FE persists its *own* in-memory increment — the map entries at or newer than its own persisted watermark — with a blind `INSERT`. The table is an aggregate table keyed on `(db, table, partition)` with a `MAX last_access_time_ms`, so each FE's writes merge into the newest value with no cross-FE coordination and no read-modify-write (monotonic in both run modes, even under cross-FE clock skew). The watermark boundary is inclusive so an entry sharing the watermark timestamp is never lost; a failed persist advances no watermark and retries next cycle.
- **Leader baseline (leader only).** While an FE is the leader it loads the whole table into its in-memory map once; the load is re-armed whenever it is not leader, so a promotion rebuilds a fresh baseline. That copy is the historical baseline the read path serves.
- **Reads from memory.** `PartitionAccessTimeMgr.getAccessTimes` merges this FE's records with every peer's over the `getPartitionAccessTimes` RPC; the leader's reply carries the baseline, so a follower gets the historical values from the leader's memory — no SQL on the read path. Best-effort; never feeds the "all remote peers failed" error path.
- **Cleanup (rate-limited, ~12h at the default flush interval).** Every FE evicts from its *own* map the partitions that no longer resolve; the leader additionally full-scans the table (`SELECT` — the authoritative row set, since no single FE's map is a superset of every FE's writes) and deletes their rows, re-checking leadership immediately before the `DELETE`. "No longer resolves" is checked precisely down to the exact partition across the live catalog and the partition / table / database `CatalogRecycleBin`, so a `RECOVER` does not lose access times while a truly-gone partition (e.g. a partition dropped and GC'd before its table was dropped) is not kept as an orphan. Lock-free catalog lookups follow the statistics-cleanup convention.
- Isolate all internal-table SQL in `PartitionAccessTimeStore`; upsert/delete chunk within `expr_children_limit` and the DELETE IN-list cap (`max_allowed_in_element_num_of_delete`).
- Create the table via `StatisticsMetaManager` (AST-based, `replication_num` from `AutoInferUtil.calDefaultReplicationNum()` like the other `_statistics_` tables), registered in `StatsConstants`.
- New FE config `partition_access_time_flush_interval_sec` (default 600s, mutable); cleanup runs once per 72 flush cycles (~12h at the default).
- `enable_collect_partition_access_time` now defaults to `false` (feature is opt-in); docs updated in en/zh/ja.

Covered by unit tests (`PartitionAccessTimeMgrTest` / `PartitionAccessTimeStoreTest` / `PartitionAccessTimePersisterTest`); the end-to-end behavior (record → persist to the aggregate table → survive a real FE restart → rate-limited cleanup of dropped partitions) was validated on a shared-data cluster.

Fixes #76680

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5