### PR TITLE
[BugFix] Parse checksummed tablet metadata when restoring a lake snapshot

### DIFF
--- a/be/src/data_workflows/snapshot/lake_snapshot_loader.cpp
+++ b/be/src/data_workflows/snapshot/lake_snapshot_loader.cpp
@@ -26,6 +26,7 @@
 #include "storage/lake/filenames.h"
 #include "storage/lake/lake_proto_normalizer.h"
 #include "storage/lake/tablet.h"
+#include "storage/protobuf_file.h"
 #include "storage/storage_env.h"
 
 namespace starrocks {
@@ -307,9 +308,14 @@ Status LakeSnapshotLoader::restore(const ::starrocks::RestoreSnapshotsRequest* r
             raw::stl_string_resize_uninitialized(&read_buf, size);
             RETURN_IF_ERROR(rf->read_at_fully(0, read_buf.data(), size));
             std::shared_ptr<starrocks::TabletMetadata> meta = std::make_shared<starrocks::TabletMetadata>();
-            bool parsed = meta->ParseFromArray(read_buf.data(), static_cast<int>(size));
-            if (!parsed) {
-                return Status::Corruption(fmt::format("failed to parse tablet meta {}", full_remote_file));
+            // The backup copied the metadata file byte-for-byte, so the blob carries whatever on-disk
+            // format the source cluster wrote: the checksummed header when
+            // lake_enable_protobuf_file_checksum was on, plain protobuf otherwise. Auto-detect both.
+            auto st = ProtobufFileWithHeader::load_from_buffer(meta.get(), read_buf, LAKE_META_HEADER_MAGIC_NUMBER,
+                                                               /*allow_plain_protobuf_fallback=*/true);
+            if (!st.ok()) {
+                return Status::Corruption(
+                        fmt::format("failed to parse tablet meta {}: {}", full_remote_file, st.message()));
             }
             meta->set_id(restore_info.tablet_id());
             // The snapshot blob is parsed directly (it never went through a load path), so a backup taken


### PR DESCRIPTION
## Why I'm doing:

`BACKUP` of a shared-data table copies the tablet metadata file into the repository
byte-for-byte (`LakeSnapshotLoader::upload` registers `tablet_metadata_filename(...)` →
`tablet->metadata_location(version)` and then `fs::copy`s it, with no re-serialization).
So the snapshot blob carries whatever on-disk format the source cluster wrote.

Since #75334 `lake_enable_protobuf_file_checksum` defaults to `true`, that format is the
checksummed one: a 36-byte `FixedFileHeader` whose first on-disk byte is `0xFE`.

`LakeSnapshotLoader::restore` parsed the blob with a bare `ParseFromArray`, which cannot skip
that header — `0xFE` decodes to protobuf wire type 6, which is not a valid wire type, so the
parse can never succeed. Every restore of such a backup fails with:

```
failed to parse tablet meta <repo>/<snapshot>/<tablet>_<version>.meta.<md5>
```

The failure mode is unpleasant: the `BACKUP` itself succeeds and its md5 matches, so the
problem only surfaces at `RESTORE` time — every backup taken since the default flip is
silently unusable until then.

This is a gap left by #74924 / #75334: the write side and all the `TabletManager` read paths
were converted to the header-aware loader, but this call site parses the bytes directly and
was missed. #77362 fixed the same class of gap in the cross-cluster replication path.

## What I'm doing:

Load the snapshot blob through `ProtobufFileWithHeader::load_from_buffer` with
`LAKE_META_HEADER_MAGIC_NUMBER` and `allow_plain_protobuf_fallback=true` — the same
auto-detecting path `TabletManager::load_lake_protobuf` and
`lake_replication_txn_manager.cpp` already use. The fallback keeps backups taken before the
feature (plain headerless protobuf) restorable, so this is compatible in both directions.

The existing `Status::Corruption` type and the `failed to parse tablet meta <file>` message
prefix are preserved; the underlying reason is now appended.

### Affected branches

Both `branch-4.1` and `branch-4.0` carry the same unfixed call site and need this change:

- **4.1** — `lake_enable_protobuf_file_checksum` defaults to `true`, so backup/restore is
  broken out of the box.
- **4.0** — the flag defaults to `false`, so the bug is latent there; it arms as soon as an
  operator enables the config.

The backports will be raised manually rather than via the auto-backport labels, because the
file was moved on main (`be/src/runtime/lake_snapshot_loader.cpp` →
`be/src/data_workflows/snapshot/lake_snapshot_loader.cpp`) and a cherry-pick would conflict.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

### On tests

No unit test is added, deliberately. Reaching this call site requires a broker plus a thrift
server plus a lake `TabletManager`; the existing `be/test/data_workflows/snapshot/snapshot_loader_test.cpp`
has none of that scaffolding, and standing it up for a single call site would dwarf the change.
The parsing helper this now calls is already covered for both on-disk formats in
`be/test/storage/protobuf_file_test.cpp` (`new_format_roundtrip`, `read_legacy_plain_protobuf`,
`read_legacy_small_protobuf`, `static_buffer_load_fallback`, `empty_file_rejected_in_fallback`).

This has not been validated end to end yet. The meaningful check is a `BACKUP` followed by a
`RESTORE` of a shared-data table on a cluster running with
`lake_enable_protobuf_file_checksum = true`; that run is still pending.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
