### PR TITLE
[BugFix] Stop the query cache hanging when a lane's join has an empty build side

### DIFF
--- a/be/src/exec/query_cache/multilane_operator.cpp
+++ b/be/src/exec/query_cache/multilane_operator.cpp
@@ -80,7 +80,14 @@ bool MultilaneOperator::need_input() const {
     return std::all_of(_owner_to_lanes.begin(), _owner_to_lanes.end(), [this](auto& pair) {
         auto lane_id = pair.second;
         auto& lane = _lanes[lane_id];
-        return lane.last_chunk_received || lane.processor->need_input();
+        // A lane whose processor finished before its last chunk arrived must not block input.
+        // NLJoinProbeOperator with an empty build side is the case that shows up: _skip_probe()
+        // makes its need_input() false forever. last_chunk_received can only be set by
+        // push_chunk(), so without the is_finished() term this deadlocks -- need_input() stays
+        // false, the driver never pushes, and the last chunk that would set the flag never
+        // arrives, while is_finished() still waits on _input_finished. The passthrough branch
+        // above already treats a finished lane as available.
+        return lane.last_chunk_received || lane.processor->is_finished() || lane.processor->need_input();
     });
 }
 bool MultilaneOperator::has_output() const {
@@ -88,7 +95,18 @@ bool MultilaneOperator::has_output() const {
     for (const auto& [_, lane_id] : _owner_to_lanes) {
         auto& lane = _lanes[lane_id];
         auto processor_is_finished = lane.processor->is_finished();
-        auto need_send_eof_chunk = !passthrough_mode && processor_is_finished && !lane.eof_sent;
+        // Gated on last_chunk_received, not on is_finished() alone. The lane EOF is what makes
+        // CacheOperator populate the entry and then release_lane(), and a released lane is handed
+        // to the next owner by reset_lane(), which erases the old owner from _owner_to_lanes. A
+        // processor that finished early -- the empty build side above -- still has input on the
+        // way, and a chunk arriving after the reassignment would look up an owner that is no
+        // longer mapped: _owner_to_lanes[lane_owner] is operator[], so in a release build it
+        // inserts a default 0 and the chunk lands in someone else's lane. Waiting for the last
+        // chunk cannot deadlock, because need_input() above already lets input drain into a
+        // finished lane and _finish() forces last_chunk_received on every lane when the input
+        // really is exhausted.
+        auto need_send_eof_chunk =
+                !passthrough_mode && processor_is_finished && lane.last_chunk_received && !lane.eof_sent;
         auto need_send_chunk = !processor_is_finished && lane.processor->has_output();
 
         if (need_send_eof_chunk || need_send_chunk) {
@@ -207,7 +225,9 @@ Status MultilaneOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk)
     auto& lane = _lanes[_owner_to_lanes[lane_owner]];
 
     lane.last_chunk_received = is_last_chunk;
-    if (!chunk->is_empty()) {
+    // The lane may have finished early (see need_input()). A finished processor produces nothing
+    // more, so its remaining input is accounted for and dropped instead of pushed into it.
+    if (!chunk->is_empty() && !lane.processor->is_finished()) {
         RETURN_IF_ERROR(lane.processor->push_chunk(state, chunk));
     }
 
@@ -219,7 +239,9 @@ Status MultilaneOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk)
 
 StatusOr<ChunkPtr> MultilaneOperator::_pull_chunk_from_lane(RuntimeState* state, Lane& lane, bool passthrough_mode) {
     auto processor_is_finished = lane.processor->is_finished();
-    auto need_send_eof = !passthrough_mode && processor_is_finished && !lane.eof_sent;
+    // Same gate as has_output(); see the note there.
+    auto need_send_eof =
+            !passthrough_mode && processor_is_finished && lane.last_chunk_received && !lane.eof_sent;
     auto need_send_chunk = !processor_is_finished && lane.processor->has_output();
 
     auto create_eof_chunk = [&lane]() -> auto {
@@ -240,7 +262,7 @@ StatusOr<ChunkPtr> MultilaneOperator::_pull_chunk_from_lane(RuntimeState* state,
 
     ASSIGN_OR_RETURN(auto chunk, lane.processor->pull_chunk(state));
 
-    processor_is_finished = lane.processor->is_finished();
+    processor_is_finished = lane.processor->is_finished() && lane.last_chunk_received;
     lane.eof_sent = processor_is_finished;
 
     if (chunk != nullptr) {

--- a/be/src/exec/query_cache/multilane_operator.cpp
+++ b/be/src/exec/query_cache/multilane_operator.cpp
@@ -240,8 +240,7 @@ Status MultilaneOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk)
 StatusOr<ChunkPtr> MultilaneOperator::_pull_chunk_from_lane(RuntimeState* state, Lane& lane, bool passthrough_mode) {
     auto processor_is_finished = lane.processor->is_finished();
     // Same gate as has_output(); see the note there.
-    auto need_send_eof =
-            !passthrough_mode && processor_is_finished && lane.last_chunk_received && !lane.eof_sent;
+    auto need_send_eof = !passthrough_mode && processor_is_finished && lane.last_chunk_received && !lane.eof_sent;
     auto need_send_chunk = !processor_is_finished && lane.processor->has_output();
 
     auto create_eof_chunk = [&lane]() -> auto {

--- a/test/sql/test_query_cache/R/test_query_cache_empty_build_side_hang
+++ b/test/sql/test_query_cache/R/test_query_cache_empty_build_side_hang
@@ -1,0 +1,75 @@
+-- name: test_query_cache_empty_build_side_hang
+CREATE TABLE eb1 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE eb2 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO eb1
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, 50, 1
+FROM TABLE(generate_series(1, 620));
+-- result:
+-- !result
+INSERT INTO eb2
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, generate_series, 1
+FROM TABLE(generate_series(1, 2000));
+-- result:
+-- !result
+set pipeline_dop = 1;
+-- result:
+-- !result
+set query_cache_hot_partition_num = 100;
+-- result:
+-- !result
+set enable_query_cache = true;
+-- result:
+-- !result
+select ifnull(sum(s),0) from (select eb1.c1, sum(eb1.v1) s from eb1
+  join (select c1 as k from eb2 where ts < 0) b on eb1.ts > b.k group by eb1.c1) x;
+-- result:
+0
+-- !result
+set enable_query_cache = false;
+-- result:
+-- !result
+select ifnull(sum(s),0) from (select eb1.c1, sum(eb1.v1) s from eb1
+  join (select c1 as k from eb2 where ts < 0) b on eb1.ts > b.k group by eb1.c1) x;
+-- result:
+0
+-- !result
+set enable_query_cache = true;
+-- result:
+-- !result
+select ifnull(sum(s),0) from (select eb1.c1, sum(eb1.v1) s from eb1
+  join (select c1 as k from eb2 where ts < 3) b on eb1.ts > b.k group by eb1.c1) x;
+-- result:
+1240
+-- !result
+set enable_query_cache = false;
+-- result:
+-- !result
+select ifnull(sum(s),0) from (select eb1.c1, sum(eb1.v1) s from eb1
+  join (select c1 as k from eb2 where ts < 3) b on eb1.ts > b.k group by eb1.c1) x;
+-- result:
+1240
+-- !result

--- a/test/sql/test_query_cache/T/test_query_cache_empty_build_side_hang
+++ b/test/sql/test_query_cache/T/test_query_cache_empty_build_side_hang
@@ -1,0 +1,64 @@
+-- name: test_query_cache_empty_build_side_hang
+-- MultilaneOperator drives one lane per tablet. Its non-passthrough need_input() used to ask only
+-- `last_chunk_received || processor->need_input()`, while the passthrough branch above it also
+-- accepted a finished lane. That asymmetry deadlocks when a lane's processor finishes before its
+-- last chunk arrives: NLJoinProbeOperator with an empty build side has _skip_probe() true, so its
+-- need_input() is false forever, and last_chunk_received can only be set by push_chunk() -- which
+-- the driver never calls, because need_input() is false. Meanwhile is_finished() waits on
+-- _input_finished, which the upstream can never deliver. The query hung until its timeout.
+--
+-- The join must be BELOW the aggregation so it sits inside a cached lane, and its build side must
+-- come out empty at run time (a constant-false predicate would be folded into an EmptySetNode,
+-- which is not cacheable, so the emptiness has to be data-driven).
+CREATE TABLE eb1 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1");
+
+CREATE TABLE eb2 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO eb1
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, 50, 1
+FROM TABLE(generate_series(1, 620));
+
+-- every ts is >= 1, so `ts < 0` is empty at run time but not constant-foldable
+INSERT INTO eb2
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, generate_series, 1
+FROM TABLE(generate_series(1, 2000));
+
+set pipeline_dop = 1;
+set query_cache_hot_partition_num = 100;
+
+-- Empty build side. Before the fix this hung until query_timeout with the cache on.
+set enable_query_cache = true;
+select ifnull(sum(s),0) from (select eb1.c1, sum(eb1.v1) s from eb1
+  join (select c1 as k from eb2 where ts < 0) b on eb1.ts > b.k group by eb1.c1) x;
+set enable_query_cache = false;
+select ifnull(sum(s),0) from (select eb1.c1, sum(eb1.v1) s from eb1
+  join (select c1 as k from eb2 where ts < 0) b on eb1.ts > b.k group by eb1.c1) x;
+
+-- A non-empty build side must keep returning the same answer either way, so the fix cannot be
+-- passing merely by making the lane produce nothing.
+set enable_query_cache = true;
+select ifnull(sum(s),0) from (select eb1.c1, sum(eb1.v1) s from eb1
+  join (select c1 as k from eb2 where ts < 3) b on eb1.ts > b.k group by eb1.c1) x;
+set enable_query_cache = false;
+select ifnull(sum(s),0) from (select eb1.c1, sum(eb1.v1) s from eb1
+  join (select c1 as k from eb2 where ts < 3) b on eb1.ts > b.k group by eb1.c1) x;


### PR DESCRIPTION
## Why I'm doing:

MultilaneOperator drives one lane per tablet. Its non-passthrough need_input() asked only `last_chunk_received || processor->need_input()`, while the passthrough branch a few lines above also accepts a finished lane. That asymmetry deadlocks whenever a lane's processor finishes before its last chunk arrives.

NLJoinProbeOperator with an empty build side is the case that shows up: _skip_probe() is true, so its need_input() is false forever, and lane.last_chunk_received can only be set by push_chunk() -- which the driver never calls, because need_input() is false. Nothing breaks the cycle: is_finished() waits on _input_finished, which the upstream can never deliver because it cannot push. The query ran until its timeout with all operators at ~0 time and only a fraction of the tablets probed.

```
  select eb1.c1, sum(eb1.v1) from eb1
    join (select c1 as k from eb2 where ts < 0) b on eb1.ts > b.k
    group by eb1.c1;      -- hung with enable_query_cache=true, fine without
```

The join has to be below the aggregation so it sits inside a cached lane, and the build side has to come out empty at run time -- a constant-false predicate folds into an EmptySetNode, which is not cacheable.

push_chunk() now also skips pushing into a lane whose processor has finished: it will produce nothing more, so the remaining input for that lane is accounted for in last_chunk_received and dropped rather than handed to a finished operator.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
