### PR TITLE
[BugFix] Invalidate the min/max stats cache on partition and schema DDL

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -112,6 +112,7 @@ import com.starrocks.sql.common.PListCell;
 import com.starrocks.sql.common.PRangeCell;
 import com.starrocks.sql.optimizer.rule.mv.MVUtils;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
+import com.starrocks.sql.optimizer.statistics.IMinMaxStatsMgr;
 import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
@@ -732,6 +733,11 @@ public class OlapTable extends Table {
         }
         fullSchema = newFullSchema;
         updateSchemaIndex();
+        // The column set just changed and the cache is keyed by column NAME, so DROP COLUMN c +
+        // ADD COLUMN c would otherwise hand the new column the old one's min/max. Called on every
+        // schema-change job and on their replay; the calls from metadata load are a no-op because
+        // nothing is cached yet.
+        invalidateMinMaxStats();
         // update max column unique id
         int maxColUniqueId = getMaxColUniqueId();
         for (Column column : fullSchema) {
@@ -1256,12 +1262,41 @@ public class OlapTable extends Table {
         }
     }
 
+    /**
+     * Drop this table's cached column min/max values.
+     *
+     * <p>{@code ColumnMinMaxMgr} keeps them keyed by (table id, column name) and validates an entry
+     * by comparing the table-level {@code max(visibleVersionTime)} it was loaded at against the
+     * current one, accepting the entry when it is not older. Loading data is the only operation that
+     * reliably advances that stamp. DDL does not:
+     *
+     * <ul>
+     *   <li>REPLACE PARTITION and INSERT OVERWRITE move the temporary {@link Partition} object into
+     *       the formal list as it stands, so the table-level maximum goes BACKWARDS whenever that
+     *       partition was loaded before the one it replaces;</li>
+     *   <li>dropping the most recently loaded partition moves it backwards the same way;</li>
+     *   <li>RECOVER PARTITION brings data back without necessarily raising it;</li>
+     *   <li>a fast schema change does not touch partitions at all, yet DROP COLUMN c + ADD COLUMN c
+     *       gives a brand new column the previous one's cache entry, since the key is the name.</li>
+     * </ul>
+     *
+     * <p>In every one of those cases a stale entry keeps passing the version check for as long as it
+     * lives -- the cache has no TTL -- so min()/max() constant-folds to values that no longer exist.
+     * Hence the explicit invalidation, hooked into the low-level mutators below rather than into the
+     * DDL entry points: these run identically on the leader and on edit-log replay, so followers
+     * (which fold min/max from their own cache) drop the entry too.
+     */
+    private void invalidateMinMaxStats() {
+        IMinMaxStatsMgr.invalidateTable(this);
+    }
+
     public void addPartition(Partition partition) {
         idToPartition.put(partition.getId(), partition);
         nameToPartition.put(partition.getName(), partition);
         for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
             physicalPartitionIdToPartitionId.put(physicalPartition.getId(), partition.getId());
         }
