### PR TITLE
[BugFix] Add getPartitions() override to ClickhouseSchemaResolver

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolver.java
@@ -15,6 +15,9 @@
 package com.starrocks.connector.jdbc;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.JDBCTable;
+import com.starrocks.catalog.Table;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.Type;
@@ -24,10 +27,12 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -170,6 +175,58 @@ public class ClickhouseSchemaResolver extends JDBCSchemaResolver {
             }
         }
         return -1L;
+    }
+
+    @Override
+    public List<Partition> getPartitions(Connection connection, Table table) {
+        // ClickHouse has no engine-agnostic system table for per-partition metadata, so return a single
+        // synthetic partition for the whole table, matching MysqlSchemaResolver/PostgresSchemaResolver's
+        // handling of non-partitioned tables. The "modified time" used to decide whether an MV built on
+        // this table is stale must reflect actual data changes, not just DDL:
+        // system.tables.metadata_modification_time only updates on schema changes (e.g. ALTER TABLE), so
+        // relying on it alone would make StarRocks silently skip refreshes after plain INSERTs.
+        // system.parts.modification_time (MergeTree-family engines only) updates whenever a new part is
+        // written (INSERT/merge), so prefer it and fall back to metadata_modification_time for engines
+        // without entries there (e.g. Distributed, Memory, Log).
+        JDBCTable jdbcTable = (JDBCTable) table;
+        long modifiedTime = System.currentTimeMillis();
+        boolean gotPartsSignal = false;
+        String partsSql = "SELECT MAX(modification_time) FROM system.parts WHERE database = ? AND table = ? AND active = 1";
+        try (PreparedStatement ps = connection.prepareStatement(partsSql)) {
+            ps.setString(1, jdbcTable.getCatalogDBName());
+            ps.setString(2, jdbcTable.getCatalogTableName());
+            ps.setQueryTimeout(getQueryTimeoutSeconds());
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    Timestamp ts = rs.getTimestamp(1);
+                    if (ts != null) {
+                        modifiedTime = ts.getTime();
+                        gotPartsSignal = true;
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            // ignore: engines without system.parts entries fall through to the metadata-time query below
+        }
+        if (!gotPartsSignal) {
+            String metaSql = "SELECT metadata_modification_time FROM system.tables WHERE database = ? AND name = ?";
+            try (PreparedStatement ps = connection.prepareStatement(metaSql)) {
+                ps.setString(1, jdbcTable.getCatalogDBName());
+                ps.setString(2, jdbcTable.getCatalogTableName());
+                ps.setQueryTimeout(getQueryTimeoutSeconds());
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (rs.next()) {
+                        Timestamp ts = rs.getTimestamp(1);
+                        if (ts != null) {
+                            modifiedTime = ts.getTime();
+                        }
+                    }
+                }
+            } catch (SQLException e) {
+                throw new StarRocksConnectorException(e.getMessage(), e);
+            }
+        }
+        return Lists.newArrayList(new Partition(table.getName(), modifiedTime));
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolverTest.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.JDBCResource;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.type.VarcharType;
 import com.zaxxer.hikari.HikariDataSource;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -317,5 +318,87 @@ public class ClickhouseSchemaResolverTest {
 
         long count = resolver.getTableRowCount(connection, "testdb", "tbl1");
         Assertions.assertEquals(-1L, count, "Should return -1 when total_rows is NULL (e.g. Distributed engine)");
+    }
+
+    // -------------------------------------------------------------------------
+    // getPartitions tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testGetPartitionsUsesPartsModificationTimeWhenAvailable() throws SQLException {
+        ClickhouseSchemaResolver resolver = new ClickhouseSchemaResolver(properties);
+        JDBCTable jdbcTable = new JDBCTable(100000, "tbl1", Arrays.asList(new Column("d", VarcharType.VARCHAR)),
+                Lists.newArrayList(), "test", "catalog", properties);
+        MockResultSet partsRs = new MockResultSet("parts");
+        partsRs.addColumn("max_modification_time", Arrays.asList("2023-08-02 00:00:00"));
+
+        new Expectations() {
+            {
+                connection.prepareStatement(anyString);
+                result = preparedStatement;
+                minTimes = 1;
+
+                preparedStatement.executeQuery();
+                result = partsRs;
+                minTimes = 1;
+                maxTimes = 1;
+            }
+        };
+
+        List<Partition> partitions = resolver.getPartitions(connection, jdbcTable);
+        Assertions.assertEquals(1, partitions.size());
+        Assertions.assertEquals("tbl1", partitions.get(0).getPartitionName());
+    }
+
+    @Test
+    public void testGetPartitionsFallsBackToMetadataTimeWhenPartsEmpty() throws SQLException {
+        // Non-MergeTree engines (Distributed/Memory/Log/...) have no rows in system.parts.
+        ClickhouseSchemaResolver resolver = new ClickhouseSchemaResolver(properties);
+        JDBCTable jdbcTable = new JDBCTable(100000, "tbl1", Arrays.asList(new Column("d", VarcharType.VARCHAR)),
+                Lists.newArrayList(), "test", "catalog", properties);
+        MockResultSet emptyPartsRs = new MockResultSet("parts");
+        emptyPartsRs.addColumn("max_modification_time", Arrays.asList());
+        MockResultSet metaRs = new MockResultSet("meta");
+        metaRs.addColumn("metadata_modification_time", Arrays.asList("2023-08-01 00:00:00"));
+
+        new Expectations() {
+            {
+                connection.prepareStatement(anyString);
+                result = preparedStatement;
+                minTimes = 2;
+
+                preparedStatement.executeQuery();
+                returns(emptyPartsRs, metaRs);
+            }
+        };
+
+        List<Partition> partitions = resolver.getPartitions(connection, jdbcTable);
+        Assertions.assertEquals(1, partitions.size());
+        Assertions.assertEquals("tbl1", partitions.get(0).getPartitionName());
+    }
+
+    @Test
+    public void testGetPartitionsFallsBackToCurrentTimeWhenBothEmpty() throws SQLException {
+        ClickhouseSchemaResolver resolver = new ClickhouseSchemaResolver(properties);
+        JDBCTable jdbcTable = new JDBCTable(100000, "tbl1", Arrays.asList(new Column("d", VarcharType.VARCHAR)),
+                Lists.newArrayList(), "test", "catalog", properties);
+        MockResultSet emptyPartsRs = new MockResultSet("parts");
+        emptyPartsRs.addColumn("max_modification_time", Arrays.asList());
+        MockResultSet emptyMetaRs = new MockResultSet("meta");
+        emptyMetaRs.addColumn("metadata_modification_time", Arrays.asList());
+
+        new Expectations() {
+            {
+                connection.prepareStatement(anyString);
+                result = preparedStatement;
+                minTimes = 2;
+
+                preparedStatement.executeQuery();
+                returns(emptyPartsRs, emptyMetaRs);
+            }
+        };
+
+        List<Partition> partitions = resolver.getPartitions(connection, jdbcTable);
+        Assertions.assertEquals(1, partitions.size(), "Should still return one synthetic partition when both queries are empty");
     }
 }


