### PR TITLE
[BugFix] Derive the query tracker reserve limit from the effective query memory limit

### DIFF
--- a/be/src/exec/runtime/query_context.cpp
+++ b/be/src/exec/runtime/query_context.cpp
@@ -163,10 +163,27 @@ void QueryContext::init_mem_tracker(int64_t query_mem_limit, MemTracker* parent,
                 ADD_COUNTER_SKIP_MERGE(_profile.get(), "MemoryLimit", TUnit::BYTES, TCounterMergeType::SKIP_ALL);
         COUNTER_SET(mem_tracker_counter, query_mem_limit);
         size_t lowest_limit = parent->lowest_limit();
-        size_t tracker_reserve_limit = -1;
 
-        if (spill_mem_reserve_ratio.has_value()) {
-            tracker_reserve_limit = lowest_limit * spill_mem_reserve_ratio.value();
+        // The effective memory limit of this query is the tightest of the parent chain limit, the
+        // explicit query_mem_limit and the resource group big query limit. It has to be computed
+        // before the reserve limit below, which is derived from it.
+        _static_query_mem_limit = lowest_limit;
+        if (query_mem_limit > 0) {
+            _static_query_mem_limit = std::min(query_mem_limit, _static_query_mem_limit);
+        }
+        if (big_query_mem_limit > 0) {
+            _static_query_mem_limit = std::min(big_query_mem_limit, _static_query_mem_limit);
+        }
+
+        int64_t tracker_reserve_limit = -1;
+        if (spill_mem_reserve_ratio.has_value() && _static_query_mem_limit > 0) {
+            // The reserve limit is the early-warning line probed by the AUTO spill trigger in
+            // PipelineDriver::_adjust_memory_usage, so it must sit below the hard limit this query
+            // is actually checked against. Deriving it from the parent chain alone made it ignore an
+            // explicit and possibly much smaller query_mem_limit: the reservation probe then never
+            // failed, the operator was never switched to the low memory mode, and the query OOMed
+            // instead of spilling.
+            tracker_reserve_limit = _static_query_mem_limit * spill_mem_reserve_ratio.value();
         }
 
         if (wg != nullptr && big_query_mem_limit > 0 &&
@@ -182,13 +199,6 @@ void QueryContext::init_mem_tracker(int64_t query_mem_limit, MemTracker* parent,
         }
         _query_runtime_state.set_query_mem_tracker(_mem_tracker.get());
 
-        _static_query_mem_limit = lowest_limit;
-        if (query_mem_limit > 0) {
-            _static_query_mem_limit = std::min(query_mem_limit, _static_query_mem_limit);
-        }
-        if (big_query_mem_limit > 0) {
-            _static_query_mem_limit = std::min(big_query_mem_limit, _static_query_mem_limit);
-        }
         _connector_scan_operator_mem_share_arbitrator = _object_pool.add(new ConnectorScanOperatorMemShareArbitrator(
                 _static_query_mem_limit, connector_scan_node_number, connector_scan_default_data_source_mem_bytes));
         if (runtime_state != nullptr && runtime_state->enable_global_late_materialization()) {

--- a/be/test/exec/pipeline/query_context_manger_test.cpp
+++ b/be/test/exec/pipeline/query_context_manger_test.cpp
@@ -650,4 +650,95 @@ TEST(QueryContextManagerTest, testInitMemTrackerWiresQueryRuntimeStateMemTracker
     EXPECT_EQ(query_ctx.mem_tracker().get(), query_ctx.query_runtime_state().query_mem_tracker());
 }
 
+// The reserve limit is the early-warning line the AUTO spill trigger probes through
+// try_mem_reserve, so it must always stay below the hard limit the query is checked against.
+class QueryContextReserveLimitTest : public ::testing::Test {
+protected:
+    static constexpr int64_t kParentMemLimit = 100L * 1024 * 1024 * 1024; // 100GB
+    static constexpr int64_t kQueryMemLimit = 64L * 1024 * 1024;          // 64MB
+    static constexpr int64_t kBigQueryMemLimit = 128L * 1024 * 1024;      // 128MB
+    static constexpr double kSpillMemReserveRatio = 0.8;
+
+    // The production code truncates the double product, so the expectations must do the same.
+    static int64_t expected_reserve_limit(int64_t limit) { return limit * kSpillMemReserveRatio; }
+
+    void SetUp() override {
+        _parent_mem_tracker =
+                std::make_shared<MemTracker>(MemTrackerType::QUERY_POOL, kParentMemLimit, "parent", nullptr);
+        // init_mem_tracker runs under std::call_once, so every case needs a fresh QueryContext.
+        _query_ctx = std::make_unique<QueryContext>();
+        TUniqueId query_id;
+        query_id.hi = 7;
+        query_id.lo = 8;
+        _query_ctx->set_query_id(query_id);
+    }
+
+    std::shared_ptr<MemTracker> _parent_mem_tracker;
+    std::unique_ptr<QueryContext> _query_ctx;
+};
+
+TEST_F(QueryContextReserveLimitTest, ReserveLimitHonorsSmallQueryMemLimit) {
+    _query_ctx->init_mem_tracker(kQueryMemLimit, _parent_mem_tracker.get(), -1, kSpillMemReserveRatio);
+
+    auto tracker = _query_ctx->mem_tracker();
+    ASSERT_NE(nullptr, tracker);
+    EXPECT_EQ(kQueryMemLimit, tracker->limit());
+    EXPECT_EQ(expected_reserve_limit(kQueryMemLimit), tracker->reserve_limit());
+    // The early-warning line must sit below the hard limit, otherwise the reservation probe never
+    // fails and an AUTO mode query OOMs instead of spilling.
+    EXPECT_LT(tracker->reserve_limit(), tracker->limit());
+}
+
+TEST_F(QueryContextReserveLimitTest, ReserveLimitFallsBackToParentWhenNoQueryLimit) {
+    _query_ctx->init_mem_tracker(-1, _parent_mem_tracker.get(), -1, kSpillMemReserveRatio);
+
+    auto tracker = _query_ctx->mem_tracker();
+    ASSERT_NE(nullptr, tracker);
+    EXPECT_EQ(expected_reserve_limit(kParentMemLimit), tracker->reserve_limit());
+}
+
+TEST_F(QueryContextReserveLimitTest, ReserveLimitUnsetWhenRatioAbsent) {
+    // Spill is disabled, so no reserve limit is set and the reservation path falls back to limit().
+    _query_ctx->init_mem_tracker(kQueryMemLimit, _parent_mem_tracker.get());
+
+    auto tracker = _query_ctx->mem_tracker();
+    ASSERT_NE(nullptr, tracker);
+    EXPECT_EQ(-1, tracker->reserve_limit());
+    EXPECT_EQ(kQueryMemLimit, tracker->limit());
+}
+
+TEST_F(QueryContextReserveLimitTest, ReserveLimitHonorsBigQueryMemLimit) {
+    auto wg = std::make_shared<workgroup::WorkGroup>("wg", 1, 0, 1, -1, 0, 1.0, TWorkGroupType::WG_NORMAL, "");
+    _query_ctx->init_mem_tracker(-1, _parent_mem_tracker.get(), kBigQueryMemLimit, kSpillMemReserveRatio, wg.get());
+
+    auto tracker = _query_ctx->mem_tracker();
+    ASSERT_NE(nullptr, tracker);
+    EXPECT_EQ(MemTrackerType::RESOURCE_GROUP_BIG_QUERY, tracker->type());
+    EXPECT_EQ(kBigQueryMemLimit, tracker->limit());
+    EXPECT_EQ(expected_reserve_limit(kBigQueryMemLimit), tracker->reserve_limit());
+    EXPECT_LT(tracker->reserve_limit(), tracker->limit());
+}
+
+TEST_F(QueryContextReserveLimitTest, ReserveLimitTakesMinOfAllLimits) {
+    auto wg = std::make_shared<workgroup::WorkGroup>("wg", 1, 0, 1, -1, 0, 1.0, TWorkGroupType::WG_NORMAL, "");
+    _query_ctx->init_mem_tracker(kQueryMemLimit, _parent_mem_tracker.get(), kBigQueryMemLimit, kSpillMemReserveRatio,
+                                 wg.get());
+
+    auto tracker = _query_ctx->mem_tracker();
+    ASSERT_NE(nullptr, tracker);
+    EXPECT_EQ(kQueryMemLimit, tracker->limit());
+    EXPECT_EQ(expected_reserve_limit(kQueryMemLimit), tracker->reserve_limit());
+    EXPECT_LT(tracker->reserve_limit(), tracker->limit());
+}
+
+TEST_F(QueryContextReserveLimitTest, StaticQueryMemLimitTakesMinOfAllLimits) {
+    auto wg = std::make_shared<workgroup::WorkGroup>("wg", 1, 0, 1, -1, 0, 1.0, TWorkGroupType::WG_NORMAL, "");
+    _query_ctx->init_mem_tracker(kQueryMemLimit, _parent_mem_tracker.get(), kBigQueryMemLimit, kSpillMemReserveRatio,
+                                 wg.get());
+
+    // Computing the effective limit earlier must not change its value.
+    EXPECT_EQ(kQueryMemLimit, _query_ctx->get_static_query_mem_limit());
+    EXPECT_EQ(kQueryMemLimit, _query_ctx->query_runtime_state().static_query_mem_limit());
+}
+
 } // namespace starrocks::pipeline


### PR DESCRIPTION
## Why I'm doing:

`QueryContext::init_mem_tracker` computes the query tracker's `reserve_limit` — the early-warning line that the AUTO spill trigger probes through `try_mem_reserve` — from `parent->lowest_limit()` only, ignoring an explicit `query_mem_limit`.

`limit` and `reserve_limit` are two separate ceilings:

| | set from | checked by | when exceeded |
|---|---|---|---|
| `limit` | `query_mem_limit` | `MemTracker::try_consume` | allocation fails → **OOM** |
| `reserve_limit` | `lowest_limit * spill_mem_limit_threshold` | `MemTracker::try_consume_with_limited` | reservation fails → **spill** |

By design the warning line has to sit *below* the hard limit so an operator can spill before hitting it. When a user sets a `query_mem_limit` well below the BE / workgroup limit, the warning line instead ends up orders of magnitude *above* it, so the reservation probe in `PipelineDriver::_adjust_memory_usage` never fails, `set_execute_mode(spill::MEM_RESOURCE_LOW_MEMORY)` is never called, and the query OOMs instead of spilling.

Scope: **every spillable operator**, not one specific operator. It only shows up on queries with `enable_spill=true` (that is the only path that sets `reserve_limit` at all — otherwise it stays `-1` and the reservation path falls back to `limit`) plus an explicitly small `query_mem_limit` — which is exactly the natural way to cap one query's memory.

The correct handling already exists a dozen lines further down in the same function, for `_static_query_mem_limit`, which is what makes this look like an omission rather than a deliberate choice.

### Measured

BE `mem_limit` 151GB, `query_mem_limit=67108864` (64MB), `enable_spill=true`, `spill_mode='auto'`. Spilled bytes read as the delta of `starrocks_be_query_spill_bytes_write_total{storage_type="local"}` around each query.

| query | result | spilled bytes |
|---|---|---|
| hash agg (3M groups) | OOM | **0** |
| hash join (broadcast self join, 3M rows) | OOM | **0** |
| sort (3M rows) | OOM | **0** |
| nestloop join (164MB build side) | OOM | **0** |

Same nestloop join, changing only *how* spilling is triggered — every path that bypasses the reservation probe works fine:

| mode | which check decides | result | spilled bytes |
|---|---|---|---|
| `spill_mode='auto'` (default) | reservation probe | ❌ OOM | **0** |
| `auto` + `spill_revocable_max_bytes=1MB` | revocable-bytes branch | ✅ correct results | 92,552,724 |
| `spill_mode='random'` + `spill_rand_ratio=1.0` | RANDOM branch | ✅ correct results | 92,552,724 |
| `spill_mode='force'` | trigger chain skipped | ✅ correct results | 92,552,724 |

The last three spill an identical number of bytes, so the spill/restore machinery itself is healthy — the reservation probe is the only broken link.

## What I'm doing:

Move the `_static_query_mem_limit` computation — which already takes the min of the parent chain limit, `query_mem_limit` and `big_query_mem_limit` — a few lines up, and derive `tracker_reserve_limit` from it instead of from `parent->lowest_limit()`. Nothing between the old and the new position reads or writes `_static_query_mem_limit`, so its value is unchanged (asserted by a UT). Additionally, no reserve limit is set when there is no effective limit at all, instead of multiplying `(size_t)-1` by the ratio.

With `query_mem_limit=64MB` and the default `spill_mem_limit_threshold=0.8` the warning line is now 51.2MB, below the 64MB hard limit, leaving ~13MB of headroom for the spill itself.

### Behavior change / risk

Before this fix, an AUTO-mode query with a small `query_mem_limit` practically never spilled — it OOMed. Those queries now really do spill: they succeed instead of failing, at the cost of spill IO. If spilling turns out to start too early for a workload, the session variable `spill_mem_limit_threshold` (default 0.8) is the knob to tune, rather than the old behavior.

### Tests

`QueryContextReserveLimitTest` in `be/test/exec/pipeline/query_context_manger_test.cpp`, 6 cases:

- `ReserveLimitHonorsSmallQueryMemLimit` — the core one: `reserve_limit == query_mem_limit * ratio` **and** `reserve_limit < limit`
- `ReserveLimitHonorsBigQueryMemLimit` / `ReserveLimitTakesMinOfAllLimits` — same invariant through the resource-group big-query tracker, and with all three limits set
- `ReserveLimitFallsBackToParentWhenNoQueryLimit` / `ReserveLimitUnsetWhenRatioAbsent` — no regression when no `query_mem_limit` is set, and no reserve limit when spill is off
- `StaticQueryMemLimitTakesMinOfAllLimits` — moving the computation earlier did not change its value

Run as a negative control with the fix reverted: exactly the 3 bug-exposing cases fail (`reserve_limit` 85899345920 vs `limit` 67108864) while the 3 behavior-preserving ones still pass.

```
[==========] 20 tests from 2 test suites ran. (3805 ms total)
[  PASSED  ] 20 tests.
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
