### PR TITLE
[BugFix] Keep the current row when an analytic frame starts at a FOLLOWING offset

### DIFF
--- a/be/src/exec/analytor.cpp
+++ b/be/src/exec/analytor.cpp
@@ -843,9 +843,13 @@ void Analytor::_remove_unused_rows(RuntimeState* state) {
             return;
         }
     } else if (_use_removable_cumulative_process || !_is_unbounded_preceding) {
-        // Both cumulative process or sliding process need to access position around range.start
+        // Both cumulative process or sliding process need to access position around range.start.
+        // For a frame starting at a FOLLOWING offset, range.start runs ahead of the current row, so the
+        // current row position is the one that must be kept, otherwise it would be removed along with the
+        // rows before it and turn negative.
         const auto frame = _get_frame_for_rows();
-        if (_get_global_position(frame.start - 1) <= remove_end_position) {
+        const int64_t referenced_position = std::min(_current_row_position, frame.start - 1);
+        if (_get_global_position(referenced_position) <= remove_end_position) {
             return;
         }
     } else {

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -51,7 +51,6 @@ set(EXEC_FILES
         ./exec/hash_variant_test.cpp
         ./exec/pipeline/olap_scan_operator_test.cpp
         ./exec/analytor_test.cpp
-        ./exec/analytor_test.cpp
         ./exec/chunks_sorter_heap_sort_test.cpp
         ./exec/chunks_sorter_test.cpp
         ./exec/connector_scan_node_test.cpp

--- a/be/test/exec/analytor_test.cpp
+++ b/be/test/exec/analytor_test.cpp
@@ -17,7 +17,9 @@
 #include <gtest/gtest.h>
 
 #include "column/fixed_length_column.h"
+#include "common/config_exec_flow_fwd.h"
 #include "common/config_exec_fwd.h"
+#include "common/runtime_profile.h"
 #include "gen_cpp/PlanNodes_types.h"
 
 namespace starrocks {
@@ -25,6 +27,54 @@ class AnalytorTest : public ::testing::Test {
 public:
     void SetUp() override { config::vector_chunk_size = 1024; }
 };
+
+namespace {
+
+TPlanNode make_rows_window_plan_node(TAnalyticWindowBoundaryType::type start_type, int64_t start_offset,
+                                     TAnalyticWindowBoundaryType::type end_type, int64_t end_offset) {
+    TAnalyticWindowBoundary start;
+    start.type = start_type;
+    if (start_type != TAnalyticWindowBoundaryType::CURRENT_ROW) {
+        start.__set_rows_offset_value(start_offset);
+    }
+    TAnalyticWindowBoundary end;
+    end.type = end_type;
+    if (end_type != TAnalyticWindowBoundaryType::CURRENT_ROW) {
+        end.__set_rows_offset_value(end_offset);
+    }
+
+    TAnalyticWindow window;
+    window.type = TAnalyticWindowType::ROWS;
+    window.__set_window_start(start);
+    window.__set_window_end(end);
+
+    TPlanNode plan_node;
+    plan_node.analytic_node.__set_window(window);
+    return plan_node;
+}
+
+// _remove_unused_rows() updates a few profile counters before it touches the buffered columns, so a bare
+// Analytor needs them wired up before the removal path can be exercised.
+void prepare_removal_counters(Analytor* analytor, RuntimeProfile* profile) {
+    analytor->_peak_buffered_rows = ADD_PEAK_COUNTER(profile, "PeakBufferedRows", TUnit::UNIT);
+    analytor->_remove_unused_rows_cnt = ADD_COUNTER(profile, "RemoveUnusedRowsCount", TUnit::UNIT);
+    analytor->_remove_unused_total_rows = ADD_COUNTER(profile, "RemoveUnusedTotalRows", TUnit::UNIT);
+    analytor->_column_resize_timer = ADD_TIMER(profile, "ColumnResizeTime");
+}
+
+// Fill in enough chunk positions that _remove_unused_rows() gets past its "not enough buffered chunks" guard,
+// and return the position the removal would stop at.
+int64_t fill_input_chunk_positions(Analytor* analytor, int64_t chunk_size) {
+    const int64_t removable_chunk_num = config::pipeline_analytic_removable_chunk_num;
+    const int64_t num_chunks = removable_chunk_num + 3;
+    for (int64_t i = 0; i < num_chunks; i++) {
+        analytor->_input_chunk_first_row_positions.emplace_back(i * chunk_size);
+    }
+    analytor->_input_rows = num_chunks * chunk_size;
+    return removable_chunk_num * chunk_size;
+}
+
+} // namespace
 
 // NOLINTNEXTLINE
 TEST_F(AnalytorTest, find_peer_group_end) {
@@ -123,6 +173,63 @@ TEST_F(AnalytorTest, find_partition_end) {
     analytor3._find_partition_end();
     ASSERT_FALSE(analytor3._partition.is_real);
     ASSERT_EQ(analytor3._partition.end, 0);
+}
+
+// For `ROWS BETWEEN N FOLLOWING AND M FOLLOWING` the frame start runs ahead of the current row, so the
+// frame start alone is not a safe lower bound of the rows that are still referenced: removing up to it
+// would drop the current row as well and drive _current_row_position negative.
+// NOLINTNEXTLINE
+TEST_F(AnalytorTest, remove_unused_rows_keeps_current_row_of_following_frame) {
+    constexpr int64_t kChunkSize = 4096;
+    constexpr int64_t kStartOffset = 5000;
+
+    TPlanNode plan_node = make_rows_window_plan_node(TAnalyticWindowBoundaryType::FOLLOWING, kStartOffset,
+                                                     TAnalyticWindowBoundaryType::FOLLOWING, 15000);
+    Analytor analytor(plan_node, nullptr, false);
+    ASSERT_FALSE(analytor._need_partition_materializing);
+    ASSERT_EQ(analytor._rows_start_offset, kStartOffset);
+
+    RuntimeProfile profile("AnalytorTest");
+    prepare_removal_counters(&analytor, &profile);
+    const int64_t remove_end_position = fill_input_chunk_positions(&analytor, kChunkSize);
+
+    // The evaluation cursor still lags behind the removal boundary, while the frame start is already past
+    // it. Removing here used to leave _current_row_position at -2712.
+    const int64_t current_row_position = remove_end_position - 2712;
+    analytor._current_row_position = current_row_position;
+    analytor._partition.end = analytor._input_rows;
+
+    analytor._remove_unused_rows(nullptr);
+
+    ASSERT_EQ(analytor._current_row_position, current_row_position);
+    ASSERT_EQ(analytor._removed_from_buffer_rows, 0);
+    ASSERT_EQ(analytor._removed_chunk_index, 0);
+}
+
+// The counterpart of the case above: for a frame that only looks backwards, the rows before the frame start
+// must still be removed, otherwise the buffer would grow without bound.
+// NOLINTNEXTLINE
+TEST_F(AnalytorTest, remove_unused_rows_removes_rows_before_preceding_frame) {
+    constexpr int64_t kChunkSize = 4096;
+
+    TPlanNode plan_node = make_rows_window_plan_node(TAnalyticWindowBoundaryType::PRECEDING, 5000,
+                                                     TAnalyticWindowBoundaryType::CURRENT_ROW, 0);
+    Analytor analytor(plan_node, nullptr, false);
+    ASSERT_EQ(analytor._rows_start_offset, -5000);
+
+    RuntimeProfile profile("AnalytorTest");
+    prepare_removal_counters(&analytor, &profile);
+    const int64_t remove_end_position = fill_input_chunk_positions(&analytor, kChunkSize);
+
+    const int64_t current_row_position = remove_end_position + 6000;
+    analytor._current_row_position = current_row_position;
+    analytor._partition.end = analytor._input_rows;
+
+    analytor._remove_unused_rows(nullptr);
+
+    ASSERT_EQ(analytor._removed_from_buffer_rows, remove_end_position);
+    ASSERT_EQ(analytor._current_row_position, current_row_position - remove_end_position);
+    ASSERT_EQ(analytor._removed_chunk_index, config::pipeline_analytic_removable_chunk_num);
 }
 
 } // namespace starrocks

--- a/test/sql/test_window_function/R/test_rows_following_frame_with_removed_rows
+++ b/test/sql/test_window_function/R/test_rows_following_frame_with_removed_rows
@@ -1,0 +1,25 @@
+-- name: test_rows_following_frame_with_removed_rows
+CREATE TABLE `t0` (
+    `k` bigint(20) NOT NULL,
+    `v` bigint(20) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO `t0` SELECT generate_series, generate_series % 1000 FROM TABLE(generate_series(1, 600000));
+-- result:
+-- !result
+SELECT count(wv), sum(wv) FROM (
+    SELECT sum(v) OVER (ORDER BY k ROWS BETWEEN 5000 FOLLOWING AND 15000 FOLLOWING) AS wv FROM `t0`) a;
+-- result:
+595000	2948173042500
+-- !result
+SELECT count(wv), sum(wv) FROM (
+    SELECT sum(v) OVER (ORDER BY k ROWS BETWEEN 15000 PRECEDING AND 5000 PRECEDING) AS wv FROM `t0`) a;
+-- result:
+595000	2946516367500
+-- !result

--- a/test/sql/test_window_function/T/test_rows_following_frame_with_removed_rows
+++ b/test/sql/test_window_function/T/test_rows_following_frame_with_removed_rows
@@ -1,0 +1,23 @@
+-- name: test_rows_following_frame_with_removed_rows
+CREATE TABLE `t0` (
+    `k` bigint(20) NOT NULL,
+    `v` bigint(20) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+-- The analytic operator only starts dropping already evaluated rows once it has buffered more than
+-- `pipeline_analytic_removable_chunk_num` chunks, so the table needs to be large enough to get there.
+INSERT INTO `t0` SELECT generate_series, generate_series % 1000 FROM TABLE(generate_series(1, 600000));
+
+-- A frame that starts ahead of the current row: everything before the current row may be dropped, but the
+-- current row itself is still needed to emit the result.
+SELECT count(wv), sum(wv) FROM (
+    SELECT sum(v) OVER (ORDER BY k ROWS BETWEEN 5000 FOLLOWING AND 15000 FOLLOWING) AS wv FROM `t0`) a;
+
+-- The backward looking counterpart, which must keep dropping rows.
+SELECT count(wv), sum(wv) FROM (
+    SELECT sum(v) OVER (ORDER BY k ROWS BETWEEN 15000 PRECEDING AND 5000 PRECEDING) AS wv FROM `t0`) a;


### PR DESCRIPTION
## Why I'm doing:

```
  CREATE DATABASE IF NOT EXISTS repro_analytor_dcheck;
  CREATE TABLE repro_analytor_dcheck.t1 (k BIGINT, v BIGINT) DUPLICATE KEY(k)
    DISTRIBUTED BY HASH(k) BUCKETS 1 PROPERTIES("replication_num"="1");
  INSERT INTO repro_analytor_dcheck.t1
    SELECT generate_series, generate_series % 1000 FROM TABLE(generate_series(1, 600000));

  SELECT count(wv) FROM (SELECT sum(v) OVER (ORDER BY k
    ROWS BETWEEN 5000 FOLLOWING AND 15000 FOLLOWING) AS wv FROM repro_analytor_dcheck.t1) a;
```

```
query_id:019fd058-632f-7489-8463-8874e702ca83, fragment_instance:019fd058-632f-7489-8463-8874e702ca85, plan_node_id:2
[1785906883.732][thread: 137414143383232] je_mallctl execute purge success
[1785906883.732][thread: 137414143383232] je_mallctl execute dontdump success
*** Aborted at 1785906883 (unix time) try "date -d @1785906883" if you are using GNU date ***
PC: @     0x7cfd3c75bb2c pthread_kill
*** SIGABRT (@0x1f5e4a) received by PID 2055754 (TID 0x7cfa393416c0) LWP(2080018) from PID 2055754; stack trace: ***
    @         0x32ddc347 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7cfd3c75eed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)
    @         0x32ddbb46 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7cfd3c702330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @     0x7cfd3c75bb2c pthread_kill
    @     0x7cfd3c70227e gsignal
    @     0x7cfd3c6e58ff abort
    @         0x1cc06548 starrocks::failure_function()
    @         0x32dcfc5d google::LogMessage::Fail()
    @         0x32dd0d44 google::LogMessageFatal::~LogMessageFatal()
    @         0x1e24397b starrocks::Analytor::_remove_unused_rows(starrocks::RuntimeState*)
    @         0x1e23c284 starrocks::Analytor::process(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @         0x1ec0d721 starrocks::pipeline::AnalyticSinkOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @         0x23607af8 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @         0x1e591b39 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @         0x1e58fed0 starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}::operator()() const
    @         0x1e597bda void std::__invoke_impl<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(std::__invoke_other, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&)
    @         0x1e597320 std::enable_if<is_invocable_r_v<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>, void>::type std::__invoke_r<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int
)::{lambda()#1}&>(starrocks::pipeline::GlobalDriver@
    @         0x1e596df0 std::_Function_handler<void (), starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}>::_M_invoke(std::_Any_data const&)
    @         0x1ca92d58 std::function<void ()>::operator()() const
    @         0x2e2870dc starrocks::FunctionRunnable::run()
F20260805 05:14:44.311206 137413340075712 analytor.cpp:915] Check failed: _current_row_position >= 0 (-2712 vs. 0) 
    @         0x2e281123 starrocks::ThreadPool::dispatch_thread()
    @         0x2e2a237c void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @         0x2e2a0d1a std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starro
cks::ThreadPool*&)
    @         0x2e29f78e void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>)
    @         0x2e29ddea void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>()
    @         0x2e29c070 void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&)
    @         0x2e299973 std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadP
ool*))()>&>(std::_Bind<void (starrocks::ThreadPool:@
    @         0x2e295209 std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&)
    @         0x1ca92d58 std::function<void ()>::operator()() const
    @         0x2e2673c7 starrocks::Thread::supervise_thread(void*)
    @         0x1c8f4616 asan_thread_start(void*)

```

Analytor::_remove_unused_rows() drops rows that the window evaluation can no longer reach. For a cumulative or sliding ROWS frame it derived the lower bound of the rows to keep from the frame start alone, but a frame such as `ROWS BETWEEN 5000 FOLLOWING AND 15000 FOLLOWING` starts ahead of the current row. The rows between the removal boundary and the current row were then dropped together with the current row itself, leaving _current_row_position negative:

  Check failed: _current_row_position >= 0 (-2712 vs. 0)

which aborts a debug or ASAN backend and keeps indexing the buffered columns with a negative position in a release one. Take the current row position into account as well.

The removal only kicks in once more than pipeline_analytic_removable_chunk_num chunks are buffered, so the regression test needs a table large enough to get the analytic operator there.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
