### PR TITLE
[BugFix] Keep array_sort's lambda comparator from driving the sort out of bounds

### DIFF
--- a/be/src/exprs/array_sort_lambda_expr.cpp
+++ b/be/src/exprs/array_sort_lambda_expr.cpp
@@ -20,7 +20,6 @@
 #include <memory>
 #include <sstream>
 
-#include "base/orlp/pdqsort.h"
 #include "base/simd/simd.h"
 #include "column/array_column.h"
 #include "column/array_view_column.h"
@@ -168,6 +167,98 @@ private:
     Status _error_status{};
 };
 
+// Merge the adjacent sorted runs [lo, mid) and [mid, hi) of `data` in place, through `buffer`.
+template <typename Compare>
+static void merge_adjacent_runs(std::vector<uint32_t>& data, std::vector<uint32_t>& buffer, size_t lo, size_t mid,
+                                size_t hi, Compare comp) {
+    size_t left = lo;
+    size_t right = mid;
+    size_t out = lo;
+    while (left < mid && right < hi) {
+        // Only take from the right run when it strictly precedes the left one, so that
+        // equivalent elements keep their relative order.
+        buffer[out++] = comp(data[right], data[left]) ? data[right++] : data[left++];
+    }
+    while (left < mid) {
+        buffer[out++] = data[left++];
+    }
+    while (right < hi) {
+        buffer[out++] = data[right++];
+    }
+    std::copy(buffer.begin() + lo, buffer.begin() + hi, data.begin() + lo);
+}
+
+// Sort `data` with a comparator that CANNOT be trusted to be a strict weak ordering.
+//
+// validate_strict_weak_ordering() below only samples a bounded number of elements, so a
+// lambda that misbehaves on values outside that sample still reaches the sort. Introsort
+// family algorithms (pdqsort, std::sort) rely on the ordering to terminate the unguarded
+// scans of their partition loops; with an inconsistent comparator those scans walk off both
+// ends of the range and read and write out of bounds, which corrupts the heap and crashes
+// the BE, sometimes only much later when an unrelated allocation is freed. std::stable_sort
+// is no safer: both of its paths start with std::__insertion_sort, whose
+// __unguarded_linear_insert has the same unbounded scan.
+//
+// A natural merge sort only ever indexes inside [0, num), so an inconsistent comparator can
+// at worst produce an arbitrary permutation of the input - never memory unsafety.
+//
+// It first splits the range into maximal runs and then merges those pairwise, rather than
+// unconditionally running every merge level over runs of width 1, 2, 4 ... That matters
+// because every comparison evaluates a lambda through the expression engine and so dominates
+// everything else here: pdqsort finishes already sorted input in a linear number of
+// comparisons, and without run detection this would spend n*log(n) of them on the same input
+// and regress a common case of array_sort.
+template <typename Compare>
+static void merge_sort_indices(std::vector<uint32_t>& data, std::vector<uint32_t>& buffer,
+                               std::vector<size_t>& run_starts, Compare comp) {
+    const size_t num = data.size();
+    if (num < 2) {
+        return;
+    }
+    buffer.resize(num);
+
+    // Split into maximal runs, reversing the descending ones. A run is only extended over a
+    // strict descent, so no two of its elements are equivalent and reversing it cannot
+    // reorder equivalent elements. Already sorted input yields a single run and no merging.
+    run_starts.clear();
+    for (size_t pos = 0; pos < num;) {
+        run_starts.emplace_back(pos);
+        size_t end = pos + 1;
+        if (end < num && comp(data[end], data[pos])) {
+            while (end + 1 < num && comp(data[end + 1], data[end])) {
+                ++end;
+            }
+            std::reverse(data.begin() + pos, data.begin() + end + 1);
+        } else {
+            while (end + 1 < num && !comp(data[end + 1], data[end])) {
+                ++end;
+            }
+        }
+        pos = end + 1;
+    }
+    // Sentinel, so that run i spans [run_starts[i], run_starts[i + 1]).
+    run_starts.emplace_back(num);
+
+    // Merge adjacent runs pairwise until a single run covers the whole range. Each pass
+    // rewrites `run_starts` in place; the write index trails the read index, so it never
+    // clobbers a boundary the pass still needs.
+    while (run_starts.size() > 2) {
+        const size_t num_runs = run_starts.size() - 1;
+        size_t out = 0;
+        size_t i = 0;
+        for (; i + 1 < num_runs; i += 2) {
+            merge_adjacent_runs(data, buffer, run_starts[i], run_starts[i + 1], run_starts[i + 2], comp);
+            run_starts[out++] = run_starts[i];
+        }
+        if (i < num_runs) {
+            // Odd run at the end, carried into the next pass as it is.
+            run_starts[out++] = run_starts[i];
+        }
+        run_starts[out++] = num;
+        run_starts.resize(out);
+    }
+}
+
 StatusOr<ColumnPtr> ArraySortLambdaExpr::evaluate_lambda_expr(ExprContext* context, Chunk* chunk,
                                                               const Column* data_column) {
     const auto& element_col = down_cast<const ArrayColumn*>(data_column)->elements_column();
@@ -214,6 +305,10 @@ StatusOr<ColumnPtr> ArraySortLambdaExpr::evaluate_lambda_expr(ExprContext* conte
         }
     }
 
