### PR TITLE
[Enhancement] Split segment_init timing into per-step counters in lake compaction PROFILE

### DIFF
--- a/be/src/storage/lake/compaction_task_context.cpp
+++ b/be/src/storage/lake/compaction_task_context.cpp
@@ -32,6 +32,11 @@ void CompactionTaskStats::collect(const OlapReaderStatistics& reader_stats) {
     io_bytes_read_local_disk = reader_stats.compressed_bytes_read_local_disk;
     segment_init_ns = reader_stats.segment_init_ns;
     column_iterator_init_ns = reader_stats.column_iterator_init_ns;
+    seg_init_access_path_ns = reader_stats.seg_init_access_path_ns;
+    seg_init_ann_reader_ns = reader_stats.seg_init_ann_reader_ns;
+    seg_init_low_card_ns = reader_stats.seg_init_low_card_ns;
+    seg_init_scan_range_ns = reader_stats.seg_init_scan_range_ns;
+    seg_init_cache_size_ns = reader_stats.seg_init_cache_size_ns;
     io_count_local_disk = reader_stats.io_count_local_disk;
     io_count_remote = reader_stats.io_count_remote;
     // Note: read_segment_count is managed explicitly in compaction task code
@@ -52,6 +57,11 @@ CompactionTaskStats CompactionTaskStats::operator+(const CompactionTaskStats& th
     diff.io_bytes_read_local_disk += that.io_bytes_read_local_disk;
     diff.segment_init_ns += that.segment_init_ns;
     diff.column_iterator_init_ns += that.column_iterator_init_ns;
+    diff.seg_init_access_path_ns += that.seg_init_access_path_ns;
+    diff.seg_init_ann_reader_ns += that.seg_init_ann_reader_ns;
+    diff.seg_init_low_card_ns += that.seg_init_low_card_ns;
+    diff.seg_init_scan_range_ns += that.seg_init_scan_range_ns;
+    diff.seg_init_cache_size_ns += that.seg_init_cache_size_ns;
     diff.io_count_local_disk += that.io_count_local_disk;
     diff.io_count_remote += that.io_count_remote;
     diff.read_segment_count += that.read_segment_count;
@@ -72,6 +82,11 @@ CompactionTaskStats CompactionTaskStats::operator-(const CompactionTaskStats& th
     diff.io_bytes_read_local_disk -= that.io_bytes_read_local_disk;
     diff.segment_init_ns -= that.segment_init_ns;
     diff.column_iterator_init_ns -= that.column_iterator_init_ns;
+    diff.seg_init_access_path_ns -= that.seg_init_access_path_ns;
+    diff.seg_init_ann_reader_ns -= that.seg_init_ann_reader_ns;
+    diff.seg_init_low_card_ns -= that.seg_init_low_card_ns;
+    diff.seg_init_scan_range_ns -= that.seg_init_scan_range_ns;
+    diff.seg_init_cache_size_ns -= that.seg_init_cache_size_ns;
     diff.io_count_local_disk -= that.io_count_local_disk;
     diff.io_count_remote -= that.io_count_remote;
     diff.read_segment_count -= that.read_segment_count;
@@ -95,6 +110,21 @@ static void fill_stats_fields(rapidjson::Document& root, const CompactionTaskSta
     root.AddMember("segment_init_sec", rapidjson::Value(s.segment_init_ns / TIME_UNIT_NS_PER_SECOND), allocator);
     root.AddMember("column_iterator_init_sec", rapidjson::Value(s.column_iterator_init_ns / TIME_UNIT_NS_PER_SECOND),
                    allocator);
+    // segment_init breakdown, in ms: these steps are individually sub-second in healthy runs and
+    // would truncate to 0 under the *_sec fields, which is exactly what made the black box opaque.
+    static constexpr long TIME_UNIT_NS_PER_MS = 1000000;
+    root.AddMember("seg_init_access_path_ms", rapidjson::Value(s.seg_init_access_path_ns / TIME_UNIT_NS_PER_MS),
+                   allocator);
+    root.AddMember("seg_init_ann_reader_ms", rapidjson::Value(s.seg_init_ann_reader_ns / TIME_UNIT_NS_PER_MS),
+                   allocator);
+    root.AddMember("seg_init_low_card_ms", rapidjson::Value(s.seg_init_low_card_ns / TIME_UNIT_NS_PER_MS), allocator);
+    root.AddMember("seg_init_col_iter_ms", rapidjson::Value(s.column_iterator_init_ns / TIME_UNIT_NS_PER_MS),
+                   allocator);
+    root.AddMember("seg_init_scan_range_ms", rapidjson::Value(s.seg_init_scan_range_ns / TIME_UNIT_NS_PER_MS),
+                   allocator);
+    root.AddMember("seg_init_cache_size_ms", rapidjson::Value(s.seg_init_cache_size_ns / TIME_UNIT_NS_PER_MS),
+                   allocator);
+    root.AddMember("segment_init_ms", rapidjson::Value(s.segment_init_ns / TIME_UNIT_NS_PER_MS), allocator);
     root.AddMember("read_segment_count", rapidjson::Value(s.read_segment_count), allocator);
     root.AddMember("write_segment_count", rapidjson::Value(s.write_segment_count), allocator);
     root.AddMember("write_remote_mb", rapidjson::Value(s.write_segment_bytes / BYTES_UNIT_MB), allocator);

--- a/be/src/storage/lake/compaction_task_context.h
+++ b/be/src/storage/lake/compaction_task_context.h
@@ -49,6 +49,12 @@ struct CompactionTaskStats {
     int64_t io_bytes_read_local_disk = 0;
     int64_t segment_init_ns = 0;
     int64_t column_iterator_init_ns = 0;
+    // Breakdown of segment_init_ns, see StorageStats for why.
+    int64_t seg_init_access_path_ns = 0;
+    int64_t seg_init_ann_reader_ns = 0;
+    int64_t seg_init_low_card_ns = 0;
+    int64_t seg_init_scan_range_ns = 0;
+    int64_t seg_init_cache_size_ns = 0;
     int64_t io_count_local_disk = 0;
     int64_t io_count_remote = 0;
     int64_t in_queue_time_sec = 0;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1087,16 +1087,34 @@ Status SegmentIterator::_init_internal() {
 
     /// the calling order matters, do not change unless you know why.
 
-    _segment->turn_on_batch_update_cache_size();
-    DeferOp op([&] { _segment->turn_off_batch_update_cache_size(); });
+    {
+        SCOPED_RAW_TIMER(&_opts.stats->seg_init_cache_size_ns);
+        _segment->turn_on_batch_update_cache_size();
+    }
+    DeferOp op([&] {
+        SCOPED_RAW_TIMER(&_opts.stats->seg_init_cache_size_ns);
+        _segment->turn_off_batch_update_cache_size();
+    });
     // init stage
     // The main task is to do some initialization,
     // initialize the iterator and check if certain optimizations can be applied
-    _init_column_access_paths();
-    RETURN_IF_ERROR(_init_ann_reader());
-    RETURN_IF_ERROR(_check_low_cardinality_optimization());
-    RETURN_IF_ERROR(_init_column_iterators<true>(_schema));
-    RETURN_IF_ERROR(_init_scan_range_and_context());
+    {
+        SCOPED_RAW_TIMER(&_opts.stats->seg_init_access_path_ns);
+        _init_column_access_paths();
+    }
+    {
+        SCOPED_RAW_TIMER(&_opts.stats->seg_init_ann_reader_ns);
+        RETURN_IF_ERROR(_init_ann_reader());
+    }
+    {
+        SCOPED_RAW_TIMER(&_opts.stats->seg_init_low_card_ns);
+        RETURN_IF_ERROR(_check_low_cardinality_optimization());
+    }
+    RETURN_IF_ERROR(_init_column_iterators<true>(_schema)); // timed by column_iterator_init_ns
+    {
+        SCOPED_RAW_TIMER(&_opts.stats->seg_init_scan_range_ns);
+        RETURN_IF_ERROR(_init_scan_range_and_context());
+    }
 
     _one_time_setup_done = true;
     return Status::OK();

--- a/be/src/storage_primitive/storage_stats.h
+++ b/be/src/storage_primitive/storage_stats.h
@@ -77,6 +77,14 @@ struct OlapReaderStatistics {
     int64_t get_delta_column_group_ns = 0;
     int64_t segment_init_ns = 0;
     int64_t column_iterator_init_ns = 0;
+    // Breakdown of segment_init_ns. `_init_internal` was a black box: a field profile showed
+    // segment_init_sec=1114 while column_iterator_init_sec was only 2, i.e. the cost sat in
+    // steps that had no timer at all. These split it per step so the dominant one is visible.
+    int64_t seg_init_access_path_ns = 0;
+    int64_t seg_init_ann_reader_ns = 0;
+    int64_t seg_init_low_card_ns = 0;
+    int64_t seg_init_scan_range_ns = 0;
+    int64_t seg_init_cache_size_ns = 0;
     int64_t bitmap_index_iterator_init_ns = 0;
     int64_t zone_map_filter_ns = 0;
     int64_t rows_key_range_filter_ns = 0;


### PR DESCRIPTION
## Why I'm doing:

`segment_init_ns` is effectively a black box. A field profile from a shared-data
compaction showed:

```
segment_init_sec        1114     (task was only at 21% progress)
column_iterator_init_sec   2
read_local_sec             1
read_remote_sec / count  0 / 0
```

So ~99.8% of the initialization cost sat in steps of
`SegmentIterator::_init_internal()` that have **no timer at all**, and it cannot
be attributed by reading the code. Reproducing the same shape (1000 columns,
500 fragmented segments, zero remote reads) on a healthy node gave
`segment_init_sec = 15` for the identical structure -- the per-init cost differs
by ~74x between the field and a lab node, and there is currently no way to tell
which step is responsible.

Without this breakdown, any optimization aimed at `segment_init` is guesswork.

## What I'm doing:

Add per-step timers for the five stages of `_init_internal()`:

- `_init_column_access_paths()`
- `_init_ann_reader()`
- `_check_low_cardinality_optimization()`
- `_init_scan_range_and_context()`
- the batch metacache-size update (`turn_on/off_batch_update_cache_size`)

`_init_column_iterators()` already has `column_iterator_init_ns`, so it is
reported alongside them for a complete split.

The counters are threaded through `OlapReaderStatistics` into
`CompactionTaskStats` and surfaced in the compaction `PROFILE`
(`information_schema.be_cloud_native_compactions`) **in milliseconds** -- the
existing `*_sec` fields are integer nanosecond division and truncate every
sub-second step to `0`, which is a large part of why the box stayed opaque.

Accounting only: no allocation, no control flow, and no behavior change.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)