### PR TITLE
[BugFix] Preserve shared lake files during replication

### DIFF
--- a/be/src/storage/lake/lake_replication_txn_manager.cpp
+++ b/be/src/storage/lake/lake_replication_txn_manager.cpp
@@ -16,6 +16,7 @@
 
 #include <atomic>
 #include <mutex>
+#include <unordered_set>
 
 #include "base/coding.h"
 #include "base/testutil/sync_point.h"
@@ -353,6 +354,14 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
         return Status::Corruption("Failed to get source schema");
     }
     const TabletSchemaPB& source_schema_pb = src_tablet_meta->schema();
+    std::unordered_set<std::string> bundled_segment_names;
+    for (const auto& rowset : src_tablet_meta->rowsets()) {
+        for (const auto& segment : rowset.segment_metas()) {
+            if (segment.has_bundle_file_offset()) {
+                bundled_segment_names.emplace(segment.filename());
+            }
+        }
+    }
     std::unordered_map<uint32_t, uint32_t> column_unique_id_map;
     ReplicationUtils::calc_column_unique_id_map(source_schema_pb.column(), target_tablet_meta->schema().column(),
                                                 &column_unique_id_map);
@@ -360,6 +369,10 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
     if (column_unique_id_map.size() > 0) {
         LOG(INFO) << "Lake replicate storage task, need rebuild column unique id, txn_id: " << txn_id
                   << ", tablet_id: " << target_tablet_id << ", unique_id_map size: " << column_unique_id_map.size();
+        if (!bundled_segment_names.empty()) {
+            return Status::NotSupported(
+                    "Fast schema conversion of bundled segments is not supported in lake replication");
+        }
     }
     std::vector<std::string> files_to_delete;
     CancelableDefer clean_files([&files_to_delete]() { lake::delete_files_async(std::move(files_to_delete)); });
@@ -418,6 +431,7 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
             src_file_size = size_it->second;
         }
         bool is_seg = is_segment(src_file_name);
+        bool is_bundled_segment = is_seg && bundled_segment_names.contains(src_file_name);
         // Segments and .del files go through download_lake_file_with_converter + file_converters,
         // which routes .del files through DelFileStreamConverter when V1→V2 transcoding is needed.
         bool use_converter = is_seg || is_del(src_file_name);
@@ -428,7 +442,7 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
         }
 
         tasks.emplace_back([&, src_file_name, src_file_location, target_file_location, target_file_name, src_file_size,
-                            is_seg, use_converter, encryption_info]() -> Status {
+                            is_seg, is_bundled_segment, use_converter, encryption_info]() -> Status {
             // Fast cancel: check right before each file copy starts.
             if (txn_id < get_master_info().min_active_txn_id) {
                 LOG(WARNING) << "Lake replication task cancelled before file copy, transaction is aborted"
@@ -452,7 +466,7 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
                             src_file_location, src_file_name, src_file_size, shared_src_fs, active_file_converters,
                             &final_file_size));
                 }
-                if (is_seg && final_file_size > 0 && final_file_size != src_file_size) {
+                if (is_seg && !is_bundled_segment && final_file_size > 0 && final_file_size != src_file_size) {
                     if (shared_mutex != nullptr) {
                         std::lock_guard lock(*shared_mutex);
                         segment_size_changes[target_file_name] = final_file_size;
@@ -713,23 +727,19 @@ StatusOr<TabletMetadataPtr> LakeReplicationTxnManager::try_build_source_tablet_m
 }
 
 Status LakeReplicationTxnManager::build_existed_filename_uuids_map(
-        const TabletMetadataPtr& target_data_version_tablet_meta,
-        std::unordered_map<std::string, std::pair<std::string, std::string>>& existed_filename_uuids) {
+        const TabletMetadataPtr& target_data_version_tablet_meta, ExistingFileMap& existed_filename_uuids) {
     // Collect UUIDs from rowsets (segments and del files)
     for (const auto& rowset : target_data_version_tablet_meta->rowsets()) {
         for (const auto& segment_meta : rowset.segment_metas()) {
             const auto& segment_name = segment_meta.filename();
-            if (segment_meta.has_encryption_meta()) {
-                existed_filename_uuids.emplace(extract_uuid_from(segment_name),
-                                               std::make_pair(segment_name, segment_meta.encryption_meta()));
-            } else {
-                existed_filename_uuids.emplace(extract_uuid_from(segment_name), std::make_pair(segment_name, ""));
-            }
+            existed_filename_uuids.emplace(
+                    extract_uuid_from(segment_name),
+                    ExistingFileInfo{segment_name, segment_meta.encryption_meta(), segment_meta.shared()});
         }
         for (const auto& del : rowset.del_files()) {
             const auto& del_filename = del.name();
             existed_filename_uuids.emplace(extract_uuid_from(del_filename),
-                                           std::make_pair(del_filename, del.encryption_meta()));
+                                           ExistingFileInfo{del_filename, del.encryption_meta(), del.shared()});
         }
     }
 
@@ -739,7 +749,7 @@ Status LakeReplicationTxnManager::build_existed_filename_uuids_map(
         for (const auto& sst : dest_meta.sstables()) {
             const auto& sst_filename = sst.filename();
             existed_filename_uuids.emplace(extract_uuid_from(sst_filename),
-                                           std::make_pair(sst_filename, sst.encryption_meta()));
+                                           ExistingFileInfo{sst_filename, sst.encryption_meta(), sst.shared()});
         }
     }
 
@@ -748,8 +758,9 @@ Status LakeReplicationTxnManager::build_existed_filename_uuids_map(
         const auto& dest_meta = target_data_version_tablet_meta->delvec_meta();
         for (const auto& [_, file_meta_pb] : dest_meta.version_to_file()) {
             const auto& delvec_filename = file_meta_pb.name();
-            // Note: delvec files don't have separate encryption metas in current implementation
-            existed_filename_uuids.emplace(extract_uuid_from(delvec_filename), std::make_pair(delvec_filename, ""));
+            existed_filename_uuids.emplace(
+                    extract_uuid_from(delvec_filename),
+                    ExistingFileInfo{delvec_filename, file_meta_pb.encryption_meta(), file_meta_pb.shared()});
         }
     }
 
@@ -760,12 +771,10 @@ Status LakeReplicationTxnManager::build_existed_filename_uuids_map(
             bool has_encryption_meta = dcg_ver_pb.column_files_size() == dcg_ver_pb.encryption_metas_size();
             for (int i = 0; i < dcg_ver_pb.column_files_size(); ++i) {
                 const auto& dcg_filename = dcg_ver_pb.column_files(i);
-                if (has_encryption_meta) {
-                    existed_filename_uuids.emplace(extract_uuid_from(dcg_filename),
-                                                   std::make_pair(dcg_filename, dcg_ver_pb.encryption_metas(i)));
-                } else {
-                    existed_filename_uuids.emplace(extract_uuid_from(dcg_filename), std::make_pair(dcg_filename, ""));
-                }
+                const std::string encryption_meta = has_encryption_meta ? dcg_ver_pb.encryption_metas(i) : "";
+                const bool shared = i < dcg_ver_pb.shared_files_size() && dcg_ver_pb.shared_files(i);
+                existed_filename_uuids.emplace(extract_uuid_from(dcg_filename),
+                                               ExistingFileInfo{dcg_filename, encryption_meta, shared});
             }
         }
     }
@@ -779,8 +788,9 @@ Status LakeReplicationTxnManager::build_existed_filename_uuids_map(
                 if (!entry.has_index_file() || entry.index_file().empty()) {
                     continue;
                 }
-                existed_filename_uuids.emplace(extract_uuid_from(entry.index_file()),
-                                               std::make_pair(entry.index_file(), entry.encryption_meta()));
+                existed_filename_uuids.emplace(
+                        extract_uuid_from(entry.index_file()),
+                        ExistingFileInfo{entry.index_file(), entry.encryption_meta(), entry.shared_file()});
             }
         }
     }
@@ -797,12 +807,33 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
     VLOG(3) << "Lake replicate storage task, building new tablet meta for tablet: " << target_tablet_id
             << ", src_tablet_id: " << src_tablet_id << ", txn_id: " << txn_id << ", data_version: " << data_version;
     // find all files that already replicated to target storage in previous txns
-    ASSIGN_OR_RETURN(auto target_data_version_tablet_meta,
-                     _tablet_manager->get_tablet_metadata(target_tablet_id, data_version, false, 0, nullptr));
+    auto target_data_version_tablet_meta_or =
+            _tablet_manager->get_tablet_metadata(target_tablet_id, data_version, false, 0, nullptr);
+    TabletMetadataPtr target_data_version_tablet_meta;
+    if (target_data_version_tablet_meta_or.ok()) {
+        target_data_version_tablet_meta = std::move(target_data_version_tablet_meta_or).value();
+    } else if (target_data_version_tablet_meta_or.status().is_not_found() && target_tablet_meta->has_range() &&
+               target_tablet_meta->version() > data_version) {
+        target_data_version_tablet_meta = target_tablet_meta;
+    } else {
+        return target_data_version_tablet_meta_or.status();
+    }
     // `existed_filename_uuids` represented files that already replicated to target storage in previous txns
-    // <uuid, pair<existed_filename, encryption_meta>>
-    std::unordered_map<std::string, std::pair<std::string, std::string>> existed_filename_uuids;
+    // <uuid, destination filename/encryption/shared ownership>
+    ExistingFileMap existed_filename_uuids;
     RETURN_IF_ERROR(build_existed_filename_uuids_map(target_data_version_tablet_meta, existed_filename_uuids));
+
+    auto destination_shared = [&existed_filename_uuids](const std::string& source_filename,
+                                                        bool existed) -> StatusOr<bool> {
+        if (!existed) {
+            return false;
+        }
+        auto it = existed_filename_uuids.find(extract_uuid_from(source_filename));
+        if (it == existed_filename_uuids.end()) {
+            return Status::Corruption("Existing replicated file disappeared from the UUID map: " + source_filename);
+        }
+        return it->second.shared;
+    };
 
     VLOG(3) << "Lake replicate storage task, found " << existed_filename_uuids.size() << " existed files";
     // make new metadata
@@ -842,6 +873,8 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
             auto* new_seg_meta = new_rowset_meta->mutable_segment_metas(i);
             new_seg_meta->set_filename(final_segment_filename);
             new_seg_meta->clear_encryption_meta();
+            ASSIGN_OR_RETURN(auto destination_file_shared, destination_shared(src_segment_filename, is_existed));
+            new_seg_meta->set_shared(destination_file_shared);
 
             // Add encryption metadata for files
             if (config::enable_transparent_data_encryption) {
@@ -854,7 +887,7 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
                     auto uuid = extract_uuid_from(src_segment_filename);
                     auto it = existed_filename_uuids.find(uuid);
                     if (it != existed_filename_uuids.end()) {
-                        const std::string& existing_encryption_meta = it->second.second;
+                        const std::string& existing_encryption_meta = it->second.encryption_meta;
                         new_seg_meta->set_encryption_meta(existing_encryption_meta);
                     } else {
                         // should never happend
@@ -865,7 +898,7 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
             }
 
             // build segment_name_to_size_map, record the size of source segment file
-            if (src_seg_meta.has_size()) {
+            if (src_seg_meta.has_size() && !src_seg_meta.has_bundle_file_offset()) {
                 segment_name_to_size_map.emplace(src_segment_filename, src_seg_meta.size());
             }
         }
@@ -889,6 +922,8 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
             // predict here whether this particular file gets transcoded: absent means "not recorded"
             // and readers skip verification, same as the shared-nothing replication path.
             new_del->clear_crc32c();
+            ASSIGN_OR_RETURN(auto destination_file_shared, destination_shared(src_del_filename, is_existed));
+            new_del->set_shared(destination_file_shared);
 
             if (config::enable_transparent_data_encryption) {
                 if (!is_existed) {
@@ -900,7 +935,7 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
                     auto uuid = extract_uuid_from(src_del_filename);
                     auto it = existed_filename_uuids.find(uuid);
                     if (it != existed_filename_uuids.end()) {
-                        const std::string& existing_encryption_meta = it->second.second;
+                        const std::string& existing_encryption_meta = it->second.encryption_meta;
                         new_del->set_encryption_meta(existing_encryption_meta);
                     }
                 }
@@ -920,6 +955,8 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
                                                                        final_sst_filename, target_tablet_id,
                                                                        src_data_dir, file_locations, filename_map));
             sst->set_filename(final_sst_filename);
