### PR TITLE
[BugFix] Reflect colocate_with for materialized views from the MV ddl

### DIFF
--- a/contrib/starrocks-python-client/starrocks/common/defaults.py
+++ b/contrib/starrocks-python-client/starrocks/common/defaults.py
@@ -196,6 +196,26 @@ class ReflectionMVDefaults(ReflectionViewDefaults):
         'replication_num': '1',  # Different for shared-data
     }, **_DEFAULT_PROPERTIES}
 
+    # Properties that information_schema.tables_config omits for materialized views, and which
+    # must therefore be read from the PROPERTIES clause of the CREATE MATERIALIZED VIEW ddl.
+    # Without this, such a property looks absent on the reflected side while being present in
+    # the metadata, so autogenerate reports the same phantom change on every run.
+    #
+    # Keep this an explicit allowlist rather than merging the whole ddl PROPERTIES clause:
+    # SHOW CREATE MATERIALIZED VIEW also prints effective values that tables_config leaves out
+    # on purpose (e.g. replicated_storage), and those have no entry in _DEFAULT_PROPERTIES, so
+    # merging them in would warn about an unmanaged database value on every autogenerate.
+    _DDL_ONLY_PROPERTIES: frozenset = frozenset({
+        'colocate_with',
+    })
+
+    @classmethod
+    def ddl_only_properties(cls) -> frozenset:
+        """Property names (lowercase) to take from the MV ddl instead of tables_config.
+        See ``_DDL_ONLY_PROPERTIES``.
+        """
+        return cls._DDL_ONLY_PROPERTIES
+
     @classmethod
     def apply(cls, *, name: str, definition: str, comment: Union[str, None] = None, security: Union[str, None] = None) -> ReflectedMVState:
         """Apply defaults and normalization to reflected materialized view values.

--- a/contrib/starrocks-python-client/starrocks/common/defaults.py
+++ b/contrib/starrocks-python-client/starrocks/common/defaults.py
@@ -205,16 +205,16 @@ class ReflectionMVDefaults(ReflectionViewDefaults):
     # SHOW CREATE MATERIALIZED VIEW also prints effective values that tables_config leaves out
     # on purpose (e.g. replicated_storage), and those have no entry in _DEFAULT_PROPERTIES, so
     # merging them in would warn about an unmanaged database value on every autogenerate.
-    _DDL_ONLY_PROPERTIES: frozenset = frozenset({
+    _DDL_ONLY_PROPERTY_KEYS: frozenset = frozenset({
         'colocate_with',
     })
 
     @classmethod
-    def ddl_only_properties(cls) -> frozenset:
+    def ddl_only_property_keys(cls) -> frozenset:
         """Property names (lowercase) to take from the MV ddl instead of tables_config.
