### PR TITLE
[BugFix] Put join predicate common sub-expressions into the query cache digest

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
@@ -35,6 +35,7 @@
 package com.starrocks.planner;
 
 import com.starrocks.common.Config;
+import com.starrocks.common.Pair;
 import com.starrocks.planner.expression.ExprOpcodeRegistry;
 import com.starrocks.planner.expression.ExprToThrift;
 import com.starrocks.qe.ConnectContext;
@@ -53,6 +54,7 @@ import com.starrocks.thrift.TNormalPlanNode;
 import com.starrocks.thrift.TPlanNode;
 import com.starrocks.thrift.TPlanNodeType;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -217,6 +219,15 @@ public class HashJoinNode extends JoinNode {
         hashJoinNode.setPartition_exprs(normalizer.normalizeOrderedExprs(partitionExprs));
         hashJoinNode.setOutput_columns(normalizer.remapIntegerSlotIds(outputSlots));
         hashJoinNode.setLate_materialization(enableLateMaterialization);
+        // Same reasoning as NestLoopJoinNode: the conjuncts reference these definitions by slot id.
+        // A HashJoinNode reaches the digested subtree under narrower conditions (isTransformJoin()
+        // also demands a left-transform op and a non-shuffled distribution), and no probe of mine
+        // made this one collide, but the omission is identical and costs nothing to close.
+        if (commonSlotMap != null) {
+            Pair<List<Integer>, List<ByteBuffer>> cse = normalizer.normalizeSlotIdsAndExprs(commonSlotMap);
+            hashJoinNode.setCse_slot_ids(cse.first);
+            hashJoinNode.setCse_exprs(cse.second);
+        }
         planNode.setHash_join_node(hashJoinNode);
         planNode.setNode_type(TPlanNodeType.HASH_JOIN_NODE);
         normalizeConjuncts(normalizer, planNode, conjuncts);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/NestLoopJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/NestLoopJoinNode.java
@@ -16,6 +16,7 @@ package com.starrocks.planner;
 
 import com.google.common.base.Preconditions;
 import com.starrocks.common.IdGenerator;
+import com.starrocks.common.Pair;
 import com.starrocks.planner.expression.ExprToThrift;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
@@ -34,6 +35,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -148,6 +150,16 @@ public class NestLoopJoinNode extends JoinNode implements RuntimeFilterBuildNode
         TNormalNestLoopJoinNode nlJoinNode = new TNormalNestLoopJoinNode();
         nlJoinNode.setJoin_op(ExprToThrift.joinOperatorToThrift(getJoinOp()));
         nlJoinNode.setJoin_conjuncts(normalizer.normalizeExprs(otherJoinConjuncts));
+        // join_conjuncts above reference the predicate's common sub-expressions by slot id, so the
+        // definitions have to be normalized too -- otherwise `(t.ts % 7) > s.a and (t.ts % 7) < s.b`
+        // and the same predicate with % 9 produce the same digest, and since isTransformJoin() is
+        // unconditionally true for a NestLoopJoinNode this node sits inside the digested subtree and
+        // decides which rows the cached per-tablet aggregate is built from.
+        if (commonSlotMap != null) {
+            Pair<List<Integer>, List<ByteBuffer>> cse = normalizer.normalizeSlotIdsAndExprs(commonSlotMap);
+            nlJoinNode.setCse_slot_ids(cse.first);
+            nlJoinNode.setCse_exprs(cse.second);
+        }
         planNode.setNestloop_join_node(nlJoinNode);
         planNode.setNode_type(TPlanNodeType.NESTLOOP_JOIN_NODE);
         normalizeConjuncts(normalizer, planNode, conjuncts);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheJoinPredicateCseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheJoinPredicateCseTest.java
@@ -1,0 +1,114 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.common.FeConstants;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.thrift.TCacheParam;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Objects;
+import java.util.Optional;
+
+// A join predicate's common sub-expressions are factored out into JoinNode.commonSlotMap, and the
+// join conjuncts then reference them by slot id alone. If the digest does not carry the definitions,
+// two joins whose predicates differ only inside a factored-out subexpression share a cache key --
+// and a JoinNode below the aggregation is inside the cached subtree, so it decides which rows the
+// cached per-tablet aggregate is computed from. The result is that whichever query runs first
+// populates the entries and the second one silently inherits its answer.
+//
+// Three things have to line up for this to be reachable, and getting any of them wrong makes the
+// bug invisible rather than absent:
+//   1. the join must sit BELOW the aggregation (above it, it is outside the digested subtree);
+//   2. both bounds must reference the other side of the join. With literal bounds the whole
+//      predicate is pushed into the right scan and never becomes a join predicate at all, so the
+//      subexpression reaches the digest through the scan's conjuncts and the digests differ for a
+//      reason that has nothing to do with commonSlotMap;
+//   3. the subexpression must appear twice, or it is never factored out into commonSlotMap.
+//
+// End-to-end coverage lives in test/sql/test_query_cache/T/test_query_cache_join_predicate_cse.
+public class QueryCacheJoinPredicateCseTest {
+    private static ConnectContext ctx;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        ctx = UtFrameUtils.createDefaultCtx();
+        ctx.getSessionVariable().setEnableQueryCache(true);
+        ctx.getSessionVariable().setOptimizerExecuteTimeout(30000);
+        ctx.getSessionVariable().setEnableRewriteSimpleAggToMetaScan(false);
+        FeConstants.runningUnitTest = true;
+        StarRocksAssert sa = new StarRocksAssert(ctx);
+        sa.withDatabase("qc_cse_db").useDatabase("qc_cse_db");
+        // Colocate, so an INNER join below the aggregation is a transform join
+        // (isLeftTransform() && !areBothSidesShuffled()) and stays cacheable.
+        for (String name : new String[] {"c1t", "c2t"}) {
+            sa.withTable("" +
+                    "CREATE TABLE " + name + "(\n" +
+                    "dt DATE NOT NULL,\n" +
+                    "c1 INT NOT NULL,\n" +
+                    "ts BIGINT NOT NULL,\n" +
+                    "v1 BIGINT NOT NULL\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`dt`, `c1`)\n" +
+                    "PARTITION BY RANGE(dt) (\n" +
+                    "  START (\"2022-01-01\") END (\"2022-02-01\") EVERY (INTERVAL 1 day))\n" +
+                    "DISTRIBUTED BY HASH(`c1`) BUCKETS 10\n" +
+                    "PROPERTIES(\"replication_num\" = \"1\", \"colocate_with\" = \"cg_qc_cse\");");
+        }
+    }
+
+    private byte[] digestOf(String sql) throws Exception {
+        ExecPlan plan = UtFrameUtils.getPlanAndFragment(ctx, sql).second;
+        Optional<TCacheParam> param = plan.getFragments().stream().map(PlanFragment::getCacheParam)
+                .filter(Objects::nonNull).findFirst();
+        return param.orElseThrow(() -> new AssertionError("expected a cacheable plan for: " + sql)).getDigest();
+    }
+
+    private static final String AGG = "select a.c1, sum(a.v1) s from c1t a ";
+
+    @Test
+    public void testNestLoopJoinPredicateCseIsPartOfTheDigest() throws Exception {
+        // No equi conjunct -> NestLoopJoinNode, which isTransformJoin() accepts unconditionally,
+        // so this is the shape with the widest reach.
+        String mod7 = AGG + "join c2t b on (b.ts % 7) > a.ts and (b.ts % 7) < a.v1 group by a.c1";
+        String mod9 = AGG + "join c2t b on (b.ts % 9) > a.ts and (b.ts % 9) < a.v1 group by a.c1";
+
+        Assertions.assertFalse(java.util.Arrays.equals(digestOf(mod7), digestOf(mod9)),
+                "two nest loop joins whose predicate CSE differs must not share a cache key");
+
+        // Guard against the assertion passing for the wrong reason: the same shape with an
+        // unchanged predicate must still be stable.
+        Assertions.assertArrayEquals(digestOf(mod7), digestOf(mod7),
+                "the digest must be stable for an unchanged plan");
+    }
+
+    @Test
+    public void testHashJoinPredicateCseIsPartOfTheDigest() throws Exception {
+        // Equi conjunct -> HashJoinNode. Bounds still reference the left side so the residual
+        // predicate cannot be pushed into the right scan.
+        String mod7 = AGG + "join c2t b on a.c1 = b.c1 and (b.ts % 7) > a.ts and (b.ts % 7) < a.v1 group by a.c1";
+        String mod9 = AGG + "join c2t b on a.c1 = b.c1 and (b.ts % 9) > a.ts and (b.ts % 9) < a.v1 group by a.c1";
+
+        Assertions.assertFalse(java.util.Arrays.equals(digestOf(mod7), digestOf(mod9)),
+                "two hash joins whose predicate CSE differs must not share a cache key");
+    }
+
+}

