### PR TITLE
[BugFix] Skip the mv rewrite for a time-travel query

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -343,6 +343,16 @@ public class QueryOptimizer extends Optimizer {
                 !sessionVariable.isEnableMaterializedViewRewrite()) {
             return;
         }
+        // A materialized view holds the base table's state as of its last refresh, so it cannot answer a read
+        // pinned to an explicit snapshot, tag or branch: the targeted snapshot is not the one materialized, and
+        // for a non-main branch the MV is not even considered stale because the table's current snapshot never
+        // moved. Mirror the definition side, which rejects time-travel clauses outright
+        // (see AnalyzerUtils#prohibitTimeTravelQuery), and skip the rewrite until snapshot-aware MVs exist.
+        if (MvUtils.containsTimeTravelScan(logicOperatorTree)) {
+            OptimizerTraceUtil.logMVPrepare(connectContext,
+                    "Skip mv rewrite because the query reads a table at an explicit time-travel version");
+            return;
+        }
         // prepare related mvs if needed and initialize mv rewrite strategy
         new MvRewritePreprocessor(connectContext, columnRefFactory, context, requiredColumns)
                 .prepare(logicOperatorTree);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -36,6 +36,7 @@ import com.starrocks.catalog.RangeDistributionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Pair;
+import com.starrocks.common.tvr.TvrTableDelta;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.LogUtil;
 import com.starrocks.common.util.RangeUtils;
@@ -228,6 +229,19 @@ public class MvUtils {
                 getAllTables(child, tables);
             }
         }
+    }
+
+    /**
+     * True when any scan below root reads a table pinned to an explicit time-travel version, i.e. a
+     * {@code FOR VERSION/TIMESTAMP AS OF} clause (a snapshot id, tag or branch name). An ordinary read
+     * carries a {@link com.starrocks.common.tvr.TvrTableSnapshot} of the table's current version instead,
+     * so only a query period produces a delta range on a freshly transformed plan.
+     */
+    public static boolean containsTimeTravelScan(OptExpression root) {
+        if (root.getOp() instanceof LogicalScanOperator) {
+            return ((LogicalScanOperator) root.getOp()).getTvrVersionRange() instanceof TvrTableDelta;
+        }
+        return root.getInputs().stream().anyMatch(MvUtils::containsTimeTravelScan);
     }
 
     public static List<MaterializedView> collectMaterializedViews(OptExpression optExpression) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -92,6 +92,7 @@ import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalMysqlScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
@@ -233,13 +234,23 @@ public class MvUtils {
 
     /**
      * True when any scan below root reads a table pinned to an explicit time-travel version, i.e. a
-     * {@code FOR VERSION/TIMESTAMP AS OF} clause (a snapshot id, tag or branch name). An ordinary read
-     * carries a {@link com.starrocks.common.tvr.TvrTableSnapshot} of the table's current version instead,
-     * so only a query period produces a delta range on a freshly transformed plan.
+     * {@code FOR VERSION/TIMESTAMP AS OF} clause (a snapshot id, tag or branch name).
+     * <p>
+     * A query period reaches the plan in one of two shapes, the same two that
+     * {@link com.starrocks.sql.analyzer.AnalyzerUtils#prohibitTimeTravelQuery} has to handle on the
+     * definition side: connectors that resolve the version themselves carry a delta range on the scan,
+     * while a MySQL temporal read keeps the clause verbatim on the operator and leaves its range at the
+     * default. An ordinary read carries a {@link com.starrocks.common.tvr.TvrTableSnapshot} of the
+     * table's current version, so only a query period produces a delta range on a freshly transformed plan.
      */
     public static boolean containsTimeTravelScan(OptExpression root) {
         if (root.getOp() instanceof LogicalScanOperator) {
-            return ((LogicalScanOperator) root.getOp()).getTvrVersionRange() instanceof TvrTableDelta;
+            LogicalScanOperator scanOperator = (LogicalScanOperator) root.getOp();
+            if (scanOperator.getTvrVersionRange() instanceof TvrTableDelta) {
+                return true;
+            }
+            return scanOperator instanceof LogicalMysqlScanOperator
+                    && !Strings.isNullOrEmpty(((LogicalMysqlScanOperator) scanOperator).getTemporalClause());
         }
         return root.getInputs().stream().anyMatch(MvUtils::containsTimeTravelScan);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.catalog.Partition;
 import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
 import com.starrocks.connector.iceberg.MockIcebergMetadata;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.MaterializedViewAnalyzer;
@@ -47,6 +48,44 @@ public class MvRefreshAndRewriteIcebergTest extends MVTestBase {
         connectContext.getSessionVariable().setMaterializedViewUnionRewriteMode(1);
         connectContext.getSessionVariable().setEnableMaterializedViewTransparentUnionRewrite(false);
         connectContext.getSessionVariable().setEnableRewriteSimpleAggToMetaScan(false);
+    }
+
+    @Test
+    public void testTimeTravelQueryIsNotRewrittenByMv() throws Exception {
+        String mvName = "mv_time_travel_guard";
+        starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
+                    "distributed by hash(a) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1'" +
+                    ") " +
+                    "as select a, b, d from iceberg0.partitioned_db.part_tbl1;");
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " with sync mode");
+
+        // Control: an ordinary read of the same table is rewritten to the MV.
+        {
+            String query = "select a, b, d from iceberg0.partitioned_db.part_tbl1";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, mvName);
+        }
+
+        // A time-travel read targets a snapshot the MV knows nothing about: the MV materializes the
+        // table's state as of its last refresh, so it must not answer the query. See StarRocksTest#11377.
+        // The plan helper wraps each query in a CREATE VIEW to check view compatibility, which
+        // AnalyzerUtils#prohibitTimeTravelQuery rejects by design, so skip that wrapper here.
+        boolean savedUnitTestView = FeConstants.unitTestView;
+        FeConstants.unitTestView = false;
+        try {
+            // A bigint literal: snapshot ids are bigints, and a small literal would parse as tinyint.
+            String query = "select a, b, d from iceberg0.partitioned_db.part_tbl1 FOR VERSION AS OF 1000000000000";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertNotContains(plan, mvName);
+            PlanTestBase.assertContains(plan, "IcebergScanNode");
+        } finally {
+            FeConstants.unitTestView = savedUnitTestView;
+        }
+
+        starRocksAssert.dropMaterializedView(mvName);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtilsTest.java
@@ -15,8 +15,10 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization;
 