+            ASSIGN_OR_RETURN(auto destination_file_shared, destination_shared(src_sst_filename, is_existed));
+            sst->set_shared(destination_file_shared);
 
             if (config::enable_transparent_data_encryption) {
                 if (!is_existed) {
@@ -931,7 +968,7 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
                     auto uuid = extract_uuid_from(src_sst_filename);
                     auto it = existed_filename_uuids.find(uuid);
                     if (it != existed_filename_uuids.end()) {
-                        const std::string& existing_encryption_meta = it->second.second;
+                        const std::string& existing_encryption_meta = it->second.encryption_meta;
                         sst->set_encryption_meta(existing_encryption_meta);
                     }
                 }
@@ -952,6 +989,8 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
                                              target_tablet_id, src_data_dir, file_locations, filename_map));
             auto& item = (*dest_meta->mutable_version_to_file())[version];
             item.set_name(final_delvec_filename);
+            ASSIGN_OR_RETURN(auto destination_file_shared, destination_shared(src_delvec_filename, is_existed));
+            item.set_shared(destination_file_shared);
 
             if (config::enable_transparent_data_encryption) {
                 if (!is_existed) {
@@ -963,7 +1002,7 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
                     auto uuid = extract_uuid_from(src_delvec_filename);
                     auto it = existed_filename_uuids.find(uuid);
                     if (it != existed_filename_uuids.end()) {
-                        const std::string& existing_encryption_meta = it->second.second;
+                        const std::string& existing_encryption_meta = it->second.encryption_meta;
                         item.set_encryption_meta(existing_encryption_meta);
                     }
                 }
@@ -976,6 +1015,7 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
         DeltaColumnGroupMetadataPB* dest_meta = new_metadata->mutable_dcg_meta();
         dest_meta->CopyFrom(src_tablet_meta->dcg_meta());
         for (auto& [segment_id, dcg_ver_pb] : *dest_meta->mutable_dcgs()) {
+            dcg_ver_pb.clear_shared_files();
             for (int i = 0; i < dcg_ver_pb.column_files_size(); ++i) {
                 auto src_dcg_filename = dcg_ver_pb.column_files(i);
                 std::string final_dcg_filename;
@@ -984,6 +1024,8 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
                         determine_final_filename(src_dcg_filename, txn_id, existed_filename_uuids, final_dcg_filename,
                                                  target_tablet_id, src_data_dir, file_locations, filename_map));
                 dcg_ver_pb.set_column_files(i, final_dcg_filename);
+                ASSIGN_OR_RETURN(auto destination_file_shared, destination_shared(src_dcg_filename, is_existed));
+                dcg_ver_pb.add_shared_files(destination_file_shared);
 
                 if (config::enable_transparent_data_encryption) {
                     if (!is_existed) {
@@ -999,7 +1041,7 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
                         auto uuid = extract_uuid_from(src_dcg_filename);
                         auto it = existed_filename_uuids.find(uuid);
                         if (it != existed_filename_uuids.end()) {
-                            const std::string& existing_encryption_meta = it->second.second;
+                            const std::string& existing_encryption_meta = it->second.encryption_meta;
                             if (dcg_ver_pb.encryption_metas_size() > i) {
                                 dcg_ver_pb.set_encryption_metas(i, existing_encryption_meta);
                             } else {
@@ -1063,6 +1105,8 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
                         determine_final_filename(src_idx_filename, txn_id, existed_filename_uuids, final_idx_filename,
                                                  target_tablet_id, src_data_dir, file_locations, filename_map));
                 entry.set_index_file(final_idx_filename);
+                ASSIGN_OR_RETURN(auto destination_file_shared, destination_shared(src_idx_filename, is_existed));
+                entry.set_shared_file(destination_file_shared);
                 // The source's encryption meta belongs to the source cluster; drop it and
                 // re-derive against the target (matching the segment handling above).
                 entry.clear_encryption_meta();
@@ -1077,7 +1121,7 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
                         auto uuid = extract_uuid_from(src_idx_filename);
                         auto it = existed_filename_uuids.find(uuid);
                         if (it != existed_filename_uuids.end()) {
-                            entry.set_encryption_meta(it->second.second);
+                            entry.set_encryption_meta(it->second.encryption_meta);
                         }
                     }
                 }
@@ -1089,8 +1133,7 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
 }
 
 StatusOr<bool> LakeReplicationTxnManager::determine_final_filename(
-        const std::string& src_filename, TTransactionId txn_id,
-        const std::unordered_map<std::string, std::pair<std::string, std::string>>& existed_filename_uuids,
+        const std::string& src_filename, TTransactionId txn_id, const ExistingFileMap& existed_filename_uuids,
         std::string& final_filename, const int64_t target_tablet_id, const std::string& src_data_dir,
         std::map<std::string, std::string>& file_locations,
         std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>>& filename_map) {
@@ -1098,10 +1141,18 @@ StatusOr<bool> LakeReplicationTxnManager::determine_final_filename(
     auto it = existed_filename_uuids.find(uuid);
     if (it != existed_filename_uuids.end()) {
         // UUID exists, use the existing target filename
-        final_filename = it->second.first; // pair.first is the filename
+        final_filename = it->second.filename;
         LOG(INFO) << "File: " << src_filename
                   << " already exists on target cluster, use existing target filename: " << final_filename;
         return true;
+    }
+
+    // One physical bundle object can appear as multiple logical segment slices. Register and
+    // copy it once, while every SegmentMetadataPB keeps its own bundle_file_offset and size.
+    auto pending_it = filename_map.find(src_filename);
+    if (pending_it != filename_map.end()) {
+        final_filename = pending_it->second.first;
+        return false;
     }
 
     // UUID not exists, generate new filename

--- a/be/src/storage/lake/lake_replication_txn_manager.cpp
+++ b/be/src/storage/lake/lake_replication_txn_manager.cpp
@@ -341,13 +341,6 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
 
     ASSIGN_OR_RETURN(auto target_tablet, _tablet_manager->get_tablet(target_tablet_id));
     ASSIGN_OR_RETURN(auto target_tablet_meta, target_tablet.get_metadata(target_visible_version));
-    // Copy the rowsets, sstables etc. into tablet metadata on target cluster,
-    // then replace file names and return `copied_target_tablet_meta` as the final target tablet metadata
-    ASSIGN_OR_RETURN(auto copied_target_tablet_meta,
-                     convert_and_build_new_tablet_meta(src_tablet_meta, target_tablet_meta, src_tablet_id,
-                                                       target_tablet_id, txn_id, data_version, src_data_dir,
-                                                       segment_name_to_size_map, file_locations, filename_map));
-    // calc column unique id to adapt for fast schema change
     if (!src_tablet_meta->has_schema()) {
         LOG(WARNING) << "Failed to get source schema, source tablet: " << src_tablet_id
                      << ", target tablet: " << target_tablet_id;
@@ -357,11 +350,22 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
     std::unordered_set<std::string> bundled_segment_names;
     for (const auto& rowset : src_tablet_meta->rowsets()) {
         for (const auto& segment : rowset.segment_metas()) {
-            if (segment.has_bundle_file_offset()) {
-                bundled_segment_names.emplace(segment.filename());
+            if (!segment.has_bundle_file_offset()) {
+                continue;
+            }
+            bundled_segment_names.emplace(segment.filename());
+            if (!segment.encryption_meta().empty()) {
+                return Status::NotSupported("Encrypted bundled segments are not supported in lake replication");
             }
         }
     }
+    // Copy the rowsets, sstables etc. into tablet metadata on target cluster,
+    // then replace file names and return `copied_target_tablet_meta` as the final target tablet metadata
+    ASSIGN_OR_RETURN(auto copied_target_tablet_meta,
+                     convert_and_build_new_tablet_meta(src_tablet_meta, target_tablet_meta, src_tablet_id,
+                                                       target_tablet_id, txn_id, data_version, src_data_dir,
+                                                       segment_name_to_size_map, file_locations, filename_map));
+    // calc column unique id to adapt for fast schema change
     std::unordered_map<uint32_t, uint32_t> column_unique_id_map;
     ReplicationUtils::calc_column_unique_id_map(source_schema_pb.column(), target_tablet_meta->schema().column(),
                                                 &column_unique_id_map);

--- a/be/src/storage/lake/lake_replication_txn_manager.cpp
+++ b/be/src/storage/lake/lake_replication_txn_manager.cpp
@@ -827,8 +827,17 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
     ExistingFileMap existed_filename_uuids;
     RETURN_IF_ERROR(build_existed_filename_uuids_map(target_data_version_tablet_meta, existed_filename_uuids));
 
-    auto destination_shared = [&existed_filename_uuids](const std::string& source_filename,
-                                                        bool existed) -> StatusOr<bool> {
+    const bool preserve_source_shared = src_tablet_meta->has_range() && target_tablet_meta->has_range();
+    auto destination_shared = [&existed_filename_uuids, preserve_source_shared](const std::string& source_filename,
+                                                                                bool source_shared,
+                                                                                bool existed) -> StatusOr<bool> {
+        // For aligned range tablets, a source-shared segment can contain rows for multiple
+        // split children. The shared bit makes each child apply its tablet range while reading.
+        // The corresponding target children also use one physical copied file, so preserve the
+        // bit for all associated sidecars as well.
+        if (preserve_source_shared && source_shared) {
+            return true;
+        }
         if (!existed) {
             return false;
         }
@@ -877,7 +886,8 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
             auto* new_seg_meta = new_rowset_meta->mutable_segment_metas(i);
             new_seg_meta->set_filename(final_segment_filename);
             new_seg_meta->clear_encryption_meta();
-            ASSIGN_OR_RETURN(auto destination_file_shared, destination_shared(src_segment_filename, is_existed));
+            ASSIGN_OR_RETURN(auto destination_file_shared,
+                             destination_shared(src_segment_filename, src_seg_meta.shared(), is_existed));
             new_seg_meta->set_shared(destination_file_shared);
 
             // Add encryption metadata for files
@@ -926,7 +936,8 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
             // predict here whether this particular file gets transcoded: absent means "not recorded"
             // and readers skip verification, same as the shared-nothing replication path.
             new_del->clear_crc32c();
-            ASSIGN_OR_RETURN(auto destination_file_shared, destination_shared(src_del_filename, is_existed));
+            ASSIGN_OR_RETURN(auto destination_file_shared,
+                             destination_shared(src_del_filename, src_del.shared(), is_existed));
             new_del->set_shared(destination_file_shared);
 
             if (config::enable_transparent_data_encryption) {
@@ -959,7 +970,8 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
                                                                        final_sst_filename, target_tablet_id,
                                                                        src_data_dir, file_locations, filename_map));
             sst->set_filename(final_sst_filename);
-            ASSIGN_OR_RETURN(auto destination_file_shared, destination_shared(src_sst_filename, is_existed));
+            ASSIGN_OR_RETURN(auto destination_file_shared,
+                             destination_shared(src_sst_filename, sst->shared(), is_existed));
             sst->set_shared(destination_file_shared);
 
             if (config::enable_transparent_data_encryption) {
@@ -993,7 +1005,8 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
                                              target_tablet_id, src_data_dir, file_locations, filename_map));
             auto& item = (*dest_meta->mutable_version_to_file())[version];
             item.set_name(final_delvec_filename);
-            ASSIGN_OR_RETURN(auto destination_file_shared, destination_shared(src_delvec_filename, is_existed));
+            ASSIGN_OR_RETURN(auto destination_file_shared,
+                             destination_shared(src_delvec_filename, file_meta_pb.shared(), is_existed));
             item.set_shared(destination_file_shared);
 
             if (config::enable_transparent_data_encryption) {
@@ -1019,6 +1032,11 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
         DeltaColumnGroupMetadataPB* dest_meta = new_metadata->mutable_dcg_meta();
         dest_meta->CopyFrom(src_tablet_meta->dcg_meta());
         for (auto& [segment_id, dcg_ver_pb] : *dest_meta->mutable_dcgs()) {
+            std::vector<bool> source_shared_files;
+            source_shared_files.reserve(dcg_ver_pb.column_files_size());
+            for (int i = 0; i < dcg_ver_pb.column_files_size(); ++i) {
+                source_shared_files.emplace_back(i < dcg_ver_pb.shared_files_size() && dcg_ver_pb.shared_files(i));
+            }
             dcg_ver_pb.clear_shared_files();
             for (int i = 0; i < dcg_ver_pb.column_files_size(); ++i) {
                 auto src_dcg_filename = dcg_ver_pb.column_files(i);
@@ -1028,7 +1046,8 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
                         determine_final_filename(src_dcg_filename, txn_id, existed_filename_uuids, final_dcg_filename,
                                                  target_tablet_id, src_data_dir, file_locations, filename_map));
                 dcg_ver_pb.set_column_files(i, final_dcg_filename);
-                ASSIGN_OR_RETURN(auto destination_file_shared, destination_shared(src_dcg_filename, is_existed));
+                ASSIGN_OR_RETURN(auto destination_file_shared,
+                                 destination_shared(src_dcg_filename, source_shared_files[i], is_existed));
                 dcg_ver_pb.add_shared_files(destination_file_shared);
 
                 if (config::enable_transparent_data_encryption) {
@@ -1109,7 +1128,8 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
                         determine_final_filename(src_idx_filename, txn_id, existed_filename_uuids, final_idx_filename,
                                                  target_tablet_id, src_data_dir, file_locations, filename_map));
                 entry.set_index_file(final_idx_filename);
-                ASSIGN_OR_RETURN(auto destination_file_shared, destination_shared(src_idx_filename, is_existed));
+                ASSIGN_OR_RETURN(auto destination_file_shared,
+                                 destination_shared(src_idx_filename, entry.shared_file(), is_existed));
                 entry.set_shared_file(destination_file_shared);
                 // The source's encryption meta belongs to the source cluster; drop it and
                 // re-derive against the target (matching the segment handling above).

--- a/be/src/storage/lake/lake_replication_txn_manager.cpp
+++ b/be/src/storage/lake/lake_replication_txn_manager.cpp
@@ -828,21 +828,24 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
     RETURN_IF_ERROR(build_existed_filename_uuids_map(target_data_version_tablet_meta, existed_filename_uuids));
 
     const bool preserve_source_shared = src_tablet_meta->has_range() && target_tablet_meta->has_range();
-    auto destination_shared = [&existed_filename_uuids, preserve_source_shared](const std::string& source_filename,
-                                                                                bool source_shared,
-                                                                                bool existed) -> StatusOr<bool> {
+    auto destination_shared = [&existed_filename_uuids, preserve_source_shared](
+                                      const std::string& source_filename, bool source_shared, bool existed,
+                                      bool source_bundled = false) -> StatusOr<bool> {
+        // Bundled segments can share one physical object across tablet tasks regardless of the
+        // distribution type. Range split children also share one partition data path. Separate
+        // tasks cannot safely encrypt a new shared object with independently generated DEKs;
+        // existing objects are safe because their destination encryption metadata is reused.
+        if (config::enable_transparent_data_encryption && !existed &&
+            (source_bundled || (preserve_source_shared && source_shared))) {
+            return Status::NotSupported(
+                    "Copying new shared or bundled physical files with transparent data encryption is not "
+                    "supported");
+        }
         // For aligned range tablets, a source-shared segment can contain rows for multiple
         // split children. The shared bit makes each child apply its tablet range while reading.
         // The corresponding target children also use one physical copied file, so preserve the
         // bit for all associated sidecars as well.
         if (preserve_source_shared && source_shared) {
-            // Split children share one partition data path. Separate replication tasks cannot
-            // safely encrypt a newly copied shared object with independently generated DEKs.
-            // Existing objects are safe because their destination encryption metadata is reused.
-            if (config::enable_transparent_data_encryption && !existed) {
-                return Status::NotSupported(
-                        "Copying new shared range files with transparent data encryption is not supported");
-            }
             return true;
         }
         if (!existed) {
@@ -893,8 +896,10 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
             auto* new_seg_meta = new_rowset_meta->mutable_segment_metas(i);
             new_seg_meta->set_filename(final_segment_filename);
             new_seg_meta->clear_encryption_meta();
-            ASSIGN_OR_RETURN(auto destination_file_shared,
-                             destination_shared(src_segment_filename, src_seg_meta.shared(), is_existed));
+            ASSIGN_OR_RETURN(
+                    auto destination_file_shared,
+                    destination_shared(src_segment_filename, src_seg_meta.shared(), is_existed,
+                                       src_seg_meta.has_bundle_file_offset()));
             new_seg_meta->set_shared(destination_file_shared);
 
             // Add encryption metadata for files

--- a/be/src/storage/lake/lake_replication_txn_manager.cpp
+++ b/be/src/storage/lake/lake_replication_txn_manager.cpp
@@ -16,6 +16,7 @@
 
 #include <atomic>
 #include <mutex>
+#include <optional>
 #include <unordered_set>
 
 #include "base/coding.h"
@@ -56,6 +57,69 @@ namespace {
 // Parallel copy is disabled when queue depth exceeds num_threads * this factor
 // to avoid adding more pressure to an already saturated pool.
 constexpr int kParallelCopyMaxQueuePerThread = 8;
+
+std::unordered_set<std::string> collect_shared_file_names(const TabletMetadataPB& metadata) {
+    std::unordered_set<std::string> files;
+    for (const auto& rowset : metadata.rowsets()) {
+        for (const auto& segment : rowset.segment_metas()) {
+            if (segment.shared()) {
+                files.emplace(segment.filename());
+            }
+        }
+        for (const auto& del : rowset.del_files()) {
+            if (del.shared()) {
+                files.emplace(del.name());
+            }
+        }
+    }
+    for (const auto& sstable : metadata.sstable_meta().sstables()) {
+        if (sstable.shared()) {
+            files.emplace(sstable.filename());
+        }
+    }
+    for (const auto& [_, file] : metadata.delvec_meta().version_to_file()) {
+        if (file.shared()) {
+            files.emplace(file.name());
+        }
+    }
+    for (const auto& [_, dcg] : metadata.dcg_meta().dcgs()) {
+        for (int i = 0; i < dcg.column_files_size(); ++i) {
+            if (i < dcg.shared_files_size() && dcg.shared_files(i)) {
+                files.emplace(dcg.column_files(i));
+            }
+        }
+    }
+    for (const auto& [_, idg] : metadata.idg_meta().idgs()) {
+        for (const auto& entry : idg.entries()) {
+            if (entry.shared_file() && entry.has_index_file() && !entry.index_file().empty()) {
+                files.emplace(entry.index_file());
+            }
+        }
+    }
+    return files;
+}
+
+StatusOr<std::optional<size_t>> get_existing_file_size(const std::string& path) {
+    ASSIGN_OR_RETURN(auto fs, FileSystemFactory::CreateSharedFromString(path));
+    auto size = fs->get_file_size(path);
+    std::optional<size_t> existing_size;
+    if (size.ok()) {
+        existing_size = static_cast<size_t>(*size);
+    } else if (!size.status().is_not_found()) {
+        return size.status();
+    }
+    TEST_SYNC_POINT_CALLBACK("LakeReplicationTxnManager::get_existing_file_size", &existing_size);
+    return existing_size;
+}
+
+void remove_cleanup_file(std::vector<std::string>* files_to_delete, const std::string& path, std::mutex* mutex) {
+    if (mutex != nullptr) {
+        std::lock_guard lock(*mutex);
+        std::erase(*files_to_delete, path);
+    } else {
+        std::erase(*files_to_delete, path);
+    }
+}
 
 StatusOr<TabletMetadataPtr> load_source_standalone_tablet_metadata(const std::string& metadata_path,
                                                                    const std::shared_ptr<FileSystem>& source_fs) {
@@ -365,6 +429,12 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
                      convert_and_build_new_tablet_meta(src_tablet_meta, target_tablet_meta, src_tablet_id,
                                                        target_tablet_id, txn_id, data_version, src_data_dir,
                                                        segment_name_to_size_map, file_locations, filename_map));
+    std::unordered_set<std::string> shared_file_names;
+    if (src_tablet_meta->has_range() && target_tablet_meta->has_range()) {
+        // Aligned range children retain the source shared-file flags and resolve to the same
+        // partition data path, so their per-tablet replication tasks may target the same object.
+        shared_file_names = collect_shared_file_names(*src_tablet_meta);
+    }
     // calc column unique id to adapt for fast schema change
     std::unordered_map<uint32_t, uint32_t> column_unique_id_map;
     ReplicationUtils::calc_column_unique_id_map(source_schema_pb.column(), target_tablet_meta->schema().column(),
@@ -436,6 +506,7 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
         }
         bool is_seg = is_segment(src_file_name);
         bool is_bundled_segment = is_seg && bundled_segment_names.contains(src_file_name);
+        bool is_shared_file = shared_file_names.contains(src_file_name);
         // Segments and .del files go through download_lake_file_with_converter + file_converters,
         // which routes .del files through DelFileStreamConverter when V1→V2 transcoding is needed.
         bool use_converter = is_seg || is_del(src_file_name);
@@ -446,7 +517,7 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
         }
 
         tasks.emplace_back([&, src_file_name, src_file_location, target_file_location, target_file_name, src_file_size,
-                            is_seg, is_bundled_segment, use_converter, encryption_info]() -> Status {
+                            is_seg, is_bundled_segment, is_shared_file, use_converter, encryption_info]() -> Status {
             // Fast cancel: check right before each file copy starts.
             if (txn_id < get_master_info().min_active_txn_id) {
                 LOG(WARNING) << "Lake replication task cancelled before file copy, transaction is aborted"
@@ -461,14 +532,41 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
                       << ", txn_id: " << txn_id << ", tablet_id: " << target_tablet_id;
 
             size_t final_file_size = 0;
+            bool copy_needed = true;
             auto start_ts = butil::gettimeofday_us();
-            if (use_converter) {
+            if (is_shared_file) {
+                // Reuse a sibling's completed copy. Remote shared-data filesystems expose the
+                // final path after close/rename, rather than exposing an in-progress multipart or
+                // temporary file at this path.
+                ASSIGN_OR_RETURN(auto existing_size, get_existing_file_size(target_file_location));
+                if (existing_size.has_value()) {
+                    final_file_size = *existing_size;
+                    copy_needed = false;
+                    LOG(INFO) << "Skip copying an existing shared range file, src: " << src_file_location
+                              << ", target: " << target_file_location << ", txn_id: " << txn_id
+                              << ", tablet_id: " << target_tablet_id << ", size: " << final_file_size;
+                }
+            }
+            if (copy_needed && use_converter) {
                 TEST_SYNC_POINT_CALLBACK("LakeReplicationTxnManager::replicate_task::download_segment",
                                          &final_file_size);
                 if (final_file_size == 0) {
-                    RETURN_IF_ERROR(ReplicationUtils::download_lake_file_with_converter(
+                    auto copy_status = ReplicationUtils::download_lake_file_with_converter(
                             src_file_location, src_file_name, src_file_size, shared_src_fs, active_file_converters,
-                            &final_file_size));
+                            &final_file_size);
+                    if (is_shared_file) {
+                        remove_cleanup_file(&files_to_delete, target_file_location, shared_mutex);
+                        if (copy_status.is_already_exist()) {
+                            ASSIGN_OR_RETURN(auto existing_size, get_existing_file_size(target_file_location));
+                            if (!existing_size.has_value()) {
+                                return Status::Corruption("Shared range file disappeared after concurrent copy: " +
+                                                          target_file_location);
+                            }
+                            final_file_size = *existing_size;
+                            copy_status = Status::OK();
+                        }
+                    }
+                    RETURN_IF_ERROR(copy_status);
                 }
                 if (is_seg && !is_bundled_segment && final_file_size > 0 && final_file_size != src_file_size) {
                     if (shared_mutex != nullptr) {
@@ -481,7 +579,7 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
                               << ", target_file: " << target_file_name << ", original size: " << src_file_size
                               << ", final size: " << final_file_size;
                 }
-            } else {
+            } else if (copy_needed) {
                 WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
                 if (config::enable_transparent_data_encryption) {
                     opts.encryption_info = encryption_info;
@@ -490,15 +588,26 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
                 TEST_SYNC_POINT_CALLBACK("LakeReplicationTxnManager::replicate_task::copy_non_segment",
                                          &final_file_size);
                 if (final_file_size == 0) {
-                    ASSIGN_OR_RETURN(final_file_size,
-                                     copy_non_segment_file_with_retry(src_file_location, shared_src_fs,
-                                                                      target_file_location, opts, max_retry));
+                    auto copy_result = copy_non_segment_file_with_retry(src_file_location, shared_src_fs,
+                                                                        target_file_location, opts, max_retry);
+                    if (!copy_result.ok() && is_shared_file && copy_result.status().is_already_exist()) {
+                        ASSIGN_OR_RETURN(auto existing_size, get_existing_file_size(target_file_location));
+                        if (!existing_size.has_value()) {
+                            return Status::Corruption("Shared range file disappeared after concurrent copy: " +
+                                                      target_file_location);
+                        }
+                        final_file_size = *existing_size;
+                    } else {
+                        ASSIGN_OR_RETURN(final_file_size, std::move(copy_result));
+                    }
                 }
-                if (shared_mutex != nullptr) {
-                    std::lock_guard lock(*shared_mutex);
-                    files_to_delete.push_back(target_file_location);
-                } else {
-                    files_to_delete.push_back(target_file_location);
+                if (!is_shared_file) {
+                    if (shared_mutex != nullptr) {
+                        std::lock_guard lock(*shared_mutex);
+                        files_to_delete.push_back(target_file_location);
+                    } else {
+                        files_to_delete.push_back(target_file_location);
+                    }
                 }
             }
 

--- a/be/src/storage/lake/lake_replication_txn_manager.cpp
+++ b/be/src/storage/lake/lake_replication_txn_manager.cpp
@@ -896,10 +896,9 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
             auto* new_seg_meta = new_rowset_meta->mutable_segment_metas(i);
             new_seg_meta->set_filename(final_segment_filename);
             new_seg_meta->clear_encryption_meta();
-            ASSIGN_OR_RETURN(
-                    auto destination_file_shared,
-                    destination_shared(src_segment_filename, src_seg_meta.shared(), is_existed,
-                                       src_seg_meta.has_bundle_file_offset()));
+            ASSIGN_OR_RETURN(auto destination_file_shared,
+                             destination_shared(src_segment_filename, src_seg_meta.shared(), is_existed,
+                                                src_seg_meta.has_bundle_file_offset()));
             new_seg_meta->set_shared(destination_file_shared);
 
             // Add encryption metadata for files

--- a/be/src/storage/lake/lake_replication_txn_manager.cpp
+++ b/be/src/storage/lake/lake_replication_txn_manager.cpp
@@ -836,6 +836,13 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
         // The corresponding target children also use one physical copied file, so preserve the
         // bit for all associated sidecars as well.
         if (preserve_source_shared && source_shared) {
+            // Split children share one partition data path. Separate replication tasks cannot
+            // safely encrypt a newly copied shared object with independently generated DEKs.
+            // Existing objects are safe because their destination encryption metadata is reused.
+            if (config::enable_transparent_data_encryption && !existed) {
+                return Status::NotSupported(
+                        "Copying new shared range files with transparent data encryption is not supported");
+            }
             return true;
         }
         if (!existed) {

--- a/be/src/storage/lake/lake_replication_txn_manager.cpp
+++ b/be/src/storage/lake/lake_replication_txn_manager.cpp
@@ -506,7 +506,7 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
         }
         bool is_seg = is_segment(src_file_name);
         bool is_bundled_segment = is_seg && bundled_segment_names.contains(src_file_name);
-        bool is_shared_file = shared_file_names.contains(src_file_name);
+        bool is_shared_file = is_bundled_segment || shared_file_names.contains(src_file_name);
         // Segments and .del files go through download_lake_file_with_converter + file_converters,
         // which routes .del files through DelFileStreamConverter when V1→V2 transcoding is needed.
         bool use_converter = is_seg || is_del(src_file_name);
@@ -542,7 +542,7 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
                 if (existing_size.has_value()) {
                     final_file_size = *existing_size;
                     copy_needed = false;
-                    LOG(INFO) << "Skip copying an existing shared range file, src: " << src_file_location
+                    LOG(INFO) << "Skip copying an existing shared physical file, src: " << src_file_location
                               << ", target: " << target_file_location << ", txn_id: " << txn_id
                               << ", tablet_id: " << target_tablet_id << ", size: " << final_file_size;
                 }
@@ -559,7 +559,7 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
                         if (copy_status.is_already_exist()) {
                             ASSIGN_OR_RETURN(auto existing_size, get_existing_file_size(target_file_location));
                             if (!existing_size.has_value()) {
-                                return Status::Corruption("Shared range file disappeared after concurrent copy: " +
+                                return Status::Corruption("Shared physical file disappeared after concurrent copy: " +
                                                           target_file_location);
                             }
                             final_file_size = *existing_size;
@@ -593,7 +593,7 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
                     if (!copy_result.ok() && is_shared_file && copy_result.status().is_already_exist()) {
                         ASSIGN_OR_RETURN(auto existing_size, get_existing_file_size(target_file_location));
                         if (!existing_size.has_value()) {
-                            return Status::Corruption("Shared range file disappeared after concurrent copy: " +
+                            return Status::Corruption("Shared physical file disappeared after concurrent copy: " +
                                                       target_file_location);
                         }
                         final_file_size = *existing_size;

--- a/be/src/storage/lake/lake_replication_txn_manager.h
+++ b/be/src/storage/lake/lake_replication_txn_manager.h
@@ -16,6 +16,8 @@
 
 #include <atomic>
 #include <functional>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "common/status.h"
@@ -41,6 +43,13 @@ class TabletManager;
 class LakeReplicationTxnManager {
 public:
     using ReplicationTask = std::function<Status()>;
+
+    struct ExistingFileInfo {
+        std::string filename;
+        std::string encryption_meta;
+        bool shared = false;
+    };
+    using ExistingFileMap = std::unordered_map<std::string, ExistingFileInfo>;
 
     explicit LakeReplicationTxnManager(lake::TabletManager* tablet_manager)
             : _tablet_manager(tablet_manager)
@@ -72,9 +81,8 @@ public:
     // For files that replicated from source storage, we keep the `uuid` part of file name, and use it to decide if the file
     // is already replicated to target storage. Map from UUID to target filename.
     // Also, in order to support file encryption, we also need to keep the encryption meta.
-    Status build_existed_filename_uuids_map(
-            const TabletMetadataPtr& target_data_version_tablet_meta,
-            std::unordered_map<std::string, std::pair<std::string, std::string>>& existed_filename_uuids);
+    Status build_existed_filename_uuids_map(const TabletMetadataPtr& target_data_version_tablet_meta,
+                                            ExistingFileMap& existed_filename_uuids);
 
     // Helper function to create replication txn log with converted metadata
     // generate and replace file names to adapt for target storage
@@ -87,8 +95,7 @@ public:
 
     // Helper functions for filename conversion and building file mappings
     StatusOr<bool> determine_final_filename(
-            const std::string& src_filename, TTransactionId txn_id,
-            const std::unordered_map<std::string, std::pair<std::string, std::string>>& existed_filename_uuids,
+            const std::string& src_filename, TTransactionId txn_id, const ExistingFileMap& existed_filename_uuids,
             std::string& final_filename, int64_t target_tablet_id, const std::string& src_data_dir,
             std::map<std::string, std::string>& file_locations,
             std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>>& filename_map);

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -2442,6 +2442,94 @@ TEST_F(LakeReplicationRemoteStorageTest, copies_complete_bundle_object_through_f
     EXPECT_EQ(physical_contents, copied_contents);
 }
 
+TEST_F(LakeReplicationRemoteStorageTest, range_siblings_reuse_shared_file_without_failed_cleanup) {
+    const std::string contents = "shared-range-segment";
+    auto mock_fs = std::make_shared<MockStarletFileSystemForReplication>(contents);
+    SyncPoint::GetInstance()->SetCallBack("new_fs_starlet::get_shard_filesystem", [&](void* arg) {
+        auto* fs_st = static_cast<absl::StatusOr<std::shared_ptr<staros::starlet::fslib::FileSystem>>*>(arg);
+        *fs_st = mock_fs;
+    });
+
+    const std::string segment_name = "0000000000000001_aaaaaaaa-bbbb-cccc-dddd-000000000073.dat";
+    auto source = std::make_shared<TabletMetadata>(*_src_tablet_metadata);
+    source->set_version(2);
+    source->mutable_range();
+    auto* rowset = source->add_rowsets();
+    rowset->set_id(1);
+    auto* segment = rowset->add_segment_metas();
+    segment->set_filename(segment_name);
+    segment->set_size(contents.size());
+    segment->set_shared(true);
+    source->set_next_rowset_id(2);
+
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::build_source_tablet_meta::inject",
+                                          [&](void* arg) {
+                                              auto* meta_ptr = static_cast<TabletMetadataPtr*>(arg);
+                                              *meta_ptr = source;
+                                          });
+    bool hide_existing_file = false;
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::get_existing_file_size", [&](void* arg) {
+        if (hide_existing_file) {
+            static_cast<std::optional<size_t>*>(arg)->reset();
+        }
+    });
+
+    _target_tablet_metadata->mutable_range();
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*_target_tablet_metadata));
+
+    auto original_master_info = get_master_info();
+    TMasterInfo info = original_master_info;
+    info.__set_min_active_txn_id(0);
+    ASSERT_TRUE(update_master_info(info));
+
+    auto first_request = build_request(false /* with_full_path */);
+    first_request.__set_virtual_tablet_id(_virtual_tablet_id + 73);
+    ASSERT_OK(_replication_txn_manager->replicate_lake_remote_storage(first_request, nullptr));
+
+    ASSIGN_OR_ABORT(auto first_txn_log, _tablet_mgr->get_txn_log(_target_tablet_id, _transaction_id));
+    const auto& target_segment = first_txn_log->op_replication().tablet_metadata().rowsets(0).segment_metas(0);
+    const std::string target_path = _tablet_mgr->segment_location(_target_tablet_id, target_segment.filename());
+    ASSERT_TRUE(fs::path_exist(target_path));
+
+    const int64_t sibling_tablet_id = _target_tablet_id + 1;
+    auto sibling = generate_simple_tablet_metadata(sibling_tablet_id);
+    sibling->mutable_range();
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*sibling));
+
+    PFailPointTriggerMode trigger_mode;
+    trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
+    auto* fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get("put_txn_log_fail");
+    ASSERT_NE(nullptr, fp);
+    fp->setMode(trigger_mode);
+
+    auto sibling_request = first_request;
+    sibling_request.__set_tablet_id(sibling_tablet_id);
+    // Model the concurrent interleaving where this sibling checked the target before the first
+    // copy became visible. It must copy independently but must not acquire cleanup ownership.
+    hide_existing_file = true;
+    Status sibling_status = _replication_txn_manager->replicate_lake_remote_storage(sibling_request, nullptr);
+    hide_existing_file = false;
+
+    trigger_mode.set_mode(FailPointTriggerModeType::DISABLE);
+    fp->setMode(trigger_mode);
+
+    ASSERT_TRUE(sibling_status.is_internal_error()) << sibling_status;
+    StorageEngine::instance()->wait_storage_cleanup_tasks();
+    EXPECT_TRUE(fs::path_exist(target_path));
+    EXPECT_EQ(2, mock_fs->open_count());
+
+    const int64_t third_tablet_id = sibling_tablet_id + 1;
+    auto third = generate_simple_tablet_metadata(third_tablet_id);
+    third->mutable_range();
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*third));
+    auto third_request = first_request;
+    third_request.__set_tablet_id(third_tablet_id);
+    ASSERT_OK(_replication_txn_manager->replicate_lake_remote_storage(third_request, nullptr));
+    EXPECT_EQ(2, mock_fs->open_count());
+
+    (void)update_master_info(original_master_info);
+}
+
 TEST_F(LakeReplicationRemoteStorageTest, rejects_bundled_fast_schema_conversion__encrypted_slices_before_copy) {
     auto mock_fs = std::make_shared<MockStarletFileSystemForReplication>();
     SyncPoint::GetInstance()->SetCallBack("new_fs_starlet::get_shard_filesystem", [&](void* arg) {

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -1243,6 +1243,21 @@ TEST_F(LakeReplicationMetadataConversionTest, shared_file_ownership_matrix) {
     EXPECT_TRUE((*result)->sstable_meta().sstables(2).filename().ends_with(".sst"));
 }
 
+TEST_F(LakeReplicationMetadataConversionTest, range_shared_files_remain_shared_after_copy) {
+    auto source = make_metadata(53011, 2, true);
+    auto target = make_metadata(53012, 1, true);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*target));
+
+    // A split range tablet can reference only a slice of a physical segment. The shared bit
+    // also tells the reader to apply the tablet range, so clearing it after copying the file
+    // would make every split child read the complete physical segment.
+    add_file_set(source.get(), 0, true);
+
+    auto result = convert(source, target, 1, lake::join_path(_test_dir, "source_data"));
+    ASSERT_OK(result.status());
+    expect_file_set_shared(**result, 0, 0, true);
+}
+
 TEST_F(LakeReplicationMetadataConversionTest, shared_file_ownership_matrix_tde_metadata) {
     EncryptionKeyPB pb;
     pb.set_id(EncryptionKey::DEFAULT_MASTER_KYE_ID);

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -1288,6 +1288,29 @@ TEST_F(LakeReplicationMetadataConversionTest, range_new_shared_files_with_tde_ar
     EXPECT_TRUE(result.status().is_not_supported()) << result.status();
 }
 
+TEST_F(LakeReplicationMetadataConversionTest, new_bundled_segments_with_tde_are_rejected) {
+    seed_test_encryption_keys();
+    BoolConfigGuard enc_guard(&config::enable_transparent_data_encryption);
+    config::enable_transparent_data_encryption = true;
+
+    for (bool range_table : {true, false}) {
+        auto source = make_metadata(range_table ? 53025 : 53027, 2, range_table);
+        auto target = make_metadata(range_table ? 53026 : 53028, 1, range_table);
+        ASSERT_OK(_tablet_mgr->put_tablet_metadata(*target));
+        auto* rowset = source->add_rowsets();
+        rowset->set_id(1);
+        auto* segment = rowset->add_segment_metas();
+        segment->set_filename(file_name(25, "dat"));
+        segment->set_size(11);
+        segment->set_bundle_file_offset(0);
+        segment->set_shared(false);
+
+        auto result = convert(source, target, 1, lake::join_path(_test_dir, "source_data"));
+        ASSERT_FALSE(result.ok()) << "range_table=" << range_table;
+        EXPECT_TRUE(result.status().is_not_supported()) << result.status();
+    }
+}
+
 TEST_F(LakeReplicationMetadataConversionTest, range_existing_shared_files_with_tde_reuse_encryption_meta) {
     seed_test_encryption_keys();
     BoolConfigGuard enc_guard(&config::enable_transparent_data_encryption);

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -1258,6 +1258,66 @@ TEST_F(LakeReplicationMetadataConversionTest, range_shared_files_remain_shared_a
     expect_file_set_shared(**result, 0, 0, true);
 }
 
+TEST_F(LakeReplicationMetadataConversionTest, range_new_shared_files_with_tde_are_rejected) {
+    EncryptionKeyPB pb;
+    pb.set_id(EncryptionKey::DEFAULT_MASTER_KYE_ID);
+    pb.set_type(EncryptionKeyTypePB::NORMAL_KEY);
+    pb.set_algorithm(EncryptionAlgorithmPB::AES_128);
+    pb.set_plain_key("0000000000000000");
+    std::unique_ptr<EncryptionKey> root_encryption_key = EncryptionKey::create_from_pb(pb).value();
+    auto val_st = root_encryption_key->generate_key();
+    ASSERT_TRUE(val_st.ok());
+    std::unique_ptr<EncryptionKey> encryption_key = std::move(val_st.value());
+    encryption_key->set_id(2);
+    KeyCache::instance().add_key(root_encryption_key);
+    KeyCache::instance().add_key(encryption_key);
+    BoolConfigGuard enc_guard(&config::enable_transparent_data_encryption);
+    config::enable_transparent_data_encryption = true;
+
+    auto source = make_metadata(53021, 2, true);
+    auto target = make_metadata(53022, 1, true);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*target));
+    add_file_set(source.get(), 0, true);
+
+    auto result = convert(source, target, 1, lake::join_path(_test_dir, "source_data"));
+    ASSERT_FALSE(result.ok());
+    EXPECT_TRUE(result.status().is_not_supported()) << result.status();
+}
+
+TEST_F(LakeReplicationMetadataConversionTest, range_existing_shared_files_with_tde_reuse_encryption_meta) {
+    EncryptionKeyPB pb;
+    pb.set_id(EncryptionKey::DEFAULT_MASTER_KYE_ID);
+    pb.set_type(EncryptionKeyTypePB::NORMAL_KEY);
+    pb.set_algorithm(EncryptionAlgorithmPB::AES_128);
+    pb.set_plain_key("0000000000000000");
+    std::unique_ptr<EncryptionKey> root_encryption_key = EncryptionKey::create_from_pb(pb).value();
+    auto val_st = root_encryption_key->generate_key();
+    ASSERT_TRUE(val_st.ok());
+    std::unique_ptr<EncryptionKey> encryption_key = std::move(val_st.value());
+    encryption_key->set_id(2);
+    KeyCache::instance().add_key(root_encryption_key);
+    KeyCache::instance().add_key(encryption_key);
+    BoolConfigGuard enc_guard(&config::enable_transparent_data_encryption);
+    config::enable_transparent_data_encryption = true;
+
+    auto source = make_metadata(53031, 2, true);
+    auto target = make_metadata(53032, 1, true);
+    add_file_set(target.get(), 0, true);
+    set_file_set_encryption_meta(target.get(), 0, 0, "target-reused");
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*target));
+
+    add_file_set(source.get(), 0, true);
+    set_file_set_encryption_meta(source.get(), 0, 0, "source-reused");
+
+    auto result = convert(source, target, 1, lake::join_path(_test_dir, "source_data"));
+    ASSERT_OK(result.status());
+    const std::array<std::string, 6> expected_reused = {"target-reused-segment", "target-reused-del",
+                                                        "target-reused-sst",     "target-reused-delvec",
+                                                        "target-reused-dcg",     "target-reused-idg"};
+    EXPECT_EQ(expected_reused, file_set_encryption_meta(**result, 0, 0));
+    expect_file_set_shared(**result, 0, 0, true);
+}
+
 TEST_F(LakeReplicationMetadataConversionTest, shared_file_ownership_matrix_tde_metadata) {
     EncryptionKeyPB pb;
     pb.set_id(EncryptionKey::DEFAULT_MASTER_KYE_ID);

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -2442,6 +2442,85 @@ TEST_F(LakeReplicationRemoteStorageTest, copies_complete_bundle_object_through_f
     EXPECT_EQ(physical_contents, copied_contents);
 }
 
+TEST_F(LakeReplicationRemoteStorageTest, bundle_siblings_reuse_shared_file_without_failed_cleanup) {
+    const std::string contents = "shared-bundle-segment";
+    auto mock_fs = std::make_shared<MockStarletFileSystemForReplication>(contents);
+    SyncPoint::GetInstance()->SetCallBack("new_fs_starlet::get_shard_filesystem", [&](void* arg) {
+        auto* fs_st = static_cast<absl::StatusOr<std::shared_ptr<staros::starlet::fslib::FileSystem>>*>(arg);
+        *fs_st = mock_fs;
+    });
+
+    const std::string segment_name = "0000000000000001_aaaaaaaa-bbbb-cccc-dddd-000000000074.dat";
+    auto source = std::make_shared<TabletMetadata>(*_src_tablet_metadata);
+    source->set_version(2);
+    auto* rowset = source->add_rowsets();
+    rowset->set_id(1);
+    auto* segment = rowset->add_segment_metas();
+    segment->set_filename(segment_name);
+    segment->set_size(contents.size());
+    segment->set_bundle_file_offset(0);
+    segment->set_shared(false);
+    source->set_next_rowset_id(2);
+
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::build_source_tablet_meta::inject",
+                                          [&](void* arg) {
+                                              auto* meta_ptr = static_cast<TabletMetadataPtr*>(arg);
+                                              *meta_ptr = source;
+                                          });
+    bool hide_existing_file = false;
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::get_existing_file_size", [&](void* arg) {
+        if (hide_existing_file) {
+            static_cast<std::optional<size_t>*>(arg)->reset();
+        }
+    });
+
+    auto original_master_info = get_master_info();
+    TMasterInfo info = original_master_info;
+    info.__set_min_active_txn_id(0);
+    ASSERT_TRUE(update_master_info(info));
+
+    auto first_request = build_request(false /* with_full_path */);
+    first_request.__set_virtual_tablet_id(_virtual_tablet_id + 74);
+    ASSERT_OK(_replication_txn_manager->replicate_lake_remote_storage(first_request, nullptr));
+
+    ASSIGN_OR_ABORT(auto first_txn_log, _tablet_mgr->get_txn_log(_target_tablet_id, _transaction_id));
+    const auto& target_segment = first_txn_log->op_replication().tablet_metadata().rowsets(0).segment_metas(0);
+    const std::string target_path = _tablet_mgr->segment_location(_target_tablet_id, target_segment.filename());
+    ASSERT_TRUE(fs::path_exist(target_path));
+
+    const int64_t sibling_tablet_id = _target_tablet_id + 1;
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*generate_simple_tablet_metadata(sibling_tablet_id)));
+
+    PFailPointTriggerMode trigger_mode;
+    trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
+    auto* fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get("put_txn_log_fail");
+    ASSERT_NE(nullptr, fp);
+    fp->setMode(trigger_mode);
+
+    auto sibling_request = first_request;
+    sibling_request.__set_tablet_id(sibling_tablet_id);
+    hide_existing_file = true;
+    Status sibling_status = _replication_txn_manager->replicate_lake_remote_storage(sibling_request, nullptr);
+    hide_existing_file = false;
+
+    trigger_mode.set_mode(FailPointTriggerModeType::DISABLE);
+    fp->setMode(trigger_mode);
+
+    ASSERT_TRUE(sibling_status.is_internal_error()) << sibling_status;
+    StorageEngine::instance()->wait_storage_cleanup_tasks();
+    EXPECT_TRUE(fs::path_exist(target_path));
+    EXPECT_EQ(2, mock_fs->open_count());
+
+    const int64_t third_tablet_id = sibling_tablet_id + 1;
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*generate_simple_tablet_metadata(third_tablet_id)));
+    auto third_request = first_request;
+    third_request.__set_tablet_id(third_tablet_id);
+    ASSERT_OK(_replication_txn_manager->replicate_lake_remote_storage(third_request, nullptr));
+    EXPECT_EQ(2, mock_fs->open_count());
+
+    (void)update_master_info(original_master_info);
+}
+
 TEST_F(LakeReplicationRemoteStorageTest, range_siblings_reuse_shared_file_without_failed_cleanup) {
     const std::string contents = "shared-range-segment";
     auto mock_fs = std::make_shared<MockStarletFileSystemForReplication>(contents);

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -1133,6 +1133,21 @@ protected:
                 metadata.idg_meta().idgs().at(base + 6).entries(0).encryption_meta()};
     }
 
+    static void seed_test_encryption_keys() {
+        EncryptionKeyPB pb;
+        pb.set_id(EncryptionKey::DEFAULT_MASTER_KYE_ID);
+        pb.set_type(EncryptionKeyTypePB::NORMAL_KEY);
+        pb.set_algorithm(EncryptionAlgorithmPB::AES_128);
+        pb.set_plain_key("0000000000000000");
+        std::unique_ptr<EncryptionKey> root_encryption_key = EncryptionKey::create_from_pb(pb).value();
+        auto val_st = root_encryption_key->generate_key();
+        ASSERT_TRUE(val_st.ok());
+        std::unique_ptr<EncryptionKey> encryption_key = std::move(val_st.value());
+        encryption_key->set_id(2);
+        KeyCache::instance().add_key(root_encryption_key);
+        KeyCache::instance().add_key(encryption_key);
+    }
+
     StatusOr<std::shared_ptr<TabletMetadataPB>> convert(
             const TabletMetadataPtr& source, const TabletMetadataPtr& target, int64_t data_version,
             const std::string& source_data_dir, std::unordered_map<std::string, size_t>* segment_sizes = nullptr,
@@ -1259,18 +1274,7 @@ TEST_F(LakeReplicationMetadataConversionTest, range_shared_files_remain_shared_a
 }
 
 TEST_F(LakeReplicationMetadataConversionTest, range_new_shared_files_with_tde_are_rejected) {
-    EncryptionKeyPB pb;
-    pb.set_id(EncryptionKey::DEFAULT_MASTER_KYE_ID);
-    pb.set_type(EncryptionKeyTypePB::NORMAL_KEY);
-    pb.set_algorithm(EncryptionAlgorithmPB::AES_128);
-    pb.set_plain_key("0000000000000000");
-    std::unique_ptr<EncryptionKey> root_encryption_key = EncryptionKey::create_from_pb(pb).value();
-    auto val_st = root_encryption_key->generate_key();
-    ASSERT_TRUE(val_st.ok());
-    std::unique_ptr<EncryptionKey> encryption_key = std::move(val_st.value());
-    encryption_key->set_id(2);
-    KeyCache::instance().add_key(root_encryption_key);
-    KeyCache::instance().add_key(encryption_key);
+    seed_test_encryption_keys();
     BoolConfigGuard enc_guard(&config::enable_transparent_data_encryption);
     config::enable_transparent_data_encryption = true;
 
@@ -1285,18 +1289,7 @@ TEST_F(LakeReplicationMetadataConversionTest, range_new_shared_files_with_tde_ar
 }
 
 TEST_F(LakeReplicationMetadataConversionTest, range_existing_shared_files_with_tde_reuse_encryption_meta) {
-    EncryptionKeyPB pb;
-    pb.set_id(EncryptionKey::DEFAULT_MASTER_KYE_ID);
-    pb.set_type(EncryptionKeyTypePB::NORMAL_KEY);
-    pb.set_algorithm(EncryptionAlgorithmPB::AES_128);
-    pb.set_plain_key("0000000000000000");
-    std::unique_ptr<EncryptionKey> root_encryption_key = EncryptionKey::create_from_pb(pb).value();
-    auto val_st = root_encryption_key->generate_key();
-    ASSERT_TRUE(val_st.ok());
-    std::unique_ptr<EncryptionKey> encryption_key = std::move(val_st.value());
-    encryption_key->set_id(2);
-    KeyCache::instance().add_key(root_encryption_key);
-    KeyCache::instance().add_key(encryption_key);
+    seed_test_encryption_keys();
     BoolConfigGuard enc_guard(&config::enable_transparent_data_encryption);
     config::enable_transparent_data_encryption = true;
 
@@ -1319,18 +1312,7 @@ TEST_F(LakeReplicationMetadataConversionTest, range_existing_shared_files_with_t
 }
 
 TEST_F(LakeReplicationMetadataConversionTest, shared_file_ownership_matrix_tde_metadata) {
-    EncryptionKeyPB pb;
-    pb.set_id(EncryptionKey::DEFAULT_MASTER_KYE_ID);
-    pb.set_type(EncryptionKeyTypePB::NORMAL_KEY);
-    pb.set_algorithm(EncryptionAlgorithmPB::AES_128);
-    pb.set_plain_key("0000000000000000");
-    std::unique_ptr<EncryptionKey> root_encryption_key = EncryptionKey::create_from_pb(pb).value();
-    auto val_st = root_encryption_key->generate_key();
-    ASSERT_TRUE(val_st.ok());
-    std::unique_ptr<EncryptionKey> encryption_key = std::move(val_st.value());
-    encryption_key->set_id(2);
-    KeyCache::instance().add_key(root_encryption_key);
-    KeyCache::instance().add_key(encryption_key);
+    seed_test_encryption_keys();
     BoolConfigGuard enc_guard(&config::enable_transparent_data_encryption);
     config::enable_transparent_data_encryption = true;
 

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -18,8 +18,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <array>
 #include <atomic>
 #include <chrono>
+#include <cstring>
+#include <optional>
 #include <random>
 #include <thread>
 
@@ -1104,6 +1107,32 @@ protected:
         EXPECT_EQ(shared, metadata.idg_meta().idgs().at(base + 6).entries(0).shared_file());
     }
 
+    static void set_file_set_encryption_meta(TabletMetadata* metadata, int set_index, int base,
+                                             std::string_view prefix) {
+        auto* rowset = metadata->mutable_rowsets(set_index);
+        rowset->mutable_segment_metas(0)->set_encryption_meta(fmt::format("{}-segment", prefix));
+        rowset->mutable_del_files(0)->set_encryption_meta(fmt::format("{}-del", prefix));
+        metadata->mutable_sstable_meta()->mutable_sstables(set_index)->set_encryption_meta(
+                fmt::format("{}-sst", prefix));
+        (*metadata->mutable_delvec_meta()->mutable_version_to_file())[base + 4].set_encryption_meta(
+                fmt::format("{}-delvec", prefix));
+        auto& dcg = (*metadata->mutable_dcg_meta()->mutable_dcgs())[base + 5];
+        dcg.clear_encryption_metas();
+        dcg.add_encryption_metas(fmt::format("{}-dcg", prefix));
+        (*metadata->mutable_idg_meta()->mutable_idgs())[base + 6].mutable_entries(0)->set_encryption_meta(
+                fmt::format("{}-idg", prefix));
+    }
+
+    static std::array<std::string, 6> file_set_encryption_meta(const TabletMetadataPB& metadata, int set_index,
+                                                               int base) {
+        return {metadata.rowsets(set_index).segment_metas(0).encryption_meta(),
+                metadata.rowsets(set_index).del_files(0).encryption_meta(),
+                metadata.sstable_meta().sstables(set_index).encryption_meta(),
+                metadata.delvec_meta().version_to_file().at(base + 4).encryption_meta(),
+                metadata.dcg_meta().dcgs().at(base + 5).encryption_metas(0),
+                metadata.idg_meta().idgs().at(base + 6).entries(0).encryption_meta()};
+    }
+
     StatusOr<std::shared_ptr<TabletMetadataPB>> convert(
             const TabletMetadataPtr& source, const TabletMetadataPtr& target, int64_t data_version,
             const std::string& source_data_dir, std::unordered_map<std::string, size_t>* segment_sizes = nullptr,
@@ -1148,10 +1177,39 @@ protected:
 TEST_F(LakeReplicationMetadataConversionTest, target_split_child_without_data_version_metadata) {
     auto source = make_metadata(51001, 3);
     auto target = make_metadata(51002, 2, true);
+    const std::string source_filename = "0000000000000001_aaaaaaaa-bbbb-cccc-dddd-000000000081.dat";
+    const std::string target_filename = "00000000000000ff_aaaaaaaa-bbbb-cccc-dddd-000000000081.dat";
+    auto* source_rowset = source->add_rowsets();
+    source_rowset->set_id(1);
+    source_rowset->add_segment_metas()->set_filename(source_filename);
+    auto* target_rowset = target->add_rowsets();
+    target_rowset->set_id(1);
+    auto* target_segment = target_rowset->add_segment_metas();
+    target_segment->set_filename(target_filename);
+    target_segment->set_shared(true);
     ASSERT_OK(_tablet_mgr->put_tablet_metadata(*target));
 
-    auto result = convert(source, target, 1, lake::join_path(_test_dir, "source_data"));
+    std::map<std::string, std::string> file_locations;
+    std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
+    auto result = convert(source, target, 1, lake::join_path(_test_dir, "source_data"), nullptr, &file_locations,
+                          &filename_map);
     ASSERT_OK(result.status());
+    ASSERT_EQ(1, (*result)->rowsets_size());
+    ASSERT_EQ(1, (*result)->rowsets(0).segment_metas_size());
+    EXPECT_EQ(target_filename, (*result)->rowsets(0).segment_metas(0).filename());
+    EXPECT_TRUE((*result)->rowsets(0).segment_metas(0).shared());
+    EXPECT_TRUE(file_locations.empty());
+    EXPECT_TRUE(filename_map.empty());
+}
+
+TEST_F(LakeReplicationMetadataConversionTest,
+       target_split_child_without_data_version_metadata_current_version_not_newer) {
+    auto source = make_metadata(51101, 3);
+    auto target = make_metadata(51102, 1, true);
+
+    auto result = convert(source, target, 1, lake::join_path(_test_dir, "source_data"));
+    ASSERT_FALSE(result.ok());
+    EXPECT_TRUE(result.status().is_not_found()) << result.status();
 }
 
 TEST_F(LakeReplicationMetadataConversionTest, target_hash_tablet_without_data_version_metadata) {
@@ -1183,6 +1241,52 @@ TEST_F(LakeReplicationMetadataConversionTest, shared_file_ownership_matrix) {
     expect_file_set_shared(**result, 1, 20, false);
     expect_file_set_shared(**result, 2, 40, false);
     EXPECT_TRUE((*result)->sstable_meta().sstables(2).filename().ends_with(".sst"));
+}
+
+TEST_F(LakeReplicationMetadataConversionTest, shared_file_ownership_matrix_tde_metadata) {
+    EncryptionKeyPB pb;
+    pb.set_id(EncryptionKey::DEFAULT_MASTER_KYE_ID);
+    pb.set_type(EncryptionKeyTypePB::NORMAL_KEY);
+    pb.set_algorithm(EncryptionAlgorithmPB::AES_128);
+    pb.set_plain_key("0000000000000000");
+    std::unique_ptr<EncryptionKey> root_encryption_key = EncryptionKey::create_from_pb(pb).value();
+    auto val_st = root_encryption_key->generate_key();
+    ASSERT_TRUE(val_st.ok());
+    std::unique_ptr<EncryptionKey> encryption_key = std::move(val_st.value());
+    encryption_key->set_id(2);
+    KeyCache::instance().add_key(root_encryption_key);
+    KeyCache::instance().add_key(encryption_key);
+    BoolConfigGuard enc_guard(&config::enable_transparent_data_encryption);
+    config::enable_transparent_data_encryption = true;
+
+    auto source = make_metadata(53101, 2);
+    auto target = make_metadata(53102, 1);
+    add_file_set(target.get(), 0, true);
+    set_file_set_encryption_meta(target.get(), 0, 0, "target-reused");
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*target));
+
+    add_file_set(source.get(), 0, false);
+    set_file_set_encryption_meta(source.get(), 0, 0, "source-reused");
+    add_file_set(source.get(), 40, true);
+    set_file_set_encryption_meta(source.get(), 1, 40, "source-new");
+
+    auto result = convert(source, target, 1, lake::join_path(_test_dir, "source_data"));
+    ASSERT_OK(result.status());
+    const std::array<std::string, 6> expected_reused = {"target-reused-segment", "target-reused-del",
+                                                        "target-reused-sst",     "target-reused-delvec",
+                                                        "target-reused-dcg",     "target-reused-idg"};
+    EXPECT_EQ(expected_reused, file_set_encryption_meta(**result, 0, 0));
+
+    const auto new_encryption_meta = file_set_encryption_meta(**result, 1, 40);
+    const std::array<std::string, 6> source_encryption_meta = {"source-new-segment", "source-new-del",
+                                                               "source-new-sst",     "source-new-delvec",
+                                                               "source-new-dcg",     "source-new-idg"};
+    for (size_t i = 0; i < new_encryption_meta.size(); ++i) {
+        EXPECT_FALSE(new_encryption_meta[i].empty());
+        EXPECT_NE(source_encryption_meta[i], new_encryption_meta[i]);
+    }
+    expect_file_set_shared(**result, 0, 0, true);
+    expect_file_set_shared(**result, 1, 40, false);
 }
 
 TEST_F(LakeReplicationMetadataConversionTest, copies_complete_bundle_object) {
@@ -1238,18 +1342,90 @@ TEST_F(LakeReplicationMetadataConversionTest, copies_complete_bundle_object) {
 }
 
 #ifdef USE_STAROS
+class InMemoryStarletInputStreamForReplication : public staros::starlet::fslib::InputStream {
+public:
+    explicit InMemoryStarletInputStreamForReplication(std::string contents) : _contents(std::move(contents)) {}
+
+    bool support_seek() override { return true; }
+    bool support_tell() override { return true; }
+    bool support_size() override { return true; }
+
+    absl::StatusOr<size_t> seek(int64_t offset, Anchor anchor) override {
+        int64_t base = 0;
+        if (anchor == CURRENT) {
+            base = static_cast<int64_t>(_position);
+        } else if (anchor == END) {
+            base = static_cast<int64_t>(_contents.size());
+        }
+        const int64_t next = base + offset;
+        if (next < 0 || next > static_cast<int64_t>(_contents.size())) {
+            return absl::InvalidArgumentError("seek outside in-memory file");
+        }
+        _position = static_cast<size_t>(next);
+        return _position;
+    }
+
+    absl::StatusOr<size_t> tell() override { return _position; }
+    absl::StatusOr<size_t> size() override { return _contents.size(); }
+    absl::Status close() override { return absl::OkStatus(); }
+
+    absl::StatusOr<size_t> read(void* data, size_t length) override {
+        const size_t bytes_to_read = std::min(length, _contents.size() - _position);
+        std::memcpy(data, _contents.data() + _position, bytes_to_read);
+        _position += bytes_to_read;
+        return bytes_to_read;
+    }
+
+private:
+    std::string _contents;
+    size_t _position = 0;
+};
+
+class InMemoryStarletReadOnlyFileForReplication : public staros::starlet::fslib::ReadOnlyFile {
+public:
+    explicit InMemoryStarletReadOnlyFileForReplication(std::string contents)
+            : _stream(std::make_unique<InMemoryStarletInputStreamForReplication>(std::move(contents))) {}
+
+    const std::string& name() override { return _name; }
+    absl::StatusOr<size_t> size() override { return _stream->size(); }
+    absl::StatusOr<std::string> get_meta(std::string_view) override {
+        return absl::UnimplementedError("get_meta not implemented");
+    }
+    absl::Status set_meta(std::string_view, std::string_view) override {
+        return absl::UnimplementedError("set_meta not implemented");
+    }
+    absl::Status remove_meta(std::string_view) override {
+        return absl::UnimplementedError("remove_meta not implemented");
+    }
+    absl::Status close() override { return absl::OkStatus(); }
+    absl::StatusOr<staros::starlet::fslib::InputStream*> stream() override { return _stream.get(); }
+
+private:
+    std::unique_ptr<InMemoryStarletInputStreamForReplication> _stream;
+    std::string _name = "in-memory-replication-source";
+};
+
 // Mock staros::starlet::fslib::FileSystem for SyncPoint injection
 class MockStarletFileSystemForReplication : public staros::starlet::fslib::FileSystem {
 public:
     MockStarletFileSystemForReplication() : staros::starlet::fslib::FileSystem() {}
+    explicit MockStarletFileSystemForReplication(std::string contents)
+            : staros::starlet::fslib::FileSystem(), _contents(std::move(contents)) {}
     ~MockStarletFileSystemForReplication() override = default;
 
     std::string_view scheme() override { return "mock"; }
 
     absl::StatusOr<std::unique_ptr<staros::starlet::fslib::ReadOnlyFile>> open(
             std::string_view path, const staros::starlet::fslib::ReadOptions& opts) override {
+        if (_contents.has_value()) {
+            ++_open_count;
+            return std::unique_ptr<staros::starlet::fslib::ReadOnlyFile>(
+                    new InMemoryStarletReadOnlyFileForReplication(*_contents));
+        }
         return absl::UnimplementedError("MockStarletFileSystemForReplication::open not implemented");
     }
+
+    int open_count() const { return _open_count; }
 
     absl::StatusOr<std::unique_ptr<staros::starlet::fslib::WritableFile>> create(
             std::string_view path, const staros::starlet::fslib::WriteOptions& opts) override {
@@ -1296,6 +1472,10 @@ public:
 
 protected:
     absl::Status initialize(const staros::starlet::fslib::Configuration& conf) override { return absl::OkStatus(); }
+
+private:
+    std::optional<std::string> _contents;
+    int _open_count = 0;
 };
 
 // Test fixture for testing the USE_STAROS code path in replicate_lake_remote_storage
@@ -2112,6 +2292,120 @@ TEST_F(LakeReplicationRemoteStorageTest, test_idg_meta_skipped_on_divergent_colu
     ASSERT_EQ(1, built_meta.rowsets_size());
     // idg_meta must be empty: neither the source's entry nor any target stale entry survives.
     EXPECT_TRUE(built_meta.idg_meta().idgs().empty());
+}
+
+TEST_F(LakeReplicationRemoteStorageTest, copies_complete_bundle_object_through_full_replication) {
+    const std::string physical_contents = "AAAAABBBBBBB-physical-tail";
+    auto mock_fs = std::make_shared<MockStarletFileSystemForReplication>(physical_contents);
+    SyncPoint::GetInstance()->SetCallBack("new_fs_starlet::get_shard_filesystem", [&](void* arg) {
+        auto* fs_st = static_cast<absl::StatusOr<std::shared_ptr<staros::starlet::fslib::FileSystem>>*>(arg);
+        *fs_st = mock_fs;
+    });
+
+    const std::string bundle_name = "0000000000000001_aaaaaaaa-bbbb-cccc-dddd-000000000072.dat";
+    auto source = std::make_shared<TabletMetadata>(*_src_tablet_metadata);
+    source->set_version(2);
+    auto* rowset = source->add_rowsets();
+    rowset->set_id(1);
+    for (const auto [logical_size, offset] : {std::pair<int64_t, int64_t>{5, 0}, {7, 5}}) {
+        auto* segment = rowset->add_segment_metas();
+        segment->set_filename(bundle_name);
+        segment->set_size(logical_size);
+        segment->set_bundle_file_offset(offset);
+        segment->set_shared(true);
+    }
+    source->set_next_rowset_id(2);
+
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::build_source_tablet_meta::inject",
+                                          [&](void* arg) {
+                                              auto* meta_ptr = static_cast<TabletMetadataPtr*>(arg);
+                                              *meta_ptr = source;
+                                          });
+    int copy_count = 0;
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::replicate_lake_remote_storage::before_copy",
+                                          [&](void*) { ++copy_count; });
+
+    auto original_master_info = get_master_info();
+    TMasterInfo info = original_master_info;
+    info.__set_min_active_txn_id(0);
+    ASSERT_TRUE(update_master_info(info));
+    auto request = build_request(false /* with_full_path */);
+    // new_fs_starlet caches by shard id across tests in this process. Use a dedicated id so
+    // earlier error-path tests cannot leave an unimplemented filesystem in this test's slot.
+    request.__set_virtual_tablet_id(_virtual_tablet_id + 72);
+    Status status = _replication_txn_manager->replicate_lake_remote_storage(request, nullptr);
+    (void)update_master_info(original_master_info);
+    ASSERT_OK(status);
+
+    EXPECT_EQ(1, copy_count);
+    EXPECT_EQ(1, mock_fs->open_count());
+    ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_log(_target_tablet_id, _transaction_id));
+    ASSERT_TRUE(txn_log->op_replication().has_tablet_metadata());
+    const auto& built_meta = txn_log->op_replication().tablet_metadata();
+    ASSERT_EQ(1, built_meta.rowsets_size());
+    ASSERT_EQ(2, built_meta.rowsets(0).segment_metas_size());
+    const auto& first_slice = built_meta.rowsets(0).segment_metas(0);
+    const auto& second_slice = built_meta.rowsets(0).segment_metas(1);
+    EXPECT_EQ(first_slice.filename(), second_slice.filename());
+    EXPECT_NE(bundle_name, first_slice.filename());
+    EXPECT_EQ(5, first_slice.size());
+    EXPECT_EQ(0, first_slice.bundle_file_offset());
+    EXPECT_EQ(7, second_slice.size());
+    EXPECT_EQ(5, second_slice.bundle_file_offset());
+
+    const std::string target_path = _tablet_mgr->segment_location(_target_tablet_id, first_slice.filename());
+    ASSIGN_OR_ABORT(auto target_fs, FileSystemFactory::CreateSharedFromString(target_path));
+    ASSIGN_OR_ABORT(auto target_file, target_fs->new_random_access_file(target_path));
+    ASSIGN_OR_ABORT(auto target_size, target_file->get_size());
+    std::string copied_contents(target_size, '\0');
+    ASSERT_OK(target_file->read_at_fully(0, copied_contents.data(), target_size));
+    EXPECT_EQ(physical_contents, copied_contents);
+}
+
+TEST_F(LakeReplicationRemoteStorageTest, rejects_bundled_fast_schema_conversion__encrypted_slices_before_copy) {
+    auto mock_fs = std::make_shared<MockStarletFileSystemForReplication>();
+    SyncPoint::GetInstance()->SetCallBack("new_fs_starlet::get_shard_filesystem", [&](void* arg) {
+        auto* fs_st = static_cast<absl::StatusOr<std::shared_ptr<staros::starlet::fslib::FileSystem>>*>(arg);
+        *fs_st = mock_fs;
+    });
+
+    auto source = std::make_shared<TabletMetadata>(*_src_tablet_metadata);
+    source->set_version(2);
+    auto* rowset = source->add_rowsets();
+    rowset->set_id(1);
+    const std::string bundle_name = "0000000000000001_aaaaaaaa-bbbb-cccc-dddd-000000000073.dat";
+    for (const auto [offset, encryption_meta] :
+         {std::pair<int64_t, const char*>{0, "slice-zero-encryption"}, {11, "slice-one-encryption"}}) {
+        auto* segment = rowset->add_segment_metas();
+        segment->set_filename(bundle_name);
+        segment->set_size(11);
+        segment->set_bundle_file_offset(offset);
+        segment->set_encryption_meta(encryption_meta);
+    }
+    source->set_next_rowset_id(2);
+
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::build_source_tablet_meta::inject",
+                                          [&](void* arg) {
+                                              auto* meta_ptr = static_cast<TabletMetadataPtr*>(arg);
+                                              *meta_ptr = source;
+                                          });
+    bool copy_started = false;
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::replicate_lake_remote_storage::before_copy",
+                                          [&](void*) { copy_started = true; });
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::replicate_task::download_segment",
+                                          [&](void* arg) { *static_cast<size_t*>(arg) = 22; });
+
+    auto original_master_info = get_master_info();
+    TMasterInfo info = original_master_info;
+    info.__set_min_active_txn_id(0);
+    ASSERT_TRUE(update_master_info(info));
+    auto request = build_request(false /* with_full_path */);
+    Status status = _replication_txn_manager->replicate_lake_remote_storage(request, nullptr);
+    (void)update_master_info(original_master_info);
+
+    EXPECT_TRUE(status.is_not_supported()) << status;
+    EXPECT_FALSE(copy_started);
+    EXPECT_TRUE(_tablet_mgr->get_txn_log(_target_tablet_id, _transaction_id).status().is_not_found());
 }
 
 TEST_F(LakeReplicationRemoteStorageTest, rejects_bundled_fast_schema_conversion) {

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -54,6 +54,7 @@
 #include "platform/key_cache.h"
 #include "runtime/descriptors.h"
 #include "storage/chunk_helper.h"
+#include "storage/file_stream_converter.h"
 #include "storage/lake/delta_writer.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/fixed_location_provider.h"
@@ -67,6 +68,7 @@
 #include "storage/lake/update_manager.h"
 #include "storage/options.h"
 #include "storage/protobuf_file.h"
+#include "storage/replication_utils.h"
 #include "storage/rowset/rowset_options.h"
 #include "storage/rowset/segment.h"
 #include "storage/tablet_manager.h"
@@ -1019,6 +1021,222 @@ TEST_F(TryBuildSourceTabletMetaWithFallbackTest, replication_source_read_bypasse
     EXPECT_EQ(101, cached->gtid());
 }
 
+class LakeReplicationMetadataConversionTest : public testing::Test {
+protected:
+    void SetUp() override {
+        (void)fs::remove_all(_test_dir);
+        CHECK_OK(fs::create_directories(lake::join_path(_test_dir, lake::kSegmentDirectoryName)));
+        CHECK_OK(fs::create_directories(lake::join_path(_test_dir, lake::kMetadataDirectoryName)));
+        CHECK_OK(fs::create_directories(lake::join_path(_test_dir, lake::kTxnLogDirectoryName)));
+        _location_provider = std::make_shared<lake::FixedLocationProvider>(_test_dir);
+        _mem_tracker = std::make_unique<MemTracker>(1024 * 1024);
+        _update_manager = std::make_unique<lake::UpdateManager>(_location_provider, _mem_tracker.get());
+        _tablet_mgr = std::make_unique<lake::TabletManager>(_location_provider, _update_manager.get(), 16384);
+        _replication_txn_manager = std::make_unique<lake::LakeReplicationTxnManager>(_tablet_mgr.get());
+    }
+
+    void TearDown() override {
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
+        ASSERT_OK(fs::remove_all(_test_dir));
+    }
+
+    std::shared_ptr<TabletMetadata> make_metadata(int64_t tablet_id, int64_t version, bool range_table = false) {
+        auto metadata = std::make_shared<TabletMetadata>();
+        metadata->set_id(tablet_id);
+        metadata->set_version(version);
+        metadata->set_next_rowset_id(1);
+        auto* schema = metadata->mutable_schema();
+        schema->set_keys_type(DUP_KEYS);
+        schema->set_id(1);
+        schema->set_num_short_key_columns(1);
+        auto* column = schema->add_column();
+        column->set_unique_id(1);
+        column->set_name("c0");
+        column->set_type("INT");
+        column->set_is_key(true);
+        column->set_is_nullable(false);
+        if (range_table) {
+            metadata->mutable_range();
+        }
+        return metadata;
+    }
+
+    static std::string file_name(int id, std::string_view extension) {
+        return fmt::format("0000000000000001_aaaaaaaa-bbbb-cccc-dddd-{:012d}.{}", id, extension);
+    }
+
+    static void add_file_set(TabletMetadata* metadata, int base, bool shared) {
+        auto* rowset = metadata->add_rowsets();
+        rowset->set_id(base + 1);
+        rowset->set_overlapped(false);
+        auto* segment = rowset->add_segment_metas();
+        segment->set_filename(file_name(base + 1, "dat"));
+        segment->set_size(11);
+        segment->set_shared(shared);
+        auto* del = rowset->add_del_files();
+        del->set_name(file_name(base + 2, "del"));
+        del->set_shared(shared);
+
+        auto* sst = metadata->mutable_sstable_meta()->add_sstables();
+        sst->set_filename(file_name(base + 3, "sst"));
+        sst->set_shared(shared);
+
+        auto& delvec = (*metadata->mutable_delvec_meta()->mutable_version_to_file())[base + 4];
+        delvec.set_name(file_name(base + 4, "delvec"));
+        delvec.set_shared(shared);
+
+        auto& dcg = (*metadata->mutable_dcg_meta()->mutable_dcgs())[base + 5];
+        dcg.add_column_files(file_name(base + 5, "cols"));
+        dcg.add_shared_files(shared);
+
+        auto& idg = (*metadata->mutable_idg_meta()->mutable_idgs())[base + 6];
+        auto* entry = idg.add_entries();
+        entry->set_index_file(file_name(base + 6, "idx"));
+        entry->set_shared_file(shared);
+    }
+
+    static void expect_file_set_shared(const TabletMetadataPB& metadata, int set_index, int base, bool shared) {
+        EXPECT_EQ(shared, metadata.rowsets(set_index).segment_metas(0).shared());
+        EXPECT_EQ(shared, metadata.rowsets(set_index).del_files(0).shared());
+        EXPECT_EQ(shared, metadata.sstable_meta().sstables(set_index).shared());
+        EXPECT_EQ(shared, metadata.delvec_meta().version_to_file().at(base + 4).shared());
+        EXPECT_EQ(shared, metadata.dcg_meta().dcgs().at(base + 5).shared_files(0));
+        EXPECT_EQ(shared, metadata.idg_meta().idgs().at(base + 6).entries(0).shared_file());
+    }
+
+    StatusOr<std::shared_ptr<TabletMetadataPB>> convert(
+            const TabletMetadataPtr& source, const TabletMetadataPtr& target, int64_t data_version,
+            const std::string& source_data_dir, std::unordered_map<std::string, size_t>* segment_sizes = nullptr,
+            std::map<std::string, std::string>* file_locations_out = nullptr,
+            std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>>* filename_map_out = nullptr) {
+        std::unordered_map<std::string, size_t> local_segment_sizes;
+        std::map<std::string, std::string> local_file_locations;
+        std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> local_filename_map;
+        return _replication_txn_manager->convert_and_build_new_tablet_meta(
+                source, target, source->id(), target->id(), 70001, data_version, source_data_dir,
+                segment_sizes != nullptr ? *segment_sizes : local_segment_sizes,
+                file_locations_out != nullptr ? *file_locations_out : local_file_locations,
+                filename_map_out != nullptr ? *filename_map_out : local_filename_map);
+    }
+
+    static Status write_file(const std::string& path, std::string_view content) {
+        ASSIGN_OR_RETURN(auto local_fs, FileSystemFactory::CreateSharedFromString(path));
+        WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+        ASSIGN_OR_RETURN(auto output, local_fs->new_writable_file(opts, path));
+        RETURN_IF_ERROR(output->append(content));
+        return output->close();
+    }
+
+    static StatusOr<std::string> read_file(const std::string& path) {
+        ASSIGN_OR_RETURN(auto local_fs, FileSystemFactory::CreateSharedFromString(path));
+        ASSIGN_OR_RETURN(auto input, local_fs->new_random_access_file(path));
+        ASSIGN_OR_RETURN(auto size, input->get_size());
+        std::string content(size, '\0');
+        RETURN_IF_ERROR(input->read_at_fully(0, content.data(), size));
+        return content;
+    }
+
+    static constexpr const char* kTestDirectory = "test_lake_replication_metadata_conversion";
+    std::string _test_dir = kTestDirectory;
+    std::shared_ptr<lake::FixedLocationProvider> _location_provider;
+    std::unique_ptr<MemTracker> _mem_tracker;
+    std::unique_ptr<lake::UpdateManager> _update_manager;
+    std::unique_ptr<lake::TabletManager> _tablet_mgr;
+    std::unique_ptr<lake::LakeReplicationTxnManager> _replication_txn_manager;
+};
+
+TEST_F(LakeReplicationMetadataConversionTest, target_split_child_without_data_version_metadata) {
+    auto source = make_metadata(51001, 3);
+    auto target = make_metadata(51002, 2, true);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*target));
+
+    auto result = convert(source, target, 1, lake::join_path(_test_dir, "source_data"));
+    ASSERT_OK(result.status());
+}
+
+TEST_F(LakeReplicationMetadataConversionTest, target_hash_tablet_without_data_version_metadata) {
+    auto source = make_metadata(52001, 3);
+    auto target = make_metadata(52002, 2);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*target));
+
+    auto result = convert(source, target, 1, lake::join_path(_test_dir, "source_data"));
+    ASSERT_FALSE(result.ok());
+    EXPECT_TRUE(result.status().is_not_found()) << result.status();
+}
+
+TEST_F(LakeReplicationMetadataConversionTest, shared_file_ownership_matrix) {
+    auto source = make_metadata(53001, 2);
+    auto target = make_metadata(53002, 1);
+    add_file_set(target.get(), 0, true);
+    add_file_set(target.get(), 20, false);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*target));
+
+    // Reuse two destination file sets with opposite ownership, then add a source-shared set
+    // that must become private because it is copied into this destination for the first time.
+    add_file_set(source.get(), 0, false);
+    add_file_set(source.get(), 20, true);
+    add_file_set(source.get(), 40, true);
+
+    auto result = convert(source, target, 1, lake::join_path(_test_dir, "source_data"));
+    ASSERT_OK(result.status());
+    expect_file_set_shared(**result, 0, 0, true);
+    expect_file_set_shared(**result, 1, 20, false);
+    expect_file_set_shared(**result, 2, 40, false);
+    EXPECT_TRUE((*result)->sstable_meta().sstables(2).filename().ends_with(".sst"));
+}
+
+TEST_F(LakeReplicationMetadataConversionTest, copies_complete_bundle_object) {
+    auto source = make_metadata(54001, 2);
+    auto target = make_metadata(54002, 1);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*target));
+
+    const std::string bundle_name = file_name(61, "dat");
+    auto* rowset = source->add_rowsets();
+    rowset->set_id(1);
+    for (const auto [logical_size, offset] : {std::pair<int64_t, int64_t>{5, 0}, {7, 5}}) {
+        auto* segment = rowset->add_segment_metas();
+        segment->set_filename(bundle_name);
+        segment->set_size(logical_size);
+        segment->set_bundle_file_offset(offset);
+        segment->set_shared(true);
+    }
+
+    const std::string source_data_dir = lake::join_path(_test_dir, "source_data");
+    ASSERT_OK(fs::create_directories(source_data_dir));
+    const std::string source_path = lake::join_path(source_data_dir, bundle_name);
+    const std::string physical_contents = "AAAAABBBBBBB-physical-tail";
+    ASSERT_OK(write_file(source_path, physical_contents));
+
+    std::unordered_map<std::string, size_t> segment_sizes;
+    std::map<std::string, std::string> file_locations;
+    std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
+    auto result = convert(source, target, 1, source_data_dir, &segment_sizes, &file_locations, &filename_map);
+    ASSERT_OK(result.status());
+    ASSERT_EQ(1, filename_map.size());
+    ASSERT_EQ(1, file_locations.size());
+    EXPECT_EQ(5, (*result)->rowsets(0).segment_metas(0).size());
+    EXPECT_EQ(0, (*result)->rowsets(0).segment_metas(0).bundle_file_offset());
+    EXPECT_EQ(7, (*result)->rowsets(0).segment_metas(1).size());
+    EXPECT_EQ(5, (*result)->rowsets(0).segment_metas(1).bundle_file_offset());
+
+    const size_t source_size_for_copy = segment_sizes.contains(bundle_name) ? segment_sizes.at(bundle_name) : 0;
+    ASSIGN_OR_ABORT(auto source_fs, FileSystemFactory::CreateSharedFromString(source_path));
+    const auto& target_path = file_locations.begin()->second;
+    FileConverterCreatorFunc converter = [target_path](
+                                                 const std::string& file_name,
+                                                 uint64_t file_size) -> StatusOr<std::unique_ptr<FileStreamConverter>> {
+        WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+        ASSIGN_OR_RETURN(auto output, fs::new_writable_file(opts, target_path));
+        return std::make_unique<FileStreamConverter>(file_name, file_size, std::move(output));
+    };
+    size_t copied_size = 0;
+    ASSERT_OK(ReplicationUtils::download_lake_file_with_converter(source_path, bundle_name, source_size_for_copy,
+                                                                  source_fs, converter, &copied_size));
+    EXPECT_EQ(physical_contents.size(), copied_size);
+    ASSIGN_OR_ABORT(auto copied_contents, read_file(target_path));
+    EXPECT_EQ(physical_contents, copied_contents);
+}
+
 #ifdef USE_STAROS
 // Mock staros::starlet::fslib::FileSystem for SyncPoint injection
 class MockStarletFileSystemForReplication : public staros::starlet::fslib::FileSystem {
@@ -1894,6 +2112,49 @@ TEST_F(LakeReplicationRemoteStorageTest, test_idg_meta_skipped_on_divergent_colu
     ASSERT_EQ(1, built_meta.rowsets_size());
     // idg_meta must be empty: neither the source's entry nor any target stale entry survives.
     EXPECT_TRUE(built_meta.idg_meta().idgs().empty());
+}
+
+TEST_F(LakeReplicationRemoteStorageTest, rejects_bundled_fast_schema_conversion) {
+    auto mock_fs = std::make_shared<MockStarletFileSystemForReplication>();
+    SyncPoint::GetInstance()->SetCallBack("new_fs_starlet::get_shard_filesystem", [&](void* arg) {
+        auto* fs_st = static_cast<absl::StatusOr<std::shared_ptr<staros::starlet::fslib::FileSystem>>*>(arg);
+        *fs_st = mock_fs;
+    });
+
+    auto source = std::make_shared<TabletMetadata>(*_src_tablet_metadata);
+    source->set_version(2);
+    source->mutable_schema()->mutable_column(1)->set_unique_id(9999);
+    auto* rowset = source->add_rowsets();
+    rowset->set_id(1);
+    auto* segment = rowset->add_segment_metas();
+    segment->set_filename("0000000000000001_aaaaaaaa-bbbb-cccc-dddd-000000000071.dat");
+    segment->set_size(17);
+    segment->set_bundle_file_offset(0);
+    source->set_next_rowset_id(2);
+
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::build_source_tablet_meta::inject",
+                                          [&](void* arg) {
+                                              auto* meta_ptr = static_cast<TabletMetadataPtr*>(arg);
+                                              *meta_ptr = source;
+                                          });
+    bool copy_started = false;
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::replicate_task::download_segment",
+                                          [&](void* arg) {
+                                              copy_started = true;
+                                              *static_cast<size_t*>(arg) = 17;
+                                          });
+
+    auto original_master_info = get_master_info();
+    TMasterInfo info = original_master_info;
+    info.__set_min_active_txn_id(0);
+    ASSERT_TRUE(update_master_info(info));
+    auto request = build_request(false /* with_full_path */);
+    Status status = _replication_txn_manager->replicate_lake_remote_storage(request, nullptr);
+    (void)update_master_info(original_master_info);
+
+    ASSERT_TRUE(status.is_not_supported()) << status;
+    EXPECT_FALSE(copy_started);
+    EXPECT_TRUE(_tablet_mgr->get_txn_log(_target_tablet_id, _transaction_id).status().is_not_found());
 }
 
 // Regression companion: with transparent data encryption ON, the replicated source IDG entry must


