### PR TITLE
[BugFix] Fix integer overflow in BinaryColumnBase::replicate when computing total size

### DIFF
--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -193,7 +193,9 @@ StatusOr<MutableColumnPtr> BinaryColumnBase<T>::replicate(const Buffer<uint32_t>
     size_t total_size = 0;              // total size to copy
     for (auto i = 0; i < src_size; ++i) {
         auto bytes_size = _offsets[i + 1] - _offsets[i];
-        total_size += bytes_size * (offsets[i + 1] - offsets[i]);
+        auto repeat_count = offsets[i + 1] - offsets[i];
+        // widen to size_t before multiplying, otherwise bytes_size * repeat_count can overflow T (e.g. uint32_t)
+        total_size += static_cast<size_t>(bytes_size) * repeat_count;
     }
 
     if (total_size >= Column::MAX_CAPACITY_LIMIT) {

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -670,6 +670,26 @@ PARALLEL_TEST(BinaryColumnTest, test_replicate) {
     ASSERT_EQ("def", slices[4]);
 }
 
+// NOLINTNEXTLINE
+GROUP_SLOW_PARALLEL_TEST(BinaryColumnTest, test_replicate_overflow) {
+    // one element of 64KB, repeated 65537 times: true total size is
+    // 65536 * 65537 = 4295032832, which exceeds Column::MAX_CAPACITY_LIMIT (2^32).
+    // If bytes_size * repeat_count were computed in 32-bit (T) arithmetic instead of
+    // being widened to size_t first, it would wrap around to 65536 and wrongly pass
+    // the capacity check, leading to a too-small buffer allocation and an out-of-bounds
+    // write in the copy loop below.
+    auto c1 = BinaryColumn::create();
+    std::string large_str(65536, 'a');
+    c1->append_datum(Slice(large_str));
+
+    Offsets offsets;
+    offsets.emplace_back(0);
+    offsets.emplace_back(65537);
+
+    auto result = c1->replicate(offsets);
+    ASSERT_FALSE(result.ok());
+}
+
 PARALLEL_TEST(BinaryColumnTest, test_reference_memory_usage) {
     auto column = BinaryColumn::create();
     column->append("");


### PR DESCRIPTION
## Why I'm doing:

```
*** Aborted at 1786417945 (unix time) try "date -d @1786417945" if you are using GNU date ***
PC: @          0xa4b8f82 starrocks::BinaryColumnBase<unsigned int>::replicate(std::vector<unsigned int, starrocks::ColumnAllocator<unsigned int> > const&)
*** SIGSEGV (@0xafdca800000) received by PID 61357 (TID 0xafde755d6c0) LWP(61735) from PID 18446744072811970560; stack trace: ***
    @      0xafe090a1fb3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1fb2)
    @         0x147bd806 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @      0xafe09045330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @          0xa4b8f82 starrocks::BinaryColumnBase<unsigned int>::replicate(std::vector<unsigned int, starrocks::ColumnAllocator<unsigned int> > const&)
    @          0xf0b9f70 starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > starrocks::ArrayMapExpr::evaluate_lambda_expr<false, false>(starrocks::ExprContext*, starrocks::Chunk*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::@
    @          0xf0b27d8 starrocks::ArrayMapExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
    @          0xbb89973 starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*)
    @          0xbb89e3b starrocks::ExprContext::evaluate(starrocks::Chunk*, unsigned char*)
    @          0xee13723 starrocks::pipeline::ProjectOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @          0xd067ad9 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0xe7186e1 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @         0x10b8314b starrocks::ThreadPool::dispatch_thread()
    @         0x10b7975e starrocks::Thread::supervise_thread(void*)
    @      0xafe0909cb84 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x9cb83)
    @      0xafe09129d6c (/usr/lib/x86_64-linux-gnu/libc.so.6+0x129d6b)
```


  `BinaryColumnBase<T>::replicate()` computes the total number of bytes to
  allocate for the replicated column as:

  ```cpp
  auto bytes_size = _offsets[i + 1] - _offsets[i];
  total_size += bytes_size * (offsets[i + 1] - offsets[i]);
 ```

  bytes_size and the repeat count are both of the column's offset type T
  (e.g. uint32_t for BinaryColumn), so the multiplication is evaluated in
  32-bit arithmetic before being added into the size_t accumulator
  total_size. When a single element is large and it is repeated many times,
  bytes_size * repeat_count can overflow T and silently wrap around to a
  small value. That corrupts the total_size >= Column::MAX_CAPACITY_LIMIT
  guard, so dest_bytes.resize(total_size) allocates a buffer far smaller than
  what the following copy loop actually writes, causing a heap-buffer-overflow.

## What I'm doing:

  Widen bytes_size to size_t before multiplying, so the product is computed
  in 64-bit arithmetic and correctly reflects the true total size, whether or
  not it overflows T. MAX_CAPACITY_LIMIT is then checked against the
  correct value and the function returns Status::InternalError instead of
  allocating an undersized buffer.

  Added a SLOW-only unit test (test_replicate_overflow, gated by
  GROUP_SLOW_PARALLEL_TEST since it allocates a 64KB string and drives the
  size computation past the overflow boundary) that reproduces the overflow
  scenario and asserts replicate() correctly reports an error instead of
  under-allocating.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [x] 3.5

