### PR TITLE
[BugFix] Fix BE crash when query cache reuses a lane for a partitioned hash join (backport #77564)

### DIFF
--- a/be/src/exec/hash_join_components.cpp
+++ b/be/src/exec/hash_join_components.cpp
@@ -361,6 +361,7 @@ void PartitionedHashJoinProberImpl::reset(RuntimeState* runtime_state) {
     }
     _partition_input_channels.clear();
     _mem_tracker.release(_mem_tracker.consumption());
+    _partition_input_channels.resize(_probers.size(), PartitionChunkChannel(&_mem_tracker));
     _all_input_finished = false;
     _remain_partition_idx = 0;
 }


### PR DESCRIPTION
## Why I'm doing:

A partitioned hash join splits the probe side into N partitions. For that the prober keeps two vectors, `_probers` and `_partition_input_channels`, both indexed by the same partition id, so they must always have the same length.

Query cache caches results per tablet, so it gives each tablet its own lane and reuses that lane for the next tablet by sending `reset_state()` down the operator chain, a call that ends up in `PartitionedHashJoinProberImpl::reset()`.

That reset breaks the invariant: the probers are reset in place and still number N, while the channels are wiped by `clear()`. `push_probe_chunk()` resizes the channels back before using them, so as long as a chunk arrives after the reset, the mismatch stays invisible.

But a tablet whose rows are all filtered out never pushes a chunk, it only emits an EOF marker. The channels are therefore never rebuilt, and `probe_chunk()` indexes the destroyed channels out of bounds, trusts the stale `_processing` flag left behind in the freed memory, and pulls from a freed deque, which crashes the BE.

## What I'm doing:

Rebuild `_partition_input_channels` right after clearing it, so that it stays the same length as `_probers`.

```cpp
_partition_input_channels.clear();
_mem_tracker.release(_mem_tracker.consumption());
_partition_input_channels.resize(_probers.size(), PartitionChunkChannel(&_mem_tracker));
```

Manual backport of #77564, replaces #77674. The regression test added in #77564 relies on the `always_use_partition_join` failpoint introduced by #67038, which does not exist on branch-3.5, so only the fix is backported here. The test keeps guarding this code path on main, branch-4.0 and branch-4.1.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr