### PR TITLE
[BugFix] Safely remap rowset IDs and references during tablet merge

### DIFF
--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -166,6 +166,7 @@ public:
     }
 
     bool has_next_rowset() const { return _current_rowset_index < _metadata->rowsets_size(); }
+    int current_rowset_index() const { return _current_rowset_index; }
     const RowsetMetadataPB& current_rowset() const { return _metadata->rowsets(_current_rowset_index); }
     void advance_rowset() { ++_current_rowset_index; }
 
@@ -243,41 +244,6 @@ void union_delvec(DelVector* target, DelVector& source, int64_t version) {
     target->init(version, all_dels.data(), all_dels.size());
 }
 
-// Shift that lifts |append_metadata|'s rowset id space above |base_metadata|'s watermark, so the
-// two can be concatenated without colliding. Derived from the LIVE rowsets' minimum id, which is
-// the lowest id add_rowset will map through TabletMergeContext::map_rssid... almost: add_rowset
-// also maps two fields that reference rowsets which no longer exist, and therefore sit BELOW that
-// minimum -- max_compact_input_rowset_id (the compaction inputs, erased by apply_opcompaction) and
-// del_files[].origin_rowset_id (the input rowset a compaction-inherited del file came from).
-//
-// Clamped at 0 so the shift is never negative. A negative shift is otherwise reachable whenever the
-// merge inputs' id spaces have diverged -- writes into a range-distributed table are range-routed,
-// so a hot range burns through rowset ids while a cold sibling stays low, and merging them asks for
-// a large downward shift of the hot tablet. Under such a shift the two dead-reference fields above
-// map below zero and map_rssid fails the whole publish with "Segment id overflow during tablet
-// merge"; the FE then retries that publish forever and the table is left permanently unwritable.
-//
-// Declining to shift down is collision-free by construction: the caller only reaches the negative
-// case when min_id already exceeds the cumulative ceiling, i.e. when every one of this metadata's
-// rowset ids is already strictly above every id projected from an earlier merge input. The cost is
-// a sparser id space in the merged output (next_rowset_id inherits the max of the inputs instead of
-// being repacked), which update_next_rowset_id recomputes and which the uint32 id space absorbs.
-//
-// Deliberately NOT fixed by folding the dead references into the min_id scan: that keeps the tight
-// packing but only holds for the fields enumerated here, so a future field referencing an older
-// rssid would silently reintroduce the failure. A non-negative shift can never map any uint32 rssid
-// below zero, whatever the field.
-int64_t compute_rssid_offset(const TabletMetadataPB& base_metadata, const TabletMetadataPB& append_metadata) {
-    uint32_t min_id = std::numeric_limits<uint32_t>::max();
-    for (const auto& rowset : append_metadata.rowsets()) {
-        min_id = std::min(min_id, rowset.id());
-    }
-    if (min_id == std::numeric_limits<uint32_t>::max()) {
-        return 0;
-    }
-    return std::max<int64_t>(0, static_cast<int64_t>(base_metadata.next_rowset_id()) - min_id);
-}
-
 // Duplicate detection for merge: two rowsets are the same logical rowset across
 // split siblings iff they carry the same global uid. The uid is minted once at
 // rowset creation and carried verbatim by CopyFrom across SPLIT and cross-publish,
