### PR TITLE
[BugFix] Hand the disconnect kill to a worker instead of the I/O thread

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/nio/MySQLReadListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/nio/MySQLReadListener.java
@@ -66,7 +66,13 @@ public class MySQLReadListener implements ChannelListener<ConduitStreamSourceCha
                     LOG.info("Client closed connection: {} remote={}", ctx.getConnectionId(),
                             ctx.getMysqlChannel().getRemoteHostPortString());
                     if (Config.mysql_service_kill_after_disconnect) {
-                        killRunningQuery();
+                        // Hand the kill to a worker, the same way a request is handed over below.
+                        // Cancelling takes the coordinator's lock, and the query's own thread holds
+                        // that lock for the whole of fragment deployment - up to
+                        // brpc_send_plan_fragment_timeout_ms. Running the kill here would park one
+                        // of the few shared XNIO I/O threads for that long, and every other
+                        // connection served by that thread stops being read in the meantime.
+                        channel.getWorker().execute(this::killRunningQuery);
                     } else {
                         tryCleanup();
                     }

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/nio/MySQLReadListenerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/nio/MySQLReadListenerTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.mysql.nio;
 
+import com.starrocks.common.Config;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ConnectProcessor;
@@ -22,14 +23,21 @@ import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GracefulExitFlag;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.parser.SqlParser;
+import mockit.Delegate;
 import mockit.Expectations;
 import mockit.Mocked;
+import mockit.Verifications;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.xnio.XnioWorker;
+import org.xnio.conduits.ConduitStreamSourceChannel;
 
 import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 
 public class MySQLReadListenerTest {
     @Mocked
@@ -219,5 +227,55 @@ public class MySQLReadListenerTest {
 
         Assertions.assertFalse(result,
                 "isTerminated should return false when graceful exit is active but statement is connection_id()");
+    }
+
+    @Test
+    public void testClientDisconnectHandsTheKillToAWorker(@Mocked ConduitStreamSourceChannel channel,
+                                                          @Mocked XnioWorker worker) throws Exception {
+        boolean savedKillAfterDisconnect = Config.mysql_service_kill_after_disconnect;
+        Config.mysql_service_kill_after_disconnect = true;
+        List<Runnable> handedToWorker = new ArrayList<>();
+        try {
+            new Expectations() {
+                {
+                    channel.read((ByteBuffer) any);
+                    result = -1;
+                    channel.getWorker();
+                    result = worker;
+                    worker.execute((Runnable) any);
+                    result = new Delegate<Void>() {
+                        @SuppressWarnings("unused")
+                        void execute(Runnable task) {
+                            handedToWorker.add(task);
+                        }
+                    };
+                }
+            };
+
+            listener.handleEvent(channel);
+
+            // handleEvent runs on a shared XNIO I/O thread. Killing the running query takes the
+            // coordinator's lock, which the query's own thread holds across fragment deployment,
+            // so none of it may happen before handleEvent returns.
+            Assertions.assertEquals(1, handedToWorker.size(),
+                    "the disconnect kill should have been handed to a worker");
+            new Verifications() {
+                {
+                    ctx.cleanup();
+                    times = 0;
+                }
+            };
+
+            handedToWorker.get(0).run();
+
+            new Verifications() {
+                {
+                    ctx.cleanup();
+                    times = 1;
+                }
+            };
+        } finally {
+            Config.mysql_service_kill_after_disconnect = savedKillAfterDisconnect;
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

MySQLReadListener.handleEvent() runs on the XNIO I/O thread. Every request it decodes is handed to a worker:

    channel.getWorker().execute(() -> handleRequest(req));

The client-disconnect branch was the one path that was not. With mysql_service_kill_after_disconnect on (the default, added in #64355) it ran killRunningQuery() inline, which goes ctx.kill() -> StmtExecutor.cancel() -> DefaultCoordinator.cancel() -> an unbounded lock.lock(). That lock is held by DefaultCoordinator.deliverExecFragments() for the whole of fragment deployment -- including waitForDeploymentCompletion(), which waits out brpc_send_plan_fragment_timeout_ms (60s by default). So one slow deployment plus one client hanging up parks a shared I/O thread for up to a minute.

Hand the kill to a worker, the same way the same method already hands over a request. The cancel still blocks for as long as the lock is held; it just blocks a pooled worker instead of one of the four threads that read every connection on the server.

Deliberately not done here: giving DefaultCoordinator.cancel() a bounded tryLock. cancel() is called from many places and a cancel that quietly gives up is worse than one that waits. The lock being held across a network wait is a separate defect in deliverExecFragments and wants its own change.

MySQLReadListenerTest gains a case that captures the Runnable handed to the worker without running it, asserts nothing happened while handleEvent was on the I/O thread, then runs it and asserts the cleanup did happen. It probes ctx.cleanup() rather than ctx.kill(), because killRunningQuery() calls cleanup unconditionally while kill() depends on connection state that a mocked context reports as not running -- an assertion on kill() would pass no matter what.

The new case passes. Four pre-existing cases in the same class fail with NoClassDefFoundError on a generated ANTLR parser class; the same four fail the same way on an unpatched upstream worktree, so they are an artifact of the local build, not of this change.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
