### PR TITLE
[Enhancement] Persist AWS web identity credentials for storage volumes

### DIFF
--- a/docs/en/sql-reference/sql-statements/cluster-management/storage_volume/AWS_CREDENTIAL_SUPPORT.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/storage_volume/AWS_CREDENTIAL_SUPPORT.md
@@ -1,0 +1,108 @@
+---
+displayed_sidebar: docs
+description: "Compare AWS credential support in the FE runtime and StarOS-backed storage volumes."
+sidebar_position: 10
+---
+
+# AWS credential support for storage volumes
+
+StarRocks FE uses `AwsCloudCredential` to configure AWS authentication for storage volumes and other AWS consumers.
+Storage volumes additionally serialize their credentials to StarOS. Some combinations supported by the FE runtime cannot
+yet be preserved in a storage volume.
+
+## Support matrix
+
+| Authentication method | Required properties | FE runtime | Storage volume | Notes |
+|---|---|:---:|:---:|---|
+| AWS SDK default chain | `aws.s3.use_aws_sdk_default_behavior=true` | Supported | Supported | Uses the AWS SDK default credential provider chain. |
+| Default chain followed by AssumeRole | `aws.s3.use_aws_sdk_default_behavior=true`<br />`aws.s3.iam_role_arn=<arn>`<br />Optional: `aws.s3.external_id` | Supported | Not supported | The storage volume preserves only the default-chain selection. |
+| Instance Profile | `aws.s3.use_instance_profile=true` | Supported | Supported | Uses EC2 Instance Profile credentials. |
+| Instance Profile followed by AssumeRole | `aws.s3.use_instance_profile=true`<br />`aws.s3.iam_role_arn=<arn>`<br />Optional: `aws.s3.external_id` | Supported | Supported | The role ARN and external ID are preserved. |
+| Web Identity Token file | `aws.s3.use_web_identity_token_file=true`<br />Worker environment: `AWS_WEB_IDENTITY_TOKEN_FILE` and `AWS_ROLE_ARN` | Supported | Supported | The token file and primary role are resolved on each worker. |
+| Web Identity followed by a second AssumeRole operation | `aws.s3.use_web_identity_token_file=true`<br />`aws.s3.iam_role_arn=<second_hop_arn>`<br />Optional: `aws.s3.external_id`<br />Worker environment: `AWS_WEB_IDENTITY_TOKEN_FILE` and `AWS_ROLE_ARN` | Supported | Supported | The configured role ARN represents the second STS hop. |
+| Static Access Key and Secret Key | `aws.s3.access_key=<access_key>`<br />`aws.s3.secret_key=<secret_key>` | Supported | Supported | The Access Key and Secret Key are preserved. |
+| Static session credentials | Access Key and Secret Key properties<br />`aws.s3.session_token=<token>` | Supported | Not supported | The session token is not preserved by the storage volume. |
+| Access Key and Secret Key followed by AssumeRole | Access Key and Secret Key properties<br />`aws.s3.iam_role_arn=<arn>`<br />Optional: `aws.s3.external_id` | Supported | Not supported | The AssumeRole settings are not preserved by the storage volume. |
+| Custom STS region or endpoint | Valid base credentials<br />`aws.s3.sts.region=<region>` and/or `aws.s3.sts.endpoint=<endpoint>`<br />`aws.s3.iam_role_arn=<arn>` | Supported | Not supported | Custom STS settings are not preserved by the storage volume. |
+| Role ARN without base credentials | `aws.s3.iam_role_arn=<arn>` only | Not supported | Not supported | AssumeRole requires a valid base credential provider. |
+
+Do not configure a storage volume with a combination marked **Not supported**. Although FE can construct the credential
+provider, the complete configuration is not retained when the storage volume is serialized to StarOS.
+
+## Credential resolution order
+
+If you configure multiple base authentication methods, FE selects the first matching method in this order:
+
+```text
+AWS SDK default chain > Instance Profile > Web Identity > Access Key and Secret Key
+```
+
+After selecting the base credential provider, FE performs an STS AssumeRole operation when `aws.s3.iam_role_arn` is not
+empty.
+
+## Switching authentication methods
+
+`ALTER STORAGE VOLUME` merges the properties you specify into the storage volume's existing properties instead of
+replacing them. Combined with the resolution order above, a statement that sets only the new method's properties can
+succeed without changing the credential that the storage volume actually uses.
+
+To switch a storage volume from one authentication method to another:
+
+- Set every `use_*` property explicitly, with exactly one of them set to `true`.
+- Clear `aws.s3.iam_role_arn` and `aws.s3.external_id` unless the new method must also assume a role. These are not
+  `use_*` properties, so they survive the merge and are applied to the new method.
+
+### Statements that do not switch the method
+
+Each statement below succeeds, but the storage volume keeps its previous credential, and the properties you supplied
+are not stored.
+
+```SQL
+-- The storage volume currently uses a web identity token file.
+-- No effect: Web Identity outranks Access Key and Secret Key.
+ALTER STORAGE VOLUME <storage_volume_name> SET (
+    "aws.s3.access_key" = "<access_key>",
+    "aws.s3.secret_key" = "<secret_key>"
+);
+
+-- The storage volume currently uses Instance Profile.
+-- No effect: Instance Profile outranks Web Identity.
+ALTER STORAGE VOLUME <storage_volume_name> SET (
+    "aws.s3.use_web_identity_token_file" = "true"
+);
+```
+
+### Statements that switch the method
+
+```SQL
+-- Web Identity to Access Key and Secret Key.
+ALTER STORAGE VOLUME <storage_volume_name> SET (
+    "aws.s3.use_aws_sdk_default_behavior" = "false",
+    "aws.s3.use_instance_profile" = "false",
+    "aws.s3.use_web_identity_token_file" = "false",
+    "aws.s3.access_key" = "<access_key>",
+    "aws.s3.secret_key" = "<secret_key>"
+);
+
+-- Instance Profile to Web Identity, dropping the previous Role.
+ALTER STORAGE VOLUME <storage_volume_name> SET (
+    "aws.s3.use_aws_sdk_default_behavior" = "false",
+    "aws.s3.use_instance_profile" = "false",
+    "aws.s3.use_web_identity_token_file" = "true",
+    "aws.s3.iam_role_arn" = "",
+    "aws.s3.external_id" = ""
+);
+```
+
+Switching to a method that outranks the current one also works without disabling the current method, because the new
+method is matched first. For example, a storage volume that uses Access Key and Secret Key switches to Web Identity
+when you set only `aws.s3.use_web_identity_token_file` to `true`. Setting every `use_*` property explicitly works in
+both directions and does not require you to know which method is currently in effect.
+
+:::caution
+A Role ARN left over from the previous method is applied to the new method. If a storage volume used Web Identity with
+a second AssumeRole hop and you switch it to Instance Profile, the leftover `aws.s3.iam_role_arn` becomes the role that
+Instance Profile assumes. Clear `aws.s3.iam_role_arn` and `aws.s3.external_id` in the same statement to avoid this.
+:::
+
+For storage-volume configuration examples, see [CREATE STORAGE VOLUME](CREATE_STORAGE_VOLUME.md#credential-information).

--- a/docs/en/sql-reference/sql-statements/cluster-management/storage_volume/CREATE_STORAGE_VOLUME.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/storage_volume/CREATE_STORAGE_VOLUME.md
@@ -49,6 +49,7 @@ import Beta from '../../../../_assets/commonMarkdown/_beta.mdx'
 | aws.s3.endpoint                     | The endpoint URL used to access your S3 bucket, for example, `https://s3.us-west-2.amazonaws.com`. [Preview] From v3.3.0 onwards, the Amazon S3 Express One Zone storage class is supported, for example, `https://s3express.us-west-2.amazonaws.com`.  <Beta /> |
 | aws.s3.use_aws_sdk_default_behavior | Whether to use the default authentication credential of AWS SDK. Valid values: `true` and `false` (Default). |
 | aws.s3.use_instance_profile         | Whether to use Instance Profile and Assumed Role as credential methods for accessing S3. Valid values: `true` and `false` (Default).<ul><li>If you use IAM user-based credential (Access Key and Secret Key) to access S3, you must specify this item as `false`, and specify `aws.s3.access_key` and `aws.s3.secret_key`.</li><li>If you use Instance Profile to access S3, you must specify this item as `true`.</li><li>If you use Assumed Role to access S3, you must specify this item as `true`, and specify `aws.s3.iam_role_arn`.</li><li>And if you use an external AWS account, you must specify this item as `true`, and specify `aws.s3.iam_role_arn` and `aws.s3.external_id`.</li></ul> |
+| aws.s3.use_web_identity_token_file  | Whether to use a web identity token file to access S3. Valid values: `true` and `false` (Default). When enabled, the AWS SDK on each worker reads the token file and IAM role from the `AWS_WEB_IDENTITY_TOKEN_FILE` and `AWS_ROLE_ARN` environment variables. |
 | aws.s3.access_key                   | The Access Key ID used to access your S3 bucket.             |
 | aws.s3.secret_key                   | The Secret Access Key used to access your S3 bucket.         |
 | aws.s3.iam_role_arn                 | The ARN of the IAM role that has privileges on your S3 bucket in which your data files are stored. |
@@ -82,6 +83,9 @@ import Beta from '../../../../_assets/commonMarkdown/_beta.mdx'
 
 #### Credential information
 
+For a comparison of credential combinations supported by FE and storage volumes, see
+[AWS credential support for storage volumes](AWS_CREDENTIAL_SUPPORT.md).
+
 ##### AWS S3
 
 - If you use the default authentication credential of AWS SDK to access S3, set the following properties:
@@ -114,6 +118,27 @@ import Beta from '../../../../_assets/commonMarkdown/_beta.mdx'
   "aws.s3.use_aws_sdk_default_behavior" = "false",
   "aws.s3.use_instance_profile" = "true"
   ```
+
+- If you use a web identity token file, such as an EKS IAM role for a service account (IRSA), set the following
+  properties. Set `AWS_WEB_IDENTITY_TOKEN_FILE` and `AWS_ROLE_ARN` in the environment of every worker that accesses the
+  storage volume.
+
+  ```SQL
+  "enabled" = "{ true | false }",
+  "aws.s3.region" = "<region>",
+  "aws.s3.endpoint" = "<endpoint_url>",
+  "aws.s3.use_aws_sdk_default_behavior" = "false",
+  "aws.s3.use_instance_profile" = "false",
+  "aws.s3.use_web_identity_token_file" = "true"
+  ```
+
+  To assume another IAM role after obtaining credentials through web identity, additionally set
+  `aws.s3.iam_role_arn`. For cross-account access, you can also set `aws.s3.external_id`.
+
+  :::caution
+  Before using web identity for a storage volume, make sure every FE, StarManager, BE, and CN in the cluster supports
+  this authentication method. During a rolling upgrade, do not use the storage volume until all nodes are upgraded.
+  :::
 
 - If you use Assumed Role to access S3, set the following properties:
 

--- a/docs/ja/sql-reference/sql-statements/cluster-management/storage_volume/AWS_CREDENTIAL_SUPPORT.md
+++ b/docs/ja/sql-reference/sql-statements/cluster-management/storage_volume/AWS_CREDENTIAL_SUPPORT.md
@@ -1,0 +1,108 @@
+---
+displayed_sidebar: docs
+description: "FE ランタイムと StarOS ベースのストレージボリュームにおける AWS 認証情報のサポートを比較します。"
+sidebar_position: 10
+---
+
+# ストレージボリュームの AWS 認証情報サポート
+
+StarRocks FE は `AwsCloudCredential` を使用して、ストレージボリュームやその他の AWS コンシューマーの AWS
+認証を設定します。ストレージボリュームはさらに認証情報を StarOS にシリアライズします。FE ランタイムで
+サポートされる一部の組み合わせは、現在ストレージボリュームに完全には保存できません。
+
+## サポートマトリックス
+
+| 認証方式 | 必須プロパティ | FE ランタイム | ストレージボリューム | 説明 |
+|---|---|:---:|:---:|---|
+| AWS SDK デフォルト認証情報チェーン | `aws.s3.use_aws_sdk_default_behavior=true` | サポート | サポート | AWS SDK のデフォルト認証情報プロバイダーチェーンを使用します。 |
+| デフォルト認証情報チェーンの後に AssumeRole | `aws.s3.use_aws_sdk_default_behavior=true`<br />`aws.s3.iam_role_arn=<arn>`<br />任意：`aws.s3.external_id` | サポート | 非サポート | ストレージボリュームにはデフォルトチェーンの選択のみが保存されます。 |
+| Instance Profile | `aws.s3.use_instance_profile=true` | サポート | サポート | EC2 Instance Profile 認証情報を使用します。 |
+| Instance Profile の後に AssumeRole | `aws.s3.use_instance_profile=true`<br />`aws.s3.iam_role_arn=<arn>`<br />任意：`aws.s3.external_id` | サポート | サポート | Role ARN と External ID が保存されます。 |
+| Web Identity Token ファイル | `aws.s3.use_web_identity_token_file=true`<br />ワーカー環境：`AWS_WEB_IDENTITY_TOKEN_FILE` と `AWS_ROLE_ARN` | サポート | サポート | Token ファイルと最初の Role は各ワーカーで解決されます。 |
+| Web Identity の後に 2 回目の AssumeRole | `aws.s3.use_web_identity_token_file=true`<br />`aws.s3.iam_role_arn=<second_hop_arn>`<br />任意：`aws.s3.external_id`<br />ワーカー環境：`AWS_WEB_IDENTITY_TOKEN_FILE` と `AWS_ROLE_ARN` | サポート | サポート | 設定した Role ARN は 2 回目の STS ホップを表します。 |
+| 静的 Access Key と Secret Key | `aws.s3.access_key=<access_key>`<br />`aws.s3.secret_key=<secret_key>` | サポート | サポート | Access Key と Secret Key が保存されます。 |
+| 静的セッション認証情報 | Access Key と Secret Key のプロパティ<br />`aws.s3.session_token=<token>` | サポート | 非サポート | Session Token はストレージボリュームに保存されません。 |
+| Access Key と Secret Key の後に AssumeRole | Access Key と Secret Key のプロパティ<br />`aws.s3.iam_role_arn=<arn>`<br />任意：`aws.s3.external_id` | サポート | 非サポート | AssumeRole 設定はストレージボリュームに保存されません。 |
+| カスタム STS Region または Endpoint | 有効なベース認証情報<br />`aws.s3.sts.region=<region>` および/または `aws.s3.sts.endpoint=<endpoint>`<br />`aws.s3.iam_role_arn=<arn>` | サポート | 非サポート | カスタム STS 設定はストレージボリュームに保存されません。 |
+| ベース認証情報なしで Role ARN のみを設定 | `aws.s3.iam_role_arn=<arn>` のみ | 非サポート | 非サポート | AssumeRole には有効なベース認証情報プロバイダーが必要です。 |
+
+**非サポート**と示された組み合わせでストレージボリュームを設定しないでください。FE は対応する認証情報
+プロバイダーを構築できますが、ストレージボリュームを StarOS にシリアライズすると完全な設定が保持されません。
+
+## 認証情報の解決順序
+
+複数のベース認証方式を設定した場合、FE は次の順序で最初に一致する方式を選択します。
+
+```text
+AWS SDK デフォルト認証情報チェーン > Instance Profile > Web Identity > Access Key と Secret Key
+```
+
+ベース認証情報プロバイダーを選択した後、`aws.s3.iam_role_arn` が空でなければ、FE は STS AssumeRole
+操作を実行します。
+
+## 認証方式の切り替え
+
+`ALTER STORAGE VOLUME` は、指定したプロパティをストレージボリュームの既存のプロパティに置き換えるのではなく
+マージします。上記の解決順序と組み合わさるため、新しい認証方式のプロパティのみを設定した文は成功しても、
+ストレージボリュームが実際に使用する認証情報は変わらないことがあります。
+
+ストレージボリュームの認証方式を切り替えるには、次のようにします。
+
+- すべての `use_*` プロパティを明示的に設定し、そのうち 1 つだけを `true` にします。
+- 新しい認証方式でも AssumeRole が必要な場合を除き、`aws.s3.iam_role_arn` と `aws.s3.external_id` をクリア
+  します。これらは `use_*` プロパティではないためマージ後も残り、新しい認証方式に適用されます。
+
+### 認証方式が切り替わらない文
+
+次の文はいずれも成功しますが、ストレージボリュームは以前の認証情報を保持し、指定したプロパティは保存されません。
+
+```SQL
+-- ストレージボリュームは現在 Web Identity Token ファイルを使用しています。
+-- 効果なし: Web Identity は Access Key と Secret Key より優先されます。
+ALTER STORAGE VOLUME <storage_volume_name> SET (
+    "aws.s3.access_key" = "<access_key>",
+    "aws.s3.secret_key" = "<secret_key>"
+);
+
+-- ストレージボリュームは現在 Instance Profile を使用しています。
+-- 効果なし: Instance Profile は Web Identity より優先されます。
+ALTER STORAGE VOLUME <storage_volume_name> SET (
+    "aws.s3.use_web_identity_token_file" = "true"
+);
+```
+
+### 認証方式が切り替わる文
+
+```SQL
+-- Web Identity から Access Key と Secret Key へ。
+ALTER STORAGE VOLUME <storage_volume_name> SET (
+    "aws.s3.use_aws_sdk_default_behavior" = "false",
+    "aws.s3.use_instance_profile" = "false",
+    "aws.s3.use_web_identity_token_file" = "false",
+    "aws.s3.access_key" = "<access_key>",
+    "aws.s3.secret_key" = "<secret_key>"
+);
+
+-- Instance Profile から Web Identity へ。以前の Role は削除します。
+ALTER STORAGE VOLUME <storage_volume_name> SET (
+    "aws.s3.use_aws_sdk_default_behavior" = "false",
+    "aws.s3.use_instance_profile" = "false",
+    "aws.s3.use_web_identity_token_file" = "true",
+    "aws.s3.iam_role_arn" = "",
+    "aws.s3.external_id" = ""
+);
+```
+
+現在の方式より優先度の高い方式へ切り替える場合は、現在の方式を無効にしなくても切り替わります。新しい方式が
+先に一致するためです。たとえば、Access Key と Secret Key を使用するストレージボリュームは、
+`aws.s3.use_web_identity_token_file` を `true` に設定するだけで Web Identity に切り替わります。すべての
+`use_*` プロパティを明示的に設定する方法は双方向で有効であり、現在有効な方式を知る必要がありません。
+
+:::caution
+以前の認証方式から残った Role ARN は、新しい認証方式に適用されます。ストレージボリュームが Web Identity と
+2 回目の AssumeRole を使用していた場合、Instance Profile に切り替えると、残った `aws.s3.iam_role_arn` が
+Instance Profile が Assume する Role になります。これを避けるには、同じ文の中で `aws.s3.iam_role_arn` と
+`aws.s3.external_id` をクリアしてください。
+:::
+
+ストレージボリュームの設定例については、[CREATE STORAGE VOLUME](CREATE_STORAGE_VOLUME.md#認証情報) を参照してください。

--- a/docs/ja/sql-reference/sql-statements/cluster-management/storage_volume/CREATE_STORAGE_VOLUME.md
+++ b/docs/ja/sql-reference/sql-statements/cluster-management/storage_volume/CREATE_STORAGE_VOLUME.md
@@ -49,6 +49,7 @@ import Beta from '../../../../_assets/commonMarkdown/_beta.mdx'
 | aws.s3.endpoint                     | S3 バケットにアクセスするためのエンドポイント URL です。例：`https://s3.us-west-2.amazonaws.com`。[プレビュー] v3.3.0 以降、Amazon S3 Express One Zone ストレージクラスがサポートされています。例：`https://s3express.us-west-2.amazonaws.com`。 <Beta />  |
 | aws.s3.use_aws_sdk_default_behavior | AWS SDK のデフォルト認証情報を使用するかどうか。有効な値は `true` と `false`（デフォルト）です。 |
 | aws.s3.use_instance_profile         | S3 にアクセスするための認証方法としてインスタンスプロファイルとアサインドロールを使用するかどうか。有効な値は `true` と `false`（デフォルト）です。<ul><li>IAM ユーザー認証（アクセスキーとシークレットキー）を使用して S3 にアクセスする場合、この項目を `false` に設定し、`aws.s3.access_key` と `aws.s3.secret_key` を指定する必要があります。</li><li>インスタンスプロファイルを使用して S3 にアクセスする場合、この項目を `true` に設定する必要があります。</li><li>アサインドロールを使用して S3 にアクセスする場合、この項目を `true` に設定し、`aws.s3.iam_role_arn` を指定する必要があります。</li><li>外部 AWS アカウントを使用する場合、この項目を `true` に設定し、`aws.s3.iam_role_arn` と `aws.s3.external_id` を指定する必要があります。</li></ul> |
+| aws.s3.use_web_identity_token_file  | Web Identity Token ファイルを使用して S3 にアクセスするかどうか。有効な値は `true` と `false`（デフォルト）です。有効にすると、各ワーカーの AWS SDK は環境変数 `AWS_WEB_IDENTITY_TOKEN_FILE` と `AWS_ROLE_ARN` から Token ファイルと IAM ロールを取得します。 |
 | aws.s3.access_key                   | S3 バケットにアクセスするためのアクセスキー ID です。             |
 | aws.s3.secret_key                   | S3 バケットにアクセスするためのシークレットアクセスキーです。         |
 | aws.s3.iam_role_arn                 | データファイルが保存されている S3 バケットに対して権限を持つ IAM ロールの ARN です。 |
@@ -82,6 +83,9 @@ import Beta from '../../../../_assets/commonMarkdown/_beta.mdx'
 
 #### 認証情報
 
+FE とストレージボリュームでサポートされる認証情報の組み合わせについては、
+[ストレージボリュームの AWS 認証情報サポート](AWS_CREDENTIAL_SUPPORT.md) を参照してください。
+
 ##### AWS S3
 
 - AWS SDK のデフォルト認証情報を使用して S3 にアクセスする場合、次のプロパティを設定します：
@@ -114,6 +118,28 @@ import Beta from '../../../../_assets/commonMarkdown/_beta.mdx'
   "aws.s3.use_aws_sdk_default_behavior" = "false",
   "aws.s3.use_instance_profile" = "true"
   ```
+
+- Web Identity Token ファイル（EKS IAM Roles for Service Accounts、IRSA など）を使用する場合、次の
+  プロパティを設定します。また、ストレージボリュームにアクセスするすべてのワーカーの環境に
+  `AWS_WEB_IDENTITY_TOKEN_FILE` と `AWS_ROLE_ARN` を設定します。
+
+  ```SQL
+  "enabled" = "{ true | false }",
+  "aws.s3.region" = "<region>",
+  "aws.s3.endpoint" = "<endpoint_url>",
+  "aws.s3.use_aws_sdk_default_behavior" = "false",
+  "aws.s3.use_instance_profile" = "false",
+  "aws.s3.use_web_identity_token_file" = "true"
+  ```
+
+  Web Identity で認証情報を取得した後に別の IAM ロールを引き受けるには、`aws.s3.iam_role_arn` も設定します。
+  クロスアカウントアクセスでは、`aws.s3.external_id` も設定できます。
+
+  :::caution
+  ストレージボリュームで Web Identity を使用する前に、クラスター内のすべての FE、StarManager、BE、CN が
+  この認証方法をサポートしていることを確認してください。ローリングアップグレード中は、すべてのノードの
+  アップグレードが完了するまで、このストレージボリュームを使用しないでください。
+  :::
 
 - アサインドロールを使用して S3 にアクセスする場合、次のプロパティを設定します：
 

--- a/docs/zh/sql-reference/sql-statements/cluster-management/storage_volume/AWS_CREDENTIAL_SUPPORT.md
+++ b/docs/zh/sql-reference/sql-statements/cluster-management/storage_volume/AWS_CREDENTIAL_SUPPORT.md
@@ -1,0 +1,103 @@
+---
+displayed_sidebar: docs
+description: "对比 FE 运行时与基于 StarOS 的存储卷对 AWS 凭证的支持情况。"
+sidebar_position: 10
+---
+
+# 存储卷 AWS 凭证支持情况
+
+StarRocks FE 使用 `AwsCloudCredential` 为存储卷及其他 AWS 使用方配置 AWS 认证。存储卷还会将凭证序列化至
+StarOS。FE 运行时支持的部分组合目前无法完整保存在存储卷中。
+
+## 支持矩阵
+
+| 认证方式 | 必需属性 | FE 运行时 | 存储卷 | 说明 |
+|---|---|:---:|:---:|---|
+| AWS SDK 默认凭证链 | `aws.s3.use_aws_sdk_default_behavior=true` | 支持 | 支持 | 使用 AWS SDK 默认凭证提供链。 |
+| 默认凭证链后执行 AssumeRole | `aws.s3.use_aws_sdk_default_behavior=true`<br />`aws.s3.iam_role_arn=<arn>`<br />可选：`aws.s3.external_id` | 支持 | 不支持 | 存储卷仅保留默认凭证链的选择。 |
+| Instance Profile | `aws.s3.use_instance_profile=true` | 支持 | 支持 | 使用 EC2 Instance Profile 凭证。 |
+| Instance Profile 后执行 AssumeRole | `aws.s3.use_instance_profile=true`<br />`aws.s3.iam_role_arn=<arn>`<br />可选：`aws.s3.external_id` | 支持 | 支持 | Role ARN 和 External ID 均会保留。 |
+| Web Identity Token 文件 | `aws.s3.use_web_identity_token_file=true`<br />Worker 环境变量：`AWS_WEB_IDENTITY_TOKEN_FILE` 和 `AWS_ROLE_ARN` | 支持 | 支持 | Token 文件和第一跳 Role 由各 Worker 解析。 |
+| Web Identity 后执行第二次 AssumeRole | `aws.s3.use_web_identity_token_file=true`<br />`aws.s3.iam_role_arn=<second_hop_arn>`<br />可选：`aws.s3.external_id`<br />Worker 环境变量：`AWS_WEB_IDENTITY_TOKEN_FILE` 和 `AWS_ROLE_ARN` | 支持 | 支持 | 配置的 Role ARN 表示第二次 STS 跳转。 |
+| 静态 Access Key 和 Secret Key | `aws.s3.access_key=<access_key>`<br />`aws.s3.secret_key=<secret_key>` | 支持 | 支持 | Access Key 和 Secret Key 均会保留。 |
+| 静态临时凭证 | Access Key 和 Secret Key 属性<br />`aws.s3.session_token=<token>` | 支持 | 不支持 | Session Token 不会保存在存储卷中。 |
+| Access Key 和 Secret Key 后执行 AssumeRole | Access Key 和 Secret Key 属性<br />`aws.s3.iam_role_arn=<arn>`<br />可选：`aws.s3.external_id` | 支持 | 不支持 | AssumeRole 配置不会保存在存储卷中。 |
+| 自定义 STS Region 或 Endpoint | 有效的基础凭证<br />`aws.s3.sts.region=<region>` 和/或 `aws.s3.sts.endpoint=<endpoint>`<br />`aws.s3.iam_role_arn=<arn>` | 支持 | 不支持 | 自定义 STS 配置不会保存在存储卷中。 |
+| 仅配置 Role ARN，未配置基础凭证 | 仅配置 `aws.s3.iam_role_arn=<arn>` | 不支持 | 不支持 | AssumeRole 需要有效的基础凭证提供方。 |
+
+请勿使用标记为**不支持**的组合配置存储卷。尽管 FE 可以构造对应的凭证提供方，但存储卷序列化至 StarOS
+时无法保留完整配置。
+
+## 凭证解析顺序
+
+如果配置了多种基础认证方式，FE 按以下顺序选择第一个匹配项：
+
+```text
+AWS SDK 默认凭证链 > Instance Profile > Web Identity > Access Key 和 Secret Key
+```
+
+选择基础凭证提供方后，如果 `aws.s3.iam_role_arn` 非空，FE 将执行 STS AssumeRole 操作。
+
+## 切换认证方式
+
+`ALTER STORAGE VOLUME` 会将您指定的属性合并到存储卷现有属性中，而非替换。结合上述解析顺序，仅设置新认证方式
+属性的语句可能执行成功，但存储卷实际使用的凭证并未改变。
+
+将存储卷从一种认证方式切换为另一种时：
+
+- 显式设置全部 `use_*` 属性，且其中仅有一个为 `true`。
+- 除非新认证方式同样需要执行 AssumeRole，否则请清空 `aws.s3.iam_role_arn` 和 `aws.s3.external_id`。这两项不是
+  `use_*` 属性，因此会在合并后保留，并被应用到新的认证方式上。
+
+### 无法切换认证方式的语句
+
+以下语句均可执行成功，但存储卷仍保留原有凭证，且您设置的属性不会被保存。
+
+```SQL
+-- 存储卷当前使用 Web Identity Token 文件。
+-- 无效果：Web Identity 的优先级高于 Access Key 和 Secret Key。
+ALTER STORAGE VOLUME <storage_volume_name> SET (
+    "aws.s3.access_key" = "<access_key>",
+    "aws.s3.secret_key" = "<secret_key>"
+);
+
+-- 存储卷当前使用 Instance Profile。
+-- 无效果：Instance Profile 的优先级高于 Web Identity。
+ALTER STORAGE VOLUME <storage_volume_name> SET (
+    "aws.s3.use_web_identity_token_file" = "true"
+);
+```
+
+### 可以切换认证方式的语句
+
+```SQL
+-- Web Identity 切换为 Access Key 和 Secret Key。
+ALTER STORAGE VOLUME <storage_volume_name> SET (
+    "aws.s3.use_aws_sdk_default_behavior" = "false",
+    "aws.s3.use_instance_profile" = "false",
+    "aws.s3.use_web_identity_token_file" = "false",
+    "aws.s3.access_key" = "<access_key>",
+    "aws.s3.secret_key" = "<secret_key>"
+);
+
+-- Instance Profile 切换为 Web Identity，并清除原有 Role。
+ALTER STORAGE VOLUME <storage_volume_name> SET (
+    "aws.s3.use_aws_sdk_default_behavior" = "false",
+    "aws.s3.use_instance_profile" = "false",
+    "aws.s3.use_web_identity_token_file" = "true",
+    "aws.s3.iam_role_arn" = "",
+    "aws.s3.external_id" = ""
+);
+```
+
+切换为优先级更高的认证方式时，无需禁用当前认证方式也能生效，因为新方式会被优先匹配。例如，使用 Access Key 和
+Secret Key 的存储卷，仅将 `aws.s3.use_web_identity_token_file` 设置为 `true` 即可切换为 Web Identity。显式设置
+全部 `use_*` 属性在两个方向上均有效，且无需事先了解当前生效的认证方式。
+
+:::caution
+上一种认证方式遗留的 Role ARN 会被应用到新的认证方式上。如果存储卷此前使用 Web Identity 并执行第二次
+AssumeRole，切换为 Instance Profile 后，遗留的 `aws.s3.iam_role_arn` 将成为 Instance Profile 所要 Assume 的
+Role。请在同一条语句中清空 `aws.s3.iam_role_arn` 和 `aws.s3.external_id` 以避免该问题。
+:::
+
+有关存储卷配置示例，请参阅 [CREATE STORAGE VOLUME](CREATE_STORAGE_VOLUME.md#认证信息)。

--- a/docs/zh/sql-reference/sql-statements/cluster-management/storage_volume/CREATE_STORAGE_VOLUME.md
+++ b/docs/zh/sql-reference/sql-statements/cluster-management/storage_volume/CREATE_STORAGE_VOLUME.md
@@ -51,6 +51,7 @@ import Beta from '../../../../_assets/commonMarkdown/_beta.mdx'
 | aws.s3.endpoint                     | 访问 S3 存储空间的连接地址，如 `https://s3.us-west-2.amazonaws.com`。[Preview] 自 v3.3.0 起，支持 Amazon S3 Express One Zone Storage，如 `https://s3express.us-west-2.amazonaws.com`。<Beta /> |
 | aws.s3.use_aws_sdk_default_behavior | 是否使用 AWS SDK 默认的认证凭证。有效值：`true` 和 `false` (默认)。 |
 | aws.s3.use_instance_profile         | 是否使用 Instance Profile 或 Assumed Role 作为安全凭证访问 S3。有效值：`true` 和 `false` (默认)。<ul><li>如果您使用 IAM 用户凭证（Access Key 和 Secret Key）访问 S3，则需要将此项设为 `false`，并指定 `aws.s3.access_key` 和 `aws.s3.secret_key`。</li><li>如果您使用 Instance Profile 访问 S3，则需要将此项设为 `true`。</li><li>如果您使用 Assumed Role 访问 S3，则需要将此项设为 `true`，并指定 `aws.s3.iam_role_arn`。</li><li>如果您使用外部 AWS 账户通过 Assumed Role 认证访问 S3，则需要将此项设为 `true`，并额外指定 `aws.s3.iam_role_arn` 和 `aws.s3.external_id`。</li></ul> |
+| aws.s3.use_web_identity_token_file  | 是否使用 Web Identity Token 文件访问 S3。有效值：`true` 和 `false`（默认）。启用后，每个 Worker 上的 AWS SDK 从环境变量 `AWS_WEB_IDENTITY_TOKEN_FILE` 和 `AWS_ROLE_ARN` 中获取 Token 文件和 IAM Role。 |
 | aws.s3.access_key                   | 访问 S3 存储空间的 Access Key。                              |
 | aws.s3.secret_key                   | 访问 S3 存储空间的 Secret Key。                              |
 | aws.s3.iam_role_arn                 | 有访问 S3 存储空间权限 IAM Role 的 ARN。                     |
@@ -84,6 +85,8 @@ import Beta from '../../../../_assets/commonMarkdown/_beta.mdx'
 
 #### 认证信息
 
+有关 FE 与存储卷支持的凭证组合对比，请参阅[存储卷 AWS 凭证支持情况](AWS_CREDENTIAL_SUPPORT.md)。
+
 ##### AWS S3
 
 - 如果您使用 AWS SDK 默认的认证凭证，请设置以下属性：
@@ -116,6 +119,26 @@ import Beta from '../../../../_assets/commonMarkdown/_beta.mdx'
   "aws.s3.use_aws_sdk_default_behavior" = "false",
   "aws.s3.use_instance_profile" = "true"
   ```
+
+- 如果您使用 Web Identity Token 文件（例如 EKS IAM Roles for Service Accounts，即 IRSA）进行认证，请设置以下
+  属性，并在每个需要访问该存储卷的 Worker 环境中设置 `AWS_WEB_IDENTITY_TOKEN_FILE` 和 `AWS_ROLE_ARN`。
+
+  ```SQL
+  "enabled" = "{ true | false }",
+  "aws.s3.region" = "<region>",
+  "aws.s3.endpoint" = "<endpoint_url>",
+  "aws.s3.use_aws_sdk_default_behavior" = "false",
+  "aws.s3.use_instance_profile" = "false",
+  "aws.s3.use_web_identity_token_file" = "true"
+  ```
+
+  如果需要在通过 Web Identity 获取凭证后再 Assume 另一个 IAM Role，请额外设置 `aws.s3.iam_role_arn`。对于跨账户
+  访问，还可以设置 `aws.s3.external_id`。
+
+  :::caution
+  为存储卷启用 Web Identity 前，请确保集群中的所有 FE、StarManager、BE 和 CN 均支持此认证方式。滚动升级期间，
+  请等待所有节点升级完成后再使用该存储卷。
+  :::
 
 - 如果您使用 Assumed Role 认证，请设置以下属性：
 

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aws/AwsCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aws/AwsCloudCredential.java
@@ -20,6 +20,7 @@ import com.staros.proto.AwsCredentialInfo;
 import com.staros.proto.AwsDefaultCredentialInfo;
 import com.staros.proto.AwsInstanceProfileCredentialInfo;
 import com.staros.proto.AwsSimpleCredentialInfo;
+import com.staros.proto.AwsWebIdentityCredentialInfo;
 import com.staros.proto.FileStoreInfo;
 import com.staros.proto.FileStoreType;
 import com.staros.proto.S3FileStoreInfo;
@@ -362,15 +363,11 @@ public class AwsCloudCredential implements CloudCredential {
                 awsCredentialInfo.setProfileCredential(AwsInstanceProfileCredentialInfo.newBuilder().build());
             }
         } else if (useWebIdentityProfile) {
-            if (!iamRoleArn.isEmpty()) {
-                AwsAssumeIamRoleCredentialInfo.Builder assumeIamRoleCredentialInfo =
-                        AwsAssumeIamRoleCredentialInfo.newBuilder();
-                assumeIamRoleCredentialInfo.setIamRoleArn(iamRoleArn);
-                assumeIamRoleCredentialInfo.setExternalId(externalId);
-                awsCredentialInfo.setAssumeRoleCredential(assumeIamRoleCredentialInfo.build());
-            } else {
-                awsCredentialInfo.setDefaultCredential(AwsDefaultCredentialInfo.newBuilder().build());
-            }
+            AwsWebIdentityCredentialInfo.Builder webIdentityCredentialInfo =
+                    AwsWebIdentityCredentialInfo.newBuilder();
+            webIdentityCredentialInfo.setIamRoleArn(iamRoleArn);
+            webIdentityCredentialInfo.setExternalId(externalId);
+            awsCredentialInfo.setWebIdentityCredential(webIdentityCredentialInfo.build());
         } else if (!accessKey.isEmpty() && !secretKey.isEmpty()) {
             // TODO: Support assumeRole with AK/SK
             // TODO: Support sessionToken with AK/SK

--- a/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
+++ b/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
@@ -397,6 +397,14 @@ public class StorageVolume implements Writable, GsonPostProcessable {
                     params.put(CloudConfigurationConstants.AWS_S3_USE_INSTANCE_PROFILE, "true");
                     params.put(CloudConfigurationConstants.AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR, "false");
                     params.put(CloudConfigurationConstants.AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE, "false");
+                } else if (credentialInfo.hasWebIdentityCredential()) {
+                    params.put(CloudConfigurationConstants.AWS_S3_USE_INSTANCE_PROFILE, "false");
+                    params.put(CloudConfigurationConstants.AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR, "false");
+                    params.put(CloudConfigurationConstants.AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE, "true");
+                    params.put(CloudConfigurationConstants.AWS_S3_IAM_ROLE_ARN,
+                            credentialInfo.getWebIdentityCredential().getIamRoleArn());
+                    params.put(CloudConfigurationConstants.AWS_S3_EXTERNAL_ID,
+                            credentialInfo.getWebIdentityCredential().getExternalId());
                 } else if (credentialInfo.hasDefaultCredential()) {
                     params.put(CloudConfigurationConstants.AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR, "true");
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/credential/AwsCloudConfigurationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/AwsCloudConfigurationTest.java
@@ -135,7 +135,9 @@ public class AwsCloudConfigurationTest {
         CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
         Assertions.assertNotNull(cloudConfiguration);
         FileStoreInfo fileStoreInfo = cloudConfiguration.toFileStoreInfo();
-        Assertions.assertTrue(fileStoreInfo.getS3FsInfo().getCredential().hasDefaultCredential());
+        Assertions.assertTrue(fileStoreInfo.getS3FsInfo().getCredential().hasWebIdentityCredential());
+        Assertions.assertTrue(fileStoreInfo.getS3FsInfo().getCredential()
+                .getWebIdentityCredential().getIamRoleArn().isEmpty());
     }
 
     @Test
@@ -146,9 +148,9 @@ public class AwsCloudConfigurationTest {
         CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
         Assertions.assertNotNull(cloudConfiguration);
         FileStoreInfo fileStoreInfo = cloudConfiguration.toFileStoreInfo();
-        Assertions.assertTrue(fileStoreInfo.getS3FsInfo().getCredential().hasAssumeRoleCredential());
+        Assertions.assertTrue(fileStoreInfo.getS3FsInfo().getCredential().hasWebIdentityCredential());
         Assertions.assertEquals("arn:aws:iam::123456789:role/MyRole",
-                fileStoreInfo.getS3FsInfo().getCredential().getAssumeRoleCredential().getIamRoleArn());
+                fileStoreInfo.getS3FsInfo().getCredential().getWebIdentityCredential().getIamRoleArn());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeE2ETest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeE2ETest.java
@@ -1,0 +1,89 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.server;
+
+import com.staros.proto.AwsCredentialInfo;
+import com.staros.proto.AwsWebIdentityCredentialInfo;
+import com.staros.proto.FileStoreInfo;
+import com.staros.proto.FileStoreType;
+import com.staros.proto.S3FileStoreInfo;
+import com.starrocks.common.Config;
+import com.starrocks.utframe.TestWithFeService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+public class SharedDataStorageVolumeE2ETest extends TestWithFeService {
+    @Override
+    protected void beforeCluster() {
+        runMode = RunMode.SHARED_DATA;
+    }
+
+    @Override
+    protected void runBeforeAll() {
+        connectContext.setCurrentRoleIds(connectContext.getCurrentUserIdentity());
+    }
+
+    @Test
+    public void testCreateWebIdentityStorageVolume() throws Exception {
+        boolean oldValue = Config.enable_storage_volume_access_check;
+        Config.enable_storage_volume_access_check = false;
+        try {
+            verifyWebIdentityStorageVolume("web_identity_volume", "", "");
+            verifyWebIdentityStorageVolume("web_identity_assume_role_volume",
+                    "arn:aws:iam::123456789012:role/data", "external_id");
+        } finally {
+            Config.enable_storage_volume_access_check = oldValue;
+        }
+    }
+
+    private void verifyWebIdentityStorageVolume(String storageVolumeName, String iamRoleArn, String externalId)
+            throws Exception {
+        StringBuilder properties = new StringBuilder()
+                .append("\"aws.s3.region\" = \"us-west-2\", ")
+                .append("\"aws.s3.endpoint\" = \"https://s3.us-west-2.amazonaws.com\", ")
+                .append("\"aws.s3.use_aws_sdk_default_behavior\" = \"false\", ")
+                .append("\"aws.s3.use_instance_profile\" = \"false\", ")
+                .append("\"aws.s3.use_web_identity_token_file\" = \"true\"");
+        if (!iamRoleArn.isEmpty()) {
+            properties.append(", \"aws.s3.iam_role_arn\" = \"").append(iamRoleArn).append("\"")
+                    .append(", \"aws.s3.external_id\" = \"").append(externalId).append("\"");
+        }
+
+        String sql = "CREATE STORAGE VOLUME " + storageVolumeName + " " +
+                "TYPE = S3 " +
+                "LOCATIONS = (\"s3://web-identity-bucket/test/\") " +
+                "PROPERTIES (" + properties + ");";
+        connectContext.setQueryId(UUID.randomUUID());
+        connectContext.executeSql(sql);
+        Assertions.assertFalse(connectContext.getState().isError(), connectContext.getState().getErrorMessage());
+
+        FileStoreInfo fileStoreInfo = GlobalStateMgr.getCurrentState().getStarOSAgent()
+                .getFileStoreByName(storageVolumeName);
+        Assertions.assertNotNull(fileStoreInfo);
+        Assertions.assertEquals(FileStoreType.S3, fileStoreInfo.getFsType());
+        Assertions.assertEquals("s3://web-identity-bucket/test/", fileStoreInfo.getLocations(0));
+
+        S3FileStoreInfo s3Info = fileStoreInfo.getS3FsInfo();
+        Assertions.assertEquals("us-west-2", s3Info.getRegion());
+        Assertions.assertEquals("https://s3.us-west-2.amazonaws.com", s3Info.getEndpoint());
+        Assertions.assertEquals(AwsCredentialInfo.CredentialCase.WEB_IDENTITY_CREDENTIAL,
+                s3Info.getCredential().getCredentialCase());
+        AwsWebIdentityCredentialInfo credential = s3Info.getCredential().getWebIdentityCredential();
+        Assertions.assertEquals(iamRoleArn, credential.getIamRoleArn());
+        Assertions.assertEquals(externalId, credential.getExternalId());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
@@ -87,9 +87,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_ACCESS_KEY;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_ENDPOINT;
+import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_EXTERNAL_ID;
+import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_IAM_ROLE_ARN;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_REGION;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_SECRET_KEY;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR;
+import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_USE_INSTANCE_PROFILE;
+import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE;
 
 public class SharedDataStorageVolumeMgrTest {
     @Mocked
@@ -1663,5 +1667,236 @@ public class SharedDataStorageVolumeMgrTest {
         Assertions.assertFalse(svm.hasStorageVolumeBindAsVirtualGroup(notExistedGroupId));
 
         svm.removeStorageVolume(storageVolumeName);
+    }
+
+    // ------------------------------------------------------------------
+    // ALTER STORAGE VOLUME credential switching.
+    //
+    // ALTER merges properties into the existing set (StorageVolume.setCloudConfiguration),
+    // and AwsCloudCredential.toFileStoreInfo() picks the first match in the order
+    //   sdk_default > instance_profile > web_identity > access_key/secret_key
+    // persisting only that one credential case. The tests below pin that behavior so a
+    // change to either the merge or the ordering is caught here.
+    // ------------------------------------------------------------------
+
+    private static Map<String, String> baseParams() {
+        Map<String, String> params = new HashMap<>();
+        params.put(AWS_S3_REGION, "region");
+        params.put(AWS_S3_ENDPOINT, "endpoint");
+        params.put(AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR, "false");
+        params.put(AWS_S3_USE_INSTANCE_PROFILE, "false");
+        return params;
+    }
+
+    private static Map<String, String> webIdentityParams(String iamRoleArn, String externalId) {
+        Map<String, String> params = baseParams();
+        params.put(AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE, "true");
+        if (iamRoleArn != null) {
+            params.put(AWS_S3_IAM_ROLE_ARN, iamRoleArn);
+            params.put(AWS_S3_EXTERNAL_ID, externalId);
+        }
+        return params;
+    }
+
+    private static Map<String, String> instanceProfileParams() {
+        Map<String, String> params = baseParams();
+        params.put(AWS_S3_USE_INSTANCE_PROFILE, "true");
+        return params;
+    }
+
+    private static Map<String, String> accessKeyParams() {
+        Map<String, String> params = baseParams();
+        params.put(AWS_S3_ACCESS_KEY, "ak");
+        params.put(AWS_S3_SECRET_KEY, "sk");
+        return params;
+    }
+
+    private static StorageVolumeMgr createVolume(String svName, Map<String, String> params)
+            throws AlreadyExistsException, DdlException {
+        StorageVolumeMgr svm = new SharedDataStorageVolumeMgr();
+        svm.createStorageVolume(svName, "S3", Arrays.asList("s3://abc"), params, Optional.empty(), "");
+        return svm;
+    }
+
+    /**
+     * Reads the volume back through StarOS, so the returned map is re-synthesized from the
+     * persisted credential case rather than echoed from the FE-side param map.
+     */
+    private static Map<String, String> reloadParams(StorageVolumeMgr svm, String svName) {
+        return svm.getStorageVolumeByName(svName).getProperties();
+    }
+
+    private static void alter(StorageVolumeMgr svm, String svName, Map<String, String> params)
+            throws DdlException, MetaNotFoundException {
+        svm.updateStorageVolume(svName, null, null, params, Optional.empty(), "");
+    }
+
+    @Test
+    public void testAlterWebIdentityUpdatesRoleArnAndExternalId()
+            throws AlreadyExistsException, DdlException, MetaNotFoundException {
+        String svName = "sv_wi_update";
+        StorageVolumeMgr svm = createVolume(svName, webIdentityParams("arn:aws:iam::111:role/old", "old-ext"));
+
+        Map<String, String> update = new HashMap<>();
+        update.put(AWS_S3_IAM_ROLE_ARN, "arn:aws:iam::222:role/new");
+        update.put(AWS_S3_EXTERNAL_ID, "new-ext");
+        alter(svm, svName, update);
+
+        Map<String, String> params = reloadParams(svm, svName);
+        Assertions.assertEquals("true", params.get(AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE));
+        Assertions.assertEquals("arn:aws:iam::222:role/new", params.get(AWS_S3_IAM_ROLE_ARN));
+        Assertions.assertEquals("new-ext", params.get(AWS_S3_EXTERNAL_ID));
+    }
+
+    @Test
+    public void testAlterWebIdentityClearsRoleArnAndExternalId()
+            throws AlreadyExistsException, DdlException, MetaNotFoundException {
+        String svName = "sv_wi_clear";
+        StorageVolumeMgr svm = createVolume(svName, webIdentityParams("arn:aws:iam::111:role/old", "old-ext"));
+
+        Map<String, String> update = new HashMap<>();
+        update.put(AWS_S3_IAM_ROLE_ARN, "");
+        update.put(AWS_S3_EXTERNAL_ID, "");
+        alter(svm, svName, update);
+
+        Map<String, String> params = reloadParams(svm, svName);
+        Assertions.assertEquals("true", params.get(AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE));
+        Assertions.assertEquals("", params.get(AWS_S3_IAM_ROLE_ARN));
+        Assertions.assertEquals("", params.get(AWS_S3_EXTERNAL_ID));
+    }
+
+    /**
+     * Setting only the lower-precedence method's properties succeeds but does not switch the
+     * credential, and the supplied properties are not persisted at all.
+     */
+    @Test
+    public void testAlterDoesNotSwitchFromWebIdentityToAccessKeyWithoutDisablingIt()
+            throws AlreadyExistsException, DdlException, MetaNotFoundException {
+        String svName = "sv_wi_to_ak";
+        StorageVolumeMgr svm = createVolume(svName, webIdentityParams(null, null));
+
+        Map<String, String> update = new HashMap<>();
+        update.put(AWS_S3_ACCESS_KEY, "ak");
+        update.put(AWS_S3_SECRET_KEY, "sk");
+        alter(svm, svName, update);
+
+        Map<String, String> params = reloadParams(svm, svName);
+        Assertions.assertEquals("true", params.get(AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE));
+        Assertions.assertFalse(params.containsKey(AWS_S3_ACCESS_KEY));
+        Assertions.assertFalse(params.containsKey(AWS_S3_SECRET_KEY));
+    }
+
+    @Test
+    public void testAlterDoesNotSwitchFromInstanceProfileToWebIdentityWithoutDisablingIt()
+            throws AlreadyExistsException, DdlException, MetaNotFoundException {
+        String svName = "sv_ip_to_wi";
+        StorageVolumeMgr svm = createVolume(svName, instanceProfileParams());
+
+        Map<String, String> update = new HashMap<>();
+        update.put(AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE, "true");
+        alter(svm, svName, update);
+
+        Map<String, String> params = reloadParams(svm, svName);
+        Assertions.assertEquals("true", params.get(AWS_S3_USE_INSTANCE_PROFILE));
+        // The readback synthesizes "false" from the instance-profile branch, overwriting the
+        // value that was just set.
+        Assertions.assertEquals("false", params.get(AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE));
+    }
+
+    @Test
+    public void testAlterSwitchesFromWebIdentityToAccessKeyWhenDisabled()
+            throws AlreadyExistsException, DdlException, MetaNotFoundException {
+        String svName = "sv_wi_to_ak_ok";
+        StorageVolumeMgr svm = createVolume(svName, webIdentityParams(null, null));
+
+        Map<String, String> update = new HashMap<>();
+        update.put(AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE, "false");
+        update.put(AWS_S3_ACCESS_KEY, "ak");
+        update.put(AWS_S3_SECRET_KEY, "sk");
+        alter(svm, svName, update);
+
+        Map<String, String> params = reloadParams(svm, svName);
+        Assertions.assertEquals("false", params.get(AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE));
+        Assertions.assertEquals("ak", params.get(AWS_S3_ACCESS_KEY));
+        Assertions.assertEquals("sk", params.get(AWS_S3_SECRET_KEY));
+    }
+
+    @Test
+    public void testAlterSwitchesFromInstanceProfileToWebIdentityWhenDisabled()
+            throws AlreadyExistsException, DdlException, MetaNotFoundException {
+        String svName = "sv_ip_to_wi_ok";
+        StorageVolumeMgr svm = createVolume(svName, instanceProfileParams());
+
+        Map<String, String> update = new HashMap<>();
+        update.put(AWS_S3_USE_INSTANCE_PROFILE, "false");
+        update.put(AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE, "true");
+        update.put(AWS_S3_IAM_ROLE_ARN, "arn:aws:iam::333:role/hop");
+        alter(svm, svName, update);
+
+        Map<String, String> params = reloadParams(svm, svName);
+        Assertions.assertEquals("false", params.get(AWS_S3_USE_INSTANCE_PROFILE));
+        Assertions.assertEquals("true", params.get(AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE));
+        Assertions.assertEquals("arn:aws:iam::333:role/hop", params.get(AWS_S3_IAM_ROLE_ARN));
+    }
+
+    /**
+     * Web Identity outranks Access Key and Secret Key, so enabling it is enough to switch.
+     */
+    @Test
+    public void testAlterSwitchesFromAccessKeyToWebIdentityWithSingleProperty()
+            throws AlreadyExistsException, DdlException, MetaNotFoundException {
+        String svName = "sv_ak_to_wi";
+        StorageVolumeMgr svm = createVolume(svName, accessKeyParams());
+
+        Map<String, String> update = new HashMap<>();
+        update.put(AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE, "true");
+        alter(svm, svName, update);
+
+        Map<String, String> params = reloadParams(svm, svName);
+        Assertions.assertEquals("true", params.get(AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE));
+        Assertions.assertFalse(params.containsKey(AWS_S3_ACCESS_KEY));
+    }
+
+    /**
+     * iam_role_arn is not a use_* property, so it survives the merge and is applied to the
+     * method the volume switches to.
+     */
+    @Test
+    public void testAlterCarriesRoleArnOverToTheNewMethod()
+            throws AlreadyExistsException, DdlException, MetaNotFoundException {
+        String svName = "sv_wi_role_residue";
+        StorageVolumeMgr svm = createVolume(svName, webIdentityParams("arn:aws:iam::444:role/leftover", "leftover-ext"));
+
+        Map<String, String> update = new HashMap<>();
+        update.put(AWS_S3_USE_INSTANCE_PROFILE, "true");
+        update.put(AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE, "false");
+        alter(svm, svName, update);
+
+        Map<String, String> params = reloadParams(svm, svName);
+        Assertions.assertEquals("true", params.get(AWS_S3_USE_INSTANCE_PROFILE));
+        Assertions.assertEquals("false", params.get(AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE));
+        // The leftover role became the role that Instance Profile assumes.
+        Assertions.assertEquals("arn:aws:iam::444:role/leftover", params.get(AWS_S3_IAM_ROLE_ARN));
+        Assertions.assertEquals("leftover-ext", params.get(AWS_S3_EXTERNAL_ID));
+    }
+
+    @Test
+    public void testAlterClearingRoleArnAvoidsCarryOver()
+            throws AlreadyExistsException, DdlException, MetaNotFoundException {
+        String svName = "sv_wi_role_cleared";
+        StorageVolumeMgr svm = createVolume(svName, webIdentityParams("arn:aws:iam::444:role/leftover", "leftover-ext"));
+
+        Map<String, String> update = new HashMap<>();
+        update.put(AWS_S3_USE_INSTANCE_PROFILE, "true");
+        update.put(AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE, "false");
+        update.put(AWS_S3_IAM_ROLE_ARN, "");
+        update.put(AWS_S3_EXTERNAL_ID, "");
+        alter(svm, svName, update);
+
+        Map<String, String> params = reloadParams(svm, svName);
+        Assertions.assertEquals("true", params.get(AWS_S3_USE_INSTANCE_PROFILE));
+        // Instance profile without a role is stored as a profile credential, which carries no
+        // role fields at all.
+        Assertions.assertFalse(params.containsKey(AWS_S3_IAM_ROLE_ARN));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/storagevolume/StorageVolumeTest.java
@@ -63,6 +63,7 @@ import static com.starrocks.connector.share.credential.CloudConfigurationConstan
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_SECRET_KEY;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_USE_INSTANCE_PROFILE;
+import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_ENDPOINT;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_SAS_TOKEN;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AZURE_ADLS2_SHARED_KEY;
@@ -192,6 +193,32 @@ public class StorageVolumeTest {
                 .getRegion());
         Assertions.assertEquals("endpoint", ((AwsCloudConfiguration) cloudConfiguration).getAwsCloudCredential()
                 .getEndpoint());
+    }
+
+    @Test
+    public void testAWSWebIdentityCredentialRoundTrip() throws DdlException {
+        Map<String, String> storageParams = new HashMap<>();
+        storageParams.put(AWS_S3_REGION, "region");
+        storageParams.put(AWS_S3_ENDPOINT, "endpoint");
+        storageParams.put(AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE, "true");
+        storageParams.put(AWS_S3_IAM_ROLE_ARN, "iam_role_arn");
+        storageParams.put(AWS_S3_EXTERNAL_ID, "external_id");
+
+        StorageVolume storageVolume = new StorageVolume("1", "test", "s3", Arrays.asList("s3://abc"),
+                storageParams, true, "");
+        FileStoreInfo fileStoreInfo = storageVolume.toFileStoreInfo();
+        Assertions.assertTrue(fileStoreInfo.getS3FsInfo().getCredential().hasWebIdentityCredential());
+        Assertions.assertEquals("iam_role_arn", fileStoreInfo.getS3FsInfo().getCredential()
+                .getWebIdentityCredential().getIamRoleArn());
+        Assertions.assertEquals("external_id", fileStoreInfo.getS3FsInfo().getCredential()
+                .getWebIdentityCredential().getExternalId());
+
+        Map<String, String> restoredParams = StorageVolume.getParamsFromFileStoreInfo(fileStoreInfo);
+        Assertions.assertEquals("true", restoredParams.get(AWS_S3_USE_WEB_IDENTITY_TOKEN_FILE));
+        Assertions.assertEquals("false", restoredParams.get(AWS_S3_USE_INSTANCE_PROFILE));
+        Assertions.assertEquals("false", restoredParams.get(AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR));
+        Assertions.assertEquals("iam_role_arn", restoredParams.get(AWS_S3_IAM_ROLE_ARN));
+        Assertions.assertEquals("external_id", restoredParams.get(AWS_S3_EXTERNAL_ID));
     }
 
     @Test


### PR DESCRIPTION
Serialize aws.s3.use_web_identity_token_file into the StarOS AwsWebIdentityCredentialInfo message instead of collapsing it into a default or assume-role credential. A storage volume created with a web identity token file now round-trips its IAM role ARN and external ID through FileStoreInfo, and the second AssumeRole hop is no longer lost.

Add unit coverage for the round trip plus a shared-data end-to-end test that creates the volume through SQL, and document the supported FE/storage-volume AWS credential combinations in en, zh, and ja.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5