### PR TITLE
[BugFix] Do not cache a fragment containing an ASOF join

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
@@ -217,6 +217,28 @@ public class HashJoinNode extends JoinNode {
         hashJoinNode.setPartition_exprs(normalizer.normalizeOrderedExprs(partitionExprs));
         hashJoinNode.setOutput_columns(normalizer.remapIntegerSlotIds(outputSlots));
         hashJoinNode.setLate_materialization(enableLateMaterialization);
+        // An ASOF join's temporal condition is split out of the ON clause by PlanFragmentBuilder
+        // and is carried by neither eqJoinConjuncts nor otherJoinConjuncts, so nothing below
+        // normalizes it: `... and t.ts >= s.ts` and `... and t.ts > s.ts` produce the same digest
+        // while selecting different nearest matches, and the second query is served the first
+        // one's cached rows.
+        //
+        // The route in is a nested one. On the leftmost path an ASOF join is rejected outright --
+        // JoinOperator.isLeftTransform() lists INNER/LEFT_SEMI/LEFT_OUTER/LEFT_ANTI and was never
+        // extended to ASOF_INNER_JOIN/ASOF_LEFT_OUTER_JOIN, so isTransformJoin() is false. But
+        // isTransformJoin() is only consulted for joins ON the leftmost path; a join nested in a
+        // right subtree is filtered only by isCacheable(), which admits any HashJoinNode. An ASOF
+        // join in a build side therefore does sit inside the digested subtree, and it decides
+        // which rows the cached per-tablet aggregate is built from.
+        //
+        // The fragment is marked uncacheable rather than the condition being added to the digest.
+        // Normalizing it would work, but it buys a cache for a shape that only reaches the
+        // digested subtree by nesting, at the cost of a thrift field and of one more thing that
+        // has to be kept in step every time the ASOF representation changes. Refusing to cache
+        // cannot go stale: whatever an ASOF join grows next, it still will not be cached.
+        if (joinOp.isAsofJoin()) {
+            normalizer.setUncacheable(true);
+        }
         planNode.setHash_join_node(hashJoinNode);
         planNode.setNode_type(TPlanNodeType.HASH_JOIN_NODE);
         normalizeConjuncts(normalizer, planNode, conjuncts);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheAsofJoinConditionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheAsofJoinConditionTest.java
@@ -1,0 +1,106 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.common.FeConstants;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Objects;
+
+// PlanFragmentBuilder splits an ASOF join's temporal condition out of the ON clause into its own
+// field, so it is carried by neither eqJoinConjuncts nor otherJoinConjuncts and nothing normalizes
+// it. Two ASOF joins differing only in that condition would share a cache key, and a join inside
+// the digested subtree decides which rows the cached per-tablet aggregate is built from -- so a
+// fragment containing one is not cached at all.
+//
+// The two positions behave differently, and this file pins both:
+//   - on the leftmost path an ASOF join is rejected, because JoinOperator.isLeftTransform() lists
+//     INNER/LEFT_SEMI/LEFT_OUTER/LEFT_ANTI and was never extended to the ASOF operators;
+//   - nested in a build side isCacheable() alone decides, because isTransformJoin() is only
+//     consulted for joins ON the leftmost path -- and it takes any HashJoinNode. That is the
+//     position the guard exists for.
+//
+// End-to-end coverage lives in test/sql/test_query_cache/T/test_query_cache_asof_join_condition,
+// which populates the entries with one variant and reads them back with the other.
+public class QueryCacheAsofJoinConditionTest {
+    private static ConnectContext ctx;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        ctx = UtFrameUtils.createDefaultCtx();
+        ctx.getSessionVariable().setEnableQueryCache(true);
+        ctx.getSessionVariable().setOptimizerExecuteTimeout(30000);
+        ctx.getSessionVariable().setEnableRewriteSimpleAggToMetaScan(false);
+        FeConstants.runningUnitTest = true;
+        StarRocksAssert sa = new StarRocksAssert(ctx);
+        sa.withDatabase("qc_asof_db").useDatabase("qc_asof_db");
+        // Colocate, so an INNER join below the aggregation is a transform join
+        // (isLeftTransform() && !areBothSidesShuffled()) and stays cacheable.
+        for (String name : new String[] {"c1t", "c2t"}) {
+            sa.withTable("" +
+                    "CREATE TABLE " + name + "(\n" +
+                    "dt DATE NOT NULL,\n" +
+                    "c1 INT NOT NULL,\n" +
+                    "ts BIGINT NOT NULL,\n" +
+                    "v1 BIGINT NOT NULL\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`dt`, `c1`)\n" +
+                    "PARTITION BY RANGE(dt) (\n" +
+                    "  START (\"2022-01-01\") END (\"2022-02-01\") EVERY (INTERVAL 1 day))\n" +
+                    "DISTRIBUTED BY HASH(`c1`) BUCKETS 10\n" +
+                    "PROPERTIES(\"replication_num\" = \"1\", \"colocate_with\" = \"cg_qc_asof\");");
+        }
+    }
+
+    private boolean isCacheable(String sql) throws Exception {
+        ExecPlan plan = UtFrameUtils.getPlanAndFragment(ctx, sql).second;
+        return plan.getFragments().stream().map(PlanFragment::getCacheParam).anyMatch(Objects::nonNull);
+    }
+
+    private static final String AGG = "select a.c1, sum(a.v1) s from c1t a ";
+
+    @Test
+    public void testAsofJoinInABuildSideMakesTheFragmentUncacheable() throws Exception {
+        // The reachable position: nested in the right subtree, where isTransformJoin() is not
+        // consulted and isCacheable() alone decides. Without the guard this fragment is cacheable
+        // and the temporal condition is absent from its digest, so `>=` and `>` share an entry.
+        String outer = AGG + "join (select c.v1 as k from c2t x asof left join c2t c "
+                + "on x.c1 = c.c1 and x.ts %s c.ts) b on a.ts > b.k group by a.c1";
+        Assertions.assertFalse(isCacheable(String.format(outer, ">=")),
+                "an ASOF join in a build side reaches the digested subtree, so the fragment must "
+                        + "not be cached");
+        Assertions.assertFalse(isCacheable(String.format(outer, ">")),
+                "same for the strict operator");
+    }
+
+    @Test
+    public void testAsofJoinOnTheLeftmostPathStaysUncacheable() throws Exception {
+        // Pins the other half of the reachability story. Should isLeftTransform() ever be widened
+        // to the ASOF operators -- the omission looks accidental, since isOuterJoin(),
+        // isInnerJoin() and isLeftOuterJoin() were all made ASOF-aware -- this test fails and
+        // points at the field that already makes the widening safe.
+        String sql = AGG + "asof join c2t b on a.c1 = b.c1 and a.ts >= b.ts group by a.c1";
+        Assertions.assertFalse(isCacheable(sql),
+                "an ASOF join on the leftmost path is not a transform join, so the fragment must "
+                        + "stay uncacheable; if this changed, verify the ASOF condition is in the digest");
+    }
+}

