### PR TITLE
[Tool] (superseded by #77572) event-driven downstream forward sync

### DIFF
--- a/.github/workflows/ci-sync-mr.yml
+++ b/.github/workflows/ci-sync-mr.yml
@@ -1,0 +1,73 @@
+name: SYNC PIPELINE (MR)
+
+# Event-driven forward sync: StarRocks/starrocks -> MirrorshipOrg/mirrorship-enterprise.
+#
+# Parallel to ci-sync.yml (the CelerData path). This is a SEPARATE workflow and does
+# NOT modify ci-sync.yml or the shared run-repo-sync.sh, so the CD sync path is
+# untouched. It only ADDS the SR -> MR trigger.
+#
+# Scope (model-2, simplified):
+#   - main <-> main ONLY. Release-branch backports are each repo's own job (MR runs
+#     its own ci-merged reconcile). No branch sync.
+#   - SR-NATIVE changes only: a PR that itself arrived via sync (label `sync`, e.g. a
+#     CelerData->SR reverse-sync PR) is skipped -> MR does not receive CD-origin flow,
+#     and there is no cross-org ping-pong.
+#
+# Anti-loop: the sync PR opened on MR carries the `sync` label; MR's own sync triggers
+# skip `sync`-labeled PRs, and this scanner only reads StarRocks/starrocks (never MR's
+# own sync PRs), so it cannot bounce.
+#
+# Prereqs:
+#   - repo secret MR_SYNC_PAT: a PAT allowed to run workflows on
+#     MirrorshipOrg/mirrorship-enterprise.
+#   - MR sync runner has the StarRocks/starrocks source mirror (already needed by the
+#     reverse flow).
+#   - MR reuses its existing repo-sync.yml (executor) + sync-ci-pipeline.yml
+#     (BUILD + auto-merge) + sync-scan-pending.yml (ordering).
+
+on:
+  pull_request_target:
+    branches:
+      - main            # main-only: release branches are handled by each repo's backport
+    types:
+      - closed
+  workflow_dispatch:
+    inputs:
+      PR_ID:
+        description: 'source PR id on StarRocks/starrocks (manual re-sync)'
+        required: true
+        type: string
+
+jobs:
+  sync-mr:
+    runs-on: [self-hosted, sync]
+    if: >
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.pull_request.merged == true && github.repository == 'StarRocks/starrocks')
+    env:
+      PR_NUMBER: ${{ github.event.inputs.PR_ID || github.event.number }}
+      GH_TOKEN: ${{ secrets.MR_SYNC_PAT }}
+    steps:
+      - name: resolve commit + anti-loop guard
+        id: info
+        run: |
+          set -x
+          pr_info=$(gh pr view ${PR_NUMBER} -R StarRocks/starrocks --json mergeCommit,labels)
+          labels=$(echo "$pr_info" | jq -r '.labels[].name')
+          # SR-native only: skip anything that came IN via sync (sync / cd-sync / sr-synced ...)
+          if [[ "${labels}" =~ sync ]]; then
+            echo "is_sync=true" >> $GITHUB_OUTPUT
+          else
+            commit_sha=$(echo "$pr_info" | jq -r '.mergeCommit.oid')
+            echo "commit_sha=${commit_sha:0:7}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: dispatch MR repo-sync (main only)
+        if: steps.info.outputs.is_sync != 'true'
+        run: |
+          gh workflow run repo-sync.yml \
+            -R MirrorshipOrg/mirrorship-enterprise \
+            -f PR_ID=${PR_NUMBER} \
+            -f COMMIT_ID=${{ steps.info.outputs.commit_sha }} \
+            -f BRANCH=main \
+            -f SOURCE_REPO=StarRocks/starrocks


### PR DESCRIPTION
Superseded by #77572 — generalized so the downstream target/PAT come from repo config instead of being hard-coded. Closing this one.