### PR TITLE
[BugFix] Fix escape character handling in LIKE predicate pushdown

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/QueryConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/QueryConverter.java
@@ -165,15 +165,58 @@ public class QueryConverter implements AstVisitorExtendInterface<QueryBuilders.Q
             column = getColumnName(exprWithoutCast(node.getChild(1)));
             value = (String) valueFor(node.getChild(0));
         }
+        String wildcard = (node.getOp() == LikePredicate.Operator.LIKE)
+                ? likePatternToWildcard(value)
+                : regexpPatternToWildcard(value);
+        return QueryBuilders.wildcardQuery(column, wildcard);
+    }
+
+    private static final char ESCAPE_CHAR = '\\';
+
+    // Convert a SQL LIKE pattern to an Elasticsearch wildcard pattern. `%`/`_` become the wildcards
+    // `*`/`?`, while a `%`/`_` preceded by an (odd number of) escape char is emitted as its literal
+    // self. The escape char is consumed and only re-emitted once per escaped pair so that a literal
+    // backslash survives. Tracking the escape count's parity is what lets consecutive escapes
+    // (e.g. `\\%`) be interpreted correctly instead of relying only on the immediately preceding char.
+    private static String likePatternToWildcard(String value) {
+        StringBuilder sb = new StringBuilder(value.length());
+        int escapeCount = 0;
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c == ESCAPE_CHAR) {
+                escapeCount++;
+                if (escapeCount % 2 == 0) {
+                    sb.append(ESCAPE_CHAR);
+                }
+                continue;
+            }
+            if (c == '%' || c == '_') {
+                boolean escaped = escapeCount % 2 == 1;
+                sb.append(escaped ? c : mapWildcard(c));
+            } else {
+                sb.append(c);
+            }
+            escapeCount = 0;
+        }
+        return sb.toString();
+    }
+
+    private static char mapWildcard(char c) {
+        return c == '%' ? '*' : '?';
+    }
+
+    // Legacy behavior for REGEXP: only translate `%`/`_` unless directly preceded by a backslash,
+    // and leave backslashes untouched so regex escapes (e.g. `\d`) are preserved.
+    private static String regexpPatternToWildcard(String value) {
         char[] chars = value.toCharArray();
         for (int i = 0; i < chars.length; i++) {
             if (chars[i] == '_' || chars[i] == '%') {
-                if (i == 0 || chars[i - 1] != '\\') {
+                if (i == 0 || chars[i - 1] != ESCAPE_CHAR) {
                     chars[i] = (chars[i] == '_') ? '?' : '*';
                 }
             }
         }
-        return QueryBuilders.wildcardQuery(column, new String(chars));
+        return new String(chars);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/QueryConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/QueryConverterTest.java
@@ -114,6 +114,41 @@ public class QueryConverterTest {
     }
 
     @Test
+    public void testTranslateLikePredicateWithEscape() {
+        SlotRef name = mockSlotRef("name", StringType.STRING);
+
+        // `a\%b` matches the literal `a%b`, so `%` must be emitted as itself and the escape stripped.
+        LikePredicate escapedPercent = new LikePredicate(
+                LikePredicate.Operator.LIKE, name, new StringLiteral("a\\%b"));
+        Assertions.assertEquals("{\"wildcard\":{\"name\":\"a%b\"}}",
+                queryConverter.convert(escapedPercent).toString());
+
+        // `a\_b` matches the literal `a_b`.
+        LikePredicate escapedUnderscore = new LikePredicate(
+                LikePredicate.Operator.LIKE, name, new StringLiteral("a\\_b"));
+        Assertions.assertEquals("{\"wildcard\":{\"name\":\"a_b\"}}",
+                queryConverter.convert(escapedUnderscore).toString());
+
+        // `\\%` is a literal backslash followed by a wildcard `%` -> `\*`.
+        LikePredicate literalBackslashThenWildcard = new LikePredicate(
+                LikePredicate.Operator.LIKE, name, new StringLiteral("\\\\%"));
+        Assertions.assertEquals("{\"wildcard\":{\"name\":\"\\\\*\"}}",
+                queryConverter.convert(literalBackslashThenWildcard).toString());
+
+        // `\\\%` is a literal backslash followed by an escaped literal `%` -> `\%`.
+        LikePredicate literalBackslashThenLiteralPercent = new LikePredicate(
+                LikePredicate.Operator.LIKE, name, new StringLiteral("\\\\\\%"));
+        Assertions.assertEquals("{\"wildcard\":{\"name\":\"\\\\%\"}}",
+                queryConverter.convert(literalBackslashThenLiteralPercent).toString());
+
+        // Unescaped wildcards still translate normally.
+        LikePredicate plainWildcards = new LikePredicate(
+                LikePredicate.Operator.LIKE, name, new StringLiteral("a%b_c"));
+        Assertions.assertEquals("{\"wildcard\":{\"name\":\"a*b?c\"}}",
+                queryConverter.convert(plainWildcards).toString());
+    }
+
+    @Test
     public void testTranslateRangePredicate() {
         SlotRef valueSlotRef = mockSlotRef("value", IntegerType.INT);
         IntLiteral intLiteral = new IntLiteral(1000);


### PR DESCRIPTION
## Why I'm doing:
Currently LIKE operator can not handle escape character correctly

## What I'm doing:
Fix escape character handling in LIKE predicate pushdown

Fixes #issue
When StarRocks pushes down a SQL LIKE predicate to an Elasticsearch external table, it translates the SQL pattern into an Elasticsearch wildcard query. In SQL LIKE semantics, % and _ are wildcards,
  and a backslash (\) escapes them so they match the literal characters % and _.

  The previous implementation only checked the single character immediately preceding a %/_. If that char was a backslash, it left the wildcard untranslated. This logic was too naive and produced
  incorrect results in two ways:

  1. Escaped wildcards weren't converted to literals. A pattern like a\%b (meant to match the literal string a%b) was not correctly emitted — the escape backslash was left in place rather than being
  consumed and the % emitted as its literal self.
  2. Consecutive backslashes were mishandled. Patterns such as \\% (a literal backslash followed by a wildcard %) versus \\\% (a literal backslash followed by an escaped literal %) could not be
  distinguished, because looking only at the immediately preceding char ignores the parity of the escape sequence.

  The fix splits the translation into two paths:
  - likePatternToWildcard (for LIKE): tracks the parity of consecutive escape characters so escaped %/_ are emitted as literals, unescaped ones become */?, and literal backslashes survive correctly.
  - regexpPatternToWildcard (for REGEXP): preserves the original legacy behavior, leaving backslashes untouched so regex escapes like \d are not broken.

  New unit tests in QueryConverterTest cover escaped %/_, literal-backslash-then-wildcard, literal-backslash-then-escaped-percent, and plain unescaped wildcards.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
