### PR TITLE
[BugFix] Fold constants after MergeTwoProjectRule (backport #76867)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeTwoProjectRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeTwoProjectRule.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
@@ -27,6 +28,9 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
+import com.starrocks.sql.optimizer.rewrite.scalar.FoldConstantsRule;
+import com.starrocks.sql.optimizer.rewrite.scalar.NormalizePredicateRule;
+import com.starrocks.sql.optimizer.rewrite.scalar.ScalarOperatorRewriteRule;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
 import java.util.List;
@@ -34,6 +38,9 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 public class MergeTwoProjectRule extends TransformationRule {
+    private static final List<ScalarOperatorRewriteRule> CONSTANT_REPLACEMENT_REWRITE_RULES = Lists.newArrayList(
+            new NormalizePredicateRule(),
+            new FoldConstantsRule());
     public MergeTwoProjectRule() {
         super(RuleType.TF_MERGE_TWO_PROJECT, Pattern.create(OperatorType.LOGICAL_PROJECT)
                 .addChildren(Pattern.create(OperatorType.LOGICAL_PROJECT, OperatorType.PATTERN_LEAF)));
@@ -46,12 +53,24 @@ public class MergeTwoProjectRule extends TransformationRule {
 
         ScalarOperatorRewriter scalarRewriter = new ScalarOperatorRewriter();
         ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(secondProject.getColumnRefMap());
+        ColumnRefSet constantReplacementColumns = new ColumnRefSet();
+        secondProject.getColumnRefMap().forEach((column, expression) -> {
+            if (expression.isConstant()) {
+                constantReplacementColumns.union(column);
+            }
+        });
+
         Map<ColumnRefOperator, ScalarOperator> resultMap = Maps.newHashMap();
         for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : firstProject.getColumnRefMap().entrySet()) {
+
             ScalarOperator result = rewriter.rewrite(entry.getValue());
+            boolean mayIntroduceConstant = !result.isConstant() && !constantReplacementColumns.isEmpty() &&
+                    entry.getValue().getUsedColumns().containsAny(constantReplacementColumns);
             if (result.isConstant()) {
                 // better to rewrite all expression, but it's unnecessary
                 result = scalarRewriter.rewrite(result, ScalarOperatorRewriter.DEFAULT_REWRITE_RULES);
+            } else if (mayIntroduceConstant) {
+                result = scalarRewriter.rewrite(result, CONSTANT_REPLACEMENT_REWRITE_RULES);
             }
             resultMap.put(entry.getKey(), result);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/MergeTwoProjectRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/MergeTwoProjectRuleTest.java
@@ -15,6 +15,8 @@
 package com.starrocks.sql.optimizer.rule.transformation;
 
 import com.google.common.collect.Maps;
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -22,8 +24,10 @@ import com.starrocks.sql.optimizer.OptimizerFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import org.junit.jupiter.api.Test;
@@ -33,6 +37,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MergeTwoProjectRuleTest {
 
@@ -143,5 +148,92 @@ public class MergeTwoProjectRuleTest {
         // And the original b -> ASSERT_TRUE(a) mapping from the lower project must be preserved per rule
         assertInstanceOf(CallOperator.class, resMap.get(b));
         assertEquals(com.starrocks.catalog.FunctionSet.ASSERT_TRUE, ((CallOperator) resMap.get(b)).getFnName());
+    }
+
+    @Test
+    public void testFoldConstantComparisonIntroducedByMerge() {
+        ColumnRefOperator source = new ColumnRefOperator(1, Type.INT, "source", true);
+        ColumnRefOperator joinedValue = new ColumnRefOperator(2, Type.VARCHAR, "joined_value", true);
+        ColumnRefOperator value = new ColumnRefOperator(3, Type.INT, "value", true);
+        ColumnRefOperator output = new ColumnRefOperator(4, Type.BOOLEAN, "output", true);
+
+        Map<ColumnRefOperator, ScalarOperator> bottomMap = Maps.newHashMap();
+        bottomMap.put(joinedValue, ConstantOperator.createNull(Type.VARCHAR));
+        bottomMap.put(value, source);
+
+        BinaryPredicateOperator joinedValuePredicate = new BinaryPredicateOperator(
+                BinaryType.EQ, joinedValue, ConstantOperator.createVarchar("foo"));
+        BinaryPredicateOperator valuePredicate = new BinaryPredicateOperator(
+                BinaryType.NE, value, ConstantOperator.createInt(0));
+        CompoundPredicateOperator topExpression = new CompoundPredicateOperator(
+                CompoundPredicateOperator.CompoundType.AND, joinedValuePredicate, valuePredicate);
+
+        LogicalProjectOperator bottomProject = new LogicalProjectOperator(bottomMap);
+        LogicalProjectOperator topProject = new LogicalProjectOperator(Map.of(output, topExpression));
+        OptExpression top = OptExpression.create(topProject, OptExpression.create(bottomProject));
+
+        MergeTwoProjectRule rule = new MergeTwoProjectRule();
+        List<OptExpression> result = rule.transform(top, OptimizerFactory.mockContext(new ColumnRefFactory()));
+
+        LogicalProjectOperator mergedProject = (LogicalProjectOperator) result.get(0).getOp();
+        CompoundPredicateOperator mergedExpression =
+                assertInstanceOf(CompoundPredicateOperator.class, mergedProject.getColumnRefMap().get(output));
+        ConstantOperator foldedComparison =
+                assertInstanceOf(ConstantOperator.class, mergedExpression.getChild(0));
+        assertEquals(Type.BOOLEAN, foldedComparison.getType());
+        assertTrue(foldedComparison.isNull());
+        BinaryPredicateOperator rewrittenValuePredicate =
+                assertInstanceOf(BinaryPredicateOperator.class, mergedExpression.getChild(1));
+        assertEquals(source, rewrittenValuePredicate.getChild(0));
+    }
+
+    @Test
+    public void testNormalizeConstantComparisonIntroducedByMerge() {
+        ColumnRefOperator source = new ColumnRefOperator(1, Type.INT, "source", true);
+        ColumnRefOperator constantValue = new ColumnRefOperator(2, Type.INT, "constant_value", true);
+        ColumnRefOperator inputValue = new ColumnRefOperator(3, Type.INT, "input_value", true);
+        ColumnRefOperator output = new ColumnRefOperator(4, Type.BOOLEAN, "output", true);
+
+        LogicalProjectOperator bottomProject = new LogicalProjectOperator(Map.of(
+                constantValue, ConstantOperator.createInt(1),
+                inputValue, source));
+        BinaryPredicateOperator topExpression =
+                new BinaryPredicateOperator(BinaryType.EQ, constantValue, inputValue);
+        LogicalProjectOperator topProject = new LogicalProjectOperator(Map.of(output, topExpression));
+        OptExpression top = OptExpression.create(topProject, OptExpression.create(bottomProject));
+
+        MergeTwoProjectRule rule = new MergeTwoProjectRule();
+        List<OptExpression> result = rule.transform(top, OptimizerFactory.mockContext(new ColumnRefFactory()));
+
+        LogicalProjectOperator mergedProject = (LogicalProjectOperator) result.get(0).getOp();
+        BinaryPredicateOperator normalizedExpression =
+                assertInstanceOf(BinaryPredicateOperator.class, mergedProject.getColumnRefMap().get(output));
+        assertEquals(source, normalizedExpression.getChild(0));
+        assertEquals(ConstantOperator.createInt(1), normalizedExpression.getChild(1));
+    }
+
+    @Test
+    public void testSkipConstantFoldWithoutConstantReplacement() {
+        ColumnRefOperator source = new ColumnRefOperator(1, Type.INT, "source", true);
+        ColumnRefOperator value = new ColumnRefOperator(2, Type.INT, "value", true);
+        ColumnRefOperator output = new ColumnRefOperator(3, Type.BOOLEAN, "output", true);
+
+        LogicalProjectOperator bottomProject = new LogicalProjectOperator(Map.of(value, source));
+        BinaryPredicateOperator constantPredicate = new BinaryPredicateOperator(
+                BinaryType.EQ, ConstantOperator.createInt(1), ConstantOperator.createInt(1));
+        BinaryPredicateOperator valuePredicate = new BinaryPredicateOperator(
+                BinaryType.NE, value, ConstantOperator.createInt(0));
+        CompoundPredicateOperator topExpression = new CompoundPredicateOperator(
+                CompoundPredicateOperator.CompoundType.AND, constantPredicate, valuePredicate);
+        LogicalProjectOperator topProject = new LogicalProjectOperator(Map.of(output, topExpression));
+        OptExpression top = OptExpression.create(topProject, OptExpression.create(bottomProject));
+
+        MergeTwoProjectRule rule = new MergeTwoProjectRule();
+        List<OptExpression> result = rule.transform(top, OptimizerFactory.mockContext(new ColumnRefFactory()));
+
+        LogicalProjectOperator mergedProject = (LogicalProjectOperator) result.get(0).getOp();
+        CompoundPredicateOperator mergedExpression =
+                assertInstanceOf(CompoundPredicateOperator.class, mergedProject.getColumnRefMap().get(output));
+        assertInstanceOf(BinaryPredicateOperator.class, mergedExpression.getChild(0));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/MergeTwoProjectRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/MergeTwoProjectRuleTest.java
@@ -15,10 +15,10 @@
 package com.starrocks.sql.optimizer.rule.transformation;
 
 import com.google.common.collect.Maps;
-import com.starrocks.catalog.Type;
-import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.analysis.BinaryType;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
+import com.starrocks.catalog.Type;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/EmptyValueTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/EmptyValueTest.java
@@ -346,4 +346,65 @@ public class EmptyValueTest extends PlanTestBase {
                 "  |  <slot 19> : 19: v2\n" +
                 "  |  <slot 21> : NULL");
     }
+
+    @Test
+    public void testConstantRefCmpConstantRef() throws Exception {
+        // Pruning the empty join replaces joined_value with NULL. Merging the projects then creates
+        // `NULL = 'foo' AND input_value <> 0` inside a nonconstant CASE expression.
+        // The constant comparison must be folded before expression statistics are calculated.
+        String sql = "select\n" +
+                "    group_key,\n" +
+                "    case\n" +
+                "        when (\n" +
+                "            joined_value = 'foo'\n" +
+                "            and input_value <> 0\n" +
+                "        ) then joined_number\n" +
+                "        else cast(0.0 as double)\n" +
+                "    end = 0.0\n" +
+                "from\n" +
+                "    (\n" +
+                "        select\n" +
+                "            source.v1 as group_key,\n" +
+                "            source.v3 as input_value,\n" +
+                "            empty_side.joined_value as joined_value,\n" +
+                "            empty_side.joined_number as joined_number\n" +
+                "        from\n" +
+                "            t0 source\n" +
+                "            left outer join (\n" +
+                "                select\n" +
+                "                    v2 as join_key,\n" +
+                "                    'foo' as joined_value,\n" +
+                "                    cast(v3 as double) as joined_number\n" +
+                "                from\n" +
+                "                    t0\n" +
+                "                where\n" +
+                "                    1 = 0\n" +
+                "            ) empty_side on empty_side.join_key = source.v2\n" +
+                "    ) t\n";
+        String plan = getFragmentPlan(sql);
+        // After the fix the folded `NULL = 'foo'` predicate is eliminated, so the
+        // CASE collapses and the plan is produced without the ConstantRef-cmp-ConstantRef error.
+        assertContains(plan, "OlapScanNode\n     TABLE: t0");
+    }
+
+    @Test
+    public void testConstantRefCmpColumnRef() throws Exception {
+        // Empty-join pruning and project merging turn coalesce(NULL, 1) = input_value into 1 = input_value.
+        // The comparison must be normalized before expression statistics are calculated.
+        String sql = "select defaulted_value = input_value and rand() >= 0.0\n" +
+                "from (\n" +
+                "    select\n" +
+                "        coalesce(empty_side.joined_value, 1) as defaulted_value,\n" +
+                "        source.v1 as input_value\n" +
+                "    from\n" +
+                "        t0 source\n" +
+                "        left outer join (\n" +
+                "            select v1 as joined_value, v2 as join_key\n" +
+                "            from t0\n" +
+                "            where 1 = 0\n" +
+                "        ) empty_side on empty_side.join_key = source.v2\n" +
+                ") projected";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "OlapScanNode\n     TABLE: t0");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -1878,7 +1878,7 @@ public class SubqueryTest extends PlanTestBase {
                 "then (select type1 from tmp) > (select pretype from tmp) else null end end from tmp a;";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "Project\n"
-                + "  |  <slot 32> : if(8 = abs(0), 'a', CAST(if(33: COUNT(1) > 0, 'season' > 'a.season', NULL) AS VARCHAR))");
+                + "  |  <slot 32> : if(8 = abs(0), 'a', CAST(if(33: COUNT(1) > 0, TRUE, NULL) AS VARCHAR))");
     }
 
     // we can enable this  test after support constant in sub-query

--- a/test/sql/test_join/R/test_fold_constants_after_project_merge
+++ b/test/sql/test_join/R/test_fold_constants_after_project_merge
@@ -1,0 +1,69 @@
+-- name: test_fold_constants_after_project_merge
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t0 (
+    group_key int,
+    join_key int,
+    input_value int
+)
+duplicate key(group_key)
+distributed by hash(group_key) buckets 1
+properties ("replication_num" = "1");
+-- result:
+-- !result
+insert into t0 values
+    (1, 10, 0),
+    (2, 20, 1),
+    (3, 30, 2);
+-- result:
+-- !result
+select group_key,
+       case
+           when joined_value = 'foo' and input_value <> 0 then joined_number
+           else cast(0.0 as double)
+       end = 0.0 as is_zero
+from (
+    select source.group_key,
+           source.input_value,
+           empty_side.joined_value,
+           empty_side.joined_number
+    from t0 source
+    left outer join (
+        select join_key,
+               'foo' as joined_value,
+               cast(input_value as double) as joined_number
+        from t0
+        where 1 = 0
+    ) empty_side on empty_side.join_key = source.join_key
+) projected
+order by group_key;
+-- result:
+1	1
+2	1
+3	1
+-- !result
+select input_value, defaulted_value = input_value as is_default
+from (
+    select source.input_value,
+           coalesce(empty_side.joined_value, 1) as defaulted_value
+    from t0 source
+    left outer join (
+        select input_value as joined_value,
+               join_key
+        from t0
+        where 1 = 0
+    ) empty_side on empty_side.join_key = source.join_key
+) projected
+order by input_value;
+-- result:
+0	0
+1	1
+2	0
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_join/T/test_fold_constants_after_project_merge
+++ b/test/sql/test_join/T/test_fold_constants_after_project_merge
@@ -1,0 +1,58 @@
+-- name: test_fold_constants_after_project_merge
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t0 (
+    group_key int,
+    join_key int,
+    input_value int
+)
+duplicate key(group_key)
+distributed by hash(group_key) buckets 1
+properties ("replication_num" = "1");
+
+insert into t0 values
+    (1, 10, 0),
+    (2, 20, 1),
+    (3, 30, 2);
+
+-- Empty-join pruning replaces joined_value with NULL. Project merging must fold
+-- the resulting NULL = 'foo' comparison inside the CASE expression.
+select group_key,
+       case
+           when joined_value = 'foo' and input_value <> 0 then joined_number
+           else cast(0.0 as double)
+       end = 0.0 as is_zero
+from (
+    select source.group_key,
+           source.input_value,
+           empty_side.joined_value,
+           empty_side.joined_number
+    from t0 source
+    left outer join (
+        select join_key,
+               'foo' as joined_value,
+               cast(input_value as double) as joined_number
+        from t0
+        where 1 = 0
+    ) empty_side on empty_side.join_key = source.join_key
+) projected
+order by group_key;
+
+-- The same rewrite can introduce a constant on the left of a column comparison.
+-- It must be normalized before predicate statistics are calculated.
+select input_value, defaulted_value = input_value as is_default
+from (
+    select source.input_value,
+           coalesce(empty_side.joined_value, 1) as defaulted_value
+    from t0 source
+    left outer join (
+        select input_value as joined_value,
+               join_key
+        from t0
+        where 1 = 0
+    ) empty_side on empty_side.join_key = source.join_key
+) projected
+order by input_value;
+
+drop database db_${uuid0};


### PR DESCRIPTION
Backport of #76867 to `branch-3.5-cc`.

Original commit: 358f0694ed2e3d15934c66bdacae115113b423a1
Original PR: https://github.com/StarRocks/starrocks/pull/76867

---

<!-- Original PR description below -->

## Why I'm doing:
Empty-join pruning and project merging can replace projected columns with constants after the normal scalar rewrite phase. This can produce constant-to-constant or constant-to-column predicates inside a larger expression, which later cause `PredicateStatisticsCalculator` to fail because those forms should have been eliminated or normalized earlier.

## What I'm doing:
Track constant replacements in `MergeTwoProjectRule` and run `NormalizePredicateRule` and `FoldConstantsRule` only on affected expressions. This folds constant comparisons and moves constants to the right of column comparisons without running the full rewrite rule set for every merged projection.

Add unit and planner regression tests for both constant-to-constant and constant-to-column comparisons.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
