### PR TITLE
[BugFix] Put the scan's schema into the query cache digest

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -1706,6 +1706,24 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
         }
         scanNode.setKey_column_names(keyColumnNames);
         scanNode.setKey_column_types(keyColumnTypes);
+        // A fast schema evolution changes what this scan returns without touching any partition
+        // version, so the schema has to be part of the key or pre-DDL entries stay live. See the
+        // note on TNormalOlapScanNode.schema_id.
+        //
+        // Only when it actually carries information. MaterializedIndexMeta starts life with
+        // schemaId == indexMetaId and only diverges once a schema change assigns a new schema, and
+        // index_id is already in the digest above -- so for a table that has never been altered the
+        // field would be a second copy of a value the key already has. Emitting it unconditionally
+        // would still change the serialized bytes, which would invalidate every existing entry on
+        // upgrade for no gain. Written only when it differs, the digests of unaltered tables are
+        // byte-identical to before this fix and only the tables that were altered lose their
+        // entries -- which is exactly the set that has to.
+        if (selectedIndexMetaId != -1) {
+            MaterializedIndexMeta selectedIndexMeta = olapTable.getIndexMetaByMetaId(selectedIndexMetaId);
+            if (selectedIndexMeta != null && selectedIndexMeta.getSchemaId() != selectedIndexMetaId) {
+                scanNode.setSchema_id(selectedIndexMeta.getSchemaId());
+            }
+        }
         scanNode.setIs_preaggregation(isPreAggregation);
         scanNode.setSort_column(sortColumn);
         scanNode.setRollup_name(olapTable.getIndexNameByMetaId(selectedIndexMetaId));

