### PR TITLE
[BugFix] Fix NPE in show proc '/global_current_queries' when constant queries execute on FE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/FeExecuteCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/FeExecuteCoordinator.java
@@ -53,6 +53,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.text.DecimalFormat;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -245,7 +246,7 @@ public class FeExecuteCoordinator extends Coordinator {
 
     @Override
     public List<QueryStatisticsItem.FragmentInstanceInfo> getFragmentInstanceInfos() {
-        return null;
+        return Collections.emptyList();
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/FeExecuteCoordinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/FeExecuteCoordinatorTest.java
@@ -1,0 +1,34 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler;
+
+import com.starrocks.qe.QueryStatisticsItem;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class FeExecuteCoordinatorTest {
+
+    @Test
+    public void testGetFragmentInstanceInfosNotNull() {
+        FeExecuteCoordinator coordinator = new FeExecuteCoordinator(null, null);
+        Assertions.assertNotNull(coordinator.getFragmentInstanceInfos());
+        Assertions.assertTrue(coordinator.getFragmentInstanceInfos().isEmpty());
+        // show proc '/global_current_queries' builds QueryStatisticsItem from the
+        // coordinator of every in-flight query, including FE-execute ones
+        new QueryStatisticsItem.Builder()
+                .fragmentInstanceInfos(coordinator.getFragmentInstanceInfos())
+                .build();
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

`show proc '/global_current_queries'` (and `'/current_queries'`) intermittently fails with an NPE:

```
java.lang.NullPointerException: Cannot invoke "java.util.Collection.toArray()" because "c" is null
    at java.util.ArrayList.addAll(ArrayList.java:752)
    at com.starrocks.qe.QueryStatisticsItem$Builder.fragmentInstanceInfos(QueryStatisticsItem.java:181)
    at com.starrocks.qe.QeProcessorImpl.getQueryStatistics(QeProcessorImpl.java:241)
    at com.starrocks.qe.QueryStatisticsInfo.makeListFromMetricsAndMgrs(QueryStatisticsInfo.java:380)
    at com.starrocks.common.proc.CurrentGlobalQueryStatisticsProcDir.fetchResult(CurrentGlobalQueryStatisticsProcDir.java:72)
```

The proc iterates every in-flight query and calls `Coordinator#getFragmentInstanceInfos()` on it. Constant queries (e.g. `SELECT 1`, pure constant expressions) execute entirely on FE via `FeExecuteCoordinator`, whose `getFragmentInstanceInfos()` returns `null`, and `QueryStatisticsItem.Builder` calls `addAll` on it without a null check. So whenever the SHOW races with an in-flight FE-execute query — easy to hit with frequent health checks / monitoring polling — it throws.

## What I'm doing:

Return an empty list instead of `null`: an FE-execute query has no BE fragment instances, so the empty list is the correct answer. 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5