--- a/test/sql/test_query_cache/R/test_query_cache_asof_join_condition
+++ b/test/sql/test_query_cache/R/test_query_cache_asof_join_condition
@@ -1,0 +1,116 @@
+-- name: test_query_cache_asof_join_condition
+CREATE TABLE af1 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE av1 (c1 int NOT NULL, ts bigint NOT NULL)
+ENGINE=OLAP DUPLICATE KEY(c1) DISTRIBUTED BY HASH(c1) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE av2 (c1 int NOT NULL, ts bigint NOT NULL, v1 bigint NOT NULL)
+ENGINE=OLAP DUPLICATE KEY(c1, ts) DISTRIBUTED BY HASH(c1) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO af1
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, 50, 1
+FROM TABLE(generate_series(1, 620));
+-- result:
+-- !result
+INSERT INTO av1 VALUES (1,100),(2,100),(3,100),(4,100),(5,100),(6,100),(7,100),(8,100);
+-- result:
+-- !result
+INSERT INTO av2 VALUES
+ (1,100,10),(2,100,10),(3,100,10),(4,100,10),(5,100,10),(6,100,10),(7,100,10),(8,100,10),
+ (1,50,999),(2,50,999),(3,50,999),(4,50,999),(5,50,999),(6,50,999),(7,50,999),(8,50,999);
+-- result:
+-- !result
+set pipeline_dop = 1;
+-- result:
+-- !result
+set query_cache_hot_partition_num = 100;
+-- result:
+-- !result
+select group_concat(distinct cast(k as string)) from
+ (select c.v1 as k from av1 a asof left join av2 c on a.c1 = c.c1 and a.ts >= c.ts) t;
+-- result:
+10
+-- !result
+select group_concat(distinct cast(k as string)) from
+ (select c.v1 as k from av1 a asof left join av2 c on a.c1 = c.c1 and a.ts > c.ts) t;
+-- result:
+999
+-- !result
+set enable_query_cache = false;
+-- result:
+-- !result
+select ifnull(sum(s),0) from (select af1.c1, sum(af1.v1) s from af1
+  join (select c.v1 as k from av1 a asof left join av2 c on a.c1 = c.c1 and a.ts >= c.ts) b
+  on af1.ts > b.k group by af1.c1) x;
+-- result:
+4960
+-- !result
+select ifnull(sum(s),0) from (select af1.c1, sum(af1.v1) s from af1
+  join (select c.v1 as k from av1 a asof left join av2 c on a.c1 = c.c1 and a.ts > c.ts) b
+  on af1.ts > b.k group by af1.c1) x;
+-- result:
+0
+-- !result
+set enable_query_cache = true;
+-- result:
+-- !result
+select ifnull(sum(s),0) from (select af1.c1, sum(af1.v1) s from af1
+  join (select c.v1 as k from av1 a asof left join av2 c on a.c1 = c.c1 and a.ts >= c.ts) b
+  on af1.ts > b.k group by af1.c1) x;
+-- result:
+4960
+-- !result
+select ifnull(sum(s),0) from (select af1.c1, sum(af1.v1) s from af1
+  join (select c.v1 as k from av1 a asof left join av2 c on a.c1 = c.c1 and a.ts > c.ts) b
+  on af1.ts > b.k group by af1.c1) x;
+-- result:
+0
+-- !result
+CREATE TABLE af2 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO af2
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, 50, 1
+FROM TABLE(generate_series(1, 620));
+-- result:
+-- !result
+set enable_query_cache = true;
+-- result:
+-- !result
+select ifnull(sum(s),0) from (select af2.c1, sum(af2.v1) s from af2
+  join (select c.v1 as k from av1 a asof left join av2 c on a.c1 = c.c1 and a.ts > c.ts) b
+  on af2.ts > b.k group by af2.c1) x;
+-- result:
+0
+-- !result
+select ifnull(sum(s),0) from (select af2.c1, sum(af2.v1) s from af2
+  join (select c.v1 as k from av1 a asof left join av2 c on a.c1 = c.c1 and a.ts >= c.ts) b
+  on af2.ts > b.k group by af2.c1) x;
+-- result:
+4960
+-- !result

