### PR TITLE
[Enhancement] Export worker-thread metrics for the scan executors

### DIFF
--- a/be/src/base/concurrency/limit_setter.h
+++ b/be/src/base/concurrency/limit_setter.h
@@ -62,6 +62,10 @@ public:
         return _value.compare_exchange_strong(old_value, new_value);
     }
 
+    // The number of threads the pool is currently supposed to run, which follows configuration
+    // changes immediately, unlike the actual number that only converges as threads come and go.
+    int32_t expect_num() const { return LIMIT_SETTER_EXPECT_NUM(_value.load(std::memory_order_relaxed)); }
+
 private:
     std::atomic<int64_t> _value{0};
 };

--- a/be/src/compute_env/workgroup/scan_executor.cpp
+++ b/be/src/compute_env/workgroup/scan_executor.cpp
@@ -14,6 +14,8 @@
 
 #include "compute_env/workgroup/scan_executor.h"
 
+#include <algorithm>
+
 #include "common/thread/thread.h"
 #include "compute_env/workgroup/scan_task_queue.h"
 #include "exec_primitive/pipeline/primitives/pipeline_metrics.h"
@@ -23,12 +25,34 @@ namespace starrocks::workgroup {
 
 ScanExecutor::ScanExecutor(std::unique_ptr<ThreadPool> thread_pool, std::unique_ptr<ScanTaskQueue> task_queue,
                            pipeline::ScanExecutorMetrics* metrics)
-        : _task_queue(std::move(task_queue)), _thread_pool(std::move(thread_pool)), _metrics(metrics) {}
+        : _task_queue(std::move(task_queue)), _thread_pool(std::move(thread_pool)), _metrics(metrics) {
+    _metrics->thread_pool.monitor(this, [this] {
+        // The target follows configuration changes right away, whereas the pool was sized once at
+        // startup; workers submitted beyond that size only queue up and never become live threads,
+        // so the target is capped by it.
+        const int32_t expected = std::min(_num_threads_setter.expect_num(), _thread_pool->max_threads());
+        return pipeline::ScanThreadPoolMetrics::Sample{static_cast<uint64_t>(std::max(0, expected)),
+                                                      static_cast<uint64_t>(std::max(0, _thread_pool->num_threads()))};
+    });
+}
+
+ScanExecutor::~ScanExecutor() {
+    // The executors of a resource group with exclusive ones are destroyed when the group goes
+    // away, while the metrics instance is process-wide, so the pool must not be left behind in it.
+    _stop_monitoring();
+}
 
 void ScanExecutor::close() {
     _task_queue->close();
     _thread_pool->shutdown();
-    _metrics = nullptr;
+    _stop_monitoring();
+}
+
+void ScanExecutor::_stop_monitoring() {
+    if (_metrics != nullptr) {
+        _metrics->thread_pool.unmonitor(this);
+        _metrics = nullptr;
+    }
 }
 
 void ScanExecutor::initialize(int num_threads) {

--- a/be/src/compute_env/workgroup/scan_executor.cpp
+++ b/be/src/compute_env/workgroup/scan_executor.cpp
@@ -32,7 +32,7 @@ ScanExecutor::ScanExecutor(std::unique_ptr<ThreadPool> thread_pool, std::unique_
         // so the target is capped by it.
         const int32_t expected = std::min(_num_threads_setter.expect_num(), _thread_pool->max_threads());
         return pipeline::ScanThreadPoolMetrics::Sample{static_cast<uint64_t>(std::max(0, expected)),
-                                                      static_cast<uint64_t>(std::max(0, _thread_pool->num_threads()))};
+                                                       static_cast<uint64_t>(std::max(0, _thread_pool->num_threads()))};
     });
 }
 

