### PR TITLE
[Tool] DNM: instrument PkTabletUnsortSSTWriter spill-check cost

### DIFF
--- a/be/src/storage/lake/pk_tablet_unsort_sst_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_unsort_sst_writer.cpp
@@ -41,11 +41,6 @@
 
 namespace starrocks::lake {
 
-PkTabletUnsortSSTWriter::PkTabletUnsortSSTWriter(TabletSchemaCSPtr tablet_schema_ptr, TabletManager* tablet_mgr,
-                                                 int64_t tablet_id)
-        : PkTabletSSTWriter(std::move(tablet_schema_ptr), tablet_mgr, tablet_id),
-          _map(std::less<>(), MapAllocator(&_map_node_bytes)) {}
-
 Status PkTabletUnsortSSTWriter::reset_sst_writer(const std::shared_ptr<LocationProvider>& location_provider,
                                                  const std::shared_ptr<FileSystem>& fs) {
     _location_provider = location_provider;
@@ -199,8 +194,11 @@ bool PkTabletUnsortSSTWriter::is_map_full() const {
 }
 
 size_t PkTabletUnsortSSTWriter::map_memory_usage() const {
-    DCHECK_GE(_map_node_bytes, 0);
-    return sizeof(_map) + static_cast<size_t>(_map_node_bytes) + _keys_heap_size;
+    // Same accounting as PersistentIndexMemtable::memory_usage(): _keys_heap_size is the memory of the
+    // heap-allocated std::string keys, and _map.bytes_used() is the memory of the btree itself.
+    // Asking the container is exact by construction -- an incrementally maintained byte counter has to
+    // be kept in step with every single allocation and deallocation, and any drift is silent.
+    return _keys_heap_size + _map.bytes_used();
 }
 
 size_t PkTabletUnsortSSTWriter::memory_usage() const {

--- a/be/src/storage/lake/pk_tablet_unsort_sst_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_unsort_sst_writer.cpp
@@ -276,11 +276,10 @@ Status PkTabletUnsortSSTWriter::flush_map_to_intermediate_sst() {
     _intermediate_ssts.push_back({location, size, std::move(encryption_meta)});
     // GOALOOP-PROBE (temporary, not for merge): one line per spill, so the bound can be checked.
     ++_probe_spills;
-    LOG(INFO) << "GOALOOP_SPILL tablet=" << _tablet_id << " spill=" << _probe_spills
-              << " entries=" << _map.size() << " mem_usage=" << memory_usage()
-              << " keys_heap=" << _keys_heap_size << " bytes_used=" << _map.bytes_used()
-              << " deleted_rowids_cap=" << _deleted_rowids.capacity() << " l0_max=" << config::l0_max_mem_usage
-              << " intermediates=" << _intermediate_ssts.size();
+    LOG(INFO) << "GOALOOP_SPILL tablet=" << _tablet_id << " spill=" << _probe_spills << " entries=" << _map.size()
+              << " mem_usage=" << memory_usage() << " keys_heap=" << _keys_heap_size
+              << " bytes_used=" << _map.bytes_used() << " deleted_rowids_cap=" << _deleted_rowids.capacity()
+              << " l0_max=" << config::l0_max_mem_usage << " intermediates=" << _intermediate_ssts.size();
     _map.clear();
     _keys_heap_size = 0;
     return Status::OK();

--- a/be/src/storage/lake/pk_tablet_unsort_sst_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_unsort_sst_writer.cpp
@@ -19,6 +19,8 @@
 #include <algorithm>
 
 #include "base/string/string_util.h"
+#include "base/time/time.h"
+#include "base/utility/defer_op.h"
 #include "column/chunk.h"
 #include "common/config_cache_fwd.h"
 #include "common/config_primary_key_fwd.h"
@@ -118,6 +120,9 @@ Status PkTabletUnsortSSTWriter::append_records(const Chunk& data, const std::vec
     if (num_rows == 0) {
         return Status::OK();
     }
+    // GOALOOP-PROBE (temporary, not for merge)
+    const int64_t probe_append_start_ns = MonotonicNanos();
+    DeferOp probe_append_timer([&]() { _probe_append_ns += MonotonicNanos() - probe_append_start_ns; });
     if (rssid_rowids == nullptr || rssid_rowids->size() != num_rows) {
         return Status::InternalError(fmt::format("unsort pk sst writer requires per-row order keys, expected {} got {}",
                                                  num_rows, rssid_rowids == nullptr ? 0 : rssid_rowids->size()));
@@ -201,12 +206,22 @@ bool PkTabletUnsortSSTWriter::is_map_full() const {
     constexpr size_t kExactCheckMaxEntries = 4096;
     const size_t fixed_bytes = _keys_heap_size + _deleted_rowids.capacity() * sizeof(uint32_t);
     const size_t lower_bound = fixed_bytes + _map.size() * sizeof(decltype(_map)::value_type);
+    // GOALOOP-PROBE (temporary, not for merge)
+    ++_probe_calls;
+    _probe_sum_entries_at_call += _map.size();
     // `threshold - threshold / 5` rather than `threshold * 4 / 5`: the threshold comes from config and
     // tests set it to INT64_MAX, where the product would overflow.
     if (_map.size() > kExactCheckMaxEntries && lower_bound < threshold - threshold / 5) {
         return false;
     }
-    return memory_usage() >= threshold;
+    // GOALOOP-PROBE (temporary, not for merge): time only the exact reading.
+    const int64_t probe_start_ns = MonotonicNanos();
+    const size_t mem_usage = memory_usage();
+    _probe_walk_ns += MonotonicNanos() - probe_start_ns;
+    ++_probe_walks;
+    _probe_sum_entries_at_walk += _map.size();
+    _probe_max_mem_usage = std::max(_probe_max_mem_usage, mem_usage);
+    return mem_usage >= threshold;
 }
 
 size_t PkTabletUnsortSSTWriter::map_memory_usage() const {
@@ -259,6 +274,13 @@ Status PkTabletUnsortSSTWriter::flush_map_to_intermediate_sst() {
     const uint64_t size = builder.FileSize();
     RETURN_IF_ERROR(wf->close());
     _intermediate_ssts.push_back({location, size, std::move(encryption_meta)});
+    // GOALOOP-PROBE (temporary, not for merge): one line per spill, so the bound can be checked.
+    ++_probe_spills;
+    LOG(INFO) << "GOALOOP_SPILL tablet=" << _tablet_id << " spill=" << _probe_spills
+              << " entries=" << _map.size() << " mem_usage=" << memory_usage()
+              << " keys_heap=" << _keys_heap_size << " bytes_used=" << _map.bytes_used()
+              << " deleted_rowids_cap=" << _deleted_rowids.capacity() << " l0_max=" << config::l0_max_mem_usage
+              << " intermediates=" << _intermediate_ssts.size();
     _map.clear();
     _keys_heap_size = 0;
     return Status::OK();
@@ -403,6 +425,26 @@ StatusOr<std::pair<FileInfo, PersistentIndexSstableRangePB>> PkTabletUnsortSSTWr
         }
         delete_files_async(std::move(intermediate_paths));
     }
+    // GOALOOP-PROBE (temporary, not for merge): one line per segment. ns_per_entry is measured from the
+    // calls that actually walked the tree; projected_ns is what the unconditional version would have
+    // cost, i.e. the same rate applied to every call's map size.
+    const double ns_per_entry =
+            _probe_sum_entries_at_walk > 0 ? static_cast<double>(_probe_walk_ns) / _probe_sum_entries_at_walk : 0.0;
+    const int64_t projected_ns = static_cast<int64_t>(ns_per_entry * _probe_sum_entries_at_call);
+    LOG(INFO) << "GOALOOP_COST tablet=" << _tablet_id << " calls=" << _probe_calls << " walks=" << _probe_walks
+              << " walk_ns=" << _probe_walk_ns << " append_ns=" << _probe_append_ns
+              << " sum_entries_at_call=" << _probe_sum_entries_at_call
+              << " sum_entries_at_walk=" << _probe_sum_entries_at_walk << " ns_per_entry=" << ns_per_entry
+              << " projected_unconditional_ns=" << projected_ns << " spills=" << _probe_spills
+              << " max_mem_usage=" << _probe_max_mem_usage << " l0_max=" << config::l0_max_mem_usage;
+    _probe_calls = 0;
+    _probe_walks = 0;
+    _probe_walk_ns = 0;
+    _probe_sum_entries_at_call = 0;
+    _probe_sum_entries_at_walk = 0;
+    _probe_append_ns = 0;
+    _probe_spills = 0;
+    _probe_max_mem_usage = 0;
     _wf.reset();
     _map.clear();
     _intermediate_ssts.clear();

--- a/be/src/storage/lake/pk_tablet_unsort_sst_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_unsort_sst_writer.cpp
@@ -16,6 +16,8 @@
 
 #include <fmt/format.h>
 
+#include <algorithm>
+
 #include "base/string/string_util.h"
 #include "column/chunk.h"
 #include "common/config_cache_fwd.h"
@@ -179,18 +181,32 @@ bool PkTabletUnsortSSTWriter::is_map_full() const {
     // map keeps the writer's combined footprint near the bound instead of letting _map independently
     // pile another l0_max_mem_usage on top of the loser vector. (_delete_keys is filled only at flush,
     // never during append, so it is not part of the footprint at this spill check.)
-    const size_t mem_usage = memory_usage();
-    if (mem_usage >= static_cast<size_t>(config::l0_max_mem_usage)) {
-        return true;
-    }
+    size_t threshold = static_cast<size_t>(config::l0_max_mem_usage);
     // Under memory pressure, spill at a lower bound, mirroring LakePersistentIndex::is_memtable_full.
     auto* update_mgr = _tablet_mgr->update_mgr();
     if (update_mgr != nullptr && update_mgr->mem_tracker() != nullptr &&
-        update_mgr->mem_tracker()->limit_exceeded_by_ratio(config::memory_urgent_level) &&
-        mem_usage >= static_cast<size_t>(config::l0_min_mem_usage)) {
-        return true;
+        update_mgr->mem_tracker()->limit_exceeded_by_ratio(config::memory_urgent_level)) {
+        threshold = std::min(threshold, static_cast<size_t>(config::l0_min_mem_usage));
     }
-    return false;
+    // memory_usage() is not an O(1) reading: btree_map::bytes_used() recursively visits every node
+    // (internal_stats), and this runs once per appended chunk, so measuring unconditionally would
+    // rescan the whole growing map on every chunk of the fill/spill cycle. Skip it while the map is
+    // demonstrably far from the threshold: every entry occupies a slot inside an allocated node, so
+    // `size() * sizeof(value_type)` is a true lower bound on bytes_used(), and if even that lower bound
+    // is a fifth short of the threshold the exact reading is not going to cross it either. The bound is
+    // only tight once there are enough nodes for their per-node overhead to amortize, so below that the
+    // exact reading is taken unconditionally -- a walk over a handful of nodes costs nothing. The
+    // decision at the boundary is therefore always the exact one; only the early, obviously-not-full
+    // chunks take the shortcut.
+    constexpr size_t kExactCheckMaxEntries = 4096;
+    const size_t fixed_bytes = _keys_heap_size + _deleted_rowids.capacity() * sizeof(uint32_t);
+    const size_t lower_bound = fixed_bytes + _map.size() * sizeof(decltype(_map)::value_type);
+    // `threshold - threshold / 5` rather than `threshold * 4 / 5`: the threshold comes from config and
+    // tests set it to INT64_MAX, where the product would overflow.
+    if (_map.size() > kExactCheckMaxEntries && lower_bound < threshold - threshold / 5) {
+        return false;
+    }
+    return memory_usage() >= threshold;
 }
 
 size_t PkTabletUnsortSSTWriter::map_memory_usage() const {

--- a/be/src/storage/lake/pk_tablet_unsort_sst_writer.h
+++ b/be/src/storage/lake/pk_tablet_unsort_sst_writer.h
@@ -128,6 +128,17 @@ private:
     // Heap allocations owned by non-SSO strings in `_map`. The std::string objects themselves live in
     // the B-tree nodes and are already included in `_map.bytes_used()`.
     size_t _keys_heap_size = 0;
+    // GOALOOP-PROBE (temporary, not for merge): cost accounting for is_map_full(). `walk_*` covers the
+    // calls that actually took the exact bytes_used() reading; `sum_entries_at_call` lets us project what
+    // the unconditional version would have cost from the measured per-entry walk rate.
+    mutable size_t _probe_calls = 0;
+    mutable size_t _probe_walks = 0;
+    mutable int64_t _probe_walk_ns = 0;
+    mutable size_t _probe_sum_entries_at_call = 0;
+    mutable size_t _probe_sum_entries_at_walk = 0;
+    mutable size_t _probe_max_mem_usage = 0;
+    int64_t _probe_append_ns = 0;
+    size_t _probe_spills = 0;
     std::vector<IntermediateSst> _intermediate_ssts;
     // Running rowid within the current segment (== rows appended so far); reset per segment.
     uint32_t _next_rowid = 0;

--- a/be/src/storage/lake/pk_tablet_unsort_sst_writer.h
+++ b/be/src/storage/lake/pk_tablet_unsort_sst_writer.h
@@ -22,7 +22,6 @@
 #include <vector>
 
 #include "base/phmap/btree.h"
-#include "runtime/memory/counting_allocator.h"
 #include "storage/lake/pk_tablet_sst_writer.h"
 #include "storage/sstable/table_builder.h"
 
@@ -42,13 +41,16 @@ namespace starrocks::lake {
 // memory. At segment finalize the intermediate SSTs (plus the residual map) are k-way merged into the
 // single final SST; duplicate PKs across intermediates are resolved there (last-flushed wins) and the
 // losers appended to the delete vector.
-// Memory: the map and loser-rowid vector are charged by allocated capacity and trigger a map spill at
-// l0_max_mem_usage (100 MB default). Each parallel merge task owns its own writer, so peak usage scales
-// with the number of concurrent merge tasks. The loser-rowid vector must live until segment finalize
-// and is not released by a map spill. Writer memory is charged to the load-spill merge mem tracker.
+// Memory: the map is measured the same way LakePersistentIndex's memtable measures its own (the btree's
+// bytes_used() plus the heap of the non-SSO keys) and, together with the loser-rowid vector, triggers a
+// map spill at l0_max_mem_usage (100 MB default). Each parallel merge task owns its own writer, so peak
+// usage scales with the number of concurrent merge tasks. The loser-rowid vector must live until segment
+// finalize and is not released by a map spill. Writer memory is charged to the load-spill merge mem
+// tracker.
 class PkTabletUnsortSSTWriter : public PkTabletSSTWriter {
 public:
-    PkTabletUnsortSSTWriter(TabletSchemaCSPtr tablet_schema_ptr, TabletManager* tablet_mgr, int64_t tablet_id);
+    PkTabletUnsortSSTWriter(TabletSchemaCSPtr tablet_schema_ptr, TabletManager* tablet_mgr, int64_t tablet_id)
+            : PkTabletSSTWriter(std::move(tablet_schema_ptr), tablet_mgr, tablet_id) {}
     ~PkTabletUnsortSSTWriter() override = default;
     Status append_sst_record(const Chunk& data, const std::vector<uint64_t>* rssid_rowids = nullptr,
                              const std::vector<uint32_t>* column_indexes = nullptr) override;
@@ -83,9 +85,6 @@ private:
         uint64_t order;
         uint32_t rowid;
     };
-    using MapValue = std::pair<const std::string, Entry>;
-    using MapAllocator = STLCountingAllocator<MapValue>;
-    using Map = phmap::btree_map<std::string, Entry, std::less<>, MapAllocator>;
     // An intermediate SST spilled from `_map` when it got full. Its entries store both rowid and order
     // (order in the value's version field) so the final merge can pick the dedup winner across SSTs.
     struct IntermediateSst {
@@ -112,7 +111,7 @@ private:
     void collect_delete_key(const Slice& key);
     // Whether `_map` has reached the memtable memory threshold and should be spilled to an SST.
     bool is_map_full() const;
-    // Memory owned by `_map`: allocated B-tree nodes plus heap allocations of non-SSO keys.
+    // Memory owned by `_map`: the B-tree's own bytes plus the heap of the non-SSO keys.
     size_t map_memory_usage() const;
     // Spill the current `_map` to a new intermediate SST (storing order+rowid), then clear the map.
     Status flush_map_to_intermediate_sst();
@@ -120,17 +119,14 @@ private:
     // per key and appending the losing rowids to `_deleted_rowids`.
     Status merge_intermediates_into(sstable::TableBuilder* builder);
 
-    // Bytes allocated for B-tree nodes. MapAllocator maintains this counter incrementally, so
-    // checking the spill threshold does not have to traverse the whole tree.
-    int64_t _map_node_bytes = 0;
-    Map _map;
+    phmap::btree_map<std::string, Entry, std::less<>> _map;
     std::vector<uint32_t> _deleted_rowids;
     // Encoded primary keys (del-file binary format) whose latest op is a DELETE, collected at flush and
     // moved out via take_delete_keys(). A map/merge key IS an encoded-PK slice, so it is appended
     // straight into this column (built from clone_empty_pk_column). nullptr until the first winner.
     MutableColumnPtr _delete_keys;
-    // Heap allocations owned by non-SSO strings in `_map`. The std::string objects themselves are
-    // stored in the B-tree nodes and are already included in `_map.bytes_used()`.
+    // Heap allocations owned by non-SSO strings in `_map`. The std::string objects themselves live in
+    // the B-tree nodes and are already included in `_map.bytes_used()`.
     size_t _keys_heap_size = 0;
     std::vector<IntermediateSst> _intermediate_ssts;
     // Running rowid within the current segment (== rows appended so far); reset per segment.

--- a/be/test/storage/lake/pk_tablet_sst_writer_test.cpp
+++ b/be/test/storage/lake/pk_tablet_sst_writer_test.cpp
@@ -1036,24 +1036,21 @@ TEST_F(PkTabletSSTWriterTest, test_unsort_sst_writer_memory_usage) {
         order[i] = (static_cast<uint64_t>(1) << 32) | i;
     }
 
+    // Build the same map on the side and measure it the way the writer does -- the btree's own
+    // bytes_used() plus the heap owned by the non-SSO keys.
     struct ExpectedEntry {
         uint64_t order;
         uint32_t rowid;
     };
-    using ExpectedMapValue = std::pair<const std::string, ExpectedEntry>;
-    using ExpectedMapAllocator = STLCountingAllocator<ExpectedMapValue>;
-    using ExpectedMap = phmap::btree_map<std::string, ExpectedEntry, std::less<>, ExpectedMapAllocator>;
-    int64_t expected_map_node_bytes = 0;
-    ExpectedMap expected_map{std::less<>(), ExpectedMapAllocator(&expected_map_node_bytes)};
+    phmap::btree_map<std::string, ExpectedEntry, std::less<>> expected_map;
     size_t expected_keys_heap_size = 0;
     for (uint32_t i = 0; i < encoded_keys.size(); ++i) {
         auto [it, inserted] = expected_map.emplace(encoded_keys[i], ExpectedEntry{order[i], i});
         ASSERT_TRUE(inserted);
         expected_keys_heap_size += is_string_heap_allocated(it->first) ? it->first.capacity() : 0;
     }
-    EXPECT_EQ(expected_map.bytes_used(), sizeof(expected_map) + static_cast<size_t>(expected_map_node_bytes));
-    const size_t expected_map_usage =
-            sizeof(expected_map) + static_cast<size_t>(expected_map_node_bytes) + expected_keys_heap_size;
+    ASSERT_GT(expected_keys_heap_size, 0);
+    const size_t expected_map_usage = expected_keys_heap_size + expected_map.bytes_used();
 
     ASSERT_OK(w->append_sst_record(chunk, &order));
     EXPECT_EQ(expected_map_usage, w->memory_usage());
@@ -1083,6 +1080,68 @@ TEST_F(PkTabletSSTWriterTest, test_unsort_sst_writer_memory_usage) {
     EXPECT_LT(spill_writer->memory_usage(), expected_map_usage);
     ASSIGN_OR_ABORT(auto spill_flush_result, spill_writer->flush_sst_writer());
     EXPECT_FALSE(spill_flush_result.first.path.empty());
+}
+
+TEST_F(PkTabletSSTWriterTest, test_unsort_sst_writer_memory_usage_across_spills) {
+    // A segment is many fill -> spill -> refill rounds, and the reading has to come all the way back
+    // down on every spill. An accounting that leaves a residual behind bakes it into every later
+    // reading: too small a reading spills late (unbounded writer memory), and a residual large enough
+    // to swamp the bound pins is_map_full() at true and spills one tiny intermediate SST per chunk for
+    // the rest of the segment. Measuring the live map cannot drift, and this test locks that in.
+    const int64_t tablet_id = _tablet_metadata->id();
+    auto lp = std::make_shared<FixedLocationProvider>(kTestDirectory);
+    constexpr int kRounds = 5;
+    constexpr int kRowsPerRound = 64;
+
+    // Fixed-width keys, long enough not to fit in the string's SSO buffer, and distinct across rounds
+    // so no round produces dedup losers. Every round therefore has the exact same footprint.
+    auto round_chunk = [&](int round) {
+        std::vector<std::pair<std::string, int>> rows;
+        rows.reserve(kRowsPerRound);
+        for (int i = 0; i < kRowsPerRound; ++i) {
+            rows.emplace_back(fmt::format("unsort_spill_key_{:0>24d}", round * kRowsPerRound + i), i);
+        }
+        return make_kv_chunk(_schema, rows);
+    };
+    auto round_order = [&](int round) {
+        std::vector<uint64_t> order(kRowsPerRound);
+        for (uint32_t i = 0; i < kRowsPerRound; ++i) {
+            order[i] = (static_cast<uint64_t>(round + 1) << 32) | i;
+        }
+        return order;
+    };
+
+    // Measure the empty and the one-round footprint with spilling effectively disabled.
+    size_t empty_usage = 0;
+    size_t one_round_usage = 0;
+    {
+        ConfigResetGuard<int64_t> no_spill_guard(&config::l0_max_mem_usage, std::numeric_limits<int64_t>::max());
+        auto probe = std::make_unique<TestPkTabletUnsortSSTWriter>(_tablet_schema, _tablet_mgr.get(), tablet_id);
+        ASSERT_OK(probe->reset_sst_writer(lp, _fs));
+        empty_usage = probe->memory_usage();
+        auto chunk = round_chunk(0);
+        auto order = round_order(0);
+        ASSERT_OK(probe->append_sst_record(chunk, &order));
+        one_round_usage = probe->memory_usage();
+        ASSERT_GT(one_round_usage, empty_usage);
+        ASSERT_OK(probe->flush_sst_writer().status());
+    }
+
+    // One round now reaches the bound exactly, so every round fills the map and spills it.
+    ConfigResetGuard<int64_t> spill_guard(&config::l0_max_mem_usage, static_cast<int64_t>(one_round_usage));
+    auto w = std::make_unique<TestPkTabletUnsortSSTWriter>(_tablet_schema, _tablet_mgr.get(), tablet_id);
+    ASSERT_OK(w->reset_sst_writer(lp, _fs));
+    for (int round = 0; round < kRounds; ++round) {
+        auto chunk = round_chunk(round);
+        auto order = round_order(round);
+        ASSERT_OK(w->append_sst_record(chunk, &order));
+        // The append spilled, so the map is empty again and the writer is back to owning nothing but
+        // the empty map -- the same reading as before the very first append, round after round.
+        EXPECT_EQ(empty_usage, w->memory_usage()) << "after round " << round;
+    }
+    ASSIGN_OR_ABORT(auto flush_result, w->flush_sst_writer());
+    EXPECT_FALSE(flush_result.first.path.empty());
+    EXPECT_TRUE(w->take_deleted_rowids().empty());
 }
 
 TEST_F(PkTabletSSTWriterTest, test_unsort_sst_writer_basic_no_dup) {

--- a/be/test/storage/lake/pk_tablet_sst_writer_test.cpp
+++ b/be/test/storage/lake/pk_tablet_sst_writer_test.cpp
@@ -1144,6 +1144,58 @@ TEST_F(PkTabletSSTWriterTest, test_unsort_sst_writer_memory_usage_across_spills)
     EXPECT_TRUE(w->take_deleted_rowids().empty());
 }
 
+TEST_F(PkTabletSSTWriterTest, test_unsort_sst_writer_spill_past_estimate_shortcut) {
+    // Once the map is large, is_map_full() may answer "not full" from a cheap lower bound instead of
+    // measuring it. The shortcut must never defer a spill: past the threshold the exact reading is
+    // always the one that decides.
+    const int64_t tablet_id = _tablet_metadata->id();
+    auto lp = std::make_shared<FixedLocationProvider>(kTestDirectory);
+    // Comfortably past the entry count below which is_map_full() always measures exactly.
+    constexpr int kRowsPerChunk = 8192;
+
+    auto chunk_of = [&](int base) {
+        std::vector<std::pair<std::string, int>> rows;
+        rows.reserve(kRowsPerChunk);
+        for (int i = 0; i < kRowsPerChunk; ++i) {
+            rows.emplace_back(fmt::format("unsort_shortcut_key_{:0>20d}", base + i), i);
+        }
+        return make_kv_chunk(_schema, rows);
+    };
+    auto order_of = [&](int round) {
+        std::vector<uint64_t> order(kRowsPerChunk);
+        for (uint32_t i = 0; i < kRowsPerChunk; ++i) {
+            order[i] = (static_cast<uint64_t>(round + 1) << 32) | i;
+        }
+        return order;
+    };
+
+    size_t usage_after_one_chunk = 0;
+    {
+        ConfigResetGuard<int64_t> no_spill_guard(&config::l0_max_mem_usage, std::numeric_limits<int64_t>::max());
+        auto probe = std::make_unique<TestPkTabletUnsortSSTWriter>(_tablet_schema, _tablet_mgr.get(), tablet_id);
+        ASSERT_OK(probe->reset_sst_writer(lp, _fs));
+        auto chunk = chunk_of(0);
+        auto order = order_of(0);
+        ASSERT_OK(probe->append_sst_record(chunk, &order));
+        usage_after_one_chunk = probe->memory_usage();
+        ASSERT_OK(probe->flush_sst_writer().status());
+    }
+
+    // One chunk is already at the threshold, so the very first append must spill and leave the map empty.
+    ConfigResetGuard<int64_t> spill_guard(&config::l0_max_mem_usage, static_cast<int64_t>(usage_after_one_chunk));
+    auto w = std::make_unique<TestPkTabletUnsortSSTWriter>(_tablet_schema, _tablet_mgr.get(), tablet_id);
+    ASSERT_OK(w->reset_sst_writer(lp, _fs));
+    const size_t empty_usage = w->memory_usage();
+    for (int round = 0; round < 2; ++round) {
+        auto chunk = chunk_of(round * kRowsPerChunk);
+        auto order = order_of(round);
+        ASSERT_OK(w->append_sst_record(chunk, &order));
+        EXPECT_EQ(empty_usage, w->memory_usage()) << "after round " << round;
+    }
+    ASSIGN_OR_ABORT(auto flush_result, w->flush_sst_writer());
+    EXPECT_FALSE(flush_result.first.path.empty());
+}
+
 TEST_F(PkTabletSSTWriterTest, test_unsort_sst_writer_basic_no_dup) {
     const int64_t tablet_id = _tablet_metadata->id();
     auto w = std::make_unique<PkTabletUnsortSSTWriter>(_tablet_schema, _tablet_mgr.get(), tablet_id);


### PR DESCRIPTION
DNM / throwaway. Temporary instrumentation on top of #77498 so its spill-check cost can be measured on a TSP shared-data cluster. Will be closed once the numbers are collected; nothing here is intended for merge.
