### PR TITLE
[BugFix] Assign index ids to GIN indexes created on a materialized view (backport #77340)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1903,6 +1903,7 @@ public class OlapTable extends Table {
             this.indexes = new TableIndexes(null);
         }
         this.indexes.setIndexes(indexes);
+        tryToAssignIndexId();
     }
 
     public String getColocateGroup() {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/GINIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/GINIndexTest.java
@@ -19,11 +19,13 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Index;
 import com.starrocks.catalog.KeysType;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
 import com.starrocks.common.InvertedIndexParams.IndexParamsKey;
 import com.starrocks.common.InvertedIndexParams.InvertedIndexImpType;
 import com.starrocks.common.InvertedIndexParams.SearchParamsKey;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.IndexDef.IndexType;
@@ -176,5 +178,40 @@ public class GINIndexTest extends PlanTestBase {
         StringLiteral stringExpr = new StringLiteral("test");
         MatchExpr expr = new MatchExpr(slot, stringExpr);
         MatchExpr newMatch = (MatchExpr) expr.clone();
+    }
+
+    @Test
+    public void testMaterializedViewGINIndexGetsDistinctIndexId() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE `mv_index_base` (\n" +
+                "  `f1` int NOT NULL COMMENT \"\",\n" +
+                "  `f2` varchar(200) NOT NULL COMMENT \"\",\n" +
+                "  `f3` varchar(200) NOT NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`f1`)\n" +
+                "DISTRIBUTED BY HASH(`f1`) BUCKETS 1\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");");
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv_two_gin\n" +
+                "(f1, f2, f3,\n" +
+                " INDEX gin_idx1 (`f2`) USING GIN,\n" +
+                " INDEX gin_idx2 (`f3`) USING GIN)\n" +
+                "DISTRIBUTED BY HASH(f1) BUCKETS 1\n" +
+                "REFRESH MANUAL\n" +
+                "PROPERTIES (\"replication_num\" = \"1\")\n" +
+                "AS SELECT f1, f2, f3 FROM mv_index_base;");
+
+        OlapTable mv = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable("test", "mv_two_gin");
+        List<Index> mvIndexes = mv.getIndexes();
+        Assertions.assertEquals(2, mvIndexes.size());
+        // A GIN index must carry a real id: it goes into the tablet schema pushed to BE and, for the
+        // CLucene backend, into the on-disk index file name.
+        for (Index index : mvIndexes) {
+            Assertions.assertTrue(index.getIndexId() >= 0,
+                    "GIN index " + index.getIndexName() + " should get a valid index id, got "
+                            + index.getIndexId());
+        }
+        // Two indexes sharing an id would resolve to the same .ivt directory and clobber each other.
+        Assertions.assertNotEquals(mvIndexes.get(0).getIndexId(), mvIndexes.get(1).getIndexId(),
+                "two GIN indexes on one materialized view must not share an index id");
     }
 }

--- a/test/sql/test_index/R/test_gin_mv_index
+++ b/test/sql/test_index/R/test_gin_mv_index
@@ -1,0 +1,52 @@
+-- name: test_gin_mv_index @native
+create database test_gin_mv_index_${uuid0};
+-- result:
+-- !result
+use test_gin_mv_index_${uuid0};
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("enable_experimental_gin" = "true");
+-- result:
+-- !result
+CREATE TABLE `base_t` (
+    `id` int(11) NOT NULL COMMENT "",
+    `content` varchar(200) NOT NULL COMMENT "",
+    `content2` varchar(200) NOT NULL COMMENT ""
+)
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv_two_gin
+(id, content, content2,
+ INDEX gin_idx1 (`content`) USING GIN,
+ INDEX gin_idx2 (`content2`) USING GIN)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+REFRESH MANUAL
+PROPERTIES ("replication_num" = "1")
+AS SELECT id, content, content2 FROM base_t;
+-- result:
+-- !result
+INSERT INTO base_t VALUES (1, "alpha beta", "red green"), (2, "gamma delta", "blue cyan");
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv_two_gin WITH SYNC MODE;
+select id, content from mv_two_gin where content = "alpha beta";
+-- result:
+1	alpha beta
+-- !result
+select id, content2 from mv_two_gin where content2 = "red green";
+-- result:
+1	red green
+-- !result
+select id from mv_two_gin order by id;
+-- result:
+1
+2
+-- !result
+drop database test_gin_mv_index_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_index/T/test_gin_mv_index
+++ b/test/sql/test_index/T/test_gin_mv_index
@@ -1,0 +1,39 @@
+-- name: test_gin_mv_index @native
+create database test_gin_mv_index_${uuid0};
+use test_gin_mv_index_${uuid0};
+
+ADMIN SET FRONTEND CONFIG ("enable_experimental_gin" = "true");
+
+CREATE TABLE `base_t` (
+    `id` int(11) NOT NULL COMMENT "",
+    `content` varchar(200) NOT NULL COMMENT "",
+    `content2` varchar(200) NOT NULL COMMENT ""
+)
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+-- Two GIN indexes on one materialized view. In shared-nothing mode imp_lib defaults to
+-- clucene, whose index lives in a standalone {rowset}_{segment}_{index_id}.ivt directory,
+-- so the two indexes must get distinct index ids or they clobber each other.
+CREATE MATERIALIZED VIEW mv_two_gin
+(id, content, content2,
+ INDEX gin_idx1 (`content`) USING GIN,
+ INDEX gin_idx2 (`content2`) USING GIN)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+REFRESH MANUAL
+PROPERTIES ("replication_num" = "1")
+AS SELECT id, content, content2 FROM base_t;
+
+INSERT INTO base_t VALUES (1, "alpha beta", "red green"), (2, "gamma delta", "blue cyan");
+REFRESH MATERIALIZED VIEW mv_two_gin WITH SYNC MODE;
+
+-- Both filters must be answered correctly. Before the fix the first one returned 0 rows,
+-- because gin_idx2 had overwritten gin_idx1 index directory.
+select id, content from mv_two_gin where content = "alpha beta";
+select id, content2 from mv_two_gin where content2 = "red green";
+select id from mv_two_gin order by id;
+
+drop database test_gin_mv_index_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

