### PR TITLE
[BugFix] Honor a del file's op_offset when rebuilding the lake PK index (backport #75338)

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -637,23 +637,44 @@ Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pke
         // older than current item, and we need to igore these delete operations.
         std::vector<IndexValue> found_values(pkc->size(), IndexValue(NullIndexValue));
         std::vector<bool> filter(pkc->size(), false);
+        // A del file logically follows segment index `op_offset`, so its rssid is
+        // `origin_rowset_id + op_offset`. A key whose current index entry is NEWER than that rssid was
+        // re-inserted after this delete and must NOT be erased here.
+        //
+        // Historically the filter ran only for non-origin (compaction-inherited) del files, because an
+        // origin del file was always stamped with the max segment id -- "delete after all segments" -- so
+        // no key of that rowset could be newer and the filter was a guaranteed no-op. A writer that
+        // preserves the in-transaction upsert/delete order instead persists a real `op_offset` BELOW the
+        // max, and then a key re-UPSERTed by a LATER segment of the SAME rowset legitimately survives the
+        // delete: the row stays live in the segment and its delvec bit is never set. Erasing such a key
+        // here would drop it from the index while the delvec keeps the row live -- the read stays correct,
+        // so the damage is latent, but the next upsert of that key then misses in the index, skips the
+        // tombstone for the live row and leaves a DUPLICATE primary key. That is strictly worse than the
+        // self-consistent "missing row" this version produces on its own. So an origin del file needs the
+        // filter too, as soon as it carries `op_offset < max_segment_idx`.
+        //
+        // Data written by a BE that does not preserve the order always has `op_offset == max_segment_idx`,
+        // so `need_filter` stays false for it and the behavior here is unchanged.
+        const uint32_t max_segment_idx = static_cast<uint32_t>(std::max(rowset->num_segments(), (int64_t)1) - 1);
+        const uint32_t op_offset = del.has_op_offset() ? del.op_offset() : max_segment_idx;
+        const bool need_filter = rowset->id() != del.origin_rowset_id() || op_offset < max_segment_idx;
         auto generate_filter_fn = [&]() {
-            if (rowset->id() != del.origin_rowset_id()) {
-                // del file in origin rowset doesn't need to skip.
-                for (int i = 0; i < pkc->size(); i++) {
-                    if (found_values[i] != IndexValue(NullIndexValue) &&
-                        found_values[i].get_rssid() > del.origin_rowset_id() + del.op_offset()) {
-                        // Use `rowset_id + op_offset` as delete file's rssid.
-                        // delete operation is too old for this key.
-                        filter[i] = true;
-                    }
+            if (!need_filter) {
+                return;
+            }
+            for (int i = 0; i < pkc->size(); i++) {
+                if (found_values[i] != IndexValue(NullIndexValue) &&
+                    found_values[i].get_rssid() > del.origin_rowset_id() + op_offset) {
+                    // delete operation is too old for this key.
+                    filter[i] = true;
                 }
             }
         };
-        // Rssid of delete files is equal to `rowset_id + op_offset`, and delete is always after upsert now,
-        // so we use max segment id as `op_offset`.
+        // The erase entries are still stamped with the max segment id: this version does not interleave
+        // upserts and deletes at apply time, and the filter above has already removed the keys that a later
+        // segment re-inserted, so the remaining erases are all correctly "after all segments".
         // TODO : support real order of mix upsert and delete in one transaction.
-        const uint32_t del_rebuild_rssid = rowset->id() + std::max(rowset->num_segments(), (int64_t)1) - 1;
+        const uint32_t del_rebuild_rssid = rowset->id() + max_segment_idx;
         if (pkc->is_binary()) {
             // When PK table have multi pk columns or one pk column with varchar type,
             // we treat it as binary column.


### PR DESCRIPTION
## Why I'm doing:

`LakePersistentIndex::load_dels()` only builds the "this delete is too old for this key" filter for
non-origin (compaction-inherited) del files:

```cpp
if (rowset->id() != del.origin_rowset_id()) { ... }
```

That was safe as long as an origin del file was always stamped with the max segment id -- i.e.
"delete after all segments" -- because then no key of that rowset can be newer than the delete, and
the filter is a guaranteed no-op.

That assumption does not hold for metadata produced by a BE that preserves the in-transaction
upsert/delete order: such a writer persists a real `op_offset` **below** the max. A key that is
`DELETE`d and then re-`UPSERT`ed by a **later segment of the same rowset** legitimately survives the
delete -- the row stays live in the segment and its delvec bit is never set. Without the filter, the
rebuild erases that key from the index anyway.

The failure is latent and then escalates:

- reads stay correct, because the delvec still keeps the row live;
- the rebuilt index has dropped the key, so it now disagrees with the delvec;
- the next upsert of that key misses in the index, does not tombstone the live row, and leaves a
  **duplicate primary key**.

That is strictly worse than the self-consistent "missing row" this branch produces on its own, which
is why it is worth fixing on the read side here rather than relying on writers never emitting a real
`op_offset`.

## What I'm doing:

Apply the filter to origin del files as well, as soon as they carry `op_offset < max_segment_idx`:

```cpp
const bool need_filter = rowset->id() != del.origin_rowset_id() || op_offset < max_segment_idx;
```

This matches the condition already used on newer branches
(`need_filter = !is_origin || op_offset < get_max_segment_idx(...)`).

- `op_offset` already exists in `DelfileWithRowsetId`, so **no proto change** is needed.
- Del files written by a BE that does not preserve the order always carry
  `op_offset == max_segment_idx`, so `need_filter` stays `false` for them and behavior on this
  branch's own data is unchanged.
- Deliberate scope limit: the erase entries are still stamped with the max segment id. This branch
  does not interleave upserts and deletes at apply time; this PR only stops the rebuild from erasing
  keys that a later segment re-inserted.

**Not needed on main / 4.1**: they already carry this condition. This is a `branch-4.0`-only fix, so
there is nothing to forward-port.

## Note on tests

No new regression test here. Exercising this needs a rebuild fixture with an interleaved del file
(`op_offset < max_segment_idx`) plus a re-upsert in a later segment of the same rowset, and no such
fixture exists on this branch. The change is a no-op for data this branch writes itself
(`op_offset == max_segment_idx` always), so the existing PK index rebuild tests cover the unchanged
path. Happy to add the fixture if reviewers would like it.

Backport #75338 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

