### PR TITLE
[BugFix] Keep parquet decoder scratch buffers off the stack

### DIFF
--- a/be/src/formats/parquet/encoding_dict.h
+++ b/be/src/formats/parquet/encoding_dict.h
@@ -181,10 +181,12 @@ public:
         data_column->resize_uninitialized(cur_size + count);
         int32_t* __restrict__ data = data_column->get_data().data() + cur_size;
 
-        uint32_t read_dict_data[read_count + 1];
         if (read_count == 0) {
             return Status::OK();
         }
+        // Reusable member rather than a VLA: read_count is page-sized and blows the stack.
+        _temp_dict_codes.resize(read_count + 1);
+        uint32_t* read_dict_data = _temp_dict_codes.data();
         auto decoded_num = _rle_batch_reader.GetBatch(read_dict_data, read_count);
         if (decoded_num < read_count) {
             return Status::InternalError("didn't get enough data from dict-decoder");
@@ -201,6 +203,8 @@ protected:
     virtual Status _do_next_batch_with_nulls(size_t count, const NullInfos& null_infos, ColumnContentType content_type,
                                              Column* dst, const FilterData* filter) = 0;
     RleBatchDecoder<uint32_t> _rle_batch_reader;
+    // Scratch buffer for one batch of dictionary codes, reused across batches.
+    std::vector<uint32_t> _temp_dict_codes;
 
 private:
     size_t _dict_size_threshold = 0;
@@ -311,7 +315,9 @@ public:
                 cnt += !is_nulls[i];
             }
         } else {
-            T read_data[read_count + 1];
+            // Reusable member rather than a VLA: read_count is page-sized and blows the stack.
+            _temp_read_data.resize(read_count + 1);
+            T* read_data = _temp_read_data.data();
             auto ret = _rle_batch_reader.GetBatchWithDict(_dict.data(), _dict.size(), read_data, read_count);
             if (UNLIKELY(ret <= 0)) {
                 return Status::InternalError("DictDecoder GetBatchWithDict failed");
@@ -375,6 +381,8 @@ private:
 
     std::vector<T> _dict;
     std::vector<uint32_t> _indexes;
+    // Scratch buffer for one batch of decoded values, reused across batches.
+    std::vector<T> _temp_read_data;
 };
 
 class FixedSliceArray {
@@ -583,8 +591,11 @@ private:
                 return Status::InternalError("DictDecoder<Slice> GetBatchWithDict failed");
             }
 
-            uint32_t lengths[read_count + 1];
-            char* datas[read_count + 1];
+            // Reusable members rather than VLAs: read_count is page-sized and blows the stack.
+            _temp_lengths.resize(read_count + 1);
+            _temp_datas.resize(read_count + 1);
+            uint32_t* lengths = _temp_lengths.data();
+            char** datas = _temp_datas.data();
 
             for (size_t i = 0; i < read_count; ++i) {
                 datas[i] = _slices[i].data;
@@ -662,6 +673,9 @@ private:
     std::vector<uint32_t> _indexes;
     FixedSliceArray _slices;
     size_t _max_value_length = 0;
+    // Scratch buffers for one batch of slices, reused across batches.
+    std::vector<uint32_t> _temp_lengths;
+    std::vector<char*> _temp_datas;
 };
 
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/encoding_plain.h
+++ b/be/src/formats/parquet/encoding_plain.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <cstring>
+#include <vector>
 
 #include "column/column.h"
 #include "column/column_helper.h"
@@ -208,8 +209,13 @@ public:
 
         size_t max_size = 0;
         size_t read_count = count - null_cnt;
-        uint32_t lengths[read_count + 1];
-        char* datas[read_count + 1];
+        // Reusable members rather than VLAs: a data page may hold ~1M values and
+        // StoredColumnReaderImpl::_read() hands the whole page over in one call, so stack
+        // arrays sized by read_count overflow the thread stack.
+        _temp_lengths.resize(read_count + 1);
+        _temp_datas.resize(read_count + 1);
+        uint32_t* lengths = _temp_lengths.data();
+        char** datas = _temp_datas.data();
         size_t i = 0;
         size_t cursor = _offset;
         //
@@ -354,6 +360,8 @@ public:
 private:
     Slice _data;
     size_t _offset = 0;
+    std::vector<uint32_t> _temp_lengths;
+    std::vector<char*> _temp_datas;
 };
 
 // plain encoding for boolean type is stored as `Bit Packed`, `LSB` first format

--- a/be/test/formats/parquet/dict_encoding_test.cpp
+++ b/be/test/formats/parquet/dict_encoding_test.cpp
@@ -290,4 +290,92 @@ TEST(DictEncodingReadTest, BinaryDestinationTypeGuard) {
         ASSERT_FALSE(st.ok());
     }
 }
