### PR TITLE
[BugFix] Stop encoding a union output whose column is decoded elsewhere

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -810,6 +810,32 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         return visitPhysicalSetOperation(optExpression, context);
     }
 
+    /*
+     * Merge the dictionaries of the columns every UNION ALL branch contributes to one output
+     * position, and return the column whose dictionary the position ends up encoded with: one of
+     * the child columns, or the output column itself when the position is all constants and a
+     * dictionary was generated for it. Returns null when the position cannot be encoded at all.
+     */
+    private ColumnRefOperator mergeUnionDictionaries(List<ColumnRefOperator> childColumns,
+                                                     ColumnRefOperator outputColumn,
+                                                     ColumnRefSet encodableColumns) {
+        boolean isCandidate = childColumns.stream().allMatch(
+                c -> encodableColumns.contains(c) || unionDictionaryManager.isSupportedConstant(c));
+        if (!isCandidate) {
+            return null;
+        }
+        Integer merged = unionDictionaryManager.mergeDictionaries(
+                childColumns.stream().map(ColumnRefOperator::getId).toList(), outputColumn.getId());
+        if (merged == null) {
+            return null;
+        }
+        final int mergedId = merged;
+        if (mergedId == outputColumn.getId()) {
+            return outputColumn;
+        }
+        return childColumns.stream().filter(c -> c.getId() == mergedId).findAny().orElseThrow();
+    }
+
     private DecodeInfo visitPhysicalSetOperation(OptExpression optExpression, DecodeInfo context) {
         if (context.outputStringColumns.isEmpty()) {
             return DecodeInfo.empty();
@@ -820,32 +846,47 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
             Preconditions.checkState(!(dist instanceof HashDistributionSpec));
             DecodeInfo result = DecodeInfo.create();
             result.inputStringColumns.union(context.outputStringColumns);
-            for (int i = 0; i < setOp.getOutputColumnRefOp().size(); ++i) {
-                final int finalI = i;
-                List<ColumnRefOperator> childColumns = setOp.getChildOutputColumns().stream()
-                        .map(l -> l.get(finalI)).toList();
-                List<Integer> childColumnIds = childColumns.stream().map(ColumnRefOperator::getId).toList();
-                boolean isCandidate = childColumns.stream().allMatch(
-                        c -> context.outputStringColumns.contains(c) || unionDictionaryManager.isSupportedConstant(c));
-                ColumnRefOperator outputColumn = setOp.getOutputColumnRefOp().get(i);
-                Integer mergedId;
-                if (isCandidate && (mergedId =
-                        unionDictionaryManager.mergeDictionaries(childColumnIds, outputColumn.getId())) != null) {
-                    childColumnIds.stream().filter(context.outputStringColumns::contains).forEach(c -> {
-                        result.usedStringColumns.union(c);
-                        expressionStringRefCounter.put(c, expressionStringRefCounter.getOrDefault(c, 0) + 1);
-                    });
-                    if (mergedId == outputColumn.getId()) {
-                        setDefineExpr(outputColumn, outputColumn, 1);
-                    } else {
-                        setDefineExpr(outputColumn, childColumns.stream()
-                                .filter(c -> c.getId() == mergedId).findAny().orElseThrow(), 1);
+            List<ColumnRefOperator> outputColumns = setOp.getOutputColumnRefOp();
+            // childColumns.get(i) holds the column every branch contributes to output position i
+            List<List<ColumnRefOperator>> childColumns = IntStream.range(0, outputColumns.size())
+                    .mapToObj(i -> setOp.getChildOutputColumns().stream().map(l -> l.get(i)).toList())
+                    .toList();
+            // the column whose dictionary output position i is encoded with,
+            // null when the position cannot be dictionary encoded
+            List<ColumnRefOperator> useChildColumns = IntStream.range(0, outputColumns.size())
+                    .mapToObj(i -> mergeUnionDictionaries(childColumns.get(i), outputColumns.get(i),
+                            context.outputStringColumns))
+                    .collect(Collectors.toCollection(Lists::newArrayList));
+
+            // A child column that has to be decoded for one output position cannot stay encoded for
+            // another one: the same column ref would then reach the union as a string on one branch
+            // and as a dictionary code on another. Give up on every position sharing a column with a
+            // position we already gave up on, until the set of decoded columns stops growing.
+            int decodedColumns;
+            do {
+                decodedColumns = result.decodeStringColumns.size();
+                for (int i = 0; i < outputColumns.size(); ++i) {
+                    if (useChildColumns.get(i) != null
+                            && childColumns.get(i).stream().noneMatch(result.decodeStringColumns::contains)) {
+                        continue;
                     }
-                    result.outputStringColumns.union(outputColumn);
-                } else {
-                    childColumns.stream().filter(c -> context.outputStringColumns.contains(c))
+                    useChildColumns.set(i, null);
+                    childColumns.get(i).stream().filter(c -> context.outputStringColumns.contains(c))
                             .forEach(result.decodeStringColumns::union);
                 }
+            } while (decodedColumns != result.decodeStringColumns.size());
+
+            for (int i = 0; i < outputColumns.size(); ++i) {
+                if (useChildColumns.get(i) == null) {
+                    continue;
+                }
+                childColumns.get(i).stream().map(ColumnRefOperator::getId)
+                        .filter(context.outputStringColumns::contains).forEach(c -> {
+                            result.usedStringColumns.union(c);
+                            expressionStringRefCounter.put(c, expressionStringRefCounter.getOrDefault(c, 0) + 1);
+                        });
+                setDefineExpr(outputColumns.get(i), useChildColumns.get(i), 1);
+                result.outputStringColumns.union(outputColumns.get(i));
             }
             result.inputStringColumns.except(result.decodeStringColumns);
             return result;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -3140,6 +3140,53 @@ public class LowCardinalityTest2 extends PlanTestBase {
     }
 
     @Test
+    public void testUnionSameChildColumnPartiallyMergeable() throws Exception {
+        // C_USER feeds BOTH union output positions:
+        //   position 0: C_USER / C_DEPT     -> both have a dictionary, the merge succeeds
+        //   position 1: C_USER / CAST(int)  -> the cast has no dictionary, the merge fails
+        // The failed position forces C_USER to be decoded before the union, so position 0 must not
+        // stay dictionary encoded either - otherwise the left branch feeds a VARCHAR into an INT
+        // dict-code slot and the BE aborts in FixedLengthColumnBase<int>::append.
+        // Both sides of every position use the same type on purpose: any type mismatch makes the
+        // planner wrap the children in casts, which gives each position its own column ref.
+        String sql = """
+                  SELECT * FROM (
+                    SELECT C_USER a, C_USER b FROM low_card_t1
+                    UNION ALL
+                    SELECT C_DEPT, CAST(cpc AS VARCHAR(50)) FROM low_card_t1
+                  ) t
+                  """;
+        String plan = getVerboseExplain(sql);
+        // Neither position is dictionary encoded, and both branches feed the union strings.
+        assertContains(plan, "  0:UNION\n" +
+                "  |  output exprs:\n" +
+                "  |      [24, VARCHAR(50), true] | [25, VARCHAR(50), true]\n" +
+                "  |  child exprs:\n" +
+                "  |      [2: c_user, VARCHAR(50), true] | [2: c_user, VARCHAR(50), true]\n" +
+                "  |      [14: c_dept, VARCHAR(50), true] | [23: cast, VARCHAR(50), true]", plan);
+    }
+
+    @Test
+    public void testUnionSameChildColumnFullyMergeable() throws Exception {
+        // Same shape as testUnionSameChildColumnPartiallyMergeable, except that every position can
+        // merge its dictionaries. Giving up on a position must not spread when nothing failed.
+        String sql = """
+                  SELECT * FROM (
+                    SELECT C_USER a, C_USER b FROM low_card_t1
+                    UNION ALL
+                    SELECT C_DEPT, C_PAR FROM low_card_t1
+                  ) t
+                  """;
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "  0:UNION\n" +
+                "  |  output exprs:\n" +
+                "  |      [28, INT, true] | [29, INT, true]\n" +
+                "  |  child exprs:\n" +
+                "  |      [25: c_user, INT, true] | [25: c_user, INT, true]\n" +
+                "  |      [26: c_dept, INT, true] | [27: c_par, INT, true]", plan);
+    }
+
+    @Test
     public void testLeadWindowFunctionLowCardinalityRewrite() throws Exception {
         String sql = "select S_SUPPKEY, S_ADDRESS, lead(S_ADDRESS, 1) over(order by S_SUPPKEY) from supplier";
         String plan = getFragmentPlan(sql);

--- a/test/sql/test_global_dict/R/global_dict_union_partial_merge
+++ b/test/sql/test_global_dict/R/global_dict_union_partial_merge
@@ -1,0 +1,36 @@
+-- name: test_global_dict_union_partial_merge
+CREATE TABLE lc_union_partial (
+    id INT,
+    `s1` VARCHAR(50),
+    `s2` VARCHAR(50)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO lc_union_partial VALUES (0, 'a', 'x');
+-- result:
+-- !result
+INSERT INTO lc_union_partial VALUES (1, 'b', 'y');
+-- result:
+-- !result
+[UC]analyze full table lc_union_partial;
+function: wait_global_dict_ready('`s1`', 'lc_union_partial')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('`s2`', 'lc_union_partial')
+-- result:
+
+-- !result
+SELECT * FROM (
+  SELECT s1 AS a, s1 AS b FROM lc_union_partial
+  UNION ALL
+  SELECT s2, CAST(id AS VARCHAR(50)) FROM lc_union_partial
+) t ORDER BY 1, 2;
+-- result:
+a	a
+b	b
+x	0
+y	1
+-- !result

--- a/test/sql/test_global_dict/T/global_dict_union_partial_merge
+++ b/test/sql/test_global_dict/T/global_dict_union_partial_merge
@@ -1,0 +1,30 @@
+-- name: test_global_dict_union_partial_merge
+CREATE TABLE lc_union_partial (
+    id INT,
+    `s1` VARCHAR(50),
+    `s2` VARCHAR(50)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES('replication_num' = '1');
+
+INSERT INTO lc_union_partial VALUES (0, 'a', 'x');
+INSERT INTO lc_union_partial VALUES (1, 'b', 'y');
+
+[UC]analyze full table lc_union_partial;
+
+function: wait_global_dict_ready('`s1`', 'lc_union_partial')
+function: wait_global_dict_ready('`s2`', 'lc_union_partial')
+
+-- test_same_child_column_in_partially_mergeable_positions
+-- s1 feeds BOTH union output positions. Position 0 (s1 / s2) can merge its dictionaries,
+-- position 1 (s1 / CAST(id AS VARCHAR(50))) cannot because the cast has no dictionary.
+-- The failed position retroactively removes s1 from the encoded input set, but output
+-- position 0 stays marked as dictionary encoded, so the left branch feeds a VARCHAR into
+-- an INT dict-code slot. Every column type is identical on both sides on purpose: any type
+-- mismatch makes the planner wrap the children in casts, which gives each position its own
+-- column ref and hides the bug.
+SELECT * FROM (
+  SELECT s1 AS a, s1 AS b FROM lc_union_partial
+  UNION ALL
+  SELECT s2, CAST(id AS VARCHAR(50)) FROM lc_union_partial
+) t ORDER BY 1, 2;


### PR DESCRIPTION
## Why I'm doing:

```
query_id:019fdb99-5615-7a55-8383-8af78c1f113b, fragment_instance:019fdb99-5615-7a55-8383-8af78c1f113d, plan_node_id:-1
*** Aborted at 1786095687 (unix time) try "date -d @1786095687" if you are using GNU date ***
PC: @     0x7f74b06cf9bc pthread_kill
*** SIGABRT (@0x3eb003d41ca) received by PID 4014538 (TID 0x7f71e19ea640) LWP(4016121) from PID 4014538; stack trace: ***
    @         0x32cce4c7 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7f74b06d2ea8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ea7)
    @         0x32ccdcc6 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f74b067b520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @     0x7f74b06cf9bc pthread_kill
    @     0x7f74b067b476 raise
    @     0x7f74b06617f3 abort
    @         0x1cb0fe14 starrocks::failure_function()
    @         0x32cc1ddd google::LogMessage::Fail()
    @         0x32cc2ec4 google::LogMessageFatal::~LogMessageFatal()
    @         0x2d89eec2 starrocks::FixedLengthColumnBase<int>::append(starrocks::Column const&, unsigned long, unsigned long)
    @         0x2da237af starrocks::NullableColumn::append(starrocks::Column const&, unsigned long, unsigned long)
    @         0x2d6d37f6 starrocks::Chunk::append(starrocks::Chunk const&, unsigned long, unsigned long)
    @         0x1d3ed9c7 starrocks::Chunk::append(starrocks::Chunk const&)
    @         0x1e8632a8 starrocks::concat_chunks(std::shared_ptr<starrocks::Chunk>&, std::vector<std::shared_ptr<starrocks::Chunk>, std::allocator<std::shared_ptr<starrocks::Chunk> > > const&, unsigned long)
    @         0x1e863856 starrocks::ChunksSorterFullSort::_partial_sort(starrocks::RuntimeState*, bool)
    @         0x1e865ae3 starrocks::ChunksSorterFullSort::do_done(starrocks::RuntimeState*)
    @         0x1e7e4d3d starrocks::ChunksSorter::done(starrocks::RuntimeState*)
    @         0x1e7d5ca9 starrocks::pipeline::PartitionSortSinkOperator::set_finishing(starrocks::RuntimeState*)
    @         0x2350bc6e starrocks::pipeline::PipelineDriver::_mark_operator_finishing(std::shared_ptr<starrocks::pipeline::Operator>&, starrocks::RuntimeState*)
    @         0x23500c52 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @         0x1e4938e3 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @         0x1e491c90 starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}::operator()() const
    @         0x1e49984c void std::__invoke_impl<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(std::__invoke_other, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&)
```

A single child column ref can feed several UNION ALL output positions. When only some of those positions can merge their dictionaries, the failed position pushes the shared column into decodeStringColumns, but the position that succeeded had already been marked as dictionary encoded in the same pass. The union then reads that column as a string on one branch and as a dictionary code on another, so the BE aborts in FixedLengthColumnBase<int>::append when the chunks are concatenated.

Decide every position first, then propagate the give-up decision to all positions sharing a column with a failed one until it stops spreading, and only afterwards mark the surviving positions as encoded. Moving the reference counting to that last step also stops demoted positions from inflating the counters.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
