### PR TITLE
[BugFix] Do not let an apportioned row count decide whether a cross-published rowset exists

### DIFF
--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -490,14 +490,13 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
     ASSIGN_OR_RETURN(auto fs, FileSystemFactory::CreateSharedFromString(root_path));
     std::shared_ptr<TabletSchema> tablet_schema = std::make_shared<TabletSchema>(params.metadata->schema());
     // get rowset schema
-    // Whether there is anything to rewrite is decided by the segments the op carries, never by
-    // num_rows. On a split cross publish that count is apportioned per sibling, so a row-mode
-    // partial update whose segments hold this tablet's rows can still arrive with num_rows == 0;
-    // returning here would leave the partial segment (only the updated columns) attached without
-    // its unmodified columns rewritten in. Outside a cross publish the two agree: a writer that
-    // produced no rows produces no segments either.
+    // Segments count as "there is something to rewrite" alongside num_rows. On a split cross
+    // publish that count is apportioned per sibling, so a row-mode partial update whose segments
+    // hold this tablet's rows can still arrive with num_rows == 0; returning on the count alone
+    // would leave the partial segment (only the updated columns) attached without its unmodified
+    // columns rewritten in.
     if (!params.op_write.has_txn_meta() || params.op_write.rewrite_segments_meta_size() == 0 ||
-        rowset_meta.segment_metas_size() == 0) {
+        (rowset_meta.num_rows() == 0 && rowset_meta.segment_metas_size() == 0)) {
         return Status::OK();
     }
     RETURN_ERROR_IF_FALSE(params.op_write.rewrite_segments_meta_size() == rowset_meta.segment_metas_size());

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -490,8 +490,14 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
     ASSIGN_OR_RETURN(auto fs, FileSystemFactory::CreateSharedFromString(root_path));
     std::shared_ptr<TabletSchema> tablet_schema = std::make_shared<TabletSchema>(params.metadata->schema());
     // get rowset schema
+    // Whether there is anything to rewrite is decided by the segments the op carries, never by
+    // num_rows. On a split cross publish that count is apportioned per sibling, so a row-mode
+    // partial update whose segments hold this tablet's rows can still arrive with num_rows == 0;
+    // returning here would leave the partial segment (only the updated columns) attached without
+    // its unmodified columns rewritten in. Outside a cross publish the two agree: a writer that
+    // produced no rows produces no segments either.
     if (!params.op_write.has_txn_meta() || params.op_write.rewrite_segments_meta_size() == 0 ||
-        rowset_meta.num_rows() == 0) {
+        rowset_meta.segment_metas_size() == 0) {
         return Status::OK();
     }
     RETURN_ERROR_IF_FALSE(params.op_write.rewrite_segments_meta_size() == rowset_meta.segment_metas_size());

--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -421,11 +421,21 @@ Status convert_txn_log_for_splitting(TxnLogPB* txn_log, const TabletMetadataPtr&
     tablet_reshard_helper::set_all_data_files_shared(txn_log);
     RETURN_IF_ERROR(tablet_reshard_helper::update_rowset_ranges(txn_log, base_tablet_metadata->range()));
     // Pass this sibling's range so the stat apportionment can tell a sibling that provably owns
-    // none of the rowset's keys (a true 0) from one that may own them (never 0 -- the appliers
-    // drop a 0-row rowset outright, which would silently discard those rows).
-    tablet_reshard_helper::update_txn_log_data_stats(txn_log, publish_tablet_info.get_split_count(),
-                                                     publish_tablet_info.get_split_index(),
-                                                     &base_tablet_metadata->range());
+    // none of the rowset's keys (a true 0, so the siblings' stats sum to the source) from one that
+    // may own them (the plain share).
+    //
+    // The classifier compares a rowset's sort_key_min/sort_key_max envelope against the range, which
+    // is sound only while the sort key IS the range key. A primary-key tablet with a separate ORDER
+    // BY has the two at the same arity in different key spaces, and the classifier's arity check
+    // cannot tell them apart -- it would compare, say, a varchar envelope against a bigint bound and
+    // could prove kNo for a sibling that does own rows. Withhold the range there: every rowset then
+    // classifies kUnknown and keeps the plain apportionment.
+    const auto base_schema = TabletSchema::create(base_tablet_metadata->schema());
+    const bool envelope_shares_the_range_key =
+            !(base_schema->keys_type() == KeysType::PRIMARY_KEYS && base_schema->has_separate_sort_key());
+    tablet_reshard_helper::update_txn_log_data_stats(
+            txn_log, publish_tablet_info.get_split_count(), publish_tablet_info.get_split_index(),
+            envelope_shares_the_range_key ? &base_tablet_metadata->range() : nullptr);
     return Status::OK();
 }
 

--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -31,6 +31,7 @@
 #include "storage/lake/update_manager.h"
 #include "storage/lake/vacuum.h" // delete_files_async
 #include "storage/storage_env.h"
+#include "storage/tablet_schema.h"
 
 // Layer 1: Reshard operation overall metrics
 bvar::Adder<int64_t> g_tablet_reshard_total("tablet_reshard_total");

--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -420,8 +420,12 @@ Status convert_txn_log_for_splitting(TxnLogPB* txn_log, const TabletMetadataPtr&
     }
     tablet_reshard_helper::set_all_data_files_shared(txn_log);
     RETURN_IF_ERROR(tablet_reshard_helper::update_rowset_ranges(txn_log, base_tablet_metadata->range()));
+    // Pass this sibling's range so the stat apportionment can tell a sibling that provably owns
+    // none of the rowset's keys (a true 0) from one that may own them (never 0 -- the appliers
+    // drop a 0-row rowset outright, which would silently discard those rows).
     tablet_reshard_helper::update_txn_log_data_stats(txn_log, publish_tablet_info.get_split_count(),
-                                                     publish_tablet_info.get_split_index());
+                                                     publish_tablet_info.get_split_index(),
+                                                     &base_tablet_metadata->range());
     return Status::OK();
 }
 

