### PR TITLE
[BugFix] Invalidate Iceberg metadata cache after truncate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -459,12 +459,19 @@ public class IcebergMetadata implements ConnectorMetadata {
 
         DeleteFiles deleteFiles = table.newDelete().deleteFromRowFilter(Expressions.alwaysTrue());
         updateCommitInfo(deleteFiles, context);
+        boolean shouldInvalidateCache = true;
         try {
             deleteFiles.commit();
         } catch (UncheckedIOException | ValidationException | CommitFailedException | CommitStateUnknownException e) {
+            shouldInvalidateCache = e instanceof CommitStateUnknownException;
             LOG.error("Failed to truncate iceberg table: {}.{}", dbName, tableName, e);
             throw new StarRocksConnectorException(
                     String.format("Failed to truncate iceberg table: %s.%s", dbName, tableName), e);
+        } finally {
+            if (shouldInvalidateCache) {
+                invalidateCacheAfterCommit(dbName, tableName);
+                asyncRefreshOthersFeMetadataCache(dbName, tableName);
+            }
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -100,6 +100,7 @@ import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.TableRef;
 import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.TableRenameClause;
+import com.starrocks.sql.ast.TruncateTableStmt;
 import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
 import com.starrocks.sql.ast.expression.IntLiteral;
@@ -166,6 +167,7 @@ import org.apache.iceberg.Transaction;
 import org.apache.iceberg.UpdateProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.HiveTableOperations;
@@ -192,11 +194,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.starrocks.catalog.Table.TableType.ICEBERG;
 import static com.starrocks.connector.iceberg.IcebergCatalogProperties.ENABLE_DISTRIBUTED_PLAN_LOAD_DATA_FILE_COLUMN_STATISTICS_WITH_EQ_DELETE;
@@ -575,6 +580,193 @@ public class IcebergMetadataTest extends TableTestBase {
         parts.add(tableName.getDb());
         parts.add(tableName.getTbl());
         return new TableRef(QualifiedName.of(parts), null, NodePosition.ZERO);
+    }
+
+    @Test
+    public void testTruncateTableInvalidatesCachesAfterCommit() throws Exception {
+        String dbName = "iceberg_db";
+        String tableName = "iceberg_table";
+        mockedNativeTableB.newFastAppend().appendFile(FILE_B_1).commit();
+
+        AtomicInteger catalogGetTableCalls = new AtomicInteger();
+        IcebergCatalog icebergCatalog = Mockito.mock(IcebergCatalog.class);
+        Mockito.when(icebergCatalog.getTable(Mockito.any(), Mockito.eq(dbName), Mockito.eq(tableName)))
+                .thenAnswer(invocation -> {
+                    catalogGetTableCalls.incrementAndGet();
+                    return mockedNativeTableB;
+                });
+        Mockito.when(icebergCatalog.getDB(Mockito.any(), Mockito.eq(dbName)))
+                .thenReturn(new Database(1, dbName));
+        Mockito.when(icebergCatalog.getIcebergCatalogType()).thenReturn(IcebergCatalogType.HIVE_CATALOG);
+
+        AtomicInteger refreshOtherFeCalls = new AtomicInteger();
+        AtomicReference<TableName> refreshedTable = new AtomicReference<>();
+        AtomicReference<List<String>> refreshedPartitions = new AtomicReference<>();
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public Future<?> refreshOthersFeTableAsync(TableName table, List<String> partitionNames) {
+                refreshOtherFeCalls.incrementAndGet();
+                refreshedTable.set(table);
+                refreshedPartitions.set(partitionNames);
+                return CompletableFuture.completedFuture(null);
+            }
+        };
+        new MockUp<NodeMgr>() {
+            @Mock
+            public Frontend getMySelf() {
+                return new Frontend(FrontendNodeType.LEADER, "test-fe", "127.0.0.1", 9010);
+            }
+        };
+        new MockUp<Frontend>() {
+            @Mock
+            public String getFeVersion() {
+                return "test-version";
+            }
+        };
+
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergCatalog,
+                Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+        metadata.getTable(connectContext, dbName, tableName);
+
+        TruncateTableStmt stmt = new TruncateTableStmt(
+                createTableRef(new TableName(CATALOG_NAME, dbName, tableName)));
+        metadata.truncateTable(stmt, connectContext);
+        metadata.getTable(connectContext, dbName, tableName);
+
+        mockedNativeTableB.refresh();
+        List<FileScanTask> remainingFiles = Lists.newArrayList(mockedNativeTableB.newScan().planFiles());
+        Assertions.assertAll(
+                () -> Assertions.assertEquals(0, remainingFiles.size()),
+                () -> Assertions.assertEquals(3, catalogGetTableCalls.get(),
+                        "getTable must reload after the IcebergMetadata.tables entry is removed"),
+                () -> Mockito.verify(icebergCatalog).invalidateTableCache(dbName, tableName),
+                () -> Mockito.verify(icebergCatalog).invalidatePartitionCache(dbName, tableName),
+                () -> Assertions.assertEquals(1, refreshOtherFeCalls.get()),
+                () -> Assertions.assertEquals(new TableName(CATALOG_NAME, dbName, tableName), refreshedTable.get()),
+                () -> Assertions.assertEquals(List.of(), refreshedPartitions.get()));
+    }
+
+    @Test
+    public void testTruncateTableInvalidatesCachesWhenCommitStateIsUnknown() throws Exception {
+        String dbName = "iceberg_db";
+        String tableName = "iceberg_table";
+        mockedNativeTableB.newFastAppend().appendFile(FILE_B_1).commit();
+        TestTables.TestTable stateUnknownTable = TestTables.tableWithCommitSucceedButStateUnknown(tableDir, "tb");
+
+        AtomicInteger catalogGetTableCalls = new AtomicInteger();
+        IcebergCatalog icebergCatalog = Mockito.mock(IcebergCatalog.class);
+        Mockito.when(icebergCatalog.getTable(Mockito.any(), Mockito.eq(dbName), Mockito.eq(tableName)))
+                .thenAnswer(invocation -> {
+                    catalogGetTableCalls.incrementAndGet();
+                    return stateUnknownTable;
+                });
+        Mockito.when(icebergCatalog.getDB(Mockito.any(), Mockito.eq(dbName)))
+                .thenReturn(new Database(1, dbName));
+        Mockito.when(icebergCatalog.getIcebergCatalogType()).thenReturn(IcebergCatalogType.HIVE_CATALOG);
+
+        AtomicInteger refreshOtherFeCalls = new AtomicInteger();
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public Future<?> refreshOthersFeTableAsync(TableName table, List<String> partitionNames) {
+                refreshOtherFeCalls.incrementAndGet();
+                return CompletableFuture.completedFuture(null);
+            }
+        };
+        new MockUp<NodeMgr>() {
+            @Mock
+            public Frontend getMySelf() {
+                return new Frontend(FrontendNodeType.LEADER, "test-fe", "127.0.0.1", 9010);
+            }
+        };
+        new MockUp<Frontend>() {
+            @Mock
+            public String getFeVersion() {
+                return "test-version";
+            }
+        };
+
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergCatalog,
+                Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+        metadata.getTable(connectContext, dbName, tableName);
+
+        TruncateTableStmt stmt = new TruncateTableStmt(
+                createTableRef(new TableName(CATALOG_NAME, dbName, tableName)));
+        StarRocksConnectorException exception = Assertions.assertThrows(StarRocksConnectorException.class,
+                () -> metadata.truncateTable(stmt, connectContext));
+        metadata.getTable(connectContext, dbName, tableName);
+
+        stateUnknownTable.refresh();
+        List<FileScanTask> remainingFiles = Lists.newArrayList(stateUnknownTable.newScan().planFiles());
+        Assertions.assertAll(
+                () -> Assertions.assertTrue(exception.getCause() instanceof CommitStateUnknownException),
+                () -> Assertions.assertEquals(0, remainingFiles.size()),
+                () -> Assertions.assertEquals(3, catalogGetTableCalls.get(),
+                        "unknown commit state must reload the IcebergMetadata.tables entry"),
+                () -> Mockito.verify(icebergCatalog).invalidateTableCache(dbName, tableName),
+                () -> Mockito.verify(icebergCatalog).invalidatePartitionCache(dbName, tableName),
+                () -> Assertions.assertEquals(1, refreshOtherFeCalls.get()));
+    }
+
+    @Test
+    public void testTruncateTableDoesNotInvalidateCachesWhenCommitFails() throws Exception {
+        String dbName = "iceberg_db";
+        String tableName = "iceberg_table";
+        mockedNativeTableB.updateProperties().set(TableProperties.COMMIT_NUM_RETRIES, "0").commit();
+        mockedNativeTableB.newFastAppend().appendFile(FILE_B_1).commit();
+
+        AtomicInteger catalogGetTableCalls = new AtomicInteger();
+        IcebergCatalog icebergCatalog = Mockito.mock(IcebergCatalog.class);
+        Mockito.when(icebergCatalog.getTable(Mockito.any(), Mockito.eq(dbName), Mockito.eq(tableName)))
+                .thenAnswer(invocation -> {
+                    catalogGetTableCalls.incrementAndGet();
+                    return mockedNativeTableB;
+                });
+        Mockito.when(icebergCatalog.getDB(Mockito.any(), Mockito.eq(dbName)))
+                .thenReturn(new Database(1, dbName));
+        Mockito.when(icebergCatalog.getIcebergCatalogType()).thenReturn(IcebergCatalogType.HIVE_CATALOG);
+
+        AtomicInteger refreshOtherFeCalls = new AtomicInteger();
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public Future<?> refreshOthersFeTableAsync(TableName table, List<String> partitionNames) {
+                refreshOtherFeCalls.incrementAndGet();
+                return CompletableFuture.completedFuture(null);
+            }
+        };
+        new MockUp<NodeMgr>() {
+            @Mock
+            public Frontend getMySelf() {
+                return new Frontend(FrontendNodeType.LEADER, "test-fe", "127.0.0.1", 9010);
+            }
+        };
+        new MockUp<Frontend>() {
+            @Mock
+            public String getFeVersion() {
+                return "test-version";
+            }
+        };
+
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergCatalog,
+                Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+        metadata.getTable(connectContext, dbName, tableName);
+        mockedNativeTableB.ops().failCommits(1);
+
+        TruncateTableStmt stmt = new TruncateTableStmt(
+                createTableRef(new TableName(CATALOG_NAME, dbName, tableName)));
+        StarRocksConnectorException exception = Assertions.assertThrows(StarRocksConnectorException.class,
+                () -> metadata.truncateTable(stmt, connectContext));
+        metadata.getTable(connectContext, dbName, tableName);
+
+        mockedNativeTableB.refresh();
+        List<FileScanTask> remainingFiles = Lists.newArrayList(mockedNativeTableB.newScan().planFiles());
+        Assertions.assertAll(
+                () -> Assertions.assertTrue(exception.getMessage().contains("Failed to truncate iceberg table")),
+                () -> Assertions.assertEquals(1, remainingFiles.size()),
+                () -> Assertions.assertEquals(2, catalogGetTableCalls.get(),
+                        "failed commit must retain the IcebergMetadata.tables entry"),
+                () -> Mockito.verify(icebergCatalog, Mockito.never()).invalidateTableCache(dbName, tableName),
+                () -> Mockito.verify(icebergCatalog, Mockito.never()).invalidatePartitionCache(dbName, tableName),
+                () -> Assertions.assertEquals(0, refreshOtherFeCalls.get()));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

After an Iceberg `TRUNCATE TABLE` commit, the FE kept the table's pre-commit metadata in its local caches and did not notify other FEs. An asynchronous materialized view could therefore still be considered fresh and rewrite a query to stale pre-truncate data.

## What I'm doing:

- Invalidate the local Iceberg table and partition caches after a successful truncate commit.
- Notify other FEs to refresh the table metadata.
- Add unit tests for both successful commits and failed commits, ensuring cache invalidation only happens after commit success.

Fixes https://github.com/StarRocks/StarRocksTest/issues/11406.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

The behavior change is a correctness fix: successful Iceberg truncates now invalidate cached metadata across FEs.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

No user documentation is needed because this restores the expected semantics of existing `TRUNCATE TABLE` behavior without changing syntax or configuration.

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

