### PR TITLE
[BugFix] Accept vended credentials without a session token

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfigurationFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfigurationFactory.java
@@ -120,10 +120,14 @@ public class CloudConfigurationFactory {
                 properties.getOrDefault(CloudConfigurationConstants.AWS_S3_ENABLE_PATH_STYLE_ACCESS, null));
         String endpoint = properties.getOrDefault(S3FileIOProperties.ENDPOINT,
                 properties.getOrDefault(CloudConfigurationConstants.AWS_S3_ENDPOINT, null));
-        if (sessionAk != null && sessionSk != null && sessionToken != null) {
+        // Some catalogs (e.g. Cloudflare R2, MinIO) vend static scoped keys without an STS
+        // session token, so the token is optional.
+        if (sessionAk != null && sessionSk != null) {
             copiedProperties.put(CloudConfigurationConstants.AWS_S3_ACCESS_KEY, sessionAk);
             copiedProperties.put(CloudConfigurationConstants.AWS_S3_SECRET_KEY, sessionSk);
-            copiedProperties.put(CloudConfigurationConstants.AWS_S3_SESSION_TOKEN, sessionToken);
+            if (sessionToken != null) {
+                copiedProperties.put(CloudConfigurationConstants.AWS_S3_SESSION_TOKEN, sessionToken);
+            }
             if (region != null) {
                 copiedProperties.put(CloudConfigurationConstants.AWS_S3_REGION, region);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
@@ -75,6 +75,27 @@ public class CloudConfigurationFactoryTest {
                         "sessionToken='token', iamRoleArn='', stsRegion='', stsEndpoint='', externalId='', " +
                         "region='us-west-2', endpoint='endpoint'}, enablePathStyleAccess=false, enableSSL=true}",
                 cloudConfiguration.toConfString());
+
+        // Vended credentials without a session token (e.g. Cloudflare R2, MinIO vend static
+        // scoped keys) must still produce an AWS configuration carrying the endpoint.
+        map.remove(S3FileIOProperties.SESSION_TOKEN);
+        map.put(S3FileIOProperties.PATH_STYLE_ACCESS, "true");
+        cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForVendedCredentials(map, "");
+        Assertions.assertNotNull(cloudConfiguration);
+        Assertions.assertEquals(CloudType.AWS, cloudConfiguration.getCloudType());
+        Assertions.assertEquals(
+                "AWSCloudConfiguration{resources='', jars='', hdpuser='', " +
+                        "cred=AWSCloudCredential{useAWSSDKDefaultBehavior=false, " +
+                        "useInstanceProfile=false, useWebIdentityProfile=false, accessKey='ak', secretKey='sk', " +
+                        "sessionToken='', iamRoleArn='', stsRegion='', stsEndpoint='', externalId='', " +
+                        "region='us-west-2', endpoint='endpoint'}, enablePathStyleAccess=true, enableSSL=true}",
+                cloudConfiguration.toConfString());
+
+        // Without ak/sk there is nothing to vend: fall back to DEFAULT.
+        map.remove(S3FileIOProperties.ACCESS_KEY_ID);
+        map.remove(S3FileIOProperties.SECRET_ACCESS_KEY);
+        cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForVendedCredentials(map, "");
+        Assertions.assertEquals(CloudType.DEFAULT, cloudConfiguration.getCloudType());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

An Iceberg REST catalog with `iceberg.catalog.vended-credentials-enabled = 'true'` cannot read data files when the catalog vends static scoped keys instead of STS session credentials (e.g. Cloudflare R2, MinIO). `CloudConfigurationFactory.buildCloudConfigurationForAWSVendedCredentials` requires `s3.session-token` to be present before it accepts any vended credentials; without it the vended ak/sk/endpoint are discarded, the result is `CloudType.DEFAULT`, and the CN issues unauthenticated S3 requests against the default endpoint. On R2 this surfaces as a misleading `NoSuchBucket` (404) on every data-file read, while metadata operations (which go through the Iceberg client's own FileIO) succeed.

This is invisible on real AWS, where STS-issued vended credentials always carry a session token.

## What I'm doing:

Make the session token optional in `buildCloudConfigurationForAWSVendedCredentials`: gate on access key + secret key only, and copy `AWS_S3_SESSION_TOKEN` only when a token was vended. Region/endpoint/path-style handling is unchanged. Extended the existing unit test with the no-session-token case (must yield an AWS configuration carrying the endpoint) and a no-credentials case (must still fall back to `CloudType.DEFAULT`).

Fixes #77365

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
