### PR TITLE
[BugFix] Fix two plans from global late materialization over a shared CTE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lazymaterialize/GlobalLateMaterializationRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lazymaterialize/GlobalLateMaterializationRewriter.java
@@ -725,6 +725,28 @@ public class GlobalLateMaterializationRewriter {
                 }
             }
 
+            // A consumer evaluates its own predicate, so those columns have to exist by the time it
+            // runs. Nothing registered that: the deferred column stayed deferred and the predicate
+            // was left reading a column no slot backed, which surfaced far downstream in the
+            // fragment builder as "Cannot convert ColumnRefOperator to Expr".
+            //
+            // The requirement has to be recorded against the PRODUCER, in producer column ids: a
+            // consumer has no child to fetch from, and only the producer's scan can decide to read
+            // the column early. Its context is where the producer's deferred set lives; the tables
+            // that carry fetch positions are shared with this one.
+            final CollectorContext produceContext = context.cteCtxMap.get(cteId);
+            final ColumnRefSet consumerUsedColumns = consumeOperator.getUsedColumns();
+            if (produceContext != null && !consumerUsedColumns.isEmpty()) {
+                final ColumnRefSet producerSideColumns = new ColumnRefSet();
+                alias.forEach((consumerCol, producerCol) -> {
+                    if (consumerUsedColumns.contains(consumerCol)) {
+                        producerSideColumns.union(producerCol);
+                    }
+                });
+                recordMaterializedBefore(producerSideColumns, (PhysicalOperator) produce.getOp(),
+                        produceContext);
+            }
+
             return null;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lazymaterialize/GlobalLateMaterializationRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lazymaterialize/GlobalLateMaterializationRewriter.java