### PR DESCRIPTION
## Why I’m doing:

Shared-data replication previously assumed the target metadata at `data_version` always existed and treated every mapped file as a new private copy. A target range-split child can instead share existing destination objects while lacking that exact historical metadata. Bundle-backed segments also represent multiple logical slices in one physical object.

## What I’m doing:

- Fall back to newer current target metadata only for range-distributed tablets when the exact data-version metadata is absent; preserve the existing `NotFound` behavior for hash tablets and non-newer metadata.
- Reuse matching destination UUIDs and preserve destination ownership/TDE metadata for segments, delete files, SSTs, delvecs, DCGs, and IDGs.
- For aligned range tablets, preserve the source shared marker on newly copied files so readers continue applying each child tablet’s logical range; retain the existing private-copy behavior for hash tablets.
- Use target-generated encryption metadata for new private copies.
- Copy each unencrypted physical bundle object once at its full physical size while preserving every logical slice’s size and offset.
- Reject encrypted bundled segments and bundled fast-schema conversion before conversion, copy, or publication.
- Fail closed instead of independently encrypting the same newly copied range-shared or bundled physical object with different DEKs. Existing destination objects remain reusable with their existing encryption metadata.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function in companion PR #77360
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

## Validation:

- Focused range/hash/bundle/TDE shared-file ownership matrix: 5/5 passed under ASAN.
- The offset-only range bundle case and then its hash counterpart both failed before their respective fixes.
- GitHub BE UT, BUILD, DEPLOY SR, SQL-Tester, and ADMIT TEST passed on the previous published head; fresh required checks are running for the current head.
- `git diff --check` passed.
