### PR TITLE
[UT] Remove extra blank line in RewriteGroupingSetsByCTERuleTest imports (for backport #77391)

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/RewriteGroupingSetsByCTERuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/RewriteGroupingSetsByCTERuleTest.java
@@ -30,7 +30,6 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalValuesOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
Fixes the checkstyle violation `Extra separation in import group before 'org.junit.jupiter.api.Assertions'` on backport PR #77391, left by the previous import adjustment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)