--- a/gensrc/thrift/Normalization.thrift
+++ b/gensrc/thrift/Normalization.thrift
@@ -25,6 +25,18 @@ struct TNormalOlapScanNode {
   13: optional list<i64> selected_partition_ids;
   14: optional list<i64> selected_partition_versions;
   15: optional PlanNodes.TTableSampleOptions sample_options;
+  // The schema the scan reads with. A fast schema evolution (ADD/DROP COLUMN) deliberately does
+  // not rewrite data, so it leaves the partition versions -- and therefore the rest of the cache
+  // key -- untouched, while changing what the very same query returns. Without this field the
+  // entries populated before such a DDL keep being served after it.
+  //
+  // Set only when the schema has actually diverged from the index it belongs to, so that tables
+  // which were never altered keep the digest they had before this field existed. See the note in
+  // OlapScanNode.toNormalForm().
+  //
+  // 16 is left free on purpose: a sibling fix for the same blind spot claims it for the ANN search
+  // spec. Keeping the two ordinals apart lets either change merge first without renumbering.
+  17: optional i64 schema_id;
 }
 
 struct TNormalProjectNode {

--- a/test/sql/test_query_cache/R/test_query_cache_light_schema_change
+++ b/test/sql/test_query_cache/R/test_query_cache_light_schema_change
@@ -1,0 +1,67 @@
+-- name: test_query_cache_light_schema_change
+CREATE TABLE ls1 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  v1 bigint NOT NULL,
+  x int NOT NULL DEFAULT "1"
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO ls1
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, 1, 1
+FROM TABLE(generate_series(1, 620));
+-- result:
+-- !result
+set pipeline_dop = 1;
+-- result:
+-- !result
+set query_cache_hot_partition_num = 100;
+-- result:
+-- !result
+set enable_query_cache = true;
+-- result:
+-- !result
+select sum(s) from (select c1, sum(x) s from ls1 where dt >= '2022-01-01' group by c1) x;
+-- result:
+620
+-- !result
+ALTER TABLE ls1 DROP COLUMN x;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+ALTER TABLE ls1 ADD COLUMN x int NOT NULL DEFAULT "7";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+set enable_query_cache = true;
+-- result:
+-- !result
+select sum(s) from (select c1, sum(x) s from ls1 where dt >= '2022-01-01' group by c1) x;
+-- result:
+4340
+-- !result
+set enable_query_cache = false;
+-- result:
+-- !result
+select sum(s) from (select c1, sum(x) s from ls1 where dt >= '2022-01-01' group by c1) x;
+-- result:
+4340
+-- !result
+set enable_query_cache = true;
+-- result:
+-- !result
+select sum(s) from (select c1, sum(x) s from ls1 where dt >= '2022-01-01' group by c1) x;
+-- result:
+4340
+-- !result

--- a/test/sql/test_query_cache/T/test_query_cache_light_schema_change
+++ b/test/sql/test_query_cache/T/test_query_cache_light_schema_change
@@ -1,0 +1,48 @@
+-- name: test_query_cache_light_schema_change
+-- The cache key is [digest, partition id, partition range, tablet id] and its freshness comes from
+-- the partition version. A fast schema evolution deliberately does NOT rewrite data, so it leaves
+-- every partition version untouched while changing what the very same query returns. Without the
+-- schema in the digest, entries populated before the DDL keep being served after it.
+--
+-- Unlike the other query cache cases in this directory, this one is not two concurrent queries
+-- poisoning each other -- it is one query poisoning itself across a DDL, which is easier to hit in
+-- practice: any ADD/DROP COLUMN leaves stale entries behind until a write bumps the partition.
+CREATE TABLE ls1 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  v1 bigint NOT NULL,
+  x int NOT NULL DEFAULT "1"
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO ls1
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, 1, 1
+FROM TABLE(generate_series(1, 620));
+
+set pipeline_dop = 1;
+set query_cache_hot_partition_num = 100;
+
+-- Populate the per-tablet entries while x defaults to 1.
+set enable_query_cache = true;
+select sum(s) from (select c1, sum(x) s from ls1 where dt >= '2022-01-01' group by c1) x;
+
+-- Drop and re-add the same column with a different default. Data is not rewritten, so the existing
+-- rows now read back as 7 and the correct answer becomes 620 * 7.
+ALTER TABLE ls1 DROP COLUMN x;
+function: wait_alter_table_finish()
+ALTER TABLE ls1 ADD COLUMN x int NOT NULL DEFAULT "7";
+function: wait_alter_table_finish()
+
+-- Must reflect the new schema, not the entries populated before the DDL.
+set enable_query_cache = true;
+select sum(s) from (select c1, sum(x) s from ls1 where dt >= '2022-01-01' group by c1) x;
+set enable_query_cache = false;
+select sum(s) from (select c1, sum(x) s from ls1 where dt >= '2022-01-01' group by c1) x;
+
+-- And the cache must still be usable afterwards -- the entry is invalidated, not disabled.
+set enable_query_cache = true;
+select sum(s) from (select c1, sum(x) s from ls1 where dt >= '2022-01-01' group by c1) x;


### PR DESCRIPTION
## Why I'm doing:

The cache key is [digest, partition id, partition range, tablet id] and its freshness comes from the partition version. A fast schema evolution deliberately does not rewrite data, so ADD/DROP COLUMN leaves every partition version -- and therefore the whole key -- untouched, while changing what the very same query returns. Entries populated before the DDL kept being served after it.

```
  create table ls1 (..., x int not null default "1") properties("fast_schema_evolution"="true");
  -- 620 rows
  select c1, sum(x) from ls1 group by c1;   -- populates, sum = 620
  alter table ls1 drop column x;
  alter table ls1 add column x int not null default "7";
  select c1, sum(x) from ls1 group by c1;   -- returned 620, correct answer 4340
```

Verified on a cluster with a cold-cache control: the identical query after the same DDL returns 4340 when the entries were never populated beforehand, so this is the cache serving stale content rather than the query being miscomputed.

MaterializedIndexMeta.schemaId is what SchemaChangeHandler assigns on the fast path, and it is written to the digest only once it has actually diverged from the index it belongs to. A MaterializedIndexMeta starts with schemaId == indexMetaId and index_id is already in the digest, so for a table that was never altered the field would be a second copy of a value the key already carries -- but emitting it would still change the serialized bytes and invalidate every existing entry on upgrade for nothing. Written conditionally, an unaltered table's digest is byte-identical to before this change and only altered tables lose their entries. The added case checks both halves: the entry still hits before the DDL and the answer is fresh after it.

Unlike the other digest fixes in this series this is not two queries poisoning each other but one query poisoning itself across a DDL, which needs no concurrency to hit.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