-        See ``_DDL_ONLY_PROPERTIES``.
+        See ``_DDL_ONLY_PROPERTY_KEYS``.
         """
-        return cls._DDL_ONLY_PROPERTIES
+        return cls._DDL_ONLY_PROPERTY_KEYS
 
     @classmethod
     def apply(cls, *, name: str, definition: str, comment: Union[str, None] = None, security: Union[str, None] = None) -> ReflectedMVState:

--- a/contrib/starrocks-python-client/starrocks/reflection.py
+++ b/contrib/starrocks-python-client/starrocks/reflection.py
@@ -27,6 +27,7 @@ from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.schema import Table
 
 from starrocks.common.consts import TableConfigKey
+from starrocks.common.defaults import ReflectionMVDefaults
 from starrocks.common.params import (
     ColumnAggInfoKeyWithPrefix,
     SRKwargsPrefix,
@@ -707,15 +708,38 @@ class StarRocksTableDefinitionParser(object):
         # logger.debug("partial parsed mv state. mv: %s, state: %s", mv_fqn, parsed_state)
 
         # 2. Augment/overwrite with more reliable info from other sources.
-        parsed_state.table_options.update(self._parse_common_table_options(TableKind.MATERIALIZED_VIEW, table_row))
+        self._merge_table_options(
+            parsed_state.table_options,
+            self._parse_common_table_options(TableKind.MATERIALIZED_VIEW, table_row),
+        )
 
         if config_row:
             general_options = self._parse_general_table_options(mv_name, schema, table_config=config_row)
             logger.debug("parsed general table options for mv: %s, options: %s", mv_fqn, general_options)
-            parsed_state.table_options.update(general_options)
+            self._merge_table_options(parsed_state.table_options, general_options)
 
         logger.debug("parsed mv state. mv: %s, state: %s", mv_fqn, parsed_state)
         return parsed_state
+
+    def _merge_table_options(self, table_options: Dict[str, Any], new_options: Dict[str, Any]) -> None:
+        """
+        Merges `new_options` into `table_options` in place, with `new_options` taking precedence.
+
+        This is `dict.update()` except for PROPERTIES, whose value is itself a dict: those are
+        merged key by key instead of being replaced wholesale, so a property reported by only
+        one source survives a source that does not report it. Callers are expected to pass
+        options in increasing order of reliability.
+
+        This matters because no single source reports every property of a materialized view:
+        information_schema.tables_config is authoritative for what it does report, but omits
+        some properties (see ReflectionMVDefaults._DDL_ONLY_PROPERTIES) that are only available
+        from the CREATE MATERIALIZED VIEW ddl. Which properties are trusted from which source is
+        decided when they are parsed, not here.
+        """
+        for key, value in new_options.items():
+            if key == TableInfoKeyWithPrefix.PROPERTIES and table_options.get(key):
+                value = hashdict({**table_options[key], **value}.items())
+            table_options[key] = value
 
     def _parse_mv_ddl(
         self,
@@ -761,12 +785,19 @@ class StarRocksTableDefinitionParser(object):
             # Fallback to simple regex if lark parsing fails
             self._parse_mv_refresh_with_regex(clauses_str, state)
 
-        # NOTE: currently, it uses properties from information_schema.tables_config, not from the DDL.
-        # properties_match = self._MV_PROPERTIES_PATTERN.search(clauses_str)
-        # if properties_match:
-        #     # Use string instead of dictionary now.
-        #     # state.mv_options.properties = self._parse_properties(properties_match.group(1))
-        #     state.table_options[TableInfoKeyWithPrefix.PROPERTIES] = properties_match.group(1).strip()
+        # NOTE: properties come from information_schema.tables_config, except for the few that
+        # tables_config does not report for MVs. Only those are taken from the DDL here;
+        # parse_mv() merges tables_config on top. See ReflectionMVDefaults._DDL_ONLY_PROPERTIES.
+        properties_match = self._MV_PROPERTIES_PATTERN.search(clauses_str)
+        if properties_match:
+            ddl_properties = self._parse_properties(properties_match.group(1))
+            ddl_only_properties = {
+                key: value for key, value in ddl_properties.items()
+                if key.lower() in ReflectionMVDefaults.ddl_only_properties()
+            }
+            if ddl_only_properties:
+                logger.debug("mv: %r, ddl-only properties: %s", mv_name, ddl_only_properties)
+                state.table_options[TableInfoKeyWithPrefix.PROPERTIES] = hashdict(ddl_only_properties.items())
 
         return state
 

--- a/contrib/starrocks-python-client/starrocks/reflection.py
+++ b/contrib/starrocks-python-client/starrocks/reflection.py
@@ -732,7 +732,7 @@ class StarRocksTableDefinitionParser(object):
 
         This matters because no single source reports every property of a materialized view:
         information_schema.tables_config is authoritative for what it does report, but omits
-        some properties (see ReflectionMVDefaults._DDL_ONLY_PROPERTIES) that are only available
+        some properties (see ReflectionMVDefaults._DDL_ONLY_PROPERTY_KEYS) that are only available
         from the CREATE MATERIALIZED VIEW ddl. Which properties are trusted from which source is
         decided when they are parsed, not here.
         """
@@ -787,13 +787,13 @@ class StarRocksTableDefinitionParser(object):
 
         # NOTE: properties come from information_schema.tables_config, except for the few that
         # tables_config does not report for MVs. Only those are taken from the DDL here;
-        # parse_mv() merges tables_config on top. See ReflectionMVDefaults._DDL_ONLY_PROPERTIES.
+        # parse_mv() merges tables_config on top. See ReflectionMVDefaults._DDL_ONLY_PROPERTY_KEYS.
         properties_match = self._MV_PROPERTIES_PATTERN.search(clauses_str)
         if properties_match:
             ddl_properties = self._parse_properties(properties_match.group(1))
             ddl_only_properties = {
                 key: value for key, value in ddl_properties.items()
-                if key.lower() in ReflectionMVDefaults.ddl_only_properties()
+                if key.lower() in ReflectionMVDefaults.ddl_only_property_keys()
             }
             if ddl_only_properties:
                 logger.debug("mv: %r, ddl-only properties: %s", mv_name, ddl_only_properties)