### PR DESCRIPTION
## Why I'm doing:

`ClickhouseSchemaResolver` doesn't override `getPartitions()`, so it falls through
to `JDBCSchemaResolver`'s default implementation, which returns an empty list.
`PartitionBasedMvRefreshProcessor` indexes into that list (`.get(0)`) when building
base-table partition snapshots, so any async materialized view refresh over a
ClickHouse JDBC catalog table throws `IndexOutOfBoundsException` and never
succeeds. `FORCE` refresh works fine — the crash only happens on the normal,
non-`FORCE` refresh path.

MySQL/PostgreSQL hit the exact same gap and were fixed in #31177 by returning a
single synthetic partition for non-partitioned tables. ClickHouse was never
given the same treatment.

## What I'm doing:

Fixes #77223.

Adds a `getPartitions()` override to `ClickhouseSchemaResolver` that returns one
synthetic partition for the whole table, matching the MySQL/PostgreSQL pattern.
The partition's modified-time is resolved in two steps:
1. `system.parts.modification_time` (MergeTree-family engines) — updates on every
   INSERT/merge, so it reflects real data changes.
2. Falls back to `system.tables.metadata_modification_time` for engines with no
   `system.parts` entries (Distributed, Memory, Log, etc.) — this only updates on
   DDL, not on data changes, so it's used only when step 1 finds nothing.

Verified directly against `3.5.20-4d17879` (the version originally reported) and
`4.1.0-4ee68c0`: the crash no longer reproduces on either, and
`REFRESH MATERIALIZED VIEW ... FORCE` correctly picks up new ClickHouse data.

**Known limitation (not fixed by this PR):** plain `REFRESH MATERIALIZED VIEW`
(without `FORCE`) sometimes still reports `SKIPPED` after new data is inserted,
even with the `system.parts`-based signal. FE logs show the refresh processor
detects "partition changing: true" but then decides "no partitions to refresh"
anyway — this looks like a separate issue in how partition versions are
reconciled for external tables, not something a schema-resolver-level fix can
address. Happy to file a follow-up issue if that's useful.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior:

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: previously-crashing async MV refresh over ClickHouse JDBC catalog tables now succeeds

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1 — not applicable; this version's refresh engine (`com.starrocks.scheduler.mv.*`) no longer has the `PartitionBasedMvRefreshProcessor` code path this bug is in
  - [x] 4.0
  - [x] 3.5