+import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MysqlTable;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
@@ -31,6 +33,7 @@ import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalMysqlScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
@@ -92,6 +95,22 @@ public class MvUtilsTest {
                 "\"replication_num\" = \"1\",\n" +
                 "\"in_memory\" = \"false\"\n" +
                 ");");
+    }
+
+    @Test
+    public void testContainsTimeTravelScanDetectsMysqlTemporalClause() {
+        // A MySQL temporal read keeps the clause on the scan operator and leaves the version range empty,
+        // so a version-range check alone misses it. This is the same second representation that
+        // AnalyzerUtils#prohibitTimeTravelQuery has to handle on the definition side.
+        MysqlTable mysqlTable = new MysqlTable();
+        LogicalMysqlScanOperator ordinaryScan = new LogicalMysqlScanOperator(mysqlTable, Maps.newHashMap(),
+                Maps.newHashMap(), Operator.DEFAULT_LIMIT, null, null);
+        Assertions.assertFalse(MvUtils.containsTimeTravelScan(OptExpression.create(ordinaryScan)));
+
+        LogicalMysqlScanOperator temporalScan = new LogicalMysqlScanOperator(mysqlTable, Maps.newHashMap(),
+                Maps.newHashMap(), Operator.DEFAULT_LIMIT, null, null);
+        temporalScan.setTemporalClause("FOR SYSTEM_TIME AS OF '2026-01-01 00:00:00'");
+        Assertions.assertTrue(MvUtils.containsTimeTravelScan(OptExpression.create(temporalScan)));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

A materialized view holds the base table's state as of its last refresh, so it cannot answer a read pinned to an explicit snapshot, tag or branch. Nothing stopped it from doing so: the MV rewrite never looked at the query period.

This is worse than ordinary staleness for a branch or tag. Writing to a non-main branch does not move the table's current snapshot, so the MV is not even treated as stale and the rewrite fires with full confidence. A query reading a branch was then silently answered from data that never contained the branch's rows: `SELECT COUNT(*) ... FOR VERSION AS OF '<branch>' WHERE ...` returned 0 while `SELECT *` with the same predicate returned the row, because the MV could cover the first query but not the second. Every query the MV can cover is affected, not just `count(*)`.

The definition side already takes the opposite stance: `CREATE VIEW` / `CREATE MATERIALIZED VIEW` reject time-travel clauses outright (`AnalyzerUtils#prohibitTimeTravelQuery`, #72060) because the stored definition and the refresh path do not preserve that semantics end to end. The consumption side had no matching rule, which is the gap this PR closes.

## What I'm doing:

Skip materialized view rewrite when any scan in the query is pinned to an explicit time-travel version:

- `MvUtils#containsTimeTravelScan` reports whether any scan below the plan root carries a `TvrTableDelta` range. An ordinary read carries a `TvrTableSnapshot` of the table's current version, so on a freshly transformed plan only a query period produces a delta range.
- `QueryOptimizer#prepareMvRewrite` returns early in that case, next to the existing gates, and records the reason through the MV trace so it is visible in `trace logs mv`.

The query is left to scan its base tables, exactly as it does when materialized view rewrite is disabled; it is not rejected, because unlike a view definition the query itself is perfectly legal. The restriction is meant to hold until snapshot-aware materialized views exist, at which point a rewrite can be allowed for the snapshot an MV actually materializes.

Fixes StarRocks/StarRocksTest#11377

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5