### PR TITLE
[BugFix] Stop publish-version reports from mutating transaction state concurrently

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -84,7 +84,6 @@ import com.starrocks.lake.LakeTablet;
 import com.starrocks.load.DeleteJob;
 import com.starrocks.load.OlapDeleteJob;
 import com.starrocks.load.loadv2.SparkLoadJob;
-import com.starrocks.proto.TabletStatPB;
 import com.starrocks.rpc.ThriftConnectionPool;
 import com.starrocks.rpc.ThriftRPCRequestExecutor;
 import com.starrocks.server.GlobalStateMgr;
@@ -151,7 +150,6 @@ import com.starrocks.thrift.TTabletInfo;
 import com.starrocks.thrift.TTabletMeta;
 import com.starrocks.thrift.TTaskType;
 import com.starrocks.transaction.GlobalTransactionMgr;
-import com.starrocks.transaction.PartitionCommitInfo;
 import com.starrocks.transaction.TabletCommitInfo;
 import com.starrocks.transaction.TabletFailInfo;
 import com.starrocks.transaction.TransactionState;
@@ -709,33 +707,19 @@ public class LeaderImpl {
                         publishVersionTask.getDbId(), publishVersionTask.getTransactionId(), publishVersionTask.getBackendId());
             }
         }
-        publishVersionTask.setIsFinished(true);
+        // Park the reported stats on the task rather than writing them into the transaction's
+        // PartitionCommitInfos: this runs on a thrift handler thread holding no transaction lock,
+        // while the publish daemon may be snapshotting that very state. The daemon merges them in
+        // when it finishes the transaction. Record them before marking the task finished, since
+        // "all publish tasks finished" is the daemon's signal to finish the transaction.
+        if (request.isSetFinish_tablet_infos()) {
+            publishVersionTask.collectFirstLoadTabletStats(request.getFinish_tablet_infos());
+        }
         TransactionState txnState = publishVersionTask.getTxnState();
         if (txnState != null) {
             txnState.updatePublishTaskFinishTime();
-
-            // Used to collect statistics when the partition is first imported
-            // TODO(stephen): support insert into multiple tables in a transaction
-            if (txnState.getSourceType() == LoadJobSourceType.INSERT_STREAMING &&
-                    txnState.getIdToTableCommitInfos().size() == 1 &&
-                    request.isSetFinish_tablet_infos() &&
-                    !request.getFinish_tablet_infos().isEmpty()) {
-                Map<Long, PartitionCommitInfo> idToPartitionCommitInfo = txnState.getIdToTableCommitInfos().values()
-                        .iterator().next().getIdToPartitionCommitInfo();
-                List<TTabletInfo> tabletInfos = request.getFinish_tablet_infos();
-                for (TTabletInfo tabletInfo : tabletInfos) {
-                    long partitionId = tabletInfo.getPartition_id();
-                    PartitionCommitInfo commitInfo = idToPartitionCommitInfo.get(partitionId);
-                    if (commitInfo != null && commitInfo.getVersion() == Partition.PARTITION_INIT_VERSION + 1) {
-                        long tabletId = tabletInfo.getTablet_id();
-                        TabletStatPB stat = new TabletStatPB();
-                        stat.numRows = tabletInfo.getRow_count();
-                        stat.dataSize = tabletInfo.getData_size();
-                        commitInfo.getTabletStats().put(tabletId, stat);
-                    }
-                }
-            }
         }
