### PR TITLE
[BugFix] Do not mock partition ids when force refresh filters by retention

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
@@ -144,7 +144,7 @@ public abstract class MVPCTRefreshPartitioner {
                 .filter(mvListPartitionMap::containsKey)
                 .map(name -> Pair.create(name, mvListPartitionMap.get(name)))
                 .collect(Collectors.toMap(x -> x.first, x -> x.second));
-        filterPartitionsByTTL(validToRefreshPartitions, true);
+        filterPartitionsByTTL(validToRefreshPartitions, false);
         return validToRefreshPartitions.keySet();
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshRangePartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshRangePartitionOlapTest.java
@@ -216,6 +216,60 @@ public class PCTRefreshRangePartitionOlapTest extends MVTestBase {
     }
 
     @Test
+    public void testMVForcePartialRefreshWithRetentionCondition() throws Exception {
+        String partitionTable = "CREATE TABLE range_t2 (dt1 date, int1 int)\n" +
+                "PARTITION BY date_trunc('day', dt1)";
+        starRocksAssert.withTable(partitionTable);
+        addRangePartition("range_t2", "p1", "2024-01-04", "2024-01-05");
+        addRangePartition("range_t2", "p2", "2024-01-05", "2024-01-06");
+        String[] sqls = {
+                "INSERT INTO range_t2 partition(p1) VALUES (\"2024-01-04\",1);",
+                "INSERT INTO range_t2 partition(p2) VALUES (\"2024-01-05\",1);"
+        };
+        for (String sql : sqls) {
+            executeInsertSql(sql);
+        }
+
+        // the retention window is wide enough to keep both partitions alive, so force refresh
+        // must not treat them as expired.
+        String mvQuery = "CREATE MATERIALIZED VIEW test_mv2 " +
+                "PARTITION BY date_trunc('day', dt1) " +
+                "REFRESH DEFERRED MANUAL PROPERTIES (\"partition_refresh_number\"=\"-1\", " +
+                "\"partition_retention_condition\"=\"date_trunc('day', dt1) >= " +
+                "current_date() - interval 10 year\")\n" +
+                "AS SELECT dt1,sum(int1) from range_t2 group by dt1";
+        starRocksAssert.withMaterializedView(mvQuery);
+
+        MaterializedView mv = getMv("test_mv2");
+
+        TaskRun taskRun = buildMVTaskRun(mv, "test");
+        Map<String, String> props = taskRun.getProperties();
+        props.put(TaskRun.PARTITION_START, "2024-01-04");
+        props.put(TaskRun.PARTITION_END, "2024-01-05");
+
+        // materialize the target partition first, so it becomes an existing mv partition
+        ExecPlan execPlan = getMVRefreshExecPlan(taskRun);
+        Assertions.assertNotNull(execPlan);
+        refreshMV("test", mv);
+
+        // without force there is nothing to refresh anymore
+        execPlan = getMVRefreshExecPlan(taskRun);
+        Assertions.assertNull(execPlan);
+
+        // with force the existing partition must still be refreshed: the retention filter runs
+        // against already existing partitions here, so it must not mock their partition ids.
+        execPlan = getMVRefreshExecPlan(taskRun, true);
+        Assertions.assertNotNull(execPlan);
+        String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+        PlanTestBase.assertContains(plan, "     TABLE: range_t2\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     partitions=1/2");
+
+        starRocksAssert.dropMaterializedView("test_mv2");
+        starRocksAssert.dropTable("range_t2");
+    }
+
+    @Test
     public void testMVBatchRefreshSeedsFreshnessBaseline() throws Exception {
         String partitionTable = "CREATE TABLE range_t1 (dt1 date, int1 int)\n" +
                 "PARTITION BY date_trunc('day', dt1)";


### PR DESCRIPTION
## Why I'm doing:

`REFRESH MATERIALIZED VIEW <mv> PARTITION START(...) END(...) FORCE` silently refreshes **nothing** (task run ends `SKIPPED` with `mvPartitionsToRefresh:[]` and `planBuilderMessage:{}`) when the MV has a `partition_retention_condition`, even though the target partitions exist and are well inside the retention window. Force refresh — the standard tool to rebuild a partition regardless of change detection — is therefore unusable on such MVs on branch-4.0.

Root cause is a wrong `isMockPartitionIds` argument in the force path:

- `getMVPartitionsToRefreshWithForce` first narrows the candidates to partitions that **already exist** in the MV (`.filter(mvListPartitionMap::containsKey)`), then calls `filterPartitionsByTTL(validToRefreshPartitions, true)`.
- `isMockPartitionIds=true` is meant for cells whose partition *"is not added into table yet"* (see the comment in `PartitionSelector#getPartitionsByRetentionCondition`). It assigns mock ids `0, -1, -2 …` to the input cells.
- `getRangePartitionIdsByExpr` seeds `keyRangeById` from the real `idToRange` and then overlays those mock ids with the **same ranges**, so two ids map to one identical range. `RangePartitionPruner#prune` builds a `TreeRangeMap` keyed by range, so the second `put` overwrites the first and at most one id per range survives. When the mock id loses the slot, the partition is classified **expired** and removed from the to-refresh set — a false expiry that has nothing to do with the partition's real age.

This only triggers when `partition_retention_condition` is set (otherwise `filterPartitionsByTTL` is a no-op), which is why the existing `testMVForcePartialRefresh` does not catch it.

This is a **backport-only regression**. `#62627` on main/branch-4.1 hoisted this method into the base class using `filterPartitionsByTTL(sortedSet, false)`; its branch-4.0 backport `#63844` wrote `true` instead. `git log -S 'filterPartitionsByTTL(validToRefreshPartitions, true)' --all` returns only that backport and its follow-ups, and no later branch-4.0 commit flips it back. main and branch-4.1 are already correct, so nothing needs to change there — this PR only realigns branch-4.0 with `#62627`.

`false` is also the value every other "these partitions already exist" call site uses (`MVPCTRefreshRangePartitioner:408`, `MVPCTRefreshListPartitioner:446,480`); `true` is only used for not-yet-added partitions (`:152`/`:150` in `syncAddOrDropPartitions`).

## What I'm doing:

Pass `isMockPartitionIds=false` in `MVPCTRefreshPartitioner#getMVPartitionsToRefreshWithForce`, so the retention filter resolves the real partition ids for partitions that already exist and no id collision can occur.

Added `PCTRefreshRangePartitionOlapTest#testMVForcePartialRefreshWithRetentionCondition`: same shape as the existing `testMVForcePartialRefresh` but with `partition_retention_condition` set, asserting that a force refresh of an already-materialized partition still produces an exec plan. It fails before this change and passes after.

Verified end-to-end on a real 3-FE cluster (before/after rows from the same `information_schema.task_runs`, same MV, same partition, same command):

| build | MV with `partition_retention_condition` | MV without (control) |
|---|---|---|
| before | `SKIPPED`, `mvPartitionsToRefresh:[]` | `SUCCESS`, `["p20260605_20260606"]` |
| after | `SUCCESS`, `["p20260605_20260606"]` | `SUCCESS`, `["p20260605_20260606"]` |

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

> This PR targets `branch-4.0` directly and must NOT be backported further: main and branch-4.1 already
> carry the correct `false` from #62627, and branches 3.5/3.4 do not have this code shape.

