### PR TITLE
[BugFix] Isolate Delta Lake per-table cloud credentials

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeEngine.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeEngine.java
@@ -15,7 +15,7 @@
 package com.starrocks.connector.delta;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.cache.LoadingCache;
+import com.google.common.cache.Cache;
 import com.starrocks.common.Pair;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.defaults.engine.DefaultEngine;
@@ -31,13 +31,13 @@ public class DeltaLakeEngine extends DefaultEngine {
     private final Configuration hadoopConf;
     private final DeltaLakeCatalogProperties properties;
     // Cache for checkpoint metadata, key is file path and read schema, value is list of ColumnarBatch
-    private final LoadingCache<Pair<DeltaLakeFileStatus, StructType>, List<ColumnarBatch>> checkpointCache;
+    private final Cache<Pair<DeltaLakeFileStatus, StructType>, List<ColumnarBatch>> checkpointCache;
     // Cache for json metadata, key is file path, value is list of JsonNode
-    private final LoadingCache<DeltaLakeFileStatus, List<JsonNode>> jsonCache;
+    private final Cache<DeltaLakeFileStatus, List<JsonNode>> jsonCache;
 
     protected DeltaLakeEngine(Configuration hadoopConf, DeltaLakeCatalogProperties properties,
-                              LoadingCache<Pair<DeltaLakeFileStatus, StructType>, List<ColumnarBatch>> checkpointCache,
-                              LoadingCache<DeltaLakeFileStatus, List<JsonNode>> jsonCache) {
+                              Cache<Pair<DeltaLakeFileStatus, StructType>, List<ColumnarBatch>> checkpointCache,
+                              Cache<DeltaLakeFileStatus, List<JsonNode>> jsonCache) {
         super(new HadoopFileIO(hadoopConf));
         this.hadoopConf = hadoopConf;
         this.properties = properties;
@@ -58,8 +58,8 @@ public class DeltaLakeEngine extends DefaultEngine {
     }
 
     public static DeltaLakeEngine create(Configuration hadoopConf, DeltaLakeCatalogProperties properties,
-                                         LoadingCache<Pair<DeltaLakeFileStatus, StructType>, List<ColumnarBatch>> checkpointCache,
-                                         LoadingCache<DeltaLakeFileStatus, List<JsonNode>> jsonCache) {
+                                         Cache<Pair<DeltaLakeFileStatus, StructType>, List<ColumnarBatch>> checkpointCache,
+                                         Cache<DeltaLakeFileStatus, List<JsonNode>> jsonCache) {
         return new DeltaLakeEngine(hadoopConf, properties, checkpointCache, jsonCache);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeJsonHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeJsonHandler.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.cache.LoadingCache;
+import com.google.common.cache.Cache;
 import com.google.common.collect.Lists;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
@@ -61,9 +61,9 @@ public class DeltaLakeJsonHandler extends DefaultJsonHandler {
 
     private final Configuration hadoopConf;
     private final int maxBatchSize;
-    private final LoadingCache<DeltaLakeFileStatus, List<JsonNode>> jsonCache;
+    private final Cache<DeltaLakeFileStatus, List<JsonNode>> jsonCache;
 
-    public DeltaLakeJsonHandler(Configuration hadoopConf, LoadingCache<DeltaLakeFileStatus, List<JsonNode>> jsonCache) {
+    public DeltaLakeJsonHandler(Configuration hadoopConf, Cache<DeltaLakeFileStatus, List<JsonNode>> jsonCache) {
         super(new HadoopFileIO(hadoopConf));
         this.hadoopConf = hadoopConf;
         this.maxBatchSize = hadoopConf.getInt("delta.kernel.default.json.reader.batch-size", 1024);
@@ -169,7 +169,8 @@ public class DeltaLakeJsonHandler extends DefaultJsonHandler {
                         // can not read last_checkpoint file from cache
                         currentReadJsonList = readJsonFile(currentFile, hadoopConf);
                     } else {
-                        currentReadJsonList = jsonCache.get(fileStatus);
+                        currentReadJsonList = jsonCache.get(fileStatus,
+                                () -> readJsonFile(fileStatus.getPath(), hadoopConf));
                     }
                     currentReadLine = 0;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetastore.java
@@ -15,9 +15,8 @@
 package com.starrocks.connector.delta;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DeltaLakeTable;
@@ -43,9 +42,7 @@ import io.delta.kernel.utils.CloseableIterator;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -65,8 +62,8 @@ public abstract class DeltaLakeMetastore implements IDeltaLakeMetastore {
     protected final Configuration hdfsConfiguration;
     protected final DeltaLakeCatalogProperties properties;
 
-    private final LoadingCache<Pair<DeltaLakeFileStatus, StructType>, List<ColumnarBatch>> checkpointCache;
-    private final LoadingCache<DeltaLakeFileStatus, List<JsonNode>> jsonCache;
+    private final Cache<Pair<DeltaLakeFileStatus, StructType>, List<ColumnarBatch>> checkpointCache;
+    private final Cache<DeltaLakeFileStatus, List<JsonNode>> jsonCache;
 
     public DeltaLakeMetastore(String catalogName, IMetastore metastore, Configuration hdfsConfiguration,
                               DeltaLakeCatalogProperties properties) {
@@ -84,26 +81,13 @@ public abstract class DeltaLakeMetastore implements IDeltaLakeMetastore {
                 .weigher((key, value) -> weighCheckpointEntry((Pair<DeltaLakeFileStatus, StructType>) key,
                         (List<ColumnarBatch>) value))
                 .maximumWeight(checkpointCacheSize)
-                .build(new CacheLoader<>() {
-                    @NotNull
-                    @Override
-                    public List<ColumnarBatch> load(@NotNull Pair<DeltaLakeFileStatus, StructType> pair) {
-                        return DeltaLakeParquetHandler.readParquetFile(pair.first.getPath(), pair.first.getSize(),
-                                pair.first.getModificationTime(), pair.second, hdfsConfiguration);
-                    }
-                });
+                .build();
 
         this.jsonCache = CacheBuilder.newBuilder()
                 .expireAfterWrite(properties.getDeltaLakeJsonMetaCacheTtlSec(), TimeUnit.SECONDS)
                 .weigher((key, value) -> weighJsonEntry((DeltaLakeFileStatus) key, (List<JsonNode>) value))
                 .maximumWeight(jsonCacheSize)
-                .build(new CacheLoader<>() {
-                    @NotNull
-                    @Override
-                    public List<JsonNode> load(@NotNull DeltaLakeFileStatus fileStatus) throws IOException {
-                        return DeltaLakeJsonHandler.readJsonFile(fileStatus.getPath(), hdfsConfiguration);
-                    }
-                });
+                .build();
     }
 
     @Override
@@ -135,10 +119,13 @@ public abstract class DeltaLakeMetastore implements IDeltaLakeMetastore {
         }
 
         String path = metastoreTable.getTableLocation();
+        // A vended credential only grants access to its own table, so it must not reach the catalog-wide
+        // Configuration that every cached engine references.
+        Configuration snapshotConf = new Configuration(hdfsConfiguration);
         if (metastoreTable.getCloudConfiguration() != null) {
-            metastoreTable.getCloudConfiguration().applyToConfiguration(hdfsConfiguration);
+            metastoreTable.getCloudConfiguration().applyToConfiguration(snapshotConf);
         }
-        DeltaLakeEngine deltaLakeEngine = DeltaLakeEngine.create(hdfsConfiguration, properties, checkpointCache, jsonCache);
+        DeltaLakeEngine deltaLakeEngine = DeltaLakeEngine.create(snapshotConf, properties, checkpointCache, jsonCache);
         SnapshotImpl snapshot;
 
         try (Timer ignored = Tracers.watchScope(EXTERNAL, "DeltaLake.getSnapshot")) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeParquetHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeParquetHandler.java
@@ -14,7 +14,7 @@
 
 package com.starrocks.connector.delta;
 
-import com.google.common.cache.LoadingCache;
+import com.google.common.cache.Cache;
 import com.google.common.collect.Lists;
 import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Timer;
@@ -41,9 +41,9 @@ import static java.lang.String.format;
 
 public class DeltaLakeParquetHandler extends DefaultParquetHandler {
     private final Configuration hadoopConf;
-    private final LoadingCache<Pair<DeltaLakeFileStatus, StructType>, List<ColumnarBatch>> checkpointCache;
+    private final Cache<Pair<DeltaLakeFileStatus, StructType>, List<ColumnarBatch>> checkpointCache;
 
-    public DeltaLakeParquetHandler(Configuration hadoopConf, LoadingCache<Pair<DeltaLakeFileStatus, StructType>,
+    public DeltaLakeParquetHandler(Configuration hadoopConf, Cache<Pair<DeltaLakeFileStatus, StructType>,
             List<ColumnarBatch>> checkpointCache) {
         super(new HadoopFileIO(hadoopConf));
         this.hadoopConf = hadoopConf;
@@ -129,7 +129,9 @@ public class DeltaLakeParquetHandler extends DefaultParquetHandler {
                     currentFile = deltaLakeFileStatus.getPath();
                     if (LogReplay.containsAddOrRemoveFileActions(physicalSchema)) {
                         Pair<DeltaLakeFileStatus, StructType> key = Pair.create(deltaLakeFileStatus, physicalSchema);
-                        currentColumnarBatchList = checkpointCache.get(key);
+                        currentColumnarBatchList = checkpointCache.get(key,
+                                () -> readParquetFile(deltaLakeFileStatus.getPath(), deltaLakeFileStatus.getSize(),
+                                        deltaLakeFileStatus.getModificationTime(), physicalSchema, hadoopConf));
                     } else {
                         currentColumnarBatchList = readParquetFile(currentFile, deltaLakeFileStatus.getSize(),
                                 deltaLakeFileStatus.getModificationTime(), physicalSchema, hadoopConf);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeCredentialIsolationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeCredentialIsolationTest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.connector.MetastoreType;
+import com.starrocks.connector.hadoop.HadoopExt;
 import com.starrocks.connector.hive.HiveMetaClient;
 import com.starrocks.connector.hive.HiveMetastore;
 import com.starrocks.connector.hive.HiveMetastoreTest;
@@ -111,6 +112,17 @@ public class DeltaLakeCredentialIsolationTest {
         Assertions.assertEquals("ak-nation", observedAccessKey[0]);
     }
 
+    @Test
+    public void testEnginesOfDifferentTablesGetDistinctFileSystemCacheKeys() throws Exception {
+        DeltaLakeSnapshot nation = metastore.getLatestSnapshot("db1", "nation");
+        DeltaLakeSnapshot supplier = metastore.getLatestSnapshot("db1", "supplier");
+
+        // FileSystem instances are cached per credential fingerprint, so two tables sharing a scheme and
+        // authority only get separate clients when their fingerprints differ.
+        Assertions.assertNotEquals(credentialFingerprintOf(nation.getDeltaLakeEngine()),
+                credentialFingerprintOf(supplier.getDeltaLakeEngine()));
+    }
+
     private static CloudConfiguration vendedCredentialFor(String tableName) {
         return CloudConfigurationFactory.buildCloudConfigurationForStorage(ImmutableMap.of(
                 CloudConfigurationConstants.AWS_S3_ACCESS_KEY, "ak-" + tableName,
@@ -120,9 +132,17 @@ public class DeltaLakeCredentialIsolationTest {
     }
 
     private static String accessKeyOf(DeltaLakeEngine engine) throws Exception {
+        return configurationOf(engine).get(Constants.ACCESS_KEY);
+    }
+
+    private static String credentialFingerprintOf(DeltaLakeEngine engine) throws Exception {
+        return configurationOf(engine).get(HadoopExt.HADOOP_CLOUD_CONFIGURATION_STRING);
+    }
+
+    private static Configuration configurationOf(DeltaLakeEngine engine) throws Exception {
         Field field = DeltaLakeEngine.class.getDeclaredField("hadoopConf");
         field.setAccessible(true);
-        return ((Configuration) field.get(engine)).get(Constants.ACCESS_KEY);
+        return (Configuration) field.get(engine);
     }
 
     private static void readCheckpointThrough(DeltaLakeEngine engine) throws IOException {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeCredentialIsolationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeCredentialIsolationTest.java
@@ -1,0 +1,170 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.delta;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.connector.MetastoreType;
+import com.starrocks.connector.hive.HiveMetaClient;
+import com.starrocks.connector.hive.HiveMetastore;
+import com.starrocks.connector.hive.HiveMetastoreTest;
+import com.starrocks.connector.hive.IHiveMetastore;
+import com.starrocks.connector.metastore.MetastoreTable;
+import com.starrocks.connector.share.credential.CloudConfigurationConstants;
+import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.credential.CloudConfigurationFactory;
+import io.delta.kernel.Operation;
+import io.delta.kernel.Snapshot;
+import io.delta.kernel.TransactionBuilder;
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.exceptions.CheckpointAlreadyExistsException;
+import io.delta.kernel.exceptions.TableNotFoundException;
+import io.delta.kernel.internal.SnapshotImpl;
+import io.delta.kernel.internal.TableImpl;
+import io.delta.kernel.internal.replay.LogReplay;
+import io.delta.kernel.internal.util.Utils;
+import io.delta.kernel.types.StructType;
+import io.delta.kernel.utils.FileStatus;
+import mockit.Mock;
+import mockit.MockUp;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.s3a.Constants;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Unity vends a credential scoped to one table's storage path, so a credential loaded for one table
+ * must never end up being used to read another table's delta log.
+ */
+public class DeltaLakeCredentialIsolationTest {
+    private static final String CHECKPOINT =
+            "s3://bucket/nation/_delta_log/00000000000000000000.checkpoint.parquet";
+
+    private DeltaLakeMetastore metastore;
+
+    @BeforeEach
+    public void setUp() {
+        HiveMetaClient client = new HiveMetastoreTest.MockedHiveMetaClient();
+        IHiveMetastore hiveMetastore = new HiveMetastore(client, "delta0", MetastoreType.HMS);
+        DeltaLakeCatalogProperties properties = new DeltaLakeCatalogProperties(Maps.newHashMap());
+        metastore = new HMSBackedDeltaMetastore("delta0", hiveMetastore, new Configuration(), properties);
+
+        new MockUp<HMSBackedDeltaMetastore>() {
+            @Mock
+            public MetastoreTable getMetastoreTable(String dbName, String tableName) {
+                return new MetastoreTable(dbName, tableName, "s3://bucket/" + tableName, 123,
+                        vendedCredentialFor(tableName));
+            }
+        };
+        new MockUp<TableImpl>() {
+            @Mock
+            public io.delta.kernel.Table forPath(Engine engine, String path) {
+                return new StubDeltaTable();
+            }
+        };
+    }
+
+    @Test
+    public void testLoadingAnotherTableDoesNotOverwriteAnEarlierEngineCredential() throws Exception {
+        DeltaLakeSnapshot nation = metastore.getLatestSnapshot("db1", "nation");
+        metastore.getLatestSnapshot("db1", "supplier");
+
+        Assertions.assertEquals("ak-nation", accessKeyOf(nation.getDeltaLakeEngine()));
+    }
+
+    @Test
+    public void testCheckpointCacheLoaderUsesTheRequestingTableCredential() throws Exception {
+        String[] observedAccessKey = new String[1];
+        new MockUp<DeltaLakeParquetHandler>() {
+            @Mock
+            public List<ColumnarBatch> readParquetFile(String filePath, long fileSize, long modificationTime,
+                                                       StructType physicalSchema, Configuration hadoopConf) {
+                observedAccessKey[0] = hadoopConf.get(Constants.ACCESS_KEY);
+                return Lists.newArrayList();
+            }
+        };
+
+        DeltaLakeSnapshot nation = metastore.getLatestSnapshot("db1", "nation");
+        metastore.getLatestSnapshot("db1", "supplier");
+        readCheckpointThrough(nation.getDeltaLakeEngine());
+
+        Assertions.assertEquals("ak-nation", observedAccessKey[0]);
+    }
+
+    private static CloudConfiguration vendedCredentialFor(String tableName) {
+        return CloudConfigurationFactory.buildCloudConfigurationForStorage(ImmutableMap.of(
+                CloudConfigurationConstants.AWS_S3_ACCESS_KEY, "ak-" + tableName,
+                CloudConfigurationConstants.AWS_S3_SECRET_KEY, "sk-" + tableName,
+                CloudConfigurationConstants.AWS_S3_SESSION_TOKEN, "token-" + tableName,
+                CloudConfigurationConstants.AWS_S3_REGION, "us-west-2"));
+    }
+
+    private static String accessKeyOf(DeltaLakeEngine engine) throws Exception {
+        Field field = DeltaLakeEngine.class.getDeclaredField("hadoopConf");
+        field.setAccessible(true);
+        return ((Configuration) field.get(engine)).get(Constants.ACCESS_KEY);
+    }
+
+    private static void readCheckpointThrough(DeltaLakeEngine engine) throws IOException {
+        engine.getParquetHandler()
+                .readParquetFiles(Utils.singletonCloseableIterator(FileStatus.of(CHECKPOINT, 100, 123)),
+                        LogReplay.getAddRemoveReadSchema(true), Optional.empty())
+                .forEachRemaining(batch -> { });
+    }
+
+    private static class StubDeltaTable implements io.delta.kernel.Table {
+        @Override
+        public String getPath(Engine engine) {
+            return null;
+        }
+
+        @Override
+        public SnapshotImpl getLatestSnapshot(Engine engine) {
+            return null;
+        }
+
+        @Override
+        public Snapshot getSnapshotAsOfVersion(Engine engine, long versionId) throws TableNotFoundException {
+            return null;
+        }
+
+        @Override
+        public Snapshot getSnapshotAsOfTimestamp(Engine engine, long millisSinceEpochUTC) throws TableNotFoundException {
+            return null;
+        }
+
+        @Override
+        public TransactionBuilder createTransactionBuilder(Engine engine, String engineInfo, Operation operation) {
+            return null;
+        }
+
+        @Override
+        public void checkpoint(Engine engine, long version)
+                throws TableNotFoundException, CheckpointAlreadyExistsException, IOException {
+        }
+
+        @Override
+        public void checksum(Engine engine, long version) throws TableNotFoundException, IOException {
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetastoreTest.java
@@ -15,7 +15,7 @@
 package com.starrocks.connector.delta;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.cache.LoadingCache;
+import com.google.common.cache.Cache;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.common.Pair;
@@ -72,7 +72,7 @@ public class DeltaLakeMetastoreTest {
             }
         };
 
-        LoadingCache<Pair<DeltaLakeFileStatus, StructType>, List<ColumnarBatch>> checkpointCache =
+        Cache<Pair<DeltaLakeFileStatus, StructType>, List<ColumnarBatch>> checkpointCache =
                 getCheckpointCache(createMetastoreForTest());
         checkpointCache.put(createCheckpointCacheKey(), Lists.newArrayList());
 
@@ -105,7 +105,7 @@ public class DeltaLakeMetastoreTest {
             }
         };
 
-        LoadingCache<DeltaLakeFileStatus, List<JsonNode>> jsonCache = getJsonCache(createMetastoreForTest());
+        Cache<DeltaLakeFileStatus, List<JsonNode>> jsonCache = getJsonCache(createMetastoreForTest());
         jsonCache.put(createJsonCacheKey(), Lists.newArrayList());
 
         Assertions.assertTrue(keyEstimateCalls.get() > 0);
@@ -133,7 +133,7 @@ public class DeltaLakeMetastoreTest {
             }
         };
 
-        LoadingCache<Pair<DeltaLakeFileStatus, StructType>, List<ColumnarBatch>> checkpointCache =
+        Cache<Pair<DeltaLakeFileStatus, StructType>, List<ColumnarBatch>> checkpointCache =
                 getCheckpointCache(createMetastoreForTest());
         checkpointCache.put(createCheckpointCacheKey(), Lists.newArrayList());
 
@@ -159,7 +159,7 @@ public class DeltaLakeMetastoreTest {
             }
         };
 
-        LoadingCache<DeltaLakeFileStatus, List<JsonNode>> jsonCache = getJsonCache(createMetastoreForTest());
+        Cache<DeltaLakeFileStatus, List<JsonNode>> jsonCache = getJsonCache(createMetastoreForTest());
         jsonCache.put(createJsonCacheKey(), Lists.newArrayList());
 
         Assertions.assertTrue(fallbackCalls.get() > 0);
@@ -173,18 +173,18 @@ public class DeltaLakeMetastoreTest {
     }
 
     @SuppressWarnings("unchecked")
-    private LoadingCache<Pair<DeltaLakeFileStatus, StructType>, List<ColumnarBatch>> getCheckpointCache(
+    private Cache<Pair<DeltaLakeFileStatus, StructType>, List<ColumnarBatch>> getCheckpointCache(
             DeltaLakeMetastore testMetastore) throws Exception {
         Field checkpointCacheField = DeltaLakeMetastore.class.getDeclaredField("checkpointCache");
         checkpointCacheField.setAccessible(true);
-        return (LoadingCache<Pair<DeltaLakeFileStatus, StructType>, List<ColumnarBatch>>) checkpointCacheField.get(testMetastore);
+        return (Cache<Pair<DeltaLakeFileStatus, StructType>, List<ColumnarBatch>>) checkpointCacheField.get(testMetastore);
     }
 
     @SuppressWarnings("unchecked")
-    private LoadingCache<DeltaLakeFileStatus, List<JsonNode>> getJsonCache(DeltaLakeMetastore testMetastore) throws Exception {
+    private Cache<DeltaLakeFileStatus, List<JsonNode>> getJsonCache(DeltaLakeMetastore testMetastore) throws Exception {
         Field jsonCacheField = DeltaLakeMetastore.class.getDeclaredField("jsonCache");
         jsonCacheField.setAccessible(true);
-        return (LoadingCache<DeltaLakeFileStatus, List<JsonNode>>) jsonCacheField.get(testMetastore);
+        return (Cache<DeltaLakeFileStatus, List<JsonNode>>) jsonCacheField.get(testMetastore);
     }
 
     private Pair<DeltaLakeFileStatus, StructType> createCheckpointCacheKey() {


### PR DESCRIPTION
## Why I'm doing:

`DeltaLakeMetastore.getLatestSnapshot` applies `MetastoreTable.getCloudConfiguration()` to `hdfsConfiguration`, the single `Configuration` instance owned by the catalog's `HdfsEnvironment`, and then hands that same object **by reference** to the `DeltaLakeEngine` that is stored in the `DeltaLakeSnapshot` and cached in `CachingDeltaLakeMetastore.tableSnapshotCache`:

```java
if (metastoreTable.getCloudConfiguration() != null) {
    metastoreTable.getCloudConfiguration().applyToConfiguration(hdfsConfiguration);   // in place
}
DeltaLakeEngine deltaLakeEngine = DeltaLakeEngine.create(hdfsConfiguration, ...);     // by reference
```

`DeltaLakeEngine` keeps the reference (`this.hadoopConf = hadoopConf` and `new HadoopFileIO(hadoopConf)`), so every cached engine in a catalog observes the credential written by whichever table was loaded last. When a metastore returns credentials that are scoped to a single table's storage path, a later plan-time read of an already-cached table signs its request with another table's credential and the object store rejects it.

This needs no concurrency. With the metadata caches turned off so that every read reaches storage:

```sql
SELECT count(*) FROM c.db.table_a;  -- OK,  Configuration <- table_a credential
SELECT count(*) FROM c.db.table_b;  -- OK,  Configuration <- table_b credential (overwrites)
SELECT count(*) FROM c.db.table_a;  -- fails, cached snapshot + table_b credential
```

The read that fails comes from the statistics path, and there is no `getLatestSnapshot` frame in the stack, i.e. the credential is never re-applied for it:

```
StatisticsCalculator.computeDeltaLakeScanNode
 -> MetadataMgr.getTableStatistics
 -> DeltaLakeMetadata.getTableStatistics
 -> DeltaLakeMetadata.triggerDeltaLakePlanFilesIfNeeded
 -> DeltaLakeMetadata.collectDeltaLakePlanFiles
 -> TraceDefaultParquetHandler
 -> java.nio.file.AccessDeniedException: .../_delta_log/00000000000000000000.checkpoint.parquet
    S3Exception: Forbidden (Status Code: 403)
```

That also accounts for how the symptom presents: only analytical queries fail because only they enter `StatisticsCalculator`; `ANALYZE` or `REFRESH EXTERNAL TABLE` appear to repair it because they re-run `getLatestSnapshot` and write that table's own credential back; and the failure can take up to a day to appear because `deltalake_checkpoint_meta_cache_ttl_sec` and `deltalake_json_meta_cache_ttl_sec` default to 24h, so no read reaches storage until the entry expires.

Scope note for reviewers: this was reproduced against a metastore that vends per-table scoped credentials (Databricks Unity Catalog). `HMSBackedDeltaMetastore` returns a `MetastoreTable` with a null `CloudConfiguration`, so the HMS-backed path in this repository is not affected today; the defect is in the shared code path and applies to any `IMetastore` implementation that supplies per-table credentials.

## What I'm doing:

- `getLatestSnapshot` clones the catalog `Configuration` per snapshot load and applies the cloud configuration to the clone, so each engine keeps its own credential and nothing writes into the shared instance.
- The checkpoint and json metadata caches were `LoadingCache`s whose `CacheLoader`s closed over the same shared field, which would have preserved the bug on the default path where both caches are enabled. They are now plain `Cache`s, and the loader is supplied at the call site by the handler that already holds the engine's `Configuration`. Cached content is still shared per file path; only the credential used to fetch it follows the caller.
- Adds `DeltaLakeCredentialIsolationTest` covering both halves: the engine's `Configuration` after a second table is loaded, and the credential the checkpoint cache loader actually reads with.

Fixes #issue: N/A

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
