### PR TITLE
[BugFix] Verify block checksums on PK index sstable reads

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1625,6 +1625,13 @@ CONF_mBool(lake_enable_orphan_delvec_cleanup_on_compaction, "false");
 CONF_mInt32(lake_pk_preload_memory_limit_percent, "30");
 CONF_mInt32(lake_pk_index_sst_min_compaction_versions, "2");
 CONF_mInt32(lake_pk_index_sst_max_compaction_versions, "100");
+// Verify sstable block checksums on cloud-native PK index reads (open, point lookup,
+// and compaction merge), so corrupted bytes (usually a bad local cache copy) fail
+// deterministically as Corruption — and get healed by the drop-corrupted-cache
+// fallback — instead of being misparsed or silently returning wrong index values.
+// Mutable so the verification can be switched off quickly if the crc32c overhead
+// ever becomes a concern on a hot read path.
+CONF_mBool(lake_pk_index_sst_verify_checksum, "true");
 CONF_mBool(enable_strict_delvec_crc_check, "true");
 // When true, a shared-data del file (.del) read back during publish or primary-key index rebuild is
 // verified against the CRC32C recorded in its metadata, and a mismatch fails the operation with

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -797,6 +797,7 @@
         "lake_pk_preload_memory_limit_percent",
         "lake_pk_index_sst_min_compaction_versions",
         "lake_pk_index_sst_max_compaction_versions",
+        "lake_pk_index_sst_verify_checksum",
         "lake_pk_index_cumulative_base_compaction_ratio",
         "lake_pk_index_block_cache_limit_percent",
         "cloud_native_pk_index_rebuild_files_threshold",

--- a/be/src/common/config_primary_key_fwd.h
+++ b/be/src/common/config_primary_key_fwd.h
@@ -166,6 +166,14 @@ CONF_mInt32(lake_pk_index_sst_min_compaction_versions, "2");
 
 CONF_mInt32(lake_pk_index_sst_max_compaction_versions, "100");
 
