### PR TITLE
[Enhancement] Expose build info metrics

### DIFF
--- a/be/src/service/service_metrics.cpp
+++ b/be/src/service/service_metrics.cpp
@@ -14,6 +14,7 @@
 
 #include "service/service_metrics.h"
 
+#include "common/version.h"
 #include "gutil/macros.h"
 
 namespace starrocks {
@@ -31,6 +32,11 @@ void ServiceMetrics::install(MetricRegistry* registry) {
         return;
     }
     _registry = registry;
+
+    build_info.set_value(1);
+    registry->register_metric(
+            "build_info", MetricLabels().add("version", STARROCKS_VERSION).add("commit_hash", STARROCKS_COMMIT_HASH),
+            &build_info);
 
     registry->register_metric("short_circuit_request_total", &short_circuit_request_total);
     registry->register_metric("short_circuit_request_duration_us", &short_circuit_request_duration_us);

--- a/be/src/service/service_metrics.h
+++ b/be/src/service/service_metrics.h
@@ -28,6 +28,7 @@ public:
 
     void install(MetricRegistry* registry);
 
+    METRIC_DEFINE_INT_GAUGE(build_info, MetricUnit::NOUNIT);
     METRIC_DEFINE_INT_COUNTER(short_circuit_request_total, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(short_circuit_request_duration_us, MetricUnit::MICROSECONDS);
 

--- a/be/test/util/starrocks_metrics_test.cpp
+++ b/be/test/util/starrocks_metrics_test.cpp
@@ -43,6 +43,7 @@
 #include "cache/mem_cache/page_cache.h"
 #include "common/config_metrics_fwd.h"
 #include "common/metrics/process_metrics_registry.h"
+#include "common/version.h"
 #include "compute_env/load/stream_load_metrics.h"
 #include "compute_env/query/query_scan_metrics.h"
 #include "exec/catalog_scan_metrics.h"
@@ -165,6 +166,14 @@ TEST_F(BackendMetricsTest, Normal) {
     auto metrics = backend_metrics_registry_for_test();
     metrics->collect(&visitor);
     // check metric
+    {
+        auto metric = metrics->get_metric(
+                "build_info",
+                MetricLabels().add("version", STARROCKS_VERSION).add("commit_hash", STARROCKS_COMMIT_HASH));
+        ASSERT_TRUE(metric != nullptr);
+        ASSERT_EQ(MetricType::GAUGE, metric->type());
+        ASSERT_STREQ("1", metric->to_string().c_str());
+    }
     {
         runtime_metrics->fragment_requests_total.increment(12);
         auto metric = metrics->get_metric("fragment_requests_total");

--- a/docs/en/administration/management/monitoring/metric_details/s.md
+++ b/docs/en/administration/management/monitoring/metric_details/s.md
@@ -62,6 +62,13 @@ description: "Alphabetical s"
 - Unit: -
 - Description: Metrics returned by `/proc/net/snmp`.
 
+## `starrocks_be_build_info`
+
+- Unit: -
+- Type: Instantaneous
+- Labels: `version`, `commit_hash`
+- Description: Build information for the BE node. The metric value is always `1`.
+
 ## `starrocks_be_clone_task_copy_bytes`
 
 - Unit: Bytes
@@ -348,6 +355,13 @@ description: "Alphabetical s"
 - Unit: Count
 - Type: Cumulative
 - Description: The total number of backup snapshots deleted from their repository, whether by automatic TTL cleanup or by DROP SNAPSHOT.
+
+## `starrocks_fe_build_info`
+
+- Unit: -
+- Type: Instantaneous
+- Labels: `version`, `commit_hash`
+- Description: Build information for the FE node. The metric value is always `1`.
 
 ## `starrocks_fe_clone_task_copy_bytes`
 

--- a/docs/ja/administration/management/monitoring/metric_details/s.md
+++ b/docs/ja/administration/management/monitoring/metric_details/s.md
@@ -56,6 +56,13 @@ description: "Alphabetical s"
 - 単位: -
 - 説明: `/proc/net/snmp`によって返されるメトリクス。
 
+## `starrocks_be_build_info`
+
+- 単位: -
+- タイプ: 瞬間
+- ラベル: `version`、`commit_hash`
+- 説明: BEノードのビルド情報。メトリクスの値は常に `1` です。
+
 ## `starrocks_be_clone_task_copy_bytes`
 
 - 単位: バイト
@@ -342,6 +349,13 @@ description: "Alphabetical s"
 - 単位: 個
 - タイプ: 累積
 - 説明: リポジトリから削除されたバックアップスナップショットの合計数。TTL による自動クリーンアップと DROP SNAPSHOT の両方を含みます。
+
+## `starrocks_fe_build_info`
+
+- 単位: -
+- タイプ: 瞬間
+- ラベル: `version`、`commit_hash`
+- 説明: FEノードのビルド情報。メトリクスの値は常に `1` です。
 
 ## `starrocks_fe_clone_task_copy_bytes`
 

--- a/docs/zh/administration/management/monitoring/metric_details/s.md
+++ b/docs/zh/administration/management/monitoring/metric_details/s.md
@@ -82,6 +82,13 @@ description: "Alphabetical s"
 - 单位: -
 - 描述: `/proc/net/snmp` 返回的指标。
 
+## `starrocks_be_build_info`
+
+- 单位：-
+- 类型：瞬时值
+- 标签：`version`、`commit_hash`
+- 描述：BE 节点的构建信息。指标值恒为 `1`。
+
 ## `starrocks_be_clone_task_copy_bytes`
 
 - 单位: 字节
@@ -368,6 +375,13 @@ description: "Alphabetical s"
 - 单位：计数
 - 类型：累计
 - 描述：已从仓库中删除的备份快照总数，包括 TTL 自动清理和 DROP SNAPSHOT 两种来源。
+
+## `starrocks_fe_build_info`
+
+- 单位：-
+- 类型：瞬时值
+- 标签：`version`、`commit_hash`
+- 描述：FE 节点的构建信息。指标值恒为 `1`。
 
 ## `starrocks_fe_clone_task_copy_bytes`
 

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -61,6 +61,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.ThreadPoolManager;
+import com.starrocks.common.Version;
 import com.starrocks.common.util.KafkaUtil;
 import com.starrocks.common.util.NetUtils;
 import com.starrocks.http.HttpMetricRegistry;
@@ -522,6 +523,13 @@ public final class MetricRepo {
         GAUGE_OBJECT_COUNT_STATS = new ArrayList<>();
 
         // 1. gauge
+        // build info
+        GaugeMetricImpl<Long> buildInfo = new GaugeMetricImpl<>("build_info",
+                MetricUnit.NOUNIT, "StarRocks FE build information", 1L);
+        buildInfo.addLabel(new MetricLabel("version", Version.STARROCKS_VERSION))
+                .addLabel(new MetricLabel("commit_hash", Version.STARROCKS_COMMIT_HASH));
+        STARROCKS_METRIC_REGISTER.addMetric(buildInfo);
+
         // load jobs
         LoadMgr loadManger = GlobalStateMgr.getCurrentState().getLoadMgr();
         for (EtlJobType jobType : EtlJobType.values()) {

--- a/fe/fe-core/src/test/java/com/starrocks/metric/MetricRepoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/metric/MetricRepoTest.java
@@ -22,6 +22,7 @@ import com.starrocks.clone.TabletSchedCtx;
 import com.starrocks.clone.TabletScheduler;
 import com.starrocks.clone.TabletSchedulerStat;
 import com.starrocks.common.Config;
+import com.starrocks.common.Version;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.http.rest.MetricsAction;
 import com.starrocks.journal.JournalType;
@@ -137,7 +138,33 @@ public class MetricRepoTest extends PlanTestBase {
     }
 
     @Test
+    public void testBuildInfoMetric() {
+        List<Metric> metrics = MetricRepo.getMetricsByName("build_info");
+        Assertions.assertEquals(1, metrics.size());
 
+        Metric metric = metrics.get(0);
+        Assertions.assertEquals(1L, metric.getValue());
+
+        MetricVisitor visitor = new PrometheusMetricVisitor("starrocks_fe");
+        visitor.visit(metric);
+        String output = visitor.build();
+
+        Assertions.assertTrue(
+                output.contains("# HELP starrocks_fe_build_info StarRocks FE build information"), output);
+        Assertions.assertTrue(output.contains("# TYPE starrocks_fe_build_info gauge"), output);
+
+        String buildInfoLine = output.lines()
+                .filter(line -> line.startsWith("starrocks_fe_build_info{"))
+                .findFirst()
+                .orElseThrow();
+        Assertions.assertTrue(
+                buildInfoLine.contains("version=\"" + Version.STARROCKS_VERSION + "\""), buildInfoLine);
+        Assertions.assertTrue(
+                buildInfoLine.contains("commit_hash=\"" + Version.STARROCKS_COMMIT_HASH + "\""), buildInfoLine);
+        Assertions.assertTrue(buildInfoLine.endsWith("} 1"), buildInfoLine);
+    }
+
+    @Test
     public void testSPMMetricsExposure() {
         MetricRepo.COUNTER_SPM_REWRITE_TOTAL.getMetric("hit").increase(1L);
         MetricRepo.COUNTER_SPM_CAPTURE_CANDIDATE_TOTAL.getMetric("captured").increase(1L);


### PR DESCRIPTION
## Why I'm doing:

StarRocks currently does not expose FE and BE version information as metrics. Users need to run `SHOW FRONTENDS` or `SHOW BACKENDS` to  check it.

## What I'm doing:

- Add `starrocks_fe_build_info` and `starrocks_be_build_info`.
- Add `version` and `commit_hash` labels.
- Add unit tests for FE and BE.
- Update the metric documents in English, Chinese, and Japanese.

Fixes #77358

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5