### PR TITLE
[Enhancement] Speed up Parquet primitive-to-decimal conversion in tpcds-q28

### DIFF
--- a/be/src/formats/parquet/column_converter.cpp
+++ b/be/src/formats/parquet/column_converter.cpp
@@ -178,7 +178,11 @@ class PrimitiveToDecimalConverter final : public ColumnConverter {
 public:
     using DestDecimalType = typename RunTimeTypeTraits<DestType>::CppType;
     using DestColumnType = typename RunTimeTypeTraits<DestType>::ColumnType;
-    using DestPrimitiveType = typename RunTimeTypeTraits<TYPE_DECIMAL128>::CppType;
+    // Valid decimal data always fits DestDecimalType, so the scaled intermediate only needs to be as
+    // wide as DestDecimalType itself (min int64, since decimal32/64 arithmetic on a plain int64 is much
+    // cheaper than always widening to int128: multiply/divide compile to native instructions instead of
+    // calls to __multi3/__divti3, and the loop is far more friendly to the compiler/CPU pipeline).
+    using DestPrimitiveType = std::conditional_t<(sizeof(DestDecimalType) <= sizeof(int64_t)), int64_t, int128_t>;
 
     PrimitiveToDecimalConverter(int32_t src_scale, int32_t dst_scale) {
         if (src_scale < dst_scale) {
@@ -187,6 +191,29 @@ public:
         } else if (src_scale > dst_scale) {
             _scale_type = DecimalScaleType::kScaleDown;
             _scale_factor = get_scale_factor<DestPrimitiveType>(src_scale - dst_scale);
+        }
+    }
+
+    // _scale_type is loop-invariant but was previously re-checked on every element, which both adds a
+    // per-row branch and defeats vectorization/ILP. Dispatch on it once via a template parameter instead,
+    // matching the pattern already used by BinaryToDecimalConverter::t_convert below.
+    template <DecimalScaleType ST>
+    void t_convert(size_t size, DestDecimalType* dst_data, const SourceType* src_data) {
+        for (size_t i = 0; i < size; i++) {
+            DestPrimitiveType value;
+            if constexpr (kSourceUnsigned && std::is_integral_v<SourceType>) {
+                // Reinterpret the source through its unsigned bit pattern so a high-bit
+                // unsigned value is zero-extended instead of sign-extended.
+                value = static_cast<std::make_unsigned_t<SourceType>>(src_data[i]);
+            } else {
+                value = src_data[i];
+            }
+            if constexpr (ST == DecimalScaleType::kScaleUp) {
+                value *= _scale_factor;
+            } else if constexpr (ST == DecimalScaleType::kScaleDown) {
+                value /= _scale_factor;
+            }
+            dst_data[i] = DestDecimalType(value);
         }
     }
 
@@ -206,30 +233,25 @@ public:
         auto& src_null_data = src_nullable_column->null_column()->get_data();
         auto& dst_null_data = dst_nullable_column->null_column_raw_ptr()->get_data();
 
-        bool has_null = false;
         size_t size = src_column->size();
-        for (size_t i = 0; i < size; i++) {
-            dst_null_data[i] = src_null_data[i];
-            if (dst_null_data[i]) {
-                has_null = true;
-                continue;
-            }
-            DestPrimitiveType value;
-            if constexpr (kSourceUnsigned && std::is_integral_v<SourceType>) {
-                // Reinterpret the source through its unsigned bit pattern so a high-bit
-                // unsigned value is zero-extended instead of sign-extended.
-                value = static_cast<std::make_unsigned_t<SourceType>>(src_data[i]);
-            } else {
-                value = src_data[i];
-            }
-            if (_scale_type == DecimalScaleType::kScaleUp) {
-                value *= _scale_factor;
-            } else if (_scale_type == DecimalScaleType::kScaleDown) {
-                value /= _scale_factor;
-            }
-            dst_data[i] = DestDecimalType(value);
+        memcpy(dst_null_data.data(), src_null_data.data(), size);
+
+        // Computing the scaled value for null rows is harmless (the row is masked out by the null flag
+        // regardless), so we no longer branch per-row on nullness either — same tradeoff already made by
+        // NumericToNumericConverter::convert above.
+        switch (_scale_type) {
+        case DecimalScaleType::kScaleUp:
+            t_convert<DecimalScaleType::kScaleUp>(size, dst_data.data(), src_data.data());
+            break;
+        case DecimalScaleType::kScaleDown:
+            t_convert<DecimalScaleType::kScaleDown>(size, dst_data.data(), src_data.data());
+            break;
+        default:
+            t_convert<DecimalScaleType::kNoScale>(size, dst_data.data(), src_data.data());
+            break;
         }
-        dst_nullable_column->set_has_null(has_null);
+
+        dst_nullable_column->set_has_null(src_nullable_column->has_null());
         return Status::OK();
     }
 


### PR DESCRIPTION
## Why I'm doing:
Profiling a Parquet scan that reads an INT32 column into a DECIMAL32 column showed most of the CPU time inside `PrimitiveToDecimalConverter::convert` going to a call to `__divti3` (the compiler's 128-bit division library routine) plus a per-row branch on the scale-adjustment mode. Two issues combined to cause this:

- The scale factor was always computed and applied using a 128-bit integer, even when the destination is DECIMAL32/DECIMAL64, where the value is guaranteed to fit in 64 bits. x86-64 has no native 128÷128 division instruction, so every row paid for a library call instead of a plain `idiv`.
- Whether to scale up, scale down, or not scale at all is fixed for the whole column but was re-checked with an `if/else` on every single row, which also blocks the compiler from generating a tighter loop.

## What I'm doing:
- Pick the intermediate arithmetic type based on the destination decimal's own width instead of always widening to `int128_t`: `int64_t` for DECIMAL32/DECIMAL64, `int128_t` only for DECIMAL128/DECIMALV2 (which need the extra range). This turns the multiply/divide into native 64-bit instructions for the common cases.
- Move the scale-mode check out of the loop by dispatching once per column (via a `switch`) into a templated `t_convert<ScaleType>()`, so each row only ever executes the one operation (no scale / scale up / scale down) that actually applies — same pattern already used by the neighboring `BinaryToDecimalConverter`.
- Copy the null flags in one `memcpy` and let the value loop run unconditionally over all rows (null rows are masked out by the null flag anyway), removing the last per-row branch — the same tradeoff `NumericToNumericConverter` already makes elsewhere in this file.

Before/after shape of the hot loop:

```
Before: for each row: branch(scale_type) -> [maybe 128-bit mul/__divti3] -> branch(is_null)
After:  one branch(scale_type) up front -> tight loop of native 64-bit mul/div, no per-row branch
```

No behavior change: output values are identical, only the width of the intermediate computation and the branch placement changed.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
