### PR TITLE
[BugFix] Drop dead subfield slots pulled out of the scan by predicate expr reuse

### DIFF
--- a/be/src/column/struct_column.cpp
+++ b/be/src/column/struct_column.cpp
@@ -479,6 +479,13 @@ void StructColumn::check_or_die() const {
     // fields and field_names must have the same size.
     DCHECK(_fields.size() == _field_names.size());
 
+    // every field must hold the same number of rows: size() reports _fields[0]->size(), so a field
+    // that was never materialized is invisible to every size-based check and only surfaces as an
+    // out-of-bounds read once something appends this column.
+    for (const auto& column : _fields) {
+        DCHECK_EQ(_fields[0]->size(), column->size());
+    }
+
     for (const auto& column : _fields) {
         column->check_or_die();
     }

--- a/be/src/runtime/serde/protobuf_chunk_serde.cpp
+++ b/be/src/runtime/serde/protobuf_chunk_serde.cpp
@@ -287,7 +287,12 @@ StatusOr<Chunk> ProtobufChunkDeserializer::deserialize(std::string_view buff, in
     }
 
     if (deserialized_bytes != nullptr) *deserialized_bytes = cur - reinterpret_cast<const uint8_t*>(buff.data());
-    return Chunk(std::move(columns), _meta.slot_id_to_index, std::move(chunk_extra_data));
+    Chunk chunk(std::move(columns), _meta.slot_id_to_index, std::move(chunk_extra_data));
+    // The row-count loop above only sees Column::size(), which for a complex column is derived from its
+    // offsets or its first field, so a nested child the sender never materialized slips through it. This
+    // is the constructor that skips the check the other Chunk constructors run; do it here instead.
+    DCHECK_CHUNK(&chunk);
+    return chunk;
 }
 
 StatusOr<ProtobufChunkMeta> build_protobuf_chunk_meta(const RecordDescriptor& record_desc, const ChunkPB& chunk_pb) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PullUpScanPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PullUpScanPredicateRule.java
