### PR TITLE
[Tool] ci-merged: build centos7/rocky9 dev-env image by branch version

### DIFF
--- a/.github/workflows/ci-merged.yml
+++ b/.github/workflows/ci-merged.yml
@@ -103,6 +103,8 @@ jobs:
     if: github.event.pull_request.merged == true
     outputs:
       thirdparty: ${{ steps.filter-info.outputs.thirdparty }}
+      centos7: ${{ steps.distro.outputs.centos7 }}
+      rocky9: ${{ steps.distro.outputs.rocky9 }}
     steps:
       - uses: dorny/paths-filter@v3
         id: linux-thirdparty-filter
@@ -125,6 +127,28 @@ jobs:
           fi
           echo "thirdparty=${thirdparty}" >> $GITHUB_OUTPUT
 
+      - name: Decide distros by version
+        id: distro
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          # rocky9 replaces centos7 from 4.2 onward (CentOS 7 EOL):
+          #   < 4.2        -> ubuntu + centos7
+          #   >= 4.2, main -> ubuntu + rocky9
+          # Without this, a merge promotes a distro whose per-PR source image was
+          # never built (e.g. centos7 on main, or rocky9 on branch-4.1), and
+          # elastic-update-image.sh's `imagetools create` fails with "not found".
+          if [[ "${BASE_REF}" == "main" ]]; then
+            echo "centos7=false" >> $GITHUB_OUTPUT; echo "rocky9=true" >> $GITHUB_OUTPUT
+          else
+            ver=${BASE_REF#branch-}; major=${ver%%.*}; rest=${ver#*.}; minor=${rest%%.*}
+            if (( major > 4 || (major == 4 && minor >= 2) )); then
+              echo "centos7=false" >> $GITHUB_OUTPUT; echo "rocky9=true"  >> $GITHUB_OUTPUT
+            else
+              echo "centos7=true"  >> $GITHUB_OUTPUT; echo "rocky9=false" >> $GITHUB_OUTPUT
+            fi
+          fi
+
   thirdparty-update-image:
     needs: thirdparty-filter
     runs-on: [self-hosted, normal]
@@ -146,11 +170,13 @@ jobs:
           ./bin/elastic-update-image.sh $BRANCH $PR_NUMBER ubuntu
 
       - name: update image - centos7
+        if: needs.thirdparty-filter.outputs.centos7 == 'true'
         run: |
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
           ./bin/elastic-update-image.sh $BRANCH $PR_NUMBER centos7
 
       - name: update image - rocky9
+        if: needs.thirdparty-filter.outputs.rocky9 == 'true'
         run: |
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
           ./bin/elastic-update-image.sh $BRANCH $PR_NUMBER rocky9


### PR DESCRIPTION
## Why I'm doing:

The `MERGE PIPELINE` (`.github/workflows/ci-merged.yml`) **Thirdparty Update Image** job promotes the per-PR dev-env image for **ubuntu, centos7 and rocky9 unconditionally** after a PR merges. CentOS 7 is EOL, so `main` and `branch-4.2+` no longer build a per-PR `centos7` dev-env source image. The centos7 promotion therefore fails, e.g. in [StarRocks/starrocks#77417](https://github.com/StarRocks/starrocks/pull/77417) ([run 31459763485](https://github.com/StarRocks/starrocks/actions/runs/31459763485)):

```
./bin/elastic-update-image.sh $BRANCH $PR_NUMBER centos7
ERROR: registry-vpc.ap-southeast-1.aliyuncs.com/starrocks/dev-env-centos7:main-77417: not found
```

Symmetrically, `branch-4.1` and older never build a `rocky9` source image, so the unconditional rocky9 step is a latent "not found" failure on those branches too.

## What I'm doing:

Add a `Decide distros by version` step to the `thirdparty-filter` job (the same logic already used in `image-rebuild-three-digit.yml`, extended to handle `main`) and gate the `centos7` / `rocky9` promotion steps on its outputs:

```
< 4.2         -> ubuntu + centos7
>= 4.2, main  -> ubuntu + rocky9
```

`ubuntu` continues to run for every branch. Because `ci-merged.yml` always executes the default-branch (`main`) copy of the workflow and `github.base_ref` is evaluated at runtime, this single change on `main` covers merges into every release branch — no backport required.

Fixes the failure in [StarRocks/starrocks#77417](https://github.com/StarRocks/starrocks/pull/77417).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
