### PR TITLE
[BugFix] Reject storage volume credentials that cannot be persisted

### DIFF
--- a/docs/en/sql-reference/sql-statements/cluster-management/storage_volume/CREATE_STORAGE_VOLUME.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/storage_volume/CREATE_STORAGE_VOLUME.md
@@ -64,7 +64,7 @@ import Beta from '../../../../_assets/commonMarkdown/_beta.mdx'
 | azure.adls2.oauth2_use_managed_identity | Whether to use Managed Identity to authorize requests for your Azure Data Lake Storage Gen2. Default: `false`. |
 | azure.adls2.oauth2_tenant_id        | The Tenant ID of the Managed Identity used to authorize requests for your Azure Data Lake Storage Gen2. |
 | azure.adls2.oauth2_client_id        | <ul><li>For Managed Identity Authentication: The Client ID of the Managed Identity used to authorize requests for your Azure Data Lake Storage Gen2.</li><li>For Workload Identity: The client ID (application ID) of the Azure AD application (user-assigned managed identity or app registration) associated with the workload identity.</li></ul> |
-| azure.adls2.oauth2_token_file       | The absolute file path to the OAuth2 token file projected into the pod by the Azure Workload Identity webhook. |
+| azure.adls2.oauth2_token_file       | Not supported for storage volumes - see the note under the ADLS2 examples below. The absolute file path to the OAuth2 token file projected into the pod by the Azure Workload Identity webhook. |
 | gcp.gcs.service_account_email	      | The email address in the JSON file generated at the creation of the Service Account, for example, `user@hello.iam.gserviceaccount.com`. |
 | gcp.gcs.service_account_private_key_id | The Private Key ID in the JSON file generated at the creation of the Service Account. |
 | gcp.gcs.service_account_private_key | The Private Key in the JSON file generated at the creation of the Service Account, for example, `-----BEGIN PRIVATE KEY----xxxx-----END PRIVATE KEY-----\n`. |
@@ -234,15 +234,9 @@ Creating a storage volume on Azure Data Lake Storage Gen2 is supported from v3.4
   "azure.adls2.oauth2_client_id" = "<client_id>" 
   ```
 
-- If you use Workload Identity to access Azure Data Lake Storage Gen2, set the following properties:
-
-  ```SQL
-  "enabled" = "{ true | false }",
-  "azure.adls2.endpoint" = "<endpoint_url>",
-  "azure.adls2.oauth2_token_file" = "<path_to_token>",
-  "azure.adls2.oauth2_tenant_id" = "<service_principal_tenant_id>",
-  "azure.adls2.oauth2_client_id" = "<service_client_id>"
-  ```
+:::note
+Workload Identity cannot be used for a storage volume. A storage volume's credential is stored as a file store, which has no field for the token file, so the token file would be lost and the volume would fall back to Managed Identity. `CREATE STORAGE VOLUME` rejects `azure.adls2.oauth2_token_file`. Workload Identity remains available for external catalogs and `FILES()`.
+:::
 
 :::note
 Azure Data Lake Storage Gen1 is not supported.

--- a/docs/ja/sql-reference/sql-statements/cluster-management/storage_volume/CREATE_STORAGE_VOLUME.md
+++ b/docs/ja/sql-reference/sql-statements/cluster-management/storage_volume/CREATE_STORAGE_VOLUME.md
@@ -64,7 +64,7 @@ import Beta from '../../../../_assets/commonMarkdown/_beta.mdx'
 | azure.adls2.oauth2_use_managed_identity | Azure Data Lake Storage Gen2 へのリクエストを認証するために Managed Identity を使用するかどうか。デフォルト: `false`。|
 | azure.adls2.oauth2_tenant_id        | Azure Data Lake Storage Gen2 へのリクエストを認証するために使用される Managed Identity の Tenant ID。 |
 | azure.adls2.oauth2_client_id        | <ul><li>マネージド ID 認証の場合：Azure Data Lake Storage Gen2 へのリクエストを認証するために使用される Managed Identity の Client ID。</li><li>ワークロード ID 認証の場合：ワークロード ID に関連付けられている Azure AD アプリケーション（ユーザー割り当ての マネージド ID またはアプリ登録）のクライアント ID（アプリケーション ID）。</li></ul> |
-| azure.adls2.oauth2_token_file       | Azure ワークロード ID ウェブフックによってポッドにマッピングされた、OAuth2 トークンファイルへの絶対ファイルパス。 |
+| azure.adls2.oauth2_token_file       | ストレージボリュームでは未対応です。下記の ADLS2 の例のあとの注記を参照してください。Azure ワークロード ID ウェブフックによってポッドにマッピングされた、OAuth2 トークンファイルへの絶対ファイルパス。 |
 | gcp.gcs.service_account_email	      | Service Account 作成時に生成された JSON ファイル内のメールアドレスです。例：`user@hello.iam.gserviceaccount.com`。 |
 | gcp.gcs.service_account_private_key_id | Service Account 作成時に生成された JSON ファイル内の秘密鍵 ID です。 |
 | gcp.gcs.service_account_private_key | Service Account 作成時に生成された JSON ファイル内の秘密鍵です。例：`-----BEGIN PRIVATE KEY----xxxx-----END PRIVATE KEY-----\n`。 |
@@ -235,15 +235,9 @@ Azure Data Lake Storage Gen2 でのストレージボリュームの作成は v3
   "azure.adls2.oauth2_client_id" = "<client_id>" 
   ```
 
-- ワークロード ID を使用して Azure Data Lake Storage Gen2 にアクセスする場合、次のプロパティを設定します：
-
-  ```SQL
-  "enabled" = "{ true | false }",
-  "azure.adls2.endpoint" = "<endpoint_url>",
-  "azure.adls2.oauth2_token_file" = "<path_to_token>",
-  "azure.adls2.oauth2_tenant_id" = "<service_principal_tenant_id>",
-  "azure.adls2.oauth2_client_id" = "<service_client_id>"
-  ```
+:::note
+ストレージボリュームではワークロード ID を使用できません。ストレージボリュームの認証情報はファイルストアとして保存されますが、そこにトークンファイル用のフィールドがないため、トークンファイルは失われ、ボリュームはマネージド ID にフォールバックします。`CREATE STORAGE VOLUME` は `azure.adls2.oauth2_token_file` を拒否します。External Catalog と `FILES()` では引き続きワークロード ID を使用できます。
+:::
 
 :::note
 Azure Data Lake Storage Gen1 はサポートされていません。

--- a/docs/zh/sql-reference/sql-statements/cluster-management/storage_volume/CREATE_STORAGE_VOLUME.md
+++ b/docs/zh/sql-reference/sql-statements/cluster-management/storage_volume/CREATE_STORAGE_VOLUME.md
@@ -66,7 +66,7 @@ import Beta from '../../../../_assets/commonMarkdown/_beta.mdx'
 | azure.adls2.oauth2_use_managed_identity | 是否使用 Managed Identity 用于授权 Azure Data Lake Storage Gen2 请求。默认值：`false`。 |
 | azure.adls2.oauth2_tenant_id        | 用于授权 Azure Data Lake Storage Gen2 请求的 Managed Identity 的 Tenant ID。 |
 | azure.adls2.oauth2_client_id        | <ul><li>对于托管身份验证：用于授权 Azure Data Lake Storage Gen2 请求的 Managed Identity 的 Client ID。</li><li>对于 Workload Identity：与 Workload Identity 关联的 Azure AD 应用程序（用户分配的托管身份或应用程序注册）的客户端 ID（应用程序 ID）。</li></ul> |
-| azure.adls2.oauth2_token_file       | Azure Workload Identity Webhook 投射到 Pod 中的 OAuth2 令牌文件的绝对文件路径。 |
+| azure.adls2.oauth2_token_file       | Storage Volume 不支持该参数，详见下方 ADLS2 示例后的说明。Azure Workload Identity Webhook 投射到 Pod 中的 OAuth2 令牌文件的绝对文件路径。 |
 | gcp.gcs.service_account_email	      | 创建 Service Account 时生成的 JSON 文件中的 Email。示例：`user@hello.iam.gserviceaccount.com`。 |
 | gcp.gcs.service_account_private_key_id | 创建 Service Account 时生成的 JSON 文件中的 Private Key ID。 |
 | gcp.gcs.service_account_private_key | 创建 Service Account 时生成的 JSON 文件中的 Private Key。示例：`-----BEGIN PRIVATE KEY----xxxx-----END PRIVATE KEY-----\n`。 |