--- a/test/sql/test_query_cache/T/test_query_cache_asof_join_condition
+++ b/test/sql/test_query_cache/T/test_query_cache_asof_join_condition
@@ -1,0 +1,99 @@
+-- name: test_query_cache_asof_join_condition
+-- The ASOF temporal condition is split out of the ON clause by PlanFragmentBuilder and is carried
+-- by neither eqJoinConjuncts nor otherJoinConjuncts, so it has to be normalized on its own or two
+-- ASOF joins differing only in it share a query cache key.
+--
+-- Three things must line up, and getting any one wrong hides the bug rather than removing it:
+--   1. the ASOF join must sit in a join's BUILD SIDE. On the leftmost path isTransformJoin()
+--      rejects it outright (JoinOperator.isLeftTransform() does not list the ASOF operators), but
+--      isTransformJoin() is only consulted for joins ON the leftmost path -- a join nested in a
+--      right subtree is filtered only by isCacheable(), which admits any HashJoinNode;
+--   2. the temporal column needs EXACT TIES, so that `>=` and `>` select different rows;
+--   3. the query must select a column from the matched (right) side. Under ASOF LEFT JOIN every
+--      probe row survives, so selecting only left-side columns gives identical results either way.
+CREATE TABLE af1 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1");
+
+CREATE TABLE av1 (c1 int NOT NULL, ts bigint NOT NULL)
+ENGINE=OLAP DUPLICATE KEY(c1) DISTRIBUTED BY HASH(c1) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+CREATE TABLE av2 (c1 int NOT NULL, ts bigint NOT NULL, v1 bigint NOT NULL)
+ENGINE=OLAP DUPLICATE KEY(c1, ts) DISTRIBUTED BY HASH(c1) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- af1.ts is 50 everywhere, so a build-side key of 10 matches every row and 999 matches none.
+INSERT INTO af1
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, 50, 1
+FROM TABLE(generate_series(1, 620));
+
+INSERT INTO av1 VALUES (1,100),(2,100),(3,100),(4,100),(5,100),(6,100),(7,100),(8,100);
+
+-- Exact tie at ts = 100 (v1 = 10) plus an earlier row at ts = 50 (v1 = 999):
+--   a.ts >= c.ts  takes the tie     -> 10
+--   a.ts >  c.ts  excludes the tie  -> 999
+INSERT INTO av2 VALUES
+ (1,100,10),(2,100,10),(3,100,10),(4,100,10),(5,100,10),(6,100,10),(7,100,10),(8,100,10),
+ (1,50,999),(2,50,999),(3,50,999),(4,50,999),(5,50,999),(6,50,999),(7,50,999),(8,50,999);
+
+set pipeline_dop = 1;
+set query_cache_hot_partition_num = 100;
+
+-- The two operators really do pick different rows.
+select group_concat(distinct cast(k as string)) from
+ (select c.v1 as k from av1 a asof left join av2 c on a.c1 = c.c1 and a.ts >= c.ts) t;
+select group_concat(distinct cast(k as string)) from
+ (select c.v1 as k from av1 a asof left join av2 c on a.c1 = c.c1 and a.ts > c.ts) t;
+
+-- Ground truth.
+set enable_query_cache = false;
+select ifnull(sum(s),0) from (select af1.c1, sum(af1.v1) s from af1
+  join (select c.v1 as k from av1 a asof left join av2 c on a.c1 = c.c1 and a.ts >= c.ts) b
+  on af1.ts > b.k group by af1.c1) x;
+select ifnull(sum(s),0) from (select af1.c1, sum(af1.v1) s from af1
+  join (select c.v1 as k from av1 a asof left join av2 c on a.c1 = c.c1 and a.ts > c.ts) b
+  on af1.ts > b.k group by af1.c1) x;
+
+-- Cache on, `>=` first: it populates the per-tablet entries, then `>` must NOT inherit them.
+set enable_query_cache = true;
+select ifnull(sum(s),0) from (select af1.c1, sum(af1.v1) s from af1
+  join (select c.v1 as k from av1 a asof left join av2 c on a.c1 = c.c1 and a.ts >= c.ts) b
+  on af1.ts > b.k group by af1.c1) x;
+select ifnull(sum(s),0) from (select af1.c1, sum(af1.v1) s from af1
+  join (select c.v1 as k from av1 a asof left join av2 c on a.c1 = c.c1 and a.ts > c.ts) b
+  on af1.ts > b.k group by af1.c1) x;
+
+-- The other direction, on a table whose entries are cold, so the failure cannot hide behind
+-- whichever order happened to run first.
+CREATE TABLE af2 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO af2
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, 50, 1
+FROM TABLE(generate_series(1, 620));
+
+set enable_query_cache = true;
+select ifnull(sum(s),0) from (select af2.c1, sum(af2.v1) s from af2
+  join (select c.v1 as k from av1 a asof left join av2 c on a.c1 = c.c1 and a.ts > c.ts) b
+  on af2.ts > b.k group by af2.c1) x;
+select ifnull(sum(s),0) from (select af2.c1, sum(af2.v1) s from af2
+  join (select c.v1 as k from av1 a asof left join av2 c on a.c1 = c.c1 and a.ts >= c.ts) b
+  on af2.ts > b.k group by af2.c1) x;