@@ -287,6 +253,151 @@ int64_t compute_rssid_offset(const TabletMetadataPB& base_metadata, const Tablet
 // and never aliases. A rowset without a valid uid is never treated as a duplicate.
 bool is_duplicate_rowset(const RowsetMetadataPB& a, const RowsetMetadataPB& b) {
     return tablet_reshard_helper::same_rowset_uid(a, b);
+}
+
+struct RowsetEmissionDecision {
+    int canonical_index = -1;
+    bool emit = false;
+    bool non_pk_skip_dedup_fired = false;
+};
+
+using RowsetEmissionPlan = std::vector<std::vector<RowsetEmissionDecision>>;
+
+struct PlannedCanonicalRowset {
+    const RowsetMetadataPB* rowset = nullptr;
+    TabletRangePB range;
+    int output_index = -1;
+};
+
+// Plan the exact rowsets merge_rowsets will emit in (version, old-tablet-index)
+// order. This is the single source of truth for duplicate decisions: offset
+// preparation uses it to ignore discarded sibling copies, and merge_rowsets
+// uses the recorded canonical index instead of recomputing dedup independently.
+StatusOr<RowsetEmissionPlan> build_rowset_emission_plan(const std::vector<TabletMergeContext>& merge_contexts) {
+    RowsetEmissionPlan plan(merge_contexts.size());
+    std::vector<int> current_indices(merge_contexts.size(), 0);
+    for (size_t i = 0; i < merge_contexts.size(); ++i) {
+        plan[i].resize(merge_contexts[i].metadata()->rowsets_size());
+    }
+
+    const bool is_pk = is_primary_key(*merge_contexts.front().metadata());
+    int64_t current_version = -1;
+    int next_output_index = 0;
+    std::vector<PlannedCanonicalRowset> canonicals;
+
+    for (;;) {
+        int source_index = -1;
+        int64_t min_version = std::numeric_limits<int64_t>::max();
+        for (int i = 0; i < static_cast<int>(merge_contexts.size()); ++i) {
+            if (current_indices[i] >= merge_contexts[i].metadata()->rowsets_size()) continue;
+            const int64_t version = merge_contexts[i].metadata()->rowsets(current_indices[i]).version();
+            if (version < min_version) {
+                min_version = version;
+                source_index = i;
+            }
+        }
+        if (source_index < 0) break;
+
+        const int rowset_index = current_indices[source_index]++;
+        const auto& source_metadata = *merge_contexts[source_index].metadata();
+        const auto& rowset = source_metadata.rowsets(rowset_index);
+        if (rowset.version() != current_version) {
+            current_version = rowset.version();
+            canonicals.clear();
+        }
+
+        // Search the current version's canonical rowsets. Delete predicates dedup
+        // by version, normal rowsets by uid; non-PK same-uid siblings dedup only
+        // when their ranges are contiguous, so the canonical range cannot span a
+        // gap left by a compacted sibling.
+        int canonical_plan_index = -1;
+        bool non_pk_skip_dedup_fired = false;
+        for (int i = 0; i < static_cast<int>(canonicals.size()); ++i) {
+            if (rowset.has_delete_predicate()) {
+                if (canonicals[i].rowset->has_delete_predicate()) {
+                    canonical_plan_index = i;
+                    break;
+                }
+                continue;
+            }
+            if (!is_duplicate_rowset(rowset, *canonicals[i].rowset)) continue;
+
+            const auto& incoming_range =
+                    tablet_reshard_helper::effective_old_tablet_local_range(rowset, source_metadata);
+            if (is_pk || tablet_reshard_helper::ranges_are_contiguous(canonicals[i].range, incoming_range)) {
+                canonical_plan_index = i;
+                if (!is_pk) {
+                    ASSIGN_OR_RETURN(canonicals[i].range,
+                                     tablet_reshard_helper::union_range(canonicals[i].range, incoming_range));
+                }
+                break;
+            }
+            non_pk_skip_dedup_fired = true;
+        }
+
+        auto& decision = plan[source_index][rowset_index];
+        if (canonical_plan_index >= 0) {
+            decision.canonical_index = canonicals[canonical_plan_index].output_index;
+            continue;
+        }
+
+        decision.emit = true;
+        decision.canonical_index = next_output_index++;
+        decision.non_pk_skip_dedup_fired = non_pk_skip_dedup_fired;
+        PlannedCanonicalRowset canonical;
+        canonical.rowset = &rowset;
+        canonical.output_index = decision.canonical_index;
+        RowsetMetadataPB canonical_copy;
+        canonical_copy.CopyFrom(rowset);
+        RETURN_IF_ERROR(tablet_reshard_helper::update_rowset_range(&canonical_copy, source_metadata.range()));
+        canonical.range.CopyFrom(canonical_copy.range());
+        canonicals.emplace_back(std::move(canonical));
+    }
+
+    return plan;
+}
+
+// Shift that lifts the rowset-id space that |append_index| will actually emit
+// above |base_metadata|'s watermark, so the two can be concatenated without
+// collisions.
+//
+// The floor includes every rowset id or rowset-id reference that add_rowset()
+// carries into the merged metadata:
+//   * rowset.id
+//   * max_compact_input_rowset_id
+//   * del_files[].origin_rowset_id
+//
+// The latter two can sit below the minimum live rowset id because their referenced
+// compaction inputs have already been erased from rowsets(). Computing the shift from
+// live ids alone can therefore map a dead reference below zero, or into an earlier
+// input's live id space. Conversely, references from a same-UID sibling copy that
+// merge_rowsets will discard must not lower the floor: they are not carried into the
+// output and can make a high-ID surviving rowset overflow after an unnecessary lift.
+//
+// Using the emitted-rowset floor maps the smallest carried value to
+// base_metadata.next_rowset_id(), keeps all carried references disjoint from earlier
+// inputs, and preserves their relative ordering under the same uniform shift.
+int64_t compute_rssid_offset(const TabletMetadataPB& base_metadata,
+                             const std::vector<TabletMergeContext>& merge_contexts,
+                             const RowsetEmissionPlan& emission_plan, size_t append_index) {
+    uint32_t min_carried_id = std::numeric_limits<uint32_t>::max();
+    const auto& append_metadata = *merge_contexts[append_index].metadata();
+    for (int rowset_index = 0; rowset_index < append_metadata.rowsets_size(); ++rowset_index) {
+        if (!emission_plan[append_index][rowset_index].emit) continue;
+
+        const auto& rowset = append_metadata.rowsets(rowset_index);
+        min_carried_id = std::min(min_carried_id, rowset.id());
+        if (rowset.has_max_compact_input_rowset_id()) {
+            min_carried_id = std::min(min_carried_id, rowset.max_compact_input_rowset_id());
+        }
+        for (const auto& del_file : rowset.del_files()) {
+            min_carried_id = std::min(min_carried_id, del_file.origin_rowset_id());
+        }
+    }
+    if (min_carried_id == std::numeric_limits<uint32_t>::max()) {
+        return 0;
+    }
+    return static_cast<int64_t>(base_metadata.next_rowset_id()) - min_carried_id;
 }
 
 Status add_rowset(TabletMergeContext& ctx, const RowsetMetadataPB& rowset, TabletMetadataPB* new_metadata) {
@@ -463,12 +574,8 @@ Status update_canonical(RowsetMetadataPB* canonical_rowset, const TabletRangePB&
     return Status::OK();
 }
 
-Status merge_rowsets(std::vector<TabletMergeContext>& merge_contexts, TabletMetadataPB* new_metadata,
-                     CanonicalContribMap* canonical_contribs) {
-    const bool is_pk = is_primary_key(*new_metadata);
-    int version_start_index = 0;
-    int64_t current_version = -1;
-
+Status merge_rowsets(std::vector<TabletMergeContext>& merge_contexts, const RowsetEmissionPlan& emission_plan,
+                     TabletMetadataPB* new_metadata, CanonicalContribMap* canonical_contribs) {
     for (;;) {
         // Find old tablet with minimum (version, old_tablet_index).
         // Forward iteration with strict < ensures the smallest old_tablet_index wins on ties.
@@ -484,6 +591,7 @@ Status merge_rowsets(std::vector<TabletMergeContext>& merge_contexts, TabletMeta
         }
         if (min_old_tablet_index < 0) break;
 
+        const int source_rowset_index = merge_contexts[min_old_tablet_index].current_rowset_index();
         const auto& rowset = merge_contexts[min_old_tablet_index].current_rowset();
         const auto& ctx_meta = *merge_contexts[min_old_tablet_index].metadata();
 
@@ -503,62 +611,30 @@ Status merge_rowsets(std::vector<TabletMergeContext>& merge_contexts, TabletMeta
                                 rowset.version()));
         }
 
-        // Version change: update version_start_index
-        if (rowset.version() != current_version) {
-            current_version = rowset.version();
-            version_start_index = new_metadata->rowsets_size();
-        }
-
-        // Search [version_start_index, end) for a dedup candidate. The window is a
-        // single version (the k-way merge above feeds rowsets in version order). Decision:
-        //   - Delete-predicate rowsets dedup by VERSION, not uid: a version is one
-        //     transaction carrying one predicate, so two same-version predicates from
-        //     different merged siblings are the same logical delete. A normal post-split
-        //     DELETE runs Tablet::delete_data independently per sibling tablet and mints
-        //     an independent uid each time, so keying on uid would wrongly retain one
-        //     copy per sibling; the pre-uid merge deduped these by version. (The uid is
-        //     still required by the invariant above -- it just isn't the predicate
-        //     dedup key.)
-        //   - Shared-segment / shared-del_file dups (the only case is_duplicate_rowset
-        //     returns true on): PK always dedups; non-PK dedups only when ranges are
-        //     contiguous so that the convex-hull range stored on the canonical does not
-        //     span a gap left by a compacted sibling.
-        int canonical_index = -1;
-        bool non_pk_skip_dedup_fired = false;
-        for (int i = version_start_index; i < new_metadata->rowsets_size(); ++i) {
-            if (rowset.has_delete_predicate()) {
-                if (new_metadata->rowsets(i).has_delete_predicate()) {
-                    canonical_index = i;
-                    break;
-                }
-                continue;
-            }
-            if (!is_duplicate_rowset(rowset, new_metadata->rowsets(i))) continue;
-
-            if (is_pk) {
-                canonical_index = i;
-                break;
-            }
-            const auto& candidate_range = new_metadata->rowsets(i).range();
-            const auto& incoming_range = tablet_reshard_helper::effective_old_tablet_local_range(rowset, ctx_meta);
-            if (tablet_reshard_helper::ranges_are_contiguous(candidate_range, incoming_range)) {
-                canonical_index = i;
-                break;
-            }
-            // Non-PK + non-contiguous: keep scanning. If no other candidate
-            // matches, fall through to add_rowset and treat as a separate
-            // shared rowset — each retains its own contiguous range.
-            non_pk_skip_dedup_fired = true;
-        }
-        if (canonical_index < 0 && non_pk_skip_dedup_fired) {
+        const auto& decision = emission_plan[min_old_tablet_index][source_rowset_index];
+        if (decision.emit && decision.non_pk_skip_dedup_fired) {
             // At least one is_duplicate_rowset hit was rejected due to
             // non-contiguous ranges and no later candidate accepted it →
             // the rowset is added as a sibling of an existing shared rowset.
             g_tablet_merge_non_pk_skip_dedup_total << 1;
         }
+        if (decision.emit && decision.canonical_index != new_metadata->rowsets_size()) {
+            return Status::InternalError(fmt::format(
+                    "tablet merge rowset emission plan is out of sequence: old_tablet_index={} rowset_index={} "
+                    "planned_index={} actual_index={}",
+                    min_old_tablet_index, source_rowset_index, decision.canonical_index, new_metadata->rowsets_size()));
+        }
+        if (!decision.emit &&
+            (decision.canonical_index < 0 || decision.canonical_index >= new_metadata->rowsets_size())) {
+            return Status::InternalError(fmt::format(
+                    "tablet merge rowset emission plan has invalid canonical index: old_tablet_index={} "
+                    "rowset_index={} canonical_index={} output_size={}",
+                    min_old_tablet_index, source_rowset_index, decision.canonical_index, new_metadata->rowsets_size()));
+        }
 
-        if (canonical_index >= 0) {
+        if (!decision.emit) {
             // Duplicate: skip output
+            const int canonical_index = decision.canonical_index;
             const auto& canonical = new_metadata->rowsets(canonical_index);
             // Same-uid siblings legitimately carry different segment lists when split
             // pruned them to disjoint subsets (whether shared=false per-segment pruning
@@ -2643,11 +2719,12 @@ void reassign_fileset_ids_for_ordered_runs(google::protobuf::RepeatedPtrField<Pe
 // reference, clamped to the uint32_t key space the per-ctx
 // disagreement-key vector indexes by. Both bounds are inclusive.
 //
-// The signed arithmetic matters because |source_rssid_offset| is the
-// sstable's OWN stored rssid_offset, which can be negative in metadata
-// written before compute_rssid_offset was clamped to a non-negative
-// shift. Casting a negative low to uint32_t directly would wrap to a
-// huge value and silently miss in-range disagreement keys.
+// The signed arithmetic matters because both the sstable's own stored
+// rssid_offset and the merge context's offset can be negative. The latter
+// is safe because compute_rssid_offset derives it from the minimum of every
+// carried rowset id/reference, but casting a negative intermediate bound to
+// uint32_t would still wrap to a huge value and silently miss in-range
+// disagreement keys.
 struct ClampedLiftedRange {
     uint32_t lower = 0;
     uint32_t upper = 0;
@@ -2993,6 +3070,8 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
     // build task never skips another source's unbuilt rowsets (see the helper for the invariant).
     reconcile_vector_index_built_version(merge_contexts, new_tablet_metadata.get());
 
+    ASSIGN_OR_RETURN(auto rowset_emission_plan, build_rowset_emission_plan(merge_contexts));
+
     // Phase 1: Prepare rssid offsets and merged range. For each ctx[i],
     // set new_tablet_metadata.next_rowset_id to the watermark of all
     // earlier ctxs[0..i-1]'s projected rowset ids; compute_rssid_offset
@@ -3002,7 +3081,9 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
         const uint32_t cumulative_ceiling = compute_cumulative_rowset_id_ceiling(
                 merge_contexts, /*upper_exclusive=*/i, merge_contexts.front().metadata()->next_rowset_id());
         new_tablet_metadata->set_next_rowset_id(cumulative_ceiling);
-        merge_contexts[i].set_rssid_offset(compute_rssid_offset(*new_tablet_metadata, *merge_contexts[i].metadata()));
+        const int64_t rssid_offset =
+                compute_rssid_offset(*new_tablet_metadata, merge_contexts, rowset_emission_plan, i);
+        merge_contexts[i].set_rssid_offset(rssid_offset);
     }
 
     // Merge tablet-level range via union_range
@@ -3018,7 +3099,8 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
     // old tablets' old-tablet-local ranges; consumed by the PK fail-fast coverage
     // check below and by gap-delvec synthesis.
     CanonicalContribMap canonical_contribs;
-    RETURN_IF_ERROR(merge_rowsets(merge_contexts, new_tablet_metadata.get(), &canonical_contribs));
+    RETURN_IF_ERROR(
+            merge_rowsets(merge_contexts, rowset_emission_plan, new_tablet_metadata.get(), &canonical_contribs));
 
     // Phase 2.5: Merge schemas (must run before gap synthesis + merge_dcg_meta,
     // which need historical_schemas to locate rebuild schemas for shared-segment

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -243,6 +243,30 @@ void union_delvec(DelVector* target, DelVector& source, int64_t version) {
     target->init(version, all_dels.data(), all_dels.size());
 }
 
+// Shift that lifts |append_metadata|'s rowset id space above |base_metadata|'s watermark, so the
+// two can be concatenated without colliding. Derived from the LIVE rowsets' minimum id, which is
+// the lowest id add_rowset will map through TabletMergeContext::map_rssid... almost: add_rowset
+// also maps two fields that reference rowsets which no longer exist, and therefore sit BELOW that
+// minimum -- max_compact_input_rowset_id (the compaction inputs, erased by apply_opcompaction) and
+// del_files[].origin_rowset_id (the input rowset a compaction-inherited del file came from).
+//
+// Clamped at 0 so the shift is never negative. A negative shift is otherwise reachable whenever the
+// merge inputs' id spaces have diverged -- writes into a range-distributed table are range-routed,
+// so a hot range burns through rowset ids while a cold sibling stays low, and merging them asks for
+// a large downward shift of the hot tablet. Under such a shift the two dead-reference fields above
+// map below zero and map_rssid fails the whole publish with "Segment id overflow during tablet
+// merge"; the FE then retries that publish forever and the table is left permanently unwritable.
+//
+// Declining to shift down is collision-free by construction: the caller only reaches the negative
+// case when min_id already exceeds the cumulative ceiling, i.e. when every one of this metadata's
+// rowset ids is already strictly above every id projected from an earlier merge input. The cost is
+// a sparser id space in the merged output (next_rowset_id inherits the max of the inputs instead of
+// being repacked), which update_next_rowset_id recomputes and which the uint32 id space absorbs.
+//
+// Deliberately NOT fixed by folding the dead references into the min_id scan: that keeps the tight
+// packing but only holds for the fields enumerated here, so a future field referencing an older
+// rssid would silently reintroduce the failure. A non-negative shift can never map any uint32 rssid
+// below zero, whatever the field.
 int64_t compute_rssid_offset(const TabletMetadataPB& base_metadata, const TabletMetadataPB& append_metadata) {
     uint32_t min_id = std::numeric_limits<uint32_t>::max();
     for (const auto& rowset : append_metadata.rowsets()) {
@@ -251,7 +275,7 @@ int64_t compute_rssid_offset(const TabletMetadataPB& base_metadata, const Tablet
     if (min_id == std::numeric_limits<uint32_t>::max()) {
         return 0;
     }
-    return static_cast<int64_t>(base_metadata.next_rowset_id()) - min_id;
+    return std::max<int64_t>(0, static_cast<int64_t>(base_metadata.next_rowset_id()) - min_id);
 }
 
 // Duplicate detection for merge: two rowsets are the same logical rowset across
@@ -2619,12 +2643,11 @@ void reassign_fileset_ids_for_ordered_runs(google::protobuf::RepeatedPtrField<Pe
 // reference, clamped to the uint32_t key space the per-ctx
 // disagreement-key vector indexes by. Both bounds are inclusive.
 //
-// The signed arithmetic matters because compute_rssid_offset can
-// produce a negative ctx.rssid_offset() when ctx[N>0]'s input rowset
-// ids exceed ctx[0]'s next_rowset_id (legal — exercised by
-// test_tablet_merging_accumulates_stacked_rssid_offset). Casting a
-// negative low to uint32_t directly would wrap to a huge value and
-// silently miss in-range disagreement keys.
+// The signed arithmetic matters because |source_rssid_offset| is the
+// sstable's OWN stored rssid_offset, which can be negative in metadata
+// written before compute_rssid_offset was clamped to a non-negative
+// shift. Casting a negative low to uint32_t directly would wrap to a
+// huge value and silently miss in-range disagreement keys.
 struct ClampedLiftedRange {
     uint32_t lower = 0;
     uint32_t upper = 0;

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -357,9 +357,27 @@ StatusOr<RowsetEmissionPlan> build_rowset_emission_plan(const std::vector<Tablet
     return plan;
 }
 
-// Shift that lifts the rowset-id space that |append_index| will actually emit
-// above |base_metadata|'s watermark, so the two can be concatenated without
-// collisions.
+// True when |rowset|'s own ids still reach the merged namespace through
+// ctx.rssid_offset instead of being redirected to a canonical rowset.
+//
+// Emitted rowsets always do. Among the discarded ones, only delete predicates do:
+// merge_rowsets calls update_shared_rssid_map for a discarded duplicate exactly when
+// it is not a delete predicate, so a deduped predicate's id keeps falling through
+// map_rssid's natural-offset branch (build_legacy_rssid_lookup_maps projects every
+// rowset id, emitted or not) while a deduped data rowset's id and segment rssids all
+// resolve to the canonical rowset an earlier input already emitted.
+//
+// The floor (compute_rssid_offset) and the ceiling (compute_cumulative_rowset_id_ceiling)
+// must agree on this set. If the ceiling covers more, a later input is lifted over ids
+// nobody occupies and can overflow map_rssid near UINT32_MAX; if it covers less, a later
+// input lands on ids an earlier input still projects into.
+bool projects_via_rssid_offset(const RowsetEmissionDecision& decision, const RowsetMetadataPB& rowset) {
+    return decision.emit || rowset.has_delete_predicate();
+}
+
+// Shift that lifts the rowset-id space that |append_index| projects through its own
+// rssid_offset above |base_metadata|'s watermark, so the two can be concatenated
+// without collisions.
 //
 // The floor includes every rowset id or rowset-id reference that add_rowset()
 // carries into the merged metadata:
@@ -374,19 +392,26 @@ StatusOr<RowsetEmissionPlan> build_rowset_emission_plan(const std::vector<Tablet
 // merge_rowsets will discard must not lower the floor: they are not carried into the
 // output and can make a high-ID surviving rowset overflow after an unnecessary lift.
 //
-// Using the emitted-rowset floor maps the smallest carried value to
-// base_metadata.next_rowset_id(), keeps all carried references disjoint from earlier
-// inputs, and preserves their relative ordering under the same uniform shift.
+// A discarded delete predicate contributes its id but none of its references: the
+// references die with it, while the id itself still projects naturally (see
+// projects_via_rssid_offset) and must stay disjoint from earlier inputs.
+//
+// Using that floor maps the smallest carried value to base_metadata.next_rowset_id(),
+// keeps all carried references disjoint from earlier inputs, and preserves their
+// relative ordering under the same uniform shift.
 int64_t compute_rssid_offset(const TabletMetadataPB& base_metadata,
                              const std::vector<TabletMergeContext>& merge_contexts,
                              const RowsetEmissionPlan& emission_plan, size_t append_index) {
     uint32_t min_carried_id = std::numeric_limits<uint32_t>::max();
     const auto& append_metadata = *merge_contexts[append_index].metadata();
     for (int rowset_index = 0; rowset_index < append_metadata.rowsets_size(); ++rowset_index) {
-        if (!emission_plan[append_index][rowset_index].emit) continue;
-
         const auto& rowset = append_metadata.rowsets(rowset_index);
+        const auto& decision = emission_plan[append_index][rowset_index];
+        if (!projects_via_rssid_offset(decision, rowset)) continue;
+
         min_carried_id = std::min(min_carried_id, rowset.id());
+        if (!decision.emit) continue;
+
         if (rowset.has_max_compact_input_rowset_id()) {
             min_carried_id = std::min(min_carried_id, rowset.max_compact_input_rowset_id());
         }
@@ -2747,14 +2772,26 @@ ClampedLiftedRange clamp_lifted_range_to_uint32(int32_t source_rssid_offset, uin
 // rssid_offset assignment so each old tablet's projected rowset ids land
 // strictly above every earlier old tablet's projected ids.
 //
+// Only rowsets that project through their own ctx's rssid_offset are counted, the
+// same set compute_rssid_offset derives the floor from. A discarded duplicate's ids
+// resolve to the canonical rowset instead, which an earlier ctx already contributed
+// to this ceiling, so reserving room for it here would lift later inputs over an
+// unoccupied hole -- with three or more siblings whose id counters have diverged that
+// alone can push map_rssid past UINT32_MAX.
+//
 // Each uint32_t addend is widened to int64_t before the addition to avoid
 // uint32_t wrap when rowset.id() approaches UINT32_MAX — wrap there would
 // under-estimate the watermark and let later old tablets reuse occupied rssids.
 uint32_t compute_cumulative_rowset_id_ceiling(const std::vector<TabletMergeContext>& merge_contexts,
-                                              size_t upper_exclusive, uint32_t base_next_rowset_id) {
+                                              const RowsetEmissionPlan& emission_plan, size_t upper_exclusive,
+                                              uint32_t base_next_rowset_id) {
     uint32_t ceiling = base_next_rowset_id;
     for (size_t j = 0; j < upper_exclusive; ++j) {
-        for (const auto& rowset : merge_contexts[j].metadata()->rowsets()) {
+        const auto& metadata = *merge_contexts[j].metadata();
+        for (int rowset_index = 0; rowset_index < metadata.rowsets_size(); ++rowset_index) {
+            const auto& rowset = metadata.rowsets(rowset_index);
+            if (!projects_via_rssid_offset(emission_plan[j][rowset_index], rowset)) continue;
+
             const int64_t end_wide = static_cast<int64_t>(rowset.id()) +
                                      static_cast<int64_t>(get_rowset_id_step(rowset)) +
                                      merge_contexts[j].rssid_offset();
@@ -3078,8 +3115,9 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
     // then derives ctx[i].rssid_offset against that watermark so its
     // projected ids land strictly above every earlier ctx's.
     for (size_t i = 1; i < merge_contexts.size(); ++i) {
-        const uint32_t cumulative_ceiling = compute_cumulative_rowset_id_ceiling(
-                merge_contexts, /*upper_exclusive=*/i, merge_contexts.front().metadata()->next_rowset_id());
+        const uint32_t cumulative_ceiling =
+                compute_cumulative_rowset_id_ceiling(merge_contexts, rowset_emission_plan, /*upper_exclusive=*/i,
+                                                     merge_contexts.front().metadata()->next_rowset_id());
         new_tablet_metadata->set_next_rowset_id(cumulative_ceiling);
         const int64_t rssid_offset =
                 compute_rssid_offset(*new_tablet_metadata, merge_contexts, rowset_emission_plan, i);

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -8673,10 +8673,11 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_accumulates_stacked_rssid_offs
     // ctx[0] keeps its original offset (0); no stacking.
     EXPECT_EQ(0, sst_a->rssid_offset());
 
-    // Recover ctx[1].rssid_offset from the rowset mapping. compute_rssid_offset
-    // can be negative (base.next_rowset_id - append.min_id) when ctx[1]'s input
-    // rowset ids are already higher than ctx[0]'s, which is legal and exercises
-    // the accumulation arithmetic under signed offsets.
+    // Recover ctx[1].rssid_offset from the rowset mapping. Here ctx[1]'s input rowset
+    // ids already sit above ctx[0]'s next_rowset_id, so compute_rssid_offset clamps the
+    // shift to 0 (it never shifts down) and the accumulation is 3 + 0. Deriving the
+    // offset from the output rather than hard-coding it keeps the accumulation assertion
+    // meaningful regardless of the clamp.
     bool found_ctx1 = false;
     int32_t ctx1_offset = 0;
     for (const auto& rs : merged->rowsets()) {
@@ -8695,6 +8696,118 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_accumulates_stacked_rssid_offs
     // should be projected by +ctx1_offset.
     const uint32_t sst_b_high = static_cast<uint32_t>(sst_b->max_rss_rowid() >> 32);
     EXPECT_EQ(static_cast<uint32_t>(5 + ctx1_offset), sst_b_high);
+}
+
+// Merging a cold sibling with a hot one whose rowset id space has run far ahead must not
+// fail the publish. Regression for "Segment id overflow during tablet merge".
+//
+// The id layout below is taken verbatim from a wedged production partition: writes into a
+// range-distributed table are range-routed, so the hot range's tablet reached rowset id 860
+// / next_rowset_id 861 while the cold sibling still had a single compacted rowset at id 11 /
+// next_rowset_id 12. compute_rssid_offset used to answer 12 - 798 = -786 for the hot tablet,
+// and add_rowset applies that shift to two fields that reference rowsets which no longer
+// exist and therefore sit below the live minimum: max_compact_input_rowset_id (797) and
+// del_files[].origin_rowset_id (766, inherited from a compaction input). 766 - 786 = -20
+// tripped map_rssid's `mapped < 0` branch and failed the whole reshard publish; the FE then
+// retried it forever and the table stayed unwritable.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_hot_sibling_id_space_does_not_overflow) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t cold_tablet = next_id();
+    const int64_t hot_tablet = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(cold_tablet);
+    prepare_tablet_dirs(hot_tablet);
+    prepare_tablet_dirs(merged_tablet);
+
+    // ctx[0]: the cold sibling. Everything it ever wrote has been compacted into rowset 11,
+    // whose inputs (<= 10) are gone.
+    auto cold_meta = std::make_shared<TabletMetadataPB>();
+    cold_meta->set_id(cold_tablet);
+    cold_meta->set_version(base_version);
+    cold_meta->set_next_rowset_id(12);
+    set_primary_key_schema(cold_meta.get(), 1001);
+    add_rowset(cold_meta.get(), /*rowset_id=*/11, /*max_compact_input_rowset_id=*/10,
+               /*del_origin_rowset_id=*/11);
+
+    // ctx[1]: the hot sibling. min live id 798, and rowset 803 is a compaction output that
+    // inherited a del file from input rowset 766 -- 32 ids below its own live minimum.
+    auto hot_meta = std::make_shared<TabletMetadataPB>();
+    hot_meta->set_id(hot_tablet);
+    hot_meta->set_version(base_version);
+    hot_meta->set_next_rowset_id(861);
+    set_primary_key_schema(hot_meta.get(), 1001);
+    add_rowset(hot_meta.get(), /*rowset_id=*/798, /*max_compact_input_rowset_id=*/797,
+               /*del_origin_rowset_id=*/798);
+    add_rowset(hot_meta.get(), /*rowset_id=*/803, /*max_compact_input_rowset_id=*/797,
+               /*del_origin_rowset_id=*/766);
+    add_rowset(hot_meta.get(), /*rowset_id=*/860, /*max_compact_input_rowset_id=*/859,
+               /*del_origin_rowset_id=*/860);
+
+    ASSERT_OK(put_tablet_metadata(cold_meta));
+    ASSERT_OK(put_tablet_metadata(hot_meta));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(cold_tablet);
+    merging_tablet.add_old_tablet_ids(hot_tablet);
+    merging_tablet.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(2);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(2);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    // Before the fix this returned InvalidArgument("Segment id overflow during tablet merge").
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto it = tablet_metadatas.find(merged_tablet);
+    ASSERT_TRUE(it != tablet_metadatas.end());
+    const auto& merged = it->second;
+
+    // No dedup is possible (every rowset carries its own uid), so all four survive.
+    ASSERT_EQ(4, merged->rowsets_size());
+
+    std::map<uint32_t, const RowsetMetadataPB*> by_id;
+    for (const auto& rowset : merged->rowsets()) {
+        by_id[rowset.id()] = &rowset;
+    }
+
+    // The hot tablet's shift clamps to 0, so its ids pass through untouched. Leaving them in
+    // place is collision-free precisely because they all sit above the cold tablet's ceiling.
+    ASSERT_TRUE(by_id.count(11)) << "cold sibling's rowset must keep id 11";
+    ASSERT_TRUE(by_id.count(798)) << "hot sibling's rowsets must keep their ids";
+    ASSERT_TRUE(by_id.count(803));
+    ASSERT_TRUE(by_id.count(860));
+
+    // The two dead-reference fields are shifted by the same offset as the live ids, so with a
+    // zero shift they survive verbatim -- and, critically, non-negative.
+    const auto* compaction_output = by_id[803];
+    EXPECT_EQ(797u, compaction_output->max_compact_input_rowset_id());
+    ASSERT_EQ(1, compaction_output->del_files_size());
+    EXPECT_EQ(766u, compaction_output->del_files(0).origin_rowset_id());
+
+    // Dead references carried by the hot sibling must not be shifted into the COLD sibling's
+    // live id space. Under the old -786 shift, rowset 803's max_compact_input_rowset_id (797)
+    // landed exactly on 11 -- the cold sibling's live rowset -- which misleads the rowset
+    // ordering in LakePrimaryKeyRecover::sort_rowsets. (The cold sibling's own rowset 11
+    // legitimately references itself, so only the hot sibling's rowsets are checked here.)
+    for (const auto& rowset : merged->rowsets()) {
+        if (rowset.id() < 798) continue; // cold sibling's rowset
+        EXPECT_NE(11u, rowset.max_compact_input_rowset_id())
+                << "hot sibling's compaction input ref collided with the cold sibling's live rowset id";
+        for (const auto& del_file : rowset.del_files()) {
+            EXPECT_NE(11u, del_file.origin_rowset_id())
+                    << "hot sibling's del file origin collided with the cold sibling's live rowset id";
+        }
+    }
+
+    // Future writes must not reuse an occupied id.
+    EXPECT_GE(merged->next_rowset_id(), 861u);
 }
 
 // Merge of two PK parents that both have cloud-native persistent index enabled.

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -8962,6 +8962,104 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_discarded_duplicate_does_not_l
     EXPECT_EQ(kBaseNextRowsetId + 1, merged->next_rowset_id());
 }
 
+// Three siblings whose rowset-id counters have diverged, where the middle one
+// carries nothing but a delete predicate that dedups away against the first
+// sibling's predicate at the same version.
+//
+// A discarded predicate is the one discarded rowset whose id still reaches the
+// merged namespace through the natural offset: merge_rowsets records a
+// shared_rssid_map entry for a discarded duplicate only when it is NOT a delete
+// predicate. So the floor must include it -- otherwise the middle sibling has no
+// floor at all, keeps offset 0, and its raw id (here 4.2e9) becomes the watermark
+// the third sibling is lifted above, pushing the third sibling's own high-ID
+// rowset past UINT32_MAX even though the emitted namespace has room for it.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_discarded_predicate_does_not_inflate_later_sibling_ceiling) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t low_tablet = next_id();
+    const int64_t predicate_only_tablet = next_id();
+    const int64_t wide_tablet = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(low_tablet);
+    prepare_tablet_dirs(predicate_only_tablet);
+    prepare_tablet_dirs(wide_tablet);
+    prepare_tablet_dirs(merged_tablet);
+
+    // ctx[0]: data(v1) -> predicate(v10). Its next_rowset_id (3) is the base watermark.
+    TabletMetadataPB low_meta;
+    low_meta.set_id(low_tablet);
+    low_meta.set_version(base_version);
+    low_meta.set_next_rowset_id(3);
+    add_rowset_with_predicate(&low_meta, /*rowset_id=*/1, /*version=*/1, /*has_predicate=*/false);
+    add_rowset_with_predicate(&low_meta, /*rowset_id=*/2, /*version=*/10, /*has_predicate=*/true);
+    ASSERT_OK(put_tablet_metadata(low_meta));
+
+    // ctx[1]: the same v10 delete predicate, cross-published onto a sibling whose id
+    // counter ran far ahead. Predicates dedup by version, so this is the whole tablet
+    // and merge_rowsets emits nothing from it.
+    constexpr uint32_t kFarAheadPredicateId = 4'200'000'000;
+    TabletMetadataPB predicate_only_meta;
+    predicate_only_meta.set_id(predicate_only_tablet);
+    predicate_only_meta.set_version(base_version);
+    predicate_only_meta.set_next_rowset_id(kFarAheadPredicateId + 1);
+    add_rowset_with_predicate(&predicate_only_meta, kFarAheadPredicateId, /*version=*/10, /*has_predicate=*/true);
+    ASSERT_OK(put_tablet_metadata(predicate_only_meta));
+
+    // ctx[2]: two live rowsets ~1e8 ids apart. Lifting its floor (5) onto ctx[1]'s raw
+    // id would map the top one to 4'299'999'996 > UINT32_MAX.
+    constexpr uint32_t kWideSpanTopId = 100'000'000;
+    TabletMetadataPB wide_meta;
+    wide_meta.set_id(wide_tablet);
+    wide_meta.set_version(base_version);
+    wide_meta.set_next_rowset_id(kWideSpanTopId + 1);
+    add_rowset_with_predicate(&wide_meta, /*rowset_id=*/5, /*version=*/20, /*has_predicate=*/false);
+    add_rowset_with_predicate(&wide_meta, kWideSpanTopId, /*version=*/21, /*has_predicate=*/false);
+    ASSERT_OK(put_tablet_metadata(wide_meta));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(low_tablet);
+    merging_tablet.add_old_tablet_ids(predicate_only_tablet);
+    merging_tablet.add_old_tablet_ids(wide_tablet);
+    merging_tablet.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(2);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(2);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    // Before the fix this returned InvalidArgument("Segment id overflow during tablet merge").
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto it = tablet_metadatas.find(merged_tablet);
+    ASSERT_TRUE(it != tablet_metadatas.end());
+    const auto& merged = it->second;
+
+    // ctx[0]'s two rowsets plus ctx[2]'s two; ctx[1]'s predicate is deduped away.
+    ASSERT_EQ(4, merged->rowsets_size());
+
+    std::vector<uint32_t> rowset_ids;
+    int predicate_count = 0;
+    for (const auto& rowset : merged->rowsets()) {
+        rowset_ids.push_back(rowset.id());
+        if (rowset.has_delete_predicate()) {
+            ++predicate_count;
+            EXPECT_EQ(10, rowset.version());
+        }
+    }
+    EXPECT_EQ(1, predicate_count);
+
+    // ctx[1]'s floor is its discarded predicate id, so it shifts down to the base
+    // watermark 3 and reserves exactly that one slot. ctx[2] is then lifted to 4
+    // instead of to 4'200'000'001, and its span survives intact.
+    EXPECT_EQ((std::vector<uint32_t>{1, 2, 4, kWideSpanTopId - 1}), rowset_ids);
+    EXPECT_EQ(kWideSpanTopId, merged->next_rowset_id());
+}
+
 // Merge of two PK parents that both have cloud-native persistent index enabled.
 // This exercises the flush_parent_for_merge helper end-to-end. Parents have
 // no rowsets so load_from_lake_tablet is a no-op; the dumped sstable_meta

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -8673,11 +8673,10 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_accumulates_stacked_rssid_offs
     // ctx[0] keeps its original offset (0); no stacking.
     EXPECT_EQ(0, sst_a->rssid_offset());
 
-    // Recover ctx[1].rssid_offset from the rowset mapping. Here ctx[1]'s input rowset
-    // ids already sit above ctx[0]'s next_rowset_id, so compute_rssid_offset clamps the
-    // shift to 0 (it never shifts down) and the accumulation is 3 + 0. Deriving the
-    // offset from the output rather than hard-coding it keeps the accumulation assertion
-    // meaningful regardless of the clamp.
+    // Recover ctx[1].rssid_offset from the rowset mapping. Here ctx[1]'s complete
+    // carried rowset-id space starts at 5, above ctx[0]'s next_rowset_id, so
+    // compute_rssid_offset returns a negative shift. Deriving the offset from the
+    // output rather than hard-coding it keeps the accumulation assertion meaningful.
     bool found_ctx1 = false;
     int32_t ctx1_offset = 0;
     for (const auto& rs : merged->rowsets()) {
@@ -8777,37 +8776,181 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_hot_sibling_id_space_does_not_
         by_id[rowset.id()] = &rowset;
     }
 
-    // The hot tablet's shift clamps to 0, so its ids pass through untouched. Leaving them in
-    // place is collision-free precisely because they all sit above the cold tablet's ceiling.
+    // The complete carried floor is origin_rowset_id 766, so the hot tablet receives
+    // offset 12 - 766 = -754. Its live rowsets remain above every projected dead
+    // reference while the complete projected space starts at the cold tablet's ceiling.
     ASSERT_TRUE(by_id.count(11)) << "cold sibling's rowset must keep id 11";
-    ASSERT_TRUE(by_id.count(798)) << "hot sibling's rowsets must keep their ids";
-    ASSERT_TRUE(by_id.count(803));
-    ASSERT_TRUE(by_id.count(860));
+    ASSERT_TRUE(by_id.count(44)) << "hot sibling's rowsets must use the complete carried floor";
+    ASSERT_TRUE(by_id.count(49));
+    ASSERT_TRUE(by_id.count(106));
 
-    // The two dead-reference fields are shifted by the same offset as the live ids, so with a
-    // zero shift they survive verbatim -- and, critically, non-negative.
-    const auto* compaction_output = by_id[803];
-    EXPECT_EQ(797u, compaction_output->max_compact_input_rowset_id());
+    // The two dead-reference fields are shifted by the same offset as the live ids.
+    // The minimum reference lands exactly at base.next_rowset_id instead of below zero.
+    const auto* compaction_output = by_id[49];
+    EXPECT_EQ(43u, compaction_output->max_compact_input_rowset_id());
     ASSERT_EQ(1, compaction_output->del_files_size());
-    EXPECT_EQ(766u, compaction_output->del_files(0).origin_rowset_id());
+    EXPECT_EQ(12u, compaction_output->del_files(0).origin_rowset_id());
 
-    // Dead references carried by the hot sibling must not be shifted into the COLD sibling's
-    // live id space. Under the old -786 shift, rowset 803's max_compact_input_rowset_id (797)
-    // landed exactly on 11 -- the cold sibling's live rowset -- which misleads the rowset
-    // ordering in LakePrimaryKeyRecover::sort_rowsets. (The cold sibling's own rowset 11
-    // legitimately references itself, so only the hot sibling's rowsets are checked here.)
+    // Every value carried by the hot sibling must stay above the cold sibling's live
+    // rowset id. Under the old live-only floor, max_compact_input_rowset_id 797
+    // landed exactly on 11 and origin_rowset_id 766 underflowed to -20.
     for (const auto& rowset : merged->rowsets()) {
-        if (rowset.id() < 798) continue; // cold sibling's rowset
-        EXPECT_NE(11u, rowset.max_compact_input_rowset_id())
-                << "hot sibling's compaction input ref collided with the cold sibling's live rowset id";
+        if (rowset.id() == 11) continue; // cold sibling's rowset
+        EXPECT_GT(rowset.id(), 11u);
+        EXPECT_GT(rowset.max_compact_input_rowset_id(), 11u);
         for (const auto& del_file : rowset.del_files()) {
-            EXPECT_NE(11u, del_file.origin_rowset_id())
-                    << "hot sibling's del file origin collided with the cold sibling's live rowset id";
+            EXPECT_GT(del_file.origin_rowset_id(), 11u);
         }
     }
 
     // Future writes must not reuse an occupied id.
-    EXPECT_GE(merged->next_rowset_id(), 861u);
+    EXPECT_EQ(107u, merged->next_rowset_id());
+}
+
+// A later input's compacted-away reference can numerically equal an earlier
+// input's live rowset id. The reference must be included in the source floor so
+// the two unrelated identifiers remain disjoint in the merged namespace.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_dead_reference_does_not_collide_with_earlier_live_rowset) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t earlier_tablet = next_id();
+    const int64_t later_tablet = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(earlier_tablet);
+    prepare_tablet_dirs(later_tablet);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto earlier_meta = std::make_shared<TabletMetadataPB>();
+    earlier_meta->set_id(earlier_tablet);
+    earlier_meta->set_version(base_version);
+    earlier_meta->set_next_rowset_id(767);
+    set_primary_key_schema(earlier_meta.get(), 1001);
+    add_rowset(earlier_meta.get(), /*rowset_id=*/766, /*max_compact_input_rowset_id=*/765,
+               /*del_origin_rowset_id=*/766);
+
+    auto later_meta = std::make_shared<TabletMetadataPB>();
+    later_meta->set_id(later_tablet);
+    later_meta->set_version(base_version);
+    later_meta->set_next_rowset_id(804);
+    set_primary_key_schema(later_meta.get(), 1001);
+    add_rowset(later_meta.get(), /*rowset_id=*/798, /*max_compact_input_rowset_id=*/797,
+               /*del_origin_rowset_id=*/798);
+    add_rowset(later_meta.get(), /*rowset_id=*/803, /*max_compact_input_rowset_id=*/765,
+               /*del_origin_rowset_id=*/766);
+
+    ASSERT_OK(put_tablet_metadata(earlier_meta));
+    ASSERT_OK(put_tablet_metadata(later_meta));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(earlier_tablet);
+    merging_tablet.add_old_tablet_ids(later_tablet);
+    merging_tablet.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(2);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(2);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto it = tablet_metadatas.find(merged_tablet);
+    ASSERT_TRUE(it != tablet_metadatas.end());
+    const auto& merged = it->second;
+
+    std::map<uint32_t, const RowsetMetadataPB*> by_id;
+    for (const auto& rowset : merged->rowsets()) {
+        by_id[rowset.id()] = &rowset;
+    }
+
+    ASSERT_TRUE(by_id.count(766)) << "the earlier input's live rowset keeps id 766";
+    ASSERT_TRUE(by_id.count(800)) << "the later input shifts by 767 - 765 = 2";
+    ASSERT_TRUE(by_id.count(805));
+
+    const auto* later_compaction_output = by_id[805];
+    ASSERT_EQ(1, later_compaction_output->del_files_size());
+    EXPECT_EQ(768u, later_compaction_output->del_files(0).origin_rowset_id())
+            << "the later input's dead reference must not alias the earlier live rowset";
+    EXPECT_EQ(767u, later_compaction_output->max_compact_input_rowset_id())
+            << "the later input's compaction watermark must also stay above the earlier live rowset";
+    EXPECT_EQ(806u, merged->next_rowset_id());
+}
+
+// A same-UID sibling copy is discarded by merge_rowsets, so its historical
+// references must not lower the later input's floor. Otherwise an ancient
+// reference on the discarded copy can force a positive lift that overflows a
+// high-ID rowset that is actually emitted.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_discarded_duplicate_does_not_lower_rssid_floor) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t earlier_tablet = next_id();
+    const int64_t later_tablet = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(earlier_tablet);
+    prepare_tablet_dirs(later_tablet);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto earlier_meta = std::make_shared<TabletMetadataPB>();
+    earlier_meta->set_id(earlier_tablet);
+    earlier_meta->set_version(base_version);
+    constexpr uint32_t kBaseRowsetId = std::numeric_limits<uint32_t>::max() - 101;
+    constexpr uint32_t kBaseNextRowsetId = kBaseRowsetId + 1;
+    earlier_meta->set_next_rowset_id(kBaseNextRowsetId);
+    set_primary_key_schema(earlier_meta.get(), 1001);
+    auto* canonical = add_rowset(earlier_meta.get(), /*rowset_id=*/kBaseRowsetId,
+                                 /*max_compact_input_rowset_id=*/0, /*del_origin_rowset_id=*/0);
+
+    auto later_meta = std::make_shared<TabletMetadataPB>();
+    later_meta->set_id(later_tablet);
+    later_meta->set_version(base_version);
+    later_meta->set_next_rowset_id(std::numeric_limits<uint32_t>::max());
+    set_primary_key_schema(later_meta.get(), 1001);
+    auto* duplicate = add_rowset(later_meta.get(), /*rowset_id=*/kBaseRowsetId,
+                                 /*max_compact_input_rowset_id=*/0, /*del_origin_rowset_id=*/0);
+    duplicate->mutable_uid()->CopyFrom(canonical->uid());
+
+    constexpr uint32_t kHighRowsetId = std::numeric_limits<uint32_t>::max() - 1;
+    add_rowset(later_meta.get(), /*rowset_id=*/kHighRowsetId,
+               /*max_compact_input_rowset_id=*/kHighRowsetId,
+               /*del_origin_rowset_id=*/kHighRowsetId);
+
+    ASSERT_OK(put_tablet_metadata(earlier_meta));
+    ASSERT_OK(put_tablet_metadata(later_meta));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(earlier_tablet);
+    merging_tablet.add_old_tablet_ids(later_tablet);
+    merging_tablet.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(2);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(2);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto it = tablet_metadatas.find(merged_tablet);
+    ASSERT_TRUE(it != tablet_metadatas.end());
+    const auto& merged = it->second;
+
+    ASSERT_EQ(2, merged->rowsets_size()) << "the same-UID sibling copy must be deduplicated";
+    std::map<uint32_t, const RowsetMetadataPB*> by_id;
+    for (const auto& rowset : merged->rowsets()) {
+        by_id[rowset.id()] = &rowset;
+    }
+    ASSERT_TRUE(by_id.count(kBaseRowsetId));
+    ASSERT_TRUE(by_id.count(kBaseNextRowsetId))
+            << "the emitted high-ID rowset must map from its own floor, not the discarded copy's reference";
+    EXPECT_EQ(kBaseNextRowsetId + 1, merged->next_rowset_id());
 }
 
 // Merge of two PK parents that both have cloud-native persistent index enabled.

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -8319,6 +8319,15 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_non_shared_sstable_mixed_refs_
     // ctx_b (ctx[1], rssid_offset=1): rowset 1 shared-ancestor + rowset 2
     // child-local + non-shared sstable that mixes refs to BOTH (= post-
     // split PK-index compaction's signature output).
+    //
+    // ctx_a's next_rowset_id is 3 while its only live rowset is 1: id 2 was
+    // allocated and later compacted away. That gap is what makes ctx_b's
+    // shift non-zero. compute_rssid_offset takes the floor over the rowsets
+    // ctx_b actually EMITS -- its rowset 1 dedups into ctx_a's canonical and
+    // is discarded, so the floor is rowset 2 -- giving rssid_offset = 3 - 2 = 1.
+    // Without the gap the floor would land exactly on ctx_a's ceiling, ctx_b's
+    // natural map would agree with the plan, and the metadata-only fast path
+    // (covered by the T1 sibling above) would be correct instead.
     const std::string ns_filename = "ns_mixed.sst";
     const auto ns_path = _tablet_manager->sst_location(child_b, ns_filename);
     const uint64_t ns_filesize = write_legacy_pk_sstable(
@@ -8327,7 +8336,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_non_shared_sstable_mixed_refs_
     auto meta_a = std::make_shared<TabletMetadataPB>();
     meta_a->set_id(child_a);
     meta_a->set_version(base_version);
-    meta_a->set_next_rowset_id(2);
+    meta_a->set_next_rowset_id(3);
     set_primary_key_schema(meta_a.get(), 1001);
     auto* rs_a1 = meta_a->add_rowsets();
     rs_a1->set_id(1);


### PR DESCRIPTION
## Why I'm doing:

Reported in StarRocksTest#11823. A `MERGE TABLET` reshard publish fails on the BE with
`Segment id overflow during tablet merge`. The FE retries the publish indefinitely, the job
never leaves `RUNNING`, and the table remains pinned in `TABLET_RESHARD`.

`merge_tablet` places every merge input in one output rowset-ID namespace. For each later
input it computes a uniform shift:

```
rssid_offset = base.next_rowset_id - append.min_carried_id
mapped_rssid = source_rssid + rssid_offset
```

The original implementation used only the minimum live `rowset.id`. That is incomplete:
`add_rowset()` applies the same shift to historical rowset-ID references that may be lower
than every live rowset because their source rowsets were compacted away:

* `max_compact_input_rowset_id`
* `del_files[].origin_rowset_id`

In the affected production metadata:

```
ctx[0]: live rowset 11, next_rowset_id 12
ctx[1]: minimum live rowset 798
        rowset 803.max_compact_input_rowset_id = 797
        rowset 803.del_files[].origin_rowset_id = 766

old offset: 12 - 798 = -786
797 -> 11   (collides with ctx[0]'s live rowset)
766 -> -20  (underflows and fails map_rssid)
```

A naive scan of every rowset and reference is also too broad. `merge_rowsets()` discards
same-UID sibling copies. A low historical reference that exists only on such a discarded copy
must not lower the source floor; otherwise it can create an unnecessary positive lift and
overflow a high-ID rowset that is actually emitted.

## What I'm doing:

Precompute a rowset emission plan in the same `(version, old-tablet-index)` order and with the
same duplicate rules used by `merge_rowsets()`. The plan is the single source of truth for
both offset preparation and the actual canonical/duplicate merge decision.

For each later input, compute `min_carried_id` from every ID carried by rowsets that the plan
will actually emit:

* `rowset.id`
* `max_compact_input_rowset_id`, when present
* every `del_files[].origin_rowset_id`

This gives the complete effective floor: all values that reach the output are covered, while
values on discarded sibling copies cannot distort the mapping.

For the production layout, the floor is 766 rather than 798:

```
offset = 12 - 766 = -754

origin_rowset_id 766             -> 12
max_compact_input_rowset_id 797  -> 43
live rowset 798                  -> 44
live rowset 803                  -> 49
```

The minimum emitted value lands at the previous inputs' watermark. Emitted rowset IDs and
historical references stay non-negative, remain disjoint from the earlier namespace, and
preserve their relative ordering. Signed negative offsets remain allowed when safe.

### The floor and the ceiling must cover the same rowsets

The offset is derived against a watermark, and `compute_cumulative_rowset_id_ceiling()` produces
that watermark by scanning the earlier inputs. Narrowing only the floor to the emission plan
leaves the two sides disagreeing about discarded rowsets, which is reachable with three or more
siblings: an intermediate sibling that emits nothing at all — for example one holding only a
delete predicate that dedups away against an earlier sibling's predicate at the same version —
gets no floor, keeps offset 0, and its raw ID becomes the watermark the next sibling is lifted
above. That lift can push an emitted high-ID rowset past `UINT32_MAX` even though the emitted
namespace has room.

The set both sides need is "IDs that still reach the merged namespace through
`ctx.rssid_offset`". `merge_rowsets()` records a `shared_rssid_map` entry for a discarded
duplicate exactly when it is not a delete predicate, so that set is the emitted rowsets plus the
discarded delete predicates:

* a discarded data rowset's ID and segment rssids all resolve to the canonical rowset an earlier
  input already emitted, so reserving room for it only lifts later inputs over an unoccupied hole;
* a discarded delete predicate's ID has no redirect entry and keeps falling through `map_rssid`'s
  natural-offset branch, so it must stay disjoint from the earlier inputs.

`projects_via_rssid_offset()` names that predicate and both `compute_rssid_offset()` and
`compute_cumulative_rowset_id_ceiling()` use it. A discarded delete predicate contributes only its
ID to the floor; its historical references die with it and are never carried into the output.

### Test

* `test_tablet_merging_hot_sibling_id_space_does_not_overflow` reproduces the wedged
  production layout and verifies the complete emitted floor.
* `test_tablet_merging_dead_reference_does_not_collide_with_earlier_live_rowset` verifies
  that historical references cannot alias an earlier input's live rowset.
* `test_tablet_merging_discarded_duplicate_does_not_lower_rssid_floor` verifies that an
  ancient reference on a same-UID copy discarded by merge does not force a surviving high-ID
  rowset to overflow.
* `test_tablet_merging_discarded_predicate_does_not_inflate_later_sibling_ceiling` merges three
  siblings whose ID counters have diverged, with the middle one holding only a delete predicate
  that dedups away. Without the shared predicate the third sibling is lifted onto the middle
  sibling's raw ID (4'200'000'000) and its own high-ID rowset overflows; with it the third
  sibling lands at 4 and its span survives intact.
* `test_tablet_merging_accumulates_stacked_rssid_offset` continues to cover a safe negative
  merge-context offset.

Local structural checks:

```
clang-format-11 -i be/src/storage/lake/tablet_merger.cpp be/test/storage/lake/tablet_reshard_test.cpp
git diff --check
python3 build-support/check_be_module_boundaries.py --mode changed --base upstream/main --enforce-baseline-shrink
python3 build-support/render_be_agents.py --check
```

Fixes StarRocksTest#11823 (the `MERGE_TABLET` / `Segment id overflow` failure only).

> **Scope note.** That issue bundles three distinct BE failures. The two `SPLIT_TABLET` jobs
> wedged in `CLEANING` are blocked by different load-publish failures and are not fixed here.
> The FE-side infinite retry with an empty `ERROR_MESSAGE` is addressed separately.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

Tablet merge now derives each input's offset from all IDs and historical references carried by
the rowsets that merge actually emits, rather than from live rowset IDs alone, and computes the
watermark each input is lifted above from that same set of rowsets.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation
  - [ ] I have added documentation for my new feature or new function
  - [ ] This PR needs auto-generated documentation
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which drive automatic backports
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

`branch-4.1` carries the same live-only `compute_rssid_offset`. `branch-4.0` and
`branch-3.5` do not have `be/src/storage/lake/tablet_merger.cpp`, so they are not affected.

