### PR TITLE
[Enhancement] Adding a config for max number of dict columns in ScanNodes verbose explain. It is currently hardcoded to 5

### DIFF
--- a/docs/en/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/en/administration/management/FE_parameters/shared_lake_other.md
@@ -964,6 +964,15 @@ This topic introduces the following types of FE configurations:
 - Description: The time interval at which the FE obtains Elasticsearch indexes and synchronizes the metadata of StarRocks external tables.
 - Introduced in: -
 
+### `explain_dict_column_size`
+
+- Default: 5
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: The maximum number of low-cardinality dictionary-optimized columns listed in the `dict_col` field of each scan node in `EXPLAIN VERBOSE` output. When a scan node has more applied dictionary columns than this value, the list is truncated and followed by an ellipsis. Values less than or equal to `0` are treated as `0`, which truncates the list entirely. This item affects only the `EXPLAIN VERBOSE` output and does not change how dictionary optimization is applied to queries.
+- Introduced in: v4.2.0
+
 ### `hive_meta_cache_refresh_interval_s`
 
 - Default: 60

--- a/docs/ja/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/management/FE_parameters/shared_lake_other.md
@@ -967,6 +967,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：FE が Elasticsearch インデックスを取得し、StarRocks 外部テーブルのメタデータを同期する時間間隔。
 - 導入時期：-
 
+### `explain_dict_column_size`
+
+- デフォルト：5
+- タイプ：Int
+- 単位：-
+- 変更可能：Yes
+- 説明：`EXPLAIN VERBOSE` の出力において、各スキャンノードの `dict_col` フィールドに表示される低カーディナリティ辞書最適化カラムの最大数。スキャンノードに適用された辞書カラムの数がこの値を超える場合、リストは切り詰められ、省略記号が付加されます。`0` 以下の値は `0` として扱われ、リスト全体が切り詰められます。この項目は `EXPLAIN VERBOSE` の出力にのみ影響し、クエリに対する辞書最適化の適用方法は変更しません。
+- 導入時期：v4.2.0
+
 ### `hive_meta_cache_refresh_interval_s`
 
 - デフォルト：3600 * 2

--- a/docs/zh/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/management/FE_parameters/shared_lake_other.md
@@ -963,6 +963,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: FE 获取 Elasticsearch 索引并同步 StarRocks 外部表元数据的时间间隔。
 - 引入版本: -
 
+### `explain_dict_column_size`
+
+- 默认值: 5
+- 类型: Int
+- 单位: -
+- 是否可变: Yes
+- 描述: `EXPLAIN VERBOSE` 输出中每个 Scan 节点的 `dict_col` 字段所列出的低基数字典优化列的最大数量。当某个 Scan 节点应用的字典列数量超过该值时，列表将被截断并以省略号结尾。小于或等于 `0` 的值会被视为 `0`，即完全截断该列表。该参数仅影响 `EXPLAIN VERBOSE` 的输出，不会改变字典优化在查询中的实际应用方式。
+- 引入版本: v4.2.0
+
 ### `hive_meta_cache_refresh_interval_s`
 
 - 默认值: 3600 * 2

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -4988,6 +4988,9 @@ public class Config extends ConfigBase {
             "Default false for security. Set true to allow internal service calls.")
     public static boolean http_request_allow_private_in_allowlist = false;
 
-    @ConfField(mutable = true, comment = "number of dictified columns shown in explain verbose for each scan op")
+    @ConfField(mutable = true, comment = "The maximum number of low-cardinality dictionary-optimized columns listed " +
+            "in the dict_col field of each scan node in EXPLAIN VERBOSE output. When a scan node has more applied " +
+            "dictionary columns than this value, the list is truncated and followed by an ellipsis. Values less than " +
+            "or equal to 0 are treated as 0, which truncates the list entirely.")
     public static int explain_dict_column_size = 5;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -4987,4 +4987,7 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "Allow private IPs (127.x, 10.x, 192.168.x, 172.16-31.x) if in allowlist. " +
             "Default false for security. Set true to allow internal service calls.")
     public static boolean http_request_allow_private_in_allowlist = false;
+
+    @ConfField(mutable = true, comment = "number of dictified columns shown in explain verbose for each scan op")
+    public static int explain_dict_column_size = 5;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
@@ -39,6 +39,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.ColumnAccessPath;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.BucketProperty;
@@ -262,10 +263,10 @@ public abstract class ScanNode extends PlanNode {
     protected String explainColumnDict(String prefix) {
         StringBuilder output = new StringBuilder();
         if (!appliedDictStringColumns.isEmpty()) {
-            int maxSize = Math.min(appliedDictStringColumns.size(), 5);
+            int maxSize = Math.min(appliedDictStringColumns.size(), Config.explain_dict_column_size);
             List<String> printList = appliedDictStringColumns.subList(0, maxSize);
             String format_template = "dict_col=%s";
-            if (appliedDictStringColumns.size() > 5) {
+            if (appliedDictStringColumns.size() > Config.explain_dict_column_size) {
                 format_template = format_template + "...";
             }
             output.append(prefix).append(String.format(format_template, Joiner.on(",").join(printList)));

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
@@ -263,10 +263,11 @@ public abstract class ScanNode extends PlanNode {
     protected String explainColumnDict(String prefix) {
         StringBuilder output = new StringBuilder();
         if (!appliedDictStringColumns.isEmpty()) {
-            int maxSize = Math.min(appliedDictStringColumns.size(), Config.explain_dict_column_size);
+            int limit = Math.max(0, Config.explain_dict_column_size);
+            int maxSize = Math.min(appliedDictStringColumns.size(), limit);
             List<String> printList = appliedDictStringColumns.subList(0, maxSize);
             String format_template = "dict_col=%s";
-            if (appliedDictStringColumns.size() > Config.explain_dict_column_size) {
+            if (appliedDictStringColumns.size() > limit) {
                 format_template = format_template + "...";
             }
             output.append(prefix).append(String.format(format_template, Joiner.on(",").join(printList)));


### PR DESCRIPTION
## Why I'm doing:
Currently the max number of dictionary columns in ScanNodes explain verbose is hard coded to 5. This PR makes this columns value configurable. 

## What I'm doing:
Adding a config for number of dict columns in ScanNodes verbose explain.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5