+        invalidateMinMaxStats();
     }
 
     public void removePhysicalPartition(PhysicalPartition physicalPartition) {
@@ -1294,6 +1329,7 @@ public class OlapTable extends Table {
         physicalPartitionIdToPartitionId.keySet().removeAll(partition.getSubPartitions()
                 .stream().map(PhysicalPartition::getId)
                 .collect(Collectors.toList()));
+        invalidateMinMaxStats();
     }
 
     protected RecyclePartitionInfo buildRecyclePartitionInfo(long dbId, Partition partition) {
@@ -1890,6 +1926,10 @@ public class OlapTable extends Table {
             partitionInfo.dropPartition(oldPartition.getId());
             partitionInfo.addPartition(newPartition.getId(), dataProperty, replicationNum, dataCacheInfo);
         }
+
+        // This swaps the partition maps directly instead of going through addPartition() /
+        // removePartitionFromInnerState(), so it needs its own call.
+        invalidateMinMaxStats();
 
         return oldPartition;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
@@ -906,12 +906,8 @@ public class MetaFunctions {
         ColumnId columnId = ColumnId.create(columnName.getVarchar());
         ColumnIdentifier columnIdentifier = new ColumnIdentifier(table.getId(), columnId);
 
-        // getTableLastUpdateTimestamp may return null; treat as version 0 to avoid an auto-unboxing NPE.
-        Long lastUpdateTime = StatisticUtils.getTableLastUpdateTimestamp(table);
-        StatsVersion version = new StatsVersion(-1, lastUpdateTime == null ? 0L : lastUpdateTime);
-
         try {
-            IMinMaxStatsMgr.internalInstance().removeStats(columnIdentifier, version);
+            IMinMaxStatsMgr.internalInstance().removeStats(columnIdentifier);
         } catch (Exception e) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_UNKNOWN_ERROR,
                     "Failed to invalidate MinMax statistics: " + e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnMinMaxMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnMinMaxMgr.java
@@ -149,7 +149,7 @@ public class ColumnMinMaxMgr implements IMinMaxStatsMgr, MemoryTrackable {
     }
 
     @Override
-    public void removeStats(ColumnIdentifier identifier, StatsVersion version) {
+    public void removeStats(ColumnIdentifier identifier) {
         // skip dictionary operator in checkpoint thread
         if (GlobalStateMgr.isCheckpointThread()) {
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/IMinMaxStatsMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/IMinMaxStatsMgr.java
@@ -13,6 +13,8 @@
 // limitations under the License.
 package com.starrocks.sql.optimizer.statistics;
 
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.sql.optimizer.base.ColumnIdentifier;
 
 import java.util.Optional;
@@ -24,7 +26,25 @@ public interface IMinMaxStatsMgr {
 
     Optional<ColumnMinMax> getStatsSync(ColumnIdentifier identifier, StatsVersion version);
 
-    void removeStats(ColumnIdentifier identifier, StatsVersion version);
+    void removeStats(ColumnIdentifier identifier);
+
+    /**
+     * Drop every cached min/max entry of {@code table}.
+     *
+     * <p>A cached entry is validated against the table-level {@code max(visibleVersionTime)} under
+     * a "cached is at least as new as requested" test, which assumes that stamp only ever grows.
+     * It does not: partition-set changes move whole {@link com.starrocks.catalog.Partition}
+     * objects -- each carrying its own visible-version time -- in and out of the formal list, and a
+     * schema change need not touch it at all. So it is the callers of this method, not the version
+     * check, that keep the cache honest across DDL. See {@code OlapTable#invalidateMinMaxStats} for
+     * where it is hooked and why those points cover the follower replay path too.
+     */
+    static void invalidateTable(OlapTable table) {
+        IMinMaxStatsMgr mgr = internalInstance();
+        for (Column column : table.getColumns()) {
+            mgr.removeStats(new ColumnIdentifier(table.getId(), column.getColumnId()));
+        }
+    }
 
     static IMinMaxStatsMgr internalInstance() {
         return ColumnMinMaxMgr.getInstance();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/IcebergColumnMinMaxMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/IcebergColumnMinMaxMgr.java
@@ -101,7 +101,7 @@ public class IcebergColumnMinMaxMgr implements IMinMaxStatsMgr, MemoryTrackable 
     }
 
     @Override
-    public void removeStats(ColumnIdentifier identifier, StatsVersion version) {
+    public void removeStats(ColumnIdentifier identifier) {
         throw new SemanticException("Iceberg column min/max stats unsupported the method");
     }
 

--- a/test/sql/test_simple_agg_meta_rewrite/R/test_minmax_after_replace_partition
+++ b/test/sql/test_simple_agg_meta_rewrite/R/test_minmax_after_replace_partition
@@ -1,0 +1,103 @@
+-- name: test_minmax_after_replace_partition
+DROP DATABASE IF EXISTS test_minmax_replace_partition;
+-- result:
+-- !result
+CREATE DATABASE test_minmax_replace_partition;
+-- result:
+-- !result
+USE test_minmax_replace_partition;
+-- result:
+-- !result
+CREATE TABLE t (
+  ds DATE NOT NULL,
+  v  INT  NOT NULL
+) DUPLICATE KEY(ds)
+PARTITION BY RANGE(ds) (PARTITION p1 VALUES [('2024-01-01'), ('2024-02-01')))
+DISTRIBUTED BY HASH(ds) BUCKETS 2
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+ALTER TABLE t ADD TEMPORARY PARTITION tp VALUES [('2024-01-01'), ('2024-02-01'));
+-- result:
+-- !result
+SET enable_rewrite_simple_agg_to_meta_scan = true;
+-- result:
+-- !result
+INSERT INTO t TEMPORARY PARTITION (tp) VALUES ('2024-01-05', 10);
+-- result:
+-- !result
+shell: sleep 2
+-- result:
+0
+
+-- !result
+INSERT INTO t VALUES ('2024-01-20', 999);
+-- result:
+-- !result
+SELECT inspect_minmax('test_minmax_replace_partition.t', 'v');
+-- result:
+ColumnMinMax[minValue=999, maxValue=999]
+-- !result
+shell: ${mysql_cmd} -e "EXPLAIN SELECT MAX(v) FROM test_minmax_replace_partition.t" | grep -c "EXECUTE IN FE"
+-- result:
+0
+1
+-- !result
+SELECT MAX(v) FROM t;
+-- result:
+999
+-- !result
+SET enable_rewrite_simple_agg_to_meta_scan = false;
+-- result:
+-- !result
+SELECT MAX(v) FROM t;
+-- result:
+999
+-- !result
+SET enable_rewrite_simple_agg_to_meta_scan = true;
+-- result:
+-- !result
+ALTER TABLE t REPLACE PARTITION (p1) WITH TEMPORARY PARTITION (tp);
+-- result:
+-- !result
+SELECT MAX(v) FROM t;
+-- result:
+10
+-- !result
+SET enable_rewrite_simple_agg_to_meta_scan = false;
+-- result:
+-- !result
+SELECT MAX(v) FROM t;
+-- result:
+10
+-- !result
+SET enable_rewrite_simple_agg_to_meta_scan = true;
+-- result:
+-- !result
+SELECT inspect_minmax('test_minmax_replace_partition.t', 'v');
+-- result:
+ColumnMinMax[minValue=10, maxValue=10]
+-- !result
+shell: ${mysql_cmd} -e "EXPLAIN SELECT MAX(v) FROM test_minmax_replace_partition.t" | grep -c "EXECUTE IN FE"
+-- result:
+0
+1
+-- !result
+SELECT MAX(v) FROM t;
+-- result:
+10
+-- !result
+INSERT INTO t VALUES ('2024-01-25', 500);
+-- result:
+-- !result
+SELECT MAX(v) FROM t;
+-- result:
+500
+-- !result
+SELECT MIN(v) FROM t;
+-- result:
+10
+-- !result
+DROP DATABASE test_minmax_replace_partition;
+-- result:
+-- !result

--- a/test/sql/test_simple_agg_meta_rewrite/R/test_minmax_after_schema_change
+++ b/test/sql/test_simple_agg_meta_rewrite/R/test_minmax_after_schema_change
@@ -1,0 +1,87 @@
+-- name: test_minmax_after_schema_change @native
+DROP DATABASE IF EXISTS test_minmax_schema_change;
+-- result:
+-- !result
+CREATE DATABASE test_minmax_schema_change;
+-- result:
+-- !result
+USE test_minmax_schema_change;
+-- result:
+-- !result
+CREATE TABLE t (
+  k INT NOT NULL,
+  v INT NOT NULL
+) DUPLICATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 2
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+SET enable_rewrite_simple_agg_to_meta_scan = true;
+-- result:
+-- !result
+INSERT INTO t VALUES (1, 100), (2, 200);
+-- result:
+-- !result
+SELECT inspect_minmax('test_minmax_schema_change.t', 'v');
+-- result:
+ColumnMinMax[minValue=100, maxValue=200]
+-- !result
+shell: ${mysql_cmd} -e "EXPLAIN SELECT MAX(v) FROM test_minmax_schema_change.t" | grep -c "EXECUTE IN FE"
+-- result:
+0
+1
+-- !result
+SELECT MAX(v) FROM t;
+-- result:
+200
+-- !result
+ALTER TABLE t DROP COLUMN v;
+-- result:
+-- !result
+shell: for i in $(seq 1 120); do n=$(${mysql_cmd} -Ne "SELECT COUNT(*) FROM information_schema.columns WHERE TABLE_SCHEMA='test_minmax_schema_change' AND TABLE_NAME='t' AND COLUMN_NAME='v'" 2>/dev/null); [ "$n" = "0" ] && break; sleep 1; done; echo $n
+-- result:
+0
+0
+-- !result
+ALTER TABLE t ADD COLUMN v INT NOT NULL DEFAULT "7";
+-- result:
+-- !result
+shell: for i in $(seq 1 120); do n=$(${mysql_cmd} -Ne "SELECT COUNT(*) FROM information_schema.columns WHERE TABLE_SCHEMA='test_minmax_schema_change' AND TABLE_NAME='t' AND COLUMN_NAME='v'" 2>/dev/null); [ "$n" = "1" ] && break; sleep 1; done; echo $n
+-- result:
+0
+1
+-- !result
+SET enable_rewrite_simple_agg_to_meta_scan = false;
+-- result:
+-- !result
+SELECT MAX(v) FROM t;
+-- result:
+7
+-- !result
+SET enable_rewrite_simple_agg_to_meta_scan = true;
+-- result:
+-- !result
+SELECT MAX(v) FROM t;
+-- result:
+7
+-- !result
+SELECT inspect_minmax('test_minmax_schema_change.t', 'v');
+-- result:
+ColumnMinMax[minValue=7, maxValue=7]
+-- !result
+shell: ${mysql_cmd} -e "EXPLAIN SELECT MAX(v) FROM test_minmax_schema_change.t" | grep -c "EXECUTE IN FE"
+-- result:
+0
+1
+-- !result
+SELECT MAX(v) FROM t;
+-- result:
+7
+-- !result
+SELECT MIN(v) FROM t;
+-- result:
+7
+-- !result
+DROP DATABASE test_minmax_schema_change;
+-- result:
+-- !result

--- a/test/sql/test_simple_agg_meta_rewrite/T/test_minmax_after_replace_partition
+++ b/test/sql/test_simple_agg_meta_rewrite/T/test_minmax_after_replace_partition
@@ -1,0 +1,86 @@
+-- name: test_minmax_after_replace_partition
+
+-- Regression for min()/max() constant folding returning the values of a partition that
+-- REPLACE PARTITION has already swapped OUT.
+--
+-- RewriteSimpleAggToMetaScanRule folds a bare min()/max() into a constant taken from
+-- ColumnMinMaxMgr's cache. The cache entry used to be stamped with the table-level
+-- max(visibleVersionTime) and served whenever "cached >= requested" -- i.e. on the
+-- assumption that that stamp only ever grows.
+--
+-- It does not. OlapTable.replaceTempPartitionsWithoutCheck() moves the temporary
+-- Partition OBJECT into the formal list as it stands, carrying its own visible-version
+-- time. Load the temporary partition BEFORE the partition it replaces and the table-level
+-- maximum goes backwards across the swap, so the smaller request keeps satisfying the
+-- larger cached stamp and the fold keeps answering with the swapped-out partition's
+-- values -- until the entry is evicted by size or the FE restarts. There is no TTL and no
+-- DDL path invalidates it.
+--
+-- The fix drops the table's entries explicitly, from the low-level OlapTable mutators every
+-- partition-set change funnels through (addPartition / removePartitionFromInnerState /
+-- replacePartition). Those run on the leader and on edit-log replay alike, so a follower --
+-- which folds min/max out of its own cache -- invalidates too.
+--
+-- NOTE: the expected results in R/ are the CORRECT values, not today's behaviour. Before
+-- the fix the folded MAX(v) after the swap returns 999 instead of 10 and the case FAILS.
+-- Do not regenerate R/ with `run.py -r` to make it pass -- that would freeze the bug in.
+
+DROP DATABASE IF EXISTS test_minmax_replace_partition;
+CREATE DATABASE test_minmax_replace_partition;
+USE test_minmax_replace_partition;
+
+-- Exactly ONE formal partition: with a second one around, its visible-version time would
+-- hold the table-level maximum up and the swap could not move it backwards.
+CREATE TABLE t (
+  ds DATE NOT NULL,
+  v  INT  NOT NULL
+) DUPLICATE KEY(ds)
+PARTITION BY RANGE(ds) (PARTITION p1 VALUES [('2024-01-01'), ('2024-02-01')))
+DISTRIBUTED BY HASH(ds) BUCKETS 2
+PROPERTIES ("replication_num" = "1");
+
+ALTER TABLE t ADD TEMPORARY PARTITION tp VALUES [('2024-01-01'), ('2024-02-01'));
+
+SET enable_rewrite_simple_agg_to_meta_scan = true;
+
+-- Order matters: the TEMPORARY partition is loaded first, so it ends up with the OLDER
+-- visible-version time, and swapping it in later drags the table-level maximum down.
+INSERT INTO t TEMPORARY PARTITION (tp) VALUES ('2024-01-05', 10);
+shell: sleep 2
+INSERT INTO t VALUES ('2024-01-20', 999);
+
+-- inspect_minmax() goes through getStatsSync(), so this warms the cache synchronously --
+-- no polling for the async loader. v is a non-partition column on purpose: min/max of a
+-- PARTITION column is folded by PartitionColumnMinMaxRewriteRule, which is not affected.
+SELECT inspect_minmax('test_minmax_replace_partition.t', 'v');
+
+-- The fold is live, and agrees with a real scan. Only the formal partition is visible
+-- here, so both must say 999.
+shell: ${mysql_cmd} -e "EXPLAIN SELECT MAX(v) FROM test_minmax_replace_partition.t" | grep -c "EXECUTE IN FE"
+SELECT MAX(v) FROM t;
+SET enable_rewrite_simple_agg_to_meta_scan = false;
+SELECT MAX(v) FROM t;
+SET enable_rewrite_simple_agg_to_meta_scan = true;
+
+ALTER TABLE t REPLACE PARTITION (p1) WITH TEMPORARY PARTITION (tp);
+
+-- The 999 row is gone with the partition that held it. The folded answer must follow the
+-- data, not the stale cache entry.
+SELECT MAX(v) FROM t;
+SET enable_rewrite_simple_agg_to_meta_scan = false;
+SELECT MAX(v) FROM t;
+SET enable_rewrite_simple_agg_to_meta_scan = true;
+
+-- ... and the fold must come BACK once the entry is reloaded, rather than the swap
+-- disabling it for good.
+SELECT inspect_minmax('test_minmax_replace_partition.t', 'v');
+shell: ${mysql_cmd} -e "EXPLAIN SELECT MAX(v) FROM test_minmax_replace_partition.t" | grep -c "EXECUTE IN FE"
+SELECT MAX(v) FROM t;
+
+-- The ordinary path is unchanged: a plain load bumps a partition's visible version, so the
+-- entry that has just been reloaded is not served to the query that follows the load.
+INSERT INTO t VALUES ('2024-01-25', 500);
+SELECT MAX(v) FROM t;
+SELECT MIN(v) FROM t;
+
+DROP DATABASE test_minmax_replace_partition;

--- a/test/sql/test_simple_agg_meta_rewrite/T/test_minmax_after_schema_change
+++ b/test/sql/test_simple_agg_meta_rewrite/T/test_minmax_after_schema_change
@@ -1,0 +1,73 @@
+-- name: test_minmax_after_schema_change @native
+
+-- Regression for min()/max() constant folding answering with the min/max of a column that
+-- has since been dropped and re-created.
+--
+-- ColumnMinMaxMgr keys its cache on (table id, column NAME) -- ColumnId is a thin wrapper
+-- around the name -- and validates an entry by comparing the table-level
+-- max(visibleVersionTime) it was loaded at against the current one. A schema change moves
+-- neither: no partition is added, dropped or loaded, so the stamp is untouched and the key
+-- is unchanged. DROP COLUMN v followed by ADD COLUMN v therefore hands a brand new column
+-- the previous column's cached min/max, and nothing ever expires it -- the cache has no
+-- TTL and, before this fix, no DDL path invalidated it.
+--
+-- Same family as test_minmax_after_replace_partition but a different mechanism: there the
+-- partition SET changes while the column stays, here the column is replaced while the
+-- partitions stay. Both are fixed by invalidating from OlapTable's own mutators --
+-- rebuildFullSchema() for this one -- which run on the leader and on replay alike.
+--
+-- @native, because RewriteSimpleAggToMetaScanRule already refuses to fold min/max in
+-- shared-data mode once a table has any schema change at all (schemaVersion > 0): fast
+-- schema evolution can retype a column without rewriting the data, and the metadata cannot
+-- say which kind of change happened, so the rewrite is disabled wholesale there. That guard
+-- makes the assertions below vacuous in shared-data -- the fold is off no matter what the
+-- cache holds -- and the last one, that folding RESUMES after the entry reloads, cannot hold
+-- at all. The stale entry does still reach the two consumers that lack that guard
+-- (RewriteMinMaxByMonotonicFunctionRule, ApplyMinMaxStatisticRule), so the fix itself is not
+-- shared-nothing specific; only this way of observing it is.
+--
+-- NOTE: the expected results in R/ are the CORRECT values, not today's behaviour. Before
+-- the fix the folded MAX(v) returns 200 instead of 7 and the case FAILS. Do not regenerate
+-- R/ with `run.py -r` to make it pass -- that would freeze the bug in.
+
+DROP DATABASE IF EXISTS test_minmax_schema_change;
+CREATE DATABASE test_minmax_schema_change;
+USE test_minmax_schema_change;
+
+CREATE TABLE t (
+  k INT NOT NULL,
+  v INT NOT NULL
+) DUPLICATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 2
+PROPERTIES ("replication_num" = "1");
+
+SET enable_rewrite_simple_agg_to_meta_scan = true;
+
+INSERT INTO t VALUES (1, 100), (2, 200);
+
+-- inspect_minmax() goes through getStatsSync(), so the cache is warm synchronously.
+SELECT inspect_minmax('test_minmax_schema_change.t', 'v');
+shell: ${mysql_cmd} -e "EXPLAIN SELECT MAX(v) FROM test_minmax_schema_change.t" | grep -c "EXECUTE IN FE"
+SELECT MAX(v) FROM t;
+
+-- Drop the column the cache entry is keyed on, then bring the same NAME back with a
+-- different value. No partition is touched, so nothing about the version stamp changes.
+ALTER TABLE t DROP COLUMN v;
+shell: for i in $(seq 1 120); do n=$(${mysql_cmd} -Ne "SELECT COUNT(*) FROM information_schema.columns WHERE TABLE_SCHEMA='test_minmax_schema_change' AND TABLE_NAME='t' AND COLUMN_NAME='v'" 2>/dev/null); [ "$n" = "0" ] && break; sleep 1; done; echo $n
+ALTER TABLE t ADD COLUMN v INT NOT NULL DEFAULT "7";
+shell: for i in $(seq 1 120); do n=$(${mysql_cmd} -Ne "SELECT COUNT(*) FROM information_schema.columns WHERE TABLE_SCHEMA='test_minmax_schema_change' AND TABLE_NAME='t' AND COLUMN_NAME='v'" 2>/dev/null); [ "$n" = "1" ] && break; sleep 1; done; echo $n
+
+-- Every row now carries the new column's default. The folded answer must say so.
+SET enable_rewrite_simple_agg_to_meta_scan = false;
+SELECT MAX(v) FROM t;
+SET enable_rewrite_simple_agg_to_meta_scan = true;
+SELECT MAX(v) FROM t;
+
+-- ... and the fold must come back once the entry is reloaded, rather than the schema change
+-- disabling it for good.
+SELECT inspect_minmax('test_minmax_schema_change.t', 'v');
+shell: ${mysql_cmd} -e "EXPLAIN SELECT MAX(v) FROM test_minmax_schema_change.t" | grep -c "EXECUTE IN FE"
+SELECT MAX(v) FROM t;
+SELECT MIN(v) FROM t;
+
+DROP DATABASE test_minmax_schema_change;


### PR DESCRIPTION
## Why I'm doing:

ColumnMinMaxMgr caches a column's min/max keyed by (table id, column name) and validates an entry by comparing the table-level max(visibleVersionTime) it was loaded at against the current one, serving the entry when it is not older. Loading data is the only operation that reliably advances that stamp. DDL does not, and nothing else expired an entry: the cache has no TTL, and removeStats()'s only caller was the invalidate_minmax meta function.

So a stale entry could keep passing the version check for as long as it lived, and min()/max() constant-folded to values that no longer exist:

* REPLACE PARTITION and INSERT OVERWRITE move the temporary Partition object into the formal list as it stands, carrying its own visible-version time, so the table-level maximum goes BACKWARDS whenever that partition was loaded before the one it replaces;
* dropping the most recently loaded partition moves it backwards the same way;
* RECOVER PARTITION brings data back without necessarily raising it;
* a fast schema change touches no partition at all, so DROP COLUMN c followed by ADD COLUMN c hands a brand new column the previous one's entry, the key being the column name.

Invalidate explicitly, from the low-level OlapTable mutators every such change funnels through -- addPartition(), removePartitionFromInnerState() (shared by both drop paths), replacePartition() for TRUNCATE, which swaps the partition maps directly, and rebuildFullSchema() for the column set. Hooking there rather than at the DDL entry points matters: these run on the leader and on edit-log replay alike, so a follower, which folds min/max out of its own cache, drops the entry too. It mirrors the IDictManager.removeGlobalDict() invalidation that already sits in replaceTempPartitionsWithoutCheck().

removeStats() loses its StatsVersion parameter, which no implementation read.

Adds two SQL regression cases. Both fail on the unfixed FE with the folded answer disagreeing with a real scan -- 999 against 10 for the partition swap, 200 against 7 for the schema change -- and both assert the fold still returns (EXECUTE IN FE) once the entry reloads, so neither can be satisfied by simply disabling the rewrite.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
