### PR TITLE
[BugFix] Project split boundaries onto the current sort key after a trailing key-column add

### DIFF
--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -324,7 +324,22 @@ public:
         // sort_key_unique_ids makes it resolve the sort key by unique id and ignore sort_key_idxes
         // entirely, and those resolved indexes are in range by construction, as is the
         // "both empty => key columns" fallback.
-        if (schema_pb.sort_key_unique_ids().empty()) {
+        if (!schema_pb.sort_key_unique_ids().empty()) {
+            // _init_from_pb resolves this branch through _unique_id_to_index.at(uid), which THROWS on
+            // an id no column carries -- an uncaught exception, not something this StatusOr could
+            // report. Check the raw ids against the columns first.
+            std::unordered_set<int32_t> column_unique_ids;
+            column_unique_ids.reserve(schema_pb.column_size());
+            for (const auto& column : schema_pb.column()) {
+                column_unique_ids.insert(column.unique_id());
+            }
+            for (const int32_t uid : schema_pb.sort_key_unique_ids()) {
+                if (column_unique_ids.find(uid) == column_unique_ids.end()) {
+                    return Status::Corruption(fmt::format("Sort key unique id {} not found among the {} schema columns",
+                                                          uid, schema_pb.column_size()));
+                }
+            }
+        } else {
             for (const int32_t cid : schema_pb.sort_key_idxes()) {
                 if (cid < 0 || cid >= schema_pb.column_size()) {
                     return Status::Corruption(fmt::format("Sort key index {} out of range, column size {}", cid,
@@ -377,6 +392,14 @@ Status validate_split_range_arity(const std::vector<TabletRangeInfo>& split_rang
                                   int64_t tablet_id) {
     ASSIGN_OR_RETURN(const auto projection, SortKeyProjection::create(schema_pb));
     const size_t arity = projection.arity();
+    if (arity == 0) {
+        // The schema carries no sort key at all (no sort_key_idxes and no key columns -- e.g. the
+        // synthetic metadata reshard unit tests build, or a schema this BE cannot interpret). There is
+        // nothing to compare the bounds against, and a range-distributed tablet always has at least
+        // one sort-key column, so treat this as "cannot tell" and let the split through rather than
+        // condemning every bound as corrupt.
+        return Status::OK();
+    }
     auto check = [&](size_t index, const char* side, const TuplePB& bound) -> Status {
         if (static_cast<size_t>(bound.values_size()) != arity) {
             return Status::Corruption(

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -287,6 +287,106 @@ void distribute_segment_to_ranges(const SegmentSplitInfo& segment, std::vector<R
     DCHECK_EQ(bytes_assigned, segment.data_size);
 }
 
+// Projects a boundary tuple derived from a rowset written under a narrower (historical) sort key up
+// onto the tablet's CURRENT sort key, by appending one NULL sentinel per missing trailing column.
+//
+// A metadata-only trailing sort-key key-column ADD (FE SchemaChangeHandler's
+// tryCreateMetadataOnlyTrailingKeyAddJob -- e.g. `ALTER TABLE agg_range ADD COLUMN c INT`, which an
+// AGG table promotes to a key column) widens the sort key and reprojects every EXISTING tablet range
+// bound with a trailing NULL sentinel, but deliberately does not rewrite the data: the rowsets keep
+// their historical, narrower schema. Every boundary tuple derived from those segments --
+// sort_key_min/sort_key_max in the segment metadata, and short-key-index samples decoded with the
+// rowset's own schema -- therefore carries the OLD arity. Emitting such a tuple as a new tablet's
+// range bound persists a bound narrower than that tablet's own sort key, which breaks the tablet
+// permanently: RangeRouter::_validate_range then rejects every load ("upper_bound value size is not
+// equal to column size") and TabletRangeHelper::create_seek_range_from rejects every read of a rowset
+// written at the new arity ("Unexpected number of values in TabletRangePB bound value, expected at
+// least: N, actual: M").
+//
+// NULL sorts as the minimum (TypeInfo::cmp), so (prefix) and (prefix, MIN, ...) denote the same point
+// under the half-open range semantics -- this is exactly the FE-side
+// TrailingSortKeyRangeReprojection.appendTrailing projection, applied here to the split input.
+// Projecting the segment tuples (rather than only the emitted bounds) also keeps every comparison
+// inside calculate_range_split_boundaries arity-consistent: VariantTuple::compare orders a shorter
+// prefix-equal tuple BELOW its padded form, so an unprojected segment bound would spuriously sort
+// below the parent tablet's own (already projected) lower bound.
+class SortKeyProjection {
+public:
+    // Resolves the current sort key from |schema_pb|. TabletSchema is materialized locally instead of
+    // through GlobalTabletSchemaMap::emplace so a schema with an unset id (synthetic reshard/test
+    // metadata) cannot DCHECK-abort, while still applying the "empty sort_key_idxes => sort key is the
+    // key columns" convention that the FE mirrors in MetaUtils.getRangeDistributionColumns.
+    static StatusOr<SortKeyProjection> create(const TabletSchemaPB& schema_pb) {
+        auto schema = TabletSchema::create(schema_pb);
+        SortKeyProjection projection;
+        projection._null_by_position.reserve(schema->sort_key_idxes().size());
+        for (const ColumnId cid : schema->sort_key_idxes()) {
+            if (cid >= schema->num_columns()) {
+                return Status::Corruption(
+                        fmt::format("Sort key index {} out of range, num_columns {}", cid, schema->num_columns()));
+            }
+            auto type_info = get_type_info(schema->column(cid));
+            if (type_info == nullptr) {
+                return Status::InternalError(fmt::format("Unsupported sort key column type: {}",
+                                                         logical_type_to_string(schema->column(cid).type())));
+            }
+            projection._null_by_position.emplace_back(std::move(type_info), Datum());
+        }
+        return projection;
+    }
+
+    size_t arity() const { return _null_by_position.size(); }
+
+    // Appends the sentinels for positions [tuple->size(), arity()) to |tuple|.
+    //
+    // An EMPTY tuple is left untouched: empty means "unknown"/unbounded to every consumer (see the
+    // !min_key.empty() guards in load_samples_from_short_key_index and TabletRange::is_minimum), and
+    // padding it would turn that into a concrete minimum tuple. A tuple already at or beyond arity()
+    // is left untouched too -- a bound WIDER than the segments it seeks into is the pre-existing case
+    // create_seek_range_from projects down, and truncating here would change its semantics.
+    void project(VariantTuple* tuple) const {
+        if (tuple->empty()) {
+            return;
+        }
+        for (size_t i = tuple->size(); i < _null_by_position.size(); ++i) {
+            tuple->append(_null_by_position[i]);
+        }
+    }
+
+private:
+    std::vector<DatumVariant> _null_by_position;
+};
+
+// Rejects a split result that would persist a tablet range bound whose value count does not match the
+// tablet's current sort-key arity. Such a bound is unrecoverable once written: RangeRouter rejects
+// every subsequent load and TabletRangeHelper::create_seek_range_from rejects every read of a rowset
+// at the sort key's own arity, so the tablet becomes permanently unreadable AND unwritable. Failing
+// the split leaves the tablet untouched instead, which the reshard job surfaces as an aborted job.
+Status validate_split_range_arity(const std::vector<TabletRangeInfo>& split_ranges, const TabletSchemaPB& schema_pb,
+                                  int64_t tablet_id) {
+    ASSIGN_OR_RETURN(const auto projection, SortKeyProjection::create(schema_pb));
+    const size_t arity = projection.arity();
+    auto check = [&](size_t index, const char* side, const TuplePB& bound) -> Status {
+        if (static_cast<size_t>(bound.values_size()) != arity) {
+            return Status::Corruption(
+                    fmt::format("Split range[{}] of tablet {} has a {} bound with {} values, but the sort key "
+                                "has {} columns",
+                                index, tablet_id, side, bound.values_size(), arity));
+        }
+        return Status::OK();
+    };
+    for (size_t i = 0; i < split_ranges.size(); ++i) {
+        const auto& range = split_ranges[i].range;
+        if (range.has_lower_bound()) {
+            RETURN_IF_ERROR(check(i, "lower", range.lower_bound()));
+        }
+        if (range.has_upper_bound()) {
+            RETURN_IF_ERROR(check(i, "upper", range.upper_bound()));
+        }
+    }
+    return Status::OK();
+}
+
 } // anonymous namespace
 
 // ================================================================================
@@ -784,6 +884,13 @@ Status get_tablet_split_ranges_impl(TabletManager* tablet_manager, const TabletM
         return Status::InvalidArgument(
                 fmt::format("Insufficient split boundaries: requested {}, produced {}", split_count, produced));
     }
+
+    // Last line of defense before these ranges become the new tablets' persisted boundaries: a bound
+    // whose arity does not match the current sort key permanently breaks the tablet (both the load
+    // router and the read-side range decoder reject it), so fail the split instead. SortKeyProjection
+    // above already lifts every segment-derived tuple onto the current sort key; this converts any
+    // remaining arity skew into an aborted reshard rather than corrupt metadata.
+    RETURN_IF_ERROR(validate_split_range_arity(*split_ranges, tablet_metadata->schema(), tablet_metadata->id()));
 
     // Anchor per-split per-rowset stats to the old tablet's recorded totals so
     // that Σ new tablets stat == old tablet stat exactly for num_rows / data_size /
@@ -1438,6 +1545,11 @@ static bool rowset_schema_resolves_to_valid_id(const TabletMetadataPB& tablet_me
 // semantics on empty (one errors, the other treats it as a no-op fast path) and
 // own that check.
 //
+// Every emitted key tuple (min_key, max_key and each sort-key sample) is projected onto the tablet's
+// current sort key via SortKeyProjection, so a rowset written before a metadata-only trailing
+// sort-key key-column ADD cannot contribute a narrower-than-sort-key boundary. The projection runs
+// AFTER the loaders, whose own bound validation compares samples against the segment's raw min/max.
+//
 // When |tablet_manager| is non-null, opportunistically opens each rowset's segments
 // (via Rowset::load_segments, using that rowset's own historical schema -- a rowset
 // written under an older schema must decode with its own) to read a
@@ -1458,6 +1570,7 @@ static bool rowset_schema_resolves_to_valid_id(const TabletMetadataPB& tablet_me
 // loader is skipped entirely.
 Status build_segments_from_rowsets(TabletManager* tablet_manager, const TabletMetadataPtr& tablet_metadata,
                                    std::vector<SegmentSplitInfo>* segments) {
+    ASSIGN_OR_RETURN(const auto projection, SortKeyProjection::create(tablet_metadata->schema()));
     for (int rowset_index = 0; rowset_index < tablet_metadata->rowsets_size(); ++rowset_index) {
         const auto& rowset_meta = tablet_metadata->rowsets(rowset_index);
 
@@ -1525,6 +1638,14 @@ Status build_segments_from_rowsets(TabletManager* tablet_manager, const TabletMe
                 }
             } else if (segment_meta.deprecated_sort_key_samples_size() > 0) {
                 RETURN_IF_ERROR(segment.load_sort_key_samples(segment_meta));
+            }
+            // Lift every tuple this segment contributes onto the tablet's current sort key. Runs after
+            // the loaders above so their sample-vs-[min_key, max_key] validation still compares tuples
+            // of one arity (the segment's own).
+            projection.project(&segment.min_key);
+            projection.project(&segment.max_key);
+            for (auto& sample : segment.sort_key_samples) {
+                projection.project(&sample);
             }
             segments->push_back(std::move(segment));
         }

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -287,6 +287,71 @@ void distribute_segment_to_ranges(const SegmentSplitInfo& segment, std::vector<R
     DCHECK_EQ(bytes_assigned, segment.data_size);
 }
 
+// Resolves the sort key a split must speak: the TabletSchema for |schema_pb|, which applies the
+// "empty sort_key_idxes => sort key is the key columns" convention that the FE mirrors in
+// MetaUtils.getRangeDistributionColumns. Resolve it ONCE per split and thread the result -- the
+// colocate arity check, the segment-tuple projection and the emitted-range validation all need the
+// same schema, and a full materialization is not free.
+//
+// The corrupt shapes are ruled out on the RAW protobuf, before the schema is built: _init_from_pb
+// consumes the sort key first, and would abort or throw before this StatusOr could report anything.
+// Only the branch _init_from_pb actually takes is validated -- the indexes it resolves by unique id
+// are in range by construction, as are the ones the "both empty => key columns" fallback produces.
+StatusOr<TabletSchemaSPtr> materialize_sort_key_schema(const TabletSchemaPB& schema_pb) {
+    if (!schema_pb.sort_key_unique_ids().empty()) {
+        // _init_from_pb resolves this branch through _unique_id_to_index.at(uid), which THROWS on an
+        // id no column carries -- an uncaught exception, not something this StatusOr could report.
+        // Check the raw ids against the columns first.
+        std::unordered_set<int32_t> column_unique_ids;
+        column_unique_ids.reserve(schema_pb.column_size());
+        for (const auto& column : schema_pb.column()) {
+            column_unique_ids.insert(column.unique_id());
+        }
+        for (const int32_t uid : schema_pb.sort_key_unique_ids()) {
+            if (column_unique_ids.find(uid) == column_unique_ids.end()) {
+                return Status::Corruption(fmt::format("Sort key unique id {} not found among the {} schema columns",
+                                                      uid, schema_pb.column_size()));
+            }
+        }
+    } else {
+        // _init_from_pb indexes both schema.column(cid) and _cols[cid] with no bounds check of its
+        // own, so an out-of-range entry would abort (or write out of bounds in a release build).
+        for (const int32_t cid : schema_pb.sort_key_idxes()) {
+            if (cid < 0 || cid >= schema_pb.column_size()) {
+                return Status::Corruption(
+                        fmt::format("Sort key index {} out of range, column size {}", cid, schema_pb.column_size()));
+            }
+        }
+    }
+    // Materialized locally rather than through GlobalTabletSchemaMap::emplace: emplace DCHECKs a
+    // valid schema id, which synthetic reshard/test metadata routinely lacks, and it is keyed by id
+    // alone -- it would hand back a cached schema for an id whose PB has since changed. One local
+    // materialization per split is the price of resolving the sort key at all; the point is to pay
+    // it once.
+    return TabletSchema::create(schema_pb);
+}
+
+// The tablet's current sort-key arity, read straight off the raw protobuf with the precedence
+// TabletSchema::_init_from_pb uses (unique ids, then explicit indexes, then "the key columns").
+// Returns 0 when the schema carries no sort key at all, which every caller must read as
+// "cannot tell", not as "the sort key is empty".
+//
+// Raw-PB rather than materialize_sort_key_schema: this runs on the apply path, where the arity is
+// all that is needed and a corrupt index must not turn a publish into a hard failure.
+size_t raw_sort_key_arity(const TabletSchemaPB& schema_pb) {
+    if (!schema_pb.sort_key_unique_ids().empty()) {
+        return schema_pb.sort_key_unique_ids_size();
+    }
+    if (!schema_pb.sort_key_idxes().empty()) {
+        return schema_pb.sort_key_idxes_size();
+    }
+    size_t num_key_columns = 0;
+    for (const auto& column : schema_pb.column()) {
+        if (column.is_key()) ++num_key_columns;
+    }
+    return num_key_columns;
+}
+
 // Projects a boundary tuple derived from a rowset written under a narrower (historical) sort key up
 // onto the tablet's CURRENT sort key, by appending one NULL sentinel per missing trailing column.
 //
@@ -312,64 +377,28 @@ void distribute_segment_to_ranges(const SegmentSplitInfo& segment, std::vector<R
 // below the parent tablet's own (already projected) lower bound.
 class SortKeyProjection {
 public:
-    // Resolves the current sort key from |schema_pb|. TabletSchema is materialized locally instead of
-    // through GlobalTabletSchemaMap::emplace so a schema with an unset id (synthetic reshard/test
-    // metadata) cannot DCHECK-abort, while still applying the "empty sort_key_idxes => sort key is the
-    // key columns" convention that the FE mirrors in MetaUtils.getRangeDistributionColumns.
-    static StatusOr<SortKeyProjection> create(const TabletSchemaPB& schema_pb) {
-        // Bounds-check the raw sort_key_idxes BEFORE materializing TabletSchema: _init_from_pb consumes
-        // them first, indexing both schema.column(cid) and _cols[cid] with no bounds check of its own,
-        // so an out-of-range entry would abort (or write out of bounds in a release build) before we
-        // could report it. Only the branch _init_from_pb actually takes is validated -- a non-empty
-        // sort_key_unique_ids makes it resolve the sort key by unique id and ignore sort_key_idxes
-        // entirely, and those resolved indexes are in range by construction, as is the
-        // "both empty => key columns" fallback.
-        if (!schema_pb.sort_key_unique_ids().empty()) {
-            // _init_from_pb resolves this branch through _unique_id_to_index.at(uid), which THROWS on
-            // an id no column carries -- an uncaught exception, not something this StatusOr could
-            // report. Check the raw ids against the columns first.
-            std::unordered_set<int32_t> column_unique_ids;
-            column_unique_ids.reserve(schema_pb.column_size());
-            for (const auto& column : schema_pb.column()) {
-                column_unique_ids.insert(column.unique_id());
-            }
-            for (const int32_t uid : schema_pb.sort_key_unique_ids()) {
-                if (column_unique_ids.find(uid) == column_unique_ids.end()) {
-                    return Status::Corruption(fmt::format("Sort key unique id {} not found among the {} schema columns",
-                                                          uid, schema_pb.column_size()));
-                }
-            }
-        } else {
-            for (const int32_t cid : schema_pb.sort_key_idxes()) {
-                if (cid < 0 || cid >= schema_pb.column_size()) {
-                    return Status::Corruption(fmt::format("Sort key index {} out of range, column size {}", cid,
-                                                          schema_pb.column_size()));
-                }
-            }
-        }
-        auto schema = TabletSchema::create(schema_pb);
+    static StatusOr<SortKeyProjection> create(const TabletSchema& schema) {
         SortKeyProjection projection;
-        projection._null_by_position.reserve(schema->sort_key_idxes().size());
-        for (const ColumnId cid : schema->sort_key_idxes()) {
-            auto type_info = get_type_info(schema->column(cid));
+        projection._null_by_position.reserve(schema.sort_key_idxes().size());
+        for (const ColumnId cid : schema.sort_key_idxes()) {
+            auto type_info = get_type_info(schema.column(cid));
             if (type_info == nullptr) {
                 return Status::InternalError(fmt::format("Unsupported sort key column type: {}",
-                                                         logical_type_to_string(schema->column(cid).type())));
+                                                         logical_type_to_string(schema.column(cid).type())));
             }
             projection._null_by_position.emplace_back(std::move(type_info), Datum());
         }
         return projection;
     }
 
-    size_t arity() const { return _null_by_position.size(); }
-
-    // Appends the sentinels for positions [tuple->size(), arity()) to |tuple|.
+    // Appends the sentinels for positions [tuple->size(), the sort-key arity) to |tuple|.
     //
     // An EMPTY tuple is left untouched: empty means "unknown"/unbounded to every consumer (see the
     // !min_key.empty() guards in load_samples_from_short_key_index and TabletRange::is_minimum), and
-    // padding it would turn that into a concrete minimum tuple. A tuple already at or beyond arity()
-    // is left untouched too -- a bound WIDER than the segments it seeks into is the pre-existing case
-    // create_seek_range_from projects down, and truncating here would change its semantics.
+    // padding it would turn that into a concrete minimum tuple. A tuple already at or beyond the
+    // arity is left untouched too -- a bound WIDER than the segments it seeks into is the
+    // pre-existing case create_seek_range_from projects down, and truncating here would change its
+    // semantics.
     void project(VariantTuple* tuple) const {
         if (tuple->empty()) {
             return;
@@ -383,39 +412,32 @@ private:
     std::vector<DatumVariant> _null_by_position;
 };
 
-// Rejects a split result that would persist a tablet range bound whose value count does not match the
-// tablet's current sort-key arity. Such a bound is unrecoverable once written: RangeRouter rejects
+// Rejects a split result that would persist a malformed tablet range. A bound whose value count does
+// not match the tablet's current sort-key arity is unrecoverable once written: RangeRouter rejects
 // every subsequent load and TabletRangeHelper::create_seek_range_from rejects every read of a rowset
 // at the sort key's own arity, so the tablet becomes permanently unreadable AND unwritable. Failing
 // the split leaves the tablet untouched instead, which the reshard job surfaces as an aborted job.
-Status validate_split_range_arity(const std::vector<TabletRangeInfo>& split_ranges, const TabletSchemaPB& schema_pb,
-                                  int64_t tablet_id) {
-    ASSIGN_OR_RETURN(const auto projection, SortKeyProjection::create(schema_pb));
-    const size_t arity = projection.arity();
-    if (arity == 0) {
+//
+// validate_range_structural is the module's own build-and-apply validator (it is what
+// schema_change.cpp and txn_log_applier.cpp run on an FE-supplied range), so it also catches a
+// mistyped value, an oversized bound and an inverted or zero-width range -- all of which are equally
+// fatal once persisted.
+Status validate_split_ranges(const std::vector<TabletRangeInfo>& split_ranges, const TabletSchema& schema,
+                             int64_t tablet_id) {
+    if (schema.sort_key_idxes().empty()) {
         // The schema carries no sort key at all (no sort_key_idxes and no key columns -- e.g. the
         // synthetic metadata reshard unit tests build, or a schema this BE cannot interpret). There is
-        // nothing to compare the bounds against, and a range-distributed tablet always has at least
+        // nothing to validate the bounds against, and a range-distributed tablet always has at least
         // one sort-key column, so treat this as "cannot tell" and let the split through rather than
-        // condemning every bound as corrupt.
+        // condemning every bound as corrupt. validate_range_structural hard-fails on arity 0, hence
+        // the guard here rather than inside it.
         return Status::OK();
     }
-    auto check = [&](size_t index, const char* side, const TuplePB& bound) -> Status {
-        if (static_cast<size_t>(bound.values_size()) != arity) {
-            return Status::Corruption(
-                    fmt::format("Split range[{}] of tablet {} has a {} bound with {} values, but the sort key "
-                                "has {} columns",
-                                index, tablet_id, side, bound.values_size(), arity));
-        }
-        return Status::OK();
-    };
     for (size_t i = 0; i < split_ranges.size(); ++i) {
-        const auto& range = split_ranges[i].range;
-        if (range.has_lower_bound()) {
-            RETURN_IF_ERROR(check(i, "lower", range.lower_bound()));
-        }
-        if (range.has_upper_bound()) {
-            RETURN_IF_ERROR(check(i, "upper", range.upper_bound()));
+        auto st = TabletRangeHelper::validate_range_structural(split_ranges[i].range, schema);
+        if (!st.ok()) {
+            return Status::Corruption(
+                    fmt::format("Split range[{}] of tablet {} is invalid: {}", i, tablet_id, st.message()));
         }
     }
     return Status::OK();
@@ -696,6 +718,12 @@ StatusOr<RangeSplitResult> calculate_range_split_boundaries(const std::vector<Se
 // Tablet splitting (uses core algorithm above)
 // ================================================================================
 
+// build_segments_from_rowsets against an already-resolved sort key, so a caller that needs the
+// schema for anything else resolves it once. Defined next to the public wrapper below.
+static Status build_segments_from_rowsets_impl(TabletManager* tablet_manager, const TabletMetadataPtr& tablet_metadata,
+                                               const TabletSchema& tablet_schema,
+                                               std::vector<SegmentSplitInfo>* segments);
+
 namespace {
 
 // Per-rowset anchor totals taken from the old tablet's recorded metadata. Used to
@@ -837,17 +865,16 @@ Status get_tablet_split_ranges_impl(TabletManager* tablet_manager, const TabletM
     if (colocate_column_count < 0) {
         return Status::InvalidArgument(fmt::format("Invalid colocate_column_count {}", colocate_column_count));
     }
-    // Only a colocate-aware split needs the sort-key arity. Resolve it from the materialized
-    // TabletSchema (which applies the "empty sort_key_idxes => sort key is the key columns"
-    // convention that the FE mirrors in MetaUtils.getRangeDistributionColumns) rather than the raw
-    // TabletSchemaPB: a range-distributed table created without an explicit ORDER BY (e.g. a
-    // PRIMARY KEY table) leaves sort_key_idxes empty in the PB, so reading the raw arity (0) would
-    // reject every colocate split and silently fall back to an identical tablet. A non-colocate
-    // split (colocate_column_count == 0) must not pay this materialization, and must not require a
-    // schema id (GlobalTabletSchemaMap::emplace DCHECKs a valid id, which synthetic test metadata
-    // and any non-registered schema may lack).
+    // The one sort-key resolution for this split: the colocate arity check, the segment-tuple
+    // projection inside build_segments_from_rowsets and the final range validation all speak the
+    // same sort key, so materialize it once here and thread it through.
+    //
+    // The colocate arity is read from the materialized TabletSchema rather than the raw
+    // TabletSchemaPB because a range-distributed table created without an explicit ORDER BY (e.g. a
+    // PRIMARY KEY table) leaves sort_key_idxes empty in the PB, so the raw arity (0) would reject
+    // every colocate split and silently fall back to an identical tablet.
+    ASSIGN_OR_RETURN(const auto tablet_schema, materialize_sort_key_schema(tablet_metadata->schema()));
     if (colocate_column_count > 0) {
-        auto tablet_schema = GlobalTabletSchemaMap::Instance()->emplace(tablet_metadata->schema()).first;
         const int32_t sort_key_arity = static_cast<int32_t>(tablet_schema->sort_key_idxes().size());
         if (colocate_column_count > sort_key_arity) {
             return Status::InvalidArgument(fmt::format("Invalid colocate_column_count {}, sort key arity is {}",
@@ -856,7 +883,7 @@ Status get_tablet_split_ranges_impl(TabletManager* tablet_manager, const TabletM
     }
 
     std::vector<SegmentSplitInfo> segments;
-    RETURN_IF_ERROR(build_segments_from_rowsets(tablet_manager, tablet_metadata, &segments));
+    RETURN_IF_ERROR(build_segments_from_rowsets_impl(tablet_manager, tablet_metadata, *tablet_schema, &segments));
     if (segments.empty()) {
         return Status::InvalidArgument("No segments found in tablet metadata");
     }
@@ -924,7 +951,7 @@ Status get_tablet_split_ranges_impl(TabletManager* tablet_manager, const TabletM
     // router and the read-side range decoder reject it), so fail the split instead. SortKeyProjection
     // above already lifts every segment-derived tuple onto the current sort key; this converts any
     // remaining arity skew into an aborted reshard rather than corrupt metadata.
-    RETURN_IF_ERROR(validate_split_range_arity(*split_ranges, tablet_metadata->schema(), tablet_metadata->id()));
+    RETURN_IF_ERROR(validate_split_ranges(*split_ranges, *tablet_schema, tablet_metadata->id()));
 
     // Anchor per-split per-rowset stats to the old tablet's recorded totals so
     // that Σ new tablets stat == old tablet stat exactly for num_rows / data_size /
@@ -1404,12 +1431,17 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> build_new_tablet
     // the parsed form is invariant across rowsets, so this saves N redundant
     // proto parses for a tablet with N pruneable rowsets.
     ASSIGN_OR_RETURN(auto parsed_new_tablet_ranges, parse_tablet_ranges(new_tablet_ranges));
+    // Ownership compares a segment's stored sort-key bounds against the new tablets' ranges, which
+    // are at the tablet's current sort-key arity. A rowset written before a metadata-only trailing
+    // sort-key ADD stores narrower bounds and must not be pruned with them (see
+    // can_prune_rowset_segments); it degrades to all-shared instead.
+    const size_t sort_key_arity = raw_sort_key_arity(old_tablet_metadata->schema());
     const int rowset_count = old_tablet_metadata->rowsets_size();
     std::vector<RowsetOwnership> rowset_ownership(rowset_count);
     std::vector<bool> rowset_prunable(rowset_count, false);
     for (int rowset_index = 0; rowset_index < rowset_count; ++rowset_index) {
         const auto& source_rowset = old_tablet_metadata->rowsets(rowset_index);
-        if (!can_prune_rowset_segments(source_rowset)) continue;
+        if (!can_prune_rowset_segments(source_rowset, sort_key_arity)) continue;
         auto ownership_or = compute_rowset_segment_ownership(source_rowset, parsed_new_tablet_ranges);
         if (ownership_or.ok()) {
             rowset_ownership[rowset_index] = std::move(ownership_or.value());
@@ -1579,10 +1611,11 @@ static bool rowset_schema_resolves_to_valid_id(const TabletMetadataPB& tablet_me
 // semantics on empty (one errors, the other treats it as a no-op fast path) and
 // own that check.
 //
-// Every emitted key tuple (min_key, max_key and each sort-key sample) is projected onto the tablet's
-// current sort key via SortKeyProjection, so a rowset written before a metadata-only trailing
-// sort-key key-column ADD cannot contribute a narrower-than-sort-key boundary. The projection runs
-// AFTER the loaders, whose own bound validation compares samples against the segment's raw min/max.
+// Every emitted key tuple (min_key, max_key and each sort-key sample) is projected onto
+// |tablet_schema|'s sort key via SortKeyProjection, so a rowset written before a metadata-only
+// trailing sort-key key-column ADD cannot contribute a narrower-than-sort-key boundary. The
+// projection runs AFTER the loaders, whose own bound validation compares samples against the
+// segment's raw min/max.
 //
 // When |tablet_manager| is non-null, opportunistically opens each rowset's segments
 // (via Rowset::load_segments, using that rowset's own historical schema -- a rowset
@@ -1602,9 +1635,10 @@ static bool rowset_schema_resolves_to_valid_id(const TabletMetadataPB& tablet_me
 // optimization can only ever produce a MORE precise SegmentSplitInfo, never a
 // failing one. When |tablet_manager| is null (synthetic metadata-only callers), the
 // loader is skipped entirely.
-Status build_segments_from_rowsets(TabletManager* tablet_manager, const TabletMetadataPtr& tablet_metadata,
-                                   std::vector<SegmentSplitInfo>* segments) {
-    ASSIGN_OR_RETURN(const auto projection, SortKeyProjection::create(tablet_metadata->schema()));
+static Status build_segments_from_rowsets_impl(TabletManager* tablet_manager, const TabletMetadataPtr& tablet_metadata,
+                                               const TabletSchema& tablet_schema,
+                                               std::vector<SegmentSplitInfo>* segments) {
+    ASSIGN_OR_RETURN(const auto projection, SortKeyProjection::create(tablet_schema));
     for (int rowset_index = 0; rowset_index < tablet_metadata->rowsets_size(); ++rowset_index) {
         const auto& rowset_meta = tablet_metadata->rowsets(rowset_index);
 
@@ -1687,6 +1721,13 @@ Status build_segments_from_rowsets(TabletManager* tablet_manager, const TabletMe
     return Status::OK();
 }
 
+// Resolves the sort key itself, for callers that need nothing else from it.
+Status build_segments_from_rowsets(TabletManager* tablet_manager, const TabletMetadataPtr& tablet_metadata,
+                                   std::vector<SegmentSplitInfo>* segments) {
+    ASSIGN_OR_RETURN(const auto tablet_schema, materialize_sort_key_schema(tablet_metadata->schema()));
+    return build_segments_from_rowsets_impl(tablet_manager, tablet_metadata, *tablet_schema, segments);
+}
+
 // Public wrapper for the anon-namespace implementation. Exposed via
 // tablet_splitter.h so unit tests can drive the validation paths directly
 // without spinning up a TabletManager/filesystem fixture.
@@ -1712,7 +1753,7 @@ Status get_tablet_split_ranges(TabletManager* tablet_manager, const TabletMetada
 // Phase-1 per-segment shared optimization helpers (declared in tablet_splitter.h).
 // -----------------------------------------------------------------------------
 
-bool can_prune_rowset_segments(const RowsetMetadataPB& rowset) {
+bool can_prune_rowset_segments(const RowsetMetadataPB& rowset, size_t sort_key_arity) {
     if (rowset.next_compaction_offset() != 0) return false; // (a) no partial-compaction cursor
     // (b) every segment must carry sort-key bounds so it maps to a key range. Each
     // SegmentMetadataPB is self-contained (filename/size/shared/bundle_file_offset all
@@ -1720,6 +1761,21 @@ bool can_prune_rowset_segments(const RowsetMetadataPB& rowset) {
     // parallel-array shape check is needed.
     for (const auto& segment_meta : rowset.segment_metas()) {
         if (!segment_meta.has_sort_key_min() || !segment_meta.has_sort_key_max()) return false;
+        // (c) those bounds must be comparable with the new tablets' ranges, which are at the
+        // CURRENT sort-key arity. A rowset written before a metadata-only trailing sort-key ADD
+        // stores narrower bounds, and VariantTuple::compare orders a shorter prefix-equal tuple
+        // BELOW its padded form: a segment whose stored max is [400] would then miss the sibling
+        // whose range starts at (400, NULL), while the read side routes that segment's k=400 rows
+        // to exactly that sibling (create_seek_range_from compares the added column's read-time
+        // default against the bound's trailing values) -- the rows would be reachable from neither
+        // side. Padding the stored bounds here cannot fix it either: an old segment's rows read as
+        // (prefix, default), so padding the MAX with the NULL minimum understates the segment's
+        // reach whenever a post-ADD rowset contributed a boundary between the two. Leave such a
+        // rowset unpruned instead; the caller keeps every segment on every new tablet as shared.
+        if (sort_key_arity > 0 && (static_cast<size_t>(segment_meta.sort_key_min().values_size()) != sort_key_arity ||
+                                   static_cast<size_t>(segment_meta.sort_key_max().values_size()) != sort_key_arity)) {
+            return false;
+        }
     }
     return true;
 }

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -317,14 +317,25 @@ public:
     // metadata) cannot DCHECK-abort, while still applying the "empty sort_key_idxes => sort key is the
     // key columns" convention that the FE mirrors in MetaUtils.getRangeDistributionColumns.
     static StatusOr<SortKeyProjection> create(const TabletSchemaPB& schema_pb) {
+        // Bounds-check the raw sort_key_idxes BEFORE materializing TabletSchema: _init_from_pb consumes
+        // them first, indexing both schema.column(cid) and _cols[cid] with no bounds check of its own,
+        // so an out-of-range entry would abort (or write out of bounds in a release build) before we
+        // could report it. Only the branch _init_from_pb actually takes is validated -- a non-empty
+        // sort_key_unique_ids makes it resolve the sort key by unique id and ignore sort_key_idxes
+        // entirely, and those resolved indexes are in range by construction, as is the
+        // "both empty => key columns" fallback.
+        if (schema_pb.sort_key_unique_ids().empty()) {
+            for (const int32_t cid : schema_pb.sort_key_idxes()) {
+                if (cid < 0 || cid >= schema_pb.column_size()) {
+                    return Status::Corruption(fmt::format("Sort key index {} out of range, column size {}", cid,
+                                                          schema_pb.column_size()));
+                }
+            }
+        }
         auto schema = TabletSchema::create(schema_pb);
         SortKeyProjection projection;
         projection._null_by_position.reserve(schema->sort_key_idxes().size());
         for (const ColumnId cid : schema->sort_key_idxes()) {
-            if (cid >= schema->num_columns()) {
-                return Status::Corruption(
-                        fmt::format("Sort key index {} out of range, num_columns {}", cid, schema->num_columns()));
-            }
             auto type_info = get_type_info(schema->column(cid));
             if (type_info == nullptr) {
                 return Status::InternalError(fmt::format("Unsupported sort key column type: {}",

--- a/be/src/storage/lake/tablet_splitter.h
+++ b/be/src/storage/lake/tablet_splitter.h
@@ -213,10 +213,15 @@ struct RowsetOwnership {
 };
 
 // True iff a rowset's metadata shape permits per-segment ownership pruning:
-// (a) no partial-compaction cursor, (b) every segment has sort-key bounds. Each
-// SegmentMetadataPB is self-contained (filename/size/shared/bundle_file_offset travel
-// with it), so bundled rowsets prune uniformly with any other.
-bool can_prune_rowset_segments(const RowsetMetadataPB& rowset);
+// (a) no partial-compaction cursor, (b) every segment has sort-key bounds, (c) those bounds are at
+// |sort_key_arity|, the tablet's CURRENT sort-key arity, so they are comparable with the new
+// tablets' ranges. Each SegmentMetadataPB is self-contained
+// (filename/size/shared/bundle_file_offset travel with it), so bundled rowsets prune uniformly with
+// any other.
+//
+// |sort_key_arity| == 0 means "cannot tell" (a schema carrying no sort key at all, e.g. synthetic
+// metadata) and skips (c) rather than rejecting every rowset.
+bool can_prune_rowset_segments(const RowsetMetadataPB& rowset, size_t sort_key_arity);
 
 // Computes per-segment ownership of a pruneable rowset against the new tablets'
 // ranges. Fail-closed: returns non-OK (caller degrades the whole rowset to

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -978,6 +978,113 @@ TEST_F(LakeTabletReshardTest, test_tablet_split_per_segment_shared_invariants) {
     EXPECT_EQ(1024, r0.data_size() + r1.data_size());
 }
 
+// (k1, NULL) -- an INT prefix bound lifted onto a (k1, k2) sort key, the shape the FE's
+// TrailingSortKeyRangeReprojection stamps onto every pre-existing tablet range when a metadata-only
+// trailing sort-key ADD widens the sort key.
+static TuplePB generate_sort_key_with_trailing_null(int value) {
+    VariantTuple tuple;
+    tuple.append(DatumVariant(get_type_info(LogicalType::TYPE_INT), Datum(value)));
+    tuple.append(DatumVariant(get_type_info(LogicalType::TYPE_INT), Datum()));
+    TuplePB tuple_pb;
+    tuple.to_proto(&tuple_pb);
+    return tuple_pb;
+}
+
+// Per-segment shared, after a metadata-only trailing sort-key ADD (end-to-end). The rowsets predate
+// the ADD, so their sort_key_min/sort_key_max are one column short while the tablet's range -- and
+// therefore every boundary the split emits -- is at the widened arity. Ownership must NOT prune with
+// those non-comparable bounds: VariantTuple::compare orders a shorter prefix-equal tuple BELOW its
+// padded form, so a segment whose stored max is [k] misses the sibling whose range starts at
+// (k, NULL) -- the very sibling create_seek_range_from routes that segment's k-prefix rows to. Every
+// segment must therefore survive on every child, as shared.
+TEST_F(LakeTabletReshardTest, test_tablet_split_keeps_pre_trailing_key_add_segments_on_every_child) {
+    starrocks::TabletMetadata metadata;
+    auto tablet_id = next_id();
+    metadata.set_id(tablet_id);
+    metadata.set_version(2);
+
+    // Post-ADD schema: the sort key is (k1, k2); k2 is the column the ADD appended.
+    auto* schema = metadata.mutable_schema();
+    schema->set_id(778501);
+    schema->set_keys_type(DUP_KEYS);
+    schema->set_num_short_key_columns(1);
+    auto* k1 = schema->add_column();
+    k1->set_unique_id(1);
+    k1->set_name("k1");
+    k1->set_type("INT");
+    k1->set_is_key(true);
+    k1->set_is_nullable(false);
+    auto* k2 = schema->add_column();
+    k2->set_unique_id(2);
+    k2->set_name("k2");
+    k2->set_type("INT");
+    k2->set_is_key(true);
+    k2->set_is_nullable(true);
+    schema->add_sort_key_idxes(0);
+    schema->add_sort_key_idxes(1);
+
+    auto* range = metadata.mutable_range();
+    *range->mutable_lower_bound() = generate_sort_key_with_trailing_null(0);
+    range->set_lower_bound_included(true);
+    *range->mutable_upper_bound() = generate_sort_key_with_trailing_null(1000);
+    range->set_upper_bound_included(false);
+
+    // Two disjoint pre-ADD rowsets. Their key spans do not overlap, so with pruning enabled each
+    // child would keep only its own rowset and drop the other's segment outright.
+    auto add_pre_add_rowset = [&](uint32_t id, int lo, int hi, const std::string& segment_name) {
+        auto* rs = metadata.add_rowsets();
+        rs->set_id(id);
+        rs->set_num_rows(500);
+        rs->set_data_size(5000);
+        auto* sm = rs->add_segment_metas();
+        sm->set_filename(segment_name);
+        sm->set_size(5000);
+        sm->set_num_rows(500);
+        // Arity 1: written before the trailing `ADD COLUMN k2`.
+        sm->mutable_sort_key_min()->CopyFrom(generate_sort_key(lo));
+        sm->mutable_sort_key_max()->CopyFrom(generate_sort_key(hi));
+    };
+    add_pre_add_rowset(2, 0, 400, "seg_lo.dat");
+    add_pre_add_rowset(3, 600, 999, "seg_hi.dat");
+
+    EXPECT_OK(put_tablet_metadata(metadata));
+
+    ReshardingTabletInfoPB resharding;
+    auto& splitting = *resharding.mutable_splitting_tablet_info();
+    splitting.set_old_tablet_id(tablet_id);
+    const int64_t child0 = next_id();
+    const int64_t child1 = next_id();
+    splitting.add_new_tablet_ids(child0);
+    splitting.add_new_tablet_ids(child1);
+
+    TxnInfoPB txn_info;
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding, metadata.version(),
+                                              metadata.version() + 1, txn_info, false, tablet_metadatas,
+                                              tablet_ranges));
+
+    ASSERT_EQ(1u, tablet_metadatas.count(child1)) << "the split fell back to an identical tablet";
+    for (int64_t child : {child0, child1}) {
+        auto c = tablet_metadatas.at(child);
+        ASSERT_EQ(2, c->rowsets_size()) << "tablet " << child << " lost a pre-ADD rowset: " << c->DebugString();
+        std::set<std::string> segs;
+        for (const auto& r : c->rowsets()) {
+            for (const auto& s : r.segment_metas()) {
+                segs.insert(s.filename());
+                EXPECT_TRUE(s.shared()) << s.filename() << " must stay shared: its ownership was never proven";
+            }
+        }
+        EXPECT_EQ((std::set<std::string>{"seg_lo.dat", "seg_hi.dat"}), segs);
+        // Every emitted bound speaks the widened sort key.
+        if (c->range().has_lower_bound()) EXPECT_EQ(2, c->range().lower_bound().values_size());
+        if (c->range().has_upper_bound()) EXPECT_EQ(2, c->range().upper_bound().values_size());
+    }
+}
+
 // SPLIT propagates per-segment ownership to non-segment metadata:
 //   - a pruned-away segment's delvec page + dcg entry are erased on the tablet
 //     that doesn't keep it;

--- a/be/test/storage/lake/tablet_splitter_test.cpp
+++ b/be/test/storage/lake/tablet_splitter_test.cpp
@@ -2168,7 +2168,10 @@ static TuplePB make_bigint_null_tuple_pb(int64_t k1) {
 // range is at arity 2, but every rowset was written before the ADD and carries arity-1
 // sort_key_min/sort_key_max. |parent_bounds_arity1| reproduces an ALREADY corrupted tablet whose own
 // range bounds were never reprojected.
-static TabletMetadataPtr make_trailing_key_added_metadata(
+// Returns a MUTABLE handle (not TabletMetadataPtr, which is shared_ptr<const TabletMetadataPB>):
+// the tests below tweak the schema / segment metas after building. It converts implicitly wherever a
+// TabletMetadataPtr is expected.
+static std::shared_ptr<TabletMetadataPB> make_trailing_key_added_metadata(
         const std::vector<std::tuple<uint32_t, int64_t, int64_t, int64_t, int64_t>>& rowsets,
         bool parent_bounds_arity1 = false) {
     auto m = std::make_shared<TabletMetadataPB>();

--- a/be/test/storage/lake/tablet_splitter_test.cpp
+++ b/be/test/storage/lake/tablet_splitter_test.cpp
@@ -2338,4 +2338,42 @@ TEST(TabletSplitterTest, SortKeyProjection_RejectsOutOfRangeSortKeyIdxWithoutAbo
     EXPECT_NE(std::string_view::npos, st.message().find("out of range")) << st;
 }
 
+// A schema carrying NO sort key at all (no sort_key_idxes and no key columns) yields arity 0. That is
+// "cannot tell", not "every bound must be empty": condemning such a split made 16 pre-existing
+// LakeTabletReshardTest cases fall back to an identical tablet, because their synthetic metadata has
+// no schema columns. A real range-distributed tablet always has at least one sort-key column.
+TEST(TabletSplitterTest, DataDrivenSplit_AllowsSchemaWithoutAnySortKey) {
+    auto m = make_trailing_key_added_metadata({
+            std::make_tuple<uint32_t, int64_t, int64_t, int64_t, int64_t>(1, 0, 400, 500, 5000),
+            std::make_tuple<uint32_t, int64_t, int64_t, int64_t, int64_t>(2, 600, 999, 500, 5000),
+    });
+    // Strip the schema down to no columns and no sort key, like the synthetic reshard fixtures.
+    m->mutable_schema()->clear_column();
+    m->mutable_schema()->clear_sort_key_idxes();
+    m->mutable_schema()->clear_sort_key_unique_ids();
+
+    std::vector<TabletRangeInfo> out;
+    ASSERT_OK(get_tablet_split_ranges(/*tablet_manager=*/nullptr, m, /*split_count=*/2, &out));
+    EXPECT_EQ(2u, out.size()) << "a schema without a sort key must not be treated as corrupt";
+}
+
+// sort_key_unique_ids takes precedence in TabletSchema::_init_from_pb, which resolves it through
+// _unique_id_to_index.at(uid) -- that THROWS on an id no column carries, before any Status could be
+// returned. So the raw ids must be checked first, exactly like sort_key_idxes.
+TEST(TabletSplitterTest, SortKeyProjection_RejectsUnknownSortKeyUniqueIdWithoutAborting) {
+    auto m = make_trailing_key_added_metadata({
+            std::make_tuple<uint32_t, int64_t, int64_t, int64_t, int64_t>(1, 0, 400, 500, 5000),
+    });
+    ASSERT_EQ(2, m->schema().column_size());
+    m->mutable_schema()->clear_sort_key_idxes();
+    m->mutable_schema()->add_sort_key_unique_ids(0);
+    m->mutable_schema()->add_sort_key_unique_ids(4242); // no column carries this unique id
+
+    std::vector<SegmentSplitInfo> segments;
+    auto st = build_segments_from_rowsets(/*tablet_manager=*/nullptr, m, &segments);
+    ASSERT_FALSE(st.ok());
+    EXPECT_TRUE(st.is_corruption()) << st;
+    EXPECT_NE(std::string_view::npos, st.message().find("4242")) << st;
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_splitter_test.cpp
+++ b/be/test/storage/lake/tablet_splitter_test.cpp
@@ -2314,4 +2314,25 @@ TEST(TabletSplitterTest, DataDrivenSplit_RejectsInheritedBoundWithWrongArity) {
     EXPECT_NE(std::string_view::npos, st.message().find("sort key has 2 columns")) << st;
 }
 
+// Corrupt metadata whose sort_key_idxes points past the column list must come back as a recoverable
+// Status, not an abort. The bounds check therefore has to run on the raw protobuf: TabletSchema's
+// _init_from_pb consumes sort_key_idxes first and indexes both schema.column(cid) and _cols[cid]
+// without checking, so validating after materialization would be too late.
+TEST(TabletSplitterTest, SortKeyProjection_RejectsOutOfRangeSortKeyIdxWithoutAborting) {
+    auto m = make_trailing_key_added_metadata({
+            std::make_tuple<uint32_t, int64_t, int64_t, int64_t, int64_t>(1, 0, 400, 500, 5000),
+    });
+    ASSERT_EQ(2, m->schema().column_size());
+    m->mutable_schema()->clear_sort_key_idxes();
+    m->mutable_schema()->add_sort_key_idxes(0);
+    m->mutable_schema()->add_sort_key_idxes(5); // out of range
+    ASSERT_TRUE(m->schema().sort_key_unique_ids().empty());
+
+    std::vector<SegmentSplitInfo> segments;
+    auto st = build_segments_from_rowsets(/*tablet_manager=*/nullptr, m, &segments);
+    ASSERT_FALSE(st.ok());
+    EXPECT_TRUE(st.is_corruption()) << st;
+    EXPECT_NE(std::string_view::npos, st.message().find("out of range")) << st;
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_splitter_test.cpp
+++ b/be/test/storage/lake/tablet_splitter_test.cpp
@@ -1240,33 +1240,55 @@ TEST(TabletSplitterTest, CanPruneRowsetSegments_predicates) {
         add_bigint_seg(&rs, 0, 1, "s0");
         return rs;
     };
-    EXPECT_TRUE(can_prune_rowset_segments(make_pruneable()));
+    EXPECT_TRUE(can_prune_rowset_segments(make_pruneable(), /*sort_key_arity=*/1));
 
     {
         auto rs = make_pruneable();
         rs.mutable_segment_metas(0)->set_bundle_file_offset(0); // bundled segment is pruneable
-        EXPECT_TRUE(can_prune_rowset_segments(rs));
+        EXPECT_TRUE(can_prune_rowset_segments(rs, /*sort_key_arity=*/1));
     } // (a) ok
     {
         auto rs = make_pruneable();
         rs.set_next_compaction_offset(1);
-        EXPECT_FALSE(can_prune_rowset_segments(rs));
+        EXPECT_FALSE(can_prune_rowset_segments(rs, /*sort_key_arity=*/1));
     } // (b)
     {
         auto rs = make_pruneable();
         rs.add_segment_metas(); // extra segment lacking sort-key bounds
-        EXPECT_FALSE(can_prune_rowset_segments(rs));
+        EXPECT_FALSE(can_prune_rowset_segments(rs, /*sort_key_arity=*/1));
     } // (c) missing bound on extra segment
     {
         auto rs = make_pruneable();
         rs.mutable_segment_metas(0)->clear_sort_key_max();
-        EXPECT_FALSE(can_prune_rowset_segments(rs));
+        EXPECT_FALSE(can_prune_rowset_segments(rs, /*sort_key_arity=*/1));
     } // (c) missing bound
     {
         auto rs = make_pruneable();
         rs.mutable_segment_metas(0)->set_shared(true);
-        EXPECT_TRUE(can_prune_rowset_segments(rs));
+        EXPECT_TRUE(can_prune_rowset_segments(rs, /*sort_key_arity=*/1));
     } // (d) ok
+    {
+        // (e) bounds narrower than the current sort key (a rowset written before a metadata-only
+        // trailing sort-key ADD): not comparable with the new tablets' ranges, so not pruneable.
+        // See ComputeOwnership_narrowSegmentBoundMissesTheSiblingThatOwnsItsBoundaryRows for what
+        // pruning on them would cost.
+        auto rs = make_pruneable();
+        EXPECT_FALSE(can_prune_rowset_segments(rs, /*sort_key_arity=*/2));
+        // arity 0 == "cannot tell" (a schema carrying no sort key at all) skips the check.
+        EXPECT_TRUE(can_prune_rowset_segments(rs, /*sort_key_arity=*/0));
+    }
+    {
+        // (e) is per rowset: one narrow segment disqualifies its whole rowset, since ownership is
+        // computed per rowset.
+        TuplePB wide_bound = make_bigint_tuple_pb(5);
+        *wide_bound.add_values() = make_bigint_tuple_pb(5).values(0);
+        auto rs = make_pruneable(); // s0's bounds are arity 1
+        auto* s1 = rs.add_segment_metas();
+        s1->set_filename("s1");
+        *s1->mutable_sort_key_min() = wide_bound;
+        *s1->mutable_sort_key_max() = wide_bound;
+        EXPECT_FALSE(can_prune_rowset_segments(rs, /*sort_key_arity=*/2));
+    }
 }
 
 TEST(TabletSplitterTest, ComputeOwnership_exclusive_segment_becomes_private) {
@@ -2314,7 +2336,44 @@ TEST(TabletSplitterTest, DataDrivenSplit_RejectsInheritedBoundWithWrongArity) {
     auto st = get_tablet_split_ranges(/*tablet_manager=*/nullptr, m, /*split_count=*/2, &out);
     ASSERT_FALSE(st.ok());
     EXPECT_TRUE(st.is_corruption()) << st;
-    EXPECT_NE(std::string_view::npos, st.message().find("sort key has 2 columns")) << st;
+    EXPECT_NE(std::string_view::npos, st.message().find("!= effective sort-key arity 2")) << st;
+}
+
+// Per-segment ownership pruning compares a segment's STORED sort-key bounds against the new tablets'
+// ranges, which the projection above emits at the current arity. A pre-ADD segment's narrower bounds
+// are not comparable with them: VariantTuple::compare orders a shorter prefix-equal tuple BELOW its
+// padded form, so a segment whose max is [400] misses the sibling starting at (400, NULL) -- while
+// create_seek_range_from routes that segment's k1=400 rows to exactly that sibling (the added
+// column's read-time default is NULL here, so the projected lower bound stays inclusive). The rows
+// would be reachable from neither new tablet.
+TEST(TabletSplitterTest, ComputeOwnership_narrowSegmentBoundMissesTheSiblingThatOwnsItsBoundaryRows) {
+    // Ranges at the post-ADD arity 2: [(0,NULL), (400,NULL)) and [(400,NULL), +inf).
+    TabletRangePB lower_range;
+    *lower_range.mutable_lower_bound() = make_bigint_null_tuple_pb(0);
+    lower_range.set_lower_bound_included(true);
+    *lower_range.mutable_upper_bound() = make_bigint_null_tuple_pb(400);
+    lower_range.set_upper_bound_included(false);
+    TabletRangePB upper_range;
+    *upper_range.mutable_lower_bound() = make_bigint_null_tuple_pb(400);
+    upper_range.set_lower_bound_included(true);
+    std::vector<TabletRangePB> ranges{lower_range, upper_range};
+
+    RowsetMetadataPB rs;
+    add_bigint_seg(&rs, 0, 400, "s0"); // pre-ADD: arity-1 bounds, max == the boundary's prefix
+
+    auto own = compute_rowset_segment_ownership(rs, ranges);
+    ASSERT_TRUE(own.ok());
+    EXPECT_TRUE(own->segments[0].keep[0]);
+    EXPECT_FALSE(own->segments[0].keep[1]) << "the boundary rows' segment is dropped from their own "
+                                              "new tablet -- which is why can_prune_rowset_segments "
+                                              "refuses to prune such a rowset at all";
+
+    // The gate (predicate (e), pinned by CanPruneRowsetSegments_predicates) is what keeps those rows
+    // reachable: the rowset stays unpruned and every segment survives on every new tablet as shared.
+    // Padding the stored bounds instead would not do -- an old segment's rows read as
+    // (prefix, default), so padding its MAX with the NULL minimum understates the segment's reach
+    // whenever a post-ADD rowset contributed a boundary between (prefix, NULL) and (prefix, default).
+    EXPECT_FALSE(can_prune_rowset_segments(rs, /*sort_key_arity=*/2));
 }
 
 // Corrupt metadata whose sort_key_idxes points past the column list must come back as a recoverable

--- a/be/test/storage/lake/tablet_splitter_test.cpp
+++ b/be/test/storage/lake/tablet_splitter_test.cpp
@@ -2132,4 +2132,186 @@ TEST(TabletSplitterTest, BuildSegmentsFromRowsets_NullTabletManagerSkipsLoader) 
     EXPECT_EQ(0, segments[0].sort_key_sample_row_interval);
 }
 
+// =============================================================================
+// Segment-derived boundaries are projected onto the CURRENT sort key
+// =============================================================================
+//
+// A metadata-only trailing sort-key key-column ADD (FE
+// SchemaChangeHandler#tryCreateMetadataOnlyTrailingKeyAddJob -- e.g. `ALTER TABLE agg_range ADD
+// COLUMN k2 INT`, which an AGG table promotes to a key column) widens the tablet's sort key and
+// reprojects every EXISTING tablet range bound with a trailing NULL sentinel, but deliberately does
+// not rewrite the data: the rowsets keep their historical, narrower schema, so their
+// sort_key_min/sort_key_max stay one column short.
+//
+// Emitting such a tuple as a new tablet's range bound is unrecoverable: RangeRouter::_validate_range
+// rejects every subsequent load ("upper_bound value size is not equal to column size") and
+// TabletRangeHelper::create_seek_range_from rejects every read of a rowset written at the new arity
+// ("Unexpected number of values in TabletRangePB bound value, expected at least: 2, actual: 1").
+
+static VariantPB make_null_int_variant_pb() {
+    DatumVariant dv(get_type_info(LogicalType::TYPE_INT), Datum());
+    VariantPB pb;
+    dv.to_proto(&pb);
+    return pb;
+}
+
+// [k1, NULL] -- a bigint prefix bound lifted onto the (k1, k2) sort key. This is the shape the FE's
+// TrailingSortKeyRangeReprojection stamps onto every pre-existing tablet range.
+static TuplePB make_bigint_null_tuple_pb(int64_t k1) {
+    TuplePB t;
+    *t.add_values() = make_bigint_variant_pb(k1);
+    *t.add_values() = make_null_int_variant_pb();
+    return t;
+}
+
+// A tablet in the post-trailing-key-add state: current sort key is (k1 BIGINT, k2 INT), the parent
+// range is at arity 2, but every rowset was written before the ADD and carries arity-1
+// sort_key_min/sort_key_max. |parent_bounds_arity1| reproduces an ALREADY corrupted tablet whose own
+// range bounds were never reprojected.
+static TabletMetadataPtr make_trailing_key_added_metadata(
+        const std::vector<std::tuple<uint32_t, int64_t, int64_t, int64_t, int64_t>>& rowsets,
+        bool parent_bounds_arity1 = false) {
+    auto m = std::make_shared<TabletMetadataPB>();
+    m->set_id(1);
+    m->set_version(1);
+    auto* schema = m->mutable_schema();
+    schema->set_keys_type(AGG_KEYS);
+    schema->set_id(100);
+    auto* k1 = schema->add_column();
+    k1->set_unique_id(0);
+    k1->set_name("k1");
+    k1->set_type("BIGINT");
+    k1->set_is_key(true);
+    k1->set_is_nullable(false);
+    auto* k2 = schema->add_column();
+    k2->set_unique_id(1);
+    k2->set_name("k2");
+    k2->set_type("INT");
+    k2->set_is_key(true);
+    k2->set_is_nullable(true);
+    schema->add_sort_key_idxes(0);
+    schema->add_sort_key_idxes(1);
+
+    auto* range = m->mutable_range();
+    if (parent_bounds_arity1) {
+        *range->mutable_lower_bound() = make_bigint_tuple_pb(0);
+    } else {
+        *range->mutable_lower_bound() = make_bigint_null_tuple_pb(0);
+    }
+    range->set_lower_bound_included(true);
+    *range->mutable_upper_bound() = make_bigint_null_tuple_pb(1000);
+    range->set_upper_bound_included(false);
+
+    for (const auto& [id, lo, hi, num_rows, data_size] : rowsets) {
+        auto* r = m->add_rowsets();
+        r->set_id(id);
+        r->set_num_rows(num_rows);
+        r->set_data_size(data_size);
+        r->set_num_dels(0); // explicit to skip the PK delvec fallback in build_rowset_anchor.
+        auto* sm = r->add_segment_metas();
+        sm->set_filename("seg" + std::to_string(id));
+        sm->set_size(data_size);
+        sm->set_num_rows(num_rows);
+        // Arity 1: written before `ADD COLUMN k2`.
+        *sm->mutable_sort_key_min() = make_bigint_tuple_pb(lo);
+        *sm->mutable_sort_key_max() = make_bigint_tuple_pb(hi);
+    }
+    return m;
+}
+
+// build_segments_from_rowsets lifts every tuple a pre-ADD segment contributes (min_key, max_key and
+// each metadata sample) onto the current sort key, padding with the NULL (== MIN) sentinel.
+TEST(TabletSplitterTest, BuildSegmentsFromRowsets_ProjectsNarrowSegmentKeysOntoCurrentSortKey) {
+    auto m = make_trailing_key_added_metadata({
+            std::make_tuple<uint32_t, int64_t, int64_t, int64_t, int64_t>(1, 0, 499, 500, 5000),
+    });
+    // Metadata samples are one column short too, exactly like min/max.
+    auto* sm = m->mutable_rowsets(0)->mutable_segment_metas(0);
+    sm->set_deprecated_sort_key_sample_row_interval(100);
+    for (int64_t v : {100, 200, 300, 400}) {
+        *sm->add_deprecated_sort_key_samples() = make_bigint_tuple_pb(v);
+    }
+
+    std::vector<SegmentSplitInfo> segments;
+    ASSERT_OK(build_segments_from_rowsets(/*tablet_manager=*/nullptr, m, &segments));
+    ASSERT_EQ(1u, segments.size());
+    EXPECT_EQ(2u, segments[0].min_key.size());
+    EXPECT_EQ(2u, segments[0].max_key.size());
+    EXPECT_TRUE(segments[0].min_key[1].value().is_null());
+    EXPECT_TRUE(segments[0].max_key[1].value().is_null());
+    EXPECT_EQ(0, segments[0].min_key[0].value().get_int64());
+    EXPECT_EQ(499, segments[0].max_key[0].value().get_int64());
+    ASSERT_EQ(4u, segments[0].sort_key_samples.size());
+    for (const auto& sample : segments[0].sort_key_samples) {
+        EXPECT_EQ(2u, sample.size());
+        EXPECT_TRUE(sample[1].value().is_null());
+    }
+}
+
+// An absent sort_key_min/sort_key_max means "unknown" to every downstream consumer (the
+// !min_key.empty() guards, TabletRange::is_minimum). It must stay empty rather than becoming the
+// concrete minimum tuple (NULL, NULL).
+TEST(TabletSplitterTest, BuildSegmentsFromRowsets_LeavesUnsetSegmentKeysEmpty) {
+    auto m = make_trailing_key_added_metadata({
+            std::make_tuple<uint32_t, int64_t, int64_t, int64_t, int64_t>(1, 0, 499, 500, 5000),
+    });
+    auto* sm = m->mutable_rowsets(0)->mutable_segment_metas(0);
+    sm->clear_sort_key_min();
+    sm->clear_sort_key_max();
+
+    std::vector<SegmentSplitInfo> segments;
+    ASSERT_OK(build_segments_from_rowsets(/*tablet_manager=*/nullptr, m, &segments));
+    ASSERT_EQ(1u, segments.size());
+    EXPECT_TRUE(segments[0].min_key.empty());
+    EXPECT_TRUE(segments[0].max_key.empty());
+}
+
+// The regression itself: splitting a tablet whose rowsets predate the trailing key add must emit
+// bounds at the tablet's sort-key arity. Before the projection, the interior boundaries came straight
+// out of the arity-1 segment tuples and bricked every new tablet.
+TEST(TabletSplitterTest, DataDrivenSplit_EmitsBoundsAtCurrentSortKeyArity) {
+    // Two disjoint rowsets with a gap, the shape the parity test proves yields a K=2 boundary.
+    auto m = make_trailing_key_added_metadata({
+            std::make_tuple<uint32_t, int64_t, int64_t, int64_t, int64_t>(1, 0, 400, 500, 5000),
+            std::make_tuple<uint32_t, int64_t, int64_t, int64_t, int64_t>(2, 600, 999, 500, 5000),
+    });
+
+    std::vector<TabletRangeInfo> out;
+    ASSERT_OK(get_tablet_split_ranges(/*tablet_manager=*/nullptr, m, /*split_count=*/2, &out));
+    ASSERT_EQ(2u, out.size());
+    for (const auto& tri : out) {
+        if (tri.range.has_lower_bound()) {
+            EXPECT_EQ(2, tri.range.lower_bound().values_size()) << tri.range.DebugString();
+        }
+        if (tri.range.has_upper_bound()) {
+            EXPECT_EQ(2, tri.range.upper_bound().values_size()) << tri.range.DebugString();
+        }
+    }
+    // The interior boundary is shared: split[0].upper == split[1].lower, and it is the projected
+    // (k1, MIN) form rather than the bare (k1) the segments carried.
+    ASSERT_TRUE(out[0].range.has_upper_bound());
+    ASSERT_TRUE(out[1].range.has_lower_bound());
+    EXPECT_TRUE(MessageDifferencer::Equals(out[0].range.upper_bound(), out[1].range.lower_bound()));
+    EXPECT_EQ(VariantTypePB::NULL_VALUE, out[0].range.upper_bound().values(1).variant_type());
+}
+
+// Last line of defense: a tablet whose OWN range bound is already narrower than its sort key (the
+// end state of the bug, on a cluster that hit it before this fix) must fail the split instead of
+// propagating the corrupt bound into K new tablets. split_tablet turns this Status into the
+// identical-tablet fallback, so the table stays queryable.
+TEST(TabletSplitterTest, DataDrivenSplit_RejectsInheritedBoundWithWrongArity) {
+    auto m = make_trailing_key_added_metadata(
+            {
+                    std::make_tuple<uint32_t, int64_t, int64_t, int64_t, int64_t>(1, 0, 400, 500, 5000),
+                    std::make_tuple<uint32_t, int64_t, int64_t, int64_t, int64_t>(2, 600, 999, 500, 5000),
+            },
+            /*parent_bounds_arity1=*/true);
+
+    std::vector<TabletRangeInfo> out;
+    auto st = get_tablet_split_ranges(/*tablet_manager=*/nullptr, m, /*split_count=*/2, &out);
+    ASSERT_FALSE(st.ok());
+    EXPECT_TRUE(st.is_corruption()) << st;
+    EXPECT_NE(std::string_view::npos, st.message().find("sort key has 2 columns")) << st;
+}
+
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

A range-distribution table becomes **permanently unreadable and unwritable** after a trailing
sort-key key-column `ADD COLUMN` followed by any `SPLIT TABLET`:

```
INSERT -> ERROR 5609: upper_bound value size is not equal to column size
SELECT -> ERROR 1064: Unexpected number of values in TabletRangePB bound value,
                      expected at least: 2, actual: 1
```

`ALTER TABLE ... ADD COLUMN c INT` on an `AGGREGATE KEY` table is promoted to a **key** column
(`SchemaChangeHandler#addColumnInternal`), which routes to the metadata-only trailing-key-add job
(`tryCreateMetadataOnlyTrailingKeyAddJob`). That job widens the sort key and reprojects every
existing tablet range bound with a trailing NULL sentinel (`[25601]` -> `[25601, NULL]`), but
deliberately does **not** rewrite the data: the rowsets keep their historical, narrower schema.

The data-driven `SPLIT TABLET` path derives its boundaries from those segments —
`sort_key_min`/`sort_key_max` in the segment metadata, and short-key-index samples decoded with the
rowset's own (historical) schema in `build_segments_from_rowsets` — so every boundary it computes is
one column short. `get_tablet_split_ranges_impl` then wrote them into the new tablets' ranges
verbatim, with no projection onto the tablet's current sort key. The result is a mixed-arity range
set, e.g. from a live repro (parent range `[[76801, NULL], [102401, NULL])`):

```
80538  [[76801, NULL], [83969])      <- inherited outer bound arity 2, new split point arity 1
80539  [[83969], [91137])
80540  [[91137], [98305])
80541  [[98305], [102401, NULL])
```

From then on `RangeRouter::_validate_range` rejects every load, and
`TabletRangeHelper::create_seek_range_from` rejects every read of a rowset written at the new arity
(it projects a bound that is *wider* than the segment, but treats a *narrower* bound as corruption).

Reproduced **fully serialized, no concurrency**, on `main-69b8ab5` (shared-data):

```sql
SET enable_range_distribution = true;
CREATE TABLE t_agg (k BIGINT NOT NULL, v BIGINT SUM, cnt BIGINT SUM, pad VARCHAR(256) REPLACE)
  AGGREGATE KEY(k) PROPERTIES('replication_num'='1');
INSERT INTO t_agg SELECT g,g,1,repeat('x',200) FROM TABLE(generate_series(1,200000)) t(g);
ALTER TABLE t_agg SPLIT TABLET (<tablet>) PROPERTIES('tablet_reshard_target_size'='-8');  -- wait
ALTER TABLE t_agg ADD COLUMN c1 INT DEFAULT '0';                                          -- wait
INSERT INTO t_agg ... ;                        -- lands rowsets at the new arity
ALTER TABLE t_agg MERGE TABLET (<all>);                                                   -- wait
ALTER TABLE t_agg SPLIT TABLET (<merged>) PROPERTIES('tablet_reshard_target_size'='-8');  -- wait
SELECT COUNT(*) FROM t_agg;   -- TabletRangePB expected at least: 2, actual: 1
```

Not AGG-specific: `ALTER TABLE dup_range ADD COLUMN c1 INT KEY` on a `DUPLICATE KEY` range table
takes the same route and bricks identically. AGG is simply the only key type where the *implicit*
form (no aggregate function) is auto-promoted to a key column, which is why a chaos soak that never
writes the `KEY` keyword only tripped it on AGG tables.

## What I'm doing:

1. **`build_segments_from_rowsets` projects every segment-derived tuple onto the tablet's current
   sort key** (`min_key`, `max_key`, and each sort-key sample), padding with the NULL (== MIN)
   sentinel — the same projection the FE applies in `TrailingSortKeyRangeReprojection.appendTrailing`.
   NULL sorts as the minimum (`TypeInfo::cmp`), so `(prefix)` and `(prefix, MIN, ...)` denote the
   same point under half-open range semantics, which makes this projection value-preserving.

   Projecting the *input* rather than only the emitted bounds also keeps the comparisons inside
   `calculate_range_split_boundaries` arity-consistent: `VariantTuple::compare` orders a shorter
   prefix-equal tuple *below* its padded form, so an unprojected segment bound would spuriously sort
   below the parent tablet's own (already reprojected) lower bound. It also makes
   `build_canonical_boundary` (colocate path) emit full-arity canonical tuples, since it pads to the
   source tuple's size.

   Two carve-outs: an **empty** tuple stays empty (empty means "unknown"/unbounded to every consumer),
   and a tuple already at or beyond the arity is left alone (a bound wider than the segment is the
   pre-existing case `create_seek_range_from` projects down; truncating would change semantics). The
   projection runs *after* the sample loaders so their sample-vs-`[min_key, max_key]` validation still
   compares tuples of a single arity.

2. **Do not prune per-segment ownership with bounds narrower than the current sort key.**
   `build_new_tablets_from_split_ranges` decides, per source rowset, which new tablet keeps which
   segment, by intersecting the segment's stored `sort_key_min`/`sort_key_max` with the new tablets'
   ranges. Those ranges are now at the widened arity while a pre-ADD segment's bounds are not, and
   `VariantTuple::compare` orders a shorter prefix-equal tuple *below* its padded form: a segment
   whose stored max is `[400]` intersects `[(400, NULL), ...)` to the empty range and is pruned off
   that sibling -- the very sibling `create_seek_range_from` routes its `k1 = 400` rows to (it
   compares the added column's read-time default against the bound's trailing values). The rows would
   be reachable from neither new tablet.

   Padding the ownership bounds the same way is *not* a fix: an old segment's rows read as
   `(prefix, D)` for the read-time default D, so padding its MAX with the NULL minimum understates
   the segment's reach whenever a post-ADD rowset contributed a boundary between `(prefix, NULL)` and
   `(prefix, D)`. So `can_prune_rowset_segments` takes the tablet's current sort-key arity and gains
   predicate (c): every segment's stored bounds must be at that arity. A rowset that fails it falls
   into the pre-existing `set_all_data_files_shared` path -- every segment kept on every new tablet,
   shared. The writer always stores the full sort key (`_sort_column_indexes` covers the whole
   `sort_key_idxes()`), so this only ever fires on rowsets that predate a trailing key add; arity 0
   ("no sort key at all", e.g. synthetic reshard metadata) means "cannot tell" and skips the check.

3. **Validate the emitted bounds before they leave `get_tablet_split_ranges_impl`**, by reusing
   `TabletRangeHelper::validate_range_structural` -- the module's own build-and-apply validator, the
   one `schema_change.cpp` and `txn_log_applier.cpp` already run on an FE-supplied range. Besides the
   arity test it checks each value's type against its sort-key column, the size caps, and
   `lower < upper`; all of those are equally unrecoverable once persisted. `split_tablet` already
   routes a non-OK status to the identical-tablet fallback
   (`g_tablet_reshard_split_fallback_total`), so a tablet that was *already* corrupted by this bug
   now fails its split and stays as-is, instead of propagating the bad bound into K new tablets. This
   deliberately lives on the BE, before publish -- an FE-side check at `SplitTabletJob#runRunningJob`
   is past the non-cancellable point and could only convert the corruption into a job wedged in
   `RUNNING`. A schema with no sort key at all is allowed through (`validate_range_structural`
   hard-fails on arity 0, which would condemn the synthetic reshard fixtures).

   The sort key is now resolved **once** per split: `get_tablet_split_ranges_impl` materializes the
   `TabletSchema` and threads it into both `build_segments_from_rowsets` and the validation, instead
   of each of them materializing its own.

No new config, no metadata format change, no FE change. The external-boundaries (pre-split) path is
untouched: FE computes those boundaries and `BoundaryPlanner` already validates their arity against
the sort key.

Fixes StarRocks/StarRocksTest#11728

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: (a) a `SPLIT TABLET` on a tablet whose own range bound is already narrower than
      its sort key (only reachable on a cluster that already hit this bug) now fails and falls back to
      the identical tablet instead of splitting; (b) splitting a tablet whose rowsets predate a
      trailing sort-key `ADD COLUMN` no longer prunes those rowsets' segments per new tablet -- they
      stay shared across all of them, as they were before the per-segment optimization.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

Range distribution / tablet reshard is main-only, so no backport is needed.

## Tests

New cases in `be/test/storage/lake/tablet_splitter_test.cpp`:

- `BuildSegmentsFromRowsets_ProjectsNarrowSegmentKeysOntoCurrentSortKey` — arity-1 segment
  `sort_key_min`/`max` and metadata samples are lifted to arity 2 with a NULL trailing value.
- `BuildSegmentsFromRowsets_LeavesUnsetSegmentKeysEmpty` — an absent `sort_key_min`/`max` stays empty
  rather than becoming the concrete minimum tuple.
- `DataDrivenSplit_EmitsBoundsAtCurrentSortKeyArity` — the regression: every emitted bound is arity 2,
  and the shared interior boundary is the projected `(k1, MIN)` form.
- `DataDrivenSplit_RejectsInheritedBoundWithWrongArity` — a tablet whose own range bound is already
  arity 1 fails the split with a `Corruption` status instead of propagating it.
- `ComputeOwnership_narrowSegmentBoundMissesTheSiblingThatOwnsItsBoundaryRows` — pins the ownership
  hazard itself (`keep[upper sibling] == false` for an arity-1 segment whose max is the boundary
  prefix), then asserts the new predicate refuses to prune such a rowset.
- `CanPruneRowsetSegments_predicates` — predicate (c)/(e) cases: bounds narrower than the sort key,
  the arity-0 "cannot tell" allowance, and one narrow segment disqualifying its whole rowset.

New case in `be/test/storage/lake/tablet_reshard_test.cpp`:

- `test_tablet_split_keeps_pre_trailing_key_add_segments_on_every_child` — end-to-end through
  `publish_resharding_tablet`: both children keep both pre-ADD rowsets, every segment shared, and
  every emitted bound is at the widened arity. Fails without the ownership gate for any boundary the
  greedy algorithm picks, since the two source rowsets are disjoint.
