### PR TITLE
[Enhancement] Return 503 from BE /api/health once the process is marked as crashing

### DIFF
--- a/be/src/http/action/health_action.cpp
+++ b/be/src/http/action/health_action.cpp
@@ -34,9 +34,9 @@
 
 #include "http/action/health_action.h"
 
-#include <sstream>
 #include <string>
 
+#include "common/process_exit.h"
 #include "common/tracer.h"
 #include "platform/http/http_channel.h"
 #include "platform/http/http_headers.h"
@@ -53,21 +53,22 @@ bool HealthAction::need_auth() const {
     return true;
 }
 
+std::pair<HttpStatus, std::string_view> HealthAction::health_response(bool crashing) {
+    if (crashing) {
+        return {HttpStatus::SERVICE_UNAVAILABLE,
+                R"({"status": "CRASHING","msg": "fatal signal handler is running; process is terminating"})"};
+    }
+    // Byte-identical to the historical hardcoded 200 reply: consumers must see no
+    // change while the process is healthy.
+    return {HttpStatus::OK, R"({"status": "OK","msg": "To Be Added"})"};
+}
+
 void HealthAction::handle(HttpRequest* req) {
     auto scoped_span = trace::Scope(Tracer::Instance().start_trace("http_handle_health"));
-    std::stringstream ss;
-    ss << "{";
-    ss << R"("status": "OK",)";
-    ss << R"("msg": "To Be Added")";
-    ss << "}";
-    std::string result = ss.str();
+    auto [status, body] = health_response(is_process_crashing());
 
     req->add_output_header(HttpHeaders::CONTENT_TYPE, HEADER_JSON.c_str());
-    HttpChannel::send_reply(req, HttpStatus::OK, result);
-#if 0
-    HttpResponse response(HttpStatus::OK, HEADER_JSON, &result);
-    channel->send_response(response);
-#endif
+    HttpChannel::send_reply(req, status, body);
 }
 
 } // end namespace starrocks

--- a/be/src/http/action/health_action.h
+++ b/be/src/http/action/health_action.h
@@ -34,7 +34,11 @@
 
 #pragma once
 
+#include <string_view>
+#include <utility>
+
 #include "platform/http/http_handler.h"