--- a/contrib/starrocks-python-client/test/integration/test_autogenerate_mvs.py
+++ b/contrib/starrocks-python-client/test/integration/test_autogenerate_mvs.py
@@ -26,6 +26,7 @@ from starrocks.alembic.ops import (
     CreateMaterializedViewOp,
     DropMaterializedViewOp,
 )
+from starrocks.common.types import SystemRunMode
 from starrocks.sql.schema import MaterializedView
 from test import conftest_sr
 
@@ -371,6 +372,62 @@ class TestAlterMaterializedView(TestAutogenerateBase):
                 assert mv_ops == [], f"Unexpected op for MV with omitted distribution: {mv_ops}"
             finally:
                 conn.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {mv_name}"))
+
+    def test_no_diff_for_colocated_mv(self) -> None:
+        """No change: an MV whose metadata declares colocate_with must not diff every run.
+
+        Regression test for the reported failure. information_schema.tables_config does not
+        report colocate_with for MVs, so the reflected side looked as though the property were
+        absent while the metadata declared it. Autogenerate reported the same change on every
+        run and emitted ``ALTER MATERIALIZED VIEW ... SET ("colocate_with" = ...)``, which
+        StarRocks rejects outright: colocate_with is create-only for an MV in a shared-nothing
+        cluster, so the migration could never succeed.
+        """
+        engine = self.engine
+        if engine.dialect.run_mode == SystemRunMode.SHARED_DATA:
+            pytest.skip("MV colocation behaviour on shared-data clusters is not verified")
+
+        mv_name = "test_mv_colocate_no_diff"
+        base_table = "t_autogen_colocate"
+        group_name = "test_mv_colocate_no_diff_group"
+        with engine.connect() as conn:
+            conn.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {mv_name}"))
+            conn.execute(text(f"DROP TABLE IF EXISTS {base_table}"))
+            # The base table defines the colocation group; the MV must match its bucket count,
+            # replication count and distribution column type to join it.
+            conn.execute(text(
+                f"CREATE TABLE {base_table} (val INT) "
+                "DISTRIBUTED BY HASH(val) BUCKETS 3 "
+                f"PROPERTIES ('replication_num' = '1', 'colocate_with' = '{group_name}')"
+            ))
+            conn.execute(text(
+                f"CREATE MATERIALIZED VIEW {mv_name} "
+                "DISTRIBUTED BY HASH(val) BUCKETS 3 "
+                "REFRESH ASYNC "
+                f"PROPERTIES ('replication_num' = '1', 'colocate_with' = '{group_name}') "
+                f"AS SELECT val FROM {base_table}"
+            ))
+            try:
+                target_metadata = MetaData()
+                MaterializedView(
+                    mv_name,
+                    target_metadata,
+                    definition=f"SELECT val FROM {base_table}",
+                    starrocks_refresh="ASYNC",
+                    starrocks_distributed_by="HASH(val) BUCKETS 3",
+                    starrocks_properties={"replication_num": "1", "colocate_with": group_name},
+                )
+                mc = create_migration_context(conn, target_metadata)
+                migration_script = api.produce_migrations(mc, target_metadata)
+
+                mv_ops = [op for op in migration_script.upgrade_ops.ops if getattr(op, "view_name", None) == mv_name]
+                assert mv_ops == [], (
+                    f"Unexpected op for colocated MV whose metadata matches the database: "
+                    f"{[getattr(op, 'properties', op) for op in mv_ops]}"
+                )
+            finally:
+                conn.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {mv_name}"))
+                conn.execute(text(f"DROP TABLE IF EXISTS {base_table}"))
 
     def test_refresh_interval_change_detected(self) -> None:
         """ALTER: a genuine change to the refresh interval is still detected.

--- a/contrib/starrocks-python-client/test/integration/test_reflection_mv.py
+++ b/contrib/starrocks-python-client/test/integration/test_reflection_mv.py
@@ -210,6 +210,91 @@ class TestReflectionMaterializedViewsIntegration:
             finally:
                 connection.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {mv_name}"))
 
+    def test_reflect_mv_with_colocate_with(self, sr_root_engine: Engine):
+        """Reflection must report colocate_with for a colocated materialized view.
+
+        Regression test: information_schema.tables_config does not report colocate_with for
+        MVs (it does for tables), so reflecting properties from tables_config alone left the
+        property invisible. Autogenerate then saw it as missing on every run and emitted an
+        ALTER that StarRocks rejects ("colocate_with is not supported for materialized view
+        in shared-nothing cluster"). It is now read from the CREATE MATERIALIZED VIEW ddl.
+        """
+        sr_engine = sr_root_engine
+        if sr_engine.dialect.run_mode == SystemRunMode.SHARED_DATA:
+            pytest.skip("MV colocation behaviour on shared-data clusters is not verified")
+
+        mv_name = "test_reflect_mv_colocate"
+        base_table = "colocate_base"
+        group_name = "test_reflect_mv_colocate_group"
+
+        with sr_engine.connect() as connection:
+            connection.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {mv_name}"))
+            connection.execute(text(f"DROP TABLE IF EXISTS {base_table}"))
+            # The base table defines the colocation group; the MV must match its bucket count,
+            # replication count and distribution column type to join it.
+            connection.execute(text(f"""
+                CREATE TABLE {base_table} (id INT, val INT)
+                DISTRIBUTED BY HASH(id) BUCKETS 3
+                PROPERTIES ("replication_num" = "1", "colocate_with" = "{group_name}")
+            """))
+            connection.execute(text(f"""
+                CREATE MATERIALIZED VIEW {mv_name}
+                DISTRIBUTED BY HASH(id) BUCKETS 3
+                REFRESH ASYNC
+                PROPERTIES ("replication_num" = "1", "colocate_with" = "{group_name}")
+                AS SELECT id, sum(val) AS total FROM {base_table} GROUP BY id
+            """))
+
+            try:
+                inspector = inspect(connection)
+                _wait_for_mv_creation(inspector, mv_name)
+                inspector.clear_cache()
+
+                mv_state: ReflectedMVState = inspector.get_materialized_view(mv_name, schema=sr_engine.url.database)
+                assert mv_state is not None
+                properties: dict = mv_state.properties
+                logger.debug(f"properties: {properties}")
+
+                assert properties.get("colocate_with") == group_name
+                # Properties that tables_config does report must still come through.
+                assert properties.get("replication_num") == "1"
+                # Only allowlisted properties are taken from the ddl. SHOW CREATE also prints
+                # replicated_storage, which tables_config omits on purpose; picking it up would
+                # make autogenerate warn about an unmanaged database value on every run.
+                assert "replicated_storage" not in properties
+            finally:
+                connection.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {mv_name}"))
+                connection.execute(text(f"DROP TABLE IF EXISTS {base_table}"))
+
+    def test_reflect_mv_without_colocate_with(self, sr_root_engine: Engine):
+        """An MV with no colocation must not gain a colocate_with property from reflection."""
+        sr_engine = sr_root_engine
+        mv_name = "test_reflect_mv_no_colocate"
+
+        with sr_engine.connect() as connection:
+            connection.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {mv_name}"))
+            connection.execute(text(f"""
+                CREATE MATERIALIZED VIEW {mv_name}
+                REFRESH ASYNC
+                PROPERTIES ("replication_num" = "1")
+                AS SELECT id, name FROM users
+            """))
+
+            try:
+                inspector = inspect(connection)
+                _wait_for_mv_creation(inspector, mv_name)
+                inspector.clear_cache()
+
+                mv_state: ReflectedMVState = inspector.get_materialized_view(mv_name, schema=sr_engine.url.database)
+                assert mv_state is not None
+                properties: dict = mv_state.properties
+                logger.debug(f"properties: {properties}")
+
+                assert "colocate_with" not in properties
+                assert "replicated_storage" not in properties
+            finally:
+                connection.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {mv_name}"))
+
     def test_reflect_mv_with_comment(self, sr_root_engine: Engine):
         """Test reflection of a materialized view with comment."""
         mv_name = "test_reflect_mv_with_comment"

--- a/contrib/starrocks-python-client/test/unit/test_reflection_mv_properties.py
+++ b/contrib/starrocks-python-client/test/unit/test_reflection_mv_properties.py
@@ -16,7 +16,7 @@
 
 information_schema.tables_config does not report every property for an MV (notably
 colocate_with), so those properties are read from the CREATE MATERIALIZED VIEW ddl
-instead. See ReflectionMVDefaults._DDL_ONLY_PROPERTIES.
+instead. See ReflectionMVDefaults._DDL_ONLY_PROPERTY_KEYS.
 """
 
 import json

--- a/contrib/starrocks-python-client/test/unit/test_reflection_mv_properties.py
+++ b/contrib/starrocks-python-client/test/unit/test_reflection_mv_properties.py
@@ -1,0 +1,97 @@
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for materialized view PROPERTIES extraction during reflection.
+
+information_schema.tables_config does not report every property for an MV (notably
+colocate_with), so those properties are read from the CREATE MATERIALIZED VIEW ddl
+instead. See ReflectionMVDefaults._DDL_ONLY_PROPERTIES.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from starrocks.common.consts import TableConfigKey
+from starrocks.common.params import TableInfoKeyWithPrefix
+from starrocks.reflection import StarRocksTableDefinitionParser
+
+MV_DDL = (
+    "CREATE MATERIALIZED VIEW `m` (`id`, `sv`)\n"
+    "DISTRIBUTED BY HASH(`id`) BUCKETS 3\n"
+    "REFRESH ASYNC\n"
+    "PROPERTIES (\n"
+    '"replicated_storage" = "true",\n'
+    '"replication_num" = "1",\n'
+    '"storage_medium" = "HDD",\n'
+    '"colocate_with" = "cg_test"\n'
+    ")\n"
+    "AS SELECT id, sum(v) AS sv FROM t GROUP BY id"
+)
+
+
+def _parser() -> StarRocksTableDefinitionParser:
+    return StarRocksTableDefinitionParser.__new__(StarRocksTableDefinitionParser)
+
+
+def _ddl_properties(ddl: str = MV_DDL) -> dict:
+    state = _parser()._parse_mv_ddl("m", ddl, schema="db")
+    return dict(state.table_options.get(TableInfoKeyWithPrefix.PROPERTIES) or {})
+
+
+def test_colocate_with_taken_from_ddl():
+    """tables_config omits colocate_with for MVs, so it must come from the ddl."""
+    assert _ddl_properties()["colocate_with"] == "cg_test"
+
+
+@pytest.mark.parametrize("prop", ["replicated_storage", "replication_num", "storage_medium"])
+def test_non_allowlisted_ddl_properties_ignored(prop):
+    """Only allowlisted properties are taken from the ddl. SHOW CREATE also prints
+    effective values that tables_config leaves out on purpose; merging those in would
+    make autogenerate warn about unmanaged database values on every run."""
+    assert prop not in _ddl_properties()
+
+
+def test_mv_without_colocation_has_no_ddl_properties():
+    ddl = MV_DDL.replace(',\n"colocate_with" = "cg_test"', "")
+    assert _ddl_properties(ddl) == {}
+
+
+def _parse_mv(config_properties: dict) -> dict:
+    """Run full MV parsing with a synthetic tables_config row and return the properties."""
+    mv_row = SimpleNamespace(
+        TABLE_NAME="m",
+        TABLE_SCHEMA="db",
+        MATERIALIZED_VIEW_DEFINITION=MV_DDL,
+    )
+    config_row = {TableConfigKey.PROPERTIES: json.dumps(config_properties)}
+    state = _parser().parse_mv(mv_row, table_row=None, config_row=config_row)
+    return dict(state.table_options.get(TableInfoKeyWithPrefix.PROPERTIES) or {})
+
+
+def test_ddl_properties_merged_with_tables_config():
+    """The ddl-only property survives, and tables_config supplies the rest."""
+    properties = _parse_mv({"mv_rewrite_staleness_second": "0", "replication_num": "1"})
+    assert properties == {
+        "colocate_with": "cg_test",
+        "mv_rewrite_staleness_second": "0",
+        "replication_num": "1",
+    }
+
+
+def test_tables_config_wins_on_conflict():
+    """tables_config stays authoritative wherever both sources report a property."""
+    properties = _parse_mv({"colocate_with": "cg_from_config"})
+    assert properties["colocate_with"] == "cg_from_config"


### PR DESCRIPTION
## Why I'm doing:
`information_schema.tables_config` does not report `colocate_with` for materialized views, so a colocated MV reflected back without it and autogenerate reported the same phantom drift on every run. `colocate_with` cannot be modified on shared-nothing for MVs so the migration statement also fails. 
## What I'm doing:
Read the properties that `tables_config` omits from the DDL, gated only to specific properties that are merged into the master dict of properties instead of overwriting. `tables_config` remains the single source of truth for all properties it does report. 
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
