### PR TITLE
[Tool] Break down put_bundle_tablet_metadata into phase timings

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -360,6 +360,14 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
     }
     bool skip_write_tablet_metadata = request->has_enable_aggregate_publish() && request->enable_aggregate_publish();
 
+    if (skip_write_tablet_metadata) {
+        // Arrival marker for aggregate sub-requests, so a peer that receives one and never answers
+        // can be told apart from an aggregator that never sent it.
+        LOG(INFO) << "aggregate sub publish_version begin txns=" << get_txn_ids_string(request)
+                  << " new_version=" << request->new_version() << " tablets=" << request->tablet_ids_size()
+                  << " tasks=" << task_num << " timeout_ms=" << timeout_ms;
+    }
+
     for (const auto& tablet_info : publish_tablet_infos) {
         auto task = std::make_shared<CancellableRunnable>(
                 [&, tablet_info] {
@@ -721,7 +729,54 @@ struct AggregatePublishContext {
     using PublishRequestCtx = RequestContext<PublishVersionResponse>;
     std::vector<PublishRequestCtx> publish_request_ctx;
 
+    // Per sub-request bookkeeping, so a handler that never leaves wait() can still be told apart
+    // from one whose peers all answered: the entry log names every target, and this says which of
+    // them came back and when.
+    struct SubRequestTrace {
+        const brpc::Controller* cntl{nullptr};
+        std::string target;
+        int64_t tablet_count{0};
+        int64_t dispatch_us{0};
+        int64_t done_us{0};
+        std::string result;
+    };
+    std::vector<SubRequestTrace> sub_traces;
+
     AggregatePublishContext() : begin_us(butil::gettimeofday_us()) {}
+
+    void record_dispatch(const brpc::Controller* cntl, std::string target, int64_t tablet_count) {
+        std::lock_guard l(mutex);
+        sub_traces.push_back({cntl, std::move(target), tablet_count, butil::gettimeofday_us(), 0, "pending"});
+    }
+
+    void record_done(const brpc::Controller* cntl, std::string result) {
+        std::lock_guard l(mutex);
+        for (auto& t : sub_traces) {
+            if (t.cntl == cntl) {
+                t.done_us = butil::gettimeofday_us();
+                t.result = std::move(result);
+                return;
+            }
+        }
+    }
+
+    std::string sub_traces_string() {
+        std::lock_guard l(mutex);
+        std::string s;
+        for (const auto& t : sub_traces) {
+            const int64_t elapsed = t.done_us > 0 ? t.done_us - t.dispatch_us : -1;
+            s.append(s.empty() ? "" : " ")
+                    .append(t.target)
+                    .append("(tablets=")
+                    .append(std::to_string(t.tablet_count))
+                    .append(",us=")
+                    .append(std::to_string(elapsed))
+                    .append(",")
+                    .append(t.result)
+                    .append(")");
+        }
+        return s;
+    }
 
     void handle_failure(const std::string& error) {
         std::lock_guard l(mutex);
@@ -822,6 +877,13 @@ static void aggregate_publish_cb(brpc::Controller* cntl, PublishVersionResponse*
     // the resource will be release after all publish_request finished.
     DeferOp defer([&]() { ctx->count_down(); });
     if (cntl->Failed()) {
+        ctx->record_done(cntl, fmt::format("rpc_failed:{}", cntl->ErrorText()));
+    } else if (resp->status().status_code() != 0) {
+        ctx->record_done(cntl, fmt::format("status:{}", resp->status().status_code()));
+    } else {
+        ctx->record_done(cntl, "ok");
+    }
+    if (cntl->Failed()) {
         ctx->handle_failure("link rpc channel failed");
     } else if (resp->status().status_code() != 0) {
         std::string msg;
@@ -843,6 +905,28 @@ void LakeServiceImpl::aggregate_publish_version(::google::protobuf::RpcControlle
     // Collected up front, over every sub-request: the loop below stops dispatching once one of
     // them fails, and the expected set must describe the whole publish either way.
     collect_expected_metadata_tablet_ids(*request, &ctx.expected_tablet_ids);
+
+    // Logged before the fan-out so that a handler which never returns still leaves a record of
+    // having arrived and of who it was about to ask. Without it a stuck aggregate is invisible.
+    const int64_t trace_entry_us = butil::gettimeofday_us();
+    {
+        std::string targets;
+        for (int i = 0; i < request->publish_reqs_size(); ++i) {
+            const auto& node = request->compute_nodes(i);
+            targets.append(targets.empty() ? "" : ",")
+                    .append(node.host())
+                    .append(":")
+                    .append(std::to_string(node.brpc_port()))
+                    .append("/")
+                    .append(std::to_string(request->publish_reqs(i).tablet_ids_size()));
+        }
+        LOG(INFO) << "aggregate_publish_version begin"
+                  << " txns=" << (request->publish_reqs_size() > 0 ? get_txn_ids_string(&request->publish_reqs(0)) : "")
+                  << " new_version=" << (request->publish_reqs_size() > 0 ? request->publish_reqs(0).new_version() : -1)
+                  << " sub_reqs=" << request->publish_reqs_size()
+                  << " expected_tablets=" << ctx.expected_tablet_ids.size()
+                  << " targets(host:port/tablets)=" << targets;
+    }
 
     for (int i = 0; i < request->publish_reqs_size(); ++i) {
         if (ctx.has_failure) {
@@ -870,14 +954,28 @@ void LakeServiceImpl::aggregate_publish_version(::google::protobuf::RpcControlle
 
         auto* cntl_ptr = ctx.publish_request_ctx.back().cntl.get();
         auto* resp_ptr = ctx.publish_request_ctx.back().resp.get();
+        ctx.record_dispatch(cntl_ptr, fmt::format("{}:{}", compute_node.host(), compute_node.brpc_port()),
+                            single_req.tablet_ids_size());
         (*res)->publish_version(cntl_ptr, &single_req, resp_ptr,
                                 brpc::NewCallback(aggregate_publish_cb, cntl_ptr, resp_ptr, &ctx));
     }
 
+    const int64_t trace_dispatched_us = butil::gettimeofday_us();
     // wait for publish task finish
     ctx.wait();
+    const int64_t trace_waited_us = butil::gettimeofday_us();
     // write aggregate metadata
     ctx.put_aggregate_metadata(_env);
+    const int64_t trace_end_us = butil::gettimeofday_us();
+
+    LOG(INFO) << "aggregate_publish_version end"
+              << " txns=" << (request->publish_reqs_size() > 0 ? get_txn_ids_string(&request->publish_reqs(0)) : "")
+              << " new_version=" << (request->publish_reqs_size() > 0 ? request->publish_reqs(0).new_version() : -1)
+              << " total_us=" << (trace_end_us - trace_entry_us)
+              << " dispatch_us=" << (trace_dispatched_us - trace_entry_us)
+              << " wait_us=" << (trace_waited_us - trace_dispatched_us)
+              << " put_meta_us=" << (trace_end_us - trace_waited_us) << " status=" << ctx.publish_status << " subs=["
+              << ctx.sub_traces_string() << "]";
 
     ctx.publish_status.to_protobuf(response->mutable_status());
 }

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -614,6 +614,8 @@ Status TabletManager::put_bundle_tablet_metadata(std::map<int64_t, TabletMetadat
         return Status::InternalError("tablet_metas cannot be empty");
     }
 
+    const int64_t trace_begin_us = butil::gettimeofday_us();
+
     RETURN_IF_ERROR(check_bundle_tablet_metadata_coverage(tablet_metas, expected_tablet_ids));
 
     std::vector<int64_t> candidate_tablet_ids;
@@ -621,12 +623,15 @@ Status TabletManager::put_bundle_tablet_metadata(std::map<int64_t, TabletMetadat
     for (const auto& [tid, _meta] : tablet_metas) {
         candidate_tablet_ids.push_back(tid);
     }
+    const int64_t trace_after_cover_us = butil::gettimeofday_us();
     const int64_t anchor_tablet_id = pick_local_anchor_tablet_id(candidate_tablet_ids);
     const int64_t anchor_version = tablet_metas.at(anchor_tablet_id).version();
+    const int64_t trace_after_anchor_us = butil::gettimeofday_us();
 
     BundleTabletMetadataPB bundle_meta;
     ASSIGN_OR_RETURN(auto partition_location,
                      _location_provider->real_location(tablet_metadata_root_location(anchor_tablet_id)));
+    const int64_t trace_after_real_location_us = butil::gettimeofday_us();
     std::unordered_map<int64_t, TabletSchemaPB> unique_schemas;
     for (auto& [tablet_id, meta] : tablet_metas) {
         (*bundle_meta.mutable_tablet_to_schema())[tablet_id] = meta.schema().id();
@@ -646,18 +651,23 @@ Status TabletManager::put_bundle_tablet_metadata(std::map<int64_t, TabletMetadat
         pointer.set_size(size);
         return pointer;
     };
+    const int64_t trace_after_schema_us = butil::gettimeofday_us();
 
     const std::string meta_location = bundle_tablet_metadata_location(anchor_tablet_id, anchor_version);
 
     ASSIGN_OR_RETURN(auto fs, FileSystemFactory::CreateSharedFromString(meta_location));
     WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
     ASSIGN_OR_RETURN(auto meta_file, fs->new_writable_file(opts, meta_location));
+    const int64_t trace_after_open_us = butil::gettimeofday_us();
+    int64_t trace_serialize_us = 0;
+    int64_t trace_append_us = 0;
     std::string serialized_buf;
     int64_t current_offset = 0;
     // Snapshot the mutable config once so a single bundle file is internally consistent: every
     // tablet page and the footer use the same decision, even if the flag is flipped concurrently.
     const bool enable_checksum = config::lake_enable_protobuf_file_checksum;
     for (auto& [tablet_id, meta] : tablet_metas) {
+        const int64_t trace_tablet_begin_us = butil::gettimeofday_us();
         // Normalize RPC-received metadata on entry exactly like S3-loaded metadata: after-load
         // (extend + back-fill segment_metas from the legacy arrays) BEFORE before-save rebuilds those
         // arrays. During a mixed-version upgrade an old worker can send legacy-shaped metadata whose
@@ -681,15 +691,24 @@ Status TabletManager::put_bundle_tablet_metadata(std::map<int64_t, TabletMetadat
             (*bundle_meta.mutable_tablet_meta_page_checksum())[tablet_id] =
                     olap_adler32(ADLER32_INIT, serialized_buf.data(), serialized_buf.size());
         }
+        const int64_t trace_append_begin_us = butil::gettimeofday_us();
+        trace_serialize_us += trace_append_begin_us - trace_tablet_begin_us;
         RETURN_IF_ERROR(meta_file->append(Slice(serialized_buf)));
+        trace_append_us += butil::gettimeofday_us() - trace_append_begin_us;
         current_offset += serialized_buf.size();
     }
+    const int64_t trace_page_bytes = current_offset;
 
     serialized_buf.clear();
     if (!bundle_meta.SerializeToString(&serialized_buf)) {
         return Status::IOError("Failed to write shared metadata header");
     }
-    RETURN_IF_ERROR(meta_file->append(Slice(serialized_buf)));
+    const int64_t trace_header_bytes = static_cast<int64_t>(serialized_buf.size());
+    {
+        const int64_t trace_append_begin_us = butil::gettimeofday_us();
+        RETURN_IF_ERROR(meta_file->append(Slice(serialized_buf)));
+        trace_append_us += butil::gettimeofday_us() - trace_append_begin_us;
+    }
     std::string fixed_buf;
     uint64_t size_field_value = serialized_buf.size();
     if (enable_checksum) {
@@ -701,9 +720,27 @@ Status TabletManager::put_bundle_tablet_metadata(std::map<int64_t, TabletMetadat
         size_field_value |= LAKE_BUNDLE_META_CHECKSUM_FLAG;
     }
     put_fixed64_le(&fixed_buf, size_field_value);
+    const int64_t trace_before_footer_us = butil::gettimeofday_us();
     RETURN_IF_ERROR(meta_file->append(Slice(fixed_buf)));
+    trace_append_us += butil::gettimeofday_us() - trace_before_footer_us;
+    const int64_t trace_before_close_us = butil::gettimeofday_us();
     RETURN_IF_ERROR(meta_file->close());
+    const int64_t trace_after_close_us = butil::gettimeofday_us();
     _metacache->cache_aggregation_partition(partition_location, true);
+    const int64_t trace_end_us = butil::gettimeofday_us();
+    LOG(INFO) << "put_bundle_tablet_metadata trace"
+              << " anchor_tablet=" << anchor_tablet_id << " version=" << anchor_version
+              << " tablets=" << tablet_metas.size() << " schemas=" << unique_schemas.size()
+              << " page_bytes=" << trace_page_bytes << " header_bytes=" << trace_header_bytes
+              << " total_us=" << (trace_end_us - trace_begin_us)
+              << " coverage_us=" << (trace_after_cover_us - trace_begin_us)
+              << " anchor_us=" << (trace_after_anchor_us - trace_after_cover_us)
+              << " real_location_us=" << (trace_after_real_location_us - trace_after_anchor_us)
+              << " schema_us=" << (trace_after_schema_us - trace_after_real_location_us)
+              << " open_us=" << (trace_after_open_us - trace_after_schema_us)
+              << " serialize_us=" << trace_serialize_us << " append_us=" << trace_append_us
+              << " close_us=" << (trace_after_close_us - trace_before_close_us)
+              << " metacache_us=" << (trace_end_us - trace_after_close_us);
     return Status::OK();
 }
 

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -737,9 +737,8 @@ Status TabletManager::put_bundle_tablet_metadata(std::map<int64_t, TabletMetadat
               << " anchor_us=" << (trace_after_anchor_us - trace_after_cover_us)
               << " real_location_us=" << (trace_after_real_location_us - trace_after_anchor_us)
               << " schema_us=" << (trace_after_schema_us - trace_after_real_location_us)
-              << " open_us=" << (trace_after_open_us - trace_after_schema_us)
-              << " serialize_us=" << trace_serialize_us << " append_us=" << trace_append_us
-              << " close_us=" << (trace_after_close_us - trace_before_close_us)
+              << " open_us=" << (trace_after_open_us - trace_after_schema_us) << " serialize_us=" << trace_serialize_us
+              << " append_us=" << trace_append_us << " close_us=" << (trace_after_close_us - trace_before_close_us)
               << " metacache_us=" << (trace_end_us - trace_after_close_us);
     return Status::OK();
 }

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -293,6 +293,33 @@ void distribute_segment_to_ranges(const SegmentSplitInfo& segment, std::vector<R
 // Core range split algorithm (public API)
 // ================================================================================
 
+// True when the tablet's sort key is exactly its key columns, i.e. the tuples the writer stores per
+// segment (sort_key_min / sort_key_max / sort_key_samples, built from TabletSchema::sort_key_idxes)
+// live in the same key space as a tablet range. An empty sort_key_idxes means "the sort key IS the
+// key columns" -- that convention lives in the materialized TabletSchema, and this reads the raw PB
+// with it applied, because materializing here is not an option (see the colocate branch in
+// get_tablet_split_ranges_impl for why).
+static bool sort_key_is_key_columns(const TabletSchemaPB& schema) {
+    if (schema.sort_key_idxes_size() == 0) {
+        return true;
+    }
+    int num_key_columns = 0;
+    for (const auto& col : schema.column()) {
+        if (col.is_key()) {
+            ++num_key_columns;
+        }
+    }
+    if (schema.sort_key_idxes_size() != num_key_columns) {
+        return false;
+    }
+    for (int i = 0; i < schema.sort_key_idxes_size(); ++i) {
+        if (schema.sort_key_idxes(i) != static_cast<uint32_t>(i)) {
+            return false;
+        }
+    }
+    return true;
+}
+
 StatusOr<RangeSplitResult> calculate_range_split_boundaries(const std::vector<SegmentSplitInfo>& segments,
                                                             int32_t target_split_count, int64_t target_value_per_split,
                                                             bool use_num_rows, bool track_sources,
@@ -747,28 +774,8 @@ Status get_tablet_split_ranges_impl(TabletManager* tablet_manager, const TabletM
     // Withhold the range when the spaces differ. It only refines the per-split size estimate (it
     // pre-splits candidate ranges at the tablet's own edges so a shared segment reaching past them
     // cannot inflate one split's stats); the boundaries themselves come from the segment tuples.
-    const bool sort_key_is_key_columns = [&] {
-        const auto& schema = tablet_metadata->schema();
-        if (schema.sort_key_idxes_size() == 0) {
-            return true;
-        }
-        int num_key_columns = 0;
-        for (const auto& col : schema.column()) {
-            if (col.is_key()) {
-                ++num_key_columns;
-            }
-        }
-        if (schema.sort_key_idxes_size() != num_key_columns) {
-            return false;
-        }
-        for (int i = 0; i < schema.sort_key_idxes_size(); ++i) {
-            if (schema.sort_key_idxes(i) != static_cast<uint32_t>(i)) {
-                return false;
-            }
-        }
-        return true;
-    }();
-    const TabletRange* boundary_tablet_range = sort_key_is_key_columns ? &tablet_range : nullptr;
+    const TabletRange* boundary_tablet_range =
+            sort_key_is_key_columns(tablet_metadata->schema()) ? &tablet_range : nullptr;
 
     int64_t total_num_rows = 0;
     for (const auto& segment : segments) {
@@ -1749,6 +1756,34 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> split_tablet(
     }
     if (splitting_tablet.new_tablet_ids_size() <= 0) {
         return Status::InvalidArgument("splitting tablet has no new tablet");
+    }
+
+    // Split compares the segments' key tuples (sort_key_min / sort_key_max / sort_key_samples,
+    // which the writer produces from TabletSchema::sort_key_idxes) against tablet ranges, which are
+    // over the key columns: when picking boundaries, when filtering candidate ranges, and when
+    // deciding which new tablet each segment belongs to. Those comparisons dispatch std::get on one
+    // side's declared type, so once the two key spaces differ they throw bad_variant_access. Nothing
+    // on the publish path catches it, the BE aborts, the transaction stays unpublished, and the FE
+    // re-issues the publish to whichever CN comes back -- observed as all three CNs of a cluster
+    // going down together and staying down.
+    //
+    // This is not one bad comparison but an assumption the whole path is built on; tablet_splitter.cc
+    // alone has dozens of such comparisons, and fixing them one at a time just moves the abort to the
+    // next one (measured: boundary sort -> segment ownership). Refuse the split instead. A non-OK
+    // status here routes through make_identical_new_tablet_metadata, so the tablet simply does not
+    // split -- it keeps growing past the threshold, which is a degradation but not a correctness or
+    // availability problem.
+    //
+    // Also covers the FE-supplied-boundaries path: those boundaries are in key-column space and are
+    // fine, but segment ownership still compares them against sort-key tuples.
+    //
+    // Lifting this restriction means giving split a boundary source that is in key-column space --
+    // the primary key index is already sorted that way -- rather than sampling the segments' sort key.
+    if (!sort_key_is_key_columns(tablet_metadata->schema())) {
+        return Status::NotSupported(
+                "cannot split a tablet whose sort key differs from its key columns: split boundaries "
+                "and segment ownership are computed from the segments' sort key, which is not "
+                "comparable with the tablet range");
     }
 
     // Flush the old tablet's PK-index memtable into sstables before propagating

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -731,16 +731,55 @@ Status get_tablet_split_ranges_impl(TabletManager* tablet_manager, const TabletM
     TabletRange tablet_range;
     RETURN_IF_ERROR(tablet_range.from_proto(tablet_metadata->range()));
 
+    // The boundary list calculate_range_split_boundaries() sorts is built from the segments'
+    // sort_key_min / sort_key_max / sort_key_samples, all of which the writer produces from
+    // TabletSchema::sort_key_idxes. The tablet range is over the key columns instead. Feeding both
+    // into one std::sort compares a key-column datum against a sort-key column type and throws
+    // bad_variant_access, which on the publish path (publish_resharding_tablet -> split_tablet)
+    // aborts the BE -- all three CNs died this way, each restart re-running the same publish.
+    //
+    // The two key spaces coincide unless the table was created with an explicit ORDER BY, which is
+    // why this never fired before: an empty sort_key_idxes means "the sort key IS the key columns"
+    // (the convention the materialized TabletSchema applies), so the raw PB has to be read with that
+    // convention rather than through TabletSchema::has_separate_sort_key(), and materializing the
+    // schema here is not an option -- see the colocate branch above for why.
+    //
+    // Withhold the range when the spaces differ. It only refines the per-split size estimate (it
+    // pre-splits candidate ranges at the tablet's own edges so a shared segment reaching past them
+    // cannot inflate one split's stats); the boundaries themselves come from the segment tuples.
+    const bool sort_key_is_key_columns = [&] {
+        const auto& schema = tablet_metadata->schema();
+        if (schema.sort_key_idxes_size() == 0) {
+            return true;
+        }
+        int num_key_columns = 0;
+        for (const auto& col : schema.column()) {
+            if (col.is_key()) {
+                ++num_key_columns;
+            }
+        }
+        if (schema.sort_key_idxes_size() != num_key_columns) {
+            return false;
+        }
+        for (int i = 0; i < schema.sort_key_idxes_size(); ++i) {
+            if (schema.sort_key_idxes(i) != static_cast<uint32_t>(i)) {
+                return false;
+            }
+        }
+        return true;
+    }();
+    const TabletRange* boundary_tablet_range = sort_key_is_key_columns ? &tablet_range : nullptr;
+
     int64_t total_num_rows = 0;
     for (const auto& segment : segments) {
         total_num_rows += segment.num_rows;
     }
     int64_t avg_num_rows = std::max<int64_t>(1, total_num_rows / split_count);
 
-    ASSIGN_OR_RETURN(auto split_result,
-                     calculate_range_split_boundaries(segments, split_count, avg_num_rows,
-                                                      /*use_num_rows=*/true,
-                                                      /*track_sources=*/true, &tablet_range, colocate_column_count));
+    ASSIGN_OR_RETURN(auto split_result, calculate_range_split_boundaries(segments, split_count, avg_num_rows,
+                                                                         /*use_num_rows=*/true,
+                                                                         /*track_sources=*/true, boundary_tablet_range,
+                                                                         colocate_column_count));
 
     if (split_result.boundaries.empty()) {
         return Status::InvalidArgument("Not enough split ranges available");

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <boost/algorithm/string/predicate.hpp>
 #include <cmath>
+#include <exception>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -186,9 +187,41 @@ static std::optional<std::string> encode_full_sort_key_search_key(Segment* segme
     for (size_t i = 0; i < key.columns(); i++) {
         values.push_back(key.get(i));
     }
+    // Captured before segment_schema is moved into the tuple, so the diagnostic below can name both
+    // shapes.
+    auto type_list = [](const Schema& schema, size_t upto) {
+        std::string out;
+        for (size_t i = 0; i < upto && i < schema.num_fields(); i++) {
+            out.append(out.empty() ? "" : ",")
+                    .append(std::to_string(static_cast<int>(schema.field(i)->type()->type())));
+        }
+        return out;
+    };
+    const std::string key_types = type_list(key.schema(), key.columns());
+    const std::string segment_types = type_list(segment_schema, segment->num_sort_key_columns());
+
     SeekTuple segment_key(std::move(segment_schema), std::move(values));
-    return segment_key.full_sort_key_encode(segment->num_sort_key_columns(),
-                                            lower ? KEY_MINIMAL_MARKER : KEY_MAXIMAL_MARKER);
+    // full_sort_key_types_compatible() above only compares the two schemas' declared logical types.
+    // That is not sufficient: a datum carried by |key| can hold a different variant alternative than
+    // the schema declares, and the encoder dispatches std::get on the segment schema's type. The
+    // mismatch throws std::bad_variant_access, and on the publish path (primary index rebuild ->
+    // scan_one_rebuild_unit -> _apply_tablet_range) nothing catches it, so the BE aborts. Observed on
+    // a range-bucket primary-key table whose ORDER BY differs from the primary key: three CNs died in
+    // a loop, each restart re-running the same publish.
+    //
+    // std::nullopt is this function's documented "cannot produce compatible bytes" answer -- the
+    // caller then skips the coarse short-key prune and lets the typed fine search decide -- so it is
+    // both the safe and the correct outcome here.
+    try {
+        return segment_key.full_sort_key_encode(segment->num_sort_key_columns(),
+                                                lower ? KEY_MINIMAL_MARKER : KEY_MAXIMAL_MARKER);
+    } catch (const std::exception& e) {
+        LOG_EVERY_N(WARNING, 100) << "Skipping coarse short-key prune: full sort key encode failed: " << e.what()
+                                  << ", key_columns=" << key.columns()
+                                  << ", segment_sort_key_columns=" << segment->num_sort_key_columns() << ", key_types=["
+                                  << key_types << "], segment_types=[" << segment_types << "]";
+        return std::nullopt;
+    }
 }
 
 class SegmentIterator final : public ChunkIterator {

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2416,6 +2416,23 @@ Status SegmentIterator::_apply_tablet_range() {
         return Status::OK();
     }
 
+    // The tablet range is expressed in primary-key space; the segment's rows are ordered by the sort
+    // key. Turning the former into a contiguous rowid interval is only defined when the two agree.
+    // With a separate sort key the tablet's rows are scattered across the whole segment and NO rowid
+    // interval is the right answer -- the conversion is undefined, not merely imprecise. Attempting it
+    // compares a primary-key datum against a sort-key column type, which throws bad_variant_access out
+    // of the scan; on the publish path (primary index rebuild -> scan_one_rebuild_unit) nothing catches
+    // it and the BE aborts, so every restart re-runs the same publish and dies again.
+    //
+    // Leave the scan range untouched instead. This does not lose a restriction that anything relies on
+    // today: a split child inherits a full copy of the parent's metadata, sstable_meta included, so its
+    // primary index already carries the siblings' keys and is over-inclusive either way; and reads that
+    // do need the restriction are served from the parent layout until the UNSHARE compaction has
+    // rewritten each child's data privately.
+    if (_segment->tablet_schema().has_separate_sort_key()) {
+        return Status::OK();
+    }
+
     std::optional<Range<>> rowid_range_opt;
     if (_opts.read_state_cache.tablet_rowid_range != nullptr) {
         rowid_range_opt = *_opts.read_state_cache.tablet_rowid_range;


### PR DESCRIPTION
## Why I'm doing this

Diagnostic branch, not for merge. Cut from a test commit, only to get a TSP build.

On a live 1 FE + 3 CN shared-data cluster a load transaction committed in the same
second as a tablet-split metadata swap. Its publish has now been retried 12,000+
times over 2.5 hours and never becomes VISIBLE:

- all 11 tablets published successfully on all three CNs within 6s of commit
- the FE brpc client times out after 60s (`onceTalkTimeout`), every attempt
- the aggregator's `put_bundle_tablet_metadata` takes 177-193s per attempt
- the handler never checks `cntl->IsCanceled()`, so the timeout cancels nothing,
  and the retry starts another copy of the same write

Measured on the stuck cluster: the aggregate publish's sub-requests come back in
under 1ms, but the `put_agg_meta` pool burns 147 CPU-seconds per 90s of wall clock
(99% of all BE CPU) and moves ~350MB per 20s between the local datacache and object
storage -- while the bundle object it writes is 545KB.

No existing log or bvar says which phase of that write the time goes to.

## What this changes

`put_bundle_tablet_metadata` only. Times each phase -- coverage check, anchor pick,
`real_location`, schema collection, file open, per-tablet serialize, append, close,
metacache -- and logs them together with the tablet/schema counts and the serialized
byte counts.

No behaviour change.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

## Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr