### PR TITLE
[UT] Add repro test for view-based MV rewrite missing column statistics error

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/planner/ViewBasedMvRewriteMissingStatsReproTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/ViewBasedMvRewriteMissingStatsReproTest.java
@@ -1,0 +1,147 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Repro for the field issue (CelerData ENG-1162031, StarRocks 4.0.x and main):
+ *   ERROR 1064: only found column statistics: {...}, but missing statistic of col: cast
+ *
+ * Mechanism:
+ *  - enable_view_based_mv_rewrite folds views into LogicalViewScanOperator;
+ *  - multi-stage rewrite PHASE1 runs mv rewrite early;
+ *  - when only SOME view scans are rewritten (here: the aggregate branch matches mv_on_view,
+ *    the other two branches do not), viewBasedMvRuleRewrite replaces the remaining view scans
+ *    back via MvUtils.replaceLogicalViewScanOperator, whose predicate==null branch drops the
+ *    view scan's merged projection;
+ *  - the resulting plan's UNION childOutputColumns still references a column the child no
+ *    longer defines, so memo statistics derivation (StatisticsCalculator.computeUnionNode ->
+ *    Statistics.getColumnStatistic) throws at plan time.
+ *
+ * Matches the customer's bisection: three DISTINCT branches are required; any two pass.
+ */
+public class ViewBasedMvRewriteMissingStatsReproTest extends MaterializedViewTestBase {
+
+    // Aggregate sub-query matching mv_on_view's definition -> rewritable view usage.
+    private static final String Q_AGG_MATCH =
+            "SELECT ns_tenant_id, instance, COUNT(1) AS cnt FROM v_union " +
+                    "GROUP BY ns_tenant_id, instance";
+    private static final String Q_AGG_BRANCH =
+            "SELECT ns_tenant_id, instance, CAST(cnt AS VARCHAR), CAST(NULL AS VARCHAR), " +
+                    "CAST(NULL AS VARCHAR) FROM (" + Q_AGG_MATCH + ") s";
+    // Plain view usage projecting the view's expression columns (incl. the CAST NULL constant).
+    private static final String Q_PLAIN_BRANCH =
+            "SELECT ns_tenant_id, instance, c_coalesce, c_case, c_cast FROM v_union";
+    // View used as the right side of a LEFT JOIN: the ON condition cannot be pushed down as the
+    // view scan's predicate, so the replacement path hits the predicate==null branch.
+    private static final String Q_JOIN_BRANCH =
+            "SELECT v.ns_tenant_id, v.instance, v.c_coalesce, v.c_case, v.c_cast " +
+                    "FROM v_union v LEFT JOIN t_extra e ON v.ns_tenant_id = e.ns_tenant_id";
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        MaterializedViewTestBase.beforeClass();
+        starRocksAssert.useDatabase(MATERIALIZED_DB_NAME);
+
+        starRocksAssert.withTable("CREATE TABLE t_base (\n" +
+                "  ns_tenant_id bigint NOT NULL,\n" +
+                "  instance varchar(64),\n" +
+                "  file_root_id varchar(64),\n" +
+                "  x varchar(64),\n" +
+                "  y varchar(64),\n" +
+                "  v bigint\n" +
+                ") DUPLICATE KEY(ns_tenant_id)\n" +
+                "DISTRIBUTED BY HASH(ns_tenant_id) BUCKETS 3\n" +
+                "PROPERTIES('replication_num'='1')");
+
+        starRocksAssert.withTable("CREATE TABLE t_extra (\n" +
+                "  ns_tenant_id bigint NOT NULL,\n" +
+                "  instance varchar(64),\n" +
+                "  tag varchar(64),\n" +
+                "  arr array<varchar(64)>,\n" +
+                "  v2 bigint\n" +
+                ") DUPLICATE KEY(ns_tenant_id)\n" +
+                "DISTRIBUTED BY HASH(ns_tenant_id) BUCKETS 3\n" +
+                "PROPERTIES('replication_num'='1')");
+
+        // Logical view shaped like the customer's drives_base_mv: UNION ALL branches where one
+        // branch projects real columns plus coalesce/case expressions and the other synthesizes
+        // CAST(NULL AS STRING) constants.
+        starRocksAssert.withView("CREATE VIEW v_union AS\n" +
+                "SELECT ns_tenant_id, instance, file_root_id,\n" +
+                "       COALESCE(x, y) AS c_coalesce,\n" +
+                "       CASE WHEN x IS NOT NULL THEN x ELSE y END AS c_case,\n" +
+                "       CAST(NULL AS STRING) AS c_cast\n" +
+                "FROM t_base\n" +
+                "UNION ALL\n" +
+                "SELECT ns_tenant_id, instance, CAST(NULL AS STRING),\n" +
+                "       x, CAST(NULL AS STRING), CAST(NULL AS STRING)\n" +
+                "FROM t_base");
+
+        // SPJG MV over the view: makes the aggregate view usage rewritable so that
+        // viewBasedMvRuleRewrite hits the partial-success path.
+        createAndRefreshMV(MATERIALIZED_DB_NAME, "CREATE MATERIALIZED VIEW mv_on_view " +
+                "DISTRIBUTED BY RANDOM\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES('replication_num'='1')\n" +
+                "AS SELECT ns_tenant_id, instance, COUNT(1) AS cnt\n" +
+                "FROM v_union GROUP BY ns_tenant_id, instance");
+
+        // Non-SPJG multi-table MV with UNNEST, mirroring the customer's finding_overview
+        // candidate. Being multi-table it defers single-table mv rewrite into the memo phase
+        // (MvRewriteStrategy), which is part of the customer's trigger conditions.
+        createAndRefreshMV(MATERIALIZED_DB_NAME, "CREATE MATERIALIZED VIEW mv_nonspjg " +
+                "DISTRIBUTED BY RANDOM\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES('replication_num'='1')\n" +
+                "AS SELECT b.ns_tenant_id, b.instance, t.unnest AS tag_item, COUNT(1) AS c\n" +
+                "FROM t_base b JOIN t_extra e ON b.ns_tenant_id = e.ns_tenant_id\n" +
+                "CROSS JOIN LATERAL UNNEST(e.arr) t\n" +
+                "GROUP BY b.ns_tenant_id, b.instance, t.unnest");
+
+        connectContext.getSessionVariable().setEnableViewBasedMvRewrite(true);
+        connectContext.getSessionVariable().setEnableMaterializedViewMultiStagesRewrite(true);
+    }
+
+    @Test
+    public void testMissingColumnStatisticsWithPartialViewRewrite() {
+        String threeBranches = Q_AGG_BRANCH
+                + " UNION ALL " + Q_PLAIN_BRANCH
+                + " UNION ALL " + Q_JOIN_BRANCH;
+        Throwable t = Assertions.assertThrows(Throwable.class, () -> getQueryPlan(threeBranches));
+        Assertions.assertTrue(t.getMessage() != null && t.getMessage().contains("missing statistic of col"),
+                "expected 'missing statistic of col' but got: " + t);
+    }
+
+    @Test
+    public void testControlWorkaroundDisableViewBasedRewrite() {
+        // NOTE: 2-branch subsets are NOT used as controls here: whether they fail depends on the
+        // warmth of the MV plan cache (they DO fail when planned first on a cold cache, and pass
+        // when planned after another query already populated it), which matches how erratic the
+        // customer's synthetic-repro attempts were. The only stable control is the verified
+        // workaround: disabling view-based rewrite always plans fine.
+        connectContext.getSessionVariable().setEnableViewBasedMvRewrite(false);
+        try {
+            Assertions.assertDoesNotThrow(() -> getQueryPlan(Q_AGG_BRANCH
+                    + " UNION ALL " + Q_PLAIN_BRANCH
+                    + " UNION ALL " + Q_JOIN_BRANCH));
+        } finally {
+            connectContext.getSessionVariable().setEnableViewBasedMvRewrite(true);
+        }
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

On current main (and 4.0.x in the field), a query that references a logical view from multiple UNION ALL branches can fail at plan time with:

```
ERROR 1064: only found column statistics: {89: cast, 90: coalesce, 91: cast, 92: cast,
87: ns_tenant_id, 88: instance}, but missing statistic of col: 99: cast.
```

The failing chain is:

- `enable_view_based_mv_rewrite` folds the view into a `LogicalViewScanOperator`, and multi-stage rewrite (`enable_materialized_view_multi_stages_rewrite`, on by default) runs MV rewrite in the early PHASE1, right after `MergeProjectWithChildRule` has merged projections into the view scan.
- When the candidate MVs rewrite only **some** of the view scans, `QueryOptimizer.viewBasedMvRuleRewrite` keeps the partially rewritten tree and replaces the remaining view scans back with their inlined plans via `MvUtils.replaceLogicalViewScanOperator`.
- `doReplaceLogicalViewScanOperator` is asymmetric: the `predicate != null` branch preserves and rewrites the view scan's projection, but the `predicate == null` branch does `parent.setChild(index, inlineViewPlan)` and **drops the merged projection**. A view used as the right side of a LEFT JOIN reliably hits this branch because the ON condition is not pushed down into the view scan as a predicate.
- The resulting plan's UNION `childOutputColumns` still references a column the child no longer defines. MV rewrite rules swallow their own exceptions (`BaseMaterializedViewRewriteRule.transform`), but the broken plan reaches the memo, where statistics derivation (`StatisticsCalculator.computeUnionNode` → `Statistics.getColumnStatistic`) has no fallback and the internal error surfaces to the client.

Whether smaller (2-branch) subsets trigger the failure depends on MV plan cache warmth and in-session planning order, which is why the issue was hard to reproduce synthetically; the 3-branch statement in this test fails deterministically in a fresh session. Disabling any of `enable_view_based_mv_rewrite`, `enable_materialized_view_multi_stages_rewrite`, or `enable_materialized_view_rewrite` avoids it (verified on a real cluster built from current main).

## What I'm doing:

- Add `ViewBasedMvRewriteMissingStatsReproTest`, which pins the current behavior as a reproduction anchor for the fix:
  - `testMissingColumnStatisticsWithPartialViewRewrite`: a UNION ALL of three distinct shapes over the same view — (A) an aggregate sub-query matching an SPJG MV defined over the view (this usage gets rewritten), (B) a plain projection of the view's expression columns, and (C) the view as the right side of a LEFT JOIN — asserts the plan-time `missing statistic of col` failure.
  - `testControlWorkaroundDisableViewBasedRewrite`: asserts the same statement plans fine with `enable_view_based_mv_rewrite = false` (the verified workaround).
- The schema mirrors the field shape: the view UNION ALLs a real projection (`coalesce`/`case` expressions) with a branch synthesizing `CAST(NULL AS STRING)` constants; a non-SPJG multi-table MV with UNNEST is included so single-table MV rewrite is deferred into the memo phase, as in the original incident.
- When the underlying bug is fixed, flip the first test's assertion to expect a successful plan, turning this into the regression test for the fix.

### Standalone SQL to reproduce on a live cluster

EXPLAIN alone triggers it; verified on a cluster built from main 55f68b275e4.

```sql
CREATE DATABASE IF NOT EXISTS mv_stats_repro;
USE mv_stats_repro;

CREATE TABLE t_base (
  ns_tenant_id bigint NOT NULL,
  instance varchar(64),
  file_root_id varchar(64),
  x varchar(64),
  y varchar(64),
  v bigint
) DUPLICATE KEY(ns_tenant_id)
DISTRIBUTED BY HASH(ns_tenant_id) BUCKETS 3;

CREATE TABLE t_extra (
  ns_tenant_id bigint NOT NULL,
  instance varchar(64),
  tag varchar(64),
  arr array<varchar(64)>,
  v2 bigint
) DUPLICATE KEY(ns_tenant_id)
DISTRIBUTED BY HASH(ns_tenant_id) BUCKETS 3;

INSERT INTO t_base VALUES
  (1, 'i1', 'r1', 'x1', 'y1', 10),
  (1, 'i1', 'r2', NULL, 'y2', 20),
  (2, 'i2', 'r3', 'x3', NULL, 30),
  (3, 'i3', 'r4', 'x4', 'y4', 40);

INSERT INTO t_extra VALUES
  (1, 'i1', 't1', ['a','b'], 100),
  (2, 'i2', 't2', ['c'], 200),
  (3, 'i3', 't3', ['d','e'], 300);

-- Logical view: UNION ALL where one branch projects real columns + coalesce/case
-- expressions and the other synthesizes CAST(NULL AS STRING) constants.
CREATE VIEW v_union AS
SELECT ns_tenant_id, instance, file_root_id,
       COALESCE(x, y) AS c_coalesce,
       CASE WHEN x IS NOT NULL THEN x ELSE y END AS c_case,
       CAST(NULL AS STRING) AS c_cast
FROM t_base
UNION ALL
SELECT ns_tenant_id, instance, CAST(NULL AS STRING),
       x, CAST(NULL AS STRING), CAST(NULL AS STRING)
FROM t_base;

-- SPJG MV over the view: makes the aggregate view usage rewritable -> partial success.
CREATE MATERIALIZED VIEW mv_on_view
DISTRIBUTED BY RANDOM
REFRESH DEFERRED MANUAL
AS SELECT ns_tenant_id, instance, COUNT(1) AS cnt
FROM v_union GROUP BY ns_tenant_id, instance;

REFRESH MATERIALIZED VIEW mv_on_view WITH SYNC MODE;

-- Non-SPJG multi-table MV with UNNEST: defers single-table mv rewrite into the memo phase.
CREATE MATERIALIZED VIEW mv_nonspjg
DISTRIBUTED BY RANDOM
REFRESH DEFERRED MANUAL
AS SELECT b.ns_tenant_id, b.instance, t.unnest AS tag_item, COUNT(1) AS c
FROM t_base b JOIN t_extra e ON b.ns_tenant_id = e.ns_tenant_id
CROSS JOIN LATERAL UNNEST(e.arr) t
GROUP BY b.ns_tenant_id, b.instance, t.unnest;

REFRESH MATERIALIZED VIEW mv_nonspjg WITH SYNC MODE;

ANALYZE TABLE t_base WITH SYNC MODE;
ANALYZE TABLE t_extra WITH SYNC MODE;

-- ==== THE FAILING STATEMENT ====
-- (A) aggregate sub-query matching mv_on_view -> this view usage IS rewritten
-- (B) plain projection of the view's expression columns -> not rewritable
-- (C) view as right side of a LEFT JOIN -> not rewritable, ON not pushed down
--     => hits the predicate==null replacement branch
EXPLAIN
SELECT ns_tenant_id, instance, CAST(cnt AS VARCHAR), CAST(NULL AS VARCHAR), CAST(NULL AS VARCHAR)
FROM (SELECT ns_tenant_id, instance, COUNT(1) AS cnt FROM v_union GROUP BY ns_tenant_id, instance) s
UNION ALL
SELECT ns_tenant_id, instance, c_coalesce, c_case, c_cast FROM v_union
UNION ALL
SELECT v.ns_tenant_id, v.instance, v.c_coalesce, v.c_case, v.c_cast
FROM v_union v LEFT JOIN t_extra e ON v.ns_tenant_id = e.ns_tenant_id;
-- => ERROR 1064 (HY000): only found column statistics: {89: cast, 90: coalesce, 91: cast,
--    92: cast, 87: ns_tenant_id, 88: instance}, but missing statistic of col: 99: cast.

-- Workaround control: the same statement plans fine with any of these:
--   SET enable_view_based_mv_rewrite = false;
--   SET enable_materialized_view_multi_stages_rewrite = false;
--   SET enable_materialized_view_rewrite = false;
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
