### PR TITLE
[BugFix] Sort a run and merge the runs by the same NULL convention 

### DIFF
--- a/be/src/column/sorting/sort_column.cpp
+++ b/be/src/column/sorting/sort_column.cpp
@@ -139,9 +139,15 @@ public:
         return Status::OK();
     }
 
+    // NOTE: the comparators below feed `compare_at` with `null_first` rather than `nan_direction()`, because
+    // `sort_and_tie_helper` reverses the comparison result for a descending order. That is the same convention
+    // as the merge phase(`compare_chunk_row`) and the top-n compare phase(`ColumnCompare`), which apply
+    // `sort_order` on top of a `compare_at(null_first)` result. Passing `nan_direction()` here would place the
+    // NULLs nested in ARRAY/MAP/STRUCT at the opposite end for a descending order, so a sorted run and the
+    // merge of several sorted runs would disagree on the order.
     Status do_visit(const ArrayColumn& column) {
         auto cmp = [&](const SmallPermuteItem& lhs, const SmallPermuteItem& rhs) {
-            return column.compare_at(lhs.index_in_chunk, rhs.index_in_chunk, column, _sort_desc.nan_direction());
+            return column.compare_at(lhs.index_in_chunk, rhs.index_in_chunk, column, _sort_desc.null_first);
         };
 
         return sort_and_tie_helper(_cancel, &column, _sort_desc.asc_order(), _permutation, _tie, cmp, _range_or_ranges,
@@ -150,7 +156,7 @@ public:
 
     Status do_visit(const MapColumn& column) {
         auto cmp = [&](const SmallPermuteItem& lhs, const SmallPermuteItem& rhs) {
-            return column.compare_at(lhs.index_in_chunk, rhs.index_in_chunk, column, _sort_desc.nan_direction());
+            return column.compare_at(lhs.index_in_chunk, rhs.index_in_chunk, column, _sort_desc.null_first);
         };
 
         return sort_and_tie_helper(_cancel, &column, _sort_desc.asc_order(), _permutation, _tie, cmp, _range_or_ranges,
@@ -159,7 +165,7 @@ public:
 
     Status do_visit(const StructColumn& column) {
         auto cmp = [&](const SmallPermuteItem& lhs, const SmallPermuteItem& rhs) {
-            return column.compare_at(lhs.index_in_chunk, rhs.index_in_chunk, column, _sort_desc.nan_direction());
+            return column.compare_at(lhs.index_in_chunk, rhs.index_in_chunk, column, _sort_desc.null_first);
         };
 
         return sort_and_tie_helper(_cancel, &column, _sort_desc.asc_order(), _permutation, _tie, cmp, _range_or_ranges,
@@ -380,11 +386,12 @@ public:
         return Status::OK();
     }
 
+    // See the note on ColumnSorter for why `null_first` is the hint passed to `compare_at` here.
     Status do_visit(const ArrayColumn& column) {
         auto cmp = [&](const PermutationItem& lhs, const PermutationItem& rhs) {
             auto& lhs_col = _vertical_columns[lhs.chunk_index];
             auto& rhs_col = _vertical_columns[rhs.chunk_index];
-            return lhs_col->compare_at(lhs.index_in_chunk, rhs.index_in_chunk, *rhs_col, _sort_desc.nan_direction());
+            return lhs_col->compare_at(lhs.index_in_chunk, rhs.index_in_chunk, *rhs_col, _sort_desc.null_first);
         };
 
         RETURN_IF_ERROR(sort_and_tie_helper(_cancel, &column, _sort_desc.asc_order(), _permutation, _tie, cmp, _range,
@@ -397,7 +404,7 @@ public:
         auto cmp = [&](const PermutationItem& lhs, const PermutationItem& rhs) {
             auto& lhs_col = _vertical_columns[lhs.chunk_index];
             auto& rhs_col = _vertical_columns[rhs.chunk_index];
-            return lhs_col->compare_at(lhs.index_in_chunk, rhs.index_in_chunk, *rhs_col, _sort_desc.nan_direction());
+            return lhs_col->compare_at(lhs.index_in_chunk, rhs.index_in_chunk, *rhs_col, _sort_desc.null_first);
         };
 
         RETURN_IF_ERROR(sort_and_tie_helper(_cancel, &column, _sort_desc.asc_order(), _permutation, _tie, cmp, _range,
@@ -410,7 +417,7 @@ public:
         auto cmp = [&](const PermutationItem& lhs, const PermutationItem& rhs) {
             auto& lhs_col = _vertical_columns[lhs.chunk_index];
             auto& rhs_col = _vertical_columns[rhs.chunk_index];
-            return lhs_col->compare_at(lhs.index_in_chunk, rhs.index_in_chunk, *rhs_col, _sort_desc.nan_direction());
+            return lhs_col->compare_at(lhs.index_in_chunk, rhs.index_in_chunk, *rhs_col, _sort_desc.null_first);
         };
 
         RETURN_IF_ERROR(sort_and_tie_helper(_cancel, &column, _sort_desc.asc_order(), _permutation, _tie, cmp, _range,
@@ -429,7 +436,7 @@ public:
         auto cmp = [&](const PermutationItem& lhs, const PermutationItem& rhs) {
             auto& lhs_col = _vertical_columns[lhs.chunk_index];
             auto& rhs_col = _vertical_columns[rhs.chunk_index];
-            return lhs_col->compare_at(lhs.index_in_chunk, rhs.index_in_chunk, *rhs_col, _sort_desc.nan_direction());
+            return lhs_col->compare_at(lhs.index_in_chunk, rhs.index_in_chunk, *rhs_col, _sort_desc.null_first);
         };
 
         RETURN_IF_ERROR(sort_and_tie_helper(_cancel, &column, _sort_desc.asc_order(), _permutation, _tie, cmp, _range,

--- a/be/src/storage_primitive/merge_iterator.cpp
+++ b/be/src/storage_primitive/merge_iterator.cpp
@@ -26,14 +26,17 @@
 namespace starrocks {
 
 // Compare the row of index |m| in |lhs|, with the row of index |n| in |rhs|.
+// The `compare_at` result is multiplied by `sort_order`, so the null hint must be `null_first`, which already
+// carries the `sort_order` factor. Using `nan_direction()` here would cancel that factor out and place the NULLs
+// at the opposite end of a descending run, disagreeing with how the runs themselves were sorted.
 inline int compare_column(const ColumnPtr& lc, size_t m, const ColumnPtr& rc, size_t n, const SortDesc* sort_desc) {
     int sort_order = 1;
-    int nan_direction = -1;
+    int null_first = -1;
     if (sort_desc) {
         sort_order = sort_desc->sort_order;
-        nan_direction = sort_desc->nan_direction();
+        null_first = sort_desc->null_first;
     }
-    return lc->compare_at(m, n, *rc, nan_direction) * sort_order;
+    return lc->compare_at(m, n, *rc, null_first) * sort_order;
 }
 
 // Compare the row of index |m| in |lhs|, with the row of index |n| in |rhs|.

--- a/be/test/column/sorting/sort_core_test.cpp
+++ b/be/test/column/sorting/sort_core_test.cpp
@@ -15,11 +15,15 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <optional>
+#include <utility>
 #include <vector>
 
 #include "base/testutil/assert.h"
+#include "column/array_column.h"
 #include "column/fixed_length_column.h"
 #include "column/nullable_column.h"
+#include "column/sorting/sort_helper.h"
 #include "column/sorting/sort_permute.h"
 #include "column/sorting/sorting.h"
 
@@ -96,6 +100,73 @@ TEST(ColumnSortCoreTest, materialize_column_by_permutation_single_reorders_value
     EXPECT_EQ(10, output->get(1).get_int32());
     EXPECT_EQ(20, output->get(2).get_int32());
 }
+
+// Regression test for https://github.com/StarRocks/starrocks/issues/77374
+//
+// A full sort compares the rows twice: once when a buffered run is sorted, and once when the sorted runs are
+// merged. The merge phase compares by `compare_chunk_row`, so a run sorted by `sort_and_tie_columns` must be
+// ordered by the very same comparator, no matter where the NULLs nested in an ARRAY/MAP/STRUCT end up.
+class NestedNullSortTest : public testing::TestWithParam<std::pair<SortDescs, std::vector<uint32_t>>> {
+protected:
+    // The `arr` values of issue #77374
+    static ColumnPtr array_column() {
+        const std::vector<std::vector<std::optional<int32_t>>> arrays = {
+                {std::nullopt}, {5}, {4}, {3}, {std::nullopt, 2}, {7}, {std::nullopt, 9}, {8}};
+
+        auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+        auto offsets = UInt32Column::create();
+        offsets->append(0);
+        uint32_t offset = 0;
+        for (const auto& array : arrays) {
+            for (const auto& element : array) {
+                if (element.has_value()) {
+                    elements->append_datum(Datum(element.value()));
+                } else {
+                    elements->append_nulls(1);
+                }
+                offset++;
+            }
+            offsets->append(offset);
+        }
+        return ArrayColumn::create(std::move(elements), std::move(offsets));
+    }
+};
+
+TEST_P(NestedNullSortTest, sorted_run_agrees_with_the_merge_comparator) {
+    const auto& [sort_desc, expected] = GetParam();
+    std::atomic<bool> cancel{false};
+    Columns columns{array_column()};
+    auto perm = create_small_permutation(columns[0]->size());
+
+    ASSERT_OK(sort_and_tie_columns(cancel, columns, sort_desc, perm));
+
+    std::vector<uint32_t> sorted;
+    for (const auto& item : perm) {
+        sorted.push_back(item.index_in_chunk);
+    }
+    EXPECT_EQ(expected, sorted);
+
+    // The order of the run must be non-descending for the comparator the merge phase uses
+    for (size_t i = 1; i < perm.size(); i++) {
+        EXPECT_LE(compare_chunk_row(sort_desc, columns, columns, perm[i - 1].index_in_chunk, perm[i].index_in_chunk), 0)
+                << "row " << perm[i - 1].index_in_chunk << " must not succeed row " << perm[i].index_in_chunk;
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(ArrayWithNestedNull, NestedNullSortTest,
+                         testing::Values(
+                                 // asc, null first
+                                 std::make_pair(SortDescs(std::vector<int>{1}, std::vector<int>{-1}),
+                                                std::vector<uint32_t>{0, 4, 6, 3, 2, 1, 5, 7}),
+                                 // desc, null last: the reverse of `asc, null first`
+                                 std::make_pair(SortDescs(std::vector<int>{-1}, std::vector<int>{-1}),
+                                                std::vector<uint32_t>{7, 5, 1, 2, 3, 6, 4, 0}),
+                                 // asc, null last
+                                 std::make_pair(SortDescs(std::vector<int>{1}, std::vector<int>{1}),
+                                                std::vector<uint32_t>{3, 2, 1, 5, 7, 0, 4, 6}),
+                                 // desc, null first: the reverse of `asc, null last`
+                                 std::make_pair(SortDescs(std::vector<int>{-1}, std::vector<int>{1}),
+                                                std::vector<uint32_t>{6, 4, 0, 7, 5, 1, 2, 3})));
 
 } // namespace
 } // namespace starrocks

--- a/be/test/compute_env/sorting/sorting_test.cpp
+++ b/be/test/compute_env/sorting/sorting_test.cpp
@@ -17,17 +17,22 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <optional>
 #include <utility>
 #include <vector>
 
 #include "base/testutil/assert.h"
 #include "base/utility/defer_op.h"
+#include "column/array_column.h"
 #include "column/chunk.h"
 #include "column/column.h"
 #include "column/column_helper.h"
+#include "column/nullable_column.h"
+#include "column/sorting/sort_permute.h"
 #include "common/config_exec_fwd.h"
 #include "compute_env/sorting/merge.h"
 #include "compute_env/sorting/sort_cursor.h"
+#include "compute_env/sorting/sorted_chunks_merger.h"
 #include "exprs/column_ref.h"
 #include "exprs/expr_context.h"
 #include "exprs/expr_executor.h"
@@ -127,6 +132,143 @@ TEST_F(SortingCoreTest, merge_sorted_chunks) {
     ASSERT_OK(merge_sorted_chunks(sort_desc, &_sort_exprs, input_chunks, &output));
     ASSERT_TRUE(output.is_sorted(sort_desc));
     ASSERT_EQ(18, output.num_rows());
+}
+
+// Regression test for https://github.com/StarRocks/starrocks/issues/77374, on the path a spilled sort takes.
+//
+// A spilled sort sorts every mem table with `sort_and_tie_columns` (spill::OrderedMemTable::_do_sort) and merges
+// the restored blocks with a CascadeChunkMerger (spill::OrderedInputStream), so the two phases must agree on
+// where a NULL nested in an ARRAY goes, exactly like the non-spilled full sort does.
+class SpilledArrayNestedNullSortTest : public testing::Test {
+protected:
+    // The rows of issue #77374, `id` in column 0 and `arr` in column 1
+    static constexpr int kNumRows = 8;
+
+    void SetUp() override {
+        _runtime_state = create_runtime_state();
+        _exprs.emplace_back(
+                std::make_unique<ColumnRef>(TypeDescriptor::create_array_type(TypeDescriptor(TYPE_INT)), 1));
+        _sort_exprs.emplace_back(new ExprContext(_exprs.back().get()));
+        ASSERT_OK(ExprExecutor::prepare(_sort_exprs, _runtime_state.get()));
+        ASSERT_OK(ExprExecutor::open(_sort_exprs, _runtime_state.get()));
+    }
+
+    void TearDown() override { clear_exprs(_sort_exprs); }
+
+    static ChunkUniquePtr build_chunk(int32_t first_id, size_t num_rows) {
+        static const std::vector<std::vector<std::optional<int32_t>>> arrays = {
+                {std::nullopt}, {5}, {4}, {3}, {std::nullopt, 2}, {7}, {std::nullopt, 9}, {8}};
+
+        auto id_column = Int32Column::create();
+        auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+        auto offsets = UInt32Column::create();
+        offsets->append(0);
+        uint32_t offset = 0;
+        for (size_t i = 0; i < num_rows; i++) {
+            int32_t id = first_id + static_cast<int32_t>(i);
+            id_column->append_datum(Datum(id));
+            for (const auto& element : arrays[id - 1]) {
+                if (element.has_value()) {
+                    elements->append_datum(Datum(element.value()));
+                } else {
+                    elements->append_nulls(1);
+                }
+                offset++;
+            }
+            offsets->append(offset);
+        }
+        auto array_column = ArrayColumn::create(std::move(elements), std::move(offsets));
+
+        Chunk::SlotHashMap slot_map{{0, 0}, {1, 1}};
+        return std::make_unique<Chunk>(Columns{std::move(id_column), std::move(array_column)}, slot_map);
+    }
+
+    // The way a mem table is sorted before it is spilled
+    static ChunkUniquePtr sort_chunk(const SortDescs& sort_desc, ChunkUniquePtr chunk) {
+        std::atomic<bool> cancel{false};
+        Columns key_columns{chunk->get_column_by_index(1)};
+        Permutation perm;
+        CHECK_OK(sort_and_tie_columns(cancel, key_columns, sort_desc, &perm));
+
+        ChunkUniquePtr sorted = chunk->clone_empty_with_slot();
+        ChunkPtr input = std::move(chunk);
+        materialize_by_permutation(sorted.get(), {input}, perm);
+        return sorted;
+    }
+
+    static std::vector<int32_t> collect_ids(const Chunk& chunk) {
+        std::vector<int32_t> ids;
+        const auto& id_column = chunk.get_column_by_index(0);
+        for (size_t i = 0; i < chunk.num_rows(); i++) {
+            ids.push_back(id_column->get(i).get_int32());
+        }
+        return ids;
+    }
+
+    // The way the restored blocks are merged back together
+    std::vector<int32_t> merge_sorted_chunks(const SortDescs& sort_desc, std::vector<ChunkUniquePtr> chunks) {
+        std::vector<ChunkProvider> providers;
+        auto pending = std::make_shared<std::vector<ChunkUniquePtr>>(std::move(chunks));
+        for (size_t i = 0; i < pending->size(); i++) {
+            providers.emplace_back([pending, i](ChunkUniquePtr* output, bool* eos) {
+                if (output == nullptr || eos == nullptr) {
+                    return true;
+                }
+                if ((*pending)[i] == nullptr) {
+                    *eos = true;
+                    return false;
+                }
+                *output = std::move((*pending)[i]);
+                *eos = false;
+                return true;
+            });
+        }
+
+        CascadeChunkMerger merger(_runtime_state.get());
+        CHECK_OK(merger.init(providers, &_sort_exprs, sort_desc));
+
+        std::vector<int32_t> ids;
+        std::atomic<bool> eos{false};
+        while (!eos) {
+            ChunkUniquePtr chunk;
+            bool should_exit = false;
+            CHECK_OK(merger.get_next(&chunk, &eos, &should_exit));
+            if (chunk != nullptr && !chunk->is_empty()) {
+                auto part = collect_ids(*chunk);
+                ids.insert(ids.end(), part.begin(), part.end());
+            }
+        }
+        return ids;
+    }
+
+    void check(const SortDescs& sort_desc, const std::vector<int32_t>& expected) {
+        // A single mem table that never spills
+        ASSERT_EQ(expected, collect_ids(*sort_chunk(sort_desc, build_chunk(1, kNumRows))));
+
+        // Four spilled mem tables restored and merged back
+        std::vector<ChunkUniquePtr> spilled;
+        for (int32_t first_id = 1; first_id <= kNumRows; first_id += 2) {
+            spilled.emplace_back(sort_chunk(sort_desc, build_chunk(first_id, 2)));
+        }
+        ASSERT_EQ(expected, merge_sorted_chunks(sort_desc, std::move(spilled)));
+    }
+
+    std::shared_ptr<RuntimeState> _runtime_state;
+    std::vector<std::unique_ptr<ColumnRef>> _exprs;
+    std::vector<ExprContext*> _sort_exprs;
+};
+
+TEST_F(SpilledArrayNestedNullSortTest, asc_null_first) {
+    check(SortDescs(std::vector<int>{1}, std::vector<int>{-1}), {1, 5, 7, 4, 3, 2, 6, 8});
+}
+
+TEST_F(SpilledArrayNestedNullSortTest, desc_null_last) {
+    // The reverse of the ascending order: a NULL element is the smallest, so it is the last one
+    check(SortDescs(std::vector<int>{-1}, std::vector<int>{-1}), {8, 6, 2, 3, 4, 7, 5, 1});
+}
+
+TEST_F(SpilledArrayNestedNullSortTest, desc_null_first) {
+    check(SortDescs(std::vector<int>{-1}, std::vector<int>{1}), {7, 5, 1, 8, 6, 2, 3, 4});
 }
 
 } // namespace

--- a/be/test/connector/common/partition_chunk_writer_test.cpp
+++ b/be/test/connector/common/partition_chunk_writer_test.cpp
@@ -23,6 +23,7 @@
 
 #include "base/concurrency/await.h"
 #include "base/testutil/assert.h"
+#include "base/utility/defer_op.h"
 #include "column/array_column.h"
 #include "column/chunk_factory.h"
 #include "column/map_column.h"
@@ -82,6 +83,9 @@ protected:
         _local_spill_dir_mgr.reset();
         (void)FileSystem::Default()->delete_dir_recursive(kLocalSpillDir);
     }
+
+    // Defined below, once the mock writer/helper types it needs are declared
+    void test_sorted_spill_with_null(bool is_asc, bool is_null_first, const std::vector<std::string>& expected);
 
     constexpr static const char* const kLocalSpillDir = "./partition_chunk_writer_local_spill";
     ObjectPool _pool;
@@ -1304,6 +1308,105 @@ TEST_F(PartitionChunkWriterTest, test_buffer_partition_writer_profile_metrics) {
     }
 
     std::filesystem::remove_all(fs_base_path);
+}
+
+// An Iceberg sort order may sort a column descending (IcebergTable.java fills TSortOrder.is_ascs from the
+// table's sort fields), and the sorted write spills one sorted run per block and merges them back with a heap
+// merge iterator. The run sort and the merge must agree on which end the NULLs go to, otherwise the merged
+// file is not sorted at all.
+void PartitionChunkWriterTest::test_sorted_spill_with_null(bool is_asc, bool is_null_first,
+                                                           const std::vector<std::string>& expected) {
+    std::string fs_base_path = "base_path";
+    std::filesystem::create_directories(fs_base_path + "/c1");
+    DeferOp cleanup([&]() { std::filesystem::remove_all(fs_base_path); });
+
+    parquet::Utils::SlotDesc slot_descs[] = {{"c1", TYPE_VARCHAR_DESC}, {""}};
+    TupleDescriptor* tuple_desc = parquet::Utils::create_tuple_descriptor(_runtime_state.get(), &_pool, slot_descs);
+
+    auto writer_helper = WriterHelper::instance();
+    writer_helper->reset();
+    bool commited = false;
+    Status status;
+
+    auto mock_writer_factory = std::make_shared<MockFileWriterFactory>();
+    auto location_provider = std::make_shared<LocationProvider>(fs_base_path, "ffffff", 0, 0, "parquet");
+    EXPECT_CALL(*mock_writer_factory, create(::testing::_)).WillRepeatedly([](const std::string&) {
+        WriterAndStream ws;
+        ws.writer = std::make_unique<MockWriter>();
+        ws.stream = std::make_unique<Stream>(std::make_unique<MockFile>(), nullptr, nullptr);
+        return ws;
+    });
+
+    auto sort_ordering = std::make_shared<SortOrdering>();
+    sort_ordering->sort_key_idxes = {0};
+    sort_ordering->sort_descs.descs.emplace_back(is_asc, is_null_first);
+    const size_t max_file_size = 1073741824; // 1GB
+    auto partition_chunk_writer_ctx = std::make_shared<SpillPartitionChunkWriterContext>(
+            SpillPartitionChunkWriterContext{{mock_writer_factory, location_provider, max_file_size, false},
+                                             nullptr,
+                                             _runtime_state.get(),
+                                             _spill_executor.get(),
+                                             tuple_desc,
+                                             nullptr,
+                                             sort_ordering});
+    auto partition_chunk_writer_factory =
+            std::make_unique<SpillPartitionChunkWriterFactory>(partition_chunk_writer_ctx);
+    std::vector<int8_t> partition_field_null_list;
+    auto partition_writer = std::dynamic_pointer_cast<SpillPartitionChunkWriter>(
+            partition_chunk_writer_factory->create("c1", partition_field_null_list));
+    auto commit_callback = [&commited](const CommitResult& r) { commited = true; };
+    auto error_handler = [&status](const Status& s) { status = s; };
+    auto poller = MockPoller();
+    partition_writer->set_io_poller(&poller);
+    partition_writer->set_commit_callback(commit_callback);
+    partition_writer->set_error_handler(error_handler);
+    EXPECT_OK(partition_writer->init());
+
+    // One spilled block per chunk, each holding both NULL and non-NULL rows
+    for (size_t i = 0; i < 3; ++i) {
+        ChunkPtr chunk = RuntimeChunkHelper::new_chunk(*tuple_desc, 3);
+        std::string suffix = std::to_string(3 - i);
+        auto* column = chunk->get_column_raw_ptr_by_index(0);
+        column->append_datum(Slice("ccc" + suffix));
+        column->append_nulls(1);
+        column->append_datum(Slice("aaa" + suffix));
+
+        EXPECT_OK(partition_writer->write(chunk));
+        EXPECT_OK(partition_writer->flush());
+        EXPECT_OK(partition_writer->wait_flush());
+        Awaitility().timeout(3 * 1000 * 1000).interval(300 * 1000).until([partition_writer]() {
+            return partition_writer->_spilling_bytes_usage.load(std::memory_order_relaxed) == 0;
+        });
+        EXPECT_OK(status);
+    }
+
+    // Merge the spilled blocks
+    EXPECT_OK(partition_writer->finish());
+    Awaitility().timeout(3 * 1000 * 1000).interval(300 * 1000).until([&]() { return partition_writer->is_finished(); });
+    EXPECT_EQ(commited, true);
+    EXPECT_OK(status);
+    ASSERT_EQ(writer_helper->result_chunks().size(), 1);
+
+    auto result_chunk = writer_helper->result_chunks()[0];
+    auto column = result_chunk->get_column_by_index(0);
+    std::vector<std::string> actual;
+    for (size_t i = 0; i < column->size(); ++i) {
+        auto datum = column->get(i);
+        actual.emplace_back(datum.is_null() ? "NULL" : datum.get_slice().to_string());
+    }
+    EXPECT_EQ(expected, actual);
+}
+
+TEST_F(PartitionChunkWriterTest, sorted_spill_desc_null_last) {
+    test_sorted_spill_with_null(false, false, {"ccc3", "ccc2", "ccc1", "aaa3", "aaa2", "aaa1", "NULL", "NULL", "NULL"});
+}
+
+TEST_F(PartitionChunkWriterTest, sorted_spill_desc_null_first) {
+    test_sorted_spill_with_null(false, true, {"NULL", "NULL", "NULL", "ccc3", "ccc2", "ccc1", "aaa3", "aaa2", "aaa1"});
+}
+
+TEST_F(PartitionChunkWriterTest, sorted_spill_asc_null_first) {
+    test_sorted_spill_with_null(true, true, {"NULL", "NULL", "NULL", "aaa1", "aaa2", "aaa3", "ccc1", "ccc2", "ccc3"});
 }
 
 } // namespace

--- a/be/test/exec/sorting_test.cpp
+++ b/be/test/exec/sorting_test.cpp
@@ -455,6 +455,115 @@ TEST(SortingTest, merge_sorted_chunks) {
     ASSERT_TRUE(output.is_sorted(sort_desc));
 }
 
+// Regression test for https://github.com/StarRocks/starrocks/issues/77374
+//
+// Sorting a run and merging several sorted runs must agree on where a NULL nested in an ARRAY goes, otherwise
+// a full sort that buffers its input into several runs returns a wrongly ordered result.
+class ArrayNestedNullSortTest : public testing::Test {
+protected:
+    // The rows of issue #77374, `id` in column 0 and `arr` in column 1
+    static constexpr int kNumRows = 8;
+
+    static ChunkUniquePtr build_chunk(int32_t first_id, size_t num_rows) {
+        static const std::vector<std::vector<std::optional<int32_t>>> arrays = {
+                {std::nullopt}, {5}, {4}, {3}, {std::nullopt, 2}, {7}, {std::nullopt, 9}, {8}};
+
+        auto id_column = Int32Column::create();
+        auto elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+        auto offsets = UInt32Column::create();
+        offsets->append(0);
+        uint32_t offset = 0;
+        for (size_t i = 0; i < num_rows; i++) {
+            int32_t id = first_id + static_cast<int32_t>(i);
+            id_column->append_datum(Datum(id));
+            for (const auto& element : arrays[id - 1]) {
+                if (element.has_value()) {
+                    elements->append_datum(Datum(element.value()));
+                } else {
+                    elements->append_nulls(1);
+                }
+                offset++;
+            }
+            offsets->append(offset);
+        }
+        auto array_column = ArrayColumn::create(std::move(elements), std::move(offsets));
+
+        Chunk::SlotHashMap slot_map{{0, 0}, {1, 1}};
+        return std::make_unique<Chunk>(Columns{std::move(id_column), std::move(array_column)}, slot_map);
+    }
+
+    // Sort a single chunk by its array column, and return the ids in the sorted order
+    static std::vector<int32_t> sort_chunk(const SortDescs& sort_desc, ChunkUniquePtr* chunk) {
+        std::atomic<bool> cancel{false};
+        Columns key_columns{(*chunk)->get_column_by_index(1)};
+        auto perm = create_small_permutation((*chunk)->num_rows());
+        CHECK_OK(sort_and_tie_columns(cancel, key_columns, sort_desc, perm));
+
+        ChunkUniquePtr sorted = (*chunk)->clone_empty_with_slot();
+        ChunkPtr input = std::move(*chunk);
+        materialize_by_permutation_single(sorted.get(), input, perm);
+        std::vector<int32_t> ids = collect_ids(*sorted);
+        *chunk = std::move(sorted);
+        return ids;
+    }
+
+    static std::vector<int32_t> collect_ids(const Chunk& chunk) {
+        std::vector<int32_t> ids;
+        const auto& id_column = chunk.get_column_by_index(0);
+        for (size_t i = 0; i < chunk.num_rows(); i++) {
+            ids.push_back(id_column->get(i).get_int32());
+        }
+        return ids;
+    }
+
+    void check(const SortDescs& sort_desc, const std::vector<int32_t>& expected) {
+        auto runtime_state = create_runtime_state();
+        TypeDescriptor array_type = TypeDescriptor::create_array_type(TypeDescriptor(TYPE_INT));
+        std::vector<std::unique_ptr<ColumnRef>> exprs;
+        std::vector<ExprContext*> sort_exprs;
+        exprs.emplace_back(std::make_unique<ColumnRef>(array_type, 1));
+        sort_exprs.emplace_back(new ExprContext(exprs.back().get()));
+        ASSERT_OK(ExprExecutor::prepare(sort_exprs, runtime_state.get()));
+        ASSERT_OK(ExprExecutor::open(sort_exprs, runtime_state.get()));
+        DeferOp defer([&]() { clear_exprs(sort_exprs); });
+
+        // 1. A single sorted run: the order of a run must satisfy the comparator used by the merge phase
+        auto single_run = build_chunk(1, kNumRows);
+        ASSERT_EQ(expected, sort_chunk(sort_desc, &single_run));
+        ChunkPtr single_chunk = std::move(single_run);
+        ASSERT_TRUE(SortedRun(single_chunk, Columns{single_chunk->get_column_by_index(1)}).is_sorted(sort_desc));
+
+        // 2. Several sorted runs merged together must produce the very same order
+        std::vector<ChunkUniquePtr> input_chunks;
+        for (int32_t first_id = 1; first_id <= kNumRows; first_id += 2) {
+            auto chunk = build_chunk(first_id, 2);
+            sort_chunk(sort_desc, &chunk);
+            input_chunks.emplace_back(std::move(chunk));
+        }
+        SortedRuns output;
+        ASSERT_OK(merge_sorted_chunks(sort_desc, &sort_exprs, input_chunks, &output));
+        ASSERT_TRUE(output.is_sorted(sort_desc));
+        ASSERT_EQ(expected, collect_ids(*output.assemble()));
+    }
+};
+
+TEST_F(ArrayNestedNullSortTest, asc_null_first) {
+    check(SortDescs(std::vector<int>{1}, std::vector<int>{-1}), {1, 5, 7, 4, 3, 2, 6, 8});
+}
+
+TEST_F(ArrayNestedNullSortTest, desc_null_last) {
+    // The reverse of the ascending order: a NULL element is the smallest, so it is the last one
+    check(SortDescs(std::vector<int>{-1}, std::vector<int>{-1}), {8, 6, 2, 3, 4, 7, 5, 1});
+}
+
+TEST_F(ArrayNestedNullSortTest, desc_null_first) {
+    check(SortDescs(std::vector<int>{-1}, std::vector<int>{1}), {7, 5, 1, 8, 6, 2, 3, 4});
+}
+
+TEST_F(ArrayNestedNullSortTest, asc_null_last) {
+    check(SortDescs(std::vector<int>{1}, std::vector<int>{1}), {4, 3, 2, 6, 8, 1, 5, 7});
+}
+
 TEST(SortingTest, merge_sorted_stream) {
     auto runtime_state = create_runtime_state();
     constexpr int num_columns = 3;

--- a/test/sql/test_sort/R/test_array_desc_nested_null.sql
+++ b/test/sql/test_sort/R/test_array_desc_nested_null.sql
@@ -1,0 +1,217 @@
+-- name: test_array_desc_nested_null
+DROP DATABASE IF EXISTS test_array_desc_nested_null;
+-- result:
+-- !result
+CREATE DATABASE test_array_desc_nested_null;
+-- result:
+-- !result
+USE test_array_desc_nested_null;
+-- result:
+-- !result
+CREATE TABLE t_arr (
+    id INT,
+    arr ARRAY<INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_arr VALUES
+    (1, [NULL]), (2, [5]), (3, [4]), (4, [3]),
+    (5, [NULL, 2]), (6, [7]), (7, [NULL, 9]), (8, [8]);
+-- result:
+-- !result
+set pipeline_dop = 1;
+-- result:
+-- !result
+set chunk_size = 2;
+-- result:
+-- !result
+set full_sort_max_buffered_rows = 1073741824;
+-- result:
+-- !result
+SELECT id FROM t_arr ORDER BY arr;
+-- result:
+1
+5
+7
+4
+3
+2
+6
+8
+-- !result
+SELECT id FROM t_arr ORDER BY arr DESC;
+-- result:
+8
+6
+2
+3
+4
+7
+5
+1
+-- !result
+SELECT id FROM t_arr ORDER BY arr DESC NULLS FIRST;
+-- result:
+7
+5
+1
+8
+6
+2
+3
+4
+-- !result
+set full_sort_max_buffered_rows = 2;
+-- result:
+-- !result
+SELECT id FROM t_arr ORDER BY arr;
+-- result:
+1
+5
+7
+4
+3
+2
+6
+8
+-- !result
+SELECT id FROM t_arr ORDER BY arr DESC;
+-- result:
+8
+6
+2
+3
+4
+7
+5
+1
+-- !result
+SELECT id FROM t_arr ORDER BY arr DESC NULLS FIRST;
+-- result:
+7
+5
+1
+8
+6
+2
+3
+4
+-- !result
+set full_sort_max_buffered_rows = 1073741824;
+-- result:
+-- !result
+SELECT id FROM t_arr ORDER BY arr DESC LIMIT 3;
+-- result:
+8
+6
+2
+-- !result
+set full_sort_max_buffered_rows = 2;
+-- result:
+-- !result
+SELECT id FROM t_arr ORDER BY arr DESC LIMIT 3;
+-- result:
+8
+6
+2
+-- !result
+set full_sort_max_buffered_rows = 1073741824;
+-- result:
+-- !result
+set enable_spill = true;
+-- result:
+-- !result
+set spill_mode = "force";
+-- result:
+-- !result
+SELECT id FROM t_arr ORDER BY arr;
+-- result:
+1
+5
+7
+4
+3
+2
+6
+8
+-- !result
+SELECT id FROM t_arr ORDER BY arr DESC;
+-- result:
+8
+6
+2
+3
+4
+7
+5
+1
+-- !result
+SELECT id FROM t_arr ORDER BY arr DESC LIMIT 3;
+-- result:
+8
+6
+2
+-- !result
+set enable_spill = false;
+-- result:
+-- !result
+CREATE TABLE t_struct (
+    id INT,
+    s STRUCT<a INT, b INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_struct VALUES
+    (1, row(NULL, 1)), (2, row(1, 1)), (3, row(NULL, 9)),
+    (4, row(2, 0)), (5, row(1, NULL)), (6, row(3, 3));
+-- result:
+-- !result
+set full_sort_max_buffered_rows = 1073741824;
+-- result:
+-- !result
+SELECT id FROM t_struct ORDER BY s;
+-- result:
+1
+3
+5
+2
+4
+6
+-- !result
+SELECT id FROM t_struct ORDER BY s DESC;
+-- result:
+6
+4
+2
+5
+3
+1
+-- !result
+set full_sort_max_buffered_rows = 2;
+-- result:
+-- !result
+SELECT id FROM t_struct ORDER BY s;
+-- result:
+1
+3
+5
+2
+4
+6
+-- !result
+SELECT id FROM t_struct ORDER BY s DESC;
+-- result:
+6
+4
+2
+5
+3
+1
+-- !result
+DROP DATABASE test_array_desc_nested_null;
+-- result:
+-- !result

--- a/test/sql/test_sort/R/test_array_desc_nested_null.sql
+++ b/test/sql/test_sort/R/test_array_desc_nested_null.sql
@@ -157,6 +157,22 @@ SELECT id FROM t_arr ORDER BY arr DESC LIMIT 3;
 set enable_spill = false;
 -- result:
 -- !result
+SELECT array_agg(id ORDER BY arr) FROM t_arr;
+-- result:
+[1,5,7,4,3,2,6,8]
+-- !result
+SELECT array_agg(id ORDER BY arr DESC) FROM t_arr;
+-- result:
+[8,6,2,3,4,7,5,1]
+-- !result
+SELECT array_agg(id ORDER BY arr DESC NULLS FIRST) FROM t_arr;
+-- result:
+[7,5,1,8,6,2,3,4]
+-- !result
+SELECT group_concat(cast(id as string) ORDER BY arr DESC SEPARATOR ',') FROM t_arr;
+-- result:
+8,6,2,3,4,7,5,1
+-- !result
 CREATE TABLE t_struct (
     id INT,
     s STRUCT<a INT, b INT>

--- a/test/sql/test_sort/T/test_array_desc_nested_null.sql
+++ b/test/sql/test_sort/T/test_array_desc_nested_null.sql
@@ -45,6 +45,12 @@ SELECT id FROM t_arr ORDER BY arr DESC;
 SELECT id FROM t_arr ORDER BY arr DESC LIMIT 3;
 set enable_spill = false;
 
+-- array_agg and group_concat sort their input through the same path
+SELECT array_agg(id ORDER BY arr) FROM t_arr;
+SELECT array_agg(id ORDER BY arr DESC) FROM t_arr;
+SELECT array_agg(id ORDER BY arr DESC NULLS FIRST) FROM t_arr;
+SELECT group_concat(cast(id as string) ORDER BY arr DESC SEPARATOR ',') FROM t_arr;
+
 -- A NULL nested in a STRUCT is compared the same way
 CREATE TABLE t_struct (
     id INT,

--- a/test/sql/test_sort/T/test_array_desc_nested_null.sql
+++ b/test/sql/test_sort/T/test_array_desc_nested_null.sql
@@ -1,0 +1,67 @@
+-- name: test_array_desc_nested_null
+DROP DATABASE IF EXISTS test_array_desc_nested_null;
+CREATE DATABASE test_array_desc_nested_null;
+USE test_array_desc_nested_null;
+
+CREATE TABLE t_arr (
+    id INT,
+    arr ARRAY<INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t_arr VALUES
+    (1, [NULL]), (2, [5]), (3, [4]), (4, [3]),
+    (5, [NULL, 2]), (6, [7]), (7, [NULL, 9]), (8, [8]);
+
+set pipeline_dop = 1;
+set chunk_size = 2;
+
+-- A sort buffering everything into a single run
+set full_sort_max_buffered_rows = 1073741824;
+SELECT id FROM t_arr ORDER BY arr;
+SELECT id FROM t_arr ORDER BY arr DESC;
+SELECT id FROM t_arr ORDER BY arr DESC NULLS FIRST;
+
+-- The same sorts, but buffered into several runs that have to be merged.
+-- The order must not depend on how many runs the input was cut into.
+set full_sort_max_buffered_rows = 2;
+SELECT id FROM t_arr ORDER BY arr;
+SELECT id FROM t_arr ORDER BY arr DESC;
+SELECT id FROM t_arr ORDER BY arr DESC NULLS FIRST;
+
+-- Top-n takes another comparison path
+set full_sort_max_buffered_rows = 1073741824;
+SELECT id FROM t_arr ORDER BY arr DESC LIMIT 3;
+set full_sort_max_buffered_rows = 2;
+SELECT id FROM t_arr ORDER BY arr DESC LIMIT 3;
+
+-- A spilled sort merges one sorted run per spilled block
+set full_sort_max_buffered_rows = 1073741824;
+set enable_spill = true;
+set spill_mode = "force";
+SELECT id FROM t_arr ORDER BY arr;
+SELECT id FROM t_arr ORDER BY arr DESC;
+SELECT id FROM t_arr ORDER BY arr DESC LIMIT 3;
+set enable_spill = false;
+
+-- A NULL nested in a STRUCT is compared the same way
+CREATE TABLE t_struct (
+    id INT,
+    s STRUCT<a INT, b INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t_struct VALUES
+    (1, row(NULL, 1)), (2, row(1, 1)), (3, row(NULL, 9)),
+    (4, row(2, 0)), (5, row(1, NULL)), (6, row(3, 3));
+
+set full_sort_max_buffered_rows = 1073741824;
+SELECT id FROM t_struct ORDER BY s;
+SELECT id FROM t_struct ORDER BY s DESC;
+set full_sort_max_buffered_rows = 2;
+SELECT id FROM t_struct ORDER BY s;
+SELECT id FROM t_struct ORDER BY s DESC;
+
+DROP DATABASE test_array_desc_nested_null;


### PR DESCRIPTION
## Why I'm doing:

A full sort compares its rows twice: once when a buffered run is sorted, and
once when the runs are merged. The merge phase, the top-n compare phase and the
chunk cursors all apply `sort_order` on top of a `compare_at(null_first)`
result, but the ARRAY/MAP/STRUCT comparators of ColumnSorter and
VerticalColumnSorter handed `compare_at` a `nan_direction()` hint while
`sort_and_tie_helper` already reverses the comparison for a descending order.
The two factors cancel out, so for a descending sort a NULL nested in the sort
key lands at the opposite end of a sorted run from where the merge looks for
it, and merging such runs produces an unsorted result: `ORDER BY arr DESC`
returns the rows in insertion order as soon as the input no longer fits into a
single run. A spilled sort hits this without any tuning, because every spilled
block is a run of its own.

`compare_column` in the storage merge iterator mixed up the same two
conventions. The sorted connector writes rely on it -- an Iceberg table whose
sort order has a DESC field sorts each spilled block with
`stable_sort_and_tie_columns` and merges the blocks with
`new_heap_merge_iterator` -- so the NULLs of a descending sort key were
scattered through the written file instead of collected at one end.

Both phases now take `null_first`, which already carries the `sort_order`
factor. Ascending sorts are unaffected, since `null_first` and
`nan_direction()` agree there.

## What I'm doing:

Fixes #77374

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
