### PR TITLE
[BugFix] Fix array_map DCHECK failure when one array column is passed as several lambda arguments

### DIFF
--- a/be/src/exprs/array_map_expr.cpp
+++ b/be/src/exprs/array_map_expr.cpp
@@ -170,7 +170,11 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_lambda_expr(ExprContext* context, Chu
 
         // if lambda expr doesn't rely on argument, we don't need to put it into cur_chunk
         if constexpr (!independent_lambda_expr) {
-            cur_chunk->append_column(elements_column, arguments_ids[i]);
+            // Move it in: when the same array column is passed as two lambda arguments
+            // (e.g. array_map((x, y) -> ..., a, a)), both iterations yield the same elements
+            // column, and Chunk requires its columns to be unique. The rvalue overload
+            // copy-on-writes the duplicate instead of aliasing one column to two slots.
+            cur_chunk->append_column(std::move(elements_column), arguments_ids[i]);
         }
     }
     DCHECK(aligned_offsets != nullptr);

--- a/test/sql/test_array_fn/R/test_array_map_duplicate_args
+++ b/test/sql/test_array_fn/R/test_array_map_duplicate_args
@@ -1,0 +1,44 @@
+-- name: test_array_map_duplicate_args
+CREATE TABLE `array_map_dup` (
+  `id` tinyint(4) NOT NULL COMMENT "",
+  `arr_str` array<string> NULL COMMENT "",
+  `arr_int` array<int> NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY RANDOM
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into array_map_dup values (1, ["aa","bbb"], [1,2]), (2, null, null), (3, [], []);
+-- result:
+-- !result
+select id, array_map((x, y) -> x + y, arr_int, arr_int) from array_map_dup order by id;
+-- result:
+1	[2,4]
+2	None
+3	[]
+-- !result
+select id, array_map((x, y) -> length(x) + length(y), arr_str, arr_str) from array_map_dup order by id;
+-- result:
+1	[4,6]
+2	None
+3	[]
+-- !result
+select id, array_map((x, y, z) -> (x + y) + z, arr_int, arr_int, arr_int) from array_map_dup order by id;
+-- result:
+1	[3,6]
+2	None
+3	[]
+-- !result
+select count() from array_map_dup where array_length(array_map((x, y) -> (id + length(x)) + y, arr_str, arr_str)) > 10;
+-- result:
+0
+-- !result
+select id, array_map((x, y) -> x + length(y), arr_int, arr_str) from array_map_dup order by id;
+-- result:
+1	[3,5]
+2	None
+3	[]
+-- !result

--- a/test/sql/test_array_fn/T/test_array_map_duplicate_args
+++ b/test/sql/test_array_fn/T/test_array_map_duplicate_args
@@ -1,0 +1,23 @@
+-- name: test_array_map_duplicate_args
+-- description: passing the same array column as two (or more) lambda arguments makes every
+-- argument resolve to the very same elements column. Appending it once per argument into the
+-- lambda evaluation chunk violates Chunk's "columns must be unique" invariant and aborted the BE.
+CREATE TABLE `array_map_dup` (
+  `id` tinyint(4) NOT NULL COMMENT "",
+  `arr_str` array<string> NULL COMMENT "",
+  `arr_int` array<int> NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY RANDOM
+PROPERTIES (
+"replication_num" = "1"
+);
+insert into array_map_dup values (1, ["aa","bbb"], [1,2]), (2, null, null), (3, [], []);
+
+select id, array_map((x, y) -> x + y, arr_int, arr_int) from array_map_dup order by id;
+select id, array_map((x, y) -> length(x) + length(y), arr_str, arr_str) from array_map_dup order by id;
+select id, array_map((x, y, z) -> (x + y) + z, arr_int, arr_int, arr_int) from array_map_dup order by id;
+-- same column twice plus a captured column
+select count() from array_map_dup where array_length(array_map((x, y) -> (id + length(x)) + y, arr_str, arr_str)) > 10;
+-- control: distinct columns take the same code path and were already correct
+select id, array_map((x, y) -> x + length(y), arr_int, arr_str) from array_map_dup order by id;


### PR DESCRIPTION
## Why I'm doing:

When the same array column is passed as more than one argument of a multi-argument lambda, for example

  select array_map((x, y) -> length(x) + length(y), arr, arr) from t;

every argument resolves to the very same ColumnPtr: the arguments are identical slot references, so evaluating them yields one column, and elements_column() then hands out the same ArrayColumn member for each of them. ArrayMapExpr::evaluate_lambda_expr() appended that column into the lambda evaluation chunk once per argument, which leaves a single Column reachable through two slot ids:

```
*** Aborted at 1786032203 (unix time) try "date -d @1786032203" if you are using GNU date ***
PC: @     0x7d14b4e8fb2c pthread_kill
*** SIGABRT (@0x1d9c14) received by PID 1940500 (TID 0x7d11ae9316c0) LWP(1941690) from PID 1940500; stack trace: ***
    @         0x32de73c7 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7d14b4e92ed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)
    @         0x32de6bc6 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7d14b4e36330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @     0x7d14b4e8fb2c pthread_kill
    @     0x7d14b4e3627e gsignal
    @     0x7d14b4e198ff abort
    @         0x1cc08548 starrocks::failure_function()
    @         0x32ddacdd google::LogMessage::Fail()
    @         0x32ddbdc4 google::LogMessageFatal::~LogMessageFatal()
    @         0x2d7e9d5f starrocks::Chunk::_append_column_checked(unsigned long, starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> const&)
    @         0x2d7df755 starrocks::Chunk::append_column(starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> const&, int)
    @         0x2ace6e35 starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > starrocks::ArrayMapExpr::evaluate_lambda_expr<false, false>(starrocks::ExprContext*, starrocks::Chunk*, std::vector<star
rocks::Cow<starrocks::Column>::ImmutPtr<starrocks::@
    @         0x2acd46aa starrocks::ArrayMapExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
    @         0x2a5d57c0 starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*)
    @         0x2a5d4fb4 starrocks::ExprContext::evaluate(starrocks::Chunk*, unsigned char*)
    @         0x1e72daba starrocks::pipeline::ProjectOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @         0x2360aef0 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)

```

A chunk is required to own its columns uniquely (Chunk::_column_ptr_set), because the escape hatches that mutate a column in place bypass the copy-on-write reference count and would silently write through both slots. The abort only fires on a debug or ASAN backend; a release one keeps running with the aliased chunk.

Append by rvalue instead, the way the neighbouring call sites in this function and in LambdaFunction already do: the rvalue overload copy-on-writes a duplicate rather than sharing it. elements_column is not read again after the append.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
