### PR TITLE
[BugFix] Skip standalone GIN index directory handling for builtin inverted index backend (backport #77101)

### DIFF
--- a/be/src/storage/index/inverted/inverted_index_option.cpp
+++ b/be/src/storage/index/inverted/inverted_index_option.cpp
@@ -34,6 +34,11 @@ StatusOr<InvertedImplementType> get_inverted_imp_type(const TabletIndex& tablet_
     }
 }
 
+bool is_builtin_inverted_index(const TabletIndex& tablet_index) {
+    auto imp_type = get_inverted_imp_type(tablet_index);
+    return imp_type.ok() && *imp_type == InvertedImplementType::BUILTIN;
+}
+
 std::string inverted_index_parser_type_to_string(InvertedIndexParserType parser_type) {
     switch (parser_type) {
     case InvertedIndexParserType::PARSER_NONE:

--- a/be/src/storage/index/inverted/inverted_index_option.h
+++ b/be/src/storage/index/inverted/inverted_index_option.h
@@ -27,6 +27,8 @@ namespace starrocks {
 
 StatusOr<InvertedImplementType> get_inverted_imp_type(const TabletIndex& tablet_index);
 
+bool is_builtin_inverted_index(const TabletIndex& tablet_index);
+
 std::string inverted_index_parser_type_to_string(InvertedIndexParserType parser_type);
 
 InvertedIndexParserType get_inverted_index_parser_type_from_string(const std::string& parser_str);

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -49,6 +49,7 @@
 #include "storage/delete_predicates.h"
 #include "storage/empty_iterator.h"
 #include "storage/index/index_descriptor.h"
+#include "storage/index/inverted/inverted_index_option.h"
 #include "storage/merge_iterator.h"
 #include "storage/projection_iterator.h"
 #include "storage/rowset/metadata_cache.h"
@@ -362,10 +363,14 @@ Status Rowset::remove() {
         // delete index
         for (const auto& index : *(_schema->indexes())) {
             if (index.index_type() == IndexType::GIN) {
+                if (is_builtin_inverted_index(index)) {
+                    continue;
+                }
                 std::string inverted_index_path = IndexDescriptor::inverted_index_file_path(
                         _rowset_path, rowset_id().to_string(), i, index.index_id());
                 auto ist = fs->delete_dir_recursive(inverted_index_path);
-                LOG_IF(WARNING, !ist.ok()) << "Fail to delete vector_index_path " << inverted_index_path << ": " << ist;
+                LOG_IF(WARNING, !ist.ok())
+                        << "Fail to delete inverted_index_path " << inverted_index_path << ": " << ist;
                 merge_status(ist);
             } else if (index.index_type() == IndexType::VECTOR) {
                 std::string vector_index_path = IndexDescriptor::vector_index_file_path(
@@ -457,6 +462,9 @@ Status Rowset::link_files_to(const std::string& dir, RowsetId new_rowset_id, int
             const auto& indexes = *_schema->indexes();
             for (const auto& index : indexes) {
                 if (index.index_type() == GIN) {
+                    if (is_builtin_inverted_index(index)) {
+                        continue;
+                    }
                     std::string dst_inverted_link_path = IndexDescriptor::inverted_index_file_path(
                             dir, new_rowset_id.to_string(), segment_n, index.index_id());
                     std::string src_inverted_file_path = IndexDescriptor::inverted_index_file_path(
@@ -574,11 +582,14 @@ StatusOr<int64_t> Rowset::copy_files_to(const std::string& dir) {
         if (!indexes.empty()) {
             for (const auto& index : indexes) {
                 if (index.index_type() == IndexType::GIN) {
+                    if (is_builtin_inverted_index(index)) {
+                        continue;
+                    }
                     std::string dst_index_path = IndexDescriptor::inverted_index_file_path(dir, rowset_id().to_string(),
                                                                                            i, index.index_id());
                     if (fs::path_exist(dst_index_path)) {
-                        LOG(WARNING) << "Index path already exist: " << dst_path;
-                        return Status::AlreadyExist(fmt::format("Index path already exist: {}", dst_path));
+                        LOG(WARNING) << "Index path already exist: " << dst_index_path;
+                        return Status::AlreadyExist(fmt::format("Index path already exist: {}", dst_index_path));
                     }
 
                     std::string src_index_path = IndexDescriptor::inverted_index_file_path(

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -55,6 +55,7 @@
 #include "storage/chunk_helper.h"
 #include "storage/empty_iterator.h"
 #include "storage/index/index_descriptor.h"
+#include "storage/index/inverted/inverted_index_option.h"
 #include "storage/merge_iterator.h"
 #include "storage/metadata_util.h"
 #include "storage/olap_define.h"
@@ -547,6 +548,9 @@ HorizontalRowsetWriter::~HorizontalRowsetWriter() {
                 for (int i = 0; i < _num_segment; i++) {
                     for (const auto& index : indexes) {
                         if (index.index_type() == GIN) {
+                            if (is_builtin_inverted_index(index)) {
+                                continue;
+                            }
                             std::string index_path = IndexDescriptor::inverted_index_file_path(
                                     _context.rowset_path_prefix, _context.rowset_id.to_string(), i, index.index_id());
                             auto index_st = _fs->delete_dir_recursive(index_path);
@@ -1241,6 +1245,9 @@ VerticalRowsetWriter::~VerticalRowsetWriter() {
                 if (!indexes->empty()) {
                     for (const auto& index : *indexes) {
                         if (index.index_type() == GIN) {
+                            if (is_builtin_inverted_index(index)) {
+                                continue;
+                            }
                             std::string index_path = IndexDescriptor::inverted_index_file_path(
                                     _context.rowset_path_prefix, _context.rowset_id.to_string(), i, index.index_id());
                             auto index_st = _fs->delete_dir_recursive(index_path);

--- a/be/src/storage/snapshot_manager.cpp
+++ b/be/src/storage/snapshot_manager.cpp
@@ -47,6 +47,8 @@
 #include "runtime/exec_env.h"
 #include "storage/del_vector.h"
 #include "storage/index/index_descriptor.h"
+#include "storage/index/inverted/inverted_index_option.h"
+
 #ifndef __APPLE__
 #include "storage/index/inverted/clucene/clucene_plugin.h"
 #endif
@@ -790,6 +792,9 @@ Status SnapshotManager::assign_new_rowset_id(SnapshotMeta* snapshot_meta, const 
                 const auto& indexes = *tablet_schema->indexes();
                 for (const auto& index : indexes) {
                     if (index.index_type() == GIN) {
+                        if (is_builtin_inverted_index(index)) {
+                            continue;
+                        }
                         std::string dst_inverted_link_path = IndexDescriptor::inverted_index_file_path(
                                 clone_dir, new_rowset_id.to_string(), segment_n, index.index_id());
                         std::string src_inverted_file_path = IndexDescriptor::inverted_index_file_path(

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -671,6 +671,7 @@ SET(DW_TEST_FILES
     ./storage/del_file_stream_converter_test.cpp
     ./storage/short_key_index_test.cpp
     ./storage/size_tiered_compaction_policy_test.cpp
+    ./storage/snapshot_manager_test.cpp
     ./storage/snapshot_meta_test.cpp
     ./storage/sstable/concatenating_iterator_test.cpp
     ./storage/storage_engine_compaction_test.cpp

--- a/be/test/storage/index/builtin_inverted_index_test.cpp
+++ b/be/test/storage/index/builtin_inverted_index_test.cpp
@@ -27,6 +27,7 @@
 #include "storage/index/inverted/builtin/builtin_inverted_writer.h"
 #include "storage/index/inverted/builtin/builtin_simple_analyzer.h"
 #include "storage/index/inverted/inverted_index_common.h"
+#include "storage/index/inverted/inverted_index_option.h"
 #include "storage/rowset/bitmap_index_reader.h"
 #include "storage/tablet_index.h"
 #include "storage/types.h"
@@ -1294,6 +1295,28 @@ TEST_F(BuiltinInvertedIndexTest, test_simple_analyzer) {
 
     analyzer2.tokenize(nullptr, 0, tokens);
     ASSERT_TRUE(tokens.empty());
+}
+
+TEST_F(BuiltinInvertedIndexTest, test_is_builtin_inverted_index) {
+    {
+        TabletIndex tablet_index;
+        ASSERT_FALSE(is_builtin_inverted_index(tablet_index));
+    }
+    {
+        TabletIndex tablet_index;
+        tablet_index.add_common_properties(INVERTED_IMP_KEY, TYPE_CLUCENE);
+        ASSERT_FALSE(is_builtin_inverted_index(tablet_index));
+    }
+    {
+        TabletIndex tablet_index;
+        tablet_index.add_common_properties(INVERTED_IMP_KEY, TYPE_BUILTIN);
+        ASSERT_TRUE(is_builtin_inverted_index(tablet_index));
+    }
+    {
+        TabletIndex tablet_index;
+        tablet_index.add_common_properties(INVERTED_IMP_KEY, "invalid");
+        ASSERT_FALSE(is_builtin_inverted_index(tablet_index));
+    }
 }
 
 } // namespace starrocks

--- a/be/test/storage/rowset/rowset_test.cpp
+++ b/be/test/storage/rowset/rowset_test.cpp
@@ -69,6 +69,7 @@
 #include "storage/update_manager.h"
 #include "testutil/assert.h"
 #include "testutil/sync_point.h"
+#include "util/slice.h"
 
 using std::string;
 
@@ -1403,7 +1404,7 @@ TEST_F(RowsetTest, horizontal_writer_dtor_skips_builtin_gin_index) {
     ASSERT_OK(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer));
 
     auto schema = ChunkHelper::convert_schema(tablet_schema);
-    auto chunk = ChunkFactory::new_chunk(schema, config::vector_chunk_size);
+    auto chunk = ChunkHelper::new_chunk(schema, config::vector_chunk_size);
     auto cols = chunk->columns();
     cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(1)));
     cols[1]->as_mutable_ptr()->append_datum(Datum(Slice("apple")));
@@ -1435,7 +1436,7 @@ TEST_F(RowsetTest, vertical_writer_dtor_skips_builtin_gin_index) {
     {
         std::vector<uint32_t> column_indexes{0};
         auto schema = ChunkHelper::convert_schema(tablet_schema, column_indexes);
-        auto chunk = ChunkFactory::new_chunk(schema, 16);
+        auto chunk = ChunkHelper::new_chunk(schema, 16);
         chunk->columns()[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(1)));
         ASSERT_OK(rowset_writer->add_columns(*chunk, column_indexes, true));
         ASSERT_OK(rowset_writer->flush_columns());

--- a/be/test/storage/rowset/rowset_test.cpp
+++ b/be/test/storage/rowset/rowset_test.cpp
@@ -50,7 +50,10 @@
 #include "storage/chunk_helper.h"
 #include "storage/chunk_iterator.h"
 #include "storage/empty_iterator.h"
+#include "storage/index/index_descriptor.h"
+#include "storage/index/inverted/inverted_index_common.h"
 #include "storage/rowset/rowset_factory.h"
+#include "storage/rowset/rowset_meta.h"
 #include "storage/rowset/rowset_options.h"
 #include "storage/rowset/rowset_writer.h"
 #include "storage/rowset/rowset_writer_context.h"
@@ -1215,5 +1218,234 @@ TEST_F(RowsetTest, SegmentDeleteWriteTest) {
     auto st = segment_rowset_writer->flush_segment(*seg_info, data);
     LOG(INFO) << st;
     ASSERT_TRUE(st.ok());
+}
+
+static std::shared_ptr<TabletSchema> create_gin_tablet_schema(const std::string& imp_lib) {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(DUP_KEYS);
+    schema_pb.set_num_short_key_columns(1);
+    schema_pb.set_num_rows_per_row_block(1024);
+    schema_pb.set_next_column_unique_id(3);
+
+    ColumnPB* k1 = schema_pb.add_column();
+    k1->set_unique_id(1);
+    k1->set_name("k1");
+    k1->set_type("INT");
+    k1->set_is_key(true);
+    k1->set_length(4);
+    k1->set_index_length(4);
+    k1->set_is_nullable(false);
+
+    ColumnPB* v1 = schema_pb.add_column();
+    v1->set_unique_id(2);
+    v1->set_name("v1");
+    v1->set_type("VARCHAR");
+    v1->set_is_key(false);
+    v1->set_length(64);
+    v1->set_is_nullable(false);
+
+    TabletIndexPB* index_pb = schema_pb.add_table_indices();
+    index_pb->set_index_id(100);
+    index_pb->set_index_name("gin_v1");
+    index_pb->set_index_type(GIN);
+    index_pb->add_col_unique_id(2);
+    index_pb->set_index_properties(R"({"common_properties":{")" + INVERTED_IMP_KEY + R"(":")" + imp_lib + R"("}})");
+
+    return std::make_shared<TabletSchema>(schema_pb);
+}
+
+static RowsetSharedPtr create_gin_rowset(const TabletSchemaCSPtr& schema, const std::string& dir,
+                                         const RowsetId& rowset_id) {
+    RowsetMetaPB rowset_meta_pb;
+    rowset_meta_pb.set_rowset_id(rowset_id.to_string());
+    rowset_meta_pb.set_tablet_id(12345);
+    rowset_meta_pb.set_tablet_schema_hash(1111);
+    rowset_meta_pb.set_partition_id(1);
+    rowset_meta_pb.set_rowset_type(BETA_ROWSET);
+    rowset_meta_pb.set_rowset_state(VISIBLE);
+    rowset_meta_pb.set_start_version(2);
+    rowset_meta_pb.set_end_version(2);
+    rowset_meta_pb.set_num_rows(1);
+    rowset_meta_pb.set_num_segments(1);
+    rowset_meta_pb.set_total_disk_size(1);
+    rowset_meta_pb.set_data_disk_size(1);
+    rowset_meta_pb.set_index_disk_size(0);
+    rowset_meta_pb.set_empty(false);
+    rowset_meta_pb.set_creation_time(time(nullptr));
+
+    auto rowset_meta = std::make_shared<RowsetMeta>(rowset_meta_pb);
+    return Rowset::create(schema, dir, rowset_meta, nullptr);
+}
+
+static void create_dummy_segment_file(const std::string& dir, const RowsetId& rowset_id) {
+    ASSIGN_OR_ABORT(auto wfile, FileSystem::Default()->new_writable_file(Rowset::segment_file_path(dir, rowset_id, 0)));
+    ASSERT_OK(wfile->append("dummy segment"));
+    ASSERT_OK(wfile->close());
+}
+
+// Builtin GIN lives inside the segment file, so there is no standalone .ivt directory to relocate.
+TEST_F(RowsetTest, link_files_to_skips_builtin_gin_index) {
+    auto schema = create_gin_tablet_schema(TYPE_BUILTIN);
+    const std::string src_dir = config::storage_root_path + "/data/rowset_test";
+    const std::string dst_dir = config::storage_root_path + "/data/link_builtin_gin";
+    ASSERT_TRUE(fs::create_directories(dst_dir).ok());
+
+    RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+    create_dummy_segment_file(src_dir, rowset_id);
+    auto rowset = create_gin_rowset(schema, src_dir, rowset_id);
+
+    RowsetId new_rowset_id = StorageEngine::instance()->next_rowset_id();
+    ASSERT_OK(rowset->link_files_to(dst_dir, new_rowset_id));
+    ASSERT_TRUE(fs::path_exist(Rowset::segment_file_path(dst_dir, new_rowset_id, 0)));
+}
+
+// CLucene keeps a standalone directory, so a missing one must still be reported.
+TEST_F(RowsetTest, link_files_to_reports_missing_clucene_gin_index) {
+    auto schema = create_gin_tablet_schema(TYPE_CLUCENE);
+    const std::string src_dir = config::storage_root_path + "/data/rowset_test";
+    const std::string dst_dir = config::storage_root_path + "/data/link_clucene_gin";
+    ASSERT_TRUE(fs::create_directories(dst_dir).ok());
+
+    RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+    create_dummy_segment_file(src_dir, rowset_id);
+    auto rowset = create_gin_rowset(schema, src_dir, rowset_id);
+
+    RowsetId new_rowset_id = StorageEngine::instance()->next_rowset_id();
+    auto st = rowset->link_files_to(dst_dir, new_rowset_id);
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.is_not_found()) << st.to_string();
+}
+
+TEST_F(RowsetTest, copy_files_to_skips_builtin_gin_index) {
+    auto schema = create_gin_tablet_schema(TYPE_BUILTIN);
+    const std::string src_dir = config::storage_root_path + "/data/rowset_test";
+    const std::string dst_dir = config::storage_root_path + "/data/copy_builtin_gin";
+    ASSERT_TRUE(fs::create_directories(dst_dir).ok());
+
+    RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+    create_dummy_segment_file(src_dir, rowset_id);
+    auto rowset = create_gin_rowset(schema, src_dir, rowset_id);
+
+    auto res = rowset->copy_files_to(dst_dir);
+    ASSERT_TRUE(res.ok()) << res.status().to_string();
+    ASSERT_TRUE(fs::path_exist(Rowset::segment_file_path(dst_dir, rowset_id, 0)));
+}
+
+TEST_F(RowsetTest, copy_files_to_reports_missing_clucene_gin_index) {
+    auto schema = create_gin_tablet_schema(TYPE_CLUCENE);
+    const std::string src_dir = config::storage_root_path + "/data/rowset_test";
+    const std::string dst_dir = config::storage_root_path + "/data/copy_clucene_gin";
+    ASSERT_TRUE(fs::create_directories(dst_dir).ok());
+
+    RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+    create_dummy_segment_file(src_dir, rowset_id);
+    auto rowset = create_gin_rowset(schema, src_dir, rowset_id);
+
+    auto res = rowset->copy_files_to(dst_dir);
+    ASSERT_FALSE(res.ok());
+    ASSERT_TRUE(res.status().is_not_found()) << res.status().to_string();
+}
+
+TEST_F(RowsetTest, copy_files_to_reports_existing_index_path) {
+    auto schema = create_gin_tablet_schema(TYPE_CLUCENE);
+    const std::string src_dir = config::storage_root_path + "/data/rowset_test";
+    const std::string dst_dir = config::storage_root_path + "/data/copy_existing_gin";
+    ASSERT_TRUE(fs::create_directories(dst_dir).ok());
+
+    RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+    create_dummy_segment_file(src_dir, rowset_id);
+    auto rowset = create_gin_rowset(schema, src_dir, rowset_id);
+
+    std::string dst_index_path = IndexDescriptor::inverted_index_file_path(dst_dir, rowset_id.to_string(), 0, 100);
+    ASSERT_TRUE(fs::create_directories(dst_index_path).ok());
+
+    auto res = rowset->copy_files_to(dst_dir);
+    ASSERT_FALSE(res.ok());
+    ASSERT_TRUE(res.status().is_already_exist()) << res.status().to_string();
+    std::string err = res.status().to_string();
+    ASSERT_TRUE(err.find(dst_index_path) != std::string::npos) << err;
+}
+
+TEST_F(RowsetTest, remove_skips_builtin_gin_index) {
+    auto schema = create_gin_tablet_schema(TYPE_BUILTIN);
+    const std::string src_dir = config::storage_root_path + "/data/rowset_test";
+
+    RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+    create_dummy_segment_file(src_dir, rowset_id);
+    auto rowset = create_gin_rowset(schema, src_dir, rowset_id);
+
+    ASSERT_OK(rowset->remove());
+    ASSERT_FALSE(fs::path_exist(Rowset::segment_file_path(src_dir, rowset_id, 0)));
+}
+
+// remove() tolerates a missing CLucene directory: merge_status filters is_not_found.
+TEST_F(RowsetTest, remove_tolerates_missing_clucene_gin_index) {
+    auto schema = create_gin_tablet_schema(TYPE_CLUCENE);
+    const std::string src_dir = config::storage_root_path + "/data/rowset_test";
+
+    RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+    create_dummy_segment_file(src_dir, rowset_id);
+    auto rowset = create_gin_rowset(schema, src_dir, rowset_id);
+
+    ASSERT_OK(rowset->remove());
+    ASSERT_FALSE(fs::path_exist(Rowset::segment_file_path(src_dir, rowset_id, 0)));
+}
+
+TEST_F(RowsetTest, horizontal_writer_dtor_skips_builtin_gin_index) {
+    auto tablet_schema = create_gin_tablet_schema(TYPE_BUILTIN);
+
+    RowsetWriterContext writer_context;
+    create_rowset_writer_context(12345, tablet_schema, &writer_context);
+    writer_context.rowset_id = StorageEngine::instance()->next_rowset_id();
+    writer_context.writer_type = kHorizontal;
+
+    std::unique_ptr<RowsetWriter> rowset_writer;
+    ASSERT_OK(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer));
+
+    auto schema = ChunkHelper::convert_schema(tablet_schema);
+    auto chunk = ChunkFactory::new_chunk(schema, config::vector_chunk_size);
+    auto cols = chunk->columns();
+    cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(1)));
+    cols[1]->as_mutable_ptr()->append_datum(Datum(Slice("apple")));
+    ASSERT_OK(rowset_writer->add_chunk(*chunk));
+    ASSERT_OK(rowset_writer->flush());
+
+    std::string segment_path =
+            Rowset::segment_file_path(writer_context.rowset_path_prefix, writer_context.rowset_id, 0);
+    ASSERT_TRUE(fs::path_exist(segment_path));
+
+    // Destroying an unbuilt writer runs the garbage cleanup path, which must skip the
+    // builtin GIN index directory handling.
+    rowset_writer.reset();
+    ASSERT_FALSE(fs::path_exist(segment_path));
+}
+
+TEST_F(RowsetTest, vertical_writer_dtor_skips_builtin_gin_index) {
+    auto tablet_schema = create_gin_tablet_schema(TYPE_BUILTIN);
+
+    RowsetWriterContext writer_context;
+    create_rowset_writer_context(12345, tablet_schema, &writer_context);
+    writer_context.rowset_id = StorageEngine::instance()->next_rowset_id();
+    writer_context.writer_type = kVertical;
+    writer_context.max_rows_per_segment = 4096;
+
+    std::unique_ptr<RowsetWriter> rowset_writer;
+    ASSERT_OK(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer));
+
+    {
+        std::vector<uint32_t> column_indexes{0};
+        auto schema = ChunkHelper::convert_schema(tablet_schema, column_indexes);
+        auto chunk = ChunkFactory::new_chunk(schema, 16);
+        chunk->columns()[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(1)));
+        ASSERT_OK(rowset_writer->add_columns(*chunk, column_indexes, true));
+        ASSERT_OK(rowset_writer->flush_columns());
+    }
+
+    std::string segment_path =
+            Rowset::segment_file_path(writer_context.rowset_path_prefix, writer_context.rowset_id, 0);
+    ASSERT_TRUE(fs::path_exist(segment_path));
+
+    rowset_writer.reset();
+    ASSERT_FALSE(fs::path_exist(segment_path));
 }
 } // namespace starrocks

--- a/be/test/storage/snapshot_manager_test.cpp
+++ b/be/test/storage/snapshot_manager_test.cpp
@@ -1,0 +1,163 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/snapshot_manager.h"
+
+#include <gtest/gtest.h>
+
+#include <ctime>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "base/testutil/assert.h"
+#include "common/config_storage_fwd.h"
+#include "fs/fs.h"
+#include "fs/fs_util.h"
+#include "gen_cpp/olap_file.pb.h"
+#include "storage/index/inverted/inverted_index_common.h"
+#include "storage/options.h"
+#include "storage/rowset/rowset.h"
+#include "storage/snapshot_meta.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet_schema.h"
+
+namespace starrocks {
+
+class SnapshotManagerTest : public testing::Test {
+protected:
+    void SetUp() override {
+        _default_storage_root_path = config::storage_root_path;
+        config::storage_root_path = std::filesystem::current_path().string() + "/snapshot_manager_test";
+
+        ASSERT_OK(fs::remove_all(config::storage_root_path));
+        ASSERT_TRUE(fs::create_directories(config::storage_root_path).ok());
+
+        std::vector<StorePath> paths;
+        paths.emplace_back(config::storage_root_path);
+        EngineOptions options;
+        options.store_paths = paths;
+        ASSERT_OK(StorageEngine::open(options, &_engine));
+
+        _clone_dir = config::storage_root_path + "/clone";
+        ASSERT_TRUE(fs::create_directories(_clone_dir).ok());
+    }
+
+    void TearDown() override {
+        if (_engine != nullptr) {
+            _engine->stop();
+            delete _engine;
+            _engine = nullptr;
+        }
+        if (fs::path_exist(config::storage_root_path)) {
+            ASSERT_TRUE(fs::remove_all(config::storage_root_path).ok());
+        }
+        config::storage_root_path = _default_storage_root_path;
+    }
+
+    static std::shared_ptr<TabletSchema> create_gin_tablet_schema(const std::string& imp_lib) {
+        TabletSchemaPB schema_pb;
+        schema_pb.set_keys_type(DUP_KEYS);
+        schema_pb.set_num_short_key_columns(1);
+        schema_pb.set_num_rows_per_row_block(1024);
+        schema_pb.set_next_column_unique_id(3);
+
+        ColumnPB* k1 = schema_pb.add_column();
+        k1->set_unique_id(1);
+        k1->set_name("k1");
+        k1->set_type("INT");
+        k1->set_is_key(true);
+        k1->set_length(4);
+        k1->set_index_length(4);
+        k1->set_is_nullable(false);
+
+        ColumnPB* v1 = schema_pb.add_column();
+        v1->set_unique_id(2);
+        v1->set_name("v1");
+        v1->set_type("VARCHAR");
+        v1->set_is_key(false);
+        v1->set_length(64);
+        v1->set_is_nullable(false);
+
+        TabletIndexPB* index_pb = schema_pb.add_table_indices();
+        index_pb->set_index_id(100);
+        index_pb->set_index_name("gin_v1");
+        index_pb->set_index_type(GIN);
+        index_pb->add_col_unique_id(2);
+        index_pb->set_index_properties(R"({"common_properties":{")" + INVERTED_IMP_KEY + R"(":")" + imp_lib + R"("}})");
+
+        return std::make_shared<TabletSchema>(schema_pb);
+    }
+
+    void build_single_segment_snapshot(SnapshotMeta* snapshot_meta, RowsetId* rowset_id) {
+        *rowset_id = StorageEngine::instance()->next_rowset_id();
+
+        ASSIGN_OR_ABORT(auto wfile,
+                        FileSystem::Default()->new_writable_file(Rowset::segment_file_path(_clone_dir, *rowset_id, 0)));
+        ASSERT_OK(wfile->append("dummy segment"));
+        ASSERT_OK(wfile->close());
+
+        snapshot_meta->rowset_metas().resize(1);
+        RowsetMetaPB& rowset_meta_pb = snapshot_meta->rowset_metas()[0];
+        rowset_meta_pb.set_rowset_id(rowset_id->to_string());
+        rowset_meta_pb.set_tablet_id(12345);
+        rowset_meta_pb.set_partition_id(1);
+        rowset_meta_pb.set_rowset_state(VISIBLE);
+        rowset_meta_pb.set_start_version(2);
+        rowset_meta_pb.set_end_version(2);
+        rowset_meta_pb.set_num_rows(1);
+        rowset_meta_pb.set_num_segments(1);
+        rowset_meta_pb.set_num_delete_files(0);
+        rowset_meta_pb.set_data_disk_size(1);
+        rowset_meta_pb.set_empty(false);
+        rowset_meta_pb.set_creation_time(time(nullptr));
+    }
+
+    StorageEngine* _engine = nullptr;
+    std::string _default_storage_root_path;
+    std::string _clone_dir;
+};
+
+// Builtin GIN lives inside the segment file, so there is no standalone .ivt directory to relocate.
+TEST_F(SnapshotManagerTest, assign_new_rowset_id_skips_builtin_gin_index) {
+    auto schema = create_gin_tablet_schema(TYPE_BUILTIN);
+
+    SnapshotMeta snapshot_meta;
+    RowsetId old_rowset_id;
+    build_single_segment_snapshot(&snapshot_meta, &old_rowset_id);
+
+    ASSERT_OK(SnapshotManager::instance()->assign_new_rowset_id(&snapshot_meta, _clone_dir, schema));
+
+    const std::string& new_rowset_id = snapshot_meta.rowset_metas()[0].rowset_id();
+    ASSERT_NE(old_rowset_id.to_string(), new_rowset_id);
+
+    RowsetId parsed;
+    parsed.init(new_rowset_id);
+    ASSERT_TRUE(fs::path_exist(Rowset::segment_file_path(_clone_dir, parsed, 0)));
+}
+
+// CLucene keeps a standalone directory, so a missing one must still be reported.
+TEST_F(SnapshotManagerTest, assign_new_rowset_id_reports_missing_clucene_gin_index) {
+    auto schema = create_gin_tablet_schema(TYPE_CLUCENE);
+
+    SnapshotMeta snapshot_meta;
+    RowsetId old_rowset_id;
+    build_single_segment_snapshot(&snapshot_meta, &old_rowset_id);
+
+    auto st = SnapshotManager::instance()->assign_new_rowset_id(&snapshot_meta, _clone_dir, schema);
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.is_not_found()) << st.to_string();
+}
+
+} // namespace starrocks

--- a/be/test/storage/snapshot_manager_test.cpp
+++ b/be/test/storage/snapshot_manager_test.cpp
@@ -21,8 +21,7 @@
 #include <string>
 #include <vector>
 
-#include "base/testutil/assert.h"
-#include "common/config_storage_fwd.h"
+#include "common/config.h"
 #include "fs/fs.h"
 #include "fs/fs_util.h"
 #include "gen_cpp/olap_file.pb.h"
@@ -32,6 +31,7 @@
 #include "storage/snapshot_meta.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet_schema.h"
+#include "testutil/assert.h"
 
 namespace starrocks {
 


### PR DESCRIPTION
## Why I'm doing:

Any table carrying `INDEX ... USING GIN ("imp_lib" = "builtin")` cannot have its rowset
files relocated. Three paths that move segment files *without rewriting data* all fail:

| Entry point | Call chain |
|---|---|
| Clone / replica repair (FE-scheduled, most severe) | `snapshot_manager.cpp` → `link_files_to()` / `assign_new_rowset_id()` |
| Storage medium migration | `engine_storage_migration_task.cpp:629` → `copy_files_to()` |
| Shortcut compaction | `rowset_writer.cpp:767` → `link_files_to()` |

The failure is silent to the user — queries keep working, nothing surfaces in SQL — and the
task retries forever.

```
W engine_storage_migration_task.cpp:227] fail to copy index and data files when migrate.
  res=Not found: .../645998/1599932334/0200...aa_0_0.ivt: No such file or directory
I agent_server.cpp:459] Submit task success. type=STORAGE_MEDIUM_MIGRATE, signatures=645998   <- every ~60s, forever
```

```
W compaction_task.cpp:147] compaction finish. status:Not found: .../0200...b6_0_0.ivt: No such file or directory
   state:COMPACTION_FAILED, compaction_type:base, input_rowsets_num:2
```

Root cause: each of the three functions has a GIN block keyed only off
`index.index_type() == GIN`. It builds the standalone index directory
`{rowset_id}_{seg}_{index_id}.ivt` and calls `fs::list_dirs_files` on it under
`RETURN_IF_ERROR`. That directory exists only for the **CLucene** backend. The **builtin**
backend writes its index inside the segment file
(`InvertedWriter::finish(WritableFile*, ColumnMetaPB*)`,
`be/src/storage/index/inverted/inverted_writer.h:38`) and never creates one — so the lookup
fails and takes the whole task down. Builtin needs no work here at all: the index rides
inside the segment file, which is already linked/copied *outside* the index loop
(`rowset.cpp:453`, `:579`, `snapshot_manager.cpp:790`).

Fixes #77100

## What I'm doing:

Adding a named predicate and skipping the standalone-directory handling for the builtin
backend in the three functions:

```cpp
bool is_builtin_inverted_index(const TabletIndex& tablet_index) {
    auto imp_type = get_inverted_imp_type(tablet_index);
    return imp_type.ok() && *imp_type == InvertedImplementType::BUILTIN;
}
```

`get_inverted_imp_type()` returns `InvalidArgument` when `imp_lib` is absent (legacy
metadata predating the property) or unrecognised. The predicate is then `false`, so the
original CLucene directory handling runs unchanged — **including its loud failure when a
directory is genuinely missing**. CLucene behaviour is not altered in any way.

Two notes for reviewers:

- The four existing callers of `get_inverted_imp_type` use `ASSIGN_OR_RETURN`, i.e. they
  propagate the error. This change deliberately does not: propagating here would fail
  relocation for any tablet whose metadata predates `imp_lib`, reintroducing the same class
  of bug. The helper keeps that judgement in one place.
- `rowset.cpp:369` (`Rowset::remove()`) has a fourth GIN block that is intentionally left
  alone — it uses `delete_dir_recursive` and its `merge_status` lambda already ignores
  `is_not_found`, so a missing builtin directory is harmless there.

### Verification

Single-BE cluster, same baseline (`4f845046cd5`), before and after the change:

| Case | Before | After |
|---|---|---|
| builtin medium migration | fail — `.ivt` NotFound, retried every 60s, tablet stuck on HDD | **pass** — moved to SSD, `MATCH` result identical to the pre-migration baseline |
| builtin shortcut compaction | fail — `COMPACTION_FAILED` | **pass** — `COMPACTION_SUCCESS`, `is_shortcut_compaction:1`, `MATCH` identical |
| CLucene medium migration | pass | **pass** — `.ivt` directory and all 9 CLucene files relocated, `MATCH` ok |
| no-index migration | pass | **pass** |

The CLucene row is the guard against this degenerating into "skip everything": after the
change the directory is still genuinely moved.

```
$ ls .../storage/data/1/646016/1599932334/0200...96_0_0.ivt
_0.fdt  _0.fdx  _0.fnm  _0.frq  _0.tii  _0.tis  null_bitmap  segments_2  segments.gen
```

No new WARNINGs of any kind after the change. `BuiltinInvertedIndexTest` passes 25/25
including the new case.

**Not verified end-to-end:** clone / replica repair and BACKUP need a multi-BE cluster.
They share `snapshot_manager.cpp` with the verified paths, but I have not exercised them
directly.

### Overlap with open PRs

#76901 and #76902 (both fixing CLucene index directories lost across clone) also touch
`be/src/storage/snapshot_manager.cpp`. Their last hunk in that file is in
`snapshot_primary()`; this change is in `assign_new_rowset_id()`, so there is no
overlapping hunk, and no semantic overlap either — their only `imp_lib` references are test
fixtures setting `clucene`. Rebase should be trivial in either order.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: relocation paths that previously always failed for builtin GIN tables now succeed; CLucene and non-indexed tables are unchanged.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

Only 4.1. `be/src/storage/index/inverted/builtin` does not exist on `branch-4.0`,
`branch-3.5` or `branch-3.4`, so those releases have no builtin inverted index backend and
cannot hit this bug.


Also applied the same skip to `Rowset::remove()` and rowset writer cleanup paths per review.


---

Manual backport of #77101 (the Mergify backport #77232 was closed on conflicts).

Conflicts were confined to include blocks and were resolved as a union with `branch-4.1`'s
existing includes. A follow-up commit adapts the tests to `branch-4.1`, which predates the
`util/` → `base/` header migration and has no `ChunkFactory`:
`ChunkFactory::new_chunk` → `ChunkHelper::new_chunk`, `base/testutil/assert.h` →
`testutil/assert.h`, `common/config_storage_fwd.h` → `common/config.h`, plus
`#include "util/slice.h"`. The production-code hunks are unchanged from the original PR.

