### PR TITLE
[Enhancement] Suppress the stack trace for a global dict collection that finds no dict

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -4020,7 +4020,14 @@ public class StmtExecutor {
             } while (!batch.isEos());
             processQueryStatisticsFromResult(batch, plan, false);
         } catch (Exception e) {
-            LOG.warn("Failed to execute executeStmtWithExecPlan", e);
+            // A global dict collection that finds no dict is an expected outcome, not a failure: the caller
+            // turns it into a "not a low cardinality column" decision. Keep it out of the warn log, the same
+            // way DefaultCoordinator suppresses it, so it can't drown the real failures on this path.
+            if (coord != null && coord.getExecStatus().isSuppressedError()) {
+                LOG.debug("Failed to execute executeStmtWithExecPlan: {}", e.getMessage());
+            } else {
+                LOG.warn("Failed to execute executeStmtWithExecPlan", e);
+            }
             coord.getExecStatus().setInternalErrorStatus(e.getMessage());
         } finally {
             QeProcessorImpl.INSTANCE.unregisterQuery(context.getExecutionId());


### PR DESCRIPTION
## Why I'm doing:

Collecting a global dictionary for a column that has no dict page is an expected outcome, not a failure. The BE answers with GLOBAL_DICT_ERROR, executeStmtWithExecPlan turns that into a StarRocksException, and the catch block logged the full stack at WARN:

  StarRocksException: no global dict: BE:10002
      at StmtExecutor.executeStmtWithExecPlan
      at StatisticExecutor.executeStatisticDQLWithSample
      ...
      at CacheDictManager$1.lambda$asyncLoad$0

The caller already handles this: the status survives setInternalErrorStatus (GLOBAL_DICT_ERROR is exempt), so CacheDictManager records the column in NO_DICT_STRING_COLUMNS and stops asking for it. Only the log line is noise, and on a wide table it drowns the real failures on this path.

Honor Status.isSuppressedError() here the way DefaultCoordinator already does, and keep a message-only DEBUG line so the decision stays traceable.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
