### PR TITLE
[Tool] reverse sync P2: sync main-only + reconcile includes synced PRs (switch)

### DIFF
--- a/.github/workflows/ci-merged.yml
+++ b/.github/workflows/ci-merged.yml
@@ -74,17 +74,17 @@ jobs:
   # carrying the bug); backport_reconcile.py then prints the matrix (window /
   # affected / checked / auto / notify) and posts NOTHING. continue-on-error so
   # it can never affect the merge. Needs ci-tool #4934 on the runner.
-  backport-reconcile-shadow:
-    name: Backport Reconcile (dry-run shadow)
+  backport-reconcile:
+    name: Backport Reconcile
     runs-on: [ self-hosted, ubuntu, ai ]
+    # model-2: reverse-synced PRs (label `sync`) are now INCLUDED (previously excluded).
+    # They have no author checkbox -> AI-only-auto. Native PRs keep the checkbox x AI
+    # matrix. cherry-pick/backport PRs are still excluded (they are the backports).
     if: >
       github.event.pull_request.merged == true &&
       github.base_ref == 'main' &&
       github.repository == 'StarRocks/starrocks' &&
       startsWith(github.event.pull_request.title, '[BugFix]') &&
-      !contains(github.event.pull_request.title, '(sync #') &&
-      !contains(github.event.pull_request.labels.*.name, 'sync') &&
-      !contains(github.head_ref, '-sync-') &&
       !contains(github.event.pull_request.title, 'cherry-pick') &&
       !contains(github.event.pull_request.title, 'backport')
     continue-on-error: true
@@ -92,11 +92,22 @@ jobs:
       PR_NUMBER: ${{ github.event.number }}
       GH_TOKEN: ${{ secrets.PAT }}
       GITHUB_TOKEN: ${{ secrets.PAT }}
+      # reverse-synced PR (label `sync`) -> AI-only-auto; native PR -> checkbox x AI
+      IS_SYNCED: ${{ contains(github.event.pull_request.labels.*.name, 'sync') }}
+      # SWITCH (default OFF): only 'true' makes synced PRs run REAL (auto @Mergifyio).
+      # Otherwise synced PRs stay dry-run. Native PRs are always dry-run (phase B shadow).
+      SYNCED_REAL: ${{ vars.RECONCILE_SYNCED_REAL }}
     steps:
-      - name: reconcile dry-run (checkbox x AI affected)
+      - name: reconcile (native=dry-run shadow; synced=AI-only-auto)
         run: |
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
-          ./bin/backport_reconcile.sh --repo ${GITHUB_REPOSITORY} --pr ${PR_NUMBER} --dry-run
+          if [[ "${IS_SYNCED}" == "true" ]]; then
+            if [[ "${SYNCED_REAL}" == "true" ]]; then MODE="--no-dry-run"; else MODE="--dry-run"; fi
+            echo "reverse-synced PR -> AI-only-auto (${MODE})"
+            ./bin/backport_reconcile.sh --repo ${GITHUB_REPOSITORY} --pr ${PR_NUMBER} --synced ${MODE}
+          else
+            ./bin/backport_reconcile.sh --repo ${GITHUB_REPOSITORY} --pr ${PR_NUMBER} --dry-run
+          fi
 
   thirdparty-filter:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-merged.yml
+++ b/.github/workflows/ci-merged.yml
@@ -67,19 +67,27 @@ jobs:
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
           python3 lib/backport_fanout_run.py --repo ${GITHUB_REPOSITORY} --pr ${PR_NUMBER} --dry-run
 
-  # Decision-10 phase B shadow: checkbox x AI-affected reconciliation, DRY-RUN.
-  # Runs on [self-hosted, ubuntu, ai] — that pool has BOTH /var/lib/ci-tool AND
-  # `claude` + the github-bugfix-versions plugin (see bugfix-version-index.yml).
-  # `claude` returns this [BugFix]'s affected release lines (branches still
-  # carrying the bug); backport_reconcile.py then prints the matrix (window /
-  # affected / checked / auto / notify) and posts NOTHING. continue-on-error so
-  # it can never affect the merge. Needs ci-tool #4934 on the runner.
+  # At-merge backport reconciliation (AI-主导 for native / AI-only-auto for synced).
+  # Runs on [self-hosted, ubuntu, ai] — that pool has /var/lib/ci-tool AND `claude`.
+  # bin/backport_reconcile.sh asks `claude` (LOCAL git + gh only, NO plugin / code_kb)
+  # for this [BugFix]'s affected release lines (branches still carrying the bug), then
+  # backport_reconcile.py reconciles them and either PRINTS (dry-run) or posts
+  # @Mergifyio (real). continue-on-error so it can never affect the merge.
+  #
+  # Phase 2 (at-merge go-live) — TWO independent switches, both default OFF, so merging
+  # this PR activates NOTHING until an operator sets a repo variable:
+  #   * native PRs  -> AI-主导 (--ai-lead): auto = window ∩ affected; checkbox divergence
+  #                    -> notify FYI. REAL only when vars.RECONCILE_NATIVE_REAL == 'true'.
+  #   * synced PRs  -> AI-only-auto (--synced). REAL only when vars.RECONCILE_SYNCED_REAL.
+  # Recommended flip order: NATIVE first (its checkbox-divergence notify surfaces any AI
+  # reachability false-negative pre-merge), SYNCED last (boxless -> a false-negative there
+  # is a SILENT dropped backport, no advisory net). See design doc §验证 (76782).
   backport-reconcile:
     name: Backport Reconcile
     runs-on: [ self-hosted, ubuntu, ai ]