@@ -334,15 +334,9 @@ StarRocks 自 v3.4.1 起支持基于 Azure Data Lake Storage Gen2 创建存储�
   "azure.adls2.oauth2_client_id" = "<client_id>" 
   ```
 
-- 如果您使用 Workload Identity 认证，请设置以下 PROPERTIES：
-
-  ```SQL
-  "enabled" = "{ true | false }",
-  "azure.adls2.endpoint" = "<endpoint_url>",
-  "azure.adls2.oauth2_token_file" = "<path_to_token>",
-  "azure.adls2.oauth2_tenant_id" = "<service_principal_tenant_id>",
-  "azure.adls2.oauth2_client_id" = "<service_client_id>"
-  ```
+:::note
+Storage Volume 不支持 Workload Identity 认证。Storage Volume 的凭证以 File Store 形式存储，其中没有令牌文件字段，因此令牌文件会丢失，卷会退化为 Managed Identity 认证。`CREATE STORAGE VOLUME` 会拒绝 `azure.adls2.oauth2_token_file`。External Catalog 与 `FILES()` 仍然支持 Workload Identity。
+:::
 
 :::note
 不支持 Azure Data Lake Storage Gen1。

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -221,12 +221,21 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
         // cluster that was already snapshotting when it upgraded restores the configured name
         // straight from the image or the replayed log and never passes through that check. Without
         // this, every round would finish its local checkpoint work and then fail in HdfsUtil.
-        StorageVolume sv = GlobalStateMgr.getCurrentState().getStorageVolumeMgr()
-                .getStorageVolumeByName(storageVolumeName);
-        if (sv != null && !sv.isCredentialUsable()) {
-            LOG.warn("Skipping the automated cluster snapshot: storage volume {} has a credential " +
-                    "that cannot be used, so no new restore point is being produced.", storageVolumeName);
-            return false;
+        try {
+            StorageVolume sv = GlobalStateMgr.getCurrentState().getStorageVolumeMgr()
+                    .getStorageVolumeByName(storageVolumeName);
+            if (sv != null && !sv.isCredentialUsable()) {
+                LOG.warn("Skipping the automated cluster snapshot: storage volume {} has a credential " +
+                        "that cannot be used, so no new restore point is being produced.", storageVolumeName);
+                return false;
+            }
+        } catch (Exception e) {
+            // Looking the volume up can fail for reasons that have nothing to do with its credential
+            // - starmgr being unreachable, say. Scheduling the round anyway leaves such a failure on
+            // the job's own error path, which counts consecutive failures and warns, rather than
+            // turning it into an aborted scheduler cycle here.
+            LOG.warn("Could not check the automated snapshot storage volume {} before scheduling",
+                    storageVolumeName, e);
         }
         return true;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -213,8 +213,22 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
     }
 
     public boolean canScheduleNextJob(long lastAutomatedJobStartTimeMs) {
-        return isAutomatedSnapshotOn() && (System.currentTimeMillis()
-                - lastAutomatedJobStartTimeMs >= getEffectiveAutomatedSnapshotIntervalSeconds() * 1000L);
+        if (!isAutomatedSnapshotOn() || System.currentTimeMillis()
+                - lastAutomatedJobStartTimeMs < getEffectiveAutomatedSnapshotIntervalSeconds() * 1000L) {
+            return false;
+        }
+        // ADMIN SET AUTOMATED SNAPSHOT ON refuses a volume whose credential cannot be used, but a
+        // cluster that was already snapshotting when it upgraded restores the configured name
+        // straight from the image or the replayed log and never passes through that check. Without
+        // this, every round would finish its local checkpoint work and then fail in HdfsUtil.
+        StorageVolume sv = GlobalStateMgr.getCurrentState().getStorageVolumeMgr()
+                .getStorageVolumeByName(storageVolumeName);
+        if (sv != null && !sv.isCredentialUsable()) {
+            LOG.warn("Skipping the automated cluster snapshot: storage volume {} has a credential " +
+                    "that cannot be used, so no new restore point is being produced.", storageVolumeName);
+            return false;
+        }
+        return true;
     }
 
     public ClusterSnapshotJob getNextCluterSnapshotJob() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -6669,7 +6669,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
                 GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
                 StorageVolumeMgr storageVolumeMgr = globalStateMgr.getStorageVolumeMgr();
                 StorageVolume sv = storageVolumeMgr.getStorageVolumeByName(spillStorageVolume);
-                if (sv != null) {
+                // A volume kept readable only so that it can be dropped would hand the BE a
+                // credential it cannot use, so treat it like a volume that is not there and leave
+                // remote spilling off instead of enabling it against something unusable.
+                if (sv != null && sv.isCredentialUsable()) {
                     spillOptions.setEnable_spill_to_remote_storage(true);
                     TSpillToRemoteStorageOptions options = new TSpillToRemoteStorageOptions();
                     options.setRemote_storage_paths(sv.getLocations());

--- a/fe/fe-core/src/main/java/com/starrocks/replication/LakeReplicationJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/LakeReplicationJob.java
@@ -76,7 +76,7 @@ public class LakeReplicationJob extends ReplicationJob implements GsonPreProcess
         this.srcTableFilePathInfo = srcTableFilePathInfo;
     }
 
-    public LakeReplicationJob(TTableReplicationRequest request) throws MetaNotFoundException {
+    public LakeReplicationJob(TTableReplicationRequest request) throws MetaNotFoundException, DdlException {
         super(request);
         Preconditions.checkArgument(request.src_database_id > 0 && request.src_table_id > 0);
         this.srcDatabaseId = request.src_database_id;

--- a/fe/fe-core/src/main/java/com/starrocks/server/SharedDataStorageVolumeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/SharedDataStorageVolumeMgr.java
@@ -704,12 +704,16 @@ public class SharedDataStorageVolumeMgr extends StorageVolumeMgr {
     }
 
     public long getOrCreateVirtualTabletId(String storageVolumeName, String srcServiceId)
-            throws MetaNotFoundException {
+            throws MetaNotFoundException, DdlException {
         try (LockCloseable lock = new LockCloseable(rwLock.writeLock())) {
             StorageVolume storageVolume = this.getStorageVolumeByName(storageVolumeName);
             if (storageVolume == null) {
                 throw new MetaNotFoundException("Unknown src storage volume while creating virtual tablet: " + storageVolumeName);
             }
+            // Before any side effect: what follows allocates a path, creates a shard and a shard
+            // group and writes the volume back, and replication would only trip over the unusable
+            // credential after all of that. Same guard as the db/table binding paths.
+            checkCredentialUsable(storageVolume);
 
             long vTabletId = storageVolume.getVTabletId();
             if (vTabletId != -1) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/SharedDataStorageVolumeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/SharedDataStorageVolumeMgr.java
@@ -223,6 +223,7 @@ public class SharedDataStorageVolumeMgr extends StorageVolumeMgr {
             if (!sv.getEnabled()) {
                 throw new DdlException(String.format("Storage volume %s is disabled", svName));
             }
+            checkCredentialUsable(sv);
             return bindDbToStorageVolume(sv.getId(), dbId, false);
         }
     }
@@ -280,6 +281,7 @@ public class SharedDataStorageVolumeMgr extends StorageVolumeMgr {
             if (!sv.getEnabled()) {
                 throw new DdlException(String.format("Storage volume %s is disabled", sv.getName()));
             }
+            checkCredentialUsable(sv);
             return bindTableToStorageVolume(sv.getId(), tableId, false);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/StorageVolumeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/StorageVolumeMgr.java
@@ -361,11 +361,26 @@ public abstract class StorageVolumeMgr implements Writable, GsonPostProcessable 
         setDefaultStorageVolume(stmt.getName());
     }
 
+    /**
+     * A volume whose stored credential can no longer be turned into a usable configuration is kept
+     * readable so it can be inspected and dropped, but nothing may be stored through it. Callers
+     * about to hand data to a volume have to reject it explicitly, otherwise the failure surfaces
+     * much later, once the volume is already recorded as the location of a database or a table.
+     */
+    protected static void checkCredentialUsable(StorageVolume sv) throws DdlException {
+        if (!sv.isCredentialUsable()) {
+            throw new DdlException(String.format("Storage volume %s has a credential that cannot be used, " +
+                    "it can only be described or dropped", sv.getName()));
+        }
+    }
+
     public void setDefaultStorageVolume(String svName) {
         try (LockCloseable lock = new LockCloseable(rwLock.writeLock())) {
             StorageVolume sv = getStorageVolumeByName(svName);
             Preconditions.checkState(sv != null, "Storage volume '%s' does not exist", svName);
             Preconditions.checkState(sv.getEnabled(), "Storage volume '%s' is disabled", svName);
+            Preconditions.checkState(sv.isCredentialUsable(),
+                    "Storage volume '%s' has a credential that cannot be used", svName);
             SetDefaultStorageVolumeLog log = new SetDefaultStorageVolumeLog(sv.getId());
             GlobalStateMgr.getCurrentState().getEditLog()
                     .logSetDefaultStorageVolume(log, wal -> this.defaultStorageVolumeId = sv.getId());

--- a/fe/fe-core/src/main/java/com/starrocks/server/StorageVolumeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/StorageVolumeMgr.java
@@ -632,7 +632,7 @@ public abstract class StorageVolumeMgr implements Writable, GsonPostProcessable 
     protected abstract void updateTableStorageInfo(String storageVolumeId) throws DdlException;
 
     public abstract long getOrCreateVirtualTabletId(String storageVolumeName, String srcServiceId)
-            throws MetaNotFoundException;
+            throws MetaNotFoundException, DdlException;
 
     public abstract boolean hasStorageVolumeBindAsVirtualGroup(long shardGroupId);
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/StorageVolumeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/StorageVolumeMgr.java
@@ -246,6 +246,11 @@ public abstract class StorageVolumeMgr implements Writable, GsonPostProcessable 
                 validateParams(copied.getType(), params);
             }
             applyChangesToVolume(copied, sv.getId(), svType, locations, comment, params, enabled);
+            // Checked on the result rather than on the volume we started from, so an ALTER that
+            // supplies a working credential repairs the volume, while one that only touches the
+            // comment or the enabled flag is refused instead of trying to write back a volume whose
+            // credential can no longer be turned into a file store.
+            checkCredentialUsable(copied);
             updateInternalNoLock(copied);
         }
     }
@@ -344,6 +349,10 @@ public abstract class StorageVolumeMgr implements Writable, GsonPostProcessable 
                 locationChangedStorageVolumeId = newStorageVolume.getId();
             }
 
+            // Same reason as in updateStorageVolume: when the type is unchanged this reuses the old
+            // volume's credential, which a restore of a volume stored with an unusable one would
+            // otherwise try to write back.
+            checkCredentialUsable(newStorageVolume);
             replaceInternalNoLock(newStorageVolume);
         }
 
@@ -370,7 +379,8 @@ public abstract class StorageVolumeMgr implements Writable, GsonPostProcessable 
     protected static void checkCredentialUsable(StorageVolume sv) throws DdlException {
         if (!sv.isCredentialUsable()) {
             throw new DdlException(String.format("Storage volume %s has a credential that cannot be used, " +
-                    "it can only be described or dropped", sv.getName()));
+                            "it can only be described, dropped, or repaired by an ALTER that sets a working credential",
+                    sv.getName()));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ClusterSnapshotAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ClusterSnapshotAnalyzer.java
@@ -25,6 +25,7 @@ import com.starrocks.sql.ast.AdminSetAutomatedSnapshotOnStmt;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.expression.IntervalLiteral;
+import com.starrocks.storagevolume.StorageVolume;
 
 public class ClusterSnapshotAnalyzer {
     public static void analyze(StatementBase stmt, ConnectContext session) {
@@ -47,6 +48,14 @@ public class ClusterSnapshotAnalyzer {
             try {
                 if (!storageVolumeMgr.exists(storageVolumeName)) {
                     throw new SemanticException("Unknown storage volume: %s", storageVolumeName);
+                }
+                // A volume kept readable only so that it can be dropped would let every automated
+                // snapshot job finish its local checkpoint work and then fail in HdfsUtil with the
+                // unusable properties, so refuse it while the statement can still fail cleanly.
+                StorageVolume storageVolume = storageVolumeMgr.getStorageVolumeByName(storageVolumeName);
+                if (storageVolume != null && !storageVolume.isCredentialUsable()) {
+                    throw new SemanticException(
+                            "Storage volume %s has a credential that cannot be used", storageVolumeName);
                 }
             } catch (DdlException e) {
                 throw new SemanticException("Failed to get storage volume", e);

--- a/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
+++ b/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
@@ -232,6 +232,11 @@ public class StorageVolume implements Writable, GsonPostProcessable {
         // Assigned only once both checks pass, so a rejected ALTER leaves the volume untouched.
         this.cloudConfiguration = newConfiguration;
         this.params = newParams;
+        // An ALTER is how a volume that was only readable - stored with a credential that can no
+        // longer be used - gets repaired, so this derived flag has to follow the new configuration
+        // rather than stay false until the next metadata reload. Both update paths set the type
+        // before calling this, so the predicate already sees the final type.
+        this.credentialUsable = isValidCloudConfiguration(svt, newConfiguration);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
+++ b/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
@@ -178,6 +178,12 @@ public class StorageVolume implements Writable, GsonPostProcessable {
             LOG.warn("Storage volume '{}' has an unusable credential. It can still be listed and " +
                     "dropped, but not used: {}", name, dumpMaskedParams(params));
         }
+        if (requireUsableCredential) {
+            // Every volume that is about to be written goes through here, including the one
+            // StorageVolumeMgr#replaceStorageVolume builds when a restore changes the volume type,
+            // which reaches the file store without passing createFileStoreInfo.
+            validateCredentialIsPersistable(this.cloudConfiguration, params);
+        }
         validateStorageVolumeConstraints();
     }
 
@@ -353,10 +359,12 @@ public class StorageVolume implements Writable, GsonPostProcessable {
      * accepts is richer than what the file store models: an ADLS2 credential authenticating with a
      * workload identity loses its token file and reads back as a managed identity, so the volume
      * stays valid while quietly authenticating as somebody else. The second half therefore requires,
-     * for Azure volumes, that every credential property that was given also survives the round trip.
-     * The same class of loss exists for the AWS web identity profile, which is stored as an assume
-     * role or a default credential, but volumes relying on it exist in the wild and rejecting them
-     * belongs in its own change rather than in this fix.
+     * for Azure volumes, that the credential properties given and the ones read back are the same
+     * set. The comparison runs both ways on purpose: the file store records no OAuth2 flow, so the
+     * read-back path infers one, and a property it infers is as much of a mode change as a property
+     * it drops. The same class of loss exists for the AWS web identity profile, which is stored as
+     * an assume role or a default credential, but volumes relying on it exist in the wild and
+     * rejecting them belongs in its own change rather than in this fix.
      *
      * <p>The restored parameters go through the same {@link #preprocessAuthenticationIfNeeded}
      * derivation as the incoming ones, otherwise fields derived from the locations rather than the
@@ -377,15 +385,15 @@ public class StorageVolume implements Writable, GsonPostProcessable {
         if (svt != StorageVolumeType.AZBLOB && svt != StorageVolumeType.ADLS2) {
             return;
         }
-        List<String> droppedProperties = AZURE_CREDENTIAL_PROPERTIES.stream()
-                .filter(key -> isCredentialPropertySet(params, key) && !isCredentialPropertySet(restored, key))
+        List<String> changedProperties = AZURE_CREDENTIAL_PROPERTIES.stream()
+                .filter(key -> isCredentialPropertySet(params, key) != isCredentialPropertySet(restored, key))
                 .sorted()
                 .collect(Collectors.toList());
-        if (!droppedProperties.isEmpty()) {
+        if (!changedProperties.isEmpty()) {
             // Names only: the values are the credential we are refusing to store.
             throw new SemanticException(String.format(
                     "Storage params contain a credential that cannot be stored for a %s storage volume, " +
-                            "storing it would drop %s", svt, String.join(", ", droppedProperties)));
+                            "storing it would change %s", svt, String.join(", ", changedProperties)));
         }
     }
 
@@ -430,7 +438,6 @@ public class StorageVolume implements Writable, GsonPostProcessable {
                                                     List<String> locations, Map<String, String> params,
                                                     boolean enabled, String comment) throws DdlException {
         StorageVolume sv = new StorageVolume("", name, svt, locations, params, enabled, comment);
-        sv.validateCredentialIsPersistable(sv.cloudConfiguration, params);
         return sv.toFileStoreInfo();
     }
 
@@ -583,12 +590,18 @@ public class StorageVolume implements Writable, GsonPostProcessable {
                 if (!Strings.isNullOrEmpty(clientId)) {
                     params.put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_ID, clientId);
                 }
-                if (!Strings.isNullOrEmpty(tenantId) && !Strings.isNullOrEmpty(clientId)) {
-                    params.put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_USE_MANAGED_IDENTITY, "true");
-                }
                 String clientSecret = adls2credentialInfo.getClientSecret();
                 if (!Strings.isNullOrEmpty(clientSecret)) {
                     params.put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_SECRET, clientSecret);
+                }
+                // The file store has no field saying which OAuth2 flow was used, so it is inferred: a
+                // tenant and a client with no secret is a managed identity, the same three with a
+                // secret is a service principal. Inferring a managed identity from the tenant and the
+                // client alone made a stored service principal come back as a managed identity, since
+                // the credential builder prefers a managed identity over the client secret.
+                if (!Strings.isNullOrEmpty(tenantId) && !Strings.isNullOrEmpty(clientId)
+                        && Strings.isNullOrEmpty(clientSecret)) {
+                    params.put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_USE_MANAGED_IDENTITY, "true");
                 }
                 String clientEndpoint = adls2credentialInfo.getAuthorityHost();
                 if (!Strings.isNullOrEmpty(clientEndpoint)) {

--- a/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
+++ b/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
@@ -391,6 +391,18 @@ public class StorageVolume implements Writable, GsonPostProcessable {
                     "Storage params contain a credential that cannot be stored for a %s storage volume: %s",
                     svt, new Gson().toJson(maskedParams)));
         }
+        if (svt == StorageVolumeType.S3
+                && isCredentialPropertySet(params, CloudConfigurationConstants.AWS_S3_SESSION_TOKEN)) {
+            // AwsSimpleCredentialInfo carries the access key and its secret and nothing else - the
+            // credential's own toFileStoreInfo says as much with a TODO - so the session token is
+            // dropped and what reads back is a pair of temporary keys that can no longer
+            // authenticate. Unlike the ADLS2 workload identity this form is not documented for
+            // storage volumes, and temporary keys would expire during the volume's life anyway, so
+            // refuse it rather than warn.
+            throw new SemanticException(String.format(
+                    "Storage params contain a credential that cannot be stored for a %s storage volume, " +
+                            "storing it would drop %s", svt, CloudConfigurationConstants.AWS_S3_SESSION_TOKEN));
+        }
         if (svt != StorageVolumeType.AZBLOB && svt != StorageVolumeType.ADLS2) {
             return;
         }
@@ -477,7 +489,21 @@ public class StorageVolume implements Writable, GsonPostProcessable {
         if (vTabletGroupId != -1L) {
             properties.put(V_SHARD_GROUP_ID, String.valueOf(vTabletGroupId));
         }
-        FileStoreInfo.Builder builder = cloudConfiguration.toFileStoreInfo().toBuilder();
+        // What the configuration serialises to has to be a file store of this volume's own type.
+        // For a volume tolerated on read-back it is not: the factory chain falls through the cloud
+        // providers to the HDFS one, which accepts anything, so an AZBLOB volume whose credential
+        // cannot be rebuilt serialises to an HDFS file store carrying the azure properties as plain
+        // Hadoop configuration. Writing that back would silently change the volume's type in the
+        // file store rather than fail. The callers that write a volume back check
+        // isCredentialUsable() first, so reaching this means one was added without that check.
+        FileStoreInfo credentialInfo = cloudConfiguration.toFileStoreInfo();
+        if (credentialInfo == null || !credentialInfo.getFsType().name().equals(svt.name())) {
+            throw new IllegalStateException(String.format(
+                    "Storage volume '%s' of type %s has a credential that serialises to %s, " +
+                            "it must not be written back", name, svt,
+                    credentialInfo == null ? "nothing" : credentialInfo.getFsType()));
+        }
+        FileStoreInfo.Builder builder = credentialInfo.toBuilder();
         builder.setFsKey(id)
                 .setFsName(this.name)
                 .setComment(this.comment)

--- a/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
+++ b/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
@@ -17,7 +17,6 @@ package com.starrocks.storagevolume;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
@@ -50,7 +49,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 public class StorageVolume implements Writable, GsonPostProcessable {
@@ -198,8 +196,15 @@ public class StorageVolume implements Writable, GsonPostProcessable {
         this.enabled = sv.enabled;
         this.vTabletId = sv.vTabletId;
         this.vTabletGroupId = sv.vTabletGroupId;
-        this.cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(sv.params, true);
-        this.credentialUsable = sv.credentialUsable;
+        // Same derivation as the main constructor: an AZBLOB credential takes its container from the
+        // locations rather than from the properties, so rebuilding from the raw params alone would
+        // fall through the cloud providers to the HDFS one and make a perfectly usable volume look
+        // broken. Usability follows the rebuilt configuration for the same reason - a copied flag
+        // would disagree with the configuration this copy actually holds.
+        Map<String, String> configurationParams = new HashMap<>(sv.params);
+        preprocessAuthenticationIfNeeded(configurationParams);
+        this.cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(configurationParams, true);
+        this.credentialUsable = isValidCloudConfiguration(this.svt, this.cloudConfiguration);
         this.params = new HashMap<>(sv.params);
         validateStorageVolumeConstraints();
     }
@@ -369,11 +374,16 @@ public class StorageVolume implements Writable, GsonPostProcessable {
      * both ways on purpose: the file store records no OAuth2 flow, so the read-back path infers one,
      * and a property it infers is as much of a mode change as a property it drops.
      *
-     * <p>Two kinds of loss are knowingly left alone because refusing them would take away something
-     * users have today rather than protect them: the ADLS2 workload identity, which is documented
-     * and only warned about below, and the AWS web identity profile, which is stored as an assume
-     * role or a default credential. Both deserve their own change - a token file field in the file
-     * store for the former - rather than being turned into errors by this fix.
+     * <p>The ADLS2 workload identity is refused by this comparison. Its token file has no field in
+     * {@link ADLS2CredentialInfo}, so it lives only in the params of the FE that created the volume:
+     * a read-back turns it into a managed identity, and the file store is also the only credential a
+     * lake table's storage location carries, so nothing downstream ever sees the token. The English
+     * and Chinese CREATE STORAGE VOLUME pages used to offer it and were corrected together with this
+     * change. Supporting it needs a token file field in the file store, not a lenient check here.
+     *
+     * <p>The AWS web identity profile loses just as much - it is stored as an assume role or a
+     * default credential - but volumes relying on it exist in the wild, so turning that into an
+     * error belongs in its own change.
      *
      * <p>The restored parameters go through the same {@link #preprocessAuthenticationIfNeeded}
      * derivation as the incoming ones, otherwise fields derived from the locations rather than the
@@ -406,26 +416,7 @@ public class StorageVolume implements Writable, GsonPostProcessable {
         if (svt != StorageVolumeType.AZBLOB && svt != StorageVolumeType.ADLS2) {
             return;
         }
-        Set<String> tolerated = ImmutableSet.of();
-        if (isCredentialPropertySet(params, CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_TOKEN_FILE)) {
-            // A workload identity is a documented way to reach ADLS2 - see the "If you use Workload
-            // Identity" recipe in CREATE_STORAGE_VOLUME.md - yet ADLS2CredentialInfo has no field
-            // for the token file: it carries the shared key, the SAS token, the tenant, the client,
-            // the client secret, the certificate path and the authority host. The token file is
-            // therefore dropped and the volume reads back as a managed identity. Withdrawing a
-            // documented capability is not this fix's call, so warn instead of rejecting and leave
-            // the repair to the only place it can happen, a token file field in the file store.
-            // Only the two properties that follow from this are tolerated, so anything else the
-            // file store would drop is still refused.
-            LOG.warn("Storage volume '{}' authenticates to ADLS2 with a workload identity. The token " +
-                    "file is not part of the stored credential, so once the volume is read back it " +
-                    "authenticates as a managed identity instead.", name);
-            tolerated = ImmutableSet.of(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_TOKEN_FILE,
-                    CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_USE_MANAGED_IDENTITY);
-        }
-        Set<String> toleratedProperties = tolerated;
         List<String> changedProperties = AZURE_CREDENTIAL_PROPERTIES.stream()
-                .filter(key -> !toleratedProperties.contains(key))
                 .filter(key -> isCredentialPropertySet(params, key) != isCredentialPropertySet(restored, key))
                 .sorted()
                 .collect(Collectors.toList());

--- a/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
+++ b/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
@@ -17,6 +17,7 @@ package com.starrocks.storagevolume;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
@@ -49,6 +50,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class StorageVolume implements Writable, GsonPostProcessable {
@@ -361,15 +363,17 @@ public class StorageVolume implements Writable, GsonPostProcessable {
      * configuration of the same cloud, which also covers credential forms added later.
      *
      * <p>Staying the same cloud is not sufficient on Azure though, where the credential the factory
-     * accepts is richer than what the file store models: an ADLS2 credential authenticating with a
-     * workload identity loses its token file and reads back as a managed identity, so the volume
-     * stays valid while quietly authenticating as somebody else. The second half therefore requires,
-     * for Azure volumes, that the credential properties given and the ones read back are the same
-     * set. The comparison runs both ways on purpose: the file store records no OAuth2 flow, so the
-     * read-back path infers one, and a property it infers is as much of a mode change as a property
-     * it drops. The same class of loss exists for the AWS web identity profile, which is stored as
-     * an assume role or a default credential, but volumes relying on it exist in the wild and
-     * rejecting them belongs in its own change rather than in this fix.
+     * accepts is richer than what the file store models, so a volume can stay valid while quietly
+     * authenticating as somebody else. The second half therefore requires, for Azure volumes, that
+     * the credential properties given and the ones read back are the same set. The comparison runs
+     * both ways on purpose: the file store records no OAuth2 flow, so the read-back path infers one,
+     * and a property it infers is as much of a mode change as a property it drops.
+     *
+     * <p>Two kinds of loss are knowingly left alone because refusing them would take away something
+     * users have today rather than protect them: the ADLS2 workload identity, which is documented
+     * and only warned about below, and the AWS web identity profile, which is stored as an assume
+     * role or a default credential. Both deserve their own change - a token file field in the file
+     * store for the former - rather than being turned into errors by this fix.
      *
      * <p>The restored parameters go through the same {@link #preprocessAuthenticationIfNeeded}
      * derivation as the incoming ones, otherwise fields derived from the locations rather than the
@@ -390,7 +394,26 @@ public class StorageVolume implements Writable, GsonPostProcessable {
         if (svt != StorageVolumeType.AZBLOB && svt != StorageVolumeType.ADLS2) {
             return;
         }
+        Set<String> tolerated = ImmutableSet.of();
+        if (isCredentialPropertySet(params, CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_TOKEN_FILE)) {
+            // A workload identity is a documented way to reach ADLS2 - see the "If you use Workload
+            // Identity" recipe in CREATE_STORAGE_VOLUME.md - yet ADLS2CredentialInfo has no field
+            // for the token file: it carries the shared key, the SAS token, the tenant, the client,
+            // the client secret, the certificate path and the authority host. The token file is
+            // therefore dropped and the volume reads back as a managed identity. Withdrawing a
+            // documented capability is not this fix's call, so warn instead of rejecting and leave
+            // the repair to the only place it can happen, a token file field in the file store.
+            // Only the two properties that follow from this are tolerated, so anything else the
+            // file store would drop is still refused.
+            LOG.warn("Storage volume '{}' authenticates to ADLS2 with a workload identity. The token " +
+                    "file is not part of the stored credential, so once the volume is read back it " +
+                    "authenticates as a managed identity instead.", name);
+            tolerated = ImmutableSet.of(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_TOKEN_FILE,
+                    CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_USE_MANAGED_IDENTITY);
+        }
+        Set<String> toleratedProperties = tolerated;
         List<String> changedProperties = AZURE_CREDENTIAL_PROPERTIES.stream()
+                .filter(key -> !toleratedProperties.contains(key))
                 .filter(key -> isCredentialPropertySet(params, key) != isCredentialPropertySet(restored, key))
                 .sorted()
                 .collect(Collectors.toList());

--- a/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
+++ b/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
@@ -230,8 +230,14 @@ public class StorageVolume implements Writable, GsonPostProcessable {
     public void setCloudConfiguration(Map<String, String> params) {
         Map<String, String> newParams = new HashMap<>(this.params);
         newParams.putAll(params);
+        // Build from a preprocessed copy, exactly as the constructors do: an AZBLOB credential takes
+        // its container from the locations, params deliberately never carries it, and building from
+        // the raw map would fall through to the HDFS provider and refuse an ALTER of a perfectly
+        // usable volume. The derived container stays out of what is stored.
+        Map<String, String> configurationParams = new HashMap<>(newParams);
+        preprocessAuthenticationIfNeeded(configurationParams);
         CloudConfiguration newConfiguration =
-                CloudConfigurationFactory.buildCloudConfigurationForStorage(newParams, true);
+                CloudConfigurationFactory.buildCloudConfigurationForStorage(configurationParams, true);
         if (!isValidCloudConfiguration(svt, newConfiguration)) {
             throw new SemanticException("Storage params is not valid " + dumpMaskedParams(newParams));
         }
@@ -377,9 +383,10 @@ public class StorageVolume implements Writable, GsonPostProcessable {
      * and Chinese CREATE STORAGE VOLUME pages used to offer it and were corrected together with this
      * change. Supporting it needs a token file field in the file store, not a lenient check here.
      *
-     * <p>The AWS web identity profile loses just as much - it is stored as an assume role or a
-     * default credential - but volumes relying on it exist in the wild, so turning that into an
-     * error belongs in its own change.
+     * <p>The AWS web identity profile used to lose just as much, being stored as an assume role or a
+     * default credential, but #77638 has since given it a credential case of its own, so it now
+     * round-trips and needs nothing from this check. What stays lossy on S3 is the session token,
+     * refused above.
      *
      * <p>The restored parameters go through the same {@link #preprocessAuthenticationIfNeeded}
      * derivation as the incoming ones, otherwise fields derived from the locations rather than the
@@ -684,7 +691,13 @@ public class StorageVolume implements Writable, GsonPostProcessable {
 
     @Override
     public void gsonPostProcess() throws IOException {
-        cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(params);
+        // Same derivation as the constructors, for the same reason: params does not carry the AZBLOB
+        // container, so rebuilding from the raw map would fall through to the HDFS provider and mark
+        // a usable volume unusable on every image or edit-log reload - which the guards would then
+        // act on after each FE restart.
+        Map<String, String> configurationParams = new HashMap<>(params);
+        preprocessAuthenticationIfNeeded(configurationParams);
+        cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(configurationParams);
         credentialUsable = isValidCloudConfiguration(svt, cloudConfiguration);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
+++ b/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
@@ -115,6 +115,22 @@ public class StorageVolume implements Writable, GsonPostProcessable {
 
     public StorageVolume(String id, String name, String svt, List<String> locations,
                          Map<String, String> params, boolean enabled, String comment) throws DdlException {
+        this(id, name, svt, locations, params, enabled, comment, true);
+    }
+
+    /**
+     * @param requireUsableCredential when false, a credential that can no longer be turned into
+     *                                a usable configuration is tolerated instead of rejected.
+     *                                Only the read-back path passes false: identity, locations
+     *                                and virtual-tablet bookkeeping are still intact there, and
+     *                                the operations that rely solely on those - listing, resolving
+     *                                the name for a privilege check, dropping - have to keep
+     *                                working, otherwise such a volume is stuck in the cluster
+     *                                with no way to remove it.
+     */
+    private StorageVolume(String id, String name, String svt, List<String> locations,
+                          Map<String, String> params, boolean enabled, String comment,
+                          boolean requireUsableCredential) throws DdlException {
         this.id = id;
         this.name = name;
         this.svt = toStorageVolumeType(svt);
@@ -125,8 +141,12 @@ public class StorageVolume implements Writable, GsonPostProcessable {
         Map<String, String> configurationParams = new HashMap<>(params);
         preprocessAuthenticationIfNeeded(configurationParams);
         this.cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(configurationParams, true);
-        if (!isValidCloudConfiguration()) {
-            throw new SemanticException("Storage params is not valid " + dumpMaskedParams(params));
+        if (!isValidCloudConfiguration(this.svt, this.cloudConfiguration)) {
+            if (requireUsableCredential) {
+                throw new SemanticException("Storage params is not valid " + dumpMaskedParams(params));
+            }
+            LOG.warn("Storage volume '{}' has an unusable credential. It can still be listed and " +
+                    "dropped, but not used: {}", name, dumpMaskedParams(params));
         }
         validateStorageVolumeConstraints();
     }
@@ -166,10 +186,14 @@ public class StorageVolume implements Writable, GsonPostProcessable {
     public void setCloudConfiguration(Map<String, String> params) {
         Map<String, String> newParams = new HashMap<>(this.params);
         newParams.putAll(params);
-        this.cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(newParams, true);
-        if (!isValidCloudConfiguration()) {
+        CloudConfiguration newConfiguration =
+                CloudConfigurationFactory.buildCloudConfigurationForStorage(newParams, true);
+        if (!isValidCloudConfiguration(svt, newConfiguration)) {
             throw new SemanticException("Storage params is not valid " + dumpMaskedParams(newParams));
         }
+        validateCredentialIsPersistable(svt, newConfiguration, newParams);
+        // Assigned only once both checks pass, so a rejected ALTER leaves the volume untouched.
+        this.cloudConfiguration = newConfiguration;
         this.params = newParams;
     }
 
@@ -255,19 +279,47 @@ public class StorageVolume implements Writable, GsonPostProcessable {
     }
 
     private boolean isValidCloudConfiguration() {
+        return isValidCloudConfiguration(svt, cloudConfiguration);
+    }
+
+    private static boolean isValidCloudConfiguration(StorageVolumeType svt, CloudConfiguration configuration) {
         switch (svt) {
             case S3:
-                return cloudConfiguration.getCloudType() == CloudType.AWS;
+                return configuration.getCloudType() == CloudType.AWS;
             case HDFS:
-                return cloudConfiguration.getCloudType() == CloudType.HDFS;
+                return configuration.getCloudType() == CloudType.HDFS;
             case AZBLOB:
-                return cloudConfiguration.getCloudType() == CloudType.AZURE;
+                return configuration.getCloudType() == CloudType.AZURE;
             case ADLS2:
-                return cloudConfiguration.getCloudType() == CloudType.AZURE;
+                return configuration.getCloudType() == CloudType.AZURE;
             case GS:
-                return cloudConfiguration.getCloudType() == CloudType.GCP;
+                return configuration.getCloudType() == CloudType.GCP;
             default:
                 return false;
+        }
+    }
+
+    /**
+     * Not every credential the factory accepts can be stored: a credential's {@code toFileStoreInfo}
+     * only carries the fields the file store models, and anything else is dropped silently. A volume
+     * created from such a credential is written successfully and can never be rebuilt into a usable
+     * one afterwards, so reject it while the statement can still fail cleanly.
+     *
+     * <p>The check is deliberately generic - it round-trips the configuration through
+     * {@link FileStoreInfo} and verifies the result is still the same kind of cloud - so it also
+     * covers credential forms added later.
+     */
+    private static void validateCredentialIsPersistable(StorageVolumeType svt, CloudConfiguration configuration,
+                                                        Map<String, String> params) {
+        Map<String, String> restored = getParamsFromFileStoreInfo(configuration.toFileStoreInfo());
+        CloudConfiguration restoredConfiguration =
+                CloudConfigurationFactory.buildCloudConfigurationForStorage(restored, true);
+        if (!isValidCloudConfiguration(svt, restoredConfiguration)) {
+            Map<String, String> maskedParams = new HashMap<>(params);
+            addMaskForCredential(maskedParams);
+            throw new SemanticException(String.format(
+                    "Storage params contain a credential that cannot be stored for a %s storage volume: %s",
+                    svt, new Gson().toJson(maskedParams)));
         }
     }
 
@@ -299,6 +351,7 @@ public class StorageVolume implements Writable, GsonPostProcessable {
                                                     List<String> locations, Map<String, String> params,
                                                     boolean enabled, String comment) throws DdlException {
         StorageVolume sv = new StorageVolume("", name, svt, locations, params, enabled, comment);
+        validateCredentialIsPersistable(sv.svt, sv.cloudConfiguration, params);
         return sv.toFileStoreInfo();
     }
 
@@ -324,7 +377,7 @@ public class StorageVolume implements Writable, GsonPostProcessable {
         String svt = fsInfo.getFsType().toString();
         Map<String, String> params = getParamsFromFileStoreInfo(fsInfo);
         StorageVolume storageVolume = new StorageVolume(fsInfo.getFsKey(), fsInfo.getFsName(), svt,
-                fsInfo.getLocationsList(), params, fsInfo.getEnabled(), fsInfo.getComment());
+                fsInfo.getLocationsList(), params, fsInfo.getEnabled(), fsInfo.getComment(), false);
 
         Map<String, String> propertiesMap = fsInfo.getPropertiesMap();
         if (propertiesMap.containsKey(V_SHARD_ID)) {

--- a/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
+++ b/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
@@ -336,10 +336,6 @@ public class StorageVolume implements Writable, GsonPostProcessable {
         }
     }
 
-    private boolean isValidCloudConfiguration() {
-        return isValidCloudConfiguration(svt, cloudConfiguration);
-    }
-
     private static boolean isValidCloudConfiguration(StorageVolumeType svt, CloudConfiguration configuration) {
         switch (svt) {
             case S3:

--- a/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
+++ b/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
@@ -16,6 +16,7 @@ package com.starrocks.storagevolume;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
@@ -48,6 +49,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class StorageVolume implements Writable, GsonPostProcessable {
     private static final Logger LOG = LogManager.getLogger(StorageVolume.class);
@@ -77,6 +79,13 @@ public class StorageVolume implements Writable, GsonPostProcessable {
 
     private CloudConfiguration cloudConfiguration;
 
+    /**
+     * Derived from {@link #cloudConfiguration} and never persisted: a volume that was stored with a
+     * credential which can no longer be turned into a usable configuration stays readable, so that
+     * it can be listed and dropped, but it must not be used to store data.
+     */
+    private boolean credentialUsable = true;
+
     @SerializedName("p")
     private Map<String, String> params;
 
@@ -105,6 +114,26 @@ public class StorageVolume implements Writable, GsonPostProcessable {
     public static final String V_SHARD_GROUP_ID = "v_shard_group_id";
 
     public static String CREDENTIAL_MASK = "******";
+
+    /**
+     * The credential properties an Azure volume can be created with. Kept next to
+     * {@link #getParamsFromFileStoreInfo}, which is the read-back side of the same round trip.
+     */
+    private static final List<String> AZURE_CREDENTIAL_PROPERTIES = ImmutableList.of(
+            CloudConfigurationConstants.AZURE_BLOB_SHARED_KEY,
+            CloudConfigurationConstants.AZURE_BLOB_SAS_TOKEN,
+            CloudConfigurationConstants.AZURE_BLOB_OAUTH2_USE_MANAGED_IDENTITY,
+            CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_ID,
+            CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_SECRET,
+            CloudConfigurationConstants.AZURE_BLOB_OAUTH2_TENANT_ID,
+            CloudConfigurationConstants.AZURE_ADLS2_SHARED_KEY,
+            CloudConfigurationConstants.AZURE_ADLS2_SAS_TOKEN,
+            CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_USE_MANAGED_IDENTITY,
+            CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_TENANT_ID,
+            CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_ID,
+            CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_SECRET,
+            CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_ENDPOINT,
+            CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_TOKEN_FILE);
 
     private String dumpMaskedParams(Map<String, String> params) {
         Gson gson = new Gson();
@@ -141,7 +170,8 @@ public class StorageVolume implements Writable, GsonPostProcessable {
         Map<String, String> configurationParams = new HashMap<>(params);
         preprocessAuthenticationIfNeeded(configurationParams);
         this.cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(configurationParams, true);
-        if (!isValidCloudConfiguration(this.svt, this.cloudConfiguration)) {
+        this.credentialUsable = isValidCloudConfiguration(this.svt, this.cloudConfiguration);
+        if (!this.credentialUsable) {
             if (requireUsableCredential) {
                 throw new SemanticException("Storage params is not valid " + dumpMaskedParams(params));
             }
@@ -161,6 +191,7 @@ public class StorageVolume implements Writable, GsonPostProcessable {
         this.vTabletId = sv.vTabletId;
         this.vTabletGroupId = sv.vTabletGroupId;
         this.cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(sv.params, true);
+        this.credentialUsable = sv.credentialUsable;
         this.params = new HashMap<>(sv.params);
         validateStorageVolumeConstraints();
     }
@@ -191,10 +222,19 @@ public class StorageVolume implements Writable, GsonPostProcessable {
         if (!isValidCloudConfiguration(svt, newConfiguration)) {
             throw new SemanticException("Storage params is not valid " + dumpMaskedParams(newParams));
         }
-        validateCredentialIsPersistable(svt, newConfiguration, newParams);
+        validateCredentialIsPersistable(newConfiguration, newParams);
         // Assigned only once both checks pass, so a rejected ALTER leaves the volume untouched.
         this.cloudConfiguration = newConfiguration;
         this.params = newParams;
+    }
+
+    /**
+     * False when the stored credential can no longer be turned into a usable configuration. Such a
+     * volume is kept readable on purpose - see the tolerating constructor - so callers that are
+     * about to store data through it have to reject it explicitly.
+     */
+    public boolean isCredentialUsable() {
+        return credentialUsable;
     }
 
     public CloudConfiguration getCloudConfiguration() {
@@ -305,13 +345,26 @@ public class StorageVolume implements Writable, GsonPostProcessable {
      * created from such a credential is written successfully and can never be rebuilt into a usable
      * one afterwards, so reject it while the statement can still fail cleanly.
      *
-     * <p>The check is deliberately generic - it round-trips the configuration through
-     * {@link FileStoreInfo} and verifies the result is still the same kind of cloud - so it also
-     * covers credential forms added later.
+     * <p>The first half of the check applies to every volume type and is deliberately generic: the
+     * configuration is round-tripped through {@link FileStoreInfo} and has to come back as a usable
+     * configuration of the same cloud, which also covers credential forms added later.
+     *
+     * <p>Staying the same cloud is not sufficient on Azure though, where the credential the factory
+     * accepts is richer than what the file store models: an ADLS2 credential authenticating with a
+     * workload identity loses its token file and reads back as a managed identity, so the volume
+     * stays valid while quietly authenticating as somebody else. The second half therefore requires,
+     * for Azure volumes, that every credential property that was given also survives the round trip.
+     * The same class of loss exists for the AWS web identity profile, which is stored as an assume
+     * role or a default credential, but volumes relying on it exist in the wild and rejecting them
+     * belongs in its own change rather than in this fix.
+     *
+     * <p>The restored parameters go through the same {@link #preprocessAuthenticationIfNeeded}
+     * derivation as the incoming ones, otherwise fields derived from the locations rather than the
+     * properties - the AZBLOB container - would look lost and reject perfectly storable credentials.
      */
-    private static void validateCredentialIsPersistable(StorageVolumeType svt, CloudConfiguration configuration,
-                                                        Map<String, String> params) {
+    private void validateCredentialIsPersistable(CloudConfiguration configuration, Map<String, String> params) {
         Map<String, String> restored = getParamsFromFileStoreInfo(configuration.toFileStoreInfo());
+        preprocessAuthenticationIfNeeded(restored);
         CloudConfiguration restoredConfiguration =
                 CloudConfigurationFactory.buildCloudConfigurationForStorage(restored, true);
         if (!isValidCloudConfiguration(svt, restoredConfiguration)) {
@@ -321,6 +374,30 @@ public class StorageVolume implements Writable, GsonPostProcessable {
                     "Storage params contain a credential that cannot be stored for a %s storage volume: %s",
                     svt, new Gson().toJson(maskedParams)));
         }
+        if (svt != StorageVolumeType.AZBLOB && svt != StorageVolumeType.ADLS2) {
+            return;
+        }
+        List<String> droppedProperties = AZURE_CREDENTIAL_PROPERTIES.stream()
+                .filter(key -> isCredentialPropertySet(params, key) && !isCredentialPropertySet(restored, key))
+                .sorted()
+                .collect(Collectors.toList());
+        if (!droppedProperties.isEmpty()) {
+            // Names only: the values are the credential we are refusing to store.
+            throw new SemanticException(String.format(
+                    "Storage params contain a credential that cannot be stored for a %s storage volume, " +
+                            "storing it would drop %s", svt, String.join(", ", droppedProperties)));
+        }
+    }
+
+    /**
+     * A property explicitly turned off says as little about the credential as an absent one, and the
+     * read-back path only writes the flags that are on, so treat both the same way. Without this an
+     * {@code oauth2_use_managed_identity = false} spelled out next to a shared key would look like a
+     * property the file store had dropped.
+     */
+    private static boolean isCredentialPropertySet(Map<String, String> params, String key) {
+        String value = params.get(key);
+        return !Strings.isNullOrEmpty(value) && !value.equalsIgnoreCase("false");
     }
 
     public static void addMaskForCredential(Map<String, String> params) {
@@ -330,6 +407,8 @@ public class StorageVolume implements Writable, GsonPostProcessable {
         params.computeIfPresent(CloudConfigurationConstants.AZURE_BLOB_SAS_TOKEN, (key, value) -> CREDENTIAL_MASK);
         params.computeIfPresent(CloudConfigurationConstants.AZURE_ADLS2_SHARED_KEY, (key, value) -> CREDENTIAL_MASK);
         params.computeIfPresent(CloudConfigurationConstants.AZURE_ADLS2_SAS_TOKEN, (key, value) -> CREDENTIAL_MASK);
+        params.computeIfPresent(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_SECRET, (key, value) -> CREDENTIAL_MASK);
+        params.computeIfPresent(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_SECRET, (key, value) -> CREDENTIAL_MASK);
         params.computeIfPresent(CloudConfigurationConstants.GCP_GCS_SERVICE_ACCOUNT_EMAIL, (key, value) -> CREDENTIAL_MASK);
         params.computeIfPresent(CloudConfigurationConstants.GCP_GCS_SERVICE_ACCOUNT_PRIVATE_KEY_ID,
                 (key, value) -> CREDENTIAL_MASK);
@@ -351,7 +430,7 @@ public class StorageVolume implements Writable, GsonPostProcessable {
                                                     List<String> locations, Map<String, String> params,
                                                     boolean enabled, String comment) throws DdlException {
         StorageVolume sv = new StorageVolume("", name, svt, locations, params, enabled, comment);
-        validateCredentialIsPersistable(sv.svt, sv.cloudConfiguration, params);
+        sv.validateCredentialIsPersistable(sv.cloudConfiguration, params);
         return sv.toFileStoreInfo();
     }
 
@@ -552,5 +631,6 @@ public class StorageVolume implements Writable, GsonPostProcessable {
     @Override
     public void gsonPostProcess() throws IOException {
         cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(params);
+        credentialUsable = isValidCloudConfiguration(svt, cloudConfiguration);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotTest.java
@@ -14,6 +14,9 @@
 
 package com.starrocks.lake.snapshot;
 
+import com.staros.proto.AzBlobFileStoreInfo;
+import com.staros.proto.FileStoreInfo;
+import com.staros.proto.FileStoreType;
 import com.starrocks.alter.AlterJobV2;
 import com.starrocks.alter.AlterTest;
 import com.starrocks.alter.MaterializedViewHandler;
@@ -41,6 +44,7 @@ import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
+import com.starrocks.server.SharedDataStorageVolumeMgr;
 import com.starrocks.server.StorageVolumeMgr;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.analyzer.ClusterSnapshotAnalyzer;
@@ -51,6 +55,7 @@ import com.starrocks.sql.ast.AdminSetAutomatedSnapshotOnStmt;
 import com.starrocks.sql.ast.UnitIdentifier;
 import com.starrocks.sql.ast.expression.IntervalLiteral;
 import com.starrocks.sql.ast.expression.StringLiteral;
+import com.starrocks.storagevolume.StorageVolume;
 import com.starrocks.thrift.TBrokerFD;
 import mockit.Mock;
 import mockit.MockUp;
@@ -1227,4 +1232,53 @@ public class ClusterSnapshotTest {
         Assertions.assertFalse(scheduler.interruptOnStop());
     }
 
+    @Test
+    public void testAutomatedSnapshotRefusesAndSkipsVolumeWithUnusableCredential() throws Exception {
+        // A volume kept readable only so that it can be dropped would let every snapshot round do
+        // its local checkpoint work and then fail in HdfsUtil, so it is refused when the statement
+        // turns snapshots on, and skipped by the scheduler for a cluster that was already
+        // snapshotting when it upgraded and therefore never passed through the statement.
+        StorageVolume unusable = StorageVolume.fromFileStoreInfo(FileStoreInfo.newBuilder()
+                .setFsKey("1")
+                .setFsName(storageVolumeName)
+                .setFsType(FileStoreType.AZBLOB)
+                .setEnabled(true)
+                .addLocations("azblob://aaa")
+                .setAzblobFsInfo(AzBlobFileStoreInfo.newBuilder().setEndpoint("endpoint").build())
+                .build());
+        Assertions.assertFalse(unusable.isCredentialUsable());
+
+        // The mocked manager has to be the one GlobalStateMgr hands out: it picks its subclass by
+        // run mode when it is built, which happens before this test switches RunMode over, so the
+        // instance the FE actually holds is the shared-nothing one.
+        SharedDataStorageVolumeMgr storageVolumeMgr = new SharedDataStorageVolumeMgr();
+        new MockUp<SharedDataStorageVolumeMgr>() {
+            @Mock
+            public StorageVolume getStorageVolumeByName(String svName) {
+                return unusable;
+            }
+
+            @Mock
+            public boolean exists(String svName) {
+                return true;
+            }
+        };
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public StorageVolumeMgr getStorageVolumeMgr() {
+                return storageVolumeMgr;
+            }
+        };
+
+        // ADMIN SET AUTOMATED SNAPSHOT ON refuses it.
+        AdminSetAutomatedSnapshotOnStmt onStmt = new AdminSetAutomatedSnapshotOnStmt(storageVolumeName, null);
+        SemanticException e = Assertions.assertThrows(SemanticException.class,
+                () -> ClusterSnapshotAnalyzer.analyze(onStmt, AnalyzeTestUtil.getConnectContext()));
+        Assertions.assertTrue(e.getMessage().contains("credential that cannot be used"), e.getMessage());
+
+        // And the scheduler skips a round rather than creating a job that would fail.
+        setAutomatedSnapshotOn(false);
+        Assertions.assertFalse(clusterSnapshotMgr.canScheduleNextJob(0L));
+        setAutomatedSnapshotOff(false);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
@@ -13,10 +13,21 @@
 // limitations under the License.
 package com.starrocks.qe;
 
+import com.staros.proto.AzBlobFileStoreInfo;
+import com.staros.proto.FileStoreInfo;
+import com.staros.proto.FileStoreType;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.SharedDataStorageVolumeMgr;
+import com.starrocks.server.StorageVolumeMgr;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.storagevolume.StorageVolume;
 import com.starrocks.thrift.TBinaryEncodingFormat;
 import com.starrocks.thrift.TBinaryEncodingLevel;
 import com.starrocks.thrift.TQueryOptions;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -219,5 +230,45 @@ public class SessionVariableTest {
                 SessionVariable.SCAN_LAKE_PARTITION_NUM_LIMIT + "\": 4096, \"" +
                 SessionVariable.SCAN_HIVE_PARTITION_NUM_LIMIT + "\": 512}");
         Assertions.assertEquals(4096, sessionVariable.getScanLakePartitionNumLimit());
+    }
+
+    @Test
+    public void testRemoteSpillStaysOffForVolumeWithUnusableCredential() throws DdlException {
+        // A volume kept readable only so that it can be dropped carries a DEFAULT cloud
+        // configuration. Shipping that to the BE would fail once a query actually spills, and with
+        // disable_spill_to_local_disk there is nowhere else to go, so remote spilling has to stay
+        // off - the same thing that happens when the named volume does not exist.
+        StorageVolume unusable = StorageVolume.fromFileStoreInfo(FileStoreInfo.newBuilder()
+                .setFsKey("1")
+                .setFsName("sv")
+                .setFsType(FileStoreType.AZBLOB)
+                .setEnabled(true)
+                .addLocations("azblob://aaa")
+                .setAzblobFsInfo(AzBlobFileStoreInfo.newBuilder().setEndpoint("endpoint").build())
+                .build());
+        Assertions.assertFalse(unusable.isCredentialUsable());
+
+        SharedDataStorageVolumeMgr svm = new SharedDataStorageVolumeMgr();
+        new MockUp<SharedDataStorageVolumeMgr>() {
+            @Mock
+            public StorageVolume getStorageVolumeByName(String svName) {
+                return unusable;
+            }
+        };
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public StorageVolumeMgr getStorageVolumeMgr() {
+                return svm;
+            }
+        };
+
+        SessionVariable sessionVariable = new SessionVariable();
+        sessionVariable.setEnableSpill(true);
+        Deencapsulation.setField(sessionVariable, "enableSpillToRemoteStorage", true);
+        Deencapsulation.setField(sessionVariable, "spillStorageVolume", "sv");
+
+        TQueryOptions queryOptions = sessionVariable.toThrift();
+        Assertions.assertFalse(queryOptions.getSpill_options().isEnable_spill_to_remote_storage());
+        Assertions.assertNull(queryOptions.getSpill_options().getSpill_to_remote_storage_options());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
@@ -17,9 +17,11 @@ package com.starrocks.server;
 import com.google.common.collect.Lists;
 import com.google.gson.stream.JsonReader;
 import com.staros.client.StarClientException;
+import com.staros.proto.AzBlobFileStoreInfo;
 import com.staros.proto.FileCacheInfo;
 import com.staros.proto.FilePathInfo;
 import com.staros.proto.FileStoreInfo;
+import com.staros.proto.FileStoreType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DistributionInfo;
@@ -1898,5 +1900,48 @@ public class SharedDataStorageVolumeMgrTest {
         // Instance profile without a role is stored as a profile credential, which carries no
         // role fields at all.
         Assertions.assertFalse(params.containsKey(AWS_S3_IAM_ROLE_ARN));
+    }
+
+    @Test
+    public void testGetOrCreateVirtualTabletIdRejectsVolumeWithUnusableCredential() {
+        // A volume stored with a credential that can no longer be used is tolerated on read-back so
+        // it can still be shown and dropped. Lake replication names such a volume as its source, and
+        // everything after this point has side effects - allocating a path, creating a shard and a
+        // shard group, writing the volume back - so it has to be refused up front.
+        String storageVolumeName = "unusable_sv";
+        String srcServiceId = "test_service_id";
+        FileStoreInfo unusable = FileStoreInfo.newBuilder()
+                .setFsKey("1")
+                .setFsName(storageVolumeName)
+                .setFsType(FileStoreType.AZBLOB)
+                .setEnabled(true)
+                .addLocations("azblob://aaa")
+                .setAzblobFsInfo(AzBlobFileStoreInfo.newBuilder().setEndpoint("endpoint").build())
+                .build();
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public StarOSAgent getStarOSAgent() {
+                return starOSAgent;
+            }
+        };
+
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public FileStoreInfo getFileStoreByName(String fsName) {
+                return storageVolumeName.equals(fsName) ? unusable : null;
+            }
+
+            @Mock
+            public FilePathInfo allocateFilePath(String svKey, String serviceId) {
+                throw new IllegalStateException("allocateFilePath must not run for an unusable volume");
+            }
+        };
+
+        StorageVolumeMgr svm = new SharedDataStorageVolumeMgr();
+        Assertions.assertFalse(svm.getStorageVolumeByName(storageVolumeName).isCredentialUsable());
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                "Storage volume " + storageVolumeName + " has a credential that cannot be used",
+                () -> svm.getOrCreateVirtualTabletId(storageVolumeName, srcServiceId));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
@@ -1944,4 +1944,44 @@ public class SharedDataStorageVolumeMgrTest {
                 "Storage volume " + storageVolumeName + " has a credential that cannot be used",
                 () -> svm.getOrCreateVirtualTabletId(storageVolumeName, srcServiceId));
     }
+
+    @Test
+    public void testMetadataOnlyAlterOnUnusableVolumeFailsCleanly() {
+        // Writing such a volume back cannot produce a file store, so a comment-only ALTER used to
+        // die with a NullPointerException. It must fail with something an operator can act on, and
+        // the message has to name the ways out: drop it, or repair it in the same ALTER.
+        String storageVolumeName = "unusable_sv";
+        FileStoreInfo unusable = FileStoreInfo.newBuilder()
+                .setFsKey("1")
+                .setFsName(storageVolumeName)
+                .setFsType(FileStoreType.AZBLOB)
+                .setEnabled(true)
+                .addLocations("azblob://aaa")
+                .setAzblobFsInfo(AzBlobFileStoreInfo.newBuilder().setEndpoint("endpoint").build())
+                .build();
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public StarOSAgent getStarOSAgent() {
+                return starOSAgent;
+            }
+        };
+
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public FileStoreInfo getFileStoreByName(String fsName) {
+                return storageVolumeName.equals(fsName) ? unusable : null;
+            }
+
+            @Mock
+            public void updateFileStore(FileStoreInfo fsInfo) {
+                throw new IllegalStateException("an unusable volume must never be written back");
+            }
+        };
+
+        StorageVolumeMgr svm = new SharedDataStorageVolumeMgr();
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                "Storage volume " + storageVolumeName + " has a credential that cannot be used",
+                () -> svm.updateStorageVolume(storageVolumeName, null, null, new HashMap<>(), "new comment"));
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
@@ -1984,4 +1984,57 @@ public class SharedDataStorageVolumeMgrTest {
                 "Storage volume " + storageVolumeName + " has a credential that cannot be used",
                 () -> svm.updateStorageVolume(storageVolumeName, null, null, new HashMap<>(), "new comment"));
     }
+
+    @Test
+    public void testVolumeWithUnusableCredentialCanStillBeListedAndDropped() throws DdlException, MetaNotFoundException {
+        // The point of the whole change: a volume stored with a credential that can no longer be
+        // rebuilt used to make every DDL path fail, including DROP, so it was stuck in the cluster
+        // for good and SHOW STORAGE VOLUMES stayed broken for every other volume too. Listing it and
+        // dropping it have to work; using it is what the guards refuse.
+        String storageVolumeName = "unusable_sv";
+        FileStoreInfo unusable = FileStoreInfo.newBuilder()
+                .setFsKey("1")
+                .setFsName(storageVolumeName)
+                .setFsType(FileStoreType.AZBLOB)
+                .setEnabled(true)
+                .addLocations("azblob://aaa")
+                .setAzblobFsInfo(AzBlobFileStoreInfo.newBuilder().setEndpoint("endpoint").build())
+                .build();
+        List<FileStoreInfo> fileStores = new ArrayList<>();
+        fileStores.add(unusable);
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public StarOSAgent getStarOSAgent() {
+                return starOSAgent;
+            }
+        };
+
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public FileStoreInfo getFileStoreByName(String fsName) {
+                return fileStores.stream().filter(fs -> fs.getFsName().equals(fsName)).findFirst().orElse(null);
+            }
+
+            @Mock
+            public List<FileStoreInfo> listFileStore() {
+                return fileStores;
+            }
+
+            @Mock
+            public void removeFileStoreByName(String fsName) {
+                fileStores.removeIf(fs -> fs.getFsName().equals(fsName));
+            }
+        };
+
+        StorageVolumeMgr svm = new SharedDataStorageVolumeMgr();
+
+        // SHOW STORAGE VOLUMES lists it instead of failing on it.
+        Assertions.assertTrue(svm.listStorageVolumeNames().contains(storageVolumeName));
+        // DESC reaches it, and it reports itself as unusable rather than throwing.
+        Assertions.assertFalse(svm.getStorageVolumeByName(storageVolumeName).isCredentialUsable());
+        // DROP removes it.
+        svm.removeStorageVolume(storageVolumeName);
+        Assertions.assertFalse(svm.exists(storageVolumeName));
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
@@ -528,21 +528,19 @@ public class StorageVolumeTest {
     }
 
     @Test
-    public void testAdls2RejectsWorkloadIdentityBecauseTheTokenFileIsNotStored() {
-        // A workload identity survives as an ADLS2 credential - the tenant and the client are
-        // stored - but its token file is not, so what is read back authenticates as a managed
-        // identity instead. Same kind of cloud, different identity: checking the cloud type alone
-        // would let this through.
+    public void testAdls2WorkloadIdentityStaysAcceptedEvenThoughTheTokenFileIsNotStored()
+            throws DdlException {
+        // The token file has no field in ADLS2CredentialInfo, so it is dropped and the volume reads
+        // back as a managed identity. CREATE_STORAGE_VOLUME.md documents this authentication, so it
+        // is warned about rather than refused - refusing it would withdraw a documented capability.
         Map<String, String> storageParams = new HashMap<>();
         storageParams.put(AZURE_ADLS2_ENDPOINT, "endpoint");
         storageParams.put(AZURE_ADLS2_OAUTH2_TENANT_ID, "tenant_id");
         storageParams.put(AZURE_ADLS2_OAUTH2_CLIENT_ID, "client_id");
         storageParams.put(AZURE_ADLS2_OAUTH2_TOKEN_FILE, "/var/run/secrets/azure/token");
 
-        SemanticException e = Assertions.assertThrows(SemanticException.class, () ->
-                StorageVolume.createFileStoreInfo("test", "adls2", Arrays.asList("adls2://aaa"),
-                        storageParams, true, ""));
-        Assertions.assertTrue(e.getMessage().contains(AZURE_ADLS2_OAUTH2_TOKEN_FILE), e.getMessage());
+        StorageVolume.createFileStoreInfo("test", "adls2", Arrays.asList("adls2://aaa"),
+                storageParams, true, "");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
@@ -68,6 +68,8 @@ import static com.starrocks.connector.share.credential.CloudConfigurationConstan
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_SAS_TOKEN;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_SHARED_KEY;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_ENDPOINT;
+import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_ID;
+import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_OAUTH2_USE_MANAGED_IDENTITY;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_SAS_TOKEN;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_SHARED_KEY;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.GCP_GCS_IMPERSONATION_SERVICE_ACCOUNT;
@@ -460,6 +462,61 @@ public class StorageVolumeTest {
         azBlobFileStoreInfo = fileStore.getAzblobFsInfo();
         Assertions.assertEquals("endpoint", azBlobFileStoreInfo.getEndpoint());
         Assertions.assertEquals("sas_token", azBlobFileStoreInfo.getCredential().getSasToken());
+    }
+
+    @Test
+    public void testAzureBlobRejectsCredentialThatCannotBePersisted() {
+        // Managed identity is accepted by the shared credential factory (FILES() supports it),
+        // but an AZBLOB file store can only carry a shared key or a SAS token. Creating such a
+        // volume used to succeed and leave behind something that could never be read or dropped.
+        Map<String, String> storageParams = new HashMap<>();
+        storageParams.put(AZURE_BLOB_ENDPOINT, "endpoint");
+        storageParams.put(AZURE_BLOB_OAUTH2_USE_MANAGED_IDENTITY, "true");
+        storageParams.put(AZURE_BLOB_OAUTH2_CLIENT_ID, "client_id");
+
+        SemanticException e = Assertions.assertThrows(SemanticException.class, () ->
+                StorageVolume.createFileStoreInfo("test", "azblob", Arrays.asList("azblob://aaa"),
+                        storageParams, true, ""));
+        Assertions.assertTrue(e.getMessage().contains("cannot be stored"), e.getMessage());
+    }
+
+    @Test
+    public void testAzureBlobAlterRejectsCredentialThatCannotBePersistedAndKeepsVolumeIntact() throws DdlException {
+        Map<String, String> storageParams = new HashMap<>();
+        storageParams.put(AZURE_BLOB_ENDPOINT, "endpoint");
+        storageParams.put(AZURE_BLOB_SHARED_KEY, "shared_key");
+        StorageVolume sv = new StorageVolume("1", "test", "azblob", Arrays.asList("azblob://aaa"),
+                storageParams, true, "");
+
+        Map<String, String> badParams = new HashMap<>();
+        badParams.put(AZURE_BLOB_SHARED_KEY, "");
+        badParams.put(AZURE_BLOB_OAUTH2_USE_MANAGED_IDENTITY, "true");
+        badParams.put(AZURE_BLOB_OAUTH2_CLIENT_ID, "client_id");
+        Assertions.assertThrows(SemanticException.class, () -> sv.setCloudConfiguration(badParams));
+
+        // A rejected ALTER must not damage the volume it failed on.
+        Assertions.assertEquals(CloudType.AZURE, sv.getCloudConfiguration().getCloudType());
+        Assertions.assertEquals("shared_key",
+                sv.getCloudConfiguration().toFileStoreInfo().getAzblobFsInfo().getCredential().getSharedKey());
+    }
+
+    @Test
+    public void testStorageVolumeWithUnusableCredentialIsStillReadable() throws DdlException {
+        // A volume already stored with a credential that can no longer be rebuilt - the state this
+        // bug leaves behind. Reading it back must not throw, otherwise SHOW STORAGE VOLUMES fails
+        // for every volume and the broken one can never be dropped.
+        FileStoreInfo fsInfo = FileStoreInfo.newBuilder()
+                .setFsKey("1")
+                .setFsName("test")
+                .setFsType(FileStoreType.AZBLOB)
+                .setEnabled(true)
+                .addLocations("azblob://aaa")
+                .setAzblobFsInfo(AzBlobFileStoreInfo.newBuilder().setEndpoint("endpoint").build())
+                .build();
+
+        StorageVolume sv = StorageVolume.fromFileStoreInfo(fsInfo);
+        Assertions.assertEquals("1", sv.getId());
+        Assertions.assertEquals("test", sv.getName());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
@@ -61,6 +61,7 @@ import static com.starrocks.connector.share.credential.CloudConfigurationConstan
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_IAM_ROLE_ARN;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_REGION;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_SECRET_KEY;
+import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_SESSION_TOKEN;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_USE_INSTANCE_PROFILE;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE;
@@ -608,6 +609,57 @@ public class StorageVolumeTest {
         Assertions.assertTrue(sv.isCredentialUsable());
         // The copy the managers cache must carry the repaired flag, not the stale one.
         Assertions.assertTrue(new StorageVolume(sv).isCredentialUsable());
+    }
+
+    @Test
+    public void testS3RejectsTemporaryKeysBecauseTheSessionTokenIsNotStored() {
+        // AwsSimpleCredentialInfo stores the access key and its secret only, so the session token is
+        // dropped and the temporary keys that come back can no longer authenticate.
+        Map<String, String> storageParams = new HashMap<>();
+        storageParams.put(AWS_S3_REGION, "region");
+        storageParams.put(AWS_S3_ENDPOINT, "endpoint");
+        storageParams.put(AWS_S3_ACCESS_KEY, "access_key");
+        storageParams.put(AWS_S3_SECRET_KEY, "secret_key");
+        storageParams.put(AWS_S3_SESSION_TOKEN, "session_token");
+
+        SemanticException e = Assertions.assertThrows(SemanticException.class, () ->
+                StorageVolume.createFileStoreInfo("test", "s3", Arrays.asList("s3://bucket"),
+                        storageParams, true, ""));
+        Assertions.assertTrue(e.getMessage().contains(AWS_S3_SESSION_TOKEN), e.getMessage());
+    }
+
+    @Test
+    public void testS3AccessKeyWithoutSessionTokenRemainsStorable() throws DdlException {
+        Map<String, String> storageParams = new HashMap<>();
+        storageParams.put(AWS_S3_REGION, "region");
+        storageParams.put(AWS_S3_ENDPOINT, "endpoint");
+        storageParams.put(AWS_S3_ACCESS_KEY, "access_key");
+        storageParams.put(AWS_S3_SECRET_KEY, "secret_key");
+        StorageVolume.createFileStoreInfo("test", "s3", Arrays.asList("s3://bucket"), storageParams, true, "");
+    }
+
+    @Test
+    public void testUnusableVolumeRefusesToBeWrittenBackAsAnotherType() throws DdlException {
+        // The factory chain falls through the cloud providers to the HDFS one, which accepts any
+        // properties, so an AZBLOB volume whose credential cannot be rebuilt serialises to an HDFS
+        // file store with the azure properties as plain Hadoop configuration. Writing that back
+        // would quietly turn the volume into an HDFS one, which is worse than failing, so
+        // toFileStoreInfo refuses instead.
+        FileStoreInfo fsInfo = FileStoreInfo.newBuilder()
+                .setFsKey("1")
+                .setFsName("test")
+                .setFsType(FileStoreType.AZBLOB)
+                .setEnabled(true)
+                .addLocations("azblob://aaa")
+                .setAzblobFsInfo(AzBlobFileStoreInfo.newBuilder().setEndpoint("endpoint").build())
+                .build();
+        StorageVolume sv = StorageVolume.fromFileStoreInfo(fsInfo);
+        Assertions.assertFalse(sv.isCredentialUsable());
+        // The premise of the refusal: the configuration no longer serialises to an AZBLOB file store.
+        Assertions.assertNotEquals(FileStoreType.AZBLOB, sv.getCloudConfiguration().toFileStoreInfo().getFsType());
+
+        IllegalStateException e = Assertions.assertThrows(IllegalStateException.class, sv::toFileStoreInfo);
+        Assertions.assertTrue(e.getMessage().contains("must not be written back"), e.getMessage());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
@@ -65,6 +65,7 @@ import static com.starrocks.connector.share.credential.CloudConfigurationConstan
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_USE_INSTANCE_PROFILE;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_ENDPOINT;
+import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_ENDPOINT;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_ID;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_SECRET;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_TENANT_ID;
@@ -605,6 +606,42 @@ public class StorageVolumeTest {
         StorageVolume usable = new StorageVolume("1", "test", "azblob", Arrays.asList("azblob://aaa"),
                 storageParams, true, "");
         Assertions.assertTrue(usable.isCredentialUsable());
+    }
+
+    @Test
+    public void testAdls2ServicePrincipalStaysAServicePrincipal() throws DdlException {
+        // The file store records no OAuth2 flow, so the read-back path infers one. Inferring a
+        // managed identity from the tenant and the client alone turned a stored service principal
+        // into a managed identity, because the credential builder prefers a managed identity over
+        // the client secret - a silent change of who the volume authenticates as.
+        Map<String, String> storageParams = new HashMap<>();
+        storageParams.put(AZURE_ADLS2_ENDPOINT, "endpoint");
+        storageParams.put(AZURE_ADLS2_OAUTH2_TENANT_ID, "tenant_id");
+        storageParams.put(AZURE_ADLS2_OAUTH2_CLIENT_ID, "client_id");
+        storageParams.put(AZURE_ADLS2_OAUTH2_CLIENT_SECRET, "client_secret");
+        storageParams.put(AZURE_ADLS2_OAUTH2_CLIENT_ENDPOINT, "client_endpoint");
+
+        FileStoreInfo fsInfo = StorageVolume.createFileStoreInfo("test", "adls2",
+                Arrays.asList("adls2://aaa"), storageParams, true, "");
+
+        Map<String, String> restored = StorageVolume.getParamsFromFileStoreInfo(fsInfo);
+        Assertions.assertEquals("client_secret", restored.get(AZURE_ADLS2_OAUTH2_CLIENT_SECRET));
+        Assertions.assertEquals("client_endpoint", restored.get(AZURE_ADLS2_OAUTH2_CLIENT_ENDPOINT));
+        Assertions.assertFalse(restored.containsKey(AZURE_ADLS2_OAUTH2_USE_MANAGED_IDENTITY), restored.toString());
+    }
+
+    @Test
+    public void testConstructorRejectsCredentialThatCannotBePersisted() {
+        // Not every write goes through createFileStoreInfo: StorageVolumeMgr#replaceStorageVolume
+        // builds the replacement with this constructor when a restore changes the volume type and
+        // then hands its file store straight to the store, so the check has to sit here.
+        Map<String, String> storageParams = new HashMap<>();
+        storageParams.put(AZURE_BLOB_ENDPOINT, "endpoint");
+        storageParams.put(AZURE_BLOB_OAUTH2_USE_MANAGED_IDENTITY, "true");
+        storageParams.put(AZURE_BLOB_OAUTH2_CLIENT_ID, "client_id");
+
+        Assertions.assertThrows(SemanticException.class, () ->
+                new StorageVolume("1", "test", "azblob", Arrays.asList("azblob://aaa"), storageParams, true, ""));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
@@ -65,10 +65,17 @@ import static com.starrocks.connector.share.credential.CloudConfigurationConstan
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_USE_INSTANCE_PROFILE;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_ENDPOINT;
+import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_ID;
+import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_SECRET;
+import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_TENANT_ID;
+import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_TOKEN_FILE;
+import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_USE_MANAGED_IDENTITY;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_SAS_TOKEN;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_SHARED_KEY;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_ENDPOINT;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_ID;
+import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_SECRET;
+import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_OAUTH2_TENANT_ID;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_OAUTH2_USE_MANAGED_IDENTITY;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_SAS_TOKEN;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_SHARED_KEY;
@@ -517,6 +524,87 @@ public class StorageVolumeTest {
         StorageVolume sv = StorageVolume.fromFileStoreInfo(fsInfo);
         Assertions.assertEquals("1", sv.getId());
         Assertions.assertEquals("test", sv.getName());
+    }
+
+    @Test
+    public void testAdls2RejectsWorkloadIdentityBecauseTheTokenFileIsNotStored() {
+        // A workload identity survives as an ADLS2 credential - the tenant and the client are
+        // stored - but its token file is not, so what is read back authenticates as a managed
+        // identity instead. Same kind of cloud, different identity: checking the cloud type alone
+        // would let this through.
+        Map<String, String> storageParams = new HashMap<>();
+        storageParams.put(AZURE_ADLS2_ENDPOINT, "endpoint");
+        storageParams.put(AZURE_ADLS2_OAUTH2_TENANT_ID, "tenant_id");
+        storageParams.put(AZURE_ADLS2_OAUTH2_CLIENT_ID, "client_id");
+        storageParams.put(AZURE_ADLS2_OAUTH2_TOKEN_FILE, "/var/run/secrets/azure/token");
+
+        SemanticException e = Assertions.assertThrows(SemanticException.class, () ->
+                StorageVolume.createFileStoreInfo("test", "adls2", Arrays.asList("adls2://aaa"),
+                        storageParams, true, ""));
+        Assertions.assertTrue(e.getMessage().contains(AZURE_ADLS2_OAUTH2_TOKEN_FILE), e.getMessage());
+    }
+
+    @Test
+    public void testAdls2ManagedIdentityAndSharedKeyRemainStorable() throws DdlException {
+        // The forms an ADLS2 file store does carry must keep working: a managed identity, and a
+        // shared key that spells out the managed identity flag it is not using.
+        Map<String, String> managedIdentity = new HashMap<>();
+        managedIdentity.put(AZURE_ADLS2_ENDPOINT, "endpoint");
+        managedIdentity.put(AZURE_ADLS2_OAUTH2_USE_MANAGED_IDENTITY, "true");
+        managedIdentity.put(AZURE_ADLS2_OAUTH2_TENANT_ID, "tenant_id");
+        managedIdentity.put(AZURE_ADLS2_OAUTH2_CLIENT_ID, "client_id");
+        StorageVolume.createFileStoreInfo("test", "adls2", Arrays.asList("adls2://aaa"), managedIdentity, true, "");
+
+        Map<String, String> sharedKey = new HashMap<>();
+        sharedKey.put(AZURE_ADLS2_ENDPOINT, "endpoint");
+        sharedKey.put(AZURE_ADLS2_SHARED_KEY, "shared_key");
+        sharedKey.put(AZURE_ADLS2_OAUTH2_USE_MANAGED_IDENTITY, "false");
+        StorageVolume.createFileStoreInfo("test", "adls2", Arrays.asList("adls2://aaa"), sharedKey, true, "");
+    }
+
+    @Test
+    public void testRejectionDoesNotLeakOAuth2ClientSecret() {
+        Map<String, String> storageParams = new HashMap<>();
+        storageParams.put(AZURE_BLOB_ENDPOINT, "endpoint");
+        storageParams.put(AZURE_BLOB_OAUTH2_TENANT_ID, "tenant_id");
+        storageParams.put(AZURE_BLOB_OAUTH2_CLIENT_ID, "client_id");
+        storageParams.put(AZURE_BLOB_OAUTH2_CLIENT_SECRET, "should_never_be_echoed");
+
+        SemanticException e = Assertions.assertThrows(SemanticException.class, () ->
+                StorageVolume.createFileStoreInfo("test", "azblob", Arrays.asList("azblob://aaa"),
+                        storageParams, true, ""));
+        Assertions.assertFalse(e.getMessage().contains("should_never_be_echoed"), e.getMessage());
+    }
+
+    @Test
+    public void testAddMaskForCredentialMasksOAuth2ClientSecrets() {
+        Map<String, String> params = new HashMap<>();
+        params.put(AZURE_BLOB_OAUTH2_CLIENT_SECRET, "blob_secret");
+        params.put(AZURE_ADLS2_OAUTH2_CLIENT_SECRET, "adls2_secret");
+        StorageVolume.addMaskForCredential(params);
+        Assertions.assertEquals(StorageVolume.CREDENTIAL_MASK, params.get(AZURE_BLOB_OAUTH2_CLIENT_SECRET));
+        Assertions.assertEquals(StorageVolume.CREDENTIAL_MASK, params.get(AZURE_ADLS2_OAUTH2_CLIENT_SECRET));
+    }
+
+    @Test
+    public void testStorageVolumeWithUnusableCredentialIsNotUsable() throws DdlException {
+        FileStoreInfo fsInfo = FileStoreInfo.newBuilder()
+                .setFsKey("1")
+                .setFsName("test")
+                .setFsType(FileStoreType.AZBLOB)
+                .setEnabled(true)
+                .addLocations("azblob://aaa")
+                .setAzblobFsInfo(AzBlobFileStoreInfo.newBuilder().setEndpoint("endpoint").build())
+                .build();
+        // Readable, so it can be shown and dropped, but not something data may be stored through.
+        Assertions.assertFalse(StorageVolume.fromFileStoreInfo(fsInfo).isCredentialUsable());
+
+        Map<String, String> storageParams = new HashMap<>();
+        storageParams.put(AZURE_BLOB_ENDPOINT, "endpoint");
+        storageParams.put(AZURE_BLOB_SHARED_KEY, "shared_key");
+        StorageVolume usable = new StorageVolume("1", "test", "azblob", Arrays.asList("azblob://aaa"),
+                storageParams, true, "");
+        Assertions.assertTrue(usable.isCredentialUsable());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
@@ -529,19 +529,39 @@ public class StorageVolumeTest {
     }
 
     @Test
-    public void testAdls2WorkloadIdentityStaysAcceptedEvenThoughTheTokenFileIsNotStored()
-            throws DdlException {
-        // The token file has no field in ADLS2CredentialInfo, so it is dropped and the volume reads
-        // back as a managed identity. CREATE_STORAGE_VOLUME.md documents this authentication, so it
-        // is warned about rather than refused - refusing it would withdraw a documented capability.
+    public void testAdls2RejectsWorkloadIdentityBecauseTheTokenFileIsNotStored() {
+        // ADLS2CredentialInfo has no token file field, so the token lives only in the params of the
+        // FE that created the volume: a read-back turns it into a managed identity, and the file
+        // store is also the only credential a lake table's storage location carries. The English and
+        // Chinese pages were corrected together with this, so the form is refused outright.
         Map<String, String> storageParams = new HashMap<>();
         storageParams.put(AZURE_ADLS2_ENDPOINT, "endpoint");
         storageParams.put(AZURE_ADLS2_OAUTH2_TENANT_ID, "tenant_id");
         storageParams.put(AZURE_ADLS2_OAUTH2_CLIENT_ID, "client_id");
         storageParams.put(AZURE_ADLS2_OAUTH2_TOKEN_FILE, "/var/run/secrets/azure/token");
 
-        StorageVolume.createFileStoreInfo("test", "adls2", Arrays.asList("adls2://aaa"),
+        SemanticException e = Assertions.assertThrows(SemanticException.class, () ->
+                StorageVolume.createFileStoreInfo("test", "adls2", Arrays.asList("adls2://aaa"),
+                        storageParams, true, ""));
+        Assertions.assertTrue(e.getMessage().contains(AZURE_ADLS2_OAUTH2_TOKEN_FILE), e.getMessage());
+    }
+
+    @Test
+    public void testCopyingAnAzblobSasVolumeKeepsItUsable() throws DdlException {
+        // The container comes from the locations, not from the params, so a copy that rebuilt the
+        // configuration from the raw params alone fell through to HDFS and made a usable SAS volume
+        // look broken - which then failed a comment-only ALTER on the type guard in toFileStoreInfo.
+        Map<String, String> storageParams = new HashMap<>();
+        storageParams.put(AZURE_BLOB_ENDPOINT, "endpoint");
+        storageParams.put(AZURE_BLOB_SAS_TOKEN, "sas_token");
+        StorageVolume sv = new StorageVolume("1", "test", "azblob", Arrays.asList("azblob://aaa"),
                 storageParams, true, "");
+        Assertions.assertTrue(sv.isCredentialUsable());
+
+        StorageVolume copied = new StorageVolume(sv);
+        Assertions.assertTrue(copied.isCredentialUsable());
+        // The copy must still serialise to its own type, which is what a write-back needs.
+        Assertions.assertEquals(FileStoreType.AZBLOB, copied.toFileStoreInfo().getFsType());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
@@ -74,6 +74,7 @@ import static com.starrocks.connector.share.credential.CloudConfigurationConstan
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_USE_MANAGED_IDENTITY;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_SAS_TOKEN;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_SHARED_KEY;
+import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_CONTAINER;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_ENDPOINT;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_ID;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_BLOB_OAUTH2_CLIENT_SECRET;
@@ -544,6 +545,33 @@ public class StorageVolumeTest {
                 StorageVolume.createFileStoreInfo("test", "adls2", Arrays.asList("adls2://aaa"),
                         storageParams, true, ""));
         Assertions.assertTrue(e.getMessage().contains(AZURE_ADLS2_OAUTH2_TOKEN_FILE), e.getMessage());
+    }
+
+    @Test
+    public void testAzblobSasVolumeSurvivesAlterAndReload() throws Exception {
+        // The container comes from the locations, and params never carries it, so any path that
+        // rebuilds the configuration from the raw params alone falls through to the HDFS provider and
+        // makes a usable SAS volume look broken. Two such paths are exercised here: an ALTER, which
+        // would have been refused outright, and a metadata reload, after which every guard would have
+        // rejected the volume on each FE restart.
+        Map<String, String> storageParams = new HashMap<>();
+        storageParams.put(AZURE_BLOB_ENDPOINT, "endpoint");
+        storageParams.put(AZURE_BLOB_SAS_TOKEN, "sas_token");
+        StorageVolume sv = new StorageVolume("1", "test", "azblob", Arrays.asList("azblob://aaa"),
+                storageParams, true, "");
+        Assertions.assertTrue(sv.isCredentialUsable());
+
+        Map<String, String> rotated = new HashMap<>();
+        rotated.put(AZURE_BLOB_SAS_TOKEN, "rotated_sas_token");
+        sv.setCloudConfiguration(rotated);
+        Assertions.assertTrue(sv.isCredentialUsable());
+        Assertions.assertEquals(FileStoreType.AZBLOB, sv.toFileStoreInfo().getFsType());
+        // The derived container must not leak into what gets stored.
+        Assertions.assertFalse(sv.getProperties().containsKey(AZURE_BLOB_CONTAINER));
+
+        // A reload rebuilds from the stored params; the volume has to come back usable.
+        sv.gsonPostProcess();
+        Assertions.assertTrue(sv.isCredentialUsable());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
@@ -588,6 +588,31 @@ public class StorageVolumeTest {
     }
 
     @Test
+    public void testAlterRepairsUnusableCredentialAndMarksVolumeUsableAgain() throws DdlException {
+        // ALTER is how such a volume gets repaired, so the derived flag has to follow the new
+        // configuration. It used to stay false until the next metadata reload, which left the
+        // repaired volume rejected by every path that checks isCredentialUsable().
+        FileStoreInfo fsInfo = FileStoreInfo.newBuilder()
+                .setFsKey("1")
+                .setFsName("test")
+                .setFsType(FileStoreType.AZBLOB)
+                .setEnabled(true)
+                .addLocations("azblob://aaa")
+                .setAzblobFsInfo(AzBlobFileStoreInfo.newBuilder().setEndpoint("endpoint").build())
+                .build();
+        StorageVolume sv = StorageVolume.fromFileStoreInfo(fsInfo);
+        Assertions.assertFalse(sv.isCredentialUsable());
+
+        Map<String, String> repaired = new HashMap<>();
+        repaired.put(AZURE_BLOB_SHARED_KEY, "shared_key");
+        sv.setCloudConfiguration(repaired);
+
+        Assertions.assertTrue(sv.isCredentialUsable());
+        // The copy the managers cache must carry the repaired flag, not the stale one.
+        Assertions.assertTrue(new StorageVolume(sv).isCredentialUsable());
+    }
+
+    @Test
     public void testStorageVolumeWithUnusableCredentialIsNotUsable() throws DdlException {
         FileStoreInfo fsInfo = FileStoreInfo.newBuilder()
                 .setFsKey("1")


### PR DESCRIPTION
## Why I'm doing:

`CloudConfigurationFactory` is shared between storage volumes and external data access, so `CREATE STORAGE VOLUME` accepts credential forms that a file store cannot carry. Managed identity is the case that surfaced this: `azure.blob.oauth2_use_managed_identity` / `azure.blob.oauth2_client_id` are valid properties for [`FILES()`](https://docs.starrocks.io/docs/sql-reference/sql-functions/table-functions/files/), and `CREATE STORAGE VOLUME` happily accepts them even though its documentation lists only `azure.blob.endpoint`, `azure.blob.shared_key` and `azure.blob.sas_token` for `TYPE = AZBLOB`.

Such a volume is created and reported as successful, but `AzBlobCredentialInfo` only stores `sharedKey` and `sasToken`, so what actually gets persisted is an empty credential. Reading it back produces params of `{azure.blob.endpoint}` alone — not a valid Azure configuration — and the `StorageVolume` constructor threw for it. Every path that re-materialises the volume then failed:

```
ERROR 1064 (HY000): Getting analyzing error. Detail message:
Storage params is not valid {"azure.blob.endpoint":"https://reproacct.blob.core.windows.net"}
```

`DESC`, `ALTER`, `SHOW STORAGE VOLUMES` (which resolves every name to an id for the privilege check) and — worst — `DROP` all hit it. The volume could not be removed by any statement, and one such volume broke the listing for every other volume in the cluster.

Reproduces on any shared-data cluster; no real Azure account is needed, since the defect is entirely in the FE metadata round trip:

```sql
CREATE STORAGE VOLUME sv_repro
TYPE = AZBLOB
LOCATIONS = ('azblob://repro-container/p/')
PROPERTIES (
    'azure.blob.endpoint'                    = 'https://reproacct.blob.core.windows.net',
    'azure.blob.oauth2_use_managed_identity' = 'true',
    'azure.blob.oauth2_client_id'            = '00000000-0000-0000-0000-000000000000'
);
-- succeeds, and from here on SHOW / DESC / ALTER / DROP all fail
```

## What I'm doing:

The fix has two halves, and the issue's two expectations map onto them one to one: **refuse a credential that cannot survive persistence**, and **keep a volume that was already stored with one readable enough to drop**.

### 1. Refuse it at CREATE and ALTER, before anything is written

`validateCredentialIsPersistable` round-trips the configuration through `FileStoreInfo` and compares what comes back with what went in. It runs from the constructor, so every volume about to be written passes through it — including the replacement `replaceStorageVolume` builds when a restore changes the volume type, which reaches the file store without going through `createFileStoreInfo`.

The generic half of the check is that the restored configuration must still be a usable configuration of the same cloud. That is what catches the reported case: an AZBLOB OAuth2 credential restores to `{azure.blob.endpoint}` alone, which builds no Azure credential at all.

Staying the same cloud is not sufficient on Azure, where the credential the factory accepts is richer than what the file store models, so a volume can stay valid while quietly authenticating as somebody else. For AZBLOB and ADLS2 the credential properties given and the ones read back must therefore be the same set. The comparison runs **both ways** on purpose: the file store records no OAuth2 flow, so the read-back path infers one, and a property it infers changes the authentication just as much as a property it drops.

| form | disposition | why |
|---|---|---|
| AZBLOB managed identity / service principal | refused | `AzBlobCredentialInfo` stores only `sharedKey` and `sasToken`; nothing else survives. The reported bug |
| ADLS2 workload identity | refused, and the docs corrected | `ADLS2CredentialInfo` has no token-file field, so the token lives only in the params of the FE that created the volume. A read-back turns it into a managed identity, and that same file store is the only credential a lake table's storage location carries, so nothing downstream ever sees the token. The EN/ZH/JA pages offered it and were corrected here; external catalogs and `FILES()` are unaffected, they do not go through a file store |
| S3 temporary keys (`aws.s3.session_token`) | refused | `AwsSimpleCredentialInfo` stores the access key and its secret only — its own `toFileStoreInfo` says so with a TODO — so the keys that read back cannot authenticate. Not documented for storage volumes, and temporary keys would expire during the volume's life anyway |
| AWS web identity profile | **nothing needed** | It used to lose just as much, being stored as an assume role or a default credential, but #77638 has since given it a credential case of its own, so it round-trips correctly now |
| GCP impersonation | **left alone** | `getParamsFromFileStoreInfo` restores the impersonation account under the wrong key. A real defect, but a pre-existing one unrelated to this round trip; better fixed on its own where it can be validated against GCP. Filed as #77655 |

Also fixed here: an ALTER that was rejected used to leave the volume with the new configuration already assigned. The assignment now happens only after both checks pass.

### 2. Tolerate it on read-back, so the stuck volume can be cleaned up

`fromFileStoreInfo` logs a warning instead of throwing. Identity, locations and virtual-tablet bookkeeping are all intact in `FileStoreInfo` and none of them depend on the credential, so `SHOW STORAGE VOLUMES`, `DESC` and — the point of the whole change — `DROP` keep working. Without this, a volume created before this fix stays in the cluster forever and keeps the listing broken for every other volume.

The volume carries a derived, never-persisted `credentialUsable` flag, and *readable* is not *usable*: everything that would hand data to such a volume refuses it, so tolerance cannot turn into silent breakage somewhere downstream.

| consumer | what it would otherwise do |
|---|---|
| `bindDbToStorageVolume` / `bindTableToStorageVolume` | record it as a database's or table's storage location |
| `getOrCreateVirtualTabletId` (lake replication) | allocate a path, create a shard and a shard group, then write the volume back, all before replication notices |
| `spill_storage_volume` (`SessionVariable#toThrift`) | hand the BE a DEFAULT cloud configuration; with `disable_spill_to_local_disk` there is no fallback |
| `ADMIN SET AUTOMATED SNAPSHOT ON`, and the scheduler | do the local checkpoint work every interval, then fail in `HdfsUtil`. The scheduler is checked too, because a cluster that was already snapshotting when it upgraded restores the volume name from the image and never passes the analyzer |
| `setDefaultStorageVolume` | make it the cluster default |

