### PR TITLE
[BugFix] Opting out of PushDownNonGroupedAggregateBelowUnion when there is a DictMappingOperator in rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PushDownNonGroupedAggregateBelowUnion.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PushDownNonGroupedAggregateBelowUnion.java
@@ -35,6 +35,7 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.DictMappingOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rule.tree.exprreuse.ScalarOperatorsReuse;
@@ -128,6 +129,35 @@ public class PushDownNonGroupedAggregateBelowUnion implements TreeRewriteRule {
             return optExpression;
         }
 
+        private static boolean hasDictMappingOperator(ScalarOperator op) {
+            if (op instanceof DictMappingOperator) {
+                return true;
+            }
+            return op.getChildren().stream().anyMatch(
+                    PushDownNonGroupedAggregateBelowUnionVisitor::hasDictMappingOperator);
+        }
+
+        private static boolean hasDictMappingOperator(Map<ColumnRefOperator, ScalarOperator> mapping) {
+            if (mapping == null) {
+                return false;
+            }
+            return mapping.values().stream().anyMatch(
+                    PushDownNonGroupedAggregateBelowUnionVisitor::hasDictMappingOperator);
+        }
+
+        private static boolean hasDictMappingOperator(Operator op) {
+            if (op.getProjection() != null &&
+                    (hasDictMappingOperator(op.getProjection().getColumnRefMap())
+                            || hasDictMappingOperator(op.getProjection().getCommonSubOperatorMap()))) {
+                return true;
+            }
+            if (op instanceof PhysicalProjectOperator project && (hasDictMappingOperator(project.getColumnRefMap())
+                    || hasDictMappingOperator(project.getCommonSubOperatorMap()))) {
+                return true;
+            }
+            return false;
+        }
+
         // ----------------------------------------------------------------------------------------
         // Match phase: identify the LOCAL split aggregate above a UNION ALL and validate every
         // push-down precondition. No new plan node is constructed here.
@@ -151,7 +181,9 @@ public class PushDownNonGroupedAggregateBelowUnion implements TreeRewriteRule {
                 return Optional.empty();
             }
             PhysicalUnionOperator union = unionExpr.getOp().cast();
-            if (!union.isUnionAll() || union.getPredicate() != null || union.hasLimit()) {
+            if (!union.isUnionAll() || union.getPredicate() != null || union.hasLimit() || hasDictMappingOperator(union)
+                    || (projectExpr != null && hasDictMappingOperator(projectExpr.getOp()))
+                    || hasDictMappingOperator(localAgg)) {
                 return Optional.empty();
             }
             return Optional.of(new RewriteContext(aggExpr, projectExpr, unionExpr));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.plan;
 import com.google.gson.GsonBuilder;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.planner.OlapScanNode;
 import com.starrocks.sql.analyzer.SemanticException;
@@ -3347,5 +3348,66 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "  |      [29: cast, INT, true] | [32: expr, INT, true] | [20: expr, BOOLEAN, true]", plan);
         String thrift = getThriftPlan(sql);
         Assertions.assertTrue(thrift.contains("TGlobalDict(columnId:28"), thrift);
