### PR TITLE
[BugFix] Report data cache read stats in intermediate query statistics

### DIFF
--- a/be/src/compute_env/query/query_runtime_state.h
+++ b/be/src/compute_env/query/query_runtime_state.h
@@ -95,9 +95,13 @@ public:
     void incr_read_stats(int64_t read_local_cnt, int64_t read_remote_cnt) {
         _total_read_local_cnt += read_local_cnt;
         _total_read_remote_cnt += read_remote_cnt;
+        _delta_read_local_cnt += read_local_cnt;
+        _delta_read_remote_cnt += read_remote_cnt;
     }
     int64_t get_read_local_cnt() const { return _total_read_local_cnt.load(); }
     int64_t get_read_remote_cnt() const { return _total_read_remote_cnt.load(); }
+    int64_t consume_delta_read_local_cnt() { return _delta_read_local_cnt.exchange(0); }
+    int64_t consume_delta_read_remote_cnt() { return _delta_read_remote_cnt.exchange(0); }
 
     void set_enable_profile() { _enable_profile.store(true, std::memory_order_relaxed); }
     bool get_enable_profile_flag() const { return _enable_profile.load(std::memory_order_relaxed); }
@@ -248,6 +252,8 @@ private:
     std::atomic<int64_t> _delta_scan_bytes = 0;
     std::atomic<int64_t> _total_read_local_cnt = 0;
     std::atomic<int64_t> _total_read_remote_cnt = 0;
+    std::atomic<int64_t> _delta_read_local_cnt = 0;
+    std::atomic<int64_t> _delta_read_remote_cnt = 0;
 
     // @TODO(silverbullet233):
     // our phmap's version is too old and it doesn't provide a thread-safe iteration interface,

