### PR TITLE
[BugFix] Disable light-weight tablet creation for lake schema change jobs carrying index or bloom filter changes

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -412,7 +412,8 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
         try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.READ)) {
             OlapTable table = getTableOrThrow();
             Preconditions.checkState(table.getState() == OlapTable.OlapTableState.SCHEMA_CHANGE);
-            lightWeight = table.isLightWeightTabletCreation();
+            // Light-weight's on-demand shadow schema reads the table's index/BF set, written back only at job finish.
+            lightWeight = table.isLightWeightTabletCreation() && !indexChange && !hasBfChange;
 
             // disable tablet creation optimaization to avoid overwriting files with the same name.
             if (table.isFileBundling()) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
@@ -338,6 +338,81 @@ public class LakeTableSchemaChangeJobTest {
         Assertions.assertEquals(AlterJobV2.JobState.CANCELLED, schemaChangeJob.getJobState());
     }
 
+    // ADD INDEX ... USING GIN carries a table-level index change, so light-weight tablet creation must be
+    // disabled: the shadow tablet's on-demand schema would otherwise be built from the table's pre-alter
+    // index set (only written back at job finish) and the rewritten segments would silently lack the index.
+    @Test
+    public void testIndexChangeDisablesLightWeightTabletCreation() throws Exception {
+        boolean savedEnableGin = Config.enable_experimental_gin;
+        Config.enable_experimental_gin = true;
+        try {
+            LakeTable ginTable = createTable(connectContext,
+                        "CREATE TABLE t_gin(c0 INT, c1 VARCHAR(64)) duplicate key(c0) distributed by hash(c0) buckets "
+                                    + NUM_BUCKETS);
+            alterTable(connectContext, "ALTER TABLE t_gin SET ('light_weight_tablet_creation' = 'true')");
+            Assertions.assertTrue(ginTable.isLightWeightTabletCreation());
+
+            AtomicBoolean sendCalled = new AtomicBoolean(false);
+            new MockUp<LakeTableSchemaChangeJob>() {
+                @Mock
+                public void sendAgentTaskAndWait(AgentBatchTask batchTask,
+                                                 MarkedCountDownLatch<Long, Long> countDownLatch,
+                                                 long timeoutSeconds, AtomicBoolean waitingCreatingReplica,
+                                                 AtomicBoolean isCancelling) throws AlterCancelException {
+                    sendCalled.set(true);
+                }
+            };
+
+            alterTable(connectContext,
+                        "ALTER TABLE t_gin ADD INDEX idx_c1 (c1) USING GIN ('parser' = 'english')");
+            LakeTableSchemaChangeJob schemaChangeJob = getAlterJob(ginTable);
+            schemaChangeJob.runPendingJob();
+            Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, schemaChangeJob.getJobState());
+            Assertions.assertTrue(sendCalled.get(),
+                        "an index change must fall back to normal tablet creation even when "
+                                    + "light_weight_tablet_creation is enabled");
+
+            schemaChangeJob.cancel("test");
+            Assertions.assertEquals(AlterJobV2.JobState.CANCELLED, schemaChangeJob.getJobState());
+        } finally {
+            Config.enable_experimental_gin = savedEnableGin;
+        }
+    }
+
+    // Same contract for a bloom filter change; a mixed add+drop is used because a pure add or drop takes the
+    // lake IDG fast path (no shadow tablet) and would not produce a LakeTableSchemaChangeJob at all.
+    @Test
+    public void testBloomFilterChangeDisablesLightWeightTabletCreation() throws Exception {
+        LakeTable bfTable = createTable(connectContext,
+                    "CREATE TABLE t_bf(c0 INT, c1 VARCHAR(64), c2 VARCHAR(64)) duplicate key(c0) "
+                                + "distributed by hash(c0) buckets " + NUM_BUCKETS
+                                + " properties('bloom_filter_columns' = 'c1')");
+        alterTable(connectContext, "ALTER TABLE t_bf SET ('light_weight_tablet_creation' = 'true')");
+        Assertions.assertTrue(bfTable.isLightWeightTabletCreation());
+
+        AtomicBoolean sendCalled = new AtomicBoolean(false);
+        new MockUp<LakeTableSchemaChangeJob>() {
+            @Mock
+            public void sendAgentTaskAndWait(AgentBatchTask batchTask,
+                                             MarkedCountDownLatch<Long, Long> countDownLatch,
+                                             long timeoutSeconds, AtomicBoolean waitingCreatingReplica,
+                                             AtomicBoolean isCancelling) throws AlterCancelException {
+                sendCalled.set(true);
+            }
+        };
+
+        alterTable(connectContext, "ALTER TABLE t_bf SET ('bloom_filter_columns' = 'c2')");
+        LakeTableSchemaChangeJob schemaChangeJob = getAlterJob(bfTable);
+        schemaChangeJob.runPendingJob();
+        Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, schemaChangeJob.getJobState());
+        Assertions.assertTrue(sendCalled.get(),
+                    "a bloom filter change must fall back to normal tablet creation even when "
+                                + "light_weight_tablet_creation is enabled");
+
+        schemaChangeJob.cancel("test");
+        Assertions.assertEquals(AlterJobV2.JobState.CANCELLED, schemaChangeJob.getJobState());
+    }
+
     @Test
     public void testPreviousTxnNotFinished() throws Exception {
         LakeTableSchemaChangeJob schemaChangeJob = alterTableAddColumn();

--- a/test/sql/test_inverted_index/R/test_lake_lightweight_add_index
+++ b/test/sql/test_inverted_index/R/test_lake_lightweight_add_index
@@ -1,0 +1,60 @@
+-- name: test_lake_lightweight_add_index @cloud
+ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
+-- result:
+-- !result
+set low_cardinality_optimize_v2 = false;
+-- result:
+-- !result
+set cbo_enable_low_cardinality_optimize = false;
+-- result:
+-- !result
+CREATE TABLE `t_lw_gin` (
+  `id` bigint(20) NOT NULL COMMENT "",
+  `v1` varchar(255) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 3
+PROPERTIES (
+"light_weight_tablet_creation" = "true"
+);
+-- result:
+-- !result
+INSERT INTO t_lw_gin
+SELECT generate_series,
+       CASE WHEN generate_series < 100 THEN 'alpha needleold gamma'
+            ELSE concat('alpha hay gamma ', cast(generate_series as string))
+       END
+FROM TABLE(generate_series(0, 99999));
+-- result:
+-- !result
+ALTER TABLE t_lw_gin ADD INDEX gin_v1 (v1) USING GIN ('parser' = 'english');
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT count(*) FROM t_lw_gin WHERE v1 MATCH 'needleold';
+-- result:
+100
+-- !result
+SELECT count(*) FROM t_lw_gin WHERE v1 LIKE '%needleold%';
+-- result:
+100
+-- !result
+INSERT INTO t_lw_gin
+SELECT generate_series,
+       CASE WHEN generate_series < 100100 THEN 'alpha needlenew gamma'
+            ELSE concat('alpha hay gamma ', cast(generate_series as string))
+       END
+FROM TABLE(generate_series(100000, 199999));
+-- result:
+-- !result
+SELECT count(*) FROM t_lw_gin WHERE v1 MATCH 'needlenew';
+-- result:
+100
+-- !result
+SELECT count(*) FROM t_lw_gin WHERE v1 MATCH 'needleold';
+-- result:
+100
+-- !result

--- a/test/sql/test_inverted_index/T/test_lake_lightweight_add_index
+++ b/test/sql/test_inverted_index/T/test_lake_lightweight_add_index
@@ -1,0 +1,37 @@
+-- name: test_lake_lightweight_add_index @cloud
+ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
+set low_cardinality_optimize_v2 = false;
+set cbo_enable_low_cardinality_optimize = false;
+CREATE TABLE `t_lw_gin` (
+  `id` bigint(20) NOT NULL COMMENT "",
+  `v1` varchar(255) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 3
+PROPERTIES (
+"light_weight_tablet_creation" = "true"
+);
+
+INSERT INTO t_lw_gin
+SELECT generate_series,
+       CASE WHEN generate_series < 100 THEN 'alpha needleold gamma'
+            ELSE concat('alpha hay gamma ', cast(generate_series as string))
+       END
+FROM TABLE(generate_series(0, 99999));
+
+ALTER TABLE t_lw_gin ADD INDEX gin_v1 (v1) USING GIN ('parser' = 'english');
+function: wait_alter_table_finish()
+
+-- MATCH errors out instead of returning 100 when the shadow rewrite loses the new index.
+SELECT count(*) FROM t_lw_gin WHERE v1 MATCH 'needleold';
+SELECT count(*) FROM t_lw_gin WHERE v1 LIKE '%needleold%';
+
+INSERT INTO t_lw_gin
+SELECT generate_series,
+       CASE WHEN generate_series < 100100 THEN 'alpha needlenew gamma'
+            ELSE concat('alpha hay gamma ', cast(generate_series as string))
+       END
+FROM TABLE(generate_series(100000, 199999));
+
+SELECT count(*) FROM t_lw_gin WHERE v1 MATCH 'needlenew';
+SELECT count(*) FROM t_lw_gin WHERE v1 MATCH 'needleold';


### PR DESCRIPTION
## Why I'm doing:

On a shared-data cluster with `light_weight_tablet_creation` enabled, `ALTER TABLE ... ADD INDEX ... USING GIN`
silently produces an empty index. The ALTER reports `FINISHED` and `SHOW CREATE TABLE` shows the index, but a
`MATCH` query fails with `Match can only used as a pushdown predicate on column with GIN in a single query.`,
because the rewritten segments carry no inverted index.

Light-weight tablet creation skips `CreateReplicaTask`, so the shadow tablet has no version-1 metadata and the
compute node fetches its schema on demand from FE. That path (`FrontendServiceImpl` →
`SchemaInfo.fromMaterializedIndex`) builds the table-level `indexes` / `bloomFilterColumnNames` /
`bloomFilterFpp` from the table's **current** state, but the job only writes its new values back onto the table
when it finishes. The shadow tablet is therefore rewritten with the stale index / bloom-filter set.

The non-light-weight path is correct because it builds the shadow tablet schema from the job's own fields
(`indexes` / `bfColumns` / `bfFpp`) rather than from the table.

## What I'm doing:

Jobs that carry a table-level property change must not take the light-weight path:

```java
lightWeight = table.isLightWeightTabletCreation() && !indexChange && !hasBfChange;
```

`indexChange` and `hasBfChange` are already set at job-construction time
(`LakeTableAlterJobV2Builder.build()`) and are `@SerializedName`-persisted, so this also holds after an FE
restart and replay. Such a job falls back to normal tablet creation, which stamps the shadow tablet with the
job's own (new) index / bloom-filter set. The bottleneck of these ALTERs is the full data rewrite (~26s for
100k rows in testing), so the extra `CreateReplicaTask` round-trip is negligible.

Jobs without a table-level change (plain ADD COLUMN, rollup) keep using the light-weight path unchanged.

**Verified on a shared-data cluster (1 FE + 1 BE, MinIO-backed storage volume), with the FE swapped between a
with-fix and a without-fix build on the same cluster:**

| Index / property | Before fix (`light_weight_tablet_creation = true`) | After fix | Status |
|---|---|---|---|
| GIN ADD INDEX | `MATCH` fails with the error above | `MATCH` = 100, `GinFilterRows` = 99900, `RawRowsRead` = 100 | confirmed by measurement |
| NGRAMBF ADD INDEX | no `BloomFilterFilter` counter, `RawRowsRead` = 100000 (full scan) | `BloomFilterFilter` = 94358, `RawRowsRead` = 5642 | confirmed by measurement |
| Bloom filter change on the legacy path (mixed add+drop) | no `BloomFilterFilter` counter, `RawRowsRead` = 100000 | `BloomFilterFilter` = 94538, `RawRowsRead` = 5462 | confirmed by measurement |
| VECTOR index add/drop | not separately measured | — | takes the same shadow-rewrite path with `indexChange` set, expected to be affected |

In every "after fix" row the numbers are identical to the same operation on a table with
`light_weight_tablet_creation = false`. BITMAP add/drop and pure add / pure drop bloom-filter changes are not
affected: they take the lake IDG fast path and never create a shadow tablet.

(For the bloom-filter row, the segment- and page-level zone-map filters were disabled on the BE
(`enable_index_segment_level_zonemap_filter` / `enable_index_page_level_zonemap_filter`) so that the bloom
filter is the deciding filter; querying an absent value otherwise gets pruned by the zone map before the bloom
filter is consulted. Both configs were restored afterwards.)

**Tests.** Two FE unit tests in `LakeTableSchemaChangeJobTest` assert that `sendAgentTaskAndWait` *is* invoked
(i.e. the light-weight path is disabled) for a GIN `ADD INDEX` and for a legacy-path bloom-filter change, while
the pre-existing `testLightWeightTabletCreationSkipsSendTask` still asserts the opposite for a plain ADD COLUMN.
Reverting the one-line fix makes exactly the two new tests fail and leaves the other 32 green.

A new SQL regression case `test/sql/test_inverted_index/test_lake_lightweight_add_index` covers the end-to-end
path. The 21 existing GIN cases in `test/sql/test_inverted_index` are all tagged `@native`, so GIN was never
exercised in shared-data CI runs — which is why this defect survived. The new case is tagged `@cloud` and runs
when CI schedules the PR in shared-data mode. Verified that it fails before the fix and passes after.

### Assumption completeness

The faulty assumption is *"the table-level fields of `SchemaInfo.fromMaterializedIndex` are usable in a
shadow-tablet context"*. All call sites were reviewed:

| Site | Status |
|---|---|
| `FrontendServiceImpl.java:3993` (light-weight shadow tablet, on-demand fetch) | Fixed by this PR |
| `LakeOnlineRewriteJobBase.java:431` | Not applicable — range-rewrite jobs never carry a table-level index/BF change (`needsRangeRewriteSchemaChange` only routes Reorder / Modify / Drop / Add(Columns) clauses), and a DROP COLUMN that would implicitly change the table-level set is explicitly rejected at `SchemaChangeHandler.java:2702-2726` |
| `LakeRollupJob.java:229` (same light-weight branch) | Not applicable — a rollup never changes the table-level index / bloom-filter set, so reading the current value is correct |
| The other 8 call sites | Not applicable — they intentionally want the *old* schema (base-tablet read schema, IDG fast-path read schema, `oldSchemaInfo`), or are not shadow-tablet scenarios (current-schema queries, table creation, query planning) |

Fixes #77534

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

The `light_weight_tablet_creation` feature was introduced in #73422 and exists only on main —
`lake_enable_light_weight_tablet_creation` is absent from `Config.java` on branch-4.1, branch-4.0 and
branch-3.5 — so no backport is needed.
