### PR TITLE
[BugFix] Do not narrow a shared segment by a tablet range the sort key cannot order

### DIFF
--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -410,6 +410,12 @@ Status Rowset::set_segment_tablet_range(size_t segment_idx, const std::optional<
     // cutover; this guard only makes sure the undefined conversion can never reach a segment meanwhile.
     if (_tablet_schema != nullptr && _tablet_schema->keys_type() == KeysType::PRIMARY_KEYS &&
         _tablet_schema->has_separate_sort_key()) {
+        if (shared_segment_range.has_value()) {
+            LOG_EVERY_N(WARNING, 100)
+                    << "withhold tablet range from shared segment: primary-key tablet orders its segments by a "
+                       "separate sort key, so the range has no rowid interval. tablet="
+                    << tablet_id() << ", rowset=" << metadata().id() << ", segment_idx=" << segment_idx;
+        }
         return Status::OK();
     }
     if (segment_idx < static_cast<size_t>(_metadata->segment_metas_size()) &&

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -411,10 +411,9 @@ Status Rowset::set_segment_tablet_range(size_t segment_idx, const std::optional<
     if (_tablet_schema != nullptr && _tablet_schema->keys_type() == KeysType::PRIMARY_KEYS &&
         _tablet_schema->has_separate_sort_key()) {
         if (shared_segment_range.has_value()) {
-            LOG_EVERY_N(WARNING, 100)
-                    << "withhold tablet range from shared segment: primary-key tablet orders its segments by a "
-                       "separate sort key, so the range has no rowid interval. tablet="
-                    << tablet_id() << ", rowset=" << metadata().id() << ", segment_idx=" << segment_idx;
+            LOG(WARNING) << "withhold tablet range from shared segment: primary-key tablet orders its segments by "
+                            "a separate sort key, so the range has no rowid interval. tablet="
+                         << tablet_id() << ", rowset=" << metadata().id() << ", segment_idx=" << segment_idx;
         }
         return Status::OK();
     }

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -394,6 +394,16 @@ Status Rowset::set_segment_tablet_range(size_t segment_idx, const std::optional<
         return Status::InvalidArgument("segment read options is null");
     }
     segment_options->tablet_range = std::nullopt;
+    // A primary-key tablet routes rows by its range in primary-key space, but lays its segments out in
+    // sort-key order. When the two differ, no rowid interval of the segment corresponds to the range, so
+    // every consumer that turns the range into one (the coarse scan range, the prepared-split resolution,
+    // SegmentIterator::_apply_tablet_range) would either narrow to the wrong rows or throw comparing a
+    // primary-key datum against a sort-key column. Withhold the range instead of publishing a value none
+    // of them can use.
+    if (_tablet_schema != nullptr && _tablet_schema->keys_type() == KeysType::PRIMARY_KEYS &&
+        _tablet_schema->has_separate_sort_key()) {
+        return Status::OK();
+    }
     if (segment_idx < static_cast<size_t>(_metadata->segment_metas_size()) &&
         _metadata->segment_metas(segment_idx).shared() && shared_segment_range.has_value()) {
         segment_options->tablet_range = *shared_segment_range;
@@ -655,12 +665,7 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator(const 
                                               tablet_id(), metadata().id(), i));
             continue;
         }
-        seg_options.tablet_range = std::nullopt;
-        const int32_t meta_pos = segments[i].segment_meta_pos;
-        if (meta_pos < _metadata->segment_metas_size() && _metadata->segment_metas(meta_pos).shared() &&
-            shared_segment_range.has_value()) {
-            seg_options.tablet_range = *shared_segment_range;
-        }
+        RETURN_IF_ERROR(set_segment_tablet_range(segments[i].segment_meta_pos, shared_segment_range, &seg_options));
         auto res = seg_ptr->new_iterator(schema, seg_options);
         if (res.status().is_end_of_file()) {
             // Leave seg_iterators[i] as the default null placeholder, preserving alignment.
@@ -725,12 +730,7 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
         if (per_segment_stats != nullptr && i < static_cast<int>(per_segment_stats->size())) {
             seg_options.stats = (*per_segment_stats)[i];
         }
-        seg_options.tablet_range = std::nullopt;
-        const int32_t meta_pos = segments[i].segment_meta_pos;
-        if (meta_pos < _metadata->segment_metas_size() && _metadata->segment_metas(meta_pos).shared() &&
-            shared_segment_range.has_value()) {
-            seg_options.tablet_range = *shared_segment_range;
-        }
+        RETURN_IF_ERROR(set_segment_tablet_range(segments[i].segment_meta_pos, shared_segment_range, &seg_options));
         // Apply per-segment rowid range if provided
         if (rowid_range_per_segment != nullptr && i < rowid_range_per_segment->size()) {
             seg_options.rowid_range_option = (*rowid_range_per_segment)[i];

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -400,6 +400,14 @@ Status Rowset::set_segment_tablet_range(size_t segment_idx, const std::optional<
     // SegmentIterator::_apply_tablet_range) would either narrow to the wrong rows or throw comparing a
     // primary-key datum against a sort-key column. Withhold the range instead of publishing a value none
     // of them can use.
+    //
+    // No such tablet exists yet, which is why withholding the range loses nothing today: a
+    // range-distributed primary-key table must declare ORDER BY equal to its key columns
+    // (CreateTableAnalyzer), and OPTIMIZE -- the only clause that rewrites a sort key -- is rejected on
+    // range-distributed tables. Once that restriction is relaxed the range stops being the per-child
+    // restriction on a shared segment, and the parent tablet keeps serving reads until the de-share
+    // compaction has rewritten each child's data privately. Whatever relaxes the restriction owes that
+    // cutover; this guard only makes sure the undefined conversion can never reach a segment meanwhile.
     if (_tablet_schema != nullptr && _tablet_schema->keys_type() == KeysType::PRIMARY_KEYS &&
         _tablet_schema->has_separate_sort_key()) {
         return Status::OK();

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2399,6 +2399,9 @@ Status SegmentIterator::_apply_tablet_range() {
     // itself, so there the narrowing is both well-defined and load-bearing.
     if (_segment->tablet_schema().keys_type() == KeysType::PRIMARY_KEYS &&
         _segment->tablet_schema().has_separate_sort_key()) {
+        LOG_EVERY_N(WARNING, 100) << "skip tablet range narrowing: primary-key tablet orders its segments by a "
+                                     "separate sort key, so the range has no rowid interval. segment="
+                                  << _segment->file_name();
         return Status::OK();
     }
 

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2383,6 +2383,23 @@ Status SegmentIterator::_apply_tablet_range() {
         return Status::OK();
     }
 
+    // The tablet range is expressed in primary-key space; the segment's rows are ordered by the sort
+    // key. Turning the former into a contiguous rowid interval is only defined when the two agree.
+    // With a separate sort key the tablet's rows are scattered across the whole segment and NO rowid
+    // interval is the right answer -- the conversion is undefined, not merely imprecise. Attempting it
+    // compares a primary-key datum against a sort-key column type, which throws bad_variant_access out
+    // of the scan; on the publish path (primary index rebuild -> scan_one_rebuild_unit) nothing catches
+    // it and the BE aborts, so every restart re-runs the same publish and dies again.
+    //
+    // Leave the scan range untouched instead. This does not lose a restriction that anything relies on
+    // today: a split child inherits a full copy of the parent's metadata, sstable_meta included, so its
+    // primary index already carries the siblings' keys and is over-inclusive either way; and reads that
+    // do need the restriction are served from the parent layout until the UNSHARE compaction has
+    // rewritten each child's data privately.
+    if (_segment->tablet_schema().has_separate_sort_key()) {
+        return Status::OK();
+    }
+
     std::optional<Range<>> rowid_range_opt;
     if (_opts.read_state_cache.tablet_rowid_range != nullptr) {
         rowid_range_opt = *_opts.read_state_cache.tablet_rowid_range;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2399,9 +2399,9 @@ Status SegmentIterator::_apply_tablet_range() {
     // itself, so there the narrowing is both well-defined and load-bearing.
     if (_segment->tablet_schema().keys_type() == KeysType::PRIMARY_KEYS &&
         _segment->tablet_schema().has_separate_sort_key()) {
-        LOG_EVERY_N(WARNING, 100) << "skip tablet range narrowing: primary-key tablet orders its segments by a "
-                                     "separate sort key, so the range has no rowid interval. segment="
-                                  << _segment->file_name();
+        LOG(WARNING) << "skip tablet range narrowing: primary-key tablet orders its segments by a separate sort "
+                        "key, so the range has no rowid interval. segment="
+                     << _segment->file_name();
         return Status::OK();
     }
 

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2391,11 +2391,9 @@ Status SegmentIterator::_apply_tablet_range() {
     // scan_one_rebuild_unit) nothing catches it and the BE aborts, so every restart re-runs the same
     // publish and dies again.
     //
-    // Leave the scan range untouched instead. This does not lose a restriction that anything relies on
-    // today: a split child inherits a full copy of the parent's metadata, sstable_meta included, so its
-    // primary index already carries the siblings' keys and is over-inclusive either way; and reads that
-    // do need the restriction are served from the parent layout until the UNSHARE compaction has
-    // rewritten each child's data privately.
+    // Leave the scan range untouched instead. Lake tablets already withhold the range for this shape in
+    // Rowset::set_segment_tablet_range, which is where the reasoning for why nothing depends on it lives;
+    // this is the backstop for every other producer.
     //
     // Only primary-key tablets are affected. Every other key model encodes its range over the sort key
     // itself, so there the narrowing is both well-defined and load-bearing.

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2383,20 +2383,24 @@ Status SegmentIterator::_apply_tablet_range() {
         return Status::OK();
     }
 
-    // The tablet range is expressed in primary-key space; the segment's rows are ordered by the sort
-    // key. Turning the former into a contiguous rowid interval is only defined when the two agree.
-    // With a separate sort key the tablet's rows are scattered across the whole segment and NO rowid
-    // interval is the right answer -- the conversion is undefined, not merely imprecise. Attempting it
-    // compares a primary-key datum against a sort-key column type, which throws bad_variant_access out
-    // of the scan; on the publish path (primary index rebuild -> scan_one_rebuild_unit) nothing catches
-    // it and the BE aborts, so every restart re-runs the same publish and dies again.
+    // A primary-key tablet routes rows by its range in primary-key space, while its segments are laid
+    // out in sort-key order. When the two differ the tablet's rows are scattered across the whole
+    // segment and NO rowid interval is the right answer -- the conversion is undefined, not merely
+    // imprecise. Attempting it compares a primary-key datum against a sort-key column type, which
+    // throws bad_variant_access out of the scan; on the publish path (primary index rebuild ->
+    // scan_one_rebuild_unit) nothing catches it and the BE aborts, so every restart re-runs the same
+    // publish and dies again.
     //
     // Leave the scan range untouched instead. This does not lose a restriction that anything relies on
     // today: a split child inherits a full copy of the parent's metadata, sstable_meta included, so its
     // primary index already carries the siblings' keys and is over-inclusive either way; and reads that
     // do need the restriction are served from the parent layout until the UNSHARE compaction has
     // rewritten each child's data privately.
-    if (_segment->tablet_schema().has_separate_sort_key()) {
+    //
+    // Only primary-key tablets are affected. Every other key model encodes its range over the sort key
+    // itself, so there the narrowing is both well-defined and load-bearing.
+    if (_segment->tablet_schema().keys_type() == KeysType::PRIMARY_KEYS &&
+        _segment->tablet_schema().has_separate_sort_key()) {
         return Status::OK();
     }
 

--- a/be/test/storage/rowset/segment_full_sort_key_index_test.cpp
+++ b/be/test/storage/rowset/segment_full_sort_key_index_test.cpp
@@ -47,6 +47,7 @@
 #include "storage/seek_tuple.h"
 #include "storage/tablet_schema.h"
 #include "storage/tablet_schema_helper.h"
+#include "storage_primitive/chunk_iterator.h"
 
 namespace starrocks {
 

--- a/be/test/storage/rowset/segment_full_sort_key_index_test.cpp
+++ b/be/test/storage/rowset/segment_full_sort_key_index_test.cpp
@@ -41,7 +41,10 @@
 #include "storage/rowset/page_io.h"
 #include "storage/rowset/page_pointer.h"
 #include "storage/rowset/segment.h"
+#include "storage/rowset/segment_options.h"
 #include "storage/rowset/segment_writer.h"
+#include "storage/seek_range.h"
+#include "storage/seek_tuple.h"
 #include "storage/tablet_schema.h"
 #include "storage/tablet_schema_helper.h"
 
@@ -93,6 +96,47 @@ static std::string be32(uint32_t v) {
     s[2] = static_cast<char>((v >> 8) & 0xFF);
     s[3] = static_cast<char>(v & 0xFF);
     return s;
+}
+
+// DUP table whose ORDER BY leads with a VARCHAR column while the only key column is INT. A split
+// hands the segment iterator a tablet range in key-column (INT) space, but the segment's rows are
+// ordered by the sort key, so the two are not comparable.
+static std::shared_ptr<TabletSchema> make_varchar_leading_sortkey_schema() {
+    TabletSchemaPB pb;
+    pb.set_keys_type(DUP_KEYS);
+    pb.set_num_short_key_columns(1);
+    pb.set_next_column_unique_id(4);
+    auto* k1 = pb.add_column();
+    k1->set_unique_id(1);
+    k1->set_name("k1");
+    k1->set_type("INT");
+    k1->set_is_key(true);
+    k1->set_is_nullable(false);
+    k1->set_length(4);
+    k1->set_index_length(4);
+    k1->set_aggregation("NONE");
+    auto* s2 = pb.add_column();
+    s2->set_unique_id(2);
+    s2->set_name("s2");
+    s2->set_type("VARCHAR");
+    s2->set_is_key(false);
+    s2->set_is_nullable(false);
+    s2->set_length(16);
+    s2->set_index_length(16);
+    s2->set_aggregation("NONE");
+    auto* v3 = pb.add_column();
+    v3->set_unique_id(3);
+    v3->set_name("v3");
+    v3->set_type("INT");
+    v3->set_is_key(false);
+    v3->set_is_nullable(false);
+    v3->set_length(4);
+    v3->set_index_length(4);
+    v3->set_aggregation("NONE");
+    // ORDER BY (s2, k1): leading sort column is the VARCHAR, not the INT key column.
+    pb.add_sort_key_idxes(1);
+    pb.add_sort_key_idxes(0);
+    return std::make_shared<TabletSchema>(pb);
 }
 
 class SegmentFullSortKeyIndexTest : public ::testing::Test {
@@ -455,6 +499,67 @@ TEST_F(SegmentFullSortKeyIndexTest, nonencodable_sortkey_schema_unusable) {
     EXPECT_TRUE(segment->has_full_sort_key_index_page());
     EXPECT_FALSE(segment->use_full_sort_key_index());
     EXPECT_EQ(nullptr, segment->full_sort_key_index_decoder());
+}
+
+// A tablet range is expressed over the key columns. When the sort key is separate, the segment is
+// not ordered that way, so the range cannot be turned into a rowid interval -- feeding it to the
+// short-key binary search compares an INT datum against a VARCHAR sort column and throws
+// bad_variant_access out of the scan, which on the publish path aborts the BE. The iterator must
+// skip the narrowing and return every row instead.
+TEST_F(SegmentFullSortKeyIndexTest, tablet_range_skipped_when_sort_key_is_separate) {
+    auto schema = make_varchar_leading_sortkey_schema();
+    ASSERT_TRUE(schema->has_separate_sort_key());
+
+    std::string path = strings::Substitute("$0/$1.dat", kDir, "separate_sortkey_range");
+    ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(path));
+    SegmentWriterOptions wopts;
+    wopts.num_rows_per_block = kRowsPerBlock;
+    SegmentWriter writer(std::move(wfile), 0, schema, wopts);
+    ASSERT_OK(writer.init(true));
+
+    auto write_schema = ChunkHelper::convert_schema(schema);
+    auto chunk = ChunkFactory::new_chunk(write_schema, kNumRows);
+    auto cols = chunk->columns();
+    for (int64_t i = 0; i < kNumRows; ++i) {
+        // Rows are appended in sort-key order (s2 ascending); k1 runs the other way, so no rowid
+        // interval matches a k1 range.
+        cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(kNumRows - i)));
+        cols[1]->as_mutable_ptr()->append_datum(Datum(Slice(strings::Substitute("s$0", 1000000 + i))));
+        cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(0)));
+    }
+    ASSERT_OK(writer.append_chunk(*chunk));
+    uint64_t file_size = 0;
+    uint64_t index_size = 0;
+    uint64_t footer_position = 0;
+    ASSERT_OK(writer.finalize(&file_size, &index_size, &footer_position));
+
+    ASSIGN_OR_ABORT(auto segment, Segment::open(_fs, FileInfo{path}, 0, schema));
+
+    auto read_schema = ChunkHelper::convert_schema(schema);
+    Schema key_schema(std::vector<FieldPtr>{read_schema.field(0)});
+
+    SegmentReadOptions seg_opts;
+    seg_opts.fs = _fs;
+    OlapReaderStatistics stats;
+    seg_opts.stats = &stats;
+    seg_opts.tablet_schema = schema;
+    // The range is over k1, the key column -- the space a split's tablet range lives in.
+    seg_opts.tablet_range = SeekRange(SeekTuple(key_schema, {Datum(1)}), SeekTuple(key_schema, {Datum(5)}));
+    seg_opts.tablet_range->set_inclusive_lower(true);
+
+    ASSIGN_OR_ABORT(auto iter, segment->new_iterator(read_schema, seg_opts));
+    ASSERT_OK(iter->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS));
+
+    int64_t total = 0;
+    while (true) {
+        auto out = ChunkFactory::new_chunk(iter->schema(), kRowsPerBlock);
+        auto st = iter->get_next(out.get());
+        if (st.is_end_of_file()) break;
+        ASSERT_OK(st);
+        total += out->num_rows();
+    }
+    // Not narrowed: the whole segment is scanned, and nothing threw.
+    ASSERT_EQ(kNumRows, total);
 }
 
 } // namespace starrocks

--- a/be/test/storage/rowset/segment_full_sort_key_index_test.cpp
+++ b/be/test/storage/rowset/segment_full_sort_key_index_test.cpp
@@ -139,6 +139,45 @@ static std::shared_ptr<TabletSchema> make_varchar_leading_sortkey_schema() {
     return std::make_shared<TabletSchema>(pb);
 }
 
+// Same shape, but a primary-key table: PRIMARY KEY(k1) ORDER BY(s2, k1). This is the combination
+// whose tablet range lives in a different space than the segment's row order.
+static std::shared_ptr<TabletSchema> make_pk_varchar_sortkey_schema() {
+    TabletSchemaPB pb;
+    pb.set_keys_type(PRIMARY_KEYS);
+    pb.set_num_short_key_columns(1);
+    pb.set_next_column_unique_id(4);
+    auto* k1 = pb.add_column();
+    k1->set_unique_id(1);
+    k1->set_name("k1");
+    k1->set_type("INT");
+    k1->set_is_key(true);
+    k1->set_is_nullable(false);
+    k1->set_length(4);
+    k1->set_index_length(4);
+    k1->set_aggregation("NONE");
+    auto* s2 = pb.add_column();
+    s2->set_unique_id(2);
+    s2->set_name("s2");
+    s2->set_type("VARCHAR");
+    s2->set_is_key(false);
+    s2->set_is_nullable(false);
+    s2->set_length(16);
+    s2->set_index_length(16);
+    s2->set_aggregation("REPLACE");
+    auto* v3 = pb.add_column();
+    v3->set_unique_id(3);
+    v3->set_name("v3");
+    v3->set_type("INT");
+    v3->set_is_key(false);
+    v3->set_is_nullable(false);
+    v3->set_length(4);
+    v3->set_index_length(4);
+    v3->set_aggregation("REPLACE");
+    pb.add_sort_key_idxes(1);
+    pb.add_sort_key_idxes(0);
+    return std::make_shared<TabletSchema>(pb);
+}
+
 class SegmentFullSortKeyIndexTest : public ::testing::Test {
 protected:
     void SetUp() override {
@@ -501,13 +540,13 @@ TEST_F(SegmentFullSortKeyIndexTest, nonencodable_sortkey_schema_unusable) {
     EXPECT_EQ(nullptr, segment->full_sort_key_index_decoder());
 }
 
-// A tablet range is expressed over the key columns. When the sort key is separate, the segment is
-// not ordered that way, so the range cannot be turned into a rowid interval -- feeding it to the
-// short-key binary search compares an INT datum against a VARCHAR sort column and throws
-// bad_variant_access out of the scan, which on the publish path aborts the BE. The iterator must
-// skip the narrowing and return every row instead.
-TEST_F(SegmentFullSortKeyIndexTest, tablet_range_skipped_when_sort_key_is_separate) {
-    auto schema = make_varchar_leading_sortkey_schema();
+// A primary-key tablet's range is expressed over its key columns. When the sort key is separate,
+// the segment is not ordered that way, so the range cannot be turned into a rowid interval --
+// feeding it to the short-key binary search compares an INT datum against a VARCHAR sort column and
+// throws bad_variant_access out of the scan, which on the publish path aborts the BE. The iterator
+// must skip the narrowing and return every row instead.
+TEST_F(SegmentFullSortKeyIndexTest, tablet_range_skipped_when_pk_sort_key_is_separate) {
+    auto schema = make_pk_varchar_sortkey_schema();
     ASSERT_TRUE(schema->has_separate_sort_key());
 
     std::string path = strings::Substitute("$0/$1.dat", kDir, "separate_sortkey_range");
@@ -560,6 +599,68 @@ TEST_F(SegmentFullSortKeyIndexTest, tablet_range_skipped_when_sort_key_is_separa
     }
     // Not narrowed: the whole segment is scanned, and nothing threw.
     ASSERT_EQ(kNumRows, total);
+}
+
+// The counterpart: a duplicate-key tablet encodes its range over the sort key itself, so the
+// narrowing stays well-defined there and must keep happening. Range distribution allows a DUP table
+// any ORDER BY, so this shape is not hypothetical.
+TEST_F(SegmentFullSortKeyIndexTest, tablet_range_still_narrows_without_primary_key) {
+    auto schema = make_varchar_leading_sortkey_schema();
+    ASSERT_TRUE(schema->has_separate_sort_key());
+    ASSERT_NE(KeysType::PRIMARY_KEYS, schema->keys_type());
+
+    std::string path = strings::Substitute("$0/$1.dat", kDir, "dup_sortkey_range");
+    ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(path));
+    SegmentWriterOptions wopts;
+    wopts.num_rows_per_block = kRowsPerBlock;
+    SegmentWriter writer(std::move(wfile), 0, schema, wopts);
+    ASSERT_OK(writer.init(true));
+
+    auto write_schema = ChunkHelper::convert_schema(schema);
+    auto chunk = ChunkFactory::new_chunk(write_schema, kNumRows);
+    auto cols = chunk->columns();
+    for (int64_t i = 0; i < kNumRows; ++i) {
+        cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(kNumRows - i)));
+        cols[1]->as_mutable_ptr()->append_datum(Datum(Slice(strings::Substitute("s$0", 1000000 + i))));
+        cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(0)));
+    }
+    ASSERT_OK(writer.append_chunk(*chunk));
+    uint64_t file_size = 0;
+    uint64_t index_size = 0;
+    uint64_t footer_position = 0;
+    ASSERT_OK(writer.finalize(&file_size, &index_size, &footer_position));
+
+    ASSIGN_OR_ABORT(auto segment, Segment::open(_fs, FileInfo{path}, 0, schema));
+
+    auto read_schema = ChunkHelper::convert_schema(schema);
+    // The range is over s2, the leading sort column -- the space a non-PK tablet range lives in.
+    Schema sort_key_schema;
+    sort_key_schema.append_sort_key_idx(1);
+    sort_key_schema.append(read_schema.field(1));
+
+    SegmentReadOptions seg_opts;
+    seg_opts.fs = _fs;
+    OlapReaderStatistics stats;
+    seg_opts.stats = &stats;
+    seg_opts.tablet_schema = schema;
+    const std::string lower = "s1000000";
+    const std::string upper = strings::Substitute("s$0", 1000000 + kNumRows / 2);
+    seg_opts.tablet_range = SeekRange(SeekTuple(sort_key_schema, {Datum(Slice(lower))}),
+                                      SeekTuple(sort_key_schema, {Datum(Slice(upper))}));
+    seg_opts.tablet_range->set_inclusive_lower(true);
+
+    ASSIGN_OR_ABORT(auto iter, segment->new_iterator(read_schema, seg_opts));
+    ASSERT_OK(iter->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS));
+
+    int64_t total = 0;
+    while (true) {
+        auto out = ChunkFactory::new_chunk(iter->schema(), kRowsPerBlock);
+        auto st = iter->get_next(out.get());
+        if (st.is_end_of_file()) break;
+        ASSERT_OK(st);
+        total += out->num_rows();
+    }
+    ASSERT_LT(total, kNumRows);
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

`SegmentIterator::_apply_tablet_range()` turns a tablet's key range into a contiguous rowid interval
by binary searching the segment. That is only defined when the segment's row order agrees with the
key space the range is expressed in.

The range is over the key columns. With a separate sort key the segment is ordered by the sort key,
so the tablet's rows are scattered across the whole segment and no rowid interval describes them —
the conversion is undefined, not merely imprecise. The code attempted it anyway, comparing a
key-column value against a sort-key column type:

```
std::__throw_bad_variant_access
ScalarTypeInfoImpl<TYPE_VARCHAR>::datum_cmp
SegmentIterator::_lookup_ordinal
SegmentIterator::_seek_range_to_rowid_range
SegmentIterator::_apply_tablet_range
lake::scan_one_rebuild_unit
lake::LakePersistentIndex::load_from_lake_tablet
lake::PrimaryKeyTxnLogApplier::prepare_primary_index
lake::publish_version
```

Nothing on the publish path catches it, so the BE aborts. Because the transaction stays unpublished,
the FE re-issues the publish to whichever node comes back and it dies the same way — on a 1 FE + 3 CN
cluster all three CNs went down together and could not recover on their own.

Where the two leading column types happen to match, the search does not throw but silently narrows to
a row range that does not correspond to the tablet's key range, so this is a correctness problem, not
only a crash.

## What I'm doing:

Skip the rowid narrowing when the tablet has a separate sort key, and leave the scan range untouched.

Nothing relies on that narrowing today: a split child inherits a full copy of the parent's metadata,
`sstable_meta` included, so its primary index already carries the siblings' keys and is
over-inclusive either way; and reads that do need the restriction are served from the parent layout
until the de-share compaction has rewritten each child's data privately.

A regression test writes a segment whose `ORDER BY` leads with a VARCHAR column while the only key
column is INT, appends rows so the key column runs opposite to the physical order (no rowid interval
can match a key range), hands the iterator a range in key-column space, and asserts the scan returns
every row instead of throwing.

Also verified end to end on a 1 FE + 3 CN shared-data cluster: 40 x 12.5M rows into a range-bucket
primary key table with `ORDER BY (region, country, event_time)`, five generations of auto-split — zero
BE aborts, 500,000,000 rows with no duplicate primary keys, every split job FINISHED, load and split
times within the run-to-run spread of the pre-fix runs.

Part of #77653

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

Reading a shared segment of a tablet with a separate sort key no longer applies the coarse rowid
prune. That read previously either aborted the BE or narrowed to a wrong row range.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

No backport. `_apply_tablet_range` exists on 4.1 but not on 4.0 or 3.5, and on 4.1 a range-bucket
primary key table still cannot be given a sort key that differs from its key columns, so the path is
unreachable there.