### 3. Never write such a volume back

`toFileStoreInfo` requires the serialised type to match the volume's own. Writing one back does **not** fail with a NullPointerException as it first looks: the factory chain falls through the cloud providers to the HDFS one, which accepts any properties, so an AZBLOB volume whose credential cannot be rebuilt serialises to an **HDFS** file store carrying the azure properties as plain Hadoop configuration. The volume's type would quietly change in the store instead — worse than a crash. `ALTER` and the snapshot-restore replacement check usability before persisting, so a metadata-only change is refused with a message naming the ways out (drop it, or repair it in the same ALTER) rather than rewriting it; letting it through would erase credential bytes that a later version might still parse.

The copy constructor applies the same authentication preprocessing as the main one and derives usability from what it rebuilt. Without that, a copy of a usable AZBLOB SAS volume dropped the container that comes from the locations, fell through to the HDFS provider, and failed a comment-only ALTER on the type guard above.

### Deliberately not done

Teaching AZBLOB to persist OAuth2 the way ADLS2 does. `AzBlobCredentialInfo` carries `tenantId` / `clientId` / `clientSecret`, so it would be easy, but managed identity is not documented for AZBLOB storage volumes — that is a feature addition needing a product decision, not a bug fix. Happy to follow up separately.

Fixes #77502

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

