### PR TITLE
[BugFix] Fix expired slot reclamation blocking and RequestWorker busy spin in query queue

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/BaseSlotTracker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/BaseSlotTracker.java
@@ -56,8 +56,11 @@ public abstract class BaseSlotTracker {
     private static final Logger LOG = LogManager.getLogger(BaseSlotTracker.class);
 
     protected final ConcurrentMap<TUniqueId, LogicalSlot> slots = new ConcurrentHashMap<>();
+    // Ordered by the allocated deadline: the same field peakExpiredSlots() judges with and
+    // getMinExpiredTimeMs() reports. One shared key keeps the early break sound and makes a
+    // past getMinExpiredTimeMs() imply there is something to reclaim.
     protected final Set<LogicalSlot> slotsOrderByExpiredTime = new TreeSet<>(
-            Comparator.comparingLong(LogicalSlot::getExpiredPendingTimeMs)
+            Comparator.comparingLong(LogicalSlot::getExpiredAllocatedTimeMs)
                     .thenComparing(LogicalSlot::getSlotId));
 
     protected final Map<TUniqueId, LogicalSlot> pendingSlots = new HashMap<>();
@@ -306,7 +309,7 @@ public abstract class BaseSlotTracker {
         if (slotsOrderByExpiredTime.isEmpty()) {
             return 0;
         }
-        return slotsOrderByExpiredTime.iterator().next().getExpiredPendingTimeMs();
+        return slotsOrderByExpiredTime.iterator().next().getExpiredAllocatedTimeMs();
     }
 
     public double getEarliestQueryWaitTimeSecond() {

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotTrackerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotTrackerTest.java
@@ -110,6 +110,12 @@ public class SlotTrackerTest {
                 0, 0);
     }
 
+    private static LogicalSlot generateSlot(int numSlots, long expiredPendingTimeMs, long expiredAllocatedTimeMs) {
+        return new LogicalSlot(UUIDUtil.genTUniqueId(), "fe", WarehouseManager.DEFAULT_WAREHOUSE_ID,
+                LogicalSlot.ABSENT_GROUP_ID, numSlots, expiredPendingTimeMs, expiredAllocatedTimeMs, 0,
+                0, 0);
+    }
+
     @Test
     public void testSlotTrackerMetrics() {
         SlotTracker slotTracker = new SlotTracker(slotManager, ImmutableList.of());
@@ -200,5 +206,63 @@ public class SlotTrackerTest {
         slotTracker.allocateSlot(slot1);
         waitTime = slotTracker.getEarliestQueryWaitTimeSecond();
         assertThat(waitTime).isEqualTo(0.0);
+    }
+
+    @Test
+    public void testPeakExpiredSlotsWithDivergentDeadlines() {
+        SlotTracker slotTracker = new SlotTracker(slotManager, ImmutableList.of());
+
+        long nowMs = System.currentTimeMillis();
+        // Pending deadline long past but allocated deadline far in the future, like a DML whose
+        // query timeout is much longer than its pending timeout. Its pending deadline is the
+        // earliest of the two slots, so ordering by that field puts it first and its unexpired
+        // allocated deadline ends the scan before the expired slot is reached.
+        LogicalSlot longDeadlineSlot = generateSlot(1, nowMs - 3_600_000, nowMs + 3_600_000);
+        // Both deadlines already past.
+        LogicalSlot expiredSlot = generateSlot(1, nowMs - 700_000, nowMs - 400_000);
+
+        assertThat(slotTracker.requireSlot(longDeadlineSlot)).isTrue();
+        assertThat(slotTracker.requireSlot(expiredSlot)).isTrue();
+        slotTracker.allocateSlot(longDeadlineSlot);
+        slotTracker.allocateSlot(expiredSlot);
+
+        // The expired slot must be reclaimable even though the long-deadline slot
+        // precedes it in pending-deadline order.
+        assertThat(slotTracker.peakExpiredSlots()).containsExactly(expiredSlot);
+
+        assertThat(slotTracker.releaseSlot(expiredSlot.getSlotId())).isSameAs(expiredSlot);
+        assertThat(slotTracker.peakExpiredSlots()).isEmpty();
+        assertThat(slotTracker.getMinExpiredTimeMs()).isEqualTo(longDeadlineSlot.getExpiredAllocatedTimeMs());
+    }
+
+    @Test
+    public void testGetMinExpiredTimeMs() {
+        SlotTracker slotTracker = new SlotTracker(slotManager, ImmutableList.of());
+        assertThat(slotTracker.getMinExpiredTimeMs()).isZero();
+
+        long nowMs = System.currentTimeMillis();
+        LogicalSlot longDeadlineSlot = generateSlot(1, nowMs - 3_600_000, nowMs + 3_600_000);
+        LogicalSlot expiredSlot = generateSlot(1, nowMs - 700_000, nowMs - 400_000);
+        assertThat(slotTracker.requireSlot(longDeadlineSlot)).isTrue();
+        assertThat(slotTracker.requireSlot(expiredSlot)).isTrue();
+
+        // The wake-up deadline must be the earliest allocated deadline, not the earliest
+        // pending deadline, so the worker never wakes with nothing to reclaim.
+        assertThat(slotTracker.getMinExpiredTimeMs()).isEqualTo(expiredSlot.getExpiredAllocatedTimeMs());
+    }
+
+    @Test
+    public void testMinExpiredTimeMsAfterPendingDeadlinePassed() {
+        SlotTracker slotTracker = new SlotTracker(slotManager, ImmutableList.of());
+
+        long nowMs = System.currentTimeMillis();
+        LogicalSlot slot = generateSlot(1, nowMs - 60_000, nowMs + 3_600_000);
+        assertThat(slotTracker.requireSlot(slot)).isTrue();
+        slotTracker.allocateSlot(slot);
+
+        // Nothing is reclaimable, so the worker's only blocking deadline must be in
+        // the future; a past value here makes RequestWorker spin without waiting.
+        assertThat(slotTracker.peakExpiredSlots()).isEmpty();
+        assertThat(slotTracker.getMinExpiredTimeMs()).isGreaterThan(nowMs);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Two defects in the leader FE slot manager, both introduced when #65802 changed `expiredAllocatedTimeMs` from being equal to `expiredPendingTimeMs` to `expiredPendingTimeMs + query_timeout`:

1. `BaseSlotTracker.peakExpiredSlots()` iterates `slotsOrderByExpiredTime` (sorted by the pending deadline) and breaks at the first slot that is not allocated-expired. Since the two deadlines diverged, a slot with a long allocated deadline (for example a DML running under the `insert_timeout` default of 14400s) that sorts first blocks reclamation of every slot behind it that is already expired. We hit this on a 4.1.1 cluster: a slot whose releaseSlot RPC was lost stayed past its own deadline, kept occupying the queue concurrency limit, and `SHOW RUNNING QUERIES` kept reporting the long-finished query as RUNNING.

2. `SlotManager.RequestWorker` sleeps only until the head slot's pending deadline (`getMinExpiredTimeMs`). Once that instant is in the past while the head is not yet allocated-expired, neither `requests.take()` nor the timed `requests.poll()` runs, so the loop keeps calling `schedule()` without waiting and pins one leader FE core. Any query that holds a slot longer than `query_queue_pending_timeout_second` (default 300s) triggers this.

Both defects affect query queue v1 and v2 alike: they live in the shared `BaseSlotTracker` and `SlotManager.RequestWorker` code, and `Config.enable_query_queue_v2` only swaps the slot selection strategy, which never reads this ordering.

## What I'm doing:

- `BaseSlotTracker.java`: key `slotsOrderByExpiredTime` by `LogicalSlot::getExpiredAllocatedTimeMs` (slotId tie-break unchanged) and return the head slot's allocated deadline from `getMinExpiredTimeMs()`, so the tracker ordering, the reclamation predicate (`isAllocatedExpired`), and the worker's sleep deadline share one key.
- `SlotTrackerTest.java`: add three regression tests plus a `generateSlot` overload with explicit deadlines.

Behaviour notes:

- Admission order, `SHOW RUNNING QUERIES` output, and queue metrics are unchanged: the selection strategies and every display path use their own structures, never this TreeSet.
- Pending timeouts are still enforced by the requesting FE (`QueryQueueManager.maybeWait` cancels via `cancelSlotRequirement`), which reaches the leader as a releaseSlot RPC and wakes the worker. The leader-side sweep judged only allocated deadlines both before and after this change.
- Rolling upgrade is safe in both directions: pre-#65802 senders transmit `expired_allocated_time_ms` equal to the pending deadline, which reproduces their old single-deadline semantics under the new key.
- Wake-up bound: with the tracker otherwise idle, the worker's next unforced wake-up moves from the earliest pending deadline to the earliest allocated deadline. Every event that can free or add capacity still wakes it immediately, because `requireSlotAsync`, `releaseSlotAsync`, `notifyResourceUsageAvailable`, `notifyFrontendDeadAsync` and `notifyFrontendRestartAsync` all enqueue into the same request queue the worker blocks on. The one path with no such event is an out-of-band capacity raise (for example `SET GLOBAL query_queue_concurrency_limit`) while queries sit queued and nothing else happens; that is then noticed when the earliest queued query's own FE cancels at its pending deadline, which arrives as a releaseSlot RPC. Before #65802 the worker woke at every pending deadline, and today the spin polls continuously, so this is the one place where the change trades reaction latency for not burning a core. Happy to add an explicit notify on those setters if you would rather not have that gap.

## Alternatives considered

- Scan the whole set in `peakExpiredSlots()` instead of breaking early, keeping the pending key. That fixes the reclamation blocking but not the spin, since `getMinExpiredTimeMs()` would still hand the worker a deadline in the past, and it turns an O(expired) scan into O(tracked) on every loop.
- Compute the wait in `SlotManager.RequestWorker` from a separate minimum instead of `getMinExpiredTimeMs()`. That needs a second ordered structure or a full scan per iteration for a value the tracker already knows, and it leaves the tracker ordered by a key nothing reads.
- Key the ordering on whichever deadline applies to the slot's current state. `LogicalSlot.state` is mutable, so the comparator key would change while the slot sits in the `TreeSet` and `remove()` would silently miss it, leaking slots.

After the change the wait-free branch always makes progress: `nowMs >= getMinExpiredTimeMs()` means the head is allocated-expired, so `peakExpiredSlots()` is non-empty and `handleReleaseSlotTask` removes it in that same iteration.

## Tests

- `testPeakExpiredSlotsWithDivergentDeadlines`: an allocated-expired slot behind a longer-deadline slot is reclaimable, and the sweep head advances after release.
- `testGetMinExpiredTimeMs`: the worker wake-up deadline equals the minimum allocated deadline (0 sentinel for an empty tracker preserved).
- `testMinExpiredTimeMsAfterPendingDeadlinePassed`: a slot past its pending deadline but before its allocated deadline leaves the worker a future deadline to sleep until, which is the exact condition that busy-spins today.

The spin itself lives in `SlotManager.RequestWorker`, a private inner class whose only observable symptom is CPU time, so it is pinned at the tracker level instead: `testMinExpiredTimeMsAfterPendingDeadlinePassed` asserts the exact state that makes the worker take neither `requests.take()` nor the timed `requests.poll()`.

Each test fails without the fix. Applying only one of the two edits is also caught: at least two of the three tests fail under either partial variant.

Locally I ran every test class that references `BaseSlotTracker`, `SlotTracker`, `SlotManager` or `LogicalSlot` (16 classes, 173 tests, all green), then the full fe-core suite: 1858 classes, 21544 tests, 5 failures across 4 classes (`RefreshTableStmtTest`, `PaimonTableTest`, `ProfilingExecPlanTest`, `ExternalResourceCleanupTest`). All four fail identically on unpatched `c14abd5508d`, so they are pre-existing and unrelated to this change. `mvn checkstyle:check -pl fe-core` is clean.

Measured against a running `SlotManager` (same tree, same build, only the two lines differing), registering one slot whose pending deadline has passed and whose allocated deadline is an hour away, then sampling the `slot-mgr-req` thread with `ThreadMXBean` over a 3 second window:

| | before | after |
|---|---|---|
| `slot-mgr-req` CPU time / wall time | 2960.8ms / 3005.1ms (98.5% of one core) | 0.0ms / 3002.4ms (0%) |
| expired slot registered behind a longer-deadline slot | still tracked after 3s | reclaimed, the longer-deadline slot kept |

Fixes #77483

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5