### PR TITLE
[BugFix] Measure the unsorted PK SST writer's map instead of counting its allocations

### DIFF
--- a/be/src/storage/lake/pk_tablet_unsort_sst_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_unsort_sst_writer.cpp
@@ -41,11 +41,6 @@
 
 namespace starrocks::lake {
 
-PkTabletUnsortSSTWriter::PkTabletUnsortSSTWriter(TabletSchemaCSPtr tablet_schema_ptr, TabletManager* tablet_mgr,
-                                                 int64_t tablet_id)
-        : PkTabletSSTWriter(std::move(tablet_schema_ptr), tablet_mgr, tablet_id),
-          _map(std::less<>(), MapAllocator(&_map_node_bytes)) {}
-
 Status PkTabletUnsortSSTWriter::reset_sst_writer(const std::shared_ptr<LocationProvider>& location_provider,
                                                  const std::shared_ptr<FileSystem>& fs) {
     _location_provider = location_provider;
@@ -199,8 +194,11 @@ bool PkTabletUnsortSSTWriter::is_map_full() const {
 }
 
 size_t PkTabletUnsortSSTWriter::map_memory_usage() const {
-    DCHECK_GE(_map_node_bytes, 0);
-    return sizeof(_map) + static_cast<size_t>(_map_node_bytes) + _keys_heap_size;
+    // Same accounting as PersistentIndexMemtable::memory_usage(): _keys_heap_size is the memory of the
+    // heap-allocated std::string keys, and _map.bytes_used() is the memory of the btree itself.
+    // Asking the container is exact by construction -- an incrementally maintained byte counter has to
+    // be kept in step with every single allocation and deallocation, and any drift is silent.
+    return _keys_heap_size + _map.bytes_used();
 }
 
 size_t PkTabletUnsortSSTWriter::memory_usage() const {

--- a/be/src/storage/lake/pk_tablet_unsort_sst_writer.h
+++ b/be/src/storage/lake/pk_tablet_unsort_sst_writer.h
@@ -22,7 +22,6 @@
 #include <vector>
 
 #include "base/phmap/btree.h"
-#include "runtime/memory/counting_allocator.h"
 #include "storage/lake/pk_tablet_sst_writer.h"
 #include "storage/sstable/table_builder.h"
 
@@ -42,13 +41,16 @@ namespace starrocks::lake {
 // memory. At segment finalize the intermediate SSTs (plus the residual map) are k-way merged into the
 // single final SST; duplicate PKs across intermediates are resolved there (last-flushed wins) and the
 // losers appended to the delete vector.
-// Memory: the map and loser-rowid vector are charged by allocated capacity and trigger a map spill at
-// l0_max_mem_usage (100 MB default). Each parallel merge task owns its own writer, so peak usage scales
-// with the number of concurrent merge tasks. The loser-rowid vector must live until segment finalize
-// and is not released by a map spill. Writer memory is charged to the load-spill merge mem tracker.
+// Memory: the map is measured the same way LakePersistentIndex's memtable measures its own (the btree's
+// bytes_used() plus the heap of the non-SSO keys) and, together with the loser-rowid vector, triggers a
+// map spill at l0_max_mem_usage (100 MB default). Each parallel merge task owns its own writer, so peak
+// usage scales with the number of concurrent merge tasks. The loser-rowid vector must live until segment
+// finalize and is not released by a map spill. Writer memory is charged to the load-spill merge mem
+// tracker.
 class PkTabletUnsortSSTWriter : public PkTabletSSTWriter {
 public:
-    PkTabletUnsortSSTWriter(TabletSchemaCSPtr tablet_schema_ptr, TabletManager* tablet_mgr, int64_t tablet_id);
+    PkTabletUnsortSSTWriter(TabletSchemaCSPtr tablet_schema_ptr, TabletManager* tablet_mgr, int64_t tablet_id)
+            : PkTabletSSTWriter(std::move(tablet_schema_ptr), tablet_mgr, tablet_id) {}
     ~PkTabletUnsortSSTWriter() override = default;
     Status append_sst_record(const Chunk& data, const std::vector<uint64_t>* rssid_rowids = nullptr,
                              const std::vector<uint32_t>* column_indexes = nullptr) override;
@@ -83,9 +85,6 @@ private:
         uint64_t order;
         uint32_t rowid;
     };
-    using MapValue = std::pair<const std::string, Entry>;
-    using MapAllocator = STLCountingAllocator<MapValue>;
-    using Map = phmap::btree_map<std::string, Entry, std::less<>, MapAllocator>;
     // An intermediate SST spilled from `_map` when it got full. Its entries store both rowid and order
     // (order in the value's version field) so the final merge can pick the dedup winner across SSTs.
     struct IntermediateSst {
@@ -112,7 +111,7 @@ private:
     void collect_delete_key(const Slice& key);
     // Whether `_map` has reached the memtable memory threshold and should be spilled to an SST.
     bool is_map_full() const;
-    // Memory owned by `_map`: allocated B-tree nodes plus heap allocations of non-SSO keys.
+    // Memory owned by `_map`: the B-tree's own bytes plus the heap of the non-SSO keys.
     size_t map_memory_usage() const;
     // Spill the current `_map` to a new intermediate SST (storing order+rowid), then clear the map.
     Status flush_map_to_intermediate_sst();
@@ -120,17 +119,14 @@ private:
     // per key and appending the losing rowids to `_deleted_rowids`.
     Status merge_intermediates_into(sstable::TableBuilder* builder);
 
-    // Bytes allocated for B-tree nodes. MapAllocator maintains this counter incrementally, so
-    // checking the spill threshold does not have to traverse the whole tree.
-    int64_t _map_node_bytes = 0;
-    Map _map;
+    phmap::btree_map<std::string, Entry, std::less<>> _map;
     std::vector<uint32_t> _deleted_rowids;
     // Encoded primary keys (del-file binary format) whose latest op is a DELETE, collected at flush and
     // moved out via take_delete_keys(). A map/merge key IS an encoded-PK slice, so it is appended
     // straight into this column (built from clone_empty_pk_column). nullptr until the first winner.
     MutableColumnPtr _delete_keys;
-    // Heap allocations owned by non-SSO strings in `_map`. The std::string objects themselves are
-    // stored in the B-tree nodes and are already included in `_map.bytes_used()`.
+    // Heap allocations owned by non-SSO strings in `_map`. The std::string objects themselves live in
+    // the B-tree nodes and are already included in `_map.bytes_used()`.
     size_t _keys_heap_size = 0;
     std::vector<IntermediateSst> _intermediate_ssts;
     // Running rowid within the current segment (== rows appended so far); reset per segment.

--- a/be/test/storage/lake/pk_tablet_sst_writer_test.cpp
+++ b/be/test/storage/lake/pk_tablet_sst_writer_test.cpp
@@ -1036,24 +1036,21 @@ TEST_F(PkTabletSSTWriterTest, test_unsort_sst_writer_memory_usage) {
         order[i] = (static_cast<uint64_t>(1) << 32) | i;
     }
 
+    // Build the same map on the side and measure it the way the writer does -- the btree's own
+    // bytes_used() plus the heap owned by the non-SSO keys.
     struct ExpectedEntry {
         uint64_t order;
         uint32_t rowid;
     };
-    using ExpectedMapValue = std::pair<const std::string, ExpectedEntry>;
-    using ExpectedMapAllocator = STLCountingAllocator<ExpectedMapValue>;
-    using ExpectedMap = phmap::btree_map<std::string, ExpectedEntry, std::less<>, ExpectedMapAllocator>;
-    int64_t expected_map_node_bytes = 0;
-    ExpectedMap expected_map{std::less<>(), ExpectedMapAllocator(&expected_map_node_bytes)};
+    phmap::btree_map<std::string, ExpectedEntry, std::less<>> expected_map;
     size_t expected_keys_heap_size = 0;
     for (uint32_t i = 0; i < encoded_keys.size(); ++i) {
         auto [it, inserted] = expected_map.emplace(encoded_keys[i], ExpectedEntry{order[i], i});
         ASSERT_TRUE(inserted);
         expected_keys_heap_size += is_string_heap_allocated(it->first) ? it->first.capacity() : 0;
     }
-    EXPECT_EQ(expected_map.bytes_used(), sizeof(expected_map) + static_cast<size_t>(expected_map_node_bytes));
-    const size_t expected_map_usage =
-            sizeof(expected_map) + static_cast<size_t>(expected_map_node_bytes) + expected_keys_heap_size;
+    ASSERT_GT(expected_keys_heap_size, 0);
+    const size_t expected_map_usage = expected_keys_heap_size + expected_map.bytes_used();
 
     ASSERT_OK(w->append_sst_record(chunk, &order));
     EXPECT_EQ(expected_map_usage, w->memory_usage());
@@ -1083,6 +1080,68 @@ TEST_F(PkTabletSSTWriterTest, test_unsort_sst_writer_memory_usage) {
     EXPECT_LT(spill_writer->memory_usage(), expected_map_usage);
     ASSIGN_OR_ABORT(auto spill_flush_result, spill_writer->flush_sst_writer());
     EXPECT_FALSE(spill_flush_result.first.path.empty());
+}
+
+TEST_F(PkTabletSSTWriterTest, test_unsort_sst_writer_memory_usage_across_spills) {
+    // A segment is many fill -> spill -> refill rounds, and the reading has to come all the way back
+    // down on every spill. An accounting that leaves a residual behind bakes it into every later
+    // reading: too small a reading spills late (unbounded writer memory), and a residual large enough
+    // to swamp the bound pins is_map_full() at true and spills one tiny intermediate SST per chunk for
+    // the rest of the segment. Measuring the live map cannot drift, and this test locks that in.
+    const int64_t tablet_id = _tablet_metadata->id();
+    auto lp = std::make_shared<FixedLocationProvider>(kTestDirectory);
+    constexpr int kRounds = 5;
+    constexpr int kRowsPerRound = 64;
+
+    // Fixed-width keys, long enough not to fit in the string's SSO buffer, and distinct across rounds
+    // so no round produces dedup losers. Every round therefore has the exact same footprint.
+    auto round_chunk = [&](int round) {
+        std::vector<std::pair<std::string, int>> rows;
+        rows.reserve(kRowsPerRound);
+        for (int i = 0; i < kRowsPerRound; ++i) {
+            rows.emplace_back(fmt::format("unsort_spill_key_{:0>24d}", round * kRowsPerRound + i), i);
+        }
+        return make_kv_chunk(_schema, rows);
+    };
+    auto round_order = [&](int round) {
+        std::vector<uint64_t> order(kRowsPerRound);
+        for (uint32_t i = 0; i < kRowsPerRound; ++i) {
+            order[i] = (static_cast<uint64_t>(round + 1) << 32) | i;
+        }
+        return order;
+    };
+
+    // Measure the empty and the one-round footprint with spilling effectively disabled.
+    size_t empty_usage = 0;
+    size_t one_round_usage = 0;
+    {
+        ConfigResetGuard<int64_t> no_spill_guard(&config::l0_max_mem_usage, std::numeric_limits<int64_t>::max());
+        auto probe = std::make_unique<TestPkTabletUnsortSSTWriter>(_tablet_schema, _tablet_mgr.get(), tablet_id);
+        ASSERT_OK(probe->reset_sst_writer(lp, _fs));
+        empty_usage = probe->memory_usage();
+        auto chunk = round_chunk(0);
+        auto order = round_order(0);
+        ASSERT_OK(probe->append_sst_record(chunk, &order));
+        one_round_usage = probe->memory_usage();
+        ASSERT_GT(one_round_usage, empty_usage);
+        ASSERT_OK(probe->flush_sst_writer().status());
+    }
+
+    // One round now reaches the bound exactly, so every round fills the map and spills it.
+    ConfigResetGuard<int64_t> spill_guard(&config::l0_max_mem_usage, static_cast<int64_t>(one_round_usage));
+    auto w = std::make_unique<TestPkTabletUnsortSSTWriter>(_tablet_schema, _tablet_mgr.get(), tablet_id);
+    ASSERT_OK(w->reset_sst_writer(lp, _fs));
+    for (int round = 0; round < kRounds; ++round) {
+        auto chunk = round_chunk(round);
+        auto order = round_order(round);
+        ASSERT_OK(w->append_sst_record(chunk, &order));
+        // The append spilled, so the map is empty again and the writer is back to owning nothing but
+        // the empty map -- the same reading as before the very first append, round after round.
+        EXPECT_EQ(empty_usage, w->memory_usage()) << "after round " << round;
+    }
+    ASSIGN_OR_ABORT(auto flush_result, w->flush_sst_writer());
+    EXPECT_FALSE(flush_result.first.path.empty());
+    EXPECT_TRUE(w->take_deleted_rowids().empty());
 }
 
 TEST_F(PkTabletSSTWriterTest, test_unsort_sst_writer_basic_no_dup) {


### PR DESCRIPTION
## Why I'm doing:

`PkTabletUnsortSSTWriter` buffers the segment's primary keys in a `phmap::btree_map` and spills it to an
intermediate SST once it reaches `l0_max_mem_usage`. Since #77251 that threshold has been driven by an
`int64_t` counter maintained incrementally by `STLCountingAllocator`.

That counter is charged from `tls_delta_memory`, the thread-local the jemalloc mem hook stamps on
`malloc`/`free`. `malloc` and `free` are compiler builtins whose modelled memory effects do not include
"writes a thread-local", so an optimized build may reuse a value loaded before the call: the charge is
stale (or missing), and because `deallocate` has to observe its own `free()` for the counter to come
back down, the error accumulates instead of cancelling out.

Measured on a Release CN (shared-data, 3x16c64g, a 40,000,000-row import into a PK table whose
`ORDER BY` differs from its primary key, so the separate-sort-key writer runs), comparing the counter
against `_map.bytes_used()` on the live map, 6552 samples:

| | |
|---|---|
| counter while the map grows | **35.6%-36.3%** of the bytes the b-tree actually owned |
| map footprint when the writer believed it was at the 100 MB bound | **162,109,642 B = 1.55x** the bound |
| counter after the first spill cleared the map | **negative on 99.1% of samples**, min `-195,774,752` |
| resulting `memory_usage()` | up to **18,446,744,073,651,729,059** |
| intermediate SSTs held by one writer | **812** (one tiny spill per chunk, each a remote PUT, all re-read at merge) |

`map_memory_usage()` casts the counter to `size_t` behind a `DCHECK_GE` that is compiled out in Release,
which is what turns the negative value into ~1.8e19 and pins `is_map_full()` at true.

The unit test added with #77251 could not see any of this: it runs under `BE_TEST`, where
`STLCountingAllocator` compiles a different branch (`+= n * sizeof(T)` / `-= n * sizeof(T)`) that is
exactly inverse by construction. The tested branch and the shipped branch were not the same code.

## What I'm doing:

Stop maintaining a counter and ask the container, exactly as `PersistentIndexMemtable::memory_usage()`
already does for the same kind of map:

```cpp
size_t PkTabletUnsortSSTWriter::map_memory_usage() const {
    return _keys_heap_size + _map.bytes_used();
}
```

`bytes_used()` is derived from the tree's actual structure, so the reading cannot drift, cannot go
negative, and needs no allocator plumbing. `_map` goes back to a plain
`phmap::btree_map<std::string, Entry, std::less<>>`; `_map_node_bytes`, the `MapValue`/`MapAllocator`/`Map`
typedefs, the out-of-line constructor that existed only to inject the allocator, and the
`counting_allocator.h` include are all removed. `_keys_heap_size` (the heap owned by the non-SSO keys,
which live outside the b-tree nodes) is unchanged and is maintained exactly as
`PersistentIndexMemtable` maintains its own. One PK write path should not carry two memory-accounting
idioms.

### On the cost of the exact reading

`bytes_used()` is not O(1) -- `internal_stats()` recurses over every node -- and `is_map_full()` runs
once per appended chunk, so this walks the growing map on every chunk of a fill/spill cycle. That cost
was measured on the same cluster and workload as above, with a probe build that timed the reading:

| | |
|---|---|
| one reading at ~973K entries | 4.34 ms (4.46 ns/entry) |
| readings per fill/spill cycle | ~1220 |
| summed over the 8 writers of a 40M-row load | 22.8 s of CPU |
| as a share of the time those writers spent in `append_records()` | 28% |
| as a share of the cluster's CPU during the load (3x16c64g, 29.8 s wall) | **1.6%** |

An O(1) lower-bound estimate (`size() * sizeof(value_type)` for the node bytes) was prototyped and
measured too: it removes that cost, but it undercounts the real footprint by 5.3% on this workload
(worst 5.4% over 40 spill samples) and by up to ~9% when the keys are short enough to fit in the
string's SSO buffer, because it cannot see the B-tree's per-node overhead. That means the map would
exceed `l0_max_mem_usage` by roughly that much before spilling.

This PR deliberately keeps the exact reading: the bug being fixed here is precisely a memory bound that
was not being enforced, and 1.6% of cluster CPU is a reasonable price for a bound that holds exactly.
The estimate remains an option if the walk ever shows up in a profile.

Tests: `test_unsort_sst_writer_memory_usage` is updated to compute the expectation the same way (a
side-built map, measured with `bytes_used()`), and `test_unsort_sst_writer_memory_usage_across_spills`
drives five fill -> spill -> refill rounds with the threshold set to exactly one round's footprint and
asserts the reading returns to the empty-map value after every spill -- the property any
residual-leaving accounting breaks.

### Validation

The "before" numbers come from an instrumented Release CN running unmodified `main`. The fix was then
built and run on the same cluster and the same 40,000,000-row load:

| | before (`main`) | after |
|---|---|---|
| peak `memory_usage()` vs the 100 MB bound | 1.55x, then ~1.8e19 | **1.0027x** (0 of 40 spills above 1.01x) |
| max intermediate SSTs held by one writer | 812 | **5** |
| rows / `count(distinct id)` / `count(distinct k1)` | -- | 40,000,000 / 40,000,000 / 5,000,000, PK spot checks correct |
| CN OOM or crash | -- | none on any of the 3 CNs |

The writer path was confirmed to have run (8 x `SpillMemTableSink parallel merge blocks to segment
finished`, one per tablet). One caveat for exactness: the build used for that run also carried a
lower-bound shortcut that skipped the reading while the map was far below the threshold. It changed no
spill decision -- every decision at the boundary was the same exact reading this PR takes -- so the
numbers above apply, but the shortcut itself is not part of this PR.

Known and deliberately out of scope: `STLCountingAllocator`'s `BE_TEST`-vs-production divergence still
affects its two remaining users, `be/src/exprs/agg/data_sketch/ds_hll.h` and `ds_theta.h`. That is a
separate change with a different blast radius; this PR removes the lake writer's dependency on it.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

`l0_max_mem_usage` now bounds what the writer actually holds, so the unsorted PK SST writer spills at
the configured threshold instead of at ~1.55x it (and stops spilling on every chunk once the counter
had gone negative).

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

No documentation is needed: this corrects internal accounting for an existing configuration threshold.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

This targets `main` only; #77251, which introduced the counter, was never backported.