A `CREATE` / `ALTER STORAGE VOLUME` that used to be accepted and produce an unusable volume is now rejected with a clear message. Volumes already stored in that state become listable and droppable instead of poisoning every storage-volume statement.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

## Verification

Built and tested in the official dev-env image. 119 cases across the five classes this change touches, all green:

| test class | cases |
|---|---|
| `StorageVolumeTest` | 36 |
| `SharedDataStorageVolumeMgrTest` | 40 |
| `ClusterSnapshotTest` | 28 |
| `SessionVariableTest` | 13 |
| `SharedNothingStorageVolumeMgrTest` | 2 |

The last three are there to catch regressions from the new guards rather than to cover new code.

The case that matters most is `testVolumeWithUnusableCredentialCanStillBeListedAndDropped`, which walks the issue's own expectation end to end: a volume stored with an unusable credential is listed by `SHOW`, reached by `DESC` where it reports itself unusable, and removed by `DROP`. The tolerant read-back is visible in the run:

```
WARN StorageVolume - Storage volume 'unusable_sv' has an unusable credential.
     It can still be listed and dropped, but not used: {"azure.blob.endpoint":"endpoint"}
```

Other cases worth naming:

| test | asserts |
|---|---|
| `testAzureBlobRejectsCredentialThatCannotBePersisted` | the reported `CREATE` is rejected before anything is written |
| `testAzureBlobAlterRejectsCredentialThatCannotBePersistedAndKeepsVolumeIntact` | a rejected `ALTER` leaves the original credential untouched |
| `testAdls2RejectsWorkloadIdentityBecauseTheTokenFileIsNotStored` | the form the docs used to offer is refused |
| `testS3RejectsTemporaryKeysBecauseTheSessionTokenIsNotStored` / `...WithoutSessionTokenRemainsStorable` | temporary keys refused, plain access keys still fine |
| `testAdls2ManagedIdentityAndSharedKeyRemainStorable` | the ADLS2 forms the file store does carry keep working |
| `testUnusableVolumeRefusesToBeWrittenBackAsAnotherType` | the write-back would produce an HDFS file store, so it is refused |
| `testCopyingAnAzblobSasVolumeKeepsItUsable` | a copy of a usable SAS volume stays usable and serialises to AZBLOB |
| `testAlterRepairsUnusableCredentialAndMarksVolumeUsableAgain` | repairing by `ALTER` clears the flag, including on the copy the managers cache |
| `testMetadataOnlyAlterOnUnusableVolumeFailsCleanly` | a comment-only `ALTER` fails with a message naming the ways out, and never writes |
| `testGetOrCreateVirtualTabletIdRejectsVolumeWithUnusableCredential` | replication refuses it before allocating a path or creating a shard |
| `testRemoteSpillStaysOffForVolumeWithUnusableCredential` | remote spilling stays off instead of shipping a DEFAULT configuration |