### PR TITLE
[BugFix] Fail the internal DML/CONTROL statement that only records an error state

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/FileListTableRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/FileListTableRepo.java
@@ -146,7 +146,13 @@ public class FileListTableRepo extends FileListRepo {
 
     @Override
     public void destroy() {
-        RepoAccessor.getInstance().deleteByPipe(pipeId.getId());
+        try {
+            RepoAccessor.getInstance().deleteByPipe(pipeId.getId());
+        } catch (Exception e) {
+            // Removing the file list is best-effort: dropping the pipe must not be blocked when the
+            // internal bookkeeping table is unavailable, it only leaves stale records behind.
+            LOG.warn("failed to remove the file list of pipe {}", pipeId, e);
+        }
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SimpleExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SimpleExecutor.java
@@ -18,6 +18,7 @@ import com.google.common.base.Preconditions;
 import com.starrocks.common.AuditLog;
 import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
+import com.starrocks.common.StarRocksException;
 import com.starrocks.common.Status;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.SqlCredentialRedactor;
@@ -109,6 +110,12 @@ public class SimpleExecutor {
             AuditLog.getInternalAudit().info("{} execute SQL | Query_id {} | {} {}",
                     name, DebugUtil.printId(context.getQueryId()), type.name(), SqlCredentialRedactor.redact(sql));
             executor.execute();
+            if (context.getState().isError()) {
+                // StmtExecutor.execute() does not rethrow the failure of the statement, it only records
+                // the error in the ConnectContext state. Surface it here, otherwise the caller takes a
+                // failed statement for a successful one and may discard the data it wanted to persist.
+                throw new StarRocksException(context.getState().getErrorMessage());
+            }
         } catch (Exception e) {
             LOG.error(name + " execute SQL {} failed: {}", SqlCredentialRedactor.redact(sql), e.getMessage(), e);
             throw new SemanticException(String.format(name + " execute sql failed: %s", e.getMessage()), e);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SimpleExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SimpleExecutorTest.java
@@ -1,0 +1,84 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe;
+
+import com.starrocks.common.FeConstants;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.thrift.TResultSinkType;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SimpleExecutorTest {
+
+    private static final String INSERT_SQL = "INSERT INTO db1.t1 VALUES(1)";
+
+    @BeforeAll
+    public static void beforeAll() {
+        UtFrameUtils.createMinStarRocksCluster();
+        FeConstants.runningUnitTest = false;
+    }
+
+    /**
+     * StmtExecutor.execute() does not rethrow a StarRocksException, it only records the failure in
+     * the ConnectContext state and returns normally. The internal executor must not report that as
+     * a success, otherwise its callers silently lose the data they believe they have persisted.
+     */
+    @Test
+    public void testExecuteDMLFailsWhenStatementSetsErrorState() {
+        mockStatementFailure("Tablet lost replicas. Check if any backend is down or not. tablet_id: 10093");
+
+        SimpleExecutor executor = new SimpleExecutor("testExecutor", TResultSinkType.HTTP_PROTOCAL);
+        SemanticException e =
+                assertThrows(SemanticException.class, () -> executor.executeDML(INSERT_SQL));
+        assertTrue(e.getMessage().contains("Tablet lost replicas"), e.getMessage());
+    }
+
+    @Test
+    public void testExecuteControlFailsWhenStatementSetsErrorState() {
+        mockStatementFailure("Unknown thread id: 1024");
+
+        SimpleExecutor executor = new SimpleExecutor("testExecutor", TResultSinkType.MYSQL_PROTOCAL);
+        SemanticException e =
+                assertThrows(SemanticException.class, () -> executor.executeControl("KILL 1024"));
+        assertTrue(e.getMessage().contains("Unknown thread id"), e.getMessage());
+    }
+
+    @Test
+    public void testExecuteDMLSucceedsWhenStatementIsOk() {
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void execute() {
+            }
+        };
+
+        SimpleExecutor executor = new SimpleExecutor("testExecutor", TResultSinkType.HTTP_PROTOCAL);
+        executor.executeDML(INSERT_SQL);
+    }
+
+    private static void mockStatementFailure(String errorMessage) {
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void execute() {
+                ConnectContext.get().getState().setError(errorMessage);
+            }
+        };
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -20,7 +20,9 @@ import com.google.gson.JsonSyntaxException;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SimpleExecutor;
+import com.starrocks.qe.StmtExecutor;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.statistic.StatisticsMetaManager;
@@ -252,6 +254,40 @@ public class TaskRunHistoryTest {
         history.addHistory(run3);
         history.vacuum(true);
         assertEquals(2, history.getInMemoryHistory().size());
+    }
+
+    /**
+     * A failed archive INSERT must not drop the in-memory history. StmtExecutor swallows the
+     * failure by only recording it in the ConnectContext state, so the archive has to detect it:
+     * otherwise the finished task run is erased from both memory and the history table, and
+     * callers waiting for that task run (e.g. OptimizeJobV2) never see it finish.
+     */
+    @Test
+    public void testHistoryVacuumKeepsStateWhenInsertFailsSilently() {
+        new MockUp<TableKeeper>() {
+            @Mock
+            public boolean isReady() {
+                return true;
+            }
+        };
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void execute() {
+                ConnectContext.get().getState()
+                        .setError("Tablet lost replicas. Check if any backend is down or not. tablet_id: 10093");
+            }
+        };
+
+        TaskRunHistory history = new TaskRunHistory();
+        TaskRunStatus run = new TaskRunStatus();
+        run.setExpireTime(System.currentTimeMillis() + 10000);
+        run.setQueryId("q1");
+        run.setTaskName("t1");
+        run.setState(Constants.TaskRunState.SUCCESS);
+        history.addHistory(run);
+
+        history.vacuum(true);
+        assertEquals(1, history.getInMemoryHistory().size());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

`StmtExecutor.execute()` does not rethrow the failure of a statement: it catches `StarRocksException`,
logs it and records the message in the `ConnectContext` state. `SimpleExecutor.executeDMLOrControl()`
never inspected that state, so every internal writer that goes through it (task run history archive,
SPM baselines, pipe file list, loads history, predicate columns) took a failed statement for a
successful one.

The worst outcome is the task run history archive. On a cluster where `_statistics_.task_run_history`
cannot be written — the shadow partition of that automatic-partition table only had replicas on
backend ids that no longer existed, so the INSERT failed in `OlapTableSink.createLocation()` with
`Tablet lost replicas. Check if any backend is down or not. tablet_id: 10093 ... Check quorum number
failed(OlapTableSink): BeReplicaSize:0, quorum:2` — `TaskRunHistory.archiveHistory()` believed the
INSERT succeeded, erased every finished task run from memory and wrote `ArchiveTaskRunsLog`. The
SUCCESS state of an already finished optimize sub task was then in neither memory nor the history
table, so `OptimizeJobV2.runRunningJob()` kept waiting for a task run that no longer existed:
`ALTER TABLE ... DISTRIBUTED BY HASH(...) BUCKETS n` stayed in RUNNING with progress 0 for ~20 hours,
until the job hit its `alter_table_timeout_second` (24h), and no error was ever reported to the user.

## What I'm doing:

Check `ConnectContext.getState().isError()` after `executor.execute()` in
`SimpleExecutor.executeDMLOrControl()` and raise the recorded error, the same way
`DataCacheSelectExecutor` already does. The archive then keeps the in-memory task run state (and logs
the failure) instead of dropping it, so the optimize job still finishes; the other internal writers
report their failure instead of silently losing data.

One caller is adapted to the new failure semantics: removing the file list of a dropped pipe stays
best-effort (`FileListTableRepo.destroy()` logs instead of propagating), because `DROP PIPE` must not
be blocked when the internal bookkeeping table is unavailable — that was the behaviour before this
change as well.

Tests:
- `SimpleExecutorTest` — `executeDML` / `executeControl` must fail when the statement only records an
  error state, and must still succeed when it does not.
- `TaskRunHistoryTest#testHistoryVacuumKeepsStateWhenInsertFailsSilently` — reproduces the reported
  issue: a silently failing archive INSERT used to erase the finished task run from memory.

Fixes MIR-38525

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

An internal DML/CONTROL statement that fails now raises the error to its caller instead of returning
silently. All existing callers already handle a failure of `SimpleExecutor` (their own try/catch, or
the `Daemon.run()` / `PipeScheduler` per-cycle `catch (Throwable)`), so a failed internal write is now
logged and retried on the next round instead of being taken for a success.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
