### PR TITLE
[BugFix] Keep slot-mgr-req worker alive on task failures

### DIFF
--- a/docs/en/administration/configuration/FE_parameters/user_query_loading.md
+++ b/docs/en/administration/configuration/FE_parameters/user_query_loading.md
@@ -807,6 +807,14 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: Maximum wait time for semi-synchronous statistics collection during DML operations (INSERT INTO and INSERT OVERWRITE statements). Stream Load and Broker Load use asynchronous mode and are not affected by this configuration. If statistics collection time exceeds this value, the load operation continues without waiting for collection to complete. This configuration works in conjunction with `enable_statistic_collect_on_first_load`.
 - Introduced in: v3.1
 
+### `slot_manager_error_retry_interval_ms`
+
+- Default: 100
+- Type: Long
+- Unit: Milliseconds
+- Is mutable: Yes
+- Description: The pause that the leader FE slot manager request worker takes after an unexpected error, before it retries its loop. This worker is the only thread that admits queries into the query queue and reclaims expired slots, so while it pauses no slot request is processed and the pause is added to the pending latency of every queued query. It exists so that a persistent failure cannot retry with no wait and saturate a CPU. Keep it small, and raise it only if the FE log is flooded by repeated slot manager errors.
+
 ### `slow_query_analyze_threshold`
 
 - Default: 5000

--- a/docs/ja/administration/configuration/FE_parameters/user_query_loading.md
+++ b/docs/ja/administration/configuration/FE_parameters/user_query_loading.md
@@ -788,6 +788,14 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：DML 操作 (INSERT INTO および INSERT OVERWRITE ステートメント) 中の半同期統計収集の最大待機時間。ストリームロードおよびブローカーロードは非同期モードを使用するため、この設定の影響を受けません。統計収集時間がこの値を超えると、ロード操作は収集完了を待たずに続行します。この設定は `enable_statistic_collect_on_first_load` と連携して機能します。
 - 導入時期：v3.1
 
+### `slot_manager_error_retry_interval_ms`
+
+- デフォルト：100
+- タイプ：Long
+- 単位：Milliseconds
+- 変更可能：Yes
+- 説明：Leader FE の slot manager リクエストワーカーが予期しないエラーの後、ループを再試行するまでの待機時間。このワーカーはクエリをクエリキューに受け入れ、期限切れの slot を回収する唯一のスレッドであるため、待機中は slot リクエストが一切処理されず、この待機時間はキューに入っているすべてのクエリの待機レイテンシーに加算されます。継続的な失敗が待機なしで再試行され CPU を占有することを防ぐために存在します。小さい値を保ち、FE ログに slot manager のエラーが繰り返し出力される場合にのみ大きくしてください。
+
 ### `slow_query_analyze_threshold`
 
 - デフォルト：5

--- a/docs/zh/administration/configuration/FE_parameters/user_query_loading.md
+++ b/docs/zh/administration/configuration/FE_parameters/user_query_loading.md
@@ -806,6 +806,14 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: DML 操作（INSERT INTO 和 INSERT OVERWRITE 语句）期间半同步统计信息收集的最大等待时间。Stream Load 和 Broker Load 使用异步模式，不受此配置影响。如果统计信息收集时间超过此值，加载操作将继续，而不等待收集完成。此配置与 `enable_statistic_collect_on_first_load` 协同工作。
 - 引入版本: v3.1
 