+    // Scratch space for the merge sort, reused across rows.
+    std::vector<uint32_t> merge_buffer;
+    std::vector<size_t> merge_run_starts;
+
     // Process each row
     for (size_t row = 0; row < num_rows; ++row) {
         // if Array column comes from ConstColumn, always use the first offsets
@@ -239,9 +334,11 @@ StatusOr<ColumnPtr> ArraySortLambdaExpr::evaluate_lambda_expr(ExprContext* conte
         std::vector<uint32_t> indices(array_size);
         std::iota(indices.begin(), indices.end(), 0);
 
-        // Sort using comparator lambda
-        pdqsort(indices.begin(), indices.end(),
-                [&comparator](uint32_t i, uint32_t j) { return comparator.compare(i, j); });
+        // Sort using comparator lambda. The comparator is user supplied and may violate the
+        // strict weak ordering the validation below could not rule out, so the sort must stay
+        // in bounds no matter what it returns - see merge_sort_indices().
+        merge_sort_indices(indices, merge_buffer, merge_run_starts,
+                           [&comparator](uint32_t i, uint32_t j) { return comparator.compare(i, j); });
         // Check for any errors during comparison
         RETURN_IF_ERROR(comparator.error_status());
 
@@ -334,12 +431,6 @@ Status ArraySortLambdaExpr::validate_strict_weak_ordering(ExprContext* context, 
         return Status::OK();
     }
 
-    // Create a temporary array column with just the unique elements for validation
-    auto validation_elements = element_col->clone_empty();
-    for (size_t idx : unique_indices) {
-        validation_elements->append(*element_col, idx, 1);
-    }
-
     const vector<SlotId>& argument_ids = lambda_func->get_lambda_arguments_ids();
     DCHECK(argument_ids.size() == 2);
 
@@ -353,14 +444,17 @@ Status ArraySortLambdaExpr::validate_strict_weak_ordering(ExprContext* context, 
     // Use SortComparator for validation
     SortComparator comparator(context, lambda_func, element_col, one_row_chunk);
     comparator.set_argument_ids(argument_ids);
-    comparator.set_array_start(0); // Elements start at index 0 in validation array
+    comparator.set_array_start(0); // unique_indices are absolute positions in element_col
 
-    // Helper function to compare two elements by their indices in unique_indices
+    // Helper function to compare two elements by their indices in unique_indices.
+    // Note the indirection through unique_indices: the checks below must run on the DISTINCT
+    // elements that were selected, not on the first few physical elements of the column.
     auto compare = [&](size_t i, size_t j) -> StatusOr<bool> {
         if (!comparator.error_status().ok()) {
             return comparator.error_status();
         }
-        bool result = comparator.compare(static_cast<uint32_t>(i), static_cast<uint32_t>(j));
+        bool result =
+                comparator.compare(static_cast<uint32_t>(unique_indices[i]), static_cast<uint32_t>(unique_indices[j]));
         if (!comparator.error_status().ok()) {
             return comparator.error_status();
         }

--- a/test/sql/test_array_fn/R/test_array_sort_lambda
+++ b/test/sql/test_array_fn/R/test_array_sort_lambda
@@ -265,3 +265,44 @@ select array_sort([1,3,2,1,3,6,100,200],(x,y)->-1)[1] <= array_max([1,3,2,1,3,6,
 -- result:
 E: (1064, 'Getting analyzing error. Detail message: Lambda function in sort_array should only depend on both two arguments and contain no non-deterministic functions.')
 -- !result
+-- name: test_array_sort_lambda_inconsistent_comparator
+create table t0 (
+    k0 int,
+    c0 array<int>
+)
+properties(
+   "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t0 select i, [1,2,3,4,5,6,7,8,9,10,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160]
+from table(generate_series(0,199)) t(i);
+-- result:
+-- !result
+SELECT distinct cardinality(array_sort(c0, (x, y) -> if(x > 100 and y > 100, -1, if(x < y, -1, if(x = y, 0, 1))))) from t0;
+-- result:
+70
+-- !result
+SELECT distinct array_max(array_sort(c0, (x, y) -> if(x > 100 and y > 100, -1, if(x < y, -1, if(x = y, 0, 1))))) = array_max(c0) from t0;
+-- result:
+1
+-- !result
+SELECT distinct array_min(array_sort(c0, (x, y) -> if(x > 100 and y > 100, -1, if(x < y, -1, if(x = y, 0, 1))))) = array_min(c0) from t0;
+-- result:
+1
+-- !result
+SELECT distinct array_sum(array_sort(c0, (x, y) -> if(x > 100 and y > 100, -1, if(x < y, -1, if(x = y, 0, 1))))) = array_sum(c0) from t0;
+-- result:
+1
+-- !result
+drop table t0;
+-- result:
+-- !result
+SELECT array_sort([101, 102, 103, 104, 105], (x, y) -> if(x > 100 and y > 100, -1, if(x < y, -1, if(x = y, 0, 1))));
+-- result:
+[REGEX].*Comparator violates irreflexivity.*
+-- !result
+SELECT array_sort([7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,1,2,3,4,5], (x, y) -> if(x = y, 0, -1));
+-- result:
+[REGEX].*Comparator violates asymmetry.*
+-- !result

--- a/test/sql/test_array_fn/T/test_array_sort_lambda
+++ b/test/sql/test_array_fn/T/test_array_sort_lambda
@@ -136,3 +136,36 @@ select array_sort([1,3,2,1,3,6,100,200],(x,y)->rand()-0.5)[1] <= array_max([1,3,
 select array_sort([1,3,2,1,3,6,100,200],(x,y)->0)[1] <= array_max([1,3,2,1,3,6,100,200]);
 select array_sort([1,3,2,1,3,6,100,200],(x,y)->1)[1] <= array_max([1,3,2,1,3,6,100,200]);
 select array_sort([1,3,2,1,3,6,100,200],(x,y)->-1)[1] <= array_max([1,3,2,1,3,6,100,200]);
+
+-- name: test_array_sort_lambda_inconsistent_comparator
+-- The lambda comparator is validated by sampling a bounded number of elements, so one that
+-- only breaks strict weak ordering outside that sample still reaches the sort. The sort must
+-- stay in bounds for such a comparator: it used to walk off both ends of its index vector and
+-- corrupt the heap, which crashed the BE either right away or later, while freeing unrelated
+-- memory during query teardown.
+create table t0 (
+    k0 int,
+    c0 array<int>
+)
+properties(
+   "replication_num" = "1"
+);
+
+-- the first 10 distinct values are the ones the validator samples, and the comparator is a
+-- well-formed ascending order on them; it only breaks down on the values above 100
+insert into t0 select i, [1,2,3,4,5,6,7,8,9,10,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160]
+from table(generate_series(0,199)) t(i);
+
+-- an inconsistent comparator may return an arbitrary permutation, but never anything else
+SELECT distinct cardinality(array_sort(c0, (x, y) -> if(x > 100 and y > 100, -1, if(x < y, -1, if(x = y, 0, 1))))) from t0;
+SELECT distinct array_max(array_sort(c0, (x, y) -> if(x > 100 and y > 100, -1, if(x < y, -1, if(x = y, 0, 1))))) = array_max(c0) from t0;
+SELECT distinct array_min(array_sort(c0, (x, y) -> if(x > 100 and y > 100, -1, if(x < y, -1, if(x = y, 0, 1))))) = array_min(c0) from t0;
+SELECT distinct array_sum(array_sort(c0, (x, y) -> if(x > 100 and y > 100, -1, if(x < y, -1, if(x = y, 0, 1))))) = array_sum(c0) from t0;
+drop table t0;
+
+-- the same comparator is rejected outright once the broken region is inside the sample
+SELECT array_sort([101, 102, 103, 104, 105], (x, y) -> if(x > 100 and y > 100, -1, if(x < y, -1, if(x = y, 0, 1))));
+
+-- duplicates must not crowd the distinct values out of the sample: the leading run of equal
+-- elements compares consistently, the comparator only breaks on pairs of different values
+SELECT array_sort([7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,1,2,3,4,5], (x, y) -> if(x = y, 0, -1));


### PR DESCRIPTION
## Why I'm doing:

```
==533364==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x512003a56158 at pc 0x00002abed004 bp 0x7f6ff66d6fa0 sp 0x7f6ff66d6f98
READ of size 4 at 0x512003a56158 thread T673
    #0 0x2abed003 in partition_right<__gnu_cxx::__normal_iterator<unsigned int*, std::vector<unsigned int, std::allocator<unsigned int> > >, starrocks::ArraySortLambdaExpr::evaluate_lambda_expr(starrocks::
ExprContext*, starrocks::Chunk*, const starrocks::Column*)::<lambda(uint32_t, uint32_t)> > be/src/base/orlp/pdqsort.h:395
    #1 0x2abeaf35 in pdqsort_loop<__gnu_cxx::__normal_iterator<unsigned int*, std::vector<unsigned int, std::allocator<unsigned int> > >, starrocks::ArraySortLambdaExpr::evaluate_lambda_expr(starrocks::Exp
rContext*, starrocks::Chunk*, const starrocks::Column*)::<lambda(uint32_t, uint32_t)>, false> be/src/base/orlp/pdqsort.h:507
    #2 0x2abea985 in pdqsort<__gnu_cxx::__normal_iterator<unsigned int*, std::vector<unsigned int, std::allocator<unsigned int> > >, starrocks::ArraySortLambdaExpr::evaluate_lambda_expr(starrocks::ExprCont
ext*, starrocks::Chunk*, const starrocks::Column*)::<lambda(uint32_t, uint32_t)> > be/src/base/orlp/pdqsort.h:572
    #3 0x2abe558d in starrocks::ArraySortLambdaExpr::evaluate_lambda_expr(starrocks::ExprContext*, starrocks::Chunk*, starrocks::Column const*) be/src/exprs/array_sort_lambda_expr.cpp:243
    #4 0x2abe9bc0 in starrocks::ArraySortLambdaExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*) be/src/exprs/array_sort_lambda_expr.cpp:474
    #5 0x2a4cacdb in starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*) be/src/exprs/expr_context.cpp:189
    #6 0x2ca2e5f7 in starrocks::VectorizedFunctionCallExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*) be/src/exprs/function_call_expr.cpp:184
    #7 0x2a4cacdb in starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*) be/src/exprs/expr_context.cpp:189
    #8 0x2a4ca4cf in starrocks::ExprContext::evaluate(starrocks::Chunk*, unsigned char*) be/src/exprs/expr_context.cpp:165
    #9 0x1e62d135 in starrocks::pipeline::ProjectOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&) be/src/exec/pipeline/project_operator.cpp:63
    #10 0x235000f7 in starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int) be/src/exec/runtime/pipeline_driver.cpp:480
    #11 0x1e4938e2 in starrocks::pipeline::GlobalDriverExecutor::_worker_thread() be/src/exec/pipeline/pipeline_driver_executor.cpp:180
    #12 0x1e491c8f in operator() be/src/exec/pipeline/pipeline_driver_executor.cpp:71
    #13 0x1e49984b in __invoke_impl<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::<lambda()>&> /opt/gcc-toolset-14/include/c++/14.3.0/bits/invoke.h:61
    #14 0x1e498f91 in __invoke_r<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::<lambda()>&> /opt/gcc-toolset-14/include/c++/14.3.0/bits/invoke.h:111
    #15 0x1e498a61 in _M_invoke /opt/gcc-toolset-14/include/c++/14.3.0/bits/std_function.h:290
    #16 0x1c99c923 in std::function<void ()>::operator()() const /opt/gcc-toolset-14/include/c++/14.3.0/bits/std_function.h:591
    #17 0x2e17d98f in starrocks::FunctionRunnable::run() be/src/common/thread/threadpool.cpp:68
    #18 0x2e177795 in starrocks::ThreadPool::dispatch_thread() be/src/common/thread/threadpool.cpp:689
    #19 0x2e198c2f in void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /op
t/gcc-toolset-14/include/c++/14.3.0/bits/invoke.h:74
    #20 0x2e1975cd in std::__invoke_result<void (starrock
```

array_sort(array, (x, y) -> ...) checks that the lambda is a strict weak ordering by sampling at most ten elements, so a comparator that only breaks down on values outside that sample still reaches the sort. pdqsort relies on the ordering to terminate the unguarded scans in its partition loops, so such a comparator walks the iterators past both ends of the index vector and reads and writes out of bounds. In a release build that either faults immediately in FixedLengthColumnBase::append with a wild index, or corrupts the heap silently and takes the BE down much later, while an unrelated allocation is freed as the query is torn down.

Sort the indices with a bottom-up merge sort instead. It only ever indexes inside the range, so an inconsistent comparator now yields an arbitrary permutation rather than undefined behaviour, and it is stable, which pdqsort was not. Every comparison evaluates a lambda through the expression engine, so the algorithm change is not measurable next to that.

Also make the validation check the elements it selected: it built a column of the distinct elements and then never used it, comparing the first k physical elements of the chunk instead. A leading run of equal elements therefore hid every comparator that only misbehaves on distinct values.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
