### PR TITLE
[BugFix] Keep decoded CTE-consume output columns as string refs (backport #76004)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -650,12 +650,17 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
     public OptExpression visitPhysicalCTEConsume(OptExpression optExpression, ColumnRefSet fragmentUseDictExprs) {
         PhysicalCTEConsumeOperator consume = optExpression.getOp().cast();
         DecodeInfo info = context.operatorDecodeInfo.get(consume);
+        // Only rewrite the CTE output map to dict refs for columns that still arrive at this
+        // consume in dict form. A column that was decoded inside the CTE producer (e.g. by
+        // lead() with a non-null default) must keep its string ref here; otherwise the consume
+        // references a producer dict slot that the produce fragment no longer emits, and the
+        // query fails at BE with "slot_id N not found".
         Map<ColumnRefOperator, ScalarOperator> newMap = consume.getCteOutputColumnRefMap().entrySet().stream().map(
-                        (e) -> new Pair<>(
-                                context.stringRefToDictRefMap.getOrDefault(e.getKey(), e.getKey()),
-                                e.getValue().isColumnRef()
-                                        && context.stringRefToDictRefMap.containsKey((ColumnRefOperator) e.getValue())
-                                ? context.stringRefToDictRefMap.get((ColumnRefOperator) e.getValue()) : e.getValue()))
+                        (e) -> e.getValue() instanceof ColumnRefOperator col &&
+                                info.inputStringColumns.contains(col.getId())
+                                ? new Pair<>(context.stringRefToDictRefMap.getOrDefault(e.getKey(), e.getKey()),
+                                        context.stringRefToDictRefMap.getOrDefault(col, col))
+                                : new Pair<>(e.getKey(), e.getValue()))
                 .collect(Collectors.toMap(p -> p.first, p -> p.second));
         ColumnRefSet supportColumns = new ColumnRefSet(consume.getCteOutputColumnRefMap().entrySet().stream()
                 .filter(k -> info.inputStringColumns.contains(k.getValue().cast())).map(Map.Entry::getKey).toList());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -2881,6 +2881,31 @@ public class LowCardinalityTest2 extends PlanTestBase {
     }
 
     @Test
+    public void testCTEConsumeDecodedColumnKeepsStringRef() throws Exception {
+        // `c_par` is a passthrough low-card column that stays dict across the materialized CTE
+        // (so the CTE-consume is visited by DecodeRewriter); `c_user` is in the global dict map
+        // but is decoded inside the producer by lead(...,'NONE'). visitPhysicalCTEConsume must
+        // NOT rewrite the c_user CTE-output entry to its dict ref, otherwise the consume carries
+        // c_user as a dict (INT) slot the produce fragment no longer emits and BE fails with
+        // "slot_id not found".
+        String sql = """
+                  WITH CTE AS (
+                    SELECT c_par, c_user, c_dept,
+                           lead(c_user, 1, 'NONE') over (partition by c_dept order by c_user) nx
+                    FROM low_card_t1
+                  ) [materialized]
+                  SELECT /*+ SET_VAR(cbo_cte_reuse=true, cbo_cte_reuse_rate_v2=0) */
+                    c_par, c_user, count(*) cnt
+                  FROM CTE
+                  WHERE nx != 'ZZZ'
+                  GROUP BY c_par, c_user
+                  """;
+        String plan = getVerboseExplain(sql);
+        // c_user was decoded in the producer; it must never be carried past the CTE as a dict ref.
+        assertNotContains(plan, "c_user, INT");
+    }
+
+    @Test
     public void testCTEConsumeWithProjection() throws Exception {
         String sql = """
                   WITH CTE AS (

--- a/test/sql/test_low_cardinality/R/test_cte_consume_decoded_column
+++ b/test/sql/test_low_cardinality/R/test_cte_consume_decoded_column
@@ -1,0 +1,60 @@
+-- name: test_cte_consume_decoded_column
+set cbo_enable_low_cardinality_optimize = true;
+-- result:
+-- !result
+set low_cardinality_optimize_v2 = true;
+-- result:
+-- !result
+CREATE TABLE `cte_decoded_t` (
+  `id` bigint NOT NULL,
+  `c_user` varchar(128) NULL,
+  `c_dept` varchar(128) NULL,
+  `c_par` varchar(128) NULL,
+  `ts` datetime NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into cte_decoded_t
+select
+    generate_series,
+    concat('U', generate_series % 2),
+    concat('D', generate_series % 2),
+    concat('P', generate_series % 2),
+    seconds_add('2026-01-01 00:00:00', generate_series)
+from TABLE(generate_series(0, 299));
+-- result:
+-- !result
+[UC] analyze full table cte_decoded_t;
+function: wait_global_dict_ready('c_user', 'cte_decoded_t')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('c_dept', 'cte_decoded_t')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('c_par', 'cte_decoded_t')
+-- result:
+
+-- !result
+[ORDER]
+WITH CTE AS (
+  SELECT c_par, c_user, c_dept,
+         lead(c_user, 1, 'NONE') over (partition by c_dept order by c_user) nx
+  FROM cte_decoded_t
+) [materialized]
+SELECT /*+ SET_VAR(cbo_cte_reuse=true, cbo_cte_reuse_rate_v2=0) */
+  c_par, c_user, count(*) cnt
+FROM CTE
+WHERE nx != 'ZZZ'
+GROUP BY c_par, c_user
+ORDER BY c_par, c_user;
+-- result:
+P0	U0	150
+P1	U1	150
+-- !result

--- a/test/sql/test_low_cardinality/T/test_cte_consume_decoded_column
+++ b/test/sql/test_low_cardinality/T/test_cte_consume_decoded_column
@@ -1,0 +1,50 @@
+-- name: test_cte_consume_decoded_column
+
+set cbo_enable_low_cardinality_optimize = true;
+set low_cardinality_optimize_v2 = true;
+
+CREATE TABLE `cte_decoded_t` (
+  `id` bigint NOT NULL,
+  `c_user` varchar(128) NULL,
+  `c_dept` varchar(128) NULL,
+  `c_par` varchar(128) NULL,
+  `ts` datetime NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into cte_decoded_t
+select
+    generate_series,
+    concat('U', generate_series % 2),
+    concat('D', generate_series % 2),
+    concat('P', generate_series % 2),
+    seconds_add('2026-01-01 00:00:00', generate_series)
+from TABLE(generate_series(0, 299));
+
+[UC] analyze full table cte_decoded_t;
+
+function: wait_global_dict_ready('c_user', 'cte_decoded_t')
+function: wait_global_dict_ready('c_dept', 'cte_decoded_t')
+function: wait_global_dict_ready('c_par', 'cte_decoded_t')
+
+-- `c_par` is a passthrough low-card column that stays dict across the materialized CTE
+-- (so the CTE-consume is visited by DecodeRewriter); `c_user` is in the global dict map
+-- but is decoded inside the producer by lead(...,'NONE'). Before the fix,
+-- DecodeRewriter.visitPhysicalCTEConsume rewrote the c_user CTE-output entry to the
+-- producer dict slot the producer no longer emits, so BE failed with "slot_id not found".
+[ORDER]
+WITH CTE AS (
+  SELECT c_par, c_user, c_dept,
+         lead(c_user, 1, 'NONE') over (partition by c_dept order by c_user) nx
+  FROM cte_decoded_t
+) [materialized]
+SELECT /*+ SET_VAR(cbo_cte_reuse=true, cbo_cte_reuse_rate_v2=0) */
+  c_par, c_user, count(*) cnt
+FROM CTE
+WHERE nx != 'ZZZ'
+GROUP BY c_par, c_user
+ORDER BY c_par, c_user;


### PR DESCRIPTION
(cherry picked from commit 89b80b5d37d121f1a97828a305d0c00a621553af)

## Why I'm doing:

For low-cardinality string columns, DecodeRewriter.visitPhysicalCTEConsume rewrote every entry of the CTE output column map to its dict ref unconditionally, without checking whether the column still arrives at the consume in dict form. If a column was decoded inside the CTE producer (e.g. by lead() with a non-null default) it is emitted by the produce fragment as a string slot, but the consume was rewritten to reference the (now absent) dict slot. The query then fails at BE with "Runtime error: slot_id N not found" (debug builds: Check failed: is_slot_exist(slot_id)).

Only rewrite a CTE output column to its dict ref when the producer column is still in dict form (DecodeInfo.inputStringColumns) -- the same guard order-by, group-by and partition-by columns already use.

Add an FE plan test and a SQL regression test.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

