### PR TITLE
[UT] Fix remaining branch-4.0 SQL-tester division TAB and flat_json waits

### DIFF
--- a/test/sql/test_push_down_predicate/R/test_expr_predicate_push_down
+++ b/test/sql/test_push_down_predicate/R/test_expr_predicate_push_down
@@ -55,7 +55,7 @@ SELECT id, c, 10 DIV c AS quotient FROM division_monotonicity_${uuid0} WHERE 10 
 -- !result
 SELECT id, c, c DIV 10 AS quotient FROM division_monotonicity_${uuid0} WHERE c DIV 10 > 5 ORDER BY id;
 -- result:
-5\t100\t10
+5	100	10
 -- !result
 DROP TABLE division_monotonicity_${uuid0};
 -- result:

--- a/test/sql/test_semi/R/test_flat_json
+++ b/test/sql/test_semi/R/test_flat_json
@@ -210,6 +210,10 @@ select JSON_LENGTH(j1, "$.key12"), JSON_LENGTH(j2, "$.key13"), JSON_LENGTH(j2, "
 ALTER TABLE js1 ADD COLUMN j3 JSON DEFAULT NULL AFTER j2;
 -- result:
 -- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
 ALTER TABLE js1 ADD COLUMN j4 JSON DEFAULT NULL AFTER j1;
 -- result:
 -- !result
@@ -307,6 +311,10 @@ select JSON_LENGTH(j4, "$.key12"), JSON_LENGTH(j3, "$.key13"), JSON_LENGTH(j2, "
 -- !result
 ALTER TABLE js1 DROP COLUMN j1;
 -- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
 -- !result
 ALTER TABLE js1 DROP COLUMN j4;
 -- result:

--- a/test/sql/test_semi/R/test_flat_json_schema_change
+++ b/test/sql/test_semi/R/test_flat_json_schema_change
@@ -23,8 +23,16 @@ INSERT INTO t_json_schema_change VALUES
 ALTER TABLE t_json_schema_change ADD COLUMN col4 int;
 -- result:
 -- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
 ALTER TABLE t_json_schema_change ADD COLUMN col5 int;
 -- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
 -- !result
 ALTER TABLE t_json_schema_change ADD COLUMN col6 int;
 -- result:
@@ -36,8 +44,16 @@ None
 ALTER TABLE t_json_schema_change DROP COLUMN col1;
 -- result:
 -- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
 ALTER TABLE t_json_schema_change DROP COLUMN col2;
 -- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
 -- !result
 ALTER TABLE t_json_schema_change DROP COLUMN col3;
 -- result:
@@ -48,6 +64,10 @@ None
 -- !result
 ALTER TABLE t_json_schema_change ADD COLUMN col7 int;
 -- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
 -- !result
 ALTER TABLE t_json_schema_change ADD COLUMN col8 int;
 -- result:

--- a/test/sql/test_semi/R/test_flat_json_with_properties
+++ b/test/sql/test_semi/R/test_flat_json_with_properties
@@ -214,6 +214,10 @@ select JSON_LENGTH(j1, "$.key12"), JSON_LENGTH(j2, "$.key13"), JSON_LENGTH(j2, "
 ALTER TABLE js1 ADD COLUMN j3 JSON DEFAULT NULL AFTER j2;
 -- result:
 -- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
 ALTER TABLE js1 ADD COLUMN j4 JSON DEFAULT NULL AFTER j1;
 -- result:
 -- !result
@@ -311,6 +315,10 @@ select JSON_LENGTH(j4, "$.key12"), JSON_LENGTH(j3, "$.key13"), JSON_LENGTH(j2, "
 -- !result
 ALTER TABLE js1 DROP COLUMN j1;
 -- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
 -- !result
 ALTER TABLE js1 DROP COLUMN j4;
 -- result:

--- a/test/sql/test_semi/R/test_unique_flat_json
+++ b/test/sql/test_semi/R/test_unique_flat_json
@@ -208,6 +208,10 @@ select JSON_LENGTH(j1, "$.key12"), JSON_LENGTH(j2, "$.key13"), JSON_LENGTH(j2, "
 ALTER TABLE ujs1 ADD COLUMN j3 JSON DEFAULT NULL AFTER j2;
 -- result:
 -- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
 ALTER TABLE ujs1 ADD COLUMN j4 JSON DEFAULT NULL AFTER j1;
 -- result:
 -- !result
@@ -303,6 +307,10 @@ select JSON_LENGTH(j4, "$.key12"), JSON_LENGTH(j3, "$.key13"), JSON_LENGTH(j2, "
 -- !result
 ALTER TABLE ujs1 DROP COLUMN j1;
 -- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
 -- !result
 ALTER TABLE ujs1 DROP COLUMN j4;
 -- result:

--- a/test/sql/test_semi/T/test_flat_json
+++ b/test/sql/test_semi/T/test_flat_json
@@ -110,6 +110,7 @@ select JSON_LENGTH(j1, "$.key12"), JSON_LENGTH(j2, "$.key13"), JSON_LENGTH(j2, "
 
 -- schema change
 ALTER TABLE js1 ADD COLUMN j3 JSON DEFAULT NULL AFTER j2;
+function: wait_alter_table_finish()
 ALTER TABLE js1 ADD COLUMN j4 JSON DEFAULT NULL AFTER j1;
 
 function: wait_alter_table_finish()
@@ -138,6 +139,7 @@ select JSON_LENGTH(j4, "$.key12"), JSON_LENGTH(j3, "$.key13"), JSON_LENGTH(j2, "
 
 
 ALTER TABLE js1 DROP COLUMN j1;
+function: wait_alter_table_finish()
 ALTER TABLE js1 DROP COLUMN j4;
 
 function: wait_alter_table_finish()

--- a/test/sql/test_semi/T/test_flat_json_schema_change
+++ b/test/sql/test_semi/T/test_flat_json_schema_change
@@ -25,16 +25,21 @@ INSERT INTO t_json_schema_change VALUES
 (3, parse_json('{"name": "charlie", "age": 35, "city": "chicago"}'), 7, 8, 9);
 
 ALTER TABLE t_json_schema_change ADD COLUMN col4 int;
+function: wait_alter_table_finish()
 ALTER TABLE t_json_schema_change ADD COLUMN col5 int;
+function: wait_alter_table_finish()
 ALTER TABLE t_json_schema_change ADD COLUMN col6 int;
 function: wait_alter_table_finish()
 
 ALTER TABLE t_json_schema_change DROP COLUMN col1;
+function: wait_alter_table_finish()
 ALTER TABLE t_json_schema_change DROP COLUMN col2;
+function: wait_alter_table_finish()
 ALTER TABLE t_json_schema_change DROP COLUMN col3;
 function: wait_alter_table_finish()
 
 ALTER TABLE t_json_schema_change ADD COLUMN col7 int;
+function: wait_alter_table_finish()
 ALTER TABLE t_json_schema_change ADD COLUMN col8 int;
 function: wait_alter_table_finish()
 

--- a/test/sql/test_semi/T/test_flat_json_with_properties
+++ b/test/sql/test_semi/T/test_flat_json_with_properties
@@ -114,6 +114,7 @@ select JSON_LENGTH(j1, "$.key12"), JSON_LENGTH(j2, "$.key13"), JSON_LENGTH(j2, "
 
 -- schema change
 ALTER TABLE js1 ADD COLUMN j3 JSON DEFAULT NULL AFTER j2;
+function: wait_alter_table_finish()
 ALTER TABLE js1 ADD COLUMN j4 JSON DEFAULT NULL AFTER j1;
 
 function: wait_alter_table_finish()
@@ -142,6 +143,7 @@ select JSON_LENGTH(j4, "$.key12"), JSON_LENGTH(j3, "$.key13"), JSON_LENGTH(j2, "
 
 
 ALTER TABLE js1 DROP COLUMN j1;
+function: wait_alter_table_finish()
 ALTER TABLE js1 DROP COLUMN j4;
 
 function: wait_alter_table_finish()

--- a/test/sql/test_semi/T/test_unique_flat_json
+++ b/test/sql/test_semi/T/test_unique_flat_json
@@ -110,6 +110,7 @@ select JSON_LENGTH(j1, "$.key12"), JSON_LENGTH(j2, "$.key13"), JSON_LENGTH(j2, "
 
 -- schema change
 ALTER TABLE ujs1 ADD COLUMN j3 JSON DEFAULT NULL AFTER j2;
+function: wait_alter_table_finish()
 ALTER TABLE ujs1 ADD COLUMN j4 JSON DEFAULT NULL AFTER j1;
 
 function: wait_alter_table_finish()
@@ -138,6 +139,7 @@ select JSON_LENGTH(j4, "$.key12"), JSON_LENGTH(j3, "$.key13"), JSON_LENGTH(j2, "
 
 
 ALTER TABLE ujs1 DROP COLUMN j1;
+function: wait_alter_table_finish()
 ALTER TABLE ujs1 DROP COLUMN j4;
 
 function: wait_alter_table_finish()


### PR DESCRIPTION
## Why I'm doing:

4.0.14 inspection (`bfacd8c`) still fails after #77396:

- `test_division_monotonicity`: the second SELECT expectation remained `5\\t100\\t10` (double-escaped TAB) while the first row was already fixed.
- `test_flat_json_*`: multiple `ALTER TABLE` statements were issued before `wait_alter_table_finish()`, so the next ALTER failed with `A schema change operation is in progress`.

## What I'm doing:

- Replace the remaining double-escaped TAB in `test_division_monotonicity` with a real TAB.
- Insert `wait_alter_table_finish()` after **each** ALTER in flat_json / unique_flat_json / flat_json_with_properties / flat_json_schema_change (T and R).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5


Made with [Cursor](https://cursor.com)