+        publishVersionTask.setIsFinished(true);
 
         if (request.getTask_status().getStatus_code() != TStatusCode.OK) {
             // not remove the task from queue and be will retry

--- a/fe/fe-core/src/main/java/com/starrocks/task/PublishVersionTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PublishVersionTask.java
@@ -36,6 +36,7 @@ package com.starrocks.task;
 
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
@@ -43,9 +44,11 @@ import com.starrocks.common.TraceManager;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.memory.estimate.IgnoreMemoryTrack;
+import com.starrocks.proto.TabletStatPB;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TPartitionVersionInfo;
 import com.starrocks.thrift.TPublishVersionRequest;
+import com.starrocks.thrift.TTabletInfo;
 import com.starrocks.thrift.TTabletVersionPair;
 import com.starrocks.thrift.TTaskType;
 import com.starrocks.transaction.TransactionState;
@@ -55,8 +58,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -75,6 +81,14 @@ public class PublishVersionTask extends AgentTask {
     private TransactionType txnType;
     private final long globalTransactionId;
     private boolean isVersionOverwrite = false;
+
+    // Per-tablet stats this BE reported for partitions being loaded for the first time, keyed by
+    // physical partition id then tablet id. Filled by the thrift finishTask handler thread and read
+    // by the thread that finishes the transaction, so it is guarded by the task monitor exactly like
+    // errorTablets/errorReplicas. The handler must NOT write these straight into the transaction's
+    // PartitionCommitInfos: that races with the publish daemon snapshotting the transaction state
+    // and used to throw ConcurrentModificationException out of the daemon (issue #77595).
+    private Map<Long, Map<Long, TabletStatPB>> firstLoadTabletStats = Collections.emptyMap();
 
     public PublishVersionTask(long backendId, long transactionId, long globalTransactionId, long dbId, long commitTimestamp,
                               List<TPartitionVersionInfo> partitionVersionInfos, String traceParent, Span txnSpan,
@@ -140,6 +154,54 @@ public class PublishVersionTask extends AgentTask {
 
     public synchronized Set<Long> getErrorReplicas() {
         return errorReplicas;
+    }
+
+    /**
+     * Record the per-tablet stats this BE reported for partitions being loaded for the first time.
+     * <p>
+     * Called from the thrift finishTask handler thread. It deliberately reads nothing but this task's
+     * own immutable partitionVersionInfos, so the handler never touches state the publish daemon owns;
+     * {@link TransactionState#applyPublishTaskTabletStats()} merges the result into the commit infos
+     * on the thread that finishes the transaction.
+     */
+    public void collectFirstLoadTabletStats(List<TTabletInfo> finishTabletInfos) {
+        if (finishTabletInfos == null || finishTabletInfos.isEmpty() || txnState == null ||
+                txnState.getSourceType() != TransactionState.LoadJobSourceType.INSERT_STREAMING) {
+            return;
+        }
+        // partitionVersionInfos carries the same versions as the PartitionCommitInfos this task was
+        // built from, so filtering here is equivalent to checking the commit info's version, and it
+        // keeps us from retaining stats for anything but a first load.
+        Set<Long> firstLoadPartitionIds = new HashSet<>();
+        for (TPartitionVersionInfo versionInfo : partitionVersionInfos) {
+            if (versionInfo.getVersion() == Partition.PARTITION_INIT_VERSION + 1) {
+                firstLoadPartitionIds.add(versionInfo.getPartition_id());
+            }
+        }
+        if (firstLoadPartitionIds.isEmpty()) {
+            return;
+        }
+
+        Map<Long, Map<Long, TabletStatPB>> stats = new HashMap<>();
+        for (TTabletInfo tabletInfo : finishTabletInfos) {
+            long partitionId = tabletInfo.getPartition_id();
+            if (!firstLoadPartitionIds.contains(partitionId)) {
+                continue;
+            }
+            TabletStatPB stat = new TabletStatPB();
+            stat.numRows = tabletInfo.getRow_count();
+            stat.dataSize = tabletInfo.getData_size();
+            stats.computeIfAbsent(partitionId, k -> new HashMap<>()).put(tabletInfo.getTablet_id(), stat);
+        }
+        setFirstLoadTabletStats(stats);
+    }
+
+    private synchronized void setFirstLoadTabletStats(Map<Long, Map<Long, TabletStatPB>> stats) {
+        this.firstLoadTabletStats = stats;
+    }
+
+    public synchronized Map<Long, Map<Long, TabletStatPB>> getFirstLoadTabletStats() {
+        return firstLoadTabletStats;
     }
 
     public synchronized void setErrorTablets(List<Long> errorTablets) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1264,6 +1264,9 @@ public class DatabaseTransactionMgr {
         try {
             transactionState.writeLock();
             try {
+                // Fold in the stats the BEs reported through their publish tasks before snapshotting,
+                // so the finishing thread is the only writer of the commit infos (see issue #77595).
+                transactionState.applyPublishTaskTabletStats();
                 copiedState = new TransactionState(transactionState);
                 boolean hasError = false;
                 Set<Long> droppedTableIds = Sets.newHashSet();
@@ -2400,6 +2403,9 @@ public class DatabaseTransactionMgr {
         try {
             transactionState.writeLock();
             try {
+                // See the sibling call in finishTransaction(): merge the publish tasks' reported stats
+                // here, under the txn write lock, so nothing mutates the commit infos while we copy.
+                transactionState.applyPublishTaskTabletStats();
                 copiedState = new TransactionState(transactionState);
 
                 finishSpan.addEvent("txnmgr_lock");

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PartitionCommitInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PartitionCommitInfo.java
@@ -88,6 +88,17 @@ public class PartitionCommitInfo implements Writable {
     // (range-distribution tablets, and any tablet on first import), for shared-nothing tables
     // from TTabletInfo on first import. Transient (not serialized), leader-only. Consumed for
     // first-load statistics collection and (lake only) real-time reshard triggering.
+    //
+    // Deliberately an unsynchronized HashMap: exactly one thread may touch a given instance at a
+    // time, and that must stay true.
+    //  - shared-nothing: written only by the thread finishing the transaction, via
+    //    TransactionState.applyPublishTaskTabletStats() under the txn write lock. The thrift
+    //    finishTask handlers write to their own PublishVersionTask, never here.
+    //  - lake: written only by the publish thread that owns this partition, which happens-before
+    //    the finish through the publish CompletableFuture.
+    // Writing this map from a thread that does not own it is a bug, not a tuning question - it is
+    // what made the publish daemon's snapshot throw ConcurrentModificationException in issue #77595.
+    // Leaving it unsynchronized keeps such a mistake loud instead of silently truncating stats.
     private final Map<Long, TabletStatPB> tabletStats = new HashMap<>();
 
     private boolean isDoubleWrite = false;
@@ -200,6 +211,21 @@ public class PartitionCommitInfo implements Writable {
 
     public Map<Long, TabletStatPB> getTabletStats() {
         return tabletStats;
+    }
+
+    // Single entry point for adding stats, so every writer of tabletStats is greppable and can be
+    // checked against the single-owner-thread rule documented on the field.
+    public void putAllTabletStats(@Nullable Map<Long, TabletStatPB> stats) {
+        if (stats == null) {
+            return;
+        }
+        // Lake entries come straight off a publish RPC response; every consumer null-checks the
+        // value, so drop null stats here instead of storing them.
+        stats.forEach((tabletId, stat) -> {
+            if (stat != null) {
+                tabletStats.put(tabletId, stat);
+            }
+        });
     }
 
     @Nullable

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -1201,7 +1201,7 @@ public class PublishVersionDaemon extends LeaderDaemon {
                 Quantiles quantiles = Quantiles.compute(compactionScores.values());
                 partitionCommitInfo.setCompactionScore(quantiles);
                 if (!tabletStats.isEmpty()) {
-                    partitionCommitInfo.getTabletStats().putAll(tabletStats);
+                    partitionCommitInfo.putAllTabletStats(tabletStats);
                 }
             }
             return true;

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -1245,6 +1245,44 @@ public class TransactionState implements Writable, GsonPreProcessable {
         return publishVersionTasks;
     }
 
+    /**
+     * Merge the first-load per-tablet stats each BE reported through its publish task into the
+     * partition commit infos.
+     * <p>
+     * Must be called while holding this transaction's write lock, immediately before the state is
+     * snapshotted. That makes the finishing thread the only writer of
+     * {@link PartitionCommitInfo#getTabletStats()}: the thrift finishTask handlers only ever write to
+     * their own {@link PublishVersionTask}, so nothing mutates the commit infos while they are being
+     * copied. Doing it the other way round - handler threads writing the commit infos directly - is
+     * what threw ConcurrentModificationException out of PublishVersionDaemon in issue #77595.
+     * <p>
+     * Idempotent, so a transaction whose finish is retried simply re-applies the same stats.
+     */
+    public void applyPublishTaskTabletStats() {
+        // TODO(stephen): support insert into multiple tables in a transaction
+        if (sourceType != LoadJobSourceType.INSERT_STREAMING || idToTableCommitInfos.size() != 1 ||
+                publishVersionTasks.isEmpty()) {
+            return;
+        }
+        TableCommitInfo tableCommitInfo = idToTableCommitInfos.values().iterator().next();
+        if (tableCommitInfo == null) {
+            return;
+        }
+        for (PublishVersionTask task : publishVersionTasks.values()) {
+            // An unfinished task has not published its stats yet; reading them would be a torn read
+            // of a report still in flight. Its stats land on the next finish attempt, if any.
+            if (!task.isFinished()) {
+                continue;
+            }
+            task.getFirstLoadTabletStats().forEach((partitionId, tabletStats) -> {
+                PartitionCommitInfo commitInfo = tableCommitInfo.getPartitionCommitInfo(partitionId);
+                if (commitInfo != null) {
+                    commitInfo.putAllTabletStats(tabletStats);
+                }
+            });
+        }
+    }
+
     public void clearAfterPublished() {
         publishVersionTasks.clear();
         finishChecker = null;

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStateBatch.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStateBatch.java
@@ -82,7 +82,7 @@ public class TransactionStateBatch implements Writable {
                 .map(transactionState -> transactionState.getTableCommitInfo(tableId))
                 .filter(commitInfo -> commitInfo != null && commitInfo.getPartitionCommitInfo(partitionId) != null)
                 .forEach(commitInfo ->
-                        commitInfo.getPartitionCommitInfo(partitionId).getTabletStats().putAll(tabletStats));
+                        commitInfo.getPartitionCommitInfo(partitionId).putAllTabletStats(tabletStats));
     }
 
     public void putBeTablets(long partitionId, Map<ComputeNode, List<Long>> nodeToTablets)  {

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/PartitionCommitInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/PartitionCommitInfoTest.java
@@ -15,10 +15,20 @@
 package com.starrocks.transaction;
 
 import com.google.common.collect.Lists;
+import com.starrocks.catalog.Partition;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.proto.TabletStatPB;
+import com.starrocks.task.PublishVersionTask;
+import com.starrocks.thrift.TPartitionVersionInfo;
+import com.starrocks.thrift.TTabletInfo;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class PartitionCommitInfoTest {
     private static final long PID = 12345L;
@@ -48,6 +58,137 @@ public class PartitionCommitInfoTest {
         PartitionCommitInfo copy = new PartitionCommitInfo(src);
         Assertions.assertEquals(1, copy.getTabletStats().size());
         Assertions.assertEquals(100L, copy.getTabletStats().get(7L).dataSize);
+    }
+
+    @Test
+    public void testPutAllTabletStatsSkipsNullValues() {
+        PartitionCommitInfo pci = new PartitionCommitInfo(PID, 2L, 3L);
+        pci.putAllTabletStats(null);
+        Assertions.assertTrue(pci.getTabletStats().isEmpty());
+
+        TabletStatPB stat = new TabletStatPB();
+        stat.numRows = 10L;
+        Map<Long, TabletStatPB> stats = new HashMap<>();
+        stats.put(1L, stat);
+        stats.put(2L, null);
+        pci.putAllTabletStats(stats);
+
+        Assertions.assertEquals(1, pci.getTabletStats().size());
+        Assertions.assertEquals(10L, pci.getTabletStats().get(1L).numRows);
+    }
+
+    private TransactionState newFirstLoadTxnState(PartitionCommitInfo pci) {
+        TableCommitInfo tableCommitInfo = new TableCommitInfo(TABLE_ID);
+        tableCommitInfo.addPartitionCommitInfo(pci);
+        TransactionState state = new TransactionState(1000L, Lists.newArrayList(TABLE_ID),
+                3000, "label", null, TransactionState.LoadJobSourceType.INSERT_STREAMING, null, 0, 60_000);
+        state.putIdToTableCommitInfo(TABLE_ID, tableCommitInfo);
+        return state;
+    }
+
+    private PublishVersionTask newPublishVersionTask(long backendId, TransactionState state) {
+        // PARTITION_INIT_VERSION + 1 marks a first load, which is the only case stats are collected for.
+        TPartitionVersionInfo versionInfo =
+                new TPartitionVersionInfo(PID, Partition.PARTITION_INIT_VERSION + 1, 0);
+        return new PublishVersionTask(backendId, state.getTransactionId(), state.getGlobalTransactionId(),
+                state.getDbId(), 0, Lists.newArrayList(versionInfo), null, null, 0, state, false,
+                TransactionType.TXN_NORMAL);
+    }
+
+    private TTabletInfo newTabletInfo(long tabletId, long rowCount) {
+        TTabletInfo tabletInfo = new TTabletInfo(tabletId, 0, 2L, 0, rowCount, rowCount * 10);
+        tabletInfo.setPartition_id(PID);
+        return tabletInfo;
+    }
+
+    // The reported stats must survive the handoff: the finishTask handler parks them on its own task,
+    // and the thread finishing the transaction folds them into the commit infos before snapshotting.
+    @Test
+    public void testPublishTaskTabletStatsAreAppliedBeforeSnapshot() {
+        PartitionCommitInfo pci = new PartitionCommitInfo(PID, Partition.PARTITION_INIT_VERSION + 1, 3L);
+        TransactionState state = newFirstLoadTxnState(pci);
+
+        PublishVersionTask task = newPublishVersionTask(10001L, state);
+        state.addPublishVersionTask(10001L, task);
+        task.setErrorTablets(null);
+        task.collectFirstLoadTabletStats(Lists.newArrayList(newTabletInfo(7L, 123L)));
+
+        // Collecting on the handler side must not touch the shared commit info.
+        Assertions.assertTrue(pci.getTabletStats().isEmpty());
+
+        task.setIsFinished(true);
+        state.applyPublishTaskTabletStats();
+        Assertions.assertEquals(123L, pci.getTabletStats().get(7L).numRows);
+
+        PartitionCommitInfo copied = new TransactionState(state).getTableCommitInfo(TABLE_ID)
+                .getPartitionCommitInfo(PID);
+        Assertions.assertEquals(123L, copied.getTabletStats().get(7L).numRows);
+    }
+
+    // Stats of a task that has not reported yet must not be picked up: an unfinished task may still be
+    // being written by its handler thread.
+    @Test
+    public void testUnfinishedPublishTaskStatsAreNotApplied() {
+        PartitionCommitInfo pci = new PartitionCommitInfo(PID, Partition.PARTITION_INIT_VERSION + 1, 3L);
+        TransactionState state = newFirstLoadTxnState(pci);
+
+        PublishVersionTask task = newPublishVersionTask(10001L, state);
+        state.addPublishVersionTask(10001L, task);
+        task.collectFirstLoadTabletStats(Lists.newArrayList(newTabletInfo(7L, 123L)));
+
+        state.applyPublishTaskTabletStats();
+        Assertions.assertTrue(pci.getTabletStats().isEmpty());
+    }
+
+    // Regression test for the ConcurrentModificationException reported in issue #77595. Reporting BEs
+    // (thrift finishTask handler threads) used to write PartitionCommitInfo.tabletStats directly while
+    // PublishVersionDaemon deep-copied the transaction state to finish it, with no lock covering the
+    // map. Handling a report must not touch anything the finishing thread is copying.
+    @Test
+    public void testHandlingReportsDoesNotRaceWithSnapshot() throws Exception {
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        PartitionCommitInfo pci = new PartitionCommitInfo(PID, Partition.PARTITION_INIT_VERSION + 1, 3L);
+        TransactionState state = newFirstLoadTxnState(pci);
+
+        // One task per reporting BE, all reporting concurrently for the same partition.
+        List<PublishVersionTask> tasks = new ArrayList<>();
+        for (long backendId = 10001L; backendId <= 10003L; backendId++) {
+            PublishVersionTask task = newPublishVersionTask(backendId, state);
+            state.addPublishVersionTask(backendId, task);
+            tasks.add(task);
+        }
+
+        List<Thread> reporters = new ArrayList<>();
+        for (int i = 0; i < tasks.size(); i++) {
+            PublishVersionTask task = tasks.get(i);
+            long tabletBase = i * 10_000L;
+            Thread reporter = new Thread(() -> {
+                try {
+                    for (long tabletId = 0; tabletId < 20_000; tabletId++) {
+                        task.collectFirstLoadTabletStats(
+                                Lists.newArrayList(newTabletInfo(tabletBase + tabletId, tabletId)));
+                    }
+                } catch (Throwable t) {
+                    failure.compareAndSet(null, t);
+                }
+            });
+            reporter.start();
+            reporters.add(reporter);
+        }
+
+        try {
+            while (reporters.stream().anyMatch(Thread::isAlive)) {
+                // Never throws ConcurrentModificationException, whatever the reporters are doing.
+                new TransactionState(state);
+            }
+        } catch (Throwable t) {
+            failure.compareAndSet(null, t);
+        } finally {
+            for (Thread reporter : reporters) {
+                reporter.join(30_000);
+            }
+        }
+        Assertions.assertNull(failure.get(), () -> "unexpected failure: " + failure.get());
     }
 
     @Test


### PR DESCRIPTION
PublishVersionDaemon crashes with a ConcurrentModificationException while snapshotting the transaction state to finish it:
```
  java.util.HashMap.putMapEntries(HashMap.java:519)
  java.util.HashMap.putAll(HashMap.java:791)
  com.starrocks.transaction.PartitionCommitInfo.<init>(PartitionCommitInfo.java:137)
  com.starrocks.transaction.TableCommitInfo.<init>(TableCommitInfo.java:65)
  com.starrocks.transaction.TransactionState.deepCopyIdToTableCommitInfos(...)
  com.starrocks.transaction.DatabaseTransactionMgr.finishTransaction(...)
  com.starrocks.transaction.PublishVersionDaemon.tryFinishTransaction(...)
```
Root cause: LeaderImpl.finishPublishVersion writes first-load per-tablet stats
straight into the transaction's PartitionCommitInfos. It runs on thrift
finishTask handler threads - one per reporting BE - and holds no transaction
lock, while DatabaseTransactionMgr.finishTransaction deep-copies that same
state under the txn write lock. PartitionCommitInfo's copy constructor iterates
tabletStats via putAll, so the copy trips over a concurrent insert.

The window is not incidental. finishPublishVersion marked the publish task
finished before filling in the stats, and tryFinishTransaction uses "all
publish tasks finished" as its signal to finish the transaction: the last
reporting BE flips the task to finished, the daemon starts the deep copy, and
the handler thread is still inserting. Several BEs also report the same
transaction at once, so two handler threads could insert into one HashMap
concurrently.

Fix the ownership rather than the symptom. Making tabletStats concurrent would
stop the exception, but the daemon would then snapshot a half-written map and
silently drop stats - the race would still be there, just quiet. So keep the
handler off the shared state entirely:

- PublishVersionTask gains firstLoadTabletStats, guarded by the task monitor
  like errorTablets/errorReplicas. finishPublishVersion records the BE's report
  there and touches nothing else; it derives "is this a first load" from the
  task's own immutable partitionVersionInfos rather than reading the commit
  infos. Recording still happens before setIsFinished(true), and the monitor
  release/acquire pair between the setter and the getter publishes it safely,
  so a plain isFinished read can only be stale-false, which just defers the
  stats to the next finish attempt.
- TransactionState.applyPublishTaskTabletStats() merges the finished tasks'
  stats into the commit infos. DatabaseTransactionMgr calls it under the txn
  write lock immediately before the snapshot, in both finishTransaction() and
  finishTransactionNew(), so the finishing thread is the only writer.
- PartitionCommitInfo.tabletStats stays an unsynchronized HashMap, now with the
  single-owner-thread rule spelled out and all writes funnelled through
  putAllTabletStats(). A future cross-thread write should keep failing loudly
  instead of silently truncating statistics.

A BE that re-reports a task now replaces its stats instead of accumulating
them, which is what the report means: each report carries that task's full
finish_tablet_infos.


## Why I'm doing:

## What I'm doing:

Fixes #77595

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
