### PR TITLE
[BugFix] Cache the compaction txn log that file bundling skips writing

### DIFF
--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -170,10 +170,15 @@ void CompactionTaskCallback::finish_task(std::unique_ptr<CompactionTaskContext>&
         if (auto st = normalize_txn_log_before_save(&normalized); st.ok()) {
             _response->add_txn_logs()->Swap(&normalized);
             if (context->status.ok()) {
-                // Only cache a log that will actually become durable. Once any tablet in the request
-                // fails, the aggregator skips write_combined_txn_log() altogether, so a failed
-                // tablet's log exists nowhere remotely and its txn is headed for abort -- caching it
-                // would put an entry in the metacache that no publish can ever validate against.
+                // Skip a tablet whose own compaction failed -- publish will never ask for its log.
+                // That is ALL this guard establishes; it does not make the cached log guaranteed
+                // durable. write_combined_txn_log() is gated on the whole AggregateCompactRequest
+                // succeeding (FE pins allow_partial_success to false on this path), so when a
+                // SIBLING tablet fails this log is cached while the combined object is never
+                // written, and the entry then survives until LRU eviction -- abort_txn()'s combined
+                // branch bails out on the NotFound before reaching collect_files_in_log(), the only
+                // place that erases the per-tablet key. Harmless: txn_id is never reused, so no
+                // later publish can read the stale entry.
                 cache_txn_log(*context);
             }
         } else {

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -40,6 +40,7 @@
 #include "platform/thrift_rpc_helper.h"
 #include "storage/lake/compaction_task.h"
 #include "storage/lake/lake_proto_normalizer.h"
+#include "storage/lake/metacache.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_parallel_compaction_manager.h"
 #include "storage/memtable_flush_executor.h"
@@ -107,6 +108,36 @@ Status CompactionTaskCallback::has_error() const {
     }
 }
 
+// Populate the metacache with a txn log that this node produced but did NOT persist itself.
+//
+// On the aggregate/file-bundling path the compaction txn log is not written to object storage by the
+// compaction worker: it travels back in `CompactResponse.txn_logs` and the aggregator folds every
+// tablet's log into one combined `<txn_id>.logs` object. Without a cache entry the subsequent publish
+// of this tablet has to download that combined object (`load_txn_log()` in transactions.cpp first
+// probes the metacache under the per-tablet txn log path, then falls back to
+// `get_combined_txn_log()`), so every file-bundling compaction pays an extra remote GET at publish
+// time. This mirrors what the file-bundling tablet metadata path already does -- skip the object
+// storage write, but still cache the metadata (`publish_version()` -> `cache_tablet_metadata()`) --
+// and what the load path already does for its own combined txn logs
+// (`DeltaWriterImpl::finish_with_txnlog()` under kDontWriteTxnLog).
+//
+// The raw (non-normalized) log is cached, exactly like `put_txn_log()` caches the caller's log rather
+// than the dual-written copy it serializes: the legacy arrays only exist for on-disk rollback compat
+// and are folded back into the structured fields by `normalize_txn_log_after_load()` on read.
+//
+// Only the complete log for a tablet reaches here. Parallel compaction subtasks carry
+// skip_write_txnlog=true as well, but their partial logs are funneled through
+// `TabletParallelCompactionManager::on_subtask_complete()` and only the merged context is handed to
+// finish_task(), so a partial log can never land in the cache under the tablet's txn log key.
+void CompactionTaskCallback::cache_txn_log(const CompactionTaskContext& context) {
+    if (_scheduler == nullptr) { // unit tests may construct a callback without a scheduler
+        return;
+    }
+    auto* tablet_mgr = _scheduler->_tablet_mgr;
+    tablet_mgr->metacache()->cache_txn_log(tablet_mgr->txn_log_location(context.tablet_id, context.txn_id),
+                                           context.txn_log);
+}
+
 void CompactionTaskCallback::finish_task(std::unique_ptr<CompactionTaskContext>&& context) {
     std::unique_lock l(_mtx);
 
@@ -138,6 +169,13 @@ void CompactionTaskCallback::finish_task(std::unique_ptr<CompactionTaskContext>&
         TxnLogPB normalized(*context->txn_log);
         if (auto st = normalize_txn_log_before_save(&normalized); st.ok()) {
             _response->add_txn_logs()->Swap(&normalized);
+            if (context->status.ok()) {
+                // Only cache a log that will actually become durable. Once any tablet in the request
+                // fails, the aggregator skips write_combined_txn_log() altogether, so a failed
+                // tablet's log exists nowhere remotely and its txn is headed for abort -- caching it
+                // would put an entry in the metacache that no publish can ever validate against.
+                cache_txn_log(*context);
+            }
         } else {
             LOG(WARNING) << "Fail to normalize aggregate-compact txn log: " << st
                          << " tablet_id=" << context->tablet_id;

--- a/be/src/storage/lake/compaction_scheduler.h
+++ b/be/src/storage/lake/compaction_scheduler.h
@@ -93,6 +93,10 @@ public:
 private:
     const static int64_t kDefaultTimeoutMs = 24L * 60 * 60 * 1000; // 1 day
 
+    // Cache a txn log that this node produced but handed to the aggregator to persist, so that the
+    // following publish does not have to read the combined txn log back from object storage.
+    void cache_txn_log(const CompactionTaskContext& context);
+
     CompactionScheduler* _scheduler;
     mutable StackTraceMutex<bthread::Mutex> _mtx;
     const CompactRequest* _request;

--- a/be/test/storage/lake/compaction_scheduler_test.cpp
+++ b/be/test/storage/lake/compaction_scheduler_test.cpp
@@ -22,6 +22,7 @@
 #include "gen_cpp/lake_service.pb.h"
 #include "runtime/descriptors.h"
 #include "storage/lake/compaction_task_context.h"
+#include "storage/lake/metacache.h"
 #include "storage/lake/test_util.h"
 
 namespace starrocks::lake {
@@ -311,6 +312,47 @@ TEST_F(LakeCompactionSchedulerTest, test_abort_with_not_write_txnlog) {
     TEST_DISABLE_ERROR_POINT("HorizontalCompactionTask::execute::1");
     TEST_DISABLE_ERROR_POINT("CloudNativeIndexCompactionTask::execute::1");
     SyncPoint::GetInstance()->DisableProcessing();
+
+    // A task that failed before producing a txn log must not leave anything behind in the metacache.
+    EXPECT_EQ(nullptr,
+              _tablet_mgr->metacache()->lookup_txn_log(_tablet_mgr->txn_log_location(_tablet_metadata->id(), txn_id)));
+}
+
+// skip_write_txnlog is the aggregate/file-bundling path: the compaction worker returns the txn log
+// inline instead of persisting it, and the aggregator folds every tablet's log into one combined
+// `<txn_id>.logs` object. The worker must still populate the metacache under the per-tablet txn log
+// key, because that is what the publish path (`load_txn_log()` in transactions.cpp) probes before
+// falling back to a remote read of the combined log.
+TEST_F(LakeCompactionSchedulerTest, test_skip_write_txnlog_fills_metacache) {
+    auto txn_id = next_id();
+    auto latch = std::make_shared<CountDownLatch>(1);
+    auto request = CompactRequest{};
+    auto response = CompactResponse{};
+    request.add_tablet_ids(_tablet_metadata->id());
+    request.set_timeout_ms(/*1 minute=*/60 * 1000);
+    request.set_txn_id(txn_id);
+    request.set_version(1);
+    request.set_skip_write_txnlog(true);
+
+    auto log_path = _tablet_mgr->txn_log_location(_tablet_metadata->id(), txn_id);
+    ASSERT_EQ(nullptr, _tablet_mgr->metacache()->lookup_txn_log(log_path));
+
+    auto cb = ::google::protobuf::NewCallback(notify_for_callback, latch);
+    _compaction_scheduler.compact(nullptr, &request, &response, cb);
+    latch->wait();
+
+    ASSERT_EQ(0, response.failed_tablets_size());
+    ASSERT_EQ(1, response.txn_logs_size());
+
+    // The log was not written to object storage ...
+    EXPECT_FALSE(fs::path_exist(log_path));
+    // ... but the publish path can still find it without a remote read.
+    auto cached = _tablet_mgr->metacache()->lookup_txn_log(log_path);
+    ASSERT_NE(nullptr, cached);
+    EXPECT_EQ(_tablet_metadata->id(), cached->tablet_id());
+    EXPECT_EQ(txn_id, cached->txn_id());
+    EXPECT_TRUE(cached->has_op_compaction());
+    EXPECT_EQ(response.txn_logs(0).op_compaction().compact_version(), cached->op_compaction().compact_version());
 }
 
 // Test for process_parallel_compaction (lines 299-369 in compaction_scheduler.cpp)


### PR DESCRIPTION
## Why I'm doing:

When a table has `file_bundling` enabled, FE routes compaction through `createAggregateCompactionTask()` and sets `skip_write_txnlog` on every `CompactRequest` (`fe/fe-core/.../lake/compaction/CompactionScheduler.java:408,522`). The compaction worker then keeps its txn log in the task context and returns it inline via `CompactResponse.txn_logs`, so the aggregator can fold every tablet's log into a single combined `<txn_id>.logs` object instead of one object per tablet.

That path skips the object storage write, but it also skips the metacache fill that `TabletManager::put_txn_log()` performs on the normal path. The publish side probes the metacache under the per-tablet txn log key *before* falling back to a remote read of the combined log:

```cpp
// storage/lake/transactions.cpp, load_txn_log()
} else {
    auto cache_key = tablet_mgr->txn_log_location(tablet_id, txn_info.txn_id());
    auto ptr = tablet_mgr->metacache()->lookup_txn_log(cache_key);
    if (ptr) { txn_logs.push_back(ptr); continue; }          // <-- always missed for compaction
    auto log_path = tablet_mgr->combined_txn_log_location(tablet_id, txn_info.txn_id());
    ASSIGN_OR_RETURN(auto combined_log, tablet_mgr->get_combined_txn_log(log_path, true));
    ...
}
```

So every file-bundling compaction paid an extra remote GET of the combined txn log at publish time. The load path does not have this problem — `DeltaWriterImpl::finish_with_txnlog()` already caches under `kDontWriteTxnLog`. The same is true of the file-bundling tablet metadata path, which skips the write but still calls `cache_tablet_metadata()`. Compaction was the one producer that dropped the log on the floor.

Note this only affects the **aggregate** column below. Parallel compaction on a non-file-bundling table persists its merged log through `put_txn_log()` (`tablet_parallel_compaction_manager.cpp:869`), which caches internally, so it was already fine:

|  | non-file-bundling (`skip=false`) | file bundling (`skip=true`) |
|---|---|---|
| serial | `put_txn_log` (caches) | returned to aggregator — **was missing the cache** |
| parallel | merged log → local `put_txn_log` (caches) | merged log → returned to aggregator — **was missing the cache** |

## What I'm doing:

Fill the metacache at the point where the log is handed to the aggregator, in `CompactionTaskCallback::finish_task()`.

**Why `finish_task()` and not the compaction tasks themselves.** Parallel compaction subtasks also carry `skip_write_txnlog=true` (`tablet_parallel_compaction_manager.cpp:1455` — set so their logs stay in the context to be merged later), so caching inside `HorizontalCompactionTask` / `VerticalCompactionTask` / `CloudNativeIndexCompactionTask` would let every subtask write its **partial** log under the tablet's single `txn_log_location(tablet_id, txn_id)` key, last writer winning. Publish would then read a truncated log straight out of the cache without ever validating it against object storage. Subtasks are funneled through `TabletParallelCompactionManager::on_subtask_complete()` and only the merged context reaches `finish_task()`, which makes it the single point where the log is known to be complete. It is also downstream of the horizontal/vertical/index task choice, so all three are covered without touching them.

**A tablet whose own compaction failed is not cached** — publish will never ask for its log. That is all the `context->status.ok()` guard establishes; it does not make a cached log guaranteed durable. `write_combined_txn_log()` is gated on the whole `AggregateCompactRequest` succeeding (FE pins `allow_partial_success` to false on this path), so a tablet that succeeds alongside a **failing sibling** is cached even though the combined object is never written.

The raw (non-normalized) log is cached, exactly like `put_txn_log()` caches the caller's log rather than the dual-written copy it serializes: the legacy parallel arrays exist only for on-disk rollback compat and are folded back into the structured fields by `normalize_txn_log_after_load()` on read.

On a normal abort the entry is erased by the existing `collect_files_in_log()`, the same mechanism that cleans up the load path's cached logs. In the failing-sibling case above it is **not**: `abort_txn()`'s combined branch reads the never-written combined object, gets `NotFound` and `continue`s before reaching `collect_files_in_log()`, so the entry survives until LRU eviction. That is not a correctness hazard — `txn_id` is never reused, so no later publish can read it — and it is the same shape the load path already has (delta writer caches, combined write fails, abort 404s). Thanks to @kevincai for catching both overclaims; fixed in 0a406b1.

### Tests

- `test_skip_write_txnlog_fills_metacache` — runs a real compaction with `skip_write_txnlog=true` through the scheduler and asserts the log is **not** on object storage but **is** in the metacache under the key publish probes, with a `compact_version` matching the one returned in the response.
- `test_abort_with_not_write_txnlog` — extended to assert a task that failed before producing a txn log leaves nothing behind in the metacache.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5

