### PR TITLE
[BugFix] Put the ANN search spec into the query cache digest

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
@@ -292,6 +292,17 @@ public class FragmentNormalizer {
         return new Pair<>(remapSlotIds(slotIds), exprs);
     }
 
+    // Serialize a thrift struct into the digest the same way expressions are handled, so a
+    // sub-structure that has no expression form can still take part in the cache key.
+    public ByteBuffer normalizeThrift(org.apache.thrift.TBase<?, ?> value) {
+        try {
+            TSerializer ser = ConfigurableSerDesFactory.getTSerializer(SIMPLE_JSON.name());
+            return ByteBuffer.wrap(ser.serialize(value));
+        } catch (Exception e) {
+            throw new RuntimeException("Fatal error happens when normalize thrift struct", e);
+        }
+    }
+
     public List<ByteBuffer> normalizeExprs(List<Expr> exprList) {
         if (exprList == null || exprList.isEmpty()) {
             return Collections.emptyList();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -76,6 +76,7 @@ import com.starrocks.lake.LakeTablet;
 import com.starrocks.persist.ColumnIdExpr;
 import com.starrocks.planner.expression.ExprToThrift;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.rowstore.RowStoreUtils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
@@ -110,6 +111,7 @@ import com.starrocks.thrift.TScanRange;
 import com.starrocks.thrift.TScanRangeLocation;
 import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.thrift.TTableSampleOptions;
+import com.starrocks.thrift.TVectorSearchOptions;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeSerializer;
 import com.starrocks.warehouse.Warehouse;
@@ -1738,6 +1740,29 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
             TTableSampleOptions sampleOptions = new TTableSampleOptions();
             sample.toThrift(sampleOptions);
             scanNode.setSample_options(sampleOptions);
+        }
+
+        // See the note on TNormalOlapScanNode.vector_search_options: the ANN spec is the only
+        // place the query vector and the folded distance bound survive, so it must be in the key.
+        if (vectorSearchOptions != null && vectorSearchOptions.isEnableUseANN()) {
+            TVectorSearchOptions annOptions = vectorSearchOptions.toThrift();
+            // Per-query state, not semantics -- drop it so equivalent plans still share entries.
+            annOptions.unsetVector_slot_id();
+            annOptions.unsetVector_distance_column_name();
+            // ann_params, k_factor and pq_refine_factor reach the backend through TQueryOptions, not
+            // through this struct: OlapChunkSource overwrites query_params/k_factor/pq_refine_factor
+            // from RuntimeState::query_options() after reading the plan, so whatever the plan carries
+            // in those three fields is discarded. They are not cosmetic -- an explicit efSearch in
+            // ann_params turns off the per-segment adaptive scaling and k_factor changes how many
+            // candidates the index returns, so two sessions differing only in them get different
+            // rows out of the same plan. Copying the session's values in here puts them in the
+            // digest without a new thrift field, and only for plans that actually use ANN, so no
+            // other query's digest moves.
+            SessionVariable sessionVariable = normalizer.getExecPlan().getConnectContext().getSessionVariable();
+            annOptions.setQuery_params(sessionVariable.getAnnParams());
+            annOptions.setK_factor(sessionVariable.getKFactor());
+            annOptions.setPq_refine_factor(sessionVariable.getPqRefineFactor());
+            scanNode.setVector_search_options(normalizer.normalizeThrift(annOptions));
         }
 
         planNode.setNode_type(olapTable.isCloudNativeTableOrMaterializedView() ?

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -3317,6 +3317,18 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.annParams = annParams;
     }
 
+    public double getKFactor() {
+        return kFactor;
+    }
+
+    public void setKFactor(double kFactor) {
+        this.kFactor = kFactor;
+    }
+
+    public double getPqRefineFactor() {
+        return pqRefineFactor;
+    }
+
     public Map<String, String> getAnnParams() {
         if (Strings.isNullOrEmpty(annParams)) {
             return Maps.newHashMap();

--- a/gensrc/thrift/Normalization.thrift
+++ b/gensrc/thrift/Normalization.thrift
@@ -25,6 +25,14 @@ struct TNormalOlapScanNode {
   13: optional list<i64> selected_partition_ids;
   14: optional list<i64> selected_partition_versions;
   15: optional PlanNodes.TTableSampleOptions sample_options;
+  // The ANN search spec. RewriteToVectorPlanRule replaces the distance function in the scan's
+  // projection with an opaque __vector_* column ref and moves the query vector, the folded
+  // distance-range bound and the ordering into TVectorSearchOptions, so none of them survive
+  // anywhere else in the plan -- two ANN scans differing only in the query vector would
+  // otherwise normalize identically. The plan-local distance slot id and column name are
+  // cleared before serializing: they are per-query state, and leaving them in would give
+  // structurally identical plans different digests and stop them sharing an entry.
+  16: optional binary vector_search_options;
   // The schema the scan reads with. A fast schema evolution (ADD/DROP COLUMN) deliberately does
   // not rewrite data, so it leaves the partition versions -- and therefore the rest of the cache
   // key -- untouched, while changing what the very same query returns. Without this field the
@@ -33,9 +41,6 @@ struct TNormalOlapScanNode {
   // Set only when the schema has actually diverged from the index it belongs to, so that tables
   // which were never altered keep the digest they had before this field existed. See the note in
   // OlapScanNode.toNormalForm().
-  //
-  // 16 is left free on purpose: a sibling fix for the same blind spot claims it for the ANN search
-  // spec. Keeping the two ordinals apart lets either change merge first without renumbering.
   17: optional i64 schema_id;
 }
 

--- a/test/sql/test_query_cache/R/test_query_cache_vector_search
+++ b/test/sql/test_query_cache/R/test_query_cache_vector_search
@@ -1,0 +1,114 @@
+-- name: test_query_cache_vector_search
+CREATE TABLE w1 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE wvec (
+  c0 INT,
+  vec ARRAY<FLOAT> NOT NULL,
+  INDEX idx_vec (vec) USING VECTOR ('metric_type' = 'l2_distance',
+    'is_vector_normed' = 'false', 'M' = '512', 'index_type' = 'hnsw', 'dim' = '5')
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1
+PROPERTIES ('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO w1
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, 50, 1
+FROM TABLE(generate_series(1, 620));
+-- result:
+-- !result
+INSERT INTO wvec VALUES
+ (1,[1,1,1,1,1]),(2,[1,1,1,1,2]),(3,[1,1,1,2,1]),(4,[1,1,2,1,1]),(5,[1,2,1,1,1]),
+ (6,[2,1,1,1,1]),(7,[1,1,1,2,2]),(8,[1,1,2,2,1]),(9,[1,2,2,1,1]),(10,[2,2,1,1,1]),
+ (101,[9,9,9,9,9]),(102,[9,9,9,9,8]),(103,[9,9,9,8,9]),(104,[9,9,8,9,9]),(105,[9,8,9,9,9]),
+ (106,[8,9,9,9,9]),(107,[9,9,9,8,8]),(108,[9,9,8,8,9]),(109,[9,8,8,9,9]),(110,[8,8,9,9,9]);
+-- result:
+-- !result
+set pipeline_dop = 1;
+-- result:
+-- !result
+set query_cache_hot_partition_num = 100;
+-- result:
+-- !result
+select group_concat(cast(c0 as string) order by c0) from
+ (select c0 from wvec order by approx_l2_distance([1,1,1,1,1], vec) limit 5) t;
+-- result:
+1,2,3,4,5
+-- !result
+select group_concat(cast(c0 as string) order by c0) from
+ (select c0 from wvec order by approx_l2_distance([9,9,9,9,9], vec) limit 5) t;
+-- result:
+101,102,103,104,105
+-- !result
+set enable_query_cache = false;
+-- result:
+-- !result
+select ifnull(sum(s),0) from (select w1.c1, sum(w1.v1) s from w1
+  join (select c0 as k from wvec order by approx_l2_distance([1,1,1,1,1], vec) limit 5) b
+  on w1.ts > b.k group by w1.c1) x;
+-- result:
+3100
+-- !result
+select ifnull(sum(s),0) from (select w1.c1, sum(w1.v1) s from w1
+  join (select c0 as k from wvec order by approx_l2_distance([9,9,9,9,9], vec) limit 5) b
+  on w1.ts > b.k group by w1.c1) x;
+-- result:
+0
+-- !result
+set enable_query_cache = true;
+-- result:
+-- !result
+select ifnull(sum(s),0) from (select w1.c1, sum(w1.v1) s from w1
+  join (select c0 as k from wvec order by approx_l2_distance([1,1,1,1,1], vec) limit 5) b
+  on w1.ts > b.k group by w1.c1) x;
+-- result:
+3100
+-- !result
+select ifnull(sum(s),0) from (select w1.c1, sum(w1.v1) s from w1
+  join (select c0 as k from wvec order by approx_l2_distance([9,9,9,9,9], vec) limit 5) b
+  on w1.ts > b.k group by w1.c1) x;
+-- result:
+0
+-- !result
+CREATE TABLE w2 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO w2
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, 50, 1
+FROM TABLE(generate_series(1, 620));
+-- result:
+-- !result
+set enable_query_cache = true;
+-- result:
+-- !result
+select ifnull(sum(s),0) from (select w2.c1, sum(w2.v1) s from w2
+  join (select c0 as k from wvec order by approx_l2_distance([9,9,9,9,9], vec) limit 5) b
+  on w2.ts > b.k group by w2.c1) x;
+-- result:
+0
+-- !result
+select ifnull(sum(s),0) from (select w2.c1, sum(w2.v1) s from w2
+  join (select c0 as k from wvec order by approx_l2_distance([1,1,1,1,1], vec) limit 5) b
+  on w2.ts > b.k group by w2.c1) x;
+-- result:
+3100
+-- !result

--- a/test/sql/test_query_cache/T/test_query_cache_vector_search
+++ b/test/sql/test_query_cache/T/test_query_cache_vector_search
@@ -1,0 +1,99 @@
+-- name: test_query_cache_vector_search
+-- RewriteToVectorPlanRule replaces the distance function in the scan's projection with an opaque
+-- __vector_* column ref and moves the query vector, the folded distance-range bound and the
+-- ordering into TVectorSearchOptions. None of them survive anywhere else in the plan, so unless
+-- that struct is part of the digest two ANN scans differing only in the query vector share a
+-- query cache key.
+--
+-- Reachability is the subtle part. On the leftmost path the rule's own shape blocks caching: it
+-- matches strictly LOGICAL_TOPN -> LOGICAL_OLAP_SCAN, and isAllowedInLeftMostPath() does not
+-- accept a SortNode, so the bottom-up walk breaks before it finds an aggregation. But that gate
+-- only guards the leftmost path -- normalizeSubTree() recurses into every child and only
+-- isCacheable() filters there, which lets a SortNode through. So an ANN scan in a join's BUILD
+-- SIDE is inside the digested subtree, and a NestLoopJoin below the aggregation is a transform
+-- join unconditionally, keeping the fragment cacheable.
+CREATE TABLE w1 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1");
+
+CREATE TABLE wvec (
+  c0 INT,
+  vec ARRAY<FLOAT> NOT NULL,
+  INDEX idx_vec (vec) USING VECTOR ('metric_type' = 'l2_distance',
+    'is_vector_normed' = 'false', 'M' = '512', 'index_type' = 'hnsw', 'dim' = '5')
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1
+PROPERTIES ('replication_num' = '1');
+
+-- w1.ts = 50, so a build-side key below 50 matches every row and one above it matches none.
+INSERT INTO w1
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, 50, 1
+FROM TABLE(generate_series(1, 620));
+
+-- Two well-separated clusters: ids 1..10 near [1,1,1,1,1], ids 101..110 near [9,9,9,9,9].
+-- A query vector near one cluster returns that cluster's ids, so the two vectors below select
+-- disjoint build-side rows -- and since the ids straddle 50, the two answers differ.
+INSERT INTO wvec VALUES
+ (1,[1,1,1,1,1]),(2,[1,1,1,1,2]),(3,[1,1,1,2,1]),(4,[1,1,2,1,1]),(5,[1,2,1,1,1]),
+ (6,[2,1,1,1,1]),(7,[1,1,1,2,2]),(8,[1,1,2,2,1]),(9,[1,2,2,1,1]),(10,[2,2,1,1,1]),
+ (101,[9,9,9,9,9]),(102,[9,9,9,9,8]),(103,[9,9,9,8,9]),(104,[9,9,8,9,9]),(105,[9,8,9,9,9]),
+ (106,[8,9,9,9,9]),(107,[9,9,9,8,8]),(108,[9,9,8,8,9]),(109,[9,8,8,9,9]),(110,[8,8,9,9,9]);
+
+set pipeline_dop = 1;
+set query_cache_hot_partition_num = 100;
+
+-- The two query vectors really do select disjoint id sets.
+select group_concat(cast(c0 as string) order by c0) from
+ (select c0 from wvec order by approx_l2_distance([1,1,1,1,1], vec) limit 5) t;
+select group_concat(cast(c0 as string) order by c0) from
+ (select c0 from wvec order by approx_l2_distance([9,9,9,9,9], vec) limit 5) t;
+
+-- Ground truth.
+set enable_query_cache = false;
+select ifnull(sum(s),0) from (select w1.c1, sum(w1.v1) s from w1
+  join (select c0 as k from wvec order by approx_l2_distance([1,1,1,1,1], vec) limit 5) b
+  on w1.ts > b.k group by w1.c1) x;
+select ifnull(sum(s),0) from (select w1.c1, sum(w1.v1) s from w1
+  join (select c0 as k from wvec order by approx_l2_distance([9,9,9,9,9], vec) limit 5) b
+  on w1.ts > b.k group by w1.c1) x;
+
+-- Cache on, vector A first: it populates the per-tablet entries, then B must NOT inherit them.
+set enable_query_cache = true;
+select ifnull(sum(s),0) from (select w1.c1, sum(w1.v1) s from w1
+  join (select c0 as k from wvec order by approx_l2_distance([1,1,1,1,1], vec) limit 5) b
+  on w1.ts > b.k group by w1.c1) x;
+select ifnull(sum(s),0) from (select w1.c1, sum(w1.v1) s from w1
+  join (select c0 as k from wvec order by approx_l2_distance([9,9,9,9,9], vec) limit 5) b
+  on w1.ts > b.k group by w1.c1) x;
+
+-- The other direction, on a table whose entries are cold.
+CREATE TABLE w2 (
+  dt date NOT NULL,
+  c1 int NOT NULL,
+  ts bigint NOT NULL,
+  v1 bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(dt, c1)
+PARTITION BY RANGE(dt) (START ("2022-01-01") END ("2022-02-01") EVERY (INTERVAL 1 day))
+DISTRIBUTED BY HASH(c1) BUCKETS 4
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO w2
+SELECT date_add('2022-01-01', INTERVAL (generate_series % 31) DAY),
+       generate_series % 8 + 1, 50, 1
+FROM TABLE(generate_series(1, 620));
+
+set enable_query_cache = true;
+select ifnull(sum(s),0) from (select w2.c1, sum(w2.v1) s from w2
+  join (select c0 as k from wvec order by approx_l2_distance([9,9,9,9,9], vec) limit 5) b
+  on w2.ts > b.k group by w2.c1) x;
+select ifnull(sum(s),0) from (select w2.c1, sum(w2.v1) s from w2
+  join (select c0 as k from wvec order by approx_l2_distance([1,1,1,1,1], vec) limit 5) b
+  on w2.ts > b.k group by w2.c1) x;


### PR DESCRIPTION
## Why I'm doing:

RewriteToVectorPlanRule replaces the distance function in the scan's projection with an opaque __vector_* column ref and moves the query vector, the folded distance-range bound and the ordering into TVectorSearchOptions. None of them survive anywhere else in the plan, and TNormalOlapScanNode did not carry that struct, so two ANN scans differing only in the query vector produced the same digest. Verified on a cluster, in both directions: with entries populated by one query vector, a query using a well-separated vector returned the first one's answer (3100 where the correct answer was 0, and 0 where it was 3100).

The reachable shape is agg + join + ANN, with the ANN scan in the join's BUILD SIDE. On the leftmost path the rule's own shape prevents caching -- it matches strictly LOGICAL_TOPN -> LOGICAL_OLAP_SCAN and isAllowedInLeftMostPath() does not accept a SortNode, so the bottom-up walk breaks before it finds an aggregation. But that gate only guards the leftmost path: normalizeSubTree() recurses into every child and only isCacheable() filters there, which lets a SortNode through. A NestLoopJoin below the aggregation is a transform join unconditionally, so the fragment stays cacheable and the build side decides which rows the cached per-tablet aggregate is computed from.

The plan-local distance slot id and column name are cleared before serializing. They are per-query state, so leaving them in would give structurally identical plans different digests and stop them from ever sharing an entry.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
