### PR TITLE
[BugFix] Validate bundle tablet metadata identity

### DIFF
--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -1072,6 +1072,9 @@ StatusOr<TabletMetadataPtr> TabletManager::get_single_tablet_metadata(int64_t ta
         (void)corrupted_tablet_meta_handler(corrupted_status, path);
         return corrupted_status;
     }
+    RETURN_IF(!metadata->has_id() || metadata->id() != tablet_id,
+              Status::Corruption(fmt::format("mismatched tablet id in bundle metadata {}. real={} expect={}", path,
+                                             metadata->has_id() ? metadata->id() : 0, tablet_id)));
     normalize_tablet_metadata_after_load(metadata.get());
 
     FAIL_POINT_TRIGGER_EXECUTE(tablet_schema_not_found_in_bundle_metadata, { tablet_id = 10003; });

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -1443,6 +1443,46 @@ TEST_F(LakeTabletManagerTest, get_single_tablet_metadata_parse_failure) {
     EXPECT_TRUE(handler_called) << "corrupted_tablet_meta_handler should have been called";
 }
 
+TEST_F(LakeTabletManagerTest, get_single_tablet_metadata_rejects_mismatched_tablet_id) {
+    auto old_flag = config::lake_enable_protobuf_file_checksum;
+    DeferOp guard([old_flag]() { config::lake_enable_protobuf_file_checksum = old_flag; });
+    config::lake_enable_protobuf_file_checksum = false;
+
+    constexpr int64_t kTabletId = 101;
+    std::map<int64_t, TabletMetadataPB> metadatas;
+    auto& metadata = metadatas[kTabletId];
+    metadata.set_id(kTabletId);
+    metadata.set_version(2);
+    metadata.mutable_schema()->set_id(10);
+    ASSERT_OK(_tablet_manager->put_bundle_tablet_metadata(metadatas));
+
+    auto path = _tablet_manager->bundle_tablet_metadata_location(kTabletId, 2);
+    auto fs = FileSystem::Default();
+    ASSIGN_OR_ABORT(auto read_file, fs->new_random_access_file(path));
+    ASSIGN_OR_ABORT(auto content, read_file->read_all());
+    ASSIGN_OR_ABORT(auto bundle_metadata, TabletManager::parse_bundle_tablet_metadata(path, content));
+    auto page_it = bundle_metadata->tablet_meta_pages().find(kTabletId);
+    ASSERT_NE(bundle_metadata->tablet_meta_pages().end(), page_it);
+    const auto& page = page_it->second;
+
+    TabletMetadataPB corrupted_metadata;
+    ASSERT_TRUE(corrupted_metadata.ParseFromArray(content.data() + page.offset(), page.size()));
+    corrupted_metadata.set_id(kTabletId + 1);
+    std::string corrupted_page;
+    ASSERT_TRUE(corrupted_metadata.SerializeToString(&corrupted_page));
+    ASSERT_EQ(page.size(), corrupted_page.size());
+    content.replace(page.offset(), page.size(), corrupted_page);
+
+    ASSERT_OK(fs->delete_file(path));
+    ASSIGN_OR_ABORT(auto write_file, fs->new_writable_file(path));
+    ASSERT_OK(write_file->append(content));
+    ASSERT_OK(write_file->close());
+    _tablet_manager->metacache()->prune();
+
+    auto result = _tablet_manager->get_single_tablet_metadata(kTabletId, 2);
+    ASSERT_TRUE(result.status().is_corruption()) << result.status();
+}
+
 // Bundle tablet metadata checksum: the footer carries a crc32 over the bundle header plus a
 // magic so the read path can tell the new checksummed layout from the legacy one. Verifies:
 //   - new format (flag on): footer magic present, header crc + per-page checksums populated, reads OK;


### PR DESCRIPTION
## Why I'm doing:

The bulk bundle-metadata read path validates that each parsed tablet metadata ID matches its bundle page key, but the single-tablet bundle read path did not perform the same check. A malformed bundle page could therefore return metadata for a different tablet.

Related to #75103.

## What I'm doing:

- Validate that metadata parsed by the single-tablet bundle read path has the requested tablet ID.
- Add a regression test that replaces a bundle page with a valid protobuf carrying a different tablet ID and verifies that the read returns corruption.

This intentionally does not change standalone metadata, transaction-log, vacuum, or generic protobuf fallback behavior.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

The single-tablet bundle read now reports corruption when the parsed tablet ID does not match the requested tablet.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

## Validation

Not run locally per request; rely on CI.
