### PR TITLE
[Enhancement] Add full-chain lake compaction task profiles

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1481,7 +1481,7 @@ CONF_mBool(lake_print_delete_log, "false");
 CONF_mInt64(lake_compaction_stream_buffer_size_bytes, "1048576"); // 1MB
 // The interval to check whether lake compaction is valid. Set to <= 0 to disable the check.
 CONF_mInt32(lake_compaction_check_valid_interval_minutes, "10"); // 10 minutes
-// Minimum elapsed time in milliseconds for logging a completed lake compaction task or subtask profile.
+// Minimum elapsed time in milliseconds for logging a completed lake compaction attempt or parallel subtask profile.
 CONF_mInt64(lake_compact_slow_log_ms, "5000");
 
 // Maximum data volume (bytes) per parallel compaction subtask.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1481,6 +1481,8 @@ CONF_mBool(lake_print_delete_log, "false");
 CONF_mInt64(lake_compaction_stream_buffer_size_bytes, "1048576"); // 1MB
 // The interval to check whether lake compaction is valid. Set to <= 0 to disable the check.
 CONF_mInt32(lake_compaction_check_valid_interval_minutes, "10"); // 10 minutes
+// Minimum elapsed time in milliseconds for logging a completed lake compaction task or subtask profile.
+CONF_mInt64(lake_compact_slow_log_ms, "5000");
 
 // Maximum data volume (bytes) per parallel compaction subtask.
 // If total picked rowsets data size is less than this threshold, parallel compaction

--- a/be/src/common/config_compaction_fwd.h
+++ b/be/src/common/config_compaction_fwd.h
@@ -145,6 +145,9 @@ CONF_mInt64(lake_compaction_stream_buffer_size_bytes, "1048576"); // 1MB
 // The interval to check whether lake compaction is valid. Set to <= 0 to disable the check.
 CONF_mInt32(lake_compaction_check_valid_interval_minutes, "10"); // 10 minutes
 
+// Minimum elapsed time in milliseconds for logging a completed lake compaction task or subtask profile.
+CONF_mInt64(lake_compact_slow_log_ms, "5000");
+
 // Maximum data volume (bytes) per parallel compaction subtask.
 // If total picked rowsets data size is less than this threshold, parallel compaction
 // will be skipped and fallback to normal compaction flow.

--- a/be/src/common/config_compaction_fwd.h
+++ b/be/src/common/config_compaction_fwd.h
@@ -145,7 +145,7 @@ CONF_mInt64(lake_compaction_stream_buffer_size_bytes, "1048576"); // 1MB
 // The interval to check whether lake compaction is valid. Set to <= 0 to disable the check.
 CONF_mInt32(lake_compaction_check_valid_interval_minutes, "10"); // 10 minutes
 
-// Minimum elapsed time in milliseconds for logging a completed lake compaction task or subtask profile.
+// Minimum elapsed time in milliseconds for logging a completed lake compaction attempt or parallel subtask profile.
 CONF_mInt64(lake_compact_slow_log_ms, "5000");
 
 // Maximum data volume (bytes) per parallel compaction subtask.

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -718,6 +718,7 @@
         "meta_threshold_to_manual_compact",
         "lake_compaction_stream_buffer_size_bytes",
         "lake_compaction_check_valid_interval_minutes",
+        "lake_compact_slow_log_ms",
         "lake_compaction_max_bytes_per_subtask",
         "lake_compaction_max_rowset_size",
         "lake_enable_compaction_async_write",

--- a/be/src/schema_scanner/schema_be_cloud_native_compactions_scanner.cpp
+++ b/be/src/schema_scanner/schema_be_cloud_native_compactions_scanner.cpp
@@ -38,7 +38,8 @@ SchemaScanner::ColumnDesc SchemaBeCloudNativeCompactionsScanner::_s_columns[] = 
         {"FINISH_TIME", TypeDescriptor::from_logical_type(TYPE_DATETIME), sizeof(DateTimeValue), true},
         {"PROGRESS", TypeDescriptor::from_logical_type(TYPE_INT), sizeof(int32_t), false},
         {"STATUS", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
-        {"PROFILE", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false}};
+        {"PROFILE", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
+        {"SUBTASK_ID", TypeDescriptor::from_logical_type(TYPE_INT), sizeof(int32_t), true}};
 
 SchemaBeCloudNativeCompactionsScanner::SchemaBeCloudNativeCompactionsScanner()
         : SchemaScanner(_s_columns, sizeof(_s_columns) / sizeof(SchemaScanner::ColumnDesc)) {}
