### PR TITLE
[BugFix] Skip conjunct evaluation on an empty chunk in NLJoin probe

### DIFF
--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
@@ -697,6 +697,12 @@ StatusOr<ChunkPtr> NLJoinProbeOperator::pull_chunk(RuntimeState* state) {
 
 // eval conjuncts for nest loop join, apply common exprs and conjuncts first
 Status NLJoinProbeOperator::_eval_conjuncts(const ChunkPtr& chunk) {
+    // The permuted chunk may have no row left, either because the join conjuncts filtered all of
+    // them out, or because the previous round already consumed the last probe row. There is nothing
+    // to evaluate on it, and the common exprs cannot be evaluated against an empty chunk.
+    if (chunk == nullptr || chunk->is_empty()) {
+        return Status::OK();
+    }
     CommonExprEvalScopeGuard guard(chunk, _common_expr_ctxs);
     RETURN_IF_ERROR(guard.evaluate());
     RETURN_IF_ERROR(eval_conjuncts(_conjunct_ctxs, chunk.get(), nullptr));

--- a/test/sql/test_nest_loop_join/R/test_nljoin_empty_chunk_common_expr
+++ b/test/sql/test_nest_loop_join/R/test_nljoin_empty_chunk_common_expr
@@ -1,0 +1,76 @@
+-- name: test_nljoin_empty_chunk_common_expr
+CREATE TABLE `nlj_probe` (
+  `k` bigint(20) NULL COMMENT "",
+  `v` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `nlj_build` (
+  `k` bigint(20) NULL COMMENT "",
+  `v` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `nlj_build_multi_chunk` (
+  `k` bigint(20) NULL COMMENT "",
+  `v` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into nlj_probe select generate_series, generate_series from table(generate_series(1, 10));
+-- result:
+-- !result
+insert into nlj_build select generate_series, generate_series from table(generate_series(1, 10000));
+-- result:
+-- !result
+insert into nlj_build_multi_chunk select generate_series, generate_series from table(generate_series(1, 5000));
+-- result:
+-- !result
+select count(*) from nlj_probe left join nlj_build on nlj_probe.k > nlj_build.k + 1000000
+where abs(nlj_probe.v + coalesce(nlj_build.v, 0)) > 5 or abs(nlj_probe.v + coalesce(nlj_build.v, 0)) < 3;
+-- result:
+7
+-- !result
+set enable_predicate_expr_reuse = false;
+-- result:
+-- !result
+select count(*) from nlj_probe left join nlj_build on nlj_probe.k > nlj_build.k + 1000000
+where abs(nlj_probe.v + coalesce(nlj_build.v, 0)) > 5 or abs(nlj_probe.v + coalesce(nlj_build.v, 0)) < 3;
+-- result:
+7
+-- !result
+set enable_predicate_expr_reuse = true;
+-- result:
+-- !result
+select count(*) from nlj_probe left join nlj_build on nlj_probe.k > nlj_build.k
+where abs(nlj_probe.v + coalesce(nlj_build.v, 0)) > 5 or abs(nlj_probe.v + coalesce(nlj_build.v, 0)) < 3;
+-- result:
+42
+-- !result
+select count(*) from nlj_probe full outer join nlj_build on nlj_probe.k > nlj_build.k + 1000000
+where abs(coalesce(nlj_probe.v, 0) + coalesce(nlj_build.v, 0)) > 5
+   or abs(coalesce(nlj_probe.v, 0) + coalesce(nlj_build.v, 0)) < 3;
+-- result:
+10004
+-- !result
+select count(*) from nlj_build_multi_chunk left join nlj_probe on nlj_build_multi_chunk.k > nlj_probe.k + 1000000
+where abs(nlj_build_multi_chunk.v + coalesce(nlj_probe.v, 0)) > 5
+   or abs(nlj_build_multi_chunk.v + coalesce(nlj_probe.v, 0)) < 3;
+-- result:
+4997
+-- !result

--- a/test/sql/test_nest_loop_join/T/test_nljoin_empty_chunk_common_expr
+++ b/test/sql/test_nest_loop_join/T/test_nljoin_empty_chunk_common_expr
@@ -1,0 +1,59 @@
+-- name: test_nljoin_empty_chunk_common_expr
+CREATE TABLE `nlj_probe` (
+  `k` bigint(20) NULL COMMENT "",
+  `v` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `nlj_build` (
+  `k` bigint(20) NULL COMMENT "",
+  `v` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+-- More than one chunk on the build side, so the operator also walks the path where a permuted
+-- chunk comes back empty because the previous round already consumed the last probe row.
+CREATE TABLE `nlj_build_multi_chunk` (
+  `k` bigint(20) NULL COMMENT "",
+  `v` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into nlj_probe select generate_series, generate_series from table(generate_series(1, 10));
+insert into nlj_build select generate_series, generate_series from table(generate_series(1, 10000));
+insert into nlj_build_multi_chunk select generate_series, generate_series from table(generate_series(1, 5000));
+
+-- The nest loop join node carries a join conjunct AND a where predicate whose repeated sub
+-- expression is extracted into the node's common sub expressions. Once the join conjunct filters
+-- every row out of a permuted chunk, those common exprs used to be evaluated on an empty chunk.
+select count(*) from nlj_probe left join nlj_build on nlj_probe.k > nlj_build.k + 1000000
+where abs(nlj_probe.v + coalesce(nlj_build.v, 0)) > 5 or abs(nlj_probe.v + coalesce(nlj_build.v, 0)) < 3;
+
+set enable_predicate_expr_reuse = false;
+select count(*) from nlj_probe left join nlj_build on nlj_probe.k > nlj_build.k + 1000000
+where abs(nlj_probe.v + coalesce(nlj_build.v, 0)) > 5 or abs(nlj_probe.v + coalesce(nlj_build.v, 0)) < 3;
+set enable_predicate_expr_reuse = true;
+
+-- Same shape, but the join conjunct does match, so the common exprs still have to be applied.
+select count(*) from nlj_probe left join nlj_build on nlj_probe.k > nlj_build.k
+where abs(nlj_probe.v + coalesce(nlj_build.v, 0)) > 5 or abs(nlj_probe.v + coalesce(nlj_build.v, 0)) < 3;
+
+select count(*) from nlj_probe full outer join nlj_build on nlj_probe.k > nlj_build.k + 1000000
+where abs(coalesce(nlj_probe.v, 0) + coalesce(nlj_build.v, 0)) > 5
+   or abs(coalesce(nlj_probe.v, 0) + coalesce(nlj_build.v, 0)) < 3;
+
+select count(*) from nlj_build_multi_chunk left join nlj_probe on nlj_build_multi_chunk.k > nlj_probe.k + 1000000
+where abs(nlj_build_multi_chunk.v + coalesce(nlj_probe.v, 0)) > 5
+   or abs(nlj_build_multi_chunk.v + coalesce(nlj_probe.v, 0)) < 3;


### PR DESCRIPTION
## Why I'm doing:

```
  create table t1 (k bigint, v bigint) duplicate key(k)
    distributed by hash(k) buckets 1 properties('replication_num'='1');
  create table t2 (k bigint, v bigint) duplicate key(k)
    distributed by hash(k) buckets 1 properties('replication_num'='1');
  insert into t1 select generate_series, generate_series from table(generate_series(1, 10));
  insert into t2 select generate_series, generate_series from table(generate_series(1, 10000));

  select count(*) from t1 left join t2 on t1.k > t2.k + 1000000
  where abs(t1.v + coalesce(t2.v,0)) > 5 or abs(t1.v + coalesce(t2.v,0)) < 3;


PC: @     0x7fdeb6940b2c pthread_kill
*** SIGABRT (@0x33f985) received by PID 3406213 (TID 0x7fdb824196c0) LWP(3412323) from PID 3406213; stack trace: ***
    @         0x32ddc407 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7fdeb6943ed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)
    @         0x32ddbc06 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7fdeb68e7330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @     0x7fdeb6940b2c pthread_kill
    @     0x7fdeb68e727e gsignal
    @     0x7fdeb68ca8ff abort
    @         0x1cc06548 starrocks::failure_function()
    @         0x32dcfd1d google::LogMessage::Fail()
    @         0x32dd0e04 google::LogMessageFatal::~LogMessageFatal()
    @         0x2a5cb5ed starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*)
    @         0x2a5caec2 starrocks::ExprContext::evaluate(starrocks::Chunk*, unsigned char*)
    @         0x21e9b20c starrocks::CommonExprEvalScopeGuard::evaluate()
    @         0x1e8c5237 starrocks::pipeline::NLJoinProbeOperator::_eval_conjuncts(std::shared_ptr<starrocks::Chunk> const&)
    @         0x1e8c619d starrocks::pipeline::NLJoinProbeOperator::_pull_chunk_for_other_join(unsigned long)
    @         0x1e8c4615 starrocks::pipeline::NLJoinProbeOperator::pull_chunk(starrocks::RuntimeState*)
    @         0x23606aee starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @         0x1e591c11 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
```

NLJoinProbeOperator::_eval_conjuncts() is the only place in the operator that hands a chunk to CommonExprEvalScopeGuard without checking that the chunk still has rows; the three other call sites are all guarded by !chunk->is_empty(), and ChunkPredicateEvaluator::eval_conjuncts() returns early on a row-less chunk by itself. So once the node carries common sub expressions -- which a nest loop join does whenever enable_predicate_expr_reuse extracts a repeated sub expression out of its where predicate -- evaluating them on an empty chunk trips CHECK(!chunk->is_empty()) in ExprContext::evaluate() and aborts the backend in a debug/ASan build.

A permuted chunk legitimately ends up empty in two ways:

  - for a join type that applies the filter in place (RIGHT/FULL OUTER), the join conjuncts can reject every row of the chunk, and no left-join back-fill runs afterwards to put rows back;
  - with more than one build chunk, the round that follows the last probe row permutes nothing at all.

Neither is an error, and the downstream ChunkAccumulator already treats a row-less chunk as a no-op, so the fix is to leave the chunk alone instead of evaluating anything against it.

Reproduced on an ASan backend with a nest loop RIGHT OUTER JOIN whose on predicate never matches and whose where predicate repeats a sub expression spanning both sides; the added sql test covers that shape plus the matching predicate, FULL OUTER and multi build chunk variants.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
