### PR TITLE
[BugFix] Do not push a non-positive ranking predicate into a TopN

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownLimitRankingWindowRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownLimitRankingWindowRule.java
@@ -186,6 +186,14 @@ public class PushDownLimitRankingWindowRule extends TransformationRule {
         }
 
         long limitValue = topNOperator.getOffset() + topNOperator.getLimit();
+        // A zero limit keeps no row at all, so there is nothing worth pushing down. A TopN built out of it
+        // breaks the `limit != 0` invariant of LogicalTopNOperator, and reaches the BE as
+        // `partition_limit = 0`, where creating the sorter of the first partition fails a CHECK.
+        // This only ever fires for an explicit `LIMIT 0`: DEFAULT_LIMIT is already filtered out by the
+        // hasLimit() check above, and the offset of a TopN is never negative.
+        if (limitValue <= 0) {
+            return Collections.emptyList();
+        }
         TopNType topNType = TopNType.parse(callOperator.getFnName());
 
         if (partitionByColumns.isEmpty() && rankRelatedWindowOperator.getEnforceSortColumns().isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateRankingWindowRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateRankingWindowRule.java
@@ -178,6 +178,19 @@ public class PushDownPredicateRankingWindowRule extends TransformationRule {
         ConstantOperator rightChild = lessPredicate.getChild(1).cast();
         long limitValue = rightChild.getBigint();
 
+        // Ranking window functions start from 1, so a non-positive bound makes the predicate unsatisfiable and
+        // there is nothing worth pushing down. Turning such a bound into a TopN goes wrong three ways:
+        //   0  breaks the `limit != 0` invariant of LogicalTopNOperator, and reaches the BE as
+        //      `partition_limit = 0`, where creating the sorter of the first partition fails a CHECK;
+        //   -1 is indistinguishable from Operator.DEFAULT_LIMIT, the value a plan without a partition limit
+        //      already carries;
+        //   every negative value wraps around into a SIZE_MAX-ish limit once the BE sorter takes it as a
+        //      size_t, so the partition TopN silently prunes nothing.
+        // Leave the filter where it is, it produces the empty result on its own.
+        if (limitValue <= 0) {
+            return Collections.emptyList();
+        }
+
         List<ColumnRefOperator> partitionByColumns = rankRelatedWindowOperator.getPartitionExpressions().stream()
                 .map(ScalarOperator::<ColumnRefOperator>cast)
                 .collect(Collectors.toList());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
@@ -624,6 +624,61 @@ public class WindowTest extends PlanTestBase {
     }
 
     @Test
+    public void testRankingWindowWithNonPositivePredicateNotPushDown() throws Exception {
+        FeConstants.runningUnitTest = true;
+        // Ranking window functions start from 1, so these predicates keep no row at all. Pushing them down
+        // used to build a PARTITION-TOP-N with `partition limit: 0`, which crashes the BE when it creates
+        // the per-partition sorter, or a TopN with `limit 0`, which throws from LogicalTopNOperator.
+        for (String predicate : List.of("rk <= 0", "rk = 0", "rk < 0", "rk <= -3")) {
+            String sql = "select * from (\n" +
+                    "    select *, " +
+                    "        row_number() over (partition by v3 order by v2) as rk " +
+                    "    from t0\n" +
+                    ") sub_t0\n" +
+                    "where " + predicate + ";";
+            String plan = getFragmentPlan(sql);
+            assertNotContains(plan, "PARTITION-TOP-N");
+            assertContains(plan, ":SELECT");
+
+            // Without partition by there is no PARTITION-TOP-N, the pushdown used to fail the planner instead.
+            sql = "select * from (\n" +
+                    "    select *, " +
+                    "        row_number() over (order by v2) as rk " +
+                    "    from t0\n" +
+                    ") sub_t0\n" +
+                    "where " + predicate + ";";
+            plan = getFragmentPlan(sql);
+            assertNotContains(plan, "TOP-N");
+            assertContains(plan, ":SELECT");
+        }
+
+        for (String predicate : List.of("rk <= 0", "rk = 0", "rk < 0", "rk <= -3")) {
+            String sql = "select * from (\n" +
+                    "    select *, " +
+                    "        rank() over (partition by v3 order by v2) as rk " +
+                    "    from t0\n" +
+                    ") sub_t0\n" +
+                    "where " + predicate + ";";
+            String plan = getFragmentPlan(sql);
+            assertNotContains(plan, "PARTITION-TOP-N");
+        }
+
+        // A positive bound still gets pushed down.
+        String sql = "select * from (\n" +
+                "    select *, " +
+                "        row_number() over (partition by v3 order by v2) as rk " +
+                "    from t0\n" +
+                ") sub_t0\n" +
+                "where rk <= 1;";
+        assertContains(getFragmentPlan(sql), "  1:PARTITION-TOP-N\n" +
+                "  |  partition by: 3: v3 \n" +
+                "  |  partition limit: 1\n" +
+                "  |  order by: <slot 3> 3: v3 ASC, <slot 2> 2: v2 ASC\n" +
+                "  |  offset: 0");
+        FeConstants.runningUnitTest = false;
+    }
+
+    @Test
     public void testRankingWindowWithPartitionLimitPushDown() throws Exception {
         FeConstants.runningUnitTest = true;
         {


### PR DESCRIPTION
## Why I'm doing:

```
F00000000 00:00:00.000000 137928452425408 logging.cc:1962] RAW: Check data_->num_chars_to_log_ > 0 && data_->message_text_[data_->num_chars_to_log_ - 1] == '\n' failed: 
PC: @     0x7d74dac54b2c pthread_kill
*** SIGABRT (@0x3b6ec) received by PID 243436 (TID 0x7d71e40fd6c0) LWP(244579) from PID 243436; stack trace: ***
    @         0x32de7407 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7d74dac57ed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)
    @         0x32de6c06 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7d74dabfb330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @     0x7d74dac54b2c pthread_kill
    @     0x7d74dabfb27e gsignal
    @     0x7d74dabde8ff abort
    @         0x1cc08548 starrocks::failure_function()
    @         0x32ddad1d google::LogMessage::Fail()
    @         0x32ddbe04 google::LogMessageFatal::~LogMessageFatal()
    @         0x1e931969 starrocks::ChunksSorterTopn::ChunksSorterTopn(starrocks::RuntimeState*, std::vector<starrocks::ExprContext*, std::allocator<starrocks::ExprContext*> > const*, std::vector<bool, std::allocator<bool> > const
*, std::vector<bool, std::allocator<bool> > const*,@
    @         0x1ea5ccd7 void std::_Construct<starrocks::ChunksSorterTopn, starrocks::RuntimeState* const&, std::vector<starrocks::ExprContext*, std::allocator<starrocks::ExprContext*> > const*, std::vector<bool, std::allocator<bo
ol> >*, std::vector<bool, std::allocator<bool> >*, @
    @         0x1ea59467 std::_Sp_counted_ptr_inplace<starrocks::ChunksSorterTopn, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<starrocks::RuntimeState* const&, std::vector<starrocks::ExprContext*, st
d::allocator<starrocks::ExprContext*> > const*, std@
    @         0x1ea57666 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<starrocks::ChunksSorterTopn, std::allocator<void>, starrocks::RuntimeState* const&, std::vector<starrocks::ExprContext*, std::allocator<starr
ocks::ExprContext*> > const*, std::vector<bool, std@
    @         0x1ea54ea1 std::__shared_ptr<starrocks::ChunksSorterTopn, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<void>, starrocks::RuntimeState* const&, std::vector<starrocks::ExprContext*, std::allocator<starrocks
::ExprContext*> > const*, std::vector<bool, std::al@
    @         0x1ea51ae1 std::shared_ptr<starrocks::ChunksSorterTopn>::shared_ptr<std::allocator<void>, starrocks::RuntimeState* const&, std::vector<starrocks::ExprContext*, std::allocator<starrocks::ExprContext*> > const*, std::v
ector<bool, std::allocator<bool> >*, std::vector<bo@
    @         0x1ea4f665 std::shared_ptr<starrocks::ChunksSorterTopn> std::make_shared<starrocks::ChunksSorterTopn, starrocks::RuntimeState* const&, std::vector<starrocks::ExprContext*, std::allocator<starrocks::ExprContext*> > co
nst*, std::vector<bool, std::allocator<bool> >*, st@
    @         0x1e9cab4b starrocks::pipeline::LocalPartitionTopnContext::push_one_chunk_to_partitioner(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)::{lambda(unsigned long)#1}::operator()(unsigned long) const
    @         0x1ea3658b starrocks::Status starrocks::PartitionHashMapBase<true, false>::append_chunk_for_one_nullable_key<true, phmap::flat_hash_map<starrocks::Slice, starrocks::PartitionChunks*, starrocks::SliceHashWithSeed<(sta
rrocks::PhmapSeed)0>, starrocks::SliceEqual, std::a@
    @         0x1ea0e13a starrocks::StatusOr<bool> starrocks::PartitionHashMapWithOneNullableStringKey<phmap::flat_hash_map<starrocks::Slice, starrocks::PartitionChunks*, starrocks::SliceHashWithSeed<(starrocks::PhmapSeed)0>, star
rocks::SliceEqual, std::allocator<std::pair<starroc@

```

Ranking window functions start from 1, so a bound like `rk <= 0`, `rk = 0` or `rk <= -3` keeps no row at all. PushDownPredicateRankingWindowRule took the constant as-is and built a TopN out of it, and PushDownLimitRankingWindowRule does the same for a zero limit. Two ways that goes wrong:

- with a partition by, the plan reaches the BE as `partition_limit = 0`, and LocalPartitionTopnContext crashes the BE when it creates the sorter for the first partition: `chunks_sorter_topn.cpp:74 Check failed: _get_number_of_rows_to_sort() > 0 (0 vs. 0)`;
- without a partition by, the zero limit reaches LogicalTopNOperator through SplitTopNRule and trips its `checkState(limit != 0)`, so the query fails with "Unknown error".

Skip the pushdown when the bound is non-positive. The filter stays where it is and already produces the empty result.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
