### PR TITLE
[BugFix] Also disable the query cache when a SortNode builds the TOPN_FILTER

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
@@ -688,6 +688,18 @@ public class FragmentNormalizer {
         }
     }
 
+    // Ids of every PlanNode of the subtree rooted at `node` that still belongs to this fragment. The
+    // recursion stops at an ExchangeNode's children, which live in another fragment.
+    private void collectNodeIdsOfSameFragment(PlanNode node, Set<Integer> ids) {
+        if (node.getFragment() != fragment) {
+            return;
+        }
+        ids.add(node.getId().asInt());
+        for (PlanNode child : node.getChildren()) {
+            collectNodeIdsOfSameFragment(child, ids);
+        }
+    }
+
     public static void collectRightSiblingFragments(PlanNode root, List<PlanFragment> siblings,
                                                     Set<PlanFragmentId> visitedMultiCastFragments) {
         if (root.getChildren().isEmpty()) {
@@ -810,10 +822,21 @@ public class FragmentNormalizer {
         //     over a table distributed by k, which is planned as a one-phase aggregation that the rule's
         //     TopN->Agg(GLOBAL)->Agg(LOCAL) pattern cannot match.
         // Neither is visible to the alien-GRF check below: both are onlyLocal/non-remote filters.
-        boolean buildsRuntimeFilters = leftNodesTopDown.stream()
+        // Only a filter that actually probes inside the cached subtree matters, though. When a JoinNode
+        // sits between the builder and the cache point, the filter may land entirely on the other input
+        // -- `... join r on l.k = r.k order by r.v limit n` builds a TOPN_FILTER on r.v that only r's
+        // scan can probe. That one cannot change a single row the cache point produces, so rejecting it
+        // would give up the cache for nothing.
+        Set<Integer> cachedSubtreeNodeIds = Sets.newHashSet();
+        collectNodeIdsOfSameFragment(firstAggNode, cachedSubtreeNodeIds);
+        boolean filtersCachedRows = leftNodesTopDown.stream()
                 .filter(node -> node instanceof RuntimeFilterBuildNode && !(node instanceof JoinNode))
-                .anyMatch(node -> !((RuntimeFilterBuildNode) node).getBuildRuntimeFilters().isEmpty());
-        if (buildsRuntimeFilters) {
+                .flatMap(node -> ((RuntimeFilterBuildNode) node).getBuildRuntimeFilters().stream())
+                // an empty probe map should not happen -- a filter with no target is never added to the
+                // build list -- but treat it as unknown, hence unsafe, rather than as harmless.
+                .anyMatch(rf -> rf.getNodeIdToProbeExpr().isEmpty() ||
+                        rf.getNodeIdToProbeExpr().keySet().stream().anyMatch(cachedSubtreeNodeIds::contains));
+        if (filtersCachedRows) {
             return false;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
@@ -792,19 +792,28 @@ public class FragmentNormalizer {
             return false;
         }
 
-        // Not cacheable if an AggregationNode of the leftmost path builds runtime filters itself
-        // (AGG_IN_FILTER/TOPN_FILTER). Such a filter probes the OlapScanNode that feeds the cache
-        // interpolation point, so the per-tablet results that get populated only contain the rows that
-        // survived it. Its content is decided at run time -- it depends on which tablets this instance
-        // happened to scan, in which order, and which of them were served from the cache -- so unlike a
-        // JoinNode's runtime filter, whose build side is packed into the digest together with the data
-        // versions of its OlapScanNodes, there is nothing here that could be packed into the cache key.
-        // A populated entry would therefore not be a function of the cache key, and would produce wrong
-        // results as soon as it is read back by a query that needs the rows the filter dropped.
-        boolean aggBuildsRuntimeFilters = leftNodesTopDown.stream()
-                .filter(node -> node instanceof AggregationNode)
-                .anyMatch(node -> !((AggregationNode) node).getBuildRuntimeFilters().isEmpty());
-        if (aggBuildsRuntimeFilters) {
+        // Not cacheable if a node of the leftmost path builds a runtime filter of its own. Such a filter
+        // probes the OlapScanNode that feeds the cache interpolation point, so the per-tablet results
+        // that get populated only contain the rows that survived it. Its content is decided at run time
+        // -- it depends on which tablets this instance happened to scan, in which order, and which of
+        // them were served from the cache -- so unlike a JoinNode's runtime filter, whose build side is
+        // packed into the digest together with the data versions of its OlapScanNodes, there is nothing
+        // here that could be packed into the cache key. A populated entry would therefore not be a
+        // function of the cache key, and would produce wrong results as soon as it is read back by a
+        // query that needs the rows the filter dropped.
+        // Both of the nodes that can build such a filter have to be checked, because the two are
+        // mutually exclusive and depend on whether PushDownTopNToPreAggRule fired:
+        //   - AggregationNode builds an AGG_IN_FILTER when it carries a LIMIT of its own, and a
+        //     TOPN_FILTER when the rule attached the TopN to it (SortNode.perPipeline is then true and
+        //     the SortNode builds nothing);
+        //   - SortNode builds the TOPN_FILTER in every other shape, e.g. `group by k order by k limit n`
+        //     over a table distributed by k, which is planned as a one-phase aggregation that the rule's
+        //     TopN->Agg(GLOBAL)->Agg(LOCAL) pattern cannot match.
+        // Neither is visible to the alien-GRF check below: both are onlyLocal/non-remote filters.
+        boolean buildsRuntimeFilters = leftNodesTopDown.stream()
+                .filter(node -> node instanceof RuntimeFilterBuildNode && !(node instanceof JoinNode))
+                .anyMatch(node -> !((RuntimeFilterBuildNode) node).getBuildRuntimeFilters().isEmpty());
+        if (buildsRuntimeFilters) {
             return false;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
@@ -688,16 +688,17 @@ public class FragmentNormalizer {
         }
     }
 
-    // Ids of every PlanNode of the subtree rooted at `node` that still belongs to this fragment. The
-    // recursion stops at an ExchangeNode's children, which live in another fragment.
-    private void collectNodeIdsOfSameFragment(PlanNode node, Set<Integer> ids) {
+    // Whether any PlanNode of the subtree rooted at `node` still retains one of the given runtime
+    // filters as a probe. The recursion stops at an ExchangeNode's children, which live in another
+    // fragment, and a local runtime filter cannot reach them anyway.
+    private boolean probesAnyFilterOfSameFragment(PlanNode node, Set<Integer> filterIds) {
         if (node.getFragment() != fragment) {
-            return;
+            return false;
         }
-        ids.add(node.getId().asInt());
-        for (PlanNode child : node.getChildren()) {
-            collectNodeIdsOfSameFragment(child, ids);
+        if (node.getProbeRuntimeFilters().stream().anyMatch(rf -> filterIds.contains(rf.getFilterId()))) {
+            return true;
         }
+        return node.getChildren().stream().anyMatch(child -> probesAnyFilterOfSameFragment(child, filterIds));
     }
 
     public static void collectRightSiblingFragments(PlanNode root, List<PlanFragment> siblings,
@@ -827,16 +828,17 @@ public class FragmentNormalizer {
         // -- `... join r on l.k = r.k order by r.v limit n` builds a TOPN_FILTER on r.v that only r's
         // scan can probe. That one cannot change a single row the cache point produces, so rejecting it
         // would give up the cache for nothing.
-        Set<Integer> cachedSubtreeNodeIds = Sets.newHashSet();
-        collectNodeIdsOfSameFragment(firstAggNode, cachedSubtreeNodeIds);
-        boolean filtersCachedRows = leftNodesTopDown.stream()
+        // The targets are read off the probe nodes rather than off RuntimeFilterDescription's
+        // nodeIdToProbeExpr, because that map is only ever added to: a probe dropped afterwards -- by
+        // removeDictMappingProbeRuntimeFilters for a DictMappingExpr probe, or by computeLocalRfWaitingSet
+        // when global runtime filters are off -- leaves its node id behind and would read as an active
+        // probe here. A PlanNode's retained probe list is what the BE actually applies.
+        Set<Integer> localFilterIds = leftNodesTopDown.stream()
                 .filter(node -> node instanceof RuntimeFilterBuildNode && !(node instanceof JoinNode))
                 .flatMap(node -> ((RuntimeFilterBuildNode) node).getBuildRuntimeFilters().stream())
-                // an empty probe map should not happen -- a filter with no target is never added to the
-                // build list -- but treat it as unknown, hence unsafe, rather than as harmless.
-                .anyMatch(rf -> rf.getNodeIdToProbeExpr().isEmpty() ||
-                        rf.getNodeIdToProbeExpr().keySet().stream().anyMatch(cachedSubtreeNodeIds::contains));
-        if (filtersCachedRows) {
+                .map(RuntimeFilterDescription::getFilterId)
+                .collect(Collectors.toSet());
+        if (!localFilterIds.isEmpty() && probesAnyFilterOfSameFragment(firstAggNode, localFilterIds)) {
             return false;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheRuntimeFilterAndTimeZoneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheRuntimeFilterAndTimeZoneTest.java
@@ -95,6 +95,28 @@ public class QueryCacheRuntimeFilterAndTimeZoneTest {
         for (Partition partition : t3.getAllPartitions()) {
             partition.getDefaultPhysicalPartition().getLatestBaseIndex().setRowCount(40);
         }
+        // A colocate pair for the join shapes. j1 is made huge and j2 tiny so that the aggregated j1
+        // side is chosen as the probe (left) input, which is what puts the aggregation -- and hence the
+        // cache interpolation point -- on the leftmost path below the join.
+        for (String name : new String[] {"j1", "j2"}) {
+            starRocksAssert.withTable("" +
+                    "CREATE TABLE " + name + "(\n" +
+                    "dt DATE NOT NULL,\n" +
+                    "c1 INT NOT NULL,\n" +
+                    "v1 BIGINT NOT NULL\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`dt`, `c1`)\n" +
+                    "PARTITION BY RANGE(dt) (\n" +
+                    "  START (\"2022-01-01\") END (\"2022-02-01\") EVERY (INTERVAL 1 day))\n" +
+                    "DISTRIBUTED BY HASH(`c1`) BUCKETS 4\n" +
+                    "PROPERTIES(\"replication_num\" = \"1\", \"colocate_with\" = \"cg_qc_join\");");
+            OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getDb("qc_rf_db").getTable(name);
+            long rows = name.equals("j1") ? 10000000L : 20L;
+            for (Partition partition : table.getAllPartitions()) {
+                partition.getDefaultPhysicalPartition().getLatestBaseIndex().setRowCount(rows);
+            }
+        }
     }
 
     private Optional<TCacheParam> cacheParamOf(String sql) throws Exception {
@@ -144,6 +166,24 @@ public class QueryCacheRuntimeFilterAndTimeZoneTest {
                         "select c1, sum(v1) from t1 where dt between '2022-01-01' and '2022-02-01' " +
                                 "group by c1")
                 .isPresent(), "the one-phase baseline without a TopN must stay cacheable");
+    }
+
+    @Test
+    public void testTopNFilterLandingOutsideTheCachedSubtreeKeepsTheCache() throws Exception {
+        String join = "select a.c1, a.s, j2.v1 from (select c1, sum(v1) s from j1 group by c1) a " +
+                "join j2 on a.c1 = j2.c1 ";
+        // Baseline: this shape is cacheable, the aggregation sits on the leftmost path below the join.
+        Assertions.assertTrue(cacheParamOf(join).isPresent(), "the join baseline must be cacheable");
+
+        // Ordering by a column only the right input has: the TOPN_FILTER can only be probed by the
+        // right scan, so no row the cache point produces is affected and the cache must survive.
+        Assertions.assertTrue(cacheParamOf(join + "order by j2.v1 limit 10").isPresent(),
+                "a TopN filter that cannot probe the cached subtree must not disable the cache");
+
+        // Ordering by the join column instead: equivalence propagates the filter onto the left scan
+        // too, which does truncate what gets populated, so this one has to stay uncached.
+        Assertions.assertFalse(cacheParamOf(join + "order by a.c1 limit 10").isPresent(),
+                "a TopN filter probing the cached subtree must disable the cache");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheRuntimeFilterAndTimeZoneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheRuntimeFilterAndTimeZoneTest.java
@@ -28,7 +28,8 @@ import java.util.Optional;
 
 // Guards the two cache-key invariants that the query cache relies on:
 // 1. nothing below the cache interpolation point may filter rows by something that is decided at
-//    run time and is absent from the cache key (a runtime filter built by the aggregation itself);
+//    run time and is absent from the cache key (a runtime filter the fragment builds for itself,
+//    whether by the AggregationNode or by the SortNode above it);
 // 2. session variables that change how the BE evaluates the plan must be part of the digest.
 public class QueryCacheRuntimeFilterAndTimeZoneTest {
     private static ConnectContext ctx;
@@ -96,10 +97,30 @@ public class QueryCacheRuntimeFilterAndTimeZoneTest {
         Assertions.assertTrue(cacheParamOf(
                         "select c1, sum(v1) from t2 where dt between '2022-01-01' and '2022-02-01' group by c1")
                 .isPresent(), "the two-phase baseline must stay cacheable");
-        // The other filter an aggregation can build, TOPN_FILTER, goes through the very same branch.
-        // It is not asserted here because PushDownTopNToPreAggRule needs table statistics this test
-        // environment does not have; it is covered end-to-end by
+    }
+
+    @Test
+    public void testTopNBuiltRuntimeFilterDisablesQueryCache() throws Exception {
+        // TOPN_FILTER has two mutually exclusive builders, decided by whether PushDownTopNToPreAggRule
+        // fired. Here it cannot: c1 is both the distribution key and the group-by key, so the plan is a
+        // one-phase aggregation and the rule's TopN -> Agg(GLOBAL) -> Agg(LOCAL) pattern does not match.
+        // The filter is then built by the SortNode sitting above the cache interpolation point (its
+        // `perPipeline` is false, which is exactly the case SortNode.buildRuntimeFilters handles), and
+        // it probes the scan feeding that cache point all the same.
+        // This is the shape that escaped the first version of the check, which only looked at
+        // AggregationNode; end-to-end coverage lives in
         // test/sql/test_query_cache/T/test_query_cache_topn_filter_stale_entry.
+        Assertions.assertFalse(cacheParamOf(
+                        "select c1, sum(v1) from t1 where dt between '2022-01-01' and '2022-02-01' " +
+                                "group by c1 order by c1 limit 10")
+                .isPresent(), "a SortNode building a TOPN_FILTER below the cache point must not be cached");
+
+        // The very same query without the TopN keeps the same cache point and must stay cacheable, so
+        // the assertion above cannot pass merely because this shape is uncacheable for other reasons.
+        Assertions.assertTrue(cacheParamOf(
+                        "select c1, sum(v1) from t1 where dt between '2022-01-01' and '2022-02-01' " +
+                                "group by c1")
+                .isPresent(), "the one-phase baseline without a TopN must stay cacheable");
     }
 
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheRuntimeFilterAndTimeZoneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheRuntimeFilterAndTimeZoneTest.java
@@ -14,8 +14,11 @@
 
 package com.starrocks.planner;
 
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TCacheParam;
 import com.starrocks.utframe.StarRocksAssert;
@@ -72,6 +75,26 @@ public class QueryCacheRuntimeFilterAndTimeZoneTest {
                 "  START (\"2022-01-01\") END (\"2022-03-01\") EVERY (INTERVAL 1 day))\n" +
                 "DISTRIBUTED BY HASH(`c1`) BUCKETS 10\n" +
                 "PROPERTIES(\"replication_num\" = \"1\");");
+        // Same as t2, but carrying row counts. PushDownTopNToPreAggRule only wins on cost once the
+        // table is not empty, and it is that rule firing which moves the partial TopN down into the
+        // scan fragment where it can build a filter against the cache point at all.
+        starRocksAssert.withTable("" +
+                "CREATE TABLE t3(\n" +
+                "dt DATE NOT NULL,\n" +
+                "c1 INT NOT NULL,\n" +
+                "ts BIGINT NOT NULL,\n" +
+                "v1 BIGINT NOT NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`dt`, `c1`)\n" +
+                "PARTITION BY RANGE(dt) (\n" +
+                "  START (\"2022-01-01\") END (\"2022-03-01\") EVERY (INTERVAL 1 day))\n" +
+                "DISTRIBUTED BY HASH(`c1`) BUCKETS 10\n" +
+                "PROPERTIES(\"replication_num\" = \"1\");");
+        OlapTable t3 = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getDb("qc_rf_db").getTable("t3");
+        for (Partition partition : t3.getAllPartitions()) {
+            partition.getDefaultPhysicalPartition().getLatestBaseIndex().setRowCount(40);
+        }
     }
 
     private Optional<TCacheParam> cacheParamOf(String sql) throws Exception {
@@ -121,6 +144,31 @@ public class QueryCacheRuntimeFilterAndTimeZoneTest {
                         "select c1, sum(v1) from t1 where dt between '2022-01-01' and '2022-02-01' " +
                                 "group by c1")
                 .isPresent(), "the one-phase baseline without a TopN must stay cacheable");
+    }
+
+    @Test
+    public void testPreAggTopNRuntimeFilterDisablesQueryCacheUnderEitherPushDownMode() throws Exception {
+        // The shape the end-to-end case actually plans on a populated table: with real row counts
+        // PushDownTopNToPreAggRule wins on cost and moves the partial TopN into the scan fragment,
+        // right on top of the pre-aggregation that is the cache interpolation point. Which node then
+        // builds the TOPN_FILTER is decided by topn_push_down_agg_mode:
+        //   >= 1  the rule hands the sort info to the aggregation, which builds the filter, and the
+        //         SortNode returns early -- this is what the default value plans;
+        //   == 0  the rule leaves the aggregation without sort info, so the SortNode builds it instead.
+        // Both probe the scan below the cache point and poison its per-tablet entries identically, so
+        // neither may leave the fragment cacheable. Only the first was covered before.
+        String sql = "select count(*), sum(s), min(s), max(s) from " +
+                "(select c1, sum(v1) s from t3 group by c1 order by c1 limit 10) x";
+        int originalMode = ctx.getSessionVariable().getTopNPushDownAggMode();
+        try {
+            for (int mode : new int[] {0, 1}) {
+                ctx.getSessionVariable().setEnablePreAggTopNPushDown(mode);
+                Assertions.assertFalse(cacheParamOf(sql).isPresent(),
+                        "a pre-aggregation TopN filter must not be cached, topn_push_down_agg_mode=" + mode);
+            }
+        } finally {
+            ctx.getSessionVariable().setEnablePreAggTopNPushDown(originalMode);
+        }
     }
 
 

--- a/test/sql/test_query_cache/T/test_query_cache_topn_filter_stale_entry
+++ b/test/sql/test_query_cache/T/test_query_cache_topn_filter_stale_entry
@@ -1,8 +1,9 @@
 -- name: test_query_cache_topn_filter_stale_entry
--- PushDownTopNToPreAggRule attaches the TopN of `group by k order by k limit n` to the local
--- aggregation, which is exactly where the query cache interpolates its cache operator. The
--- aggregation then builds a TOPN_FILTER that probes the scan feeding it, so the per-tablet results
--- that get populated only hold the rows below the boundary that filter happened to reach. The
+-- c1 is both the distribution key and the group-by key, so `group by c1 order by c1 limit 10` is
+-- planned as a one-phase aggregation and the partial TopN stays in the scan fragment, right above
+-- the aggregation where the query cache interpolates its cache operator. That SortNode builds a
+-- TOPN_FILTER that probes the scan feeding the cache point, so the per-tablet results that get
+-- populated only hold the rows below the boundary that filter happened to reach. The
 -- boundary is a property of the whole query's data scope, not of the tablet, and it is not part of
 -- the cache key -- so the entries are only accidentally safe while every later reader's scope is a
 -- superset of the writer's. Dropping the partitions that held the small keys narrows the scope,


### PR DESCRIPTION
## Why I'm doing:

Follow-up to #77066, which stopped the query cache from populating entries below a runtime filter but only inspected AggregationNode. TOPN_FILTER has two mutually exclusive builders, and which one fires depends on whether PushDownTopNToPreAggRule matched:

  - the rule attaches the TopN to the local aggregation, which then builds the filter itself -- this is the half #77066 covered;
  - otherwise the SortNode above the aggregation builds it, and the aggregation builds nothing.

`group by k order by k limit n` over a table distributed by k takes the second path: the plan is a one-phase aggregation, so the rule's TopN -> Agg(GLOBAL) -> Agg(LOCAL) pattern cannot match and the partial TopN stays in the scan fragment. Its filter probes the very scan that feeds the cache interpolation point all the same, so the per-tablet entries that get populated hold only the rows below a boundary that is decided at run time and is absent from the cache key. Neither builder is visible to the alien-GRF check, because both filters are local.

Check every non-join RuntimeFilterBuildNode of the leftmost path instead of just AggregationNode. JoinNodes keep their existing treatment: their build side is packed into the digest together with the data versions of their OlapScanNodes.

The plan-level test now covers the SortNode shape, which needs no table statistics and therefore asserts deterministically; reverting the production change makes it fail with a cache param present. The comment on the end-to-end case, which named the wrong mechanism and misled the first fix, is corrected.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
