### PR TITLE
[BugFix] Fix chunks_sorter_bench build failures and non-nullable crash

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -931,10 +931,12 @@ set (TEST_LINK_LIBS
     ${WL_END_GROUP}
 )
 
+# Several benches assert with gtest macros, so benchmarks need gtest just like tests do.
 set (BENCH_LINK_LIBS
     ${STARROCKS_LINK_LIBS}
     ${WL_START_GROUP}
     ${DIRECT_CONNECTOR_LINK_LIBS}
+    gtest
     ${WL_END_GROUP}
 )
 

--- a/be/src/bench/chunks_sorter_bench.cpp
+++ b/be/src/bench/chunks_sorter_bench.cpp
@@ -74,7 +74,9 @@ public:
         for (int32_t x : elements) {
             column->append_datum(Datum((int32_t)x));
         }
-        down_cast<NullableColumn*>(column.get())->update_has_null();
+        if (nullable) {
+            down_cast<NullableColumn*>(column.get())->update_has_null();
+        }
 
         return {std::move(column), std::move(expr)};
     }
@@ -419,7 +421,8 @@ static void do_merge_columnwise(benchmark::State& state, int num_runs, bool null
         null_first.push_back(true);
         map[i] = i;
     }
-    ChunkPtr chunk1 = std::make_shared<Chunk>(columns, map);
+    // Chunk only takes its columns by rvalue, so the first chunk needs its own copy of the vector.
+    ChunkPtr chunk1 = std::make_shared<Chunk>(Columns(columns), map);
     ChunkPtr chunk2 = std::make_shared<Chunk>(std::move(columns), map);
 
     int64_t num_rows = 0;


### PR DESCRIPTION
## Why I'm doing:

`be/src/bench/chunks_sorter_bench.cpp` has been broken for a long time and cannot be built or run
at all. `be/src/bench/README.md` tells contributors to build benchmarks with
`sh build.sh --be --with-bench`, so anyone following the README hits a hard failure.

CI never noticed because `WITH_BENCH` defaults to `OFF` (`be/CMakeLists.txt`), so no CI job
compiles `be/src/bench/` — the benchmarks silently rot while wide refactors keep touching them.

Fixes #77490

## What I'm doing:

Three fixes:

1. **Compile error** — `do_merge_columnwise()` passed a `Columns` lvalue to
   `std::make_shared<Chunk>()`, but every `Chunk` constructor takes `Columns&&`
   (`be/src/column/chunk.h:81-86`). The first chunk now gets its own copy via `Columns(columns)`,
   and the second keeps the `std::move`.
2. **Link error** — benchmarks that assert with gtest macros could not link, because
   `BENCH_LINK_LIBS` does not carry gtest (unlike `TEST_LINK_LIBS`). Rather than patching one
   target, `gtest` is added to `BENCH_LINK_LIBS` — this is not specific to `chunks_sorter_bench`.
   I built each suspect target individually before and after the change:

   | target | before | after |
   |---|---|---|
   | `chunks_sorter_bench` | `undefined symbol: testing::...` | builds |
   | `runtime_filter_bench` | `undefined symbol: testing::...` | builds |
   | `mem_equal_bench` | `undefined symbol: testing::...` | builds |
   | `filter_data_bench` | `undefined symbol: testing::...` | builds |
   | `hyperscan_vec_bench` | `undefined symbol: testing::...` | builds |

   All five failed at link only — they compiled fine — and every failure was gtest symbols.
   `persistent_index_bench` also asserts, but through its own `assert()`-based `ASSERT_CHECK`
   macro, so it never needed gtest.
3. **Runtime crash** — `build_sorted_column()` creates its column with
   `ColumnHelper::create_column(type_desc, nullable)` and then unconditionally does
   `down_cast<NullableColumn*>(...)->update_has_null()`. `down_cast` does no runtime check, so the
   non-nullable benchmarks (`BM_merge_columnwise`) segfaulted. The call is now guarded by
   `nullable`.

`WITH_BENCH` stays `OFF` by default, so no CI job's link line changes.

### Found but deliberately not fixed here

In `build_sorted_column()`, `append_nulls()` is a no-op on a non-nullable column, so the
non-nullable benchmarks build chunks of `vector_chunk_size - null_count` rows while the nullable
ones get `vector_chunk_size`. Each chunk is internally consistent, so nothing breaks — but the
`items_per_second` numbers of `BM_merge_columnwise` and `BM_merge_columnwise_nullable` are not
directly comparable across the two groups. Changing it would move the benchmark baseline, which
belongs in its own change rather than in a build fix.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

Benchmark-only change; no product code is touched.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

No backport: this only repairs benchmark scaffolding and changes no released product behavior.

## Verification

```
make chunks_sorter_bench runtime_filter_bench mem_equal_bench filter_data_bench hyperscan_vec_bench -j20
./src/bench/output/chunks_sorter_bench --benchmark_min_time=0.01 --benchmark_filter='BM_merge_columnwise'
```

All five targets build. Both the nullable and non-nullable `BM_merge_columnwise` groups
(32 cases) run to completion — the non-nullable group is the one that used to segfault.