@@ -126,10 +126,12 @@ public class PullUpScanPredicateRule extends TransformationRule {
         SubfieldCollector collector = new SubfieldCollector(context.getColumnRefFactory());
         collector.visit(reservedPredicates, null);
 
+        Map<ScalarOperator, ColumnRefOperator> collectedMappings = new HashMap<>();
         collector.getExpressionMapping().forEach((k, v) -> {
             if (!translatingMap.containsKey(k)) {
                 translatingMap.put(k, v);
                 newProjections.put(v, k);
+                collectedMappings.put(k, v);
             }
         });
 
@@ -139,6 +141,21 @@ public class PullUpScanPredicateRule extends TransformationRule {
         }
 
         ColumnRefSet predicateUsedColumnRefSet = reservedPredicates.getUsedColumns();
+
+        // SubfieldCollector mints a column ref for every subfield node it walks, the intermediate ones
+        // included: for `s1.s2[1].a` it maps `s1.s2`, `s1.s2[1]` and `s1.s2[1].a`, while
+        // replaceScalarOperator only substitutes the outermost match into the predicate. Projecting the
+        // unreferenced ones out of the scan makes it emit a wider slice of the column than the
+        // ColumnAccessPath PruneSubfieldRule already computed for this scan, so such a slot is served by a
+        // partially materialized column - e.g. an ARRAY<STRUCT<a, b>> whose `b` field holds no rows, which
+        // reads out of bounds as soon as anything appends that column. Keep only the refs the rewritten
+        // predicate really uses.
+        collectedMappings.forEach((expr, ref) -> {
+            if (!predicateUsedColumnRefSet.contains(ref)) {
+                translatingMap.remove(expr);
+                newProjections.remove(ref);
+            }
+        });
         newScanOperator.buildColumnFilters(pushedPredicates);
 
         List<ColumnRefOperator> predicateUsedColumns = predicateUsedColumnRefSet

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/SelectStmtWithCaseWhenTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/SelectStmtWithCaseWhenTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.wildfly.common.Assert;
 
 import java.util.Arrays;
 import java.util.List;
@@ -637,7 +636,7 @@ class SelectStmtWithCaseWhenTest {
                 "FROM cte01\n" +
                 "WHERE len_bucket IS NOT NULL;";
         String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql);
-        Assert.assertTrue(plan.contains("  2:SELECT\n" +
+        Assertions.assertTrue(plan.contains("  2:SELECT\n" +
                 "  |  predicates: 3: case IS NOT NULL\n" +
                 "  |  cardinality: 1\n" +
                 "  |  \n" +
@@ -646,10 +645,9 @@ class SelectStmtWithCaseWhenTest {
                 "  |  1 <-> [1: id, VARCHAR, false]\n" +
                 "  |  3 <-> CASE WHEN [5: array_length, INT, true] < 2 THEN 'bucket1' " +
                 "WHEN ([5: array_length, INT, true] >= 2) AND ([5: array_length, INT, true] < 4) THEN 'bucket2' ELSE NULL END\n" +
-                "  |  4 <-> [5: array_length, INT, true]\n" +
                 "  |  common expressions:\n" +
                 "  |  5 <-> array_length[([2: col_arr, ARRAY<VARCHAR(100)>, true]); " +
-                "args: INVALID_TYPE; result: INT; args nullable: true; result nullable: true]"));
+                "args: INVALID_TYPE; result: INT; args nullable: true; result nullable: true]"), plan);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -170,6 +170,19 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
     }
 
     @Test
+    public void testPredicateExprReuseKeepsAccessPathCoveringScanProjection() throws Exception {
+        // `st6.a3[1].s5` appears in both the predicate and the output list. PullUpScanPredicateRule used to
+        // project the intermediate `st6.a3` - the whole ARRAY<STRUCT<s5, s6>> - out of the scan even though
+        // nothing referenced that slot, while the access path only delivered /st6/a3/INDEX/s5. The scan then
+        // emitted an array whose `s6` field held no rows, which read out of bounds downstream.
+        String sql = "select st6.a3[1].s5 from sc0 where v1 = st6.a3[1].s5 order by v1 limit 2";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "ColumnAccessPath: [/st6/a3/INDEX/s5]");
+        // no slot holds the bare `st6.a3`, which would need /st6/a3 as a whole
+        assertNotContains(plan, "].a3[true]\n");
+    }
+
+    @Test
     public void testJoinPruneColumn() throws Exception {
         String sql = "select sc0.st1.s1, st1.s2 from t0 join sc0 on sc0.v1 = t0.v1";
         String plan = getVerboseExplain(sql);

--- a/test/sql/test_complex_type_prune/R/test_scan_predicate_reuse_subfield_prune
+++ b/test/sql/test_complex_type_prune/R/test_scan_predicate_reuse_subfield_prune
@@ -1,0 +1,62 @@
+-- name: test_scan_predicate_reuse_subfield_prune
+drop database if exists test_scan_predicate_reuse_subfield_prune;
+-- result:
+-- !result
+create database test_scan_predicate_reuse_subfield_prune;
+-- result:
+-- !result
+use test_scan_predicate_reuse_subfield_prune;
+-- result:
+-- !result
+create table scs3 (
+  v1 bigint null,
+  str string null,
+  s1 struct<s1 int, s2 array<struct<a int, b int>>, s3 map<int,int>, s4 struct<e int, f int>>
+) duplicate key(v1)
+distributed by hash(v1) buckets 3 properties("replication_num"="1");
+-- result:
+-- !result
+insert into scs3 values
+  (1, 'aa', row(1, [row(1,11), row(2,21)], map{1:101}, row(1,1))),
+  (2, '5',  row(2, [row(5,12), row(6,22)], map{1:102}, row(2,2))),
+  (3, '7',  row(3, [row(7,13), row(8,23)], map{1:103}, row(3,3))),
+  (4, '9',  row(4, [row(9,14), row(0,24)], map{1:104}, row(4,4)));
+-- result:
+-- !result
+set cbo_enable_low_cardinality_optimize = false;
+-- result:
+-- !result
+select s1.s2[1].a from scs3 where str = s1.s2[1].a order by v1 limit 2;
+-- result:
+5
+7
+-- !result
+select map_size(s1.s3), s1.s2[1].a, s1.s3[1], s1.s4.f from scs3
+where str in ('aa', (s1.s2[1].a), 'ii', 'cc') order by v1 limit 2;
+-- result:
+1	5	102	2
+1	7	103	3
+-- !result
+select s1.s2[1].a from scs3 where str = s1.s2[1].a order by v1;
+-- result:
+5
+7
+9
+-- !result
+select s1.s2[1].a, s1.s2[1].b from scs3 where str = s1.s2[1].a order by v1;
+-- result:
+5	12
+7	13
+9	14
+-- !result
+function: assert_explain_verbose_contains('select s1.s2[1].a from scs3 where str = s1.s2[1].a order by v1 limit 2', 'ColumnAccessPath: [/s1/s2/INDEX/a]')
+-- result:
+None
+-- !result
+function: assert_explain_not_contains('select s1.s2[1].a from scs3 where str = s1.s2[1].a order by v1 limit 2', '].s2[true]\n')
+-- result:
+None
+-- !result
+drop database test_scan_predicate_reuse_subfield_prune;
+-- result:
+-- !result

--- a/test/sql/test_complex_type_prune/T/test_scan_predicate_reuse_subfield_prune
+++ b/test/sql/test_complex_type_prune/T/test_scan_predicate_reuse_subfield_prune
@@ -1,0 +1,50 @@
+-- name: test_scan_predicate_reuse_subfield_prune
+-- Bug: PullUpScanPredicateRule mints a scan projection slot for every subfield node its
+-- SubfieldCollector walks, the intermediate ones included: for `s1.s2[1].a` it maps `s1.s2`,
+-- `s1.s2[1]` and `s1.s2[1].a`, while replaceScalarOperator only substitutes the outermost one into
+-- the predicate. The dead `s1.s2` slot holds the whole ARRAY<STRUCT<a, b>>, but the rule runs after
+-- PruneSubfieldRule has already fixed the scan's ColumnAccessPath to /s1/s2/INDEX/a, so the scan
+-- emits an array whose `b` field holds no rows. A MERGING-EXCHANGE then reads out of bounds:
+--   FixedLengthColumnBase<int>::append <- StructColumn::append <- ArrayColumn::append
+--   <- Chunk::append <- ChunkSliceTemplate::cutoff <- CascadeChunkMerger::get_next
+-- SIGSEGV, release builds included. Workaround: set enable_scan_predicate_expr_reuse = false.
+drop database if exists test_scan_predicate_reuse_subfield_prune;
+create database test_scan_predicate_reuse_subfield_prune;
+use test_scan_predicate_reuse_subfield_prune;
+
+create table scs3 (
+  v1 bigint null,
+  str string null,
+  s1 struct<s1 int, s2 array<struct<a int, b int>>, s3 map<int,int>, s4 struct<e int, f int>>
+) duplicate key(v1)
+distributed by hash(v1) buckets 3 properties("replication_num"="1");
+
+insert into scs3 values
+  (1, 'aa', row(1, [row(1,11), row(2,21)], map{1:101}, row(1,1))),
+  (2, '5',  row(2, [row(5,12), row(6,22)], map{1:102}, row(2,2))),
+  (3, '7',  row(3, [row(7,13), row(8,23)], map{1:103}, row(3,3))),
+  (4, '9',  row(4, [row(9,14), row(0,24)], map{1:104}, row(4,4)));
+
+-- the low-cardinality rewrite would put its own never-materialized dict slot first, which the
+-- deserializer's top-level row-count guard rejects before the merger ever sees the array
+set cbo_enable_low_cardinality_optimize = false;
+
+-- `s1.s2[1].a` in both the predicate and the output list; ORDER BY forces a MERGING-EXCHANGE
+select s1.s2[1].a from scs3 where str = s1.s2[1].a order by v1 limit 2;
+
+-- same shape, wider projection - this is the statement the fuzzer found
+select map_size(s1.s3), s1.s2[1].a, s1.s3[1], s1.s4.f from scs3
+where str in ('aa', (s1.s2[1].a), 'ii', 'cc') order by v1 limit 2;
+
+-- no LIMIT still goes through the merging exchange
+select s1.s2[1].a from scs3 where str = s1.s2[1].a order by v1;
+
+-- reading `b` as well must keep both fields in the access path
+select s1.s2[1].a, s1.s2[1].b from scs3 where str = s1.s2[1].a order by v1;
+
+-- nothing may project the bare `s1.s2` out of the scan: that slot needs all of /s1/s2, which the
+-- access path does not deliver
+function: assert_explain_verbose_contains('select s1.s2[1].a from scs3 where str = s1.s2[1].a order by v1 limit 2', 'ColumnAccessPath: [/s1/s2/INDEX/a]')
+function: assert_explain_not_contains('select s1.s2[1].a from scs3 where str = s1.s2[1].a order by v1 limit 2', '].s2[true]\n')
+
+drop database test_scan_predicate_reuse_subfield_prune;


### PR DESCRIPTION
## Why I'm doing:

```
❯ query_id:019fd8fe-c402-7a13-8f86-78ca63fe2b63, fragment_instance:019fd8fe-c402-7a13-8f86-78ca63fe2b64, plan_node_id:4                                                                                                               
  *** Aborted at 1786052002 (unix time) try "date -d @1786052002" if you are using GNU date ***                                                                                                                                       
  PC: @          0xe42d57f starrocks::FixedLengthColumnBase<int>::append(starrocks::Column const&, unsigned long, unsigned long)                                                                                                      
  *** SIGSEGV (@0x0) received by PID 4112915 (TID 0x7faafefff6c0) LWP(4113631) from PID 0; stack trace: ***                                                                                                                           
      @     0x7fad957cbed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)                                                                                                                                                              
      @         0x1260d186 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)                                                                                                                                
      @     0x7fad9576f330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)                                                                                                                                                              
      @          0xe42d57f starrocks::FixedLengthColumnBase<int>::append(starrocks::Column const&, unsigned long, unsigned long)                                                                                                      
      @          0xe391182 starrocks::StructColumn::append(starrocks::Column const&, unsigned long, unsigned long)                                                                                                                    
      @          0xe375029 starrocks::ArrayColumn::append(starrocks::Column const&, unsigned long, unsigned long)                                                                                                                     
      @          0xe34970d starrocks::Chunk::append(starrocks::Chunk const&, unsigned long, unsigned long)                                                                                                                            
      @          0xe355d67 starrocks::ChunkSliceTemplate<std::unique_ptr<starrocks::Chunk, std::default_delete<starrocks::Chunk> > >::cutoff(unsigned long)                                                                           
      @          0xae7d200 starrocks::CascadeChunkMerger::get_next(std::unique_ptr<starrocks::Chunk, std::default_delete<starrocks::Chunk> >*, std::atomic<bool>*, bool*)                                                             
      @          0xae15e15 starrocks::DataStreamRecvr::get_next_for_pipeline(std::shared_ptr<starrocks::Chunk>*, std::atomic<bool>*, bool*)                                                                                           
      @          0x97418e4 starrocks::pipeline::ExchangeMergeSortSourceOperator::get_next_merging(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)                                                                       
      @          0x97422fb starrocks::pipeline::ExchangeMergeSortSourceOperator::pull_chunk(starrocks::RuntimeState*)                                                                                                                 
      @          0xaddf607 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)                                                                                                                                
      @          0x9716596 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()                                                                                                                                                
      @          0xe7952fb starrocks::ThreadPool::dispatch_thread()                                                                                                                                                                   
      @          0xe78c1af starrocks::Thread::supervise_thread(void*)                                                                                                                                                                 
      @     0x7fad957c6aa4 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x9caa3)                                                                                                                                                              
      @     0x7fad95853c6c (/usr/lib/x86_64-linux-gnu/libc.so.6+0x129c6b)                                                                                                                                                             
  [1786052002.963][thread: 140372399355584] je_mallctl execute purge success                                                                                                                                                          
  [1786052002.963][thread: 140372399355584] je_mallctl execute dontdump success  
```

PullUpScanPredicateRule's SubfieldCollector mints a scan projection slot for every subfield node it walks, the intermediate ones included: for `s1.s2[1].a` it maps `s1.s2`, `s1.s2[1]` and `s1.s2[1].a`, while replaceScalarOperator only substitutes the outermost one into the predicate. The others are never referenced, yet they are still projected out of the scan.

The rule runs after PruneSubfieldRule has fixed the scan's ColumnAccessPath, so the dead `s1.s2` slot asks for the whole ARRAY<STRUCT<a, b>> while the access path only delivers /s1/s2/INDEX/a. The scan then emits an array whose `b` field holds no rows. The top-level row count still matches, so the deserializer's guard lets the chunk through, and the merging exchange reads out of bounds:

  FixedLengthColumnBase<int>::append <- StructColumn::append <- ArrayColumn::append
  <- Chunk::append <- ChunkSliceTemplate::cutoff <- CascadeChunkMerger::get_next

Keep only the collected mappings the rewritten predicate actually references.

StructColumn::check_or_die() was missing the matching invariant - every field must hold the same number of rows - and the Chunk constructor the deserializer uses is the only one that never calls check_or_die(). Add both so a debug build catches this class of never-materialized column instead of crashing on it.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