--- a/be/src/compute_env/workgroup/scan_executor.h
+++ b/be/src/compute_env/workgroup/scan_executor.h
@@ -37,7 +37,7 @@ class ScanExecutor {
 public:
     explicit ScanExecutor(std::unique_ptr<ThreadPool> thread_pool, std::unique_ptr<ScanTaskQueue> task_queue,
                           pipeline::ScanExecutorMetrics* metrics);
-    virtual ~ScanExecutor() = default;
+    virtual ~ScanExecutor();
 
     void initialize(int32_t num_threads);
     void close();
@@ -53,6 +53,8 @@ public:
 
 private:
     void worker_thread();
+    // Detaches the thread pool from the process-wide metrics. Idempotent.
+    void _stop_monitoring();
 
     LimitSetter _num_threads_setter;
     std::atomic<int> _next_worker_id{0};

--- a/be/src/exec_primitive/pipeline/primitives/pipeline_metrics.cpp
+++ b/be/src/exec_primitive/pipeline/primitives/pipeline_metrics.cpp
@@ -14,6 +14,7 @@
 
 #include "exec_primitive/pipeline/primitives/pipeline_metrics.h"
 
+#include <algorithm>
 #include <numeric>
 #include <utility>
 
@@ -76,12 +77,45 @@ IntCounter* QueryTypeTimeMetric::counter(TQueryType::type query_type) {
 // Metrics.
 // ------------------------------------------------------------------------------------
 
+void ScanThreadPoolMetrics::register_all_metrics(MetricRegistry* registry, const std::string& prefix) {
+    registry->register_metric(prefix + "expected_worker_threads", &expected_worker_threads);
+    registry->register_metric(prefix + "worker_threads", &worker_threads);
+    registry->register_hook(prefix + "threadpool_metrics", [this] { _update(); });
+}
+
+void ScanThreadPoolMetrics::monitor(const void* key, Sampler sampler) {
+    std::lock_guard guard(_mutex);
+    _samplers.emplace_back(key, std::move(sampler));
+}
+
+void ScanThreadPoolMetrics::unmonitor(const void* key) {
+    std::lock_guard guard(_mutex);
+    auto it = std::find_if(_samplers.begin(), _samplers.end(), [key](const auto& e) { return e.first == key; });
+    if (it != _samplers.end()) {
+        _samplers.erase(it);
+    }
+}
+
+void ScanThreadPoolMetrics::_update() {
+    std::lock_guard guard(_mutex);
+    uint64_t total_expected = 0;
+    uint64_t total_alive = 0;
+    for (const auto& [_, sampler] : _samplers) {
+        const Sample sample = sampler();
+        total_expected += sample.expected_threads;
+        total_alive += sample.alive_threads;
+    }
+    expected_worker_threads.set_value(total_expected);
+    worker_threads.set_value(total_alive);
+}
+
 void ScanExecutorMetrics::register_all_metrics(MetricRegistry* registry, const std::string& prefix) {
     const std::string base_name = "pipe_" + prefix + "_";
     execution_time.register_metrics(registry, base_name + "execution_time");
     registry->register_metric(base_name + "finished_tasks", &finished_tasks);
     registry->register_metric(base_name + "running_tasks", &running_tasks);
     registry->register_metric(base_name + "pending_tasks", &pending_tasks);
+    thread_pool.register_all_metrics(registry, base_name);
 }
 
 void ThreadPoolMetrics::register_all_metrics(MetricRegistry* registry, const std::string& prefix) {

--- a/be/src/exec_primitive/pipeline/primitives/pipeline_metrics.h
+++ b/be/src/exec_primitive/pipeline/primitives/pipeline_metrics.h
@@ -19,6 +19,7 @@
 #include <functional>
 #include <mutex>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "base/metrics.h"
@@ -42,11 +43,59 @@ private:
     METRIC_DEFINE_INT_COUNTER(_unknown_counter, MetricUnit::NANOSECONDS);
 };
 
+// Metrics about the worker threads of the thread pools backing a scan executor.
+//
+// These count threads, whereas the counters in ScanExecutorMetrics count tasks. They are worth
+// exporting separately because a ScanExecutor worker occupies its pool thread for the whole
+// lifetime of the executor -- worker_thread() only returns when the pool is asked to shrink -- so
+// losing a worker is invisible in the task counters: the executor simply consumes less. Exporting
+// how many workers are expected next to how many are alive makes the loss directly observable:
+//
+//     worker_threads < expected_worker_threads  =>  workers are gone and were not replaced.
+//
+// The reverse gap is normal and transient: workers notice that the executor shrank only once they
+// wake up for a task, so they linger while the expectation has already dropped.
+//
+// One executor set is created per resource group that has exclusive executors, and all of them
+// share a single metrics instance, so the values are summed over every monitored executor, in the
+// same way as the task counters.
+//
+// The expected count has to follow the executor's own target rather than the capacity its thread
+// pool was built with: the number of workers is derived from the share of the CPUs the executor
+// set owns, so it legitimately drops whenever resource groups are reconfigured, and reporting a
+// stale capacity would make every such change look like workers had been lost.
+struct ScanThreadPoolMetrics {
+    struct Sample {
+        // Workers the executor is currently supposed to run.
+        uint64_t expected_threads = 0;
+        // Workers that are actually alive, including the ones about to start.
+        uint64_t alive_threads = 0;
+    };
+    using Sampler = std::function<Sample()>;
+
+    METRIC_DEFINE_UINT_GAUGE(expected_worker_threads, MetricUnit::NOUNIT);
+    METRIC_DEFINE_UINT_GAUGE(worker_threads, MetricUnit::NOUNIT);
+
+    void register_all_metrics(MetricRegistry* registry, const std::string& prefix);
+
+    // `key` identifies the sampler so that it can be removed again; the caller must unmonitor it
+    // before anything the sampler touches goes away.
+    void monitor(const void* key, Sampler sampler);
+    void unmonitor(const void* key);
+
+private:
+    void _update();
+
+    std::mutex _mutex;
+    std::vector<std::pair<const void*, Sampler>> _samplers;
+};
+
 struct ScanExecutorMetrics {
     QueryTypeTimeMetric execution_time;
     METRIC_DEFINE_INT_COUNTER(finished_tasks, MetricUnit::NOUNIT);
     METRIC_DEFINE_INT_CORE_LOCAL_GAUGE(running_tasks, MetricUnit::NOUNIT);
     METRIC_DEFINE_INT_CORE_LOCAL_GAUGE(pending_tasks, MetricUnit::NOUNIT);
+    ScanThreadPoolMetrics thread_pool;
 
     void register_all_metrics(MetricRegistry* registry, const std::string& prefix);
 };

--- a/be/test/compute_env/workgroup/scan_task_queue_test.cpp
+++ b/be/test/compute_env/workgroup/scan_task_queue_test.cpp
@@ -15,6 +15,7 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <functional>
 #include <future>
@@ -22,6 +23,7 @@
 #include <mutex>
 #include <thread>
 
+#include "base/metrics.h"
 #include "base/testutil/assert.h"
 #include "base/testutil/parallel_test.h"
 #include "compute_env/workgroup/priority_scan_task_queue.h"
@@ -111,6 +113,93 @@ PARALLEL_TEST(ScanExecutorTest, test_yield) {
     std::unique_lock lock(mutex);
     cv.wait(lock, [&]() { return submit_tasks == finished_tasks.load(); });
     ASSERT_EQ(submit_tasks, finished_tasks.load());
+}
+
+PARALLEL_TEST(ScanExecutorTest, test_thread_pool_metrics) {
+    constexpr int kNumThreads = 4;
+    // Declared before the registry so that the registry is destroyed first.
+    pipeline::ScanExecutorMetrics metrics;
+    MetricRegistry registry("test");
+    metrics.thread_pool.register_all_metrics(&registry, "pipe_scan_");
+
+    auto& expected_threads = metrics.thread_pool.expected_worker_threads;
+    auto& alive_threads = metrics.thread_pool.worker_threads;
+    ASSERT_TRUE(registry.get_metric("pipe_scan_expected_worker_threads") != nullptr);
+    ASSERT_TRUE(registry.get_metric("pipe_scan_worker_threads") != nullptr);
+
+    auto make_executor = [&]() {
+        std::unique_ptr<ThreadPool> thread_pool;
+        CHECK(ThreadPoolBuilder("scan_metrics")
+                      .set_min_threads(0)
+                      .set_max_threads(kNumThreads)
+                      .set_max_queue_size(100)
+                      .build(&thread_pool)
+                      .ok());
+        return std::make_unique<ScanExecutor>(std::move(thread_pool), std::make_unique<PriorityScanTaskQueue>(100),
+                                              &metrics);
+    };
+    // Workers are started asynchronously.
+    auto collect_until_alive = [&](uint64_t target) {
+        for (int i = 0; i < 500 && alive_threads.value() != target; ++i) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            registry.trigger_hook();
+        }
+    };
+
+    registry.trigger_hook();
+    ASSERT_EQ(0, expected_threads.value());
+    ASSERT_EQ(0, alive_threads.value());
+
+    {
+        auto executor = make_executor();
+
+        // No worker is expected before initialize(), even though the pool can already hold them.
+        registry.trigger_hook();
+        ASSERT_EQ(0, expected_threads.value());
+        ASSERT_EQ(0, alive_threads.value());
+
+        executor->initialize(kNumThreads);
+        collect_until_alive(kNumThreads);
+        ASSERT_EQ(kNumThreads, expected_threads.value());
+        ASSERT_EQ(kNumThreads, alive_threads.value());
+
+        // Shrinking the executor lowers the expectation immediately, so a resource group being
+        // resized cannot be mistaken for workers that went missing. The workers themselves only
+        // leave once they wake up for a task, so the count of alive ones may lag behind.
+        executor->change_num_threads(kNumThreads / 2);
+        registry.trigger_hook();
+        ASSERT_EQ(kNumThreads / 2, expected_threads.value());
+        ASSERT_GE(alive_threads.value(), expected_threads.value());
+
+        executor->close();
+        registry.trigger_hook();
+        ASSERT_EQ(0, expected_threads.value());
+        ASSERT_EQ(0, alive_threads.value());
+    }
+
+    // An executor destroyed without close() must stop being sampled as well: a sampler left behind
+    // would reach into freed memory on the next collection.
+    {
+        auto executor = make_executor();
+        registry.trigger_hook();
+    }
+    registry.trigger_hook();
+    ASSERT_EQ(0, expected_threads.value());
+    ASSERT_EQ(0, alive_threads.value());
+
+    // Every executor contributes, as a resource group with exclusive executors has its own.
+    auto first = make_executor();
+    auto second = make_executor();
+    first->initialize(kNumThreads);
+    second->initialize(kNumThreads);
+    collect_until_alive(2 * kNumThreads);
+    ASSERT_EQ(2 * kNumThreads, expected_threads.value());
+    ASSERT_EQ(2 * kNumThreads, alive_threads.value());
+    first->close();
+    second->close();
+    registry.trigger_hook();
+    ASSERT_EQ(0, expected_threads.value());
+    ASSERT_EQ(0, alive_threads.value());
 }
 
 PARALLEL_TEST(WorkGroupScanTaskQueueTest, test_should_yield_uses_injected_policy) {

--- a/docs/en/administration/management/monitoring/metric_details/s.md
+++ b/docs/en/administration/management/monitoring/metric_details/s.md
@@ -213,11 +213,35 @@ description: "Alphabetical s"
 - Type: Instantaneous
 - Description: Number of resource groups assigned to each memory pool.
 
+## `starrocks_be_pipe_connector_scan_expected_worker_threads`
+
+- Unit: Count
+- Type: Instantaneous
+- Description: Number of worker threads the scan executors for external tables are currently supposed to run, summed over all resource groups. It follows configuration and resource group changes right away, so comparing it with `starrocks_be_pipe_connector_scan_worker_threads` tells whether the executors are fully staffed.
+
+## `starrocks_be_pipe_connector_scan_worker_threads`
+
+- Unit: Count
+- Type: Instantaneous
+- Description: Number of worker threads that are actually alive in the scan executors for external tables, summed over all resource groups. A value below `starrocks_be_pipe_connector_scan_expected_worker_threads` means workers were lost and not replaced, so fewer scan tasks are consumed than configured. Exceeding it is normal and transient, as workers leave a shrunken executor only once they wake up.
+
 ## `starrocks_be_pipe_prepare_pool_queue_len`
 
 - Unit: Count
 - Type: Instantaneous
 - Description: Instantaneous value of pipeline prepare thread pool task queue length.
+
+## `starrocks_be_pipe_scan_expected_worker_threads`
+
+- Unit: Count
+- Type: Instantaneous
+- Description: Number of worker threads the scan executors for internal tables are currently supposed to run, summed over all resource groups. It follows configuration and resource group changes right away, so comparing it with `starrocks_be_pipe_scan_worker_threads` tells whether the executors are fully staffed.
+
+## `starrocks_be_pipe_scan_worker_threads`
+
+- Unit: Count
+- Type: Instantaneous
+- Description: Number of worker threads that are actually alive in the scan executors for internal tables, summed over all resource groups. A value below `starrocks_be_pipe_scan_expected_worker_threads` means workers were lost and not replaced, so fewer scan tasks are consumed than configured. Exceeding it is normal and transient, as workers leave a shrunken executor only once they wake up.
 
 ## `starrocks_be_priority_exec_state_report_active_threads`
 

--- a/docs/ja/administration/management/monitoring/metric_details/s.md
+++ b/docs/ja/administration/management/monitoring/metric_details/s.md
@@ -207,11 +207,35 @@ description: "Alphabetical s"
 - タイプ: 瞬間値
 - 説明: 各メモリプールに割り当てられたリソースグループの数。
 
+## `starrocks_be_pipe_connector_scan_expected_worker_threads`
+
+- 単位: カウント
+- タイプ: 瞬間値
+- 説明: 外部テーブル用 Scan エグゼキューターが現在実行すべきワーカースレッド数で、すべてのリソースグループの合計です。設定変更やリソースグループの変更が即座に反映されるため、`starrocks_be_pipe_connector_scan_worker_threads` と比較することで定員を満たしているかを判断できます。
+
+## `starrocks_be_pipe_connector_scan_worker_threads`
+
+- 単位: カウント
+- タイプ: 瞬間値
+- 説明: 外部テーブル用 Scan エグゼキューターで実際に生存しているワーカースレッド数で、すべてのリソースグループの合計です。`starrocks_be_pipe_connector_scan_expected_worker_threads` を下回る場合、ワーカーが失われたまま補充されておらず、設定値より少ない Scan タスクしか消費できていないことを意味します。上回るのは正常かつ一時的で、縮小されたエグゼキューターのワーカーは次に起こされたときに初めて終了するためです。
+
 ## `starrocks_be_pipe_prepare_pool_queue_len`
 
 - 単位: カウント
 - タイプ: 瞬間値
 - 説明: パイプライン準備スレッドプールタスクキューの長さの瞬間値。
+
+## `starrocks_be_pipe_scan_expected_worker_threads`
+
+- 単位: カウント
+- タイプ: 瞬間値
+- 説明: 内部テーブル用 Scan エグゼキューターが現在実行すべきワーカースレッド数で、すべてのリソースグループの合計です。設定変更やリソースグループの変更が即座に反映されるため、`starrocks_be_pipe_scan_worker_threads` と比較することで定員を満たしているかを判断できます。
+
+## `starrocks_be_pipe_scan_worker_threads`
+
+- 単位: カウント
+- タイプ: 瞬間値
+- 説明: 内部テーブル用 Scan エグゼキューターで実際に生存しているワーカースレッド数で、すべてのリソースグループの合計です。`starrocks_be_pipe_scan_expected_worker_threads` を下回る場合、ワーカーが失われたまま補充されておらず、設定値より少ない Scan タスクしか消費できていないことを意味します。上回るのは正常かつ一時的で、縮小されたエグゼキューターのワーカーは次に起こされたときに初めて終了するためです。
 
 ## `starrocks_be_priority_exec_state_report_active_threads`
 

--- a/docs/zh/administration/management/monitoring/metric_details/s.md
+++ b/docs/zh/administration/management/monitoring/metric_details/s.md
@@ -233,11 +233,35 @@ description: "Alphabetical s"
 - 类型：瞬时
 - 描述：分配给每个内存池的资源组数量。
 
+## `starrocks_be_pipe_connector_scan_expected_worker_threads`
+
+- 单位：计数
+- 类型：瞬时
+- 描述：外表 Scan 执行器当前应运行的工作线程数，为所有资源组之和。该值随配置变更和资源组调整立即生效，与 `starrocks_be_pipe_connector_scan_worker_threads` 对比即可判断执行器是否满编。
+
+## `starrocks_be_pipe_connector_scan_worker_threads`
+
+- 单位：计数
+- 类型：瞬时
+- 描述：外表 Scan 执行器中实际存活的工作线程数，为所有资源组之和。该值低于 `starrocks_be_pipe_connector_scan_expected_worker_threads` 说明工作线程已丢失且未被补充，消费 Scan 任务的能力低于配置值；高于该值属正常的短暂现象，因为执行器缩容后工作线程要等下一次被唤醒才会退出。
+
 ## `starrocks_be_pipe_prepare_pool_queue_len`
 
 - 单位：计数
 - 类型：瞬时
 - 描述：管道准备线程池任务队列长度的瞬时值。
+
+## `starrocks_be_pipe_scan_expected_worker_threads`
+
+- 单位：计数
+- 类型：瞬时
+- 描述：内表 Scan 执行器当前应运行的工作线程数，为所有资源组之和。该值随配置变更和资源组调整立即生效，与 `starrocks_be_pipe_scan_worker_threads` 对比即可判断执行器是否满编。
+
+## `starrocks_be_pipe_scan_worker_threads`
+
+- 单位：计数
+- 类型：瞬时
+- 描述：内表 Scan 执行器中实际存活的工作线程数，为所有资源组之和。该值低于 `starrocks_be_pipe_scan_expected_worker_threads` 说明工作线程已丢失且未被补充，消费 Scan 任务的能力低于配置值；高于该值属正常的短暂现象，因为执行器缩容后工作线程要等下一次被唤醒才会退出。
 
 ## `starrocks_be_priority_exec_state_report_active_threads`
 


### PR DESCRIPTION
## Why I'm doing:

The scan executors only expose task counters today, which cannot tell a busy pool from an empty one. A ScanExecutor worker occupies its pool thread for the whole lifetime of the executor -- worker_thread() only returns when the pool is asked to shrink -- so a worker that is lost, for example to an exception escaping the task it runs, never comes back and is invisible in the task counters: the executor merely consumes fewer tasks. running_tasks is no help either, because it is incremented before task.run() and decremented after, so a worker dying inside run() leaves the counter pinned high, which is indistinguishable from real work.

Export the configured capacity next to the number of live workers for both scan pools, so the loss is directly observable:

    pipe_scan_worker_threads < pipe_scan_threadpool_size

The values are summed over every monitored pool, matching the existing task counters, as a resource group with exclusive executors has pools of its own. ScanExecutor registers its pool on construction and detaches it on close() or destruction, so the metrics never retain a freed pool.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5