### PR TITLE
[BugFix] Pace reshard publish retries instead of spinning

### DIFF
--- a/docs/en/administration/management/monitoring/metric_details/s.md
+++ b/docs/en/administration/management/monitoring/metric_details/s.md
@@ -630,6 +630,39 @@ All transaction metrics share the following labels:
 - Type: Cumulative
 - Description: Total load transactions aborted because Sample-Based Tablet Pre-Split could not confirm the admitted reshard job reached `FINISHED` in time. Sibling counter of `tablet_pre_split_post_submit_hard_cap`. Production load paths proceed without abort against the currently visible layout on post-submit timeout rather than abort, so this counter stays at zero in production today; it only fires when a caller uses the strict `runPreSplit` wrapper (tests, or a future caller that opts into abort-on-timeout).
 
+## `starrocks_fe_tablet_reshard_job_total`
+
+- Unit: Count
+- Type: Cumulative
+- Labels: `type` (`split` or `merge`)
+- Description: Total tablet reshard jobs admitted by `TabletReshardJobMgr`, counted once the job has been queued and journaled. Covers both automatic reshard (tablet split and merge) and jobs submitted by Sample-Based Tablet Pre-Split. Per-state job counts are also exposed through the generic `job` gauge with the labels `job="tablet_reshard"`, `type`, and `state`. Only the Leader FE increments this counter; it stays at zero on followers and restarts from zero after an FE restart or a leader change.
+
+## `starrocks_fe_tablet_reshard_job_finished`
+
+- Unit: Count
+- Type: Cumulative
+- Labels: `type` (`split` or `merge`)
+- Description: Total tablet reshard jobs that reached `FINISHED`. Compare with `tablet_reshard_job_total` to see how many admitted jobs have completed. Only the Leader FE increments this counter.
+
+## `starrocks_fe_tablet_reshard_job_aborted`
+
+- Unit: Count
+- Type: Cumulative
+- Labels: `type` (`split` or `merge`)
+- Description: Total tablet reshard jobs that ended in `ABORTED`. A job can only abort before its transaction commits; once committed there is no rollback path, so a failure after that point is retried instead of aborted and is never counted here. Use `tablet_reshard_publish_failed` to detect that case. Only the Leader FE increments this counter.
+
+## `starrocks_fe_tablet_reshard_publish_failed`
+
+- Unit: Count
+- Type: Cumulative
+- Description: Total reshard publish attempts that failed and will be retried, one increment per attempt. Because a reshard transaction is already committed by publish time, a failed publish is retried with exponential backoff (1s, doubling, capped at 30s) until it succeeds: the job stays `RUNNING` and never aborts, so `tablet_reshard_job_aborted` stays flat while the job is stuck. This counter is therefore the metric to alert on. At the 30s cap a permanently failing partition keeps it moving about twice a minute, so `increase(starrocks_fe_tablet_reshard_publish_failed[5m]) > 0` catches a stuck job within roughly a minute of the first failure. The reason for each failure is reported in the `ERROR_MESSAGE` column of `information_schema.tablet_reshard_jobs` and in `fe.warn.log`. Only the Leader FE increments this counter.
+
+## `starrocks_fe_tablet_reshard_parallel_tablets`
+
+- Unit: Count
+- Type: Instantaneous
+- Description: Number of tablets currently being resharded across all unfinished reshard jobs, that is, the live reshard parallelism. Non-Leader FE nodes report `0`.
+
 ## `starrocks_fe_tablet_max_compaction_score`
 
 - Unit: Count

--- a/docs/ja/administration/management/monitoring/metric_details/s.md
+++ b/docs/ja/administration/management/monitoring/metric_details/s.md
@@ -626,6 +626,39 @@ description: "Alphabetical s"
 - タイプ: 累積
 - 説明: サンプリングベースのタブレット事前分割が、受理された reshard ジョブの `FINISHED` 到達を期限内に確認できなかったために中止された取り込みトランザクションの累計回数。`tablet_pre_split_post_submit_hard_cap` の兄弟カウンタ。本番の取り込み経路は post-submit タイムアウト時に取り込みを中止せず、その時点で可視のレイアウトに対して継続実行するため、このカウンタは現状の本番環境では 0 のままです。厳格な `runPreSplit` ラッパー（テスト、または将来「タイムアウト＝中止」を選択する呼び出し元）を使った場合にのみ発火します。
 
