### PR TITLE
[BugFix] Propagate child expression errors instead of aborting the BE

### DIFF
--- a/be/src/exprs/arithmetic_expr.cpp
+++ b/be/src/exprs/arithmetic_expr.cpp
@@ -496,8 +496,8 @@ class VectorizedBitShiftArithmeticExpr final : public Expr
 public:
     DEFINE_CLASS_CONSTRUCTOR(VectorizedBitShiftArithmeticExpr);
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override {
-        auto l = _children[0]->evaluate(context, ptr);
-        auto r = _children[1]->evaluate(context, ptr);
+        ASSIGN_OR_RETURN(auto l, _children[0]->evaluate_checked(context, ptr));
+        ASSIGN_OR_RETURN(auto r, _children[1]->evaluate_checked(context, ptr));
 
         using ArithmeticOp = ArithmeticBinaryOperator<OP, Type>;
         return VectorizedStrictBinaryFunction<ArithmeticOp>::template evaluate<Type, TYPE_BIGINT, Type>(l, r);

--- a/be/src/exprs_ext/dict/dict_query_expr.cpp
+++ b/be/src/exprs_ext/dict/dict_query_expr.cpp
@@ -37,7 +37,7 @@ StatusOr<ColumnPtr> DictQueryExpr::evaluate_checked(ExprContext* context, Chunk*
     size_t size = ptr != nullptr ? ptr->num_rows() : 1;
     bool null_if_not_found = !_dict_query_expr.strict_mode;
     for (int i = 0; i < _children.size(); ++i) {
-        columns[i] = _children[i]->evaluate(context, ptr);
+        ASSIGN_OR_RETURN(columns[i], _children[i]->evaluate_checked(context, ptr));
     }
 
     MutableColumnPtr res;

--- a/be/src/exprs_ext/dict/dictionary_get_expr.cpp
+++ b/be/src/exprs_ext/dict/dictionary_get_expr.cpp
@@ -34,7 +34,7 @@ StatusOr<ColumnPtr> DictionaryGetExpr::evaluate_checked(ExprContext* context, Ch
     // calculate all child expression which used to construct keys
     size_t size = ptr != nullptr ? ptr->num_rows() : 1;
     for (int i = 0; i < _children.size(); ++i) {
-        columns[i] = _children[i]->evaluate(context, ptr);
+        ASSIGN_OR_RETURN(columns[i], _children[i]->evaluate_checked(context, ptr));
     }
 
     for (auto& column : columns) {

--- a/be/src/storage/rowset/cast_column_iterator.cpp
+++ b/be/src/storage/rowset/cast_column_iterator.cpp
@@ -41,8 +41,8 @@ CastColumnIterator::CastColumnIterator(std::unique_ptr<ColumnIterator> source_it
 
 CastColumnIterator::~CastColumnIterator() = default;
 
-void CastColumnIterator::do_cast(Column* target) {
-    auto cast_result = _cast_expr->evaluate(nullptr, &_source_chunk);
+Status CastColumnIterator::do_cast(Column* target) {
+    ASSIGN_OR_RETURN(auto cast_result, _cast_expr->evaluate_checked(nullptr, &_source_chunk));
     cast_result = ColumnHelper::unfold_const_column(_cast_expr->type(), _source_chunk.num_rows(), cast_result);
     if ((target->is_nullable() == cast_result->is_nullable()) && (target->size() == 0)) {
         target->swap_column(*(cast_result->as_mutable_raw_ptr()));
@@ -52,13 +52,14 @@ void CastColumnIterator::do_cast(Column* target) {
     } else {
         target->append(*cast_result, 0, cast_result->size());
     }
+    return Status::OK();
 }
 
 Status CastColumnIterator::next_batch(size_t* n, Column* dst) {
     _source_chunk.reset();
     auto* source_column = _source_chunk.get_column_raw_ptr_by_index(0);
     RETURN_IF_ERROR(_parent->next_batch(n, source_column));
-    do_cast(dst);
+    RETURN_IF_ERROR(do_cast(dst));
     return Status::OK();
 }
 
@@ -66,7 +67,7 @@ Status CastColumnIterator::next_batch(const SparseRange<>& range, Column* dst) {
     _source_chunk.reset();
     auto* source_column = _source_chunk.get_column_raw_ptr_by_index(0);
     RETURN_IF_ERROR(_parent->next_batch(range, source_column));
-    do_cast(dst);
+    RETURN_IF_ERROR(do_cast(dst));
     return Status::OK();
 }
 
@@ -74,7 +75,7 @@ Status CastColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t s
     _source_chunk.reset();
     auto* source_column = _source_chunk.get_column_raw_ptr_by_index(0);
     RETURN_IF_ERROR(_parent->fetch_values_by_rowid(rowids, size, source_column));
-    do_cast(values);
+    RETURN_IF_ERROR(do_cast(values));
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/cast_column_iterator.h
+++ b/be/src/storage/rowset/cast_column_iterator.h
@@ -65,7 +65,7 @@ public:
     std::string name() const override { return "CastColumnIterator"; }
 
 private:
-    void do_cast(Column* target);
+    Status do_cast(Column* target);
 
     std::unique_ptr<ObjectPool> _obj_pool;
     // managed by |_obj_pool|

--- a/be/test/exprs/arithmetic_expr_test.cpp
+++ b/be/test/exprs/arithmetic_expr_test.cpp
@@ -705,4 +705,39 @@ TEST_F(VectorizedArithmeticExprTest, constModN128Expr) {
     }
 }
 
+// An expression that fails at evaluation time, like dict_mapping() on a NULL key.
+class FailingExpr final : public Expr {
+public:
+    explicit FailingExpr(const TExprNode& node) : Expr(node) {}
+
+    Expr* clone(ObjectPool* pool) const override { return pool->add(new FailingExpr(*this)); }
+
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override {
+        return Status::InternalError("child evaluation failed");
+    }
+
+    bool is_constant() const override { return false; }
+};
+
+TEST_F(VectorizedArithmeticExprTest, bitShiftPropagatesChildError) {
+    expr_node.opcode = TExprOpcode::BIT_SHIFT_LEFT;
+    expr_node.child_type = TPrimitiveType::BIGINT;
+    expr_node.type = gen_type_desc(TPrimitiveType::BIGINT);
+
+    std::unique_ptr<Expr> expr(VectorizedArithmeticExprFactory::from_thrift(expr_node));
+    ASSERT_TRUE(expr != nullptr);
+
+    MockVectorizedExpr<TYPE_BIGINT> lhs(expr_node, 10, 1);
+    FailingExpr rhs(expr_node);
+
+    expr->_children.push_back(&lhs);
+    expr->_children.push_back(&rhs);
+
+    // The child error must come back as a Status. Unwrapping it instead throws out of a pipeline
+    // worker thread, where nothing catches it, and aborts the whole BE process.
+    auto result = expr->evaluate_checked(nullptr, nullptr);
+    ASSERT_FALSE(result.ok());
+    ASSERT_TRUE(result.status().is_internal_error());
+}
+
 } // namespace starrocks

--- a/test/sql/test_dict_mapping_function/R/test_dict_mapping_function
+++ b/test/sql/test_dict_mapping_function/R/test_dict_mapping_function
@@ -59,6 +59,7 @@ DROP TABLE t_dict_mapping_streamload;
 DROP DATABASE test_dict_mapping_streamload;
 -- result:
 -- !result
+
 -- name: test_dictmapping_multiple_column @native
 CREATE DATABASE test_dictmapping_multiple_column;
 -- result:
@@ -95,6 +96,7 @@ SELECT dict_mapping("dict", col_1, col_2) FROM t;
 DROP DATABASE test_dictmapping_multiple_column;
 -- result:
 -- !result
+
 -- name: test_dictmapping_null_column @native
 CREATE DATABASE test_dictmapping_null_column;
 -- result:
@@ -129,6 +131,51 @@ SELECT dict_mapping("dict", col_1, col_2) FROM t;
 [REGEX].*invalid parameter : get NULL paramenter.*
 -- !result
 DROP DATABASE test_dictmapping_null_column;
+-- result:
+-- !result
+
+-- name: test_dictmapping_nested_null_key @native
+CREATE DATABASE test_dictmapping_nested_null_key;
+-- result:
+-- !result
+use test_dictmapping_nested_null_key;
+-- result:
+-- !result
+create table dict(col_1 int, col_2 string, col_3 bigint not null auto_increment, col_4 int)
+primary key(col_1, col_2)
+distributed by hash(col_1, col_2)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO dict VALUES (1, "abc", default, 0);
+-- result:
+-- !result
+create table t(col_1 int, col_2 string)
+primary key(col_1)
+distributed by hash(col_1)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t VALUES (1, NULL);
+-- result:
+-- !result
+SELECT dict_mapping("dict", col_1, dict_mapping("dict", col_1, col_2)) FROM t;
+-- result:
+[REGEX].*invalid parameter : get NULL paramenter.*
+-- !result
+SELECT bit_shift_left(1, dict_mapping("dict", col_1, col_2)) FROM t;
+-- result:
+[REGEX].*invalid parameter : get NULL paramenter.*
+-- !result
+SELECT count(*) FROM t;
+-- result:
+1
+-- !result
+DROP DATABASE test_dictmapping_nested_null_key;
 -- result:
 -- !result
 -- name: test_dictmapping_DictQueryOperator_bug @native
@@ -192,6 +239,7 @@ insert into fact_tbl_2
 DROP DATABASE test_dictmapping_DictQueryOperator_bug;
 -- result:
 -- !result
+
 -- name: test_dictmapping_add_generated_column_with_dict_mapping @native
 CREATE DATABASE test_dictmapping_add_generated_column_with_dict_mapping;
 -- result:
@@ -239,6 +287,7 @@ DROP TABLE t_dictmapping_add_generated_column_with_dict_mapping;
 DROP DATABASE test_dictmapping_add_generated_column_with_dict_mapping;
 -- result:
 -- !result
+
 -- name: test_dictmapping_generated_column_in_create_table @native
 CREATE DATABASE test_dictmapping_generated_column_in_create_table;
 -- result:
@@ -264,6 +313,7 @@ E: (1064, 'Getting analyzing error. Detail message: column:COL_1 does not exist.
 DROP DATABASE test_dictmapping_generated_column_in_create_table;
 -- result:
 -- !result
+
 -- name: test_dictmapping_null_if_not_found @native
 CREATE DATABASE test_dictmapping_null_if_not_found;
 -- result:
@@ -307,6 +357,7 @@ drop table t_dictmapping_null_if_not_found;
 drop database test_dictmapping_null_if_not_found;
 -- result:
 -- !result
+
 -- name: test_dictmapping_multiple_open_crash @native
 CREATE TABLE `t_dictmapping_multiple_open_crash` (
   `k` BIGINT NOT NULL COMMENT "",

--- a/test/sql/test_dict_mapping_function/T/test_dict_mapping_function
+++ b/test/sql/test_dict_mapping_function/T/test_dict_mapping_function
@@ -86,6 +86,38 @@ SELECT dict_mapping("dict", col_1, col_2) FROM t;
 
 DROP DATABASE test_dictmapping_null_column;
 
+-- name: test_dictmapping_nested_null_key @native
+CREATE DATABASE test_dictmapping_nested_null_key;
+use test_dictmapping_nested_null_key;
+create table dict(col_1 int, col_2 string, col_3 bigint not null auto_increment, col_4 int)
+primary key(col_1, col_2)
+distributed by hash(col_1, col_2)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO dict VALUES (1, "abc", default, 0);
+
+create table t(col_1 int, col_2 string)
+primary key(col_1)
+distributed by hash(col_1)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO t VALUES (1, NULL);
+
+-- dict_mapping() fails on the NULL key. When that failure was the input of another
+-- expression it used to be unwrapped by the unchecked Expr::evaluate(), which throws
+-- BadStatusOrAccess instead of returning the Status and took the whole BE down.
+SELECT dict_mapping("dict", col_1, dict_mapping("dict", col_1, col_2)) FROM t;
+SELECT bit_shift_left(1, dict_mapping("dict", col_1, col_2)) FROM t;
+
+-- The BE must still be serving queries.
+SELECT count(*) FROM t;
+
+DROP DATABASE test_dictmapping_nested_null_key;
+
 -- name: test_dictmapping_DictQueryOperator_bug @native
 CREATE DATABASE test_dictmapping_DictQueryOperator_bug;
 USE test_dictmapping_DictQueryOperator_bug;


### PR DESCRIPTION
## Why I'm doing:

```
query_id:019fda5b-d45c-7330-a15e-4d2425b71983, fragment_instance:019fda5b-d45c-7330-a15e-4d2425b71985, plan_node_id:0
*** Aborted at 1786074879 (unix time) try "date -d @1786074879" if you are using GNU date ***
PC: @     0x7a1957beeb2c pthread_kill
*** SIGABRT (@0x10cfaf) received by PID 1101743 (TID 0x7a16898226c0) LWP(1103274) from PID 1101743; stack trace: ***
    @         0x32e7cc87 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7a1957bf1ed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)
    @         0x32e7c486 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7a1957b95330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @     0x7a1957beeb2c pthread_kill
    @     0x7a1957b9527e gsignal
    @     0x7a1957b788ff abort
    @         0x3bb66d50 __gnu_cxx::__verbose_terminate_handler() [clone .cold]
    @         0x3bb6547a __cxxabiv1::__terminate(void (*)())
    @         0x3bb654e1 std::terminate()
    @     0x7a195798d391 __cxa_throw
    @         0x3bc472de __wrap___cxa_throw
    @         0x2e53bdea starrocks::internal_statusor::ThrowBadStatusOrAccess(starrocks::Status)
    @         0x1d51e140 starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> >::value() &&
    @         0x1ef23004 starrocks::Expr::evaluate(starrocks::ExprContext*, starrocks::Chunk*)
    @         0x2a394a4c starrocks::VectorizedBitShiftArithmeticExpr<(starrocks::LogicalType)1, starrocks::BitShiftLeftOp>::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
    @         0x2a64dc9e starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*)
    @         0x2a64d492 starrocks::ExprContext::evaluate(starrocks::Chunk*, unsigned char*)
    @         0x1e77287e starrocks::pipeline::ProjectOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @         0x23676ac4 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @         0x1e5d8b31 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()

```

Expr::evaluate() is the deprecated unchecked wrapper around evaluate_checked(): it calls StatusOr::value(), which throws BadStatusOrAccess when the child returned an error Status. Turning a recoverable Status into a throw is never what the caller wants:

  - on a debug/ASAN build nothing catches it, because the driver's TRY_CATCH_ALL (pipeline_driver_executor.cpp) is compiled in only under NDEBUG, so __cxa_throw goes straight to std::terminate and the whole BE process aborts;
  - on a release build the driver catches it, but the query then fails with "Internal error: Bad StatusOr access" instead of the actual error;
  - on scan and compaction threads there is no containment in any build type (ScanExecutor::worker_thread has no handler, and the ThreadPool one is gated on enable_threadpool_catch_task_exception, default false).

Four places still evaluated an expression through that wrapper. dict_mapping() is a child that fails on ordinary data: it returns InternalError when a key column contains NULL, and NotFound on a strict-mode miss. So a nested call aborts an ASAN BE:

  INSERT INTO t VALUES (1, NULL);
  SELECT dict_mapping('dict', col_1, dict_mapping('dict', col_1, col_2)) FROM t;
  SELECT bit_shift_left(1, dict_mapping('dict', col_1, col_2)) FROM t;

Both were reproduced; the single-level call already reported a plain query error, so only the unchecked unwrapping was at fault.

Evaluate through evaluate_checked() with ASSIGN_OR_RETURN so the error is returned as a Status and surfaces as the real query error. CastColumnIterator::do_cast() cannot report an error at all today, so give it a Status return: it runs on the threads that have no containment, and the nested and variant cast exprs it can build do return non-OK. After this there is no caller of the unchecked wrapper left in be/src.

Adds a SQL regression case next to the existing test_dictmapping_null_column, which already builds the same dict/NULL-key fixture, plus a unit test that gives the bit-shift expression a failing child.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