### PR DESCRIPTION
## Why I'm doing:

PlanFragmentBuilder splits an ASOF join's temporal condition out of the ON
clause into TAsofJoinCondition, so it is carried by neither eqJoinConjuncts nor
otherJoinConjuncts and toNormalForm() never saw it. Two ASOF joins differing
only in that condition therefore produced the same query cache digest:

    ... asof left join c on a.c1 = c.c1 and a.ts >= c.ts
    ... asof left join c on a.c1 = c.c1 and a.ts >  c.ts

`>=` and `>` pick different nearest matches whenever the temporal column has
exact ties, so the two queries have different answers while sharing a cache key.
A join inside the digested subtree decides which rows the cached per-tablet
aggregate is built from, so whichever query ran first populated the entries and
the second silently inherited its answer. Verified on a cluster, in both
directions and on cold tables: 4960 versus 0.

The route in is a nested one, and it is worth being precise about because the
two positions behave differently:

  - on the leftmost path an ASOF join is rejected outright, because
    JoinOperator.isLeftTransform() lists INNER/LEFT_SEMI/LEFT_OUTER/LEFT_ANTI
    and was never extended to ASOF_INNER_JOIN/ASOF_LEFT_OUTER_JOIN, which makes
    isTransformJoin() false;
  - isTransformJoin() is only consulted for joins ON the leftmost path. A join
    nested in a right subtree is filtered only by isCacheable(), which admits
    any HashJoinNode -- so an ASOF join in a build side does reach the digested
    subtree. That is the shape the end-to-end case uses.

The fragment is marked uncacheable rather than the temporal condition being
added to the digest. Normalizing it would work and was the first version of this
change, but it buys a cache for a shape that only reaches the digested subtree
by nesting, and it pays for that with a new thrift field plus one more thing
that has to be kept in step every time the ASOF representation changes -- the
condition moved out of the conjunct lists once already, which is how this bug
happened. Refusing to cache cannot go stale in that way. It also means the
whitelist above can be widened to the ASOF operators later without a correctness
question attached, since a fragment holding one is not cached from either
position.

The end-to-end case populates the per-tablet entries with one variant and reads
them back with the other, in both directions, so a failure cannot hide behind
whichever order ran first. It needs exact ties on the temporal column, and must
select a column from the matched side: under ASOF LEFT JOIN every probe row
survives, so selecting only left-side columns gives the same answer either way.

Signed-off-by: Hyper-FF <253014618+Hyper-FF@users.noreply.github.com>

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
