### PR TITLE
[BugFix] Use a minimal TSD fetch in jemalloc malloc_usable_size

### DIFF
--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -688,6 +688,15 @@ if [[ -d $TP_SOURCE_DIR/$JEMALLOC_SOURCE ]] ; then
         apply_patch -p0 $TP_PATCH_DIR/jemalloc_nodump.patch
         touch $PATCHED_MARK
     fi
+    # Patches added after PATCHED_MARK was introduced carry their own mark: a
+    # source directory unpacked by an older revision already has PATCHED_MARK,
+    # so the block above never runs there and the build would keep the unpatched
+    # sources. Replaying that block instead is not an option, apply_patch passes
+    # -N and stops on the patches which are already applied.
+    if [ ! -f $PATCHED_MARK.usable_size_minimal_tsd ] && [ $JEMALLOC_SOURCE = "jemalloc-5.3.0" ]; then
+        apply_patch -p0 $TP_PATCH_DIR/jemalloc_malloc_usable_size_minimal_tsd.patch
+        touch $PATCHED_MARK.usable_size_minimal_tsd
+    fi
     cd -
     echo "Finished patching $JEMALLOC_SOURCE"
 fi

--- a/thirdparty/patches/jemalloc_malloc_usable_size_minimal_tsd.patch
+++ b/thirdparty/patches/jemalloc_malloc_usable_size_minimal_tsd.patch
@@ -1,0 +1,27 @@
+--- src/jemalloc.c
++++ src/jemalloc.c
+@@ -4074,7 +4074,23 @@
+ je_malloc_usable_size_impl(JEMALLOC_USABLE_SIZE_CONST void *ptr) {
+ 	assert(malloc_initialized() || IS_INITIALIZER);
+ 
+-	tsdn_t *tsdn = tsdn_fetch();
++	/*
++	 * Use a minimal TSD fetch, same rationale as free_default(): this can
++	 * run during thread teardown -- an allocator hook querying the size
++	 * before free(), reached from glibc's _dl_deallocate_tls() -- that is,
++	 * after the TSD destructors have already run.  A full init there builds
++	 * a tcache that is never destructed, leaving a dangling tcache_slow_t
++	 * (it lives in the dying thread's TLS) linked into arena->tcache_ql,
++	 * which later faults in another thread's tcache_arena_associate().
++	 * The size lookup itself needs no TSD.
++	 */
++	tsdn_t *tsdn;
++	if (unlikely(!tsd_booted_get())) {
++		tsdn = TSDN_NULL;
++	} else {
++		tsd_t *tsd = tsd_fetch_min();
++		tsdn = tsd_tsdn(tsd);
++	}
+ 	check_entry_exit_locking(tsdn);
+ 
+ 	size_t ret;


### PR DESCRIPTION
## Why I'm doing:

BE/CN can crash inside jemalloc with stacks that have nothing to do with the
allocation being made. Two shapes seen so far:

```
PC: @ je_arena_stats_merge -> ctl_arena_stats_amerge -> ctl_refresh -> epoch_ctl
    @ je_ctl_byname -> starrocks::jemalloc_tracker_daemon(void*)      # metrics thread
```
```
PC: @ tcache_arena_associate -> ...                                   # a new thread's first malloc
```

`mem_hook`'s `my_free()` calls `je_malloc_usable_size(p)` before every `free()`
to account the freed size (`STARROCKS_MALLOC_SIZE`, `be/src/service/mem_hook.cpp`).
That call does a full `tsdn_fetch()`, whereas jemalloc's own `free_default()`
deliberately uses only `tsd_fetch_min()` — with a comment explaining why: `free`
can run during thread teardown, after that thread's TSD destructors have already
run.

The extra `usable_size` call defeats that protection. When glibc tears a thread
down and frees the DTV (`__free_tcb` -> `_dl_deallocate_tls` -> `free` ->
`my_free` -> `usable_size`), the full fetch takes `tsd_fetch_slow()` out of the
`minimal_initialized` state and runs `tsd_data_init()` ->
`tsd_tcache_data_init()` -> `tcache_arena_associate()`. That links
`tsd_nominal_tsds`, `arena->tcache_ql` and `arena->cache_bin_array_descriptor_ql`
to objects that live in the TLS of the thread being destroyed, and no destructor
will run again to unlink them. Once that TLS block is unmapped the nodes dangle,
and the next thread that walks either list — a first-time allocator, another
exiting thread, or the memory-metrics thread reading jemalloc stats — dereferences
freed memory. That is why the reported stacks vary and none of them point at the
code that actually triggered the teardown.

Reported as #77605 against quantized vector index builds: the OpenMP team that
`OmpSetNumThreads()` starts can have helper threads that never allocate through
the hook and then exit together when the pool reclaims their primary worker, so
every build round takes a draw. The defect itself is not vector-index specific —
any thread that exits without having allocated can plant the dangling node.

## What I'm doing:

Patch `je_malloc_usable_size_impl()` to take the same minimal TSD fetch that
`free_default()` takes, since the size lookup itself needs no TSD.

On Linux this is a no-op for `nominal` threads (they never enter
`tsd_fetch_slow()`), and for `uninitialized`/`minimal_initialized` ones it only
defers tcache setup to the next real allocation: `tsd_get_allocates()` is false
and `tsd_get()` ignores the `init` argument for both `tsd_tls.h` and
`tsd_malloc_thread_cleanup.h`, so the `init` difference between `tsd_fetch_min()`
and `tsdn_fetch()` cannot allocate here. `mem_hook` is compiled out on Darwin,
where `tsd_generic` would behave differently.

Fixes #77605

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
