### PR TITLE
[Enhancement] Push file_path predicate down when reading Iceberg position-delete files

### DIFF
--- a/be/src/formats/iceberg/iceberg_delete_builder.cpp
+++ b/be/src/formats/iceberg/iceberg_delete_builder.cpp
@@ -28,6 +28,7 @@
 #include "runtime/chunk_helper.h"
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
+#include "storage_primitive/column_predicate_factory.h"
 #include "storage_primitive/predicate_tree/predicate_tree.h"
 
 namespace starrocks::formats {
@@ -60,7 +61,8 @@ Status visit_position_delete_rows(const ChunkPtr& chunk, const IcebergPositionDe
 
 Status read_parquet_rows(RandomAccessFile* file, int64_t length, int32_t chunk_size, const std::string& timezone,
                          const FormatScannerOptions& options, FormatScannerStats* stats,
-                         const IcebergPositionDeleteReader::RowCallback& cb) {
+                         const IcebergPositionDeleteReader::RowCallback& cb,
+                         const std::string* pushdown_file_path_eq) {
     std::unique_ptr<parquet::FileReader> reader;
     try {
         reader = std::make_unique<parquet::FileReader>(chunk_size, file, length);
@@ -94,8 +96,18 @@ Status read_parquet_rows(RandomAccessFile* file, int64_t length, int32_t chunk_s
     iceberg_schema.__set_fields(schema_fields);
 
     std::atomic<int32_t> lazy_column_coalesce_counter = 0;
-    // TODO: Remove this empty placeholder once FileReader supports a null predicate tree for predicate-free scans.
-    PredicateTree predicate_tree;
+
+    // Push `file_path == pushdown_file_path_eq` down so row-group/page zonemap stats can skip ranges
+    // that can't match. Not row-exact, so `visit_position_delete_rows` below still re-checks each row.
+    std::unique_ptr<ColumnPredicate> file_path_eq_pred;
+    PredicateAndNode predicate_root;
+    if (pushdown_file_path_eq != nullptr) {
+        file_path_eq_pred.reset(new_column_eq_predicate(get_type_info(TYPE_VARCHAR),
+                                                        IcebergDeleteFileMeta::get_delete_file_path_slot().id(),
+                                                        Slice(*pushdown_file_path_eq)));
+        predicate_root.add_child(PredicateColumnNode{file_path_eq_pred.get()});
+    }
+    PredicateTree predicate_tree = PredicateTree::create(std::move(predicate_root));
     FormatScanContext format_scan_context;
     format_scan_context.timezone = timezone;
     format_scan_context.materialized_columns = std::move(columns);
@@ -161,15 +173,17 @@ Status read_orc_rows(RandomAccessFile* file, const std::string& path, int64_t le
 Status IcebergPositionDeleteReader::read_rows(RandomAccessFile* file, const std::string& path, int64_t length,
                                               const std::string& format, int32_t chunk_size,
                                               const std::string& timezone, const FormatScannerOptions& options,
-                                              FormatScannerStats* stats, const RowCallback& cb) {
+                                              FormatScannerStats* stats, const RowCallback& cb,
+                                              const std::string* pushdown_file_path_eq) {
     FormatScannerStats local_stats;
     if (stats == nullptr) {
         stats = &local_stats;
     }
     if (format == PARQUET) {
-        return read_parquet_rows(file, length, chunk_size, timezone, options, stats, cb);
+        return read_parquet_rows(file, length, chunk_size, timezone, options, stats, cb, pushdown_file_path_eq);
     }
     if (format == ORC) {
+        // TODO: push the same predicate down via ORC's SearchArgument once available.
         return read_orc_rows(file, path, length, chunk_size, timezone, cb);
     }
     return Status::NotSupported(strings::Substitute("unsupported iceberg position-delete file format: $0", format));
@@ -210,11 +224,13 @@ Status IcebergDeleteBuilder::build(const TIcebergDeleteFile& delete_file, const 
 
     RETURN_IF_ERROR(IcebergPositionDeleteReader::read_rows(
             file.get(), delete_file.full_path, delete_file.length, format, _ctx.chunk_size, _ctx.scan_context->timezone,
-            _ctx.scan_context->options, &app_stats, [this](const Slice& file_path, int64_t pos) {
+            _ctx.scan_context->options, &app_stats,
+            [this](const Slice& file_path, int64_t pos) {
                 if (file_path == _ctx.data_file_path) {
                     _deletion_bitmap->add_value(pos);
                 }
-            }));
+            },
+            &_ctx.data_file_path));
     update_delete_file_io_counter(_ctx.runtime_profile, app_stats, fs_stats, cache_input_stream,
                                   shared_buffered_input_stream);
     return Status::OK();

--- a/be/src/formats/iceberg/iceberg_delete_builder.cpp
+++ b/be/src/formats/iceberg/iceberg_delete_builder.cpp
@@ -61,8 +61,7 @@ Status visit_position_delete_rows(const ChunkPtr& chunk, const IcebergPositionDe
 
 Status read_parquet_rows(RandomAccessFile* file, int64_t length, int32_t chunk_size, const std::string& timezone,
                          const FormatScannerOptions& options, FormatScannerStats* stats,
-                         const IcebergPositionDeleteReader::RowCallback& cb,
-                         const std::string* pushdown_file_path_eq) {
+                         const IcebergPositionDeleteReader::RowCallback& cb, const std::string* pushdown_file_path_eq) {
     std::unique_ptr<parquet::FileReader> reader;
     try {
         reader = std::make_unique<parquet::FileReader>(chunk_size, file, length);

--- a/be/src/formats/iceberg/iceberg_delete_builder.h
+++ b/be/src/formats/iceberg/iceberg_delete_builder.h
@@ -55,10 +55,15 @@ public:
 
     // Invokes cb once per row. `path` is used for error reporting only; `length` is the file
     // size in bytes. `stats` may be null when the caller does not collect scanner stats.
+    //
+    // `pushdown_file_path_eq`, if set, is pushed down as a `file_path == *pushdown_file_path_eq`
+    // predicate to prune row-groups/pages (parquet only). `cb` still fires for every surviving row,
+    // since pruning isn't row-exact.
     static Status read_rows(RandomAccessFile* file, const std::string& path, int64_t length,
                             const std::string& format, // "parquet" | "orc"
                             int32_t chunk_size, const std::string& timezone, const FormatScannerOptions& options,
-                            FormatScannerStats* stats, const RowCallback& cb);
+                            FormatScannerStats* stats, const RowCallback& cb,
+                            const std::string* pushdown_file_path_eq = nullptr);
 };
 
 class IcebergDeleteBuilder {

--- a/be/test/formats/iceberg/iceberg_delete_builder_test.cpp
+++ b/be/test/formats/iceberg/iceberg_delete_builder_test.cpp
@@ -219,12 +219,13 @@ TEST_F(IcebergDeleteBuilderTest, TestParquetBuilderWithSortedMultiFileDeleteFile
     // Real Iceberg position-delete files are written sorted by (file_path, pos) and commonly cover
     // multiple data files. Exercise build()'s predicate pushdown against that realistic shape and
     // check it still produces the correct bitmap for each data file.
-    write_parquet_delete_file(_fs, _parquet_delete_path, {{"data_file_1.parquet", 2},
-                                                          {"data_file_1.parquet", 5},
-                                                          {"data_file_2.parquet", 1},
-                                                          {"data_file_2.parquet", 3},
-                                                          {"data_file_2.parquet", 10},
-                                                          {"data_file_3.parquet", 7}});
+    write_parquet_delete_file(_fs, _parquet_delete_path,
+                              {{"data_file_1.parquet", 2},
+                               {"data_file_1.parquet", 5},
+                               {"data_file_2.parquet", 1},
+                               {"data_file_2.parquet", 3},
+                               {"data_file_2.parquet", 10},
+                               {"data_file_3.parquet", 7}});
 
     FormatScanContext scan_context;
     scan_context.timezone = "UTC";

--- a/be/test/formats/iceberg/iceberg_delete_builder_test.cpp
+++ b/be/test/formats/iceberg/iceberg_delete_builder_test.cpp
@@ -213,6 +213,48 @@ TEST_F(IcebergDeleteBuilderTest, TestReadRowsVisitsAllRows) {
     EXPECT_EQ(expected, rows);
 }
 
+TEST_F(IcebergDeleteBuilderTest, TestParquetBuilderWithSortedMultiFileDeleteFile) {
+    RuntimeProfile runtime_profile("IcebergDeleteBuilderTest");
+
+    // Real Iceberg position-delete files are written sorted by (file_path, pos) and commonly cover
+    // multiple data files. Exercise build()'s predicate pushdown against that realistic shape and
+    // check it still produces the correct bitmap for each data file.
+    write_parquet_delete_file(_fs, _parquet_delete_path, {{"data_file_1.parquet", 2},
+                                                          {"data_file_1.parquet", 5},
+                                                          {"data_file_2.parquet", 1},
+                                                          {"data_file_2.parquet", 3},
+                                                          {"data_file_2.parquet", 10},
+                                                          {"data_file_3.parquet", 7}});
+
+    FormatScanContext scan_context;
+    scan_context.timezone = "UTC";
+
+    ASSIGN_OR_ABORT(const int64_t delete_file_size, _fs.get_file_size(_parquet_delete_path));
+    TIcebergDeleteFile delete_file;
+    delete_file.__set_full_path(_parquet_delete_path);
+    delete_file.__set_length(delete_file_size);
+
+    const std::vector<std::pair<std::string, std::vector<uint64_t>>> cases{
+            {"data_file_1.parquet", {2, 5}},
+            {"data_file_2.parquet", {1, 3, 10}},
+            {"data_file_3.parquet", {7}},
+    };
+    for (const auto& [data_file_path, expected_rowids] : cases) {
+        IcebergDeleteBuilder builder(IcebergDeleteBuilderContext{
+                .scan_context = &scan_context,
+                .fs = &_fs,
+                .data_file_path = data_file_path,
+                .runtime_profile = &runtime_profile,
+                .chunk_size = 4096,
+        });
+        ASSERT_OK(builder.build_parquet(delete_file));
+        auto deletion_bitmap = builder.deletion_bitmap();
+        std::vector<uint64_t> rowids(deletion_bitmap->get_cardinality());
+        deletion_bitmap->to_array(rowids);
+        EXPECT_EQ(expected_rowids, rowids);
+    }
+}
+
 TEST_F(IcebergDeleteBuilderTest, TestReadRowsRejectsUnknownFormat) {
     write_parquet_delete_file(_fs, _parquet_delete_path, {{"dataA", 1}});
 


### PR DESCRIPTION

Push a file_path == data_file_path equality predicate into the parquet reader when scanning an Iceberg position-delete file, so row-group/page zonemap stats can skip ranges that cannot match instead of decoding every row.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