+    }
+
+    @Test
+    void unionAllDictificationWithAggregateUnionRewriteWithDictMapping() throws Exception {
+        boolean prevConfig = Config.push_down_non_grouped_aggregate_below_union;
+        try {
+            Config.push_down_non_grouped_aggregate_below_union = true;
+            String sql = """
+                     SELECT
+                       max(source), min(source), count(source), sum(length(source)),
+                       max(value), min(value), count(value), sum(length(value))
+                     FROM (
+                         SELECT 'test_table_1' as source, c_user as value FROM low_card_t1
+                         UNION ALL
+                         SELECT 'test_table_2' as source, c_mr as value FROM low_card_t2
+                     ) T;
+                    """;
+
+            String plan = getFragmentPlan(sql);
+            // Aggregate is not pushed
+            assertContains(plan, "  10:AGGREGATE (update serialize)\n" +
+                    "  |  output: max(34: expr), min(34: expr), count(34: expr), sum(22: length), max(36: c_user)," +
+                    " min(36: c_user), count(36: c_user), sum(23: length)\n" +
+                    "  |  group by: \n" +
+                    "  |  \n" +
+                    "  9:Project\n" +
+                    "  |  <slot 22> : DictDecode(34: expr, [length(<place-holder>)])\n" +
+                    "  |  <slot 23> : DictDecode(36: c_user, [length(<place-holder>)])\n" +
+                    "  |  <slot 34> : 34: expr\n" +
+                    "  |  <slot 36> : 36: c_user\n" +
+                    "  |  \n" +
+                    "  0:UNION", plan);
+        } finally {
+            Config.push_down_non_grouped_aggregate_below_union = prevConfig;
+        }
+    }
+
+    @Test
+    void unionAllDictificationWithAggregateUnionRewriteWithoutDictMapping() throws Exception {
+        boolean prevConfig = Config.push_down_non_grouped_aggregate_below_union;
+        try {
+            Config.push_down_non_grouped_aggregate_below_union = true;
+            String sql = """
+                     SELECT max(source), min(source), count(source), max(value), min(value), count(value)
+                     FROM (
+                         SELECT 'test_table_1' as source, c_user as value FROM low_card_t1
+                         UNION ALL
+                         SELECT 'test_table_2' as source, c_mr as value FROM low_card_t2
+                     ) T;
+                    """;
+
+            String plan = getFragmentPlan(sql);
+            // update stage is pushed below the union, merge stage is above it.
+            assertContains(plan, "  11:AGGREGATE (merge serialize)\n" +
+                    "  |  output: max(33: max), min(34: min), count(24: count), max(35: max), min(36: min), count(27: count)\n" +
+                    "  |  group by: \n" +
+                    "  |  \n" +
+                    "  0:UNION", plan);
+        } finally {
+            Config.push_down_non_grouped_aggregate_below_union = prevConfig;
+        }
     }
 }

--- a/test/sql/test_global_dict/R/global_dict_with_union
+++ b/test/sql/test_global_dict/R/global_dict_with_union
@@ -1411,6 +1411,15 @@ FROM (
 -- result:
 test_table_2	test_table_1	6	f	a	6
 -- !result
+SELECT max(upper(source)), sum(length(source)), max(upper(value)), sum(length(value))
+FROM (
+    SELECT 'test_table_1' as source, value FROM test_table_1
+    UNION ALL
+    SELECT 'test_table_2' as source, value FROM test_table_2
+) T;
+-- result:
+TEST_TABLE_2	72	F	6
+-- !result
 ADMIN SET FRONTEND CONFIG ('push_down_non_grouped_aggregate_below_union' = 'false');
 -- result:
 -- !result

--- a/test/sql/test_global_dict/T/global_dict_with_union
+++ b/test/sql/test_global_dict/T/global_dict_with_union
@@ -956,4 +956,11 @@ FROM (
     SELECT 'test_table_2' as source, value FROM test_table_2
 ) T;
 
+SELECT max(upper(source)), sum(length(source)), max(upper(value)), sum(length(value))
+FROM (
+    SELECT 'test_table_1' as source, value FROM test_table_1
+    UNION ALL
+    SELECT 'test_table_2' as source, value FROM test_table_2
+) T;
+
 ADMIN SET FRONTEND CONFIG ('push_down_non_grouped_aggregate_below_union' = 'false');


### PR DESCRIPTION
## Why I'm doing:
PushDownNonGroupedAggregateBelowUnion can does handle DictMappingOperators correctly.

## What I'm doing:
Opting out of PushDownNonGroupedAggregateBelowUnion when there is a DictMappingOperator between the union and the aggregate when there is a DictMappingperator between the aggregate and union. 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
