### PR TITLE
[BugFix] Bound information_schema.materialized_views internal queries by query_timeout

### DIFF
--- a/be/src/schema_scanner/schema_materialized_views_scanner.cpp
+++ b/be/src/schema_scanner/schema_materialized_views_scanner.cpp
@@ -575,6 +575,12 @@ Status SchemaMaterializedViewsScanner::get_materialized_views() {
         }
     }
     table_params.__set_type(TTableType::MATERIALIZED_VIEW);
+    // Forward the outer query's query_timeout (seconds) so the FE keeps the internal task_run_history read
+    // bounded by it instead of the 1h statistic_collect_query_timeout. _ss_state.timeout_ms is derived from
+    // query_options().query_timeout in init_schema_scanner_state().
+    if (_ss_state.timeout_ms > 0) {
+        table_params.__set_query_timeout(_ss_state.timeout_ms / 1000);
+    }
 
     RETURN_IF_ERROR(SchemaHelper::list_materialized_view_status(_ss_state, table_params, &_mv_results));
     _table_index = 0;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
@@ -32,8 +32,11 @@ import com.starrocks.common.Pair;
 import com.starrocks.common.PatternMatcher;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ShowMaterializedViewStatus;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Authorizer;
+import com.starrocks.sql.common.ErrorType;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -177,6 +180,14 @@ public class MaterializedViewsSystemTable extends SystemTable {
             TListMaterializedViewStatusResult result = query(params, context);
             return result.getMaterialized_views().stream().map(this::infoToScalar).collect(Collectors.toList());
         } catch (Exception e) {
+            // Propagate query_timeout (see ShowMaterializedViewStatus.listMaterializedViewStatus): when the
+            // outer query's time budget is exhausted the whole materialized_views query should time out
+            // rather than silently returning an empty/partial result.
+            if (SimpleExecutor.outerRemainingQueryTimeoutS() <= 0) {
+                throw new StarRocksPlannerException(
+                        "querying information_schema.materialized_views exceeded query_timeout",
+                        ErrorType.INTERNAL_ERROR);
+            }
             LOG.warn("Failed to query materialized views", e);
             // Return empty result if query failed
             return Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
@@ -43,6 +43,8 @@ import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
+import com.starrocks.sql.common.ErrorType;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.thrift.TMaterializedViewStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -996,6 +998,14 @@ public class ShowMaterializedViewStatus {
                                         .collect(Collectors.toSet())
                         ));
             } catch (Exception e) {
+                // If the outer user query has already exhausted its query_timeout budget, the internal
+                // task_run_history read hit that timeout: surface it as a timeout so the outer query exits,
+                // instead of silently falling back to unknown refresh status.
+                if (SimpleExecutor.outerRemainingQueryTimeoutS() <= 0) {
+                    throw new StarRocksPlannerException(
+                            "querying information_schema.materialized_views exceeded query_timeout while "
+                                    + "reading task run history", ErrorType.INTERNAL_ERROR);
+                }
                 LOG.warn("Failed to list MV refreshed task run status, fallback to unknown status. db: {}",
                         dbName, e);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SimpleExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SimpleExecutor.java
@@ -140,6 +140,43 @@ public class SimpleExecutor {
         }
     }
 
