### PR TITLE
[BugFix] Keep agg spill available when small-limit group-by has unbounded aggregate states

### DIFF
--- a/be/src/exec/aggregate/agg_state_bounded.h
+++ b/be/src/exec/aggregate/agg_state_bounded.h
@@ -1,0 +1,72 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <vector>
+
+#include "exprs/agg/aggregate.h"
+#include "exprs/agg/aggregate_factory.h"
+#include "gen_cpp/Exprs_types.h"
+#include "types/type_descriptor.h"
+
+namespace starrocks {
+
+// Returns true only when every aggregate function in the list provably has a
+// fixed-size state. Boundedness is derived from aggregate-state metadata instead
+// of a hand-maintained name list: is_pod_state() is computed by the compiler as
+// std::is_trivially_destructible_v<State>, so a true result guarantees the state
+// owns no heap memory and its size stays sizeof(State) no matter how many input
+// rows a group receives (sum/count/avg/min/max/variance/stddev/...).
+//
+// Everything else conservatively reports false so spill stays available:
+// collect-style states that grow with input rows (array_agg, group_concat,
+// multi_distinct_count, bitmap_union, ...), agg-state combinators, UDAFs, and
+// any function that fails to resolve. Non-POD but bounded states (string
+// min/max, HLL sketches) also report false; they only lose the small-limit
+// pruning optimization, never correctness.
+inline bool all_agg_states_bounded(const std::vector<TExpr>& aggregate_functions, int func_version) {
+    for (const auto& agg_expr : aggregate_functions) {
+        if (agg_expr.nodes.empty() || !agg_expr.nodes[0].__isset.fn) {
+            return false;
+        }
+        const TExprNode& node = agg_expr.nodes[0];
+        const TFunction& fn = node.fn;
+        // agg-state combinators carry their own state description; stay conservative.
+        if (fn.__isset.agg_state_desc) {
+            return false;
+        }
+        const AggregateFunction* func = nullptr;
+        if (fn.name.function_name == "count") {
+            // count may have no argument (count(*)); resolve it the same way Aggregator does.
+            func = get_aggregate_function("count", TYPE_BIGINT, TYPE_BIGINT, node.is_nullable);
+        } else if (!fn.arg_types.empty()) {
+            std::vector<TypeDescriptor> arg_types;
+            arg_types.reserve(fn.arg_types.size());
+            for (const auto& arg_type : fn.arg_types) {
+                arg_types.push_back(TypeDescriptor::from_thrift(arg_type));
+            }
+            TypeDescriptor return_type = TypeDescriptor::from_thrift(fn.ret_type);
+            bool is_arrow_input = fn.__isset.input_type && fn.input_type == "arrow";
+            func = get_aggregate_function(fn.name.function_name, return_type, arg_types, node.is_nullable,
+                                          fn.binary_type, func_version, is_arrow_input);
+        }
+        if (func == nullptr || !func->is_pod_state()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace starrocks

--- a/be/src/exec/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/aggregate/aggregate_blocking_node.cpp
@@ -18,6 +18,7 @@
 #include <type_traits>
 
 #include "base/simd/simd.h"
+#include "exec/aggregate/agg_state_bounded.h"
 #include "exec/aggregator.h"
 #include "exec/pipeline/aggregate/aggregate_blocking_sink_operator.h"
 #include "exec/pipeline/aggregate/aggregate_blocking_source_operator.h"
@@ -182,8 +183,12 @@ StatusOr<pipeline::OpFactories> AggregateBlockingNode::decompose_to_pipeline(
         // disable spill when group by with a small limit
         // having clause filters rows after aggregation, so a small limit does not bound the
         // aggregation input size; only disable spill when there is no having clause.
+        // a small limit only bounds the number of groups, not the size of a single aggregate
+        // state: collect-style states (array_agg/group_concat/multi_distinct_count/...) can grow
+        // unboundedly within one group, so only disable spill when every aggregate state is bounded.
         bool enable_agg_spill = runtime_state()->enable_spill() && runtime_state()->enable_agg_spill();
-        if (limit() != -1 && limit() < runtime_state()->chunk_size() && _tnode.conjuncts.empty()) {
+        if (limit() != -1 && limit() < runtime_state()->chunk_size() && _tnode.conjuncts.empty() &&
+            all_agg_states_bounded(_tnode.agg_node.aggregate_functions, runtime_state()->func_version())) {
             enable_agg_spill = false;
         }
         if (enable_agg_spill && has_group_by_keys) {

--- a/be/test/exprs/CMakeLists.txt
+++ b/be/test/exprs/CMakeLists.txt
@@ -19,6 +19,7 @@ endif()
 
 set(EXPR_TEST_FILES
     ${BE_TEST_MACOS_LINK_STUBS}
+    agg/agg_state_bounded_test.cpp
     agg/aggregate_factory_core_test.cpp
     ai_functions_test.cpp
     arithmetic_expr_test.cpp

--- a/be/test/exprs/agg/agg_state_bounded_test.cpp
+++ b/be/test/exprs/agg/agg_state_bounded_test.cpp
@@ -1,0 +1,138 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/aggregate/agg_state_bounded.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "types/logical_type.h"
+
+namespace starrocks {
+namespace {
+
+constexpr int kFuncVersion = 1;
+
+TExpr make_agg_expr_typed(const std::string& function_name, const TypeDescriptor& ret_type,
+                          const std::vector<TypeDescriptor>& arg_types, bool is_nullable = false) {
+    TFunctionName fn_name;
+    fn_name.__set_function_name(function_name);
+    TFunction fn;
+    fn.__set_name(fn_name);
+    fn.__set_binary_type(TFunctionBinaryType::BUILTIN);
+    std::vector<TTypeDesc> targs;
+    targs.reserve(arg_types.size());
+    for (const auto& arg : arg_types) {
+        targs.push_back(arg.to_thrift());
+    }
+    fn.__set_arg_types(targs);
+    fn.__set_ret_type(ret_type.to_thrift());
+    TExprNode node;
+    node.__set_fn(fn);
+    node.__set_is_nullable(is_nullable);
+    TExpr expr;
+    expr.nodes.push_back(node);
+    return expr;
+}
+
+TExpr make_agg_expr(const std::string& function_name, LogicalType ret_type, const std::vector<LogicalType>& arg_types,
+                    bool is_nullable = false) {
+    std::vector<TypeDescriptor> args;
+    args.reserve(arg_types.size());
+    for (auto lt : arg_types) {
+        args.push_back(TypeDescriptor::from_logical_type(lt));
+    }
+    return make_agg_expr_typed(function_name, TypeDescriptor::from_logical_type(ret_type), args, is_nullable);
+}
+
+} // namespace
+
+TEST(AggStateBoundedTest, pod_states_are_bounded) {
+    EXPECT_TRUE(all_agg_states_bounded({make_agg_expr("count", TYPE_BIGINT, {})}, kFuncVersion));
+    EXPECT_TRUE(all_agg_states_bounded({make_agg_expr("sum", TYPE_BIGINT, {TYPE_BIGINT})}, kFuncVersion));
+    EXPECT_TRUE(all_agg_states_bounded({make_agg_expr("min", TYPE_BIGINT, {TYPE_BIGINT})}, kFuncVersion));
+    EXPECT_TRUE(all_agg_states_bounded({make_agg_expr("max", TYPE_BIGINT, {TYPE_BIGINT})}, kFuncVersion));
+    EXPECT_TRUE(all_agg_states_bounded({make_agg_expr("any_value", TYPE_BIGINT, {TYPE_BIGINT})}, kFuncVersion));
+    EXPECT_TRUE(all_agg_states_bounded({make_agg_expr("avg", TYPE_DOUBLE, {TYPE_DOUBLE})}, kFuncVersion));
+}
+
+TEST(AggStateBoundedTest, variance_family_is_bounded) {
+    // The exact case from the PR review: variance/stddev states are (count, mean, m2),
+    // trivially destructible, so they keep the small-limit pruning optimization.
+    EXPECT_TRUE(all_agg_states_bounded({make_agg_expr("variance", TYPE_DOUBLE, {TYPE_DOUBLE})}, kFuncVersion));
+    EXPECT_TRUE(all_agg_states_bounded({make_agg_expr("stddev", TYPE_DOUBLE, {TYPE_DOUBLE})}, kFuncVersion));
+}
+
+TEST(AggStateBoundedTest, nullable_wrapper_preserves_boundedness) {
+    EXPECT_TRUE(all_agg_states_bounded({make_agg_expr("sum", TYPE_BIGINT, {TYPE_BIGINT}, /*is_nullable=*/true)},
+                                       kFuncVersion));
+}
+
+TEST(AggStateBoundedTest, collect_style_states_are_unbounded) {
+    const TypeDescriptor bigint = TypeDescriptor::from_logical_type(TYPE_BIGINT);
+    const TypeDescriptor array_bigint = TypeDescriptor::create_array_type(bigint);
+    EXPECT_FALSE(all_agg_states_bounded({make_agg_expr_typed("array_agg", array_bigint, {bigint})}, kFuncVersion));
+    EXPECT_FALSE(all_agg_states_bounded({make_agg_expr("group_concat", TYPE_VARCHAR, {TYPE_VARCHAR})}, kFuncVersion));
+    EXPECT_FALSE(
+            all_agg_states_bounded({make_agg_expr("multi_distinct_count", TYPE_BIGINT, {TYPE_BIGINT})}, kFuncVersion));
+    EXPECT_FALSE(all_agg_states_bounded({make_agg_expr("bitmap_union", TYPE_OBJECT, {TYPE_OBJECT})}, kFuncVersion));
+    EXPECT_FALSE(all_agg_states_bounded({make_agg_expr("hll_raw_agg", TYPE_HLL, {TYPE_HLL})}, kFuncVersion));
+}
+
+TEST(AggStateBoundedTest, non_pod_bounded_states_stay_conservative) {
+    // String min/max holds a single value but its state owns heap memory, so it is
+    // conservatively treated as unbounded (loses the pruning optimization only).
+    EXPECT_FALSE(all_agg_states_bounded({make_agg_expr("min", TYPE_VARCHAR, {TYPE_VARCHAR})}, kFuncVersion));
+    EXPECT_FALSE(all_agg_states_bounded({make_agg_expr("max", TYPE_VARCHAR, {TYPE_VARCHAR})}, kFuncVersion));
+}
+
+TEST(AggStateBoundedTest, one_unbounded_state_taints_the_whole_list) {
+    const TypeDescriptor bigint = TypeDescriptor::from_logical_type(TYPE_BIGINT);
+    const TypeDescriptor array_bigint = TypeDescriptor::create_array_type(bigint);
+    EXPECT_FALSE(all_agg_states_bounded({make_agg_expr("sum", TYPE_BIGINT, {TYPE_BIGINT}),
+                                         make_agg_expr_typed("array_agg", array_bigint, {bigint})},
+                                        kFuncVersion));
+}
+
+TEST(AggStateBoundedTest, unresolvable_functions_are_treated_as_unbounded) {
+    EXPECT_FALSE(
+            all_agg_states_bounded({make_agg_expr("some_future_agg_func", TYPE_BIGINT, {TYPE_BIGINT})}, kFuncVersion));
+}
+
+TEST(AggStateBoundedTest, agg_state_combinators_are_treated_as_unbounded) {
+    TExpr expr = make_agg_expr("sum_union", TYPE_BIGINT, {TYPE_BIGINT});
+    expr.nodes[0].fn.__set_agg_state_desc(TAggStateDesc());
+    EXPECT_FALSE(all_agg_states_bounded({expr}, kFuncVersion));
+}
+
+TEST(AggStateBoundedTest, empty_function_list_is_bounded) {
+    EXPECT_TRUE(all_agg_states_bounded({}, kFuncVersion));
+}
+
+TEST(AggStateBoundedTest, malformed_exprs_are_treated_as_unbounded) {
+    TExpr no_nodes;
+    EXPECT_FALSE(all_agg_states_bounded({no_nodes}, kFuncVersion));
+
+    TExprNode bare_node;
+    TExpr no_fn;
+    no_fn.nodes.push_back(bare_node);
+    EXPECT_FALSE(all_agg_states_bounded({no_fn}, kFuncVersion));
+
+    // arg-less non-count function cannot be resolved.
+    EXPECT_FALSE(all_agg_states_bounded({make_agg_expr("sum", TYPE_BIGINT, {})}, kFuncVersion));
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

`AggregateBlockingNode::decompose_to_pipeline` disables agg spill when the aggregation has a small limit (`limit < chunk_size`) and no having clause, assuming a small limit bounds aggregation memory:

```cpp
bool enable_agg_spill = runtime_state()->enable_spill() && runtime_state()->enable_agg_spill();
if (limit() != -1 && limit() < runtime_state()->chunk_size() && _tnode.conjuncts.empty()) {
    enable_agg_spill = false;
}
```

The assumption only holds for the **number of groups**. The small-limit optimization stops the hash table from accepting new groups once it reaches `limit`, but rows belonging to the kept groups must still be aggregated for correctness, so collect-style aggregate states (`array_agg`, `group_concat`, `multi_distinct_count`, `bitmap_union`, ...) can still grow without bound inside a single group.

Since this decision happens at plan-decompose time, the non-spillable operator pair is selected and the query has no way to spill at runtime — not even with `spill_mode = 'force'`. The query fails with mem-limit-exceeded although the user explicitly enabled spill, and the profile shows no spillable agg operator at all.

Reproduce (~51MB single `array_agg` state in one group under a 64MB query mem limit):

```sql
SET enable_spill = true;
SET spill_mode = 'auto';
SET query_mem_limit = 67108864;

-- wide_rows: 200k rows, payload VARCHAR(256), one dominant group
SELECT grp, array_length(array_agg(payload)) AS result
FROM wide_rows
GROUP BY grp
LIMIT 1;   -- OOM before this fix; returns 200000 with spill after this fix
```

A similar previously-fixed hole in the same condition was the having-clause case (#72705). The common real-world shape of this one is `count(distinct high_cardinality_col)` with `GROUP BY ... LIMIT n`, which rewrites to `multi_distinct_count` whose state is also unbounded.

## What I'm doing:

Only disable spill for small-limit aggregations when **every** aggregate function provably has a fixed-size state. Boundedness is derived from aggregate-state metadata instead of a hand-maintained name list (addressing the review feedback): `all_agg_states_bounded()` resolves each aggregate function at plan-decompose time and checks `AggregateFunction::is_pod_state()`, which the compiler derives as `std::is_trivially_destructible_v<State>` — a true result guarantees the state owns no heap memory and never grows with input rows.

- `sum`/`count`/`avg`/`min`/`max`/`variance`/`stddev`/... (and their nullable variants) are automatically classified as bounded and keep the small-limit pruning optimization from #55455 — no per-function maintenance needed for future aggregates.
- Collect-style states (`array_agg`, `group_concat`, `multi_distinct_count`, `bitmap_union`, ...), agg-state combinators, UDAFs, and unresolvable functions all report unbounded, keeping the spillable operator so they can spill under memory pressure. Non-POD but bounded states (string `min`/`max`, HLL sketches) are conservatively treated as unbounded; they only lose the pruning optimization, never correctness.
- Add UT `AggStateBoundedTest` (10 cases: POD states incl. the variance family and nullable wrappers, collect-style states, conservative non-POD cases, mixed lists, combinators, unknown functions, empty list, malformed exprs).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