+## `starrocks_fe_tablet_reshard_job_total`
+
+- 単位: カウント
+- タイプ: 累積
+- ラベル: `type`（`split` または `merge`）
+- 説明: `TabletReshardJobMgr` が受理したタブレット reshard ジョブの累計数。ジョブがキューに入り journal に書き込まれた時点でインクリメントされます。自動 reshard（タブレットの分割とマージ）と、サンプリングベースのタブレット事前分割が提出したジョブの両方を含みます。状態別のジョブ数は、`job="tablet_reshard"`、`type`、`state` のラベルを持つ汎用の `job` ゲージからも取得できます。このカウンタをインクリメントするのは Leader FE のみで、フォロワーでは 0 のままです。また FE の再起動やリーダー切り替え後は 0 から再開します。
+
+## `starrocks_fe_tablet_reshard_job_finished`
+
+- 単位: カウント
+- タイプ: 累積
+- ラベル: `type`（`split` または `merge`）
+- 説明: `FINISHED` に到達したタブレット reshard ジョブの累計数。`tablet_reshard_job_total` と比較することで、受理されたジョブのうちどれだけが完了したかが分かります。このカウンタをインクリメントするのは Leader FE のみです。
+
+## `starrocks_fe_tablet_reshard_job_aborted`
+
+- 単位: カウント
+- タイプ: 累積
+- ラベル: `type`（`split` または `merge`）
+- 説明: `ABORTED` で終了したタブレット reshard ジョブの累計数。ジョブが中止できるのはトランザクションのコミット前だけです。コミット後はロールバック経路がないため、それ以降の失敗は中止ではなく再試行され、ここには計上されません。そのケースは `tablet_reshard_publish_failed` で検出してください。このカウンタをインクリメントするのは Leader FE のみです。
+
+## `starrocks_fe_tablet_reshard_publish_failed`
+
+- 単位: カウント
+- タイプ: 累積
+- 説明: 失敗して再試行される reshard publish 試行の累計数。試行ごとに 1 ずつインクリメントされます。reshard のトランザクションは publish 時点で既にコミット済みなので、publish が失敗すると成功するまで指数バックオフ（1 秒から倍増、上限 30 秒）で再試行されます。ジョブは `RUNNING` のままで中止されないため、ジョブが詰まっている間も `tablet_reshard_job_aborted` は平坦なままです。したがってアラートはこのカウンタを対象にしてください。30 秒の上限に達した後も、失敗し続けるパーティションは 1 分あたり約 2 回このカウンタを動かすため、`increase(starrocks_fe_tablet_reshard_publish_failed[5m]) > 0` で最初の失敗から 1 分程度で詰まりを検出できます。各失敗の理由は `information_schema.tablet_reshard_jobs` の `ERROR_MESSAGE` 列と `fe.warn.log` に記録されます。このカウンタをインクリメントするのは Leader FE のみです。
+
+## `starrocks_fe_tablet_reshard_parallel_tablets`
+
+- 単位: カウント
+- タイプ: 瞬間
+- 説明: 未完了のすべての reshard ジョブにおいて現在 reshard 中のタブレット数、すなわちリアルタイムの reshard 並列度。Leader 以外の FE ノードは `0` を報告します。
+
 ## `starrocks_fe_tablet_max_compaction_score`
 
 - 単位: カウント

--- a/docs/zh/administration/management/monitoring/metric_details/s.md
+++ b/docs/zh/administration/management/monitoring/metric_details/s.md
@@ -652,6 +652,39 @@ description: "Alphabetical s"
 - 类型：累计
 - 描述：因基于采样的 Tablet 预分裂未能在限定时间内确认 reshard 作业到达 `FINISHED` 而导致回滚的导入事务总数。`tablet_pre_split_post_submit_hard_cap` 的姊妹计数器。生产导入路径超时后不中止地继续执行（按当时可见的布局做计划）而非中止事务，因此该计数器在当前生产环境保持为零；仅在使用严格语义的 `runPreSplit` 包装路径（测试，或未来选择 "超时即中止" 的调用方）时触发。
 
