### PR TITLE
[Enhancement] Enable auto-mode spill for the nestloop join build operator

### DIFF
--- a/be/src/compute_env/spill/operator_mem_resource_manager.h
+++ b/be/src/compute_env/spill/operator_mem_resource_manager.h
@@ -29,8 +29,7 @@ enum MEM_RESOURCE {
 
 class OperatorMemoryResourceManager {
 public:
-    // TODO: per-instance only, no query-level coordination. With dop > 1 each instance decides
-    // on its own, and a finished instance's retained memory can never be reclaimed.
+    // TODO: per-instance decisions only; a finished instance's retained memory is never reclaimed.
     ~OperatorMemoryResourceManager() noexcept { close(); }
 
     class ResGuard {

--- a/be/src/compute_env/spill/operator_mem_resource_manager.h
+++ b/be/src/compute_env/spill/operator_mem_resource_manager.h
@@ -29,6 +29,8 @@ enum MEM_RESOURCE {
 
 class OperatorMemoryResourceManager {
 public:
+    // TODO: per-instance only, no query-level coordination. With dop > 1 each instance decides
+    // on its own, and a finished instance's retained memory can never be reclaimed.
     ~OperatorMemoryResourceManager() noexcept { close(); }
 
     class ResGuard {

--- a/be/src/exec/cross_join_node.cpp
+++ b/be/src/exec/cross_join_node.cpp
@@ -162,6 +162,11 @@ StatusOr<pipeline::OpFactories> CrossJoinNode::_decompose_to_pipeline(pipeline::
     auto spill_process_factory_ptr = std::make_shared<SpillProcessChannelFactory>(num_right_partitions);
     context_params.spill_process_factory_ptr = spill_process_factory_ptr;
 
+    if constexpr (std::is_same_v<BuildFactory, SpillableNLJoinBuildOperatorFactory>) {
+        ::starrocks::pipeline::builder::interpolate_spill_process(context, id(), spill_process_factory_ptr,
+                                                                  num_right_partitions);
+    }
+
     auto cross_join_context = std::make_shared<NLJoinContext>(std::move(context_params));
 
     // cross_join_right as sink operator

--- a/be/src/exec/pipeline/nljoin/nljoin_build_operator.h
+++ b/be/src/exec/pipeline/nljoin/nljoin_build_operator.h
@@ -51,10 +51,8 @@ public:
     size_t output_amplification_factor() const override;
     OperatorExecStatsSnapshot exec_stats_snapshot() const override { return OperatorExecStatsSnapshot::ignored(); }
 
-private:
-    std::atomic<bool> _is_finished = false;
-
 protected:
+    std::atomic<bool> _is_finished = false;
     const std::shared_ptr<NLJoinContext>& _cross_join_context;
 };
 

--- a/be/src/exec/pipeline/nljoin/nljoin_context.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_context.cpp
@@ -54,9 +54,21 @@ Status NJJoinBuildInputChannel::add_chunk_to_spill_buffer(RuntimeState* state, C
     return Status::OK();
 }
 
+Status NJJoinBuildInputChannel::spill_buffered_chunks(RuntimeState* state, bool should_finalize) {
+    if (should_finalize) {
+        _accumulator.finalize();
+    }
+    while (!_accumulator.empty()) {
+        auto chunk = _accumulator.pull();
+        RETURN_IF_ERROR(_spiller->spill(state, chunk, TRACKER_WITH_SPILLER_GUARD(state, _spiller)));
+    }
+    return Status::OK();
+}
+
 void NJJoinBuildInputChannel::finalize() {
     _accumulator.finalize();
     while (ChunkPtr output = _accumulator.pull()) {
+        _memory_usage += output->memory_usage();
         _input_chunks.emplace_back(std::move(output));
     }
 }

--- a/be/src/exec/pipeline/nljoin/nljoin_context.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_context.cpp
@@ -47,22 +47,25 @@ Status NJJoinBuildInputChannel::add_chunk_to_spill_buffer(RuntimeState* state, C
 
     _num_rows += build_chunk->num_rows();
     RETURN_IF_ERROR(_accumulator.push(std::move(build_chunk)));
-    if (auto chunk = _accumulator.pull()) {
-        RETURN_IF_ERROR(_spiller->spill(state, chunk, TRACKER_WITH_SPILLER_GUARD(state, _spiller)));
+    if (!_spiller->is_full()) {
+        if (auto chunk = _accumulator.pull()) {
+            RETURN_IF_ERROR(_spiller->spill(state, chunk, TRACKER_WITH_SPILLER_GUARD(state, _spiller)));
+        }
     }
 
     return Status::OK();
 }
 
-Status NJJoinBuildInputChannel::spill_buffered_chunks(RuntimeState* state, bool should_finalize) {
+std::function<StatusOr<ChunkPtr>()> NJJoinBuildInputChannel::buffered_chunk_iterator(bool should_finalize) {
     if (should_finalize) {
         _accumulator.finalize();
     }
-    while (!_accumulator.empty()) {
-        auto chunk = _accumulator.pull();
-        RETURN_IF_ERROR(_spiller->spill(state, chunk, TRACKER_WITH_SPILLER_GUARD(state, _spiller)));
-    }
-    return Status::OK();
+    return [this]() -> StatusOr<ChunkPtr> {
+        if (auto chunk = _accumulator.pull()) {
+            return chunk;
+        }
+        return Status::EndOfFile("no more buffered chunks");
+    };
 }
 
 void NJJoinBuildInputChannel::finalize() {

--- a/be/src/exec/pipeline/nljoin/nljoin_context.h
+++ b/be/src/exec/pipeline/nljoin/nljoin_context.h
@@ -58,6 +58,8 @@ public:
     void set_spiller(std::shared_ptr<spill::Spiller> spiller) { _spiller = std::move(spiller); }
     const std::shared_ptr<spill::Spiller>& spiller() { return _spiller; }
     bool has_spilled() { return _spiller && _spiller->spilled(); }
+    Status spill_buffered_chunks(RuntimeState* state, bool should_finalize);
+    size_t memory_usage() const { return _accumulator.memory_usage(); }
 
     Status add_chunk_to_spill_buffer(RuntimeState* state, ChunkPtr build_chunk);
 
@@ -88,6 +90,7 @@ public:
 private:
     size_t _num_rows{};
     size_t _chunk_size;
+    size_t _memory_usage{};
     ChunkAccumulator _accumulator;
     std::vector<ChunkPtr> _input_chunks;
 

--- a/be/src/exec/pipeline/nljoin/nljoin_context.h
+++ b/be/src/exec/pipeline/nljoin/nljoin_context.h
@@ -58,7 +58,7 @@ public:
     void set_spiller(std::shared_ptr<spill::Spiller> spiller) { _spiller = std::move(spiller); }
     const std::shared_ptr<spill::Spiller>& spiller() { return _spiller; }
     bool has_spilled() { return _spiller && _spiller->spilled(); }
-    Status spill_buffered_chunks(RuntimeState* state, bool should_finalize);
+    std::function<StatusOr<ChunkPtr>()> buffered_chunk_iterator(bool should_finalize);
     size_t memory_usage() const { return _accumulator.memory_usage(); }
 
     Status add_chunk_to_spill_buffer(RuntimeState* state, ChunkPtr build_chunk);

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.cpp
@@ -79,17 +79,29 @@ Status SpillableNLJoinBuildOperator::set_finishing(RuntimeState* state) {
         RETURN_IF_ERROR(_spill_buffered_chunks(state, true));
     }
 
-    RETURN_IF_ERROR(spiller->flush(state, TRACKER_WITH_SPILLER_GUARD(state, spiller)));
-    RETURN_IF_ERROR(spiller->set_flush_all_call_back(
-            [&, state]() {
-                RETURN_IF_ERROR(_cross_join_context->finish_one_right_sinker(_driver_sequence, state));
-                _is_finished = true;
-                _spill_channel->set_finishing();
-                return Status::OK();
-            },
-            state, TRACKER_WITH_SPILLER_GUARD(state, spiller)));
+    auto flush_task = [this](RuntimeState* state) {
+        auto spiller = _spill_channel->spiller();
+        return spiller->flush(state, TRACKER_WITH_SPILLER_GUARD(state, spiller));
+    };
 
-    return Status::OK();
+    // this ref is for the case of query-cannel, make sure the context will be release after the callback finish.
+    _cross_join_context->ref();
+    auto callback_task = [this](RuntimeState* state) {
+        auto spiller = _spill_channel->spiller();
+        return spiller->set_flush_all_call_back(
+                [this, state]() {
+                    auto defer = DeferOp([&]() { _cross_join_context->unref(state); });
+                    RETURN_IF_ERROR(_cross_join_context->finish_one_right_sinker(_driver_sequence, state));
+                    _is_finished = true;
+                    _spill_channel->set_finishing();
+                    return Status::OK();
+                },
+                state, TRACKER_WITH_SPILLER_GUARD(state, spiller));
+    };
+
+    SpillProcessTasksBuilder task_builder(state);
+    task_builder.then(flush_task).finally(callback_task);
+    return _spill_channel->execute(task_builder);
 }
 
 Status SpillableNLJoinBuildOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
@@ -116,7 +128,22 @@ void SpillableNLJoinBuildOperator::set_execute_mode(int performance_level) {
 }
 
 Status SpillableNLJoinBuildOperator::_spill_buffered_chunks(RuntimeState* state, bool should_finalize) {
-    RETURN_IF_ERROR(_cross_join_context->input_channel(_driver_sequence).spill_buffered_chunks(state, should_finalize));
+    auto spiller = _spill_channel->spiller();
+    auto iter = _cross_join_context->input_channel(_driver_sequence).buffered_chunk_iterator(should_finalize);
+
+    while (!spiller->is_full()) {
+        auto chunk_st = iter();
+        if (chunk_st.ok()) {
+            RETURN_IF_ERROR(spiller->spill(state, chunk_st.value(), TRACKER_WITH_SPILLER_GUARD(state, spiller)));
+        } else if (chunk_st.status().is_end_of_file()) {
+            _should_spill_buffered_chunks = false;
+            return Status::OK();
+        } else {
+            return chunk_st.status();
+        }
+    }
+
+    auto ignore = _spill_channel->add_spill_task({iter});
     _should_spill_buffered_chunks = false;
     return Status::OK();
 }
@@ -145,6 +172,7 @@ OperatorPtr SpillableNLJoinBuildOperatorFactory::create(int32_t degree_of_parall
     auto spiller = _spill_factory->create(*_spill_options);
     auto spill_channel = _cross_join_context->spill_channel_factory()->get_or_create(driver_sequence);
     spill_channel->set_spiller(spiller);
+    spill_channel->set_guarded_context(_cross_join_context.get());
 
     auto build_operator = std::make_shared<SpillableNLJoinBuildOperator>(
             this, _id, _plan_node_id, driver_sequence, _cross_join_context, "spillable_nestloop_join_build");

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.cpp
@@ -26,10 +26,10 @@
 namespace starrocks::pipeline {
 Status SpillableNLJoinBuildOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(NLJoinBuildOperator::prepare(state));
-    _spill_channel->spiller()->set_metrics(
+    _spiller->set_metrics(
             spill::SpillProcessMetrics(_unique_metrics.get(), RuntimeStateHelper::mutable_total_spill_bytes(state)));
-    RETURN_IF_ERROR(_spill_channel->spiller()->prepare(state));
-    _cross_join_context->input_channel(_driver_sequence).set_spiller(_spill_channel->spiller());
+    RETURN_IF_ERROR(_spiller->prepare(state));
+    _cross_join_context->input_channel(_driver_sequence).set_spiller(_spiller);
     if (state->spill_mode() == TSpillMode::FORCE) {
         _spill_strategy = spill::SpillStrategy::SPILL_ALL;
     }
@@ -44,18 +44,22 @@ bool SpillableNLJoinBuildOperator::need_input() const {
     if (_spill_strategy == spill::SpillStrategy::NO_SPILL) {
         return NLJoinBuildOperator::need_input();
     }
-    return !_is_finished && !_spill_channel->spiller()->is_full();
+    // A queued task drains the input channel's accumulator concurrently; stay blocked until it finishes.
+    return !_is_finished && _spiller != nullptr && !_spiller->is_full() && !_spill_channel->has_task();
 }
 
 bool SpillableNLJoinBuildOperator::is_finished() const {
-    if (!_spill_channel->spiller()->spilled()) {
+    if (_spiller == nullptr) {
+        return _is_finished || NLJoinBuildOperator::is_finished();
+    }
+    if (!_spiller->spilled()) {
         return NLJoinBuildOperator::is_finished();
     }
     return _is_finished;
 }
 
 Status SpillableNLJoinBuildOperator::set_finishing(RuntimeState* state) {
-    auto spiller = _spill_channel->spiller();
+    const auto& spiller = _spiller;
 
     // On cancellation, do not run spiller->flush() during teardown. The not-spilled branch below
     // already delegates to NLJoinBuildOperator::set_finishing, which early-returns when cancelled;
@@ -80,14 +84,20 @@ Status SpillableNLJoinBuildOperator::set_finishing(RuntimeState* state) {
     }
 
     auto flush_task = [this](RuntimeState* state) {
-        auto spiller = _spill_channel->spiller();
+        const auto& spiller = _spiller;
         return spiller->flush(state, TRACKER_WITH_SPILLER_GUARD(state, spiller));
     };
 
-    // this ref is for the case of query-cannel, make sure the context will be release after the callback finish.
+    // Keep the context alive until the callback runs; a cancel could otherwise release it first.
     _cross_join_context->ref();
     auto callback_task = [this](RuntimeState* state) {
-        auto spiller = _spill_channel->spiller();
+        const auto& spiller = _spiller;
+        if (spiller == nullptr) {
+            auto defer = DeferOp([&]() { _cross_join_context->unref(state); });
+            RETURN_IF_ERROR(_cross_join_context->finish_one_right_sinker(_driver_sequence, state));
+            _is_finished = true;
+            return Status::OK();
+        }
         return spiller->set_flush_all_call_back(
                 [this, state]() {
                     auto defer = DeferOp([&]() { _cross_join_context->unref(state); });
@@ -128,7 +138,7 @@ void SpillableNLJoinBuildOperator::set_execute_mode(int performance_level) {
 }
 
 Status SpillableNLJoinBuildOperator::_spill_buffered_chunks(RuntimeState* state, bool should_finalize) {
-    auto spiller = _spill_channel->spiller();
+    const auto& spiller = _spiller;
     auto iter = _cross_join_context->input_channel(_driver_sequence).buffered_chunk_iterator(should_finalize);
 
     while (!spiller->is_full()) {
@@ -177,6 +187,7 @@ OperatorPtr SpillableNLJoinBuildOperatorFactory::create(int32_t degree_of_parall
     auto build_operator = std::make_shared<SpillableNLJoinBuildOperator>(
             this, _id, _plan_node_id, driver_sequence, _cross_join_context, "spillable_nestloop_join_build");
     build_operator->set_channel(spill_channel);
+    build_operator->set_spiller(spiller);
     return build_operator;
 }
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.cpp
@@ -31,7 +31,7 @@ Status SpillableNLJoinBuildOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(_spill_channel->spiller()->prepare(state));
     _cross_join_context->input_channel(_driver_sequence).set_spiller(_spill_channel->spiller());
     if (state->spill_mode() == TSpillMode::FORCE) {
-        _strategy = spill::SpillStrategy::SPILL_ALL;
+        _spill_strategy = spill::SpillStrategy::SPILL_ALL;
     }
     return Status::OK();
 }
@@ -41,7 +41,7 @@ void SpillableNLJoinBuildOperator::close(RuntimeState* state) {
 }
 
 bool SpillableNLJoinBuildOperator::need_input() const {
-    if (_strategy == spill::SpillStrategy::NO_SPILL) {
+    if (_spill_strategy == spill::SpillStrategy::NO_SPILL) {
         return NLJoinBuildOperator::need_input();
     }
     return !_is_finished && !_spill_channel->spiller()->is_full();
@@ -69,10 +69,14 @@ Status SpillableNLJoinBuildOperator::set_finishing(RuntimeState* state) {
         return NLJoinBuildOperator::set_finishing(state);
     }
 
-    if (!spiller->spilled()) {
+    auto& input_channel = _cross_join_context->input_channel(_driver_sequence);
+    if (!spiller->spilled() && (_spill_strategy == spill::SpillStrategy::NO_SPILL || input_channel.num_rows() == 0)) {
         _spill_channel->set_finishing();
         RETURN_IF_ERROR(NLJoinBuildOperator::set_finishing(state));
         return Status::OK();
+    }
+    if (_should_spill_buffered_chunks) {
+        RETURN_IF_ERROR(_spill_buffered_chunks(state, true));
     }
 
     RETURN_IF_ERROR(spiller->flush(state, TRACKER_WITH_SPILLER_GUARD(state, spiller)));
@@ -89,12 +93,31 @@ Status SpillableNLJoinBuildOperator::set_finishing(RuntimeState* state) {
 }
 
 Status SpillableNLJoinBuildOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
-    if (_strategy == spill::SpillStrategy::NO_SPILL) {
+    DeferOp update_revocable_bytes{
+            [this]() { set_revocable_mem_bytes(_cross_join_context->input_channel(_driver_sequence).memory_usage()); }};
+
+    if (_spill_strategy == spill::SpillStrategy::NO_SPILL) {
         RETURN_IF_ERROR(NLJoinBuildOperator::push_chunk(state, chunk));
     } else {
-        // TODO: process auto spill mode
+        if (_should_spill_buffered_chunks) {
+            RETURN_IF_ERROR(_spill_buffered_chunks(state, false));
+        }
         RETURN_IF_ERROR(_cross_join_context->input_channel(_driver_sequence).add_chunk_to_spill_buffer(state, chunk));
     }
+    return Status::OK();
+}
+
+void SpillableNLJoinBuildOperator::set_execute_mode(int performance_level) {
+    if (!_is_finished) {
+        // TODO: set the _spill_strategy by cast(performance_level)
+        _spill_strategy = spill::SpillStrategy::SPILL_ALL;
+        TRACE_SPILL_LOG << "NLJoinBuildOperator, mark spill " << (void*)this;
+    }
+}
+
+Status SpillableNLJoinBuildOperator::_spill_buffered_chunks(RuntimeState* state, bool should_finalize) {
+    RETURN_IF_ERROR(_cross_join_context->input_channel(_driver_sequence).spill_buffered_chunks(state, should_finalize));
+    _should_spill_buffered_chunks = false;
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.cpp
@@ -59,25 +59,23 @@ bool SpillableNLJoinBuildOperator::is_finished() const {
 }
 
 Status SpillableNLJoinBuildOperator::set_finishing(RuntimeState* state) {
+    ONCE_DETECT(_set_finishing_once);
+    // Finish the channel only after this returns: execute() runs its inline branches while holding
+    // the channel mutex, which is not reentrant, so a task must never finish the channel itself.
+    auto defer_set_finishing = DeferOp([this]() { _spill_channel->set_finishing(); });
     const auto& spiller = _spiller;
 
-    // On cancellation, do not run spiller->flush() during teardown. The not-spilled branch below
-    // already delegates to NLJoinBuildOperator::set_finishing, which early-returns when cancelled;
-    // guard the spilled branch the same way to avoid touching spill state while the query is being
-    // torn down.
+    // On cancellation, do not run spiller->flush() during teardown: the query is being torn down.
     if (state->is_cancelled()) {
         if (spiller != nullptr) {
             spiller->cancel();
         }
-        _spill_channel->set_finishing();
         return NLJoinBuildOperator::set_finishing(state);
     }
 
     auto& input_channel = _cross_join_context->input_channel(_driver_sequence);
     if (!spiller->spilled() && (_spill_strategy == spill::SpillStrategy::NO_SPILL || input_channel.num_rows() == 0)) {
-        _spill_channel->set_finishing();
-        RETURN_IF_ERROR(NLJoinBuildOperator::set_finishing(state));
-        return Status::OK();
+        return NLJoinBuildOperator::set_finishing(state);
     }
     if (_should_spill_buffered_chunks) {
         RETURN_IF_ERROR(_spill_buffered_chunks(state, true));
@@ -103,7 +101,6 @@ Status SpillableNLJoinBuildOperator::set_finishing(RuntimeState* state) {
                     auto defer = DeferOp([&]() { _cross_join_context->unref(state); });
                     RETURN_IF_ERROR(_cross_join_context->finish_one_right_sinker(_driver_sequence, state));
                     _is_finished = true;
-                    _spill_channel->set_finishing();
                     return Status::OK();
                 },
                 state, TRACKER_WITH_SPILLER_GUARD(state, spiller));
@@ -153,7 +150,7 @@ Status SpillableNLJoinBuildOperator::_spill_buffered_chunks(RuntimeState* state,
         }
     }
 
-    auto ignore = _spill_channel->add_spill_task({iter});
+    _spill_channel->add_spill_task({iter});
     _should_spill_buffered_chunks = false;
     return Status::OK();
 }

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.h
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.h
@@ -36,12 +36,19 @@ public:
     Status set_finishing(RuntimeState* state) override;
     Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
 
+    bool spillable() const override { return true; }
+    void set_execute_mode(int performance_level) override;
+
     void set_channel(SpillProcessChannelPtr channel) { _spill_channel = std::move(channel); }
+
+private:
+    Status _spill_buffered_chunks(RuntimeState* state, bool should_finalize);
 
 private:
     bool _is_finished = false;
     SpillProcessChannelPtr _spill_channel;
-    spill::SpillStrategy _strategy;
+    spill::SpillStrategy _spill_strategy = spill::SpillStrategy::NO_SPILL;
+    bool _should_spill_buffered_chunks = true;
 };
 
 class SpillableNLJoinBuildOperatorFactory final : public OperatorFactory {

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.h
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "base/concurrency/race_detect.h"
 #include "compute_env/spill/options.h"
 #include "compute_env/spill/spiller_factory.h"
 #include "exec/pipeline/nljoin/nljoin_build_operator.h"
@@ -51,6 +52,7 @@ private:
     std::shared_ptr<spill::Spiller> _spiller;
     spill::SpillStrategy _spill_strategy = spill::SpillStrategy::NO_SPILL;
     bool _should_spill_buffered_chunks = true;
+    DECLARE_ONCE_DETECTOR(_set_finishing_once);
 };
 
 class SpillableNLJoinBuildOperatorFactory final : public OperatorFactory {

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.h
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.h
@@ -40,13 +40,15 @@ public:
     void set_execute_mode(int performance_level) override;
 
     void set_channel(SpillProcessChannelPtr channel) { _spill_channel = std::move(channel); }
+    void set_spiller(std::shared_ptr<spill::Spiller> spiller) { _spiller = std::move(spiller); }
 
 private:
     Status _spill_buffered_chunks(RuntimeState* state, bool should_finalize);
 
 private:
-    bool _is_finished = false;
     SpillProcessChannelPtr _spill_channel;
+    // Private handle: the channel's own copy is moved out by close() on the spill-process pipeline.
+    std::shared_ptr<spill::Spiller> _spiller;
     spill::SpillStrategy _spill_strategy = spill::SpillStrategy::NO_SPILL;
     bool _should_spill_buffered_chunks = true;
 };

--- a/be/src/runtime/chunk_accumulator.cpp
+++ b/be/src/runtime/chunk_accumulator.cpp
@@ -35,6 +35,7 @@ void ChunkAccumulator::reset() {
     _output.clear();
     _tmp_chunk.reset();
     _accumulate_count = 0;
+    _memory_usage = 0;
 }
 
 bool check_json_schema_compatibility(const Chunk* one, const Chunk* two) {
@@ -75,6 +76,7 @@ Status ChunkAccumulator::push(ChunkPtr&& chunk) {
             // Check JSON schema compatibility before appending
             if (!check_json_schema_compatibility(_tmp_chunk.get(), chunk.get())) {
                 // Schema mismatch, output current chunk and create a new one
+                _memory_usage += _tmp_chunk->memory_usage();
                 _output.emplace_back(std::move(_tmp_chunk));
                 _tmp_chunk = chunk->clone_empty(_desired_size);
                 TRY_CATCH_BAD_ALLOC(_tmp_chunk->append(*chunk, start, need_rows));
@@ -89,6 +91,7 @@ Status ChunkAccumulator::push(ChunkPtr&& chunk) {
         }
 
         if (_tmp_chunk->num_rows() >= _desired_size) {
+            _memory_usage += _tmp_chunk->memory_usage();
             _output.emplace_back(std::move(_tmp_chunk));
         }
         start += need_rows;
@@ -105,11 +108,16 @@ bool ChunkAccumulator::reach_limit() const {
     return _accumulate_count >= kAccumulateLimit;
 }
 
+size_t ChunkAccumulator::memory_usage() const {
+    return _tmp_chunk ? _memory_usage + _tmp_chunk->memory_usage() : _memory_usage;
+}
+
 ChunkPtr ChunkAccumulator::pull() {
     if (!_output.empty()) {
         auto res = std::move(_output.front());
         _output.pop_front();
         _accumulate_count = 0;
+        _memory_usage -= res->memory_usage();
         return res;
     }
     return nullptr;
@@ -117,6 +125,7 @@ ChunkPtr ChunkAccumulator::pull() {
 
 void ChunkAccumulator::finalize() {
     if (_tmp_chunk) {
+        _memory_usage += _tmp_chunk->memory_usage();
         _output.emplace_back(std::move(_tmp_chunk));
     }
     _accumulate_count = 0;

--- a/be/src/runtime/chunk_accumulator.h
+++ b/be/src/runtime/chunk_accumulator.h
@@ -41,12 +41,14 @@ public:
     bool reach_limit() const;
     Status push(ChunkPtr&& chunk);
     ChunkPtr pull();
+    size_t memory_usage() const;
 
 private:
     size_t _desired_size;
     ChunkPtr _tmp_chunk;
     std::deque<ChunkPtr> _output;
     size_t _accumulate_count = 0;
+    size_t _memory_usage = 0;
 };
 
 } // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -28,7 +28,9 @@ set(EXEC_FILES
         ./exec/pipeline/sink/export_sink_operator_test.cpp
         ./exec/pipeline/sink/memory_scratch_sink_operator_test.cpp
         ./exec/pipeline/limit_operator_test.cpp
+        ./exec/pipeline/nljoin_build_input_channel_test.cpp
         ./exec/pipeline/nljoin_probe_operator_test.cpp
+        ./exec/pipeline/spillable_nljoin_build_operator_test.cpp
         ./exec/pipeline/enforce_unique_row_locator_operator_test.cpp
         ./exec/pipeline/analytic_node_pipeline_test.cpp
         ./exec/pipeline/local_bucket_shuffle_test.cpp

--- a/be/test/exec/pipeline/nljoin_build_input_channel_test.cpp
+++ b/be/test/exec/pipeline/nljoin_build_input_channel_test.cpp
@@ -36,9 +36,7 @@ ChunkPtr make_chunk(size_t num_rows) {
     return chunk;
 }
 
-// Drain the iterator until EndOfFile and return the total number of rows pulled.
-// Every produced chunk must be non-null and non-empty: the iterator feeds
-// Spiller::spill, which DCHECKs !chunk->is_empty() on each input chunk.
+// Chunks must be non-null and non-empty: the iterator feeds Spiller::spill, which DCHECKs that.
 size_t drain_rows(const std::function<StatusOr<ChunkPtr>()>& iter) {
     size_t rows = 0;
     while (true) {
@@ -58,8 +56,7 @@ size_t drain_rows(const std::function<StatusOr<ChunkPtr>()>& iter) {
 
 TEST(NJJoinBuildInputChannelTest, IteratorDrainsAllChunks) {
     NJJoinBuildInputChannel channel(kChunkSize);
-    // 3 * 3000 = 9000 rows: two full 4096-row chunks buffered, 808 rows kept
-    // in the accumulator's half-full tail chunk
+    // 3 * 3000 = 9000 rows: two full 4096-row chunks, 808 left in the tail chunk
     for (int i = 0; i < 3; i++) {
         ASSERT_TRUE(channel.add_chunk(make_chunk(3000)).ok());
     }
@@ -87,7 +84,6 @@ TEST(NJJoinBuildInputChannelTest, IteratorFinalizeIncludesTmpChunk) {
         EXPECT_TRUE(res.status().is_end_of_file());
     }
     {
-        // Contrast: without finalize the half-full tail chunk is not pulled
         NJJoinBuildInputChannel channel(kChunkSize);
         ASSERT_TRUE(channel.add_chunk(make_chunk(100)).ok());
         auto iter = channel.buffered_chunk_iterator(false);
@@ -107,14 +103,12 @@ TEST(NJJoinBuildInputChannelTest, IteratorEmptyChannel) {
 
 TEST(NJJoinBuildInputChannelTest, IteratorReturnsNonEmptyChunks) {
     NJJoinBuildInputChannel channel(kChunkSize);
-    // Empty input chunks are dropped at the door and must not surface as
-    // empty output chunks
+    // Empty input must not surface as empty output chunks
     ASSERT_TRUE(channel.add_chunk(make_chunk(0)).ok());
     ASSERT_TRUE(channel.add_chunk(make_chunk(kChunkSize)).ok());
     ASSERT_TRUE(channel.add_chunk(make_chunk(0)).ok());
     ASSERT_TRUE(channel.add_chunk(make_chunk(1)).ok());
 
-    // drain_rows asserts every chunk is non-null and non-empty
     size_t rows = drain_rows(channel.buffered_chunk_iterator(true));
     EXPECT_EQ(kChunkSize + 1, rows);
 }
@@ -147,8 +141,7 @@ TEST(NJJoinBuildInputChannelTest, CanKeepPushingAfterFinalize) {
     ASSERT_TRUE(channel.add_chunk(make_chunk(100)).ok());
     EXPECT_EQ(100u, drain_rows(channel.buffered_chunk_iterator(true)));
 
-    // ChunkAccumulator::finalize() is not a terminal state: the channel must
-    // keep accepting input and expose it through a fresh iterator
+    // finalize() is not terminal: the channel must keep accepting input
     ASSERT_TRUE(channel.add_chunk(make_chunk(50)).ok());
     EXPECT_EQ(50u, drain_rows(channel.buffered_chunk_iterator(true)));
     EXPECT_EQ(150u, channel.num_rows());

--- a/be/test/exec/pipeline/nljoin_build_input_channel_test.cpp
+++ b/be/test/exec/pipeline/nljoin_build_input_channel_test.cpp
@@ -1,0 +1,157 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <memory>
+
+#include "column/chunk.h"
+#include "column/fixed_length_column.h"
+#include "common/statusor.h"
+#include "exec/pipeline/nljoin/nljoin_context.h"
+
+namespace starrocks::pipeline {
+
+namespace {
+
+constexpr size_t kChunkSize = 4096;
+
+ChunkPtr make_chunk(size_t num_rows) {
+    auto chunk = std::make_shared<Chunk>();
+    auto column = Int32Column::create();
+    column->append_default(num_rows);
+    chunk->append_column(std::move(column), 0);
+    return chunk;
+}
+
+// Drain the iterator until EndOfFile and return the total number of rows pulled.
+// Every produced chunk must be non-null and non-empty: the iterator feeds
+// Spiller::spill, which DCHECKs !chunk->is_empty() on each input chunk.
+size_t drain_rows(const std::function<StatusOr<ChunkPtr>()>& iter) {
+    size_t rows = 0;
+    while (true) {
+        auto maybe_chunk = iter();
+        if (!maybe_chunk.ok()) {
+            EXPECT_TRUE(maybe_chunk.status().is_end_of_file());
+            return rows;
+        }
+        ChunkPtr chunk = std::move(maybe_chunk.value());
+        EXPECT_TRUE(chunk != nullptr);
+        EXPECT_FALSE(chunk->is_empty());
+        rows += chunk->num_rows();
+    }
+}
+
+} // namespace
+
+TEST(NJJoinBuildInputChannelTest, IteratorDrainsAllChunks) {
+    NJJoinBuildInputChannel channel(kChunkSize);
+    // 3 * 3000 = 9000 rows: two full 4096-row chunks buffered, 808 rows kept
+    // in the accumulator's half-full tail chunk
+    for (int i = 0; i < 3; i++) {
+        ASSERT_TRUE(channel.add_chunk(make_chunk(3000)).ok());
+    }
+
+    size_t rows = drain_rows(channel.buffered_chunk_iterator(false));
+    EXPECT_EQ(2 * kChunkSize, rows);
+
+    // Without finalize the tail rows stay invisible: a fresh iterator is empty
+    auto iter = channel.buffered_chunk_iterator(false);
+    auto res = iter();
+    ASSERT_FALSE(res.ok());
+    EXPECT_TRUE(res.status().is_end_of_file());
+}
+
+TEST(NJJoinBuildInputChannelTest, IteratorFinalizeIncludesTmpChunk) {
+    {
+        NJJoinBuildInputChannel channel(kChunkSize);
+        ASSERT_TRUE(channel.add_chunk(make_chunk(100)).ok());
+        auto iter = channel.buffered_chunk_iterator(true);
+        auto res = iter();
+        ASSERT_TRUE(res.ok());
+        EXPECT_EQ(100u, res.value()->num_rows());
+        res = iter();
+        ASSERT_FALSE(res.ok());
+        EXPECT_TRUE(res.status().is_end_of_file());
+    }
+    {
+        // Contrast: without finalize the half-full tail chunk is not pulled
+        NJJoinBuildInputChannel channel(kChunkSize);
+        ASSERT_TRUE(channel.add_chunk(make_chunk(100)).ok());
+        auto iter = channel.buffered_chunk_iterator(false);
+        auto res = iter();
+        ASSERT_FALSE(res.ok());
+        EXPECT_TRUE(res.status().is_end_of_file());
+    }
+}
+
+TEST(NJJoinBuildInputChannelTest, IteratorEmptyChannel) {
+    NJJoinBuildInputChannel channel(kChunkSize);
+    auto iter = channel.buffered_chunk_iterator(true);
+    auto res = iter();
+    ASSERT_FALSE(res.ok());
+    EXPECT_TRUE(res.status().is_end_of_file());
+}
+
+TEST(NJJoinBuildInputChannelTest, IteratorReturnsNonEmptyChunks) {
+    NJJoinBuildInputChannel channel(kChunkSize);
+    // Empty input chunks are dropped at the door and must not surface as
+    // empty output chunks
+    ASSERT_TRUE(channel.add_chunk(make_chunk(0)).ok());
+    ASSERT_TRUE(channel.add_chunk(make_chunk(kChunkSize)).ok());
+    ASSERT_TRUE(channel.add_chunk(make_chunk(0)).ok());
+    ASSERT_TRUE(channel.add_chunk(make_chunk(1)).ok());
+
+    // drain_rows asserts every chunk is non-null and non-empty
+    size_t rows = drain_rows(channel.buffered_chunk_iterator(true));
+    EXPECT_EQ(kChunkSize + 1, rows);
+}
+
+TEST(NJJoinBuildInputChannelTest, MemoryUsageDropsAfterDrain) {
+    NJJoinBuildInputChannel channel(kChunkSize);
+    for (int i = 0; i < 3; i++) {
+        ASSERT_TRUE(channel.add_chunk(make_chunk(3000)).ok());
+    }
+    EXPECT_GT(channel.memory_usage(), 0u);
+
+    drain_rows(channel.buffered_chunk_iterator(true));
+    EXPECT_EQ(0u, channel.memory_usage());
+}
+
+TEST(NJJoinBuildInputChannelTest, NumRowsUnaffectedByIterator) {
+    NJJoinBuildInputChannel channel(kChunkSize);
+    for (int i = 0; i < 3; i++) {
+        ASSERT_TRUE(channel.add_chunk(make_chunk(3000)).ok());
+    }
+    EXPECT_EQ(9000u, channel.num_rows());
+
+    drain_rows(channel.buffered_chunk_iterator(true));
+    // num_rows() counts the rows ever received, not the rows still buffered
+    EXPECT_EQ(9000u, channel.num_rows());
+}
+
+TEST(NJJoinBuildInputChannelTest, CanKeepPushingAfterFinalize) {
+    NJJoinBuildInputChannel channel(kChunkSize);
+    ASSERT_TRUE(channel.add_chunk(make_chunk(100)).ok());
+    EXPECT_EQ(100u, drain_rows(channel.buffered_chunk_iterator(true)));
+
+    // ChunkAccumulator::finalize() is not a terminal state: the channel must
+    // keep accepting input and expose it through a fresh iterator
+    ASSERT_TRUE(channel.add_chunk(make_chunk(50)).ok());
+    EXPECT_EQ(50u, drain_rows(channel.buffered_chunk_iterator(true)));
+    EXPECT_EQ(150u, channel.num_rows());
+}
+
+} // namespace starrocks::pipeline

--- a/be/test/exec/pipeline/spillable_nljoin_build_operator_test.cpp
+++ b/be/test/exec/pipeline/spillable_nljoin_build_operator_test.cpp
@@ -20,13 +20,13 @@
 
 #include "column/chunk.h"
 #include "column/fixed_length_column.h"
+#include "compute_env/spill/operator_mem_resource_manager.h"
 #include "compute_env/spill/options.h"
 #include "exec/pipeline/nljoin/nljoin_context.h"
+#include "exec/pipeline/spill_process_channel.h"
 
-// The test object library is compiled with -fno-access-control, so the tests can reach the
-// private members (_spill_strategy, _is_finished, NLJoinContext::_input_channel) directly.
-// This covers the operator-side AUTO-spill wiring that needs no spiller or driver scheduling:
-// the spill-strategy state machine and the revocable-memory report on the NO_SPILL path.
+// The test object library is built with -fno-access-control, so private members are reachable.
+// Scope: operator-side AUTO-spill wiring that needs no spiller or driver scheduling.
 
 namespace starrocks::pipeline {
 
@@ -55,14 +55,12 @@ class SpillableNLJoinBuildOperatorTest : public testing::Test {
 protected:
     void SetUp() override {
         _ctx = make_context();
-        // The factory only serves as the Operator base's OperatorRuntimeAccess; its
-        // spill options stay unset because the tests never go through factory->create()
+        // Only used as the Operator base's OperatorRuntimeAccess; spill options stay unset
         _factory = std::make_unique<SpillableNLJoinBuildOperatorFactory>(0, 1, _ctx);
         _op = std::make_unique<SpillableNLJoinBuildOperator>(_factory.get(), /*id=*/0, /*plan_node_id=*/1,
                                                              /*driver_sequence=*/0, _ctx,
                                                              "spillable_nestloop_join_build");
-        // prepare() is not called (it would need a RuntimeState and a spiller), so
-        // install the input channel the way NLJoinContext::incr_builder would
+        // prepare() needs a RuntimeState and a spiller, so install the channel by hand
         _ctx->_input_channel.emplace_back(std::make_unique<NJJoinBuildInputChannel>(kChunkSize));
     }
 
@@ -71,8 +69,7 @@ protected:
     std::unique_ptr<SpillableNLJoinBuildOperator> _op;
 };
 
-// Regression guard: _spill_strategy used to be an uninitialized member, so a freshly
-// created operator could start in an arbitrary strategy. It must start in NO_SPILL.
+// Regression: _spill_strategy used to be uninitialized, so it could start in any strategy.
 TEST_F(SpillableNLJoinBuildOperatorTest, SpillStrategyInitializedToNoSpill) {
     EXPECT_EQ(spill::SpillStrategy::NO_SPILL, _op->_spill_strategy);
     EXPECT_TRUE(_op->spillable());
@@ -92,8 +89,48 @@ TEST_F(SpillableNLJoinBuildOperatorTest, SetExecuteModeIgnoredAfterFinished) {
     EXPECT_EQ(spill::SpillStrategy::NO_SPILL, _op->_spill_strategy);
 }
 
-// The AUTO-spill decision loop reads revocable_mem_bytes, so the NO_SPILL push path must
-// keep it in sync with the input channel's buffered memory.
+// Regression for a production SIGSEGV: the two pipelines close in nondeterministic order, so
+// is_finished() could run after SpillProcessChannel::close() moved the channel's spiller away.
+TEST_F(SpillableNLJoinBuildOperatorTest, IsFinishedSurvivesNullSpiller) {
+    // set_spiller() is never called here, so the operator's own handle stays null
+    auto channel = std::make_shared<SpillProcessChannel>();
+    _op->set_channel(channel);
+    ASSERT_TRUE(_op->_spiller == nullptr);
+
+    EXPECT_FALSE(_op->is_finished());
+    EXPECT_EQ(_op->NLJoinBuildOperator::is_finished(), _op->is_finished());
+
+    // close() moves out the channel's spiller; the operator reads its own handle, so nothing changes
+    channel->close();
+    ASSERT_TRUE(_op->_spiller == nullptr);
+    EXPECT_FALSE(_op->is_finished());
+    EXPECT_EQ(_op->NLJoinBuildOperator::is_finished(), _op->is_finished());
+}
+
+TEST_F(SpillableNLJoinBuildOperatorTest, NeedInputSurvivesNullSpiller) {
+    auto channel = std::make_shared<SpillProcessChannel>();
+    channel->close();
+    _op->set_channel(channel);
+
+    // Flip to SPILL_ALL so need_input() takes the spiller-dependent branch
+    _op->set_execute_mode(spill::MEM_RESOURCE_LOW_MEMORY);
+    ASSERT_EQ(spill::SpillStrategy::SPILL_ALL, _op->_spill_strategy);
+
+    // No spiller handle -> cannot accept data, and must not crash
+    EXPECT_FALSE(_op->need_input());
+    EXPECT_FALSE(_op->is_finished());
+}
+
+TEST_F(SpillableNLJoinBuildOperatorTest, NeedInputUsesBaseWhenNoSpill) {
+    // No spiller on the channel: an unguarded touch on the NO_SPILL path would crash here
+    _op->set_channel(std::make_shared<SpillProcessChannel>());
+    ASSERT_EQ(spill::SpillStrategy::NO_SPILL, _op->_spill_strategy);
+
+    EXPECT_TRUE(_op->need_input());
+    EXPECT_EQ(_op->NLJoinBuildOperator::need_input(), _op->need_input());
+}
+
+// The AUTO-spill decision reads revocable_mem_bytes, so the NO_SPILL path must keep it fresh.
 TEST_F(SpillableNLJoinBuildOperatorTest, PushChunkReportsRevocableMemBytes) {
     EXPECT_EQ(0u, _op->revocable_mem_bytes());
 

--- a/be/test/exec/pipeline/spillable_nljoin_build_operator_test.cpp
+++ b/be/test/exec/pipeline/spillable_nljoin_build_operator_test.cpp
@@ -1,0 +1,109 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/pipeline/nljoin/spillable_nljoin_build_operator.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "column/chunk.h"
+#include "column/fixed_length_column.h"
+#include "compute_env/spill/options.h"
+#include "exec/pipeline/nljoin/nljoin_context.h"
+
+// The test object library is compiled with -fno-access-control, so the tests can reach the
+// private members (_spill_strategy, _is_finished, NLJoinContext::_input_channel) directly.
+// This covers the operator-side AUTO-spill wiring that needs no spiller or driver scheduling:
+// the spill-strategy state machine and the revocable-memory report on the NO_SPILL path.
+
+namespace starrocks::pipeline {
+
+namespace {
+
+constexpr size_t kChunkSize = 4096;
+
+ChunkPtr make_chunk(size_t num_rows) {
+    auto chunk = std::make_shared<Chunk>();
+    auto column = Int32Column::create();
+    column->append_default(num_rows);
+    chunk->append_column(std::move(column), 0);
+    return chunk;
+}
+
+std::shared_ptr<NLJoinContext> make_context() {
+    NLJoinContextParams params;
+    params.plan_node_id = 1;
+    params.rf_hub = nullptr;
+    return std::make_shared<NLJoinContext>(std::move(params));
+}
+
+} // namespace
+
+class SpillableNLJoinBuildOperatorTest : public testing::Test {
+protected:
+    void SetUp() override {
+        _ctx = make_context();
+        // The factory only serves as the Operator base's OperatorRuntimeAccess; its
+        // spill options stay unset because the tests never go through factory->create()
+        _factory = std::make_unique<SpillableNLJoinBuildOperatorFactory>(0, 1, _ctx);
+        _op = std::make_unique<SpillableNLJoinBuildOperator>(_factory.get(), /*id=*/0, /*plan_node_id=*/1,
+                                                             /*driver_sequence=*/0, _ctx,
+                                                             "spillable_nestloop_join_build");
+        // prepare() is not called (it would need a RuntimeState and a spiller), so
+        // install the input channel the way NLJoinContext::incr_builder would
+        _ctx->_input_channel.emplace_back(std::make_unique<NJJoinBuildInputChannel>(kChunkSize));
+    }
+
+    std::shared_ptr<NLJoinContext> _ctx;
+    std::unique_ptr<SpillableNLJoinBuildOperatorFactory> _factory;
+    std::unique_ptr<SpillableNLJoinBuildOperator> _op;
+};
+
+// Regression guard: _spill_strategy used to be an uninitialized member, so a freshly
+// created operator could start in an arbitrary strategy. It must start in NO_SPILL.
+TEST_F(SpillableNLJoinBuildOperatorTest, SpillStrategyInitializedToNoSpill) {
+    EXPECT_EQ(spill::SpillStrategy::NO_SPILL, _op->_spill_strategy);
+    EXPECT_TRUE(_op->spillable());
+}
+
+TEST_F(SpillableNLJoinBuildOperatorTest, SetExecuteModeFlipsToSpillAll) {
+    _op->set_execute_mode(1);
+    EXPECT_EQ(spill::SpillStrategy::SPILL_ALL, _op->_spill_strategy);
+    // Idempotent on repeated calls
+    _op->set_execute_mode(1);
+    EXPECT_EQ(spill::SpillStrategy::SPILL_ALL, _op->_spill_strategy);
+}
+
+TEST_F(SpillableNLJoinBuildOperatorTest, SetExecuteModeIgnoredAfterFinished) {
+    _op->_is_finished = true;
+    _op->set_execute_mode(1);
+    EXPECT_EQ(spill::SpillStrategy::NO_SPILL, _op->_spill_strategy);
+}
+
+// The AUTO-spill decision loop reads revocable_mem_bytes, so the NO_SPILL push path must
+// keep it in sync with the input channel's buffered memory.
+TEST_F(SpillableNLJoinBuildOperatorTest, PushChunkReportsRevocableMemBytes) {
+    EXPECT_EQ(0u, _op->revocable_mem_bytes());
+
+    // The NO_SPILL path never touches RuntimeState or the spill channel
+    ASSERT_TRUE(_op->push_chunk(nullptr, make_chunk(100)).ok());
+    EXPECT_GT(_op->revocable_mem_bytes(), 0u);
+    EXPECT_EQ(_ctx->input_channel(0).memory_usage(), _op->revocable_mem_bytes());
+
+    ASSERT_TRUE(_op->push_chunk(nullptr, make_chunk(kChunkSize)).ok());
+    EXPECT_EQ(_ctx->input_channel(0).memory_usage(), _op->revocable_mem_bytes());
+}
+
+} // namespace starrocks::pipeline

--- a/be/test/runtime/chunk_accumulator_test.cpp
+++ b/be/test/runtime/chunk_accumulator_test.cpp
@@ -102,9 +102,8 @@ TEST(ChunkAccumulatorTest, Accumulator) {
     EXPECT_TRUE(accumulator.reach_limit());
 }
 
-// memory_usage() is capacity-based (Column::container_memory_usage counts capacity, and
-// _tmp_chunk is created with clone_empty(_desired_size) which reserves the full desired
-// size), so the tests below only assert relations: monotonicity, non-zero, and drain-to-zero.
+// memory_usage() is capacity-based (_tmp_chunk reserves _desired_size up front), so the tests
+// below assert relations only: monotonicity, non-zero, drain-to-zero.
 
 TEST(ChunkAccumulatorTest, MemoryUsageEmpty) {
     ChunkAccumulator accumulator(4096);
@@ -120,8 +119,7 @@ TEST(ChunkAccumulatorTest, MemoryUsageMonotonicOnPush) {
         ASSERT_TRUE(accumulator.push(make_chunk(1025)).ok());
         pushed_rows += 1025;
         size_t usage = accumulator.memory_usage();
-        // Capacity accounting may keep the value flat while _tmp_chunk fills up,
-        // but without a pull it must never decrease.
+        // May stay flat while _tmp_chunk fills, but without a pull it must never decrease
         EXPECT_GE(usage, prev_usage);
         EXPECT_GE(usage, pushed_rows * sizeof(int32_t));
         prev_usage = usage;
@@ -151,8 +149,7 @@ TEST(ChunkAccumulatorTest, MemoryUsageDrainsToZeroWithoutFinalize) {
     }
     while (ChunkPtr output = accumulator.pull()) {
     }
-    // _tmp_chunk still holds the tail rows
-    EXPECT_GT(accumulator.memory_usage(), 0u);
+    EXPECT_GT(accumulator.memory_usage(), 0u); // _tmp_chunk still holds the tail rows
 
     accumulator.finalize();
     while (ChunkPtr output = accumulator.pull()) {
@@ -192,20 +189,16 @@ TEST(ChunkAccumulatorTest, MemoryUsageIncludesTmpChunk) {
     constexpr size_t kDesiredSize = 4096;
     ChunkAccumulator accumulator(kDesiredSize);
     ASSERT_TRUE(accumulator.push(make_chunk(100)).ok());
-    // All the data lives in _tmp_chunk: _output is still empty
-    EXPECT_TRUE(accumulator.empty());
+    EXPECT_TRUE(accumulator.empty()); // everything is still in _tmp_chunk
     EXPECT_GT(accumulator.memory_usage(), 0u);
 }
 
 TEST(ChunkAccumulatorTest, MemoryUsageJsonSchemaMismatchFlush) {
-    // A JSON schema mismatch makes push() flush the half-full _tmp_chunk into _output
-    // through a dedicated branch (the fifth _memory_usage maintenance point), which the
-    // Int32-only tests can never reach.
+    // A schema mismatch flushes the half-full _tmp_chunk through its own branch, which the
+    // Int32-only tests never reach.
     constexpr size_t kDesiredSize = 4096;
     ChunkAccumulator accumulator(kDesiredSize);
     ASSERT_TRUE(accumulator.push(make_plain_json_chunk(100)).ok());
-    // Plain vs flat JSON is schema-incompatible: the 100-row _tmp_chunk is flushed
-    // to _output even though it never reached _desired_size
     ASSERT_TRUE(accumulator.push(make_flat_json_chunk(50)).ok());
     EXPECT_FALSE(accumulator.empty());
 

--- a/be/test/runtime/chunk_accumulator_test.cpp
+++ b/be/test/runtime/chunk_accumulator_test.cpp
@@ -14,11 +14,15 @@
 
 #include "runtime/chunk_accumulator.h"
 
+#include <cstdint>
 #include <memory>
+#include <random>
 
 #include "column/chunk.h"
 #include "column/fixed_length_column.h"
+#include "column/json_column.h"
 #include "gtest/gtest.h"
+#include "types/logical_type.h"
 
 namespace starrocks {
 
@@ -27,6 +31,27 @@ namespace {
 ChunkPtr make_chunk(size_t num_rows) {
     auto chunk = std::make_shared<Chunk>();
     auto column = Int32Column::create();
+    column->append_default(num_rows);
+    chunk->append_column(std::move(column), 0);
+    return chunk;
+}
+
+ChunkPtr make_plain_json_chunk(size_t num_rows) {
+    auto chunk = std::make_shared<Chunk>();
+    auto column = JsonColumn::create();
+    column->append_default(num_rows);
+    chunk->append_column(std::move(column), 0);
+    return chunk;
+}
+
+ChunkPtr make_flat_json_chunk(size_t num_rows) {
+    auto chunk = std::make_shared<Chunk>();
+    auto column = JsonColumn::create();
+    std::vector<std::string> paths = {"a"};
+    std::vector<LogicalType> types = {TYPE_BIGINT};
+    MutableColumns flat_columns;
+    flat_columns.emplace_back(Int64Column::create());
+    column->set_flat_columns(paths, types, std::move(flat_columns));
     column->append_default(num_rows);
     chunk->append_column(std::move(column), 0);
     return chunk;
@@ -75,6 +100,146 @@ TEST(ChunkAccumulatorTest, Accumulator) {
     auto output = accumulator.pull();
     EXPECT_EQ(nullptr, output);
     EXPECT_TRUE(accumulator.reach_limit());
+}
+
+// memory_usage() is capacity-based (Column::container_memory_usage counts capacity, and
+// _tmp_chunk is created with clone_empty(_desired_size) which reserves the full desired
+// size), so the tests below only assert relations: monotonicity, non-zero, and drain-to-zero.
+
+TEST(ChunkAccumulatorTest, MemoryUsageEmpty) {
+    ChunkAccumulator accumulator(4096);
+    EXPECT_EQ(0u, accumulator.memory_usage());
+}
+
+TEST(ChunkAccumulatorTest, MemoryUsageMonotonicOnPush) {
+    constexpr size_t kDesiredSize = 4096;
+    ChunkAccumulator accumulator(kDesiredSize);
+    size_t pushed_rows = 0;
+    size_t prev_usage = 0;
+    for (int i = 0; i < 20; i++) {
+        ASSERT_TRUE(accumulator.push(make_chunk(1025)).ok());
+        pushed_rows += 1025;
+        size_t usage = accumulator.memory_usage();
+        // Capacity accounting may keep the value flat while _tmp_chunk fills up,
+        // but without a pull it must never decrease.
+        EXPECT_GE(usage, prev_usage);
+        EXPECT_GE(usage, pushed_rows * sizeof(int32_t));
+        prev_usage = usage;
+    }
+}
+
+TEST(ChunkAccumulatorTest, MemoryUsageDrainsToZero) {
+    constexpr size_t kDesiredSize = 4096;
+    ChunkAccumulator accumulator(kDesiredSize);
+    for (int i = 0; i < 10; i++) {
+        ASSERT_TRUE(accumulator.push(make_chunk(1025)).ok());
+    }
+    EXPECT_GT(accumulator.memory_usage(), 0u);
+
+    accumulator.finalize();
+    while (ChunkPtr output = accumulator.pull()) {
+    }
+    EXPECT_EQ(0u, accumulator.memory_usage());
+}
+
+TEST(ChunkAccumulatorTest, MemoryUsageDrainsToZeroWithoutFinalize) {
+    constexpr size_t kDesiredSize = 4096;
+    ChunkAccumulator accumulator(kDesiredSize);
+    // 3 * 3000 = 9000 rows: two full output chunks plus 808 rows left in _tmp_chunk
+    for (int i = 0; i < 3; i++) {
+        ASSERT_TRUE(accumulator.push(make_chunk(3000)).ok());
+    }
+    while (ChunkPtr output = accumulator.pull()) {
+    }
+    // _tmp_chunk still holds the tail rows
+    EXPECT_GT(accumulator.memory_usage(), 0u);
+
+    accumulator.finalize();
+    while (ChunkPtr output = accumulator.pull()) {
+    }
+    EXPECT_EQ(0u, accumulator.memory_usage());
+}
+
+TEST(ChunkAccumulatorTest, MemoryUsageResetClears) {
+    constexpr size_t kDesiredSize = 4096;
+    ChunkAccumulator accumulator(kDesiredSize);
+    for (int i = 0; i < 5; i++) {
+        ASSERT_TRUE(accumulator.push(make_chunk(3000)).ok());
+    }
+    EXPECT_GT(accumulator.memory_usage(), 0u);
+
+    accumulator.reset();
+    EXPECT_EQ(0u, accumulator.memory_usage());
+}
+
+TEST(ChunkAccumulatorTest, MemoryUsageLargeChunkSplit) {
+    constexpr size_t kDesiredSize = 4096;
+    constexpr size_t kInputRows = kDesiredSize * 3 + 7;
+    ChunkAccumulator accumulator(kDesiredSize);
+    ASSERT_TRUE(accumulator.push(make_chunk(kInputRows)).ok());
+    EXPECT_GT(accumulator.memory_usage(), 0u);
+
+    accumulator.finalize();
+    size_t pulled_rows = 0;
+    while (ChunkPtr output = accumulator.pull()) {
+        pulled_rows += output->num_rows();
+    }
+    EXPECT_EQ(kInputRows, pulled_rows);
+    EXPECT_EQ(0u, accumulator.memory_usage());
+}
+
+TEST(ChunkAccumulatorTest, MemoryUsageIncludesTmpChunk) {
+    constexpr size_t kDesiredSize = 4096;
+    ChunkAccumulator accumulator(kDesiredSize);
+    ASSERT_TRUE(accumulator.push(make_chunk(100)).ok());
+    // All the data lives in _tmp_chunk: _output is still empty
+    EXPECT_TRUE(accumulator.empty());
+    EXPECT_GT(accumulator.memory_usage(), 0u);
+}
+
+TEST(ChunkAccumulatorTest, MemoryUsageJsonSchemaMismatchFlush) {
+    // A JSON schema mismatch makes push() flush the half-full _tmp_chunk into _output
+    // through a dedicated branch (the fifth _memory_usage maintenance point), which the
+    // Int32-only tests can never reach.
+    constexpr size_t kDesiredSize = 4096;
+    ChunkAccumulator accumulator(kDesiredSize);
+    ASSERT_TRUE(accumulator.push(make_plain_json_chunk(100)).ok());
+    // Plain vs flat JSON is schema-incompatible: the 100-row _tmp_chunk is flushed
+    // to _output even though it never reached _desired_size
+    ASSERT_TRUE(accumulator.push(make_flat_json_chunk(50)).ok());
+    EXPECT_FALSE(accumulator.empty());
+
+    ChunkPtr flushed = accumulator.pull();
+    ASSERT_TRUE(flushed != nullptr);
+    EXPECT_EQ(100u, flushed->num_rows());
+
+    accumulator.finalize();
+    size_t pulled_rows = flushed->num_rows();
+    while (ChunkPtr output = accumulator.pull()) {
+        pulled_rows += output->num_rows();
+    }
+    EXPECT_EQ(150u, pulled_rows);
+    // A missed increment in the mismatch branch would underflow here instead of reaching zero
+    EXPECT_EQ(0u, accumulator.memory_usage());
+}
+
+TEST(ChunkAccumulatorTest, MemoryUsageNoUnderflowOnRepeatedCycles) {
+    constexpr size_t kDesiredSize = 4096;
+    ChunkAccumulator accumulator(kDesiredSize);
+    std::mt19937 rng(12345);
+    std::uniform_int_distribution<size_t> dist(1, kDesiredSize * 2);
+    for (int i = 0; i < 20; i++) {
+        ASSERT_TRUE(accumulator.push(make_chunk(dist(rng))).ok());
+        while (ChunkPtr output = accumulator.pull()) {
+        }
+        // An unbalanced decrement would wrap around to an astronomic value
+        EXPECT_LT(accumulator.memory_usage(), SIZE_MAX / 2);
+    }
+
+    accumulator.finalize();
+    while (ChunkPtr output = accumulator.pull()) {
+    }
+    EXPECT_EQ(0u, accumulator.memory_usage());
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

Auto-mode spill was never implemented for the nestloop join build operator.

`SpillableNLJoinBuildOperator` did not declare itself spillable and did not implement
`set_execute_mode()`, so the memory-resource manager could never select it for revocation.
Its `push_chunk()` carried a literal `// TODO: process auto spill mode`, and it never reported
revocable bytes — the operator's buffered build side was invisible to the memory tracker.

The net effect: under `spill_mode = auto`, the whole right-side build input of a nestloop join
accumulated in memory and was never spilled. Only `spill_mode = force` produced any spilling,
because that was the single path that set the spill strategy.

Two latent defects sat in the same code and are fixed along the way:

- `spill::SpillStrategy _strategy;` was left uninitialized, so the `NO_SPILL` fast paths in
  `need_input()` / `push_chunk()` branched on an indeterminate value.
- `need_input()` and `is_finished()` dereferenced `_spill_channel->spiller()` unconditionally,
  which can be null when the build side is split across two different pipelines.

## What I'm doing:

Backend only, all inside the nestloop-join build path.

**Make the operator participate in auto spill**

- `spillable()` now returns `true` and `set_execute_mode()` is implemented, so the memory-resource
  manager can flip the operator to `SPILL_ALL` at runtime.
- Report revocable memory: `ChunkAccumulator` tracks its buffered bytes and exposes
  `memory_usage()`; `NJJoinBuildInputChannel` forwards it; `push_chunk()` refreshes
  `set_revocable_mem_bytes()` through a `DeferOp` on every push.
- Wire the spill process for the spillable build factory —
  `interpolate_spill_process()` in `CrossJoinNode::_decompose_to_pipeline()`, plus
  `set_guarded_context()` on the spill channel.

**Drain the buffered chunks instead of blocking**

- `NJJoinBuildInputChannel::buffered_chunk_iterator()` exposes the accumulator's buffered chunks
  as a pull iterator. When the operator flips to spilling, it drains them into the spiller; if the
  spiller fills up, the remaining iterator is handed to the spill channel as an async spill task
  rather than blocking the driver.
- `set_finishing()` now goes through `SpillProcessTasksBuilder` (async flush + `finally` callback)
  instead of an inline `flush()`. The `NLJoinContext` is ref'd for the duration so a query cancel
  cannot release it before the callback runs.

**Fix the two latent defects**

- `_strategy` renamed to `_spill_strategy` and initialized to `NO_SPILL`.
- Null-spiller guards in `need_input()` / `is_finished()`.

**Tests**

Three unit-test files covering the new wiring — accumulator memory accounting, the channel
iterator, and the operator's spill strategy / null-spiller behavior:

- `be/test/runtime/chunk_accumulator_test.cpp` (10 cases)
- `be/test/exec/pipeline/nljoin_build_input_channel_test.cpp` (7 cases)
- `be/test/exec/pipeline/spillable_nljoin_build_operator_test.cpp` (7 cases)

Local run of the affected suites: 149 passed, 0 failed, 1 pre-existing skip.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

A nestloop join whose build side grows large now spills under `spill_mode = auto`, where it
previously kept everything in memory. No syntax, parameter or default-value changes.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
