### PR TITLE
[Enhancement] Say which distribution an incremental MV actually uses

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -1429,20 +1429,38 @@ public class MaterializedViewAnalyzer {
             int numBuckets = 0;
             if (distributionDesc != null) {
                 numBuckets = distributionDesc.getBuckets();
-                if (distributionDesc instanceof RandomDistributionDesc) {
-                    LOG.warn("Check distribution for primary key mv, ignore random distribution, " +
-                            "use hash distribution with key columns: {}",
-                            Joiner.on(",").join(keyColNames));
-                } else if (distributionDesc instanceof HashDistributionDesc) {
-                    HashDistributionDesc hashDistributionDesc = (HashDistributionDesc) distributionDesc;
-                    List<String> distColumns = hashDistributionDesc.getDistributionColumnNames();
-                    LOG.warn("Check distribution for primary key mv, ignore defined dist columns: {}, key columns: {}",
-                            Joiner.on(",").join(distColumns), Joiner.on(",").join(keyColNames));
+                String replaced = describeReplacedDistribution(distributionDesc, keyColNames);
+                if (replaced != null) {
+                    LOG.warn("Incremental materialized view {}: {} is ignored, the view is distributed by HASH({}) " +
+                                    "so that incremental refresh can locate rows by primary key. " +
+                                    "The bucket number is unchanged.",
+                            statement.getTblName(), replaced, Joiner.on(", ").join(keyColNames));
                 }
             }
             HashDistributionDesc result = new HashDistributionDesc(numBuckets, keyColNames);
             statement.setDistributionDesc(result);
             return result;
+        }
+
+        /**
+         * The distribution clause as written, rendered for a message, or null when the normalization
+         * above keeps it as written.
+         */
+        @VisibleForTesting
+        static String describeReplacedDistribution(DistributionDesc distributionDesc, List<String> keyColNames) {
+            if (distributionDesc instanceof RandomDistributionDesc) {
+                return "DISTRIBUTED BY RANDOM";
+            }
+            if (!(distributionDesc instanceof HashDistributionDesc)) {
+                return null;
+            }
+            List<String> distColumns = ((HashDistributionDesc) distributionDesc).getDistributionColumnNames();
+            if (distColumns.size() == keyColNames.size()
+                    && IntStream.range(0, distColumns.size())
+                    .allMatch(i -> distColumns.get(i).equalsIgnoreCase(keyColNames.get(i)))) {
+                return null;
+            }
+            return "DISTRIBUTED BY HASH(" + Joiner.on(", ").join(distColumns) + ")";
         }
 
         private Short autoInferReplicationNum(Map<TableName, Table> tableNameTableMap) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
@@ -30,6 +30,8 @@ import com.starrocks.qe.ShowResultSet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
+import com.starrocks.sql.ast.HashDistributionDesc;
+import com.starrocks.sql.ast.RandomDistributionDesc;
 import com.starrocks.sql.ast.RangeDistributionDesc;
 import com.starrocks.sql.ast.ShowStmt;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
@@ -632,5 +634,33 @@ public class MaterializedViewAnalyzerTest {
         String sql = "create materialized view mv_on_iceberg_view refresh manual as " +
                 "SELECT id, data, date FROM `iceberg0`.`view_db`.`iceberg_view` as a;";
         analyzeFail(sql, "Create/Rebuild materialized view do not support the table type: ICEBERG_VIEW");
+    }
+
+    /**
+     * Report the distribution the DDL asked for only when it differs from the one the MV gets: a
+     * reconstructed DDL already names the key columns and must stay quiet.
+     */
+    @Test
+    public void testDescribeReplacedDistribution() {
+        List<String> keyColumns = Arrays.asList("__ROW_ID__", "id");
+
+        Assertions.assertEquals("DISTRIBUTED BY HASH(id)",
+                MaterializedViewAnalyzer.MaterializedViewAnalyzerVisitor.describeReplacedDistribution(
+                        new HashDistributionDesc(8, Lists.newArrayList("id")), keyColumns));
+        Assertions.assertEquals("DISTRIBUTED BY RANDOM",
+                MaterializedViewAnalyzer.MaterializedViewAnalyzerVisitor.describeReplacedDistribution(
+                        new RandomDistributionDesc(), keyColumns));
+        Assertions.assertEquals("DISTRIBUTED BY HASH(id, __ROW_ID__)",
+                MaterializedViewAnalyzer.MaterializedViewAnalyzerVisitor.describeReplacedDistribution(
+                        new HashDistributionDesc(8, Lists.newArrayList("id", "__ROW_ID__")), keyColumns),
+                "a different column order is a different distribution");
+
+        Assertions.assertNull(MaterializedViewAnalyzer.MaterializedViewAnalyzerVisitor.describeReplacedDistribution(
+                new HashDistributionDesc(8, Lists.newArrayList("__ROW_ID__", "id")), keyColumns));
+        Assertions.assertNull(MaterializedViewAnalyzer.MaterializedViewAnalyzerVisitor.describeReplacedDistribution(
+                new HashDistributionDesc(8, Lists.newArrayList("__row_id__", "ID")), keyColumns),
+                "column names are case-insensitive");
+        Assertions.assertNull(MaterializedViewAnalyzer.MaterializedViewAnalyzerVisitor.describeReplacedDistribution(
+                new RangeDistributionDesc(), keyColumns));
     }
 }


### PR DESCRIPTION
## Why I'm doing:

An incremental materialized view is always hash-distributed over its key columns, so the `DISTRIBUTED BY` columns written in the DDL are replaced. That replacement is reported only in `fe.log`, by two messages that are hard to act on:

```
Check distribution for primary key mv, ignore defined dist columns: id, key columns: __ROW_ID__
Check distribution for primary key mv, ignore random distribution, use hash distribution with key columns: __ROW_ID__
```

They name "key columns" — a set the user never wrote and cannot see in the DDL — and say neither *why* the replacement happens nor that the bucket number survives it, which is the next thing anyone asks.

They also fire when nothing was replaced. A DDL reconstructed by `SHOW CREATE MATERIALIZED VIEW` already names the key columns, so re-analysing it (`ALTER MATERIALIZED VIEW ... ACTIVE`) logs a warning about a replacement that never happened.

## What I'm doing:

Merge the two calls into one message that names the distribution actually used and why:

```
Incremental materialized view mv1: DISTRIBUTED BY HASH(id) is ignored, the view is distributed by
HASH(__ROW_ID__) so that incremental refresh can locate rows by primary key. The bucket number is unchanged.
```

Emit it only when the DDL's column list really differs from the key columns (element-wise, case-insensitive), so a reconstructed DDL stays quiet.

Behavior is unchanged: the replacement itself, the preserved bucket number and the RANGE selection are all untouched. The new `describeReplacedDistribution` helper carries the "was anything actually replaced?" decision and is unit-tested directly.

Fixes #issue: N/A — FE log message only, no functional change.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
