### PR TITLE
[BugFix] Surface internal INSERT failures in recursive CTE execution

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/recursivecte/RecursiveCTEExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/recursivecte/RecursiveCTEExecutor.java
@@ -21,7 +21,6 @@ import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DDLStmtExecutor;
-import com.starrocks.qe.QueryState;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.AstToSQLBuilder;
@@ -150,7 +149,7 @@ public class RecursiveCTEExecutor {
                 executor = StmtExecutor.newInternalExecutor(connectContext, insert);
                 connectContext.setQueryId(UUIDUtil.genUUID());
                 executor.execute();
-                if (!connectContext.getState().getErrType().equals(QueryState.ErrType.UNKNOWN)) {
+                if (connectContext.getState().isError()) {
                     LOG.warn("Error occurred during executing recursive CTE start statement: {}",
                             connectContext.getState().getErrorMessage());
                     throw new RuntimeException("Error occurred during executing recursive CTE start statement: " +
@@ -165,15 +164,16 @@ public class RecursiveCTEExecutor {
                     executor = StmtExecutor.newInternalExecutor(connectContext, insert);
                     connectContext.setQueryId(UUIDUtil.genUUID());
                     executor.execute();
+                    // Once the insert has failed, checking affected rows is meaningless.
+                    if (connectContext.getState().isError()) {
+                        LOG.warn("Error occurred during executing recursive CTE recursive statement at iteration {}: {}",
+                                i, connectContext.getState().getErrorMessage());
+                        throw new RuntimeException("Error occurred during executing recursive CTE recursive statement" +
+                                " at iteration " + i + ": " + connectContext.getState().getErrorMessage());
+                    }
                     if (connectContext.getState().getAffectedRows() <= 0) {
                         // no more rows inserted, break
                         break;
-                    }
-                    if (connectContext.getState().getErrType() != QueryState.ErrType.UNKNOWN) {
-                        LOG.warn("Error occurred during executing recursive CTE recursive statement: {}",
-                                connectContext.getState().getErrorMessage());
-                        throw new RuntimeException("Error occurred during executing recursive CTE recursive statement: " +
-                                connectContext.getState().getErrorMessage());
                     }
                 }
                 if (connectContext.getState().getAffectedRows() > 0

--- a/test/sql/test_cte/R/test_recursive_cte
+++ b/test/sql/test_cte/R/test_recursive_cte
@@ -345,3 +345,25 @@ ORDER BY steps;
 2	Bob	CTO	3	10
 1	Alicia	CEO	4	10
 -- !result
+WITH RECURSIVE r AS (
+    SELECT 1 AS n, 0.5 AS bal
+    UNION ALL
+    SELECT n + 1, bal + 1 FROM r WHERE n < 5
+)
+SELECT /*+ SET_VAR(enable_recursive_cte=true, recursive_cte_max_depth=20, enable_insert_strict=true, insert_max_filter_ratio=0)*/ * FROM r ORDER BY n;
+-- result:
+[REGEX].*recursive CTE recursive statement at iteration 1.*Insert has filtered data.*
+-- !result
+WITH RECURSIVE r AS (
+    SELECT 1 AS n, CAST(0.5 AS DECIMAL(10,1)) AS bal
+    UNION ALL
+    SELECT n + 1, bal + 1 FROM r WHERE n < 5
+)
+SELECT /*+ SET_VAR(enable_recursive_cte=true, recursive_cte_max_depth=20, enable_insert_strict=true, insert_max_filter_ratio=0)*/ * FROM r ORDER BY n;
+-- result:
+1	0.5
+2	1.5
+3	2.5
+4	3.5
+5	4.5
+-- !result

--- a/test/sql/test_cte/T/test_recursive_cte
+++ b/test/sql/test_cte/T/test_recursive_cte
@@ -236,3 +236,21 @@ manager_chain AS (
 SELECT /*+ SET_VAR(enable_recursive_cte=true)*/ employee_id, name, title, steps, id
 FROM manager_chain, const_cte
 ORDER BY steps;
+
+-- Test 13: Error case - the anchor infers DECIMAL(1,1) for bal, so the first iteration produces
+-- 1.5 and its insert fails in strict mode. The failure must be reported instead of ending the
+-- recursion as if it had converged.
+WITH RECURSIVE r AS (
+    SELECT 1 AS n, 0.5 AS bal
+    UNION ALL
+    SELECT n + 1, bal + 1 FROM r WHERE n < 5
+)
+SELECT /*+ SET_VAR(enable_recursive_cte=true, recursive_cte_max_depth=20, enable_insert_strict=true, insert_max_filter_ratio=0)*/ * FROM r ORDER BY n;
+
+-- Test 13.1: widening the anchor column type keeps the same recursion working
+WITH RECURSIVE r AS (
+    SELECT 1 AS n, CAST(0.5 AS DECIMAL(10,1)) AS bal
+    UNION ALL
+    SELECT n + 1, bal + 1 FROM r WHERE n < 5
+)
+SELECT /*+ SET_VAR(enable_recursive_cte=true, recursive_cte_max_depth=20, enable_insert_strict=true, insert_max_filter_ratio=0)*/ * FROM r ORDER BY n;


### PR DESCRIPTION
## Why I'm doing:

A recursive CTE whose internal INSERT fails reports success and silently returns a
truncated result. The failed iteration writes no rows, the next iteration reads nothing
from that empty level and therefore inserts nothing, and the loop cannot tell this apart
from the recursion having converged — so it exits normally and the outer statement
finishes on a temp table holding only the levels written before the failure. The error is
left in `information_schema.load_tracking_logs` and is never shown to the client.

## What I'm doing:

Check `state.isError()` instead of `errType`, for both the anchor and the per-iteration
insert. `errType` is only set when an exception is caught, so a strict-mode filtered-rows
rejection — which calls `setError()` and returns — left it UNKNOWN and the check never
fired. In the loop the error check now runs before the affected-rows convergence check,
since affected rows is stale once the insert has failed. The reported error carries the
iteration number and the original message, including the tracking sql.
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
