### PR TITLE
[Tool] Grant contents: read to the CI DOC Checker workflow

### DIFF
--- a/.github/workflows/ci-doc-checker.yml
+++ b/.github/workflows/ci-doc-checker.yml
@@ -10,6 +10,7 @@ on:
       - 'branch*'
 
 permissions:
+  contents: read
   issues: write
   pull-requests: write
 


### PR DESCRIPTION
## Why I'm doing:

`ci-doc-checker.yml` declares a `permissions:` block that omits `contents:`:

```yaml
permissions:
  issues: write
  pull-requests: write
```

When a workflow declares *any* `permissions:` block, every scope not listed is set to **`none`**. So the job token receives `contents: none`, and `actions/checkout` cannot read the repository.

On `StarRocks/starrocks` this is invisible, because the repository is public and an anonymous clone still succeeds. On a **private** fork or downstream mirror the identical workflow fails at the checkout step in every job:

```
remote: Repository not found.
##[error]fatal: repository 'https://github.com/<org>/<repo>/' not found
The process '/usr/bin/git' failed with exit code 128
```

Because the failure is at `actions/checkout`, it happens *before* any linting: `link-check` and `markdownlint` fail outright, and `docusaurus-build` is skipped since it `needs: markdownlint`. The whole doc gate is inert on private downstreams, and the failure mode gives no hint that permissions are the cause.

`ci-vale.yml` in this same repository already declares `contents: read` for the identical checkout pattern, so today the two doc workflows disagree — Vale works on private downstreams and the doc checker cannot.

## What I'm doing:

Adding the single missing scope:

```diff
 permissions:
+  contents: read
   issues: write
   pull-requests: write
```

This is least-privilege-correct on its own merits — `contents: read` is exactly what these jobs need to check out and lint — and it makes `ci-doc-checker.yml` consistent with `ci-vale.yml`.

No behavior change for this repository: the jobs already clone successfully here, and read access is what they were effectively getting anyway. The only difference is that the token now carries the scope explicitly rather than relying on the repository being public.

Note that this cannot be validated from within a PR: `pull_request_target` runs the workflow definition from the **base branch**, so the effect only appears once the change is on `main`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
