### PR TITLE
[BugFix] [Revert] Honor CREATE TABLE IF NOT EXISTS on Iceberg REST catalogs (#76308)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -257,7 +257,7 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public boolean createTable(CreateTableStmt stmt) throws DdlException, AlreadyExistsException {
+    public boolean createTable(CreateTableStmt stmt) throws DdlException {
         return normal.createTable(stmt);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -259,7 +259,7 @@ public interface ConnectorMetadata {
         return Lists.newArrayList();
     }
 
-    default boolean createTable(CreateTableStmt stmt) throws DdlException, AlreadyExistsException {
+    default boolean createTable(CreateTableStmt stmt) throws DdlException {
         throw new StarRocksConnectorException("This connector doesn't support creating tables");
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -267,7 +267,7 @@ public class IcebergMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public boolean createTable(CreateTableStmt stmt) throws DdlException, AlreadyExistsException {
+    public boolean createTable(CreateTableStmt stmt) throws DdlException {
         String dbName = stmt.getDbName();
         String tableName = stmt.getTableName();
 
@@ -284,11 +284,7 @@ public class IcebergMetadata implements ConnectorMetadata {
         }
         Map<String, String> createTableProperties = IcebergApiConverter.rebuildCreateTableProperties(properties);
 
-        try {
-            return icebergCatalog.createTable(dbName, tableName, schema, partitionSpec, tableLocation, createTableProperties);
-        } catch (org.apache.iceberg.exceptions.AlreadyExistsException e) {
-            throw new AlreadyExistsException("Table Already Exists: " + tableName);
-        }
+        return icebergCatalog.createTable(dbName, tableName, schema, partitionSpec, tableLocation, createTableProperties);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
@@ -250,7 +250,7 @@ public class UnifiedMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public boolean createTable(CreateTableStmt stmt) throws DdlException, AlreadyExistsException {
+    public boolean createTable(CreateTableStmt stmt) throws DdlException {
         requireNonNull(stmt.getEngineName(), "engine name is null");
         Table.TableType type = Table.TableType.deserialize(stmt.getEngineName().toUpperCase());
         return metadataMap.get(type).createTable(stmt);

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -297,15 +297,7 @@ public class MetadataMgr {
                     }
                 }
             }
-            try {
-                return connectorMetadata.get().createTable(stmt);
-            } catch (AlreadyExistsException e) {
-                if (!stmt.isSetIfNotExists()) {
-                    ErrorReport.reportDdlException(ErrorCode.ERR_TABLE_EXISTS_ERROR, stmt.getTableName());
-                }
-                LOG.info("create table[{}] which already exists", stmt.getTableName());
-                return false;
-            }
+            return connectorMetadata.get().createTable(stmt);
         } else {
             throw new DdlException("Invalid catalog " + catalogName + " , ConnectorMetadata doesn't exist");
         }
@@ -362,15 +354,7 @@ public class MetadataMgr {
                     ErrorReport.reportDdlException(ErrorCode.ERR_TABLE_EXISTS_ERROR, tableName);
                 }
             }
-            try {
-                return connectorMetadata.get().createTable(stmt);
-            } catch (AlreadyExistsException e) {
-                if (!stmt.isSetIfNotExists()) {
-                    ErrorReport.reportDdlException(ErrorCode.ERR_TABLE_EXISTS_ERROR, tableName);
-                }
-                LOG.info("create temporary table[{}] which already exists in session[{}]", tableName, sessionId);
-                return false;
-            }
+            return connectorMetadata.get().createTable(stmt);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -75,7 +75,6 @@ import com.starrocks.sql.ast.AlterTableOperationClause;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.ColumnRenameClause;
-import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.DropColumnClause;
 import com.starrocks.sql.ast.DropTableStmt;
 import com.starrocks.sql.ast.ModifyColumnClause;
@@ -111,8 +110,6 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetricsModes;
-import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableProperties;
@@ -374,67 +371,6 @@ public class IcebergMetadataTest extends TableTestBase {
                 () -> metadata.createDb("TEST_PROBE", new HashMap<>()));
         Assertions.assertTrue(e.getMessage().contains("TEST_PROBE"),
                 "translated message should carry the database name, but was: " + e.getMessage());
-    }
-
-    @Test
-    public void testCreateTableTranslatesConnectorAlreadyExists(
-            @Mocked IcebergHiveCatalog icebergHiveCatalog, @Mocked CreateTableStmt stmt) {
-        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
-                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
-        new Expectations() {
-            {
-                stmt.getDbName();
-                result = "db";
-                minTimes = 0;
-                stmt.getTableName();
-                result = "tbl";
-                minTimes = 0;
-                stmt.getColumns();
-                result = Lists.newArrayList(new Column("id", Type.INT));
-                minTimes = 0;
-                stmt.getPartitionDesc();
-                result = null;
-                minTimes = 0;
-
-                icebergHiveCatalog.createTable(anyString, anyString, (Schema) any,
-                        (PartitionSpec) any, anyString, (Map<String, String>) any);
-                result = new org.apache.iceberg.exceptions.AlreadyExistsException("Table already exists: db.tbl");
-                times = 1;
-            }
-        };
-        AlreadyExistsException e = assertThrows(AlreadyExistsException.class,
-                () -> metadata.createTable(stmt));
-        Assertions.assertTrue(e.getMessage().contains("tbl"),
-                "translated message should carry the table name, but was: " + e.getMessage());
-    }
-
-    @Test
-    public void testCreateTableReturnsConnectorResult(
-            @Mocked IcebergHiveCatalog icebergHiveCatalog, @Mocked CreateTableStmt stmt) throws Exception {
-        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
-                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
-        new Expectations() {
-            {
-                stmt.getDbName();
-                result = "db";
-                minTimes = 0;
-                stmt.getTableName();
-                result = "tbl";
-                minTimes = 0;
-                stmt.getColumns();
-                result = Lists.newArrayList(new Column("id", Type.INT));
-                minTimes = 0;
-                stmt.getPartitionDesc();
-                result = null;
-                minTimes = 0;
-
-                icebergHiveCatalog.createTable(anyString, anyString, (Schema) any,
-                        (PartitionSpec) any, anyString, (Map<String, String>) any);
-                result = true;
-                times = 1;
-            }
-        };
-        Assertions.assertTrue(metadata.createTable(stmt));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
@@ -164,7 +164,7 @@ public class UnifiedMetadataTest {
     }
 
     @Test
-    public void testRouteToHiveConnector() throws DdlException, AlreadyExistsException {
+    public void testRouteToHiveConnector() throws DdlException {
         HiveTable hiveTable = new HiveTable();
 
         new Expectations() {
@@ -234,7 +234,7 @@ public class UnifiedMetadataTest {
     }
 
     @Test
-    public void testRouteToIcebergConnector(@Mocked HiveTable hiveTable) throws DdlException, AlreadyExistsException {
+    public void testRouteToIcebergConnector(@Mocked HiveTable hiveTable) throws DdlException {
         Table icebergTable = new IcebergTable();
 
         new Expectations() {
@@ -330,7 +330,7 @@ public class UnifiedMetadataTest {
     }
 
     @Test
-    public void testRouteToHudiConnector() throws DdlException, AlreadyExistsException {
+    public void testRouteToHudiConnector() throws DdlException {
         HudiTable hudiTable = new HudiTable();
 
         new Expectations() {
@@ -405,7 +405,7 @@ public class UnifiedMetadataTest {
     }
 
     @Test
-    public void testRouteToDeltaLakeConnector(@Mocked HiveTable hiveTable) throws DdlException, AlreadyExistsException {
+    public void testRouteToDeltaLakeConnector(@Mocked HiveTable hiveTable) throws DdlException {
         Table deltaLakeTable = new DeltaLakeTable();
 
         new Expectations() {

--- a/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
@@ -15,9 +15,6 @@
 package com.starrocks.server;
 
 import com.google.common.collect.Lists;
-import com.starrocks.analysis.TableName;
-import com.starrocks.catalog.InternalCatalog;
-import com.starrocks.common.AlreadyExistsException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker;
@@ -36,7 +33,6 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.ast.CreateTableLikeStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
-import com.starrocks.sql.ast.CreateTemporaryTableStmt;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
@@ -53,7 +49,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -282,93 +277,6 @@ public class MetadataMgrTest {
         createTableStmt.setIfNotExists();
         Assertions.assertFalse(metadataMgr.createTable(AnalyzeTestUtil.getConnectContext(), createTableStmt));
         AnalyzeTestUtil.getStarRocksAssert().dropCatalog("iceberg_catalog");
-    }
-
-    @Test
-    public void testCreateTableHonorsConnectorAlreadyExists(@Mocked ConnectorMetadata connectorMetadata) throws Exception {
-        String catalogName = "iceberg_catalog_metadata_mgr_already_exists";
-        ConnectContext context = AnalyzeTestUtil.getConnectContext();
-        MetadataMgr metadataMgr = context.getGlobalStateMgr().getMetadataMgr();
-
-        CreateTableStmt createTableStmt = new CreateTableStmt(false, true,
-                new TableName(catalogName, "iceberg_db", "iceberg_table"),
-                Collections.emptyList(), "iceberg", null, null, null, null, null, null);
-
-        new Expectations(metadataMgr) {
-            {
-                metadataMgr.getOptionalMetadata(catalogName);
-                result = Optional.of(connectorMetadata);
-                minTimes = 0;
-
-                metadataMgr.getDb((ConnectContext) any, catalogName, "iceberg_db");
-                result = new com.starrocks.catalog.Database();
-                minTimes = 0;
-
-                metadataMgr.tableExists((ConnectContext) any, catalogName, "iceberg_db", "iceberg_table");
-                result = false;
-                minTimes = 0;
-            }
-        };
-        new Expectations() {
-            {
-                connectorMetadata.createTable((CreateTableStmt) any);
-                result = new AlreadyExistsException("Table Already Exists: iceberg_table");
-                minTimes = 0;
-            }
-        };
-
-        // Without IF NOT EXISTS, the connector-level AlreadyExistsException surfaces as ERR_TABLE_EXISTS_ERROR.
-        DdlException e = assertThrows(DdlException.class, () -> metadataMgr.createTable(context, createTableStmt));
-        Assertions.assertTrue(e.getMessage().contains("iceberg_table"));
-
-        // With IF NOT EXISTS, the create becomes a no-op that returns false.
-        createTableStmt.setIfNotExists();
-        Assertions.assertFalse(metadataMgr.createTable(context, createTableStmt));
-    }
-
-    @Test
-    public void testCreateTemporaryTableHonorsConnectorAlreadyExists(
-            @Mocked ConnectorMetadata connectorMetadata,
-            @Mocked LocalMetastore localMetastore,
-            @Mocked TemporaryTableMgr temporaryTableMgr) throws Exception {
-        MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
-
-        CreateTemporaryTableStmt stmt = new CreateTemporaryTableStmt(false, false,
-                new TableName(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, "test_db", "test_tbl"),
-                Collections.emptyList(), null, null, null, null, null, null,
-                Collections.emptyMap(), Collections.emptyMap(), null, null, null);
-        stmt.setSessionId(UUIDUtil.genUUID());
-
-        new Expectations(metadataMgr) {
-            {
-                metadataMgr.getOptionalMetadata(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME);
-                result = Optional.of(connectorMetadata);
-                minTimes = 0;
-            }
-        };
-        new Expectations() {
-            {
-                localMetastore.getDb("test_db");
-                result = new com.starrocks.catalog.Database();
-                minTimes = 0;
-
-                temporaryTableMgr.tableExists((UUID) any, anyLong, "test_tbl");
-                result = false;
-                minTimes = 0;
-
-                connectorMetadata.createTable((CreateTableStmt) any);
-                result = new AlreadyExistsException("Table Already Exists: test_tbl");
-                minTimes = 0;
-            }
-        };
-
-        // Without IF NOT EXISTS, the connector-level AlreadyExistsException surfaces as ERR_TABLE_EXISTS_ERROR.
-        DdlException e = assertThrows(DdlException.class, () -> metadataMgr.createTemporaryTable(stmt));
-        Assertions.assertTrue(e.getMessage().contains("test_tbl"));
-
-        // With IF NOT EXISTS, the create becomes a no-op that returns false.
-        stmt.setIfNotExists();
-        Assertions.assertFalse(metadataMgr.createTemporaryTable(stmt));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Reverts #76308 on `branch-3.5`, for two reasons.

**1. The change landed on `branch-3.5` before its upstream PR on `main` was merged.**

| PR | base | state |
| --- | --- | --- |
| #76307 | `main` | **OPEN, never merged** (opened 2026-07-13, `REVIEW_REQUIRED` / `BLOCKED`, CI green) |
| #76308 | `branch-3.5` | merged 2026-08-04 |
| #77280 | `branch-3.5-cc` | merged 2026-08-05 (mergify backport of #76308) |

#76308 was not a mergify backport — it was opened manually with `branch-3.5` as its base, so it bypassed `main` entirely. The release branch now carries a behavior change (#76307 is labeled `behavior_changed`) that `main` does not have, and the two stay diverged for as long as #76307 sits unreviewed. Reverting here so the fix arrives through the normal `main` -> backport path once #76307 lands.

**2. The test added by this change is flaky.**

`MetadataMgrTest#testCreateTemporaryTableHonorsConnectorAlreadyExists` declares `@Mocked LocalMetastore`, which is class-level mocking: it stubs every method on every `LocalMetastore` instance, including `getDbIdsIncludeRecycleBin()` — a method the test never records. That method is called by the `TabletChecker` daemon (`TabletChecker.java:277`), started by `UtFrameUtils.createMinStarRocksCluster()` in `@BeforeAll` and cycling every `tablet_sched_checker_interval_seconds` (default 20s). When a daemon cycle lands inside the test's mocking window, JMockit reports it against the mock instance:

```
Missing 1 invocation to:
com.starrocks.server.LocalMetastore#getDbIdsIncludeRecycleBin()
   on mock instance: com.starrocks.server.LocalMetastore@4e609e75
Caused by: Missing invocations
    at com.starrocks.clone.TabletChecker.doCheck(TabletChecker.java:277)
    at com.starrocks.clone.TabletChecker.checkNonUrgentTablets(TabletChecker.java:248)
```

`Daemon#run` executes one cycle immediately at start and then sleeps, so running the class alone (~10-12s locally, 15/15 green) only ever sees the cycle fired during `@BeforeAll` and passes. Under parallel forks in CI the class run stretches past 20s, a second cycle fires mid-test, and it fails. Suggested fix on #76307: narrow the mock to a `MockUp<LocalMetastore>` faking only `getDb(String)` — the sole `LocalMetastore` method `createTemporaryTable` needs — so `main` does not inherit the flake.

Note: `branch-3.5-cc` also carries this change via #77280 and needs the same revert.

## What I'm doing:

`git revert` of 566081c3b1dca69fc46263029a2a4aa62c4e0530, no manual edits.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

This is a pure revert: it removes the tests and code that came with #76308 and adds none.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

This PR targets `branch-3.5` directly, so no auto-backport applies. `branch-3.5-cc` needs a separate revert of #77280.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
