### PR TITLE
[BugFix] Reject a reshard whose source tablet lives in a superseded materialized index

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
@@ -227,6 +227,12 @@ public class MergeTabletJob extends TabletReshardJob {
                         || publishResult.publishState() == PublishState.FAILED) {
                     // Publish not started or publish failed
                     allPartitionFinished = false;
+                    // Surface why the publish failed. A failed publish is only retried, so without
+                    // this the job stays in RUNNING with an empty ERROR_MESSAGE in
+                    // information_schema.tablet_reshard_jobs and the cause lives only in fe.log.
+                    if (publishResult.publishState() == PublishState.FAILED) {
+                        errorMessage = "publish version failed (retrying): " + publishResult.failureReason();
+                    }
                     // Start publish asynchronously
                     List<Tablet> tablets = new ArrayList<>();
                     for (MaterializedIndex index : physicalPartition.getLatestMaterializedIndices(IndexExtState.ALL)) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
@@ -213,6 +213,12 @@ public class MergeTabletJob extends TabletReshardJob {
                 PhysicalPartition physicalPartition = olapTable
                         .getPhysicalPartition(reshardingPhysicalPartition.getPhysicalPartitionId());
                 if (physicalPartition == null) {
+                    // The partition was dropped mid-job (DROP PARTITION / TRUNCATE are permitted while
+                    // the table is in TABLET_RESHARD). Its publish will never be retried again, so drop
+                    // any failure reason it left behind instead of reporting a failure that can no
+                    // longer recover -- note this skip also leaves allPartitionFinished alone, so the
+                    // job goes on to finish.
+                    reshardingPhysicalPartition.setPublishFailureReason(null);
                     continue;
                 }
 
@@ -516,13 +522,7 @@ public class MergeTabletJob extends TabletReshardJob {
         item.setParallel_tablets(getParallelTablets());
         item.setCreated_time(createdTimeMs / 1000);
         item.setFinished_time(finishedTimeMs / 1000);
-        if (errorMessage != null) {
-            item.setError_message(errorMessage);
-        } else {
-            String publishFailureReason = anyPublishFailureReason();
-            item.setError_message(publishFailureReason == null
-                    ? "" : "publish version failed (retrying): " + publishFailureReason);
-        }
+        item.setError_message(reportedErrorMessage());
         return item;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
@@ -202,6 +202,9 @@ public class MergeTabletJob extends TabletReshardJob {
     protected void runRunningJob() {
         // 1. Publish the merge transaction, update new tablet ranges
         boolean allPartitionFinished = true;
+        // Publish failure seen in THIS pass, if any. Recomputed every pass so a retry that
+        // succeeds clears the reported reason instead of leaving it on a healthy job.
+        String failureReason = null;
         ThreadPoolExecutor publishThreadPool = GlobalStateMgr.getCurrentState().getPublishVersionDaemon()
                 .getTaskExecutor();
 
@@ -227,11 +230,11 @@ public class MergeTabletJob extends TabletReshardJob {
                         || publishResult.publishState() == PublishState.FAILED) {
                     // Publish not started or publish failed
                     allPartitionFinished = false;
-                    // Surface why the publish failed. A failed publish is only retried, so without
-                    // this the job stays in RUNNING with an empty ERROR_MESSAGE in
-                    // information_schema.tablet_reshard_jobs and the cause lives only in fe.log.
+                    // Remember why the publish failed so this pass can surface it (see
+                    // publishFailureReason); without it a job stuck retrying shows an empty
+                    // ERROR_MESSAGE and the cause lives only in fe.log.
                     if (publishResult.publishState() == PublishState.FAILED) {
-                        errorMessage = "publish version failed (retrying): " + publishResult.failureReason();
+                        failureReason = publishResult.failureReason();
                     }
                     // Start publish asynchronously
                     List<Tablet> tablets = new ArrayList<>();
@@ -270,6 +273,8 @@ public class MergeTabletJob extends TabletReshardJob {
                 }
             }
         }
+
+        publishFailureReason = failureReason;
 
         if (!allPartitionFinished) {
             return;
@@ -501,6 +506,8 @@ public class MergeTabletJob extends TabletReshardJob {
         item.setFinished_time(finishedTimeMs / 1000);
         if (errorMessage != null) {
             item.setError_message(errorMessage);
+        } else if (publishFailureReason != null) {
+            item.setError_message("publish version failed (retrying): " + publishFailureReason);
         } else {
             item.setError_message("");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
@@ -274,7 +274,17 @@ public class MergeTabletJob extends TabletReshardJob {
             }
         }
 
-        publishFailureReason = failureReason;
+        if (failureReason != null) {
+            // A publish failed in this pass.
+            publishFailureReason = failureReason;
+        } else if (allPartitionFinished) {
+            // Every partition published: the retry recovered, so stop reporting the old reason.
+            publishFailureReason = null;
+        }
+        // Otherwise a resubmitted publish is still IN_PROGRESS. Keep the previous reason: the
+        // scheduler ticks every few milliseconds, so clearing it here would expose the diagnostic
+        // for a single tick and then blank ERROR_MESSAGE again for the whole duration of a slow or
+        // hung retry -- exactly the case it exists to explain.
 
         if (!allPartitionFinished) {
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
@@ -115,8 +115,8 @@ public class MergeTabletJob extends TabletReshardJob {
 
     @Override
     public void init() throws StarRocksException {
-        try {
-            setTableState(OlapTable.OlapTableState.NORMAL, OlapTable.OlapTableState.TABLET_RESHARD);
+        try (LockedObject<OlapTable> lockedTable = getLockedTable(LockType.WRITE)) {
+            reserveTableForReshard(dbId, lockedTable.get(), reshardingPhysicalPartitions);
         } catch (TabletReshardException e) {
             // Surface admission rejection (table not NORMAL / dropped) as a checked exception so
             // callers' StarRocksException handling (e.g. TabletPreSplitCoordinator) takes effect.

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
@@ -202,9 +202,6 @@ public class MergeTabletJob extends TabletReshardJob {
     protected void runRunningJob() {
         // 1. Publish the merge transaction, update new tablet ranges
         boolean allPartitionFinished = true;
-        // Publish failure seen in THIS pass, if any. Recomputed every pass so a retry that
-        // succeeds clears the reported reason instead of leaving it on a healthy job.
-        String failureReason = null;
         ThreadPoolExecutor publishThreadPool = GlobalStateMgr.getCurrentState().getPublishVersionDaemon()
                 .getTaskExecutor();
 
@@ -230,11 +227,13 @@ public class MergeTabletJob extends TabletReshardJob {
                         || publishResult.publishState() == PublishState.FAILED) {
                     // Publish not started or publish failed
                     allPartitionFinished = false;
-                    // Remember why the publish failed so this pass can surface it (see
-                    // publishFailureReason); without it a job stuck retrying shows an empty
-                    // ERROR_MESSAGE and the cause lives only in fe.log.
+                    // Remember why THIS partition's publish failed so a job stuck retrying can
+                    // explain itself; without it ERROR_MESSAGE is empty and the cause lives only in
+                    // fe.log. Kept until this partition publishes (an IN_PROGRESS retry must not
+                    // blank it) and scoped per partition so recovery here is not masked by a
+                    // sibling partition that is still retrying.
                     if (publishResult.publishState() == PublishState.FAILED) {
-                        failureReason = publishResult.failureReason();
+                        reshardingPhysicalPartition.setPublishFailureReason(publishResult.failureReason());
                     }
                     // Start publish asynchronously
                     List<Tablet> tablets = new ArrayList<>();
@@ -248,6 +247,8 @@ public class MergeTabletJob extends TabletReshardJob {
                     // Publish is in progress
                     allPartitionFinished = false;
                 } else if (publishResult.publishState() == PublishState.SUCCESS) {
+                    // This partition published: its earlier failure (if any) has recovered.
+                    reshardingPhysicalPartition.setPublishFailureReason(null);
                     // Publish success, update new tablet ranges
                     Map<Long, TabletRange> tabletRanges = publishResult.tabletRanges();
                     for (ReshardingMaterializedIndex reshardingIndex : reshardingPhysicalPartition
@@ -273,18 +274,6 @@ public class MergeTabletJob extends TabletReshardJob {
                 }
             }
         }
-
-        if (failureReason != null) {
-            // A publish failed in this pass.
-            publishFailureReason = failureReason;
-        } else if (allPartitionFinished) {
-            // Every partition published: the retry recovered, so stop reporting the old reason.
-            publishFailureReason = null;
-        }
-        // Otherwise a resubmitted publish is still IN_PROGRESS. Keep the previous reason: the
-        // scheduler ticks every few milliseconds, so clearing it here would expose the diagnostic
-        // for a single tick and then blank ERROR_MESSAGE again for the whole duration of a slow or
-        // hung retry -- exactly the case it exists to explain.
 
         if (!allPartitionFinished) {
             return;
@@ -486,6 +475,19 @@ public class MergeTabletJob extends TabletReshardJob {
         return sb.toString();
     }
 
+    // First partition currently retrying a failed publish, or null when none is. Read live from the
+    // per-partition state so a partition that recovers drops out without any job-level bookkeeping.
+    @Override
+    protected String anyPublishFailureReason() {
+        for (ReshardingPhysicalPartition reshardingPhysicalPartition : reshardingPhysicalPartitions.values()) {
+            String reason = reshardingPhysicalPartition.getPublishFailureReason();
+            if (reason != null) {
+                return reason;
+            }
+        }
+        return null;
+    }
+
     @Override
     public TTabletReshardJobsItem getInfo() {
         TTabletReshardJobsItem item = new TTabletReshardJobsItem();
@@ -516,10 +518,10 @@ public class MergeTabletJob extends TabletReshardJob {
         item.setFinished_time(finishedTimeMs / 1000);
         if (errorMessage != null) {
             item.setError_message(errorMessage);
-        } else if (publishFailureReason != null) {
-            item.setError_message("publish version failed (retrying): " + publishFailureReason);
         } else {
-            item.setError_message("");
+            String publishFailureReason = anyPublishFailureReason();
+            item.setError_message(publishFailureReason == null
+                    ? "" : "publish version failed (retrying): " + publishFailureReason);
         }
         return item;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJobFactory.java
@@ -236,6 +236,10 @@ public class MergeTabletJobFactory implements TabletReshardJobFactory {
                         + " in physical partition " + physicalPartition.getId()
                         + " in table " + db.getFullName() + '.' + table.getName());
             }
+            // A superseded index passes every check above (still reachable via getIndex, still NORMAL,
+            // still owns the tablets, still mapped by TabletInvertedIndex), so it needs its own gate.
+            TabletReshardUtils.checkIndexNotSuperseded(physicalPartition, index, firstTabletId,
+                    db.getFullName(), table.getName());
 
             for (long tabletId : group) {
                 TabletMeta meta = tabletMetaMap.get(tabletId);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ReshardingPhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ReshardingPhysicalPartition.java
@@ -72,9 +72,18 @@ public class ReshardingPhysicalPartition {
         FAILED, // Publish failed
     }
 
+    /**
+     * {@code failureReason} is set only for {@link PublishState#FAILED} and carries the publish
+     * error text, so a job that keeps retrying can surface why in its errorMessage instead of
+     * sitting in RUNNING with nothing but a log line.
+     */
     public static record PublishResult(
             PublishState publishState,
-            Map<Long, TabletRange> tabletRanges) {
+            Map<Long, TabletRange> tabletRanges,
+            String failureReason) {
+        public PublishResult(PublishState publishState, Map<Long, TabletRange> tabletRanges) {
+            this(publishState, tabletRanges, null);
+        }
     }
 
     public PublishResult getPublishResult() {
@@ -95,7 +104,8 @@ public class ReshardingPhysicalPartition {
             return new PublishResult(PublishState.IN_PROGRESS, null);
         } catch (Exception e) {
             LOG.warn("Failed to publish future get. ", e);
-            return new PublishResult(PublishState.FAILED, null);
+            Throwable cause = (e.getCause() != null) ? e.getCause() : e;
+            return new PublishResult(PublishState.FAILED, null, cause.getMessage());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ReshardingPhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ReshardingPhysicalPartition.java
@@ -39,7 +39,8 @@ public class ReshardingPhysicalPartition {
 
     protected Future<Map<Long, TabletRange>> publishFuture;
 
-    // Reason this partition's last publish attempt failed, or null while it is healthy. Scoped to
+    // Reason this partition's last publish attempt failed, cleared once it publishes or the partition
+    // is dropped from the table (runRunningJob then skips it, so no publish result would). Scoped to
     // the partition (not the job) so a partition that recovers stops reporting even while a sibling
     // partition is still retrying. Deliberately NOT serialized: a publish failure is always retried
     // and never terminal, so it must not reach the journal. volatile because runRunningJob writes it

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ReshardingPhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ReshardingPhysicalPartition.java
@@ -39,6 +39,14 @@ public class ReshardingPhysicalPartition {
 
     protected Future<Map<Long, TabletRange>> publishFuture;
 
+    // Reason this partition's last publish attempt failed, or null while it is healthy. Scoped to
+    // the partition (not the job) so a partition that recovers stops reporting even while a sibling
+    // partition is still retrying. Deliberately NOT serialized: a publish failure is always retried
+    // and never terminal, so it must not reach the journal. volatile because runRunningJob writes it
+    // from the reshard daemon while getInfo() reads it on an RPC thread, and the job stays in
+    // RUNNING throughout, so there is no other happens-before edge to publish the write.
+    protected transient volatile String publishFailureReason;
+
     public ReshardingPhysicalPartition(long physicalPartitionId,
             Map<Long, ReshardingMaterializedIndex> reshardingIndexes) {
         this.physicalPartitionId = physicalPartitionId;
@@ -63,6 +71,14 @@ public class ReshardingPhysicalPartition {
 
     public void setPublishFuture(Future<Map<Long, TabletRange>> publishFuture) {
         this.publishFuture = publishFuture;
+    }
+
+    public void setPublishFailureReason(String publishFailureReason) {
+        this.publishFailureReason = publishFailureReason;
+    }
+
+    public String getPublishFailureReason() {
+        return publishFailureReason;
     }
 
     public enum PublishState {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -301,7 +301,17 @@ public class SplitTabletJob extends TabletReshardJob {
             }
         }
 
-        publishFailureReason = failureReason;
+        if (failureReason != null) {
+            // A publish failed in this pass.
+            publishFailureReason = failureReason;
+        } else if (allPartitionFinished) {
+            // Every partition published: the retry recovered, so stop reporting the old reason.
+            publishFailureReason = null;
+        }
+        // Otherwise a resubmitted publish is still IN_PROGRESS. Keep the previous reason: the
+        // scheduler ticks every few milliseconds, so clearing it here would expose the diagnostic
+        // for a single tick and then blank ERROR_MESSAGE again for the whole duration of a slow or
+        // hung retry -- exactly the case it exists to explain.
 
         if (!allPartitionFinished) {
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -225,6 +225,12 @@ public class SplitTabletJob extends TabletReshardJob {
                 PhysicalPartition physicalPartition = olapTable
                         .getPhysicalPartition(reshardingPhysicalPartition.getPhysicalPartitionId());
                 if (physicalPartition == null) {
+                    // The partition was dropped mid-job (DROP PARTITION / TRUNCATE are permitted while
+                    // the table is in TABLET_RESHARD). Its publish will never be retried again, so drop
+                    // any failure reason it left behind instead of reporting a failure that can no
+                    // longer recover -- note this skip also leaves allPartitionFinished alone, so the
+                    // job goes on to finish.
+                    reshardingPhysicalPartition.setPublishFailureReason(null);
                     continue;
                 }
 
@@ -550,13 +556,7 @@ public class SplitTabletJob extends TabletReshardJob {
         item.setParallel_tablets(getParallelTablets());
         item.setCreated_time(createdTimeMs / 1000);
         item.setFinished_time(finishedTimeMs / 1000);
-        if (errorMessage != null) {
-            item.setError_message(errorMessage);
-        } else {
-            String publishFailureReason = anyPublishFailureReason();
-            item.setError_message(publishFailureReason == null
-                    ? "" : "publish version failed (retrying): " + publishFailureReason);
-        }
+        item.setError_message(reportedErrorMessage());
         return item;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -214,6 +214,9 @@ public class SplitTabletJob extends TabletReshardJob {
     protected void runRunningJob() {
         // 1. Publish the split transaction, update new tablet ranges
         boolean allPartitionFinished = true;
+        // Publish failure seen in THIS pass, if any. Recomputed every pass so a retry that
+        // succeeds clears the reported reason instead of leaving it on a healthy job.
+        String failureReason = null;
         ThreadPoolExecutor publishThreadPool = GlobalStateMgr.getCurrentState().getPublishVersionDaemon()
                 .getTaskExecutor();
 
@@ -239,11 +242,11 @@ public class SplitTabletJob extends TabletReshardJob {
                         || publishResult.publishState() == PublishState.FAILED) {
                     // Publish not started or publish failed
                     allPartitionFinished = false;
-                    // Surface why the publish failed. A failed publish is only retried, so without
-                    // this the job stays in RUNNING with an empty ERROR_MESSAGE in
-                    // information_schema.tablet_reshard_jobs and the cause lives only in fe.log.
+                    // Remember why the publish failed so this pass can surface it (see
+                    // publishFailureReason); without it a job stuck retrying shows an empty
+                    // ERROR_MESSAGE and the cause lives only in fe.log.
                     if (publishResult.publishState() == PublishState.FAILED) {
-                        errorMessage = "publish version failed (retrying): " + publishResult.failureReason();
+                        failureReason = publishResult.failureReason();
                     }
                     // Start publish asynchronously
                     List<Tablet> tablets = new ArrayList<>();
@@ -297,6 +300,8 @@ public class SplitTabletJob extends TabletReshardJob {
                 }
             }
         }
+
+        publishFailureReason = failureReason;
 
         if (!allPartitionFinished) {
             return;
@@ -535,6 +540,8 @@ public class SplitTabletJob extends TabletReshardJob {
         item.setFinished_time(finishedTimeMs / 1000);
         if (errorMessage != null) {
             item.setError_message(errorMessage);
+        } else if (publishFailureReason != null) {
+            item.setError_message("publish version failed (retrying): " + publishFailureReason);
         } else {
             item.setError_message("");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -127,8 +127,8 @@ public class SplitTabletJob extends TabletReshardJob {
 
     @Override
     public void init() throws StarRocksException {
-        try {
-            setTableState(OlapTable.OlapTableState.NORMAL, OlapTable.OlapTableState.TABLET_RESHARD);
+        try (LockedObject<OlapTable> lockedTable = getLockedTable(LockType.WRITE)) {
+            reserveTableForReshard(dbId, lockedTable.get(), reshardingPhysicalPartitions);
         } catch (TabletReshardException e) {
             // Surface admission rejection (table not NORMAL / dropped) as a checked exception so
             // callers' StarRocksException handling (e.g. TabletPreSplitCoordinator) takes effect.

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -239,6 +239,12 @@ public class SplitTabletJob extends TabletReshardJob {
                         || publishResult.publishState() == PublishState.FAILED) {
                     // Publish not started or publish failed
                     allPartitionFinished = false;
+                    // Surface why the publish failed. A failed publish is only retried, so without
+                    // this the job stays in RUNNING with an empty ERROR_MESSAGE in
+                    // information_schema.tablet_reshard_jobs and the cause lives only in fe.log.
+                    if (publishResult.publishState() == PublishState.FAILED) {
+                        errorMessage = "publish version failed (retrying): " + publishResult.failureReason();
+                    }
                     // Start publish asynchronously
                     List<Tablet> tablets = new ArrayList<>();
                     for (MaterializedIndex index : physicalPartition.getLatestMaterializedIndices(IndexExtState.ALL)) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -214,9 +214,6 @@ public class SplitTabletJob extends TabletReshardJob {
     protected void runRunningJob() {
         // 1. Publish the split transaction, update new tablet ranges
         boolean allPartitionFinished = true;
-        // Publish failure seen in THIS pass, if any. Recomputed every pass so a retry that
-        // succeeds clears the reported reason instead of leaving it on a healthy job.
-        String failureReason = null;
         ThreadPoolExecutor publishThreadPool = GlobalStateMgr.getCurrentState().getPublishVersionDaemon()
                 .getTaskExecutor();
 
@@ -242,11 +239,13 @@ public class SplitTabletJob extends TabletReshardJob {
                         || publishResult.publishState() == PublishState.FAILED) {
                     // Publish not started or publish failed
                     allPartitionFinished = false;
-                    // Remember why the publish failed so this pass can surface it (see
-                    // publishFailureReason); without it a job stuck retrying shows an empty
-                    // ERROR_MESSAGE and the cause lives only in fe.log.
+                    // Remember why THIS partition's publish failed so a job stuck retrying can
+                    // explain itself; without it ERROR_MESSAGE is empty and the cause lives only in
+                    // fe.log. Kept until this partition publishes (an IN_PROGRESS retry must not
+                    // blank it) and scoped per partition so recovery here is not masked by a
+                    // sibling partition that is still retrying.
                     if (publishResult.publishState() == PublishState.FAILED) {
-                        failureReason = publishResult.failureReason();
+                        reshardingPhysicalPartition.setPublishFailureReason(publishResult.failureReason());
                     }
                     // Start publish asynchronously
                     List<Tablet> tablets = new ArrayList<>();
@@ -260,6 +259,8 @@ public class SplitTabletJob extends TabletReshardJob {
                     // Publish is in progress
                     allPartitionFinished = false;
                 } else if (publishResult.publishState() == PublishState.SUCCESS) {
+                    // This partition published: its earlier failure (if any) has recovered.
+                    reshardingPhysicalPartition.setPublishFailureReason(null);
                     // Publish success, update new tablet ranges
                     // Note this will be executed repeatedly when retry job, it should be idempotent
                     Map<Long, TabletRange> tabletRanges = publishResult.tabletRanges();
@@ -300,18 +301,6 @@ public class SplitTabletJob extends TabletReshardJob {
                 }
             }
         }
-
-        if (failureReason != null) {
-            // A publish failed in this pass.
-            publishFailureReason = failureReason;
-        } else if (allPartitionFinished) {
-            // Every partition published: the retry recovered, so stop reporting the old reason.
-            publishFailureReason = null;
-        }
-        // Otherwise a resubmitted publish is still IN_PROGRESS. Keep the previous reason: the
-        // scheduler ticks every few milliseconds, so clearing it here would expose the diagnostic
-        // for a single tick and then blank ERROR_MESSAGE again for the whole duration of a slow or
-        // hung retry -- exactly the case it exists to explain.
 
         if (!allPartitionFinished) {
             return;
@@ -520,6 +509,19 @@ public class SplitTabletJob extends TabletReshardJob {
         return sb.toString();
     }
 
+    // First partition currently retrying a failed publish, or null when none is. Read live from the
+    // per-partition state so a partition that recovers drops out without any job-level bookkeeping.
+    @Override
+    protected String anyPublishFailureReason() {
+        for (ReshardingPhysicalPartition reshardingPhysicalPartition : reshardingPhysicalPartitions.values()) {
+            String reason = reshardingPhysicalPartition.getPublishFailureReason();
+            if (reason != null) {
+                return reason;
+            }
+        }
+        return null;
+    }
+
     @Override
     public TTabletReshardJobsItem getInfo() {
         TTabletReshardJobsItem item = new TTabletReshardJobsItem();
@@ -550,10 +552,10 @@ public class SplitTabletJob extends TabletReshardJob {
         item.setFinished_time(finishedTimeMs / 1000);
         if (errorMessage != null) {
             item.setError_message(errorMessage);
-        } else if (publishFailureReason != null) {
-            item.setError_message("publish version failed (retrying): " + publishFailureReason);
         } else {
-            item.setError_message("");
+            String publishFailureReason = anyPublishFailureReason();
+            item.setError_message(publishFailureReason == null
+                    ? "" : "publish version failed (retrying): " + publishFailureReason);
         }
         return item;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJobFactory.java
@@ -282,6 +282,10 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
                     + " in physical partition " + physicalPartition.getId()
                     + " in table " + db.getFullName() + '.' + table.getName());
         }
+        // A superseded index passes every check above (still reachable via getIndex, still NORMAL,
+        // still owns the tablet, still mapped by TabletInvertedIndex), so it needs its own gate.
+        TabletReshardUtils.checkIndexNotSuperseded(physicalPartition, index, tabletId,
+                db.getFullName(), table.getName());
         Tablet tablet = index.getTablet(tabletId);
         if (tablet == null) {
             throw new StarRocksException("Cannot find tablet " + tabletId

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
@@ -74,6 +74,15 @@ public abstract class TabletReshardJob implements Writable {
     @SerializedName(value = "errorMessage")
     protected String errorMessage;
 
+    // Reason of the publish failure the job is currently retrying, or null while the publish is
+    // healthy. Deliberately NOT serialized and NOT folded into errorMessage: a publish failure is
+    // always retried and never terminal, so it must not be journaled, and it must not outlive the
+    // failure -- a job whose retry succeeded would otherwise reach FINISHED still advertising an
+    // error. Recomputed on every runRunningJob pass and surfaced through getInfo(), so
+    // information_schema.tablet_reshard_jobs explains a job that is stuck retrying a publish
+    // instead of showing an empty ERROR_MESSAGE.
+    protected transient String publishFailureReason;
+
     // The warehouse this job should run its compute work (shard creation + publish) in. Set by the
     // pre-split caller to the triggering load's warehouse; null for an online split / merge (and for a
     // job journaled before this field existed), which then fall back to the background warehouse.

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
@@ -74,14 +74,14 @@ public abstract class TabletReshardJob implements Writable {
     @SerializedName(value = "errorMessage")
     protected String errorMessage;
 
-    // Reason of the publish failure the job is currently retrying, or null while the publish is
-    // healthy. Deliberately NOT serialized and NOT folded into errorMessage: a publish failure is
-    // always retried and never terminal, so it must not be journaled, and it must not outlive the
-    // failure -- a job whose retry succeeded would otherwise reach FINISHED still advertising an
-    // error. Recomputed on every runRunningJob pass and surfaced through getInfo(), so
-    // information_schema.tablet_reshard_jobs explains a job that is stuck retrying a publish
-    // instead of showing an empty ERROR_MESSAGE.
-    protected transient String publishFailureReason;
+    // Reason of a publish failure the job is currently retrying, or null while every partition's
+    // publish is healthy. The state lives per partition (see
+    // ReshardingPhysicalPartition#publishFailureReason) rather than on the job, so a partition that
+    // recovers stops reporting even while a sibling is still retrying, and it is never journaled --
+    // a publish failure is always retried and never terminal. Surfaced through getInfo() so
+    // information_schema.tablet_reshard_jobs explains a job stuck retrying a publish instead of
+    // showing an empty ERROR_MESSAGE.
+    protected abstract String anyPublishFailureReason();
 
     // The warehouse this job should run its compute work (shard creation + publish) in. Set by the
     // pre-split caller to the triggering load's warehouse; null for an online split / merge (and for a

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
@@ -83,6 +83,26 @@ public abstract class TabletReshardJob implements Writable {
     // showing an empty ERROR_MESSAGE.
     protected abstract String anyPublishFailureReason();
 
+    // ERROR_MESSAGE for information_schema.tablet_reshard_jobs: a terminal error always wins, and
+    // otherwise the reason of a publish the job is still retrying.
+    //
+    // Only RUNNING retries a publish, so the reason is reported only in that state. That gate is what
+    // keeps a reason from outliving the retry it describes: a partition can be dropped mid-job (DROP
+    // PARTITION / TRUNCATE are permitted while the table is in TABLET_RESHARD), after which the
+    // publish loop skips it and no publish result can clear its reason. runRunningJob() clears it on
+    // that skip, but the gate also covers any future early-return added to the loop -- otherwise a
+    // finished job would keep advertising a failure that already stopped being retried.
+    protected String reportedErrorMessage() {
+        if (errorMessage != null) {
+            return errorMessage;
+        }
+        if (jobState != JobState.RUNNING) {
+            return "";
+        }
+        String publishFailureReason = anyPublishFailureReason();
+        return publishFailureReason == null ? "" : "publish version failed (retrying): " + publishFailureReason;
+    }
+
     // The warehouse this job should run its compute work (shard creation + publish) in. Set by the
     // pre-split caller to the triggering load's warehouse; null for an online split / merge (and for a
     // job journaled before this field existed), which then fall back to the background warehouse.

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
@@ -15,6 +15,7 @@
 package com.starrocks.alter.reshard;
 
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.RecycleMaterializedIndexInfo;
@@ -323,6 +324,54 @@ public abstract class TabletReshardJob implements Writable {
     protected abstract void registerReshardingTabletsOnRestart();
 
     public abstract TTabletReshardJobsItem getInfo();
+
+    /**
+     * Admission-time reservation body, shared by the split and merge jobs. The caller runs it under
+     * the table WRITE lock: the table must be NORMAL, every index the job is about to reshard must
+     * still be the live version of its index meta, and only then does the table flip to
+     * {@code TABLET_RESHARD}.
+     *
+     * <p>All three steps belong in one lock scope. The job was built from a snapshot the factory took
+     * under a lock it has since released, so the layout can have moved on; and the state flip is what
+     * stops it from moving again, because the factories and this method both require NORMAL, so no
+     * second reshard job can be admitted while this one holds the table. Validating before the flip
+     * and under the same lock is therefore the only point at which "these indexes are live" can be
+     * established and stay true for the rest of the job.
+     */
+    protected static void reserveTableForReshard(long dbId, OlapTable olapTable,
+            Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions) throws StarRocksException {
+        if (olapTable.getState() != OlapTable.OlapTableState.NORMAL) {
+            throw new TabletReshardException(
+                    "Unexpected table state " + olapTable.getState() + " in table " + olapTable.getName());
+        }
+        checkReshardingIndexesStillLatest(dbId, olapTable, reshardingPhysicalPartitions);
+        olapTable.setState(OlapTable.OlapTableState.TABLET_RESHARD);
+    }
+
+    private static void checkReshardingIndexesStillLatest(long dbId, OlapTable olapTable,
+            Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions) throws StarRocksException {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
+        String dbName = db == null ? "" : db.getFullName();
+        for (ReshardingPhysicalPartition reshardingPhysicalPartition : reshardingPhysicalPartitions.values()) {
+            PhysicalPartition physicalPartition = olapTable
+                    .getPhysicalPartition(reshardingPhysicalPartition.getPhysicalPartitionId());
+            if (physicalPartition == null) {
+                // Dropped in the same gap (DROP PARTITION / TRUNCATE are permitted alongside a reshard).
+                // Every later step of the job already skips a partition that is missing, so this is not
+                // a reason to reject the job.
+                continue;
+            }
+            for (ReshardingMaterializedIndex reshardingIndex : reshardingPhysicalPartition
+                    .getReshardingIndexes().values()) {
+                // The new index the job will install carries the source index's meta id, so the meta id
+                // is still available even when the source index itself is already gone.
+                TabletReshardUtils.checkIndexStillLatest(physicalPartition,
+                        reshardingIndex.getMaterializedIndexId(),
+                        reshardingIndex.getMaterializedIndex().getMetaId(),
+                        dbName, olapTable.getName());
+            }
+        }
+    }
 
     /**
      * Shared reshard-cleanup step for split and merge: for every superseded (old) materialized index,

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardUtils.java
@@ -16,8 +16,10 @@ package com.starrocks.alter.reshard;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
+import com.starrocks.common.StarRocksException;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.warehouse.cngroup.ComputeResource;
@@ -191,5 +193,36 @@ public class TabletReshardUtils {
             min = Math.min(min, v);
         }
         return min == Long.MAX_VALUE ? 0L : min;
+    }
+
+    /**
+     * Rejects a reshard whose source tablet lives in a materialized index that a previous reshard has
+     * already superseded.
+     *
+     * <p>Every other admission check passes for such a tablet: the superseded index is still reachable
+     * through {@link PhysicalPartition#getIndex}, its state is still {@code NORMAL}, the tablet is
+     * still one of its tablets, and {@code TabletInvertedIndex} still maps the tablet id. Only the
+     * partition's index-meta -> index-id chain records that the index has been replaced. Admitting the
+     * job anyway is unrecoverable in practice: the publish resolves no live tablet
+     * ("Fail to publish version for tablets:[]"), and because a publish failure is only retried, the
+     * job stays in {@code RUNNING} forever with an empty error message.
+     *
+     * <p>This is easy to hit by accident because {@code SHOW TABLET FROM <table>} keeps listing the
+     * superseded tablets alongside the live ones -- after a split the old parent is still the first
+     * row -- so a script that takes a tablet id from that output can feed a stale one straight back
+     * into {@code ALTER TABLE ... SPLIT/MERGE TABLET}.
+     */
+    public static void checkIndexNotSuperseded(PhysicalPartition physicalPartition, MaterializedIndex index,
+                                               long tabletId, String dbName, String tableName)
+            throws StarRocksException {
+        MaterializedIndex latest = physicalPartition.getLatestIndex(index.getMetaId());
+        if (latest != null && latest.getId() != index.getId()) {
+            throw new StarRocksException("Tablet " + tabletId + " belongs to materialized index "
+                    + index.getId() + ", which has already been superseded by index " + latest.getId()
+                    + " in physical partition " + physicalPartition.getId() + " in table "
+                    + dbName + '.' + tableName + ". It is no longer part of the table; list the current"
+                    + " tablets with SHOW PROC '/dbs/" + dbName + '/' + tableName + "/partitions/"
+                    + physicalPartition.getId() + '/' + latest.getId() + "'");
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardUtils.java
@@ -227,6 +227,41 @@ public class TabletReshardUtils {
         }
     }
 
+    /**
+     * Admission-time counterpart of {@link #checkIndexNotSuperseded}: an index a reshard job was
+     * built against must still be the latest version of its index meta when the job reserves the
+     * table.
+     *
+     * <p>The creation-time check cannot cover this. A job factory releases the table lock before its
+     * job is handed to {@code TabletReshardJobMgr#addTabletReshardJob}, so another reshard job on the
+     * same table can complete in that gap and install a new version of the very index this job is
+     * about to reshard -- turning a source index that was live at creation into a superseded one.
+     * The consequences are the same as admitting a superseded tablet in the first place, plus one
+     * more: {@code addMaterializedIndex} would fail its "index id already exists" precondition past
+     * the job's no-abort boundary.
+     *
+     * <p>Takes ids rather than a {@link MaterializedIndex} because the index may be gone from the
+     * partition altogether by now, which this also rejects -- resharding an index that no longer
+     * exists produces nothing, and installing its successor would fail the same precondition.
+     */
+    public static void checkIndexStillLatest(PhysicalPartition physicalPartition, long indexId, long indexMetaId,
+                                             String dbName, String tableName) throws StarRocksException {
+        MaterializedIndex latest = physicalPartition.getLatestIndex(indexMetaId);
+        if (latest != null && latest.getId() == indexId) {
+            return;
+        }
+        String indexDesc = "materialized index " + indexId + " in physical partition "
+                + physicalPartition.getId() + " in table " + dbName + '.' + tableName;
+        if (latest == null) {
+            throw new StarRocksException("Cannot reshard " + indexDesc
+                    + ": it was removed after this tablet reshard job was created");
+        }
+        throw new StarRocksException("Cannot reshard " + indexDesc
+                + ": it has already been superseded by index " + latest.getId()
+                + " since this tablet reshard job was created. The current tablets of that partition are "
+                + describeTablets(latest));
+    }
+
     // The replacement ids, spelled out in the message rather than pointed at with SHOW PROC: the
     // partition-level proc path requires system-level OPERATE, while triggering this rejection only
     // requires ALTER on the table, so a user who can hit the error may not be able to run the command

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardUtils.java
@@ -31,6 +31,8 @@ import java.util.List;
 public class TabletReshardUtils {
     private static final Logger LOG = LogManager.getLogger(TabletReshardUtils.class);
 
+    private static final int MAX_TABLETS_IN_ERROR_MESSAGE = 20;
+
     // Reshard size invariants — DO NOT change individually.
     //
     // Let T = Config.tablet_reshard_target_size.
@@ -220,9 +222,30 @@ public class TabletReshardUtils {
             throw new StarRocksException("Tablet " + tabletId + " belongs to materialized index "
                     + index.getId() + ", which has already been superseded by index " + latest.getId()
                     + " in physical partition " + physicalPartition.getId() + " in table "
-                    + dbName + '.' + tableName + ". It is no longer part of the table; list the current"
-                    + " tablets with SHOW PROC '/dbs/" + dbName + '/' + tableName + "/partitions/"
-                    + physicalPartition.getId() + '/' + latest.getId() + "'");
+                    + dbName + '.' + tableName + ". It is no longer part of the table; the current"
+                    + " tablets of that partition are " + describeTablets(latest));
         }
+    }
+
+    // The replacement ids, spelled out in the message rather than pointed at with SHOW PROC: the
+    // partition-level proc path requires system-level OPERATE, while triggering this rejection only
+    // requires ALTER on the table, so a user who can hit the error may not be able to run the command
+    // that would resolve it. Truncated because a partition can hold a lot of tablets and this goes into
+    // an error string.
+    private static String describeTablets(MaterializedIndex index) {
+        List<Tablet> tablets = index.getTablets();
+        StringBuilder sb = new StringBuilder("[");
+        int shown = Math.min(tablets.size(), MAX_TABLETS_IN_ERROR_MESSAGE);
+        for (int i = 0; i < shown; ++i) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append(tablets.get(i).getId());
+        }
+        sb.append(']');
+        if (shown < tablets.size()) {
+            sb.append(" (first ").append(shown).append(" of ").append(tablets.size()).append(')');
+        }
+        return sb.toString();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
@@ -1230,31 +1230,39 @@ public class MergeTabletJobTest {
     // getInfo() therefore renders publishFailureReason only when there is no terminal errorMessage.
     @Test
     public void testGetInfoReportsRetriedPublishFailureWithoutJournalingIt() {
+        Map<Long, ReshardingPhysicalPartition> partitions = new HashMap<>();
+        ReshardingPhysicalPartition p1 = new ReshardingPhysicalPartition(1L, new HashMap<>());
+        ReshardingPhysicalPartition p2 = new ReshardingPhysicalPartition(2L, new HashMap<>());
+        partitions.put(1L, p1);
+        partitions.put(2L, p2);
         MergeTabletJob job = new MergeTabletJob(GlobalStateMgr.getCurrentState().getNextId(),
-                db.getId(), table.getId(), new HashMap<>());
+                db.getId(), table.getId(), partitions);
 
         // healthy: nothing to report
         Assertions.assertEquals("", job.getInfo().getError_message());
 
-        // retrying a failed publish: surfaced, but errorMessage (the journaled field) stays null
-        job.publishFailureReason = "link rpc channel failed";
+        // one partition is retrying a failed publish: surfaced, but errorMessage (the journaled
+        // field) stays null, and it keeps being reported for as long as that partition holds the
+        // reason -- an IN_PROGRESS retry must not blank the diagnostic after a single tick
+        p1.setPublishFailureReason("link rpc channel failed");
+        Assertions.assertEquals("publish version failed (retrying): link rpc channel failed",
+                job.getInfo().getError_message());
         Assertions.assertEquals("publish version failed (retrying): link rpc channel failed",
                 job.getInfo().getError_message());
         Assertions.assertNull(job.errorMessage);
 
-        // the reason survives across passes while the resubmitted publish is still IN_PROGRESS --
-        // runRunningJob only clears it once every partition has published, so a slow or hung retry
-        // keeps explaining itself instead of blanking after a single scheduler tick
-        Assertions.assertEquals("publish version failed (retrying): link rpc channel failed",
-                job.getInfo().getError_message());
-
-        // the retry succeeded: runRunningJob clears the reason, so nothing is reported
-        job.publishFailureReason = null;
+        // that partition recovered while the sibling is still publishing: reporting stops even
+        // though not every partition has finished
+        p1.setPublishFailureReason(null);
         Assertions.assertEquals("", job.getInfo().getError_message());
+
+        // a failure on any partition is reported
+        p2.setPublishFailureReason("no alive node");
+        Assertions.assertEquals("publish version failed (retrying): no alive node",
+                job.getInfo().getError_message());
 
         // a terminal error always wins over a transient publish failure
         job.errorMessage = "Table not found";
-        job.publishFailureReason = "link rpc channel failed";
         Assertions.assertEquals("Table not found", job.getInfo().getError_message());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
@@ -1227,7 +1227,8 @@ public class MergeTabletJobTest {
     // A publish failure is always retried, never terminal, so it must be reported WITHOUT being
     // written into the journaled errorMessage: a job whose retry later succeeds would otherwise
     // reach FINISHED still advertising an error, and the next state transition would persist it.
-    // getInfo() therefore renders publishFailureReason only when there is no terminal errorMessage.
+    // getInfo() therefore renders publishFailureReason only while the job is RUNNING and has no
+    // terminal errorMessage.
     @Test
     public void testGetInfoReportsRetriedPublishFailureWithoutJournalingIt() {
         Map<Long, ReshardingPhysicalPartition> partitions = new HashMap<>();
@@ -1237,6 +1238,7 @@ public class MergeTabletJobTest {
         partitions.put(2L, p2);
         MergeTabletJob job = new MergeTabletJob(GlobalStateMgr.getCurrentState().getNextId(),
                 db.getId(), table.getId(), partitions);
+        job.jobState = TabletReshardJob.JobState.RUNNING;
 
         // healthy: nothing to report
         Assertions.assertEquals("", job.getInfo().getError_message());
@@ -1261,8 +1263,46 @@ public class MergeTabletJobTest {
         Assertions.assertEquals("publish version failed (retrying): no alive node",
                 job.getInfo().getError_message());
 
-        // a terminal error always wins over a transient publish failure
+        // only RUNNING retries a publish, so a reason left on a partition stops being reported once
+        // the job moves on -- this is what keeps a partition dropped mid-job, which runRunningJob
+        // skips so that no publish result can clear its reason, from making a finished job advertise
+        // a failure that is no longer being retried
+        for (TabletReshardJob.JobState state : TabletReshardJob.JobState.values()) {
+            job.jobState = state;
+            Assertions.assertEquals(state == TabletReshardJob.JobState.RUNNING
+                            ? "publish version failed (retrying): no alive node" : "",
+                    job.getInfo().getError_message(), "job state " + state);
+        }
+
+        // a terminal error always wins over a transient publish failure, in any state
+        job.jobState = TabletReshardJob.JobState.RUNNING;
         job.errorMessage = "Table not found";
         Assertions.assertEquals("Table not found", job.getInfo().getError_message());
+    }
+
+    // runRunningJob() skips a partition that has been dropped mid-job (DROP PARTITION / TRUNCATE are
+    // permitted while the table is in TABLET_RESHARD) without marking the job unfinished, so nothing
+    // would ever clear a publish failure reason that partition left behind. Clear it on the skip, so
+    // the job does not keep attributing a failure to a partition whose publish is no longer retried.
+    @Test
+    public void testRunRunningJobClearsPublishFailureReasonOfDroppedPartition() throws Exception {
+        MergeTabletJob mergeJob = createMergeTabletReshardJob();
+        mergeJob.init();
+        mergeJob.run();
+        Assertions.assertEquals(TabletReshardJob.JobState.RUNNING, mergeJob.getJobState());
+
+        ReshardingPhysicalPartition droppedPartition = new ReshardingPhysicalPartition(
+                GlobalStateMgr.getCurrentState().getNextId(), new HashMap<>());
+        droppedPartition.setPublishFailureReason("link rpc channel failed");
+        mergeJob.getReshardingPhysicalPartitions().put(droppedPartition.getPhysicalPartitionId(), droppedPartition);
+        Assertions.assertEquals("publish version failed (retrying): link rpc channel failed",
+                mergeJob.getInfo().getError_message());
+
+        // The partition id is not in the table, so the publish loop skips it -- and the skip must not
+        // leave the reason behind for the finished job to report.
+        mergeJob.run();
+        Assertions.assertNull(droppedPartition.getPublishFailureReason());
+        Assertions.assertEquals(TabletReshardJob.JobState.FINISHED, mergeJob.getJobState());
+        Assertions.assertEquals("", mergeJob.getInfo().getError_message());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
@@ -1223,4 +1223,32 @@ public class MergeTabletJobTest {
                 "expected original cause message, got: " + thrown.getMessage());
     }
 
+
+    // A publish failure is always retried, never terminal, so it must be reported WITHOUT being
+    // written into the journaled errorMessage: a job whose retry later succeeds would otherwise
+    // reach FINISHED still advertising an error, and the next state transition would persist it.
+    // getInfo() therefore renders publishFailureReason only when there is no terminal errorMessage.
+    @Test
+    public void testGetInfoReportsRetriedPublishFailureWithoutJournalingIt() {
+        MergeTabletJob job = new MergeTabletJob(GlobalStateMgr.getCurrentState().getNextId(),
+                db.getId(), table.getId(), new HashMap<>());
+
+        // healthy: nothing to report
+        Assertions.assertEquals("", job.getInfo().getError_message());
+
+        // retrying a failed publish: surfaced, but errorMessage (the journaled field) stays null
+        job.publishFailureReason = "link rpc channel failed";
+        Assertions.assertEquals("publish version failed (retrying): link rpc channel failed",
+                job.getInfo().getError_message());
+        Assertions.assertNull(job.errorMessage);
+
+        // the retry succeeded: recomputed to null every pass, so nothing is reported
+        job.publishFailureReason = null;
+        Assertions.assertEquals("", job.getInfo().getError_message());
+
+        // a terminal error always wins over a transient publish failure
+        job.errorMessage = "Table not found";
+        job.publishFailureReason = "link rpc channel failed";
+        Assertions.assertEquals("Table not found", job.getInfo().getError_message());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
@@ -1242,7 +1242,13 @@ public class MergeTabletJobTest {
                 job.getInfo().getError_message());
         Assertions.assertNull(job.errorMessage);
 
-        // the retry succeeded: recomputed to null every pass, so nothing is reported
+        // the reason survives across passes while the resubmitted publish is still IN_PROGRESS --
+        // runRunningJob only clears it once every partition has published, so a slow or hung retry
+        // keeps explaining itself instead of blanking after a single scheduler tick
+        Assertions.assertEquals("publish version failed (retrying): link rpc channel failed",
+                job.getInfo().getError_message());
+
+        // the retry succeeded: runRunningJob clears the reason, so nothing is reported
         job.publishFailureReason = null;
         Assertions.assertEquals("", job.getInfo().getError_message());
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
@@ -1223,6 +1223,36 @@ public class MergeTabletJobTest {
                 "expected original cause message, got: " + thrown.getMessage());
     }
 
+    /**
+     * The factory releases the table lock before the job reaches the manager, so another reshard job
+     * can complete in that gap and supersede the very index this job was built against -- the
+     * creation-time check cannot see it. init() re-checks under the write lock that reserves the
+     * table, so the job is rejected at admission instead of publishing against tablets that are no
+     * longer part of the table and then spinning in RUNNING forever.
+     */
+    @Test
+    public void testInitRejectsSupersededIndex() throws Exception {
+        MergeTabletJob mergeJob = createMergeTabletReshardJob();
+
+        PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
+        MaterializedIndex sourceIndex = physicalPartition.getLatestBaseIndex();
+        MaterializedIndex supersedingIndex = new MaterializedIndex(
+                GlobalStateMgr.getCurrentState().getNextId(), sourceIndex.getMetaId(),
+                IndexState.NORMAL, sourceIndex.getShardGroupId());
+        supersedingIndex.addTablet(new LakeTablet(GlobalStateMgr.getCurrentState().getNextId()), null, false);
+        physicalPartition.addMaterializedIndex(supersedingIndex, true);
+        try {
+            StarRocksException e = Assertions.assertThrows(StarRocksException.class, mergeJob::init);
+            Assertions.assertTrue(e.getMessage().contains("superseded by index " + supersedingIndex.getId()),
+                    e.getMessage());
+            // Rejected before the reservation, so the table is left available to whoever can still use it.
+            Assertions.assertEquals(OlapTable.OlapTableState.NORMAL, table.getState());
+        } finally {
+            // Tests in this class share a single static table.
+            physicalPartition.deleteMaterializedIndexByIndexId(supersedingIndex.getId());
+        }
+    }
+
 
     // A publish failure is always retried, never terminal, so it must be reported WITHOUT being
     // written into the journaled errorMessage: a job whose retry later succeeds would otherwise

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
@@ -846,7 +846,13 @@ public class SplitTabletJobTest {
                 job.getInfo().getError_message());
         Assertions.assertNull(job.errorMessage);
 
-        // the retry succeeded: recomputed to null every pass, so nothing is reported
+        // the reason survives across passes while the resubmitted publish is still IN_PROGRESS --
+        // runRunningJob only clears it once every partition has published, so a slow or hung retry
+        // keeps explaining itself instead of blanking after a single scheduler tick
+        Assertions.assertEquals("publish version failed (retrying): link rpc channel failed",
+                job.getInfo().getError_message());
+
+        // the retry succeeded: runRunningJob clears the reason, so nothing is reported
         job.publishFailureReason = null;
         Assertions.assertEquals("", job.getInfo().getError_message());
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
@@ -30,6 +30,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.Range;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.StarOSAgent;
 import com.starrocks.lake.Utils;
 import com.starrocks.lake.compaction.CompactionMgr;
@@ -825,6 +826,36 @@ public class SplitTabletJobTest {
             Assertions.assertEquals(OlapTable.OlapTableState.SCHEMA_CHANGE, table.getState());
         } finally {
             table.setState(OlapTable.OlapTableState.NORMAL);
+        }
+    }
+
+    /**
+     * The factory releases the table lock before the job reaches the manager, so another reshard job
+     * can complete in that gap and supersede the very index this job was built against -- the
+     * creation-time check cannot see it. init() re-checks under the write lock that reserves the
+     * table, so the job is rejected at admission instead of publishing against tablets that are no
+     * longer part of the table and then spinning in RUNNING forever.
+     */
+    @Test
+    public void testInitRejectsSupersededIndex() throws Exception {
+        TabletReshardJob tabletReshardJob = createTabletReshardJob();
+
+        PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
+        MaterializedIndex sourceIndex = physicalPartition.getLatestBaseIndex();
+        MaterializedIndex supersedingIndex = new MaterializedIndex(
+                GlobalStateMgr.getCurrentState().getNextId(), sourceIndex.getMetaId(),
+                MaterializedIndex.IndexState.NORMAL, sourceIndex.getShardGroupId());
+        supersedingIndex.addTablet(new LakeTablet(GlobalStateMgr.getCurrentState().getNextId()), null, false);
+        physicalPartition.addMaterializedIndex(supersedingIndex, true);
+        try {
+            StarRocksException e = Assertions.assertThrows(StarRocksException.class, tabletReshardJob::init);
+            Assertions.assertTrue(e.getMessage().contains("superseded by index " + supersedingIndex.getId()),
+                    e.getMessage());
+            // Rejected before the reservation, so the table is left available to whoever can still use it.
+            Assertions.assertEquals(OlapTable.OlapTableState.NORMAL, table.getState());
+        } finally {
+            // Tests in this class share a single static table.
+            physicalPartition.deleteMaterializedIndexByIndexId(supersedingIndex.getId());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
@@ -831,7 +831,8 @@ public class SplitTabletJobTest {
     // A publish failure is always retried, never terminal, so it must be reported WITHOUT being
     // written into the journaled errorMessage: a job whose retry later succeeds would otherwise
     // reach FINISHED still advertising an error, and the next state transition would persist it.
-    // getInfo() therefore renders publishFailureReason only when there is no terminal errorMessage.
+    // getInfo() therefore renders publishFailureReason only while the job is RUNNING and has no
+    // terminal errorMessage.
     @Test
     public void testGetInfoReportsRetriedPublishFailureWithoutJournalingIt() {
         Map<Long, ReshardingPhysicalPartition> partitions = new HashMap<>();
@@ -841,6 +842,7 @@ public class SplitTabletJobTest {
         partitions.put(2L, p2);
         SplitTabletJob job = new SplitTabletJob(GlobalStateMgr.getCurrentState().getNextId(),
                 db.getId(), table.getId(), partitions);
+        job.jobState = TabletReshardJob.JobState.RUNNING;
 
         // healthy: nothing to report
         Assertions.assertEquals("", job.getInfo().getError_message());
@@ -865,8 +867,49 @@ public class SplitTabletJobTest {
         Assertions.assertEquals("publish version failed (retrying): no alive node",
                 job.getInfo().getError_message());
 
-        // a terminal error always wins over a transient publish failure
+        // only RUNNING retries a publish, so a reason left on a partition stops being reported once
+        // the job moves on -- this is what keeps a partition dropped mid-job, which runRunningJob
+        // skips so that no publish result can clear its reason, from making a finished job advertise
+        // a failure that is no longer being retried
+        for (TabletReshardJob.JobState state : TabletReshardJob.JobState.values()) {
+            job.jobState = state;
+            Assertions.assertEquals(state == TabletReshardJob.JobState.RUNNING
+                            ? "publish version failed (retrying): no alive node" : "",
+                    job.getInfo().getError_message(), "job state " + state);
+        }
+
+        // a terminal error always wins over a transient publish failure, in any state
+        job.jobState = TabletReshardJob.JobState.RUNNING;
         job.errorMessage = "Table not found";
         Assertions.assertEquals("Table not found", job.getInfo().getError_message());
+    }
+
+    // runRunningJob() skips a partition that has been dropped mid-job (DROP PARTITION / TRUNCATE are
+    // permitted while the table is in TABLET_RESHARD) without marking the job unfinished, so nothing
+    // would ever clear a publish failure reason that partition left behind. Clear it on the skip, so
+    // the job does not keep attributing a failure to a partition whose publish is no longer retried.
+    @Test
+    public void testRunRunningJobClearsPublishFailureReasonOfDroppedPartition() throws Exception {
+        installLakeServiceMock(this::addDataDrivenRanges);
+
+        TabletReshardJob tabletReshardJob = createTabletReshardJob();
+        tabletReshardJob.init();
+        tabletReshardJob.run();
+        Assertions.assertEquals(TabletReshardJob.JobState.RUNNING, tabletReshardJob.getJobState());
+
+        SplitTabletJob splitJob = (SplitTabletJob) tabletReshardJob;
+        ReshardingPhysicalPartition droppedPartition = new ReshardingPhysicalPartition(
+                GlobalStateMgr.getCurrentState().getNextId(), new HashMap<>());
+        droppedPartition.setPublishFailureReason("link rpc channel failed");
+        splitJob.getReshardingPhysicalPartitions().put(droppedPartition.getPhysicalPartitionId(), droppedPartition);
+        Assertions.assertEquals("publish version failed (retrying): link rpc channel failed",
+                splitJob.getInfo().getError_message());
+
+        // The partition id is not in the table, so the publish loop skips it -- and the skip must not
+        // leave the reason behind for the finished job to report.
+        tabletReshardJob.run();
+        Assertions.assertNull(droppedPartition.getPublishFailureReason());
+        Assertions.assertEquals(TabletReshardJob.JobState.FINISHED, tabletReshardJob.getJobState());
+        Assertions.assertEquals("", splitJob.getInfo().getError_message());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
@@ -827,4 +827,32 @@ public class SplitTabletJobTest {
             table.setState(OlapTable.OlapTableState.NORMAL);
         }
     }
+
+    // A publish failure is always retried, never terminal, so it must be reported WITHOUT being
+    // written into the journaled errorMessage: a job whose retry later succeeds would otherwise
+    // reach FINISHED still advertising an error, and the next state transition would persist it.
+    // getInfo() therefore renders publishFailureReason only when there is no terminal errorMessage.
+    @Test
+    public void testGetInfoReportsRetriedPublishFailureWithoutJournalingIt() {
+        SplitTabletJob job = new SplitTabletJob(GlobalStateMgr.getCurrentState().getNextId(),
+                db.getId(), table.getId(), new HashMap<>());
+
+        // healthy: nothing to report
+        Assertions.assertEquals("", job.getInfo().getError_message());
+
+        // retrying a failed publish: surfaced, but errorMessage (the journaled field) stays null
+        job.publishFailureReason = "link rpc channel failed";
+        Assertions.assertEquals("publish version failed (retrying): link rpc channel failed",
+                job.getInfo().getError_message());
+        Assertions.assertNull(job.errorMessage);
+
+        // the retry succeeded: recomputed to null every pass, so nothing is reported
+        job.publishFailureReason = null;
+        Assertions.assertEquals("", job.getInfo().getError_message());
+
+        // a terminal error always wins over a transient publish failure
+        job.errorMessage = "Table not found";
+        job.publishFailureReason = "link rpc channel failed";
+        Assertions.assertEquals("Table not found", job.getInfo().getError_message());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
@@ -834,31 +834,39 @@ public class SplitTabletJobTest {
     // getInfo() therefore renders publishFailureReason only when there is no terminal errorMessage.
     @Test
     public void testGetInfoReportsRetriedPublishFailureWithoutJournalingIt() {
+        Map<Long, ReshardingPhysicalPartition> partitions = new HashMap<>();
+        ReshardingPhysicalPartition p1 = new ReshardingPhysicalPartition(1L, new HashMap<>());
+        ReshardingPhysicalPartition p2 = new ReshardingPhysicalPartition(2L, new HashMap<>());
+        partitions.put(1L, p1);
+        partitions.put(2L, p2);
         SplitTabletJob job = new SplitTabletJob(GlobalStateMgr.getCurrentState().getNextId(),
-                db.getId(), table.getId(), new HashMap<>());
+                db.getId(), table.getId(), partitions);
 
         // healthy: nothing to report
         Assertions.assertEquals("", job.getInfo().getError_message());
 
-        // retrying a failed publish: surfaced, but errorMessage (the journaled field) stays null
-        job.publishFailureReason = "link rpc channel failed";
+        // one partition is retrying a failed publish: surfaced, but errorMessage (the journaled
+        // field) stays null, and it keeps being reported for as long as that partition holds the
+        // reason -- an IN_PROGRESS retry must not blank the diagnostic after a single tick
+        p1.setPublishFailureReason("link rpc channel failed");
+        Assertions.assertEquals("publish version failed (retrying): link rpc channel failed",
+                job.getInfo().getError_message());
         Assertions.assertEquals("publish version failed (retrying): link rpc channel failed",
                 job.getInfo().getError_message());
         Assertions.assertNull(job.errorMessage);
 
-        // the reason survives across passes while the resubmitted publish is still IN_PROGRESS --
-        // runRunningJob only clears it once every partition has published, so a slow or hung retry
-        // keeps explaining itself instead of blanking after a single scheduler tick
-        Assertions.assertEquals("publish version failed (retrying): link rpc channel failed",
-                job.getInfo().getError_message());
-
-        // the retry succeeded: runRunningJob clears the reason, so nothing is reported
-        job.publishFailureReason = null;
+        // that partition recovered while the sibling is still publishing: reporting stops even
+        // though not every partition has finished
+        p1.setPublishFailureReason(null);
         Assertions.assertEquals("", job.getInfo().getError_message());
+
+        // a failure on any partition is reported
+        p2.setPublishFailureReason("no alive node");
+        Assertions.assertEquals("publish version failed (retrying): no alive node",
+                job.getInfo().getError_message());
 
         // a terminal error always wins over a transient publish failure
         job.errorMessage = "Table not found";
-        job.publishFailureReason = "link rpc channel failed";
         Assertions.assertEquals("Table not found", job.getInfo().getError_message());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardJobMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardJobMgrTest.java
@@ -156,6 +156,11 @@ public class TabletReshardJobMgrTest {
         public TTabletReshardJobsItem getInfo() {
             return new TTabletReshardJobsItem();
         }
+
+        @Override
+        protected String anyPublishFailureReason() {
+            return null;
+        }
     }
 
     public static class TestAbnormalTabletReshardJob extends TestNormalTabletReshardJob {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardUtilsTest.java
@@ -310,10 +310,35 @@ public class TabletReshardUtilsTest {
                 TabletReshardUtils.checkIndexNotSuperseded(partition, oldIndex, 1000L, "db", "t"));
         assertTrue(e.getMessage().contains("superseded by index 200"), e.getMessage());
         assertTrue(e.getMessage().contains("1000"), e.getMessage());
+        // The replacement tablet ids are spelled out: the partition-level SHOW PROC path this message
+        // used to point at needs system-level OPERATE, which a user holding only ALTER on the table --
+        // enough to trigger this rejection -- does not have.
+        assertTrue(e.getMessage().contains("[2000]"), e.getMessage());
 
         // The live index is still accepted.
         assertDoesNotThrowStarRocks(() ->
                 TabletReshardUtils.checkIndexNotSuperseded(partition, newIndex, 2000L, "db", "t"));
+    }
+
+    // A partition can hold far more tablets than belong in an error string, so the list is truncated
+    // with the full count kept.
+    @Test
+    public void checkIndexNotSuperseded_truncatesLongTabletList() {
+        MaterializedIndex oldIndex = new MaterializedIndex(100L, 100L, IndexState.NORMAL, 0L);
+        oldIndex.addTablet(new LakeTablet(1000L), null, false);
+        PhysicalPartition partition = new PhysicalPartition(1L, 0L, oldIndex);
+
+        MaterializedIndex newIndex = new MaterializedIndex(200L, 100L, IndexState.NORMAL, 0L);
+        for (int i = 0; i < 25; ++i) {
+            newIndex.addTablet(new LakeTablet(2000L + i), null, false);
+        }
+        partition.addMaterializedIndex(newIndex, true);
+
+        StarRocksException e = assertThrows(StarRocksException.class, () ->
+                TabletReshardUtils.checkIndexNotSuperseded(partition, oldIndex, 1000L, "db", "t"));
+        assertTrue(e.getMessage().contains("2019]"), e.getMessage());
+        assertTrue(e.getMessage().contains("(first 20 of 25)"), e.getMessage());
+        assertFalse(e.getMessage().contains("2020"), e.getMessage());
     }
 
     private interface ThrowingRunnable {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardUtilsTest.java
@@ -341,6 +341,43 @@ public class TabletReshardUtilsTest {
         assertFalse(e.getMessage().contains("2020"), e.getMessage());
     }
 
+    // Admission-time counterpart of the check above. The factory builds a job from a snapshot taken
+    // under a lock it then releases, so a source index that was live at creation can be superseded --
+    // or removed outright -- before the job reserves the table. Both leave the job with nothing live
+    // to reshard, so both are rejected.
+    @Test
+    public void checkIndexStillLatest_rejectsSupersededOrRemovedIndex() {
+        MaterializedIndex oldIndex = new MaterializedIndex(100L, 100L, IndexState.NORMAL, 0L);
+        oldIndex.addTablet(new LakeTablet(1000L), null, false);
+        PhysicalPartition partition = new PhysicalPartition(1L, 0L, oldIndex);
+
+        // Still the latest version of its meta: admission proceeds.
+        assertDoesNotThrowStarRocks(() ->
+                TabletReshardUtils.checkIndexStillLatest(partition, 100L, 100L, "db", "t"));
+
+        // A reshard job admitted first installs a new version of the same index meta.
+        MaterializedIndex newIndex = new MaterializedIndex(200L, 100L, IndexState.NORMAL, 0L);
+        newIndex.addTablet(new LakeTablet(2000L), null, false);
+        partition.addMaterializedIndex(newIndex, true);
+
+        StarRocksException e = assertThrows(StarRocksException.class, () ->
+                TabletReshardUtils.checkIndexStillLatest(partition, 100L, 100L, "db", "t"));
+        assertTrue(e.getMessage().contains("superseded by index 200"), e.getMessage());
+        assertTrue(e.getMessage().contains("[2000]"), e.getMessage());
+
+        // The winner of that race is of course still admissible.
+        assertDoesNotThrowStarRocks(() ->
+                TabletReshardUtils.checkIndexStillLatest(partition, 200L, 100L, "db", "t"));
+
+        // Index meta gone from the partition entirely: there is nothing left to reshard, and
+        // installing a successor would fail addMaterializedIndex's precondition well past the job's
+        // no-abort boundary.
+        partition.deleteMaterializedIndexByMetaId(100L);
+        e = assertThrows(StarRocksException.class, () ->
+                TabletReshardUtils.checkIndexStillLatest(partition, 200L, 100L, "db", "t"));
+        assertTrue(e.getMessage().contains("was removed after"), e.getMessage());
+    }
+
     private interface ThrowingRunnable {
         void run() throws StarRocksException;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardUtilsTest.java
@@ -16,7 +16,10 @@ package com.starrocks.alter.reshard;
 
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndex.IndexState;
+import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.common.Config;
+import com.starrocks.common.StarRocksException;
 import com.starrocks.lake.LakeTablet;
 import mockit.Mock;
 import mockit.MockUp;
@@ -30,6 +33,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TabletReshardUtilsTest {
@@ -279,5 +283,48 @@ public class TabletReshardUtilsTest {
         assertEquals(100L, TabletReshardUtils.minVectorIndexBuiltVersion(index, Lists.newArrayList(101L)));
         // empty -> 0
         assertEquals(0L, TabletReshardUtils.minVectorIndexBuiltVersion(index, Collections.emptyList()));
+    }
+
+    // A reshard whose source tablet lives in a materialized index that an earlier reshard already
+    // superseded must be rejected at admission. Such an index passes every other check -- it is
+    // still returned by getIndex, its state is still NORMAL, and it still owns the tablet -- so
+    // without this gate the job is admitted, its publish resolves no live tablet, and it spins in
+    // RUNNING forever with an empty error message. Easy to hit because SHOW TABLET keeps listing
+    // the superseded tablets (after a split the old parent is still the first row).
+    @Test
+    public void checkIndexNotSuperseded_rejectsSupersededIndex() {
+        MaterializedIndex oldIndex = new MaterializedIndex(100L, 100L, IndexState.NORMAL, 0L);
+        oldIndex.addTablet(new LakeTablet(1000L), null, false);
+        PhysicalPartition partition = new PhysicalPartition(1L, 0L, oldIndex);
+
+        // Nothing has superseded it yet: the check passes.
+        assertDoesNotThrowStarRocks(() ->
+                TabletReshardUtils.checkIndexNotSuperseded(partition, oldIndex, 1000L, "db", "t"));
+
+        // A later reshard installs a new version of the same index meta.
+        MaterializedIndex newIndex = new MaterializedIndex(200L, 100L, IndexState.NORMAL, 0L);
+        newIndex.addTablet(new LakeTablet(2000L), null, false);
+        partition.addMaterializedIndex(newIndex, true);
+
+        StarRocksException e = assertThrows(StarRocksException.class, () ->
+                TabletReshardUtils.checkIndexNotSuperseded(partition, oldIndex, 1000L, "db", "t"));
+        assertTrue(e.getMessage().contains("superseded by index 200"), e.getMessage());
+        assertTrue(e.getMessage().contains("1000"), e.getMessage());
+
+        // The live index is still accepted.
+        assertDoesNotThrowStarRocks(() ->
+                TabletReshardUtils.checkIndexNotSuperseded(partition, newIndex, 2000L, "db", "t"));
+    }
+
+    private interface ThrowingRunnable {
+        void run() throws StarRocksException;
+    }
+
+    private static void assertDoesNotThrowStarRocks(ThrowingRunnable r) {
+        try {
+            r.run();
+        } catch (StarRocksException e) {
+            throw new AssertionError("unexpected StarRocksException: " + e.getMessage(), e);
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

`ALTER TABLE ... SPLIT TABLET (<id>)` accepts a tablet that an earlier reshard has already replaced,
returns **success**, and then the job **never terminates**: it stays in `RUNNING` with an **empty**
`ERROR_MESSAGE` while its publish fails in a tight retry loop (measured: **51913** failures in ~2
minutes). `SELECT COUNT(*)` keeps working, so nothing surfaces to the operator.

### Why every existing check passes

`SplitTabletJobFactory#resolveTabletMeta` validates, in order:

| check | superseded tablet |
|---|---|
| tablet present in `TabletInvertedIndex` | ✅ passes — the inverted index is not pruned when an index is superseded |
| physical partition exists | ✅ |
| `physicalPartition.getIndex(indexId)` non-null | ✅ the superseded index is still returned |
| `index.getState() == NORMAL` | ✅ the superseded index is still `NORMAL` |
| `index.getTablet(tabletId)` non-null | ✅ it still owns the tablet |

Only the partition's `indexMetaId -> indexIds` chain records that the index was replaced, and nothing
consults it. `MergeTabletJobFactory` has the identical gap.

The admitted job then publishes against nothing:

```
RpcException: Fail to publish version for tablets:[], error msg: link rpc channel failed
    at SplitTabletJob.publishVersion(SplitTabletJob.java:592)
    at Utils.aggregatePublishVersion(Utils.java:541)
```

Note the **empty tablet list**. A normal load publish on the same cluster succeeds at the same moment,
so the `link rpc channel failed` text is a symptom of the empty target list, not an RPC problem. The
failure is swallowed into `PublishState.FAILED` with only a `LOG.warn`, and `runRunningJob` resubmits
immediately — hence "RUNNING forever, no error, undiagnosable".

### Why this is easy to hit

`SHOW TABLET FROM <table>` keeps listing superseded tablets alongside the live ones. After a split the
**old parent is still the first row**:

```
10356  (-∞, +∞)             <- superseded index 10354 (state still NORMAL)
10360  (-∞, [25601])        <- live index 10364
10361  [[25601], [51201])
10362  [[51201], [76801])
10363  [[76801], +∞)
```

confirmed by `SHOW PROC '/dbs/<db>/<tbl>/partitions/<pid>'`: index `10354` holds `{10356}`, index
`10364` holds `{10360..10363}`. A script that takes a tablet id from `SHOW TABLET` after a split can
feed a stale one straight back into `SPLIT/MERGE TABLET`.

Splitting a **live** child tablet is fine — it finishes in ~1s, verified 8/8 across 1-FE and 3-FE
clusters, PK and `DUPLICATE KEY`, with and without `tablet_reshard_target_size` / `enable_tablet_merge`
overrides.

## What I'm doing:

1. **Reject it at admission.** New `TabletReshardUtils#checkIndexNotSuperseded`, called from both the
   split and merge factories. The error names the superseding index and points at the `SHOW PROC` path
   that lists the partition's current tablets, so the fix is self-explanatory:

   > Tablet 10356 belongs to materialized index 10354, which has already been superseded by index
   > 10364 in physical partition 10355 in table db.t. It is no longer part of the table; list the
   > current tablets with SHOW PROC '/dbs/db/t/partitions/10355/10364'

2. **Make a stuck job diagnosable.** `PublishResult` now carries the failure text and the split/merge
   jobs copy it into `errorMessage`, so `information_schema.tablet_reshard_jobs.ERROR_MESSAGE` reports
   the reason instead of being empty while the job retries.

I deliberately did **not** bound the publish retries or auto-abort on repeated failure. A publish
failure can be genuinely transient, so turning it into an abort is a policy change that deserves its
own review; with (1) in place the reported job is never created, and with (2) any remaining stuck job
explains itself.

Related to StarRocks/StarRocksTest#11730. The reporter describes their second-generation split as
targeting a *child* tablet; a live child split works in my runs (8/8), while the superseded-parent id —
which `SHOW TABLET` presents first — reproduces their signature exactly (`RUNNING` forever, empty
error, `SELECT` fine). Their control case (splitting the original tablet of a never-split partition)
passing is consistent with that reading. One symptom I could not reproduce: they report `INSERT`
blocking, whereas `INSERT` returned normally while my job was stuck.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: `ALTER TABLE ... SPLIT/MERGE TABLET` on a tablet belonging to a superseded
      materialized index now fails fast with an explicit error instead of being accepted and hanging.
      `ERROR_MESSAGE` in `information_schema.tablet_reshard_jobs` is now populated while a job retries
      a failing publish.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

Range distribution / tablet reshard is main-only, so no backport is needed.

## Tests

`TabletReshardUtilsTest#checkIndexNotSuperseded_rejectsSupersededIndex` — builds a partition whose base
index is later superseded via `addMaterializedIndex`, and asserts the check passes before the
supersession, throws afterwards naming the superseding index, and still accepts the live index.

## Follow-up worth considering (not in this PR)

`SHOW TABLET FROM <table>` listing tablets of superseded indexes is what leads users and harnesses into
this trap. Filtering to the live index, or adding an index/state column, would remove the foot-gun at
the source.