+
+// A dictionary-encoded data page: one bit-width byte, then RLE/bit-packed runs. A single
+// repeated run covers every value, so the page is a handful of bytes however many values it
+// claims -- which is what keeps a multi-million-value test cheap. (Building the same page with
+// RleEncoder::Put would not: it costs seconds per 100k values.)
+static void build_repeated_run_page(faststring* page, uint32_t code, size_t num_values, int bit_width = 32) {
+    auto put_byte = [page](uint32_t b) {
+        auto byte = static_cast<uint8_t>(b);
+        page->append(&byte, 1);
+    };
+
+    put_byte(bit_width);
+    // Run indicator, ULEB128 of (num_values << 1); lsb 0 marks a repeated run.
+    uint64_t indicator = static_cast<uint64_t>(num_values) << 1;
+    for (; indicator >= 0x80; indicator >>= 7) {
+        put_byte((indicator & 0x7f) | 0x80);
+    }
+    put_byte(indicator);
+    // The repeated value, ceil(bit_width / 8) bytes, little endian.
+    for (int i = 0; i < (bit_width + 7) / 8; ++i) {
+        put_byte(code >> (8 * i));
+    }
+}
+
+// The batch size handed to a decoder is not the chunk size: StoredColumnReaderImpl::_read() passes
+// everything left in the current data page in one call, so a page holding millions of values
+// produces a batch that big. Scratch space sized by that batch must live on the heap; the VLAs
+// these paths used to declare killed the BE with a SIGSEGV raised inside the decoder.
+template <LogicalType DICT_TYPE, LogicalType TARGET_TYPE>
+static void large_batch_with_nulls_test() {
+    using TARGET_CXX_TYPE = RunTimeCppType<TARGET_TYPE>;
+    // 2^21 values: the removed VLAs wanted 8MB for the dict codes and the fixed-width values,
+    // and 24MB for the slices, against the 8MB stack a scan thread has.
+    constexpr size_t kCount = 1 << 21;
+    constexpr size_t kNullStride = 8;
+    constexpr uint32_t kCode = 3;
+
+    faststring page;
+    build_repeated_run_page(&page, kCode, kCount);
+
+    NullInfos infos;
+    infos.reset_with_capacity(kCount);
+    infos.num_nulls = 0;
+    for (size_t i = 0; i < kCount; ++i) {
+        infos.nulls_data()[i] = (i % kNullStride) == 0;
+        infos.num_nulls += infos.nulls_data()[i];
+    }
+    // num_ranges > 2 routes to the batched paths rather than the row-by-row fallback.
+    infos.num_ranges = kCount / 2;
+
+    // The dictionary holds "0".."9", every code in the page is kCode, and FakeDictDecoder makes
+    // dictionary entry i render as "i" for both the int and the string dictionary.
+    auto check = [&](const auto& dst) {
+        EXPECT_EQ(dst->size(), kCount);
+        EXPECTED_UNQUOTE(dst->debug_item(0), "NULL");
+        EXPECTED_UNQUOTE(dst->debug_item(kNullStride), "NULL");
+        EXPECTED_UNQUOTE(dst->debug_item(1), "3");
+        EXPECTED_UNQUOTE(dst->debug_item(kCount - 1), "3");
+    };
+
+    {
+        // dict codes
+        DictDecoder<TARGET_CXX_TYPE> decoder;
+        FakeDictDecoder<TARGET_TYPE> inner_decoder;
+        ASSERT_OK(decoder.set_data(Slice(page.data(), page.length())));
+        ASSERT_OK(decoder.set_dict(10, 10, &inner_decoder));
+
+        auto dst = ColumnHelper::create_column(TypeDescriptor(DICT_TYPE), true);
+        ASSERT_OK(decoder.next_batch_with_nulls(kCount, infos, ColumnContentType::DICT_CODE, dst.get(), nullptr));
+        check(dst);
+    }
+    {
+        // values
+        DictDecoder<TARGET_CXX_TYPE> decoder;
+        FakeDictDecoder<TARGET_TYPE> inner_decoder;
+        ASSERT_OK(decoder.set_data(Slice(page.data(), page.length())));
+        ASSERT_OK(decoder.set_dict(10, 10, &inner_decoder));
+
+        auto dst = ColumnHelper::create_column(TypeDescriptor(TARGET_TYPE), true);
+        ASSERT_OK(decoder.next_batch_with_nulls(kCount, infos, ColumnContentType::VALUE, dst.get(), nullptr));
+        check(dst);
+    }
+}
+
+TEST(DictEncodingReadTest, LargeBatchWithNulls) {
+    large_batch_with_nulls_test<LogicalType::TYPE_INT, LogicalType::TYPE_INT>();
+    large_batch_with_nulls_test<LogicalType::TYPE_INT, LogicalType::TYPE_VARCHAR>();
+}
 } // namespace starrocks::parquet

