### PR TITLE
[Enhancement] update tenann to v0.5.1-rc2

### DIFF
--- a/thirdparty/vars-aarch64.sh
+++ b/thirdparty/vars-aarch64.sh
@@ -43,12 +43,12 @@ JINDOSDK_MD5SUM="27a4e2cd9a403c6e21079a866287d88b"
 TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-rc2/tenann-v0.5.1-rc2-nosve-arm64.tar.gz"
 TENANN_NAME="tenann-v0.5.1-rc2-nosve-arm64.tar.gz"
 TENANN_SOURCE="tenann-v0.5.1-rc2-nosve"
-TENANN_MD5SUM="79ffdf9621c9c579c5f92dd0ebe7b6f3"
+TENANN_MD5SUM="6f3b7f3c8144f855edfd8a9abf04f82e"
 # uncomment this for SVE version for better performance on ARM servers with SVE support
 #TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-rc2/tenann-v0.5.1-rc2-arm64.tar.gz"
 #TENANN_NAME="tenann-v0.5.1-rc2-arm64.tar.gz"
 #TENANN_SOURCE="tenann-v0.5.1-rc2"
-#TENANN_MD5SUM="694ef43221e72ead5e37f857cd294330"
+#TENANN_MD5SUM="8b056305af24dab45ad21f6a037163b8"
 
 # starcache
 STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v4.2-rc2/starcache-centos7_arm64.tar.gz"

--- a/thirdparty/vars-aarch64.sh
+++ b/thirdparty/vars-aarch64.sh
@@ -40,15 +40,15 @@ JINDOSDK_SOURCE="jindosdk-4.6.8-linux-el7-aarch64"
 JINDOSDK_MD5SUM="27a4e2cd9a403c6e21079a866287d88b"
 
 # tenann
-TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-rc1/tenann-v0.5.1-rc1-nosve-arm64.tar.gz"
-TENANN_NAME="tenann-v0.5.1-rc1-nosve-arm64.tar.gz"
-TENANN_SOURCE="tenann-v0.5.1-rc1-nosve"
-TENANN_MD5SUM="b48f21ada7aeb153245a8c8a25a534d9"
+TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-rc2/tenann-v0.5.1-rc2-nosve-arm64.tar.gz"
+TENANN_NAME="tenann-v0.5.1-rc2-nosve-arm64.tar.gz"
+TENANN_SOURCE="tenann-v0.5.1-rc2-nosve"
+TENANN_MD5SUM="79ffdf9621c9c579c5f92dd0ebe7b6f3"
 # uncomment this for SVE version for better performance on ARM servers with SVE support
-#TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-rc1/tenann-v0.5.1-rc1-arm64.tar.gz"
-#TENANN_NAME="tenann-v0.5.1-rc1-arm64.tar.gz"
-#TENANN_SOURCE="tenann-v0.5.1-rc1"
-#TENANN_MD5SUM="11b35d1d7aea0c48ba6d7c60633a7348"
+#TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-rc2/tenann-v0.5.1-rc2-arm64.tar.gz"
+#TENANN_NAME="tenann-v0.5.1-rc2-arm64.tar.gz"
+#TENANN_SOURCE="tenann-v0.5.1-rc2"
+#TENANN_MD5SUM="694ef43221e72ead5e37f857cd294330"
 
 # starcache
 STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v4.2-rc2/starcache-centos7_arm64.tar.gz"

--- a/thirdparty/vars-x86_64.sh
+++ b/thirdparty/vars-x86_64.sh
@@ -40,10 +40,10 @@ JINDOSDK_SOURCE="jindosdk-4.6.8-linux"
 JINDOSDK_MD5SUM="5436e4fe39c4dfdc942e41821f1dd8a9"
 
 # tenann
-TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-rc1/tenann-v0.5.1-rc1-x86_64.tar.gz"
-TENANN_NAME="tenann-v0.5.1-rc1-x86_64.tar.gz"
-TENANN_SOURCE="tenann-v0.5.1-rc1"
-TENANN_MD5SUM="a1b3c1507797ad9ae02f9690a1387cfc"
+TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-rc2/tenann-v0.5.1-rc2-x86_64.tar.gz"
+TENANN_NAME="tenann-v0.5.1-rc2-x86_64.tar.gz"
+TENANN_SOURCE="tenann-v0.5.1-rc2"
+TENANN_MD5SUM="f72e03c1965cb9d65a4acc7949399fe0"
 
 # starcache
 STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v4.2-rc2/starcache-centos7_amd64.tar.gz"

--- a/thirdparty/vars-x86_64.sh
+++ b/thirdparty/vars-x86_64.sh
@@ -43,7 +43,7 @@ JINDOSDK_MD5SUM="5436e4fe39c4dfdc942e41821f1dd8a9"
 TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.1-rc2/tenann-v0.5.1-rc2-x86_64.tar.gz"
 TENANN_NAME="tenann-v0.5.1-rc2-x86_64.tar.gz"
 TENANN_SOURCE="tenann-v0.5.1-rc2"
-TENANN_MD5SUM="f72e03c1965cb9d65a4acc7949399fe0"
+TENANN_MD5SUM="d3ee63132e0d3633fb417789feb9cb03"
 
 # starcache
 STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v4.2-rc2/starcache-centos7_amd64.tar.gz"


### PR DESCRIPTION
## Why I'm doing:

The prebuilt tenann (vector index library) archives pinned in `thirdparty/` are still
`v0.5.1-rc1`. `v0.5.1-rc2` is the next release candidate and carries the fixes /
improvements we need on the vector-index side, so the thirdparty pin has to move.

## What I'm doing:

Bump the tenann prebuilt archives from `v0.5.1-rc1` to `v0.5.1-rc2` in both
`thirdparty/vars-x86_64.sh` and `thirdparty/vars-aarch64.sh` — download URL, archive
name, extracted source directory and MD5 checksum. On aarch64 both variants are
updated: the default NoSVE build and the commented-out SVE build.

What v0.5.1-rc2 brings ([full changelog](https://github.com/StarRocks/tenann/compare/v0.5.1-rc1...v0.5.1-rc2)):

- **Support explicit cosine backends and inner product indexes** 
- **Charge quantized HNSW index memory by its storage code size**
- **Fix IVF-PQ block cache safety and accounting** 
- **Make OpenBLAS safe for concurrent calls** 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