--- a/gensrc/thrift/Normalization.thrift
+++ b/gensrc/thrift/Normalization.thrift
@@ -63,12 +63,27 @@ struct TNormalHashJoinNode {
   6: optional list<binary> partition_exprs
   7: optional list<Types.TSlotId> output_columns
   8: optional bool late_materialization
+  // Same commonSlotMap omission as TNormalNestLoopJoinNode above.
+  //
+  // 9 is reserved and unused. It was claimed by a sibling fix for the ASOF temporal condition,
+  // which sits outside the conjunct lists in the same way; that fix ended up marking the fragment
+  // uncacheable instead and needs no field at all. The ordinal is left alone rather than reused,
+  // so that the numbering here does not depend on which of the two changes landed first.
+  10: optional list<Types.TSlotId> cse_slot_ids
+  11: optional list<binary> cse_exprs
 }
 
 
 struct TNormalNestLoopJoinNode {
   1: optional PlanNodes.TJoinOp join_op
   2: optional list<binary> join_conjuncts
+  // Common sub-expressions of the join predicate. join_conjuncts reference these by slot id
+  // only, so without their definitions two joins whose predicates share a shape but differ in
+  // a factored-out subexpression -- `(t.ts % 7) > s.a and (t.ts % 7) < s.b` versus the same
+  // with % 9 -- normalize identically. A NestLoopJoinNode is always a transform join, so it
+  // sits inside the digested subtree and decides which rows the cached aggregate is built from.
+  3: optional list<Types.TSlotId> cse_slot_ids
+  4: optional list<binary> cse_exprs
 }
 
 