+    /**
+     * Same as {@link #executeDQL(String)} but bounds the internal query with an explicit
+     * {@code query_timeout} (seconds) instead of the default {@code statistic_collect_query_timeout}.
+     * Used by serving-path internal queries (e.g. filling {@code information_schema.materialized_views}
+     * or {@code lookup_string}) so they never outlive the outer user query.
+     */
+    public List<TResultBatch> executeDQL(String sql, int queryTimeoutSeconds) {
+        ConnectContext prev = ConnectContext.get();
+        try {
+            ConnectContext context = createConnectContext();
+            context.getSessionVariable().setQueryTimeoutS(queryTimeoutSeconds);
+            context.getSessionVariable().setInsertTimeoutS(queryTimeoutSeconds);
+            return executeDQL(sql, context);
+        } finally {
+            ConnectContext.remove();
+            if (prev != null) {
+                prev.setThreadLocalInfo();
+            }
+        }
+    }
+
+    /**
+     * Remaining time budget (in seconds) derived from the outer (triggering) user query's
+     * {@code query_timeout}: {@code query_timeout - elapsed}. Serving-path internal queries should be
+     * bounded by this so a single one cannot outlive the outer query. When there is no outer user query
+     * (background jobs), falls back to {@code statistic_collect_query_timeout} to keep the old behavior.
+     * The returned value may be {@code <= 0}, meaning the outer query has already exhausted its budget.
+     */
+    public static int outerRemainingQueryTimeoutS() {
+        ConnectContext outer = ConnectContext.get();
+        if (outer == null || outer.getStartTime() <= 0) {
+            return (int) Config.statistic_collect_query_timeout;
+        }
+        long elapsedSeconds = (System.currentTimeMillis() - outer.getStartTime()) / 1000;
+        return (int) (outer.getSessionVariable().getQueryTimeoutS() - elapsedSeconds);
+    }
+
     public List<TResultBatch> executeDQL(String sql, ConnectContext context) {
         try {
             StatementBase parsedStmt = SqlParser.parseOneWithStarRocksDialect(sql, context.getSessionVariable());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
@@ -229,7 +229,7 @@ public class TaskRunHistoryTable {
             sql += " ORDER BY create_time DESC LIMIT " + Config.task_runs_max_history_number;
         }
 
-        List<TResultBatch> batch = SimpleExecutor.getRepoExecutor().executeDQL(sql);
+        List<TResultBatch> batch = executeRepoDQL(sql);
         List<TaskRunStatus> result = TaskRunStatus.fromResultBatch(batch);
         // sort results by create time desc to make the result more stable.
         Collections.sort(result, TaskRunStatus.COMPARATOR_BY_CREATE_TIME_DESC);
@@ -248,7 +248,7 @@ public class TaskRunHistoryTable {
         }
 
         String sql = LOOKUP + Joiner.on(" AND ").join(predicates);
-        List<TResultBatch> batch = SimpleExecutor.getRepoExecutor().executeDQL(sql);
+        List<TResultBatch> batch = executeRepoDQL(sql);
         List<TaskRunStatus> result = TaskRunStatus.fromResultBatch(batch);
         // sort results by create time desc to make the result more stable.
         Collections.sort(result, TaskRunStatus.COMPARATOR_BY_CREATE_TIME_DESC);
@@ -295,7 +295,20 @@ public class TaskRunHistoryTable {
         DEFAULT_VELOCITY_ENGINE.evaluate(context, sw, "", template);
         String sql = sw.toString();
 
-        List<TResultBatch> batch = SimpleExecutor.getRepoExecutor().executeDQL(sql);
+        List<TResultBatch> batch = executeRepoDQL(sql);
         return TaskRunStatus.fromResultBatch(batch);
+    }
+
+    /**
+     * Run an internal DQL against the task-run history table, bounded by the outer user query's
+     * remaining {@code query_timeout} instead of the default {@code statistic_collect_query_timeout}.
+     * This keeps serving-path callers (e.g. {@code information_schema.materialized_views} /
+     * {@code SHOW MATERIALIZED VIEWS}) from outliving the user query when the underlying scan is
+     * unavailable. Background callers keep the previous (large) timeout via
+     * {@link SimpleExecutor#outerRemainingQueryTimeoutS()}.
+     */
+    private static List<TResultBatch> executeRepoDQL(String sql) {
+        int remaining = SimpleExecutor.outerRemainingQueryTimeoutS();
+        return SimpleExecutor.getRepoExecutor().executeDQL(sql, Math.max(1, remaining));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -611,6 +611,20 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     public TListMaterializedViewStatusResult listMaterializedViewStatus(TGetTablesParams params) throws TException {
         LOG.debug("get list table request: {}", params);
         ConnectContext context = new ConnectContext();
+        // When this is served for a BE schema scan (the non-FE-evaluated information_schema.materialized_views
+        // path, e.g. a LIKE predicate), the BE forwards the outer query's query_timeout. Install the context
+        // as thread-local and stamp its start time so SimpleExecutor.outerRemainingQueryTimeoutS() bounds the
+        // internal task_run_history read by query_timeout instead of statistic_collect_query_timeout.
+        if (params.isSetQuery_timeout() && params.getQuery_timeout() > 0) {
+            context.getSessionVariable().setQueryTimeoutS((int) params.getQuery_timeout());
+            context.setStartTime();
+            context.setThreadLocalInfo();
+            try {
+                return MaterializedViewsSystemTable.query(params, context);
+            } finally {
+                ConnectContext.remove();
+            }
+        }
         return MaterializedViewsSystemTable.query(params, context);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
@@ -780,7 +780,10 @@ public class MetaFunctions {
         String sql = String.format("select cast(`%s` as string) from %s where `%s` = '%s' limit 1",
                 returnColumn.getVarchar(), tableNameValue.toString(), keyColumn.getName(), lookupKey.getVarchar());
         try {
-            List<TResultBatch> result = SimpleExecutor.getRepoExecutor().executeDQL(sql);
+            // lookup_string is folded in the optimizer during the outer query's planning; bound the
+            // internal point-lookup by the outer query's remaining query_timeout (not the 1h default).
+            int remaining = SimpleExecutor.outerRemainingQueryTimeoutS();
+            List<TResultBatch> result = SimpleExecutor.getRepoExecutor().executeDQL(sql, Math.max(1, remaining));
             return deserializeLookupResult(result);
         } catch (Throwable e) {
             final String notFoundMessage = "query failed if record not exist in dict table";

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SimpleExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SimpleExecutorTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.qe;
 
+import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.thrift.TResultSinkType;
@@ -23,6 +24,9 @@ import mockit.MockUp;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -71,6 +75,32 @@ public class SimpleExecutorTest {
 
         SimpleExecutor executor = new SimpleExecutor("testExecutor", TResultSinkType.HTTP_PROTOCAL);
         executor.executeDML(INSERT_SQL);
+    }
+
+    /**
+     * Serving-path internal queries (e.g. filling information_schema.materialized_views, lookup_string)
+     * must be bounded by the outer user query's remaining query_timeout, not the 1h
+     * statistic_collect_query_timeout. Background callers (no outer query) keep the old fallback.
+     */
+    @Test
+    public void testOuterRemainingQueryTimeoutS() throws Exception {
+        // No outer user-query context: fall back to statistic_collect_query_timeout (old behavior).
+        ConnectContext.remove();
+        assertEquals((int) Config.statistic_collect_query_timeout, SimpleExecutor.outerRemainingQueryTimeoutS());
+
+        // Outer query with query_timeout=300s started ~100s ago -> remaining ~200s.
+        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+        ctx.setThreadLocalInfo();
+        ctx.getSessionVariable().setQueryTimeoutS(300);
+        ctx.setStartTime(Instant.now().minusSeconds(100));
+        int remaining = SimpleExecutor.outerRemainingQueryTimeoutS();
+        assertTrue(remaining > 190 && remaining <= 200, "remaining=" + remaining);
+
+        // Budget already exhausted (started ~400s ago, budget 300s) -> <= 0, so the caller can time out.
+        ctx.setStartTime(Instant.now().minusSeconds(400));
+        assertTrue(SimpleExecutor.outerRemainingQueryTimeoutS() <= 0);
+
+        ConnectContext.remove();
     }
 
     private static void mockStatementFailure(String errorMessage) {

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SimpleExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SimpleExecutorTest.java
@@ -16,7 +16,9 @@ package com.starrocks.qe;
 
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
+import com.starrocks.scheduler.history.TaskRunHistoryTable;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.thrift.TResultBatch;
 import com.starrocks.thrift.TResultSinkType;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
@@ -25,6 +27,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -101,6 +105,34 @@ public class SimpleExecutorTest {
         assertTrue(SimpleExecutor.outerRemainingQueryTimeoutS() <= 0);
 
         ConnectContext.remove();
+    }
+
+    /**
+     * The internal task_run_history read (fired while filling information_schema.materialized_views /
+     * SHOW MATERIALIZED VIEWS) must inherit the OUTER user query's remaining query_timeout, not the
+     * default statistic_collect_query_timeout (1h).
+     */
+    @Test
+    public void testInternalTaskRunHistoryReadUsesOuterQueryTimeout() {
+        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+        ctx.setThreadLocalInfo();
+        ctx.getSessionVariable().setQueryTimeoutS(300);
+        ctx.setStartTime(Instant.now());
+
+        int[] capturedTimeout = {-1};
+        new MockUp<SimpleExecutor>() {
+            @Mock
+            public List<TResultBatch> executeDQL(String sql, int queryTimeoutSeconds) {
+                capturedTimeout[0] = queryTimeoutSeconds;
+                return Collections.emptyList();
+            }
+        };
+
+        new TaskRunHistoryTable().lookupLastJobOfTasks("db", Collections.singleton("mvTask"));
+        ConnectContext.remove();
+
+        // Inherited the outer query_timeout (~300s), not statistic_collect_query_timeout (3600s).
+        assertTrue(capturedTimeout[0] > 290 && capturedTimeout[0] <= 300, "timeout=" + capturedTimeout[0]);
     }
 
     private static void mockStatementFailure(String errorMessage) {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/ShowMaterializedViewStatusTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/ShowMaterializedViewStatusTest.java
@@ -15,10 +15,13 @@
 
 package com.starrocks.scheduler;
 
+import com.starrocks.catalog.MaterializedView;
 import com.starrocks.qe.ShowMaterializedViewStatus;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.thrift.TMaterializedViewStatus;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -29,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 public class ShowMaterializedViewStatusTest {
 
@@ -276,5 +280,54 @@ public class ShowMaterializedViewStatusTest {
         TMaterializedViewStatus thriftStatus = viewStatus.toThrift();
 
         Assertions.assertEquals("2025-01-01 10:05:00", thriftStatus.getLast_refresh_time());
+    }
+
+    @Test
+    public void listMaterializedViewStatusPropagatesTimeoutWhenBudgetExhausted(
+            @Mocked MaterializedView mv, @Mocked SimpleExecutor simpleExecutor) {
+        // The internal task_run_history read failed (e.g. its BE scan is stuck) AND the outer user query has
+        // already burned its whole query_timeout budget: the listing must surface the timeout so the outer
+        // information_schema.materialized_views query exits, instead of silently reporting unknown status.
+        new Expectations() {
+            {
+                mv.getId();
+                result = 1L;
+                minTimes = 0;
+
+                taskManager.listMVRefreshedTaskRunStatus(anyString, (Set<String>) any);
+                result = new RuntimeException("internal task_run_history read timed out");
+                minTimes = 0;
+
+                SimpleExecutor.outerRemainingQueryTimeoutS();
+                result = -1;
+                minTimes = 0;
+            }
+        };
+
+        StarRocksPlannerException e = Assertions.assertThrows(StarRocksPlannerException.class,
+                () -> ShowMaterializedViewStatus.listMaterializedViewStatus(
+                        "testDb", Collections.singletonList(mv), Collections.emptyList()));
+        Assertions.assertTrue(e.getMessage().contains("exceeded query_timeout"), e.getMessage());
+    }
+
+    @Test
+    public void listMaterializedViewStatusFallsBackWhenBudgetRemains(
+            @Mocked MaterializedView mv, @Mocked SimpleExecutor simpleExecutor) {
+        // Same internal failure, but the outer query still has budget left: swallow it and fall back to
+        // unknown refresh status (previous behavior) rather than failing the whole query.
+        new Expectations() {
+            {
+                taskManager.listMVRefreshedTaskRunStatus(anyString, (Set<String>) any);
+                result = new RuntimeException("internal task_run_history read failed");
+                minTimes = 0;
+
+                SimpleExecutor.outerRemainingQueryTimeoutS();
+                result = 100;
+                minTimes = 0;
+            }
+        };
+
+        Assertions.assertDoesNotThrow(() -> ShowMaterializedViewStatus.listMaterializedViewStatus(
+                "testDb", Collections.singletonList(mv), Collections.emptyList()));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -101,7 +101,7 @@ public class TaskRunHistoryTest {
             {
                 repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history WHERE TRUE AND  " +
                         "get_json_string(history_content_json, 'dbName') = 'default_cluster:d1' " +
-                        "ORDER BY create_time DESC LIMIT 10000");
+                        "ORDER BY create_time DESC LIMIT 10000", anyInt);
             }
         };
         params.setDb("d1");
@@ -111,7 +111,7 @@ public class TaskRunHistoryTest {
             {
                 repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history WHERE TRUE AND  " +
                         "task_state = 'SUCCESS'" +
-                        " ORDER BY create_time DESC LIMIT " + Config.task_runs_max_history_number);
+                        " ORDER BY create_time DESC LIMIT " + Config.task_runs_max_history_number, anyInt);
             }
         };
         params.setDb(null);
@@ -122,7 +122,7 @@ public class TaskRunHistoryTest {
             {
                 repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history WHERE TRUE AND  " +
                         "task_name = 't1'" +
-                        " ORDER BY create_time DESC LIMIT " + Config.task_runs_max_history_number);
+                        " ORDER BY create_time DESC LIMIT " + Config.task_runs_max_history_number, anyInt);
             }
         };
         params.setDb(null);
@@ -134,7 +134,7 @@ public class TaskRunHistoryTest {
             {
                 repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history WHERE TRUE AND  " +
                         "task_run_id = 'q1'" +
-                        " ORDER BY create_time DESC LIMIT " + Config.task_runs_max_history_number);
+                        " ORDER BY create_time DESC LIMIT " + Config.task_runs_max_history_number, anyInt);
             }
         };
         params.setDb(null);
@@ -149,7 +149,7 @@ public class TaskRunHistoryTest {
         new Expectations() {
             {
                 repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history WHERE TRUE AND  " +
-                        "task_name IN ('t1','t2')");
+                        "task_name IN ('t1','t2')", anyInt);
             }
         };
         history.lookupByTaskNames(dbName, taskNames);
@@ -160,7 +160,7 @@ public class TaskRunHistoryTest {
         new Expectations() {
             {
                 repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history WHERE TRUE AND  " +
-                        "task_run_id = 'q1' LIMIT 100");
+                        "task_run_id = 'q1' LIMIT 100", anyInt);
             }
         };
         history.lookup(params);
