### PR TITLE
[BugFix] Sort lake compaction candidates by max tablet score

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/Quantiles.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/Quantiles.java
@@ -68,15 +68,21 @@ public class Quantiles implements Comparable<Quantiles> {
 
     @Override
     public int compareTo(@NotNull Quantiles o) {
+        // Compare by max first: ScoreSorter uses this natural order to rank compaction
+        // candidates, and ScoreSelector admits a partition based on its MAX tablet score. A
+        // partition whose compaction debt is concentrated in a few tablets (high max, low avg)
+        // must still sort ahead of partitions with a lower max, or it is admitted every round
+        // yet never scheduled on a cluster whose compaction task slots stay saturated -- avg and
+        // p50 only break ties between partitions with an equal max.
         // must use Double.compare to avoid float type precision issue
+        if (Double.compare(max, o.max) != 0) {
+            return Double.compare(max, o.max);
+        }
         if (Double.compare(avg, o.avg) != 0) {
             return Double.compare(avg, o.avg);
         }
         if (Double.compare(p50, o.p50) != 0) {
             return Double.compare(p50, o.p50);
-        }
-        if (Double.compare(max, o.max) != 0) {
-            return Double.compare(max, o.max);
         }
         return 0;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/ScoreSorter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/ScoreSorter.java
@@ -24,6 +24,9 @@ public class ScoreSorter implements Sorter {
     @Override
     @NotNull
     public List<PartitionStatisticsSnapshot> sort(@NotNull List<PartitionStatisticsSnapshot> partitionStatistics) {
+        // Quantiles' natural order (see Quantiles#compareTo) ranks by max score first, matching
+        // the metric ScoreSelector admits on -- an admitted partition can never sort below the
+        // ambient workload solely because its debt is concentrated in a few tablets.
         return partitionStatistics.stream()
                 .filter(p -> p.getCompactionScore() != null)
                 .sorted(Comparator.comparingInt((PartitionStatisticsSnapshot stats) -> stats.getPriority().getValue()).reversed()

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/ScoreSorterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/ScoreSorterTest.java
@@ -54,6 +54,34 @@ public class ScoreSorterTest {
     }
 
     @Test
+    public void testMaxScoreDominatesAvg() {
+        // Partition 3: debt spread over every tablet -> high avg, moderate max.
+        List<PartitionStatisticsSnapshot> statisticsList = new ArrayList<>();
+        PartitionStatistics statistics = new PartitionStatistics(new PartitionIdentifier(1, 2, 3));
+        statistics.setCompactionScore(Quantiles.compute(Arrays.asList(60.0, 60.0, 60.0, 60.0, 60.0)));
+        statisticsList.add(new PartitionStatisticsSnapshot(statistics));
+
+        // Partition 4: debt concentrated in one tablet -> low avg, highest max. It must sort
+        // first, matching ScoreSelector's max-based admission, or it starves on a saturated
+        // cluster even though it is the partition every max-score view reports on top.
+        statistics = new PartitionStatistics(new PartitionIdentifier(1, 2, 4));
+        statistics.setCompactionScore(Quantiles.compute(Arrays.asList(1.0, 1.0, 1.0, 1.0, 384.0)));
+        statisticsList.add(new PartitionStatisticsSnapshot(statistics));
+
+        // Partition 5: same max as partition 4, higher avg -> avg breaks the tie in its favor.
+        statistics = new PartitionStatistics(new PartitionIdentifier(1, 2, 5));
+        statistics.setCompactionScore(Quantiles.compute(Arrays.asList(50.0, 50.0, 50.0, 50.0, 384.0)));
+        statisticsList.add(new PartitionStatisticsSnapshot(statistics));
+
+        ScoreSorter sorter = new ScoreSorter();
+        List<PartitionStatisticsSnapshot> sortedList = sorter.sort(statisticsList);
+        Assertions.assertEquals(3, sortedList.size());
+        Assertions.assertEquals(5, sortedList.get(0).getPartition().getPartitionId());
+        Assertions.assertEquals(4, sortedList.get(1).getPartition().getPartitionId());
+        Assertions.assertEquals(3, sortedList.get(2).getPartition().getPartitionId());
+    }
+
+    @Test
     public void testPriority() {
         // no priority
         {


### PR DESCRIPTION
## Why I'm doing:

On a shared-data cluster we found a partition holding the highest MAX_CS of the whole cluster (384) that had not been compacted for hours, while every other partition kept compacting normally. The scheduler admitted it on every round but never started it, and only `ALTER TABLE ... COMPACT` could get it compacted.

Root cause: `ScoreSelector` admits a partition when its MAX tablet compaction score reaches `lake_compaction_score_selector_min_score`, but `ScoreSorter` orders the admitted candidates by `Quantiles`' natural order, which compares **avg** first. A partition whose remaining compaction debt is concentrated in a few tablets (high max, low avg — typically an update-hotspot tablet of a primary-key table) sorts below the ambient workload. On a cluster whose compaction task slots stay saturated, the scheduler hits the per-warehouse task limit before reaching that partition in the sorted list on every round, so the partition starves indefinitely even though it is admitted on every round and is exactly the partition every max-score view (`partitions_meta`, ingest slowdown, selector) reports on top.

## What I'm doing:

- `Quantiles#compareTo`: compare by max first, using avg and then p50 only to break ties between partitions with an equal max — instead of the previous avg-first order. `ScoreSorter` is the only caller relying on this natural order (every other usage of `Quantiles` is field storage or a getter/setter), so the fix lands at the source: `ScoreSorter` keeps delegating to `Comparator.comparing(...)`'s natural order unchanged, with manual compaction priority still sorting first.
- With admission (`ScoreSelector`) and ordering (`ScoreSorter` via `Quantiles`) now on the same metric, an admitted partition can no longer starve behind partitions whose max scores are all lower.
- Add `ScoreSorterTest#testMaxScoreDominatesAvg`, which fails under the old ordering: a high-max/low-avg partition must sort before a lower-max/higher-avg one, and avg still breaks the tie between partitions with an equal max.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
