### PR TITLE
[BugFix] Skip checkpoint thread pool metrics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
@@ -40,6 +40,7 @@ import com.starrocks.metric.GaugeMetric;
 import com.starrocks.metric.Metric.MetricUnit;
 import com.starrocks.metric.MetricLabel;
 import com.starrocks.metric.MetricRepo;
+import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -83,6 +84,10 @@ public class ThreadPoolManager {
             "completed_task_count"};
 
     private static final long KEEP_ALIVE_TIME = 60L;
+
+    private static boolean shouldRegisterMetric(boolean needRegisterMetric) {
+        return needRegisterMetric && !GlobalStateMgr.isCheckpointThread();
+    }
 
     private static final ThreadPoolExecutor STATS_CACHE_THREAD_POOL =
             ThreadPoolManager.newCollectThreadPool(Config.dict_collect_thread_pool_size, "cache-stats"
@@ -177,7 +182,7 @@ public class ThreadPoolManager {
         PriorityThreadPoolExecutor threadPool = new PriorityThreadPoolExecutor(numThread, numThread, 0,
                 TimeUnit.SECONDS, new PriorityBlockingQueue<>(queueSize), threadFactory,
                 new BlockedPolicy(poolName, 60));
-        if (needRegisterMetric) {
+        if (shouldRegisterMetric(needRegisterMetric)) {
             nameToThreadPoolMap.put(poolName, threadPool);
         }
         return threadPool;
@@ -195,7 +200,7 @@ public class ThreadPoolManager {
         ThreadPoolExecutor threadPool =
                 new ThreadPoolExecutor(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory,
                         handler);
-        if (needRegisterMetric) {
+        if (shouldRegisterMetric(needRegisterMetric)) {
             nameToThreadPoolMap.put(poolName, threadPool);
         }
         return threadPool;
@@ -209,7 +214,7 @@ public class ThreadPoolManager {
         ThreadFactory threadFactory = namedThreadFactory(poolName);
         ScheduledThreadPoolExecutor scheduledThreadPoolExecutor =
                 new ScheduledThreadPoolExecutor(corePoolSize, threadFactory);
-        if (needRegisterMetric) {
+        if (shouldRegisterMetric(needRegisterMetric)) {
             nameToThreadPoolMap.put(poolName, scheduledThreadPoolExecutor);
         }
         return scheduledThreadPoolExecutor;
@@ -316,4 +321,3 @@ public class ThreadPoolManager {
         return Integer.max(2, cpuCores() * 3 / 4);
     }
 }
-

--- a/fe/fe-core/src/test/java/com/starrocks/common/ThreadPoolManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/ThreadPoolManagerTest.java
@@ -19,13 +19,61 @@ package com.starrocks.common;
 
 import com.starrocks.metric.Metric;
 import com.starrocks.metric.MetricRepo;
+import com.starrocks.server.GlobalStateMgr;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadPoolExecutor;
 
 public class ThreadPoolManagerTest {
+
+    @Test
+    public void testCheckpointThreadDoesNotBufferMetrics() throws Exception {
+        Field checkpointThreadIdField = GlobalStateMgr.class.getDeclaredField("checkpointThreadId");
+        checkpointThreadIdField.setAccessible(true);
+        long previousCheckpointThreadId = checkpointThreadIdField.getLong(null);
+
+        Field poolMapField = ThreadPoolManager.class.getDeclaredField("nameToThreadPoolMap");
+        poolMapField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, ThreadPoolExecutor> poolMap =
+                (Map<String, ThreadPoolExecutor>) poolMapField.get(null);
+
+        String daemonPoolName = "checkpoint-daemon-pool";
+        String priorityPoolName = "checkpoint-priority-pool";
+        String scheduledPoolName = "checkpoint-scheduled-pool";
+        ThreadPoolExecutor daemonPool = null;
+        PriorityThreadPoolExecutor priorityPool = null;
+        ScheduledThreadPoolExecutor scheduledPool = null;
+        try {
+            checkpointThreadIdField.setLong(null, Thread.currentThread().getId());
+            daemonPool = ThreadPoolManager.newDaemonCacheThreadPool(1, daemonPoolName, true);
+            priorityPool = ThreadPoolManager.newDaemonFixedPriorityThreadPool(1, 1, priorityPoolName, true);
+            scheduledPool = ThreadPoolManager.newDaemonScheduledThreadPool(1, scheduledPoolName, true);
+
+            Assertions.assertFalse(poolMap.containsKey(daemonPoolName));
+            Assertions.assertFalse(poolMap.containsKey(priorityPoolName));
+            Assertions.assertFalse(poolMap.containsKey(scheduledPoolName));
+        } finally {
+            checkpointThreadIdField.setLong(null, previousCheckpointThreadId);
+            poolMap.remove(daemonPoolName);
+            poolMap.remove(priorityPoolName);
+            poolMap.remove(scheduledPoolName);
+            if (daemonPool != null) {
+                daemonPool.shutdownNow();
+            }
+            if (priorityPool != null) {
+                priorityPool.shutdownNow();
+            }
+            if (scheduledPool != null) {
+                scheduledPool.shutdownNow();
+            }
+        }
+    }
 
     @Test
     public void testNormal() throws InterruptedException {

--- a/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionOnSharedDataClusterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionOnSharedDataClusterTest.java
@@ -59,6 +59,11 @@ public class TransactionLoadActionOnSharedDataClusterTest extends TransactionLoa
             boolean isLeader() {
                 return true;
             }
+
+            @Mock
+            public static boolean isCheckpointThread() {
+                return false;
+            }
         };
 
         new MockUp<WarehouseComputeResourceProvider>() {

--- a/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
@@ -126,6 +126,11 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
             boolean isLeader() {
                 return true;
             }
+
+            @Mock
+            public static boolean isCheckpointThread() {
+                return false;
+            }
         };
 
         new MockUp<TransactionLoadAction>() {


### PR DESCRIPTION
Prevent pools created by the checkpoint thread from entering the metric registration buffer. Cover normal, priority, and scheduled pool creation paths without changing daemon lifecycle behavior.

## Why I'm doing:

## What I'm doing:

Fixes #76741

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
