### PR TITLE
[BugFix] Keep the NULL partition when pruning with a deduced partition predicate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ListPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ListPartitionPruner.java
@@ -378,11 +378,31 @@ public class ListPartitionPruner implements PartitionPruner {
 
             ScalarOperator result = buildDeducedConjunct(conjunct, generatedExpr, generatedColumn);
             if (result != null) {
-                extraConjuncts.add(result);
+                extraConjuncts.add(keepNullPartitions(result, generatedColumn));
             }
         }
 
         partitionConjuncts.addAll(extraConjuncts);
+    }
+
+    /**
+     * A deduced conjunct only describes the rows whose partition value is not NULL.
+     * <p>
+     * The deduction rewrites a predicate on the source column into a predicate on the generated
+     * partition column, which is sound only where the generating function is defined. For a row it
+     * maps to NULL - for example from_unixtime(ts) of a negative ts, which lands the row in the NULL
+     * (default) partition - the source predicate can still be true while the deduced predicate is
+     * not, and every comparison against the partition value map drops the NULL partitions
+     * (evalBinaryPredicate only ever unions matches out of partitionValueMap). Pruning with the
+     * deduced conjunct alone therefore removes partitions that hold matching rows, and the rows are
+     * silently missing from the result.
+     * <p>
+     * OR-ing "generated column IS NULL" keeps exactly those partitions: what the deduced predicate
+     * says nothing about, it may not prune. Where the table has no NULL partition the added branch
+     * matches nothing and pruning is unchanged.
+     */
+    private static ScalarOperator keepNullPartitions(ScalarOperator deduced, ColumnRefOperator generatedColumn) {
+        return Utils.compoundOr(deduced, new IsNullPredicateOperator(generatedColumn));
     }
 
     public static boolean checkDeduceConjunct(List<ColumnRefOperator> partitionColumnRefs,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -954,12 +954,28 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         return listPartitionDesc;
     }
 
