### PR TITLE
[Tool] Phase 1: pre-merge backport advisory workflow (ai-lead, comment only)

### DIFF
--- a/.github/workflows/backport-advisory.yml
+++ b/.github/workflows/backport-advisory.yml
@@ -1,0 +1,43 @@
+name: BACKPORT ADVISORY
+
+# Phase 1 (pre-merge advisory). For a native [BugFix] PR, comment which release
+# branches the AI thinks the fix should be backported to (AI-主导) and where that
+# differs from the author's version checkbox — so the owner can adjust BEFORE merge.
+#
+# Advisory ONLY: it upserts a single "<!-- backport-advisory -->" comment and NEVER
+# posts @Mergifyio. The actual backport still happens at merge (ci-merged reconcile).
+#
+# Affected lines are derived by `claude` over local git + gh (no plugin / no code_kb),
+# see ci-tool/bin/backport_reconcile.sh. Synced PRs (label `sync`) are excluded here —
+# they auto-merge with no human to advise; their backport is decided at merge.
+#
+# Runner: [self-hosted, ubuntu, ai]. Requires ci-tool Phase 0 (reconcile --ai-lead
+# --advisory) on the runner.
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  advisory:
+    runs-on: [self-hosted, ubuntu, ai]
+    if: >
+      github.repository == 'StarRocks/starrocks' &&
+      startsWith(github.event.pull_request.title, '[BugFix]') &&
+      !contains(github.event.pull_request.labels.*.name, 'sync') &&
+      !contains(github.event.pull_request.title, 'cherry-pick') &&
+      !contains(github.event.pull_request.title, 'backport')
+    continue-on-error: true
+    env:
+      PR_NUMBER: ${{ github.event.number }}
+      GH_TOKEN: ${{ secrets.PAT }}
+      GITHUB_TOKEN: ${{ secrets.PAT }}
+    steps:
+      - name: pre-merge backport advisory (AI-主导, comment only)
+        run: |
+          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
+          ./bin/backport_reconcile.sh --repo ${GITHUB_REPOSITORY} --pr ${PR_NUMBER} --ai-lead --advisory --no-dry-run


### PR DESCRIPTION
## Why I'm doing:

Surface the AI backport decision **before merge** so the PR owner can adjust their version checkbox. Advisory only — the actual backport still happens at merge.

## What I'm doing:

New `backport-advisory.yml`: on a native `[BugFix]` PR (opened/edited/reopened), run `backport_reconcile.sh --ai-lead --advisory` → upsert one `<!-- backport-advisory -->` comment listing the AI-affected lines that will auto-backport on merge + diffs vs the checkbox. **Never posts @Mergifyio.** Synced PRs excluded (auto-merge, no human to advise).

Affected lines via `claude` + local git/gh (no plugin/code_kb). Requires ci-tool Phase 0 (`reconcile --ai-lead --advisory`, PR #4992) on the `[self-hosted, ubuntu, ai]` runner.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5