### PR TITLE
[BugFix] Duplicate a limit as a limit, not as a set operator 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
@@ -54,6 +54,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalCTEConsumeOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEProduceOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalLimitOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalRepeatOperator;
@@ -572,10 +573,14 @@ public class OptExpressionDuplicator {
         @Override
         public OptExpression visitLogicalLimit(OptExpression optExpression, Void context) {
             List<OptExpression> inputs = processChildren(optExpression);
-            LogicalSetOperator setOperator = (LogicalSetOperator) optExpression.getOp();
-            LogicalSetOperator.Builder opBuilder = OperatorBuilderFactory.build(optExpression.getOp());
-            opBuilder.withOperator(setOperator);
-            processSetOperator(setOperator, opBuilder);
+            // A limit carries only its offset and row count -- it has no output column list to
+            // remap, so copying the operator and letting processCommon rewrite the projection
+            // and predicate is the whole job. This body used to be a copy of visitLogicalUnion,
+            // which cast the operator to LogicalSetOperator and could therefore never succeed:
+            // any limit reaching the duplicator threw ClassCastException.
+            LogicalLimitOperator limitOperator = (LogicalLimitOperator) optExpression.getOp();
+            LogicalLimitOperator.Builder opBuilder = OperatorBuilderFactory.build(optExpression.getOp());
+            opBuilder.withOperator(limitOperator);
             processCommon(opBuilder);
             return OptExpression.create(opBuilder.build(), inputs);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistinctWindowOverExistsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistinctWindowOverExistsTest.java
@@ -1,0 +1,82 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * A DISTINCT aggregate over a window, filtered by an uncorrelated EXISTS.
+ *
+ * <p>{@code DistinctAggregationOverWindowRule} duplicates the subtree through
+ * {@code OptExpressionDuplicator}. An uncorrelated EXISTS is rewritten into a join whose child
+ * carries a LIMIT, so the duplicator walks into a {@code LogicalLimit} -- and
+ * {@code visitLogicalLimit} was a copy of {@code visitLogicalUnion} that cast the operator to
+ * {@code LogicalSetOperator}, which can never succeed. Every such query died with
+ * {@code ClassCastException: LogicalLimitOperator cannot be cast to LogicalSetOperator}.
+ *
+ * <p>The broken method was introduced in 2024-04 with transparent MV rewrite (#43304), where
+ * nothing put a limit inside a duplicated subtree, and lay dormant until
+ * {@code DistinctAggregationOverWindowRule} (#65030, 2025-11) reused the same duplicator on a
+ * shape that does. Three unrelated features have to meet for it to fire, which is why the
+ * existing MV-rewrite suite never touched it.
+ *
+ * <p>The control cases below matter as much as the failing one: the defect needs the DISTINCT,
+ * the window, and an *uncorrelated* EXISTS together. A correlated EXISTS or an IN subquery takes
+ * a different path.
+ */
+public class DistinctWindowOverExistsTest extends PlanTestBase {
+
+    @Test
+    public void testDistinctWindowWithUncorrelatedExists() throws Exception {
+        String plan = getFragmentPlan(
+                "SELECT count(DISTINCT v1) OVER () FROM t0 WHERE EXISTS (SELECT 1 FROM t1)");
+        assertContains(plan, "OUTPUT EXPRS");
+    }
+
+    @Test
+    public void testDistinctWindowWithPartitionAndExists() throws Exception {
+        String plan = getFragmentPlan(
+                "SELECT sum(DISTINCT v2) OVER (PARTITION BY v1) FROM t0 "
+                        + "WHERE EXISTS (SELECT 1 FROM t1)");
+        assertContains(plan, "OUTPUT EXPRS");
+    }
+
+    @Test
+    public void testDistinctWindowWithExplicitLimit() throws Exception {
+        // An explicit LIMIT reaches the repaired visitor directly. Before the fix that method had
+        // never executed successfully even once, so this is the case that shows the replacement
+        // body actually works rather than merely not throwing.
+        String plan = getFragmentPlan(
+                "SELECT count(DISTINCT v1) OVER () FROM t0 "
+                        + "WHERE EXISTS (SELECT 1 FROM t1) LIMIT 5");
+        assertContains(plan, "OUTPUT EXPRS");
+    }
+
+    @Test
+    public void testDistinctWindowWithCorrelatedExists() throws Exception {
+        // Control: a correlated EXISTS plans through another path and was never affected.
+        String plan = getFragmentPlan(
+                "SELECT count(DISTINCT v1) OVER () FROM t0 "
+                        + "WHERE EXISTS (SELECT v4 FROM t1 WHERE t1.v4 = t0.v1)");
+        assertContains(plan, "OUTPUT EXPRS");
+    }
+
+    @Test
+    public void testDistinctWindowWithoutExists() throws Exception {
+        // Control: without the EXISTS there is no limit in the duplicated subtree.
+        String plan = getFragmentPlan("SELECT count(DISTINCT v1) OVER () FROM t0");
+        assertContains(plan, "OUTPUT EXPRS");
+    }
+}

--- a/test/sql/test_subquery/R/test_distinct_window_over_exists
+++ b/test/sql/test_subquery/R/test_distinct_window_over_exists
@@ -1,0 +1,53 @@
+-- name: test_distinct_window_over_exists
+CREATE TABLE dw_t1 (
+  a int,
+  b int
+) ENGINE=OLAP
+DUPLICATE KEY(a)
+DISTRIBUTED BY HASH(a) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE dw_t2 (
+  c int
+) ENGINE=OLAP
+DUPLICATE KEY(c)
+DISTRIBUTED BY HASH(c) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO dw_t1 VALUES (1, 10), (2, 20), (3, 30);
+-- result:
+-- !result
+INSERT INTO dw_t2 VALUES (1), (2);
+-- result:
+-- !result
+SELECT count(DISTINCT a) OVER () FROM dw_t1 WHERE EXISTS (SELECT 1 FROM dw_t2);
+-- result:
+3
+3
+3
+-- !result
+SELECT sum(DISTINCT b) OVER (PARTITION BY a) FROM dw_t1 WHERE EXISTS (SELECT 1 FROM dw_t2) ORDER BY 1;
+-- result:
+10
+20
+30
+-- !result
+SELECT count(DISTINCT a) OVER () FROM dw_t1 WHERE EXISTS (SELECT 1 FROM dw_t2) LIMIT 5;
+-- result:
+3
+3
+3
+-- !result
+SELECT count(DISTINCT a) OVER () FROM dw_t1 WHERE EXISTS (SELECT c FROM dw_t2 WHERE dw_t2.c = dw_t1.a);
+-- result:
+2
+2
+-- !result
+SELECT count(DISTINCT a) OVER () FROM dw_t1;
+-- result:
+3
+3
+3
+-- !result

--- a/test/sql/test_subquery/T/test_distinct_window_over_exists
+++ b/test/sql/test_subquery/T/test_distinct_window_over_exists
@@ -33,8 +33,9 @@ INSERT INTO dw_t2 VALUES (1), (2);
 -- The defect: DISTINCT aggregate + window + uncorrelated EXISTS.
 SELECT count(DISTINCT a) OVER () FROM dw_t1 WHERE EXISTS (SELECT 1 FROM dw_t2);
 
--- Same with a PARTITION BY.
-SELECT sum(DISTINCT b) OVER (PARTITION BY a) FROM dw_t1 WHERE EXISTS (SELECT 1 FROM dw_t2);
+-- Same with a PARTITION BY. This one needs the ORDER BY: it is the only statement here whose rows
+-- are distinguishable, and the harness compares multi-row results as an exact ordered string.
+SELECT sum(DISTINCT b) OVER (PARTITION BY a) FROM dw_t1 WHERE EXISTS (SELECT 1 FROM dw_t2) ORDER BY 1;
 
 -- An explicit LIMIT reaches the repaired visitor directly; that method had never once executed
 -- successfully before the fix.

--- a/test/sql/test_subquery/T/test_distinct_window_over_exists
+++ b/test/sql/test_subquery/T/test_distinct_window_over_exists
@@ -1,0 +1,47 @@
+-- name: test_distinct_window_over_exists
+-- A DISTINCT aggregate over a window, filtered by an uncorrelated EXISTS.
+--
+-- DistinctAggregationOverWindowRule duplicates the subtree through OptExpressionDuplicator; the
+-- uncorrelated EXISTS becomes a join whose child carries a LIMIT, so the duplicator walks into a
+-- LogicalLimit. visitLogicalLimit was a copy of visitLogicalUnion and cast the operator to
+-- LogicalSetOperator, which can never succeed:
+--
+--   class ...operator.logical.LogicalLimitOperator cannot be cast to
+--   class ...operator.logical.LogicalSetOperator
+--
+-- No statistics are needed here -- unlike the correlated-ORDER-BY case, this one fires on empty
+-- tables.
+
+CREATE TABLE dw_t1 (
+  a int,
+  b int
+) ENGINE=OLAP
+DUPLICATE KEY(a)
+DISTRIBUTED BY HASH(a) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+CREATE TABLE dw_t2 (
+  c int
+) ENGINE=OLAP
+DUPLICATE KEY(c)
+DISTRIBUTED BY HASH(c) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO dw_t1 VALUES (1, 10), (2, 20), (3, 30);
+INSERT INTO dw_t2 VALUES (1), (2);
+
+-- The defect: DISTINCT aggregate + window + uncorrelated EXISTS.
+SELECT count(DISTINCT a) OVER () FROM dw_t1 WHERE EXISTS (SELECT 1 FROM dw_t2);
+
+-- Same with a PARTITION BY.
+SELECT sum(DISTINCT b) OVER (PARTITION BY a) FROM dw_t1 WHERE EXISTS (SELECT 1 FROM dw_t2);
+
+-- An explicit LIMIT reaches the repaired visitor directly; that method had never once executed
+-- successfully before the fix.
+SELECT count(DISTINCT a) OVER () FROM dw_t1 WHERE EXISTS (SELECT 1 FROM dw_t2) LIMIT 5;
+
+-- Control: a correlated EXISTS takes another path and was never affected.
+SELECT count(DISTINCT a) OVER () FROM dw_t1 WHERE EXISTS (SELECT c FROM dw_t2 WHERE dw_t2.c = dw_t1.a);
+
+-- Control: no EXISTS, so no limit inside the duplicated subtree.
+SELECT count(DISTINCT a) OVER () FROM dw_t1;


### PR DESCRIPTION
## Why I'm doing:

OptExpressionDuplicator.visitLogicalLimit was a copy of visitLogicalUnion: it cast the operator
to LogicalSetOperator and ran processSetOperator on it. A limit is not a set operator, so the
method could never succeed -- every LogicalLimit reaching the duplicator threw
ClassCastException. The branch had simply never executed.

Reachable from ordinary analytic SQL:

    CREATE TABLE t1 (a INT, b INT) DUPLICATE KEY(a) DISTRIBUTED BY HASH(a) BUCKETS 1;
    CREATE TABLE t2 (c INT) DUPLICATE KEY(c) DISTRIBUTED BY HASH(c) BUCKETS 1;
    EXPLAIN SELECT count(DISTINCT a) OVER () FROM t1 WHERE EXISTS (SELECT 1 FROM t2);

Three ingredients are all required, which is why it went unnoticed: the DISTINCT aggregate over
a window enters DistinctAggregationOverWindowRule, which duplicates the subtree; the
uncorrelated EXISTS is rewritten into a join whose child carries a LIMIT; and the duplicator
then walks into that limit. A correlated EXISTS or an IN subquery takes a different path and
does not trigger it.

A limit carries only its offset and row count, with no output column list to remap, so copying
the operator and letting processCommon rewrite the projection and predicate is the whole job.
Note the override cannot simply be dropped: the duplicator's default visit() returns null, which
would trade the ClassCastException for a harder-to-place NPE.

Verified on this branch (which already carries every fix through 2026-08-11):

  * the repro planned 0 -> 4 additional statements OK, with PLAN_INTERNAL_ERROR going 4 -> 0.
    The OK count rising by exactly the number that stopped throwing is the check that matters --
    an exception that merely turns into a rejection would leave it flat.
  * table-backed variants, including an explicit `... WHERE EXISTS (...) LIMIT 5` that exercises
    the repaired visitor directly, all plan.
  * 119 materialized-view rewrite tests pass, including OptExpressionDuplicatorRangeTest.

Found by mutation-fuzzing a seed corpus extracted from DuckDB's test suite: the mutator wrapped
a window over an existing EXISTS query, which is not a combination anyone writes by hand.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