--- a/test/sql/test_query_cache/R/test_query_cache_join_predicate_cse
+++ b/test/sql/test_query_cache/R/test_query_cache_join_predicate_cse
@@ -1,0 +1,139 @@
+-- name: test_query_cache_join_predicate_cse
+CREATE TABLE n1 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1", "colocate_with" = "cg_nlj_${uuid0}");
+-- result:
+-- !result
+CREATE TABLE n2 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1", "colocate_with" = "cg_nlj_${uuid0}");
+-- result:
+-- !result
+INSERT INTO n1
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, 0, 100
+FROM TABLE(generate_series(1, 620));
+-- result:
+-- !result
+INSERT INTO n2
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, generate_series, 1
+FROM TABLE(generate_series(1, 63));
+-- result:
+-- !result
+set pipeline_dop = 1;
+-- result:
+-- !result
+set query_cache_hot_partition_num = 100;
+-- result:
+-- !result
+set enable_query_cache = false;
+-- result:
+-- !result
+select sum(s) from (select n1.c1, sum(n1.v1) s from n1 join n2
+  on (n2.ts % 7) > n1.ts and (n2.ts % 7) < n1.v1 group by n1.c1) x;
+-- result:
+3348000
+-- !result
+select sum(s) from (select n1.c1, sum(n1.v1) s from n1 join n2
+  on (n2.ts % 9) > n1.ts and (n2.ts % 9) < n1.v1 group by n1.c1) x;
+-- result:
+3472000
+-- !result
+set enable_query_cache = true;
+-- result:
+-- !result
+select sum(s) from (select n1.c1, sum(n1.v1) s from n1 join n2
+  on (n2.ts % 7) > n1.ts and (n2.ts % 7) < n1.v1 group by n1.c1) x;
+-- result:
+3348000
+-- !result
+select sum(s) from (select n1.c1, sum(n1.v1) s from n1 join n2
+  on (n2.ts % 9) > n1.ts and (n2.ts % 9) < n1.v1 group by n1.c1) x;
+-- result:
+3472000
+-- !result
+CREATE TABLE n3 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1", "colocate_with" = "cg_nlj3_${uuid0}");
+-- result:
+-- !result
+CREATE TABLE n4 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1", "colocate_with" = "cg_nlj3_${uuid0}");
+-- result:
+-- !result
+INSERT INTO n3
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, 0, 100
+FROM TABLE(generate_series(1, 620));
+-- result:
+-- !result
+INSERT INTO n4
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, generate_series, 1
+FROM TABLE(generate_series(1, 63));
+-- result:
+-- !result
+set enable_query_cache = true;
+-- result:
+-- !result
+select sum(s) from (select n3.c1, sum(n3.v1) s from n3 join n4
+  on (n4.ts % 9) > n3.ts and (n4.ts % 9) < n3.v1 group by n3.c1) x;
+-- result:
+3472000
+-- !result
+select sum(s) from (select n3.c1, sum(n3.v1) s from n3 join n4
+  on (n4.ts % 7) > n3.ts and (n4.ts % 7) < n3.v1 group by n3.c1) x;
+-- result:
+3348000
+-- !result
+set enable_query_cache = true;
+-- result:
+-- !result
+select sum(s) from (select n1.c1, sum(n1.v1) s from n1 join n2
+  on n1.c1 = n2.c1 and (n2.ts % 7) > n1.ts and (n2.ts % 7) < n1.v1 group by n1.c1) x;
+-- result:
+418600
+-- !result
+select sum(s) from (select n1.c1, sum(n1.v1) s from n1 join n2
+  on n1.c1 = n2.c1 and (n2.ts % 9) > n1.ts and (n2.ts % 9) < n1.v1 group by n1.c1) x;
+-- result:
+434000
+-- !result
+set enable_query_cache = false;
+-- result:
+-- !result
+select sum(s) from (select n1.c1, sum(n1.v1) s from n1 join n2
+  on n1.c1 = n2.c1 and (n2.ts % 9) > n1.ts and (n2.ts % 9) < n1.v1 group by n1.c1) x;
+-- result:
+434000
+-- !result

