### PR TITLE
[BugFix] Put AggregationNode.localLimit into the query cache digest

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
@@ -553,6 +553,12 @@ public class AggregationNode extends PlanNode implements RuntimeFilterBuildNode 
         } else {
             aggrNode.setStreaming_preaggregation_mode(TStreamingPreaggregationMode.AUTO);
         }
+        // localLimit is a second, separate limit: toThrift() asserts !hasLimit() and then
+        // overwrites msg.limit with it, so PlanNode.normalize() -- which reads getLimit() --
+        // records -1 and the value never reaches the digest on its own.
+        if (localLimit > 0) {
+            aggrNode.setLocal_limit(localLimit);
+        }
         aggrNode.setAgg_func_set_version(FeConstants.AGG_FUNC_VERSION);
         planNode.setNode_type(TPlanNodeType.AGGREGATION_NODE);
         planNode.setAgg_node(aggrNode);

--- a/gensrc/thrift/Normalization.thrift
+++ b/gensrc/thrift/Normalization.thrift
@@ -44,6 +44,11 @@ struct TNormalAggregationNode {
   7: optional i32 agg_func_set_version = 1
   8: optional bool has_outer_join_child
   9: optional PlanNodes.TStreamingPreaggregationMode streaming_preaggregation_mode
+  // AggregationNode.localLimit, which is NOT PlanNode.limit -- toThrift() asserts !hasLimit()
+  // before overwriting msg.limit with it, so PlanNode.normalize() records -1 and the value is
+  // invisible to the digest. SplitTwoPhaseAggRule sets it on the local aggregation of a
+  // group-by-only split.
+  10: optional i64 local_limit
 }
 
 struct TNormalDecodeNode {


### PR DESCRIPTION
## Why I'm doing:

This is currently an unreachable path, and this PR is a defensive programming measure to prevent subsequent modifications from causing cache issues.

localLimit is a second, separate limit from PlanNode.limit: toThrift() asserts !hasLimit() and then overwrites msg.limit with it, so PlanNode.normalize() -- which reads getLimit() -- records -1 and the value never reaches the digest. SplitTwoPhaseAggRule sets it on the local aggregation of a group-by-only split.

This one is DEFENSIVE, and weaker than the other digest fixes in this series. What is demonstrated: two plans differing only in localLimit share a digest, in a shape that is cacheable -- a `select distinct ... limit N` subquery used as a join's build side, where the build side decides which rows the cached per-tablet aggregate is computed from. Disabling the line below makes that pair collide again, so the field is what separates them.

What is NOT demonstrated: a wrong result on a cluster. With real statistics the optimizer planned the same SQL differently -- the limit landed on the global `AGGREGATE (merge finalize)` as an ordinary PlanNode.limit, which the digest already captures -- so the collision did not translate into cache poisoning in any shape I could construct. An earlier attempt to reach it through the leftmost path is impossible for a separate reason: making the distinct sink truncate requires a limit below the per-lane distinct count, while letting the query run to completion (so entries are populated at all) requires a limit above the total distinct count, and the former is bounded by the latter.

So this closes a gap that is real at plan level and whose end-to-end reachability is unproven, rather than a bug with a repro. It is committed separately from the proven fixes so it can be dropped on its own.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