-    # model-2: reverse-synced PRs (label `sync`) are now INCLUDED (previously excluded).
-    # They have no author checkbox -> AI-only-auto. Native PRs keep the checkbox x AI
-    # matrix. cherry-pick/backport PRs are still excluded (they are the backports).
+    # model-2: reverse-synced PRs (label `sync`) are INCLUDED (previously excluded).
+    # They have no author checkbox -> AI-only-auto. Native PRs -> AI-主导 (checkbox x AI).
+    # cherry-pick/backport PRs are still excluded (they are the backports).
     if: >
       github.event.pull_request.merged == true &&
       github.base_ref == 'main' &&
@@ -92,13 +100,13 @@ jobs:
       PR_NUMBER: ${{ github.event.number }}
       GH_TOKEN: ${{ secrets.PAT }}
       GITHUB_TOKEN: ${{ secrets.PAT }}
-      # reverse-synced PR (label `sync`) -> AI-only-auto; native PR -> checkbox x AI
+      # reverse-synced PR (label `sync`) -> AI-only-auto; native PR -> AI-主导 (checkbox x AI)
       IS_SYNCED: ${{ contains(github.event.pull_request.labels.*.name, 'sync') }}
-      # SWITCH (default OFF): only 'true' makes synced PRs run REAL (auto @Mergifyio).
-      # Otherwise synced PRs stay dry-run. Native PRs are always dry-run (phase B shadow).
-      SYNCED_REAL: ${{ vars.RECONCILE_SYNCED_REAL }}
+      # SWITCHES (both default OFF -> dry-run shadow; 'true' -> REAL auto @Mergifyio):
+      NATIVE_REAL: ${{ vars.RECONCILE_NATIVE_REAL }}   # native [BugFix] AI-主导 go-live
+      SYNCED_REAL: ${{ vars.RECONCILE_SYNCED_REAL }}   # synced PR AI-only-auto go-live (flip last)
     steps:
-      - name: reconcile (native=dry-run shadow; synced=AI-only-auto)
+      - name: reconcile (native=AI-主导; synced=AI-only-auto; each switch-gated)
         run: |
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
           if [[ "${IS_SYNCED}" == "true" ]]; then
@@ -106,7 +114,9 @@ jobs:
             echo "reverse-synced PR -> AI-only-auto (${MODE})"
             ./bin/backport_reconcile.sh --repo ${GITHUB_REPOSITORY} --pr ${PR_NUMBER} --synced ${MODE}
           else
-            ./bin/backport_reconcile.sh --repo ${GITHUB_REPOSITORY} --pr ${PR_NUMBER} --dry-run
+            if [[ "${NATIVE_REAL}" == "true" ]]; then MODE="--no-dry-run"; else MODE="--dry-run"; fi
+            echo "native PR -> AI-主导 (${MODE})"
+            ./bin/backport_reconcile.sh --repo ${GITHUB_REPOSITORY} --pr ${PR_NUMBER} --ai-lead ${MODE}
           fi
 
   thirdparty-filter:

--- a/.github/workflows/ci-sync.yml
+++ b/.github/workflows/ci-sync.yml
@@ -2,9 +2,11 @@ name: SYNC PIPELINE
 
 on:
   pull_request_target:
+    # model-2 闸3: sync only main <-> main. Release-branch backports are NOT synced
+    # to the peer (each repo backports its own main via its reconcile engine), which
+    # avoids double-backport / cross-repo loops once reconcile-synced is live.
     branches:
       - main
-      - 'branch-[0-9].[0-9]*'
     types:
       - closed
   workflow_dispatch:


### PR DESCRIPTION
## Why I'm doing:

Model-2 backport cutover (StarRocks side). Design: `docs/superpowers/specs/2026-08-06-celerdata-first-sync-backport-design.md`. **Must go live ATOMICALLY with the CelerData counterpart PR and the switch flip — see below.**

## What I'm doing:

`ci-sync.yml`:
- Trigger only on `main` (drop release branches). 闸3: release-branch backports are no longer synced to the peer; each repo backports its own main via reconcile. Prevents double-backport once reconcile-synced is live.

`ci-merged.yml` (`backport-reconcile`):
- INCLUDE reverse-synced PRs (remove the `sync`/`(sync #`/`-sync-` exclusions). Synced PRs have no author checkbox → run with `--synced` (AI-only-auto); native PRs keep the checkbox × AI matrix, still dry-run (phase B shadow).
- SWITCH `vars.RECONCILE_SYNCED_REAL` (default OFF): synced PRs run REAL (auto `@Mergifyio`) only when set to `true`; otherwise dry-run. Flip without a code change to go live / roll back.

Requires `StarRocks/ci-tool#4976` (`--synced` AI-only-auto) on the runner.

**Go-live coordination:** limiting `ci-sync` to main removes forward release-branch sync, so CelerData branches only stay covered for SR-origin fixes once CelerData's reconcile-synced is ON. Merge this together with the CelerData `ci-merged` PR and flip `RECONCILE_SYNCED_REAL=true` on both repos as one step. With the switch OFF this PR is behavior-neutral for backports (synced = dry-run), but `ci-sync` main-only IS a hard cutover — do not merge until go-live.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5