@@ -418,7 +418,7 @@ public class TaskRunHistoryTest {
         Collections.shuffle(taskRuns);
         new MockUp<SimpleExecutor>() {
             @Mock
-            public List<TResultBatch> executeDQL(String sql) {
+            public List<TResultBatch> executeDQL(String sql, int queryTimeoutSeconds) {
                 TaskRunStatus.TaskRunStatusJSONRecord record = new TaskRunStatus.TaskRunStatusJSONRecord();
                 record.data = taskRuns;
                 String json = GsonUtils.GSON.toJson(record);
@@ -461,7 +461,7 @@ public class TaskRunHistoryTest {
 
         new MockUp<SimpleExecutor>() {
             @Mock
-            public List<TResultBatch> executeDQL(String sql) {
+            public List<TResultBatch> executeDQL(String sql, int queryTimeoutSeconds) {
                 TaskRunStatus.TaskRunStatusJSONRecord record = new TaskRunStatus.TaskRunStatusJSONRecord();
                 record.data = taskRuns;
                 String json = GsonUtils.GSON.toJson(record);
@@ -494,7 +494,7 @@ public class TaskRunHistoryTest {
             {
                 repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history WHERE TRUE AND  " +
                         "task_name = 't1'' OR ''1''=''1'" +
-                        " ORDER BY create_time DESC LIMIT " + Config.task_runs_max_history_number);
+                        " ORDER BY create_time DESC LIMIT " + Config.task_runs_max_history_number, anyInt);
             }
         };
         TGetTasksParams params = new TGetTasksParams();
@@ -506,7 +506,7 @@ public class TaskRunHistoryTest {
             {
                 repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history WHERE TRUE AND  " +
                         "task_run_id = 'q1'' UNION SELECT 1 -- '" +
-                        " ORDER BY create_time DESC LIMIT " + Config.task_runs_max_history_number);
+                        " ORDER BY create_time DESC LIMIT " + Config.task_runs_max_history_number, anyInt);
             }
         };
         TGetTasksParams params2 = new TGetTasksParams();
@@ -517,7 +517,7 @@ public class TaskRunHistoryTest {
         new Expectations() {
             {
                 repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history WHERE TRUE AND  " +
-                        "task_name IN ('a'',''b')");
+                        "task_name IN ('a'',''b')", anyInt);
             }
         };
         history.lookupByTaskNames("", Set.of("a','b"));
@@ -529,7 +529,7 @@ public class TaskRunHistoryTest {
             {
                 repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history WHERE TRUE AND  " +
                         "task_name = 'x\\\\' AND  task_run_id = ' UNION SELECT 1 -- '" +
-                        " ORDER BY create_time DESC LIMIT " + Config.task_runs_max_history_number);
+                        " ORDER BY create_time DESC LIMIT " + Config.task_runs_max_history_number, anyInt);
             }
         };
         TGetTasksParams params3 = new TGetTasksParams();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/MetaFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/MetaFunctionsTest.java
@@ -204,7 +204,7 @@ public class MetaFunctionsTest extends MVTestBase {
             // normal
             new MockUp<SimpleExecutor>() {
                 @Mock
-                public List<TResultBatch> executeDQL(String sql) {
+                public List<TResultBatch> executeDQL(String sql, int queryTimeoutSeconds) {
                     MetaFunctions.LookupRecord record = new MetaFunctions.LookupRecord();
                     record.data = Lists.newArrayList("v1");
                     String json = GsonUtils.GSON.toJson(record);
@@ -220,7 +220,7 @@ public class MetaFunctionsTest extends MVTestBase {
             // record not found
             new MockUp<SimpleExecutor>() {
                 @Mock
-                public List<TResultBatch> executeDQL(String sql) {
+                public List<TResultBatch> executeDQL(String sql, int queryTimeoutSeconds) {
                     throw new RuntimeException("query failed if record not exist in dict table");
                 }
             };

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -372,6 +372,11 @@ struct TGetTablesParams {
   // If not set, match default_catalog
   22: optional string catalog_name
   23: optional string table_name
+
+  // Remaining query_timeout (seconds) of the outer user query. Forwarded by the BE schema scanner so the
+  // FE side can bound internal reads (e.g. task_run_history for information_schema.materialized_views) by
+  // the user's query_timeout instead of statistic_collect_query_timeout when the request is not FE-evaluated.
+  24: optional i64 query_timeout
 }
 
 struct TTableStatus {


### PR DESCRIPTION
## Why I'm doing:

Filling `information_schema.materialized_views` (and `SHOW MATERIALIZED VIEWS`) triggers an internal SQL against `_statistics_.task_run_history` through the repo executor, and `lookup_string()` triggers an internal point-lookup during constant folding. Both of these internal queries run with `statistic_collect_query_timeout` (default **1h**) regardless of the outer user query's `query_timeout`.

As a result, when the internal scan cannot make progress (for example when BE scan workers are unavailable), the outer user query hangs for up to an hour and ignores the user-configured `query_timeout`. A customer monitoring query `SELECT ... FROM information_schema.materialized_views WHERE TABLE_SCHEMA=? AND TABLE_NAME=?` was observed hanging ~1h before failing with `INTERNAL_ERR`, even though `query_timeout` was 5 minutes.

## What I'm doing:

Bound these serving-path internal queries by the **outer user query's remaining** `query_timeout` (`query_timeout - elapsed`) instead of the fixed 1h statistics timeout:

- Add `SimpleExecutor.outerRemainingQueryTimeoutS()` and an `executeDQL(sql, queryTimeoutSeconds)` overload.
- `TaskRunHistoryTable` (used to fill `materialized_views` / `SHOW MATERIALIZED VIEWS`) runs its repo DQL under the remaining budget, and the `materialized_views` evaluation path propagates the timeout (throws instead of silently returning unknown status) once the budget is exhausted, so the whole query exits within `query_timeout`.
- `lookup_string()` constant folding runs its internal point-lookup under the remaining budget as well.

Background callers that have no outer user query (ANALYZE stats collection, `PartitionSelector` external-table stats, PIPE file listing, cache loaders) are unchanged — with no outer `ConnectContext`, `outerRemainingQueryTimeoutS()` falls back to `statistic_collect_query_timeout`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