+// Verify sstable block checksums on cloud-native PK index reads (open, point lookup,
+// and compaction merge), so corrupted bytes (usually a bad local cache copy) fail
+// deterministically as Corruption — and get healed by the drop-corrupted-cache
+// fallback — instead of being misparsed or silently returning wrong index values.
+// Mutable so the verification can be switched off quickly if the crc32c overhead
+// ever becomes a concern on a hot read path.
+CONF_mBool(lake_pk_index_sst_verify_checksum, "true");
+
 // When the ratio of cumulative level to base level is greater than this config, use base merge.
 CONF_mDouble(lake_pk_index_cumulative_base_compaction_ratio, "0.1");
 

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -717,6 +717,9 @@ Status LakePersistentIndex::prepare_merging_iterator(
     sstable::ReadOptions read_options;
     // No need to cache input sst's blocks.
     read_options.fill_cache = false;
+    // Catch corrupted data blocks as Corruption instead of merging garbage into the
+    // compaction output.
+    read_options.verify_checksums = config::lake_pk_index_sst_verify_checksum;
     std::vector<sstable::Iterator*> iters;
     DeferOp free_iters([&] {
         for (sstable::Iterator* iter : iters) {

--- a/be/src/storage/lake/lake_persistent_index_parallel_compact_mgr.cpp
+++ b/be/src/storage/lake/lake_persistent_index_parallel_compact_mgr.cpp
@@ -116,6 +116,9 @@ Status LakePersistentIndexParallelCompactTask::do_run() {
 
     sstable::ReadOptions read_options;
     read_options.fill_cache = false;
+    // Catch corrupted data blocks as Corruption instead of merging garbage into the
+    // compaction output.
+    read_options.verify_checksums = config::lake_pk_index_sst_verify_checksum;
 
     bool contain_shared_sstables = false;
     // Open each sstable and create iterator

--- a/be/src/storage/lake/persistent_index_sstable.cpp
+++ b/be/src/storage/lake/persistent_index_sstable.cpp
@@ -79,6 +79,10 @@ Status PersistentIndexSstable::init(std::unique_ptr<RandomAccessFile> rf, const 
         options.filter_policy = _filter_policy.get();
     }
     options.block_cache = cache;
+    // Verify block checksums when reading the index/meta blocks, so corrupted bytes
+    // (usually from the local cache) fail deterministically as Corruption instead of
+    // being misparsed, and can be healed by the drop-cache-and-retry below.
+    options.paranoid_checks = config::lake_pk_index_sst_verify_checksum;
     std::unique_ptr<sstable::Table> table;
     auto open_st = sstable::Table::Open(options, rf.get(), sstable_pb.filesize(), table);
     TEST_SYNC_POINT_CALLBACK("PersistentIndexSstable::init:table_open_error", &open_st);
@@ -208,6 +212,9 @@ Status PersistentIndexSstable::multi_get(const Slice* keys, const KeyIndexSet& k
     sstable::ReadIOStat stat;
     sstable::ReadOptions options;
     options.stat = &stat;
+    // Catch corrupted data blocks as Corruption (instead of silently returning wrong
+    // index values) so the drop-cache-and-retry below can heal a bad local cache.
+    options.verify_checksums = config::lake_pk_index_sst_verify_checksum;
     std::unique_ptr<RandomAccessFile> rf;
     if (config::enable_pk_index_parallel_execution) {
         RandomAccessFileOptions opts;
@@ -342,6 +349,9 @@ Status PersistentIndexSstable::sample_data_keys(std::vector<std::string>* keys, 
 
     sstable::ReadOptions options;
     options.fill_cache = false;
+    // The seeks below read real data blocks; catch corrupted bytes as Corruption
+    // instead of letting them feed wrong keys into the split samples.
+    options.verify_checksums = config::lake_pk_index_sst_verify_checksum;
     std::unique_ptr<sstable::Iterator> iterator(_sst->NewIterator(options));
     for (const auto& separator : separators) {
         iterator->Seek(Slice(separator));

--- a/be/src/storage/lake/pk_tablet_unsort_sst_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_unsort_sst_writer.cpp
@@ -271,8 +271,15 @@ Status PkTabletUnsortSSTWriter::merge_intermediates_into(sstable::TableBuilder* 
             ASSIGN_OR_RETURN(rf, fs::new_random_access_file(opts, sst.location));
         }
         std::unique_ptr<sstable::Table> table;
-        RETURN_IF_ERROR(sstable::Table::Open(sstable::Options{}, rf.get(), sst.size, table));
-        auto* iter = table->NewIterator(sstable::ReadOptions{});
+        // Verify block checksums when re-reading the intermediate ssts this load just
+        // wrote: corrupted bytes (usually a bad local cache copy) must fail as
+        // Corruption instead of being silently merged into a wrong dedup result.
+        sstable::Options open_options;
+        open_options.paranoid_checks = config::lake_pk_index_sst_verify_checksum;
+        RETURN_IF_ERROR(sstable::Table::Open(open_options, rf.get(), sst.size, table));
+        sstable::ReadOptions read_options;
+        read_options.verify_checksums = config::lake_pk_index_sst_verify_checksum;
+        auto* iter = table->NewIterator(read_options);
         iter_holders.emplace_back(iter);
         child_iters.push_back(iter);
         rfs.push_back(std::move(rf));

--- a/be/test/storage/lake/persistent_index_sstable_test.cpp
+++ b/be/test/storage/lake/persistent_index_sstable_test.cpp
@@ -837,6 +837,78 @@ TEST_F(PersistentIndexSstableTest, test_multiget_retry_after_clear_corrupted_cac
 }
 #endif // USE_STAROS && !BUILD_FORMAT_LIB
 
+// Flip a few bytes inside the first data block (data blocks start at file offset 0),
+// keeping the file tail (filter/index blocks and footer) intact so Table::Open still
+// succeeds and the corruption is only hit when the data block itself is read.
+static void corrupt_sst_data_block(const std::string& path) {
+    ASSIGN_OR_ABORT(auto rf, fs::new_random_access_file(path));
+    ASSIGN_OR_ABORT(auto file_size, rf->get_size());
+    std::string content(file_size, '\0');
+    ASSERT_OK(rf->read_at_fully(0, content.data(), file_size));
+    for (size_t i = 16; i < 24 && i < content.size(); i++) {
+        content[i] ^= 0xff;
+    }
+    WritableFileOptions opts;
+    opts.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE;
+    ASSIGN_OR_ABORT(auto wf, FileSystem::Default()->new_writable_file(opts, path));
+    ASSERT_OK(wf->append(Slice(content)));
+    ASSERT_OK(wf->close());
+}
+
+// A data block whose bytes were tampered with must surface as Corruption via the block
+// checksum, not be misparsed (the "bad block type" failure mode) or silently return
+// wrong index values.
+TEST_F(PersistentIndexSstableTest, test_multiget_detects_corrupted_data_block) {
+    bool old_verify = config::lake_pk_index_sst_verify_checksum;
+    config::lake_pk_index_sst_verify_checksum = true;
+    const std::string path = lake::join_path(kTestDir, "multiget_corrupted_block.sst");
+    uint64_t filesize = 0;
+    build_test_sst(path, &filesize);
+    corrupt_sst_data_block(path);
+
+    auto sst = std::make_unique<PersistentIndexSstable>();
+    ASSIGN_OR_ABORT(auto rf, fs::new_random_access_file(path));
+    PersistentIndexSstablePB sstable_pb;
+    sstable_pb.set_filename("multiget_corrupted_block.sst");
+    sstable_pb.set_filesize(filesize);
+    ASSERT_OK(sst->init(std::move(rf), sstable_pb, nullptr));
+
+    std::string key_str = fmt::format("key_{:04d}", 0);
+    Slice key(key_str);
+    KeyIndexSet key_indexes{0};
+    std::vector<IndexValue> values(1, IndexValue(NullIndexValue));
+    KeyIndexSet found;
+    auto st = sst->multi_get(&key, key_indexes, -1, values.data(), &found);
+    ASSERT_TRUE(st.is_corruption()) << st;
+    config::lake_pk_index_sst_verify_checksum = old_verify;
+}
+
+// The tablet-split sampling path (sample_data_keys) seeks real data blocks to fetch
+// the sampled keys; a tampered data block must fail as Corruption instead of feeding
+// wrong keys into the split points. The first separator always maps to the first data
+// block (sample_keys_in_range emits index 0 unconditionally), which is the block
+// corrupt_sst_data_block tampers with, so the failure is deterministic.
+TEST_F(PersistentIndexSstableTest, test_sample_data_keys_detects_corrupted_data_block) {
+    bool old_verify = config::lake_pk_index_sst_verify_checksum;
+    config::lake_pk_index_sst_verify_checksum = true;
+    const std::string path = lake::join_path(kTestDir, "sample_corrupted_block.sst");
+    uint64_t filesize = 0;
+    build_test_sst(path, &filesize);
+    corrupt_sst_data_block(path);
+
+    auto sst = std::make_unique<PersistentIndexSstable>();
+    ASSIGN_OR_ABORT(auto rf, fs::new_random_access_file(path));
+    PersistentIndexSstablePB sstable_pb;
+    sstable_pb.set_filename("sample_corrupted_block.sst");
+    sstable_pb.set_filesize(filesize);
+    ASSERT_OK(sst->init(std::move(rf), sstable_pb, nullptr));
+
+    std::vector<std::string> keys;
+    auto st = sst->sample_data_keys(&keys, Slice(), Slice(), /*max_samples=*/4);
+    ASSERT_TRUE(st.is_corruption()) << st;
+    config::lake_pk_index_sst_verify_checksum = old_verify;
+}
+
 // Tombstones are stored as (rssid=UINT32_MAX, rowid=UINT32_MAX) so that the
 // 64-bit packed value equals NullIndexValue on the way out. When the owning
 // sstable has a non-zero rssid_offset (child-tablet contribution after a

--- a/docs/en/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/en/administration/configuration/BE_parameters/shared_lake_other.md
@@ -525,6 +525,15 @@ This topic introduces the following types of BE configurations:
 - Description: Whether to allow the system to clear the corrupted data cache in a shared-data cluster.
 - Introduced in: v3.4
 
+### lake_pk_index_sst_verify_checksum
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether to verify sstable block checksums when reading the cloud-native Primary Key index (point lookups and compaction merges) in a shared-data cluster. When enabled, corrupted bytes (usually from a corrupted local cache copy) deterministically fail as a Corruption error and trigger the corrupted-cache cleanup, instead of being misparsed or silently returning wrong index values. Note that the automatic cleanup of the corrupted cache additionally requires `lake_clear_corrupted_cache_data` to be enabled.
+- Introduced in: v4.1
+
 ### lake_clear_corrupted_cache_meta
 
 - Default: true

--- a/docs/ja/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/configuration/BE_parameters/shared_lake_other.md
@@ -516,6 +516,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 説明: 共有データクラスタにおいて、システムが破損したデータキャッシュをクリアすることを許可するかどうか。
 - 導入バージョン: v3.4
 
+### lake_pk_index_sst_verify_checksum
+
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: はい
+- 説明: 共有データクラスタにおいて、クラウドネイティブ主キーインデックスの sstable を読み取る際（ポイントルックアップおよび Compaction マージ）にブロックの Checksum を検証するかどうか。有効にすると、破損したバイト列（通常は破損したローカルキャッシュのコピーに起因）は Corruption エラーとして確定的に失敗し、破損キャッシュのクリーンアップがトリガーされます。誤って解析されたり、誤ったインデックス値が静かに返されたりすることを防ぎます。なお、破損キャッシュの自動クリーンアップには `lake_clear_corrupted_cache_data` の有効化も必要です。
+- 導入バージョン: v4.1
+
 ### lake_clear_corrupted_cache_meta
 
 - デフォルト: true

--- a/docs/zh/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/configuration/BE_parameters/shared_lake_other.md
@@ -522,6 +522,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 描述：存算分离集群下，是否允许自动清理损坏的数据缓存。
 - 引入版本：v3.4
 
+### lake_pk_index_sst_verify_checksum
+
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：存算分离集群下，读取云原生主键索引 sstable（点查与 Compaction 归并）时是否校验数据块 Checksum。开启后，损坏的字节（通常来自损坏的本地缓存副本）会确定性地报 Corruption 错误并触发损坏缓存清理，而不是被错误解析或静默返回错误的索引值。注意：自动清理损坏缓存还需同时开启 `lake_clear_corrupted_cache_data`。
+- 引入版本：v4.1
+
 ### lake_clear_corrupted_cache_meta
 
 - 默认值：true


### PR DESCRIPTION
## Why I'm doing:

In shared-data clusters, a corrupted local cache copy of a PK index sstable surfaces in confusing and even dangerous ways, e.g. compaction failing with:

```
Fail to compact tablet ... : Corruption: bad block type
```

The root cause is that PK index sstable block reads never verify the crc32c block trailer that `TableBuilder` has always written (`verify_checksums` / `paranoid_checks` default to false). Without CRC verification, what a corrupted block turns into depends on where the bad bytes land:

- the 1-byte compression-type trailer is hit and becomes invalid → the confusing "bad block type";
- the block payload is hit and breaks the entry encoding → "bad entry in block";
- worst case, the bytes still parse as a syntactically valid block → garbage is **silently** returned as legal index entries: `multi_get` can hand back wrong `(rssid, rowid)` values, and compaction can merge the garbage into its output sstable, permanently baking the corruption into the index.

It also makes corruption detection unreliable: the existing drop-cache-and-retry self-healing hooks (in `PersistentIndexSstable::init` and `multi_get`, gated by `lake_clear_corrupted_cache_data`) only trigger on `is_corruption()`, which without CRC is a matter of luck.

## What I'm doing:

- Enable block checksum verification on all PK index sstable read paths, gated by a new **mutable** BE config `lake_pk_index_sst_verify_checksum` (default `true`) so it can be switched off online without a restart if the crc32c overhead ever shows up on a hot read path (review feedback):
  - `PersistentIndexSstable::init`: `paranoid_checks`, so `Table::Open` verifies the index/metaindex/filter blocks; failures are healed by the existing drop-cache-and-retry in `init`.
  - `PersistentIndexSstable::multi_get`: `verify_checksums`, so a corrupted data block deterministically fails as Corruption (instead of silently returning wrong index values) and is healed by the existing drop-cache-and-retry there.
  - Compaction merge readers — `LakePersistentIndex::prepare_merging_iterator` (serial) and `LakePersistentIndexParallelCompactTask::do_run` (parallel): `verify_checksums`, so corrupted input blocks fail the merge as Corruption instead of being silently merged into the output sstable.
  - Tablet-merge sstable rebuild readers: no instrumentation needed anymore — #78032 removed the eager rebuild (`rebuild_legacy_shared_sstable` / `rebuild_non_shared_legacy_sstable`) from `tablet_merger.cpp` in favor of lazy rebuild, whose reads go through the `PersistentIndexSstable` open/read paths already covered above.
  - Intermediate sst re-reads during large PK loads — `PkTabletUnsortSSTWriter::merge_intermediates_into`: `paranoid_checks` on open and `verify_checksums` on iteration, so corrupted intermediate bytes cannot be silently merged into a wrong dedup result. No drop-cache fallback is needed here: a load retry rewrites the intermediates under new filenames, refreshing the cache naturally.
  
  With these, every production read path of the cloud-native PK index sstables verifies checksums (all gated by the same config).
- The config is declared in `common/config.h`, added to the `config_primary_key_fwd.h` group (manifest + regenerated header), and documented in `docs/{en,zh,ja}` BE parameter pages. Backport note: the default stays `true` for main / 4.1 / 4.0; the 3.5 backport will flip the default to `false` (opt-in) to be conservative about performance on that branch.
- No behavior change for intact files: `TableBuilder` has always written the crc32c trailer, so verification is compatible with all existing sstables. The CRC (hardware crc32c) is only computed on block-cache misses; the cost is negligible compared with the IO it accompanies.
- UT: `PersistentIndexSstableTest.test_multiget_detects_corrupted_data_block` — tamper with data-block bytes in a real sstable file (keeping the file tail intact so open still succeeds) and assert `multi_get` fails as Corruption (config pinned on in the test).

A follow-up PR will add drop-cache self-healing to the compaction merge path (which today has no such hook, so a corrupted cached block fails every compaction round until the cache is cleared manually); this PR provides the deterministic Corruption signal it relies on.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5