### PR TITLE
[Enhancement] Add vector index query profile statistics

### DIFF
--- a/be/src/connector/lake/lake_connector.cpp
+++ b/be/src/connector/lake/lake_connector.cpp
@@ -1311,24 +1311,33 @@ void LakeDataSource::init_counter(RuntimeState* state) {
     _zone_map_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "ZoneMapIndexFilter", segment_init_name);
     _rows_key_range_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "ShortKeyFilter", segment_init_name);
     _bf_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "BloomFilterFilter", segment_init_name);
+
+    const std::string vector_index_name = "VectorIndex";
+    const std::string vector_index_load_name = "VectorIndexLoad";
+    const std::string vector_index_cache_lookup_name = "VectorIndexCacheLookup";
+    const std::string vector_index_search_name = "VectorIndexSearch";
+    _vector_index_timer = ADD_CHILD_TIMER(_runtime_profile, vector_index_name, segment_init_name);
+    _vector_index_load_timer = ADD_CHILD_TIMER(_runtime_profile, vector_index_load_name, vector_index_name);
     _get_row_ranges_by_vector_index_timer =
-            ADD_CHILD_TIMER(_runtime_profile, "GetVectorRowRangesTime", segment_init_name);
+            ADD_CHILD_TIMER(_runtime_profile, vector_index_search_name, vector_index_name);
     _vector_index_cache_lookup_timer =
-            ADD_CHILD_TIMER(_runtime_profile, "VectorIndexCacheLookupTime", segment_init_name);
-    _vector_index_file_open_timer = ADD_CHILD_TIMER(_runtime_profile, "VectorIndexFileOpenTime", segment_init_name);
-    _vector_index_read_file_timer = ADD_CHILD_TIMER(_runtime_profile, "VectorIndexReadFileTime", segment_init_name);
-    _vector_index_init_index_timer = ADD_CHILD_TIMER(_runtime_profile, "VectorIndexInitIndexTime", segment_init_name);
+            ADD_CHILD_TIMER(_runtime_profile, vector_index_cache_lookup_name, vector_index_load_name);
+    _vector_index_file_open_timer =
+            ADD_CHILD_TIMER(_runtime_profile, "VectorIndexFileOpenAndGetSize", vector_index_load_name);
+    _vector_index_read_file_timer = ADD_CHILD_TIMER(_runtime_profile, "VectorIndexFileRead", vector_index_load_name);
+    _vector_index_init_index_timer =
+            ADD_CHILD_TIMER(_runtime_profile, "VectorIndexDeserialize", vector_index_load_name);
     _vector_index_searcher_init_timer =
-            ADD_CHILD_TIMER(_runtime_profile, "VectorIndexSearcherInitTime", segment_init_name);
+            ADD_CHILD_TIMER(_runtime_profile, "VectorIndexSearcherCreate", vector_index_load_name);
     _vector_index_cache_hit_counter =
-            ADD_CHILD_COUNTER(_runtime_profile, "VectorIndexCacheHitCount", TUnit::UNIT, segment_init_name);
+            ADD_CHILD_COUNTER(_runtime_profile, "VectorIndexCacheHit", TUnit::UNIT, vector_index_cache_lookup_name);
     _vector_index_cache_miss_counter =
-            ADD_CHILD_COUNTER(_runtime_profile, "VectorIndexCacheMissCount", TUnit::UNIT, segment_init_name);
-    _vector_search_timer = ADD_CHILD_TIMER(_runtime_profile, "VectorSearchTime", segment_init_name);
+            ADD_CHILD_COUNTER(_runtime_profile, "VectorIndexCacheMiss", TUnit::UNIT, vector_index_cache_lookup_name);
+    _vector_search_timer = ADD_CHILD_TIMER(_runtime_profile, "VectorANNSearch", vector_index_search_name);
     _process_vector_distance_and_id_timer =
-            ADD_CHILD_TIMER(_runtime_profile, "ProcessVectorDistanceAndIdTime", segment_init_name);
+            ADD_CHILD_TIMER(_runtime_profile, "VectorResultProcess", vector_index_search_name);
     _vector_index_filtered_counter =
-            ADD_CHILD_COUNTER(_runtime_profile, "VectorIndexFilterRows", TUnit::UNIT, segment_init_name);
+            ADD_CHILD_COUNTER(_runtime_profile, "VectorIndexFilterRows", TUnit::UNIT, vector_index_search_name);
 
     const std::string gin_filter_name = "GinFilter";
     _gin_filtered_timer = ADD_CHILD_TIMER(_runtime_profile, gin_filter_name, segment_init_name);
@@ -1389,27 +1398,36 @@ void LakeDataSource::init_counter(RuntimeState* state) {
     _lake_seed_io_timer = ADD_CHILD_TIMER(_runtime_profile, "SeedIOTime", "SeedPrepareTime");
     _lake_seed_io_count_counter = ADD_CHILD_COUNTER(_runtime_profile, "SeedIOCount", TUnit::UNIT, "SeedPrepareTime");
     _lake_seed_segment_init_timer = ADD_CHILD_TIMER(_runtime_profile, "SeedSegmentInitTime", "SeedPrepareTime");
+
+    const std::string seed_vector_index_name = "SeedVectorIndex";
+    const std::string seed_vector_index_load_name = "SeedVectorIndexLoad";
+    const std::string seed_vector_index_cache_lookup_name = "SeedVectorIndexCacheLookup";
+    const std::string seed_vector_index_search_name = "SeedVectorIndexSearch";
+    _lake_seed_vector_index_timer = ADD_CHILD_TIMER(_runtime_profile, seed_vector_index_name, "SeedSegmentInitTime");
+    _lake_seed_vector_index_load_timer =
+            ADD_CHILD_TIMER(_runtime_profile, seed_vector_index_load_name, seed_vector_index_name);
     _lake_seed_get_row_ranges_by_vector_index_timer =
-            ADD_CHILD_TIMER(_runtime_profile, "SeedGetVectorRowRangesTime", "SeedSegmentInitTime");
+            ADD_CHILD_TIMER(_runtime_profile, seed_vector_index_search_name, seed_vector_index_name);
     _lake_seed_vector_index_cache_lookup_timer =
-            ADD_CHILD_TIMER(_runtime_profile, "SeedVectorIndexCacheLookupTime", "SeedSegmentInitTime");
+            ADD_CHILD_TIMER(_runtime_profile, seed_vector_index_cache_lookup_name, seed_vector_index_load_name);
     _lake_seed_vector_index_file_open_timer =
-            ADD_CHILD_TIMER(_runtime_profile, "SeedVectorIndexFileOpenTime", "SeedSegmentInitTime");
+            ADD_CHILD_TIMER(_runtime_profile, "SeedVectorIndexFileOpenAndGetSize", seed_vector_index_load_name);
     _lake_seed_vector_index_read_file_timer =
-            ADD_CHILD_TIMER(_runtime_profile, "SeedVectorIndexReadFileTime", "SeedSegmentInitTime");
+            ADD_CHILD_TIMER(_runtime_profile, "SeedVectorIndexFileRead", seed_vector_index_load_name);
     _lake_seed_vector_index_init_index_timer =
-            ADD_CHILD_TIMER(_runtime_profile, "SeedVectorIndexInitIndexTime", "SeedSegmentInitTime");
+            ADD_CHILD_TIMER(_runtime_profile, "SeedVectorIndexDeserialize", seed_vector_index_load_name);
     _lake_seed_vector_index_searcher_init_timer =
-            ADD_CHILD_TIMER(_runtime_profile, "SeedVectorIndexSearcherInitTime", "SeedSegmentInitTime");
-    _lake_seed_vector_index_cache_hit_counter =
-            ADD_CHILD_COUNTER(_runtime_profile, "SeedVectorIndexCacheHitCount", TUnit::UNIT, "SeedSegmentInitTime");
-    _lake_seed_vector_index_cache_miss_counter =
-            ADD_CHILD_COUNTER(_runtime_profile, "SeedVectorIndexCacheMissCount", TUnit::UNIT, "SeedSegmentInitTime");
-    _lake_seed_vector_search_timer = ADD_CHILD_TIMER(_runtime_profile, "SeedVectorSearchTime", "SeedSegmentInitTime");
+            ADD_CHILD_TIMER(_runtime_profile, "SeedVectorIndexSearcherCreate", seed_vector_index_load_name);
+    _lake_seed_vector_index_cache_hit_counter = ADD_CHILD_COUNTER(_runtime_profile, "SeedVectorIndexCacheHit",
+                                                                  TUnit::UNIT, seed_vector_index_cache_lookup_name);
+    _lake_seed_vector_index_cache_miss_counter = ADD_CHILD_COUNTER(_runtime_profile, "SeedVectorIndexCacheMiss",
+                                                                   TUnit::UNIT, seed_vector_index_cache_lookup_name);
+    _lake_seed_vector_search_timer =
+            ADD_CHILD_TIMER(_runtime_profile, "SeedVectorANNSearch", seed_vector_index_search_name);
     _lake_seed_process_vector_distance_and_id_timer =
-            ADD_CHILD_TIMER(_runtime_profile, "SeedProcessVectorDistanceAndIdTime", "SeedSegmentInitTime");
-    _lake_seed_vector_index_filtered_counter =
-            ADD_CHILD_COUNTER(_runtime_profile, "SeedVectorIndexFilterRows", TUnit::UNIT, "SeedSegmentInitTime");
+            ADD_CHILD_TIMER(_runtime_profile, "SeedVectorResultProcess", seed_vector_index_search_name);
+    _lake_seed_vector_index_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "SeedVectorIndexFilterRows",
+                                                                 TUnit::UNIT, seed_vector_index_search_name);
     _lake_seed_zonemap_timer = ADD_CHILD_TIMER(_runtime_profile, "SeedZoneMapFilterTime", "SeedPrepareTime");
     _lake_seed_zonemap_filtered_counter =
             ADD_CHILD_COUNTER(_runtime_profile, "SeedZoneMapFilteredRows", TUnit::UNIT, "SeedPrepareTime");
