### PR TITLE
[BugFix] Do not cache a fragment whose plan defers columns to a lookup fragment

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/FetchNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FetchNode.java
@@ -21,6 +21,7 @@ import com.starrocks.server.WarehouseManager;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.thrift.TFetchNode;
 import com.starrocks.thrift.TNodesInfo;
+import com.starrocks.thrift.TNormalPlanNode;
 import com.starrocks.thrift.TPlanNode;
 import com.starrocks.thrift.TPlanNodeType;
 import com.starrocks.warehouse.cngroup.ComputeResource;
@@ -56,6 +57,24 @@ public class FetchNode extends PlanNode {
 
     public PlanNodeId getTargetNodeId() {
         return targetNodeId;
+    }
+
+    @Override
+    protected void toNormalForm(TNormalPlanNode planNode, FragmentNormalizer normalizer) {
+        // Global late materialization defers the wide columns to a lookup fragment that
+        // PlanFragmentBuilder moves into preExecutedFragments. That fragment is not a child of
+        // this node -- it is referenced by node id alone -- so normalizeSubTree() never reaches
+        // it, and neither the columns it fetches nor its own scan and predicates can enter the
+        // digest. The scan below here reads only row positions, identically whichever column the
+        // query ultimately wants, so nothing else distinguishes two plans that defer different
+        // columns either: they would share a cache key and the first to run would decide the
+        // second's answer.
+        //
+        // Normalizing this node alone would not be enough -- the lookup fragment would still be
+        // invisible -- so the fragment is marked uncacheable instead. Late materialization is a
+        // performance optimization, so the cost is losing the cache for these plans, not a wrong
+        // answer.
+        normalizer.setUncacheable(true);
     }
 
     @Override

--- a/test/sql/test_query_cache/R/test_query_cache_global_late_materialization
+++ b/test/sql/test_query_cache/R/test_query_cache_global_late_materialization
@@ -1,0 +1,114 @@
+-- name: test_query_cache_global_late_materialization
+CREATE TABLE gb (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE gw (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL,
+  s1 varchar(200),
+  s2 varchar(200)
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO gb
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, 50, 1
+FROM TABLE(generate_series(1, 620));
+-- result:
+-- !result
+INSERT INTO gw
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, generate_series, 1, repeat('a', 180), repeat('b', 100)
+FROM TABLE(generate_series(1, 200000));
+-- result:
+-- !result
+set pipeline_dop = 1;
+-- result:
+-- !result
+set query_cache_hot_partition_num = 100;
+-- result:
+-- !result
+set enable_global_late_materialization = true;
+-- result:
+-- !result
+set enable_global_late_materialization_cost_based = false;
+-- result:
+-- !result
+set enable_query_cache = false;
+-- result:
+-- !result
+select ifnull(sum(s),0) from (select gb.c1, sum(gb.v1) s from gb
+  join (select c1 as k, s1 from gw order by ts limit 10) b
+  on gb.ts > b.k and length(b.s1) = 180 group by gb.c1) x;
+-- result:
+6200
+-- !result
+select ifnull(sum(s),0) from (select gb.c1, sum(gb.v1) s from gb
+  join (select c1 as k, s2 from gw order by ts limit 10) b
+  on gb.ts > b.k and length(b.s2) = 180 group by gb.c1) x;
+-- result:
+0
+-- !result
+set enable_query_cache = true;
+-- result:
+-- !result
+select ifnull(sum(s),0) from (select gb.c1, sum(gb.v1) s from gb
+  join (select c1 as k, s1 from gw order by ts limit 10) b
+  on gb.ts > b.k and length(b.s1) = 180 group by gb.c1) x;
+-- result:
+6200
+-- !result
+select ifnull(sum(s),0) from (select gb.c1, sum(gb.v1) s from gb
+  join (select c1 as k, s2 from gw order by ts limit 10) b
+  on gb.ts > b.k and length(b.s2) = 180 group by gb.c1) x;
+-- result:
+0
+-- !result
+CREATE TABLE gb2 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO gb2
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, 50, 1
+FROM TABLE(generate_series(1, 620));
+-- result:
+-- !result
+set enable_query_cache = true;
+-- result:
+-- !result
+select ifnull(sum(s),0) from (select gb2.c1, sum(gb2.v1) s from gb2
+  join (select c1 as k, s2 from gw order by ts limit 10) b
+  on gb2.ts > b.k and length(b.s2) = 180 group by gb2.c1) x;
+-- result:
+0
+-- !result
+select ifnull(sum(s),0) from (select gb2.c1, sum(gb2.v1) s from gb2
+  join (select c1 as k, s1 from gw order by ts limit 10) b
+  on gb2.ts > b.k and length(b.s1) = 180 group by gb2.c1) x;
+-- result:
+6200
+-- !result

--- a/test/sql/test_query_cache/T/test_query_cache_global_late_materialization
+++ b/test/sql/test_query_cache/T/test_query_cache_global_late_materialization
@@ -1,0 +1,98 @@
+-- name: test_query_cache_global_late_materialization
+-- Global late materialization makes the scan emit row positions and defers the wide columns to a
+-- lookup fragment that PlanFragmentBuilder moves into preExecutedFragments -- it is not a child of
+-- the FetchNode, only referenced by node id, so normalizeSubTree() never walks it. FetchNode itself
+-- had no toNormalForm(), so it fell through to PlanNode's empty default, which sets not even a
+-- node_type.
+--
+-- The result: with GLM on, the scan reads the same row-position columns whichever wide column the
+-- query actually wants, the deferred column's identity lives only in the invisible lookup fragment,
+-- and two queries deferring DIFFERENT columns produce the same digest. Whichever ran first
+-- populated the per-tablet entries and the second inherited its answer.
+--
+-- The join must be below the aggregation so it sits inside a cached lane, and the build side must
+-- carry a wide column that the query really consumes (otherwise it is pruned and never deferred).
+CREATE TABLE gb (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1");
+
+-- s1 is 180 chars and s2 is 100, so length(...) = 180 selects every build row for s1 and none for s2.
+CREATE TABLE gw (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL,
+  s1 varchar(200),
+  s2 varchar(200)
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO gb
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, 50, 1
+FROM TABLE(generate_series(1, 620));
+
+INSERT INTO gw
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, generate_series, 1, repeat('a', 180), repeat('b', 100)
+FROM TABLE(generate_series(1, 200000));
+
+set pipeline_dop = 1;
+set query_cache_hot_partition_num = 100;
+-- The cost-based gate wants a TopN-with-limit or a limit-after-join at the plan root; this shape
+-- has an aggregation there, so GLM is forced on to reach the same plan a top-level LIMIT would.
+set enable_global_late_materialization = true;
+set enable_global_late_materialization_cost_based = false;
+
+-- Ground truth.
+set enable_query_cache = false;
+select ifnull(sum(s),0) from (select gb.c1, sum(gb.v1) s from gb
+  join (select c1 as k, s1 from gw order by ts limit 10) b
+  on gb.ts > b.k and length(b.s1) = 180 group by gb.c1) x;
+select ifnull(sum(s),0) from (select gb.c1, sum(gb.v1) s from gb
+  join (select c1 as k, s2 from gw order by ts limit 10) b
+  on gb.ts > b.k and length(b.s2) = 180 group by gb.c1) x;
+
+-- Cache on, s1 first: it populates the per-tablet entries, then s2 must NOT inherit them.
+set enable_query_cache = true;
+select ifnull(sum(s),0) from (select gb.c1, sum(gb.v1) s from gb
+  join (select c1 as k, s1 from gw order by ts limit 10) b
+  on gb.ts > b.k and length(b.s1) = 180 group by gb.c1) x;
+select ifnull(sum(s),0) from (select gb.c1, sum(gb.v1) s from gb
+  join (select c1 as k, s2 from gw order by ts limit 10) b
+  on gb.ts > b.k and length(b.s2) = 180 group by gb.c1) x;
+
+-- The other direction, on a table whose entries are still cold.
+CREATE TABLE gb2 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO gb2
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, 50, 1
+FROM TABLE(generate_series(1, 620));
+
+set enable_query_cache = true;
+select ifnull(sum(s),0) from (select gb2.c1, sum(gb2.v1) s from gb2
+  join (select c1 as k, s2 from gw order by ts limit 10) b
+  on gb2.ts > b.k and length(b.s2) = 180 group by gb2.c1) x;
+select ifnull(sum(s),0) from (select gb2.c1, sum(gb2.v1) s from gb2
+  join (select c1 as k, s1 from gw order by ts limit 10) b
+  on gb2.ts > b.k and length(b.s1) = 180 group by gb2.c1) x;


### PR DESCRIPTION


Global late materialization makes the scan emit row positions and defers the wide columns to a lookup fragment. PlanFragmentBuilder moves that fragment into preExecutedFragments and leaves only its node id behind, so it is not a child of the FetchNode and normalizeSubTree() never walks it: neither the columns it fetches nor its own scan and predicates can enter the digest. FetchNode itself had no toNormalForm(), so it fell through to PlanNode's empty default, which sets not even a node_type.

The scan below the FetchNode reads only row positions, identically whichever wide column the query ultimately wants, so nothing else distinguishes two plans that defer different columns. They shared a cache key, and whichever ran first decided the second's answer. Verified on a cluster, in both directions, with GLM as the only variable -- the same pair is correct with enable_global_late_ materialization off, and the plan then contains no FETCH:

```
  ... join (select c1 as k, s1 from gw order by ts limit 10) b
        on gb.ts > b.k and length(b.s1) = 180 ...   -- 6200
  ... same with s2 (100 chars, so nothing matches) ...  -- 6200, want 0
```

Normalizing FetchNode alone would not fix it, because the lookup fragment stays invisible, so the fragment is marked uncacheable instead. Late materialization is a performance optimization; the cost is losing the cache for these plans rather than returning a wrong answer.

Note for a follow-up: PlanNode.toNormalForm()'s default is an empty no-op, which makes the normalizer fail-open for every node type it does not explicitly support -- this bug is one instance. Making that default mark the fragment uncacheable would close the class, but RawValuesNode, SetOperationNode and ExchangeNode all call super.toNormalForm(), so they would have to stop doing so first or they would lose the cache too.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