+## `starrocks_fe_tablet_reshard_job_total`
+
+- 单位：计数
+- 类型：累计
+- 标签：`type`（`split` 或 `merge`）
+- 描述：`TabletReshardJobMgr` 接纳的 Tablet reshard 作业总数，在作业入队并写入 journal 后递增。既包含自动 reshard（Tablet 分裂与合并），也包含由基于采样的 Tablet 预分裂提交的作业。按状态细分的作业数还可通过通用的 `job` gauge 观察，其标签为 `job="tablet_reshard"`、`type` 与 `state`。仅 Leader FE 递增该计数器；Follower 上保持为零，FE 重启或主从切换后从零重新开始。
+
+## `starrocks_fe_tablet_reshard_job_finished`
+
+- 单位：计数
+- 类型：累计
+- 标签：`type`（`split` 或 `merge`）
+- 描述：到达 `FINISHED` 的 Tablet reshard 作业总数。与 `tablet_reshard_job_total` 对比即可看出已接纳的作业中有多少完成。仅 Leader FE 递增该计数器。
+
+## `starrocks_fe_tablet_reshard_job_aborted`
+
+- 单位：计数
+- 类型：累计
+- 标签：`type`（`split` 或 `merge`）
+- 描述：以 `ABORTED` 结束的 Tablet reshard 作业总数。作业只能在其事务提交前中止；一旦提交便没有回滚路径，此后的失败只会重试而不会中止，因此不会计入这里。该情形请用 `tablet_reshard_publish_failed` 观察。仅 Leader FE 递增该计数器。
+
+## `starrocks_fe_tablet_reshard_publish_failed`
+
+- 单位：计数
+- 类型：累计
+- 描述：失败并将被重试的 reshard publish 尝试总数，每次尝试递增一次。由于 reshard 事务在 publish 时已经提交，publish 失败会按指数退避（1s 起翻倍，上限 30s）一直重试直到成功：作业保持 `RUNNING` 且永不中止，所以作业卡住期间 `tablet_reshard_job_aborted` 一直是平的。因此告警应以该计数器为准。退避到 30s 上限后，持续失败的分区仍会让它每分钟递增约两次，故 `increase(starrocks_fe_tablet_reshard_publish_failed[5m]) > 0` 可在首次失败后约一分钟内发现卡住的作业。每次失败的原因会写入 `information_schema.tablet_reshard_jobs` 的 `ERROR_MESSAGE` 列以及 `fe.warn.log`。仅 Leader FE 递增该计数器。
+
+## `starrocks_fe_tablet_reshard_parallel_tablets`
+
+- 单位：计数
+- 类型：瞬时
+- 描述：所有未完成的 reshard 作业中当前正在 reshard 的 Tablet 数量，即实时的 reshard 并行度。非 Leader FE 节点上报 `0`。
+
 ## `starrocks_fe_tablet_max_compaction_score`
 
 - 单位：计数

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
@@ -240,6 +240,12 @@ public class MergeTabletJob extends TabletReshardJob {
                     // sibling partition that is still retrying.
                     if (publishResult.publishState() == PublishState.FAILED) {
                         reshardingPhysicalPartition.setPublishFailureReason(publishResult.failureReason());
+                        // A failed publish is retried until it succeeds, but only once its backoff has
+                        // elapsed: resubmitting the same doomed publish on every tick of the reshard
+                        // daemon is what turned one stuck publish into a hot loop.
+                        if (!reshardingPhysicalPartition.isPublishRetryDue()) {
+                            continue;
+                        }
                     }
                     // Start publish asynchronously
                     List<Tablet> tablets = new ArrayList<>();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ReshardingPhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ReshardingPhysicalPartition.java
@@ -16,6 +16,7 @@ package com.starrocks.alter.reshard;
 
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.TabletRange;
+import com.starrocks.metric.MetricRepo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -27,6 +28,14 @@ import java.util.concurrent.Future;
  */
 public class ReshardingPhysicalPartition {
     private static final Logger LOG = LogManager.getLogger(ReshardingPhysicalPartition.class);
+
+    // Exponential backoff between publish attempts: 1s, 2s, 4s ... capped at 30s. A transient failure
+    // (restarting node, brief RPC error) still recovers within seconds, while a deterministic one
+    // settles at one attempt per PUBLISH_RETRY_MAX_INTERVAL_MS instead of tens per second. The cap is
+    // kept at half a minute rather than a full one so a stuck publish keeps ticking
+    // COUNTER_TABLET_RESHARD_PUBLISH_FAILED often enough for a rate-based alert to see it promptly.
+    private static final long PUBLISH_RETRY_BASE_INTERVAL_MS = 1000L;
+    private static final long PUBLISH_RETRY_MAX_INTERVAL_MS = 30000L;
 
     @SerializedName(value = "physicalPartitionId")
     protected final long physicalPartitionId;
@@ -47,6 +56,20 @@ public class ReshardingPhysicalPartition {
     // from the reshard daemon while getInfo() reads it on an RPC thread, and the job stays in
     // RUNNING throughout, so there is no other happens-before edge to publish the write.
     protected transient volatile String publishFailureReason;
+
+    // Publish-retry pacing. A reshard publish is retried until it succeeds, because a merge / split
+    // whose transaction is already committed has no rollback path. The retry therefore has to be paced:
+    // resubmitting a deterministically failing publish on every daemon tick is an unbounded hot loop,
+    // observed in the field at ~95 identical warn lines per second per job.
+    // Not serialized, like publishFailureReason: a retry a leader change interrupts simply starts over
+    // from the first interval.
+    protected transient int consecutivePublishFailures;
+    protected transient long nextPublishRetryTimeMs;
+    // Whether the failure of the future currently held has already been counted, logged and turned into
+    // a retry deadline. getPublishResult() is polled once per daemon tick and keeps reporting FAILED
+    // for the same failed attempt, so without this the deadline would be pushed further out on every
+    // poll and the retry would never come due -- the pacing would turn into a permanent block.
+    protected transient boolean publishFailureAccounted;
 
     public ReshardingPhysicalPartition(long physicalPartitionId,
             Map<Long, ReshardingMaterializedIndex> reshardingIndexes) {
@@ -72,6 +95,8 @@ public class ReshardingPhysicalPartition {
 
     public void setPublishFuture(Future<Map<Long, TabletRange>> publishFuture) {
         this.publishFuture = publishFuture;
+        // A new attempt: its failure, if it fails, is a new one to count and to back off from.
+        this.publishFailureAccounted = false;
     }
 
     public void setPublishFailureReason(String publishFailureReason) {
@@ -114,16 +139,49 @@ public class ReshardingPhysicalPartition {
 
         try {
             Map<Long, TabletRange> tabletRanges = publishFuture.get();
+            // This attempt succeeded, so the failures before it were not consecutive after all: should
+            // this partition ever be published again, it starts from the first interval.
+            consecutivePublishFailures = 0;
+            nextPublishRetryTimeMs = 0;
             return new PublishResult(PublishState.SUCCESS, tabletRanges);
         } catch (InterruptedException e) {
             LOG.warn("Interrupted to future get. ", e);
             Thread.currentThread().interrupt();
             return new PublishResult(PublishState.IN_PROGRESS, null);
         } catch (Exception e) {
-            LOG.warn("Failed to publish future get. ", e);
             Throwable cause = (e.getCause() != null) ? e.getCause() : e;
+            if (!publishFailureAccounted) {
+                publishFailureAccounted = true;
+                ++consecutivePublishFailures;
+                long retryIntervalMs = publishRetryIntervalMs();
+                nextPublishRetryTimeMs = System.currentTimeMillis() + retryIntervalMs;
+                // One increment per failed attempt, so a stuck reshard is alertable without reading
+                // fe.warn.log or polling information_schema.tablet_reshard_jobs. Counting it here rather
+                // than per poll keeps the rate tracking attempts instead of daemon ticks.
+                if (MetricRepo.hasInit) {
+                    MetricRepo.COUNTER_TABLET_RESHARD_PUBLISH_FAILED.increase(1L);
+                }
+                // Logged once per attempt for the same reason: re-logging the same completed-exceptionally
+                // future on every poll is what grew fe.warn.log to hundreds of MB in the field.
+                LOG.warn("Failed to publish future get. Partition {} publish attempt {} failed, retry in {} ms. ",
+                        physicalPartitionId, consecutivePublishFailures, retryIntervalMs, e);
+            }
             return new PublishResult(PublishState.FAILED, null, cause.getMessage());
         }
+    }
+
+    private long publishRetryIntervalMs() {
+        // Shift by at most 5: 1s << 5 is already past the cap, so a higher shift only risks overflow.
+        int shift = Math.min(Math.max(consecutivePublishFailures - 1, 0), 5);
+        return Math.min(PUBLISH_RETRY_BASE_INTERVAL_MS << shift, PUBLISH_RETRY_MAX_INTERVAL_MS);
+    }
+
+    /**
+     * Whether a new publish attempt may be submitted now. Always true before the first attempt and
+     * after a success; after a failure it stays false until the backoff computed above has elapsed.
+     */
+    public boolean isPublishRetryDue() {
+        return System.currentTimeMillis() >= nextPublishRetryTimeMs;
     }
 
     public long getParallelTablets() {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -253,6 +253,12 @@ public class SplitTabletJob extends TabletReshardJob {
                     // sibling partition that is still retrying.
                     if (publishResult.publishState() == PublishState.FAILED) {
                         reshardingPhysicalPartition.setPublishFailureReason(publishResult.failureReason());
+                        // A failed publish is retried until it succeeds, but only once its backoff has
+                        // elapsed: resubmitting the same doomed publish on every tick of the reshard
+                        // daemon is what turned one stuck publish into a hot loop.
+                        if (!reshardingPhysicalPartition.isPublishRetryDue()) {
+                            continue;
+                        }
                     }
                     // Start publish asynchronously
                     List<Tablet> tablets = new ArrayList<>();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/SystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/SystemTable.java
@@ -31,6 +31,7 @@ import com.starrocks.catalog.system.information.PipesSystemTable;
 import com.starrocks.catalog.system.information.RoutineLoadJobsSystemTable;
 import com.starrocks.catalog.system.information.StreamLoadsSystemTable;
 import com.starrocks.catalog.system.information.TablesConfigSystemTable;
+import com.starrocks.catalog.system.information.TabletReshardJobsTable;
 import com.starrocks.catalog.system.information.TaskRunsSystemTable;
 import com.starrocks.catalog.system.information.TasksSystemTable;
 import com.starrocks.catalog.system.information.TemporaryTablesTable;
@@ -85,6 +86,7 @@ public class SystemTable extends Table {
                     .add(RoutineLoadJobsSystemTable.NAME)
                     .add(StreamLoadsSystemTable.NAME)
                     .add(TablesConfigSystemTable.NAME)
+                    .add(TabletReshardJobsTable.NAME)
                     .add(TaskRunsSystemTable.NAME)
                     .add(TasksSystemTable.NAME)
                     .add(TemporaryTablesTable.NAME)

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -359,6 +359,10 @@ public final class MetricRepo {
     public static LongCounterMetric COUNTER_TABLET_RESHARD_MERGE_JOB_FINISHED;
     public static LongCounterMetric COUNTER_TABLET_RESHARD_SPLIT_JOB_ABORTED;
     public static LongCounterMetric COUNTER_TABLET_RESHARD_MERGE_JOB_ABORTED;
+    // A reshard publish is retried until it succeeds (its transaction is already committed, so there is
+    // no rollback path), which means a deterministic failure never shows up as an aborted job. This
+    // counter is the only signal that a reshard job is stuck retrying, so alert on its rate.
+    public static LongCounterMetric COUNTER_TABLET_RESHARD_PUBLISH_FAILED;
 
     // Sample-Based Tablet Pre-Split metrics. The coordinator wires the eligibility-skip,
     // post-submit hard-cap, load-abort counters and the two wait-time histograms. The
@@ -1081,6 +1085,10 @@ public final class MetricRepo {
                 MetricUnit.REQUESTS, "total tablet reshard merge jobs aborted");
         COUNTER_TABLET_RESHARD_MERGE_JOB_ABORTED.addLabel(new MetricLabel("type", "merge"));
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_TABLET_RESHARD_MERGE_JOB_ABORTED);
+
+        COUNTER_TABLET_RESHARD_PUBLISH_FAILED = new LongCounterMetric("tablet_reshard_publish_failed",
+                MetricUnit.REQUESTS, "total tablet reshard publish attempts that failed and will be retried");
+        STARROCKS_METRIC_REGISTER.addMetric(COUNTER_TABLET_RESHARD_PUBLISH_FAILED);
 
         COUNTER_TABLET_PRE_SPLIT_POST_SUBMIT_HARD_CAP = new LongCounterMetric(
                 "tablet_pre_split_post_submit_hard_cap", MetricUnit.REQUESTS,

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
@@ -333,6 +333,40 @@ public class MergeTabletJobTest {
         Assertions.assertEquals(TabletReshardJob.JobState.RUNNING, mergeJob.getJobState());
     }
 
+    /**
+     * A publish that fails leaves the job retrying -- once the reshard transaction has committed there
+     * is no rollback path -- but the retry has to be paced. While the backoff runs, a publish pass must
+     * neither resubmit the doomed publish nor lose the reason it failed, which is what a job stuck in
+     * RUNNING reports as its ERROR_MESSAGE.
+     */
+    @Test
+    public void testRunRunningDefersRetryOfFailedPublish() throws Exception {
+        MergeTabletJob mergeJob = createMergeTabletReshardJob();
+        mergeJob.setJobState(TabletReshardJob.JobState.RUNNING);
+        PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
+        ReshardingPhysicalPartition reshardingPhysicalPartition =
+                mergeJob.getReshardingPhysicalPartitions().values().iterator().next();
+        reshardingPhysicalPartition.setCommitVersion(physicalPartition.getVisibleVersion() + 1);
+
+        CompletableFuture<Map<Long, TabletRange>> failedPublish = new CompletableFuture<>();
+        failedPublish.completeExceptionally(
+                new TabletReshardException("Segment id overflow during tablet merge"));
+        reshardingPhysicalPartition.setPublishFuture(failedPublish);
+
+        // The pass that observes the failure is already subject to the backoff it stamps, so this one
+        // pass covers what every later pass within the backoff does too.
+        mergeJob.runRunningJob();
+
+        // Still retrying, not wedged into a terminal state...
+        Assertions.assertEquals(TabletReshardJob.JobState.RUNNING, mergeJob.getJobState());
+        // ...and the failed attempt is still the one in place: the pass did not resubmit it.
+        Assertions.assertSame(failedPublish, reshardingPhysicalPartition.publishFuture);
+        Assertions.assertEquals(1, reshardingPhysicalPartition.consecutivePublishFailures);
+        Assertions.assertFalse(reshardingPhysicalPartition.isPublishRetryDue());
+        Assertions.assertEquals("Segment id overflow during tablet merge",
+                reshardingPhysicalPartition.getPublishFailureReason());
+    }
+
     @Test
     public void testRunRunningUnknownState() throws Exception {
         MergeTabletJob mergeJob = createMergeTabletReshardJob();

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/ReshardingPhysicalPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/ReshardingPhysicalPartitionTest.java
@@ -1,0 +1,192 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.reshard;
+
+import com.starrocks.alter.reshard.ReshardingPhysicalPartition.PublishState;
+import com.starrocks.catalog.TabletRange;
+import com.starrocks.metric.LongCounterMetric;
+import com.starrocks.metric.Metric.MetricUnit;
+import com.starrocks.metric.MetricRepo;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Publish-retry pacing in ReshardingPhysicalPartition. A reshard publish has no rollback path once its
+ * transaction is committed, so it is retried until it succeeds; these tests pin the pacing that keeps a
+ * deterministic BE-side failure from becoming an unbounded hot loop.
+ */
+public class ReshardingPhysicalPartitionTest {
+
+    /** Mirrors PUBLISH_RETRY_MAX_INTERVAL_MS, which is private to the class under test. */
+    private static final long PUBLISH_RETRY_CAP_MS = 30000L;
+
+    private static ReshardingPhysicalPartition newPartition() {
+        return new ReshardingPhysicalPartition(1L, new HashMap<>());
+    }
+
+    private static CompletableFuture<Map<Long, TabletRange>> failedPublish(String message) {
+        CompletableFuture<Map<Long, TabletRange>> future = new CompletableFuture<>();
+        future.completeExceptionally(new TabletReshardException(message));
+        return future;
+    }
+
+    @Test
+    public void testNoAttemptYetIsNotStartedAndImmediatelyDue() {
+        ReshardingPhysicalPartition partition = newPartition();
+
+        Assertions.assertEquals(PublishState.NOT_STARTED, partition.getPublishResult().publishState());
+        // Nothing to back off from, so the first attempt must be allowed right away.
+        Assertions.assertTrue(partition.isPublishRetryDue());
+    }
+
+    @Test
+    public void testInProgressWhileFutureIsPending() {
+        ReshardingPhysicalPartition partition = newPartition();
+        partition.setPublishFuture(new CompletableFuture<>());
+
+        Assertions.assertEquals(PublishState.IN_PROGRESS, partition.getPublishResult().publishState());
+        Assertions.assertTrue(partition.isPublishRetryDue());
+    }
+
+    @Test
+    public void testFailureDefersTheNextAttemptAndCarriesItsReason() {
+        ReshardingPhysicalPartition partition = newPartition();
+        partition.setPublishFuture(failedPublish("Segment id overflow during tablet merge"));
+
+        ReshardingPhysicalPartition.PublishResult result = partition.getPublishResult();
+        Assertions.assertEquals(PublishState.FAILED, result.publishState());
+        // The reason must be retrievable, not just logged: the job reports it as its ERROR_MESSAGE.
+        Assertions.assertEquals("Segment id overflow during tablet merge", result.failureReason());
+        // A resubmit is only allowed once the backoff elapses; without this the job resubmits the same
+        // doomed publish on every daemon tick.
+        Assertions.assertFalse(partition.isPublishRetryDue());
+    }
+
+    @Test
+    public void testPollingAFailedAttemptDoesNotPushTheDeadlineOut() {
+        ReshardingPhysicalPartition partition = newPartition();
+        partition.setPublishFuture(failedPublish("boom"));
+
+        Assertions.assertEquals(PublishState.FAILED, partition.getPublishResult().publishState());
+        long deadlineMs = partition.nextPublishRetryTimeMs;
+
+        // The job polls the same failed attempt once per daemon tick. Re-stamping the deadline on every
+        // poll would push the retry forever out of reach, turning the backoff into a permanent block --
+        // and re-counting the attempt would make the failure metric track ticks instead of attempts.
+        for (int i = 0; i < 10; ++i) {
+            ReshardingPhysicalPartition.PublishResult result = partition.getPublishResult();
+            Assertions.assertEquals(PublishState.FAILED, result.publishState());
+            Assertions.assertEquals("boom", result.failureReason());
+        }
+        Assertions.assertEquals(deadlineMs, partition.nextPublishRetryTimeMs);
+        Assertions.assertEquals(1, partition.consecutivePublishFailures);
+    }
+
+    @Test
+    public void testBackoffGrowsWithConsecutiveFailures() {
+        ReshardingPhysicalPartition partition = newPartition();
+
+        long previousDelayMs = -1;
+        for (int attempt = 1; attempt <= 4; ++attempt) {
+            partition.setPublishFuture(failedPublish("boom " + attempt));
+            long before = System.currentTimeMillis();
+            Assertions.assertEquals(PublishState.FAILED, partition.getPublishResult().publishState());
+            long delayMs = partition.nextPublishRetryTimeMs - before;
+            Assertions.assertTrue(delayMs > previousDelayMs,
+                    "attempt " + attempt + " delay " + delayMs + " should exceed previous " + previousDelayMs);
+            previousDelayMs = delayMs;
+        }
+    }
+
+    @Test
+    public void testBackoffIsCappedAtThirtySeconds() {
+        ReshardingPhysicalPartition partition = newPartition();
+
+        // Doubling from 1s would pass 30s at the sixth attempt, so run well past it: a deterministic
+        // failure must settle at one attempt per 30s, not drift towards minutes between attempts.
+        for (int attempt = 1; attempt <= 12; ++attempt) {
+            partition.setPublishFuture(failedPublish("boom " + attempt));
+            long before = System.currentTimeMillis();
+            Assertions.assertEquals(PublishState.FAILED, partition.getPublishResult().publishState());
+            long after = System.currentTimeMillis();
+            // The deadline is stamped somewhere in [before, after], so the interval it encodes is at
+            // most (deadline - before) and at least (deadline - after) regardless of scheduling noise.
+            Assertions.assertTrue(partition.nextPublishRetryTimeMs - after <= PUBLISH_RETRY_CAP_MS,
+                    "attempt " + attempt + " must not back off beyond " + PUBLISH_RETRY_CAP_MS + " ms");
+            if (attempt >= 6) {
+                Assertions.assertTrue(partition.nextPublishRetryTimeMs - before >= PUBLISH_RETRY_CAP_MS,
+                        "attempt " + attempt + " must have reached the " + PUBLISH_RETRY_CAP_MS + " ms cap");
+            }
+        }
+    }
+
+    @Test
+    public void testFailureBumpsThePublishFailedCounter() {
+        boolean savedHasInit = MetricRepo.hasInit;
+        LongCounterMetric savedCounter = MetricRepo.COUNTER_TABLET_RESHARD_PUBLISH_FAILED;
+        // The counter is only assigned by MetricRepo.init(), which a plain unit test does not run.
+        MetricRepo.COUNTER_TABLET_RESHARD_PUBLISH_FAILED = new LongCounterMetric(
+                "tablet_reshard_publish_failed", MetricUnit.REQUESTS, "test");
+        MetricRepo.hasInit = true;
+        try {
+            ReshardingPhysicalPartition partition = newPartition();
+            partition.setPublishFuture(failedPublish("boom"));
+            Assertions.assertEquals(PublishState.FAILED, partition.getPublishResult().publishState());
+            Assertions.assertEquals(1L,
+                    MetricRepo.COUNTER_TABLET_RESHARD_PUBLISH_FAILED.getValue().longValue());
+
+            // Polling an already-counted failure must not inflate the counter: the rate has to track
+            // attempts, otherwise it reads as an escalating failure while the partition is merely
+            // waiting out its backoff.
+            for (int i = 0; i < 5; ++i) {
+                Assertions.assertEquals(PublishState.FAILED, partition.getPublishResult().publishState());
+            }
+            Assertions.assertEquals(1L,
+                    MetricRepo.COUNTER_TABLET_RESHARD_PUBLISH_FAILED.getValue().longValue());
+
+            // A genuinely new attempt is counted again.
+            partition.setPublishFuture(failedPublish("boom again"));
+            Assertions.assertEquals(PublishState.FAILED, partition.getPublishResult().publishState());
+            Assertions.assertEquals(2L,
+                    MetricRepo.COUNTER_TABLET_RESHARD_PUBLISH_FAILED.getValue().longValue());
+        } finally {
+            MetricRepo.hasInit = savedHasInit;
+            MetricRepo.COUNTER_TABLET_RESHARD_PUBLISH_FAILED = savedCounter;
+        }
+    }
+
+    @Test
+    public void testSuccessResetsThePacing() {
+        ReshardingPhysicalPartition partition = newPartition();
+        partition.setPublishFuture(failedPublish("boom"));
+        Assertions.assertEquals(PublishState.FAILED, partition.getPublishResult().publishState());
+        Assertions.assertFalse(partition.isPublishRetryDue());
+
+        Map<Long, TabletRange> ranges = new HashMap<>();
+        partition.setPublishFuture(CompletableFuture.completedFuture(ranges));
+
+        Assertions.assertEquals(PublishState.SUCCESS, partition.getPublishResult().publishState());
+        // The failures before a success were not consecutive after all, and no deadline may outlive the
+        // attempt it was meant to defer.
+        Assertions.assertEquals(0, partition.consecutivePublishFailures);
+        Assertions.assertTrue(partition.isPublishRetryDue());
+        // Success stays readable across polls: the job re-reads tabletRanges while other partitions run.
+        Assertions.assertEquals(PublishState.SUCCESS, partition.getPublishResult().publishState());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/system/information/TabletReshardJobsTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/system/information/TabletReshardJobsTableTest.java
@@ -1,0 +1,33 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog.system.information;
+
+import com.starrocks.catalog.system.SystemTable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TabletReshardJobsTableTest {
+
+    @Test
+    public void testRoutedToLeader() {
+        // Reshard jobs live only on the leader: TabletReshardJobMgr runs there, and a job's mutable state
+        // (including the reason it is stuck retrying a publish) is not journaled on every change -- only
+        // state transitions are. A follower answering this scan from its own replayed copy would report a
+        // job as RUNNING with an empty ERROR_MESSAGE while the leader knows why it is not progressing,
+        // which defeats the point of reporting the reason at all. Same rationale as the other job-state
+        // tables in QUERY_FROM_LEADER_TABLES (loads, routine_load_jobs, task_runs, ...).
+        Assertions.assertTrue(SystemTable.needQueryFromLeader(TabletReshardJobsTable.NAME));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Companion to #77690, from StarRocksTest#11823. That issue's headline symptom is a BE publish error,
but what turned a single publish failure into an unrecoverable, undiagnosable, log-flooding wedge is
on the FE side — and it applies to **any** publish error, not just the one #77690 fixes. The same
investigation found two more distinct BE publish errors wedging jobs in the same cluster, so this
path needs to fail visibly regardless of the underlying cause.

A tablet reshard publish is retried until it succeeds, because a split / merge whose transaction is
already committed has no rollback path. **That retry has no pacing.** The failed future stays parked
on the partition, so every tick of the reshard daemon re-`get()`s the same completed-exceptionally
future, re-logs the same stack trace, and resubmits the same publish. Measured in the field:
**~95 identical warn lines per second per job** (82,327 lines for one job; 531,716
`Segment id overflow` lines in `fe.warn.log`), growing `fe.warn.log` to 525–718 MB and rotating a
1 GB `fe.log` every few hours, while burning FE CPU. On the BE side the same loop produced 140,293
hits in a single log rotation.

**This is an availability bug, not log hygiene.** On 2026-08-13 two wedged jobs took the test
cluster down: the retry loop wrote **6 GB/hour** (100.4 MB/min measured on the leader), filled the
50 GB FE data disk overnight (`fe/log` at 40 GB against a 462 MB `fe/meta`), and the FE then hit
`failed to append journal after retried 3 times!` — **2 of 3 FEs died and the cluster lost quorum**.
After recovery the flood measured the same 6 GB/hour, i.e. ~7 hours to fill the disk again. Because a
job past `RUNNING` has no abort path (see below), the only way to stop it was `DROP DATABASE`, which
dropped the write rate from 100 MB/min to 0 — and destroyed the four preserved reproduction sites in
the process. A deterministic publish failure anywhere in this path is therefore a cluster-availability
risk until this PR lands, independent of which BE bug caused it.

Nothing in the metric set moves while this happens, either. A reshard job that fails after its
transaction commits never aborts, so `tablet_reshard_job_aborted` stays flat for as long as the job
retries, and the only other signals (`ERROR_MESSAGE` in `information_schema.tablet_reshard_jobs`,
`fe.warn.log`) have to be looked at deliberately by someone who already suspects a reshard job.

> **Rebased.** The reporting half of this PR — keeping the per-partition publish failure reason and
> surfacing it as the job's `ERROR_MESSAGE` while it retries — has since landed on main with #77512,
> which also fixed the empty-`ERROR_MESSAGE` half of the original report. This PR is rebased onto
> that and now carries only the pacing, the alertable counter, and the leader routing.

## What I'm doing:

In `ReshardingPhysicalPartition`:

* Account for a publish failure **exactly once per attempt** — count it, log it, and stamp a retry
  deadline — rather than once per poll. `getPublishResult()` is polled once per daemon tick and keeps
  reporting `FAILED` for the same failed attempt, so re-stamping the deadline on every poll would
  push the retry permanently out of reach, and re-logging is what produced the flood.
* Defer the next attempt with exponential backoff — 1s, 2s, 4s … capped at 30s — exposed via
  `isPublishRetryDue()`. A transient failure (restarting node, brief RPC error) still recovers within
  seconds; a deterministic one settles at one attempt per 30s instead of tens per second.
* Reset the pacing on a success, so no deadline outlives the attempt it was meant to defer.
* Count every failed attempt in a new FE metric, `tablet_reshard_publish_failed`, so a stuck job is
  alertable instead of only being visible to someone reading `fe.warn.log` or polling
  `information_schema`. The 30s cap and the counter go together: at one attempt per 30s a permanently
  failing partition keeps it ticking about twice a minute, so
  `increase(starrocks_fe_tablet_reshard_publish_failed[5m]) > 0` fires within roughly a minute of the
  first failure. Requested by @kevincai in review, together with halving the cap.

In `SplitTabletJob` and `MergeTabletJob` (identical retry code in both): skip the resubmit until the
backoff has elapsed. The failure reason is still recorded on the partition first, so a job waiting out
its backoff keeps explaining itself through `ERROR_MESSAGE`.

The constants are deliberately not new `Config` entries: there is no plausible reason to tune the
pacing of a retry that has no alternative, and it keeps this out of the FE config surface.

Route `information_schema.tablet_reshard_jobs` to the leader. Reshard jobs only exist there —
`TabletReshardJobMgr` runs on the leader and a job's mutable state (including the reason it is stuck
retrying) is not journaled on every change — so a follower answering the scan from its replayed copy
reports the job as `RUNNING` with an empty `ERROR_MESSAGE` while the leader knows why it is not
progressing. Same rationale as the other job-state tables already in `QUERY_FROM_LEADER_TABLES`.

In the docs: none of the `tablet_reshard_*` metric family had an entry, so the new counter would have
landed in a gap rather than a list. All five (`job_total`, `job_finished`, `job_aborted`,
`parallel_tablets`, `publish_failed`) are now documented in `metric_details/s.md` for en, zh and ja,
including the Leader-only increment semantics and the alert expression above.

### What this does and does not fix

It does **not** make a wedged table writable again — that needs the underlying publish error fixed
(#77690 for the `Segment id overflow` case). What it does is stop the log flood and make the failure
alertable, so the next occurrence of *any* publish error can no longer fill the FE data disk and take
out journal writes, and does not have to be found by digging through `fe.warn.log`. Given the incident
above, a wedged reshard job is currently un-investigable in place: the evidence cannot be preserved
long enough to debug it, because keeping the job alive is what kills the cluster. That is the main
reason to land this ahead of the individual BE fixes.

**Known remaining gap, deliberately out of scope:** `canAbort()` admits only `PENDING` in both job
types, so a job past `RUNNING` has no abort path at all — automatic or manual — and there is no
`CANCEL RESHARD` syntax. Widening that needs its own design, since aborting a reshard transaction
that is already committed is not a simple rollback. Filed as a follow-up rather than bolted on here.

### Test

New `ReshardingPhysicalPartitionTest` pins the pacing:

* polling the same failed attempt 10 times leaves the retry deadline and the failure count untouched
  while every poll still reports `FAILED` with its reason — the deadline has to stay reachable, and
  the metric has to track attempts rather than daemon ticks,
* a failure defers the next attempt and carries its reason, and the backoff grows across consecutive
  failures,
* the backoff reaches the 30s cap at the sixth attempt and never exceeds it through the twelfth
  (bounded from the before/after timestamps around each call, so it does not depend on scheduling
  precision),
* a failed attempt bumps `tablet_reshard_publish_failed` exactly once, five more polls leave it
  unchanged, and a genuinely new attempt bumps it again,
* a success resets the pacing and stays re-readable across polls,
* a pending future still reports `IN_PROGRESS`, and a never-started one `NOT_STARTED`.

`MergeTabletJobTest.testRunRunningDefersRetryOfFailedPublish` covers the job side: two publish passes
inside the backoff leave the failed future in place — neither resubmits it — the job stays `RUNNING`,
the attempt is counted once, and the reason is still recorded for `ERROR_MESSAGE`.

`TabletReshardJobsTableTest` asserts the table is in `QUERY_FROM_LEADER_TABLES`.

Existing `MergeTabletJobTest` / `SplitTabletJobTest` cases construct partitions with no publish
future, which still report `NOT_STARTED`, so their behaviour is unchanged.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

A failing reshard publish is now retried at most once per 30s instead of once per scheduler tick, and
logged once per attempt instead of once per tick; a new `tablet_reshard_publish_failed` FE metric
counts the attempts; and `information_schema.tablet_reshard_jobs` is answered by the leader. No
metadata format or interface change; the retry bookkeeping is transient (not journaled), so a leader
switch simply starts from the first attempt as before.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

`branch-4.1` has the same unpaced retry in `getPublishResult()`. `branch-4.0` and `branch-3.5` do not
have the tablet reshard feature, so they are not affected.