--- a/test/sql/test_query_cache/T/test_query_cache_join_predicate_cse
+++ b/test/sql/test_query_cache/T/test_query_cache_join_predicate_cse
@@ -1,0 +1,115 @@
+-- name: test_query_cache_join_predicate_cse
+-- A join predicate's common sub-expressions are factored out into JoinNode.commonSlotMap,
+-- and the join conjuncts then reference them by slot id alone. When those definitions are
+-- missing from the digest, two joins whose predicates differ only inside a factored-out
+-- subexpression share a cache key -- and a join below the cache interpolation point is
+-- inside the digested subtree, so it decides which rows the cached per-tablet aggregate is
+-- computed from. Whichever query runs first populates the entries and the second silently
+-- inherits its answer.
+--
+-- Three things must line up, and getting any one wrong hides the bug rather than removing it:
+--   1. the join sits BELOW the aggregation (above it, it is outside the digested subtree);
+--   2. both bounds reference the other side of the join -- with literal bounds the whole
+--      predicate is pushed into the right scan and never becomes a join predicate at all;
+--   3. the subexpression appears twice, or it is never factored out into commonSlotMap.
+CREATE TABLE n1 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1", "colocate_with" = "cg_nlj_${uuid0}");
+
+CREATE TABLE n2 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1", "colocate_with" = "cg_nlj_${uuid0}");
+
+-- ts = 0 and v1 = 100, so the join condition reduces to 0 < (n2.ts % M) < 100 and matches
+-- whenever the modulus is non-zero: 54 of 63 rows for %7, 56 of 63 for %9.
+INSERT INTO n1
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, 0, 100
+FROM TABLE(generate_series(1, 620));
+
+INSERT INTO n2
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, generate_series, 1
+FROM TABLE(generate_series(1, 63));
+
+set pipeline_dop = 1;
+set query_cache_hot_partition_num = 100;
+
+-- Ground truth: the two moduli give genuinely different answers.
+set enable_query_cache = false;
+select sum(s) from (select n1.c1, sum(n1.v1) s from n1 join n2
+  on (n2.ts % 7) > n1.ts and (n2.ts % 7) < n1.v1 group by n1.c1) x;
+select sum(s) from (select n1.c1, sum(n1.v1) s from n1 join n2
+  on (n2.ts % 9) > n1.ts and (n2.ts % 9) < n1.v1 group by n1.c1) x;
+
+-- Cache on, %7 first: it populates the per-tablet entries, then %9 must NOT inherit them.
+set enable_query_cache = true;
+select sum(s) from (select n1.c1, sum(n1.v1) s from n1 join n2
+  on (n2.ts % 7) > n1.ts and (n2.ts % 7) < n1.v1 group by n1.c1) x;
+select sum(s) from (select n1.c1, sum(n1.v1) s from n1 join n2
+  on (n2.ts % 9) > n1.ts and (n2.ts % 9) < n1.v1 group by n1.c1) x;
+
+-- The same in the other direction, on tables whose entries are still cold, so the failure
+-- cannot hide behind whichever order happened to run first.
+CREATE TABLE n3 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1", "colocate_with" = "cg_nlj3_${uuid0}");
+
+CREATE TABLE n4 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1", "colocate_with" = "cg_nlj3_${uuid0}");
+
+INSERT INTO n3
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, 0, 100
+FROM TABLE(generate_series(1, 620));
+
+INSERT INTO n4
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, generate_series, 1
+FROM TABLE(generate_series(1, 63));
+
+set enable_query_cache = true;
+select sum(s) from (select n3.c1, sum(n3.v1) s from n3 join n4
+  on (n4.ts % 9) > n3.ts and (n4.ts % 9) < n3.v1 group by n3.c1) x;
+select sum(s) from (select n3.c1, sum(n3.v1) s from n3 join n4
+  on (n4.ts % 7) > n3.ts and (n4.ts % 7) < n3.v1 group by n3.c1) x;
+
+-- A HashJoin reaches the digested subtree too, under narrower conditions: an equi conjunct
+-- plus a colocate distribution keeps isTransformJoin() satisfied.
+set enable_query_cache = true;
+select sum(s) from (select n1.c1, sum(n1.v1) s from n1 join n2
+  on n1.c1 = n2.c1 and (n2.ts % 7) > n1.ts and (n2.ts % 7) < n1.v1 group by n1.c1) x;
+select sum(s) from (select n1.c1, sum(n1.v1) s from n1 join n2
+  on n1.c1 = n2.c1 and (n2.ts % 9) > n1.ts and (n2.ts % 9) < n1.v1 group by n1.c1) x;
+set enable_query_cache = false;
+select sum(s) from (select n1.c1, sum(n1.v1) s from n1 join n2
+  on n1.c1 = n2.c1 and (n2.ts % 9) > n1.ts and (n2.ts % 9) < n1.v1 group by n1.c1) x;


