### PR TITLE
[BugFix] Don't orphan lake PK index input sstables when the compaction has no output (backport #75338)

### DIFF
--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -282,6 +282,24 @@ void trim_partial_compaction_last_input_rowset(const MutableTabletMetadataPtr& m
 }
 
 void MetaFileBuilder::remove_compacted_sst(const TxnLogPB_OpCompaction& op_compaction) {
+    // Orphaning the input sstables and dropping them from `sstable_meta` must stay ONE decision.
+    // LakePersistentIndex::apply_opcompaction() bails out early when there is no output sstable, so the
+    // inputs are then left in `_sstables` and LakePersistentIndex::commit() writes them straight back into
+    // `sstable_meta`. Orphaning them here regardless would schedule files for deletion that the tablet
+    // metadata still references: once lake vacuum removes them, the next PK index load fails with a
+    // missing .sst and the tablet needs a full index rebuild to recover.
+    //
+    // A compaction that records input sstables but no output is reachable in two ways:
+    //   - major_compact() records the inputs in prepare_merging_iterator() and can still return early
+    //     (an empty merging iterator with an OK status), leaving the output unset;
+    //   - a newer BE may report its outputs in a field this version does not know, so has_output_sstable()
+    //     is false even though the compaction did produce output.
+    // In both cases the correct behavior is the same: keep the inputs alive. The compaction then makes no
+    // progress (and any output file it did produce leaks), which is recoverable, unlike a dangling
+    // reference in `sstable_meta`.
+    if (!op_compaction.has_output_sstable()) {
+        return;
+    }
     // remove compacted sst
     for (auto& input_sstable : op_compaction.input_sstables()) {
         FileMetaPB file_meta;

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -991,4 +991,41 @@ TEST_F(MetaFileTest, test_cleanup_preexisting_orphan_delvecs_on_compaction) {
 
     config::lake_enable_orphan_delvec_cleanup_on_compaction = false;
 }
+
+// A compaction that records input sstables but no output must NOT orphan those inputs.
+// LakePersistentIndex::apply_opcompaction() skips its whole apply when there is no output sstable, so the
+// inputs stay in `_sstables` and are written straight back into `sstable_meta` by commit(). Orphaning them
+// here would leave the tablet metadata referencing files that lake vacuum is free to delete, and the next
+// PK index load would then fail on a missing .sst.
+TEST_F(MetaFileTest, test_remove_compacted_sst_keeps_inputs_without_output) {
+    const int64_t tablet_id = 10021;
+    auto tablet = std::make_shared<Tablet>(_tablet_manager.get(), tablet_id);
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(tablet_id);
+    metadata->set_version(12);
+
+    TxnLogPB_OpCompaction op_compaction;
+    for (int i = 0; i < 3; i++) {
+        auto* input_sstable = op_compaction.add_input_sstables();
+        input_sstable->set_filename(std::string("input_") + std::to_string(i) + ".sst");
+        input_sstable->set_filesize(1024);
+    }
+
+    // No output sstable: the index apply is skipped, so the inputs must be kept alive.
+    {
+        MetaFileBuilder builder(*tablet, metadata);
+        builder.remove_compacted_sst(op_compaction);
+        EXPECT_EQ(0, metadata->orphan_files_size());
+    }
+
+    // With an output sstable the inputs are genuinely superseded and are orphaned as before.
+    {
+        op_compaction.mutable_output_sstable()->set_filename("output.sst");
+        MetaFileBuilder builder(*tablet, metadata);
+        builder.remove_compacted_sst(op_compaction);
+        ASSERT_EQ(3, metadata->orphan_files_size());
+        EXPECT_EQ("input_0.sst", metadata->orphan_files(0).name());
+        EXPECT_EQ(1024, metadata->orphan_files(0).size());
+    }
+}
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

`MetaFileBuilder::remove_compacted_sst()` pushes every `op_compaction.input_sstables()` entry into
`orphan_files` unconditionally, but `LakePersistentIndex::apply_opcompaction()` bails out early when
there is no output sstable:

```cpp
if (op_compaction.input_sstables().empty() || !op_compaction.has_output_sstable()) {
    return Status::OK();
}
```

When that early return is taken, the input sstables are still in `_sstables`, and
`LakePersistentIndex::commit()` writes them straight back into `sstable_meta` via
`finalize_sstable_meta()`. The tablet metadata therefore keeps referencing files that lake vacuum has
already been told to delete. `TabletRetainInfo` only protects files belonging to cluster-snapshot
retain versions and is empty in the common case, so the files really do get deleted, and the next PK
index load then fails on a missing `.sst`. The tablet cannot publish again until its PK index is fully
rebuilt.

A compaction that records input sstables but no output is reachable today: `major_compact()` records
the inputs inside `prepare_merging_iterator()` and can still return early afterwards, when the merging
iterator turns out to be empty with an OK status.

This is the same hazard that `remove_compacted_sst()` on newer branches already guards against from a
different angle -- there it skips input files that are reused as output, with the comment *"to avoid
the same file appearing in both sstable_meta and orphan_files, which would cause vacuum to delete a
still-referenced SST file"*. This PR closes the other instance of it.

## What I'm doing:

Keep "orphan the inputs" and "drop them from `sstable_meta`" as **one** decision: return early from
`remove_compacted_sst()` when there is no output sstable, matching the condition the index side uses.

The compaction then simply makes no progress, and any output file it did produce leaks. Both are
recoverable, unlike a dangling reference in `sstable_meta`.

Added `MetaFileTest.test_remove_compacted_sst_keeps_inputs_without_output`, asserting that no orphan
files are recorded when there is no output sstable, and that the pre-existing behavior (all inputs
orphaned) is unchanged once an output sstable is present.

**Not needed on main / 4.1**: there `LakePersistentIndex::apply_opcompaction()` only requires
`input_sstables()` to be non-empty, so both sides act on the same input and the metadata never
diverges. This is a `branch-4.0`-only fix, so there is nothing to forward-port.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