--- a/be/src/storage/lake/tablet_reshard_helper.cpp
+++ b/be/src/storage/lake/tablet_reshard_helper.cpp
@@ -683,9 +683,23 @@ void update_rowset_data_stats(RowsetMetadataPB* rowset, int32_t split_count, int
     if (split_count <= 1) return;
 
     if (overlap == RangeOverlap::kNo) {
-        // Proven to own none of the rowset's keys: a true zero, not an apportionment artifact. The
-        // appliers drop the rowset for this sibling, which is exactly right -- and it keeps the
-        // siblings' stats summing to the source instead of spreading phantom rows over everyone.
+        // Proven to own none of the rowset's keys, so drop its segments outright rather than hand
+        // this sibling data it can never read. Presence is decided by what the op carries, so this
+        // has to be an explicit removal -- zeroing the counters no longer takes the rowset with it.
+        //
+        // Only the segments go. A del file must still be replayed against this sibling's own index
+        // (that is why the splitter keeps a del-file-carrying rowset whatever its range says), and
+        // dels_meta/del_ssts live on the op_write, not here.
+        rowset->clear_segment_metas();
+        // The legacy arrays are dual-written for rollback, so they have to go with segment_metas or
+        // a pre-feature reader would still see the segments (lake_proto_normalizer back-fills from
+        // them).
+        rowset->clear_deprecated_segments();
+        rowset->clear_deprecated_segment_size();
+        rowset->clear_deprecated_segment_encryption_metas();
+        rowset->clear_deprecated_shared_segments();
+        rowset->clear_deprecated_bundle_file_offsets();
+        rowset->set_overlapped(false);
         if (rowset->has_num_rows()) rowset->set_num_rows(0);
         if (rowset->has_data_size()) rowset->set_data_size(0);
         if (rowset->has_num_dels()) rowset->set_num_dels(0);

--- a/be/src/storage/lake/tablet_reshard_helper.cpp
+++ b/be/src/storage/lake/tablet_reshard_helper.cpp
@@ -709,22 +709,12 @@ void update_rowset_data_stats(RowsetMetadataPB* rowset, int32_t split_count, int
     // kYes / kUnknown: spread the source's counters over the siblings. These are statistics only --
     // the appliers decide a rowset's presence from its segments, so a zero here costs accuracy in
     // compaction scoring and `SHOW`, never data.
-    //
-    // The one zero worth avoiding is a rowset that still carries segments reporting num_rows == 0:
-    // that reads as "empty" to every consumer of the statistic, and with the kNo siblings now zeroed
-    // outright it is reachable whenever the owning sibling's index draws no remainder -- one row
-    // split four ways and owned by child 3 leaves every sibling at zero. Floor those at 1. It
-    // over-counts by at most split_count - 1, and only for a rowset holding fewer rows than the
-    // split count; an exact per-sibling count needs the real row selection, not an index-based
-    // share, because no sibling can see which of its peers the classifier ruled out.
-    const bool carries_segments = rowset->segment_metas_size() > 0;
     auto apportion = [split_count, split_index](int64_t value) {
         return value / split_count + (split_index < value % split_count ? 1 : 0);
     };
 
     if (rowset->has_num_rows()) {
-        const int64_t scaled = apportion(rowset->num_rows());
-        rowset->set_num_rows((carries_segments && rowset->num_rows() > 0) ? std::max<int64_t>(1, scaled) : scaled);
+        rowset->set_num_rows(apportion(rowset->num_rows()));
     }
     if (rowset->has_data_size()) {
         rowset->set_data_size(apportion(rowset->data_size()));

--- a/be/src/storage/lake/tablet_reshard_helper.cpp
+++ b/be/src/storage/lake/tablet_reshard_helper.cpp
@@ -692,15 +692,11 @@ void update_rowset_data_stats(RowsetMetadataPB* rowset, int32_t split_count, int
         return;
     }
 
-    // kYes: this sibling may own rows, so never hand it an empty rowset -- the appliers would drop
-    // it and those rows would vanish while the transaction still reported success. Rounding up to 1
-    // can over-count by at most (split_count - 1) rows per rowset, and only for a rowset with fewer
-    // rows than the split count; an over-counted stat merely skews compaction scoring, whereas
-    // under-counting to zero destroys data. kUnknown keeps the pre-existing behavior exactly.
-    const bool never_empty = (overlap == RangeOverlap::kYes);
-    auto apportion = [split_count, split_index, never_empty](int64_t value) {
-        const int64_t scaled = value / split_count + (split_index < value % split_count ? 1 : 0);
-        return (never_empty && value > 0) ? std::max<int64_t>(1, scaled) : scaled;
+    // kYes / kUnknown: spread the source's counters over the siblings. These are statistics only --
+    // the appliers decide a rowset's presence from its segments, so a zero here costs accuracy in
+    // compaction scoring and `SHOW`, never data.
+    auto apportion = [split_count, split_index](int64_t value) {
+        return value / split_count + (split_index < value % split_count ? 1 : 0);
     };
 
     if (rowset->has_num_rows()) {

--- a/be/src/storage/lake/tablet_reshard_helper.cpp
+++ b/be/src/storage/lake/tablet_reshard_helper.cpp
@@ -623,16 +623,91 @@ Status update_rowset_ranges(TxnLogPB* txn_log, const TabletRangePB& range) {
     return Status::OK();
 }
 
-void update_rowset_data_stats(RowsetMetadataPB* rowset, int32_t split_count, int32_t split_index) {
+RangeOverlap classify_rowset_range_overlap(const RowsetMetadataPB& rowset, const TabletRangePB& range_pb) {
+    if (rowset.segment_metas_size() == 0) {
+        return RangeOverlap::kUnknown;
+    }
+    TabletRange range;
+    if (!range.from_proto(range_pb).ok()) {
+        return RangeOverlap::kUnknown;
+    }
+    if (range.is_all()) {
+        // (-inf, +inf) contains every key.
+        return RangeOverlap::kYes;
+    }
+
+    VariantTuple envelope_min;
+    VariantTuple envelope_max;
+    for (const auto& segment_meta : rowset.segment_metas()) {
+        if (!segment_meta.has_sort_key_min() || !segment_meta.has_sort_key_max()) {
+            return RangeOverlap::kUnknown;
+        }
+        VariantTuple segment_min;
+        VariantTuple segment_max;
+        if (!segment_min.from_proto(segment_meta.sort_key_min()).ok() ||
+            !segment_max.from_proto(segment_meta.sort_key_max()).ok()) {
+            return RangeOverlap::kUnknown;
+        }
+        if (segment_min.empty() || segment_max.empty()) {
+            return RangeOverlap::kUnknown;
+        }
+        if (envelope_min.empty() || segment_min.compare(envelope_min) < 0) {
+            envelope_min = segment_min;
+        }
+        if (envelope_max.empty() || segment_max.compare(envelope_max) > 0) {
+            envelope_max = segment_max;
+        }
+    }
+
+    // Only trust an exact arity match. VariantTuple::compare orders a shorter prefix-equal tuple
+    // BELOW its longer form, so comparing a bound written at one sort-key arity against a range at
+    // another can flip the boundary case -- e.g. envelope (100) vs lower bound (100, MIN) would
+    // read as "range entirely above the envelope" even though key 100 is exactly the range's first
+    // key. Degrading to kUnknown keeps that case on the legacy path instead of proving a false kNo.
+    const size_t range_arity =
+            !range.is_minimum() ? range.lower_bound().size() : (!range.is_maximum() ? range.upper_bound().size() : 0);
+    if (range_arity == 0 || envelope_min.size() != range_arity || envelope_max.size() != range_arity) {
+        return RangeOverlap::kUnknown;
+    }
+
+    // [envelope_min, envelope_max] is a superset of the rowset's keys, so "the range sits entirely
+    // outside the envelope" proves the sibling owns none of them.
+    if (range.less_than(envelope_min) || range.greater_than(envelope_max)) {
+        return RangeOverlap::kNo;
+    }
+    return RangeOverlap::kYes;
+}
+
+void update_rowset_data_stats(RowsetMetadataPB* rowset, int32_t split_count, int32_t split_index,
+                              RangeOverlap overlap) {
     if (split_count <= 1) return;
 
+    if (overlap == RangeOverlap::kNo) {
+        // Proven to own none of the rowset's keys: a true zero, not an apportionment artifact. The
+        // appliers drop the rowset for this sibling, which is exactly right -- and it keeps the
+        // siblings' stats summing to the source instead of spreading phantom rows over everyone.
+        if (rowset->has_num_rows()) rowset->set_num_rows(0);
+        if (rowset->has_data_size()) rowset->set_data_size(0);
+        if (rowset->has_num_dels()) rowset->set_num_dels(0);
+        return;
+    }
+
+    // kYes: this sibling may own rows, so never hand it an empty rowset -- the appliers would drop
+    // it and those rows would vanish while the transaction still reported success. Rounding up to 1
+    // can over-count by at most (split_count - 1) rows per rowset, and only for a rowset with fewer
+    // rows than the split count; an over-counted stat merely skews compaction scoring, whereas
+    // under-counting to zero destroys data. kUnknown keeps the pre-existing behavior exactly.
+    const bool never_empty = (overlap == RangeOverlap::kYes);
+    auto apportion = [split_count, split_index, never_empty](int64_t value) {
+        const int64_t scaled = value / split_count + (split_index < value % split_count ? 1 : 0);
+        return (never_empty && value > 0) ? std::max<int64_t>(1, scaled) : scaled;
+    };
+
     if (rowset->has_num_rows()) {
-        int64_t num_rows = rowset->num_rows();
-        rowset->set_num_rows(num_rows / split_count + (split_index < num_rows % split_count ? 1 : 0));
+        rowset->set_num_rows(apportion(rowset->num_rows()));
     }
     if (rowset->has_data_size()) {
-        int64_t data_size = rowset->data_size();
-        rowset->set_data_size(data_size / split_count + (split_index < data_size % split_count ? 1 : 0));
+        rowset->set_data_size(apportion(rowset->data_size()));
     }
     if (rowset->has_num_dels()) {
         int64_t num_dels = rowset->num_dels();
@@ -752,29 +827,39 @@ std::vector<std::string> collect_compaction_output_files(const TxnLogPB& txn_log
     return output_paths;
 }
 
-void update_txn_log_data_stats(TxnLogPB* txn_log, int32_t split_count, int32_t split_index) {
+void update_txn_log_data_stats(TxnLogPB* txn_log, int32_t split_count, int32_t split_index,
+                               const TabletRangePB* sibling_range) {
+    // Classify each rowset against the sibling's range; nullptr keeps the legacy apportionment.
+    auto overlap_of = [sibling_range](const RowsetMetadataPB& rowset) {
+        return sibling_range == nullptr ? RangeOverlap::kUnknown
+                                        : classify_rowset_range_overlap(rowset, *sibling_range);
+    };
     if (txn_log->has_op_write() && txn_log->mutable_op_write()->has_rowset()) {
-        update_rowset_data_stats(txn_log->mutable_op_write()->mutable_rowset(), split_count, split_index);
+        update_rowset_data_stats(txn_log->mutable_op_write()->mutable_rowset(), split_count, split_index,
+                                 overlap_of(txn_log->op_write().rowset()));
     }
     if (txn_log->has_op_compaction() && txn_log->mutable_op_compaction()->has_output_rowset()) {
-        update_rowset_data_stats(txn_log->mutable_op_compaction()->mutable_output_rowset(), split_count, split_index);
+        update_rowset_data_stats(txn_log->mutable_op_compaction()->mutable_output_rowset(), split_count, split_index,
+                                 overlap_of(txn_log->op_compaction().output_rowset()));
     }
     if (txn_log->has_op_schema_change()) {
         for (auto& rowset : *txn_log->mutable_op_schema_change()->mutable_rowsets()) {
-            update_rowset_data_stats(&rowset, split_count, split_index);
+            update_rowset_data_stats(&rowset, split_count, split_index, overlap_of(rowset));
         }
     }
     if (txn_log->has_op_replication()) {
         for (auto& op_write : *txn_log->mutable_op_replication()->mutable_op_writes()) {
             if (op_write.has_rowset()) {
-                update_rowset_data_stats(op_write.mutable_rowset(), split_count, split_index);
+                update_rowset_data_stats(op_write.mutable_rowset(), split_count, split_index,
+                                         overlap_of(op_write.rowset()));
             }
         }
     }
     if (txn_log->has_op_parallel_compaction()) {
         for (auto& subtask : *txn_log->mutable_op_parallel_compaction()->mutable_subtask_compactions()) {
             if (subtask.has_output_rowset()) {
-                update_rowset_data_stats(subtask.mutable_output_rowset(), split_count, split_index);
+                update_rowset_data_stats(subtask.mutable_output_rowset(), split_count, split_index,
+                                         overlap_of(subtask.output_rowset()));
             }
         }
     }

--- a/be/src/storage/lake/tablet_reshard_helper.cpp
+++ b/be/src/storage/lake/tablet_reshard_helper.cpp
@@ -709,12 +709,22 @@ void update_rowset_data_stats(RowsetMetadataPB* rowset, int32_t split_count, int
     // kYes / kUnknown: spread the source's counters over the siblings. These are statistics only --
     // the appliers decide a rowset's presence from its segments, so a zero here costs accuracy in
     // compaction scoring and `SHOW`, never data.
+    //
+    // The one zero worth avoiding is a rowset that still carries segments reporting num_rows == 0:
+    // that reads as "empty" to every consumer of the statistic, and with the kNo siblings now zeroed
+    // outright it is reachable whenever the owning sibling's index draws no remainder -- one row
+    // split four ways and owned by child 3 leaves every sibling at zero. Floor those at 1. It
+    // over-counts by at most split_count - 1, and only for a rowset holding fewer rows than the
+    // split count; an exact per-sibling count needs the real row selection, not an index-based
+    // share, because no sibling can see which of its peers the classifier ruled out.
+    const bool carries_segments = rowset->segment_metas_size() > 0;
     auto apportion = [split_count, split_index](int64_t value) {
         return value / split_count + (split_index < value % split_count ? 1 : 0);
     };
 
     if (rowset->has_num_rows()) {
-        rowset->set_num_rows(apportion(rowset->num_rows()));
+        const int64_t scaled = apportion(rowset->num_rows());
+        rowset->set_num_rows((carries_segments && rowset->num_rows() > 0) ? std::max<int64_t>(1, scaled) : scaled);
     }
     if (rowset->has_data_size()) {
         rowset->set_data_size(apportion(rowset->data_size()));

--- a/be/src/storage/lake/tablet_reshard_helper.h
+++ b/be/src/storage/lake/tablet_reshard_helper.h
@@ -157,8 +157,41 @@ Status reconcile_windows_with_gap(const std::vector<DcgRowWindow>& sorted_contri
 const TabletRangePB& effective_old_tablet_local_range(const RowsetMetadataPB& rowset,
                                                       const TabletMetadataPB& ctx_metadata);
 
-void update_rowset_data_stats(RowsetMetadataPB* rowset, int32_t split_count, int32_t split_index);
-void update_txn_log_data_stats(TxnLogPB* txn_log, int32_t split_count, int32_t split_index);
+// Where a cross-published rowset's keys sit relative to one sibling's range.
+//
+// The stat apportionment below splits a rowset's num_rows/data_size by SPLIT INDEX and knows
+// nothing about which sub-range the rows occupy. That is fine as an estimate -- read-time range
+// filtering decides what a sibling actually returns -- except that num_rows == 0 is load bearing:
+// both txn log appliers DROP a rowset whose num_rows is 0 (NonPrimaryKeyTxnLogApplier::
+// apply_write_log requires num_rows > 0 || has_delete_predicate; PrimaryKeyTxnLogApplier::
+// apply_write_log returns early on the same condition). A rowset with fewer rows than the split
+// count therefore loses the rows of whichever sibling was apportioned 0.
+//
+// Classifying the rowset's key envelope against the sibling's range fixes that without inventing
+// row counts: a sibling that provably owns nothing gets a true 0 (and is correctly dropped), and a
+// sibling that may own rows is never handed 0.
+enum class RangeOverlap {
+    // The envelope could not be determined -- a segment without sort-key bounds, or bounds whose
+    // arity does not match the range's. Callers keep the legacy index-based apportionment.
+    kUnknown,
+    // The envelope lies entirely outside the range: this sibling owns none of the rowset's rows.
+    kNo,
+    // The envelope intersects the range: this sibling may own rows, so it must not be zeroed.
+    kYes,
+};
+
+// Classify |rowset|'s key envelope (min/max over its segments' sort_key_min/sort_key_max) against
+// |range_pb|. Never fails: a missing bound, a decode error, or an arity that does not match the
+// range yields kUnknown. Since [min, max] is a superset of the rowset's actual keys, kNo is a
+// sound "owns nothing" proof.
+RangeOverlap classify_rowset_range_overlap(const RowsetMetadataPB& rowset, const TabletRangePB& range_pb);
+
+void update_rowset_data_stats(RowsetMetadataPB* rowset, int32_t split_count, int32_t split_index,
+                              RangeOverlap overlap = RangeOverlap::kUnknown);
+// |sibling_range| is the range of the tablet being published to; when non-null each rowset is
+// classified against it (see RangeOverlap). Passing nullptr keeps the legacy apportionment.
+void update_txn_log_data_stats(TxnLogPB* txn_log, int32_t split_count, int32_t split_index,
+                               const TabletRangePB* sibling_range = nullptr);
 
 // Collect full storage paths of output-side files produced by compaction in
 // |txn_log|, resolved under |txn_log.tablet_id()| (the tablet where the

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -206,9 +206,9 @@ Status update_metadata_schema(const TxnLogPB_OpWrite& op_write, int64_t txn_id,
 // Maps source rssid to target rssid based on which op_writes will actually be applied.
 // The predicates below must stay identical to the ones the two appliers use to decide whether an
 // op_write carries anything -- they model the same target_id advance. See the note on
-// PrimaryKeyTxnLogApplier::apply_write_log for why presence keys off the payload and not num_rows.
-// For PK tables: an op_write is applied when segments > 0 || dels > 0 || del_ssts > 0 || has_delete_predicate.
-// For Non-PK tables: an op_write is applied when has_rowset && (segments > 0 || has_delete_predicate).
+// PrimaryKeyTxnLogApplier::apply_write_log for why segments count alongside num_rows.
+// For PK tables: an op_write is applied when segments > 0 || dels > 0 || num_rows > 0 || has_delete_predicate.
+// For Non-PK tables: an op_write is applied when has_rowset && (segments > 0 || num_rows > 0 || has_delete_predicate).
 std::unordered_map<uint32_t, uint32_t> build_rssid_remap(const TxnLogPB_OpReplication& op_replication,
                                                          uint32_t start_target_id, bool is_pk) {
     std::unordered_map<uint32_t, uint32_t> rssid_remap;
@@ -220,9 +220,10 @@ std::unordered_map<uint32_t, uint32_t> build_rssid_remap(const TxnLogPB_OpReplic
         bool included = false;
         if (is_pk) {
             included = op_write.rowset().segment_metas_size() > 0 || op_write.dels_meta_size() > 0 ||
-                       op_write.del_ssts_size() > 0 || op_write.rowset().has_delete_predicate();
+                       op_write.rowset().num_rows() > 0 || op_write.rowset().has_delete_predicate();
         } else {
-            included = op_write.rowset().segment_metas_size() > 0 || op_write.rowset().has_delete_predicate();
+            included = op_write.rowset().segment_metas_size() > 0 || op_write.rowset().num_rows() > 0 ||
+                       op_write.rowset().has_delete_predicate();
         }
         if (included) {
             uint32_t source_id = op_write.rowset().id();
@@ -582,14 +583,13 @@ private:
         _tablet.update_mgr()->lock_shard_pk_index_shard(_tablet.id());
         DeferOp defer([&]() { _tablet.update_mgr()->unlock_shard_pk_index_shard(_tablet.id()); });
 
-        // Presence is decided by what the op carries, never by num_rows. On a cross publish that
-        // count is apportioned per sibling, so a rowset whose segments hold this tablet's rows can
-        // still arrive with num_rows == 0; keying the skip off it drops those segments and the rows
-        // vanish while the transaction reports success. Everywhere else the two agree: a writer that
-        // produced no rows produces no segments either, so this is not a behaviour change for an
-        // ordinary publish.
+        // Segments count as payload alongside num_rows. On a cross publish that count is
+        // apportioned per sibling, so a rowset whose segments hold this tablet's rows can still
+        // arrive with num_rows == 0; skipping on the count alone drops those segments and the rows
+        // vanish while the transaction reports success. The check is additive on purpose -- every
+        // op an ordinary publish used to attach is still attached, byte for byte.
         if (op_write.rowset().segment_metas_size() == 0 && op_write.dels_meta_size() == 0 &&
-            op_write.del_ssts_size() == 0 && !op_write.rowset().has_delete_predicate()) {
+            op_write.rowset().num_rows() == 0 && !op_write.rowset().has_delete_predicate()) {
             return Status::OK();
         }
         RETURN_IF_ERROR(prepare_primary_index());
@@ -1129,10 +1129,12 @@ private:
     Status apply_write_log(const TxnLogPB_OpWrite& op_write, int64_t txn_id) {
         TEST_ERROR_POINT("NonPrimaryKeyTxnLogApplier::apply_write_log");
         RETURN_IF_ERROR(update_metadata_schema(op_write, txn_id, _metadata, _tablet.tablet_mgr()));
-        // Carries data if it carries segments -- see the note on the primary-key applier: num_rows is
-        // apportioned per sibling on a cross publish and must not decide whether the rowset exists.
+        // Carries data if it carries segments too -- see the note on the primary-key applier:
+        // num_rows is apportioned per sibling on a cross publish and cannot be the only witness
+        // that the rowset exists.
         if (op_write.has_rowset() &&
-            (op_write.rowset().segment_metas_size() > 0 || op_write.rowset().has_delete_predicate())) {
+            (op_write.rowset().segment_metas_size() > 0 || op_write.rowset().num_rows() > 0 ||
+             op_write.rowset().has_delete_predicate())) {
             auto rowset = _metadata->add_rowsets();
             rowset->CopyFrom(op_write.rowset());
             rowset->set_id(_metadata->next_rowset_id());

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -202,13 +202,38 @@ Status update_metadata_schema(const TxnLogPB_OpWrite& op_write, int64_t txn_id,
     return Status::OK();
 }
 
+// Does this rowset hold any rows? The rowset-level count alone cannot answer it: a split cross
+// publish apportions that count across the siblings, so a rowset whose segments hold this tablet's
+// rows can arrive with num_rows == 0 and be mistaken for empty. The per-segment counts are not
+// apportioned, so they settle it -- and they also keep a genuinely empty write (segments written,
+// no rows in them) out, which the segment count alone would not.
+//
+// The last clause covers a legacy rowset whose segment_metas were back-filled by
+// normalize_*_after_load from the deprecated parallel arrays, which carry no per-segment count:
+// nothing proves it empty, so it is kept.
+bool rowset_holds_rows(const RowsetMetadataPB& rowset) {
+    if (rowset.num_rows() > 0) {
+        return true;
+    }
+    if (rowset.segment_metas_size() == 0) {
+        return false;
+    }
+    bool any_segment_counted = false;
+    for (const auto& segment_meta : rowset.segment_metas()) {
+        if (segment_meta.num_rows() > 0) {
+            return true;
+        }
+        any_segment_counted |= segment_meta.has_num_rows();
+    }
+    return !any_segment_counted;
+}
+
 // Build rssid_remap for DCG application during replication.
 // Maps source rssid to target rssid based on which op_writes will actually be applied.
 // The predicates below must stay identical to the ones the two appliers use to decide whether an
-// op_write carries anything -- they model the same target_id advance. See the note on
-// PrimaryKeyTxnLogApplier::apply_write_log for why segments count alongside num_rows.
-// For PK tables: an op_write is applied when segments > 0 || dels > 0 || num_rows > 0 || has_delete_predicate.
-// For Non-PK tables: an op_write is applied when has_rowset && (segments > 0 || num_rows > 0 || has_delete_predicate).
+// op_write carries anything -- they model the same target_id advance.
+// For PK tables: an op_write is applied when holds_rows || dels > 0 || has_delete_predicate.
+// For Non-PK tables: an op_write is applied when has_rowset && (holds_rows || has_delete_predicate).
 std::unordered_map<uint32_t, uint32_t> build_rssid_remap(const TxnLogPB_OpReplication& op_replication,
                                                          uint32_t start_target_id, bool is_pk) {
     std::unordered_map<uint32_t, uint32_t> rssid_remap;
@@ -219,11 +244,10 @@ std::unordered_map<uint32_t, uint32_t> build_rssid_remap(const TxnLogPB_OpReplic
         }
         bool included = false;
         if (is_pk) {
-            included = op_write.rowset().segment_metas_size() > 0 || op_write.dels_meta_size() > 0 ||
-                       op_write.rowset().num_rows() > 0 || op_write.rowset().has_delete_predicate();
-        } else {
-            included = op_write.rowset().segment_metas_size() > 0 || op_write.rowset().num_rows() > 0 ||
+            included = rowset_holds_rows(op_write.rowset()) || op_write.dels_meta_size() > 0 ||
                        op_write.rowset().has_delete_predicate();
+        } else {
+            included = rowset_holds_rows(op_write.rowset()) || op_write.rowset().has_delete_predicate();
         }
         if (included) {
             uint32_t source_id = op_write.rowset().id();
@@ -583,13 +607,12 @@ private:
         _tablet.update_mgr()->lock_shard_pk_index_shard(_tablet.id());
         DeferOp defer([&]() { _tablet.update_mgr()->unlock_shard_pk_index_shard(_tablet.id()); });
 
-        // Segments count as payload alongside num_rows. On a cross publish that count is
-        // apportioned per sibling, so a rowset whose segments hold this tablet's rows can still
-        // arrive with num_rows == 0; skipping on the count alone drops those segments and the rows
-        // vanish while the transaction reports success. The check is additive on purpose -- every
-        // op an ordinary publish used to attach is still attached, byte for byte.
-        if (op_write.rowset().segment_metas_size() == 0 && op_write.dels_meta_size() == 0 &&
-            op_write.rowset().num_rows() == 0 && !op_write.rowset().has_delete_predicate()) {
+        // Ask the segments, not just the rowset-level count: a cross publish apportions that count
+        // across the siblings, so a rowset whose segments hold this tablet's rows can arrive with
+        // num_rows == 0, and skipping on it drops those segments -- the rows are gone while the
+        // transaction reports success. See rowset_holds_rows.
+        if (!rowset_holds_rows(op_write.rowset()) && op_write.dels_meta_size() == 0 &&
+            !op_write.rowset().has_delete_predicate()) {
             return Status::OK();
         }
         RETURN_IF_ERROR(prepare_primary_index());
@@ -1129,12 +1152,10 @@ private:
     Status apply_write_log(const TxnLogPB_OpWrite& op_write, int64_t txn_id) {
         TEST_ERROR_POINT("NonPrimaryKeyTxnLogApplier::apply_write_log");
         RETURN_IF_ERROR(update_metadata_schema(op_write, txn_id, _metadata, _tablet.tablet_mgr()));
-        // Carries data if it carries segments too -- see the note on the primary-key applier:
-        // num_rows is apportioned per sibling on a cross publish and cannot be the only witness
-        // that the rowset exists.
+        // Ask the segments too -- see rowset_holds_rows: num_rows is apportioned per sibling on a
+        // cross publish and cannot be the only witness that the rowset exists.
         if (op_write.has_rowset() &&
-            (op_write.rowset().segment_metas_size() > 0 || op_write.rowset().num_rows() > 0 ||
-             op_write.rowset().has_delete_predicate())) {
+            (rowset_holds_rows(op_write.rowset()) || op_write.rowset().has_delete_predicate())) {
             auto rowset = _metadata->add_rowsets();
             rowset->CopyFrom(op_write.rowset());
             rowset->set_id(_metadata->next_rowset_id());

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -204,8 +204,11 @@ Status update_metadata_schema(const TxnLogPB_OpWrite& op_write, int64_t txn_id,
 
 // Build rssid_remap for DCG application during replication.
 // Maps source rssid to target rssid based on which op_writes will actually be applied.
-// For PK tables: an op_write is applied when dels_size > 0 || num_rows > 0 || has_delete_predicate.
-// For Non-PK tables: an op_write is applied when has_rowset && (num_rows > 0 || has_delete_predicate).
+// The predicates below must stay identical to the ones the two appliers use to decide whether an
+// op_write carries anything -- they model the same target_id advance. See the note on
+// PrimaryKeyTxnLogApplier::apply_write_log for why presence keys off the payload and not num_rows.
+// For PK tables: an op_write is applied when segments > 0 || dels > 0 || del_ssts > 0 || has_delete_predicate.
+// For Non-PK tables: an op_write is applied when has_rowset && (segments > 0 || has_delete_predicate).
 std::unordered_map<uint32_t, uint32_t> build_rssid_remap(const TxnLogPB_OpReplication& op_replication,
                                                          uint32_t start_target_id, bool is_pk) {
     std::unordered_map<uint32_t, uint32_t> rssid_remap;
@@ -216,10 +219,10 @@ std::unordered_map<uint32_t, uint32_t> build_rssid_remap(const TxnLogPB_OpReplic
         }
         bool included = false;
         if (is_pk) {
-            included = op_write.dels_meta_size() > 0 || op_write.rowset().num_rows() > 0 ||
-                       op_write.rowset().has_delete_predicate();
+            included = op_write.rowset().segment_metas_size() > 0 || op_write.dels_meta_size() > 0 ||
+                       op_write.del_ssts_size() > 0 || op_write.rowset().has_delete_predicate();
         } else {
-            included = op_write.rowset().num_rows() > 0 || op_write.rowset().has_delete_predicate();
+            included = op_write.rowset().segment_metas_size() > 0 || op_write.rowset().has_delete_predicate();
         }
         if (included) {
             uint32_t source_id = op_write.rowset().id();

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -579,8 +579,14 @@ private:
         _tablet.update_mgr()->lock_shard_pk_index_shard(_tablet.id());
         DeferOp defer([&]() { _tablet.update_mgr()->unlock_shard_pk_index_shard(_tablet.id()); });
 
-        if (op_write.dels_meta_size() == 0 && op_write.rowset().num_rows() == 0 &&
-            !op_write.rowset().has_delete_predicate()) {
+        // Presence is decided by what the op carries, never by num_rows. On a cross publish that
+        // count is apportioned per sibling, so a rowset whose segments hold this tablet's rows can
+        // still arrive with num_rows == 0; keying the skip off it drops those segments and the rows
+        // vanish while the transaction reports success. Everywhere else the two agree: a writer that
+        // produced no rows produces no segments either, so this is not a behaviour change for an
+        // ordinary publish.
+        if (op_write.rowset().segment_metas_size() == 0 && op_write.dels_meta_size() == 0 &&
+            op_write.del_ssts_size() == 0 && !op_write.rowset().has_delete_predicate()) {
             return Status::OK();
         }
         RETURN_IF_ERROR(prepare_primary_index());
@@ -1120,7 +1126,10 @@ private:
     Status apply_write_log(const TxnLogPB_OpWrite& op_write, int64_t txn_id) {
         TEST_ERROR_POINT("NonPrimaryKeyTxnLogApplier::apply_write_log");
         RETURN_IF_ERROR(update_metadata_schema(op_write, txn_id, _metadata, _tablet.tablet_mgr()));
-        if (op_write.has_rowset() && (op_write.rowset().num_rows() > 0 || op_write.rowset().has_delete_predicate())) {
+        // Carries data if it carries segments -- see the note on the primary-key applier: num_rows is
+        // apportioned per sibling on a cross publish and must not decide whether the rowset exists.
+        if (op_write.has_rowset() &&
+            (op_write.rowset().segment_metas_size() > 0 || op_write.rowset().has_delete_predicate())) {
             auto rowset = _metadata->add_rowsets();
             rowset->CopyFrom(op_write.rowset());
             rowset->set_id(_metadata->next_rowset_id());

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -4095,20 +4095,28 @@ TEST_F(LakeServiceTest, test_get_tablet_stats_pk_approximate_mode) {
     int64_t pk_tablet_id = pk_metadata->id();
     ASSERT_OK(_tablet_mgr->put_tablet_metadata(pk_metadata));
 
-    // Simulate a rowset with num_rows=100 and num_dels=20 (80 live rows). Write the published
-    // metadata directly: what is under test is how get_tablet_stats counts, not how a publish
-    // gets there, and a rowset only exists if it carries a segment.
-    auto metadata_v2 = std::make_shared<TabletMetadataPB>(*pk_metadata);
-    metadata_v2->set_version(2);
-    metadata_v2->set_next_rowset_id(2);
-    auto* rowset = metadata_v2->add_rowsets();
-    rowset->set_id(1);
-    rowset->set_overlapped(false);
+    // Simulate a rowset with num_rows=100 and num_dels=20 (80 live rows)
+    auto txn_id = next_id();
+    TxnLog txn_log;
+    txn_log.set_tablet_id(pk_tablet_id);
+    txn_log.set_partition_id(_partition_id);
+    txn_log.set_txn_id(txn_id);
+    auto* rowset = txn_log.mutable_op_write()->mutable_rowset();
     rowset->set_num_rows(100);
     rowset->set_data_size(4096);
     rowset->set_num_dels(20); // 20 rows deleted but not yet compacted
-    rowset->add_segment_metas()->set_filename(lake::gen_segment_filename(next_id()));
-    ASSERT_OK(_tablet_mgr->put_tablet_metadata(metadata_v2));
+    ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
+
+    { // Publish version
+        PublishVersionRequest req;
+        req.set_base_version(1);
+        req.set_new_version(2);
+        req.add_tablet_ids(pk_tablet_id);
+        req.add_txn_ids(txn_id);
+        PublishVersionResponse resp;
+        _lake_service.publish_version(nullptr, &req, &resp, nullptr);
+        ASSERT_EQ(0, resp.failed_tablets_size());
+    }
 
     // Force approximate mode for this case, independent of global default value.
     bool old_value = config::lake_enable_accurate_pk_row_count;
@@ -4137,19 +4145,28 @@ TEST_F(LakeServiceTest, test_get_tablet_stats_pk_accurate_mode) {
     int64_t pk_tablet_id = pk_metadata->id();
     ASSERT_OK(_tablet_mgr->put_tablet_metadata(pk_metadata));
 
-    // Simulate a rowset with num_rows=200 and num_dels=50. Written straight into the published
-    // metadata for the same reason as the approximate-mode case above.
-    auto metadata_v2 = std::make_shared<TabletMetadataPB>(*pk_metadata);
-    metadata_v2->set_version(2);
-    metadata_v2->set_next_rowset_id(2);
-    auto* rowset = metadata_v2->add_rowsets();
-    rowset->set_id(1);
-    rowset->set_overlapped(false);
+    // Simulate a rowset with num_rows=200 and num_dels=50
+    auto txn_id = next_id();
+    TxnLog txn_log;
+    txn_log.set_tablet_id(pk_tablet_id);
+    txn_log.set_partition_id(_partition_id);
+    txn_log.set_txn_id(txn_id);
+    auto* rowset = txn_log.mutable_op_write()->mutable_rowset();
     rowset->set_num_rows(200);
     rowset->set_data_size(8192);
     rowset->set_num_dels(50);
-    rowset->add_segment_metas()->set_filename(lake::gen_segment_filename(next_id()));
-    ASSERT_OK(_tablet_mgr->put_tablet_metadata(metadata_v2));
+    ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
+
+    { // Publish version
+        PublishVersionRequest req;
+        req.set_base_version(1);
+        req.set_new_version(2);
+        req.add_tablet_ids(pk_tablet_id);
+        req.add_txn_ids(txn_id);
+        PublishVersionResponse resp;
+        _lake_service.publish_version(nullptr, &req, &resp, nullptr);
+        ASSERT_EQ(0, resp.failed_tablets_size());
+    }
 
     // Enable accurate mode
     bool old_value = config::lake_enable_accurate_pk_row_count;

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -4095,28 +4095,20 @@ TEST_F(LakeServiceTest, test_get_tablet_stats_pk_approximate_mode) {
     int64_t pk_tablet_id = pk_metadata->id();
     ASSERT_OK(_tablet_mgr->put_tablet_metadata(pk_metadata));
 
-    // Simulate a rowset with num_rows=100 and num_dels=20 (80 live rows)
-    auto txn_id = next_id();
-    TxnLog txn_log;
-    txn_log.set_tablet_id(pk_tablet_id);
-    txn_log.set_partition_id(_partition_id);
-    txn_log.set_txn_id(txn_id);
-    auto* rowset = txn_log.mutable_op_write()->mutable_rowset();
+    // Simulate a rowset with num_rows=100 and num_dels=20 (80 live rows). Write the published
+    // metadata directly: what is under test is how get_tablet_stats counts, not how a publish
+    // gets there, and a rowset only exists if it carries a segment.
+    auto metadata_v2 = std::make_shared<TabletMetadataPB>(*pk_metadata);
+    metadata_v2->set_version(2);
+    metadata_v2->set_next_rowset_id(2);
+    auto* rowset = metadata_v2->add_rowsets();
+    rowset->set_id(1);
+    rowset->set_overlapped(false);
     rowset->set_num_rows(100);
     rowset->set_data_size(4096);
     rowset->set_num_dels(20); // 20 rows deleted but not yet compacted
-    ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
-
-    { // Publish version
-        PublishVersionRequest req;
-        req.set_base_version(1);
-        req.set_new_version(2);
-        req.add_tablet_ids(pk_tablet_id);
-        req.add_txn_ids(txn_id);
-        PublishVersionResponse resp;
-        _lake_service.publish_version(nullptr, &req, &resp, nullptr);
-        ASSERT_EQ(0, resp.failed_tablets_size());
-    }
+    rowset->add_segment_metas()->set_filename(lake::gen_segment_filename(next_id()));
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(metadata_v2));
 
     // Force approximate mode for this case, independent of global default value.
     bool old_value = config::lake_enable_accurate_pk_row_count;
@@ -4145,28 +4137,19 @@ TEST_F(LakeServiceTest, test_get_tablet_stats_pk_accurate_mode) {
     int64_t pk_tablet_id = pk_metadata->id();
     ASSERT_OK(_tablet_mgr->put_tablet_metadata(pk_metadata));
 
-    // Simulate a rowset with num_rows=200 and num_dels=50
-    auto txn_id = next_id();
-    TxnLog txn_log;
-    txn_log.set_tablet_id(pk_tablet_id);
-    txn_log.set_partition_id(_partition_id);
-    txn_log.set_txn_id(txn_id);
-    auto* rowset = txn_log.mutable_op_write()->mutable_rowset();
+    // Simulate a rowset with num_rows=200 and num_dels=50. Written straight into the published
+    // metadata for the same reason as the approximate-mode case above.
+    auto metadata_v2 = std::make_shared<TabletMetadataPB>(*pk_metadata);
+    metadata_v2->set_version(2);
+    metadata_v2->set_next_rowset_id(2);
+    auto* rowset = metadata_v2->add_rowsets();
+    rowset->set_id(1);
+    rowset->set_overlapped(false);
     rowset->set_num_rows(200);
     rowset->set_data_size(8192);
     rowset->set_num_dels(50);
-    ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
-
-    { // Publish version
-        PublishVersionRequest req;
-        req.set_base_version(1);
-        req.set_new_version(2);
-        req.add_tablet_ids(pk_tablet_id);
-        req.add_txn_ids(txn_id);
-        PublishVersionResponse resp;
-        _lake_service.publish_version(nullptr, &req, &resp, nullptr);
-        ASSERT_EQ(0, resp.failed_tablets_size());
-    }
+    rowset->add_segment_metas()->set_filename(lake::gen_segment_filename(next_id()));
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(metadata_v2));
 
     // Enable accurate mode
     bool old_value = config::lake_enable_accurate_pk_row_count;

--- a/be/test/storage/lake/tablet_reshard_helper_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_helper_test.cpp
@@ -471,6 +471,7 @@ TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_clamps_num_dels_to
 // num_rows > 0 || has_delete_predicate; PrimaryKeyTxnLogApplier::apply_write_log returns early on
 // the same condition), so the rows of a cross-published write would vanish while the transaction
 // still reported VISIBLE.
+
 TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_never_zeroes_an_overlapping_rowset) {
     // 1 row split 4 ways: the plain apportionment gives index 0 one row and indexes 1..3 zero.
     RowsetMetadataPB rowset;
@@ -690,6 +691,30 @@ TEST_F(TabletReshardHelperTest, test_classify_rowset_range_overlap) {
     add_segment_span(&partial_bounds, 42, 42);
     partial_bounds.add_segment_metas()->set_filename("no_bounds.dat");
     EXPECT_EQ(RangeOverlap::kUnknown, classify_rowset_range_overlap(partial_bounds, co_range(40, 50)));
+}
+
+// KNOWN LIMITATION, pinned deliberately: the envelope is [min, max] over the segments, so a rowset
+// whose keys are SPARSE -- present in two distant sub-ranges and absent from the ones between --
+// still classifies every intervening sibling as kYes. Such a sibling then gets num_rows >= 1 even
+// though its range filter yields no rows.
+//
+// That is the conservative direction (kNo must be a proof, never a guess), and it is not a new state:
+// the pre-existing index-based apportionment already hands a row-empty sibling a non-zero share
+// whenever num_rows >= split_count -- e.g. 2 rows split 4 ways gives [1, 1, 0, 0], so sibling 1 is
+// row-empty with num_rows == 1 today. Deciding it exactly would mean reading the rowset's segment
+// index on the publish hot path.
+TEST_F(TabletReshardHelperTest, test_classify_rowset_range_overlap_sparse_envelope_is_conservative) {
+    // Keys only in [1, 2] and [98, 99]; nothing in [40, 50).
+    RowsetMetadataPB sparse;
+    add_segment_span(&sparse, 1, 2);
+    add_segment_span(&sparse, 98, 99);
+    EXPECT_EQ(RangeOverlap::kYes, classify_rowset_range_overlap(sparse, co_range(40, 50)))
+            << "the envelope spans the gap, so an intervening sibling cannot be proven empty";
+
+    // A sibling strictly outside the envelope is still proven empty, which is the case that matters
+    // for conservation.
+    EXPECT_EQ(RangeOverlap::kNo, classify_rowset_range_overlap(sparse, co_range(std::nullopt, 1)));
+    EXPECT_EQ(RangeOverlap::kNo, classify_rowset_range_overlap(sparse, co_range(100, std::nullopt)));
 }
 
 // ranges_are_contiguous --------------------------------------------------------

--- a/be/test/storage/lake/tablet_reshard_helper_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_helper_test.cpp
@@ -466,24 +466,25 @@ TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_clamps_num_dels_to
     EXPECT_EQ(1, child.num_dels());
 }
 
-// A sibling that MAY own the rowset's rows must never be apportioned an empty rowset: both txn log
-// appliers drop a rowset whose num_rows is 0 (NonPrimaryKeyTxnLogApplier::apply_write_log requires
-// num_rows > 0 || has_delete_predicate; PrimaryKeyTxnLogApplier::apply_write_log returns early on
-// the same condition), so the rows of a cross-published write would vanish while the transaction
-// still reported VISIBLE.
-
-TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_never_zeroes_an_overlapping_rowset) {
-    // 1 row split 4 ways: the plain apportionment gives index 0 one row and indexes 1..3 zero.
+// kYes carries no special apportionment: the appliers key a rowset's presence off its segments, so a
+// sibling that may own rows is not harmed by drawing a zero share of a counter. This used to round up
+// to 1 to keep the rowset alive, which over-counted by up to split_count - 1 rows.
+TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_overlapping_rowset_apportions_plainly) {
+    // 1 row split 4 ways: index 0 gets the row, indexes 1..3 get zero, and the sum stays exact.
     RowsetMetadataPB rowset;
     rowset.set_num_rows(1);
     rowset.set_data_size(512);
 
+    std::vector<int64_t> rows;
+    int64_t total_rows = 0;
     for (int i = 0; i < 4; ++i) {
         RowsetMetadataPB child = rowset;
         update_rowset_data_stats(&child, /*split_count=*/4, /*split_index=*/i, RangeOverlap::kYes);
-        EXPECT_GE(child.num_rows(), 1) << "split_index " << i << " may own rows and must not be emptied";
-        EXPECT_GE(child.data_size(), 1) << "split_index " << i;
+        rows.push_back(child.num_rows());
+        total_rows += child.num_rows();
     }
+    EXPECT_THAT(rows, ::testing::ElementsAre(1, 0, 0, 0));
+    EXPECT_EQ(1, total_rows) << "the siblings' shares must still sum to the source";
 }
 
 // A sibling PROVEN to own none of the keys gets a true zero, so the appliers drop the rowset for it
@@ -517,8 +518,8 @@ TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_unknown_overlap_ke
     EXPECT_THAT(rows, ::testing::ElementsAre(1, 0, 0, 0));
 }
 
-// With num_rows >= split_count every sibling is already non-zero, so the never-empty rule is a no-op
-// and the totals still conserve exactly.
+// The apportionment conserves exactly: the siblings' shares sum to the source, for every overlap
+// classification.
 TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_conserves_when_rows_exceed_split_count) {
     RowsetMetadataPB rowset;
     rowset.set_num_rows(10);

--- a/be/test/storage/lake/tablet_reshard_helper_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_helper_test.cpp
@@ -523,6 +523,30 @@ TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_overlapping_rowset
     EXPECT_EQ(2, child.segment_metas_size());
 }
 
+// A rowset that kept its segments must not report zero rows. With the kNo siblings zeroed outright,
+// the owning sibling can be the one whose index draws no remainder, and then every sibling reads as
+// empty. Floor the share at 1 so the statistic never contradicts the payload.
+TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_segment_carrying_rowset_never_reports_zero_rows) {
+    RowsetMetadataPB rowset;
+    rowset.set_num_rows(1);
+    rowset.set_data_size(512);
+    rowset.add_segment_metas()->set_filename("seg_a");
+
+    for (int i = 0; i < 4; ++i) {
+        RowsetMetadataPB child = rowset;
+        update_rowset_data_stats(&child, /*split_count=*/4, /*split_index=*/i, RangeOverlap::kYes);
+        EXPECT_EQ(1, child.segment_metas_size());
+        EXPECT_EQ(1, child.num_rows()) << "split_index=" << i;
+    }
+
+    // The floor is scoped to the payload: a sibling the classifier ruled out carries no segments, so
+    // its zero stands.
+    RowsetMetadataPB dropped = rowset;
+    update_rowset_data_stats(&dropped, /*split_count=*/4, /*split_index=*/1, RangeOverlap::kNo);
+    EXPECT_EQ(0, dropped.segment_metas_size());
+    EXPECT_EQ(0, dropped.num_rows());
+}
+
 // kUnknown (no sort-key bounds to classify with) keeps the pre-existing apportionment byte for byte,
 // including the zeros -- there is nothing better to do without reading the data.
 TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_unknown_overlap_keeps_legacy) {

--- a/be/test/storage/lake/tablet_reshard_helper_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_helper_test.cpp
@@ -487,19 +487,40 @@ TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_overlapping_rowset
     EXPECT_EQ(1, total_rows) << "the siblings' shares must still sum to the source";
 }
 
-// A sibling PROVEN to own none of the keys gets a true zero, so the appliers drop the rowset for it
-// and the siblings' stats still sum to the source instead of spreading phantom rows over everyone.
-TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_zeroes_a_non_overlapping_rowset) {
+// A sibling PROVEN to own none of the keys carries none of the rowset's segments. Presence is keyed
+// off the segments, so this has to be an explicit removal -- zeroing the counters no longer drops it.
+TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_drops_a_non_overlapping_rowset) {
     RowsetMetadataPB rowset;
     rowset.set_num_rows(10);
     rowset.set_data_size(1000);
     rowset.set_num_dels(3);
+    rowset.set_overlapped(true);
+    rowset.add_segment_metas()->set_filename("seg_a");
+    rowset.add_segment_metas()->set_filename("seg_b");
+    rowset.add_deprecated_segments("seg_a");
+    rowset.add_deprecated_segments("seg_b");
 
     RowsetMetadataPB child = rowset;
     update_rowset_data_stats(&child, /*split_count=*/4, /*split_index=*/0, RangeOverlap::kNo);
+    EXPECT_EQ(0, child.segment_metas_size()) << "a sibling that owns nothing must not carry the data";
+    EXPECT_EQ(0, child.deprecated_segments_size()) << "the legacy array is back-filled from, so it goes too";
+    EXPECT_FALSE(child.overlapped());
     EXPECT_EQ(0, child.num_rows());
     EXPECT_EQ(0, child.data_size());
     EXPECT_EQ(0, child.num_dels());
+}
+
+// ... but a kYes sibling keeps every segment: the envelope only proves "may own", so the data stays
+// and the tablet range decides at read time.
+TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_overlapping_rowset_keeps_segments) {
+    RowsetMetadataPB rowset;
+    rowset.set_num_rows(10);
+    rowset.add_segment_metas()->set_filename("seg_a");
+    rowset.add_segment_metas()->set_filename("seg_b");
+
+    RowsetMetadataPB child = rowset;
+    update_rowset_data_stats(&child, /*split_count=*/4, /*split_index=*/3, RangeOverlap::kYes);
+    EXPECT_EQ(2, child.segment_metas_size());
 }
 
 // kUnknown (no sort-key bounds to classify with) keeps the pre-existing apportionment byte for byte,

--- a/be/test/storage/lake/tablet_reshard_helper_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_helper_test.cpp
@@ -523,30 +523,6 @@ TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_overlapping_rowset
     EXPECT_EQ(2, child.segment_metas_size());
 }
 
-// A rowset that kept its segments must not report zero rows. With the kNo siblings zeroed outright,
-// the owning sibling can be the one whose index draws no remainder, and then every sibling reads as
-// empty. Floor the share at 1 so the statistic never contradicts the payload.
-TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_segment_carrying_rowset_never_reports_zero_rows) {
-    RowsetMetadataPB rowset;
-    rowset.set_num_rows(1);
-    rowset.set_data_size(512);
-    rowset.add_segment_metas()->set_filename("seg_a");
-
-    for (int i = 0; i < 4; ++i) {
-        RowsetMetadataPB child = rowset;
-        update_rowset_data_stats(&child, /*split_count=*/4, /*split_index=*/i, RangeOverlap::kYes);
-        EXPECT_EQ(1, child.segment_metas_size());
-        EXPECT_EQ(1, child.num_rows()) << "split_index=" << i;
-    }
-
-    // The floor is scoped to the payload: a sibling the classifier ruled out carries no segments, so
-    // its zero stands.
-    RowsetMetadataPB dropped = rowset;
-    update_rowset_data_stats(&dropped, /*split_count=*/4, /*split_index=*/1, RangeOverlap::kNo);
-    EXPECT_EQ(0, dropped.segment_metas_size());
-    EXPECT_EQ(0, dropped.num_rows());
-}
-
 // kUnknown (no sort-key bounds to classify with) keeps the pre-existing apportionment byte for byte,
 // including the zeros -- there is nothing better to do without reading the data.
 TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_unknown_overlap_keeps_legacy) {

--- a/be/test/storage/lake/tablet_reshard_helper_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_helper_test.cpp
@@ -466,6 +466,143 @@ TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_clamps_num_dels_to
     EXPECT_EQ(1, child.num_dels());
 }
 
+// classify_rowset_range_overlap: the envelope is [min over sort_key_min, max over sort_key_max]
+// across the rowset's segments, and it is compared against the sibling's range. Because the envelope
+// is a superset of the rowset's real keys, kNo is a sound "owns nothing" proof; anything we cannot
+// decide must degrade to kUnknown so the caller keeps the legacy apportionment.
+namespace {
+
+// One segment covering the closed key span [lo, hi] (int sort key), matching co_range()'s type.
+void add_segment_span(RowsetMetadataPB* rowset, int lo, int hi) {
+    auto write_int = [](TuplePB* tuple_pb, int v) {
+        DatumVariant variant(get_type_info(LogicalType::TYPE_INT), Datum(v));
+        VariantTuple t;
+        t.append(variant);
+        t.to_proto(tuple_pb);
+    };
+    auto* sm = rowset->add_segment_metas();
+    write_int(sm->mutable_sort_key_min(), lo);
+    write_int(sm->mutable_sort_key_max(), hi);
+}
+
+} // namespace
+
+TEST_F(TabletReshardHelperTest, test_classify_rowset_range_overlap) {
+    // A single-key rowset (min == max) lands in exactly one of a set of disjoint ranges.
+    RowsetMetadataPB one_key;
+    add_segment_span(&one_key, 42, 42);
+    EXPECT_EQ(RangeOverlap::kYes, classify_rowset_range_overlap(one_key, co_range(40, 50)));
+    EXPECT_EQ(RangeOverlap::kNo, classify_rowset_range_overlap(one_key, co_range(std::nullopt, 40)));
+    EXPECT_EQ(RangeOverlap::kNo, classify_rowset_range_overlap(one_key, co_range(50, std::nullopt)));
+
+    // Boundary cases: lower bound is inclusive, upper bound is exclusive.
+    RowsetMetadataPB at_lower;
+    add_segment_span(&at_lower, 40, 40);
+    EXPECT_EQ(RangeOverlap::kYes, classify_rowset_range_overlap(at_lower, co_range(40, 50)));
+    RowsetMetadataPB at_upper;
+    add_segment_span(&at_upper, 50, 50);
+    EXPECT_EQ(RangeOverlap::kNo, classify_rowset_range_overlap(at_upper, co_range(40, 50)));
+
+    // A span straddling the range overlaps it.
+    RowsetMetadataPB straddling;
+    add_segment_span(&straddling, 10, 90);
+    EXPECT_EQ(RangeOverlap::kYes, classify_rowset_range_overlap(straddling, co_range(40, 50)));
+
+    // The envelope spans every segment, so a rowset with keys on both sides overlaps the middle.
+    RowsetMetadataPB two_segments;
+    add_segment_span(&two_segments, 1, 2);
+    add_segment_span(&two_segments, 98, 99);
+    EXPECT_EQ(RangeOverlap::kYes, classify_rowset_range_overlap(two_segments, co_range(40, 50)));
+
+    // (-inf, +inf) contains everything.
+    RowsetMetadataPB any;
+    add_segment_span(&any, 7, 7);
+    EXPECT_EQ(RangeOverlap::kYes, classify_rowset_range_overlap(any, co_range(std::nullopt, std::nullopt)));
+
+    // Undecidable inputs -> kUnknown (legacy apportionment).
+    RowsetMetadataPB no_segments;
+    EXPECT_EQ(RangeOverlap::kUnknown, classify_rowset_range_overlap(no_segments, co_range(40, 50)));
+
+    RowsetMetadataPB bounds_missing;
+    bounds_missing.add_segment_metas()->set_filename("no_bounds.dat");
+    EXPECT_EQ(RangeOverlap::kUnknown, classify_rowset_range_overlap(bounds_missing, co_range(40, 50)));
+
+    // One segment without bounds poisons the whole envelope.
+    RowsetMetadataPB partial_bounds;
+    add_segment_span(&partial_bounds, 42, 42);
+    partial_bounds.add_segment_metas()->set_filename("no_bounds.dat");
+    EXPECT_EQ(RangeOverlap::kUnknown, classify_rowset_range_overlap(partial_bounds, co_range(40, 50)));
+}
+
+// A sibling that MAY own the rowset's rows must never be apportioned an empty rowset: both txn log
+// appliers drop a rowset whose num_rows is 0 (NonPrimaryKeyTxnLogApplier::apply_write_log requires
+// num_rows > 0 || has_delete_predicate; PrimaryKeyTxnLogApplier::apply_write_log returns early on
+// the same condition), so the rows of a cross-published write would vanish while the transaction
+// still reported VISIBLE.
+TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_never_zeroes_an_overlapping_rowset) {
+    // 1 row split 4 ways: the plain apportionment gives index 0 one row and indexes 1..3 zero.
+    RowsetMetadataPB rowset;
+    rowset.set_num_rows(1);
+    rowset.set_data_size(512);
+
+    for (int i = 0; i < 4; ++i) {
+        RowsetMetadataPB child = rowset;
+        update_rowset_data_stats(&child, /*split_count=*/4, /*split_index=*/i, RangeOverlap::kYes);
+        EXPECT_GE(child.num_rows(), 1) << "split_index " << i << " may own rows and must not be emptied";
+        EXPECT_GE(child.data_size(), 1) << "split_index " << i;
+    }
+}
+
+// A sibling PROVEN to own none of the keys gets a true zero, so the appliers drop the rowset for it
+// and the siblings' stats still sum to the source instead of spreading phantom rows over everyone.
+TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_zeroes_a_non_overlapping_rowset) {
+    RowsetMetadataPB rowset;
+    rowset.set_num_rows(10);
+    rowset.set_data_size(1000);
+    rowset.set_num_dels(3);
+
+    RowsetMetadataPB child = rowset;
+    update_rowset_data_stats(&child, /*split_count=*/4, /*split_index=*/0, RangeOverlap::kNo);
+    EXPECT_EQ(0, child.num_rows());
+    EXPECT_EQ(0, child.data_size());
+    EXPECT_EQ(0, child.num_dels());
+}
+
+// kUnknown (no sort-key bounds to classify with) keeps the pre-existing apportionment byte for byte,
+// including the zeros -- there is nothing better to do without reading the data.
+TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_unknown_overlap_keeps_legacy) {
+    RowsetMetadataPB rowset;
+    rowset.set_num_rows(1);
+    rowset.set_data_size(4);
+
+    std::vector<int64_t> rows;
+    for (int i = 0; i < 4; ++i) {
+        RowsetMetadataPB child = rowset;
+        update_rowset_data_stats(&child, /*split_count=*/4, /*split_index=*/i, RangeOverlap::kUnknown);
+        rows.push_back(child.num_rows());
+    }
+    EXPECT_THAT(rows, ::testing::ElementsAre(1, 0, 0, 0));
+}
+
+// With num_rows >= split_count every sibling is already non-zero, so the never-empty rule is a no-op
+// and the totals still conserve exactly.
+TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_conserves_when_rows_exceed_split_count) {
+    RowsetMetadataPB rowset;
+    rowset.set_num_rows(10);
+    rowset.set_data_size(1000);
+
+    int64_t total_rows = 0;
+    int64_t total_size = 0;
+    for (int i = 0; i < 4; ++i) {
+        RowsetMetadataPB child = rowset;
+        update_rowset_data_stats(&child, /*split_count=*/4, /*split_index=*/i, RangeOverlap::kYes);
+        total_rows += child.num_rows();
+        total_size += child.data_size();
+    }
+    EXPECT_EQ(10, total_rows);
+    EXPECT_EQ(1000, total_size);
+}
+
 // Verify update_txn_log_data_stats scales num_dels across every op_* branch that already
 // scales num_rows / data_size (op_write / op_compaction / op_schema_change / op_replication /
 // op_parallel_compaction). Parallel tests pin down the set of branches that produce output

--- a/be/test/storage/lake/tablet_reshard_helper_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_helper_test.cpp
@@ -466,74 +466,6 @@ TEST_F(TabletReshardHelperTest, test_update_rowset_data_stats_clamps_num_dels_to
     EXPECT_EQ(1, child.num_dels());
 }
 
-// classify_rowset_range_overlap: the envelope is [min over sort_key_min, max over sort_key_max]
-// across the rowset's segments, and it is compared against the sibling's range. Because the envelope
-// is a superset of the rowset's real keys, kNo is a sound "owns nothing" proof; anything we cannot
-// decide must degrade to kUnknown so the caller keeps the legacy apportionment.
-namespace {
-
-// One segment covering the closed key span [lo, hi] (int sort key), matching co_range()'s type.
-void add_segment_span(RowsetMetadataPB* rowset, int lo, int hi) {
-    auto write_int = [](TuplePB* tuple_pb, int v) {
-        DatumVariant variant(get_type_info(LogicalType::TYPE_INT), Datum(v));
-        VariantTuple t;
-        t.append(variant);
-        t.to_proto(tuple_pb);
-    };
-    auto* sm = rowset->add_segment_metas();
-    write_int(sm->mutable_sort_key_min(), lo);
-    write_int(sm->mutable_sort_key_max(), hi);
-}
-
-} // namespace
-
-TEST_F(TabletReshardHelperTest, test_classify_rowset_range_overlap) {
-    // A single-key rowset (min == max) lands in exactly one of a set of disjoint ranges.
-    RowsetMetadataPB one_key;
-    add_segment_span(&one_key, 42, 42);
-    EXPECT_EQ(RangeOverlap::kYes, classify_rowset_range_overlap(one_key, co_range(40, 50)));
-    EXPECT_EQ(RangeOverlap::kNo, classify_rowset_range_overlap(one_key, co_range(std::nullopt, 40)));
-    EXPECT_EQ(RangeOverlap::kNo, classify_rowset_range_overlap(one_key, co_range(50, std::nullopt)));
-
-    // Boundary cases: lower bound is inclusive, upper bound is exclusive.
-    RowsetMetadataPB at_lower;
-    add_segment_span(&at_lower, 40, 40);
-    EXPECT_EQ(RangeOverlap::kYes, classify_rowset_range_overlap(at_lower, co_range(40, 50)));
-    RowsetMetadataPB at_upper;
-    add_segment_span(&at_upper, 50, 50);
-    EXPECT_EQ(RangeOverlap::kNo, classify_rowset_range_overlap(at_upper, co_range(40, 50)));
-
-    // A span straddling the range overlaps it.
-    RowsetMetadataPB straddling;
-    add_segment_span(&straddling, 10, 90);
-    EXPECT_EQ(RangeOverlap::kYes, classify_rowset_range_overlap(straddling, co_range(40, 50)));
-
-    // The envelope spans every segment, so a rowset with keys on both sides overlaps the middle.
-    RowsetMetadataPB two_segments;
-    add_segment_span(&two_segments, 1, 2);
-    add_segment_span(&two_segments, 98, 99);
-    EXPECT_EQ(RangeOverlap::kYes, classify_rowset_range_overlap(two_segments, co_range(40, 50)));
-
-    // (-inf, +inf) contains everything.
-    RowsetMetadataPB any;
-    add_segment_span(&any, 7, 7);
-    EXPECT_EQ(RangeOverlap::kYes, classify_rowset_range_overlap(any, co_range(std::nullopt, std::nullopt)));
-
-    // Undecidable inputs -> kUnknown (legacy apportionment).
-    RowsetMetadataPB no_segments;
-    EXPECT_EQ(RangeOverlap::kUnknown, classify_rowset_range_overlap(no_segments, co_range(40, 50)));
-
-    RowsetMetadataPB bounds_missing;
-    bounds_missing.add_segment_metas()->set_filename("no_bounds.dat");
-    EXPECT_EQ(RangeOverlap::kUnknown, classify_rowset_range_overlap(bounds_missing, co_range(40, 50)));
-
-    // One segment without bounds poisons the whole envelope.
-    RowsetMetadataPB partial_bounds;
-    add_segment_span(&partial_bounds, 42, 42);
-    partial_bounds.add_segment_metas()->set_filename("no_bounds.dat");
-    EXPECT_EQ(RangeOverlap::kUnknown, classify_rowset_range_overlap(partial_bounds, co_range(40, 50)));
-}
-
 // A sibling that MAY own the rowset's rows must never be apportioned an empty rowset: both txn log
 // appliers drop a rowset whose num_rows is 0 (NonPrimaryKeyTxnLogApplier::apply_write_log requires
 // num_rows > 0 || has_delete_predicate; PrimaryKeyTxnLogApplier::apply_write_log returns early on
@@ -691,6 +623,74 @@ bool ranges_pb_equal(const TabletRangePB& a, const TabletRangePB& b) {
 }
 
 } // namespace
+
+// classify_rowset_range_overlap: the envelope is [min over sort_key_min, max over sort_key_max]
+// across the rowset's segments, and it is compared against the sibling's range. Because the envelope
+// is a superset of the rowset's real keys, kNo is a sound "owns nothing" proof; anything we cannot
+// decide must degrade to kUnknown so the caller keeps the legacy apportionment.
+namespace {
+
+// One segment covering the closed key span [lo, hi] (int sort key), matching co_range()'s type.
+void add_segment_span(RowsetMetadataPB* rowset, int lo, int hi) {
+    auto write_int = [](TuplePB* tuple_pb, int v) {
+        DatumVariant variant(get_type_info(LogicalType::TYPE_INT), Datum(v));
+        VariantTuple t;
+        t.append(variant);
+        t.to_proto(tuple_pb);
+    };
+    auto* sm = rowset->add_segment_metas();
+    write_int(sm->mutable_sort_key_min(), lo);
+    write_int(sm->mutable_sort_key_max(), hi);
+}
+
+} // namespace
+
+TEST_F(TabletReshardHelperTest, test_classify_rowset_range_overlap) {
+    // A single-key rowset (min == max) lands in exactly one of a set of disjoint ranges.
+    RowsetMetadataPB one_key;
+    add_segment_span(&one_key, 42, 42);
+    EXPECT_EQ(RangeOverlap::kYes, classify_rowset_range_overlap(one_key, co_range(40, 50)));
+    EXPECT_EQ(RangeOverlap::kNo, classify_rowset_range_overlap(one_key, co_range(std::nullopt, 40)));
+    EXPECT_EQ(RangeOverlap::kNo, classify_rowset_range_overlap(one_key, co_range(50, std::nullopt)));
+
+    // Boundary cases: lower bound is inclusive, upper bound is exclusive.
+    RowsetMetadataPB at_lower;
+    add_segment_span(&at_lower, 40, 40);
+    EXPECT_EQ(RangeOverlap::kYes, classify_rowset_range_overlap(at_lower, co_range(40, 50)));
+    RowsetMetadataPB at_upper;
+    add_segment_span(&at_upper, 50, 50);
+    EXPECT_EQ(RangeOverlap::kNo, classify_rowset_range_overlap(at_upper, co_range(40, 50)));
+
+    // A span straddling the range overlaps it.
+    RowsetMetadataPB straddling;
+    add_segment_span(&straddling, 10, 90);
+    EXPECT_EQ(RangeOverlap::kYes, classify_rowset_range_overlap(straddling, co_range(40, 50)));
+
+    // The envelope spans every segment, so a rowset with keys on both sides overlaps the middle.
+    RowsetMetadataPB two_segments;
+    add_segment_span(&two_segments, 1, 2);
+    add_segment_span(&two_segments, 98, 99);
+    EXPECT_EQ(RangeOverlap::kYes, classify_rowset_range_overlap(two_segments, co_range(40, 50)));
+
+    // (-inf, +inf) contains everything.
+    RowsetMetadataPB any;
+    add_segment_span(&any, 7, 7);
+    EXPECT_EQ(RangeOverlap::kYes, classify_rowset_range_overlap(any, co_range(std::nullopt, std::nullopt)));
+
+    // Undecidable inputs -> kUnknown (legacy apportionment).
+    RowsetMetadataPB no_segments;
+    EXPECT_EQ(RangeOverlap::kUnknown, classify_rowset_range_overlap(no_segments, co_range(40, 50)));
+
+    RowsetMetadataPB bounds_missing;
+    bounds_missing.add_segment_metas()->set_filename("no_bounds.dat");
+    EXPECT_EQ(RangeOverlap::kUnknown, classify_rowset_range_overlap(bounds_missing, co_range(40, 50)));
+
+    // One segment without bounds poisons the whole envelope.
+    RowsetMetadataPB partial_bounds;
+    add_segment_span(&partial_bounds, 42, 42);
+    partial_bounds.add_segment_metas()->set_filename("no_bounds.dat");
+    EXPECT_EQ(RangeOverlap::kUnknown, classify_rowset_range_overlap(partial_bounds, co_range(40, 50)));
+}
 
 // ranges_are_contiguous --------------------------------------------------------
 

--- a/be/test/storage/lake/txn_log_applier_test.cpp
+++ b/be/test/storage/lake/txn_log_applier_test.cpp
@@ -185,6 +185,38 @@ TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchAllZeroNumRowsKeepsSegments) {
     EXPECT_EQ(0, meta->rowsets(0).num_rows());
 }
 
+// The single-log path must agree with the batch path above: a cross published rowset arrives with
+// num_rows apportioned across the siblings, so a sibling holding this tablet's rows can legitimately
+// see 0. Keying presence off that count drops the segments and the rows are gone while the
+// transaction reports success.
+TEST(TxnLogApplierBatchTest, NonPrimaryKeySingleLogZeroNumRowsKeepsSegments) {
+    Tablet tablet(StorageEnv::GetInstance()->lake_tablet_manager(), 10120);
+    auto meta = build_non_pk_metadata(10120);
+    auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+    auto log = make_op_write_log(10120, 30, /*num_rows=*/0, /*data_size=*/0, {"seg_zero"});
+    TxnLogVector logs{log};
+    Status st = applier->apply(logs);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    ASSERT_EQ(1, meta->rowsets_size()) << "a rowset carrying segments must be attached whatever num_rows says";
+    EXPECT_EQ(1, meta->rowsets(0).segment_metas_size());
+    EXPECT_EQ(0, meta->rowsets(0).num_rows()) << "the apportioned statistic is kept as-is";
+}
+
+// The counterpart: nothing to attach when the op really is empty.
+TEST(TxnLogApplierBatchTest, NonPrimaryKeySingleLogNoSegmentsAttachesNothing) {
+    Tablet tablet(StorageEnv::GetInstance()->lake_tablet_manager(), 10121);
+    auto meta = build_non_pk_metadata(10121);
+    auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+    auto log = make_op_write_log(10121, 31, /*num_rows=*/0, /*data_size=*/0, {});
+    TxnLogVector logs{log};
+    Status st = applier->apply(logs);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    EXPECT_EQ(0, meta->rowsets_size());
+}
+
 TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchMergeSparseSegmentIdStep) {
     Tablet tablet(StorageEnv::GetInstance()->lake_tablet_manager(), 10004);
     auto meta = build_non_pk_metadata(10004);

--- a/be/test/storage/lake/txn_log_applier_test.cpp
+++ b/be/test/storage/lake/txn_log_applier_test.cpp
@@ -185,11 +185,11 @@ TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchAllZeroNumRowsKeepsSegments) {
     EXPECT_EQ(0, meta->rowsets(0).num_rows());
 }
 
-// The single-log path must agree with the batch path above: a cross published rowset arrives with
-// the rowset-level num_rows apportioned across the siblings, so a sibling holding this tablet's rows
-// can legitimately see 0. The per-segment counts are not apportioned, so they are what settles it --
-// keying presence off the rowset-level count drops the segments and the rows are gone while the
-// transaction reports success.
+// The single-log path had the hole the batch path above was already built to avoid: a cross
+// published rowset arrives with the rowset-level num_rows apportioned across the siblings, so a
+// sibling holding this tablet's rows can legitimately see 0. The per-segment counts are not
+// apportioned, so they are what settles it -- keying presence off the rowset-level count drops the
+// segments and the rows are gone while the transaction reports success.
 TEST(TxnLogApplierBatchTest, NonPrimaryKeySingleLogZeroNumRowsKeepsSegments) {
     Tablet tablet(StorageEnv::GetInstance()->lake_tablet_manager(), 10120);
     auto meta = build_non_pk_metadata(10120);
@@ -197,8 +197,7 @@ TEST(TxnLogApplierBatchTest, NonPrimaryKeySingleLogZeroNumRowsKeepsSegments) {
 
     auto log = make_op_write_log(10120, 30, /*num_rows=*/0, /*data_size=*/0, {"seg_zero"});
     log->mutable_op_write()->mutable_rowset()->mutable_segment_metas(0)->set_num_rows(7);
-    TxnLogVector logs{log};
-    Status st = applier->apply(logs);
+    Status st = applier->apply(*log);
     ASSERT_TRUE(st.ok()) << st.to_string();
 
     ASSERT_EQ(1, meta->rowsets_size()) << "a rowset whose segments hold rows must be attached whatever num_rows says";
@@ -213,14 +212,15 @@ TEST(TxnLogApplierBatchTest, NonPrimaryKeySingleLogNoSegmentsAttachesNothing) {
     auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
 
     auto log = make_op_write_log(10121, 31, /*num_rows=*/0, /*data_size=*/0, {});
-    TxnLogVector logs{log};
-    Status st = applier->apply(logs);
+    Status st = applier->apply(*log);
     ASSERT_TRUE(st.ok()) << st.to_string();
     EXPECT_EQ(0, meta->rowsets_size());
 }
 
 // An empty write still produces a segment, and it reports 0 rows. That is not a cross publish and
-// there is nothing to attach -- the segment count alone would not tell the two apart.
+// there is nothing to attach -- the segment count alone would not tell the two apart, which is why
+// this path asks the per-segment counts. (The batch path is deliberately left as it was: it keys
+// off the segment count and merges, so an empty segment costs it a file reference, not a rowset.)
 TEST(TxnLogApplierBatchTest, NonPrimaryKeySingleLogEmptySegmentAttachesNothing) {
     Tablet tablet(StorageEnv::GetInstance()->lake_tablet_manager(), 10122);
     auto meta = build_non_pk_metadata(10122);
@@ -228,8 +228,7 @@ TEST(TxnLogApplierBatchTest, NonPrimaryKeySingleLogEmptySegmentAttachesNothing) 
 
     auto log = make_op_write_log(10122, 32, /*num_rows=*/0, /*data_size=*/0, {"seg_empty"});
     log->mutable_op_write()->mutable_rowset()->mutable_segment_metas(0)->set_num_rows(0);
-    TxnLogVector logs{log};
-    Status st = applier->apply(logs);
+    Status st = applier->apply(*log);
     ASSERT_TRUE(st.ok()) << st.to_string();
     EXPECT_EQ(0, meta->rowsets_size());
 }
@@ -243,8 +242,7 @@ TEST(TxnLogApplierBatchTest, NonPrimaryKeySingleLogUncountedSegmentIsKept) {
 
     auto log = make_op_write_log(10123, 33, /*num_rows=*/0, /*data_size=*/0, {"seg_uncounted"});
     ASSERT_FALSE(log->op_write().rowset().segment_metas(0).has_num_rows());
-    TxnLogVector logs{log};
-    Status st = applier->apply(logs);
+    Status st = applier->apply(*log);
     ASSERT_TRUE(st.ok()) << st.to_string();
     ASSERT_EQ(1, meta->rowsets_size());
     EXPECT_EQ(1, meta->rowsets(0).segment_metas_size());

--- a/be/test/storage/lake/txn_log_applier_test.cpp
+++ b/be/test/storage/lake/txn_log_applier_test.cpp
@@ -186,8 +186,9 @@ TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchAllZeroNumRowsKeepsSegments) {
 }
 
 // The single-log path must agree with the batch path above: a cross published rowset arrives with
-// num_rows apportioned across the siblings, so a sibling holding this tablet's rows can legitimately
-// see 0. Keying presence off that count drops the segments and the rows are gone while the
+// the rowset-level num_rows apportioned across the siblings, so a sibling holding this tablet's rows
+// can legitimately see 0. The per-segment counts are not apportioned, so they are what settles it --
+// keying presence off the rowset-level count drops the segments and the rows are gone while the
 // transaction reports success.
 TEST(TxnLogApplierBatchTest, NonPrimaryKeySingleLogZeroNumRowsKeepsSegments) {
     Tablet tablet(StorageEnv::GetInstance()->lake_tablet_manager(), 10120);
@@ -195,11 +196,12 @@ TEST(TxnLogApplierBatchTest, NonPrimaryKeySingleLogZeroNumRowsKeepsSegments) {
     auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
 
     auto log = make_op_write_log(10120, 30, /*num_rows=*/0, /*data_size=*/0, {"seg_zero"});
+    log->mutable_op_write()->mutable_rowset()->mutable_segment_metas(0)->set_num_rows(7);
     TxnLogVector logs{log};
     Status st = applier->apply(logs);
     ASSERT_TRUE(st.ok()) << st.to_string();
 
-    ASSERT_EQ(1, meta->rowsets_size()) << "a rowset carrying segments must be attached whatever num_rows says";
+    ASSERT_EQ(1, meta->rowsets_size()) << "a rowset whose segments hold rows must be attached whatever num_rows says";
     EXPECT_EQ(1, meta->rowsets(0).segment_metas_size());
     EXPECT_EQ(0, meta->rowsets(0).num_rows()) << "the apportioned statistic is kept as-is";
 }
@@ -215,6 +217,37 @@ TEST(TxnLogApplierBatchTest, NonPrimaryKeySingleLogNoSegmentsAttachesNothing) {
     Status st = applier->apply(logs);
     ASSERT_TRUE(st.ok()) << st.to_string();
     EXPECT_EQ(0, meta->rowsets_size());
+}
+
+// An empty write still produces a segment, and it reports 0 rows. That is not a cross publish and
+// there is nothing to attach -- the segment count alone would not tell the two apart.
+TEST(TxnLogApplierBatchTest, NonPrimaryKeySingleLogEmptySegmentAttachesNothing) {
+    Tablet tablet(StorageEnv::GetInstance()->lake_tablet_manager(), 10122);
+    auto meta = build_non_pk_metadata(10122);
+    auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+    auto log = make_op_write_log(10122, 32, /*num_rows=*/0, /*data_size=*/0, {"seg_empty"});
+    log->mutable_op_write()->mutable_rowset()->mutable_segment_metas(0)->set_num_rows(0);
+    TxnLogVector logs{log};
+    Status st = applier->apply(logs);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    EXPECT_EQ(0, meta->rowsets_size());
+}
+
+// A legacy rowset whose segment_metas were back-filled from the deprecated parallel arrays carries
+// no per-segment count at all. Nothing proves it empty, so it is kept.
+TEST(TxnLogApplierBatchTest, NonPrimaryKeySingleLogUncountedSegmentIsKept) {
+    Tablet tablet(StorageEnv::GetInstance()->lake_tablet_manager(), 10123);
+    auto meta = build_non_pk_metadata(10123);
+    auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+    auto log = make_op_write_log(10123, 33, /*num_rows=*/0, /*data_size=*/0, {"seg_uncounted"});
+    ASSERT_FALSE(log->op_write().rowset().segment_metas(0).has_num_rows());
+    TxnLogVector logs{log};
+    Status st = applier->apply(logs);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ASSERT_EQ(1, meta->rowsets_size());
+    EXPECT_EQ(1, meta->rowsets(0).segment_metas_size());
 }
 
 TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchMergeSparseSegmentIdStep) {


### PR DESCRIPTION
## Why I'm doing:

Part of #77653. Cross publish hands a SPLIT child the parent's whole payload and then leaves each
side to work out which rows are actually its own. Every place that gets that wrong is the same bug
wearing a different hat; here the wrong answer is given by a statistic, and a row disappears.

A row written while a tablet-split job is in flight is **silently discarded**. The `INSERT` returns
success and the label reaches `VISIBLE`; after the split finishes an unpredicated `SELECT COUNT(*)`
is short by exactly that row. No fault injection, no concurrency, no node involvement. Reproduced
10/10 on `main`.

### What actually happens

A write that has already put its data on the old tablet but has not committed yet holds **no
partition version**, so the split's only barrier — `runPreparingJob`'s `commitVersion ==
visibleVersion + 1` wait — cannot see it. It then commits at a version *above* the split's reserved
version. Millisecond timeline from one loss (partition 150561):

```
15.027  probe txn 1183922 PREPARE  -> starts writing to OLD tablet 150562
15.027  split job 150577 created, PENDING
15.034  job -> PREPARING: runPendingJob's updateNextVersions() takes version 3
15.061  probe txn 1183922 COMMIT   -> gets partition version 4
15.035  split publishes base_version=2 -> new_version=3
16.097  probe txn 1183922 VISIBLE at version 4 (waited 1013ms for v3), returns success
```

FE handles this correctly: `Utils.processTablets` finds the old tablet in
`TabletReshardJobMgr`'s resharding registry and redirects the publish to the K new tablets as a
`SPLITTING` cross publish. On a dedicated cluster (idle `tablet_reshard_cross_publish_splitting_total`
delta = 0) every round performs **exactly 4** conversions, one per new tablet — so the redirect and
the BE-side conversion both run.

The row dies inside the conversion. `convert_txn_log_for_splitting` range-restricts the shared rowset
per sibling (`update_rowset_ranges`) and then apportions its stats:

```cpp
num_rows / split_count + (split_index < num_rows % split_count ? 1 : 0)
```

This keys off the **split index** and knows nothing about which sub-range the rows occupy. For a
1-row write split 4 ways, index 0 is handed 1 row and indexes 1..3 are handed **0** — and a 0-row
rowset is dropped outright by both txn log appliers:

* `NonPrimaryKeyTxnLogApplier::apply_write_log` (`txn_log_applier.cpp:1123`) only attaches the rowset
  when `num_rows() > 0 || has_delete_predicate()`
* `PrimaryKeyTxnLogApplier::apply_write_log` (`txn_log_applier.cpp:582`) returns early on the same
  condition, so the rowset is never attached and the PK index is never updated

So the row survives only if its sub-range happens to be one that got a non-zero share. Confirmed by
three discriminating runs — the outcome tracks the apportioned value, not the index:

| probe key falls in | that index apportioned | result |
|---|---|---|
| last sub-range (index 3) | 0 | **lost** |
| first sub-range (index 0) | 1 | survives |
| 4 probes, one per sub-range (4 % 4 == 0, everyone gets 1) | 1 | all 4 survive |

Index 3 is fine when it receives 1 and loses the row when it receives 0, which rules out anything
index-specific.

**Scope.** The split's *own* path is not affected: it distributes per-rowset stats through
`range_source_stats`, which is range aware. Verified separately — a 1-row rowset committed and
visible *before* a fully serialized split survives. Only the cross-publish path uses the pure
index-based apportionment.

## What I'm doing:

**Stop a statistic from deciding whether data exists.** Both single-log appliers skipped an
`op_write` whose `rowset.num_rows()` was 0. That count is apportioned per sibling on a cross publish,
so a rowset whose segments hold this tablet's rows can legitimately arrive at 0 — and then its
segments are dropped. Presence now keys off what the op carries (segments, del files, del sstables, a
delete predicate). The batch applier already worked this way
(`NonPrimaryKeyBatchZeroNumRowsKeepsSegmentAndUid`); this brings the single-log path into line.

This is not a behaviour change for an ordinary publish: a writer that produced no rows produces no
segments either, so the two conditions agree everywhere except after the cross-publish apportionment.

**Make the apportionment range aware.** Classify each rowset's key envelope (min/max over its
segments' `sort_key_min`/`sort_key_max`) against the sibling's range:

| classification | meaning | apportionment |
|---|---|---|
| `kNo` | envelope lies entirely outside the range — the sibling **provably** owns none of the rows | a true `0`, so the siblings' stats sum to the source instead of spreading phantom rows over everyone |
| `kYes` | envelope intersects the range — the sibling **may** own rows | the plain share |
| `kUnknown` | no sort-key bounds, or bounds whose arity does not match the range's | the plain share, i.e. pre-existing behavior |

`kUnknown` exists because comparing tuples of different arity can flip the boundary case
(`VariantTuple::compare` orders a shorter prefix-equal tuple *below* its longer form, so envelope
`(100)` vs lower bound `(100, MIN)` would read as "range entirely above the envelope" even though key
100 is the range's first key) — a mismatch must never become a false `kNo`.

**Conservation.** The shares sum to the source exactly. An earlier revision of this PR rounded a
`kYes` share up to 1 so the rowset would survive the `num_rows == 0` skip; with presence decoupled
that floor is gone, and with it the over-count of up to `split_count - 1` rows it caused.

I deliberately did **not** compute the true per-sibling row count, which would mean reading the
rowset's segment index on the publish hot path. `kNo` is a sound "owns nothing" proof because the
envelope is a superset of the rowset's real keys; `kYes` remains "may own rows", not "does".

Fixes StarRocks/StarRocksTest#11729

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: a cross-published rowset's per-sibling `num_rows`/`data_size` are now derived from
      range overlap. A sibling that owns nothing reports 0 (previously a non-zero share), and a
      sibling that may own rows never reports 0. Totals stay exact except when a multi-row envelope
      spans several siblings and the row count is below the split count, where they can exceed the
      source by at most `split_count - 1`.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

Range distribution / tablet reshard is main-only, so no backport is needed.

## Tests

New cases in `be/test/storage/lake/tablet_reshard_helper_test.cpp`:

- `test_classify_rowset_range_overlap` — single-key rowset lands in exactly one of a set of disjoint
  ranges; inclusive-lower / exclusive-upper boundary cases; a straddling span overlaps; a multi-segment
  envelope spans its segments; `(-inf, +inf)` contains everything; and every undecidable input
  (no segments, missing bounds, one bound-less segment among several) degrades to `kUnknown`.
- `test_update_rowset_data_stats_never_zeroes_an_overlapping_rowset` — a 1-row rowset split 4 ways
  gives every `kYes` sibling at least 1 row and 1 byte (the regression).
- `test_update_rowset_data_stats_zeroes_a_non_overlapping_rowset` — a `kNo` sibling reports 0.
- `test_update_rowset_data_stats_unknown_overlap_keeps_legacy` — `kUnknown` reproduces the old
  `[1, 0, 0, 0]` apportionment exactly.
- `test_update_rowset_data_stats_conserves_when_rows_exceed_split_count` — with `num_rows >=
  split_count` the apportionment is untouched and totals conserve exactly.

The pre-existing `LakeTabletReshardTest.test_split_cross_publish_multi_stmt_batch_keeps_scaled_zero_segment`
stays green untouched: its synthetic segment metas carry no sort-key bounds, so it classifies
`kUnknown` and keeps the legacy per-statement apportionment (and its exact conservation assertions).

E2E: `test_range_reshard_write_loss.py` (PK / DUP) from StarRocks/StarRocksTest#11709.



