### PR TITLE
[BugFix] Recover Iceberg REST catalog on 419/RESTException token expiry

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -473,16 +473,34 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         try {
             return action.get();
         } catch (RuntimeException e) {
-            if (!causedByNotAuthorized(e) || !tryRecoverAuthSession(e)) {
+            if (!causedByAuthFailure(e) || !tryRecoverAuthSession(e)) {
                 throw e;
             }
             return action.get();
         }
     }
 
-    // the view DDL default methods wrap the 401 in StarRocksConnectorException, so walk the cause chain
-    private static boolean causedByNotAuthorized(RuntimeException failure) {
-        return Throwables.getCausalChain(failure).stream().anyMatch(NotAuthorizedException.class::isInstance);
+    // Recover whenever the REST catalog rejects our OAuth2 token. Walk the cause chain because
+    // the view DDL default methods wrap the auth error in StarRocksConnectorException.
+    //
+    // The Iceberg REST spec defines two token-expiry responses, and both say the client MAY
+    // refresh and retry:
+    //   * HTTP 401 (UnauthorizedResponse) -> NotAuthorizedException.
+    //   * HTTP 419 (AuthenticationTimeoutResponse) -> not mapped by the Iceberg client, so it
+    //     surfaces as a generic RESTException ("Unable to process: Authentication token is expired").
+    // Treat either as recoverable and rebuild the session.
+    private static boolean causedByAuthFailure(RuntimeException failure) {
+        List<Throwable> chain = Throwables.getCausalChain(failure);
+        if (chain.stream().anyMatch(NotAuthorizedException.class::isInstance)) {
+            return true;
+        }
+        return chain.stream()
+                .filter(t -> t instanceof RESTException)
+                .anyMatch(t -> {
+                    String message = t.getMessage() == null ? "" : t.getMessage().toLowerCase();
+                    return message.contains("code: 419")
+                            || (message.contains("token") && message.contains("expired"));
+                });
     }
 
     private void runWithAuthRecovery(Runnable action) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalogAuthRecoveryHttpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalogAuthRecoveryHttpTest.java
@@ -50,6 +50,7 @@ public class IcebergRESTCatalogAuthRecoveryHttpTest {
     private final AtomicInteger tokenSequence = new AtomicInteger();
     private final AtomicInteger tokenFetches = new AtomicInteger();
     private volatile String validToken;
+    private volatile int rejectStatus = 401; // 419 = Iceberg REST AuthenticationTimeoutResponse
 
     @BeforeEach
     public void setUp() throws IOException {
@@ -74,10 +75,16 @@ public class IcebergRESTCatalogAuthRecoveryHttpTest {
             String auth = exchange.getRequestHeaders().getFirst("Authorization");
             String expected = validToken == null ? null : "Bearer " + validToken;
             if (expected == null || !expected.equals(auth)) {
-                // exact shape observed from Apache Polaris 1.1.0: bare 401, empty body, WWW-Authenticate: Bearer
-                exchange.getResponseHeaders().set("WWW-Authenticate", "Bearer");
-                exchange.sendResponseHeaders(401, -1);
-                exchange.close();
+                if (rejectStatus == 419) {
+                    // Iceberg REST 419 AuthenticationTimeoutResponse with an error body
+                    respond(exchange, 419, "{\"error\":{\"message\":\"Authentication token is expired\","
+                            + "\"type\":\"AuthenticationTimeoutException\",\"code\":419}}");
+                } else {
+                    // exact shape observed from Apache Polaris 1.1.0: bare 401, empty body, WWW-Authenticate: Bearer
+                    exchange.getResponseHeaders().set("WWW-Authenticate", "Bearer");
+                    exchange.sendResponseHeaders(401, -1);
+                    exchange.close();
+                }
             } else {
                 respond(exchange, 200, "{\"namespaces\":[[\"db1\"]]}");
             }
@@ -113,6 +120,27 @@ public class IcebergRESTCatalogAuthRecoveryHttpTest {
         Assertions.assertEquals(List.of("db1"), catalog.listAllDatabases(connectContext));
 
         // the server rotates its signing state: every token issued so far is now rejected with 401,
+        // while the client credential can still mint a fresh one
+        validToken = null;
+
+        Assertions.assertEquals(List.of("db1"), catalog.listAllDatabases(connectContext));
+        Assertions.assertTrue(tokenFetches.get() >= 2,
+                "recovery must have re-authenticated with the client credential, fetches=" + tokenFetches.get());
+    }
+
+    @Test
+    public void testRecoversWhenServerReturns419TokenExpired() {
+        rejectStatus = 419; // server returns 419 (Iceberg REST AuthenticationTimeoutResponse) for an expired token
+        String uri = "http://127.0.0.1:" + server.getAddress().getPort();
+        IcebergRESTCatalog catalog = new IcebergRESTCatalog("rest_catalog", new Configuration(),
+                ImmutableMap.of(
+                        "iceberg.catalog.uri", uri,
+                        "iceberg.catalog.security", "oauth2",
+                        "iceberg.catalog.oauth2.credential", "id:secret"));
+
+        Assertions.assertEquals(List.of("db1"), catalog.listAllDatabases(connectContext));
+
+        // the server rotates its signing state: every token issued so far is now rejected with 419,
         // while the client credential can still mint a fresh one
         validToken = null;
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalogAuthRecoveryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalogAuthRecoveryTest.java
@@ -98,6 +98,58 @@ public class IcebergRESTCatalogAuthRecoveryTest {
         };
     }
 
+    // The Iceberg REST spec's 419 (AuthenticationTimeoutResponse) is not mapped by the Iceberg
+    // client, so an expired token surfaces as a generic RESTException instead of a
+    // NotAuthorizedException (HTTP 401). Recovery must still fire on this shape. (#77546)
+    @Test
+    public void testTokenExpiredRestExceptionTriggersRebuildAndRetry() throws Exception {
+        new Expectations() {
+            {
+                restCatalog.loadNamespaceMetadata((SessionCatalog.SessionContext) any, (Namespace) any);
+                result = new RESTException("Unable to process: Authentication token is expired");
+                result = ImmutableMap.of("location", "s3://bucket/db1");
+            }
+        };
+
+        Database db = newOAuth2CredentialCatalog().getDB(connectContext, "db1");
+
+        Assertions.assertEquals("s3://bucket/db1", db.getLocation());
+        new Verifications() {
+            {
+                restCatalog.initialize(anyString, (Map<String, String>) any);
+                times = 2; // constructor + one auth-recovery rebuild
+                restCatalog.close();
+                times = 0; // replaced delegate left for GC (cached tables may still use its FileIO)
+            }
+        };
+    }
+
+    // Newer Iceberg versions include the status and error type in the fallback message
+    // (https://github.com/apache/iceberg/pull/14927). Recovery must also fire on that shape,
+    // including server texts that do not mention "token"/"expired" at all.
+    @Test
+    public void testEmbeddedCode419RestExceptionTriggersRebuildAndRetry() throws Exception {
+        new Expectations() {
+            {
+                restCatalog.loadNamespaceMetadata((SessionCatalog.SessionContext) any, (Namespace) any);
+                result = new RESTException(
+                        "Unable to process (code: 419, type: AuthenticationTimeoutException): "
+                                + "credentials are no longer valid");
+                result = ImmutableMap.of("location", "s3://bucket/db1");
+            }
+        };
+
+        Database db = newOAuth2CredentialCatalog().getDB(connectContext, "db1");
+
+        Assertions.assertEquals("s3://bucket/db1", db.getLocation());
+        new Verifications() {
+            {
+                restCatalog.initialize(anyString, (Map<String, String>) any);
+                times = 2; // constructor + one auth-recovery rebuild
+            }
+        };
+    }
+
     @Test
     public void testFailedRetryPropagatesAfterSingleRebuild() {
         new Expectations() {


### PR DESCRIPTION
## Why I'm doing:

#76457 made the Iceberg REST catalog auto-heal when its OAuth2 token gets rejected — rebuild the client
(fresh token) and retry. But it only kicks in on a **401** (`NotAuthorizedException`). The Iceberg REST
spec also defines **419** (`AuthenticationTimeoutResponse`) for an expired token, which the Iceberg client
turns into a generic `RESTException` (`"Authentication token is expired"`), so the heal never fires and
queries die until the FE restarts (#77546). Same gap on 3.5 / 4.0 / 4.1. (Full evidence in #77546.)

## What I'm doing:

Also recover when the failure is a token-expired `RESTException` (the spec's 419 shape), not just 401.
Renamed `causedByNotAuthorized()` → `causedByAuthFailure()` and broadened it. Reuses #76457's existing
single-flight, 1/min rebuild, so nothing new to worry about.

Fixes #77546

## What type of PR is this:

- [x] BugFix

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will auto-backport to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