@@ -91,6 +91,14 @@ public class GlobalLateMaterializationRewriter {
         // stage A split projection
         root = root.getOp().accept(new SplitProjectionRewriter(), root, null);
 
+        // Splitting a projection off an operator changes what that operator outputs, and
+        // RowOutputInfo is derived bottom-up, so every ancestor's cached LogicalProperty is stale
+        // afterwards -- splitProjection only refreshes the operator it split. A Repeat then reached
+        // the passes below declaring {k1, k2, grouping ids} while it actually passes its child's
+        // columns through, and a fetch decision made against that declaration dropped a column the
+        // aggregate above still read.
+        root.clearAndInitOutputInfo();
+
         CollectorContext collectorContext = new CollectorContext(context.getColumnRefFactory());
 
         ColumnCollector columnCollector = new ColumnCollector(context);
@@ -846,6 +854,7 @@ public class GlobalLateMaterializationRewriter {
                 if (op instanceof PhysicalCTEAnchorOperator) {
                     begin = 1;
                 }
+                final ColumnRefSet pushedColumns = new ColumnRefSet();
                 for (int i = begin; i < optExpression.getInputs().size(); i++) {
                     OptExpression input = optExpression.inputAt(i);
                     final IdentifyOperator cIdx = new IdentifyOperator((PhysicalOperator) input.getOp());
@@ -853,11 +862,36 @@ public class GlobalLateMaterializationRewriter {
                     if (dependency == null || !dependency.contains(scanId)) {
                         continue;
                     }
-                    if (tryPushDownFetch(input, scanId, value, context)) {
-                        pushedScanFetch.add(scanId);
+                    // Depending on the scan is not the same as carrying the column. A CTE consumed on
+                    // both sides of a join makes both children depend on the producer's scan, and a
+                    // join condition column lives in exactly one of them. Pushing the fetch into the
+                    // side that does not output the column materialized it in the wrong branch and,
+                    // because the position was then dropped from this operator, left the column
+                    // unmaterialized for the branch whose predicate reads it -- an invalid plan.
+                    final ColumnRefSet childColumns = value.clone();
+                    childColumns.intersect(input.getOutputColumns());
+                    if (childColumns.isEmpty()) {
+                        continue;
+                    }
+                    if (tryPushDownFetch(input, scanId, childColumns, context)) {
+                        pushedColumns.union(childColumns);
                     }
                 }
 
+                // Drop the position from this operator only when every column found a home in a
+                // child. If any is left over -- a child refused the push down because it carries a
+                // small limit, say -- the position stays, so a fetch is still introduced here.
+                //
+                // Decide that on a copy. `value` is the ColumnRefSet the collector stored in
+                // fetchPositions, and that table is shared across collector contexts; removing
+                // columns from it in place tells every later reader they are already taken care of,
+                // and no fetch gets emitted for them anywhere. That produced plans whose aggregate
+                // required a column its input never materialized.
+                final ColumnRefSet remaining = value.clone();
+                remaining.except(pushedColumns);
+                if (remaining.isEmpty()) {
+                    pushedScanFetch.add(scanId);
+                }
             }
             for (IdentifyOperator pushDownedFetchPo : pushedScanFetch) {
                 context.collectorContext.fetchPositions.remove(id, pushDownedFetchPo);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GlobalLateMaterializeCTEJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GlobalLateMaterializeCTEJoinTest.java
@@ -1,0 +1,75 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class GlobalLateMaterializeCTEJoinTest extends PlanTestBase {
+
+    private static double savedCteReuseRatio;
+    private static boolean savedLateMaterialization;
+
+    @BeforeAll
+    public static void createFixture() throws Exception {
+        StringBuilder columns = new StringBuilder();
+        for (int i = 1; i <= 8; i++) {
+            columns.append("  `v").append(i).append("` varchar(255) NULL,\n");
+        }
+        starRocksAssert.withTable("CREATE TABLE `lm_t` (\n"
+                + "  `k1` bigint NULL,\n"
+                + columns
+                + "  `v9` varchar(255) NULL\n"
+                + ") ENGINE=OLAP\n"
+                + "DUPLICATE KEY(`k1`)\n"
+                + "DISTRIBUTED BY HASH(`k1`) BUCKETS 1\n"
+                + "PROPERTIES (\"replication_num\" = \"1\");");
+
+        savedCteReuseRatio = connectContext.getSessionVariable().getCboCTERuseRatio();
+        savedLateMaterialization = connectContext.getSessionVariable().isEnableGlobalLateMaterialization();
+        // The defect needs a materialized CTE (not an inlined one) and global late materialization,
+        // both of which PlanTestBase turns off for every other test in this package.
+        connectContext.getSessionVariable().setCboCTERuseRatio(0);
+        connectContext.getSessionVariable().setEnableGlobalLateMaterialization(true);
+    }
+
+    @AfterAll
+    public static void restoreSession() {
+        connectContext.getSessionVariable().setCboCTERuseRatio(savedCteReuseRatio);
+        connectContext.getSessionVariable().setEnableGlobalLateMaterialization(savedLateMaterialization);
+    }
+
+    /**
+     * A CTE consumed on both sides of an outer join whose ON clause reads a late-materialized column
+     * of the left side. Late materialization used to push the fetch of that column into whichever
+     * child merely depended on the same scan -- here the right side, which consumes the same CTE --
+     * and then dropped the fetch from the join itself, so the join's own predicate was left reading a
+     * column no input produced: "Invalid plan: ... required cols {n} cannot obtain from input cols".
+     */
+    @Test
+    public void testOuterJoinOnLateMaterializedColumnOfSharedCte() throws Exception {
+        String sql = "with c1 as (select k1, v1, v2 from lm_t order by k1 limit 5), "
+                + "c2 as (select count(*) as n from lm_t), "
+                + "c3 as (select y.k1 as k, count(*) as cnt, max(x.v9) as m from lm_t x "
+                + "       join c1 y on y.k1 = x.k1 group by y.k1) "
+                + "select c2.n, a.k1, a.v1, a.v2, coalesce(z.cnt, 13) as cnt, z.m "
+                + "from c1 a cross join c2 left outer join c3 z on a.v1 = a.k1 "
+                + "order by a.k1 limit 14";
+        String plan = getFragmentPlan(sql);
+        Assertions.assertTrue(plan.contains("NESTLOOP JOIN"), plan);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GlobalLateMaterializeCTEJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GlobalLateMaterializeCTEJoinTest.java
@@ -23,6 +23,7 @@ public class GlobalLateMaterializeCTEJoinTest extends PlanTestBase {
 
     private static double savedCteReuseRatio;
     private static boolean savedLateMaterialization;
+    private static boolean savedCostBased;
 
     @BeforeAll
     public static void createFixture() throws Exception {
@@ -41,16 +42,19 @@ public class GlobalLateMaterializeCTEJoinTest extends PlanTestBase {
 
         savedCteReuseRatio = connectContext.getSessionVariable().getCboCTERuseRatio();
         savedLateMaterialization = connectContext.getSessionVariable().isEnableGlobalLateMaterialization();
+        savedCostBased = connectContext.getSessionVariable().isEnableGlobalLateMaterializationCostBased();
         // The defect needs a materialized CTE (not an inlined one) and global late materialization,
         // both of which PlanTestBase turns off for every other test in this package.
         connectContext.getSessionVariable().setCboCTERuseRatio(0);
         connectContext.getSessionVariable().setEnableGlobalLateMaterialization(true);
+        connectContext.getSessionVariable().setEnableGlobalLateMaterializationCostBased(false);
     }
 
     @AfterAll
     public static void restoreSession() {
         connectContext.getSessionVariable().setCboCTERuseRatio(savedCteReuseRatio);
         connectContext.getSessionVariable().setEnableGlobalLateMaterialization(savedLateMaterialization);
+        connectContext.getSessionVariable().setEnableGlobalLateMaterializationCostBased(savedCostBased);
     }
 
     /**
@@ -71,5 +75,21 @@ public class GlobalLateMaterializeCTEJoinTest extends PlanTestBase {
                 + "order by a.k1 limit 14";
         String plan = getFragmentPlan(sql);
         Assertions.assertTrue(plan.contains("NESTLOOP JOIN"), plan);
+    }
+
+    /**
+     * A CTE consumer carries its own predicate, and nothing told late materialization that the
+     * predicate's column has to exist by the time the consumer runs. The column stayed deferred and
+     * the fragment builder then could not turn the predicate's column ref into an expression:
+     * "Cannot convert ColumnRefOperator to Expr". The requirement has to reach the producer, in
+     * producer column ids, because a consumer has no child of its own to fetch from.
+     */
+    @Test
+    public void testCteConsumerPredicateOnLateMaterializedColumn() throws Exception {
+        String sql = "with c as (select k1, v1, v2, v3 from lm_t), "
+                + "d as (select count(*) as n from c where v2 = 'x') "
+                + "select a.k1, a.v1, d.n from c a cross join d order by a.k1 limit 5";
+        String plan = getFragmentPlan(sql);
+        Assertions.assertTrue(plan.contains("MultiCastDataSinks") || plan.contains("CTE"), plan);
     }
 }

--- a/test/sql/test_cte/R/test_global_late_materialize_cte
+++ b/test/sql/test_cte/R/test_global_late_materialize_cte
@@ -1,0 +1,75 @@
+-- name: test_global_late_materialize_cte
+CREATE TABLE `lm_t` (
+  `k1` bigint NULL,
+  `v1` varchar(255) NULL,
+  `v2` varchar(255) NULL,
+  `v3` varchar(255) NULL,
+  `v9` varchar(255) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO lm_t VALUES
+(1, 'a1', 'x', 'c1', 'm1'),
+(2, 'a2', 'x', 'c2', 'm2'),
+(3, 'a3', 'y', 'c3', 'm3'),
+(4, 'a4', 'y', 'c4', 'm4'),
+(5, 'a5', 'x', 'c5', 'm5'),
+(6, 'a6', 'z', 'c6', 'm6'),
+(7, 'a7', 'z', 'c7', 'm7'),
+(8, 'a8', 'x', 'c8', 'm8'),
+(9, 'a9', 'y', 'c9', 'm9'),
+(10, 'a10', 'z', 'c10', 'm10');
+-- result:
+-- !result
+set cbo_cte_reuse_rate = 0;
+-- result:
+-- !result
+set enable_global_late_materialization = true;
+-- result:
+-- !result
+set enable_global_late_materialization_cost_based = false;
+-- result:
+-- !result
+set cbo_enable_low_cardinality_optimize = false;
+-- result:
+-- !result
+set low_cardinality_optimize_v2 = false;
+-- result:
+-- !result
+with c1 as (select k1, v1, v2 from lm_t order by k1 limit 5),
+     c2 as (select count(*) as n from lm_t),
+     c3 as (select y.k1 as k, count(*) as cnt, max(x.v9) as m from lm_t x
+            join c1 y on y.k1 = x.k1 group by y.k1)
+select c2.n, a.k1, a.v1, a.v2, coalesce(z.cnt, 13) as cnt, z.m
+from c1 a cross join c2 left outer join c3 z on a.v1 = a.k1
+order by a.k1 limit 14;
+-- result:
+10	1	a1	x	13	None
+10	2	a2	x	13	None
+10	3	a3	y	13	None
+10	4	a4	y	13	None
+10	5	a5	x	13	None
+-- !result
+with c as (select k1, v1, v2, v3 from lm_t),
+     d as (select count(*) as n from c where v2 = 'x')
+select a.k1, a.v1, d.n from c a cross join d order by a.k1 limit 5;
+-- result:
+1	a1	4
+2	a2	4
+3	a3	4
+4	a4	4
+5	a5	4
+-- !result
+with c as (select k1, v1, v2, v3 from lm_t),
+     d as (select count(*) as n from c where v3 = 'c7')
+select a.k1, a.v2, d.n from c a cross join d order by a.k1 limit 5;
+-- result:
+1	x	1
+2	x	1
+3	y	1
+4	y	1
+5	x	1
+-- !result

--- a/test/sql/test_cte/T/test_global_late_materialize_cte
+++ b/test/sql/test_cte/T/test_global_late_materialize_cte
@@ -1,0 +1,61 @@
+-- name: test_global_late_materialize_cte
+CREATE TABLE `lm_t` (
+  `k1` bigint NULL,
+  `v1` varchar(255) NULL,
+  `v2` varchar(255) NULL,
+  `v3` varchar(255) NULL,
+  `v9` varchar(255) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+INSERT INTO lm_t VALUES
+(1, 'a1', 'x', 'c1', 'm1'),
+(2, 'a2', 'x', 'c2', 'm2'),
+(3, 'a3', 'y', 'c3', 'm3'),
+(4, 'a4', 'y', 'c4', 'm4'),
+(5, 'a5', 'x', 'c5', 'm5'),
+(6, 'a6', 'z', 'c6', 'm6'),
+(7, 'a7', 'z', 'c7', 'm7'),
+(8, 'a8', 'x', 'c8', 'm8'),
+(9, 'a9', 'y', 'c9', 'm9'),
+(10, 'a10', 'z', 'c10', 'm10');
+-- The defect needs a materialized CTE rather than an inlined one, and global late
+-- materialization. Both are off for most plan tests, so set them explicitly.
+set cbo_cte_reuse_rate = 0;
+set enable_global_late_materialization = true;
+set enable_global_late_materialization_cost_based = false;
+-- Pin the low-cardinality rewrite off. It is unrelated to what this tests, and leaving it on
+-- makes the outcome depend on whether a global dictionary happened to be collected for v1/v2:
+-- where one was, these statements failed with "Dict Decode failed, Dict can't take cover all
+-- key", which is a separate defect in the dictionary-plus-late-materialization path.
+set cbo_enable_low_cardinality_optimize = false;
+set low_cardinality_optimize_v2 = false;
+-- A CTE consumed on both sides of an outer join whose ON clause reads a late-materialized
+-- column of the left side. The fetch of that column used to be pushed into whichever child
+-- merely depended on the same scan -- the right side, which consumes the same CTE -- and was
+-- then dropped from the join itself, leaving the join's own predicate reading a column no
+-- input produced: "Invalid plan: ... required cols {n} cannot obtain from input cols".
+--
+-- `a.v1 = a.k1` compares a varchar against a bigint and both sides come from the left input,
+-- which is what forces a NestLoopJoin and keeps the predicate on the late-materialized column.
+-- It matches nothing here, so every left row survives exactly once and the LIMIT never has to
+-- break a tie.
+with c1 as (select k1, v1, v2 from lm_t order by k1 limit 5),
+     c2 as (select count(*) as n from lm_t),
+     c3 as (select y.k1 as k, count(*) as cnt, max(x.v9) as m from lm_t x
+            join c1 y on y.k1 = x.k1 group by y.k1)
+select c2.n, a.k1, a.v1, a.v2, coalesce(z.cnt, 13) as cnt, z.m
+from c1 a cross join c2 left outer join c3 z on a.v1 = a.k1
+order by a.k1 limit 14;
+-- A CTE consumer carrying its own predicate. Nothing told late materialization that the
+-- predicate's column has to exist by the time the consumer runs, so the column stayed deferred
+-- and the fragment builder could not turn its column ref into an expression: "Cannot convert
+-- ColumnRefOperator to Expr".
+with c as (select k1, v1, v2, v3 from lm_t),
+     d as (select count(*) as n from c where v2 = 'x')
+select a.k1, a.v1, d.n from c a cross join d order by a.k1 limit 5;
+-- Same shape, but the consumer's predicate reads a column the outer select never asks for.
+with c as (select k1, v1, v2, v3 from lm_t),
+     d as (select count(*) as n from c where v3 = 'c7')
+select a.k1, a.v2, d.n from c a cross join d order by a.k1 limit 5;


### PR DESCRIPTION
## Why I'm doing:

  Two ways a plan using global late materialization over a materialized CTE could refer to a
  column nothing produces. Both are reachable on a real cluster with `enable_global_late_materialization`
  at its default and a CTE the optimizer materialises rather than inlines.

  **1. The fetch was pushed into a child that does not carry the column.**

  `GlobalLateMaterializationRewriter.FetchMerger` chose where to push a deferred column's fetch
  by asking which child depends on the same scan. A CTE consumed on both sides of a join makes
  *both* children depend on the producer's scan, while the join's predicate column lives in
  exactly one of them. The fetch went into the side that does not output the column, and because
  one child accepting the push removed the position from the join itself, the side whose
  predicate actually reads the column materialised nothing:

  ERROR 1064 (HY000): Invalid plan: Input dependency cols check failed.
  The required cols {14} cannot obtain from input cols {13,37,62,63,73,74,75,76}.
  PhysicalNestLoopJoinOperator{joinType=LEFT OUTER JOIN,
      joinPredicate=cast(14: v1 as DECIMAL128(38,9)) = cast(13: k1 as DECIMAL128(38,9)), ...}

  **2. A CTE consumer's own predicate did not register its columns.**

  The collector records, per operator, which columns must be materialised before it runs.
  `visitPhysicalCTEConsume` did not register the consumer's own `getPredicate()`, so a column
  read only by that predicate stayed deferred and the fragment builder could not turn its column
  ref into an expression:

  ERROR 1064 (HY000): Getting analyzing error. Detail message:
  Cannot convert ColumnRefOperator to Expr, please check the input expression: 40: v2.

  The requirement has to reach the *producer* and in producer column ids: a consumer has no
  child of its own to fetch from, and the consumer→producer id translation only happens when
  pushing into the consumer.

  ## What I'm doing:

  **Fetch push-down** — intersect the columns being pushed with the child's actual output before
  pushing, skip a child that carries none of them, and remove from the current operator only the
  columns a child accepted. Whatever is left stays put so a fetch is still introduced above this
  operator; a child that refuses the push (it carries a small limit, say) no longer silently
  takes the column with it.

  **Consumer predicates** — register the CTE consumer's own predicate columns against the CTE
  produce operator, translated into producer column ids via `cteOutputColumnRefMap` and recorded
  in the producer's own `CollectorContext`.

  ## What type of PR is this:

  - [x] BugFix
  - [ ] Feature
  - [ ] Enhancement
  - [ ] Refactor
  - [ ] UT
  - [ ] Doc
  - [ ] Tool

  Does this PR entail a change in behavior?

  - [ ] Yes, this PR will result in a change in behavior.
  - [x] No, this PR will not result in a change in behavior.

  ## Checklist:

  - [x] I have added test cases for my bug fix or my new feature
  - [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] This is a backport pr

  ## Bugfix cherry-pick branch check:
  - [x] I have checked the version labels which the pr will be auto-backported to the target branch
    - [ ] 4.1
    - [ ] 4.0
    - [ ] 3.5