### PR TITLE
[BugFix] Stop reading past the end of the output schema in _switch_context

### DIFF
--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -25,6 +25,7 @@
 #include <unordered_set>
 #include <utility>
 
+#include "base/failpoint/fail_point.h"
 #include "base/format.h"
 #include "base/simd/simd.h"
 #include "base/utility/defer_op.h"
@@ -2007,6 +2008,12 @@ Status SegmentIterator::_init_column_iterator_by_cid(const ColumnId cid, const C
     return Status::OK();
 }
 
+// Fakes the "a global dictionary exists for the column, but this segment has no usable local
+// dictionary" state, which is otherwise reachable only through a real dictionary inconsistency
+// (a rewritten/compacted segment whose pages are not all dict-encoded). That state is what puts
+// `_switch_context` on its force-encode path.
+DEFINE_FAIL_POINT(segment_iterator_force_global_dict_encode);
+
 template <bool check_global_dict>
 Status SegmentIterator::_init_column_iterators(const Schema& schema) {
     SCOPED_RAW_TIMER(&_opts.stats->column_iterator_init_ns);
@@ -2040,9 +2047,12 @@ Status SegmentIterator::_init_column_iterators(const Schema& schema) {
                 RETURN_IF_ERROR(_init_column_iterator_by_cid(cid, f->uid(), check_dict_enc));
             }
 
+            bool all_page_dict_encoded = _column_iterators[cid]->all_page_dict_encoded();
+            FAIL_POINT_TRIGGER_EXECUTE(segment_iterator_force_global_dict_encode, { all_page_dict_encoded = false; });
+
             if constexpr (check_global_dict) {
                 _column_decoders[cid].set_iterator(_column_iterators[cid].get());
-                _column_decoders[cid].set_all_page_dict_encoded(_column_iterators[cid]->all_page_dict_encoded());
+                _column_decoders[cid].set_all_page_dict_encoded(all_page_dict_encoded);
                 if (_opts.global_dictmaps->count(cid)) {
                     _column_decoders[cid].set_global_dict(_opts.global_dictmaps->find(cid)->second);
                     _column_decoders[cid].check_global_dict();
@@ -2050,7 +2060,7 @@ Status SegmentIterator::_init_column_iterators(const Schema& schema) {
             }
 
             // turn off low cardinality if not all data pages are dict-encoded.
-            _predicate_need_rewrite[cid] &= _column_iterators[cid]->all_page_dict_encoded();
+            _predicate_need_rewrite[cid] &= all_page_dict_encoded;
         }
     }
     VLOG(2) << fmt::format("init_column_iterators schema={}", schema.to_string());
@@ -3493,13 +3503,20 @@ Status SegmentIterator::_switch_context(ScanContext* to) {
         // Rebuilding final_chunk schema. filter_unused_columns will prune out useless columns in encode_schema
         Schema final_chunk_schema;
         DCHECK_GE(_encoded_schema.num_fields(), output_schema().num_fields());
+        // `output_schema()` is a subsequence of `_encoded_schema`, so the cursor into it must stop as
+        // soon as the last output field has been matched: any encoded field left over is a column
+        // pruned by filter_unused_columns, and continuing would index the output schema one past its
+        // end. `Schema::field()` only DCHECKs the index, so a RELEASE binary would dereference the
+        // out-of-bounds slot -- a null one faults at address 0.
+        const size_t num_output_fields = output_schema().num_fields();
         size_t output_schema_idx = 0;
-        for (size_t i = 0; i < _encoded_schema.num_fields(); ++i) {
+        for (size_t i = 0; i < _encoded_schema.num_fields() && output_schema_idx < num_output_fields; ++i) {
             if (_encoded_schema.field(i)->id() == output_schema().field(output_schema_idx)->id()) {
                 final_chunk_schema.append(_encoded_schema.field(i));
                 output_schema_idx++;
             }
         }
+        DCHECK_EQ(num_output_fields, final_chunk_schema.num_fields());
         ASSIGN_OR_RETURN(to->_final_chunk,
                          RuntimeChunkHelper::new_chunk_checked(final_chunk_schema, _reserve_chunk_size));
     } else {

--- a/be/test/storage/rowset/segment_iterator_test.cpp
+++ b/be/test/storage/rowset/segment_iterator_test.cpp
@@ -371,6 +371,145 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNoLocalDictWithUnusedColumn) {
     res_chunk->reset();
 }
 
+// Regression test for an out-of-bounds read in `SegmentIterator::_switch_context`.
+//
+// Shape of the crash seen in production (4.0.12, SIGSEGV @0x0 with the PC in
+// `_switch_context`): a string column carries a global dictionary that cannot be
+// mapped onto the segment's local dictionary (the pages are not all dict-encoded),
+// so `_has_force_dict_encode` is set and the final-chunk schema is rebuilt from
+// `_encoded_schema`. That rebuild walks every field of `_encoded_schema` while
+// indexing `output_schema()` with a cursor that is never bounds-checked. As soon as
+// the LAST output field has been matched, every remaining encoded field reads
+// `output_schema().field(num_output_fields)` -- one past the end of the output
+// schema's field vector. `Schema::field()` only DCHECKs the index, so a RELEASE
+// binary dereferences whatever the read returns; a zeroed slot yields a null
+// FieldPtr and `->id()` faults at address 0.
+//
+// The trailing column here (`c2`) is predicate-only, i.e. exactly what
+// filter_unused_columns prunes from the output on a query like
+// `SELECT c0, c1 FROM t WHERE c2 >= '...'`.
+TEST_F(SegmentIteratorTest, TestForceGlobalDictEncodeWithTrailingUnusedColumn) {
+    // Two values big enough to overflow the dict page builder, so the column ends up
+    // with no usable local dictionary while a global dictionary still exists for it.
+    const int slice_num = 2;
+    const int overflow_sz = 1024 * 1024 + 10; // 1M
+    std::vector<std::string> values;
+    for (int i = 0; i < slice_num; ++i) {
+        std::string bigstr;
+        bigstr.reserve(overflow_sz);
+        for (int j = 0; j < overflow_sz; ++j) {
+            bigstr.push_back(j);
+        }
+        bigstr.push_back(i);
+        values.emplace_back(std::move(bigstr));
+    }
+    std::sort(values.begin(), values.end());
+
+    std::vector<Slice> data_strs;
+    for (const auto& data : values) {
+        data_strs.emplace_back(data);
+    }
+
+    using namespace starrocks::test;
+
+    std::string file_name = kSegmentDir + "/force_encode_trailing_unused_column";
+    ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+    TabletSchemaBuilder builder;
+    std::shared_ptr<TabletSchema> tablet_schema = builder.create(1, false, TYPE_INT, true)
+                                                          .create(2, false, TYPE_VARCHAR)
+                                                          .create(3, false, TYPE_VARCHAR)
+                                                          .set_length(overflow_sz + 10)
+                                                          .build();
+
+    SegmentWriterOptions opts;
+    opts.num_rows_per_block = 1024;
+    SegmentWriter writer(std::move(wfile), 0, tablet_schema, opts);
+
+    const int32_t chunk_size = config::vector_chunk_size;
+    const size_t num_rows = slice_num;
+
+    std::vector<std::string> small_values{"aaa", "bbb"};
+    auto i32_provider = [](int32_t i) { return i; };
+    auto small_slice_provider = [&small_values](int32_t i) { return Slice(small_values[i % small_values.size()]); };
+    auto big_slice_provider = [&data_strs](int32_t i) { return data_strs[i % data_strs.size()]; };
+
+    TabletDataBuilder segment_data_builder(writer, tablet_schema, chunk_size, num_rows);
+    ASSERT_OK(segment_data_builder.append(0, i32_provider));
+    ASSERT_OK(segment_data_builder.append(1, small_slice_provider));
+    ASSERT_OK(segment_data_builder.append(2, big_slice_provider));
+    ASSERT_OK(segment_data_builder.finalize_footer());
+
+    auto segment = *Segment::open(_fs, FileInfo{file_name}, 0, tablet_schema);
+    ASSERT_EQ(segment->num_rows(), num_rows);
+
+    OlapReaderStatistics stats;
+
+    // The trailing column must have no local dictionary, otherwise the global dict is
+    // applied directly and `_has_force_dict_encode` stays false.
+    ColumnIteratorOptions iter_opts;
+    ASSIGN_OR_ABORT(auto read_file, _fs->new_random_access_file(segment->file_name()));
+    iter_opts.stats = &stats;
+    iter_opts.use_page_cache = false;
+    iter_opts.read_file = read_file.get();
+    iter_opts.check_dict_encoding = true;
+    iter_opts.reader_type = READER_QUERY;
+    ASSIGN_OR_ABORT(auto scalar_iter, segment->new_column_iterator(tablet_schema->column(2), nullptr));
+    ASSERT_OK(scalar_iter->init(iter_opts));
+    ASSERT_FALSE(scalar_iter->all_page_dict_encoded());
+
+    VecSchemaBuilder schema_builder;
+    schema_builder.add(0, "c0", TYPE_INT).add(1, "c1", TYPE_VARCHAR).add(2, "c2", TYPE_VARCHAR);
+    auto vec_schema = schema_builder.build();
+
+    SegmentReadOptions seg_opts;
+    seg_opts.fs = _fs;
+    seg_opts.stats = &stats;
+    seg_opts.tablet_schema = tablet_schema;
+
+    ColumnIdToGlobalDictMap dict_map;
+    GlobalDictMap g_dict;
+    for (int i = 0; i < slice_num; ++i) {
+        g_dict[Slice(values[i])] = i;
+    }
+    dict_map[2] = &g_dict;
+    seg_opts.global_dictmaps = &dict_map;
+
+    // Every scanned column carries a pushed-down predicate. That keeps `new_segment_iterator()` on
+    // the branch that hands the schema to the iterator AS IS -- with fewer predicate columns than
+    // fields it would instead `reorder_schema()` the predicate columns to the front and wrap the
+    // iterator in a projection, which moves the unused column away from the tail and hides the bug.
+    std::unique_ptr<ColumnPredicate> pred_c0(new_column_ge_predicate(get_type_info(TYPE_INT), 0, "0"));
+    std::unique_ptr<ColumnPredicate> pred_c1(new_column_ge_predicate(get_type_info(TYPE_VARCHAR), 1, "a"));
+    std::unique_ptr<ColumnPredicate> pred_c2(
+            new_column_ge_predicate(get_type_info(TYPE_VARCHAR), 2, values[0].c_str()));
+    PredicateAndNode pred_root;
+    pred_root.add_child(PredicateColumnNode{pred_c0.get()});
+    pred_root.add_child(PredicateColumnNode{pred_c1.get()});
+    pred_root.add_child(PredicateColumnNode{pred_c2.get()});
+    seg_opts.pred_tree = PredicateTree::create(std::move(pred_root));
+
+    auto chunk_iter = new_segment_iterator(segment, vec_schema, seg_opts);
+    ASSERT_OK(chunk_iter->init_encoded_schema(dict_map));
+    // c2 is used by the pushed-down predicate only -- pruned from the output, and it is
+    // the last field of the schema.
+    std::unordered_set<uint32_t> unused_output_column_ids{2};
+    ASSERT_OK(chunk_iter->init_output_schema(unused_output_column_ids));
+    ASSERT_EQ(2, chunk_iter->output_schema().num_fields());
+
+    auto res_chunk = ChunkFactory::new_chunk(chunk_iter->output_schema(), chunk_size);
+    ASSERT_OK(chunk_iter->get_next(res_chunk.get()));
+
+    ASSERT_EQ(2, res_chunk->num_columns());
+    ASSERT_EQ(num_rows, res_chunk->num_rows());
+    const auto& c0 = res_chunk->get_column_by_index(0);
+    const auto& c1 = res_chunk->get_column_by_index(1);
+    for (size_t i = 0; i < num_rows; ++i) {
+        EXPECT_EQ(static_cast<int32_t>(i), c0->get(i).get_int32());
+        EXPECT_EQ(small_values[i % small_values.size()], c1->get(i).get_slice().to_string());
+    }
+    res_chunk->reset();
+}
+
 // Verify predicate late materialization keeps non-predicate columns correct.
 TEST_F(SegmentIteratorTest, TestPredicateLateMaterializationMaterializesRestColumns) {
     using namespace starrocks::test;

--- a/test/sql/test_low_cardinality/R/test_low_cardinality_force_encode_unused_column
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality_force_encode_unused_column
@@ -1,0 +1,58 @@
+-- name: test_low_cardinality_force_encode_unused_column
+set cbo_enable_low_cardinality_optimize = true;
+-- result:
+-- !result
+set enable_filter_unused_columns_in_scan_stage = true;
+-- result:
+-- !result
+CREATE TABLE `t_force_encode` (
+  `k` int NOT NULL,
+  `c_str` varchar(64) NULL,
+  `c_out` int NULL,
+  `c_pred_only` int NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into t_force_encode
+select generate_series,
+       concat('v', generate_series % 3),
+       generate_series % 11,
+       generate_series % 13
+from TABLE(generate_series(0, 999));
+-- result:
+-- !result
+[UC] analyze full table t_force_encode;
+function: wait_global_dict_ready('c_str', 't_force_encode')
+-- result:
+
+-- !result
+admin enable failpoint 'segment_iterator_force_global_dict_encode';
+-- result:
+-- !result
+select count(*), count(distinct c_str), sum(c_out) from t_force_encode
+where c_str >= 'v' and c_out >= 0 and c_pred_only >= 0;
+-- result:
+1000	3	4995
+-- !result
+select count(*), count(distinct c_str), sum(c_out), sum(c_pred_only) from t_force_encode
+where c_str >= 'v' and c_out >= 0 and c_pred_only >= 0;
+-- result:
+1000	3	4995	5994
+-- !result
+admin disable failpoint 'segment_iterator_force_global_dict_encode';
+-- result:
+-- !result
+select count(*), count(distinct c_str), sum(c_out) from t_force_encode
+where c_str >= 'v' and c_out >= 0 and c_pred_only >= 0;
+-- result:
+1000	3	4995
+-- !result
+drop table t_force_encode force;
+-- result:
+-- !result
+CLEANUP {
+    admin disable failpoint 'segment_iterator_force_global_dict_encode';
+} END CLEANUP

--- a/test/sql/test_low_cardinality/T/test_low_cardinality_force_encode_unused_column
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality_force_encode_unused_column
@@ -1,0 +1,58 @@
+-- name: test_low_cardinality_force_encode_unused_column
+set cbo_enable_low_cardinality_optimize = true;
+set enable_filter_unused_columns_in_scan_stage = true;
+
+CREATE TABLE `t_force_encode` (
+  `k` int NOT NULL,
+  `c_str` varchar(64) NULL,
+  `c_out` int NULL,
+  `c_pred_only` int NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+insert into t_force_encode
+select generate_series,
+       concat('v', generate_series % 3),
+       generate_series % 11,
+       generate_series % 13
+from TABLE(generate_series(0, 999));
+
+[UC] analyze full table t_force_encode;
+
+function: wait_global_dict_ready('c_str', 't_force_encode')
+
+-- The failpoint fakes "a global dictionary exists for c_str, but this segment has no usable
+-- local dictionary", i.e. the dictionary inconsistency that puts SegmentIterator::_switch_context
+-- on its force-encode path (read -> decode -> materialize -> encode).
+--
+-- The query shape matters as much as the failpoint:
+--   * every scanned column (c_str, c_out, c_pred_only) carries a pushed-down predicate, so
+--     new_segment_iterator() hands the schema to the iterator AS IS -- with fewer predicate
+--     columns than fields it would reorder the predicate columns to the front instead, which
+--     moves the pruned column away from the tail and hides the bug;
+--   * c_pred_only is used by the predicate only, so filter_unused_columns prunes it from the
+--     output while it stays the LAST field of the read schema.
+-- Rebuilding the final-chunk schema then matched every output field before running out of
+-- encoded fields, and the unbounded cursor read one past the end of the output schema --
+-- a null FieldPtr in a RELEASE binary, i.e. SIGSEGV at address 0 inside _switch_context.
+admin enable failpoint 'segment_iterator_force_global_dict_encode';
+
+select count(*), count(distinct c_str), sum(c_out) from t_force_encode
+where c_str >= 'v' and c_out >= 0 and c_pred_only >= 0;
+
+-- Same query without the pruned trailing column: stays correct either way.
+select count(*), count(distinct c_str), sum(c_out), sum(c_pred_only) from t_force_encode
+where c_str >= 'v' and c_out >= 0 and c_pred_only >= 0;
+
+admin disable failpoint 'segment_iterator_force_global_dict_encode';
+
+select count(*), count(distinct c_str), sum(c_out) from t_force_encode
+where c_str >= 'v' and c_out >= 0 and c_pred_only >= 0;
+
+drop table t_force_encode force;
+
+CLEANUP {
+    admin disable failpoint 'segment_iterator_force_global_dict_encode';
+} END CLEANUP


### PR DESCRIPTION
## Why I'm doing:

When a segment has to force-encode a string column to global dictionary ids -- a global dictionary exists but the segment pages are not all dict-encoded -- `_switch_context` rebuilds the final chunk schema by walking `_encoded_schema` and matching each field against `output_schema()` through a cursor that is never bounds checked.

`output_schema()` is the encoded schema minus the columns pruned by filter_unused_columns, so once the last output field has been matched, every remaining encoded field evaluates `output_schema().field(num_output_fields)`, one past the end of the field vector. `Schema::field()` only DCHECKs the index, so a RELEASE binary dereferences whatever that slot holds: a zeroed one yields a null FieldPtr and `Field::id()` faults at address 0, which is the SIGSEGV seen in production with the PC in `_switch_context`.

Those leftover fields are reachable only while the schema keeps its original order, i.e. when `new_segment_iterator()` skips `reorder_schema()` because every scanned column carries a pushed-down predicate. With a reorder the predicate columns -- and therefore the pruned ones -- move to the front and the cursor happens to stay in range, which is why the existing coverage never tripped on this.

Stop the loop as soon as every output field has been matched.

The unit test drives `_switch_context` directly: without the fix it aborts on the `Schema::field()` DCHECK, and with that DCHECK removed (as in RELEASE) ASAN reports a heap-buffer-overflow read at the same line.

The SQL test pins the query shape that reaches it. A SQL test cannot create a dictionary inconsistency on demand, so the new failpoint `segment_iterator_force_global_dict_encode` fakes it by clearing the `all_page_dict_encoded` flag the column decoder is initialized with; it is a no-op unless the backend is built with ENABLE_FAULT_INJECTION=ON. On an ASAN backend that query kills the BE without the fix -- same stack as production -- and passes with it. On a RELEASE backend the read still goes out of bounds but only faults when the slot happens to be zeroed, which is why the assertion lives in the unit test.

```
  *** Aborted at 1786480984 (unix time) try "date -d @1786480984" if you are using GNU date ***                                                                                                                                       
  PC: @          0xd071c84 starrocks::SegmentIterator::_switch_context(starrocks::SegmentIterator::ScanContext*)                                                                                                                      
  *** SIGSEGV (@0x0) received by PID 939574 (TID 0xea3042b6fa80) LWP(940432) from PID 0; stack trace: ***                                                                                                                             
      @     0xea318876aaac (/usr/lib/aarch64-linux-gnu/libc.so.6+0x8aaab)                                                                                                                                                             
      @         0x10e5b878 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)                                                                                                                                
      @     0xea3189f2da60 ([vdso]+0xa5f)                                                                                                                                                                                             
      @          0xd071c84 starrocks::SegmentIterator::_switch_context(starrocks::SegmentIterator::ScanContext*)                                                                                                                      
      @          0xd07fab0 starrocks::SegmentIterator::_init_context()                                                                                                                                                                
      @          0xd080208 starrocks::SegmentIterator::_init_internal()                                                                                                                                                               
      @          0xd080e58 starrocks::SegmentIterator::_init()                                                                                                                                                                        
      @          0xd083928 starrocks::SegmentIterator::do_get_next(starrocks::Chunk*)                                                                                                                                                 
      @          0xd5746a4 starrocks::SegmentIteratorWrapper::do_get_next(starrocks::Chunk*)                                                                                                                                          
      @          0xd2d21f8 starrocks::TimedChunkIterator::do_get_next(starrocks::Chunk*)                                                                                                                                              
      @          0xd2ff95c starrocks::UnionIterator::do_get_next(starrocks::Chunk*)                                                                                                                                                   
      @          0xd2c2cd0 starrocks::TabletReader::do_get_next(starrocks::Chunk*)                                                                                                                                                    
      @          0xc3574d8 starrocks::pipeline::OlapChunkSource::_read_chunk_from_storage(starrocks::RuntimeState*, starrocks::Chunk*)                                                                                                
      @          0xc357f94 starrocks::pipeline::OlapChunkSource::_read_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)                                                                                            
      @          0xbf188c4 starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking(starrocks::RuntimeState*, unsigned long, starrocks::workgroup::WorkGroup const*)                                                       
      @          0xae9e380 auto starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}::operator()<starrocks::workgroup::YieldContext>(starrocks::workgroup::YieldContext&) const  
  [clone .constprop.0]                                                                                                                                                                                                                
      @          0xbe77874 starrocks::workgroup::ScanExecutor::worker_thread()                                                                                                                                                        
      @          0xda37d04 starrocks::ThreadPool::dispatch_thread()                                                                                                                                                                   
      @          0xda2e2c8 starrocks::Thread::supervise_thread(void*)                                                                                                                                                                 
      @     0xea318876582c (/usr/lib/aarch64-linux-gnu/libc.so.6+0x8582b)                                                                                                                                                             
      @     0xea31887cba0c (/usr/lib/aarch64-linux-gnu/libc.so.6+0xeba0b) 
```

## What I'm doing:

Fixes #72927

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