--- a/be/test/formats/parquet/encoding_test.cpp
+++ b/be/test/formats/parquet/encoding_test.cpp
@@ -1154,4 +1154,54 @@ TEST_F(ParquetEncodingTest, DeltaBinaryPackedCorruptHeader) {
     }
 }
 
+// The batch size handed to a decoder is not the chunk size: StoredColumnReaderImpl::_read() passes
+// everything left in the current data page in one call, so a page holding ~1M values produces a
+// ~1M-value batch. Scratch space sized by that batch must live on the heap; the VLAs this path used
+// to declare needed ~12MB of stack and killed the BE with a SIGSEGV raised inside the decoder.
+TEST_F(ParquetEncodingTest, PlainByteArrayLargeBatchWithNulls) {
+    constexpr size_t kCount = 1 << 20;
+    constexpr size_t kNullStride = 8;
+    const std::string value("abcdefgh");
+
+    NullInfos null_infos;
+    null_infos.reset_with_capacity(kCount);
+    uint8_t* nulls = null_infos.nulls_data();
+    null_infos.num_nulls = 0;
+    for (size_t i = 0; i < kCount; ++i) {
+        nulls[i] = (i % kNullStride) == 0;
+        null_infos.num_nulls += nulls[i];
+    }
+    null_infos.num_ranges = kCount / 2;
+    const size_t read_count = kCount - null_infos.num_nulls;
+
+    const EncodingInfo* plain_encoding = nullptr;
+    (void)EncodingInfo::get(tparquet::Type::BYTE_ARRAY, tparquet::Encoding::PLAIN, &plain_encoding);
+    ASSERT_TRUE(plain_encoding != nullptr);
+
+    std::vector<Slice> slices(read_count, Slice(value));
+    std::unique_ptr<Encoder> encoder;
+    Status st = plain_encoding->create_encoder(&encoder);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    st = encoder->append(reinterpret_cast<uint8_t*>(slices.data()), slices.size());
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    std::unique_ptr<Decoder> decoder;
+    st = plain_encoding->create_decoder(&decoder);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    st = decoder->set_data(encoder->build());
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    auto dst = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+    st = decoder->next_batch_with_nulls(kCount, null_infos, ColumnContentType::VALUE, dst.get(), nullptr);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    ASSERT_EQ(kCount, dst->size());
+    ASSERT_TRUE(dst->is_null(0));
+    ASSERT_FALSE(dst->is_null(1));
+    ASSERT_FALSE(dst->is_null(kCount - 1));
+    auto* binary_column = down_cast<BinaryColumn*>(dst->data_column_raw_ptr());
+    ASSERT_EQ(read_count * value.size(), binary_column->get_bytes().size());
+    ASSERT_EQ(value, binary_column->get_slice(1).to_string());
+}
+
 } // namespace starrocks::parquet


### PR DESCRIPTION
## Why I'm doing:

main was resolved in https://github.com/StarRocks/starrocks/pull/73288

PlainDecoder<Slice> and both dictionary decoders sized their per-batch scratch arrays as VLAs. The batch handed to a decoder is not the chunk size: StoredColumnReaderImpl::_read() passes everything left in the current data page in a single call, bounded only by _num_values_left_in_cur_page -- unlike _skip(), which clamps to BATCH_PROCESS_SIZE. A page holding ~1M values therefore asks for ~12MB of stack, past the 8MB a scan worker thread has, and the BE dies with a SIGSEGV whose backtrace cannot be unwound past the faulting frame because the stack pointer is already off the mapped stack:

    #0 starrocks::parquet::PlainDecoder<starrocks::Slice>::next_batch_with_nulls
       (count=992028, ...) at be/src/formats/parquet/encoding_plain.h:202
    #1 0x0000000000000000 in ?? ()

The value count of a page is written in the file, so every external Parquet scan (Hive/Iceberg/FILES()) can reach this with a large enough page.

Move the five scratch arrays -- lengths/datas in PlainDecoder<Slice> and in DictDecoder<Slice>, the decoded values in DictDecoder<T>, and the dict codes in CacheAwareDictDecoder -- to members that are resized per batch and reused across batches, which is what main does after #73288.

The new unit tests decode a 2^20-value batch with nulls through the plain BYTE_ARRAY path and through both dictionary paths (dict codes and values, for a fixed-length and a string dictionary); each one overflowed the stack before this change.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

