### PR TITLE
[BugFix] Fix BE crash when query cache reuses a lane for a partitioned hash join

### DIFF
--- a/be/src/exec/hash_join_components.cpp
+++ b/be/src/exec/hash_join_components.cpp
@@ -364,6 +364,7 @@ void PartitionedHashJoinProberImpl::reset(RuntimeState* runtime_state) {
     }
     _partition_input_channels.clear();
     _mem_tracker.release(_mem_tracker.consumption());
+    _partition_input_channels.resize(_probers.size(), PartitionChunkChannel(&_mem_tracker));
     _all_input_finished = false;
     _remain_partition_idx = 0;
 }

--- a/test/sql/test_join/R/test_partition_join_query_cache_lane_reset
+++ b/test/sql/test_join/R/test_partition_join_query_cache_lane_reset
@@ -1,0 +1,38 @@
+-- name: test_partition_join_query_cache_lane_reset @sequential
+CREATE TABLE `fact` (
+  `dt` date NOT NULL,
+  `c3` int(11) NOT NULL,
+  `v1` int(11) NOT NULL,
+  `flag` int(11) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`, `c3`)
+PARTITION BY RANGE(`dt`) (START ("2022-01-01") END ("2022-02-10") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(`c3`) BUCKETS 4
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE `dim` (
+  `c3` int(11) NOT NULL,
+  `w1` int(11) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c3`)
+DISTRIBUTED BY HASH(`c3`) BUCKETS 2
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+insert into fact select date_add('2022-01-01', interval (i%40) day), i%1000, i%500, if((i%40)<20,1,0) from table(generate_series(1,50000)) t(i);
+-- result:
+-- !result
+insert into dim select i, i from table(generate_series(1,1000)) t(i);
+-- result:
+-- !result
+admin enable failpoint 'always_use_partition_join';
+-- result:
+-- !result
+select /*+SET_VAR(enable_query_cache=true,pipeline_dop=4,chunk_size=8)*/ sum(fact.v1) from fact join [broadcast] dim on fact.c3 = dim.c3 where fact.flag = 1;
+-- result:
+6237500
+-- !result
+CLEANUP {
+  admin disable failpoint 'always_use_partition_join';
+} END CLEANUP

--- a/test/sql/test_join/T/test_partition_join_query_cache_lane_reset
+++ b/test/sql/test_join/T/test_partition_join_query_cache_lane_reset
@@ -1,0 +1,39 @@
+-- name: test_partition_join_query_cache_lane_reset @sequential
+
+-- Query cache reuses a lane across tablets. A tablet that is scanned but has every row filtered
+-- out pushes no chunk at all, so the probe side must still be able to index the partition channels
+-- after the lane is reset.
+
+CREATE TABLE `fact` (
+  `dt` date NOT NULL,
+  `c3` int(11) NOT NULL,
+  `v1` int(11) NOT NULL,
+  `flag` int(11) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`, `c3`)
+PARTITION BY RANGE(`dt`) (START ("2022-01-01") END ("2022-02-10") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(`c3`) BUCKETS 4
+PROPERTIES("replication_num" = "1");
+
+CREATE TABLE `dim` (
+  `c3` int(11) NOT NULL,
+  `w1` int(11) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c3`)
+DISTRIBUTED BY HASH(`c3`) BUCKETS 2
+PROPERTIES("replication_num" = "1");
+
+-- flag=1 only lands in the first half of the partitions, so the other half is scanned but yields
+-- no row, which is what leaves a lane reset with no chunk pushed after it.
+insert into fact select date_add('2022-01-01', interval (i%40) day), i%1000, i%500, if((i%40)<20,1,0) from table(generate_series(1,50000)) t(i);
+insert into dim select i, i from table(generate_series(1,1000)) t(i);
+
+admin enable failpoint 'always_use_partition_join';
+
+-- chunk_size is kept small so a partition channel reaches its 4-chunk limit and marks itself as
+-- processing before the lane is reset.
+select /*+SET_VAR(enable_query_cache=true,pipeline_dop=4,chunk_size=8)*/ sum(fact.v1) from fact join [broadcast] dim on fact.c3 = dim.c3 where fact.flag = 1;
+
+CLEANUP {
+  admin disable failpoint 'always_use_partition_join';
+} END CLEANUP


### PR DESCRIPTION
## Why I'm doing:

A partitioned hash join splits the probe side into N partitions. For that the prober keeps two vectors, _probers and _partition_input_channels, both indexed by the same partition id, so they must always have the same length.

Query cache caches results per tablet, so it gives each tablet its own lane and reuses that lane for the next tablet by sending reset_state() down the operator chain, a call that ends up in PartitionedHashJoinProberImpl::reset().

That reset breaks the invariant: the probers are reset in place and still number N, while the channels are wiped by clear(). push_probe_chunk() resizes the channels back before using them, so as long as a chunk arrives after the reset, the mismatch stays invisible.

But a tablet whose rows are all filtered out never pushes a chunk, it only emits an EOF marker. The channels are therefore never rebuilt, and probe_chunk() indexes the destroyed channels out of bounds, trusts the stale _processing flag left behind in the freed memory, and pulls from a freed deque, which crashes the BE.

## What I'm doing:

Rebuild _partition_input_channels right after clearing it, so that it stays the same length as _probers.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
