### PR TITLE
[BugFix] Fix label uniqueness race between concurrent BEGIN WITH LABEL

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -101,6 +101,12 @@ public class GlobalTransactionMgr implements MemoryTrackable {
     // ExplicitTxnStateItem, and the transaction state is recorded in TransactionState.
     private final Map<Long, ExplicitTxnState> explicitTxnStateMap = Maps.newConcurrentMap();
 
+    // Serializes the registration of explicit transaction states. `explicitTxnStateMap` itself is concurrent, but
+    // `BEGIN WITH LABEL` has to verify that the label is unused and publish the new state as a single atomic step:
+    // without this lock two concurrent sessions can both pass the uniqueness check before either of them publishes,
+    // and both `BEGIN` succeed with the same label.
+    private final Object explicitTxnStateLock = new Object();
+
     private final GlobalStateMgr globalStateMgr;
 
     public GlobalTransactionMgr(GlobalStateMgr globalStateMgr) {
@@ -137,17 +143,39 @@ public class GlobalTransactionMgr implements MemoryTrackable {
     }
 
     public void addTransactionState(long txnId, ExplicitTxnState explicitTxnState) {
-        explicitTxnStateMap.put(txnId, explicitTxnState);
+        synchronized (explicitTxnStateLock) {
+            explicitTxnStateMap.put(txnId, explicitTxnState);
+        }
+    }
+
+    /**
+     * Register an explicit transaction state, after checking that its label is not already used by another
+     * transaction in the cluster. The check and the registration are done atomically, so that concurrent
+     * `BEGIN WITH LABEL <same label>` from different sessions can not both succeed.
+     *
+     * @throws LabelAlreadyUsedException if the label is already used by another non-aborted transaction. In that
+     *                                   case the state is not registered.
+     */
+    public void addTransactionStateWithLabelCheck(long txnId, ExplicitTxnState explicitTxnState)
+            throws LabelAlreadyUsedException {
+        synchronized (explicitTxnStateLock) {
+            checkLabelUsedInAnyDatabase(explicitTxnState.getTransactionState().getLabel());
+            explicitTxnStateMap.put(txnId, explicitTxnState);
+        }
     }
 
     /**
      * Check if a label is already used in any database's transaction.
      * This method is used to validate label uniqueness before starting an explicit transaction.
+     * <p>
+     * NOTE: the result is only meaningful while `explicitTxnStateLock` is held, otherwise another session may
+     * register a transaction with the same label right after the check returns. Callers that register a
+     * transaction afterwards must go through {@link #addTransactionStateWithLabelCheck}.
      *
      * @param label the label to check
      * @throws LabelAlreadyUsedException if the label is already used by another non-aborted transaction
      */
-    public void checkLabelUsedInAnyDatabase(String label) throws LabelAlreadyUsedException {
+    private void checkLabelUsedInAnyDatabase(String label) throws LabelAlreadyUsedException {
         for (DatabaseTransactionMgr dbTransactionMgr : dbIdToDatabaseTransactionMgrs.values()) {
             TransactionState txnState = dbTransactionMgr.getLabelTransactionState(label);
             if (txnState != null && txnState.getTransactionStatus() != TransactionStatus.ABORTED) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
@@ -130,14 +130,12 @@ public class TransactionStmtExecutor {
         // Label priority: 1. stmt.getLabel() 2. labelOverride 3. executionId
         String stmtLabel = stmt.getLabel();
         String label;
+        // A user-specified label must be unique in the cluster, align with INSERT statement behavior. The check
+        // is deferred to the registration below so that checking and publishing happen atomically.
+        boolean checkLabelConflict = false;
         if (stmtLabel != null && !stmtLabel.isEmpty()) {
             FeNameFormat.checkLabel(stmtLabel);
-            // Check if label is already used in any database, align with INSERT statement behavior
-            try {
-                globalTransactionMgr.checkLabelUsedInAnyDatabase(stmtLabel);
-            } catch (LabelAlreadyUsedException e) {
-                throw new SemanticException(e.getMessage());
-            }
+            checkLabelConflict = true;
             label = stmtLabel;
         } else if (labelOverride != null && !labelOverride.isEmpty()) {
             label = labelOverride;
@@ -160,7 +158,15 @@ public class TransactionStmtExecutor {
 
         ExplicitTxnState explicitTxnState = new ExplicitTxnState();
         explicitTxnState.setTransactionState(transactionState);
-        globalTransactionMgr.addTransactionState(transactionId, explicitTxnState);
+        if (checkLabelConflict) {
+            try {
+                globalTransactionMgr.addTransactionStateWithLabelCheck(transactionId, explicitTxnState);
+            } catch (LabelAlreadyUsedException e) {
+                throw new SemanticException(e.getMessage());
+            }
+        } else {
+            globalTransactionMgr.addTransactionState(transactionId, explicitTxnState);
+        }
 
         context.setTxnId(transactionId);
         context.getState().setOk(0, 0,

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/ExplicitTxnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/ExplicitTxnTest.java
@@ -61,10 +61,19 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyShort;
@@ -849,5 +858,92 @@ public class ExplicitTxnTest {
         // Cleanup
         globalTransactionMgr.clearExplicitTxnState(context.getTxnId());
         context.setTxnId(0);
+    }
+
+    @Test
+    public void testBeginWithLabelAlreadyUsedByAnotherSession() {
+        // BEGIN WITH LABEL must be rejected when another session already holds an explicit transaction
+        // with the same label
+        GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+
+        ConnectContext first = new ConnectContext();
+        first.setThreadLocalInfo();
+        first.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        first.setExecutionId(new TUniqueId(970, 971));
+        TransactionStmtExecutor.beginStmt(first, new BeginStmt(NodePosition.ZERO, "duplicated_label"));
+        Assertions.assertFalse(first.getState().isError());
+        Assertions.assertNotEquals(0, first.getTxnId());
+
+        ConnectContext second = new ConnectContext();
+        second.setThreadLocalInfo();
+        second.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        second.setExecutionId(new TUniqueId(972, 973));
+        SemanticException e = Assertions.assertThrows(SemanticException.class,
+                () -> TransactionStmtExecutor.beginStmt(second, new BeginStmt(NodePosition.ZERO, "duplicated_label")));
+        Assertions.assertTrue(e.getMessage().contains("has already been used"), e.getMessage());
+        // The rejected session must not be left inside a transaction
+        Assertions.assertEquals(0, second.getTxnId());
+
+        // Cleanup
+        globalTransactionMgr.clearExplicitTxnState(first.getTxnId());
+        first.setTxnId(0);
+    }
+
+    @Test
+    public void testConcurrentBeginWithSameLabel() throws Exception {
+        // Regression test for the label uniqueness race: several sessions running
+        // `BEGIN WITH LABEL <same label>` at the same time must not all succeed. The uniqueness check and the
+        // registration of the explicit transaction state have to happen atomically, otherwise every session
+        // passes the check before any of them publishes its state.
+        GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+
+        final int concurrency = 8;
+        final int rounds = 5;
+        ExecutorService executor = Executors.newFixedThreadPool(concurrency);
+        try {
+            for (int round = 0; round < rounds; round++) {
+                final String label = "concurrent_label_" + round;
+                CyclicBarrier barrier = new CyclicBarrier(concurrency);
+                AtomicInteger succeeded = new AtomicInteger();
+                AtomicInteger rejected = new AtomicInteger();
+                Queue<Long> succeededTxnIds = new ConcurrentLinkedQueue<>();
+
+                List<Future<?>> futures = new ArrayList<>(concurrency);
+                for (int i = 0; i < concurrency; i++) {
+                    final int seq = i;
+                    futures.add(executor.submit(() -> {
+                        ConnectContext context = new ConnectContext();
+                        context.setThreadLocalInfo();
+                        context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+                        context.setExecutionId(new TUniqueId(1000 + seq, 2000 + seq));
+
+                        // Line up all sessions so that they hit the label check together
+                        barrier.await(30, TimeUnit.SECONDS);
+                        try {
+                            TransactionStmtExecutor.beginStmt(context, new BeginStmt(NodePosition.ZERO, label));
+                            succeeded.incrementAndGet();
+                            succeededTxnIds.add(context.getTxnId());
+                        } catch (SemanticException e) {
+                            Assertions.assertTrue(e.getMessage().contains("has already been used"), e.getMessage());
+                            rejected.incrementAndGet();
+                        }
+                        return null;
+                    }));
+                }
+                for (Future<?> future : futures) {
+                    future.get(60, TimeUnit.SECONDS);
+                }
+
+                Assertions.assertEquals(1, succeeded.get(),
+                        "exactly one BEGIN WITH LABEL " + label + " should succeed");
+                Assertions.assertEquals(concurrency - 1, rejected.get());
+
+                for (Long txnId : succeededTxnIds) {
+                    globalTransactionMgr.clearExplicitTxnState(txnId);
+                }
+            }
+        } finally {
+            executor.shutdownNow();
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Two concurrent sessions issuing `BEGIN WITH LABEL <same label>` both succeed, so the label uniqueness check is effectively bypassed.

`TransactionStmtExecutor.beginStmt()` checked the label and only registered the explicit transaction state afterwards:

```
checkLabelUsedInAnyDatabase(label)   // scans every db's labelToTxnIds + explicitTxnStateMap
... build TransactionState / ExplicitTxnState ...   // unguarded window
addTransactionState(txnId, state)    // publishes into explicitTxnStateMap
```

Nothing guards the window in between. At `BEGIN` time an explicit transaction has no `dbId` yet — it is only registered into a `DatabaseTransactionMgr` on the first DML via `upsertTransactionState()` — so `explicitTxnStateMap` is the only cross-session registry at that moment, and being a `ConcurrentMap` its atomicity is per `txnId` key (different for the two sessions) rather than per label. Both sessions scan, both find nothing, both publish.

Multi-FE is not a factor: `BeginStmt` is `FORWARD_WITH_SYNC`, and a follower only copies the leader's `txn_id` back into its session (`LeaderOpExecutor`), so every `BEGIN` executes in the leader's JVM.

## What I'm doing:

Make the uniqueness check and the registration a single atomic step.

- `GlobalTransactionMgr.addTransactionStateWithLabelCheck()`: performs the cluster-wide label scan and the `explicitTxnStateMap` insertion while holding a dedicated `explicitTxnStateLock`.
- Plain `addTransactionState()` takes the same lock, so a registration that does not check the label (no-label `BEGIN`, multi-statement stream load) cannot slip into the window either.
- `checkLabelUsedInAnyDatabase()` is now `private` — the check-only entry point that invites this exact misuse is gone rather than left in place.
- The rejected session throws before `context.setTxnId()` is reached, so it is not left half inside a transaction.

Lock safety: inside `explicitTxnStateLock` only `DatabaseTransactionMgr`'s read lock is taken (a leaf — it never calls back into `GlobalTransactionMgr`), and both acquirers are reached from `beginStmt()` holding no other transaction-manager lock, so the "db lock first, then txn manager lock" ordering rule is preserved.

Tests (`ExplicitTxnTest`):
- `testBeginWithLabelAlreadyUsedByAnotherSession` — sequential conflict, and asserts the rejected session's `txnId` stays 0.
- `testConcurrentBeginWithSameLabel` — 8 threads x 5 rounds lined up on a `CyclicBarrier`, asserting exactly one `BEGIN` succeeds and the rest fail with `has already been used`.

Known residual, not addressed here: `BEGIN WITH LABEL 'x'` racing a regular load (stream load etc.) claiming the same label can still both start, because the load path locks only its own db and does not consult `explicitTxnStateMap`. That collision is caught later, at the explicit transaction's first DML, by `upsertTransactionState() -> checkLabel()`, so it surfaces as an error rather than silently — closing it properly needs a cross-db label reservation table, which is a much larger change.

Fixes https://github.com/StarRocks/StarRocksTest/issues/11675

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

Concurrent `BEGIN WITH LABEL` with an already-used label is now reliably rejected with `Label [...] has already been used.` where it could previously succeed.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
