### PR TITLE
[Enhancement] Upgrade StarOS to v4.1.2

### DIFF
--- a/docker/dockerfiles/dev-env/dev-env.Dockerfile
+++ b/docker/dockerfiles/dev-env/dev-env.Dockerfile
@@ -22,7 +22,7 @@ ARG predownload_thirdparty=false
 ARG thirdparty_url=https://cdn-thirdparty.starrocks.com/starrocks-thirdparty-main-20250731.tar
 ARG commit_id
 # check thirdparty/starlet-artifacts-version.sh, to get the right tag
-ARG starlet_tag=v4.1.1
+ARG starlet_tag=v4.1.2
 # build for which linux distro: centos7|ubuntu
 ARG distro=ubuntu
 # Token to access artifacts in private github repositories.

--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -78,7 +78,7 @@ subprojects {
         set("protobuf-java.version", "3.25.5")
         set("puppycrawl.version", "10.21.1")
         set("spark.version", "3.5.7")
-        set("staros.version", "4.1.1")
+        set("staros.version", "4.1.2")
         set("thrift.version", "0.24.0")
         set("tomcat.version", "8.5.70")
         set("lz4-java.version", "1.10.1")

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -81,7 +81,7 @@ under the License.
         <paimon.version>1.3.1</paimon.version>
         <delta-kernel.version>4.0.0rc1</delta-kernel.version>
         <iceberg.version>1.10.0</iceberg.version>
-        <staros.version>4.1.1</staros.version>
+        <staros.version>4.1.2</staros.version>
         <!-- hadoop-azure requires no more than jetty10+ -->
         <!-- https://stackoverflow.com/questions/66713254/spark-wasb-and-jetty-11 -->
         <jetty.version>9.4.58.v20250814</jetty.version>

--- a/thirdparty/starlet-artifacts-version.sh
+++ b/thirdparty/starlet-artifacts-version.sh
@@ -9,4 +9,4 @@
 #   https://hub.docker.com/r/starrocks/starlet-artifacts-centos7/tags
 #
 # Update the following tag when STARLET releases a new version.
-export STARLET_ARTIFACTS_TAG=v4.1.1
+export STARLET_ARTIFACTS_TAG=v4.1.2


### PR DESCRIPTION
Changelog of StarOS v4.1.1..v4.1.2:

Enhancements
- Add WEB_IDENTITY as a first class AWS credential type, so an EKS IRSA / projected service account token storage volume keeps its identity across persist + reload instead of collapsing onto the default chain; an optional iam_role_arn allows a second assume-role hop.
- Add ClearPlacementPreference to release a shard's creation-time placement pin.
- Make the object-store single-part/multipart upload thresholds and part sizes configurable via gflags for S3, GCS and Azure. Defaults are unchanged.
- Pool the gRPC Channel + Stub per StarMgrClient instead of rebuilding them per call, with a channel-reset fallback after N consecutive transport failures so a wedged channel recovers.

Performance
- Read the S3 response body directly into the caller buffer via SetResponseStreamFactory.

BugFix
- Keep the in-flight prefetch when seeking to the current position. AsyncBufferInputStream discarded a fully drained buffer's prefetch on every cachefs block boundary.

CVE / dependencies
- Upgrade gRPC Java to 1.76.0 for CVE-2025-55163, avoid the 1.75.0 shaded Netty transport corruption
- Align java dependency versions with StarRocks fe/pom.xml: protobuf-java 3.16.1 -> 3.25.5 (CVE-2024-7254), jackson managed centrally at 2.21.4, test-scoped commons-io 2.11.0 -> 2.16.1 (CVE-2024-47554).

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
