### PR TITLE
[BugFix] Keep columns read by OR-resident predicates after inverted index filtering

### DIFF
--- a/be/src/storage/column_predicate_inverted_index_fallback.cpp
+++ b/be/src/storage/column_predicate_inverted_index_fallback.cpp
@@ -14,9 +14,22 @@
 
 #include "storage/column_predicate_inverted_index_fallback.h"
 
+#include <algorithm>
+
 #include "storage_primitive/column_expr_predicate.h"
+#include "storage_primitive/predicate_tree/predicate_tree.h"
 
 namespace starrocks {
+
+bool remaining_predicates_require_column(const PredicateTree& tree, ColumnId cid) {
+    const auto& predicates = tree.get_all_column_predicate_map();
+    const auto it = predicates.find(cid);
+    if (it == predicates.end()) {
+        return false;
+    }
+    return std::any_of(it->second.begin(), it->second.end(),
+                       [](const ColumnPredicate* pred) { return pred->type() != PredicateType::kGinFallback; });
+}
 
 InvertedIndexFallbackPredicate::InvertedIndexFallbackPredicate(const ColumnExprPredicate* wrapped_predicate,
                                                                roaring::Roaring bitmap,

--- a/be/src/storage/column_predicate_inverted_index_fallback.h
+++ b/be/src/storage/column_predicate_inverted_index_fallback.h
@@ -24,6 +24,7 @@
 namespace starrocks {
 
 class ColumnExprPredicate;
+class PredicateTree;
 
 // Wrapper for ColumnExprPredicate that adds segment-specific inverted index bitmap state.
 // Used for fallback evaluation of MATCH predicates in OR queries when multiple segments
@@ -74,5 +75,9 @@ private:
     const std::vector<rowid_t>* _rowid_buffer;     // Pointer to SegmentIterator's rowid buffer
     mutable std::vector<uint8_t> _tmp_select;      // Reusable buffer for evaluate_and/evaluate_or
 };
+
+// Returns whether any remaining predicate for cid needs physical column data.
+// A GIN fallback predicate evaluates a pre-loaded rowid bitmap and does not read the column.
+bool remaining_predicates_require_column(const PredicateTree& tree, ColumnId cid);
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -4670,10 +4670,9 @@ Status SegmentIterator::_apply_inverted_index() {
     // ---------------------------------------------------------
     if (!erased_preds.empty()) {
         erase_column_pred_from_pred_tree(_opts.pred_tree, erased_preds);
-        const auto& new_cid_to_predicates = _opts.pred_tree.get_immediate_column_predicate_map();
 
         for (const auto& cid : erased_pred_col_ids) {
-            if (!new_cid_to_predicates.contains(cid)) {
+            if (!remaining_predicates_require_column(_opts.pred_tree, cid)) {
                 // predicate for pred->column_id() has been total erased by
                 // inverted index filtering.These columns may can be pruned.
                 _inverted_index_ctx->prune_cols_candidate_by_inverted_index.insert(cid);

--- a/be/test/storage/column_predicate_inverted_index_fallback_test.cpp
+++ b/be/test/storage/column_predicate_inverted_index_fallback_test.cpp
@@ -361,4 +361,45 @@ TEST(ChooseInvertedIndexQueryTypeTest, all_branches) {
     EXPECT_EQ(QT::EQUAL_QUERY, choose_inverted_index_query_type(true, false, IGN, "foobar").value());
 }
 
+namespace {
+
+PredicateTree make_or_tree(const std::vector<const ColumnPredicate*>& predicates) {
+    PredicateOrNode disjunction;
+    for (const auto* pred : predicates) {
+        disjunction.add_child(PredicateColumnNode(pred));
+    }
+    PredicateAndNode root;
+    root.add_child(std::move(disjunction));
+    return PredicateTree::create(std::move(root));
+}
+
+} // namespace
+
+// A column with no surviving predicate is prunable.
+TEST(RemainingPredicatesRequireColumnTest, column_absent) {
+    PredicateTree tree;
+    EXPECT_FALSE(remaining_predicates_require_column(tree, /*cid=*/7));
+}
+
+// An OR-resident predicate is invisible to the immediate map but still reads the column per row.
+TEST(RemainingPredicatesRequireColumnTest, ordinary_predicate_inside_or) {
+    std::unique_ptr<ColumnPredicate> ordinary(new_column_eq_predicate(get_type_info(TYPE_INT), /*cid=*/7, "1"));
+    std::unique_ptr<ColumnPredicate> sibling(new_column_eq_predicate(get_type_info(TYPE_INT), /*cid=*/8, "2"));
+    auto tree = make_or_tree({ordinary.get(), sibling.get()});
+
+    EXPECT_TRUE(remaining_predicates_require_column(tree, /*cid=*/7));
+}
+
+// A fallback predicate selects rows from its pre-loaded bitmap, so it alone does not keep the column.
+TEST_F(InvertedIndexFallbackPredicateTest, fallback_only_inside_or) {
+    std::unique_ptr<ColumnExprPredicate> wrapped(make_wrapped(/*cid=*/7));
+    roaring::Roaring bitmap;
+    std::vector<rowid_t> rowids;
+    InvertedIndexFallbackPredicate fallback(wrapped.get(), std::move(bitmap), &rowids);
+    std::unique_ptr<ColumnPredicate> sibling(new_column_eq_predicate(get_type_info(TYPE_INT), /*cid=*/8, "2"));
+    auto tree = make_or_tree({&fallback, sibling.get()});
+
+    EXPECT_FALSE(remaining_predicates_require_column(tree, /*cid=*/7));
+}
+
 } // namespace starrocks

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -2144,3 +2144,56 @@ SELECT id1 FROM t_gin_like_underscore WHERE text_column LIKE "abc" ORDER BY id1;
 DROP TABLE t_gin_like_underscore;
 -- result:
 -- !result
+-- name: test_gin_or_prune_after_index_filter @native
+ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
+-- result:
+-- !result
+CREATE TABLE `t_gin_or_prune_${uuid0}` (
+  `id` bigint NOT NULL,
+  `k`  bigint NOT NULL,
+  `v`  varchar(255) NOT NULL,
+  INDEX gin_v (`v`) USING GIN ("parser" = "none")
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1
+PROPERTIES ("replication_num" = "1", "replicated_storage" = "false");
+-- result:
+-- !result
+insert into t_gin_or_prune_${uuid0} values (1, 0, "redx"), (2, 1, "redy"), (3, 1, "blue"), (4, 0, "redz");
+-- result:
+-- !result
+select id from t_gin_or_prune_${uuid0} where v like '%red%' and (v = 'redx' or k = 1) order by id;
+-- result:
+1
+2
+-- !result
+select id from t_gin_or_prune_${uuid0} where v match '%red%' and (v = 'redx' or k = 1) order by id;
+-- result:
+1
+2
+-- !result
+set enable_prune_column_after_index_filter = false;
+-- result:
+-- !result
+select id from t_gin_or_prune_${uuid0} where v like '%red%' and (v = 'redx' or k = 1) order by id;
+-- result:
+1
+2
+-- !result
+set enable_prune_column_after_index_filter = true;
+-- result:
+-- !result
+select id, v from t_gin_or_prune_${uuid0} where v like '%red%' and (v = 'redx' or k = 1) order by id;
+-- result:
+1	redx
+2	redy
+-- !result
+select id from t_gin_or_prune_${uuid0} where v like '%red%' order by id;
+-- result:
+1
+2
+4
+-- !result
+DROP TABLE t_gin_or_prune_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_inverted_index/T/test_inverted_index
+++ b/test/sql/test_inverted_index/T/test_inverted_index
@@ -1111,3 +1111,32 @@ SELECT id1 FROM t_gin_like_underscore WHERE text_column LIKE "ab%" ORDER BY id1;
 SELECT id1 FROM t_gin_like_underscore WHERE text_column LIKE "abc" ORDER BY id1;
 
 DROP TABLE t_gin_like_underscore;
+
+-- name: test_gin_or_prune_after_index_filter @native
+ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
+CREATE TABLE `t_gin_or_prune_${uuid0}` (
+  `id` bigint NOT NULL,
+  `k`  bigint NOT NULL,
+  `v`  varchar(255) NOT NULL,
+  INDEX gin_v (`v`) USING GIN ("parser" = "none")
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1
+PROPERTIES ("replication_num" = "1", "replicated_storage" = "false");
+
+insert into t_gin_or_prune_${uuid0} values (1, 0, "redx"), (2, 1, "redy"), (3, 1, "blue"), (4, 0, "redz");
+
+-- row 4 satisfies the indexed LIKE but neither OR branch, so pruning v must not drop the OR predicate
+select id from t_gin_or_prune_${uuid0} where v like '%red%' and (v = 'redx' or k = 1) order by id;
+select id from t_gin_or_prune_${uuid0} where v match '%red%' and (v = 'redx' or k = 1) order by id;
+
+set enable_prune_column_after_index_filter = false;
+select id from t_gin_or_prune_${uuid0} where v like '%red%' and (v = 'redx' or k = 1) order by id;
+set enable_prune_column_after_index_filter = true;
+
+select id, v from t_gin_or_prune_${uuid0} where v like '%red%' and (v = 'redx' or k = 1) order by id;
+
+-- no predicate survives the index, so v stays prunable
+select id from t_gin_or_prune_${uuid0} where v like '%red%' order by id;
+
+DROP TABLE t_gin_or_prune_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

When a GIN inverted index answers a predicate, the segment iterator may prune that predicate's
column from the read set. It decides that with `PredicateTree::get_immediate_column_predicate_map()`,
which only exposes the direct children of the root AND — a predicate sitting inside an OR subtree is
invisible to it. Such a column is then wrongly pruned: it is never read, while the surviving
OR-resident predicate is still evaluated per row, so the query silently returns a wrong result set,
with no error and no log.

Repro (`enable_gin_filter` and `enable_prune_column_after_index_filter` are both on by default; the
GIN feature itself is behind `enable_experimental_gin`):

```sql
ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");

CREATE TABLE `t_gin_or_prune` (
  `id` bigint NOT NULL,
  `k`  bigint NOT NULL,
  `v`  varchar(255) NOT NULL,
  INDEX gin_v (`v`) USING GIN ("parser" = "none")
) ENGINE=OLAP
DUPLICATE KEY(`id`)
DISTRIBUTED BY HASH(`id`) BUCKETS 1
PROPERTIES ("replication_num" = "1", "replicated_storage" = "false");

insert into t_gin_or_prune values (1, 0, "redx"), (2, 1, "redy"), (3, 1, "blue"), (4, 0, "redz");

select id from t_gin_or_prune where v like '%red%' and (v = 'redx' or k = 1) order by id;
```

Expected `1, 2`; actual `1, 2, 4` — row 4 (`redz`, `k = 0`) satisfies the indexed LIKE but neither OR
branch. The same happens with `v match '%red%'`. Turning off
`enable_prune_column_after_index_filter`, or adding `v` to the projection, restores the correct
result, which pins the wrong result on the column pruning.

## What I'm doing:

Decide prunability on the whole predicate tree instead of the immediate map. The decision now lives in
`remaining_predicates_require_column()` next to the fallback predicate it reasons about: it looks the
column up in `get_all_column_predicate_map()`, which unions the immediate map with the non-immediate
one collected by walking `compound_children`, so an OR-resident predicate keeps its column alive. The
erase helper rebuilds the tree via `PredicateTree::create()`, so no stale cached map can leak in.

Predicates of type `kGinFallback` are excluded from that check: an `InvertedIndexFallbackPredicate`
ignores the column argument and selects rows from a pre-loaded bitmap by rowid, so it alone does not
keep the column alive — a column referenced only by a fallback predicate stays prunable.
`kPlaceHolder` is deliberately *not* excluded — it exists precisely to keep runtime-filter columns in
the first read phase.

Fixes #77566

## Testing

Three BE unit tests in `be/test/storage/column_predicate_inverted_index_fallback_test.cpp` cover the
three paths of the new function: a column absent from the tree, an ordinary predicate inside an OR
subtree (column kept), and a fallback predicate alone inside an OR subtree (column still prunable).

SQL regression case `test_gin_or_prune_after_index_filter` in `test/sql/test_inverted_index` covers
the end-to-end behavior: the repro query, its `match` variant, a control with
`enable_prune_column_after_index_filter = false`, a control with the column projected, and a pure-AND
control verifying that result semantics remain unchanged when no predicate survives the index. Both
repro queries return `1, 2, 4` on the unpatched binary and `1, 2` after the fix, on a rebuilt BE. The
fallback-only shape (`v like '%red%' and (v match 'redx' or k = 1)`) was also run by hand and returns
the correct `1, 2`.

## Backport

**The version checkboxes below are intentionally left empty.** `PredicateType::kGinFallback` and the
OR-MATCH fallback predicate do not exist on branch-4.1 / 4.0 / 3.5, so an automatic cherry-pick would
apply cleanly and then fail to compile. Those branches need a different, smaller form of the same fix
— the whole-tree check is already available there as `PredicateTree::contains_column(cid)`, with no
predicate-type exclusion needed. I will open the three backport PRs by hand.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
