### PR TITLE
[BugFix] Return the corrupt DELTA_BINARY_PACKED header instead of throwing it

### DIFF
--- a/be/src/formats/parquet/encoding_delta.h
+++ b/be/src/formats/parquet/encoding_delta.h
@@ -350,11 +350,11 @@ private:
         }
         values_per_mini_block_ = values_per_block_ / mini_blocks_per_block_;
         if (values_per_mini_block_ == 0) {
-            throw Status::Corruption("cannot have zero value per miniblock");
+            return Status::Corruption("cannot have zero value per miniblock");
         }
         if (values_per_mini_block_ % 32 != 0) {
-            throw Status::Corruption("the number of values in a miniblock must be multiple of 32, but it's " +
-                                     std::to_string(values_per_mini_block_));
+            return Status::Corruption("the number of values in a miniblock must be multiple of 32, but it's " +
+                                      std::to_string(values_per_mini_block_));
         }
 
         total_values_remaining_ = total_value_count_;

--- a/be/test/formats/parquet/encoding_test.cpp
+++ b/be/test/formats/parquet/encoding_test.cpp
@@ -1130,4 +1130,27 @@ TEST_F(ParquetEncodingTest, ByteStreamSplitFLBA) {
     f(31, 255);
 }
 
+// A DELTA_BINARY_PACKED page header is entirely file-controlled, so a corrupt one must come back
+// as a Status. Throwing here escapes the scan worker thread, which has no handler in any build
+// type, and aborts the BE process.
+TEST_F(ParquetEncodingTest, DeltaBinaryPackedCorruptHeader) {
+    // The header fields are ULEB128: values_per_block, mini_blocks_per_block, total_value_count
+    // and zigzag(first_value). Here values_per_block is 128 in both cases.
+    // 128 / 1000 == 0, i.e. more miniblocks than values.
+    const std::vector<uint8_t> zero_values_per_mini_block = {0x80, 0x01, 0xe8, 0x07, 0x00, 0x00};
+    // 128 / 3 == 42, which is not a multiple of 32.
+    const std::vector<uint8_t> unaligned_mini_block = {0x80, 0x01, 0x03, 0x00, 0x00};
+
+    const EncodingInfo* encoding = nullptr;
+    (void)EncodingInfo::get(tparquet::Type::INT32, tparquet::Encoding::DELTA_BINARY_PACKED, &encoding);
+    ASSERT_TRUE(encoding != nullptr);
+
+    for (const auto& header : {zero_values_per_mini_block, unaligned_mini_block}) {
+        std::unique_ptr<Decoder> decoder;
+        ASSERT_TRUE(encoding->create_decoder(&decoder).ok());
+        Status st = decoder->set_data(Slice(reinterpret_cast<const char*>(header.data()), header.size()));
+        ASSERT_TRUE(st.is_corruption()) << st;
+    }
+}
+
 } // namespace starrocks::parquet


### PR DESCRIPTION
## Why I'm doing:

DeltaBinaryPackedDecoder::InitHeader() validates the page header it just read and returns Status::Corruption for every malformed field -- except two, which throw the Status object instead:

    if (values_per_mini_block_ == 0) {
        throw Status::Corruption("cannot have zero value per miniblock");
    }

starrocks::Status does not derive from std::exception, so nothing catches it: FileReader::get_next's catch (std::exception&) does not match, TRY_CATCH_ALLOC_SCOPE does not match, and the scan worker thread has no handler of its own in any build type (ScanExecutor::worker_thread has none, and the ThreadPool one is gated on enable_threadpool_catch_task_exception, default false). A malformed Parquet file therefore aborts the BE process rather than failing the query.

Both fields come straight out of the page header as ULEB128 values, so any file can reach them: values_per_block / mini_blocks_per_block is 0 whenever a page claims more miniblocks than values, and is not a multiple of 32 for e.g. 128 / 3.

Return them like the four checks above already do.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