@@ -68,7 +69,7 @@ Status SchemaBeCloudNativeCompactionsScanner::fill_chunk(ChunkPtr* chunk) {
     for (; _cur_idx < end; _cur_idx++) {
         auto& info = _infos[_cur_idx];
         for (const auto& [slot_id, index] : slot_id_to_index_map) {
-            if (slot_id < 1 || slot_id > 11) {
+            if (slot_id < 1 || slot_id > 12) {
                 return Status::InternalError(strings::Substitute("invalid slot id:$0", slot_id));
             }
             auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(slot_id);
@@ -141,6 +142,15 @@ Status SchemaBeCloudNativeCompactionsScanner::fill_chunk(ChunkPtr* chunk) {
                 // PROFILE
                 Slice v(info.profile.data(), info.profile.size());
                 fill_column_with_slot<TYPE_VARCHAR>(column, (void*)&v);
+                break;
+            }
+            case 12: {
+                // SUBTASK_ID
+                if (info.subtask_id >= 0) {
+                    fill_column_with_slot<TYPE_INT>(column, (void*)&info.subtask_id);
+                } else {
+                    fill_data_column_with_null(column);
+                }
                 break;
             }
             default:

--- a/be/src/storage/lake/cloud_native_index_compaction_task.cpp
+++ b/be/src/storage/lake/cloud_native_index_compaction_task.cpp
@@ -22,6 +22,7 @@ namespace starrocks::lake {
 
 Status CloudNativeIndexCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush_pool) {
     _context->stats->compaction_type = "cloud_native_index";
+    _context->publish_stats_snapshot();
     std::shared_ptr<TxnLog> txn_log;
     {
         SCOPED_RAW_TIMER(&_context->stats->txn_log_build_ns);

--- a/be/src/storage/lake/cloud_native_index_compaction_task.cpp
+++ b/be/src/storage/lake/cloud_native_index_compaction_task.cpp
@@ -14,17 +14,23 @@
 
 #include "storage/lake/cloud_native_index_compaction_task.h"
 
+#include "common/runtime_profile.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/txn_log.h"
 
 namespace starrocks::lake {
 
 Status CloudNativeIndexCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush_pool) {
-    auto txn_log = std::make_shared<TxnLog>();
-    auto op_compaction = txn_log->mutable_op_compaction();
-    txn_log->set_tablet_id(_tablet.id());
-    txn_log->set_txn_id(_txn_id);
-    op_compaction->set_compact_version(_tablet.metadata()->version());
+    _context->stats->compaction_type = "cloud_native_index";
+    std::shared_ptr<TxnLog> txn_log;
+    {
+        SCOPED_RAW_TIMER(&_context->stats->txn_log_build_ns);
+        txn_log = std::make_shared<TxnLog>();
+        auto op_compaction = txn_log->mutable_op_compaction();
+        txn_log->set_tablet_id(_tablet.id());
+        txn_log->set_txn_id(_txn_id);
+        op_compaction->set_compact_version(_tablet.metadata()->version());
+    }
     RETURN_IF_ERROR(cancel_func());
     RETURN_IF_ERROR(execute_index_major_compaction(txn_log.get()));
     _context->progress.update(100);
@@ -33,10 +39,9 @@ Status CloudNativeIndexCompactionTask::execute(CancelFunc cancel_func, ThreadPoo
         // return txn_log to caller later
         _context->txn_log = txn_log;
     } else {
+        SCOPED_RAW_TIMER(&_context->stats->txn_log_write_ns);
         RETURN_IF_ERROR(_tablet.tablet_manager()->put_txn_log(txn_log));
     }
-    VLOG(2) << "CloudNative Index compaction finished. tablet: " << _tablet.id() << ", txn_id: " << _txn_id
-            << ", statistics: " << _context->stats->to_json_stats();
     return Status::OK();
 }
 

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -549,11 +549,13 @@ Status CompactionScheduler::do_compaction(std::unique_ptr<CompactionTaskContext>
     context->start_time.store(start_time, std::memory_order_relaxed);
     const int attempt = context->runs.fetch_add(1, std::memory_order_relaxed) + 1;
     context->stats->task_attempt_count = attempt;
+    context->publish_stats_snapshot();
 
     auto status = Status::OK();
     auto task_prepare_start_ns = MonotonicNanos();
     auto task_or = _tablet_mgr->compact(context.get());
     context->stats->task_prepare_ns += MonotonicNanos() - task_prepare_start_ns;
+    context->publish_stats_snapshot();
     if (task_or.ok()) {
         auto should_cancel = [&]() { return compaction_should_cancel(context.get()); };
         TEST_SYNC_POINT("CompactionScheduler::do_compaction:before_execute_task");
@@ -577,6 +579,7 @@ Status CompactionScheduler::do_compaction(std::unique_ptr<CompactionTaskContext>
     }
     context->stats->task_total_ns += MonotonicNanos() - start_time_ns;
     context->task_attempt_start_ns.store(0, std::memory_order_release);
+    context->publish_stats_snapshot();
 
     auto finish_time = std::max<int64_t>(::time(nullptr), start_time);
     auto cost = finish_time - start_time;

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -576,9 +576,11 @@ Status CompactionScheduler::do_compaction(std::unique_ptr<CompactionTaskContext>
     auto finish_time = std::max<int64_t>(::time(nullptr), start_time);
     auto cost = finish_time - start_time;
 
-    LOG(INFO) << "Compaction task attempt finished. tablet_id=" << tablet_id << " version=" << version
-              << " txn_id=" << txn_id << " status=" << status << " profile=" << context->stats->to_json_stats()
-              << " table_id=" << context->table_id << " partition_id=" << context->partition_id;
+    if (context->stats->is_slow(config::lake_compact_slow_log_ms)) {
+        LOG(INFO) << "Compaction task attempt finished. tablet_id=" << tablet_id << " version=" << version
+                  << " txn_id=" << txn_id << " status=" << status << " profile=" << context->stats->to_json_stats()
+                  << " table_id=" << context->table_id << " partition_id=" << context->partition_id;
+    }
 
     // Task failure due to memory limitations allows for retries, more threads allow for more retries.
     // If allow partial success, do not retry, task result should be reported to FE as soon as possible.
@@ -625,8 +627,7 @@ void CompactionScheduler::abort_compaction(std::unique_ptr<CompactionTaskContext
     }
     context->status = Status::Aborted("Compaction task aborted due to BE/CN shutdown!");
     LOG(WARNING) << "Fail to compact tablet " << tablet_id << ". version=" << version << " txn_id=" << txn_id << " : "
-                 << context->status << " profile=" << context->stats->to_json_stats()
-                 << " table_id=" << context->table_id << " partition_id=" << context->partition_id;
+                 << context->status << " table_id=" << context->table_id << " partition_id=" << context->partition_id;
     // make sure every task can be finished no matter it is succeeded or failed.
     context->callback->finish_task(std::move(context));
 }

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -148,15 +148,16 @@ void CompactionTaskCallback::finish_task(std::unique_ptr<CompactionTaskContext>&
     DCHECK(_request != nullptr);
     _status.update(context->status);
 
-    // For parallel merged context, register it to the scheduler's _contexts list
-    // so that it's visible in list_tasks() until RPC response is sent.
+    // Register a parallel merged context so remove_states() can defer cleanup of
+    // its individual subtask rows until the RPC response is sent. list_tasks()
+    // deliberately hides this aggregation-only context.
     if (context->is_parallel_merged && _scheduler != nullptr) {
         std::lock_guard ctx_lock(_scheduler->_contexts_lock);
         _scheduler->_contexts.Append(context.get());
     }
 
-    // Keep the context for a while until the RPC request is finished processing so that we can see the detailed
-    // and complete progress of the RPC request by calling `CompactionScheduler::list_tasks()`.
+    // Keep the context until the RPC request finishes. Regular contexts remain
+    // visible through list_tasks(); a merged context anchors parallel-state cleanup.
     _contexts.emplace_back(std::move(context));
     //                     ^^^^^^^^^^^^^^^^^ Do NOT touch "context" since here, it has been `move`ed.
 
@@ -404,6 +405,12 @@ void CompactionScheduler::list_tasks(std::vector<CompactionTaskInfo>* infos) {
         for (butil::LinkNode<CompactionTaskContext>* node = _contexts.head(); node != _contexts.end();
              node = node->next()) {
             CompactionTaskContext* context = node->value();
+            // A merged parallel context is an RPC aggregation artifact rather than
+            // an executed compaction unit. The individual subtasks are exposed by
+            // TabletParallelCompactionManager::list_tasks().
+            if (context->is_parallel_merged) {
+                continue;
+            }
             auto& info = infos->emplace_back();
             info.txn_id = context->txn_id;
             info.tablet_id = context->tablet_id;
@@ -416,7 +423,8 @@ void CompactionScheduler::list_tasks(std::vector<CompactionTaskInfo>* infos) {
             // the race condition between this thread and the `CompactionScheduler::thread_task` threads.
             info.finish_time = context->finish_time.load(std::memory_order_acquire);
             if (info.runs > 0) {
-                info.profile = context->stats->to_json_stats();
+                const bool profile_final = info.finish_time > 0;
+                info.profile = context->stats_snapshot(!profile_final).to_json_stats(profile_final);
             }
             if (info.finish_time > 0) {
                 info.status = context->status;
@@ -474,9 +482,9 @@ void CompactionScheduler::remove_states(const std::vector<std::unique_ptr<Compac
         context->RemoveFromList();
     }
 
-    // Cleanup parallel compaction states for merged contexts.
-    // This is deferred from on_subtask_complete to ensure parallel compaction tasks
-    // remain visible in list_tasks until RPC response is sent.
+    // Cleanup parallel compaction states for merged contexts. This is deferred
+    // from on_subtask_complete so individual subtask rows remain visible through
+    // list_tasks() until the RPC response is sent.
     if (_parallel_mgr != nullptr) {
         for (auto& context : states) {
             if (context->is_parallel_merged) {
@@ -521,17 +529,26 @@ Status compaction_should_cancel(CompactionTaskContext* context) {
 
 Status CompactionScheduler::do_compaction(std::unique_ptr<CompactionTaskContext> context) {
     const auto start_time = ::time(nullptr);
+    const auto start_time_ns = MonotonicNanos();
     const auto tablet_id = context->tablet_id;
     const auto txn_id = context->txn_id;
     const auto version = context->version;
 
+    context->task_attempt_start_ns.store(start_time_ns, std::memory_order_release);
+
     int64_t in_queue_time_sec = start_time > context->enqueue_time_sec ? (start_time - context->enqueue_time_sec) : 0;
     context->stats->in_queue_time_sec += in_queue_time_sec;
+    if (context->enqueue_time_ns > 0 && start_time_ns > context->enqueue_time_ns) {
+        context->stats->queue_wait_ns += start_time_ns - context->enqueue_time_ns;
+    }
+    context->stats->task_attempt_count++;
     context->start_time.store(start_time, std::memory_order_relaxed);
     context->runs.fetch_add(1, std::memory_order_relaxed);
 
     auto status = Status::OK();
+    auto task_prepare_start_ns = MonotonicNanos();
     auto task_or = _tablet_mgr->compact(context.get());
+    context->stats->task_prepare_ns += MonotonicNanos() - task_prepare_start_ns;
     if (task_or.ok()) {
         auto should_cancel = [&]() { return compaction_should_cancel(context.get()); };
         TEST_SYNC_POINT("CompactionScheduler::do_compaction:before_execute_task");
@@ -540,16 +557,28 @@ Status CompactionScheduler::do_compaction(std::unique_ptr<CompactionTaskContext>
             // CAUTION: we reuse delta writer's memory table flush pool here
             flush_pool = StorageEngine::instance()->lake_memtable_flush_executor()->get_thread_pool();
             if (UNLIKELY(flush_pool == nullptr)) {
-                return Status::InternalError("Get memory table flush pool failed");
+                status.update(Status::InternalError("Get memory table flush pool failed"));
             }
         }
-        status.update(task_or.value()->execute(std::move(should_cancel), flush_pool));
+        if (status.ok()) {
+            auto task_execute_start_ns = MonotonicNanos();
+            context->task_execute_start_ns.store(task_execute_start_ns, std::memory_order_release);
+            status.update(task_or.value()->execute(std::move(should_cancel), flush_pool));
+            context->stats->task_execute_ns += MonotonicNanos() - task_execute_start_ns;
+            context->task_execute_start_ns.store(0, std::memory_order_release);
+        }
     } else {
         status.update(task_or.status());
     }
+    context->stats->task_total_ns += MonotonicNanos() - start_time_ns;
+    context->task_attempt_start_ns.store(0, std::memory_order_release);
 
     auto finish_time = std::max<int64_t>(::time(nullptr), start_time);
     auto cost = finish_time - start_time;
+
+    LOG(INFO) << "Compaction task attempt finished. tablet_id=" << tablet_id << " version=" << version
+              << " txn_id=" << txn_id << " status=" << status << " profile=" << context->stats->to_json_stats()
+              << " table_id=" << context->table_id << " partition_id=" << context->partition_id;
 
     // Task failure due to memory limitations allows for retries, more threads allow for more retries.
     // If allow partial success, do not retry, task result should be reported to FE as soon as possible.
@@ -584,15 +613,20 @@ Status CompactionScheduler::do_compaction(std::unique_ptr<CompactionTaskContext>
 
 void CompactionScheduler::abort_compaction(std::unique_ptr<CompactionTaskContext> context) {
     const auto start_time = ::time(nullptr);
+    const auto start_time_ns = MonotonicNanos();
     const auto tablet_id = context->tablet_id;
     const auto txn_id = context->txn_id;
     const auto version = context->version;
 
     int64_t in_queue_time_sec = start_time > context->enqueue_time_sec ? (start_time - context->enqueue_time_sec) : 0;
     context->stats->in_queue_time_sec += in_queue_time_sec;
+    if (context->enqueue_time_ns > 0 && start_time_ns > context->enqueue_time_ns) {
+        context->stats->queue_wait_ns += start_time_ns - context->enqueue_time_ns;
+    }
     context->status = Status::Aborted("Compaction task aborted due to BE/CN shutdown!");
     LOG(WARNING) << "Fail to compact tablet " << tablet_id << ". version=" << version << " txn_id=" << txn_id << " : "
-                 << context->status;
+                 << context->status << " profile=" << context->stats->to_json_stats()
+                 << " table_id=" << context->table_id << " partition_id=" << context->partition_id;
     // make sure every task can be finished no matter it is succeeded or failed.
     context->callback->finish_task(std::move(context));
 }

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -534,6 +534,11 @@ Status CompactionScheduler::do_compaction(std::unique_ptr<CompactionTaskContext>
     const auto txn_id = context->txn_id;
     const auto version = context->version;
 
+    // Each retry is a new execution attempt. The previous attempt has already been
+    // emitted to the slow log, so the context only keeps stats for the latest attempt.
+    if (context->runs.load(std::memory_order_relaxed) > 0) {
+        context->reset_attempt_stats();
+    }
     context->task_attempt_start_ns.store(start_time_ns, std::memory_order_release);
 
     int64_t in_queue_time_sec = start_time > context->enqueue_time_sec ? (start_time - context->enqueue_time_sec) : 0;
@@ -541,9 +546,9 @@ Status CompactionScheduler::do_compaction(std::unique_ptr<CompactionTaskContext>
     if (context->enqueue_time_ns > 0 && start_time_ns > context->enqueue_time_ns) {
         context->stats->queue_wait_ns += start_time_ns - context->enqueue_time_ns;
     }
-    context->stats->task_attempt_count++;
     context->start_time.store(start_time, std::memory_order_relaxed);
-    context->runs.fetch_add(1, std::memory_order_relaxed);
+    const int attempt = context->runs.fetch_add(1, std::memory_order_relaxed) + 1;
+    context->stats->task_attempt_count = attempt;
 
     auto status = Status::OK();
     auto task_prepare_start_ns = MonotonicNanos();
@@ -578,14 +583,16 @@ Status CompactionScheduler::do_compaction(std::unique_ptr<CompactionTaskContext>
 
     if (context->stats->is_slow(config::lake_compact_slow_log_ms)) {
         LOG(INFO) << "Compaction task attempt finished. tablet_id=" << tablet_id << " version=" << version
-                  << " txn_id=" << txn_id << " status=" << status << " profile=" << context->stats->to_json_stats()
-                  << " table_id=" << context->table_id << " partition_id=" << context->partition_id;
+                  << " txn_id=" << txn_id << " attempt=" << attempt << " status=" << status
+                  << " profile=" << context->stats->to_json_stats() << " table_id=" << context->table_id
+                  << " partition_id=" << context->partition_id;
     }
 
     // Task failure due to memory limitations allows for retries, more threads allow for more retries.
     // If allow partial success, do not retry, task result should be reported to FE as soon as possible.
-    if (!context->callback->allow_partial_success() && status.is_mem_limit_exceeded() &&
-        context->runs.load(std::memory_order_relaxed) < _task_queues.task_queue_size() + 1) {
+    const bool should_retry = !context->callback->allow_partial_success() && status.is_mem_limit_exceeded() &&
+                              attempt < _task_queues.task_queue_size() + 1;
+    if (should_retry) {
         LOG(WARNING) << "Memory limit exceeded, will retry later. tablet_id=" << tablet_id << " version=" << version
                      << " txn_id=" << txn_id << " cost=" << cost << "s";
         context->progress.update(0);

--- a/be/src/storage/lake/compaction_scheduler.h
+++ b/be/src/storage/lake/compaction_scheduler.h
@@ -20,6 +20,7 @@
 #include <memory>
 
 #include "base/concurrency/blocking_queue.hpp"
+#include "base/time/time.h"
 #include "common/status.h"
 #include "common/util/stack_trace_mutex.h"
 #include "compaction_task_context.h"
@@ -119,6 +120,8 @@ struct CompactionTaskInfo {
     int runs;     // How many times the compaction task has been executed
     int progress; // 0-100
     bool skipped;
+    // Parallel subtask identifier. -1 means a regular, non-parallel task.
+    int32_t subtask_id = -1;
     std::string profile; // detailed execution info, such as io stats
 };
 
@@ -363,6 +366,7 @@ inline void CompactionScheduler::WrapTaskQueues::put_by_txn_id(int64_t txn_id,
     std::lock_guard<std::mutex> lock(_task_queues_mutex);
     int idx = _task_queue_safe_index(txn_id);
     context->enqueue_time_sec = ::time(nullptr);
+    context->enqueue_time_ns = MonotonicNanos();
     _internal_task_queues[idx]->put(std::move(context));
 }
 
@@ -371,8 +375,10 @@ inline void CompactionScheduler::WrapTaskQueues::put_by_txn_id(
     std::lock_guard<std::mutex> lock(_task_queues_mutex);
     int idx = _task_queue_safe_index(txn_id);
     int64_t now = ::time(nullptr);
+    int64_t now_ns = MonotonicNanos();
     for (auto& context : contexts) {
         context->enqueue_time_sec = now;
+        context->enqueue_time_ns = now_ns;
         _internal_task_queues[idx]->put(std::move(context));
     }
 }

--- a/be/src/storage/lake/compaction_task_context.cpp
+++ b/be/src/storage/lake/compaction_task_context.cpp
@@ -18,6 +18,9 @@
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 
+#include <algorithm>
+
+#include "base/time/time.h"
 #include "storage/olap_common.h"
 
 namespace starrocks::lake {
@@ -26,6 +29,21 @@ static constexpr long TIME_UNIT_NS_PER_SECOND = 1000000000;
 static constexpr long BYTES_UNIT_MB = 1048576;
 
 void CompactionTaskStats::collect(const OlapReaderStatistics& reader_stats) {
+    create_segment_iter_ns = reader_stats.create_segment_iter_ns;
+    decompress_ns = reader_stats.decompress_ns;
+    block_load_ns = reader_stats.block_load_ns;
+    block_fetch_ns = reader_stats.block_fetch_ns;
+    block_seek_ns = reader_stats.block_seek_ns;
+    block_seek_count = reader_stats.block_seek_num;
+    decode_dict_ns = reader_stats.decode_dict_ns;
+    get_rowsets_ns = reader_stats.get_rowsets_ns;
+    get_delvec_ns = reader_stats.get_delvec_ns;
+    get_delta_column_group_ns = reader_stats.get_delta_column_group_ns;
+    del_filter_ns = reader_stats.del_filter_ns;
+    blocks_load = reader_stats.blocks_load;
+    raw_rows_read = reader_stats.raw_rows_read;
+    compressed_bytes_read = reader_stats.compressed_bytes_read;
+    uncompressed_bytes_read = reader_stats.uncompressed_bytes_read;
     io_ns_read_remote = reader_stats.io_ns_remote;
     io_ns_read_local_disk = reader_stats.io_ns_read_local_disk;
     io_bytes_read_remote = reader_stats.compressed_bytes_read_remote;
@@ -46,6 +64,48 @@ void CompactionTaskStats::collect(const OlapWriterStatistics& writer_stats) {
 
 CompactionTaskStats CompactionTaskStats::operator+(const CompactionTaskStats& that) const {
     CompactionTaskStats diff = *this;
+    if (diff.compaction_type == "unknown") {
+        diff.compaction_type = that.compaction_type;
+    } else if (that.compaction_type != "unknown" && diff.compaction_type != that.compaction_type) {
+        diff.compaction_type = "mixed";
+    }
+    diff.task_attempt_count += that.task_attempt_count;
+    diff.queue_wait_ns += that.queue_wait_ns;
+    diff.task_prepare_ns += that.task_prepare_ns;
+    diff.task_execute_ns += that.task_execute_ns;
+    diff.task_total_ns += that.task_total_ns;
+    diff.input_prepare_ns += that.input_prepare_ns;
+    diff.reader_prepare_ns += that.reader_prepare_ns;
+    diff.reader_open_ns += that.reader_open_ns;
+    diff.reader_get_next_ns += that.reader_get_next_ns;
+    diff.reader_close_ns += that.reader_close_ns;
+    diff.chunk_transform_ns += that.chunk_transform_ns;
+    diff.writer_create_ns += that.writer_create_ns;
+    diff.writer_open_ns += that.writer_open_ns;
+    diff.writer_write_ns += that.writer_write_ns;
+    diff.writer_flush_ns += that.writer_flush_ns;
+    diff.writer_finish_ns += that.writer_finish_ns;
+    diff.writer_close_ns += that.writer_close_ns;
+    diff.mask_io_ns += that.mask_io_ns;
+    diff.txn_log_build_ns += that.txn_log_build_ns;
+    diff.txn_log_write_ns += that.txn_log_write_ns;
+    diff.preload_compaction_state_ns += that.preload_compaction_state_ns;
+    diff.tablet_write_log_ns += that.tablet_write_log_ns;
+    diff.create_segment_iter_ns += that.create_segment_iter_ns;
+    diff.decompress_ns += that.decompress_ns;
+    diff.block_load_ns += that.block_load_ns;
+    diff.block_fetch_ns += that.block_fetch_ns;
+    diff.block_seek_ns += that.block_seek_ns;
+    diff.block_seek_count += that.block_seek_count;
+    diff.decode_dict_ns += that.decode_dict_ns;
+    diff.get_rowsets_ns += that.get_rowsets_ns;
+    diff.get_delvec_ns += that.get_delvec_ns;
+    diff.get_delta_column_group_ns += that.get_delta_column_group_ns;
+    diff.del_filter_ns += that.del_filter_ns;
+    diff.blocks_load += that.blocks_load;
+    diff.raw_rows_read += that.raw_rows_read;
+    diff.compressed_bytes_read += that.compressed_bytes_read;
+    diff.uncompressed_bytes_read += that.uncompressed_bytes_read;
     diff.io_ns_read_remote += that.io_ns_read_remote;
     diff.io_ns_read_local_disk += that.io_ns_read_local_disk;
     diff.io_bytes_read_remote += that.io_bytes_read_remote;
@@ -54,6 +114,14 @@ CompactionTaskStats CompactionTaskStats::operator+(const CompactionTaskStats& th
     diff.column_iterator_init_ns += that.column_iterator_init_ns;
     diff.io_count_local_disk += that.io_count_local_disk;
     diff.io_count_remote += that.io_count_remote;
+    diff.input_rowset_count += that.input_rowset_count;
+    diff.input_row_count += that.input_row_count;
+    diff.output_row_count += that.output_row_count;
+    diff.read_chunk_count += that.read_chunk_count;
+    diff.write_chunk_count += that.write_chunk_count;
+    diff.column_group_count += that.column_group_count;
+    diff.vertical_key_group_ns += that.vertical_key_group_ns;
+    diff.vertical_value_group_ns += that.vertical_value_group_ns;
     diff.read_segment_count += that.read_segment_count;
     diff.write_segment_count += that.write_segment_count;
     diff.write_segment_bytes += that.write_segment_bytes;
@@ -66,6 +134,43 @@ CompactionTaskStats CompactionTaskStats::operator+(const CompactionTaskStats& th
 
 CompactionTaskStats CompactionTaskStats::operator-(const CompactionTaskStats& that) const {
     CompactionTaskStats diff = *this;
+    diff.task_attempt_count -= that.task_attempt_count;
+    diff.queue_wait_ns -= that.queue_wait_ns;
+    diff.task_prepare_ns -= that.task_prepare_ns;
+    diff.task_execute_ns -= that.task_execute_ns;
+    diff.task_total_ns -= that.task_total_ns;
+    diff.input_prepare_ns -= that.input_prepare_ns;
+    diff.reader_prepare_ns -= that.reader_prepare_ns;
+    diff.reader_open_ns -= that.reader_open_ns;
+    diff.reader_get_next_ns -= that.reader_get_next_ns;
+    diff.reader_close_ns -= that.reader_close_ns;
+    diff.chunk_transform_ns -= that.chunk_transform_ns;
+    diff.writer_create_ns -= that.writer_create_ns;
+    diff.writer_open_ns -= that.writer_open_ns;
+    diff.writer_write_ns -= that.writer_write_ns;
+    diff.writer_flush_ns -= that.writer_flush_ns;
+    diff.writer_finish_ns -= that.writer_finish_ns;
+    diff.writer_close_ns -= that.writer_close_ns;
+    diff.mask_io_ns -= that.mask_io_ns;
+    diff.txn_log_build_ns -= that.txn_log_build_ns;
+    diff.txn_log_write_ns -= that.txn_log_write_ns;
+    diff.preload_compaction_state_ns -= that.preload_compaction_state_ns;
+    diff.tablet_write_log_ns -= that.tablet_write_log_ns;
+    diff.create_segment_iter_ns -= that.create_segment_iter_ns;
+    diff.decompress_ns -= that.decompress_ns;
+    diff.block_load_ns -= that.block_load_ns;
+    diff.block_fetch_ns -= that.block_fetch_ns;
+    diff.block_seek_ns -= that.block_seek_ns;
+    diff.block_seek_count -= that.block_seek_count;
+    diff.decode_dict_ns -= that.decode_dict_ns;
+    diff.get_rowsets_ns -= that.get_rowsets_ns;
+    diff.get_delvec_ns -= that.get_delvec_ns;
+    diff.get_delta_column_group_ns -= that.get_delta_column_group_ns;
+    diff.del_filter_ns -= that.del_filter_ns;
+    diff.blocks_load -= that.blocks_load;
+    diff.raw_rows_read -= that.raw_rows_read;
+    diff.compressed_bytes_read -= that.compressed_bytes_read;
+    diff.uncompressed_bytes_read -= that.uncompressed_bytes_read;
     diff.io_ns_read_remote -= that.io_ns_read_remote;
     diff.io_ns_read_local_disk -= that.io_ns_read_local_disk;
     diff.io_bytes_read_remote -= that.io_bytes_read_remote;
@@ -74,6 +179,14 @@ CompactionTaskStats CompactionTaskStats::operator-(const CompactionTaskStats& th
     diff.column_iterator_init_ns -= that.column_iterator_init_ns;
     diff.io_count_local_disk -= that.io_count_local_disk;
     diff.io_count_remote -= that.io_count_remote;
+    diff.input_rowset_count -= that.input_rowset_count;
+    diff.input_row_count -= that.input_row_count;
+    diff.output_row_count -= that.output_row_count;
+    diff.read_chunk_count -= that.read_chunk_count;
+    diff.write_chunk_count -= that.write_chunk_count;
+    diff.column_group_count -= that.column_group_count;
+    diff.vertical_key_group_ns -= that.vertical_key_group_ns;
+    diff.vertical_value_group_ns -= that.vertical_value_group_ns;
     diff.read_segment_count -= that.read_segment_count;
     diff.write_segment_count -= that.write_segment_count;
     diff.write_segment_bytes -= that.write_segment_bytes;
@@ -84,20 +197,86 @@ CompactionTaskStats CompactionTaskStats::operator-(const CompactionTaskStats& th
     return diff;
 }
 
-static void fill_stats_fields(rapidjson::Document& root, const CompactionTaskStats& s) {
+int64_t CompactionTaskStats::task_accounted_ns() const {
+    return task_prepare_ns + input_prepare_ns + reader_prepare_ns + reader_open_ns + reader_get_next_ns +
+           reader_close_ns + chunk_transform_ns + writer_create_ns + writer_open_ns + writer_write_ns +
+           writer_flush_ns + writer_finish_ns + writer_close_ns + mask_io_ns + txn_log_build_ns + pk_sst_merge_ns +
+           txn_log_write_ns + preload_compaction_state_ns + tablet_write_log_ns;
+}
+
+int64_t CompactionTaskStats::task_unaccounted_ns() const {
+    return std::max<int64_t>(0, task_total_ns - task_accounted_ns());
+}
+
+static void fill_stats_fields(rapidjson::Document& root, const CompactionTaskStats& s, bool profile_final) {
     auto& allocator = root.GetAllocator();
+    root.AddMember("profile_version", rapidjson::Value(1), allocator);
+    root.AddMember("profile_final", rapidjson::Value(profile_final), allocator);
+    root.AddMember("compaction_type", rapidjson::Value(s.compaction_type.c_str(), allocator), allocator);
+    root.AddMember("task_attempt_count", rapidjson::Value(s.task_attempt_count), allocator);
+    root.AddMember("queue_wait_ns", rapidjson::Value(s.queue_wait_ns), allocator);
+    root.AddMember("task_prepare_ns", rapidjson::Value(s.task_prepare_ns), allocator);
+    root.AddMember("task_execute_ns", rapidjson::Value(s.task_execute_ns), allocator);
+    root.AddMember("task_total_ns", rapidjson::Value(s.task_total_ns), allocator);
+    root.AddMember("task_accounted_ns", rapidjson::Value(s.task_accounted_ns()), allocator);
+    root.AddMember("task_unaccounted_ns", rapidjson::Value(s.task_unaccounted_ns()), allocator);
+    root.AddMember("input_prepare_ns", rapidjson::Value(s.input_prepare_ns), allocator);
+    root.AddMember("reader_prepare_ns", rapidjson::Value(s.reader_prepare_ns), allocator);
+    root.AddMember("reader_open_ns", rapidjson::Value(s.reader_open_ns), allocator);
+    root.AddMember("reader_get_next_ns", rapidjson::Value(s.reader_get_next_ns), allocator);
+    root.AddMember("reader_close_ns", rapidjson::Value(s.reader_close_ns), allocator);
+    root.AddMember("chunk_transform_ns", rapidjson::Value(s.chunk_transform_ns), allocator);
+    root.AddMember("writer_create_ns", rapidjson::Value(s.writer_create_ns), allocator);
+    root.AddMember("writer_open_ns", rapidjson::Value(s.writer_open_ns), allocator);
+    root.AddMember("writer_write_ns", rapidjson::Value(s.writer_write_ns), allocator);
+    root.AddMember("writer_flush_ns", rapidjson::Value(s.writer_flush_ns), allocator);
+    root.AddMember("writer_finish_ns", rapidjson::Value(s.writer_finish_ns), allocator);
+    root.AddMember("writer_close_ns", rapidjson::Value(s.writer_close_ns), allocator);
+    root.AddMember("mask_io_ns", rapidjson::Value(s.mask_io_ns), allocator);
+    root.AddMember("txn_log_build_ns", rapidjson::Value(s.txn_log_build_ns), allocator);
+    root.AddMember("txn_log_write_ns", rapidjson::Value(s.txn_log_write_ns), allocator);
+    root.AddMember("preload_compaction_state_ns", rapidjson::Value(s.preload_compaction_state_ns), allocator);
+    root.AddMember("tablet_write_log_ns", rapidjson::Value(s.tablet_write_log_ns), allocator);
+    root.AddMember("create_segment_iter_ns", rapidjson::Value(s.create_segment_iter_ns), allocator);
+    root.AddMember("decompress_ns", rapidjson::Value(s.decompress_ns), allocator);
+    root.AddMember("block_load_ns", rapidjson::Value(s.block_load_ns), allocator);
+    root.AddMember("block_fetch_ns", rapidjson::Value(s.block_fetch_ns), allocator);
+    root.AddMember("block_seek_ns", rapidjson::Value(s.block_seek_ns), allocator);
+    root.AddMember("block_seek_count", rapidjson::Value(s.block_seek_count), allocator);
+    root.AddMember("decode_dict_ns", rapidjson::Value(s.decode_dict_ns), allocator);
+    root.AddMember("get_rowsets_ns", rapidjson::Value(s.get_rowsets_ns), allocator);
+    root.AddMember("get_delvec_ns", rapidjson::Value(s.get_delvec_ns), allocator);
+    root.AddMember("get_delta_column_group_ns", rapidjson::Value(s.get_delta_column_group_ns), allocator);
+    root.AddMember("del_filter_ns", rapidjson::Value(s.del_filter_ns), allocator);
+    root.AddMember("blocks_load", rapidjson::Value(s.blocks_load), allocator);
+    root.AddMember("raw_rows_read", rapidjson::Value(s.raw_rows_read), allocator);
+    root.AddMember("compressed_bytes_read", rapidjson::Value(s.compressed_bytes_read), allocator);
+    root.AddMember("uncompressed_bytes_read", rapidjson::Value(s.uncompressed_bytes_read), allocator);
+    root.AddMember("read_remote_ns", rapidjson::Value(s.io_ns_read_remote), allocator);
+    root.AddMember("read_local_ns", rapidjson::Value(s.io_ns_read_local_disk), allocator);
     root.AddMember("read_local_sec", rapidjson::Value(s.io_ns_read_local_disk / TIME_UNIT_NS_PER_SECOND), allocator);
     root.AddMember("read_local_mb", rapidjson::Value(s.io_bytes_read_local_disk / BYTES_UNIT_MB), allocator);
     root.AddMember("read_remote_sec", rapidjson::Value(s.io_ns_read_remote / TIME_UNIT_NS_PER_SECOND), allocator);
     root.AddMember("read_remote_mb", rapidjson::Value(s.io_bytes_read_remote / BYTES_UNIT_MB), allocator);
     root.AddMember("read_remote_count", rapidjson::Value(s.io_count_remote), allocator);
     root.AddMember("read_local_count", rapidjson::Value(s.io_count_local_disk), allocator);
+    root.AddMember("segment_init_ns", rapidjson::Value(s.segment_init_ns), allocator);
+    root.AddMember("column_iterator_init_ns", rapidjson::Value(s.column_iterator_init_ns), allocator);
     root.AddMember("segment_init_sec", rapidjson::Value(s.segment_init_ns / TIME_UNIT_NS_PER_SECOND), allocator);
     root.AddMember("column_iterator_init_sec", rapidjson::Value(s.column_iterator_init_ns / TIME_UNIT_NS_PER_SECOND),
                    allocator);
+    root.AddMember("input_rowset_count", rapidjson::Value(s.input_rowset_count), allocator);
+    root.AddMember("input_row_count", rapidjson::Value(s.input_row_count), allocator);
+    root.AddMember("output_row_count", rapidjson::Value(s.output_row_count), allocator);
+    root.AddMember("read_chunk_count", rapidjson::Value(s.read_chunk_count), allocator);
+    root.AddMember("write_chunk_count", rapidjson::Value(s.write_chunk_count), allocator);
+    root.AddMember("column_group_count", rapidjson::Value(s.column_group_count), allocator);
+    root.AddMember("vertical_key_group_ns", rapidjson::Value(s.vertical_key_group_ns), allocator);
+    root.AddMember("vertical_value_group_ns", rapidjson::Value(s.vertical_value_group_ns), allocator);
     root.AddMember("read_segment_count", rapidjson::Value(s.read_segment_count), allocator);
     root.AddMember("write_segment_count", rapidjson::Value(s.write_segment_count), allocator);
     root.AddMember("write_remote_mb", rapidjson::Value(s.write_segment_bytes / BYTES_UNIT_MB), allocator);
+    root.AddMember("write_remote_ns", rapidjson::Value(s.io_ns_write_remote), allocator);
     root.AddMember("write_remote_sec", rapidjson::Value(s.io_ns_write_remote / TIME_UNIT_NS_PER_SECOND), allocator);
     root.AddMember("in_queue_sec", rapidjson::Value(s.in_queue_time_sec), allocator);
     root.AddMember("pk_sst_merge_sec", rapidjson::Value(s.pk_sst_merge_ns / TIME_UNIT_NS_PER_SECOND), allocator);
@@ -111,21 +290,40 @@ static std::string serialize(const rapidjson::Document& root) {
     return {strbuf.GetString()};
 }
 
-std::string CompactionTaskStats::to_json_stats() const {
+std::string CompactionTaskStats::to_json_stats(bool profile_final) const {
     rapidjson::Document root;
     root.SetObject();
-    fill_stats_fields(root, *this);
+    fill_stats_fields(root, *this, profile_final);
     return serialize(root);
 }
 
-std::string CompactionTaskStats::to_json_stats_with_subtask_metadata(int32_t subtask_id, size_t input_rowsets) const {
+std::string CompactionTaskStats::to_json_stats_with_subtask_metadata(int32_t subtask_id, size_t input_rowsets,
+                                                                     bool profile_final) const {
     rapidjson::Document root;
     root.SetObject();
-    fill_stats_fields(root, *this);
+    fill_stats_fields(root, *this, profile_final);
     auto& allocator = root.GetAllocator();
     root.AddMember("subtask_id", rapidjson::Value(subtask_id), allocator);
     root.AddMember("input_rowsets", rapidjson::Value(static_cast<int64_t>(input_rowsets)), allocator);
     root.AddMember("is_parallel_subtask", rapidjson::Value(true), allocator);
     return serialize(root);
+}
+
+CompactionTaskStats CompactionTaskContext::stats_snapshot(bool include_live_timers) const {
+    CompactionTaskStats snapshot = *stats;
+    if (!include_live_timers) {
+        return snapshot;
+    }
+
+    const int64_t now_ns = MonotonicNanos();
+    const int64_t attempt_start_ns = task_attempt_start_ns.load(std::memory_order_acquire);
+    if (attempt_start_ns > 0 && now_ns > attempt_start_ns) {
+        snapshot.task_total_ns += now_ns - attempt_start_ns;
+    }
+    const int64_t execute_start_ns = task_execute_start_ns.load(std::memory_order_acquire);
+    if (execute_start_ns > 0 && now_ns > execute_start_ns) {
+        snapshot.task_execute_ns += now_ns - execute_start_ns;
+    }
+    return snapshot;
 }
 } // namespace starrocks::lake

--- a/be/src/storage/lake/compaction_task_context.cpp
+++ b/be/src/storage/lake/compaction_task_context.cpp
@@ -313,18 +313,31 @@ void CompactionTaskContext::reset_attempt_stats() {
     *stats = CompactionTaskStats();
 }
 
+void CompactionTaskContext::publish_stats_snapshot() {
+    std::lock_guard lock(_stats_snapshot_mutex);
+    _published_stats = *stats;
+    _published_task_attempt_start_ns = task_attempt_start_ns.load(std::memory_order_relaxed);
+    _published_task_execute_start_ns = task_execute_start_ns.load(std::memory_order_relaxed);
+}
+
 CompactionTaskStats CompactionTaskContext::stats_snapshot(bool include_live_timers) const {
-    CompactionTaskStats snapshot = *stats;
+    CompactionTaskStats snapshot;
+    int64_t attempt_start_ns;
+    int64_t execute_start_ns;
+    {
+        std::lock_guard lock(_stats_snapshot_mutex);
+        snapshot = _published_stats;
+        attempt_start_ns = _published_task_attempt_start_ns;
+        execute_start_ns = _published_task_execute_start_ns;
+    }
     if (!include_live_timers) {
         return snapshot;
     }
 
     const int64_t now_ns = MonotonicNanos();
-    const int64_t attempt_start_ns = task_attempt_start_ns.load(std::memory_order_acquire);
     if (attempt_start_ns > 0 && now_ns > attempt_start_ns) {
         snapshot.task_total_ns += now_ns - attempt_start_ns;
     }
-    const int64_t execute_start_ns = task_execute_start_ns.load(std::memory_order_acquire);
     if (execute_start_ns > 0 && now_ns > execute_start_ns) {
         snapshot.task_execute_ns += now_ns - execute_start_ns;
     }

--- a/be/src/storage/lake/compaction_task_context.cpp
+++ b/be/src/storage/lake/compaction_task_context.cpp
@@ -309,6 +309,10 @@ std::string CompactionTaskStats::to_json_stats_with_subtask_metadata(int32_t sub
     return serialize(root);
 }
 
+void CompactionTaskContext::reset_attempt_stats() {
+    *stats = CompactionTaskStats();
+}
+
 CompactionTaskStats CompactionTaskContext::stats_snapshot(bool include_live_timers) const {
     CompactionTaskStats snapshot = *stats;
     if (!include_live_timers) {

--- a/be/src/storage/lake/compaction_task_context.h
+++ b/be/src/storage/lake/compaction_task_context.h
@@ -212,8 +212,8 @@ struct CompactionTaskContext : public butil::LinkNode<CompactionTaskContext> {
     bool range_upper_inclusive = false;
     // Explicit bound presence flags. When has_lower_bound is false, the lower bound
     // is unbounded (scan from the beginning). When has_upper_bound is false, the upper
-    // bound is unbounded (scan to the end). This avoids relying on empty OlapTuple
-    // semantics in the segment iterator for open-ended ranges.
+    // bound is unbounded (scan to the end). The corresponding OlapTuple remains empty
+    // so both sides can still be passed to TabletReader as a paired range.
     bool has_lower_bound = false;
     bool has_upper_bound = false;
     bool is_first_range = false;

--- a/be/src/storage/lake/compaction_task_context.h
+++ b/be/src/storage/lake/compaction_task_context.h
@@ -43,6 +43,52 @@ private:
 };
 
 struct CompactionTaskStats {
+    // High-level wall-clock phases. These fields are mutually exclusive, except
+    // for the explicitly documented nested reader and vertical-group metrics
+    // below, so task_total_ns can be reconciled with task_accounted_ns and
+    // task_unaccounted_ns in the serialized profile.
+    std::string compaction_type = "unknown";
+    int64_t task_attempt_count = 0;
+    int64_t queue_wait_ns = 0;
+    int64_t task_prepare_ns = 0;
+    int64_t task_execute_ns = 0;
+    int64_t task_total_ns = 0;
+    int64_t input_prepare_ns = 0;
+    int64_t reader_prepare_ns = 0;
+    int64_t reader_open_ns = 0;
+    int64_t reader_get_next_ns = 0;
+    int64_t reader_close_ns = 0;
+    int64_t chunk_transform_ns = 0;
+    int64_t writer_create_ns = 0;
+    int64_t writer_open_ns = 0;
+    int64_t writer_write_ns = 0;
+    int64_t writer_flush_ns = 0;
+    int64_t writer_finish_ns = 0;
+    int64_t writer_close_ns = 0;
+    int64_t mask_io_ns = 0;
+    int64_t txn_log_build_ns = 0;
+    int64_t txn_log_write_ns = 0;
+    int64_t preload_compaction_state_ns = 0;
+    int64_t tablet_write_log_ns = 0;
+
+    // Nested reader breakdown. These counters explain work inside reader open
+    // and get_next and must not be added to the high-level wall-clock phases.
+    int64_t create_segment_iter_ns = 0;
+    int64_t decompress_ns = 0;
+    int64_t block_load_ns = 0;
+    int64_t block_fetch_ns = 0;
+    int64_t block_seek_ns = 0;
+    int64_t block_seek_count = 0;
+    int64_t decode_dict_ns = 0;
+    int64_t get_rowsets_ns = 0;
+    int64_t get_delvec_ns = 0;
+    int64_t get_delta_column_group_ns = 0;
+    int64_t del_filter_ns = 0;
+    int64_t blocks_load = 0;
+    int64_t raw_rows_read = 0;
+    int64_t compressed_bytes_read = 0;
+    int64_t uncompressed_bytes_read = 0;
+
     int64_t io_ns_read_remote = 0;
     int64_t io_ns_read_local_disk = 0;
     int64_t io_bytes_read_remote = 0;
@@ -52,6 +98,16 @@ struct CompactionTaskStats {
     int64_t io_count_local_disk = 0;
     int64_t io_count_remote = 0;
     int64_t in_queue_time_sec = 0;
+    int64_t input_rowset_count = 0;
+    int64_t input_row_count = 0;
+    int64_t output_row_count = 0;
+    int64_t read_chunk_count = 0;
+    int64_t write_chunk_count = 0;
+    int64_t column_group_count = 0;
+    // Nested wall-clock totals for vertical compaction groups. They overlap
+    // with the high-level reader/writer phases and are not part of accounting.
+    int64_t vertical_key_group_ns = 0;
+    int64_t vertical_value_group_ns = 0;
     int64_t read_segment_count = 0;
     int64_t write_segment_count = 0;
     int64_t write_segment_bytes = 0;
@@ -63,7 +119,9 @@ struct CompactionTaskStats {
     void collect(const OlapWriterStatistics& writer_stats);
     CompactionTaskStats operator+(const CompactionTaskStats& that) const;
     CompactionTaskStats operator-(const CompactionTaskStats& that) const;
-    std::string to_json_stats() const;
+    int64_t task_accounted_ns() const;
+    int64_t task_unaccounted_ns() const;
+    std::string to_json_stats(bool profile_final = true) const;
 
     // Same JSON layout as to_json_stats(), with parallel-subtask metadata fields
     // (subtask_id, input_rowsets, is_parallel_subtask) appended. Used for the
@@ -71,7 +129,8 @@ struct CompactionTaskStats {
     // CompactionTaskStats counters and per-subtask metadata are visible. Actual
     // read volume is already reported via read_local_mb / read_remote_mb in the
     // stats fields, so the planned input_bytes is intentionally omitted.
-    std::string to_json_stats_with_subtask_metadata(int32_t subtask_id, size_t input_rowsets) const;
+    std::string to_json_stats_with_subtask_metadata(int32_t subtask_id, size_t input_rowsets,
+                                                    bool profile_final = true) const;
 };
 
 // Context of a single tablet compaction task.
@@ -114,11 +173,16 @@ struct CompactionTaskContext : public butil::LinkNode<CompactionTaskContext> {
     const bool skip_write_txnlog;
     std::atomic<int64_t> start_time{0};
     std::atomic<int64_t> finish_time{0};
+    // Monotonic timestamps for adding the elapsed part of the current attempt
+    // to a live profile without mutating the finalized cumulative counters.
+    std::atomic<int64_t> task_attempt_start_ns{0};
+    std::atomic<int64_t> task_execute_start_ns{0};
     std::atomic<bool> skipped{false};
     std::atomic<int> runs{0};
     Status status;
     Progress progress;
     int64_t enqueue_time_sec{0}; // time point when put into queue
+    int64_t enqueue_time_ns{0};  // monotonic time point for precise queue wait accounting
     std::shared_ptr<CompactionTaskCallback> callback;
     std::unique_ptr<CompactionTaskStats> stats = std::make_unique<CompactionTaskStats>();
     std::shared_ptr<TxnLogPB> txn_log;
@@ -150,6 +214,8 @@ struct CompactionTaskContext : public butil::LinkNode<CompactionTaskContext> {
     bool has_upper_bound = false;
     bool is_first_range = false;
     bool is_last_range = false;
+
+    CompactionTaskStats stats_snapshot(bool include_live_timers) const;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/compaction_task_context.h
+++ b/be/src/storage/lake/compaction_task_context.h
@@ -121,6 +121,10 @@ struct CompactionTaskStats {
     CompactionTaskStats operator-(const CompactionTaskStats& that) const;
     int64_t task_accounted_ns() const;
     int64_t task_unaccounted_ns() const;
+    bool is_slow(int64_t slow_log_ms) const {
+        static constexpr int64_t kNanosPerMillisecond = 1'000'000;
+        return task_total_ns / kNanosPerMillisecond >= slow_log_ms;
+    }
     std::string to_json_stats(bool profile_final = true) const;
 
     // Same JSON layout as to_json_stats(), with parallel-subtask metadata fields

--- a/be/src/storage/lake/compaction_task_context.h
+++ b/be/src/storage/lake/compaction_task_context.h
@@ -18,6 +18,7 @@
 
 #include <atomic>
 #include <memory>
+#include <mutex>
 #include <string>
 
 #include "common/status.h"
@@ -220,7 +221,17 @@ struct CompactionTaskContext : public butil::LinkNode<CompactionTaskContext> {
     bool is_last_range = false;
 
     void reset_attempt_stats();
+    void publish_stats_snapshot();
     CompactionTaskStats stats_snapshot(bool include_live_timers) const;
+
+private:
+    // Running task queries read this published copy instead of racing with the
+    // worker's in-place updates to stats. The worker refreshes it only at safe
+    // phase boundaries, while the atomic timestamps keep live timers moving.
+    mutable std::mutex _stats_snapshot_mutex;
+    CompactionTaskStats _published_stats;
+    int64_t _published_task_attempt_start_ns = 0;
+    int64_t _published_task_execute_start_ns = 0;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/compaction_task_context.h
+++ b/be/src/storage/lake/compaction_task_context.h
@@ -219,6 +219,7 @@ struct CompactionTaskContext : public butil::LinkNode<CompactionTaskContext> {
     bool is_first_range = false;
     bool is_last_range = false;
 
+    void reset_attempt_stats();
     CompactionTaskStats stats_snapshot(bool include_live_timers) const;
 };
 

--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -41,6 +41,7 @@ namespace starrocks::lake {
 Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush_pool) {
     SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker.get());
     _context->stats->compaction_type = "horizontal";
+    _context->publish_stats_snapshot();
 
     int64_t total_num_rows = 0;
     int64_t input_bytes = 0;

--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -75,21 +75,17 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
                                   .buffer_size = config::lake_compaction_stream_buffer_size_bytes};
     reader_params.column_access_paths = &_column_access_paths;
 
-    // Apply range filter for range-split parallel compaction.
-    // Only set each bound when has_lower_bound / has_upper_bound is true, so that
-    // open-ended ranges (first/last subtask) leave that side unconstrained without
-    // relying on empty OlapTuple semantics in the segment iterator.
+    // Apply range filter for range-split parallel compaction. TabletReader requires
+    // start_key and end_key to contain the same number of ranges, so pass both sides
+    // together. An empty OlapTuple represents the unbounded side of the first/last
+    // range and is ignored by the segment iterator.
     if (_context->has_range_split) {
-        if (_context->has_lower_bound && !_context->range_start_key.empty()) {
-            reader_params.start_key = _context->range_start_key;
-            reader_params.range = _context->range_lower_inclusive ? TabletReaderParams::RangeStartOperation::GE
-                                                                  : TabletReaderParams::RangeStartOperation::GT;
-        }
-        if (_context->has_upper_bound && !_context->range_end_key.empty()) {
-            reader_params.end_key = _context->range_end_key;
-            reader_params.end_range = _context->range_upper_inclusive ? TabletReaderParams::RangeEndOperation::LE
-                                                                      : TabletReaderParams::RangeEndOperation::LT;
-        }
+        reader_params.start_key = _context->range_start_key;
+        reader_params.end_key = _context->range_end_key;
+        reader_params.range = _context->range_lower_inclusive ? TabletReaderParams::RangeStartOperation::GE
+                                                              : TabletReaderParams::RangeStartOperation::GT;
+        reader_params.end_range = _context->range_upper_inclusive ? TabletReaderParams::RangeEndOperation::LE
+                                                                  : TabletReaderParams::RangeEndOperation::LT;
     }
 
     {

--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -40,22 +40,32 @@ namespace starrocks::lake {
 
 Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush_pool) {
     SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker.get());
+    _context->stats->compaction_type = "horizontal";
 
     int64_t total_num_rows = 0;
     int64_t input_bytes = 0;
-    for (auto& rowset : _input_rowsets) {
-        total_num_rows += rowset->num_rows();
-        _context->stats->read_segment_count += rowset->num_segments();
-        input_bytes += rowset->data_size_after_deletion();
+    int32_t chunk_size = 0;
+    Schema schema;
+    {
+        SCOPED_RAW_TIMER(&_context->stats->input_prepare_ns);
+        for (auto& rowset : _input_rowsets) {
+            total_num_rows += rowset->num_rows();
+            _context->stats->read_segment_count += rowset->num_segments();
+            input_bytes += rowset->data_size_after_deletion();
+        }
+        _context->stats->input_rowset_count = _input_rowsets.size();
+        _context->stats->input_row_count = total_num_rows;
+        ASSIGN_OR_RETURN(chunk_size, calculate_chunk_size());
+        schema = ChunkHelper::convert_schema(_tablet_schema);
     }
-
-    ASSIGN_OR_RETURN(auto chunk_size, calculate_chunk_size());
 
     VLOG(3) << "Start horizontal compaction. tablet: " << _tablet.id() << ", reader chunk size: " << chunk_size;
 
-    Schema schema = ChunkHelper::convert_schema(_tablet_schema);
     TabletReader reader(_tablet.tablet_manager(), _tablet.metadata(), schema, _input_rowsets, _tablet_schema);
-    RETURN_IF_ERROR(reader.prepare());
+    {
+        SCOPED_RAW_TIMER(&_context->stats->reader_prepare_ns);
+        RETURN_IF_ERROR(reader.prepare());
+    }
     TabletReaderParams reader_params;
     reader_params.reader_type = READER_CUMULATIVE_COMPACTION;
     reader_params.chunk_size = chunk_size;
@@ -82,13 +92,32 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
         }
     }
 
-    RETURN_IF_ERROR(reader.open(reader_params));
+    {
+        SCOPED_RAW_TIMER(&_context->stats->reader_open_ns);
+        RETURN_IF_ERROR(reader.open(reader_params));
+    }
+    DeferOp reader_defer([&]() {
+        SCOPED_RAW_TIMER(&_context->stats->reader_close_ns);
+        reader.close();
+        _context->stats->collect(reader.stats());
+    });
 
-    ASSIGN_OR_RETURN(auto writer,
-                     _tablet.new_writer_with_schema(kHorizontal, _txn_id, 0, flush_pool, true /** compaction **/,
-                                                    _tablet_schema /** output rowset schema**/))
-    RETURN_IF_ERROR(writer->open());
-    DeferOp defer([&]() { writer->close(); });
+    std::unique_ptr<TabletWriter> writer;
+    {
+        SCOPED_RAW_TIMER(&_context->stats->writer_create_ns);
+        ASSIGN_OR_RETURN(writer,
+                         _tablet.new_writer_with_schema(kHorizontal, _txn_id, 0, flush_pool, true /** compaction **/,
+                                                        _tablet_schema /** output rowset schema**/))
+    }
+    {
+        SCOPED_RAW_TIMER(&_context->stats->writer_open_ns);
+        RETURN_IF_ERROR(writer->open());
+    }
+    DeferOp defer([&]() {
+        SCOPED_RAW_TIMER(&_context->stats->writer_close_ns);
+        writer->close();
+        _context->stats->collect(writer->stats());
+    });
 
     if (should_enable_pk_index_eager_build(input_bytes)) {
         writer->try_enable_pk_index_eager_build();
@@ -112,10 +141,13 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
 #endif
         {
             auto st = Status::OK();
-            if (_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS && enable_light_pk_compaction_publish) {
-                st = reader.get_next(chunk.get(), &rssid_rowids);
-            } else {
-                st = reader.get_next(chunk.get());
+            {
+                SCOPED_RAW_TIMER(&_context->stats->reader_get_next_ns);
+                if (_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS && enable_light_pk_compaction_publish) {
+                    st = reader.get_next(chunk.get(), &rssid_rowids);
+                } else {
+                    st = reader.get_next(chunk.get());
+                }
             }
             if (st.is_end_of_file()) {
                 break;
@@ -123,13 +155,21 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
                 return st;
             }
         }
-        ChunkHelper::padding_char_columns(char_field_indexes, schema, _tablet_schema, chunk.get());
-        if (rssid_rowids.empty()) {
-            RETURN_IF_ERROR(writer->write(*chunk));
-        } else {
-            // pk table compaction
-            RETURN_IF_ERROR(writer->write(*chunk, rssid_rowids));
+        _context->stats->read_chunk_count++;
+        {
+            SCOPED_RAW_TIMER(&_context->stats->chunk_transform_ns);
+            ChunkHelper::padding_char_columns(char_field_indexes, schema, _tablet_schema, chunk.get());
         }
+        {
+            SCOPED_RAW_TIMER(&_context->stats->writer_write_ns);
+            if (rssid_rowids.empty()) {
+                RETURN_IF_ERROR(writer->write(*chunk));
+            } else {
+                // pk table compaction
+                RETURN_IF_ERROR(writer->write(*chunk, rssid_rowids));
+            }
+        }
+        _context->stats->write_chunk_count++;
         chunk->reset();
         rssid_rowids.clear();
 
@@ -139,44 +179,47 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
         _context->stats->collect(reader.stats());
     }
 
-    RETURN_IF_ERROR(writer->finish());
+    {
+        SCOPED_RAW_TIMER(&_context->stats->writer_finish_ns);
+        RETURN_IF_ERROR(writer->finish());
+    }
+    _context->stats->output_row_count = writer->num_rows();
 
     // Adjust the progress here for 2 reasons:
     // 1. For primary key, due to the existence of the delete vector, the rows read may be less than "total_num_rows"
     // 2. If the "total_num_rows" is 0, the progress will not be updated above
     _context->progress.update(100);
 
-    // Close reader to ensure IO statistics are updated via SegmentIterator::_update_stats() before collecting
-    reader.close();
-
-    _context->stats->collect(reader.stats());
     _context->stats->collect(writer->stats());
 
-    auto txn_log = std::make_shared<TxnLog>();
-    auto op_compaction = txn_log->mutable_op_compaction();
-    txn_log->set_tablet_id(_tablet.id());
-    txn_log->set_txn_id(_txn_id);
-    RETURN_IF_ERROR(fill_compaction_segment_info(op_compaction, writer.get()));
-    op_compaction->set_compact_version(_tablet.metadata()->version());
+    std::shared_ptr<TxnLog> txn_log;
+    {
+        SCOPED_RAW_TIMER(&_context->stats->txn_log_build_ns);
+        txn_log = std::make_shared<TxnLog>();
+        auto op_compaction = txn_log->mutable_op_compaction();
+        txn_log->set_tablet_id(_tablet.id());
+        txn_log->set_txn_id(_txn_id);
+        RETURN_IF_ERROR(fill_compaction_segment_info(op_compaction, writer.get()));
+        op_compaction->set_compact_version(_tablet.metadata()->version());
+    }
     RETURN_IF_ERROR(execute_index_major_compaction(txn_log.get()));
     TEST_ERROR_POINT("HorizontalCompactionTask::execute::1");
     if (_context->skip_write_txnlog) {
         // return txn_log to caller later
         _context->txn_log = txn_log;
     } else {
+        SCOPED_RAW_TIMER(&_context->stats->txn_log_write_ns);
         RETURN_IF_ERROR(_tablet.tablet_manager()->put_txn_log(txn_log));
     }
     if (_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
         // preload primary key table's compaction state
+        SCOPED_RAW_TIMER(&_context->stats->preload_compaction_state_ns);
         Tablet t(_tablet.tablet_manager(), _tablet.id());
         _tablet.tablet_manager()->update_mgr()->preload_compaction_state(*txn_log, t, _tablet_schema);
     }
 
-    LOG(INFO) << "Horizontal compaction finished. tablet: " << _tablet.id() << ", txn_id: " << _txn_id
-              << ", statistics: " << _context->stats->to_json_stats() << ", table_id: " << _context->table_id
-              << ", partition_id: " << _context->partition_id;
-
     if (config::enable_tablet_write_log) {
+        SCOPED_RAW_TIMER(&_context->stats->tablet_write_log_ns);
         int64_t begin_time = _context->start_time.load(std::memory_order_relaxed) * 1000; // Convert to ms
         int64_t finish_time = UnixMillis();
         collect_sst_stats(writer.get(), txn_log.get());

--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -96,7 +96,7 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
         SCOPED_RAW_TIMER(&_context->stats->reader_open_ns);
         RETURN_IF_ERROR(reader.open(reader_params));
     }
-    DeferOp reader_defer([&]() {
+    CancelableDefer reader_defer([&]() {
         SCOPED_RAW_TIMER(&_context->stats->reader_close_ns);
         reader.close();
         _context->stats->collect(reader.stats());
@@ -183,6 +183,12 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
         SCOPED_RAW_TIMER(&_context->stats->writer_finish_ns);
         RETURN_IF_ERROR(writer->finish());
     }
+    {
+        SCOPED_RAW_TIMER(&_context->stats->reader_close_ns);
+        reader.close();
+        _context->stats->collect(reader.stats());
+    }
+    reader_defer.cancel();
     _context->stats->output_row_count = writer->num_rows();
 
     // Adjust the progress here for 2 reasons:

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -18,6 +18,7 @@
 #include <sstream>
 #include <utility>
 
+#include "base/time/time.h"
 #include "base/utility/defer_op.h"
 #include "column/datum_convert.h"
 #include "column/schema.h"
@@ -507,6 +508,7 @@ StatusOr<int> TabletParallelCompactionManager::submit_subtasks(
             info.input_rowset_ids = rowset_ids;
             info.input_bytes = input_bytes;
             info.start_time = ::time(nullptr);
+            info.enqueue_time_ns = MonotonicNanos();
             state_ptr->running_subtasks[subtask_id] = std::move(info);
             state_ptr->total_subtasks_created++;
         }
@@ -1455,7 +1457,11 @@ void TabletParallelCompactionManager::execute_subtask(int64_t tablet_id, int64_t
                                                              true /* skip_write_txnlog */, state->callback, subtask_id);
 
     auto start_time = ::time(nullptr);
+    auto start_time_ns = MonotonicNanos();
+    context->task_attempt_start_ns.store(start_time_ns, std::memory_order_release);
     context->start_time.store(start_time, std::memory_order_relaxed);
+    context->stats->task_attempt_count++;
+    context->runs.fetch_add(1, std::memory_order_relaxed);
 
     // Calculate in_queue_time_sec using the enqueue time from SubtaskInfo
     // Also store context pointer in SubtaskInfo for progress/status tracking in list_tasks()
@@ -1466,6 +1472,9 @@ void TabletParallelCompactionManager::execute_subtask(int64_t tablet_id, int64_t
             int64_t enqueue_time = it->second.start_time;
             int64_t in_queue_time_sec = start_time > enqueue_time ? (start_time - enqueue_time) : 0;
             context->stats->in_queue_time_sec += in_queue_time_sec;
+            if (it->second.enqueue_time_ns > 0 && start_time_ns > it->second.enqueue_time_ns) {
+                context->stats->queue_wait_ns += start_time_ns - it->second.enqueue_time_ns;
+            }
             // Snapshot the subtask input footprint onto the context so list_tasks() can
             // surface it consistently for both running and completed subtasks.
             context->subtask_input_rowsets = static_cast<int64_t>(it->second.input_rowset_ids.size());
@@ -1475,11 +1484,19 @@ void TabletParallelCompactionManager::execute_subtask(int64_t tablet_id, int64_t
     }
 
     // Create compaction task using pre-selected rowsets
+    auto task_prepare_start_ns = MonotonicNanos();
     auto compaction_task_or = _tablet_mgr->compact(context.get(), std::move(input_rowsets));
+    context->stats->task_prepare_ns += MonotonicNanos() - task_prepare_start_ns;
     if (!compaction_task_or.ok()) {
         LOG(WARNING) << "Failed to create compaction task for tablet " << tablet_id << " subtask " << subtask_id << ": "
                      << compaction_task_or.status();
         context->status = compaction_task_or.status();
+        context->stats->task_total_ns += MonotonicNanos() - start_time_ns;
+        context->task_attempt_start_ns.store(0, std::memory_order_release);
+        context->finish_time.store(std::max<int64_t>(::time(nullptr), start_time), std::memory_order_release);
+        LOG(INFO) << "Parallel compaction task finished. tablet_id=" << tablet_id << " version=" << version
+                  << " txn_id=" << txn_id << " subtask_id=" << subtask_id << " status=" << context->status
+                  << " profile=" << context->stats->to_json_stats();
         on_subtask_complete(tablet_id, txn_id, subtask_id, std::move(context));
         // Release limiter token on early return
         if (release_token) {
@@ -1489,11 +1506,6 @@ void TabletParallelCompactionManager::execute_subtask(int64_t tablet_id, int64_t
     }
 
     const auto& compaction_task = compaction_task_or.value();
-
-    // Increment runs counter to track that this subtask has actually started execution.
-    // This is important for list_tasks() to correctly display the profile for completed subtasks,
-    // as it checks "if (info.runs > 0 && ctx->stats)" before displaying the profile.
-    context->runs.fetch_add(1, std::memory_order_relaxed);
 
     // Execute compaction
     // Note: We capture 'this', tablet_id, and txn_id instead of the raw 'state' pointer
@@ -1516,7 +1528,13 @@ void TabletParallelCompactionManager::execute_subtask(int64_t tablet_id, int64_t
         flush_pool = StorageEngine::instance()->lake_memtable_flush_executor()->get_thread_pool();
     }
 
+    auto task_execute_start_ns = MonotonicNanos();
+    context->task_execute_start_ns.store(task_execute_start_ns, std::memory_order_release);
     auto exec_st = compaction_task->execute(cancel_func, flush_pool);
+    context->stats->task_execute_ns += MonotonicNanos() - task_execute_start_ns;
+    context->task_execute_start_ns.store(0, std::memory_order_release);
+    context->stats->task_total_ns += MonotonicNanos() - start_time_ns;
+    context->task_attempt_start_ns.store(0, std::memory_order_release);
 
     auto finish_time = std::max<int64_t>(::time(nullptr), start_time);
     auto cost = finish_time - start_time;
@@ -1531,6 +1549,10 @@ void TabletParallelCompactionManager::execute_subtask(int64_t tablet_id, int64_t
     }
 
     context->finish_time.store(finish_time, std::memory_order_release);
+
+    LOG(INFO) << "Parallel compaction task finished. tablet_id=" << tablet_id << " version=" << version
+              << " txn_id=" << txn_id << " subtask_id=" << subtask_id << " status=" << exec_st
+              << " profile=" << context->stats->to_json_stats();
 
     // Check if memory limit was exceeded before moving context
     bool mem_limit_exceeded = exec_st.is_mem_limit_exceeded();
@@ -1632,6 +1654,7 @@ void TabletParallelCompactionManager::list_tasks(std::vector<CompactionTaskInfo>
             info.txn_id = state_ptr->txn_id;
             info.tablet_id = state_ptr->tablet_id;
             info.version = state_ptr->version;
+            info.subtask_id = subtask_id;
             info.skipped = false;
             info.runs = 1; // Parallel subtasks run once
             info.start_time = subtask_info.start_time;
@@ -1651,13 +1674,12 @@ void TabletParallelCompactionManager::list_tasks(std::vector<CompactionTaskInfo>
             // Build profile combining CompactionTaskStats (from the running context, when
             // available) with subtask-specific metadata. Falling back to a default-constructed
             // stats object keeps the JSON schema stable when the context has not yet been linked.
-            CompactionTaskStats empty_stats;
-            const CompactionTaskStats* stats_ptr = &empty_stats;
+            CompactionTaskStats stats_snapshot;
             if (subtask_info.context != nullptr && subtask_info.context->stats) {
-                stats_ptr = subtask_info.context->stats.get();
+                stats_snapshot = subtask_info.context->stats_snapshot(true);
             }
-            info.profile =
-                    stats_ptr->to_json_stats_with_subtask_metadata(subtask_id, subtask_info.input_rowset_ids.size());
+            info.profile = stats_snapshot.to_json_stats_with_subtask_metadata(
+                    subtask_id, subtask_info.input_rowset_ids.size(), false);
         }
 
         // Add completed subtasks that haven't been cleaned up yet
@@ -1666,6 +1688,7 @@ void TabletParallelCompactionManager::list_tasks(std::vector<CompactionTaskInfo>
             info.txn_id = ctx->txn_id;
             info.tablet_id = ctx->tablet_id;
             info.version = ctx->version;
+            info.subtask_id = ctx->subtask_id;
             info.skipped = ctx->skipped.load(std::memory_order_relaxed);
             info.runs = ctx->runs.load(std::memory_order_relaxed);
             info.start_time = ctx->start_time.load(std::memory_order_relaxed);
@@ -1677,7 +1700,7 @@ void TabletParallelCompactionManager::list_tasks(std::vector<CompactionTaskInfo>
                 // parallel subtask.
                 if (ctx->subtask_id >= 0) {
                     info.profile = ctx->stats->to_json_stats_with_subtask_metadata(
-                            ctx->subtask_id, static_cast<size_t>(ctx->subtask_input_rowsets));
+                            ctx->subtask_id, static_cast<size_t>(ctx->subtask_input_rowsets), true);
                 } else {
                     info.profile = ctx->stats->to_json_stats();
                 }
@@ -2057,6 +2080,7 @@ StatusOr<int> TabletParallelCompactionManager::submit_subtasks_from_groups(
             info.input_rowset_ids = rowset_ids;
             info.input_bytes = input_bytes;
             info.start_time = ::time(nullptr);
+            info.enqueue_time_ns = MonotonicNanos();
             info.type = group.type;
             if (group.type == SubtaskType::LARGE_ROWSET_PART) {
                 info.large_rowset_id = group.large_rowset_id;
@@ -2212,7 +2236,11 @@ void TabletParallelCompactionManager::execute_subtask_segment_range(int64_t tabl
                                                              true /* skip_write_txnlog */, state->callback, subtask_id);
 
     auto start_time = ::time(nullptr);
+    auto start_time_ns = MonotonicNanos();
+    context->task_attempt_start_ns.store(start_time_ns, std::memory_order_release);
     context->start_time.store(start_time, std::memory_order_relaxed);
+    context->stats->task_attempt_count++;
+    context->runs.fetch_add(1, std::memory_order_relaxed);
 
     {
         std::lock_guard<std::mutex> lock(state->mutex);
@@ -2221,16 +2249,27 @@ void TabletParallelCompactionManager::execute_subtask_segment_range(int64_t tabl
             int64_t enqueue_time = it->second.start_time;
             int64_t in_queue_time_sec = start_time > enqueue_time ? (start_time - enqueue_time) : 0;
             context->stats->in_queue_time_sec += in_queue_time_sec;
+            if (it->second.enqueue_time_ns > 0 && start_time_ns > it->second.enqueue_time_ns) {
+                context->stats->queue_wait_ns += start_time_ns - it->second.enqueue_time_ns;
+            }
             context->subtask_input_rowsets = static_cast<int64_t>(it->second.input_rowset_ids.size());
             it->second.context = context.get();
         }
     }
 
-    // Get tablet metadata to create segment-range rowset
+    // Get tablet metadata and build the segment-range compaction task.
+    auto task_prepare_start_ns = MonotonicNanos();
     auto tablet_or = _tablet_mgr->get_tablet(tablet_id, version);
     if (!tablet_or.ok()) {
         LOG(WARNING) << "Failed to get tablet for segment-range subtask " << subtask_id << ": " << tablet_or.status();
         context->status = tablet_or.status();
+        context->stats->task_prepare_ns += MonotonicNanos() - task_prepare_start_ns;
+        context->stats->task_total_ns += MonotonicNanos() - start_time_ns;
+        context->task_attempt_start_ns.store(0, std::memory_order_release);
+        context->finish_time.store(std::max<int64_t>(::time(nullptr), start_time), std::memory_order_release);
+        LOG(INFO) << "Parallel segment-range compaction task finished. tablet_id=" << tablet_id
+                  << " version=" << version << " txn_id=" << txn_id << " subtask_id=" << subtask_id
+                  << " status=" << context->status << " profile=" << context->stats->to_json_stats();
         on_subtask_complete(tablet_id, txn_id, subtask_id, std::move(context));
         if (release_token) {
             release_token(false);
@@ -2253,6 +2292,13 @@ void TabletParallelCompactionManager::execute_subtask_segment_range(int64_t tabl
     if (rowset_index < 0) {
         LOG(WARNING) << "Rowset " << large_rowset_id << " not found in metadata for tablet " << tablet_id;
         context->status = Status::NotFound(strings::Substitute("Rowset $0 not found in metadata", large_rowset_id));
+        context->stats->task_prepare_ns += MonotonicNanos() - task_prepare_start_ns;
+        context->stats->task_total_ns += MonotonicNanos() - start_time_ns;
+        context->task_attempt_start_ns.store(0, std::memory_order_release);
+        context->finish_time.store(std::max<int64_t>(::time(nullptr), start_time), std::memory_order_release);
+        LOG(INFO) << "Parallel segment-range compaction task finished. tablet_id=" << tablet_id
+                  << " version=" << version << " txn_id=" << txn_id << " subtask_id=" << subtask_id
+                  << " status=" << context->status << " profile=" << context->stats->to_json_stats();
         on_subtask_complete(tablet_id, txn_id, subtask_id, std::move(context));
         if (release_token) {
             release_token(false);
@@ -2269,10 +2315,17 @@ void TabletParallelCompactionManager::execute_subtask_segment_range(int64_t tabl
     input_rowsets.push_back(std::move(segment_range_rowset));
 
     auto compaction_task_or = _tablet_mgr->compact(context.get(), std::move(input_rowsets));
+    context->stats->task_prepare_ns += MonotonicNanos() - task_prepare_start_ns;
     if (!compaction_task_or.ok()) {
         LOG(WARNING) << "Failed to create compaction task for segment-range subtask " << subtask_id << ": "
                      << compaction_task_or.status();
         context->status = compaction_task_or.status();
+        context->stats->task_total_ns += MonotonicNanos() - start_time_ns;
+        context->task_attempt_start_ns.store(0, std::memory_order_release);
+        context->finish_time.store(std::max<int64_t>(::time(nullptr), start_time), std::memory_order_release);
+        LOG(INFO) << "Parallel segment-range compaction task finished. tablet_id=" << tablet_id
+                  << " version=" << version << " txn_id=" << txn_id << " subtask_id=" << subtask_id
+                  << " status=" << context->status << " profile=" << context->stats->to_json_stats();
         on_subtask_complete(tablet_id, txn_id, subtask_id, std::move(context));
         if (release_token) {
             release_token(compaction_task_or.status().is_mem_limit_exceeded());
@@ -2281,8 +2334,6 @@ void TabletParallelCompactionManager::execute_subtask_segment_range(int64_t tabl
     }
 
     const auto& compaction_task = compaction_task_or.value();
-    context->runs.fetch_add(1, std::memory_order_relaxed);
-
     // Execute compaction
     auto cancel_func = [this, tablet_id, txn_id, subtask_id, version]() {
         if (get_tablet_state(tablet_id, txn_id) == nullptr) {
@@ -2299,7 +2350,13 @@ void TabletParallelCompactionManager::execute_subtask_segment_range(int64_t tabl
         flush_pool = StorageEngine::instance()->lake_memtable_flush_executor()->get_thread_pool();
     }
 
+    auto task_execute_start_ns = MonotonicNanos();
+    context->task_execute_start_ns.store(task_execute_start_ns, std::memory_order_release);
     auto exec_st = compaction_task->execute(cancel_func, flush_pool);
+    context->stats->task_execute_ns += MonotonicNanos() - task_execute_start_ns;
+    context->task_execute_start_ns.store(0, std::memory_order_release);
+    context->stats->task_total_ns += MonotonicNanos() - start_time_ns;
+    context->task_attempt_start_ns.store(0, std::memory_order_release);
 
     auto finish_time = std::max<int64_t>(::time(nullptr), start_time);
     auto cost = finish_time - start_time;
@@ -2321,6 +2378,10 @@ void TabletParallelCompactionManager::execute_subtask_segment_range(int64_t tabl
     }
 
     context->finish_time.store(finish_time, std::memory_order_release);
+
+    LOG(INFO) << "Parallel segment-range compaction task finished. tablet_id=" << tablet_id << " version=" << version
+              << " txn_id=" << txn_id << " subtask_id=" << subtask_id << " status=" << exec_st
+              << " profile=" << context->stats->to_json_stats();
 
     bool mem_limit_exceeded = exec_st.is_mem_limit_exceeded();
     on_subtask_complete(tablet_id, txn_id, subtask_id, std::move(context));

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -1478,6 +1478,7 @@ void TabletParallelCompactionManager::execute_subtask(int64_t tablet_id, int64_t
             // Snapshot the subtask input footprint onto the context so list_tasks() can
             // surface it consistently for both running and completed subtasks.
             context->subtask_input_rowsets = static_cast<int64_t>(it->second.input_rowset_ids.size());
+            context->publish_stats_snapshot();
             // Store context pointer for real-time progress/status tracking
             it->second.context = context.get();
         }
@@ -1537,6 +1538,7 @@ void TabletParallelCompactionManager::execute_subtask(int64_t tablet_id, int64_t
     context->task_execute_start_ns.store(0, std::memory_order_release);
     context->stats->task_total_ns += MonotonicNanos() - start_time_ns;
     context->task_attempt_start_ns.store(0, std::memory_order_release);
+    context->publish_stats_snapshot();
 
     auto finish_time = std::max<int64_t>(::time(nullptr), start_time);
     auto cost = finish_time - start_time;
@@ -2257,6 +2259,7 @@ void TabletParallelCompactionManager::execute_subtask_segment_range(int64_t tabl
                 context->stats->queue_wait_ns += start_time_ns - it->second.enqueue_time_ns;
             }
             context->subtask_input_rowsets = static_cast<int64_t>(it->second.input_rowset_ids.size());
+            context->publish_stats_snapshot();
             it->second.context = context.get();
         }
     }
@@ -2367,6 +2370,7 @@ void TabletParallelCompactionManager::execute_subtask_segment_range(int64_t tabl
     context->task_execute_start_ns.store(0, std::memory_order_release);
     context->stats->task_total_ns += MonotonicNanos() - start_time_ns;
     context->task_attempt_start_ns.store(0, std::memory_order_release);
+    context->publish_stats_snapshot();
 
     auto finish_time = std::max<int64_t>(::time(nullptr), start_time);
     auto cost = finish_time - start_time;
@@ -2704,6 +2708,7 @@ void TabletParallelCompactionManager::execute_subtask_range_split(
                 context->stats->queue_wait_ns += start_time_ns - it->second.enqueue_time_ns;
             }
             context->subtask_input_rowsets = static_cast<int64_t>(it->second.input_rowset_ids.size());
+            context->publish_stats_snapshot();
             it->second.context = context.get();
         }
     }
@@ -2776,6 +2781,7 @@ void TabletParallelCompactionManager::execute_subtask_range_split(
     context->task_execute_start_ns.store(0, std::memory_order_release);
     context->stats->task_total_ns += MonotonicNanos() - start_time_ns;
     context->task_attempt_start_ns.store(0, std::memory_order_release);
+    context->publish_stats_snapshot();
 
     auto finish_time = std::max<int64_t>(::time(nullptr), start_time);
     auto cost = finish_time - start_time;

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -1494,9 +1494,11 @@ void TabletParallelCompactionManager::execute_subtask(int64_t tablet_id, int64_t
         context->stats->task_total_ns += MonotonicNanos() - start_time_ns;
         context->task_attempt_start_ns.store(0, std::memory_order_release);
         context->finish_time.store(std::max<int64_t>(::time(nullptr), start_time), std::memory_order_release);
-        LOG(INFO) << "Parallel compaction task finished. tablet_id=" << tablet_id << " version=" << version
-                  << " txn_id=" << txn_id << " subtask_id=" << subtask_id << " status=" << context->status
-                  << " profile=" << context->stats->to_json_stats();
+        if (context->stats->is_slow(config::lake_compact_slow_log_ms)) {
+            LOG(INFO) << "Parallel compaction task finished. tablet_id=" << tablet_id << " version=" << version
+                      << " txn_id=" << txn_id << " subtask_id=" << subtask_id << " status=" << context->status
+                      << " profile=" << context->stats->to_json_stats();
+        }
         on_subtask_complete(tablet_id, txn_id, subtask_id, std::move(context));
         // Release limiter token on early return
         if (release_token) {
@@ -1550,9 +1552,11 @@ void TabletParallelCompactionManager::execute_subtask(int64_t tablet_id, int64_t
 
     context->finish_time.store(finish_time, std::memory_order_release);
 
-    LOG(INFO) << "Parallel compaction task finished. tablet_id=" << tablet_id << " version=" << version
-              << " txn_id=" << txn_id << " subtask_id=" << subtask_id << " status=" << exec_st
-              << " profile=" << context->stats->to_json_stats();
+    if (context->stats->is_slow(config::lake_compact_slow_log_ms)) {
+        LOG(INFO) << "Parallel compaction task finished. tablet_id=" << tablet_id << " version=" << version
+                  << " txn_id=" << txn_id << " subtask_id=" << subtask_id << " status=" << exec_st
+                  << " profile=" << context->stats->to_json_stats();
+    }
 
     // Check if memory limit was exceeded before moving context
     bool mem_limit_exceeded = exec_st.is_mem_limit_exceeded();
@@ -2267,9 +2271,11 @@ void TabletParallelCompactionManager::execute_subtask_segment_range(int64_t tabl
         context->stats->task_total_ns += MonotonicNanos() - start_time_ns;
         context->task_attempt_start_ns.store(0, std::memory_order_release);
         context->finish_time.store(std::max<int64_t>(::time(nullptr), start_time), std::memory_order_release);
-        LOG(INFO) << "Parallel segment-range compaction task finished. tablet_id=" << tablet_id
-                  << " version=" << version << " txn_id=" << txn_id << " subtask_id=" << subtask_id
-                  << " status=" << context->status << " profile=" << context->stats->to_json_stats();
+        if (context->stats->is_slow(config::lake_compact_slow_log_ms)) {
+            LOG(INFO) << "Parallel segment-range compaction task finished. tablet_id=" << tablet_id
+                      << " version=" << version << " txn_id=" << txn_id << " subtask_id=" << subtask_id
+                      << " status=" << context->status << " profile=" << context->stats->to_json_stats();
+        }
         on_subtask_complete(tablet_id, txn_id, subtask_id, std::move(context));
         if (release_token) {
             release_token(false);
@@ -2296,9 +2302,11 @@ void TabletParallelCompactionManager::execute_subtask_segment_range(int64_t tabl
         context->stats->task_total_ns += MonotonicNanos() - start_time_ns;
         context->task_attempt_start_ns.store(0, std::memory_order_release);
         context->finish_time.store(std::max<int64_t>(::time(nullptr), start_time), std::memory_order_release);
-        LOG(INFO) << "Parallel segment-range compaction task finished. tablet_id=" << tablet_id
-                  << " version=" << version << " txn_id=" << txn_id << " subtask_id=" << subtask_id
-                  << " status=" << context->status << " profile=" << context->stats->to_json_stats();
+        if (context->stats->is_slow(config::lake_compact_slow_log_ms)) {
+            LOG(INFO) << "Parallel segment-range compaction task finished. tablet_id=" << tablet_id
+                      << " version=" << version << " txn_id=" << txn_id << " subtask_id=" << subtask_id
+                      << " status=" << context->status << " profile=" << context->stats->to_json_stats();
+        }
         on_subtask_complete(tablet_id, txn_id, subtask_id, std::move(context));
         if (release_token) {
             release_token(false);
@@ -2323,9 +2331,11 @@ void TabletParallelCompactionManager::execute_subtask_segment_range(int64_t tabl
         context->stats->task_total_ns += MonotonicNanos() - start_time_ns;
         context->task_attempt_start_ns.store(0, std::memory_order_release);
         context->finish_time.store(std::max<int64_t>(::time(nullptr), start_time), std::memory_order_release);
-        LOG(INFO) << "Parallel segment-range compaction task finished. tablet_id=" << tablet_id
-                  << " version=" << version << " txn_id=" << txn_id << " subtask_id=" << subtask_id
-                  << " status=" << context->status << " profile=" << context->stats->to_json_stats();
+        if (context->stats->is_slow(config::lake_compact_slow_log_ms)) {
+            LOG(INFO) << "Parallel segment-range compaction task finished. tablet_id=" << tablet_id
+                      << " version=" << version << " txn_id=" << txn_id << " subtask_id=" << subtask_id
+                      << " status=" << context->status << " profile=" << context->stats->to_json_stats();
+        }
         on_subtask_complete(tablet_id, txn_id, subtask_id, std::move(context));
         if (release_token) {
             release_token(compaction_task_or.status().is_mem_limit_exceeded());
@@ -2379,9 +2389,11 @@ void TabletParallelCompactionManager::execute_subtask_segment_range(int64_t tabl
 
     context->finish_time.store(finish_time, std::memory_order_release);
 
-    LOG(INFO) << "Parallel segment-range compaction task finished. tablet_id=" << tablet_id << " version=" << version
-              << " txn_id=" << txn_id << " subtask_id=" << subtask_id << " status=" << exec_st
-              << " profile=" << context->stats->to_json_stats();
+    if (context->stats->is_slow(config::lake_compact_slow_log_ms)) {
+        LOG(INFO) << "Parallel segment-range compaction task finished. tablet_id=" << tablet_id
+                  << " version=" << version << " txn_id=" << txn_id << " subtask_id=" << subtask_id
+                  << " status=" << exec_st << " profile=" << context->stats->to_json_stats();
+    }
 
     bool mem_limit_exceeded = exec_st.is_mem_limit_exceeded();
     on_subtask_complete(tablet_id, txn_id, subtask_id, std::move(context));
@@ -2675,7 +2687,11 @@ void TabletParallelCompactionManager::execute_subtask_range_split(
                                                              true /* skip_write_txnlog */, state->callback, subtask_id);
 
     auto start_time = ::time(nullptr);
+    auto start_time_ns = MonotonicNanos();
+    context->task_attempt_start_ns.store(start_time_ns, std::memory_order_release);
     context->start_time.store(start_time, std::memory_order_relaxed);
+    context->stats->task_attempt_count++;
+    context->runs.fetch_add(1, std::memory_order_relaxed);
 
     {
         std::lock_guard<std::mutex> lock(state->mutex);
@@ -2684,10 +2700,15 @@ void TabletParallelCompactionManager::execute_subtask_range_split(
             int64_t enqueue_time = it->second.start_time;
             int64_t in_queue_time_sec = start_time > enqueue_time ? (start_time - enqueue_time) : 0;
             context->stats->in_queue_time_sec += in_queue_time_sec;
+            if (it->second.enqueue_time_ns > 0 && start_time_ns > it->second.enqueue_time_ns) {
+                context->stats->queue_wait_ns += start_time_ns - it->second.enqueue_time_ns;
+            }
             context->subtask_input_rowsets = static_cast<int64_t>(it->second.input_rowset_ids.size());
             it->second.context = context.get();
         }
     }
+
+    auto task_prepare_start_ns = MonotonicNanos();
 
     // Set range split info on context so compaction task applies range filtering.
     //
@@ -2711,10 +2732,19 @@ void TabletParallelCompactionManager::execute_subtask_range_split(
     context->range_upper_inclusive = context->has_upper_bound ? upper_inclusive : true;
 
     auto compaction_task_or = _tablet_mgr->compact(context.get(), std::move(all_rowsets));
+    context->stats->task_prepare_ns += MonotonicNanos() - task_prepare_start_ns;
     if (!compaction_task_or.ok()) {
         LOG(WARNING) << "Failed to create compaction task for range-split subtask " << subtask_id << ": "
                      << compaction_task_or.status();
         context->status = compaction_task_or.status();
+        context->stats->task_total_ns += MonotonicNanos() - start_time_ns;
+        context->task_attempt_start_ns.store(0, std::memory_order_release);
+        context->finish_time.store(std::max<int64_t>(::time(nullptr), start_time), std::memory_order_release);
+        if (context->stats->is_slow(config::lake_compact_slow_log_ms)) {
+            LOG(INFO) << "Parallel range-split compaction task finished. tablet_id=" << tablet_id
+                      << " version=" << version << " txn_id=" << txn_id << " subtask_id=" << subtask_id
+                      << " status=" << context->status << " profile=" << context->stats->to_json_stats();
+        }
         on_subtask_complete(tablet_id, txn_id, subtask_id, std::move(context));
         if (release_token) {
             release_token(compaction_task_or.status().is_mem_limit_exceeded());
@@ -2723,7 +2753,6 @@ void TabletParallelCompactionManager::execute_subtask_range_split(
     }
 
     auto compaction_task = compaction_task_or.value();
-    context->runs.fetch_add(1, std::memory_order_relaxed);
 
     auto cancel_func = [this, tablet_id, txn_id, subtask_id, version]() {
         if (get_tablet_state(tablet_id, txn_id) == nullptr) {
@@ -2740,7 +2769,13 @@ void TabletParallelCompactionManager::execute_subtask_range_split(
         flush_pool = StorageEngine::instance()->lake_memtable_flush_executor()->get_thread_pool();
     }
 
+    auto task_execute_start_ns = MonotonicNanos();
+    context->task_execute_start_ns.store(task_execute_start_ns, std::memory_order_release);
     auto exec_st = compaction_task->execute(cancel_func, flush_pool);
+    context->stats->task_execute_ns += MonotonicNanos() - task_execute_start_ns;
+    context->task_execute_start_ns.store(0, std::memory_order_release);
+    context->stats->task_total_ns += MonotonicNanos() - start_time_ns;
+    context->task_attempt_start_ns.store(0, std::memory_order_release);
 
     auto finish_time = std::max<int64_t>(::time(nullptr), start_time);
     auto cost = finish_time - start_time;
@@ -2768,6 +2803,12 @@ void TabletParallelCompactionManager::execute_subtask_range_split(
     }
 
     context->finish_time.store(finish_time, std::memory_order_release);
+
+    if (context->stats->is_slow(config::lake_compact_slow_log_ms)) {
+        LOG(INFO) << "Parallel range-split compaction task finished. tablet_id=" << tablet_id << " version=" << version
+                  << " txn_id=" << txn_id << " subtask_id=" << subtask_id << " status=" << exec_st
+                  << " profile=" << context->stats->to_json_stats();
+    }
 
     bool mem_limit_exceeded = exec_st.is_mem_limit_exceeded();
     on_subtask_complete(tablet_id, txn_id, subtask_id, std::move(context));

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -2714,9 +2714,9 @@ void TabletParallelCompactionManager::execute_subtask_range_split(
     //
     // has_lower_bound / has_upper_bound explicitly indicate whether the range has a
     // finite bound on each side. For open-ended ranges (first range has no lower bound,
-    // last range has no upper bound), we set the corresponding flag to false and the
-    // compaction task skips setting that side of the range filter entirely, rather than
-    // relying on empty OlapTuple producing an unbounded SeekTuple in the iterator.
+    // last range has no upper bound), the corresponding OlapTuple remains empty. Both
+    // sides are still passed to TabletReader because it represents one logical range
+    // with paired start/end vectors; the empty tuple becomes an unbounded SeekTuple.
     context->has_range_split = true;
     context->is_first_range = is_first_range;
     context->is_last_range = is_last_range;

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.h
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.h
@@ -87,6 +87,7 @@ struct SubtaskInfo {
     std::vector<uint32_t> input_rowset_ids;
     int64_t input_bytes = 0;
     int64_t start_time = 0;
+    int64_t enqueue_time_ns = 0;
     // Pointer to the running context (valid only during execution)
     // Used to get real-time progress and status in list_tasks()
     CompactionTaskContext* context = nullptr;

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -273,23 +273,18 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
     reader_params.lake_io_opts = {.fill_data_cache = config::lake_enable_vertical_compaction_fill_data_cache,
                                   .buffer_size = config::lake_compaction_stream_buffer_size_bytes};
 
-    // Apply range filter for range-split parallel compaction.
-    // Must apply to ALL column groups (key and non-key) so that segment iterators
-    // produce the same row subsets. The key group's heap_merge_iterator records
-    // RowSourceMasks, and non-key groups' mask_merge_iterator replays them.
-    // If only key group has range filter, non-key iterators read from row 0 while
-    // mask expects range-filtered rows, causing key-value misalignment.
+    // Apply range filter to ALL column groups (key and non-key) so that segment
+    // iterators produce the same row subsets. TabletReader requires start_key and
+    // end_key to contain the same number of ranges, so pass both sides together;
+    // an empty OlapTuple represents an unbounded side. The key group's
+    // heap_merge_iterator records RowSourceMasks, and non-key groups replay them.
     if (_context->has_range_split) {
-        if (_context->has_lower_bound && !_context->range_start_key.empty()) {
-            reader_params.start_key = _context->range_start_key;
-            reader_params.range = _context->range_lower_inclusive ? TabletReaderParams::RangeStartOperation::GE
-                                                                  : TabletReaderParams::RangeStartOperation::GT;
-        }
-        if (_context->has_upper_bound && !_context->range_end_key.empty()) {
-            reader_params.end_key = _context->range_end_key;
-            reader_params.end_range = _context->range_upper_inclusive ? TabletReaderParams::RangeEndOperation::LE
-                                                                      : TabletReaderParams::RangeEndOperation::LT;
-        }
+        reader_params.start_key = _context->range_start_key;
+        reader_params.end_key = _context->range_end_key;
+        reader_params.range = _context->range_lower_inclusive ? TabletReaderParams::RangeStartOperation::GE
+                                                              : TabletReaderParams::RangeStartOperation::GT;
+        reader_params.end_range = _context->range_upper_inclusive ? TabletReaderParams::RangeEndOperation::LE
+                                                                  : TabletReaderParams::RangeEndOperation::LT;
     }
 
     {

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -48,6 +48,7 @@ namespace starrocks::lake {
 Status VerticalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush_pool) {
     SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker.get());
     _context->stats->compaction_type = "vertical";
+    _context->publish_stats_snapshot();
 
     int64_t input_bytes = 0;
     {

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -47,16 +47,22 @@ namespace starrocks::lake {
 
 Status VerticalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush_pool) {
     SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker.get());
+    _context->stats->compaction_type = "vertical";
 
     int64_t input_bytes = 0;
-    for (auto& rowset : _input_rowsets) {
-        _total_num_rows += rowset->num_rows();
-        _total_data_size += rowset->data_size();
-        _total_input_segs += rowset->is_overlapped() ? rowset->num_segments() : 1;
-        // do not check `is_overlapped`, we want actual segment count here
-        _context->stats->read_segment_count += rowset->num_segments();
-        // real input bytes, which need to remove deleted rows
-        input_bytes += rowset->data_size_after_deletion();
+    {
+        SCOPED_RAW_TIMER(&_context->stats->input_prepare_ns);
+        for (auto& rowset : _input_rowsets) {
+            _total_num_rows += rowset->num_rows();
+            _total_data_size += rowset->data_size();
+            _total_input_segs += rowset->is_overlapped() ? rowset->num_segments() : 1;
+            // do not check `is_overlapped`, we want actual segment count here
+            _context->stats->read_segment_count += rowset->num_segments();
+            // real input bytes, which need to remove deleted rows
+            input_bytes += rowset->data_size_after_deletion();
+        }
+        _context->stats->input_rowset_count = _input_rowsets.size();
+        _context->stats->input_row_count = _total_num_rows;
     }
 
     const auto* store_path_registry = _tablet.tablet_manager()->store_path_registry();
@@ -68,10 +74,21 @@ Status VerticalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush
 
     uint32_t max_rows_per_segment =
             CompactionUtils::get_segment_max_rows(config::max_segment_file_size, _total_num_rows, _total_data_size);
-    ASSIGN_OR_RETURN(auto writer, _tablet.new_writer_with_schema(kVertical, _txn_id, max_rows_per_segment, flush_pool,
-                                                                 true /** is compaction**/, _tablet_schema));
-    RETURN_IF_ERROR(writer->open());
-    DeferOp defer([&]() { writer->close(); });
+    std::unique_ptr<TabletWriter> writer;
+    {
+        SCOPED_RAW_TIMER(&_context->stats->writer_create_ns);
+        ASSIGN_OR_RETURN(writer, _tablet.new_writer_with_schema(kVertical, _txn_id, max_rows_per_segment, flush_pool,
+                                                                true /** is compaction**/, _tablet_schema));
+    }
+    {
+        SCOPED_RAW_TIMER(&_context->stats->writer_open_ns);
+        RETURN_IF_ERROR(writer->open());
+    }
+    DeferOp defer([&]() {
+        SCOPED_RAW_TIMER(&_context->stats->writer_close_ns);
+        writer->close();
+        _context->stats->collect(writer->stats());
+    });
 
     if (should_enable_pk_index_eager_build(input_bytes)) {
         writer->try_enable_pk_index_eager_build();
@@ -88,6 +105,7 @@ Status VerticalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush
         move_pk_columns_into_key_group(&column_groups);
     }
     auto column_group_size = column_groups.size();
+    _context->stats->column_group_count = column_group_size;
 
     VLOG(3) << "Start vertical compaction. tablet: " << _tablet.id()
             << ", max rows per segment: " << max_rows_per_segment << ", column group size: " << column_group_size;
@@ -100,13 +118,27 @@ Status VerticalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush
         bool is_key = (i == 0);
         if (!is_key) {
             // read mask buffer from the beginning
+            SCOPED_RAW_TIMER(&_context->stats->mask_io_ns);
             RETURN_IF_ERROR(mask_buffer->flip_to_read());
         }
-        RETURN_IF_ERROR(compact_column_group(is_key, i, column_group_size, column_groups[i], writer, mask_buffer.get(),
-                                             source_masks.get(), cancel_func, pk_in_key_group));
+        int64_t column_group_ns = 0;
+        {
+            SCOPED_RAW_TIMER(&column_group_ns);
+            RETURN_IF_ERROR(compact_column_group(is_key, i, column_group_size, column_groups[i], writer,
+                                                 mask_buffer.get(), source_masks.get(), cancel_func, pk_in_key_group));
+        }
+        if (is_key) {
+            _context->stats->vertical_key_group_ns += column_group_ns;
+        } else {
+            _context->stats->vertical_value_group_ns += column_group_ns;
+        }
     }
 
-    RETURN_IF_ERROR(writer->finish());
+    {
+        SCOPED_RAW_TIMER(&_context->stats->writer_finish_ns);
+        RETURN_IF_ERROR(writer->finish());
+    }
+    _context->stats->output_row_count = writer->num_rows();
 
     // Adjust the progress here for 2 reasons:
     // 1. For primary key, due to the existence of the delete vector, the number of rows read may be less than the
@@ -115,31 +147,34 @@ Status VerticalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush
     _context->progress.update(100);
     _context->stats->collect(writer->stats());
 
-    auto txn_log = std::make_shared<TxnLog>();
-    auto op_compaction = txn_log->mutable_op_compaction();
-    txn_log->set_tablet_id(_tablet.id());
-    txn_log->set_txn_id(_txn_id);
-    RETURN_IF_ERROR(fill_compaction_segment_info(op_compaction, writer.get()));
-    op_compaction->set_compact_version(_tablet.metadata()->version());
+    std::shared_ptr<TxnLog> txn_log;
+    {
+        SCOPED_RAW_TIMER(&_context->stats->txn_log_build_ns);
+        txn_log = std::make_shared<TxnLog>();
+        auto op_compaction = txn_log->mutable_op_compaction();
+        txn_log->set_tablet_id(_tablet.id());
+        txn_log->set_txn_id(_txn_id);
+        RETURN_IF_ERROR(fill_compaction_segment_info(op_compaction, writer.get()));
+        op_compaction->set_compact_version(_tablet.metadata()->version());
+    }
     RETURN_IF_ERROR(execute_index_major_compaction(txn_log.get()));
     TEST_ERROR_POINT("VerticalCompactionTask::execute::1");
     if (_context->skip_write_txnlog) {
         // return txn_log to caller later
         _context->txn_log = txn_log;
     } else {
+        SCOPED_RAW_TIMER(&_context->stats->txn_log_write_ns);
         RETURN_IF_ERROR(_tablet.tablet_manager()->put_txn_log(txn_log));
     }
     if (_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
         // preload primary key table's compaction state
+        SCOPED_RAW_TIMER(&_context->stats->preload_compaction_state_ns);
         Tablet t(_tablet.tablet_manager(), _tablet.id());
         _tablet.tablet_manager()->update_mgr()->preload_compaction_state(*txn_log, t, _tablet_schema);
     }
 
-    LOG(INFO) << "Vertical compaction finished. tablet: " << _tablet.id() << ", txn_id: " << _txn_id
-              << ", statistics: " << _context->stats->to_json_stats() << ", table_id: " << _context->table_id
-              << ", partition_id: " << _context->partition_id;
-
     if (config::enable_tablet_write_log) {
+        SCOPED_RAW_TIMER(&_context->stats->tablet_write_log_ns);
         int64_t begin_time = _context->start_time.load(std::memory_order_relaxed) * 1000; // Convert to ms
         int64_t finish_time = UnixMillis();
         collect_sst_stats(writer.get(), txn_log.get());
@@ -202,27 +237,33 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
                                                     RowSourceMaskBuffer* mask_buffer,
                                                     std::vector<RowSourceMask>* source_masks,
                                                     const CancelFunc& cancel_func, bool pk_in_key_group) {
-    ASSIGN_OR_RETURN(auto chunk_size, calculate_chunk_size_for_column_group(column_group));
-
+    int32_t chunk_size = 0;
     Schema schema;
-    if (column_group_index != 0) {
-        schema = ChunkHelper::convert_schema(_tablet_schema, column_group);
-    } else if (_tablet_schema->sort_key_idxes().empty()) {
-        schema = ChunkHelper::convert_schema(_tablet_schema, column_group);
-    } else if (pk_in_key_group) {
-        // Key group has been widened to [sort-key columns, then PK columns]. Select those columns
-        // (in `column_group` order) and mark only the leading sort-key columns as the sort keys, so
-        // the merge still orders rows by the sort key -- the appended PK columns are carried along
-        // for the eager SST writer but do not affect ordering.
-        std::vector<ColumnId> sort_key_positions(_tablet_schema->sort_key_idxes().size());
-        std::iota(sort_key_positions.begin(), sort_key_positions.end(), 0);
-        schema = Schema(_tablet_schema->schema(), column_group, sort_key_positions);
-    } else {
-        schema = ChunkHelper::get_sort_key_schema(_tablet_schema);
+    {
+        SCOPED_RAW_TIMER(&_context->stats->input_prepare_ns);
+        ASSIGN_OR_RETURN(chunk_size, calculate_chunk_size_for_column_group(column_group));
+        if (column_group_index != 0) {
+            schema = ChunkHelper::convert_schema(_tablet_schema, column_group);
+        } else if (_tablet_schema->sort_key_idxes().empty()) {
+            schema = ChunkHelper::convert_schema(_tablet_schema, column_group);
+        } else if (pk_in_key_group) {
+            // Key group has been widened to [sort-key columns, then PK columns]. Select those columns
+            // (in `column_group` order) and mark only the leading sort-key columns as the sort keys, so
+            // the merge still orders rows by the sort key -- the appended PK columns are carried along
+            // for the eager SST writer but do not affect ordering.
+            std::vector<ColumnId> sort_key_positions(_tablet_schema->sort_key_idxes().size());
+            std::iota(sort_key_positions.begin(), sort_key_positions.end(), 0);
+            schema = Schema(_tablet_schema->schema(), column_group, sort_key_positions);
+        } else {
+            schema = ChunkHelper::get_sort_key_schema(_tablet_schema);
+        }
     }
     TabletReader reader(_tablet.tablet_manager(), _tablet.metadata(), schema, _input_rowsets, is_key, mask_buffer,
                         _tablet_schema);
-    RETURN_IF_ERROR(reader.prepare());
+    {
+        SCOPED_RAW_TIMER(&_context->stats->reader_prepare_ns);
+        RETURN_IF_ERROR(reader.prepare());
+    }
     TabletReaderParams reader_params;
     reader_params.reader_type = READER_CUMULATIVE_COMPACTION;
     reader_params.chunk_size = chunk_size;
@@ -251,9 +292,20 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
         }
     }
 
-    RETURN_IF_ERROR(reader.open(reader_params));
+    {
+        SCOPED_RAW_TIMER(&_context->stats->reader_open_ns);
+        RETURN_IF_ERROR(reader.open(reader_params));
+    }
 
     CompactionTaskStats prev_stats;
+    DeferOp reader_defer([&]() {
+        SCOPED_RAW_TIMER(&_context->stats->reader_close_ns);
+        reader.close();
+        CompactionTaskStats temp_stats;
+        temp_stats.collect(reader.stats());
+        CompactionTaskStats diff_stats = temp_stats - prev_stats;
+        *_context->stats = *_context->stats + diff_stats;
+    });
     auto chunk = ChunkFactory::new_chunk(schema, chunk_size);
     auto char_field_indexes = ChunkSchemaHelper::get_char_field_indexes(schema);
     std::vector<uint64_t> rssid_rowids;
@@ -275,11 +327,15 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
 #endif
         {
             auto st = Status::OK();
-            // Collect rssid & rowid only when compact primary key columns
-            if (_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS && is_key && enable_light_pk_compaction_publish) {
-                st = reader.get_next(chunk.get(), source_masks, &rssid_rowids);
-            } else {
-                st = reader.get_next(chunk.get(), source_masks);
+            {
+                SCOPED_RAW_TIMER(&_context->stats->reader_get_next_ns);
+                // Collect rssid & rowid only when compact primary key columns
+                if (_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS && is_key &&
+                    enable_light_pk_compaction_publish) {
+                    st = reader.get_next(chunk.get(), source_masks, &rssid_rowids);
+                } else {
+                    st = reader.get_next(chunk.get(), source_masks);
+                }
             }
             if (st.is_end_of_file()) {
                 break;
@@ -288,17 +344,26 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
             }
         }
 
-        ChunkHelper::padding_char_columns(char_field_indexes, schema, _tablet_schema, chunk.get());
-        if (rssid_rowids.empty()) {
-            RETURN_IF_ERROR(writer->write_columns(*chunk, column_group, is_key));
-        } else {
-            RETURN_IF_ERROR(writer->write_columns(*chunk, column_group, is_key, rssid_rowids));
+        _context->stats->read_chunk_count++;
+        {
+            SCOPED_RAW_TIMER(&_context->stats->chunk_transform_ns);
+            ChunkHelper::padding_char_columns(char_field_indexes, schema, _tablet_schema, chunk.get());
         }
+        {
+            SCOPED_RAW_TIMER(&_context->stats->writer_write_ns);
+            if (rssid_rowids.empty()) {
+                RETURN_IF_ERROR(writer->write_columns(*chunk, column_group, is_key));
+            } else {
+                RETURN_IF_ERROR(writer->write_columns(*chunk, column_group, is_key, rssid_rowids));
+            }
+        }
+        _context->stats->write_chunk_count++;
         chunk->reset();
         rssid_rowids.clear();
 
         if (!source_masks->empty()) {
             if (is_key) {
+                SCOPED_RAW_TIMER(&_context->stats->mask_io_ns);
                 RETURN_IF_ERROR(mask_buffer->write(*source_masks));
             }
             source_masks->clear();
@@ -315,17 +380,13 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
         *_context->stats = *_context->stats + diff_stats;
         prev_stats = temp_stats;
     }
-    RETURN_IF_ERROR(writer->flush_columns());
-
-    // Close reader to ensure IO statistics are updated via SegmentIterator::_update_stats() before collecting
-    reader.close();
-
-    CompactionTaskStats temp_stats;
-    temp_stats.collect(reader.stats());
-    CompactionTaskStats diff_stats = temp_stats - prev_stats;
-    *_context->stats = *_context->stats + diff_stats;
+    {
+        SCOPED_RAW_TIMER(&_context->stats->writer_flush_ns);
+        RETURN_IF_ERROR(writer->flush_columns());
+    }
 
     if (is_key) {
+        SCOPED_RAW_TIMER(&_context->stats->mask_io_ns);
         RETURN_IF_ERROR(mask_buffer->flush());
     }
     return Status::OK();

--- a/be/test/schema_scanner/CMakeLists.txt
+++ b/be/test/schema_scanner/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SCHEMA_SCANNER_TEST_FILES
     ${BE_TEST_MACOS_LINK_STUBS}
     ${BE_TEST_JNI_ENV_STUB}
     schema_scanner_test_main.cpp
+    schema_be_cloud_native_compactions_scanner_test.cpp
     schema_be_tablet_write_log_scanner_test.cpp
     schema_columns_scanner_test.cpp
     schema_fe_metrics_scanner_test.cpp

--- a/be/test/schema_scanner/schema_be_cloud_native_compactions_scanner_test.cpp
+++ b/be/test/schema_scanner/schema_be_cloud_native_compactions_scanner_test.cpp
@@ -1,0 +1,72 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "schema_scanner/schema_be_cloud_native_compactions_scanner.h"
+
+#include <gtest/gtest.h>
+
+#include "base/testutil/assert.h"
+#include "column/column_helper.h"
+
+namespace starrocks {
+
+class SchemaBeCloudNativeCompactionsScannerTest : public ::testing::Test {
+protected:
+    static ChunkPtr create_chunk(const std::vector<SlotDescriptor*>& slot_descs) {
+        auto chunk = std::make_shared<Chunk>();
+        for (const auto* slot_desc : slot_descs) {
+            auto column = ColumnHelper::create_column(slot_desc->type(), slot_desc->is_nullable());
+            chunk->append_column(std::move(column), slot_desc->id());
+        }
+        return chunk;
+    }
+};
+
+TEST_F(SchemaBeCloudNativeCompactionsScannerTest, subtask_id) {
+    SchemaBeCloudNativeCompactionsScanner scanner;
+    SchemaScannerParam params;
+    ObjectPool pool;
+    ASSERT_OK(scanner.init(&params, &pool));
+
+    lake::CompactionTaskInfo regular{};
+    regular.txn_id = 1;
+    regular.tablet_id = 2;
+    regular.version = 3;
+    regular.status = Status::OK();
+    scanner._infos.emplace_back(std::move(regular));
+
+    lake::CompactionTaskInfo parallel{};
+    parallel.txn_id = 1;
+    parallel.tablet_id = 2;
+    parallel.version = 3;
+    parallel.status = Status::OK();
+    parallel.subtask_id = 7;
+    scanner._infos.emplace_back(std::move(parallel));
+
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+    ASSERT_OK(scanner.get_next(&chunk, &eos));
+    ASSERT_FALSE(eos);
+    ASSERT_EQ(1, chunk->num_rows());
+    EXPECT_TRUE(chunk->get_column_by_index(11)->is_null(0));
+
+    chunk->reset();
+    ASSERT_OK(scanner.get_next(&chunk, &eos));
+    ASSERT_FALSE(eos);
+    ASSERT_EQ(1, chunk->num_rows());
+    EXPECT_FALSE(chunk->get_column_by_index(11)->is_null(0));
+    EXPECT_EQ(7, chunk->get_column_by_index(11)->get(0).get_int32());
+}
+
+} // namespace starrocks

--- a/be/test/storage/lake/compaction_scheduler_test.cpp
+++ b/be/test/storage/lake/compaction_scheduler_test.cpp
@@ -114,8 +114,21 @@ TEST_F(LakeCompactionSchedulerTest, test_list_tasks) {
     EXPECT_EQ(1, tasks[0].runs);
     EXPECT_EQ(100, tasks[0].progress);
     EXPECT_FALSE(tasks[0].skipped);
+    EXPECT_EQ(-1, tasks[0].subtask_id);
 
     bthread_join(tid, nullptr);
+}
+
+TEST_F(LakeCompactionSchedulerTest, test_list_tasks_hides_parallel_merged_context) {
+    auto context = std::make_unique<CompactionTaskContext>(100, 101, 1, false, false, nullptr);
+    context->is_parallel_merged = true;
+    _compaction_scheduler._contexts.Append(context.get());
+
+    std::vector<CompactionTaskInfo> tasks;
+    _compaction_scheduler.list_tasks(&tasks);
+    EXPECT_TRUE(tasks.empty());
+
+    context->RemoveFromList();
 }
 
 TEST_F(LakeCompactionSchedulerTest, test_abort_all) {

--- a/be/test/storage/lake/compaction_task_context_test.cpp
+++ b/be/test/storage/lake/compaction_task_context_test.cpp
@@ -223,6 +223,7 @@ TEST_F(CompactionTaskContextTest, test_per_attempt_stats_reset_for_retry) {
     context.stats->raw_rows_read = 50;
     context.stats->write_segment_bytes = 75;
     EXPECT_FALSE(context.stats->is_slow(5000));
+    context.publish_stats_snapshot();
 
     auto latest_attempt = context.stats_snapshot(false);
     EXPECT_EQ(2, latest_attempt.task_attempt_count);
@@ -300,6 +301,7 @@ TEST_F(CompactionTaskContextTest, test_live_stats_snapshot) {
     const int64_t now_ns = MonotonicNanos();
     context.task_attempt_start_ns.store(now_ns - 5'000'000, std::memory_order_release);
     context.task_execute_start_ns.store(now_ns - 3'000'000, std::memory_order_release);
+    context.publish_stats_snapshot();
 
     auto live_stats = context.stats_snapshot(true);
     EXPECT_GE(live_stats.task_total_ns, 5'000'200);
@@ -309,5 +311,28 @@ TEST_F(CompactionTaskContextTest, test_live_stats_snapshot) {
     auto final_stats = context.stats_snapshot(false);
     EXPECT_EQ(final_stats.task_total_ns, 200);
     EXPECT_EQ(final_stats.task_execute_ns, 100);
+}
+
+TEST_F(CompactionTaskContextTest, test_running_stats_use_latest_published_attempt) {
+    context.stats->compaction_type = "horizontal";
+    context.stats->task_attempt_count = 1;
+    context.stats->raw_rows_read = 100;
+    context.publish_stats_snapshot();
+
+    context.reset_attempt_stats();
+    auto previous_attempt = context.stats_snapshot(true);
+    EXPECT_EQ("horizontal", previous_attempt.compaction_type);
+    EXPECT_EQ(1, previous_attempt.task_attempt_count);
+    EXPECT_EQ(100, previous_attempt.raw_rows_read);
+
+    context.stats->compaction_type = "vertical";
+    context.stats->task_attempt_count = 2;
+    context.stats->raw_rows_read = 50;
+    context.publish_stats_snapshot();
+
+    auto latest_attempt = context.stats_snapshot(true);
+    EXPECT_EQ("vertical", latest_attempt.compaction_type);
+    EXPECT_EQ(2, latest_attempt.task_attempt_count);
+    EXPECT_EQ(50, latest_attempt.raw_rows_read);
 }
 } // namespace starrocks::lake

--- a/be/test/storage/lake/compaction_task_context_test.cpp
+++ b/be/test/storage/lake/compaction_task_context_test.cpp
@@ -17,6 +17,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "base/time/time.h"
 #include "storage/olap_common.h"
 
 namespace starrocks::lake {
@@ -68,6 +69,21 @@ TEST_F(CompactionTaskContextTest, test_calculation) {
     reader_stats.io_count_remote = 700;
     reader_stats.compressed_bytes_read_remote = 1024;
     reader_stats.compressed_bytes_read_local_disk = 1024;
+    reader_stats.create_segment_iter_ns = 101;
+    reader_stats.decompress_ns = 102;
+    reader_stats.block_load_ns = 103;
+    reader_stats.block_fetch_ns = 104;
+    reader_stats.block_seek_ns = 105;
+    reader_stats.block_seek_num = 106;
+    reader_stats.decode_dict_ns = 107;
+    reader_stats.get_rowsets_ns = 108;
+    reader_stats.get_delvec_ns = 109;
+    reader_stats.get_delta_column_group_ns = 110;
+    reader_stats.del_filter_ns = 111;
+    reader_stats.blocks_load = 112;
+    reader_stats.raw_rows_read = 113;
+    reader_stats.compressed_bytes_read = 114;
+    reader_stats.uncompressed_bytes_read = 115;
 
     stats.in_queue_time_sec = 5;
     stats.pk_sst_merge_ns = 5;
@@ -81,6 +97,21 @@ TEST_F(CompactionTaskContextTest, test_calculation) {
     EXPECT_EQ(stats.io_count_remote, 700);
     EXPECT_EQ(stats.io_bytes_read_remote, 1024);
     EXPECT_EQ(stats.io_bytes_read_local_disk, 1024);
+    EXPECT_EQ(stats.create_segment_iter_ns, 101);
+    EXPECT_EQ(stats.decompress_ns, 102);
+    EXPECT_EQ(stats.block_load_ns, 103);
+    EXPECT_EQ(stats.block_fetch_ns, 104);
+    EXPECT_EQ(stats.block_seek_ns, 105);
+    EXPECT_EQ(stats.block_seek_count, 106);
+    EXPECT_EQ(stats.decode_dict_ns, 107);
+    EXPECT_EQ(stats.get_rowsets_ns, 108);
+    EXPECT_EQ(stats.get_delvec_ns, 109);
+    EXPECT_EQ(stats.get_delta_column_group_ns, 110);
+    EXPECT_EQ(stats.del_filter_ns, 111);
+    EXPECT_EQ(stats.blocks_load, 112);
+    EXPECT_EQ(stats.raw_rows_read, 113);
+    EXPECT_EQ(stats.compressed_bytes_read, 114);
+    EXPECT_EQ(stats.uncompressed_bytes_read, 115);
     EXPECT_EQ(stats.in_queue_time_sec, 5);
     EXPECT_EQ(stats.pk_sst_merge_ns, 5);
 
@@ -118,6 +149,47 @@ TEST_F(CompactionTaskContextTest, test_calculation) {
     EXPECT_EQ(stats.io_ns_write_remote, 10);
     EXPECT_EQ(stats.write_segment_bytes, 100);
     EXPECT_EQ(stats.write_segment_count, 1000);
+}
+
+TEST_F(CompactionTaskContextTest, test_task_timing_accounting) {
+    CompactionTaskStats stats;
+    stats.compaction_type = "horizontal";
+    stats.task_attempt_count = 1;
+    stats.task_prepare_ns = 10;
+    stats.input_prepare_ns = 20;
+    stats.reader_get_next_ns = 30;
+    stats.writer_write_ns = 40;
+    stats.pk_sst_merge_ns = 50;
+    stats.task_execute_ns = 190;
+    stats.task_total_ns = 200;
+
+    // Nested reader metrics explain reader_get_next_ns but do not participate
+    // in top-level wall-time accounting.
+    stats.io_ns_read_remote = 1000;
+    stats.block_load_ns = 500;
+
+    EXPECT_EQ(150, stats.task_accounted_ns());
+    EXPECT_EQ(50, stats.task_unaccounted_ns());
+
+    auto combined = stats + stats;
+    EXPECT_EQ("horizontal", combined.compaction_type);
+    EXPECT_EQ(2, combined.task_attempt_count);
+    EXPECT_EQ(400, combined.task_total_ns);
+    EXPECT_EQ(300, combined.task_accounted_ns());
+    EXPECT_EQ(100, combined.task_unaccounted_ns());
+
+    CompactionTaskStats vertical;
+    vertical.compaction_type = "vertical";
+    EXPECT_EQ("mixed", (stats + vertical).compaction_type);
+
+    std::string json_stats = stats.to_json_stats();
+    EXPECT_THAT(json_stats, testing::HasSubstr(R"("profile_version":1)"));
+    EXPECT_THAT(json_stats, testing::HasSubstr(R"("profile_final":true)"));
+    EXPECT_THAT(json_stats, testing::HasSubstr(R"("compaction_type":"horizontal")"));
+    EXPECT_THAT(json_stats, testing::HasSubstr(R"("task_total_ns":200)"));
+    EXPECT_THAT(json_stats, testing::HasSubstr(R"("task_accounted_ns":150)"));
+    EXPECT_THAT(json_stats, testing::HasSubstr(R"("task_unaccounted_ns":50)"));
+    EXPECT_THAT(json_stats, testing::HasSubstr(R"("read_remote_ns":1000)"));
 }
 
 TEST_F(CompactionTaskContextTest, test_to_json_stats) {
@@ -180,5 +252,23 @@ TEST_F(CompactionTaskContextTest, test_to_json_stats_with_subtask_metadata) {
     EXPECT_THAT(json_profile, testing::HasSubstr(R"("input_rowsets":5)"));
     EXPECT_THAT(json_profile, testing::Not(testing::HasSubstr(R"("input_bytes")")));
     EXPECT_THAT(json_profile, testing::HasSubstr(R"("is_parallel_subtask":true)"));
+}
+
+TEST_F(CompactionTaskContextTest, test_live_stats_snapshot) {
+    context.stats->task_execute_ns = 100;
+    context.stats->task_total_ns = 200;
+
+    const int64_t now_ns = MonotonicNanos();
+    context.task_attempt_start_ns.store(now_ns - 5'000'000, std::memory_order_release);
+    context.task_execute_start_ns.store(now_ns - 3'000'000, std::memory_order_release);
+
+    auto live_stats = context.stats_snapshot(true);
+    EXPECT_GE(live_stats.task_total_ns, 5'000'200);
+    EXPECT_GE(live_stats.task_execute_ns, 3'000'100);
+    EXPECT_THAT(live_stats.to_json_stats(false), testing::HasSubstr(R"("profile_final":false)"));
+
+    auto final_stats = context.stats_snapshot(false);
+    EXPECT_EQ(final_stats.task_total_ns, 200);
+    EXPECT_EQ(final_stats.task_execute_ns, 100);
 }
 } // namespace starrocks::lake

--- a/be/test/storage/lake/compaction_task_context_test.cpp
+++ b/be/test/storage/lake/compaction_task_context_test.cpp
@@ -192,6 +192,17 @@ TEST_F(CompactionTaskContextTest, test_task_timing_accounting) {
     EXPECT_THAT(json_stats, testing::HasSubstr(R"("read_remote_ns":1000)"));
 }
 
+TEST_F(CompactionTaskContextTest, test_slow_log_threshold) {
+    CompactionTaskStats stats;
+
+    stats.task_total_ns = 4'999'999'999;
+    EXPECT_FALSE(stats.is_slow(5000));
+
+    stats.task_total_ns = 5'000'000'000;
+    EXPECT_TRUE(stats.is_slow(5000));
+    EXPECT_TRUE(stats.is_slow(0));
+}
+
 TEST_F(CompactionTaskContextTest, test_to_json_stats) {
     static constexpr long TIME_UNIT_NS_PER_SECOND = 1000000000;
 

--- a/be/test/storage/lake/compaction_task_context_test.cpp
+++ b/be/test/storage/lake/compaction_task_context_test.cpp
@@ -203,6 +203,34 @@ TEST_F(CompactionTaskContextTest, test_slow_log_threshold) {
     EXPECT_TRUE(stats.is_slow(0));
 }
 
+TEST_F(CompactionTaskContextTest, test_per_attempt_stats_reset_for_retry) {
+    context.stats->compaction_type = "horizontal";
+    context.stats->task_attempt_count = 1;
+    context.stats->task_total_ns = 6'000'000'000;
+    context.stats->raw_rows_read = 100;
+    context.stats->write_segment_bytes = 200;
+    EXPECT_TRUE(context.stats->is_slow(5000));
+
+    context.reset_attempt_stats();
+    EXPECT_EQ(0, context.stats->task_attempt_count);
+    EXPECT_EQ(0, context.stats->task_total_ns);
+    EXPECT_EQ(0, context.stats->raw_rows_read);
+    EXPECT_EQ(0, context.stats->write_segment_bytes);
+
+    context.stats->compaction_type = "horizontal";
+    context.stats->task_attempt_count = 2;
+    context.stats->task_total_ns = 3'000'000'000;
+    context.stats->raw_rows_read = 50;
+    context.stats->write_segment_bytes = 75;
+    EXPECT_FALSE(context.stats->is_slow(5000));
+
+    auto latest_attempt = context.stats_snapshot(false);
+    EXPECT_EQ(2, latest_attempt.task_attempt_count);
+    EXPECT_EQ(3'000'000'000, latest_attempt.task_total_ns);
+    EXPECT_EQ(50, latest_attempt.raw_rows_read);
+    EXPECT_EQ(75, latest_attempt.write_segment_bytes);
+}
+
 TEST_F(CompactionTaskContextTest, test_to_json_stats) {
     static constexpr long TIME_UNIT_NS_PER_SECOND = 1000000000;
 

--- a/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
+++ b/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
@@ -7350,6 +7350,7 @@ TEST_F(TabletParallelCompactionManagerTest, test_create_parallel_tasks_range_spl
 
     auto old_enable = config::enable_lake_compaction_range_split;
     config::enable_lake_compaction_range_split = true;
+    DeferOp restore_range_split([&]() { config::enable_lake_compaction_range_split = old_enable; });
 
     auto metadata = generate_simple_tablet_metadata(DUP_KEYS);
     metadata->set_id(tablet_id);
@@ -7399,15 +7400,55 @@ TEST_F(TabletParallelCompactionManagerTest, test_create_parallel_tasks_range_spl
     auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
 
     std::unique_ptr<ThreadPool> pool;
-    ThreadPoolBuilder("rng_split_test").set_max_threads(4).build(&pool);
+    ThreadPoolBuilder("rng_split_test").set_max_threads(1).build(&pool);
+
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+    std::promise<void> start_promise;
+    CancelableDefer unblock_pool([&]() { block_promise.set_value(); });
+    ASSERT_OK(pool->submit_func([&]() {
+        start_promise.set_value();
+        block_future.wait();
+    }));
+    start_promise.get_future().wait();
 
     auto st = _manager->create_parallel_tasks(
             tablet_id, txn_id, version, pconfig, callback, false, pool.get(), []() { return true; }, [](bool) {});
+    ASSERT_TRUE(st.ok());
+    ASSERT_GT(st.value(), 0);
 
+    auto state = _manager->get_tablet_state(tablet_id, txn_id);
+    ASSERT_NE(nullptr, state);
+    {
+        std::lock_guard<std::mutex> lock(state->mutex);
+        ASSERT_EQ(st.value(), state->running_subtasks.size());
+        for (auto& entry : state->running_subtasks) {
+            entry.second.enqueue_time_ns = MonotonicNanos() - 1'000'000;
+        }
+    }
+
+    block_promise.set_value();
+    unblock_pool.cancel();
     pool->wait();
-    _manager->cleanup_tablet(tablet_id, txn_id);
+    ASSERT_TRUE(closure.wait_finish());
 
-    config::enable_lake_compaction_range_split = old_enable;
+    {
+        std::lock_guard<std::mutex> lock(state->mutex);
+        ASSERT_EQ(st.value(), state->completed_subtasks.size());
+        for (const auto& context : state->completed_subtasks) {
+            ASSERT_NE(nullptr, context->stats);
+            EXPECT_EQ(1, context->runs.load(std::memory_order_relaxed));
+            EXPECT_EQ(1, context->stats->task_attempt_count);
+            EXPECT_GT(context->stats->queue_wait_ns, 0);
+            EXPECT_GT(context->stats->task_prepare_ns, 0);
+            EXPECT_GT(context->stats->task_execute_ns, 0);
+            EXPECT_GE(context->stats->task_total_ns, context->stats->task_prepare_ns + context->stats->task_execute_ns);
+            EXPECT_EQ(0, context->task_attempt_start_ns.load(std::memory_order_acquire));
+            EXPECT_EQ(0, context->task_execute_start_ns.load(std::memory_order_acquire));
+        }
+    }
+
+    _manager->cleanup_tablet(tablet_id, txn_id);
 
     // Also test execute_subtask_range_split when state not found (lines 2517-2525)
     {

--- a/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
+++ b/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
@@ -1101,6 +1101,7 @@ TEST_F(TabletParallelCompactionManagerTest, test_list_tasks) {
         EXPECT_EQ(txn_id, info.txn_id);
         EXPECT_EQ(tablet_id, info.tablet_id);
         EXPECT_EQ(version, info.version);
+        EXPECT_GE(info.subtask_id, 0);
     }
 
     block_promise.set_value();
@@ -1642,6 +1643,7 @@ TEST_F(TabletParallelCompactionManagerTest, test_list_tasks_with_completed) {
     bool found_completed_profile = false;
     for (const auto& info : infos) {
         if (info.finish_time > 0 && info.runs > 0) {
+            EXPECT_EQ(0, info.subtask_id);
             EXPECT_NE(info.profile.find(R"("in_queue_sec":7)"), std::string::npos);
             EXPECT_NE(info.profile.find(R"("subtask_id":0)"), std::string::npos);
             EXPECT_NE(info.profile.find(R"("input_rowsets":4)"), std::string::npos);

--- a/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
+++ b/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
@@ -202,11 +202,11 @@ protected:
         CHECK_OK(_tablet_mgr->put_tablet_metadata(*metadata));
     }
 
-    // Writes a real segment (key column c0 = 0..num_rows-1, value column c1 constant 0)
+    // Writes a real segment (key column c0 = start_key..start_key+num_rows-1, value column c1 constant 0)
     // for |tablet_id| at |segment_name|, under |schema_pb| and the writer-time value of
     // config::enable_full_sort_key_index. Returns the file size.
     uint64_t write_int_key_segment(int64_t tablet_id, const TabletSchemaPB& schema_pb, const std::string& segment_name,
-                                   int64_t num_rows) {
+                                   int64_t num_rows, int32_t start_key = 0) {
         auto tablet_schema = TabletSchema::create(schema_pb);
         std::string path = _lp->segment_location(tablet_id, segment_name);
         std::string dir = std::filesystem::path(path).parent_path().string();
@@ -225,7 +225,7 @@ protected:
         auto chunk = ChunkFactory::new_chunk(chunk_schema, num_rows);
         auto cols = chunk->columns();
         for (int64_t i = 0; i < num_rows; ++i) {
-            cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+            cols[0]->as_mutable_ptr()->append_datum(Datum(start_key + static_cast<int32_t>(i)));
             cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(0)));
         }
         CHECK_OK(writer.append_chunk(*chunk));
@@ -7347,6 +7347,9 @@ TEST_F(TabletParallelCompactionManagerTest, test_non_range_split_vlog_paths) {
 
 TEST_F(TabletParallelCompactionManagerTest, test_create_parallel_tasks_range_split) {
     int64_t tablet_id = 10256;
+    constexpr int kNumRowsets = 5;
+    constexpr int32_t kRowsPerRowset = 250;
+    constexpr int64_t kLogicalRowsetSize = 50 * 1024 * 1024;
 
     auto old_enable = config::enable_lake_compaction_range_split;
     config::enable_lake_compaction_range_split = true;
@@ -7354,39 +7357,34 @@ TEST_F(TabletParallelCompactionManagerTest, test_create_parallel_tasks_range_spl
 
     auto metadata = generate_simple_tablet_metadata(DUP_KEYS);
     metadata->set_id(tablet_id);
-    metadata->set_version(5);
+    metadata->set_version(kNumRowsets + 1);
+    metadata->set_next_rowset_id(kNumRowsets);
 
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < kNumRowsets; i++) {
+        const int32_t start_key = static_cast<int32_t>(i * kRowsPerRowset);
         auto* rowset = metadata->add_rowsets();
         rowset->set_id(i);
         rowset->set_overlapped(true);
-        rowset->set_num_rows(10000);
-        rowset->set_data_size(50 * 1024 * 1024);
+        rowset->set_num_rows(kRowsPerRowset);
+        // Keep the logical size large enough to create multiple range-split subtasks;
+        // the physical segment stays small so the UT remains fast.
+        rowset->set_data_size(kLogicalRowsetSize);
 
         std::string segment_name = fmt::format("rs_seg_{}.dat", i);
+        const uint64_t segment_size =
+                write_int_key_segment(tablet_id, metadata->schema(), segment_name, kRowsPerRowset, start_key);
         auto* segment_meta = rowset->add_segment_metas();
         segment_meta->set_filename(segment_name);
-        segment_meta->set_size(50 * 1024 * 1024);
-        segment_meta->mutable_sort_key_min()->CopyFrom(make_int_tuple(i * 100));
-        segment_meta->mutable_sort_key_max()->CopyFrom(make_int_tuple(i * 100 + 200));
-        segment_meta->set_num_rows(10000);
-
-        std::string path = _lp->segment_location(tablet_id, segment_name);
-        std::string dir = std::filesystem::path(path).parent_path().string();
-        CHECK_OK(fs::create_directories(dir));
-        auto fs = FileSystemFactory::CreateSharedFromString(path);
-        WritableFileOptions opts;
-        opts.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE;
-        auto st = fs.value()->new_writable_file(opts, path);
-        CHECK_OK(st.status());
-        CHECK_OK(st.value()->append("dummy_segment_data"));
-        CHECK_OK(st.value()->close());
+        segment_meta->set_size(segment_size);
+        segment_meta->mutable_sort_key_min()->CopyFrom(make_int_tuple(start_key));
+        segment_meta->mutable_sort_key_max()->CopyFrom(make_int_tuple(start_key + kRowsPerRowset - 1));
+        segment_meta->set_num_rows(kRowsPerRowset);
     }
 
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*metadata));
 
     int64_t txn_id = 20256;
-    int64_t version = 5;
+    int64_t version = kNumRowsets + 1;
 
     TabletParallelConfig pconfig;
     pconfig.set_max_parallel_per_tablet(3);
@@ -7414,7 +7412,7 @@ TEST_F(TabletParallelCompactionManagerTest, test_create_parallel_tasks_range_spl
 
     auto st = _manager->create_parallel_tasks(
             tablet_id, txn_id, version, pconfig, callback, false, pool.get(), []() { return true; }, [](bool) {});
-    ASSERT_TRUE(st.ok());
+    ASSERT_OK(st.status());
     ASSERT_GT(st.value(), 0);
 
     auto state = _manager->get_tablet_state(tablet_id, txn_id);

--- a/docs/en/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/en/administration/management/BE_parameters/log_server_meta.md
@@ -56,7 +56,7 @@ This topic introduces the following types of BE configurations:
 - Type: Int
 - Unit: Milliseconds
 - Is mutable: Yes
-- Description: Threshold for emitting detailed lake compaction profile logs. After a regular compaction attempt or parallel compaction subtask finishes, StarRocks writes an INFO log containing the task identifiers, status, and full JSON profile only when the elapsed task time is greater than or equal to this value. Set this parameter to `0` to log every completed attempt or subtask. Increase it to reduce INFO log volume.
+- Description: Threshold for emitting detailed lake compaction profile logs. After a regular compaction attempt or parallel compaction subtask finishes, StarRocks writes an INFO log containing the task identifiers, status, and full JSON profile only when the elapsed time of that attempt or subtask is greater than or equal to this value. Set this parameter to `0` to log every completed attempt or subtask. Increase it to reduce INFO log volume.
 - Introduced in: -
 
 ### lake_replication_slow_log_ms

--- a/docs/en/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/en/administration/management/BE_parameters/log_server_meta.md
@@ -50,6 +50,15 @@ This topic introduces the following types of BE configurations:
 - Description: Controls the minimum time gap between successive stack-trace diagnostics performed by DiagnoseDaemon for `STACK_TRACE` requests. When a diagnose request arrives, the daemon skips collecting and logging stack traces if the last collection happened less than `diagnose_stack_trace_interval_ms` milliseconds ago. Increase this value to reduce CPU overhead and log volume from frequent stack dumps; decrease it to capture more frequent traces to debug transient issues (for example, in load fail-point simulations of long `TabletsChannel::add_chunk` blocking).
 - Introduced in: v3.5.0
 
+### lake_compact_slow_log_ms
+
+- Default: 5000
+- Type: Int
+- Unit: Milliseconds
+- Is mutable: Yes
+- Description: Threshold for emitting detailed lake compaction profile logs. After a regular compaction attempt or parallel compaction subtask finishes, StarRocks writes an INFO log containing the task identifiers, status, and full JSON profile only when the elapsed task time is greater than or equal to this value. Set this parameter to `0` to log every completed attempt or subtask. Increase it to reduce INFO log volume.
+- Introduced in: -
+
 ### lake_replication_slow_log_ms
 
 - Default: 30000

--- a/docs/en/administration/management/compaction.md
+++ b/docs/en/administration/management/compaction.md
@@ -134,12 +134,17 @@ The following fields are returned:
 
 #### View execution details of compaction tasks
 
-Each compaction task is divided into multiple sub-tasks, each of which corresponds to a tablet. You can view the execution details of each sub-task by querying the system-defined view `information_schema.be_cloud_native_compactions`.
+Each row in `information_schema.be_cloud_native_compactions` represents one tablet compaction execution unit. When
+tablet parallel compaction is enabled, every parallel subtask is returned as a separate row with the same transaction
+and tablet IDs but a distinct `SUBTASK_ID`. Parallel merged contexts are aggregation artifacts rather than execution
+units and are not returned.
 
 Example:
 
 ```Plain
-mysql> SELECT * FROM information_schema.be_cloud_native_compactions;
+mysql> SELECT BE_ID, TXN_ID, TABLET_ID, VERSION, SKIPPED, RUNS, START_TIME, FINISH_TIME,
+              PROGRESS, STATUS, PROFILE
+       FROM information_schema.be_cloud_native_compactions;
 +-------+--------+-----------+---------+---------+------+---------------------+-------------+----------+--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | BE_ID | TXN_ID | TABLET_ID | VERSION | SKIPPED | RUNS | START_TIME          | FINISH_TIME | PROGRESS | STATUS | PROFILE                                                                                                                                                                                         |
 +-------+--------+-----------+---------+---------+------+---------------------+-------------+----------+--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -171,6 +176,41 @@ The following fields are returned:
   - `read_local_count`: The number of times the sub-task reads data from the local cache.
   - `read_remote_count`: The number of times the sub-task reads data from the remote storage.
   - `in_queue_sec`: The time of the sub-task staying in queue. Unit: Seconds.
+- `SUBTASK_ID`: The zero-based parallel subtask ID. It is `NULL` for a regular non-parallel tablet task. Rows with the
+  same `BE_ID`, `TXN_ID`, and `TABLET_ID`, but different `SUBTASK_ID` values, are parallel execution units of the same
+  tablet compaction.
+
+The full-chain fields in `PROFILE` use nanoseconds for precise accounting:
+
+- Profile state:
+  - `profile_final`: `false` while the task is running and `true` after it finishes. A live profile adds the elapsed
+    time of the current attempt to `task_total_ns` and, after entering the executor, to `task_execute_ns`. Other phase
+    timers are updated when their current scope exits, so `task_unaccounted_ns` can temporarily be larger in a live
+    profile.
+- Task envelope:
+  - `queue_wait_ns`: Time from entering the CN compaction queue until a worker starts the task. It is outside
+    `task_total_ns`.
+  - `task_prepare_ns`: Time used to select input rowsets, load tablet metadata and construct the compaction task.
+  - `task_execute_ns`: Wall time inside the horizontal, vertical, or index compaction executor, including elapsed
+    time in the current executor for a live profile.
+  - `task_total_ns`: Wall time from the CN worker starting task preparation until the profile snapshot or task return.
+  - `task_accounted_ns`: Sum of all non-overlapping top-level phases.
+  - `task_unaccounted_ns`: `task_total_ns - task_accounted_ns`. A large value indicates a missing phase or
+    scheduler/runtime overhead.
+- Non-overlapping execution phases: `input_prepare_ns`, `reader_prepare_ns`, `reader_open_ns`,
+  `reader_get_next_ns`, `reader_close_ns`, `chunk_transform_ns`, `writer_create_ns`, `writer_open_ns`,
+  `writer_write_ns`, `writer_flush_ns`, `writer_finish_ns`, `writer_close_ns`, `mask_io_ns`, `txn_log_build_ns`,
+  `pk_sst_merge_ns`, `txn_log_write_ns`, `preload_compaction_state_ns`, and `tablet_write_log_ns`.
+- Nested reader details: `read_remote_ns`, `read_local_ns`, `create_segment_iter_ns`, `segment_init_ns`,
+  `column_iterator_init_ns`, `block_load_ns`, `block_fetch_ns`, `block_seek_ns`, `decompress_ns`, `decode_dict_ns`,
+  and delete-vector/filter timers. These fields explain time inside reader phases and must not be added to
+  `task_accounted_ns` again.
+- Vertical compaction details: `column_group_count`, `vertical_key_group_ns`, and `vertical_value_group_ns`. The group
+  times overlap with reader and writer phases and are diagnostic rather than additive.
+
+When a task finishes, the same individual profile is written to the CN INFO log with tablet ID, transaction ID,
+status, table ID, and partition ID. This preserves the per-tablet profile after the row disappears from
+`be_cloud_native_compactions`.
 
 ### Configure compaction tasks
 

--- a/docs/ja/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/ja/administration/management/BE_parameters/log_server_meta.md
@@ -56,7 +56,7 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - タイプ: Int
 - 単位: Milliseconds
 - 変更可能: はい
-- 説明: Lake Compaction の詳細な Profile スローログを出力するための実行時間しきい値です。通常の Compaction Attempt または並列 Compaction Subtask の完了後、タスクの実行時間がこの値以上の場合にのみ、StarRocks はタスク識別子、ステータス、完全な JSON Profile を含む INFO ログを出力します。`0` に設定すると、完了したすべての Attempt または Subtask が記録されます。INFO ログの量を減らすには、この値を大きくします。
+- 説明: Lake Compaction の詳細な Profile スローログを出力するための実行時間しきい値です。通常の Compaction Attempt または並列 Compaction Subtask の完了後、その Attempt または Subtask の実行時間がこの値以上の場合にのみ、StarRocks はタスク識別子、ステータス、完全な JSON Profile を含む INFO ログを出力します。`0` に設定すると、完了したすべての Attempt または Subtask が記録されます。INFO ログの量を減らすには、この値を大きくします。
 - 導入バージョン: -
 
 ### log_buffer_level

--- a/docs/ja/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/ja/administration/management/BE_parameters/log_server_meta.md
@@ -50,6 +50,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 説明: DiagnoseDaemon が `STACK_TRACE` リクエストに対して行う連続したスタックトレース診断の最小時間間隔を制御します。診断リクエストが到着したとき、最後の収集が `diagnose_stack_trace_interval_ms` ミリ秒未満であれば、デーモンはスタックトレースの収集およびログ出力をスキップします。頻繁なスタックダンプによる CPU 負荷やログ量を減らすためにこの値を大きくし、短期間の問題をデバッグするためにより頻繁なトレースを取得したい場合（例えば TabletsChannel::add_chunk が長時間ブロックするロードのフェイルポイントシミュレーションなど）には値を小さくしてください。
 - 導入バージョン: v3.5.0
 
+### lake_compact_slow_log_ms
+
+- デフォルト: 5000
+- タイプ: Int
+- 単位: Milliseconds
+- 変更可能: はい
+- 説明: Lake Compaction の詳細な Profile スローログを出力するための実行時間しきい値です。通常の Compaction Attempt または並列 Compaction Subtask の完了後、タスクの実行時間がこの値以上の場合にのみ、StarRocks はタスク識別子、ステータス、完全な JSON Profile を含む INFO ログを出力します。`0` に設定すると、完了したすべての Attempt または Subtask が記録されます。INFO ログの量を減らすには、この値を大きくします。
+- 導入バージョン: -
+
 ### log_buffer_level
 
 - デフォルト: 空の文字列

--- a/docs/ja/administration/management/compaction.md
+++ b/docs/ja/administration/management/compaction.md
@@ -133,12 +133,17 @@ mysql> SHOW PROC '/compactions';
 
 #### Compaction タスクの実行詳細の表示
 
-各 compaction タスクは複数のサブタスクに分割され、それぞれがタブレットに対応します。システム定義ビュー `information_schema.be_cloud_native_compactions` をクエリすることで、各サブタスクの実行詳細を表示できます。
+`information_schema.be_cloud_native_compactions` の各行は、1 つの Tablet Compaction 実行単位を表します。
+Tablet Parallel Compaction が有効な場合、各 Parallel Subtask は、同じ Transaction ID と Tablet ID、異なる
+`SUBTASK_ID` を持つ別々の行として返されます。Parallel Compaction の merged context は実行単位ではなく
+集約用オブジェクトであるため、返されません。
 
 例:
 
 ```Plain
-mysql> SELECT * FROM information_schema.be_cloud_native_compactions;
+mysql> SELECT BE_ID, TXN_ID, TABLET_ID, VERSION, SKIPPED, RUNS, START_TIME, FINISH_TIME,
+              PROGRESS, STATUS, PROFILE
+       FROM information_schema.be_cloud_native_compactions;
 +-------+--------+-----------+---------+---------+------+---------------------+-------------+----------+--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | BE_ID | TXN_ID | TABLET_ID | VERSION | SKIPPED | RUNS | START_TIME          | FINISH_TIME | PROGRESS | STATUS | PROFILE                                                                                                                                                                                         |
 +-------+--------+-----------+---------+---------+------+---------------------+-------------+----------+--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -170,6 +175,44 @@ mysql> SELECT * FROM information_schema.be_cloud_native_compactions;
   - `read_local_count`: サブタスクがローカルキャッシュからデータを読み取った回数。
   - `read_remote_count`: サブタスクがリモートストレージからデータを読み取った回数。
   - `in_queue_sec`: サブタスクがキューに滞在する時間。単位: 秒。
+- `SUBTASK_ID`: 0 から始まる Parallel Subtask ID です。通常の非 Parallel Tablet Task では `NULL` です。
+  `BE_ID`、`TXN_ID`、`TABLET_ID` が同じで `SUBTASK_ID` が異なる行は、同じ Tablet Compaction の Parallel
+  実行単位です。
+
+`PROFILE` のフルチェーンフィールドは、正確に時間を照合できるようナノ秒単位で記録されます。
+
+- プロファイルの状態:
+  - `profile_final`: タスクの実行中は `false`、完了後は `true` です。実行中のプロファイルでは、現在の
+    attempt の経過時間を `task_total_ns` に加え、executor に入った後は現在の executor の経過時間も
+    `task_execute_ns` に加えます。その他のフェーズタイマーは現在のスコープを抜けたときに更新されるため、
+    実行中の `task_unaccounted_ns` は一時的に大きくなる場合があります。
+- タスク全体の時間:
+  - `queue_wait_ns`: タスクが CN の Compaction キューに入ってから worker が開始するまでの時間です。
+    `task_total_ns` には含まれません。
+  - `task_prepare_ns`: 入力 Rowset の選択、Tablet メタデータのロード、および Compaction Task の構築に
+    使用した時間です。
+  - `task_execute_ns`: Horizontal、Vertical、または Index Compaction executor 内の wall time です。
+    実行中のプロファイルでは、現在の executor の経過時間も含まれます。
+  - `task_total_ns`: CN worker がタスクの準備を開始してから、プロファイルのスナップショットまたはタスク
+    の完了までの wall time です。
+  - `task_accounted_ns`: 重複しない最上位フェーズの合計です。
+  - `task_unaccounted_ns`: `task_total_ns - task_accounted_ns` です。値が大きい場合は、未計測のフェーズ、
+    または scheduler/runtime のオーバーヘッドがあることを示します。
+- 重複しない実行フェーズ: `input_prepare_ns`、`reader_prepare_ns`、`reader_open_ns`、
+  `reader_get_next_ns`、`reader_close_ns`、`chunk_transform_ns`、`writer_create_ns`、`writer_open_ns`、
+  `writer_write_ns`、`writer_flush_ns`、`writer_finish_ns`、`writer_close_ns`、`mask_io_ns`、
+  `txn_log_build_ns`、`pk_sst_merge_ns`、`txn_log_write_ns`、`preload_compaction_state_ns`、
+  `tablet_write_log_ns`。
+- Reader 内部の詳細: `read_remote_ns`、`read_local_ns`、`create_segment_iter_ns`、`segment_init_ns`、
+  `column_iterator_init_ns`、`block_load_ns`、`block_fetch_ns`、`block_seek_ns`、`decompress_ns`、
+  `decode_dict_ns`、および Delete Vector/Filter の各タイマーです。これらは Reader フェーズに含まれるため、
+  `task_accounted_ns` に再度加算しないでください。
+- Vertical Compaction の詳細: `column_group_count`、`vertical_key_group_ns`、`vertical_value_group_ns`。
+  Column Group の時間は Reader/Writer フェーズと重複する診断値であり、加算対象ではありません。
+
+タスクが完了すると、同じ Tablet 単位のプロファイルが Tablet ID、Transaction ID、ステータス、Table ID、
+Partition ID とともに CN INFO ログに書き込まれます。タスクが `be_cloud_native_compactions` から消えた後も、
+個別タスクの詳細を追跡できます。
 
 ### Compaction タスクの設定
 

--- a/docs/zh/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/zh/administration/management/BE_parameters/log_server_meta.md
@@ -47,6 +47,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 描述：DiagnoseDaemon 处理 `STACK_TRACE` 请求时，两次堆栈诊断的最小时间间隔。若距离上次采集不足该间隔则跳过，以减少频繁堆栈抓取的 CPU 和日志开销；排查瞬时问题可适当调小。
 - 引入版本：v3.5.0
 
+### lake_compact_slow_log_ms
+
+- 默认值：5000
+- 类型：Int
+- 单位：Milliseconds
+- 是否动态：是
+- 描述：输出 Lake Compaction 详细 Profile 慢日志的耗时阈值。普通 Compaction Attempt 或并行 Compaction Subtask 完成后，仅当任务耗时大于等于该值时，StarRocks 才会输出一条包含任务标识、状态和完整 JSON Profile 的 INFO 日志。设置为 `0` 表示记录每个已完成的 Attempt 或 Subtask；调大该值可减少 INFO 日志量。
+- 引入版本：-
+
 ### load_rpc_slow_log_frequency_threshold_seconds
 
 - 默认值：60

--- a/docs/zh/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/zh/administration/management/BE_parameters/log_server_meta.md
@@ -53,7 +53,7 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 类型：Int
 - 单位：Milliseconds
 - 是否动态：是
-- 描述：输出 Lake Compaction 详细 Profile 慢日志的耗时阈值。普通 Compaction Attempt 或并行 Compaction Subtask 完成后，仅当任务耗时大于等于该值时，StarRocks 才会输出一条包含任务标识、状态和完整 JSON Profile 的 INFO 日志。设置为 `0` 表示记录每个已完成的 Attempt 或 Subtask；调大该值可减少 INFO 日志量。
+- 描述：输出 Lake Compaction 详细 Profile 慢日志的耗时阈值。普通 Compaction Attempt 或并行 Compaction Subtask 完成后，仅当本次 Attempt 或 Subtask 的耗时大于等于该值时，StarRocks 才会输出一条包含任务标识、状态和完整 JSON Profile 的 INFO 日志。设置为 `0` 表示记录每个已完成的 Attempt 或 Subtask；调大该值可减少 INFO 日志量。
 - 引入版本：-
 
 ### load_rpc_slow_log_frequency_threshold_seconds

--- a/docs/zh/administration/management/compaction.md
+++ b/docs/zh/administration/management/compaction.md
@@ -131,12 +131,16 @@ mysql> SHOW PROC '/compactions';
 
 #### 查看 Compaction 任务的执行详情
 
-每个 Compaction 任务被分解为多个子任务，每个子任务对应一个 Tablet。您可以通过查询系统定义视图 `information_schema.be_cloud_native_compactions` 查看每个子任务的执行详情。
+`information_schema.be_cloud_native_compactions` 中的每一行代表一个 Tablet Compaction 执行单元。启用
+Tablet 并行 Compaction 后，每个并行 Subtask 分别占一行：它们具有相同的事务 ID 和 Tablet ID，但
+`SUBTASK_ID` 不同。并行 Compaction 的 merged context 只是聚合对象，不是实际执行单元，因此不会返回。
 
 示例：
 
 ```Plain
-mysql> SELECT * FROM information_schema.be_cloud_native_compactions;
+mysql> SELECT BE_ID, TXN_ID, TABLET_ID, VERSION, SKIPPED, RUNS, START_TIME, FINISH_TIME,
+              PROGRESS, STATUS, PROFILE
+       FROM information_schema.be_cloud_native_compactions;
 +-------+--------+-----------+---------+---------+------+---------------------+-------------+----------+--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | BE_ID | TXN_ID | TABLET_ID | VERSION | SKIPPED | RUNS | START_TIME          | FINISH_TIME | PROGRESS | STATUS | PROFILE                                                                                                                                                                                         |
 +-------+--------+-----------+---------+---------+------+---------------------+-------------+----------+--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -168,6 +172,37 @@ mysql> SELECT * FROM information_schema.be_cloud_native_compactions;
   - `read_local_count`：子任务从本地缓存读取数据的次数。
   - `read_remote_count`：子任务从远程存储读取数据的次数。
   - `in_queue_sec`：子任务排队的时间。单位：秒。
+- `SUBTASK_ID`：从 0 开始的并行 Subtask ID。普通非并行 Tablet Task 的值为 `NULL`。如果多行具有相同的
+  `BE_ID`、`TXN_ID` 和 `TABLET_ID`，但 `SUBTASK_ID` 不同，它们就是同一个 Tablet Compaction 的并行执行单元。
+
+`PROFILE` 中新增的全链路字段统一使用纳秒，便于精确对账：
+
+- Profile 状态：
+  - `profile_final`：任务执行中为 `false`，完成后为 `true`。实时 Profile 会将当前 attempt 已经过的时间计入
+    `task_total_ns`；进入 executor 后，也会将当前 executor 已经过的时间计入 `task_execute_ns`。其他阶段计时在
+    当前作用域退出时更新，因此实时 Profile 中的 `task_unaccounted_ns` 可能暂时偏大。
+- Task 总体耗时：
+  - `queue_wait_ns`：任务进入 CN Compaction 队列到 worker 开始执行的时间，不包含在 `task_total_ns` 中。
+  - `task_prepare_ns`：选择输入 Rowset、加载 Tablet 元数据和构造 Compaction Task 的时间。
+  - `task_execute_ns`：进入 Horizontal、Vertical 或 Index Compaction executor 后的 wall time；实时 Profile
+    还包括当前 executor 已经过的时间。
+  - `task_total_ns`：CN worker 开始准备任务到本次 Profile 快照或任务返回的总 wall time。
+  - `task_accounted_ns`：所有互不重叠的顶层阶段之和。
+  - `task_unaccounted_ns`：`task_total_ns - task_accounted_ns`。该值较大通常表示仍有阶段未打点，或存在调度、
+    runtime 开销。
+- 互不重叠的执行阶段：`input_prepare_ns`、`reader_prepare_ns`、`reader_open_ns`、`reader_get_next_ns`、
+  `reader_close_ns`、`chunk_transform_ns`、`writer_create_ns`、`writer_open_ns`、`writer_write_ns`、
+  `writer_flush_ns`、`writer_finish_ns`、`writer_close_ns`、`mask_io_ns`、`txn_log_build_ns`、
+  `pk_sst_merge_ns`、`txn_log_write_ns`、`preload_compaction_state_ns` 和 `tablet_write_log_ns`。
+- Reader 内部明细：`read_remote_ns`、`read_local_ns`、`create_segment_iter_ns`、`segment_init_ns`、
+  `column_iterator_init_ns`、`block_load_ns`、`block_fetch_ns`、`block_seek_ns`、`decompress_ns`、
+  `decode_dict_ns`，以及 Delete Vector/Filter 相关计时。这些字段包含在 Reader 顶层阶段内，不能再次累加到
+  `task_accounted_ns`。
+- Vertical Compaction 明细：`column_group_count`、`vertical_key_group_ns` 和 `vertical_value_group_ns`。
+  Column Group 时间与 Reader/Writer 阶段重叠，仅用于诊断，不能重复累加。
+
+Task 完成时，同一份单 Tablet Profile 还会连同 Tablet ID、Transaction ID、状态、Table ID 和 Partition ID
+写入 CN INFO 日志。因此，即使该任务已经从 `be_cloud_native_compactions` 中消失，仍可以追溯单任务明细。
 
 ### 配置 Compaction 任务
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeCloudNativeCompactionsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeCloudNativeCompactionsSystemTable.java
@@ -43,6 +43,7 @@ public class BeCloudNativeCompactionsSystemTable {
                         .column("PROGRESS", IntegerType.INT)
                         .column("STATUS", VarcharType.VARCHAR)
                         .column("PROFILE", VarcharType.VARCHAR)
+                        .column("SUBTASK_ID", IntegerType.INT)
                         .build(), TSchemaTableType.SCH_BE_CLOUD_NATIVE_COMPACTIONS);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/system/information/BeCloudNativeCompactionsSystemTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/system/information/BeCloudNativeCompactionsSystemTableTest.java
@@ -1,0 +1,36 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog.system.information;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.system.SystemTable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+class BeCloudNativeCompactionsSystemTableTest {
+    @Test
+    void testColumnContract() {
+        SystemTable table = BeCloudNativeCompactionsSystemTable.create();
+        List<String> columns = table.getBaseSchema().stream().map(Column::getName).collect(Collectors.toList());
+
+        Assertions.assertEquals(List.of("BE_ID", "TXN_ID", "TABLET_ID", "VERSION", "SKIPPED", "RUNS",
+                "START_TIME", "FINISH_TIME", "PROGRESS", "STATUS", "PROFILE", "SUBTASK_ID"), columns);
+        Assertions.assertEquals(Table.TableType.SCHEMA, table.getType());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Lake compaction task details disappear from `be_cloud_native_compactions` after completion, while the existing task profile only exposes coarse I/O counters. This makes it difficult to identify whether a single compaction task is bottlenecked in queueing, reader initialization, remote reads, row decoding, writer flush/finish, transaction-log handling, or uninstrumented runtime overhead.

## What I'm doing:

- Add a versioned JSON full-chain profile to each CN compaction task, including live/final state, queue/prepare/execute/total timing, reconciled accounted/unaccounted time, reader/writer/transaction-log phases, nested reader I/O and decode details, row/chunk/segment counts, and vertical-compaction group timing.
- Cover horizontal, vertical, cloud-native-index, regular parallel, segment-range, and range-split compaction paths, including retry-aware cumulative timing.
- Expose detailed live task profiles only through `information_schema.be_cloud_native_compactions`; keep `SHOW PROC '/compactions'` at its existing coarse job-level granularity.
- Add nullable `SUBTASK_ID` to `be_cloud_native_compactions`: it is `NULL` for regular tablet tasks and a zero-based ID for parallel subtasks. Hide the parallel merged context because it is an RPC aggregation artifact, not an execution unit.
- Keep live task profiles progressing with `profile_final=false`, then write each completed per-tablet/subtask profile to the CN INFO log with task identifiers and status.
- Add BE/FE unit tests and update the English, Chinese, and Japanese compaction documentation.

Fixes N/A

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

## Test results

- `./run-fe-ut.sh --test com.starrocks.catalog.system.information.BeCloudNativeCompactionsSystemTableTest`
- `./run-fe-ut.sh --test com.starrocks.lake.compaction.CompactionProfileTest`
- `./run-fe-ut.sh --test com.starrocks.lake.compaction.CompactionJobTest`
- `python3 build-support/check_gensrc_schema_compatibility.py --mode changed --base upstream/main`
- `python3 build-support/check_be_module_boundaries.py --mode changed --base upstream/main --enforce-baseline-shrink`
- `python3 build-support/render_be_agents.py --check`
- TSP StarRocks `main`, Release, scope `all`: pending for current HEAD `1cf474479cf`.