### PR TITLE
[BugFix] Keep the decimal type of the if() built for multi-column count(distinct)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitMultiPhaseAggRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitMultiPhaseAggRule.java
@@ -41,6 +41,7 @@ import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.sql.optimizer.statistics.StatisticsCalculator;
+import com.starrocks.type.BooleanType;
 import com.starrocks.type.Type;
 
 import java.util.ArrayList;
@@ -386,10 +387,27 @@ public class SplitMultiPhaseAggRule extends SplitAggregateRule {
 
             Function fn = ExprUtils.getBuiltinFunction(FunctionSet.IF, argumentTypes,
                     Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+            fn = rectifyDecimalIfFunction(fn, elseOperator.getType());
             elseOperator = new CallOperator(FunctionSet.IF, fn.getReturnType(), ifArgs, fn);
 
         }
         return elseOperator;
+    }
+
+    /**
+     * The builtin if(BOOLEAN, DECIMAL, DECIMAL) signatures declare a wildcard decimal return type,
+     * so taking it as-is yields an expression typed DECIMAL(-1,-1). Both branches built above carry
+     * the very same concrete type, so use it: otherwise the BE cannot build a result column for the
+     * expression and aborts. This mirrors what DecimalV3FunctionAnalyzer does for if() written by users.
+     */
+    private static Function rectifyDecimalIfFunction(Function fn, Type branchType) {
+        if (!fn.getReturnType().isWildcardDecimal() || !branchType.isDecimalV3() || branchType.isWildcardDecimal()) {
+            return fn;
+        }
+        Function newFn = fn.copy();
+        newFn.setArgsType(new Type[] {BooleanType.BOOLEAN, branchType, branchType});
+        newFn.setRetType(branchType);
+        return newFn;
     }
 
     static boolean isThreeStageMoreEfficient(ConnectContext connectContext, OptExpression input,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistinctAggTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistinctAggTest.java
@@ -113,6 +113,22 @@ public class DistinctAggTest extends PlanTestBase {
         assertNotContains(plan, "array_agg_distinct");
     }
 
+    @Test
+    void testMultiColumnCountDistinctKeepsDecimalPrecision() throws Exception {
+        // The if() wrapping the distinct columns must carry the precision/scale of its branches,
+        // otherwise the BE receives an expression typed DECIMAL(-1,-1) and cannot build a result
+        // column for it.
+        String sql = "select count(distinct t1a, id_decimal) from test_all_type group by t1b";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "result: DECIMAL64(10,2)");
+        assertNotContains(plan, "result: DECIMAL64;");
+
+        sql = "select count(distinct t1a, id_decimal) from test_all_type";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "result: DECIMAL64(10,2)");
+        assertNotContains(plan, "result: DECIMAL64;");
+    }
+
     private static Stream<Arguments> sqlWithDistinctLimit() {
         List<Arguments> argumentsList = Lists.newArrayList();
         argumentsList.add(Arguments.of("select count(distinct v1, v2) from (select * from t0 limit 2) t",


### PR DESCRIPTION
## Why I'm doing:

SplitMultiPhaseAggRule rewrites count(DISTINCT a, b) into count(if(a IS NULL, NULL, b)) so that NULL combinations are not counted. The type of that if() was taken straight from the matched builtin, and the if(BOOLEAN, DECIMAL, DECIMAL) signatures declare a wildcard decimal return type. When the last distinct column is a decimal, the BE therefore receives an expression typed DECIMAL(-1,-1) and aborts while building its result column:

```
52 decimalv3_column.cpp:30] Check failed: 0 <= _scale && _scale <= _precision && _precision <= decimal_precision_limit<T> precision: -1, scale: -1, decimal_precision_limit<T>: 38
F00000000 00:00:00.000000 133387176732352 logging.cc:1962] RAW: Check data_->num_chars_to_log_ > 0 && data_->message_text_[data_->num_chars_to_log_ - 1] == '\n' failed: 
PC: @     0x7953befccb2c pthread_kill
*** SIGABRT (@0xf1d90) received by PID 990608 (TID 0x7950ab41c6c0) LWP(991515) from PID 990608; stack trace: ***
    @         0x32ddc347 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7953befcfed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)
    @         0x32ddbb46 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7953bef73330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @     0x7953befccb2c pthread_kill
    @     0x7953bef7327e gsignal
    @     0x7953bef568ff abort
    @         0x1cc06548 starrocks::failure_function()
    @         0x32dcfc5d google::LogMessage::Fail()
    @         0x32dd0d44 google::LogMessageFatal::~LogMessageFatal()
    @         0x2db415a9 starrocks::DecimalV3Column<__int128>::DecimalV3Column(int, int)
    @         0x2db416d1 starrocks::DecimalV3Column<__int128>::DecimalV3Column(int, int, unsigned long)
    @         0x2dbc646e starrocks::Cow<starrocks::Column>::MutPtr<starrocks::DecimalV3Column<__int128> > starrocks::CowFactory<starrocks::ColumnFactory<starrocks::FixedLengthColumnBase<__int128>, starrocks::DecimalV3Column<__int128> >, starrocks::DecimalV3Column<__int128>, starro@
    @         0x2dbc3f9b starrocks::Cow<starrocks::Column>::MutPtr<starrocks::Column> starrocks::ColumnBuilder::operator()<(starrocks::LogicalType)49>(starrocks::TypeDescriptor const&, unsigned long)
    @         0x2dbc1d3e auto starrocks::type_dispatch_column<starrocks::ColumnBuilder, starrocks::TypeDescriptor, unsigned long>(starrocks::LogicalType, starrocks::ColumnBuilder, starrocks::TypeDescriptor const&, unsigned long const&)
    @         0x2dbbd128 starrocks::ColumnHelper::create_column(starrocks::TypeDescriptor const&, bool, bool, unsigned long, bool)
    @         0x2dbbbdce starrocks::ColumnHelper::create_column(starrocks::TypeDescriptor const&, bool)
    @         0x2ca43bf1 starrocks::VectorizedIfExpr<(starrocks::LogicalType)49>::get_data_column(int, starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>&)
    @         0x2c9ee445 starrocks::VectorizedIfExpr<(starrocks::LogicalType)49>::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
    @         0x2a5cb5f6 starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*)
    @         0x2a5cadea starrocks::ExprContext::evaluate(starrocks::Chunk*, unsigned char*)
    @         0x1d751d2c starrocks::Aggregator::evaluate_agg_input_column(starrocks::Chunk*, std::vector<starrocks::ExprContext*, std::allocator<starrocks::ExprContext*> >&, int)
    @         0x1d752514 starrocks::Aggregator::compute_single_agg_state(starrocks::Chunk*, unsigned long)
    @         0x1eb1bb4e starrocks::pipeline::AggregateBlockingSinkOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @         0x23607af8 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)

```

Both branches of that if() carry the very same concrete type - the NULL constant is created from the else branch - so use it for the call, the way DecimalV3FunctionAnalyzer already does for an if() written by the user.

The crash needs the wildcard-typed branch to be reached at runtime, that is a NULL in one of the leading distinct columns:

  create table t (k1 int, d1 decimal(10,2) null, d2 decimal(10,2) null)
    duplicate key(k1) distributed by hash(k1) buckets 1;
  insert into t values (1, null, 1.50), (2, 2.50, 2.50), (3, 3.50, null);
  select count(distinct d1, d2) from t;

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
