### PR TITLE
[BugFix] Make spill_enable_direct_io actually engage O_DIRECT (backport #77255)

### DIFF
--- a/be/src/exec/spill/data_stream.cpp
+++ b/be/src/exec/spill/data_stream.cpp
@@ -63,6 +63,9 @@ Status BlockSpillOutputDataStream::_prepare_block(RuntimeState* state, size_t wr
         opts.plan_node_id = _spiller->options().plan_node_id;
         opts.name = _spiller->options().name;
         opts.block_size = write_size;
+        // BUGFIX: direct_io was never propagated, so spill_enable_direct_io only aligned
+        // payloads while files stayed buffered -- O_DIRECT never actually engaged.
+        opts.direct_io = state->spill_enable_direct_io();
         opts.affinity_group = _block_group->get_affinity_group();
         ASSIGN_OR_RETURN(auto block, _block_manager->acquire_block(opts));
         // update metrics

--- a/be/src/exec/spill/log_block_manager.cpp
+++ b/be/src/exec/spill/log_block_manager.cpp
@@ -16,6 +16,7 @@
 
 #include <fmt/core.h>
 
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -139,7 +140,24 @@ Status LogBlockContainer::open() {
         opt.sync_on_close = false;
     }
     opt.direct_write = _direct_io;
-    ASSIGN_OR_RETURN(_writable_file, _dir->fs()->new_writable_file(opt, file_path));
+    auto wf = _dir->fs()->new_writable_file(opt, file_path);
+    if (!wf.ok() && _direct_io) {
+        // O_DIRECT is not supported on every spill filesystem (tmpfs, some overlay/network FS).
+        // Until direct IO was actually wired up it was a silent no-op, so a deployment may run
+        // with spill_enable_direct_io=true on such an FS and depend on spilling "working" (as
+        // buffered). Fall back to a buffered open instead of failing every spill query; warn once.
+        static std::atomic<bool> warned{false};
+        if (!warned.exchange(true)) {
+            LOG(WARNING) << "spill O_DIRECT open failed (" << wf.status()
+                         << "); this filesystem does not support direct IO, falling back to "
+                            "buffered spill writes";
+        }
+        _direct_io = false;
+        opt.direct_write = false;
+        wf = _dir->fs()->new_writable_file(opt, file_path);
+    }
+    RETURN_IF_ERROR(wf.status());
+    _writable_file = std::move(wf).value();
     TRACE_SPILL_LOG << "create new container file: " << file_path;
     _has_open = true;
     return Status::OK();

--- a/be/src/exec/spill/serde.cpp
+++ b/be/src/exec/spill/serde.cpp
@@ -108,7 +108,7 @@ Status ColumnarSerde::serialize(RuntimeState* state, SerdeContext& ctx, const Ch
     if (_encode_context == nullptr) {
         return Status::InternalError("ColumnarSerde::serialize() called before prepare(): encode context is null");
     }
-    raw::RawString& serialize_buffer = ctx.serialize_buffer;
+    raw::RawStringPage& serialize_buffer = ctx.serialize_buffer;
     {
         SCOPED_TIMER(_parent->metrics().serialize_timer);
         size_t ALIGNED_SIZE = 1;

--- a/be/src/exec/spill/serde.h
+++ b/be/src/exec/spill/serde.h
@@ -84,7 +84,9 @@ private:
 };
 
 struct SerdeContext {
-    raw::RawString serialize_buffer;
+    // Page-aligned backing store: base address must be 4096-aligned so O_DIRECT spill writes
+    // (spill_enable_direct_io) satisfy pwritev's iov_base alignment requirement.
+    raw::RawStringPage serialize_buffer;
 };
 // Serde is used to serialize and deserialize spilled data.
 class Serde;

--- a/be/src/util/raw_container.h
+++ b/be/src/util/raw_container.h
@@ -132,11 +132,21 @@ public:
 // GNU libstdc++ with new CXX11 ABI
 using RawString = std::basic_string<char, std::char_traits<char>, RawAllocator<char, 0>>;
 using RawStringPad16 = std::basic_string<char, std::char_traits<char>, RawAllocator<char, 16>>;
+// Page-aligned (4096) backing store ONCE HEAP-ALLOCATED, required for O_DIRECT spill writes where
+// pwritev needs iov_base aligned to the device logical block size. Short contents stay inline in
+// the string object and never reach the allocator, so a caller that needs the alignment must size
+// the buffer past that (the O_DIRECT spill path always resizes to ALIGN_UP(n, page), clearing it).
+// NOTE: RawAllocator's second parameter is TRAILING PADDING, not alignment -- the alignment
+// comes from composing AlignmentAllocator as the underlying allocator.
+using RawStringPage =
+        std::basic_string<char, std::char_traits<char>, RawAllocator<char, 0, AlignmentAllocator<char, 4096>>>;
 #elif defined(_LIBCPP_VERSION)
 // LLVM libc++ (used on macOS and some Linux systems)
 // libc++ never used COW semantics, so RawString optimization is safe
 using RawString = std::basic_string<char, std::char_traits<char>, RawAllocator<char, 0>>;
 using RawStringPad16 = std::basic_string<char, std::char_traits<char>, RawAllocator<char, 16>>;
+using RawStringPage =
+        std::basic_string<char, std::char_traits<char>, RawAllocator<char, 0, AlignmentAllocator<char, 4096>>>;
 #else
 // Old GNU libstdc++ ABI (COW semantics) - not compatible with RawString optimization
 #error "Cannot use RawString optimization with old CXX11 ABI"

--- a/be/test/io/spill_test.cpp
+++ b/be/test/io/spill_test.cpp
@@ -19,6 +19,7 @@
 #include <filesystem>
 #include <future>
 #include <iterator>
+#include <limits>
 #include <memory>
 #include <thread>
 #include <utility>
@@ -841,7 +842,7 @@ TEST_F(SpillTest, direct_io_option_reaches_block_manager) {
         std::string dir_path = config::storage_root_path + "/spill_test_data/" + print_id(query_id);
         ASSERT_OK(FileSystem::Default()->create_dir_recursive(dir_path));
         spill::DirManager dir_mgr;
-        ASSERT_OK(dir_mgr.init(dir_path, {config::storage_root_path}));
+        ASSERT_OK(dir_mgr.init(dir_path));
         spill::LogBlockManager block_mgr(query_id, &dir_mgr);
 
         OptionsRecordingBlockManager recorder(&block_mgr);

--- a/be/test/io/spill_test.cpp
+++ b/be/test/io/spill_test.cpp
@@ -720,6 +720,219 @@ TEST_F(SpillTest, aligned_buffer) {
     ASSERT_TRUE(is_aligned(buffer.data(), 4096));
 }
 
+// Rejects exactly the O_DIRECT opens and forwards everything else, so the container's
+// direct-IO-unsupported fallback can be driven on any platform. tmpfs used to serve this purpose
+// (it had no direct_IO), but modern kernels accept O_DIRECT on it, so the refusal has to be
+// injected rather than found.
+class RefuseDirectWriteFileSystem : public FileSystem {
+public:
+    explicit RefuseDirectWriteFileSystem(std::shared_ptr<FileSystem> delegate) : _fs(std::move(delegate)) {}
+
+    size_t direct_open_attempts() const { return _direct_open_attempts; }
+
+    StatusOr<std::unique_ptr<WritableFile>> new_writable_file(const WritableFileOptions& opts,
+                                                              const std::string& fname) override {
+        if (opts.direct_write) {
+            ++_direct_open_attempts;
+            return Status::InvalidArgument("injected: filesystem does not support direct IO");
+        }
+        return _fs->new_writable_file(opts, fname);
+    }
+
+    Type type() const override { return _fs->type(); }
+    StatusOr<std::unique_ptr<SequentialFile>> new_sequential_file(const SequentialFileOptions& opts,
+                                                                  const std::string& fname) override {
+        return _fs->new_sequential_file(opts, fname);
+    }
+    StatusOr<std::unique_ptr<RandomAccessFile>> new_random_access_file(const RandomAccessFileOptions& opts,
+                                                                       const std::string& fname) override {
+        return _fs->new_random_access_file(opts, fname);
+    }
+    StatusOr<std::unique_ptr<WritableFile>> new_writable_file(const std::string& fname) override {
+        return _fs->new_writable_file(fname);
+    }
+    Status path_exists(const std::string& fname) override { return _fs->path_exists(fname); }
+    Status get_children(const std::string& dir, std::vector<std::string>* result) override {
+        return _fs->get_children(dir, result);
+    }
+    Status iterate_dir(const std::string& dir, const std::function<bool(std::string_view)>& cb) override {
+        return _fs->iterate_dir(dir, cb);
+    }
+    Status iterate_dir2(const std::string& dir, const std::function<bool(DirEntry)>& cb) override {
+        return _fs->iterate_dir2(dir, cb);
+    }
+    Status delete_file(const std::string& fname) override { return _fs->delete_file(fname); }
+    Status create_dir(const std::string& dirname) override { return _fs->create_dir(dirname); }
+    Status create_dir_if_missing(const std::string& dirname, bool* created) override {
+        return _fs->create_dir_if_missing(dirname, created);
+    }
+    Status create_dir_recursive(const std::string& dirname) override { return _fs->create_dir_recursive(dirname); }
+    Status delete_dir(const std::string& dirname) override { return _fs->delete_dir(dirname); }
+    Status delete_dir_recursive(const std::string& dirname) override { return _fs->delete_dir_recursive(dirname); }
+    Status sync_dir(const std::string& dirname) override { return _fs->sync_dir(dirname); }
+    StatusOr<bool> is_directory(const std::string& path) override { return _fs->is_directory(path); }
+    Status canonicalize(const std::string& path, std::string* result) override {
+        return _fs->canonicalize(path, result);
+    }
+    StatusOr<uint64_t> get_file_size(const std::string& fname) override { return _fs->get_file_size(fname); }
+    StatusOr<uint64_t> get_file_modified_time(const std::string& fname) override {
+        return _fs->get_file_modified_time(fname);
+    }
+    Status rename_file(const std::string& src, const std::string& target) override {
+        return _fs->rename_file(src, target);
+    }
+    Status link_file(const std::string& old_path, const std::string& new_path) override {
+        return _fs->link_file(old_path, new_path);
+    }
+
+private:
+    std::shared_ptr<FileSystem> _fs;
+    size_t _direct_open_attempts = 0;
+};
+
+// Records every AcquireBlockOptions the spill path asks for, then delegates so the write still
+// happens end to end (including the container's real open, so an O_DIRECT-hostile filesystem
+// exercises the buffered fallback rather than failing the test).
+class OptionsRecordingBlockManager : public spill::BlockManager {
+public:
+    explicit OptionsRecordingBlockManager(spill::BlockManager* delegate) : _delegate(delegate) {}
+    Status open() override { return _delegate->open(); }
+    void close() override { _delegate->close(); }
+    StatusOr<spill::BlockPtr> acquire_block(const spill::AcquireBlockOptions& opts) override {
+        _seen.push_back(opts);
+        return _delegate->acquire_block(opts);
+    }
+    Status release_block(spill::BlockPtr block) override { return _delegate->release_block(std::move(block)); }
+
+    const std::vector<spill::AcquireBlockOptions>& seen() const { return _seen; }
+
+private:
+    spill::BlockManager* _delegate;
+    std::vector<spill::AcquireBlockOptions> _seen;
+};
+
+// spill_enable_direct_io used to stop at the output stream: AcquireBlockOptions.direct_io was
+// never assigned, so the container opened the file buffered no matter what the session asked
+// for. Assert the session value actually reaches the block manager, for both settings, with a
+// full spill behind each so the container's open and write paths run for real.
+TEST_F(SpillTest, direct_io_option_reaches_block_manager) {
+    for (bool direct_io : {false, true}) {
+        ObjectPool pool;
+        TExprBuilder order_by_slots_builder;
+        order_by_slots_builder << TYPE_INT;
+        auto order_by_slots = order_by_slots_builder.get_res();
+        std::vector<bool> nullables = {false, false};
+        TExprBuilder tuple_slots_builder;
+        tuple_slots_builder << TYPE_INT << TYPE_SMALLINT;
+        auto tuple_slots = tuple_slots_builder.get_res();
+
+        dummy_rt_st._query_options.spill_enable_direct_io = direct_io;
+
+        auto ctx_st = no_partition_context(&pool, &dummy_rt_st, order_by_slots, tuple_slots);
+        ASSERT_OK(ctx_st.status());
+        auto ctx = ctx_st.value();
+        auto& tuple = ctx->sort_exprs.sort_tuple_slot_expr_ctxs();
+
+        // A private block manager per iteration, NOT the fixture's. LogBlockManager caches
+        // containers keyed by (affinity group, dir, plan node id) and direct_io is not part of
+        // that key, so a shared manager would hand the second iteration the first one's already
+        // open buffered container and never take the O_DIRECT open path at all.
+        TUniqueId query_id = generate_uuid();
+        std::string dir_path = config::storage_root_path + "/spill_test_data/" + print_id(query_id);
+        ASSERT_OK(FileSystem::Default()->create_dir_recursive(dir_path));
+        spill::DirManager dir_mgr;
+        ASSERT_OK(dir_mgr.init(dir_path, {config::storage_root_path}));
+        spill::LogBlockManager block_mgr(query_id, &dir_mgr);
+
+        OptionsRecordingBlockManager recorder(&block_mgr);
+        SpilledOptions spill_options;
+        spill_options.mem_table_pool_size = 4;
+        spill_options.spill_mem_table_bytes_size = 1 * 1024 * 1024;
+        spill_options.spill_type = spill::SpillFormaterType::SPILL_BY_COLUMN;
+        spill_options.block_manager = &recorder;
+
+        RandomChunkBuilder chunk_builder;
+        auto factory = spill::make_spilled_factory();
+        auto spiller = factory->create(spill_options);
+        spiller->set_metrics(metrics);
+        SpillerCaller<spill::RawSpillerWriter*, spill::SpillerReader*> caller(spiller.get());
+        ASSERT_OK(spiller->prepare(&dummy_rt_st));
+
+        for (size_t i = 0; i < 128; ++i) {
+            auto chunk = chunk_builder.gen(tuple, nullables);
+            ASSERT_OK(caller.spill<SyncExecutor>(&dummy_rt_st, chunk, EmptyMemGuard{}));
+            ASSERT_OK(spiller->_spilled_task_status);
+        }
+        ASSERT_OK(caller.flush<SyncExecutor>(&dummy_rt_st, EmptyMemGuard{}));
+
+        ASSERT_FALSE(recorder.seen().empty()) << "no block acquired, direct_io=" << direct_io;
+        for (const auto& opts : recorder.seen()) {
+            EXPECT_EQ(direct_io, opts.direct_io) << "direct_io not propagated, expected " << direct_io;
+        }
+    }
+    dummy_rt_st._query_options.spill_enable_direct_io = false;
+}
+
+// Not every filesystem implements direct IO, and because spill_enable_direct_io was a silent no-op
+// until now, a deployment may already run with it on such a filesystem and depend on spilling
+// working. So a failing O_DIRECT open must degrade to a buffered one rather than fail the query.
+TEST_F(SpillTest, direct_io_open_failure_falls_back_to_buffered) {
+    ObjectPool pool;
+    TExprBuilder order_by_slots_builder;
+    order_by_slots_builder << TYPE_INT;
+    auto order_by_slots = order_by_slots_builder.get_res();
+    std::vector<bool> nullables = {false, false};
+    TExprBuilder tuple_slots_builder;
+    tuple_slots_builder << TYPE_INT << TYPE_SMALLINT;
+    auto tuple_slots = tuple_slots_builder.get_res();
+
+    dummy_rt_st._query_options.spill_enable_direct_io = true;
+
+    auto ctx_st = no_partition_context(&pool, &dummy_rt_st, order_by_slots, tuple_slots);
+    ASSERT_OK(ctx_st.status());
+    auto ctx = ctx_st.value();
+    auto& tuple = ctx->sort_exprs.sort_tuple_slot_expr_ctxs();
+
+    TUniqueId query_id = generate_uuid();
+    std::string dir_path = config::storage_root_path + "/spill_test_data/" + print_id(query_id);
+    ASSERT_OK(FileSystem::Default()->create_dir_recursive(dir_path));
+    std::shared_ptr<FileSystem> posix(FileSystem::Default(), [](FileSystem*) {});
+    auto refusing_fs = std::make_shared<RefuseDirectWriteFileSystem>(std::move(posix));
+    auto dir = std::make_shared<spill::Dir>(dir_path, refusing_fs, std::numeric_limits<int64_t>::max());
+    spill::DirManager dir_mgr(std::vector<spill::DirPtr>{dir});
+    spill::LogBlockManager block_mgr(query_id, &dir_mgr);
+
+    SpilledOptions spill_options;
+    spill_options.mem_table_pool_size = 4;
+    spill_options.spill_mem_table_bytes_size = 1 * 1024 * 1024;
+    spill_options.spill_type = spill::SpillFormaterType::SPILL_BY_COLUMN;
+    spill_options.block_manager = &block_mgr;
+
+    RandomChunkBuilder chunk_builder;
+    auto factory = spill::make_spilled_factory();
+    auto spiller = factory->create(spill_options);
+    spiller->set_metrics(metrics);
+    SpillerCaller<spill::RawSpillerWriter*, spill::SpillerReader*> caller(spiller.get());
+    ASSERT_OK(spiller->prepare(&dummy_rt_st));
+
+    size_t input_rows = 0;
+    for (size_t i = 0; i < 128; ++i) {
+        auto chunk = chunk_builder.gen(tuple, nullables);
+        input_rows += chunk->num_rows();
+        ASSERT_OK(caller.spill<SyncExecutor>(&dummy_rt_st, chunk, EmptyMemGuard{}));
+        ASSERT_OK(spiller->_spilled_task_status);
+    }
+    ASSERT_OK(caller.flush<SyncExecutor>(&dummy_rt_st, EmptyMemGuard{}));
+
+    // The point of the test: the O_DIRECT open was attempted and refused, and every spill above
+    // still succeeded on the buffered retry. Without the fallback the first open failure
+    // propagates out of LogBlockContainer::open() and each of those ASSERT_OKs fails instead.
+    EXPECT_GT(refusing_fs->direct_open_attempts(), 0u) << "no O_DIRECT open was attempted";
+    EXPECT_GT(input_rows, 0u);
+
+    dummy_rt_st._query_options.spill_enable_direct_io = false;
+}
+
 /*
 TEST_F(SpillTest, file_group_test) {
     auto chunk = std::make_unique<Chunk>();

--- a/be/test/util/raw_container_test.cpp
+++ b/be/test/util/raw_container_test.cpp
@@ -35,4 +35,43 @@ TEST(TestRawContainer, testResizeWithColumnAllocator) {
     raw::stl_vector_resize_uninitialized(&v, 10);
     ASSERT_EQ(v.size(), 10);
 }
+
+// RawStringPage exists so O_DIRECT writers can hand their buffer straight to pwritev, which
+// rejects an unaligned iov_base with EINVAL. A plain RawString only guarantees max_align_t.
+//
+// The guarantee is conditional, and the condition is easy to miss: basic_string keeps short
+// contents inside the object itself, which never reaches the allocator, so data() is only
+// page-aligned once the buffer is big enough to be heap-allocated (measured threshold on
+// libstdc++: contents of 16 bytes and up). Every O_DIRECT caller clears that by construction
+// because it resizes to ALIGN_UP(n, page) -- so assert the heap sizes hold the alignment, and
+// assert separately that the page-rounded sizes callers actually request always do.
+TEST(TestRawContainer, rawStringPageIsPageAligned) {
+    constexpr size_t kPageSize = 4096;
+    constexpr size_t kInlineCapacity = 15;
+
+    const std::vector<size_t> heap_sizes = {kInlineCapacity + 1, 100,           kPageSize - 1, kPageSize,
+                                            kPageSize + 1,       4 * kPageSize, 1024 * 1024};
+    for (size_t n : heap_sizes) {
+        raw::RawStringPage s;
+        s.resize(n);
+        ASSERT_EQ(n, s.size());
+        EXPECT_EQ(0u, reinterpret_cast<uintptr_t>(s.data()) % kPageSize) << "unaligned at size " << n;
+    }
+
+    // Growing an existing buffer must not lose the alignment either: the spill path resizes the
+    // same SerdeContext buffer for every chunk.
+    raw::RawStringPage grown;
+    for (size_t n = kInlineCapacity + 1; n <= 64 * 1024; n *= 2) {
+        grown.resize(n);
+        EXPECT_EQ(0u, reinterpret_cast<uintptr_t>(grown.data()) % kPageSize) << "unaligned after growing to " << n;
+    }
+
+    // What the O_DIRECT path actually asks for: any payload length rounded up to a page. This is
+    // the invariant pwritev depends on, including for payloads far below the inline capacity.
+    for (size_t payload : {size_t{1}, size_t{12}, kInlineCapacity, kPageSize, kPageSize + 1}) {
+        raw::RawStringPage s;
+        s.resize((payload + kPageSize - 1) / kPageSize * kPageSize);
+        EXPECT_EQ(0u, reinterpret_cast<uintptr_t>(s.data()) % kPageSize) << "unaligned for payload " << payload;
+    }
+}
 } // namespace starrocks


### PR DESCRIPTION
> This is a backport of #77255 to `branch-4.1`.
>
> Two adaptations were needed on this branch, in a separate follow-up commit
> (the cherry-pick itself is unchanged):
>
> - `DirManager::init` takes only the spill dirs here; the storage-paths argument
>   was added later on main.
> - The new test uses `std::numeric_limits`, which reached it transitively through
>   main's include graph but not through this branch's, so `<limits>` is now
>   included explicitly.
>
> Supersedes #77339 — Mergify's auto-backport, which failed `BE UT` with a compile
> error on the first of those two differences and cannot be pushed to from a fork.

---

## Why I'm doing:

The session variable `spill_enable_direct_io` has never worked. Two independent
defects stack on top of each other:

1. **The flag was never propagated.** `BlockSpillOutputDataStream::_prepare_block()`
   builds `AcquireBlockOptions` but never sets `direct_io`, so it reached the block
   container as `false` no matter what the session variable said. The only place in
   the tree that ever set `AcquireBlockOptions.direct_io` is the exchange queue.
   Turning the variable on therefore only aligned the serialize payload while the
   file itself stayed buffered — O_DIRECT never actually engaged.

2. **Fixing (1) exposes an EINVAL on the first write.** `pwritev` requires a
   page-aligned `iov_base` under O_DIRECT, but `SerdeContext::serialize_buffer` is a
   plain `raw::RawString` whose allocation is only `max_align_t`-aligned. So with the
   propagation fixed, every spill write fails immediately.

Net effect today: a documented session variable is silently inert, and the code path
behind it cannot work as written.

## What I'm doing:

- Propagate `state->spill_enable_direct_io()` into `AcquireBlockOptions.direct_io`.
- Add `raw::RawStringPage` — `RawAllocator` over `AlignmentAllocator<char, 4096>` —
  and use it for the serialize buffer, so the base address satisfies `pwritev`'s
  O_DIRECT alignment requirement. Note that `RawAllocator`'s second template
  parameter is a *trailing pad*, not an alignment, so the alignment has to come from
  the composed allocator rather than from that parameter.
- Fall back to a buffered open when the O_DIRECT open fails, warning once.

The fallback is deliberate rather than defensive-by-habit. Not every filesystem
supports direct IO (tmpfs, some overlay and network mounts), and because the option
has silently done nothing until now, a deployment may already have it enabled on
such a filesystem and depend on spilling working. Failing the open would turn every
spilling query into an error the moment this fix lands.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

`spill_enable_direct_io` defaults to `false`, so the default path is unchanged. For a
deployment that has explicitly enabled it, spill writes move from buffered to
O_DIRECT — which is what the variable has always claimed to do. On a filesystem
without direct-IO support the open falls back to buffered with a one-time warning,
so such a deployment keeps working exactly as it does today.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

All three parts of the fix are observable, so they are tested directly rather than
through the spill roundtrip — that one passes either way, because buffered and direct
IO write identical bytes.

- `SpillTest.direct_io_option_reaches_block_manager` wraps the block manager in a
  recorder that captures every `AcquireBlockOptions` and then delegates to the real
  one, so the container's open and write still run and an O_DIRECT-hostile filesystem
  exercises the buffered fallback instead of failing the test. It runs a full spill
  for both settings of the session value and asserts every acquire saw it. This is
  the regression test for the propagation bug: applied to `main` without the fix it
  fails with `expected true, actual false`; with the fix it passes.

  Each iteration gets its own `DirManager`/`LogBlockManager` rather than sharing one.
  `LogBlockManager` caches containers keyed by (affinity group, dir, plan node id),
  and `direct_io` is not part of that key, so a shared manager would hand the second
  iteration the first one's already open buffered container and never take the
  O_DIRECT open path at all.

- `SpillTest.direct_io_open_failure_falls_back_to_buffered` drives the
  unsupported-filesystem path through a `RefuseDirectWriteFileSystem` that fails exactly
  the O_DIRECT opens and forwards everything else. tmpfs used to serve this purpose since
  it had no `direct_IO` implementation, but current kernels accept O_DIRECT on it, so the
  refusal has to be injected to be reproducible. Without the fallback the first open
  failure propagates and every spill in the test errors out.

- `TestRawContainer.rawStringPageIsPageAligned` pins down `RawStringPage`'s alignment
  guarantee.

Writing the second test showed that guarantee is narrower than its comment claimed.
The comment said the base address "is a multiple of 4096" with no qualification, but
`basic_string` keeps short contents inside the object itself, which never reaches the
allocator — so `data()` is unaligned below that threshold (measured: 16 bytes and up
are aligned, 15 and below are not). The O_DIRECT path is unaffected because it always
resizes to `ALIGN_UP(n, page)`, which clears the threshold by construction, but the
unqualified claim would mislead the next caller into exactly the EINVAL this PR
fixes. The comment is corrected and the test asserts both halves: the alignment holds
for heap-allocated sizes and across in-place growth, and separately it holds for the
page-rounded sizes callers actually request, including payloads far below the inline
capacity.

One note on `raw_container.h`: the diff includes a reformatted pre-existing line (a
`requires` clause) that this PR does not otherwise touch. CI's clang-format produced
it — the header is in the changed-file set only because this PR adds `RawStringPage`
to it — and it is folded into the first commit so every commit here carries a
sign-off.

Known limitation, not addressed here: the O_DIRECT alignment is the hard-coded 4096
that `AlignedBuffer::kPageSize` has always used, rather than the filesystem's actual
direct-I/O requirement queried via `statx(STATX_DIOALIGN)`. Linux caps that
requirement at `PAGE_SIZE`, so on x86-64 4096 is always sufficient; a kernel with
pages larger than 4 KiB plus a device or filesystem demanding more than 4096 would
still fail, and it would fail on the write rather than on the open, so the buffered
fallback added here would not catch it. This PR does not introduce the hard-coded
value, only makes it reachable for the first time; querying the real alignment is
worth doing separately.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5