+### `slot_manager_error_retry_interval_ms`
+
+- 默认值: 100
+- 类型: Long
+- 单位: 毫秒
+- 是否可变: Yes
+- 描述: Leader FE 的 slot manager 请求工作线程在发生意外错误后、重试其循环之前的暂停时间。该线程是唯一负责将查询接纳进查询队列并回收过期 slot 的线程，因此暂停期间不会处理任何 slot 请求，该暂停时间会叠加到每个排队查询的等待延迟上。设置该暂停是为了避免持续失败时无等待重试而占满 CPU。建议保持较小的值，仅当 FE 日志中反复出现 slot manager 错误时才调大。
+
 ### `slow_query_analyze_threshold`
 
 - 默认值: 5

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2669,7 +2669,8 @@ public class Config extends ConfigBase {
      * unexpected Throwable. While the worker pauses, no slot request is processed and no slot is
      * allocated, so the pause is added to the pending latency of every queued query.
      */
-    @ConfField(mutable = true)
+    @ConfField(mutable = true, comment = "The pause in milliseconds before the slot manager request worker " +
+            "retries its loop after an unexpected error. No slot request is processed while it pauses.")
     public static long slot_manager_error_retry_interval_ms = 100;
 
     @ConfField

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2664,6 +2664,14 @@ public class Config extends ConfigBase {
     @ConfField
     public static int slot_manager_response_thread_pool_size = 16;
 
+    /**
+     * The pause in milliseconds before the slot manager request worker retries its loop after an
+     * unexpected Throwable. While the worker pauses, no slot request is processed and no slot is
+     * allocated, so the pause is added to the pending latency of every queued query.
+     */
+    @ConfField(mutable = true)
+    public static long slot_manager_error_retry_interval_ms = 100;
+
     @ConfField
     public static long statistic_dict_columns = 100000;
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/BaseSlotManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/BaseSlotManager.java
@@ -260,6 +260,30 @@ public abstract class BaseSlotManager {
     }
 
     private void handleRequireSlotTask(LogicalSlot slot) {
+        try {
+            handleRequireSlotTaskImpl(slot);
+        } catch (Throwable t) {
+            // The requester blocks on its slot future until the pending timeout unless this task
+            // replies, so an unexpected failure must be reported here rather than left to the
+            // worker loop, which can only log and drop the task. Release first: requireSlot
+            // registers the slot before running its listeners, and the selection strategies do not
+            // filter by state, so a slot left behind would later be allocated and answered with OK
+            // after the error reply below. Releasing a slot that was never registered is a no-op.
+            LOG.warn("[Slot] SlotManager fails to handle a slot requirement [slot={}]", slot, t);
+            try {
+                handleReleaseSlotTask(slot);
+            } catch (Throwable releaseThrowable) {
+                LOG.warn("[Slot] SlotManager fails to release a slot after a failed requirement [slot={}]",
+                        slot, releaseThrowable);
+            }
+            slot.onCancel();
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.setError_msgs(Collections.singletonList("failed to handle the slot requirement: " + t));
+            finishSlotRequirementToEndpoint(slot, status);
+        }
+    }
+
+    private void handleRequireSlotTaskImpl(LogicalSlot slot) {
         Frontend frontend = GlobalStateMgr.getCurrentState().getNodeMgr().getFeByName(slot.getRequestFeName());
         if (frontend == null) {
             slot.onCancel();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotManager.java
@@ -15,6 +15,7 @@
 package com.starrocks.qe.scheduler.slot;
 
 import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.Uninterruptibles;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.extension.Inject;
 import com.starrocks.metric.MetricVisitor;
@@ -33,6 +34,11 @@ import java.util.stream.Collectors;
 
 public class SlotManager extends BaseSlotManager {
     private static final Logger LOG = LogManager.getLogger(SlotManager.class);
+
+    // Pause before retrying after the worker loop catches a Throwable, so a persistent failure
+    // (for example a still-exhausted leader heap) cannot peg a CPU or flood logs by retrying with
+    // no wait. Only reached on the error path; normal processing is event-driven and never sleeps.
+    private static final long WORKER_ERROR_BACKOFF_MS = 1000L;
 
     private final RequestWorker requestWorker = new RequestWorker();
     private final SlotTracker slotTracker;
@@ -134,15 +140,29 @@ public class SlotManager extends BaseSlotManager {
                         newTasks.add(newTask);
                     }
 
-                    newTasks.forEach(Runnable::run);
+                    for (Runnable task : newTasks) {
+                        try {
+                            task.run();
+                        } catch (Throwable t) {
+                            LOG.warn("[Slot] RequestWorker skips a task that threw", t);
+                        }
+                    }
                     newTasks.clear();
 
                     boolean isAllocatedSlots = true;
                     while (isAllocatedSlots) {
                         isAllocatedSlots = schedule();
                     }
-                } catch (Exception e) {
+                    // Catch Throwable, as Daemon.run() does: this is the only worker for slot
+                    // admission, reclamation and FE-dead cleanup, and it is never recreated, so an
+                    // Error here (for example an OutOfMemoryError under leader heap pressure) must
+                    // not terminate it and halt slot management until the FE restarts.
+                } catch (Throwable e) {
                     LOG.warn("[Slot] RequestWorker throws unexpected error", e);
+                    // Back off before retrying, mirroring the Thread.sleep in Daemon.run(): if the
+                    // failure persists (the leader heap is still exhausted), retrying with no wait
+                    // would peg a CPU and flood logs during the very incident this loop survives.
+                    Uninterruptibles.sleepUninterruptibly(WORKER_ERROR_BACKOFF_MS, TimeUnit.MILLISECONDS);
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotManager.java
@@ -16,6 +16,7 @@ package com.starrocks.qe.scheduler.slot;
 
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.Uninterruptibles;
+import com.starrocks.common.Config;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.extension.Inject;
 import com.starrocks.metric.MetricVisitor;
@@ -34,11 +35,6 @@ import java.util.stream.Collectors;
 
 public class SlotManager extends BaseSlotManager {
     private static final Logger LOG = LogManager.getLogger(SlotManager.class);
-
-    // Pause before retrying after the worker loop catches a Throwable, so a persistent failure
-    // (for example a still-exhausted leader heap) cannot peg a CPU or flood logs by retrying with
-    // no wait. Only reached on the error path; normal processing is event-driven and never sleeps.
-    private static final long WORKER_ERROR_BACKOFF_MS = 1000L;
 
     private final RequestWorker requestWorker = new RequestWorker();
     private final SlotTracker slotTracker;
@@ -153,16 +149,16 @@ public class SlotManager extends BaseSlotManager {
                     while (isAllocatedSlots) {
                         isAllocatedSlots = schedule();
                     }
+                } catch (Throwable e) {
                     // Catch Throwable, as Daemon.run() does: this is the only worker for slot
                     // admission, reclamation and FE-dead cleanup, and it is never recreated, so an
                     // Error here (for example an OutOfMemoryError under leader heap pressure) must
                     // not terminate it and halt slot management until the FE restarts.
-                } catch (Throwable e) {
                     LOG.warn("[Slot] RequestWorker throws unexpected error", e);
                     // Back off before retrying, mirroring the Thread.sleep in Daemon.run(): if the
                     // failure persists (the leader heap is still exhausted), retrying with no wait
                     // would peg a CPU and flood logs during the very incident this loop survives.
-                    Uninterruptibles.sleepUninterruptibly(WORKER_ERROR_BACKOFF_MS, TimeUnit.MILLISECONDS);
+                    Uninterruptibles.sleepUninterruptibly(Config.slot_manager_error_retry_interval_ms, TimeUnit.MILLISECONDS);
                 }
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotManagerRequestWorkerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotManagerRequestWorkerTest.java
@@ -1,0 +1,169 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler.slot;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.common.Config;
+import com.starrocks.metric.MetricRepo;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// The fix lives in the shared RequestWorker loop, so each test runs under both query queue v1 and
+// v2; Config.enable_query_queue_v2 only swaps the slot selection strategy, which this path never uses.
+public class SlotManagerRequestWorkerTest {
+    private static final String WORKER_THREAD_NAME = "slot-mgr-req";
+
+    private static boolean oldEnableQueryQueueV2;
+
+    @BeforeAll
+    public static void beforeClass() {
+        MetricRepo.init();
+        oldEnableQueryQueueV2 = Config.enable_query_queue_v2;
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        Config.enable_query_queue_v2 = oldEnableQueryQueueV2;
+    }
+
+    @AfterEach
+    public void restoreConfig() {
+        Config.enable_query_queue_v2 = oldEnableQueryQueueV2;
+    }
+
+    private static Set<Thread> workerThreadsSnapshot() {
+        Set<Thread> workers = new HashSet<>();
+        for (Thread thread : Thread.getAllStackTraces().keySet()) {
+            if (WORKER_THREAD_NAME.equals(thread.getName())) {
+                workers.add(thread);
+            }
+        }
+        return workers;
+    }
+
+    private static Thread awaitNewWorker(Set<Thread> preexisting) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 5000;
+        while (System.currentTimeMillis() < deadline) {
+            for (Thread thread : workerThreadsSnapshot()) {
+                if (!preexisting.contains(thread)) {
+                    return thread;
+                }
+            }
+            Thread.sleep(10);
+        }
+        throw new AssertionError("slot-mgr-req thread did not start within 5s");
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testWorkerSurvivesErrorFromTaskAndKeepsServing(boolean enableQueryQueueV2) throws Exception {
+        Config.enable_query_queue_v2 = enableQueryQueueV2;
+        Set<Thread> preexisting = workerThreadsSnapshot();
+        SlotManager slotManager = new SlotManager(new ResourceUsageMonitor());
+        slotManager.start();
+        Thread worker = awaitNewWorker(preexisting);
+
+        // Under leader heap exhaustion a task can throw OutOfMemoryError; this stands in for that.
+        slotManager.requests.add(() -> {
+            throw new OutOfMemoryError("injected error during task processing");
+        });
+
+        // The worker must survive the Error and keep serving the next request.
+        CountDownLatch probe = new CountDownLatch(1);
+        slotManager.requests.add(probe::countDown);
+        assertThat(probe.await(5, TimeUnit.SECONDS))
+                .as("the later task must still run after a task threw an Error")
+                .isTrue();
+        assertThat(worker.isAlive()).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testExceptionFromOneTaskDoesNotStarveOrReplay(boolean enableQueryQueueV2) throws Exception {
+        Config.enable_query_queue_v2 = enableQueryQueueV2;
+        Set<Thread> preexisting = workerThreadsSnapshot();
+        SlotManager slotManager = new SlotManager(new ResourceUsageMonitor());
+        slotManager.start();
+        Thread worker = awaitNewWorker(preexisting);
+
+        AtomicInteger poisonRuns = new AtomicInteger();
+        slotManager.requests.add(() -> {
+            poisonRuns.incrementAndGet();
+            throw new RuntimeException("injected exception during task processing");
+        });
+
+        // A later task must run, and the failed task must not be replayed on the next batch.
+        CountDownLatch probe = new CountDownLatch(1);
+        slotManager.requests.add(probe::countDown);
+        assertThat(probe.await(5, TimeUnit.SECONDS))
+                .as("the later task must still run after a task threw an Exception")
+                .isTrue();
+        assertThat(poisonRuns.get())
+                .as("the failed task must run once, not replay ahead of later tasks")
+                .isEqualTo(1);
+        assertThat(worker.isAlive()).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testWorkerSurvivesErrorFromSchedulingPathAndKeepsServing(boolean enableQueryQueueV2) throws Exception {
+        Config.enable_query_queue_v2 = enableQueryQueueV2;
+        Set<Thread> preexisting = workerThreadsSnapshot();
+        SlotManager slotManager = new SlotManager(new ResourceUsageMonitor());
+
+        // Make the non-task scheduling path throw an Error once. getMinExpiredTimeMs() is called at
+        // the top of every worker loop, outside task execution, standing in for an OutOfMemoryError
+        // that originates in the scheduling path rather than in a task. This exercises the outer
+        // catch(Throwable), which the two task-path tests never reach.
+        AtomicBoolean thrown = new AtomicBoolean();
+        SlotTracker throwingTracker = new SlotTracker(slotManager, ImmutableList.of()) {
+            @Override
+            public long getMinExpiredTimeMs() {
+                if (thrown.compareAndSet(false, true)) {
+                    throw new OutOfMemoryError("injected error in scheduling path");
+                }
+                return super.getMinExpiredTimeMs();
+            }
+        };
+        Field field = SlotManager.class.getDeclaredField("slotTracker");
+        field.setAccessible(true);
+        field.set(slotManager, throwingTracker);
+
+        slotManager.start();
+        Thread worker = awaitNewWorker(preexisting);
+
+        // The worker must survive the Error from the scheduling path and keep serving.
+        CountDownLatch probe = new CountDownLatch(1);
+        slotManager.requests.add(probe::countDown);
+        assertThat(probe.await(5, TimeUnit.SECONDS))
+                .as("the later task must still run after the scheduling path threw an Error")
+                .isTrue();
+        assertThat(worker.isAlive()).isTrue();
+        assertThat(thrown.get()).isTrue();
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotManagerRequestWorkerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotManagerRequestWorkerTest.java
@@ -16,7 +16,15 @@ package com.starrocks.qe.scheduler.slot;
 
 import com.google.common.collect.ImmutableList;
 import com.starrocks.common.Config;
+import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.metric.MetricRepo;
+import com.starrocks.server.NodeMgr;
+import com.starrocks.system.Frontend;
+import com.starrocks.thrift.TStatus;
+import com.starrocks.thrift.TStatusCode;
+import com.starrocks.thrift.TUniqueId;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -26,7 +34,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.lang.reflect.Field;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -165,5 +175,61 @@ public class SlotManagerRequestWorkerTest {
                 .isTrue();
         assertThat(worker.isAlive()).isTrue();
         assertThat(thrown.get()).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testFailedSlotRequirementIsReportedToTheRequester(boolean enableQueryQueueV2) throws Exception {
+        Config.enable_query_queue_v2 = enableQueryQueueV2;
+        Set<Thread> preexisting = workerThreadsSnapshot();
+        ReplyCapturingSlotManager slotManager = new ReplyCapturingSlotManager(new ResourceUsageMonitor());
+
+        // Make the slot requirement fail after the frontend checks, standing in for a handler bug or
+        // an Error under heap pressure. Without a reply the requester waits out its pending timeout.
+        SlotTracker throwingTracker = new SlotTracker(slotManager, ImmutableList.of()) {
+            @Override
+            public boolean requireSlot(LogicalSlot slot) {
+                throw new IllegalStateException("injected failure while requiring a slot");
+            }
+        };
+        Field field = SlotManager.class.getDeclaredField("slotTracker");
+        field.setAccessible(true);
+        field.set(slotManager, throwingTracker);
+
+        new MockUp<NodeMgr>() {
+            @Mock
+            public Frontend getFeByName(String name) {
+                return new Frontend(FrontendNodeType.FOLLOWER, name, "127.0.0.1", 9010);
+            }
+        };
+
+        slotManager.start();
+        Thread worker = awaitNewWorker(preexisting);
+
+        long nowMs = System.currentTimeMillis();
+        LogicalSlot slot = new LogicalSlot(new TUniqueId(1, 1), "FE_NAME", 0L, 0L, 1,
+                nowMs + 60_000L, nowMs + 120_000L, nowMs, 1, 1);
+        slotManager.requireSlotAsync(slot);
+
+        TStatus reply = slotManager.replies.poll(5, TimeUnit.SECONDS);
+        assertThat(reply)
+                .as("a failed slot requirement must be reported to the requester")
+                .isNotNull();
+        assertThat(reply.getStatus_code()).isEqualTo(TStatusCode.INTERNAL_ERROR);
+        assertThat(slot.getState()).isEqualTo(LogicalSlot.State.CANCELLED);
+        assertThat(worker.isAlive()).isTrue();
+    }
+
+    private static class ReplyCapturingSlotManager extends SlotManager {
+        private final BlockingQueue<TStatus> replies = new LinkedBlockingQueue<>();
+
+        ReplyCapturingSlotManager(ResourceUsageMonitor resourceUsageMonitor) {
+            super(resourceUsageMonitor);
+        }
+
+        @Override
+        protected void finishSlotRequirementToEndpoint(LogicalSlot slot, TStatus status) {
+            replies.add(status);
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

The leader FE slot manager runs all slot admission, expired-slot reclamation and FE dead/restart cleanup on a single `slot-mgr-req` worker (`SlotManager.RequestWorker`), created once per process and started once. Its loop had two liveness defects in the same error handling block (#77488):

1. It caught `Exception` only, so an `Error` such as an `OutOfMemoryError` during leader heap pressure escaped `run()` and terminated the sole worker thread. Nothing recreates it, so from that point the request queue was never consumed again: queued queries failed with `Failed to allocate resource to query: pending timeout`, expired slots were never reclaimed, and FE dead/restart cleanup stopped, until the FE process was restarted. We hit this in the field: after the leader heap recovered, every FE kept logging `[Slot] failed to require slot` for hours, `[Slot] expired slots` never reappeared, and jstack showed no `slot-mgr-req` thread.

2. The loop ran the accumulated batch with `newTasks.forEach(Runnable::run)` and cleared the reused list on the next line. When a task threw, `clear()` was skipped, so the failing task stayed in the list; the next arrivals were appended behind it and `forEach` rethrew on the stale task before reaching them. One task that throws deterministically therefore starved every later request forever, while the thread stayed alive on `requests.take()`, and tasks that already succeeded in the same batch were re-run.

A per-task guard fixes both, but it applies one policy, log and drop, to every task the worker drains. That policy is right for release, FE-dead and FE-restart tasks, which have no reply channel and whose skipped work is reclaimed by expiry. It is wrong for a require-slot task: the requesting FE is blocked on `PendingSlotRequest.slotFuture`, and `finishSlotRequirementToEndpoint` is the only thing that completes it. A silently dropped require-slot task therefore turns a failure the leader knew immediately into a `query_queue_pending_timeout_second` stall reported as `pending timeout`, which is the same misleading symptom as the incident above.

## What I'm doing:

- `SlotManager.java`: run each queued task under its own guard so one failing task no longer aborts the batch or replays, and widen the loop guard from `Exception` to `Throwable` so an `Error` no longer terminates the worker. The widened catch also pauses `slot_manager_error_retry_interval_ms` before retrying, so a persistent failure cannot retry in a hot loop. This matches the existing convention in `Daemon.run()`, which wraps each cycle in `catch (Throwable)` and sleeps between cycles.
- `Config.java`: add `slot_manager_error_retry_interval_ms`, `@ConfField(mutable = true)`, default 100ms. The worker reads it at the use site inside the catch, so `ADMIN SET FRONTEND CONFIG` applies from the next error without a restart. The worker is the sole consumer of the request queue, so this pause is also added to the pending latency of every queued query, which is why it is small and tunable rather than a constant.
- `BaseSlotManager.java`: wrap `handleRequireSlotTask` in `catch (Throwable)` that releases any partial registration, cancels the slot and sends `INTERNAL_ERROR` to the requester. This keeps the per-task guard as the worker-level policy while leaving the reply contract with the code that owns it. The release runs first because `BaseSlotTracker.requireSlot` registers the slot before running its listeners and neither selection strategy filters by state in `peakSlotsToAllocate`, so a slot left behind would be allocated on a later pass and answered `OK` after the error reply. Releasing a slot that was never registered is a no-op.
- `SlotManagerRequestWorkerTest.java`: four regression tests, one per defect plus one that drives the outer catch through the scheduling path and one that asserts a failed slot requirement reaches the requester. Each fails without the corresponding fix.

Behaviour notes:

- On an `Error`, the worker now logs and continues instead of dying. This is the same trade-off `Daemon.run()` already makes for every FE daemon; the alternative (letting the process die) is out of scope here, the silent halt was the bug.
- The pause runs only in the outer catch, which is reached only after something already threw; requests keep buffering in the bounded queue during the pause and are drained on the next pass. Normal event-driven processing never sleeps, so behaviour outside the error path is unchanged.
- A require-slot task that fails unexpectedly now ends with `INTERNAL_ERROR` carrying the real cause, so `QueryQueueManager.maybeWait` fails the query at once instead of waiting out the pending timeout. Nothing changes when the task succeeds or takes either of the two pre-existing terminal branches, which already replied.
- Normal task processing is unchanged: successful tasks run exactly once in arrival order, and `schedule()` still runs after the batch.
- Out of scope: `schedule()` itself is not per-item guarded, so a slot that makes allocation throw deterministically still stalls the allocation loop. That is a separate defect and not reachable through the queue path this PR fixes, so I would rather handle it in its own PR than widen this one.

## Tests

- `testWorkerSurvivesErrorFromTaskAndKeepsServing`: after a task throws `OutOfMemoryError`, the worker stays alive and the next task still runs.
- `testExceptionFromOneTaskDoesNotStarveOrReplay`: after a task throws `RuntimeException`, the next task runs and the failed task is not replayed.
- `testWorkerSurvivesErrorFromSchedulingPathAndKeepsServing`: after the non-task scheduling path throws an `Error`, the worker stays alive and keeps serving. This drives the outer `catch (Throwable)` that the two task-path tests do not reach.
- `testFailedSlotRequirementIsReportedToTheRequester`: when the slot requirement fails after the frontend checks, the requester receives `INTERNAL_ERROR` and the slot ends `CANCELLED`, instead of nothing being sent. Without the fix this test times out waiting for a reply, which is the client-visible stall in miniature.

The first two inject a throwing `Runnable` through the `requests` queue, the documented external entry point of `BaseSlotManager`, standing in for a handler bug or an Error under heap pressure; the third makes `getMinExpiredTimeMs()` throw once, standing in for an Error outside task execution; the fourth drives `requireSlotAsync` with a tracker whose `requireSlot` throws and captures the reply. Each is parameterized over `enable_query_queue_v2` = false and true, since the fix is in the shared worker loop and `enable_query_queue_v2` only swaps the slot selection strategy. Each fails without the fix it covers. Locally I also ran the full `qe.scheduler.slot` test package (90 tests, all green) and `mvn checkstyle:check -pl fe-core` is clean.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5