GIN (and VECTOR) indexes created on a materialized view never get an `indexId` — they stay at `-1` forever. A `CREATE TABLE` index is numbered by the `OlapTable` constructor, which ends in `tryToAssignIndexId()`. An MV passes `null` into that slot and receives its real indexes afterwards through `LocalMetastore.createMaterializedView()` → `setIndexes()`, which only stores the list; `MaterializedView` also overrides `onReload()` without that call, so a restart or metadata replay does not repair it.

The id is part of the on-disk path of a standalone CLucene GIN index (`IndexDescriptor::inverted_index_file_path`):

```
{rowset_dir}/{rowset_id}_{segment_id}_{index_id}.ivt
```

so two GIN indexes on one MV resolve to the same name: the second writer clobbers the first and the losing column's `MATCH` filter silently returns fewer rows. A base-table query rewritten onto the MV returns those wrong rows too, even when the base table carries no index itself.

Reproduced on a shared-nothing cluster with `enable_experimental_gin = true`: both ids `-1`, a single `..._0_-1.ivt` directory, and a filter on the clobbered column returns 0 rows where 1 is expected — correct only with `enable_gin_filter = false`. With the fix the ids are `0` and `1`, both directories exist, and both columns filter correctly.

Shared-data is not affected (it forces the builtin backend, which keys its metadata by `col_unique_id`), and a single-index MV works by accident because nothing collides with it.

Fixes #77319

## What I'm doing:

One line in `OlapTable.setIndexes()`, so the invariant is enforced where the indexes are attached rather than patched at the MV creation site:

```java
     this.indexes.setIndexes(indexes);
+    tryToAssignIndexId();
```

It only touches indexes whose `getIndexId() < 0`, so it is a no-op for the four schema-change callers that pass already-numbered indexes; MV creation is the only caller passing `-1`, and it runs before the `onCreate()` edit log write and before tablets are created, so the ids are persisted and reach BE with the tablet schema. BITMAP / NGRAMBF indexes are not `isCompatibleIndex` and keep `-1` by design.

Existing MVs are not repaired — recreating them is the way out. Backfilling ids on reload was deliberately left out: it would fix a broken two-index MV, but would also renumber a working single-index MV away from its existing `..._0_-1.ivt` file and silently lose its index acceleration.

### Tests

- `GINIndexTest#testMaterializedViewGINIndexGetsDistinctIndexId` — creates the MV through `LocalMetastore`, reads it back and asserts both GIN indexes have distinct ids `>= 0`. The pre-existing `testMaterializedViewGINIndexProperties` stops at analysis, which is why it could not catch this.
- `test/sql/test_index/{T,R}/test_gin_mv_index` — end-to-end: MV with two GIN indexes, filter each indexed column, both return their row.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

Queries over a newly created MV with more than one GIN index start returning correct results. Materialized views created before this change are not repaired and need to be recreated; no metadata written by this change is unreadable by an older FE, which only skips the id assignment.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

The whole chain exists unchanged on all three branches — verified on 3.5 down to the line numbers (`StarRocks.g4` allows `indexDesc` in the MV DDL, `MaterializedViewAnalyzer` builds `Index` without an id, `LocalMetastore` calls `setIndexes`, `OlapTable.setIndexes` is byte-identical, `MaterializedView` overrides `onReload` without assigning ids, `IndexDescriptor` embeds `index_id` in the `.ivt` path). 3.5 is in fact strictly worse: it only ships the CLucene backend, so there is no builtin path to fall back on.



