### PR TITLE
[Tool] Bump SonarCloud FE analysis to JDK 21

### DIFF
--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -287,13 +287,13 @@ jobs:
           git checkout -b merge_pr;
           git merge --squash --no-edit ${BRANCH} || (echo "Merge conflict, please check." && exit -1);
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         id: setup_java
         if: steps.checkout_pr.outcome == 'success'
         with:
-          java-version: 17
-          distribution: "adopt"
+          java-version: 21
+          distribution: "temurin"
 
       - name: Cache SonarCloud packages
         id: cache_sonarcloud_packages


### PR DESCRIPTION
The FE SonarCloud analysis currently runs on JDK 17 with the deprecated Adopt distribution. Use Temurin 21 so the scanner runs on the requested Java runtime and avoids the distribution deprecation.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