@@ -1519,6 +1537,9 @@ void LakeDataSource::update_counter(RuntimeState* state) {
 
     COUNTER_UPDATE(_bi_filtered_counter, _reader->stats().rows_bitmap_index_filtered);
     COUNTER_UPDATE(_bi_filter_timer, _reader->stats().bitmap_index_filter_timer);
+    COUNTER_UPDATE(_vector_index_timer,
+                   _reader->stats().vector_index_load_ns + _reader->stats().get_row_ranges_by_vector_index_timer);
+    COUNTER_UPDATE(_vector_index_load_timer, _reader->stats().vector_index_load_ns);
     COUNTER_UPDATE(_get_row_ranges_by_vector_index_timer, _reader->stats().get_row_ranges_by_vector_index_timer);
     COUNTER_UPDATE(_vector_index_cache_lookup_timer, _reader->stats().vector_index_cache_lookup_ns);
     COUNTER_UPDATE(_vector_index_file_open_timer, _reader->stats().vector_index_file_open_ns);
@@ -1544,6 +1565,10 @@ void LakeDataSource::update_counter(RuntimeState* state) {
     COUNTER_UPDATE(_lake_seed_io_timer, _reader->stats().lake_prepared_seed_io_ns);
     COUNTER_UPDATE(_lake_seed_io_count_counter, _reader->stats().lake_prepared_seed_io_count);
     COUNTER_UPDATE(_lake_seed_segment_init_timer, _reader->stats().lake_prepared_seed_segment_init_ns);
+    COUNTER_UPDATE(_lake_seed_vector_index_timer,
+                   _reader->stats().lake_prepared_seed_vector_index_load_ns +
+                           _reader->stats().lake_prepared_seed_get_row_ranges_by_vector_index_ns);
+    COUNTER_UPDATE(_lake_seed_vector_index_load_timer, _reader->stats().lake_prepared_seed_vector_index_load_ns);
     COUNTER_UPDATE(_lake_seed_get_row_ranges_by_vector_index_timer,
                    _reader->stats().lake_prepared_seed_get_row_ranges_by_vector_index_ns);
     COUNTER_UPDATE(_lake_seed_vector_index_cache_lookup_timer,

--- a/be/src/connector/lake/lake_connector.cpp
+++ b/be/src/connector/lake/lake_connector.cpp
@@ -1311,6 +1311,24 @@ void LakeDataSource::init_counter(RuntimeState* state) {
     _zone_map_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "ZoneMapIndexFilter", segment_init_name);
     _rows_key_range_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "ShortKeyFilter", segment_init_name);
     _bf_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "BloomFilterFilter", segment_init_name);
+    _get_row_ranges_by_vector_index_timer =
+            ADD_CHILD_TIMER(_runtime_profile, "GetVectorRowRangesTime", segment_init_name);
+    _vector_index_cache_lookup_timer =
+            ADD_CHILD_TIMER(_runtime_profile, "VectorIndexCacheLookupTime", segment_init_name);
+    _vector_index_file_open_timer = ADD_CHILD_TIMER(_runtime_profile, "VectorIndexFileOpenTime", segment_init_name);
+    _vector_index_read_file_timer = ADD_CHILD_TIMER(_runtime_profile, "VectorIndexReadFileTime", segment_init_name);
+    _vector_index_init_index_timer = ADD_CHILD_TIMER(_runtime_profile, "VectorIndexInitIndexTime", segment_init_name);
+    _vector_index_searcher_init_timer =
+            ADD_CHILD_TIMER(_runtime_profile, "VectorIndexSearcherInitTime", segment_init_name);
+    _vector_index_cache_hit_counter =
+            ADD_CHILD_COUNTER(_runtime_profile, "VectorIndexCacheHitCount", TUnit::UNIT, segment_init_name);
+    _vector_index_cache_miss_counter =
+            ADD_CHILD_COUNTER(_runtime_profile, "VectorIndexCacheMissCount", TUnit::UNIT, segment_init_name);
+    _vector_search_timer = ADD_CHILD_TIMER(_runtime_profile, "VectorSearchTime", segment_init_name);
+    _process_vector_distance_and_id_timer =
+            ADD_CHILD_TIMER(_runtime_profile, "ProcessVectorDistanceAndIdTime", segment_init_name);
+    _vector_index_filtered_counter =
+            ADD_CHILD_COUNTER(_runtime_profile, "VectorIndexFilterRows", TUnit::UNIT, segment_init_name);
 
     const std::string gin_filter_name = "GinFilter";
     _gin_filtered_timer = ADD_CHILD_TIMER(_runtime_profile, gin_filter_name, segment_init_name);
@@ -1371,6 +1389,27 @@ void LakeDataSource::init_counter(RuntimeState* state) {
     _lake_seed_io_timer = ADD_CHILD_TIMER(_runtime_profile, "SeedIOTime", "SeedPrepareTime");
     _lake_seed_io_count_counter = ADD_CHILD_COUNTER(_runtime_profile, "SeedIOCount", TUnit::UNIT, "SeedPrepareTime");
     _lake_seed_segment_init_timer = ADD_CHILD_TIMER(_runtime_profile, "SeedSegmentInitTime", "SeedPrepareTime");
+    _lake_seed_get_row_ranges_by_vector_index_timer =
+            ADD_CHILD_TIMER(_runtime_profile, "SeedGetVectorRowRangesTime", "SeedSegmentInitTime");
+    _lake_seed_vector_index_cache_lookup_timer =
+            ADD_CHILD_TIMER(_runtime_profile, "SeedVectorIndexCacheLookupTime", "SeedSegmentInitTime");
+    _lake_seed_vector_index_file_open_timer =
+            ADD_CHILD_TIMER(_runtime_profile, "SeedVectorIndexFileOpenTime", "SeedSegmentInitTime");
+    _lake_seed_vector_index_read_file_timer =
+            ADD_CHILD_TIMER(_runtime_profile, "SeedVectorIndexReadFileTime", "SeedSegmentInitTime");
+    _lake_seed_vector_index_init_index_timer =
+            ADD_CHILD_TIMER(_runtime_profile, "SeedVectorIndexInitIndexTime", "SeedSegmentInitTime");
+    _lake_seed_vector_index_searcher_init_timer =
+            ADD_CHILD_TIMER(_runtime_profile, "SeedVectorIndexSearcherInitTime", "SeedSegmentInitTime");
+    _lake_seed_vector_index_cache_hit_counter =
+            ADD_CHILD_COUNTER(_runtime_profile, "SeedVectorIndexCacheHitCount", TUnit::UNIT, "SeedSegmentInitTime");
+    _lake_seed_vector_index_cache_miss_counter =
+            ADD_CHILD_COUNTER(_runtime_profile, "SeedVectorIndexCacheMissCount", TUnit::UNIT, "SeedSegmentInitTime");
+    _lake_seed_vector_search_timer = ADD_CHILD_TIMER(_runtime_profile, "SeedVectorSearchTime", "SeedSegmentInitTime");
+    _lake_seed_process_vector_distance_and_id_timer =
+            ADD_CHILD_TIMER(_runtime_profile, "SeedProcessVectorDistanceAndIdTime", "SeedSegmentInitTime");
+    _lake_seed_vector_index_filtered_counter =
+            ADD_CHILD_COUNTER(_runtime_profile, "SeedVectorIndexFilterRows", TUnit::UNIT, "SeedSegmentInitTime");
     _lake_seed_zonemap_timer = ADD_CHILD_TIMER(_runtime_profile, "SeedZoneMapFilterTime", "SeedPrepareTime");
     _lake_seed_zonemap_filtered_counter =
             ADD_CHILD_COUNTER(_runtime_profile, "SeedZoneMapFilteredRows", TUnit::UNIT, "SeedPrepareTime");
@@ -1480,6 +1519,17 @@ void LakeDataSource::update_counter(RuntimeState* state) {
 
     COUNTER_UPDATE(_bi_filtered_counter, _reader->stats().rows_bitmap_index_filtered);
     COUNTER_UPDATE(_bi_filter_timer, _reader->stats().bitmap_index_filter_timer);
+    COUNTER_UPDATE(_get_row_ranges_by_vector_index_timer, _reader->stats().get_row_ranges_by_vector_index_timer);
+    COUNTER_UPDATE(_vector_index_cache_lookup_timer, _reader->stats().vector_index_cache_lookup_ns);
+    COUNTER_UPDATE(_vector_index_file_open_timer, _reader->stats().vector_index_file_open_ns);
+    COUNTER_UPDATE(_vector_index_read_file_timer, _reader->stats().vector_index_read_file_ns);
+    COUNTER_UPDATE(_vector_index_init_index_timer, _reader->stats().vector_index_init_index_ns);
+    COUNTER_UPDATE(_vector_index_searcher_init_timer, _reader->stats().vector_index_searcher_init_ns);
+    COUNTER_UPDATE(_vector_index_cache_hit_counter, _reader->stats().vector_index_cache_hit_count);
+    COUNTER_UPDATE(_vector_index_cache_miss_counter, _reader->stats().vector_index_cache_miss_count);
+    COUNTER_UPDATE(_vector_search_timer, _reader->stats().vector_search_timer);
+    COUNTER_UPDATE(_process_vector_distance_and_id_timer, _reader->stats().process_vector_distance_and_id_timer);
+    COUNTER_UPDATE(_vector_index_filtered_counter, _reader->stats().rows_vector_index_filtered);
     COUNTER_UPDATE(_block_seek_counter, _reader->stats().block_seek_num);
     COUNTER_UPDATE(_lake_prepared_rowsets_counter, _reader->stats().lake_prepared_rowsets);
     COUNTER_UPDATE(_lake_prepared_segments_counter, _reader->stats().lake_prepared_segments);
@@ -1494,6 +1544,27 @@ void LakeDataSource::update_counter(RuntimeState* state) {
     COUNTER_UPDATE(_lake_seed_io_timer, _reader->stats().lake_prepared_seed_io_ns);
     COUNTER_UPDATE(_lake_seed_io_count_counter, _reader->stats().lake_prepared_seed_io_count);
     COUNTER_UPDATE(_lake_seed_segment_init_timer, _reader->stats().lake_prepared_seed_segment_init_ns);
+    COUNTER_UPDATE(_lake_seed_get_row_ranges_by_vector_index_timer,
+                   _reader->stats().lake_prepared_seed_get_row_ranges_by_vector_index_ns);
+    COUNTER_UPDATE(_lake_seed_vector_index_cache_lookup_timer,
+                   _reader->stats().lake_prepared_seed_vector_index_cache_lookup_ns);
+    COUNTER_UPDATE(_lake_seed_vector_index_file_open_timer,
+                   _reader->stats().lake_prepared_seed_vector_index_file_open_ns);
+    COUNTER_UPDATE(_lake_seed_vector_index_read_file_timer,
+                   _reader->stats().lake_prepared_seed_vector_index_read_file_ns);
+    COUNTER_UPDATE(_lake_seed_vector_index_init_index_timer,
+                   _reader->stats().lake_prepared_seed_vector_index_init_index_ns);
+    COUNTER_UPDATE(_lake_seed_vector_index_searcher_init_timer,
+                   _reader->stats().lake_prepared_seed_vector_index_searcher_init_ns);
+    COUNTER_UPDATE(_lake_seed_vector_index_cache_hit_counter,
+                   _reader->stats().lake_prepared_seed_vector_index_cache_hit_count);
+    COUNTER_UPDATE(_lake_seed_vector_index_cache_miss_counter,
+                   _reader->stats().lake_prepared_seed_vector_index_cache_miss_count);
+    COUNTER_UPDATE(_lake_seed_vector_search_timer, _reader->stats().lake_prepared_seed_vector_search_ns);
+    COUNTER_UPDATE(_lake_seed_process_vector_distance_and_id_timer,
+                   _reader->stats().lake_prepared_seed_process_vector_distance_and_id_ns);
+    COUNTER_UPDATE(_lake_seed_vector_index_filtered_counter,
+                   _reader->stats().lake_prepared_seed_rows_vector_index_filtered);
     COUNTER_UPDATE(_lake_seed_zonemap_timer, _reader->stats().lake_prepared_seed_zonemap_ns);
     COUNTER_UPDATE(_lake_seed_zonemap_filtered_counter, _reader->stats().lake_prepared_seed_zonemap_filtered_rows);
     COUNTER_UPDATE(_lake_seed_bf_timer, _reader->stats().lake_prepared_seed_bf_ns);

--- a/be/src/connector/lake/lake_connector.h
+++ b/be/src/connector/lake/lake_connector.h
@@ -224,6 +224,8 @@ private:
     RuntimeProfile::Counter* _block_fetch_timer = nullptr;
     RuntimeProfile::Counter* _bi_filtered_counter = nullptr;
     RuntimeProfile::Counter* _bi_filter_timer = nullptr;
+    RuntimeProfile::Counter* _vector_index_timer = nullptr;
+    RuntimeProfile::Counter* _vector_index_load_timer = nullptr;
     RuntimeProfile::Counter* _get_row_ranges_by_vector_index_timer = nullptr;
     RuntimeProfile::Counter* _vector_index_cache_lookup_timer = nullptr;
     RuntimeProfile::Counter* _vector_index_file_open_timer = nullptr;
@@ -268,6 +270,8 @@ private:
     RuntimeProfile::Counter* _lake_seed_io_timer = nullptr;
     RuntimeProfile::Counter* _lake_seed_io_count_counter = nullptr;
     RuntimeProfile::Counter* _lake_seed_segment_init_timer = nullptr;
+    RuntimeProfile::Counter* _lake_seed_vector_index_timer = nullptr;
+    RuntimeProfile::Counter* _lake_seed_vector_index_load_timer = nullptr;
     RuntimeProfile::Counter* _lake_seed_get_row_ranges_by_vector_index_timer = nullptr;
     RuntimeProfile::Counter* _lake_seed_vector_index_cache_lookup_timer = nullptr;
     RuntimeProfile::Counter* _lake_seed_vector_index_file_open_timer = nullptr;

--- a/be/src/connector/lake/lake_connector.h
+++ b/be/src/connector/lake/lake_connector.h
@@ -224,6 +224,17 @@ private:
     RuntimeProfile::Counter* _block_fetch_timer = nullptr;
     RuntimeProfile::Counter* _bi_filtered_counter = nullptr;
     RuntimeProfile::Counter* _bi_filter_timer = nullptr;
+    RuntimeProfile::Counter* _get_row_ranges_by_vector_index_timer = nullptr;
+    RuntimeProfile::Counter* _vector_index_cache_lookup_timer = nullptr;
+    RuntimeProfile::Counter* _vector_index_file_open_timer = nullptr;
+    RuntimeProfile::Counter* _vector_index_read_file_timer = nullptr;
+    RuntimeProfile::Counter* _vector_index_init_index_timer = nullptr;
+    RuntimeProfile::Counter* _vector_index_searcher_init_timer = nullptr;
+    RuntimeProfile::Counter* _vector_index_cache_hit_counter = nullptr;
+    RuntimeProfile::Counter* _vector_index_cache_miss_counter = nullptr;
+    RuntimeProfile::Counter* _vector_search_timer = nullptr;
+    RuntimeProfile::Counter* _process_vector_distance_and_id_timer = nullptr;
+    RuntimeProfile::Counter* _vector_index_filtered_counter = nullptr;
 
     // Gin filter Statistics
     RuntimeProfile::Counter* _gin_filtered_timer = nullptr;
@@ -257,6 +268,17 @@ private:
     RuntimeProfile::Counter* _lake_seed_io_timer = nullptr;
     RuntimeProfile::Counter* _lake_seed_io_count_counter = nullptr;
     RuntimeProfile::Counter* _lake_seed_segment_init_timer = nullptr;
+    RuntimeProfile::Counter* _lake_seed_get_row_ranges_by_vector_index_timer = nullptr;
+    RuntimeProfile::Counter* _lake_seed_vector_index_cache_lookup_timer = nullptr;
+    RuntimeProfile::Counter* _lake_seed_vector_index_file_open_timer = nullptr;
+    RuntimeProfile::Counter* _lake_seed_vector_index_read_file_timer = nullptr;
+    RuntimeProfile::Counter* _lake_seed_vector_index_init_index_timer = nullptr;
+    RuntimeProfile::Counter* _lake_seed_vector_index_searcher_init_timer = nullptr;
+    RuntimeProfile::Counter* _lake_seed_vector_index_cache_hit_counter = nullptr;
+    RuntimeProfile::Counter* _lake_seed_vector_index_cache_miss_counter = nullptr;
+    RuntimeProfile::Counter* _lake_seed_vector_search_timer = nullptr;
+    RuntimeProfile::Counter* _lake_seed_process_vector_distance_and_id_timer = nullptr;
+    RuntimeProfile::Counter* _lake_seed_vector_index_filtered_counter = nullptr;
     RuntimeProfile::Counter* _lake_seed_zonemap_timer = nullptr;
     RuntimeProfile::Counter* _lake_seed_zonemap_filtered_counter = nullptr;
     RuntimeProfile::Counter* _lake_seed_bf_timer = nullptr;

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -650,6 +650,15 @@ void OlapScanNode::_init_counter(RuntimeState* state) {
             ADD_CHILD_COUNTER(_runtime_profile, "GinPredicateFilteredDictNum", TUnit::UNIT, gin_filter_name);
 
     _get_row_ranges_by_vector_index_timer = ADD_CHILD_TIMER(_scan_profile, "GetVectorRowRangesTime", "SegmentInit");
+    _vector_index_cache_lookup_timer = ADD_CHILD_TIMER(_scan_profile, "VectorIndexCacheLookupTime", "SegmentInit");
+    _vector_index_file_open_timer = ADD_CHILD_TIMER(_scan_profile, "VectorIndexFileOpenTime", "SegmentInit");
+    _vector_index_read_file_timer = ADD_CHILD_TIMER(_scan_profile, "VectorIndexReadFileTime", "SegmentInit");
+    _vector_index_init_index_timer = ADD_CHILD_TIMER(_scan_profile, "VectorIndexInitIndexTime", "SegmentInit");
+    _vector_index_searcher_init_timer = ADD_CHILD_TIMER(_scan_profile, "VectorIndexSearcherInitTime", "SegmentInit");
+    _vector_index_cache_hit_counter =
+            ADD_CHILD_COUNTER(_scan_profile, "VectorIndexCacheHitCount", TUnit::UNIT, "SegmentInit");
+    _vector_index_cache_miss_counter =
+            ADD_CHILD_COUNTER(_scan_profile, "VectorIndexCacheMissCount", TUnit::UNIT, "SegmentInit");
     _vector_search_timer = ADD_CHILD_TIMER(_scan_profile, "VectorSearchTime", "SegmentInit");
     _vector_index_filtered_counter =
             ADD_CHILD_COUNTER(_scan_profile, "VectorIndexFilterRows", TUnit::UNIT, "SegmentInit");

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -649,21 +649,30 @@ void OlapScanNode::_init_counter(RuntimeState* state) {
     _gin_predicate_dict_filtered_counter =
             ADD_CHILD_COUNTER(_runtime_profile, "GinPredicateFilteredDictNum", TUnit::UNIT, gin_filter_name);
 
-    _get_row_ranges_by_vector_index_timer = ADD_CHILD_TIMER(_scan_profile, "GetVectorRowRangesTime", "SegmentInit");
-    _vector_index_cache_lookup_timer = ADD_CHILD_TIMER(_scan_profile, "VectorIndexCacheLookupTime", "SegmentInit");
-    _vector_index_file_open_timer = ADD_CHILD_TIMER(_scan_profile, "VectorIndexFileOpenTime", "SegmentInit");
-    _vector_index_read_file_timer = ADD_CHILD_TIMER(_scan_profile, "VectorIndexReadFileTime", "SegmentInit");
-    _vector_index_init_index_timer = ADD_CHILD_TIMER(_scan_profile, "VectorIndexInitIndexTime", "SegmentInit");
-    _vector_index_searcher_init_timer = ADD_CHILD_TIMER(_scan_profile, "VectorIndexSearcherInitTime", "SegmentInit");
+    const std::string vector_index_name = "VectorIndex";
+    const std::string vector_index_load_name = "VectorIndexLoad";
+    const std::string vector_index_cache_lookup_name = "VectorIndexCacheLookup";
+    const std::string vector_index_search_name = "VectorIndexSearch";
+    _vector_index_timer = ADD_CHILD_TIMER(_scan_profile, vector_index_name, "SegmentInit");
+    _vector_index_load_timer = ADD_CHILD_TIMER(_scan_profile, vector_index_load_name, vector_index_name);
+    _get_row_ranges_by_vector_index_timer = ADD_CHILD_TIMER(_scan_profile, vector_index_search_name, vector_index_name);
+    _vector_index_cache_lookup_timer =
+            ADD_CHILD_TIMER(_scan_profile, vector_index_cache_lookup_name, vector_index_load_name);
+    _vector_index_file_open_timer =
+            ADD_CHILD_TIMER(_scan_profile, "VectorIndexFileOpenAndGetSize", vector_index_load_name);
+    _vector_index_read_file_timer = ADD_CHILD_TIMER(_scan_profile, "VectorIndexFileRead", vector_index_load_name);
+    _vector_index_init_index_timer = ADD_CHILD_TIMER(_scan_profile, "VectorIndexDeserialize", vector_index_load_name);
+    _vector_index_searcher_init_timer =
+            ADD_CHILD_TIMER(_scan_profile, "VectorIndexSearcherCreate", vector_index_load_name);
     _vector_index_cache_hit_counter =
-            ADD_CHILD_COUNTER(_scan_profile, "VectorIndexCacheHitCount", TUnit::UNIT, "SegmentInit");
+            ADD_CHILD_COUNTER(_scan_profile, "VectorIndexCacheHit", TUnit::UNIT, vector_index_cache_lookup_name);
     _vector_index_cache_miss_counter =
-            ADD_CHILD_COUNTER(_scan_profile, "VectorIndexCacheMissCount", TUnit::UNIT, "SegmentInit");
-    _vector_search_timer = ADD_CHILD_TIMER(_scan_profile, "VectorSearchTime", "SegmentInit");
+            ADD_CHILD_COUNTER(_scan_profile, "VectorIndexCacheMiss", TUnit::UNIT, vector_index_cache_lookup_name);
+    _vector_search_timer = ADD_CHILD_TIMER(_scan_profile, "VectorANNSearch", vector_index_search_name);
     _vector_index_filtered_counter =
-            ADD_CHILD_COUNTER(_scan_profile, "VectorIndexFilterRows", TUnit::UNIT, "SegmentInit");
+            ADD_CHILD_COUNTER(_scan_profile, "VectorIndexFilterRows", TUnit::UNIT, vector_index_search_name);
     _process_vector_distance_and_id_timer =
-            ADD_CHILD_TIMER(_scan_profile, "ProcessVectorDistanceAndIdTime", "SegmentInit");
+            ADD_CHILD_TIMER(_scan_profile, "VectorResultProcess", vector_index_search_name);
     _seg_zm_filtered_counter = ADD_CHILD_COUNTER(_scan_profile, "SegmentZoneMapFilterRows", TUnit::UNIT, "SegmentInit");
     _seg_rt_filtered_counter =
             ADD_CHILD_COUNTER(_scan_profile, "SegmentRuntimeZoneMapFilterRows", TUnit::UNIT, "SegmentInit");

--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -260,6 +260,8 @@ private:
     RuntimeProfile::Counter* _gin_ngram_dict_filtered_counter = nullptr;
     RuntimeProfile::Counter* _gin_predicate_dict_filtered_counter = nullptr;
 
+    RuntimeProfile::Counter* _vector_index_timer = nullptr;
+    RuntimeProfile::Counter* _vector_index_load_timer = nullptr;
     RuntimeProfile::Counter* _get_row_ranges_by_vector_index_timer = nullptr;
     RuntimeProfile::Counter* _vector_index_cache_lookup_timer = nullptr;
     RuntimeProfile::Counter* _vector_index_file_open_timer = nullptr;

--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -261,6 +261,13 @@ private:
     RuntimeProfile::Counter* _gin_predicate_dict_filtered_counter = nullptr;
 
     RuntimeProfile::Counter* _get_row_ranges_by_vector_index_timer = nullptr;
+    RuntimeProfile::Counter* _vector_index_cache_lookup_timer = nullptr;
+    RuntimeProfile::Counter* _vector_index_file_open_timer = nullptr;
+    RuntimeProfile::Counter* _vector_index_read_file_timer = nullptr;
+    RuntimeProfile::Counter* _vector_index_init_index_timer = nullptr;
+    RuntimeProfile::Counter* _vector_index_searcher_init_timer = nullptr;
+    RuntimeProfile::Counter* _vector_index_cache_hit_counter = nullptr;
+    RuntimeProfile::Counter* _vector_index_cache_miss_counter = nullptr;
     RuntimeProfile::Counter* _vector_search_timer = nullptr;
     RuntimeProfile::Counter* _vector_index_filtered_counter = nullptr;
     RuntimeProfile::Counter* _process_vector_distance_and_id_timer = nullptr;

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -177,22 +177,31 @@ void OlapChunkSource::_init_counter(RuntimeState* state) {
     const std::string segment_init_name = "SegmentInit";
     _seg_init_timer = ADD_CHILD_TIMER(_runtime_profile, segment_init_name, IO_TASK_EXEC_TIMER_NAME);
     _bi_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "BitmapIndexFilter", segment_init_name);
+
+    const std::string vector_index_name = "VectorIndex";
+    const std::string vector_index_load_name = "VectorIndexLoad";
+    const std::string vector_index_cache_lookup_name = "VectorIndexCacheLookup";
+    const std::string vector_index_search_name = "VectorIndexSearch";
+    _vector_index_timer = ADD_CHILD_TIMER(_runtime_profile, vector_index_name, segment_init_name);
+    _vector_index_load_timer = ADD_CHILD_TIMER(_runtime_profile, vector_index_load_name, vector_index_name);
     _get_row_ranges_by_vector_index_timer =
-            ADD_CHILD_TIMER(_runtime_profile, "GetVectorRowRangesTime", segment_init_name);
+            ADD_CHILD_TIMER(_runtime_profile, vector_index_search_name, vector_index_name);
     _vector_index_cache_lookup_timer =
-            ADD_CHILD_TIMER(_runtime_profile, "VectorIndexCacheLookupTime", segment_init_name);
-    _vector_index_file_open_timer = ADD_CHILD_TIMER(_runtime_profile, "VectorIndexFileOpenTime", segment_init_name);
-    _vector_index_read_file_timer = ADD_CHILD_TIMER(_runtime_profile, "VectorIndexReadFileTime", segment_init_name);
-    _vector_index_init_index_timer = ADD_CHILD_TIMER(_runtime_profile, "VectorIndexInitIndexTime", segment_init_name);
+            ADD_CHILD_TIMER(_runtime_profile, vector_index_cache_lookup_name, vector_index_load_name);
+    _vector_index_file_open_timer =
+            ADD_CHILD_TIMER(_runtime_profile, "VectorIndexFileOpenAndGetSize", vector_index_load_name);
+    _vector_index_read_file_timer = ADD_CHILD_TIMER(_runtime_profile, "VectorIndexFileRead", vector_index_load_name);
+    _vector_index_init_index_timer =
+            ADD_CHILD_TIMER(_runtime_profile, "VectorIndexDeserialize", vector_index_load_name);
     _vector_index_searcher_init_timer =
-            ADD_CHILD_TIMER(_runtime_profile, "VectorIndexSearcherInitTime", segment_init_name);
+            ADD_CHILD_TIMER(_runtime_profile, "VectorIndexSearcherCreate", vector_index_load_name);
     _vector_index_cache_hit_counter =
-            ADD_CHILD_COUNTER(_runtime_profile, "VectorIndexCacheHitCount", TUnit::UNIT, segment_init_name);
+            ADD_CHILD_COUNTER(_runtime_profile, "VectorIndexCacheHit", TUnit::UNIT, vector_index_cache_lookup_name);
     _vector_index_cache_miss_counter =
-            ADD_CHILD_COUNTER(_runtime_profile, "VectorIndexCacheMissCount", TUnit::UNIT, segment_init_name);
-    _vector_search_timer = ADD_CHILD_TIMER(_runtime_profile, "VectorSearchTime", segment_init_name);
+            ADD_CHILD_COUNTER(_runtime_profile, "VectorIndexCacheMiss", TUnit::UNIT, vector_index_cache_lookup_name);
+    _vector_search_timer = ADD_CHILD_TIMER(_runtime_profile, "VectorANNSearch", vector_index_search_name);
     _process_vector_distance_and_id_timer =
-            ADD_CHILD_TIMER(_runtime_profile, "ProcessVectorDistanceAndIdTime", segment_init_name);
+            ADD_CHILD_TIMER(_runtime_profile, "VectorResultProcess", vector_index_search_name);
     _bi_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "BitmapIndexFilterRows", TUnit::UNIT, segment_init_name);
     _bf_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "BloomFilterFilterRows", TUnit::UNIT, segment_init_name);
 
@@ -221,7 +230,7 @@ void OlapChunkSource::_init_counter(RuntimeState* state) {
     _zm_filtered_counter =
             ADD_CHILD_COUNTER(_runtime_profile, "ZoneMapIndexFilterRows", TUnit::UNIT, segment_init_name);
     _vector_index_filtered_counter =
-            ADD_CHILD_COUNTER(_runtime_profile, "VectorIndexFilterRows", TUnit::UNIT, segment_init_name);
+            ADD_CHILD_COUNTER(_runtime_profile, "VectorIndexFilterRows", TUnit::UNIT, vector_index_search_name);
     _sk_filtered_counter =
             ADD_CHILD_COUNTER_SKIP_MIN_MAX(_runtime_profile, "ShortKeyFilterRows", TUnit::UNIT,
                                            _get_counter_min_max_type("ShortKeyFilterRows"), segment_init_name);
@@ -842,6 +851,9 @@ void OlapChunkSource::_update_counter() {
 
     COUNTER_UPDATE(_bi_filtered_counter, _reader->stats().rows_bitmap_index_filtered);
     COUNTER_UPDATE(_bi_filter_timer, _reader->stats().bitmap_index_filter_timer);
+    COUNTER_UPDATE(_vector_index_timer,
+                   _reader->stats().vector_index_load_ns + _reader->stats().get_row_ranges_by_vector_index_timer);
+    COUNTER_UPDATE(_vector_index_load_timer, _reader->stats().vector_index_load_ns);
     COUNTER_UPDATE(_get_row_ranges_by_vector_index_timer, _reader->stats().get_row_ranges_by_vector_index_timer);
     COUNTER_UPDATE(_vector_index_cache_lookup_timer, _reader->stats().vector_index_cache_lookup_ns);
     COUNTER_UPDATE(_vector_index_file_open_timer, _reader->stats().vector_index_file_open_ns);

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -179,6 +179,17 @@ void OlapChunkSource::_init_counter(RuntimeState* state) {
     _bi_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "BitmapIndexFilter", segment_init_name);
     _get_row_ranges_by_vector_index_timer =
             ADD_CHILD_TIMER(_runtime_profile, "GetVectorRowRangesTime", segment_init_name);
+    _vector_index_cache_lookup_timer =
+            ADD_CHILD_TIMER(_runtime_profile, "VectorIndexCacheLookupTime", segment_init_name);
+    _vector_index_file_open_timer = ADD_CHILD_TIMER(_runtime_profile, "VectorIndexFileOpenTime", segment_init_name);
+    _vector_index_read_file_timer = ADD_CHILD_TIMER(_runtime_profile, "VectorIndexReadFileTime", segment_init_name);
+    _vector_index_init_index_timer = ADD_CHILD_TIMER(_runtime_profile, "VectorIndexInitIndexTime", segment_init_name);
+    _vector_index_searcher_init_timer =
+            ADD_CHILD_TIMER(_runtime_profile, "VectorIndexSearcherInitTime", segment_init_name);
+    _vector_index_cache_hit_counter =
+            ADD_CHILD_COUNTER(_runtime_profile, "VectorIndexCacheHitCount", TUnit::UNIT, segment_init_name);
+    _vector_index_cache_miss_counter =
+            ADD_CHILD_COUNTER(_runtime_profile, "VectorIndexCacheMissCount", TUnit::UNIT, segment_init_name);
     _vector_search_timer = ADD_CHILD_TIMER(_runtime_profile, "VectorSearchTime", segment_init_name);
     _process_vector_distance_and_id_timer =
             ADD_CHILD_TIMER(_runtime_profile, "ProcessVectorDistanceAndIdTime", segment_init_name);
@@ -832,6 +843,13 @@ void OlapChunkSource::_update_counter() {
     COUNTER_UPDATE(_bi_filtered_counter, _reader->stats().rows_bitmap_index_filtered);
     COUNTER_UPDATE(_bi_filter_timer, _reader->stats().bitmap_index_filter_timer);
     COUNTER_UPDATE(_get_row_ranges_by_vector_index_timer, _reader->stats().get_row_ranges_by_vector_index_timer);
+    COUNTER_UPDATE(_vector_index_cache_lookup_timer, _reader->stats().vector_index_cache_lookup_ns);
+    COUNTER_UPDATE(_vector_index_file_open_timer, _reader->stats().vector_index_file_open_ns);
+    COUNTER_UPDATE(_vector_index_read_file_timer, _reader->stats().vector_index_read_file_ns);
+    COUNTER_UPDATE(_vector_index_init_index_timer, _reader->stats().vector_index_init_index_ns);
+    COUNTER_UPDATE(_vector_index_searcher_init_timer, _reader->stats().vector_index_searcher_init_ns);
+    COUNTER_UPDATE(_vector_index_cache_hit_counter, _reader->stats().vector_index_cache_hit_count);
+    COUNTER_UPDATE(_vector_index_cache_miss_counter, _reader->stats().vector_index_cache_miss_count);
     COUNTER_UPDATE(_vector_search_timer, _reader->stats().vector_search_timer);
     COUNTER_UPDATE(_process_vector_distance_and_id_timer, _reader->stats().process_vector_distance_and_id_timer);
     COUNTER_UPDATE(_block_seek_counter, _reader->stats().block_seek_num);

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -197,6 +197,8 @@ private:
     RuntimeProfile::Counter* _block_fetch_timer = nullptr;
     RuntimeProfile::Counter* _read_pages_num_counter = nullptr;
     RuntimeProfile::Counter* _cached_pages_num_counter = nullptr;
+    RuntimeProfile::Counter* _vector_index_timer = nullptr;
+    RuntimeProfile::Counter* _vector_index_load_timer = nullptr;
     RuntimeProfile::Counter* _get_row_ranges_by_vector_index_timer = nullptr;
     RuntimeProfile::Counter* _vector_index_cache_lookup_timer = nullptr;
     RuntimeProfile::Counter* _vector_index_file_open_timer = nullptr;

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -198,6 +198,13 @@ private:
     RuntimeProfile::Counter* _read_pages_num_counter = nullptr;
     RuntimeProfile::Counter* _cached_pages_num_counter = nullptr;
     RuntimeProfile::Counter* _get_row_ranges_by_vector_index_timer = nullptr;
+    RuntimeProfile::Counter* _vector_index_cache_lookup_timer = nullptr;
+    RuntimeProfile::Counter* _vector_index_file_open_timer = nullptr;
+    RuntimeProfile::Counter* _vector_index_read_file_timer = nullptr;
+    RuntimeProfile::Counter* _vector_index_init_index_timer = nullptr;
+    RuntimeProfile::Counter* _vector_index_searcher_init_timer = nullptr;
+    RuntimeProfile::Counter* _vector_index_cache_hit_counter = nullptr;
+    RuntimeProfile::Counter* _vector_index_cache_miss_counter = nullptr;
     RuntimeProfile::Counter* _vector_search_timer = nullptr;
     RuntimeProfile::Counter* _process_vector_distance_and_id_timer = nullptr;
     RuntimeProfile::Counter* _pushdown_predicates_counter = nullptr;

--- a/be/src/exec/tablet_scanner.cpp
+++ b/be/src/exec/tablet_scanner.cpp
@@ -386,6 +386,19 @@ void TabletScanner::update_counter() {
 
     COUNTER_UPDATE(_parent->_bi_filtered_counter, _reader->stats().rows_bitmap_index_filtered);
     COUNTER_UPDATE(_parent->_bi_filter_timer, _reader->stats().bitmap_index_filter_timer);
+    COUNTER_UPDATE(_parent->_get_row_ranges_by_vector_index_timer,
+                   _reader->stats().get_row_ranges_by_vector_index_timer);
+    COUNTER_UPDATE(_parent->_vector_index_cache_lookup_timer, _reader->stats().vector_index_cache_lookup_ns);
+    COUNTER_UPDATE(_parent->_vector_index_file_open_timer, _reader->stats().vector_index_file_open_ns);
+    COUNTER_UPDATE(_parent->_vector_index_read_file_timer, _reader->stats().vector_index_read_file_ns);
+    COUNTER_UPDATE(_parent->_vector_index_init_index_timer, _reader->stats().vector_index_init_index_ns);
+    COUNTER_UPDATE(_parent->_vector_index_searcher_init_timer, _reader->stats().vector_index_searcher_init_ns);
+    COUNTER_UPDATE(_parent->_vector_index_cache_hit_counter, _reader->stats().vector_index_cache_hit_count);
+    COUNTER_UPDATE(_parent->_vector_index_cache_miss_counter, _reader->stats().vector_index_cache_miss_count);
+    COUNTER_UPDATE(_parent->_vector_search_timer, _reader->stats().vector_search_timer);
+    COUNTER_UPDATE(_parent->_process_vector_distance_and_id_timer,
+                   _reader->stats().process_vector_distance_and_id_timer);
+    COUNTER_UPDATE(_parent->_vector_index_filtered_counter, _reader->stats().rows_vector_index_filtered);
     COUNTER_UPDATE(_parent->_block_seek_counter, _reader->stats().block_seek_num);
 
     COUNTER_UPDATE(_parent->_gin_filtered_timer, _reader->stats().gin_index_filter_ns);

--- a/be/src/exec/tablet_scanner.cpp
+++ b/be/src/exec/tablet_scanner.cpp
@@ -386,6 +386,9 @@ void TabletScanner::update_counter() {
 
     COUNTER_UPDATE(_parent->_bi_filtered_counter, _reader->stats().rows_bitmap_index_filtered);
     COUNTER_UPDATE(_parent->_bi_filter_timer, _reader->stats().bitmap_index_filter_timer);
+    COUNTER_UPDATE(_parent->_vector_index_timer,
+                   _reader->stats().vector_index_load_ns + _reader->stats().get_row_ranges_by_vector_index_timer);
+    COUNTER_UPDATE(_parent->_vector_index_load_timer, _reader->stats().vector_index_load_ns);
     COUNTER_UPDATE(_parent->_get_row_ranges_by_vector_index_timer,
                    _reader->stats().get_row_ranges_by_vector_index_timer);
     COUNTER_UPDATE(_parent->_vector_index_cache_lookup_timer, _reader->stats().vector_index_cache_lookup_ns);

--- a/be/src/storage/index/vector/empty_index_reader.h
+++ b/be/src/storage/index/vector/empty_index_reader.h
@@ -23,7 +23,8 @@ class EmptyIndexReader final : public VectorIndexReader {
 public:
     ~EmptyIndexReader() override = default;
 
-    Status init_searcher(const tenann::IndexMeta& /*meta*/, const FileInfo& /*vi_file*/) override {
+    Status init_searcher(const tenann::IndexMeta& /*meta*/, const FileInfo& /*vi_file*/,
+                         OlapReaderStatistics* /*stats*/ = nullptr) override {
         return Status::NotSupported("EmptyIndexReader does not support this operation");
     }
 

--- a/be/src/storage/index/vector/tenann_index_reader.cpp
+++ b/be/src/storage/index/vector/tenann_index_reader.cpp
@@ -35,9 +35,12 @@
 #ifdef WITH_TENANN
 #include "tenann_index_reader.h"
 
+#include <algorithm>
 #include <stdexcept>
 
+#include "base/utility/defer_op.h"
 #include "common/config_vector_index_fwd.h"
+#include "common/runtime_profile.h"
 #include "common/status.h"
 #include "common/statusor.h"
 #include "fs/fs.h"
@@ -46,6 +49,7 @@
 #include "runtime/runtime_env.h"
 #include "storage/index/vector/tenann/tenann_index_utils.h"
 #include "storage/index/vector/vector_index_file_reader.h"
+#include "storage_primitive/storage_stats.h"
 #include "tenann/common/error.h"
 #include "tenann/common/seq_view.h"
 #include "tenann/factory/index_factory.h"
@@ -73,7 +77,8 @@ void apply_index_reader_cache_options(tenann::IndexMeta* meta_copy) {
 
 } // namespace
 
-Status TenANNReader::init_searcher(const tenann::IndexMeta& meta, const FileInfo& vi_file) {
+Status TenANNReader::init_searcher(const tenann::IndexMeta& meta, const FileInfo& vi_file,
+                                   OlapReaderStatistics* stats) {
     const std::string& index_path = vi_file.path;
     auto* cache = tenann::GetGlobalIndexCache();
     if (cache == nullptr) {
@@ -104,12 +109,21 @@ Status TenANNReader::init_searcher(const tenann::IndexMeta& meta, const FileInfo
     // and surfaces the real Status to init_searcher's caller — preserves
     // NotFound for the brute-force fallback at vector_index_reader_factory.
     Status load_status;
-    auto loader = [&meta_copy, &vi_file, &index_path, cache, tracker, &load_status]() -> tenann::IndexRef {
+    bool loader_invoked = false;
+    int64_t loader_ns = 0;
+    auto loader = [&meta_copy, &vi_file, &index_path, cache, tracker, stats, &load_status, &loader_invoked,
+                   &loader_ns]() -> tenann::IndexRef {
+        loader_invoked = true;
+        SCOPED_RAW_TIMER(&loader_ns);
         SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(tracker);
         try {
             std::shared_ptr<VectorIndexFileReader> external_file_reader;
             if (vi_file.fs != nullptr) {
-                auto opened_or = VectorIndexFileReader::open(vi_file);
+                auto opened_or = [&]() {
+                    int64_t ignored_ns = 0;
+                    SCOPED_RAW_TIMER(stats != nullptr ? &stats->vector_index_file_open_ns : &ignored_ns);
+                    return VectorIndexFileReader::open(vi_file);
+                }();
                 if (!opened_or.ok()) {
                     load_status = opened_or.status();
                     return nullptr;
@@ -121,6 +135,13 @@ Status TenANNReader::init_searcher(const tenann::IndexMeta& meta, const FileInfo
             if (external_file_reader != nullptr) {
                 reader->SetFileReader(external_file_reader);
             }
+            DeferOp collect_read_stats([&] {
+                if (stats != nullptr) {
+                    const auto& read_stats = reader->read_timing_stats();
+                    stats->vector_index_read_file_ns += read_stats.read_file_ns;
+                    stats->vector_index_init_index_ns += read_stats.init_index_ns;
+                }
+            });
             auto index_ref = reader->ReadIndexFile(index_path);
             if (external_file_reader != nullptr) {
                 // Only the initial load needs the sequential stream; every later block read
@@ -138,34 +159,54 @@ Status TenANNReader::init_searcher(const tenann::IndexMeta& meta, const FileInfo
         }
     };
 
-    if (!cache->GetOrCreate(tenann::CacheKey(index_path), loader, &_cache_handle)) {
+    int64_t get_or_create_ns = 0;
+    bool cache_ok = false;
+    {
+        SCOPED_RAW_TIMER(&get_or_create_ns);
+        cache_ok = cache->GetOrCreate(tenann::CacheKey(index_path), loader, &_cache_handle);
+    }
+    if (stats != nullptr) {
+        // Exclude this caller's loader time so a cold leader reports cache bookkeeping,
+        // while a concurrent follower reports its singleflight wait.
+        stats->vector_index_cache_lookup_ns += std::max<int64_t>(0, get_or_create_ns - loader_ns);
+        if (loader_invoked) {
+            ++stats->vector_index_cache_miss_count;
+        } else {
+            ++stats->vector_index_cache_hit_count;
+        }
+    }
+    if (!cache_ok) {
         return !load_status.ok() ? load_status : Status::InternalError("failed to load vector index: " + index_path);
     }
 
-    try {
-        _searcher = tenann::AnnSearcherFactory::CreateSearcherFromMeta(meta_copy);
-        // AttachIndexRef skips the second cache lookup Searcher::ReadIndex
-        // would otherwise do — we already hold the ref from GetOrCreate.
-        _searcher->AttachIndexRef(_cache_handle.index_ref());
+    {
+        int64_t ignored_ns = 0;
+        SCOPED_RAW_TIMER(stats != nullptr ? &stats->vector_index_searcher_init_ns : &ignored_ns);
+        try {
+            _searcher = tenann::AnnSearcherFactory::CreateSearcherFromMeta(meta_copy);
+            // AttachIndexRef skips the second cache lookup Searcher::ReadIndex
+            // would otherwise do — we already hold the ref from GetOrCreate.
+            _searcher->AttachIndexRef(_cache_handle.index_ref());
 
-        // Hard-check in addition to tenann's internal DCHECK: a silent
-        // AttachIndex failure would yield wrong search results downstream.
-        if (!_searcher->is_index_loaded()) {
-            return Status::InternalError("vector index searcher did not finish loading: " + index_path);
+            // Hard-check in addition to tenann's internal DCHECK: a silent
+            // AttachIndex failure would yield wrong search results downstream.
+            if (!_searcher->is_index_loaded()) {
+                return Status::InternalError("vector index searcher did not finish loading: " + index_path);
+            }
+        } catch (const tenann::Error& e) {
+            return tenann_error_to_status(e);
+        } catch (const std::exception& e) {
+            return Status::InternalError(e.what());
         }
-    } catch (const tenann::Error& e) {
-        return tenann_error_to_status(e);
-    } catch (const std::exception& e) {
-        return Status::InternalError(e.what());
     }
     return Status::OK();
 }
 
 Status TenANNReader::init_searcher(const tenann::IndexMeta& meta, const FileInfo& vi_file, size_t segment_num_rows,
-                                   int query_k, bool user_set_ef) {
+                                   int query_k, bool user_set_ef, OlapReaderStatistics* stats) {
     auto adapted_meta = meta;
     apply_adaptive_ef_search(&adapted_meta, segment_num_rows, query_k, user_set_ef);
-    return init_searcher(adapted_meta, vi_file);
+    return init_searcher(adapted_meta, vi_file, stats);
 }
 
 Status TenANNReader::search(tenann::PrimitiveSeqView query_vector, int k, int64_t* result_ids,

--- a/be/src/storage/index/vector/tenann_index_reader.h
+++ b/be/src/storage/index/vector/tenann_index_reader.h
@@ -36,10 +36,12 @@ public:
 
     // vi_file.fs == nullptr reads vi_file.path from the local filesystem; otherwise
     // VectorIndexFileReader bridges tenann to that FileSystem.
-    Status init_searcher(const tenann::IndexMeta& meta, const FileInfo& vi_file) override;
+    Status init_searcher(const tenann::IndexMeta& meta, const FileInfo& vi_file,
+                         OlapReaderStatistics* stats = nullptr) override;
 
     Status init_searcher(const tenann::IndexMeta& meta, const FileInfo& vi_file, size_t segment_num_rows, int query_k,
-                         bool user_set_ef) override;
+                         bool user_set_ef,
+                         OlapReaderStatistics* stats = nullptr) override;
 
     Status search(tenann::PrimitiveSeqView query_vector, int k, int64_t* result_ids, uint8_t* result_distances,
                   tenann::IdFilter* id_filter = nullptr) override;

--- a/be/src/storage/index/vector/tenann_index_reader.h
+++ b/be/src/storage/index/vector/tenann_index_reader.h
@@ -40,8 +40,7 @@ public:
                          OlapReaderStatistics* stats = nullptr) override;
 
     Status init_searcher(const tenann::IndexMeta& meta, const FileInfo& vi_file, size_t segment_num_rows, int query_k,
-                         bool user_set_ef,
-                         OlapReaderStatistics* stats = nullptr) override;
+                         bool user_set_ef, OlapReaderStatistics* stats = nullptr) override;
 
     Status search(tenann::PrimitiveSeqView query_vector, int k, int64_t* result_ids, uint8_t* result_distances,
                   tenann::IdFilter* id_filter = nullptr) override;

--- a/be/src/storage/index/vector/vector_index_reader.h
+++ b/be/src/storage/index/vector/vector_index_reader.h
@@ -67,8 +67,7 @@ public:
     // Per-segment context for apply_adaptive_ef_search(). Default forwards
     // to the row-count-unaware form for readers without adaptive scaling.
     virtual Status init_searcher(const tenann::IndexMeta& meta, const FileInfo& vi_file, size_t segment_num_rows,
-                                 int query_k, bool user_set_ef,
-                                 OlapReaderStatistics* stats = nullptr) {
+                                 int query_k, bool user_set_ef, OlapReaderStatistics* stats = nullptr) {
         return init_searcher(meta, vi_file, stats);
     }
 

--- a/be/src/storage/index/vector/vector_index_reader.h
+++ b/be/src/storage/index/vector/vector_index_reader.h
@@ -44,6 +44,8 @@
 
 namespace starrocks {
 
+struct OlapReaderStatistics;
+
 class VectorIndexReader {
 public:
     VectorIndexReader() = default;
@@ -59,13 +61,15 @@ public:
     // resolved. A null `vi_file.fs` means read the path from the local filesystem. The
     // FileSystem is held by shared_ptr because the reader built from it is stored in the
     // tenann index cache and outlives the SegmentIterator that started the load.
-    virtual Status init_searcher(const tenann::IndexMeta& meta, const FileInfo& vi_file) = 0;
+    virtual Status init_searcher(const tenann::IndexMeta& meta, const FileInfo& vi_file,
+                                 OlapReaderStatistics* stats = nullptr) = 0;
 
     // Per-segment context for apply_adaptive_ef_search(). Default forwards
     // to the row-count-unaware form for readers without adaptive scaling.
     virtual Status init_searcher(const tenann::IndexMeta& meta, const FileInfo& vi_file, size_t segment_num_rows,
-                                 int query_k, bool user_set_ef) {
-        return init_searcher(meta, vi_file);
+                                 int query_k, bool user_set_ef,
+                                 OlapReaderStatistics* stats = nullptr) {
+        return init_searcher(meta, vi_file, stats);
     }
 
     virtual Status search(tenann::PrimitiveSeqView query_vector, int k, int64_t* result_ids, uint8_t* result_distances,

--- a/be/src/storage/index/vector/vector_index_reader_factory.cpp
+++ b/be/src/storage/index/vector/vector_index_reader_factory.cpp
@@ -15,16 +15,19 @@
 #ifdef WITH_TENANN
 #include "storage/index/vector/vector_index_reader_factory.h"
 
+#include "common/runtime_profile.h"
 #include "fs/fs.h"
 #include "storage/index/vector/empty_index_reader.h"
 #include "storage/index/vector/tenann_index_reader.h"
 #include "storage/index/vector/vector_index_reader.h"
+#include "storage_primitive/storage_stats.h"
 #include "tenann/index/index_cache.h"
 
 namespace starrocks {
 
 static Status create_from_file_impl(FileInfo* vi_file, const std::shared_ptr<tenann::IndexMeta>& /*index_meta*/,
-                                    std::shared_ptr<VectorIndexReader>* vector_index_reader) {
+                                    std::shared_ptr<VectorIndexReader>* vector_index_reader,
+                                    OlapReaderStatistics* stats) {
     const std::string& index_path = vi_file->path;
     // Warm path: an entry in the cache means the .vi file exists and is not
     // an empty-mark placeholder, so we can skip the OSS/S3 HEAD round-trips
@@ -32,31 +35,42 @@ static Status create_from_file_impl(FileInfo* vi_file, const std::shared_ptr<ten
     auto* cache = tenann::GetGlobalIndexCache();
     if (cache != nullptr) {
         tenann::IndexCacheHandle probe;
-        if (cache->Lookup(tenann::CacheKey(index_path), &probe)) {
+        bool cache_hit = false;
+        {
+            int64_t ignored_ns = 0;
+            SCOPED_RAW_TIMER(stats != nullptr ? &stats->vector_index_cache_lookup_ns : &ignored_ns);
+            cache_hit = cache->Lookup(tenann::CacheKey(index_path), &probe);
+        }
+        if (cache_hit) {
             (*vector_index_reader) = std::make_shared<TenANNReader>();
             return Status::OK();
         }
     }
 
     std::unique_ptr<RandomAccessFile> index_file;
-    if (vi_file->fs != nullptr) {
-        // Remote FS: let new_random_access_file() be the single source of truth for
-        // NotFound. Doing a separate path_exists() here would cost an extra round-trip.
-        auto file_or = vi_file->fs->new_random_access_file(index_path);
-        if (!file_or.ok()) {
-            if (file_or.status().is_not_found()) {
+    uint64_t file_size = 0;
+    {
+        int64_t ignored_ns = 0;
+        SCOPED_RAW_TIMER(stats != nullptr ? &stats->vector_index_file_open_ns : &ignored_ns);
+        if (vi_file->fs != nullptr) {
+            // Remote FS: let new_random_access_file() be the single source of truth for
+            // NotFound. Doing a separate path_exists() here would cost an extra round-trip.
+            auto file_or = vi_file->fs->new_random_access_file(index_path);
+            if (!file_or.ok()) {
+                if (file_or.status().is_not_found()) {
+                    return Status::NotFound(fmt::format("index path {} not found", index_path));
+                }
+                return file_or.status();
+            }
+            index_file = std::move(file_or).value();
+        } else {
+            if (!fs::path_exist(index_path)) {
                 return Status::NotFound(fmt::format("index path {} not found", index_path));
             }
-            return file_or.status();
+            ASSIGN_OR_RETURN(index_file, fs::new_random_access_file(index_path));
         }
-        index_file = std::move(file_or).value();
-    } else {
-        if (!fs::path_exist(index_path)) {
-            return Status::NotFound(fmt::format("index path {} not found", index_path));
-        }
-        ASSIGN_OR_RETURN(index_file, fs::new_random_access_file(index_path));
+        ASSIGN_OR_RETURN(file_size, index_file->get_size());
     }
-    ASSIGN_OR_RETURN(auto file_size, index_file->get_size());
     // Hand the resolved size to init_searcher so it does not HEAD/stat the same file again.
     vi_file->size = file_size;
 
@@ -75,8 +89,9 @@ static Status create_from_file_impl(FileInfo* vi_file, const std::shared_ptr<ten
 
 Status VectorIndexReaderFactory::create_from_file(FileInfo* vi_file,
                                                   const std::shared_ptr<tenann::IndexMeta>& index_meta,
-                                                  std::shared_ptr<VectorIndexReader>* vector_index_reader) {
-    return create_from_file_impl(vi_file, index_meta, vector_index_reader);
+                                                  std::shared_ptr<VectorIndexReader>* vector_index_reader,
+                                                  OlapReaderStatistics* stats) {
+    return create_from_file_impl(vi_file, index_meta, vector_index_reader, stats);
 }
 
 } // namespace starrocks

--- a/be/src/storage/index/vector/vector_index_reader_factory.h
+++ b/be/src/storage/index/vector/vector_index_reader_factory.h
@@ -21,6 +21,8 @@
 
 namespace starrocks {
 
+struct OlapReaderStatistics;
+
 class VectorIndexReaderFactory {
 #ifdef WITH_TENANN
 public:
@@ -30,7 +32,8 @@ public:
     // file is never opened and size stays unset — VectorIndexFileReader::open() resolves it
     // lazily if the entry happens to be evicted before init_searcher runs.
     static Status create_from_file(FileInfo* vi_file, const std::shared_ptr<tenann::IndexMeta>& index_meta,
-                                   std::shared_ptr<VectorIndexReader>* vector_index_reader);
+                                   std::shared_ptr<VectorIndexReader>* vector_index_reader,
+                                   OlapReaderStatistics* stats = nullptr);
 #endif
 };
 

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -825,6 +825,17 @@ Status TabletReader::refine_initial_coarse_split_and_append_refined_tasks(const 
     _stats.lake_prepared_seed_io_ns += prepare_stats.io_ns;
     _stats.lake_prepared_seed_io_count += prepare_stats.io_count;
     _stats.lake_prepared_seed_segment_init_ns += prepare_stats.segment_init_ns;
+    _stats.lake_prepared_seed_get_row_ranges_by_vector_index_ns += prepare_stats.get_row_ranges_by_vector_index_timer;
+    _stats.lake_prepared_seed_vector_index_cache_lookup_ns += prepare_stats.vector_index_cache_lookup_ns;
+    _stats.lake_prepared_seed_vector_index_file_open_ns += prepare_stats.vector_index_file_open_ns;
+    _stats.lake_prepared_seed_vector_index_read_file_ns += prepare_stats.vector_index_read_file_ns;
+    _stats.lake_prepared_seed_vector_index_init_index_ns += prepare_stats.vector_index_init_index_ns;
+    _stats.lake_prepared_seed_vector_index_searcher_init_ns += prepare_stats.vector_index_searcher_init_ns;
+    _stats.lake_prepared_seed_vector_index_cache_hit_count += prepare_stats.vector_index_cache_hit_count;
+    _stats.lake_prepared_seed_vector_index_cache_miss_count += prepare_stats.vector_index_cache_miss_count;
+    _stats.lake_prepared_seed_vector_search_ns += prepare_stats.vector_search_timer;
+    _stats.lake_prepared_seed_process_vector_distance_and_id_ns += prepare_stats.process_vector_distance_and_id_timer;
+    _stats.lake_prepared_seed_rows_vector_index_filtered += prepare_stats.rows_vector_index_filtered;
     _stats.lake_prepared_seed_zonemap_ns += prepare_stats.zone_map_filter_ns;
     _stats.lake_prepared_seed_zonemap_filtered_rows += prepare_stats.rows_stats_filtered;
     _stats.lake_prepared_seed_bf_ns += prepare_stats.bf_filter_ns;

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -825,6 +825,7 @@ Status TabletReader::refine_initial_coarse_split_and_append_refined_tasks(const 
     _stats.lake_prepared_seed_io_ns += prepare_stats.io_ns;
     _stats.lake_prepared_seed_io_count += prepare_stats.io_count;
     _stats.lake_prepared_seed_segment_init_ns += prepare_stats.segment_init_ns;
+    _stats.lake_prepared_seed_vector_index_load_ns += prepare_stats.vector_index_load_ns;
     _stats.lake_prepared_seed_get_row_ranges_by_vector_index_ns += prepare_stats.get_row_ranges_by_vector_index_timer;
     _stats.lake_prepared_seed_vector_index_cache_lookup_ns += prepare_stats.vector_index_cache_lookup_ns;
     _stats.lake_prepared_seed_vector_index_file_open_ns += prepare_stats.vector_index_file_open_ns;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1257,7 +1257,7 @@ inline Status SegmentIterator::_init_reader_from_file(FileInfo* vi_file,
     _vector_index_ctx->index_meta = std::make_shared<tenann::IndexMeta>(std::move(meta));
     // create_from_file backfills vi_file->size on the cold path; init_searcher reuses it.
     auto create_st = VectorIndexReaderFactory::create_from_file(vi_file, _vector_index_ctx->index_meta,
-                                                                &_vector_index_ctx->ann_reader);
+                                                                &_vector_index_ctx->ann_reader, _opts.stats);
     // .vi file not found — caller will set up brute-force fallback
     if (create_st.is_not_found()) {
         _vector_index_ctx->use_vector_index = false;
@@ -1278,7 +1278,7 @@ inline Status SegmentIterator::_init_reader_from_file(FileInfo* vi_file,
     }
     Status status = _vector_index_ctx->ann_reader->init_searcher(*_vector_index_ctx->index_meta.get(), *vi_file,
                                                                  static_cast<size_t>(_segment->num_rows()),
-                                                                 _vector_index_ctx->k, user_set_ef);
+                                                                 _vector_index_ctx->k, user_set_ef, _opts.stats);
     // empty ann reader — caller will set up brute-force fallback
     if (status.is_not_supported()) {
         _vector_index_ctx->use_vector_index = false;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1396,7 +1396,10 @@ Status SegmentIterator::_init_ann_reader() {
             vi_file.fs = _segment->shared_file_system();
         }
         // Turns off use_vector_index on a runtime NotFound / not-supported.
-        RETURN_IF_ERROR(_init_reader_from_file(&vi_file, tablet_index_meta, _vector_index_ctx->query_params));
+        {
+            SCOPED_RAW_TIMER(&_opts.stats->vector_index_load_ns);
+            RETURN_IF_ERROR(_init_reader_from_file(&vi_file, tablet_index_meta, _vector_index_ctx->query_params));
+        }
 #else
         _vector_index_ctx->use_vector_index = false; // no TenANN
 #endif

--- a/be/src/storage_primitive/storage_stats.h
+++ b/be/src/storage_primitive/storage_stats.h
@@ -101,6 +101,13 @@ struct OlapReaderStatistics {
     int64_t rows_bitmap_index_filtered = 0;
     int64_t bitmap_index_filter_timer = 0;
     int64_t get_row_ranges_by_vector_index_timer = 0;
+    int64_t vector_index_cache_lookup_ns = 0;
+    int64_t vector_index_file_open_ns = 0;
+    int64_t vector_index_read_file_ns = 0;
+    int64_t vector_index_init_index_ns = 0;
+    int64_t vector_index_searcher_init_ns = 0;
+    int64_t vector_index_cache_hit_count = 0;
+    int64_t vector_index_cache_miss_count = 0;
     int64_t vector_search_timer = 0;
     int64_t process_vector_distance_and_id_timer = 0;
 
@@ -165,6 +172,17 @@ struct OlapReaderStatistics {
     int64_t lake_prepared_seed_io_ns = 0;
     int64_t lake_prepared_seed_io_count = 0;
     int64_t lake_prepared_seed_segment_init_ns = 0;
+    int64_t lake_prepared_seed_get_row_ranges_by_vector_index_ns = 0;
+    int64_t lake_prepared_seed_vector_index_cache_lookup_ns = 0;
+    int64_t lake_prepared_seed_vector_index_file_open_ns = 0;
+    int64_t lake_prepared_seed_vector_index_read_file_ns = 0;
+    int64_t lake_prepared_seed_vector_index_init_index_ns = 0;
+    int64_t lake_prepared_seed_vector_index_searcher_init_ns = 0;
+    int64_t lake_prepared_seed_vector_index_cache_hit_count = 0;
+    int64_t lake_prepared_seed_vector_index_cache_miss_count = 0;
+    int64_t lake_prepared_seed_vector_search_ns = 0;
+    int64_t lake_prepared_seed_process_vector_distance_and_id_ns = 0;
+    int64_t lake_prepared_seed_rows_vector_index_filtered = 0;
     int64_t lake_prepared_seed_zonemap_ns = 0;
     int64_t lake_prepared_seed_zonemap_filtered_rows = 0;
     int64_t lake_prepared_seed_bf_ns = 0;

--- a/be/src/storage_primitive/storage_stats.h
+++ b/be/src/storage_primitive/storage_stats.h
@@ -100,6 +100,7 @@ struct OlapReaderStatistics {
 
     int64_t rows_bitmap_index_filtered = 0;
     int64_t bitmap_index_filter_timer = 0;
+    int64_t vector_index_load_ns = 0;
     int64_t get_row_ranges_by_vector_index_timer = 0;
     int64_t vector_index_cache_lookup_ns = 0;
     int64_t vector_index_file_open_ns = 0;
@@ -172,6 +173,7 @@ struct OlapReaderStatistics {
     int64_t lake_prepared_seed_io_ns = 0;
     int64_t lake_prepared_seed_io_count = 0;
     int64_t lake_prepared_seed_segment_init_ns = 0;
+    int64_t lake_prepared_seed_vector_index_load_ns = 0;
     int64_t lake_prepared_seed_get_row_ranges_by_vector_index_ns = 0;
     int64_t lake_prepared_seed_vector_index_cache_lookup_ns = 0;
     int64_t lake_prepared_seed_vector_index_file_open_ns = 0;

--- a/be/test/connector/lake/lake_data_source_test.cpp
+++ b/be/test/connector/lake/lake_data_source_test.cpp
@@ -1453,6 +1453,34 @@ TEST_F(LakeDataSourceTest, init_counter_registers_prepared_split_counters) {
             EXPECT_EQ(c->value(), 0) << name;
         }
     }
+    for (const auto* name : {"GetVectorRowRangesTime",
+                             "VectorIndexCacheLookupTime",
+                             "VectorIndexFileOpenTime",
+                             "VectorIndexReadFileTime",
+                             "VectorIndexInitIndexTime",
+                             "VectorIndexSearcherInitTime",
+                             "VectorIndexCacheHitCount",
+                             "VectorIndexCacheMissCount",
+                             "VectorSearchTime",
+                             "ProcessVectorDistanceAndIdTime",
+                             "VectorIndexFilterRows",
+                             "SeedGetVectorRowRangesTime",
+                             "SeedVectorIndexCacheLookupTime",
+                             "SeedVectorIndexFileOpenTime",
+                             "SeedVectorIndexReadFileTime",
+                             "SeedVectorIndexInitIndexTime",
+                             "SeedVectorIndexSearcherInitTime",
+                             "SeedVectorIndexCacheHitCount",
+                             "SeedVectorIndexCacheMissCount",
+                             "SeedVectorSearchTime",
+                             "SeedProcessVectorDistanceAndIdTime",
+                             "SeedVectorIndexFilterRows"}) {
+        auto* c = profile->get_counter(name);
+        EXPECT_NE(c, nullptr) << name;
+        if (c != nullptr) {
+            EXPECT_EQ(c->value(), 0) << name;
+        }
+    }
 }
 
 TEST_F(LakeDataSourceTest, reopen_reader_requires_initialized_reader) {

--- a/be/test/connector/lake/lake_data_source_test.cpp
+++ b/be/test/connector/lake/lake_data_source_test.cpp
@@ -16,6 +16,7 @@
 
 #include <array>
 #include <atomic>
+#include <sstream>
 #include <vector>
 
 #include "base/testutil/assert.h"
@@ -1453,27 +1454,31 @@ TEST_F(LakeDataSourceTest, init_counter_registers_prepared_split_counters) {
             EXPECT_EQ(c->value(), 0) << name;
         }
     }
-    for (const auto* name : {"GetVectorRowRangesTime",
-                             "VectorIndexCacheLookupTime",
-                             "VectorIndexFileOpenTime",
-                             "VectorIndexReadFileTime",
-                             "VectorIndexInitIndexTime",
-                             "VectorIndexSearcherInitTime",
-                             "VectorIndexCacheHitCount",
-                             "VectorIndexCacheMissCount",
-                             "VectorSearchTime",
-                             "ProcessVectorDistanceAndIdTime",
+    for (const auto* name : {"VectorIndex",
+                             "VectorIndexLoad",
+                             "VectorIndexSearch",
+                             "VectorIndexCacheLookup",
+                             "VectorIndexFileOpenAndGetSize",
+                             "VectorIndexFileRead",
+                             "VectorIndexDeserialize",
+                             "VectorIndexSearcherCreate",
+                             "VectorIndexCacheHit",
+                             "VectorIndexCacheMiss",
+                             "VectorANNSearch",
+                             "VectorResultProcess",
                              "VectorIndexFilterRows",
-                             "SeedGetVectorRowRangesTime",
-                             "SeedVectorIndexCacheLookupTime",
-                             "SeedVectorIndexFileOpenTime",
-                             "SeedVectorIndexReadFileTime",
-                             "SeedVectorIndexInitIndexTime",
-                             "SeedVectorIndexSearcherInitTime",
-                             "SeedVectorIndexCacheHitCount",
-                             "SeedVectorIndexCacheMissCount",
-                             "SeedVectorSearchTime",
-                             "SeedProcessVectorDistanceAndIdTime",
+                             "SeedVectorIndex",
+                             "SeedVectorIndexLoad",
+                             "SeedVectorIndexSearch",
+                             "SeedVectorIndexCacheLookup",
+                             "SeedVectorIndexFileOpenAndGetSize",
+                             "SeedVectorIndexFileRead",
+                             "SeedVectorIndexDeserialize",
+                             "SeedVectorIndexSearcherCreate",
+                             "SeedVectorIndexCacheHit",
+                             "SeedVectorIndexCacheMiss",
+                             "SeedVectorANNSearch",
+                             "SeedVectorResultProcess",
                              "SeedVectorIndexFilterRows"}) {
         auto* c = profile->get_counter(name);
         EXPECT_NE(c, nullptr) << name;
@@ -1481,6 +1486,23 @@ TEST_F(LakeDataSourceTest, init_counter_registers_prepared_split_counters) {
             EXPECT_EQ(c->value(), 0) << name;
         }
     }
+
+    std::stringstream rendered;
+    profile->pretty_print(&rendered);
+    const auto text = rendered.str();
+    EXPECT_NE(text.find("     - VectorIndex: 0.000ns\n"
+                        "       - VectorIndexLoad: 0.000ns\n"),
+              std::string::npos)
+            << text;
+    EXPECT_NE(text.find("         - VectorIndexCacheLookup: 0.000ns\n"
+                        "           - VectorIndexCacheHit: 0\n"
+                        "           - VectorIndexCacheMiss: 0\n"),
+              std::string::npos)
+            << text;
+    EXPECT_NE(text.find("       - VectorIndexSearch: 0.000ns\n"
+                        "         - VectorANNSearch: 0.000ns\n"),
+              std::string::npos)
+            << text;
 }
 
 TEST_F(LakeDataSourceTest, reopen_reader_requires_initialized_reader) {

--- a/be/test/exec/pipeline/olap_scan_operator_test.cpp
+++ b/be/test/exec/pipeline/olap_scan_operator_test.cpp
@@ -18,13 +18,43 @@
 #include "exec/exec_env.h"
 #include "exec/olap_scan_node.h"
 #include "exec/pipeline/query_context.h"
+#include "exec/pipeline/scan/olap_chunk_source.h"
 #include "exec/pipeline/scan/olap_scan_prepare_operator.h"
+#include "exec_primitive/pipeline/scan/scan_morsel.h"
 #include "gtest/gtest.h"
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
 #include "storage/query/olap_fixed_morsel_queue.h"
 
 namespace starrocks::pipeline {
+
+namespace {
+
+void expect_vector_index_counter(RuntimeProfile* profile, const char* name, const char* parent) {
+    auto it = profile->_counter_map.find(name);
+    ASSERT_NE(it, profile->_counter_map.end()) << name;
+    EXPECT_EQ(it->second.second, parent) << name;
+    EXPECT_EQ(it->second.first->value(), 0) << name;
+}
+
+void expect_vector_index_counters(RuntimeProfile* profile) {
+    ASSERT_NE(profile, nullptr);
+    expect_vector_index_counter(profile, "VectorIndex", "SegmentInit");
+    expect_vector_index_counter(profile, "VectorIndexLoad", "VectorIndex");
+    expect_vector_index_counter(profile, "VectorIndexCacheLookup", "VectorIndexLoad");
+    expect_vector_index_counter(profile, "VectorIndexFileOpenAndGetSize", "VectorIndexLoad");
+    expect_vector_index_counter(profile, "VectorIndexFileRead", "VectorIndexLoad");
+    expect_vector_index_counter(profile, "VectorIndexDeserialize", "VectorIndexLoad");
+    expect_vector_index_counter(profile, "VectorIndexSearcherCreate", "VectorIndexLoad");
+    expect_vector_index_counter(profile, "VectorIndexCacheHit", "VectorIndexCacheLookup");
+    expect_vector_index_counter(profile, "VectorIndexCacheMiss", "VectorIndexCacheLookup");
+    expect_vector_index_counter(profile, "VectorIndexSearch", "VectorIndex");
+    expect_vector_index_counter(profile, "VectorANNSearch", "VectorIndexSearch");
+    expect_vector_index_counter(profile, "VectorResultProcess", "VectorIndexSearch");
+    expect_vector_index_counter(profile, "VectorIndexFilterRows", "VectorIndexSearch");
+}
+
+} // namespace
 
 class OlapScanOperatorTest : public ::testing::Test {
 public:
@@ -118,6 +148,35 @@ TEST_F(OlapScanOperatorTest, test_finish_sequence) {
     scan_node.close(&_runtime_state);
 
     SyncPoint::GetInstance()->DisableProcessing();
+}
+
+TEST_F(OlapScanOperatorTest, legacy_scan_registers_vector_index_counters) {
+    OlapScanNode scan_node(&_object_pool, _tnode, *_tbl);
+    // Legacy Gin counters still attach to the node profile instead of the scan profile.
+    ADD_TIMER(scan_node._runtime_profile, "SegmentInit");
+
+    scan_node._init_counter(&_runtime_state);
+
+    expect_vector_index_counters(scan_node._scan_profile);
+    scan_node.close(&_runtime_state);
+}
+
+TEST_F(OlapScanOperatorTest, pipeline_chunk_source_registers_vector_index_counters) {
+    OlapScanNode scan_node(&_object_pool, _tnode, *_tbl);
+    auto scan_ctx_factory =
+            std::make_shared<OlapScanContextFactory>(&scan_node, 1, false, false, std::move(_chunk_buffer_limiter));
+    OlapScanOperatorFactory scan_operator_factory(1, &scan_node, scan_ctx_factory);
+    auto scan_operator = std::make_shared<OlapScanOperator>(&scan_operator_factory, 1, 0, 1, &scan_node,
+                                                            scan_ctx_factory->get_or_create(0));
+    TScanRange scan_range;
+    auto chunk_source = scan_operator->create_chunk_source(std::make_unique<ScanMorsel>(1, scan_range), 0);
+    auto* olap_chunk_source = down_cast<OlapChunkSource*>(chunk_source.get());
+
+    ASSERT_TRUE(olap_chunk_source->ChunkSource::prepare(&_runtime_state).ok());
+    olap_chunk_source->_init_counter(&_runtime_state);
+
+    expect_vector_index_counters(olap_chunk_source->_runtime_profile);
+    scan_node.close(&_runtime_state);
 }
 
 } // namespace starrocks::pipeline

--- a/be/test/storage/index/vector/vector_index_cache_test.cpp
+++ b/be/test/storage/index/vector/vector_index_cache_test.cpp
@@ -37,6 +37,7 @@
 #include "storage/index/vector/tenann_index_reader.h"
 #include "storage/index/vector/vector_index_cache_metrics.h"
 #include "storage/index/vector/vector_index_file_reader.h"
+#include "storage_primitive/storage_stats.h"
 #include "tenann/common/error.h"
 #include "tenann/index/index.h"
 #include "tenann/index/index_cache.h"
@@ -509,8 +510,14 @@ TEST(TenANNReaderTest, InitSearcher_FileNotFoundViaFs_PropagatesNotFound) {
     MemoryFileSystem fs;
     TenANNReader r;
     auto meta = make_minimal_meta();
-    auto st = r.init_searcher(meta, remote_vi("/no/such/index.vi", &fs));
+    OlapReaderStatistics stats;
+    auto st = r.init_searcher(meta, remote_vi("/no/such/index.vi", &fs), &stats);
     EXPECT_TRUE(st.is_not_found()) << st.to_string();
+    EXPECT_EQ(0, stats.vector_index_cache_hit_count);
+    EXPECT_EQ(1, stats.vector_index_cache_miss_count);
+    EXPECT_GT(stats.vector_index_file_open_ns, 0);
+    EXPECT_EQ(0, stats.vector_index_read_file_ns);
+    EXPECT_EQ(0, stats.vector_index_init_index_ns);
 
     tenann::SetGlobalIndexCache(saved);
 }

--- a/be/test/storage/index/vector_search_test.cpp
+++ b/be/test/storage/index/vector_search_test.cpp
@@ -58,6 +58,7 @@
 #include "storage/index/index_descriptor.h"
 #include "storage/index/vector/tenann/del_id_filter.h"
 #include "storage/index/vector/tenann/tenann_index_utils.h"
+#include "storage/index/vector/vector_index_cache.h"
 #include "storage/index/vector/vector_index_reader.h"
 #include "storage/index/vector/vector_index_reader_factory.h"
 #include "storage/index/vector/vector_index_writer.h"
@@ -79,6 +80,7 @@
 #include "storage_primitive/predicate_tree/predicate_tree.h"
 #include "storage_primitive/roaring2range.h"
 #include "storage_primitive/schema_helper.h"
+#include "storage_primitive/storage_stats.h"
 #include "storage_primitive/vector_search_option.h"
 #include "testutil/exprs_test_helper.h"
 #include "types/logical_type.h"
@@ -418,6 +420,54 @@ TEST_F(VectorIndexSearchTest, tenann_reader_init_searcher_null_fs_delegates_to_l
     } catch (tenann::Error& e) {
         LOG(WARNING) << e.what();
     }
+}
+
+TEST_F(VectorIndexSearchTest, reports_index_load_timing_and_query_cache_hit_miss) {
+    auto tablet_index = prepare_tablet_index();
+    tablet_index->add_common_properties("index_type", "hnsw");
+    tablet_index->add_common_properties("dim", "3");
+    tablet_index->add_common_properties("is_vector_normed", "false");
+    tablet_index->add_common_properties("metric_type", "l2_distance");
+    tablet_index->add_common_properties("index_build_threshold", "0");
+    tablet_index->add_index_properties("efconstruction", "40");
+    tablet_index->add_index_properties("m", "16");
+    tablet_index->add_search_properties("efsearch", "40");
+
+    const auto index_path = test_vector_index_dir + "/profile_stats_hnsw.vi";
+    write_vector_index(index_path, tablet_index);
+    const auto empty_query_params = std::map<std::string, std::string>{};
+    ASSIGN_OR_ABORT(auto meta, get_vector_meta(tablet_index, empty_query_params));
+    auto index_meta = std::make_shared<tenann::IndexMeta>(std::move(meta));
+
+    MemTracker cache_tracker(-1, "vector_index_profile_test");
+    VectorIndexCache cache(/*capacity=*/64 * 1024 * 1024, &cache_tracker);
+    auto* saved_cache = tenann::GetGlobalIndexCache();
+    tenann::SetGlobalIndexCache(&cache);
+    DeferOp restore_cache([&] { tenann::SetGlobalIndexCache(saved_cache); });
+
+    OlapReaderStatistics cold_stats;
+    std::shared_ptr<VectorIndexReader> cold_reader;
+    ASSERT_OK(VectorIndexReaderFactory::create_from_file(index_path, index_meta, &cold_reader, _fs.get(), &cold_stats));
+    ASSERT_OK(cold_reader->init_searcher(*index_meta, index_path, _fs.get(), &cold_stats));
+    EXPECT_EQ(0, cold_stats.vector_index_cache_hit_count);
+    EXPECT_EQ(1, cold_stats.vector_index_cache_miss_count);
+    EXPECT_GT(cold_stats.vector_index_cache_lookup_ns, 0);
+    EXPECT_GT(cold_stats.vector_index_file_open_ns, 0);
+    EXPECT_GT(cold_stats.vector_index_read_file_ns, 0);
+    EXPECT_GT(cold_stats.vector_index_init_index_ns, 0);
+    EXPECT_GT(cold_stats.vector_index_searcher_init_ns, 0);
+
+    OlapReaderStatistics warm_stats;
+    std::shared_ptr<VectorIndexReader> warm_reader;
+    ASSERT_OK(VectorIndexReaderFactory::create_from_file(index_path, index_meta, &warm_reader, _fs.get(), &warm_stats));
+    ASSERT_OK(warm_reader->init_searcher(*index_meta, index_path, _fs.get(), &warm_stats));
+    EXPECT_EQ(1, warm_stats.vector_index_cache_hit_count);
+    EXPECT_EQ(0, warm_stats.vector_index_cache_miss_count);
+    EXPECT_GT(warm_stats.vector_index_cache_lookup_ns, 0);
+    EXPECT_EQ(0, warm_stats.vector_index_file_open_ns);
+    EXPECT_EQ(0, warm_stats.vector_index_read_file_ns);
+    EXPECT_EQ(0, warm_stats.vector_index_init_index_ns);
+    EXPECT_GT(warm_stats.vector_index_searcher_init_ns, 0);
 }
 
 #endif // WITH_TENANN

--- a/be/test/storage/index/vector_search_test.cpp
+++ b/be/test/storage/index/vector_search_test.cpp
@@ -446,9 +446,10 @@ TEST_F(VectorIndexSearchTest, reports_index_load_timing_and_query_cache_hit_miss
     DeferOp restore_cache([&] { tenann::SetGlobalIndexCache(saved_cache); });
 
     OlapReaderStatistics cold_stats;
+    FileInfo cold_vi_file{.path = index_path, .fs = _fs};
     std::shared_ptr<VectorIndexReader> cold_reader;
-    ASSERT_OK(VectorIndexReaderFactory::create_from_file(index_path, index_meta, &cold_reader, _fs.get(), &cold_stats));
-    ASSERT_OK(cold_reader->init_searcher(*index_meta, index_path, _fs.get(), &cold_stats));
+    ASSERT_OK(VectorIndexReaderFactory::create_from_file(&cold_vi_file, index_meta, &cold_reader, &cold_stats));
+    ASSERT_OK(cold_reader->init_searcher(*index_meta, cold_vi_file, &cold_stats));
     EXPECT_EQ(0, cold_stats.vector_index_cache_hit_count);
     EXPECT_EQ(1, cold_stats.vector_index_cache_miss_count);
     EXPECT_GT(cold_stats.vector_index_cache_lookup_ns, 0);
@@ -458,9 +459,10 @@ TEST_F(VectorIndexSearchTest, reports_index_load_timing_and_query_cache_hit_miss
     EXPECT_GT(cold_stats.vector_index_searcher_init_ns, 0);
 
     OlapReaderStatistics warm_stats;
+    FileInfo warm_vi_file{.path = index_path, .fs = _fs};
     std::shared_ptr<VectorIndexReader> warm_reader;
-    ASSERT_OK(VectorIndexReaderFactory::create_from_file(index_path, index_meta, &warm_reader, _fs.get(), &warm_stats));
-    ASSERT_OK(warm_reader->init_searcher(*index_meta, index_path, _fs.get(), &warm_stats));
+    ASSERT_OK(VectorIndexReaderFactory::create_from_file(&warm_vi_file, index_meta, &warm_reader, &warm_stats));
+    ASSERT_OK(warm_reader->init_searcher(*index_meta, warm_vi_file, &warm_stats));
     EXPECT_EQ(1, warm_stats.vector_index_cache_hit_count);
     EXPECT_EQ(0, warm_stats.vector_index_cache_miss_count);
     EXPECT_GT(warm_stats.vector_index_cache_lookup_ns, 0);
@@ -1780,6 +1782,8 @@ protected:
     struct ResidualCaseResult {
         std::vector<int64_t> ids;
         std::vector<float> distances; // appended ANN distance column values, when present
+        int64_t load_ns = -1;
+        int64_t vector_stage_ns = -1;
         int64_t search_ns = -1;
         int64_t raw_rows_read = -1;
         int64_t del_pruned = -1;   // rows the delete-predicate zone-map prune skipped from row-level eval
@@ -1999,6 +2003,8 @@ protected:
         }
         it->close();
         result->ids = got;
+        result->load_ns = stats.vector_index_load_ns;
+        result->vector_stage_ns = stats.get_row_ranges_by_vector_index_timer;
         // vector_search_timer accumulates ONLY inside the ANN search block; it stays exactly 0 when the
         // cardinality short-circuit skipped the search (a deterministic marker, not a timing assertion).
         result->search_ns = stats.vector_search_timer;
@@ -2203,6 +2209,8 @@ TEST_F(VectorResidualPrefilterTest, residual_with_predicate_col_late_materialize
     ResidualCaseResult res;
     run_residual_case(make_ge4_tree(pred), /*above_predicate=*/false, &res, /*pred_col_late_mat=*/true);
     EXPECT_EQ(res.ids, (std::vector<int64_t>{4, 5, 6}));
+    EXPECT_GT(res.load_ns, 0);
+    EXPECT_GT(res.vector_stage_ns, 0);
 }
 
 // `filter_col >= <value>` variant of make_ge4_tree, for the short-circuit cardinality cases.

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileKeyDictionary.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileKeyDictionary.java
@@ -178,7 +178,20 @@ public final class ProfileKeyDictionary {
     public static final String SHORT_KEY_RANGE_NUMBER = "ShortKeyRangeNumber";
     public static final String BITMAP_INDEX_FILTER_ROWS = "BitmapIndexFilterRows";
     public static final String BLOOM_FILTER_ROWS = "BloomFilterRows";
+    public static final String VECTOR_INDEX = "VectorIndex";
+    public static final String VECTOR_INDEX_LOAD = "VectorIndexLoad";
+    public static final String VECTOR_INDEX_CACHE_LOOKUP = "VectorIndexCacheLookup";
+    public static final String VECTOR_INDEX_FILE_OPEN_AND_GET_SIZE = "VectorIndexFileOpenAndGetSize";
+    public static final String VECTOR_INDEX_FILE_READ = "VectorIndexFileRead";
+    public static final String VECTOR_INDEX_DESERIALIZE = "VectorIndexDeserialize";
+    public static final String VECTOR_INDEX_SEARCHER_CREATE = "VectorIndexSearcherCreate";
+    public static final String VECTOR_INDEX_CACHE_HIT = "VectorIndexCacheHit";
+    public static final String VECTOR_INDEX_CACHE_MISS = "VectorIndexCacheMiss";
+    public static final String VECTOR_INDEX_SEARCH = "VectorIndexSearch";
+    public static final String VECTOR_ANN_SEARCH = "VectorANNSearch";
+    public static final String VECTOR_RESULT_PROCESS = "VectorResultProcess";
     public static final String VECTOR_INDEX_FILTER_ROWS = "VectorIndexFilterRows";
+    // Kept in the static dictionary so profiles collected from an older BE during rolling upgrade remain compact.
     public static final String VECTOR_SEARCH_TIME = "VectorSearchTime";
     public static final String ROWSETS_READ_COUNT = "RowsetsReadCount";
     public static final String SEGMENTS_READ_COUNT = "SegmentsReadCount";
@@ -370,6 +383,18 @@ public final class ProfileKeyDictionary {
             SHORT_KEY_RANGE_NUMBER,
             BITMAP_INDEX_FILTER_ROWS,
             BLOOM_FILTER_ROWS,
+            VECTOR_INDEX,
+            VECTOR_INDEX_LOAD,
+            VECTOR_INDEX_CACHE_LOOKUP,
+            VECTOR_INDEX_FILE_OPEN_AND_GET_SIZE,
+            VECTOR_INDEX_FILE_READ,
+            VECTOR_INDEX_DESERIALIZE,
+            VECTOR_INDEX_SEARCHER_CREATE,
+            VECTOR_INDEX_CACHE_HIT,
+            VECTOR_INDEX_CACHE_MISS,
+            VECTOR_INDEX_SEARCH,
+            VECTOR_ANN_SEARCH,
+            VECTOR_RESULT_PROCESS,
             VECTOR_INDEX_FILTER_ROWS,
             VECTOR_SEARCH_TIME,
             ROWSETS_READ_COUNT,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ExplainAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ExplainAnalyzer.java
@@ -1760,7 +1760,10 @@ public class ExplainAnalyzer {
                 "MorselsCount", "PeakIOTasks", "PeakScanTaskQueueSize", "PeakChunkBufferMemoryUsage",
                 "PeakChunkBufferSize", "ChunkBufferCapacity", "DefaultChunkBufferCapacity",
                 "CreateSegmentIter", "GetDelVec", "GetDeltaColumnGroup", "GetRowsets", "ReadPKIndex",
-                "ProcessVectorDistanceAndIdTime", "VectorSearchTime",
+                "VectorIndex", "VectorIndexLoad", "VectorIndexCacheLookup", "VectorIndexFileOpenAndGetSize",
+                "VectorIndexFileRead", "VectorIndexDeserialize", "VectorIndexSearcherCreate",
+                "VectorIndexCacheHit", "VectorIndexCacheMiss", "VectorIndexSearch", "VectorANNSearch",
+                "VectorResultProcess", "ProcessVectorDistanceAndIdTime", "VectorSearchTime",
                 "PushdownAccessPaths", "PushdownPredicates"
         );
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ExplainAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ExplainAnalyzer.java
@@ -1130,6 +1130,25 @@ public class ExplainAnalyzer {
         appendMetric(uniqueMetrics, nodeInfo, "DefaultChunkBufferCapacity");
         popIndent();
 
+        appendDetailLine("VectorIndex:");
+        pushIndent(GraphElement.LEAF_METRIC_INDENT);
+        appendMetric(uniqueMetrics, nodeInfo, "VectorIndex");
+        appendMetric(uniqueMetrics, nodeInfo, "VectorIndexLoad");
+        appendMetric(uniqueMetrics, nodeInfo, "VectorIndexCacheLookup");
+        appendMetric(uniqueMetrics, nodeInfo, "VectorIndexCacheHit");
+        appendMetric(uniqueMetrics, nodeInfo, "VectorIndexCacheMiss");
+        appendMetric(uniqueMetrics, nodeInfo, "VectorIndexFileOpenAndGetSize");
+        appendMetric(uniqueMetrics, nodeInfo, "VectorIndexFileRead");
+        appendMetric(uniqueMetrics, nodeInfo, "VectorIndexDeserialize");
+        appendMetric(uniqueMetrics, nodeInfo, "VectorIndexSearcherCreate");
+        appendMetric(uniqueMetrics, nodeInfo, "VectorIndexSearch");
+        appendMetric(uniqueMetrics, nodeInfo, "VectorANNSearch");
+        appendMetric(uniqueMetrics, nodeInfo, "VectorResultProcess");
+        // Legacy names kept visible for profiles produced during rolling upgrades.
+        appendMetric(uniqueMetrics, nodeInfo, "ProcessVectorDistanceAndIdTime");
+        appendMetric(uniqueMetrics, nodeInfo, "VectorSearchTime");
+        popIndent();
+
         appendGroupedMetricsOthers(uniqueMetrics, nodeInfo, getScanKnownMetrics());
 
         popIndent(); // main indent

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ExplainAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ExplainAnalyzerTest.java
@@ -135,6 +135,30 @@ public class ExplainAnalyzerTest {
                 new Counter(TUnit.TIME_NS, null, 11372000));
         uniqueMetrics.addCounter("PeakChunkBufferMemoryUsage", RuntimeProfile.ROOT_COUNTER,
                 new Counter(TUnit.BYTES, null, 12 * 1024 * 1024));
+        uniqueMetrics.addCounter("VectorIndex", RuntimeProfile.ROOT_COUNTER,
+                new Counter(TUnit.TIME_NS, null, 19000000));
+        uniqueMetrics.addCounter("VectorIndexLoad", RuntimeProfile.ROOT_COUNTER,
+                new Counter(TUnit.TIME_NS, null, 7000000));
+        uniqueMetrics.addCounter("VectorIndexCacheLookup", RuntimeProfile.ROOT_COUNTER,
+                new Counter(TUnit.TIME_NS, null, 1000000));
+        uniqueMetrics.addCounter("VectorIndexCacheHit", RuntimeProfile.ROOT_COUNTER,
+                new Counter(TUnit.UNIT, null, 2));
+        uniqueMetrics.addCounter("VectorIndexCacheMiss", RuntimeProfile.ROOT_COUNTER,
+                new Counter(TUnit.UNIT, null, 1));
+        uniqueMetrics.addCounter("VectorIndexFileOpenAndGetSize", RuntimeProfile.ROOT_COUNTER,
+                new Counter(TUnit.TIME_NS, null, 2000000));
+        uniqueMetrics.addCounter("VectorIndexFileRead", RuntimeProfile.ROOT_COUNTER,
+                new Counter(TUnit.TIME_NS, null, 3000000));
+        uniqueMetrics.addCounter("VectorIndexDeserialize", RuntimeProfile.ROOT_COUNTER,
+                new Counter(TUnit.TIME_NS, null, 750000));
+        uniqueMetrics.addCounter("VectorIndexSearcherCreate", RuntimeProfile.ROOT_COUNTER,
+                new Counter(TUnit.TIME_NS, null, 250000));
+        uniqueMetrics.addCounter("VectorIndexSearch", RuntimeProfile.ROOT_COUNTER,
+                new Counter(TUnit.TIME_NS, null, 12000000));
+        uniqueMetrics.addCounter("VectorANNSearch", RuntimeProfile.ROOT_COUNTER,
+                new Counter(TUnit.TIME_NS, null, 9000000));
+        uniqueMetrics.addCounter("VectorResultProcess", RuntimeProfile.ROOT_COUNTER,
+                new Counter(TUnit.TIME_NS, null, 3000000));
         uniqueMetrics.addCounter("Unknown", RuntimeProfile.ROOT_COUNTER,
                 new Counter(TUnit.BYTES, null, 12 * 1024 * 1024));
         olapScanProfile.addChild(uniqueMetrics);
@@ -169,6 +193,18 @@ public class ExplainAnalyzerTest {
         assertTrue(result.contains("SegmentProcessing"), result);
         assertTrue(result.contains("IOTask"), result);
         assertTrue(result.contains("IOBuffer"), result);
+        assertTrue(result.contains("VectorIndex:"), result);
+        assertTrue(result.contains("VectorIndexLoad: "), result);
+        assertTrue(result.contains("VectorIndexCacheLookup: "), result);
+        assertTrue(result.contains("VectorIndexCacheHit: "), result);
+        assertTrue(result.contains("VectorIndexCacheMiss: "), result);
+        assertTrue(result.contains("VectorIndexFileOpenAndGetSize: "), result);
+        assertTrue(result.contains("VectorIndexFileRead: "), result);
+        assertTrue(result.contains("VectorIndexDeserialize: "), result);
+        assertTrue(result.contains("VectorIndexSearcherCreate: "), result);
+        assertTrue(result.contains("VectorIndexSearch: "), result);
+        assertTrue(result.contains("VectorANNSearch: "), result);
+        assertTrue(result.contains("VectorResultProcess: "), result);
         assertTrue(result.contains("ZoneMapIndexFilter: "), result);
         assertTrue(result.contains("PredFilter: "), result);
         assertTrue(result.contains("ShortKeyFilter:"), result);


### PR DESCRIPTION
## Why I'm doing:

Vector index queries currently expose the row-range, search, and result-processing costs, but the runtime profile cannot show where index loading time is spent or whether the TenANN index cache was hit. This makes it difficult to distinguish remote file opening, index file reading, TenANN index deserialization, searcher creation, and cache lookup costs, especially for shared-data scan preparation.

## What I'm doing:

This change propagates `OlapReaderStatistics` through vector index reader creation and searcher initialization, records the vector index cache lookup, file open and size lookup, file read, index deserialization, and searcher creation phases, and reports cache hit and miss counts. It exposes the counters in pipeline, legacy OLAP, and Lake scan profiles, including the Lake prepared-seed path.

The runtime profile is grouped into the following hierarchy:

```text
VectorIndex
├── VectorIndexLoad
│   ├── VectorIndexCacheLookup
│   │   ├── VectorIndexCacheHit
│   │   └── VectorIndexCacheMiss
│   ├── VectorIndexFileOpenAndGetSize
│   ├── VectorIndexFileRead
│   ├── VectorIndexDeserialize
│   └── VectorIndexSearcherCreate
└── VectorIndexSearch
    ├── VectorANNSearch
    ├── VectorIndexFilterRows
    └── VectorResultProcess
```

The former `GetVectorRowRangesTime` is represented by `VectorIndexSearch`. The Lake prepared-seed path exposes the same hierarchy under `SeedVectorIndex`, using the corresponding `SeedVectorIndex*` counter names.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