### PR DESCRIPTION
## Why I'm doing:

A JoinNode's predicate can carry common sub-expressions in commonSlotMap, and the conjunct lists reference those definitions by slot id alone. toNormalForm() normalized the conjuncts but not the definitions, so two joins whose predicates share a shape and differ only in a factored-out subexpression produced the same query cache digest:

```
    (t.ts % 7) > s.a and (t.ts % 7) < s.b
    (t.ts % 9) > s.a and (t.ts % 9) < s.b
```

Both normalize to the same bytes, because after CSE extraction the conjuncts are `$slot > s.a and $slot < s.b` in either case and the `% 7` / `% 9` lives only in commonSlotMap. A join inside the digested subtree decides which rows the cached per-tablet aggregate is computed from, so whichever query ran first populated the entries and the second silently inherited its answer.

Verified on a cluster, in both directions and on cold tables, for both node types:
```
  - NestLoopJoin:  3348000 vs 3472000, the second query returned the first's
  - HashJoin:      418600 vs 434000
```
Reachability differs between the two. isTransformJoin() accepts a NestLoopJoinNode unconditionally, so it reaches the digested subtree whenever the plan has one. A HashJoinNode additionally needs a left-transform op and a non-shuffled distribution, which a colocate inner join satisfies.

The end-to-end cases populate the per-tablet entries with one variant and read them back with the other, in both directions, so a failure cannot hide behind whichever order ran first. Both need the join in a position where it is inside the digested subtree, and both bounds of the predicate referencing the other side -- with literal bounds the whole predicate is pushed into the right scan and never becomes a join predicate at all.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
