### PR TITLE
[BugFix] Skip CHAR predicate zero-padding for non-positive column length

### DIFF
--- a/be/src/storage/predicate_parser.cpp
+++ b/be/src/storage/predicate_parser.cpp
@@ -70,7 +70,14 @@ StatusOr<ColumnPredicate*> OlapPredicateParser::t_parse_thrift_cond(const Condit
     ColumnPredicate* pred = predicate_parser_detail::create_column_predicate(condition, type_info, index);
     RETURN_IF(pred == nullptr, Status::Unknown("unknown condition"));
 
-    if (type == TYPE_CHAR) {
+    // A length-less CHAR (col.length() == -1) reaches here from flat-JSON / variant subfield
+    // pushdown, e.g. CAST(json_col->'$.x' AS char), which materializes a synthetic CHAR scan
+    // column with no declared width. col.length() is int32; -1 converts to ~SIZE_MAX when passed
+    // to padding_zeros(size_t), so std::string::append() throws std::length_error. A real
+    // materialized CHAR column always has length in [1, 255], and a length-less CHAR is an
+    // unbounded string that must not be zero-padded, so only pad when the declared width is
+    // positive.
+    if (type == TYPE_CHAR && col.length() > 0) {
         pred->padding_zeros(col.length());
     }
     return pred;

--- a/test/sql/test_json/R/test_json_subfield_char_neglen_predicate
+++ b/test/sql/test_json/R/test_json_subfield_char_neglen_predicate
@@ -1,0 +1,55 @@
+-- name: test_json_subfield_char_neglen_predicate
+-- Regression for the length-less CHAR crash. CAST(json->'$.x' AS char) with no length is a
+-- wildcard CHAR whose length is -1. flat-JSON subfield pushdown (cbo_json_v2_rewrite +
+-- cbo_prune_subfield) materializes it as a synthetic CHAR scan column with length -1, and BE
+-- OlapPredicateParser::t_parse_thrift_cond then called padding_zeros(col.length()). col.length()
+-- is int32; -1 converts to ~SIZE_MAX when passed to padding_zeros(size_t), so std::string::append
+-- threw std::length_error -- aborting the BE on shared-data (lake) scans and erroring the query on
+-- shared-nothing scans. The fix guards the padding with col.length() > 0. With the pushdown on
+-- (default), the length-less char cast must now run and return the same results as the varchar
+-- cast, get_json_string, and the pushdown-off path.
+create table t(id int, j json) duplicate key(id)
+  distributed by hash(id) buckets 3 properties("replication_num"="1");
+-- result:
+-- !result
+insert into t values
+ (1, parse_json('{"f2":"hello"}')),
+ (2, parse_json('{"f2":"world"}')),
+ (3, parse_json('{"f2":"hello"}'));
+-- result:
+-- !result
+set cbo_json_v2_rewrite = true;
+-- result:
+-- !result
+set cbo_prune_subfield = true;
+-- result:
+-- !result
+select id, cast(j->'$.f2' as char) as v from t order by id;
+-- result:
+1	hello
+2	world
+3	hello
+-- !result
+select count(*) from t where cast(j->'$.f2' as char) = 'hello';
+-- result:
+2
+-- !result
+select id from t where cast(j->'$.f2' as char) = 'world' order by id;
+-- result:
+2
+-- !result
+select count(*) from t where cast(j->'$.f2' as varchar) = 'hello';
+-- result:
+2
+-- !result
+select count(*) from t where get_json_string(j, 'f2') = 'hello';
+-- result:
+2
+-- !result
+set cbo_json_v2_rewrite = false;
+-- result:
+-- !result
+select count(*) from t where cast(j->'$.f2' as char) = 'hello';
+-- result:
+2
+-- !result

--- a/test/sql/test_json/T/test_json_subfield_char_neglen_predicate
+++ b/test/sql/test_json/T/test_json_subfield_char_neglen_predicate
@@ -1,0 +1,34 @@
+-- name: test_json_subfield_char_neglen_predicate
+-- Regression for the length-less CHAR crash. CAST(json->'$.x' AS char) with no length is a
+-- wildcard CHAR whose length is -1. flat-JSON subfield pushdown (cbo_json_v2_rewrite +
+-- cbo_prune_subfield) materializes it as a synthetic CHAR scan column with length -1, and BE
+-- OlapPredicateParser::t_parse_thrift_cond then called padding_zeros(col.length()). col.length()
+-- is int32; -1 converts to ~SIZE_MAX when passed to padding_zeros(size_t), so std::string::append
+-- threw std::length_error -- aborting the BE on shared-data (lake) scans and erroring the query on
+-- shared-nothing scans. The fix guards the padding with col.length() > 0. With the pushdown on
+-- (default), the length-less char cast must now run and return the same results as the varchar
+-- cast, get_json_string, and the pushdown-off path.
+create table t(id int, j json) duplicate key(id)
+  distributed by hash(id) buckets 3 properties("replication_num"="1");
+insert into t values
+ (1, parse_json('{"f2":"hello"}')),
+ (2, parse_json('{"f2":"world"}')),
+ (3, parse_json('{"f2":"hello"}'));
+
+set cbo_json_v2_rewrite = true;
+set cbo_prune_subfield = true;
+
+-- projection: length-less char cast extracts the subfield string (crashed the BE on lake scans before the fix).
+select id, cast(j->'$.f2' as char) as v from t order by id;
+
+-- predicate on a length-less char: the crash trigger. Must return the correct rows, not crash/error.
+select count(*) from t where cast(j->'$.f2' as char) = 'hello';
+select id from t where cast(j->'$.f2' as char) = 'world' order by id;
+
+-- equivalence: a length-less char must match varchar and get_json_string on the same subfield.
+select count(*) from t where cast(j->'$.f2' as varchar) = 'hello';
+select count(*) from t where get_json_string(j, 'f2') = 'hello';
+
+-- pushdown off must give the same answer (rule-on == rule-off).
+set cbo_json_v2_rewrite = false;
+select count(*) from t where cast(j->'$.f2' as char) = 'hello';


### PR DESCRIPTION
## Why I'm doing:

`CAST(json_col->'$.x' AS char)` with no length is a wildcard CHAR whose declared length is `-1`. flat-JSON / variant subfield pushdown materializes it as a synthetic CHAR scan column with length `-1`. `OlapPredicateParser::t_parse_thrift_cond` then calls `pred->padding_zeros(col.length())`; `col.length()` is `int32`, and `-1` converts to `~SIZE_MAX` when passed to `padding_zeros(size_t)`, so `std::string::append()` throws `std::length_error`.

- On **shared-data (lake)** scans the predicate is parsed inside `LakeDataSource::open()` on the async `ScanExecutor::worker_thread`, which has no try/catch, so the exception escapes and **aborts the BE** (or, on builds with the thread-pool catch, silently retires the scan worker and hangs queries). A single query fanned out across a table's tablets can take down every BE that holds one.
- On **shared-nothing (olap)** scans it is parsed in `OlapChunkSource::prepare()` on the driver thread, which is wrapped in `TRY_CATCH_ALL`, so it merely surfaces as a query error.

## What I'm doing:

`OlapPredicateParser::t_parse_thrift_cond` is the only place in the BE that calls `padding_zeros(col.length())`, and both olap and lake scans go through it, so guarding it fixes every subfield-pushdown producer at once (JSON and variant).

A real materialized CHAR column always has length in `[1, 255]` (enforced at DDL); a length-less CHAR is an unbounded string (byte-identical to VARCHAR in StarRocks) that must not be zero-padded. Pad only when `col.length() > 0`; for a non-positive width there is nothing to pad, so skipping it is both necessary and correct.

Also adds an e2e regression test (`test_json_subfield_char_neglen_predicate`) that drives `CAST(json->'$.x' AS char)` through the pushdown and asserts correct results equal to the varchar / `get_json_string` and pushdown-off paths.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