+#include "platform/http/http_status.h"
 
 namespace starrocks {
 
@@ -55,6 +59,14 @@ public:
     // incremental-coverage attributes the line to a be/src translation unit; a
     // header-inline override is inlined into callers and not counted.
     bool need_auth() const override;
+
+    // Maps the process crashing state to the response for handle(): HTTP status plus
+    // JSON body. The crash flag (set_process_is_crashing()) is process-lifetime
+    // one-way, so a handler-level test cannot exercise the crashing state without
+    // poisoning every later test in the same binary; this pure helper keeps both
+    // states unit-testable. Defined out-of-line in the .cpp for the same
+    // coverage-attribution reason as need_auth().
+    static std::pair<HttpStatus, std::string_view> health_response(bool crashing);
 
 private:
     [[maybe_unused]] ExecEnv* _exec_env;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -123,6 +123,7 @@ set(EXEC_FILES
         ./formats/parquet/statistics_helper_test.cpp
         ./http/default_path_handlers_test.cpp
         ./http/handler_required_privilege_test.cpp
+        ./http/health_action_test.cpp
         ./http/metrics_action_test.cpp
         ./http/stop_be_action_test.cpp
         ./http/stream_load_test.cpp

--- a/be/test/http/health_action_test.cpp
+++ b/be/test/http/health_action_test.cpp
@@ -1,0 +1,95 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "http/action/health_action.h"
+
+#include <event2/http.h>
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "common/process_exit.h"
+#include "platform/http/http_channel.h"
+#include "platform/http/http_request.h"
+#include "platform/http/http_status.h"
+
+namespace starrocks {
+
+extern void (*s_injected_send_reply)(HttpRequest*, HttpStatus, std::string_view);
+
+namespace {
+HttpStatus k_response_status = HttpStatus::OK;
+std::string k_response_str;
+void inject_send_reply(HttpRequest* request, HttpStatus status, std::string_view content) {
+    k_response_status = status;
+    k_response_str = content;
+}
+} // namespace
+
+class HealthActionTest : public testing::Test {
+public:
+    static void SetUpTestSuite() { s_injected_send_reply = inject_send_reply; }
+    static void TearDownTestSuite() { s_injected_send_reply = nullptr; }
+
+    void SetUp() override {
+        k_response_status = HttpStatus::OK;
+        k_response_str = "";
+        _evhttp_req = evhttp_request_new(nullptr, nullptr);
+    }
+
+    void TearDown() override {
+        if (_evhttp_req != nullptr) {
+            evhttp_request_free(_evhttp_req);
+        }
+    }
+
+protected:
+    evhttp_request* _evhttp_req = nullptr;
+};
+
+// The healthy reply must stay byte-identical to the pre-change hardcoded reply so
+// consumers that parse the body observe no difference while the process is healthy.
+TEST_F(HealthActionTest, healthy_response_stays_byte_identical_200) {
+    auto [status, body] = HealthAction::health_response(false);
+    EXPECT_EQ(HttpStatus::OK, status);
+    EXPECT_EQ(R"({"status": "OK","msg": "To Be Added"})", body);
+}
+
+// Once the fatal-signal handler has marked the process as crashing, the endpoint must
+// turn non-2xx so orchestrator health checks (e.g. Kubernetes liveness probes) fail
+// and the node can be restarted even if the crash handler itself hangs.
+TEST_F(HealthActionTest, crashing_response_is_503) {
+    auto [status, body] = HealthAction::health_response(true);
+    EXPECT_EQ(HttpStatus::SERVICE_UNAVAILABLE, status);
+    EXPECT_EQ(R"({"status": "CRASHING","msg": "fatal signal handler is running; process is terminating"})", body);
+}
+
+// handle() must reply with exactly the mapping health_response() defines for the live
+// process state. The crash flag is process-lifetime one-way, so instead of assuming it
+// is still clear here, assert against is_process_crashing() to stay independent of
+// whatever ran earlier in this binary.
+TEST_F(HealthActionTest, handle_maps_process_state_through_health_response) {
+    HealthAction action(nullptr);
+    HttpRequest request(_evhttp_req);
+    request.set_method(HttpMethod::GET);
+    request.set_handler(&action);
+
+    action.handle(&request);
+
+    auto [expected_status, expected_body] = HealthAction::health_response(is_process_crashing());
+    EXPECT_EQ(expected_status, k_response_status);
+    EXPECT_EQ(expected_body, k_response_str);
+}
+
+} // namespace starrocks

--- a/docs/en/administration/http_interface/http_interface.md
+++ b/docs/en/administration/http_interface/http_interface.md
@@ -64,7 +64,7 @@ To facilitate the maintenance of StarRocks clusters, StarRocks provides various 
 | HEAD/GET            | `/api/_download_load`                                           | |
 | HEAD/GET            | `/api/_tablet/_download`                                        | |
 | HEAD/GET            | `/api/_load_error_log`                                          | |
-| GET                 | `/api/health`                                                   | |
+| GET                 | `/api/health`                                                   | Returns the health state of the BE process. Returns HTTP 200 while the process is healthy, and HTTP 503 once the fatal-signal handler has marked the process as crashing, so orchestrator health checks (for example, Kubernetes liveness probes) can restart a node whose crash handler hangs. |
 | GET                 | `/api/_stop_be`                                                 | |
 | GET                 | `/pprof/heap`                                                   | |
 | GET                 | `/pprof/growth`                                                 | |
@@ -95,7 +95,7 @@ To facilitate the maintenance of StarRocks clusters, StarRocks provides various 
 
 | Request Method      | Request Path                                                    | Description                                                                                                          |
 |---------------------|-----------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
-| GET                 | `/api/health`                                                   | |
+| GET                 | `/api/health`                                                   | Returns the health state of the CN process. Returns HTTP 200 while the process is healthy, and HTTP 503 once the fatal-signal handler has marked the process as crashing, so orchestrator health checks (for example, Kubernetes liveness probes) can restart a node whose crash handler hangs. |
 | GET                 | `/pprof/heap`                                                   | |
 | GET                 | `/pprof/growth`                                                 | |
 | GET                 | `/pprof/profile`                                                | |

--- a/docs/ja/administration/http_interface/http_interface.md
+++ b/docs/ja/administration/http_interface/http_interface.md
@@ -64,7 +64,7 @@ StarRocks クラスターのメンテナンスを容易にするために、Star
 | HEAD/GET                | `/api/_download_load`                                           | |
 | HEAD/GET                | `/api/_tablet/_download`                                        | |
 | HEAD/GET                | `/api/_load_error_log`                                          | |
-| GET                     | `/api/health`                                                   | |
+| GET                     | `/api/health`                                                   | BE プロセスのヘルス状態を返します。プロセスが正常な間は HTTP 200 を返し、致命的シグナルハンドラーがプロセスを crashing とマークした後は HTTP 503 を返します。これにより、オーケストレーターのヘルスチェック (例: Kubernetes の liveness probe) が、クラッシュハンドラーがハングしたノードを再起動できます。 |
 | GET                     | `/api/_stop_be`                                                 | |
 | GET                     | `/pprof/heap`                                                   | |
 | GET                     | `/pprof/growth`                                                 | |
@@ -95,7 +95,7 @@ StarRocks クラスターのメンテナンスを容易にするために、Star
 
 | リクエストメソッド | リクエストパス                                                    | 説明                                                                                                                 |
 |---------------------|-----------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
-| GET                 | `/api/health`                                                   | |
+| GET                 | `/api/health`                                                   | CN プロセスのヘルス状態を返します。プロセスが正常な間は HTTP 200 を返し、致命的シグナルハンドラーがプロセスを crashing とマークした後は HTTP 503 を返します。これにより、オーケストレーターのヘルスチェック (例: Kubernetes の liveness probe) が、クラッシュハンドラーがハングしたノードを再起動できます。 |
 | GET                 | `/pprof/heap`                                                   | |
 | GET                 | `/pprof/growth`                                                 | |
 | GET                 | `/pprof/profile`                                                | |

--- a/docs/zh/administration/http_interface/http_interface.md
+++ b/docs/zh/administration/http_interface/http_interface.md
@@ -64,7 +64,7 @@ description: "StarRocks 提供多种 HTTP 接口方便集群维护和操作。"
 | HEAD/GET         | `/api/_download_load`                                             | |
 | HEAD/GET         | `/api/_tablet/_download`                                          | |
 | HEAD/GET         | `/api/_load_error_log`                                            | |
-| GET              | `/api/health`                                                     | |
+| GET              | `/api/health`                                                     | 返回 BE 进程的健康状态。进程正常时返回 HTTP 200；当致命信号处理函数将进程标记为 crashing 后返回 HTTP 503，以便编排系统的健康检查（例如 Kubernetes liveness probe）重启崩溃处理函数卡住的节点。 |
 | GET              | `/api/_stop_be`                                                   | |
 | GET              | `/pprof/heap`                                                     | |
 | GET              | `/pprof/growth`                                                   | |
@@ -95,7 +95,7 @@ description: "StarRocks 提供多种 HTTP 接口方便集群维护和操作。"
 
 | HTTP 请求方法       | HTTP 请求路径                                                   | 描述                                                                                                                |
 |------------------| --------------------------------------------------------------  |-------------------------------------------------------------------------------------------------------------------- |
-| GET              | `/api/health`                                                     | |
+| GET              | `/api/health`                                                     | 返回 CN 进程的健康状态。进程正常时返回 HTTP 200；当致命信号处理函数将进程标记为 crashing 后返回 HTTP 503，以便编排系统的健康检查（例如 Kubernetes liveness probe）重启崩溃处理函数卡住的节点。 |
 | GET              | `/pprof/heap`                                                     | |
 | GET              | `/pprof/growth`                                                   | |
 | GET              | `/pprof/profile`                                                  | |


### PR DESCRIPTION
## Why I'm doing:

Follow-up to #76491 (discussion_r3641682289), where making `/api/health` state-aware was agreed as a separate PR; the semantics were settled in #77229.

BE `/api/health` answers a hardcoded `200 {"status": "OK", ...}` regardless of process state, while the fatal-signal handler already sets a one-way crashing flag (`set_process_is_crashing()`) that the FE heartbeat consumes as SHUTDOWN. When the crash handler hangs after setting that flag (#76441, earlier #59226), the result on Kubernetes is a permanent zombie: the FE stops scheduling to the node but cannot restart it, while the kubelet can restart it but keeps seeing a healthy 200, so the pod holds its CPU and memory indefinitely. We hit this on a 4.1.1 cluster where a group of CNs got stuck at once and could only be reclaimed by restarting the pods by hand. The watchdog from #76491 bounds this from inside the process but is opt-in; the default-on recovery layer on Kubernetes is the liveness probe, which starrocks-kubernetes-operator wires to `/api/health`, and it can never fire while 200 is hardcoded.

## What I'm doing:

Fixes #77229

When `is_process_crashing()` is set, `/api/health` returns `503 Service Unavailable` with `{"status": "CRASHING","msg": "fatal signal handler is running; process is terminating"}`. Otherwise the reply stays byte-identical to today's `200 {"status": "OK","msg": "To Be Added"}`.

- `be/src/http/action/health_action.{h,cpp}`: factor the response decision into a pure static helper `HealthAction::health_response(bool crashing)` and route `handle()` through it. The helper exists for testability: the crash flag is one-way for the process lifetime, so a handler-level test cannot reach the crashing state without poisoning every later test in the same binary. Also drops a stale `#if 0` block.
- `be/test/http/health_action_test.cpp` (new, registered in `be/test/CMakeLists.txt`): asserts the healthy reply is byte-identical to the previous one, the crashing reply is 503 with the CRASHING body, and that `handle()` routes live process state through the helper.
- `docs/{en,zh,ja}/administration/http_interface/http_interface.md`: fill in the previously empty description cells of the BE and CN `/api/health` rows.

Deliberately out of scope, as settled in #77229:

- Graceful exit (`process_exit_in_progress()`) keeps answering 200. The same endpoint backs the liveness probe, so failing it during a drain would make the kubelet kill the pod mid-drain. FE made the opposite choice for a different consumer (#56823, a load balancer), while the BE endpoint is consumed by a kubelet with restart authority and traffic draining is already handled by the heartbeat answering SHUTDOWN.
- No new BE config. The only affected state is post-fatal-signal, where the process is already condemned and every heartbeat answers SHUTDOWN. Operators who do not want probe-driven restarts can tune or remove the probe (`livenessProbeFailureSeconds=0` in the operator CRD). Precedent: #66212 made the heartbeat report SHUTDOWN in this same state without a config switch.
- FE `/api/health` is untouched.

Consumer audit in #77229: a normal crash finishes well inside the operator's default ~15s liveness threshold, so nothing changes outside the hang window, and `health_check.sh` starts failing only in the crash state, which is the intent.

Backports: 4.1 and 4.0 pair with #76491, which is already on those branches. `is_process_crashing()` also exists on 3.5, so 3.5 is applicable if maintainers want it. I tried the cherry-picks locally: all three conflict on surrounding context only, no missing files, so I will resubmit manual backports if mergify closes them.

Proposed release note bullet: BE `/api/health` now returns HTTP 503 once the fatal-signal handler has marked the process as crashing, so orchestrator health checks such as Kubernetes liveness probes can restart a node whose crash handler hangs; the healthy reply is unchanged.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5