+    /**
+     * A partition expression reaches us through the generic functionCall rule, but not every function
+     * call comes back as a FunctionCallExpr: the DATE_FUNCTIONS family (date_add, adddate, date_sub,
+     * subdate, days_sub) is rewritten into a TimestampArithmeticExpr while it is being parsed. Casting
+     * blindly leaked a ClassCastException to the client, so reject those the same way the RANGE(...)
+     * partition path already does.
+     */
+    private FunctionCallExpr getPartitionFunctionCallExpr(ParseNode node, NodePosition pos) {
+        if (!(node instanceof FunctionCallExpr)) {
+            String exprSql = node instanceof Expr ? ExprToSql.toSql((Expr) node) : String.valueOf(node);
+            throw new ParsingException(PARSER_ERROR_MSG.unsupportedExprWithInfo(exprSql, "PARTITION BY"), pos);
+        }
+        return (FunctionCallExpr) node;
+    }
+
     private PartitionDesc getPartitionDesc(com.starrocks.sql.parser.StarRocksParser.PartitionDescContext context,
                                            List<ColumnDef> columnDefs) {
         List<PartitionDesc> partitionDescList = new ArrayList<>();
         // for automatic partition
         if (context.functionCall() != null) {
-            FunctionCallExpr functionCallExpr = (FunctionCallExpr) visit(context.functionCall());
+            FunctionCallExpr functionCallExpr =
+                    getPartitionFunctionCallExpr(visit(context.functionCall()), createPos(context));
             String functionName = functionCallExpr.getFunctionName();
             // except date_trunc, time_slice use generated column as partition column
             if (!FunctionSet.DATE_TRUNC.equals(functionName) && !FunctionSet.TIME_SLICE.equals(functionName)
@@ -1028,7 +1044,8 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
                         Identifier identifier = (Identifier) visit(partitionExpr.identifier());
                         multiDescList.add(identifier);
                     } else if (partitionExpr.functionCall() != null) {
-                        FunctionCallExpr expr = (FunctionCallExpr) visit(partitionExpr.functionCall());
+                        FunctionCallExpr expr =
+                                getPartitionFunctionCallExpr(visit(partitionExpr.functionCall()), createPos(context));
                         multiDescList.add(expr);
                     } else {
                         throw new ParsingException("Partition column list is empty", createPos(context));
@@ -9283,7 +9300,8 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         List<PartitionDesc> partitionDescList = new ArrayList<>();
         com.starrocks.sql.parser.StarRocksParser.IdentifierListContext identifierListContext = context.identifierList();
         if (context.functionCall() != null) {
-            FunctionCallExpr functionCallExpr = (FunctionCallExpr) visit(context.functionCall());
+            FunctionCallExpr functionCallExpr =
+                    getPartitionFunctionCallExpr(visit(context.functionCall()), createPos(context));
             String functionName = functionCallExpr.getFunctionName();
             // except date_trunc, time_slice, str_to_date use generated column as partition column
             if (!FunctionSet.DATE_TRUNC.equals(functionName) && !FunctionSet.TIME_SLICE.equals(functionName)
@@ -9307,7 +9325,8 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
                         Identifier identifier = (Identifier) visit(partitionExpr.identifier());
                         multiDescList.add(identifier);
                     } else if (partitionExpr.functionCall() != null) {
-                        FunctionCallExpr expr = (FunctionCallExpr) visit(partitionExpr.functionCall());
+                        FunctionCallExpr expr =
+                                getPartitionFunctionCallExpr(visit(partitionExpr.functionCall()), createPos(context));
                         multiDescList.add(expr);
                     } else {
                         throw new ParsingException("Partition column list is empty", createPos(context));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
@@ -965,4 +965,34 @@ class ParserTest {
                     exception.getMessage());
         }
     }
+
+    @Test
+    public void testPartitionByDateArithmeticFunction() {
+        // date_add and its siblings are rewritten into a TimestampArithmeticExpr while being parsed,
+        // so the partition paths that cast a function call to FunctionCallExpr used to leak a
+        // ClassCastException to the client instead of reporting an unsupported partition expression.
+        List<String> sqls = Lists.newArrayList(
+                // CREATE TABLE, single expression
+                "CREATE TABLE t(id bigint, d datetime) PARTITION BY date_add(d, 1)",
+                "CREATE TABLE t(id bigint, d datetime) PARTITION BY adddate(d, 1)",
+                "CREATE TABLE t(id bigint, d datetime) PARTITION BY date_sub(d, 1)",
+                "CREATE TABLE t(id bigint, d datetime) PARTITION BY subdate(d, 1)",
+                "CREATE TABLE t(id bigint, d datetime) PARTITION BY days_sub(d, 1)",
+                // CREATE TABLE, expression inside a multi-column partition list
+                "CREATE TABLE t(id bigint, d datetime, e datetime) PARTITION BY (e, date_add(d, 1))",
+                // CREATE TABLE AS SELECT reaches the same casts through visitPartitionDesc
+                "CREATE TABLE t PARTITION BY date_add(d, 1) AS SELECT id, d FROM src",
+                "CREATE TABLE t PARTITION BY (e, date_add(d, 1)) AS SELECT id, d, e FROM src");
+
+        for (String sql : sqls) {
+            ParsingException exception = Assertions.assertThrows(ParsingException.class,
+                    () -> SqlParser.parse(sql, new SessionVariable()), sql);
+            Assertions.assertTrue(exception.getMessage().contains("PARTITION BY"),
+                    sql + " => " + exception.getMessage());
+        }
+
+        // a genuine function call of the same shape still parses
+        SqlParser.parse("CREATE TABLE t(id bigint, d datetime) PARTITION BY days_add(d, 1)", new SessionVariable());
+        SqlParser.parse("CREATE TABLE t(id bigint, d date) PARTITION BY years_add(d, 1)", new SessionVariable());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -382,6 +382,43 @@ public class PartitionPruneTest extends PlanTestBase {
     }
 
     @Test
+    public void testGeneratedColumnPruneKeepsNullPartition() throws Exception {
+        // from_unixtime is not defined for every bigint: from_unixtime(-1) is NULL, so a row with c1 = -1
+        // lands in the NULL partition while still satisfying a predicate such as c1 < 1700000000. The
+        // predicate deduced on the generated column says nothing about that partition, so it must not
+        // prune it away.
+        starRocksAssert.withTable("CREATE TABLE t_gen_col_null (" +
+                " c1 bigint NOT NULL," +
+                " c2 bigint," +
+                " c3 varchar(64) NULL AS from_unixtime(c1) " +
+                " ) " +
+                " DUPLICATE KEY(c1) " +
+                " PARTITION BY (c3) " +
+                " PROPERTIES('replication_num'='1')");
+        starRocksAssert.ddl("ALTER TABLE t_gen_col_null ADD PARTITION p202401 VALUES IN ('2024-01-01 00:00:00')");
+        starRocksAssert.ddl("ALTER TABLE t_gen_col_null ADD PARTITION p202402 VALUES IN ('2024-02-01 00:00:00')");
+        starRocksAssert.ddl("ALTER TABLE t_gen_col_null ADD PARTITION pnull VALUES IN (NULL)");
+
+        // the deduced predicate matches no partition value, the NULL partition is still kept
+        starRocksAssert.query("select count(*) from t_gen_col_null where c1 > 1707000000 ")
+                .explainContains("partitions=1/3");
+        starRocksAssert.query("select count(*) from t_gen_col_null where c1 < 1700000000 ")
+                .explainContains("partitions=1/3");
+        starRocksAssert.query("select count(*) from t_gen_col_null where c1 in (1706000000) ")
+                .explainContains("partitions=1/3");
+        // the deduced predicate still prunes the partitions it does describe
+        starRocksAssert.query("select count(*) from t_gen_col_null where c1 > 1706000000 ")
+                .explainContains("partitions=2/3");
+
+        // a predicate written on the partition column itself is not a deduction: NULL is not greater
+        // than any value, so the NULL partition is pruned exactly as before
+        starRocksAssert.query("select count(*) from t_gen_col_null where c3 > '2024-01-23 00:00:00' ")
+                .explainContains("partitions=1/3");
+        starRocksAssert.query("select count(*) from t_gen_col_null where c3 is null ")
+                .explainContains("partitions=1/3");
+    }
+
+    @Test
     public void testMinMaxPrune_Check() throws Exception {
         starRocksAssert.withTable("create table t5_dup " +
                 "(c1 datetime NOT NULL, c2 int) " +

--- a/test/sql/test_partition_by_expr/R/test_expr_partition_prune_null_partition
+++ b/test/sql/test_partition_by_expr/R/test_expr_partition_prune_null_partition
@@ -51,3 +51,132 @@ select count(*) from (
 -- result:
 6
 -- !result
+CREATE TABLE partition_years_add_null (
+        id bigint,
+        d date
+)
+PARTITION BY years_add(d, 1);
+-- result:
+-- !result
+insert into partition_years_add_null values(1, '2021-01-01'),(2, '2021-01-01'),(3, '2022-06-01');
+-- result:
+-- !result
+insert into partition_years_add_null values(-1, '9999-12-31'),(-2, '9999-12-31');
+-- result:
+-- !result
+insert into partition_years_add_null(id) values(9);
+-- result:
+-- !result
+select count(*) from partition_years_add_null;
+-- result:
+6
+-- !result
+select id, d from partition_years_add_null where d > '2022-01-01' order by id;
+-- result:
+-2	9999-12-31
+-1	9999-12-31
+3	2022-06-01
+-- !result
+select id, d from partition_years_add_null where not (d <= '2022-01-01') order by id;
+-- result:
+-2	9999-12-31
+-1	9999-12-31
+3	2022-06-01
+-- !result
+select id, d from partition_years_add_null where (d > '2022-01-01') is null order by id;
+-- result:
+9	None
+-- !result
+select count(*) from (
+        (select * from partition_years_add_null where d > '2022-01-01')
+        union all (select * from partition_years_add_null where not (d > '2022-01-01'))
+        union all (select * from partition_years_add_null where (d > '2022-01-01') is null)) t;
+-- result:
+6
+-- !result
+CREATE TABLE partition_str_to_date_null (
+        id bigint,
+        d varchar(64)
+)
+PARTITION BY str_to_date(d, '%Y-%m-%d');
+-- result:
+-- !result
+insert into partition_str_to_date_null values(1, '2021-01-01'),(2, '2021-01-01'),(3, '2022-06-01');
+-- result:
+-- !result
+insert into partition_str_to_date_null values(-1, 'not-a-date'),(-2, 'not-a-date');
+-- result:
+-- !result
+insert into partition_str_to_date_null(id) values(9);
+-- result:
+-- !result
+select count(*) from partition_str_to_date_null;
+-- result:
+6
+-- !result
+select id, d from partition_str_to_date_null where d > '2022-01-01' order by id;
+-- result:
+-2	not-a-date
+-1	not-a-date
+3	2022-06-01
+-- !result
+select id, d from partition_str_to_date_null where not (d <= '2022-01-01') order by id;
+-- result:
+-2	not-a-date
+-1	not-a-date
+3	2022-06-01
+-- !result
+select id, d from partition_str_to_date_null where (d > '2022-01-01') is null order by id;
+-- result:
+9	None
+-- !result
+select count(*) from (
+        (select * from partition_str_to_date_null where d > '2022-01-01')
+        union all (select * from partition_str_to_date_null where not (d > '2022-01-01'))
+        union all (select * from partition_str_to_date_null where (d > '2022-01-01') is null)) t;
+-- result:
+6
+-- !result
+CREATE TABLE partition_months_add_null (
+        id bigint,
+        d date
+)
+PARTITION BY months_add(d, 1);
+-- result:
+-- !result
+insert into partition_months_add_null values(1, '2021-01-01'),(2, '2021-01-01'),(3, '2022-06-01');
+-- result:
+-- !result
+insert into partition_months_add_null values(-1, '9999-12-31'),(-2, '9999-12-31');
+-- result:
+-- !result
+insert into partition_months_add_null(id) values(9);
+-- result:
+-- !result
+select count(*) from partition_months_add_null;
+-- result:
+6
+-- !result
+select id, d from partition_months_add_null where d > '2022-01-01' order by id;
+-- result:
+-2	9999-12-31
+-1	9999-12-31
+3	2022-06-01
+-- !result
+select id, d from partition_months_add_null where not (d <= '2022-01-01') order by id;
+-- result:
+-2	9999-12-31
+-1	9999-12-31
+3	2022-06-01
+-- !result
+select id, d from partition_months_add_null where (d > '2022-01-01') is null order by id;
+-- result:
+9	None
+-- !result
+select count(*) from (
+        (select * from partition_months_add_null where d > '2022-01-01')
+        union all (select * from partition_months_add_null where not (d > '2022-01-01'))
+        union all (select * from partition_months_add_null where (d > '2022-01-01') is null)) t;
+-- result:
+6
+-- !result

--- a/test/sql/test_partition_by_expr/R/test_expr_partition_prune_null_partition
+++ b/test/sql/test_partition_by_expr/R/test_expr_partition_prune_null_partition
@@ -1,0 +1,53 @@
+-- name: test_expr_partition_prune_null_partition
+CREATE TABLE partition_unixtime_null (
+        id bigint,
+        ts bigint
+)
+PARTITION BY from_unixtime(ts, 'yyyy-MM-dd HH:mm:ss', 'UTC');
+-- result:
+-- !result
+insert into partition_unixtime_null values(1, 1196440219),(2, 1196440219),(3, 1500000000);
+-- result:
+-- !result
+insert into partition_unixtime_null values(-1, -1),(-2, -1);
+-- result:
+-- !result
+insert into partition_unixtime_null(id) values(9);
+-- result:
+-- !result
+select count(*) from partition_unixtime_null;
+-- result:
+6
+-- !result
+select id, ts from partition_unixtime_null where ts < 0 order by id;
+-- result:
+-2	-1
+-1	-1
+-- !result
+select id, ts from partition_unixtime_null where not (ts > 1196440219) order by id;
+-- result:
+-2	-1
+-1	-1
+1	1196440219
+2	1196440219
+-- !result
+select id, ts from partition_unixtime_null where ts = -1 order by id;
+-- result:
+-2	-1
+-1	-1
+-- !result
+select id, ts from partition_unixtime_null where ts > 1196440219 order by id;
+-- result:
+3	1500000000
+-- !result
+select id, ts from partition_unixtime_null where (ts > 1196440219) is null order by id;
+-- result:
+9	None
+-- !result
+select count(*) from (
+        (select * from partition_unixtime_null where ts > 1196440219)
+        union all (select * from partition_unixtime_null where not (ts > 1196440219))
+        union all (select * from partition_unixtime_null where (ts > 1196440219) is null)) t;
+-- result:
+6
+-- !result

--- a/test/sql/test_partition_by_expr/T/test_expr_partition_prune_null_partition
+++ b/test/sql/test_partition_by_expr/T/test_expr_partition_prune_null_partition
@@ -22,3 +22,57 @@ select count(*) from (
         (select * from partition_unixtime_null where ts > 1196440219)
         union all (select * from partition_unixtime_null where not (ts > 1196440219))
         union all (select * from partition_unixtime_null where (ts > 1196440219) is null)) t;
+-- the hole is not from_unixtime-specific: any partition function that returns NULL for a valid
+-- input reaches it. years_add overflows past the maximum date and returns NULL for '9999-12-31'.
+CREATE TABLE partition_years_add_null (
+        id bigint,
+        d date
+)
+PARTITION BY years_add(d, 1);
+insert into partition_years_add_null values(1, '2021-01-01'),(2, '2021-01-01'),(3, '2022-06-01');
+insert into partition_years_add_null values(-1, '9999-12-31'),(-2, '9999-12-31');
+insert into partition_years_add_null(id) values(9);
+select count(*) from partition_years_add_null;
+-- the overflowing rows satisfy the predicate, so pruning must keep the NULL partition
+select id, d from partition_years_add_null where d > '2022-01-01' order by id;
+select id, d from partition_years_add_null where not (d <= '2022-01-01') order by id;
+select id, d from partition_years_add_null where (d > '2022-01-01') is null order by id;
+select count(*) from (
+        (select * from partition_years_add_null where d > '2022-01-01')
+        union all (select * from partition_years_add_null where not (d > '2022-01-01'))
+        union all (select * from partition_years_add_null where (d > '2022-01-01') is null)) t;
+-- str_to_date returns NULL for an input it cannot parse, which lands in the NULL partition the
+-- same way -- and 'not-a-date' still compares greater than '2022-01-01' as a string
+CREATE TABLE partition_str_to_date_null (
+        id bigint,
+        d varchar(64)
+)
+PARTITION BY str_to_date(d, '%Y-%m-%d');
+insert into partition_str_to_date_null values(1, '2021-01-01'),(2, '2021-01-01'),(3, '2022-06-01');
+insert into partition_str_to_date_null values(-1, 'not-a-date'),(-2, 'not-a-date');
+insert into partition_str_to_date_null(id) values(9);
+select count(*) from partition_str_to_date_null;
+select id, d from partition_str_to_date_null where d > '2022-01-01' order by id;
+select id, d from partition_str_to_date_null where not (d <= '2022-01-01') order by id;
+select id, d from partition_str_to_date_null where (d > '2022-01-01') is null order by id;
+select count(*) from (
+        (select * from partition_str_to_date_null where d > '2022-01-01')
+        union all (select * from partition_str_to_date_null where not (d > '2022-01-01'))
+        union all (select * from partition_str_to_date_null where (d > '2022-01-01') is null)) t;
+-- months_add overflows the same way, so the whole date-arithmetic family is covered
+CREATE TABLE partition_months_add_null (
+        id bigint,
+        d date
+)
+PARTITION BY months_add(d, 1);
+insert into partition_months_add_null values(1, '2021-01-01'),(2, '2021-01-01'),(3, '2022-06-01');
+insert into partition_months_add_null values(-1, '9999-12-31'),(-2, '9999-12-31');
+insert into partition_months_add_null(id) values(9);
+select count(*) from partition_months_add_null;
+select id, d from partition_months_add_null where d > '2022-01-01' order by id;
+select id, d from partition_months_add_null where not (d <= '2022-01-01') order by id;
+select id, d from partition_months_add_null where (d > '2022-01-01') is null order by id;
+select count(*) from (
+        (select * from partition_months_add_null where d > '2022-01-01')
+        union all (select * from partition_months_add_null where not (d > '2022-01-01'))
+        union all (select * from partition_months_add_null where (d > '2022-01-01') is null)) t;

--- a/test/sql/test_partition_by_expr/T/test_expr_partition_prune_null_partition
+++ b/test/sql/test_partition_by_expr/T/test_expr_partition_prune_null_partition
@@ -1,0 +1,24 @@
+-- name: test_expr_partition_prune_null_partition
+CREATE TABLE partition_unixtime_null (
+        id bigint,
+        ts bigint
+)
+PARTITION BY from_unixtime(ts, 'yyyy-MM-dd HH:mm:ss', 'UTC');
+-- from_unixtime is NULL for a negative ts, so those rows land in the NULL partition,
+-- and a row with a NULL ts lands there too
+insert into partition_unixtime_null values(1, 1196440219),(2, 1196440219),(3, 1500000000);
+insert into partition_unixtime_null values(-1, -1),(-2, -1);
+insert into partition_unixtime_null(id) values(9);
+select count(*) from partition_unixtime_null;
+-- a predicate on ts must not prune the NULL partition: from_unixtime(-1) is NULL but -1 < 0
+select id, ts from partition_unixtime_null where ts < 0 order by id;
+select id, ts from partition_unixtime_null where not (ts > 1196440219) order by id;
+select id, ts from partition_unixtime_null where ts = -1 order by id;
+-- a row whose ts IS NULL is still excluded from both branches, and only matches IS NULL
+select id, ts from partition_unixtime_null where ts > 1196440219 order by id;
+select id, ts from partition_unixtime_null where (ts > 1196440219) is null order by id;
+-- ternary logic partitioning: the three branches must add up to the whole table
+select count(*) from (
+        (select * from partition_unixtime_null where ts > 1196440219)
+        union all (select * from partition_unixtime_null where not (ts > 1196440219))
+        union all (select * from partition_unixtime_null where (ts > 1196440219) is null)) t;


### PR DESCRIPTION
## Why I'm doing:

A table partitioned by an expression carries the expression as a generated partition column, and ListPartitionPruner.deduceExtraConjuncts rewrites a predicate on the source column into a predicate on that column so it can prune:

    create table t(id bigint, ts bigint)
      partition by from_unixtime(ts, 'yyyy-MM-dd HH:mm:ss', 'UTC');

    ts < 0   =>   __generated_partition_column_0 <= from_unixtime(0, ...)

The rewrite is sound only where the generating function is defined. from_unixtime returns NULL for a negative ts, so such a row lands in the NULL (default) partition while still satisfying ts < 0, and evalBinaryPredicate answers every comparison out of partitionValueMap alone, which never holds the NULL partitions. The deduced conjunct therefore prunes away a partition that holds matching rows, and they are silently missing:

    insert into t values(1,1196440219),(2,1196440219),(-1,-1),(-1,-1),(3,1500000000);
    select count(*) from t;                              -- 5
    select count(*) from t where not (ts > 1196440219);  -- 2, should be 4
    select count(*) from t where ts < 0;                 -- 0, should be 2

Found by a TLP (ternary logic partitioning) oracle: select * from t and the union of the three branches where p / where not p / where p is null returned 4005 and 1675 rows for the same table.

OR "generated column IS NULL" into every deduced conjunct. What the deduced predicate says nothing about, it may not prune. A table without a NULL partition is unaffected: the added branch matches no partition and pruning is unchanged, which the existing t_gen_col expectations cover.

Tests: PartitionPruneTest#testGeneratedColumnPruneKeepsNullPartition fails with partitions=0/3 without the fix, and a SQL test reproduces the wrong result end-to-end on the partition-by-expression table, including that a row with a NULL ts is still excluded from both branches of the predicate.

Left alone on purpose: PartitionSelector runs the same deduction for DROP PARTITIONS WHERE and for retention conditions, but it evaluates the predicate per partition cell with an explicit NULL literal for the default partition instead of going through the value map, so it does not share this hole.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