--- a/be/src/exec/runtime/query_context.cpp
+++ b/be/src/exec/runtime/query_context.cpp
@@ -292,6 +292,8 @@ std::shared_ptr<QueryStatistics> QueryContext::intermediate_query_statistic(int6
     query_statistic->add_cpu_costs(_query_runtime_state.consume_delta_cpu_cost());
     query_statistic->add_mem_costs(mem_cost_bytes());
     query_statistic->add_transmitted_bytes(delta_transmitted_bytes);
+    query_statistic->add_read_stats(_query_runtime_state.consume_delta_read_local_cnt(),
+                                    _query_runtime_state.consume_delta_read_remote_cnt());
     _query_runtime_state.consume_delta_scan_stats(query_statistic.get());
     for (const auto& [node_id, exec_stats] : _query_runtime_state.node_exec_stats()) {
         query_statistic->add_exec_stats_item(

--- a/be/test/compute_env/query/query_runtime_state_test.cpp
+++ b/be/test/compute_env/query/query_runtime_state_test.cpp
@@ -101,6 +101,20 @@ TEST(QueryRuntimeStateTest, TracksReadStats) {
 
     EXPECT_EQ(10, state.get_read_local_cnt());
     EXPECT_EQ(16, state.get_read_remote_cnt());
+
+    // Deltas drain once consumed, while totals stay intact.
+    EXPECT_EQ(10, state.consume_delta_read_local_cnt());
+    EXPECT_EQ(16, state.consume_delta_read_remote_cnt());
+    EXPECT_EQ(0, state.consume_delta_read_local_cnt());
+    EXPECT_EQ(0, state.consume_delta_read_remote_cnt());
+    EXPECT_EQ(10, state.get_read_local_cnt());
+    EXPECT_EQ(16, state.get_read_remote_cnt());
+
+    state.incr_read_stats(2, 4);
+    EXPECT_EQ(2, state.consume_delta_read_local_cnt());
+    EXPECT_EQ(4, state.consume_delta_read_remote_cnt());
+    EXPECT_EQ(12, state.get_read_local_cnt());
+    EXPECT_EQ(20, state.get_read_remote_cnt());
 }
 
 TEST(QueryRuntimeStateTest, ProfileControlsDefaultToDisabledMergeProfile) {

--- a/be/test/exec/pipeline/query_context_manger_test.cpp
+++ b/be/test/exec/pipeline/query_context_manger_test.cpp
@@ -369,6 +369,33 @@ TEST(QueryContextManagerTest, testReadStats) {
     ASSERT_EQ(200, ctx.get_read_remote_cnt());
 }
 
+TEST(QueryContextManagerTest, testIntermediateQueryStatisticCarriesReadStats) {
+    auto parent_mem_tracker = std::make_shared<MemTracker>(MemTrackerType::QUERY_POOL, 1073741824L, "parent", nullptr);
+    QueryContext ctx;
+    ctx.init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
+
+    ctx.incr_read_stats(100, 200);
+
+    auto intermediate_stats = ctx.intermediate_query_statistic(0);
+    ASSERT_NE(nullptr, intermediate_stats);
+    PQueryStatistics intermediate_pb;
+    intermediate_stats->to_pb(&intermediate_pb);
+    EXPECT_EQ(100, intermediate_pb.read_local_cnt());
+    EXPECT_EQ(200, intermediate_pb.read_remote_cnt());
+
+    // The delta has been drained, so a second report carries nothing.
+    auto second_intermediate_stats = ctx.intermediate_query_statistic(0);
+    ASSERT_NE(nullptr, second_intermediate_stats);
+    PQueryStatistics second_intermediate_pb;
+    second_intermediate_stats->to_pb(&second_intermediate_pb);
+    EXPECT_EQ(0, second_intermediate_pb.read_local_cnt());
+    EXPECT_EQ(0, second_intermediate_pb.read_remote_cnt());
+
+    // Totals used by the final-sink path are unaffected by delta consumption.
+    EXPECT_EQ(100, ctx.get_read_local_cnt());
+    EXPECT_EQ(200, ctx.get_read_remote_cnt());
+}
+
 class MockRuntimeFilterQueryLifecycle final : public RuntimeFilterQueryLifecycle {
 public:
     void open_query(const TUniqueId& query_id, const TQueryOptions& query_options, const TRuntimeFilterParams& params,


### PR DESCRIPTION
## Why I'm doing:

In shared-data mode the audit log field `CacheHitRatio` (and the FE cache-hit-ratio metrics) is computed from the `read_local_cnt` / `read_remote_cnt` counters shipped from BEs. Only `QueryContext::final_query_statistic()` included these counters; `intermediate_query_statistic()` — the delta statistics that non-final-sink BEs piggyback on exchange traffic — did not carry them. Since the final-sink BE usually runs no scan, the scan-side counters of virtually every multi-node query were lost: the FE received zero counts, and `AuditEvent.calculateCacheHitRatio()` fell back to the constant `"100%"`.

Observed on a production shared-data cluster (4.1.4): a 12.8s query that read 4.75 GB from S3 (its profile shows a real IO-count hit ratio of 95.1%) was logged with `CacheHitRatio: "100%"`. In that FE's audit log, ~19200 entries carried the bare fallback `"100%"` while only ~1400 carried genuinely computed values — the single-node queries whose scan happened to run on the final-sink BE.

## What I'm doing:

- `QueryRuntimeState::incr_read_stats()` now also accumulates the increments into new `_delta_read_local_cnt` / `_delta_read_remote_cnt` counters, drained by `consume_delta_read_local_cnt()` / `consume_delta_read_remote_cnt()` (`exchange(0)`, the same pattern as the cpu-cost delta).
- `QueryContext::intermediate_query_statistic()` adds the drained deltas via `QueryStatistics::add_read_stats()`, so scan-side counts propagate through the exchange chain to the final-sink BE and on to the FE. Serialization and merging already handle these fields (`to_pb` / `to_thrift` / `merge` / `merge_pb` / FE `AuditStatisticsUtil`), so there is no protocol change.
- `final_query_statistic()` and `snapshot_query_statistic()` keep using the totals; non-final-sink BEs only ever ship deltas, so nothing is double counted.
- UT: extended `QueryRuntimeStateTest.TracksReadStats` with the delta-drain semantics, and added `QueryContextManagerTest.testIntermediateQueryStatisticCarriesReadStats` verifying an intermediate report carries the counts exactly once, a second report carries zero, and the totals used by the final-sink path are unaffected.

Fixes #77697

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
