### PR TITLE
[BugFix] Fix BE crash when one ALTER adds an ordinary column and a generated column

### DIFF
--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -360,10 +360,10 @@ Status LinkedSchemaChange::generate_delta_column_group_and_cols(const Tablet* ne
                 }
             }
             status = chunk_changer->append_generated_columns(read_chunk, new_chunk, all_ref_columns_ids,
-                                                             base_tablet_schema->num_columns());
+                                                             new_columns_ids);
             if (!status.ok()) {
-                LOG(WARNING) << "failed to append generated columns";
-                return Status::InternalError("failed to append generated columns");
+                LOG(WARNING) << "failed to append generated columns: " << status.to_string();
+                return Status::InternalError("failed to append generated columns: " + std::string(status.message()));
             }
         }
 

--- a/be/src/storage/schema_change_utils.cpp
+++ b/be/src/storage/schema_change_utils.cpp
@@ -405,13 +405,22 @@ Status ChunkChanger::fill_generated_columns(ChunkPtr& new_chunk) {
     }
 
     for (auto it : _gc_exprs) {
+        // |it.first| is the generated column's position in the new schema and comes from the FE,
+        // never index the chunk with it without checking.
+        if (it.first < 0 || it.first >= static_cast<int>(new_chunk->num_columns())) {
+            return Status::InternalError("generated column index out of range: " + std::to_string(it.first) +
+                                         ", new schema has " + std::to_string(new_chunk->num_columns()) + " columns");
+        }
+        Column* target = new_chunk->get_column_raw_ptr_by_index(it.first);
+        if (!target->is_nullable()) {
+            return Status::InternalError("generated column is expected to be nullable: " + std::to_string(it.first));
+        }
         ASSIGN_OR_RETURN(ColumnPtr tmp, it.second->evaluate(new_chunk.get()));
         if (tmp->only_null()) {
             // Only null column maybe lost type info, we append null
             // for the chunk instead of swapping the tmp column.
-            auto* col = new_chunk->get_column_raw_ptr_by_index(it.first);
-            col->reset_column();
-            col->append_nulls(new_chunk->num_rows());
+            target->reset_column();
+            target->append_nulls(new_chunk->num_rows());
         } else if (tmp->is_nullable()) {
             new_chunk->get_column_by_index(it.first).swap(tmp);
         } else {
@@ -419,7 +428,7 @@ Status ChunkChanger::fill_generated_columns(ChunkPtr& new_chunk) {
             // it maybe a constant column or some other column type.
             // Unpack normal const column
             ColumnPtr output_column = ColumnHelper::unpack_and_duplicate_const_column(new_chunk->num_rows(), tmp);
-            auto* col = down_cast<NullableColumn*>(new_chunk->get_column_raw_ptr_by_index(it.first));
+            auto* col = down_cast<NullableColumn*>(target);
             col->swap_by_data_column(output_column);
         }
     }
@@ -487,7 +496,7 @@ Status ChunkChanger::prepare() {
 
 Status ChunkChanger::append_generated_columns(ChunkPtr& read_chunk, ChunkPtr& new_chunk,
                                               const std::vector<uint32_t>& all_ref_columns_ids,
-                                              int base_schema_columns) {
+                                              const std::vector<uint32_t>& new_columns_ids) {
     if (_gc_exprs.size() == 0) {
         return Status::OK();
     }
@@ -500,14 +509,33 @@ Status ChunkChanger::append_generated_columns(ChunkPtr& read_chunk, ChunkPtr& ne
 
     auto tmp_new_chunk = new_chunk->clone_empty();
 
-    for (auto it : _gc_exprs) {
-        // cid for new partial schema
-        int cid = it.first - base_schema_columns;
-        ASSIGN_OR_RETURN(ColumnPtr tmp, it.second->evaluate(read_chunk.get()));
+    // |new_columns_ids| is the very vector the partial schema was built from, so its i-th entry is
+    // the generated column that sits in the i-th chunk column. Walk it instead of deriving the
+    // chunk index from the column id: any such derivation silently breaks as soon as something
+    // shifts the generated columns inside the new schema, e.g. an ordinary column added by the
+    // same ALTER, which is placed before them.
+    if (new_columns_ids.size() != tmp_new_chunk->num_columns()) {
+        return Status::InternalError("partial schema has " + std::to_string(tmp_new_chunk->num_columns()) +
+                                     " columns but " + std::to_string(new_columns_ids.size()) +
+                                     " generated columns are expected");
+    }
+
+    for (size_t cid = 0; cid < new_columns_ids.size(); ++cid) {
+        auto expr_iter = _gc_exprs.find(static_cast<int>(new_columns_ids[cid]));
+        if (expr_iter == _gc_exprs.end()) {
+            return Status::InternalError("no generated column expression for column " +
+                                         std::to_string(new_columns_ids[cid]));
+        }
+        Column* target = tmp_new_chunk->get_column_raw_ptr_by_index(cid);
+        if (!target->is_nullable()) {
+            return Status::InternalError("generated column is expected to be nullable: " +
+                                         std::to_string(new_columns_ids[cid]));
+        }
+        ASSIGN_OR_RETURN(ColumnPtr tmp, expr_iter->second->evaluate(read_chunk.get()));
         if (tmp->only_null()) {
             // Only null column maybe lost type info, we append null
             // for the chunk instead of swapping the tmp column.
-            auto* col = down_cast<NullableColumn*>(tmp_new_chunk->get_column_raw_ptr_by_index(cid));
+            auto* col = down_cast<NullableColumn*>(target);
             col->reset_column();
             col->append_nulls(read_chunk->num_rows());
         } else if (tmp->is_nullable()) {
@@ -517,7 +545,7 @@ Status ChunkChanger::append_generated_columns(ChunkPtr& read_chunk, ChunkPtr& ne
             // it maybe a constant column or some other column type
             // Unpack normal const column
             ColumnPtr output_column = ColumnHelper::unpack_and_duplicate_const_column(read_chunk->num_rows(), tmp);
-            auto* col = down_cast<NullableColumn*>(tmp_new_chunk->get_column_raw_ptr_by_index(cid));
+            auto* col = down_cast<NullableColumn*>(target);
             col->swap_by_data_column(output_column);
         }
     }

--- a/be/src/storage/schema_change_utils.h
+++ b/be/src/storage/schema_change_utils.h
@@ -71,7 +71,8 @@ public:
     void init_runtime_state(const TQueryOptions& query_options, const TQueryGlobals& query_globals, ExecEnv* exec_env);
 
     Status append_generated_columns(ChunkPtr& read_chunk, ChunkPtr& new_chunk,
-                                    const std::vector<uint32_t>& all_ref_columns_ids, int base_schema_columns);
+                                    const std::vector<uint32_t>& all_ref_columns_ids,
+                                    const std::vector<uint32_t>& new_columns_ids);
 
     const std::vector<ColumnId>& get_selected_column_indexes() const { return _selected_column_indexes; }
     std::vector<ColumnId>* get_mutable_selected_column_indexes() { return &_selected_column_indexes; }

--- a/test/sql/test_materialized_column/R/test_materialized_column
+++ b/test/sql/test_materialized_column/R/test_materialized_column
@@ -1006,6 +1006,65 @@ PROPERTIES (
 DROP DATABASE test_schema_change_for_after;
 -- result:
 -- !result
+-- name: test_add_normal_and_generated_column_with_data @native
+CREATE DATABASE test_add_normal_and_generated_column_with_data;
+-- result:
+-- !result
+USE test_add_normal_and_generated_column_with_data;
+-- result:
+-- !result
+CREATE TABLE t0 ( v1 BIGINT NOT NULL, v2 BIGINT NOT NULL) DUPLICATE KEY (v1) DISTRIBUTED BY HASH(v1) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage" = "true", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO t0 VALUES (1, 1), (2, 2), (3, 3);
+-- result:
+-- !result
+alter table t0 add column testcol1 BIGINT, add column testcol2 BIGINT as v1 * 10;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SHOW CREATE TABLE t0;
+-- result:
+t0	CREATE TABLE `t0` (
+  `v1` bigint(20) NOT NULL COMMENT "",
+  `v2` bigint(20) NOT NULL COMMENT "",
+  `testcol1` bigint(20) NULL COMMENT "",
+  `testcol2` bigint(20) NULL AS `v1` * 10 COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 1 
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+SELECT * FROM t0 ORDER BY v1;
+-- result:
+1	1	None	10
+2	2	None	20
+3	3	None	30
+-- !result
+alter table t0 add column testcol3 BIGINT, add column testcol4 BIGINT as v1 * 100, add column testcol5 BIGINT as v1 * 1000;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT * FROM t0 ORDER BY v1;
+-- result:
+1	1	None	None	10	100	1000
+2	2	None	None	20	200	2000
+3	3	None	None	30	300	3000
+-- !result
+DROP DATABASE test_add_normal_and_generated_column_with_data;
+-- result:
+-- !result
 -- name: test_compaction_after_adding_generated_column @native
 CREATE DATABASE test_compaction_after_adding_generated_column;
 -- result:

--- a/test/sql/test_materialized_column/T/test_materialized_column
+++ b/test/sql/test_materialized_column/T/test_materialized_column
@@ -379,6 +379,27 @@ SHOW CREATE TABLE t0;
 
 DROP DATABASE test_schema_change_for_after;
 
+-- name: test_add_normal_and_generated_column_with_data @native
+CREATE DATABASE test_add_normal_and_generated_column_with_data;
+USE test_add_normal_and_generated_column_with_data;
+
+CREATE TABLE t0 ( v1 BIGINT NOT NULL, v2 BIGINT NOT NULL) DUPLICATE KEY (v1) DISTRIBUTED BY HASH(v1) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage" = "true", "fast_schema_evolution" = "true");
+INSERT INTO t0 VALUES (1, 1), (2, 2), (3, 3);
+
+-- the ordinary column is placed before the generated one, which shifts the generated column's
+-- position in the new schema. Adding it to a table that already has data used to crash the BE.
+alter table t0 add column testcol1 BIGINT, add column testcol2 BIGINT as v1 * 10;
+function: wait_alter_table_finish()
+SHOW CREATE TABLE t0;
+SELECT * FROM t0 ORDER BY v1;
+
+-- two generated columns in one ALTER: their values must land in their own columns, not swapped
+alter table t0 add column testcol3 BIGINT, add column testcol4 BIGINT as v1 * 100, add column testcol5 BIGINT as v1 * 1000;
+function: wait_alter_table_finish()
+SELECT * FROM t0 ORDER BY v1;
+
+DROP DATABASE test_add_normal_and_generated_column_with_data;
+
 -- name: test_compaction_after_adding_generated_column @native
 CREATE DATABASE test_compaction_after_adding_generated_column;
 USE test_compaction_after_adding_generated_column;


### PR DESCRIPTION




## Why I'm doing:

ALTER TABLE t ADD COLUMN a BIGINT, ADD COLUMN b BIGINT AS (expr) on a table that already has data killed the BE:

```
fuzz ASAN (build 7a4f134 distro ubuntu arch x86_64)
query_id:019fd96e-fd23-7ef6-bb6f-a852e843282a, fragment_instance:019fd96e-fd23-7ef6-bb6f-a852e843282c, plan_node_id:7   
    
@         0x1cc08548 starrocks::failure_function()
    @         0x32ddad1d google::LogMessage::Fail()
    @         0x32ddbe04 google::LogMessageFatal::~LogMessageFatal()
    @         0x1e931969 starrocks::ChunksSorterTopn::ChunksSorterTopn(starrocks::RuntimeState*, std::vector<starrocks::ExprContext*, std::allocator<starrocks::ExprContext*> > const*, std::vector<bool, std::allocator<bool> > const*, std::vector<bool, std::allocator<bool> > const*,@
    @         0x1ea5ccd7 void std::_Construct<starrocks::ChunksSorterTopn, starrocks::RuntimeState* const&, std::vector<starrocks::ExprContext*, std::allocator<starrocks::ExprContext*> > const*, std::vector<bool, std::allocator<bool> >*, std::vector<bool, std::allocator<bool> >*, @
    @         0x1ea59467 std::_Sp_counted_ptr_inplace<starrocks::ChunksSorterTopn, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<starrocks::RuntimeState* const&, std::vector<starrocks::ExprContext*, std::allocator<starrocks::ExprContext*> > const*, std@
    @         0x1ea57666 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<starrocks::ChunksSorterTopn, std::allocator<void>, starrocks::RuntimeState* const&, std::vector<starrocks::ExprContext*, std::allocator<starrocks::ExprContext*> > const*, std::vector<bool, std@
    @         0x1ea54ea1 std::__shared_ptr<starrocks::ChunksSorterTopn, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<void>, starrocks::RuntimeState* const&, std::vector<starrocks::ExprContext*, std::allocator<starrocks::ExprContext*> > const*, std::vector<bool, std::al@
    @         0x1ea51ae1 std::shared_ptr<starrocks::ChunksSorterTopn>::shared_ptr<std::allocator<void>, starrocks::RuntimeState* const&, std::vector<starrocks::ExprContext*, std::allocator<starrocks::ExprContext*> > const*, std::vector<bool, std::allocator<bool> >*, std::vector<bo@
    @         0x1ea4f665 std::shared_ptr<starrocks::ChunksSorterTopn> std::make_shared<starrocks::ChunksSorterTopn, starrocks::RuntimeState* const&, std::vector<starrocks::ExprContext*, std::allocator<starrocks::ExprContext*> > const*, std::vector<bool, std::allocator<bool> >*, st@
    @         0x1e9cab4b starrocks::pipeline::LocalPartitionTopnContext::push_one_chunk_to_partitioner(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)::{lambda(unsigned long)#1}::operator()(unsigned long) const
    @         0x1ea3658b starrocks::Status starrocks::PartitionHashMapBase<true, false>::append_chunk_for_one_nullable_key<true, phmap::flat_hash_map<starrocks::Slice, starrocks::PartitionChunks*, starrocks::SliceHashWithSeed<(starrocks::PhmapSeed)0>, starrocks::SliceEqual, std::a@
    @         0x1ea0e13a starrocks::StatusOr<bool> starrocks::PartitionHashMapWithOneNullableStringKey<phmap::flat_hash_map<starrocks::Slice, starrocks::PartitionChunks*, starrocks::SliceHashWithSeed<(starrocks::PhmapSeed)0>, starrocks::SliceEqual, std::allocator<std::pair<starroc@
    @         0x1e9e37cb starrocks::Status starrocks::ChunksPartitioner::_split_chunk_by_partition<true, starrocks::PartitionHashMapWithOneNullableStringKey<phmap::flat_hash_map<starrocks::Slice, starrocks::PartitionChunks*, starrocks::SliceHashWithSeed<(starrocks::PhmapSeed)0>, s@
    @         0x1e9d71f5 starrocks::Status starrocks::ChunksPartitioner::offer<true, starrocks::pipeline::LocalPartitionTopnContext::push_one_chunk_to_partitioner(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)::{lambda(unsigned long)#1}, starrocks::pipeline::L@
    @         0x1e9d4d70 starrocks::Status std::__invoke_impl<starrocks::Status, starrocks::ChunksPartitioner::offer<true, starrocks::pipeline::LocalPartitionTopnContext::push_one_chunk_to_partitioner(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)::{lambda(uns@
```

append_generated_columns derived the chunk index of a generated column as |column id - base column count|. That only holds when the generated columns occupy exactly the tail of the new schema right after the base columns. The ordinary column added by the same ALTER is placed before the generated ones, so every generated column id is shifted by one, while the chunk being filled holds the generated columns only. The resulting index ran off the end of the column vector, and the garbage pointer read from there (usually zero) was dereferenced as a NullableColumn.

Derive the index from the generated column's rank among the sorted generated column ids instead, which is exactly how that chunk is built, and reject an out-of-range or non-nullable target with an error instead of indexing blindly. fill_generated_columns gets the same guards.

test_multi_add_column already covers this ALTER, but only on an empty table, where the missing segment files short-circuit before the bad index is used. Add a case that inserts rows first.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
