### PR TITLE
[BugFix] Create hash-colocate lake shards on colocate-aligned workers

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -542,6 +542,23 @@ public class ColocateTableIndex implements Writable {
         }
     }
 
+    /**
+     * Returns the table's {@link GroupId} iff the table participates in a colocate group backed by
+     * a StarOS meta group, or {@code null} otherwise. Wraps the
+     * {@code isMetaGroupColocateTable + getGroup} pair under a single read lock so a concurrent
+     * de-colocation between the two lookups cannot fail the second one.
+     */
+    @javax.annotation.Nullable
+    public GroupId getMetaGroupColocateGroupId(long tableId) {
+        readLock();
+        try {
+            GroupId groupId = table2Group.get(tableId);
+            return (groupId != null && metaGroups.contains(groupId)) ? groupId : null;
+        } finally {
+            readUnlock();
+        }
+    }
+
     public boolean isRangeColocateGroup(GroupId groupId) {
         readLock();
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -47,6 +47,7 @@ import com.staros.proto.WarmupLevel;
 import com.staros.proto.WorkerGroupDetailInfo;
 import com.staros.proto.WorkerGroupSpec;
 import com.staros.proto.WorkerInfo;
+import com.staros.util.Constant;
 import com.staros.util.LockCloseable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.common.Config;
@@ -630,12 +631,35 @@ public class StarOSAgent {
                                    ComputeResource computeResource)
         throws DdlException {
         return createShards(numShards, pathInfo, cacheInfo, List.of(groupId), matchShardIds, properties,
-                computeResource);
+                Constant.DEFAULT_ID /* metaGroupId */, computeResource);
+    }
+
+    /**
+     * Create shards that join {@code metaGroupId} at creation. Joining at creation has the same
+     * effect as the later {@code updateMetaGroup} join for these shards: each is appended to the
+     * meta group's anonymous group of its bucket position, so the very first placement already
+     * honors the colocation constraint and no shard migration is needed after the data is loaded.
+     */
+    public List<Long> createShards(int numShards, FilePathInfo pathInfo, FileCacheInfo cacheInfo, long groupId,
+                                   @Nullable List<Long> matchShardIds, @NotNull Map<String, String> properties,
+                                   long metaGroupId, ComputeResource computeResource)
+        throws DdlException {
+        return createShards(numShards, pathInfo, cacheInfo, List.of(groupId), matchShardIds, properties,
+                metaGroupId, computeResource);
     }
 
     public List<Long> createShards(int numShards, FilePathInfo pathInfo, FileCacheInfo cacheInfo,
                                    List<Long> groupIds, @Nullable List<Long> matchShardIds,
                                    @NotNull Map<String, String> properties,
+                                   ComputeResource computeResource)
+        throws DdlException {
+        return createShards(numShards, pathInfo, cacheInfo, groupIds, matchShardIds, properties,
+                Constant.DEFAULT_ID /* metaGroupId */, computeResource);
+    }
+
+    public List<Long> createShards(int numShards, FilePathInfo pathInfo, FileCacheInfo cacheInfo,
+                                   List<Long> groupIds, @Nullable List<Long> matchShardIds,
+                                   @NotNull Map<String, String> properties, long metaGroupId,
                                    ComputeResource computeResource)
         throws DdlException {
         Preconditions.checkArgument(groupIds != null && !groupIds.isEmpty(),
@@ -670,7 +694,7 @@ public class StarOSAgent {
                 }
                 createShardInfoList.add(builder.build());
             }
-            shardInfos = client.createShard(serviceId, createShardInfoList);
+            shardInfos = client.createShard(serviceId, createShardInfoList, metaGroupId);
             LOG.debug("Create shards success. shard infos: {}", shardInfos);
         } catch (Exception e) {
             throw new DdlException("Failed to create shards. error: " + e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/load/PartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/PartitionUtils.java
@@ -16,6 +16,7 @@ package com.starrocks.load;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
+import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.MaterializedIndex;
@@ -37,6 +38,7 @@ import com.starrocks.persist.PartitionPersistInfoV2;
 import com.starrocks.persist.RangePartitionPersistInfo;
 import com.starrocks.persist.SinglePartitionPersistInfo;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
 import com.starrocks.sql.ast.DistributionDesc;
 import com.starrocks.sql.ast.expression.DateLiteral;
 import com.starrocks.sql.ast.expression.LiteralExpr;
@@ -61,9 +63,13 @@ public class PartitionUtils {
                                                           List<Long> tmpPartitionIds,
                                                           DistributionDesc distributionDesc,
                                                           ComputeResource computeResource) throws DdlException {
-        List<Partition> newTempPartitions = GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .createTempPartitionsFromPartitions(db, targetTable, postfix, sourcePartitionIds,
-                        tmpPartitionIds, distributionDesc, computeResource);
+        LocalMetastore localMetastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        // Snapshot the colocation meta group that the lock-free tablet creation below pins the new
+        // shards to; re-validated under the WRITE lock before commit.
+        ColocateTableIndex.GroupId metaGroupColocateGroupId = GlobalStateMgr.getCurrentState()
+                .getColocateTableIndex().getMetaGroupColocateGroupId(targetTable.getId());
+        List<Partition> newTempPartitions = localMetastore.createTempPartitionsFromPartitions(db, targetTable,
+                postfix, sourcePartitionIds, tmpPartitionIds, distributionDesc, computeResource);
         Locker locker = new Locker();
         if (!locker.lockTableAndCheckDbExist(db, targetTable.getId(), LockType.WRITE)) {
             throw new DdlException("create and add partition failed. database:{}" + db.getFullName() + " not exist");
@@ -78,6 +84,7 @@ public class PartitionUtils {
             if (sourcePartitionIds.stream().anyMatch(id -> targetTable.getPartition(id) == null)) {
                 throw new DdlException("create partition failed because src partitions changed");
             }
+            localMetastore.checkIfColocateMetaGroupChange(targetTable, metaGroupColocateGroupId, targetTable.getName());
             List<Partition> sourcePartitions = sourcePartitionIds.stream()
                     .map(targetTable::getPartition).toList();
             PartitionInfo partitionInfo = targetTable.getPartitionInfo();

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2388,18 +2388,16 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         }
 
         int bucketNum = distributionInfo.getBucketNum();
-        // For hash colocate tables, create the shards already joined to the colocation meta group
-        // (same effect as the later updateMetaGroup join), so the very first placement honors the
+        // For meta-group colocate tables (hash colocate lake tables — the only groups that get a
+        // StarOS meta group), create the shards already joined to the colocation meta group (same
+        // effect as the later updateMetaGroup join), so the very first placement honors the
         // colocation constraint. Otherwise the shards get generic placement first and are only
         // migrated onto the colocate-aligned workers after their shard groups join the meta group
         // (InsertOverwriteJobRunner post-commit / StarMgrMetaSyncer), which runs after the load
         // has finished and therefore orphans the caches the load populated on the original
         // workers.
-        long metaGroupId = 0;
-        if (distributionInfoType == DistributionInfo.DistributionInfoType.HASH
-                && colocateTableIndex.isMetaGroupColocateTable(table.getId())) {
-            metaGroupId = colocateTableIndex.getGroup(table.getId()).grpId;
-        }
+        ColocateTableIndex.GroupId colocateGroupId = colocateTableIndex.getMetaGroupColocateGroupId(table.getId());
+        long metaGroupId = colocateGroupId == null ? 0 : colocateGroupId.grpId;
         List<Long> shardIds = stateMgr.getStarOSAgent().createShards(bucketNum,
                 table.getPartitionFilePathInfo(physicalPartitionId),
                 table.getPartitionFileCacheInfo(physicalPartitionId),

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2388,11 +2388,23 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         }
 
         int bucketNum = distributionInfo.getBucketNum();
+        // For hash colocate tables, create the shards already joined to the colocation meta group
+        // (same effect as the later updateMetaGroup join), so the very first placement honors the
+        // colocation constraint. Otherwise the shards get generic placement first and are only
+        // migrated onto the colocate-aligned workers after their shard groups join the meta group
+        // (InsertOverwriteJobRunner post-commit / StarMgrMetaSyncer), which runs after the load
+        // has finished and therefore orphans the caches the load populated on the original
+        // workers.
+        long metaGroupId = 0;
+        if (distributionInfoType == DistributionInfo.DistributionInfoType.HASH
+                && colocateTableIndex.isMetaGroupColocateTable(table.getId())) {
+            metaGroupId = colocateTableIndex.getGroup(table.getId()).grpId;
+        }
         List<Long> shardIds = stateMgr.getStarOSAgent().createShards(bucketNum,
                 table.getPartitionFilePathInfo(physicalPartitionId),
                 table.getPartitionFileCacheInfo(physicalPartitionId),
                 shardGroupId,
-                null, properties, computeResource);
+                null, properties, metaGroupId, computeResource);
         for (long shardId : shardIds) {
             Tablet tablet = new LakeTablet(shardId);
             if (distributionInfoType == DistributionInfo.DistributionInfoType.RANGE) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1221,6 +1221,23 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         }
     }
 
+    /**
+     * The lake tablets of a new partition (ADD PARTITION, TRUNCATE TABLE, the temp partitions of
+     * INSERT OVERWRITE / OPTIMIZE) are created outside the table lock and pinned to the colocation
+     * meta group looked up at that time (see {@link #createLakeTablets}). A concurrent
+     * {@code ALTER TABLE ... SET ('colocate_with' = ...)} in that window would leave the new shards in a
+     * meta group the table no longer belongs to: the post-commit {@code updateLakeTableColocationInfo}
+     * only knows the table's current group. Fail the DDL so the caller retries against the new colocation;
+     * the shards created by the failed attempt are reclaimed by StarMgrMetaSyncer.
+     */
+    public void checkIfColocateMetaGroupChange(OlapTable olapTable, ColocateTableIndex.GroupId expectedGroupId,
+                                               String tableName) throws DdlException {
+        ColocateTableIndex.GroupId currentGroupId = colocateTableIndex.getMetaGroupColocateGroupId(olapTable.getId());
+        if (!Objects.equals(currentGroupId, expectedGroupId)) {
+            throw new DdlException("Table[" + tableName + "]'s colocation has been changed. try again.");
+        }
+    }
+
     private static class PartitionInfoCheckResult {
         private final Map<Long, Range<PartitionKey>> idToRange;
         private final Map<Long, List<LiteralExpr>> idToLiteralExprValues;
@@ -1352,6 +1369,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         DistributionInfo distributionInfo;
         OlapTable olapTable = checkTableForAddPartitions(db, tableName);
         OlapTable copiedTable;
+        ColocateTableIndex.GroupId metaGroupColocateGroupId;
 
         Locker locker = new Locker();
         locker.lockTableWithIntensiveDbLock(db.getId(), olapTable.getId(), LockType.READ);
@@ -1373,6 +1391,9 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
 
             // check colocation
             checkColocation(db, olapTable, distributionInfo, partitionDescs);
+            // Snapshot the colocation meta group that the lock-free tablet creation below pins the new
+            // shards to; re-validated under the WRITE lock before commit.
+            metaGroupColocateGroupId = colocateTableIndex.getMetaGroupColocateGroupId(olapTable.getId());
             copiedTable = AnalyzerUtils.getShadowCopyTable(olapTable);
             copiedTable.setDefaultDistributionInfo(distributionInfo);
             checkExistPartitionName = CatalogUtils.checkPartitionNameExistForAddPartitions(olapTable, partitionDescs);
@@ -1429,6 +1450,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
 
                 // check if meta changed
                 checkIfMetaChange(olapTable, copiedTable, tableName);
+                checkIfColocateMetaGroupChange(olapTable, metaGroupColocateGroupId, tableName);
 
                 // get partition info
                 PartitionInfo partitionInfo = olapTable.getPartitionInfo();
@@ -2396,7 +2418,13 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         // (InsertOverwriteJobRunner post-commit / StarMgrMetaSyncer), which runs after the load
         // has finished and therefore orphans the caches the load populated on the original
         // workers.
-        ColocateTableIndex.GroupId colocateGroupId = colocateTableIndex.getMetaGroupColocateGroupId(table.getId());
+        // The join can only be honored once the meta group has buckets, i.e. once some shard group
+        // has joined it, which StarOS rejects otherwise. A table without any shard group yet cannot
+        // tell (its group may have been created empty, e.g. a colocate table created without any
+        // partition), so its first partition is created without the join and the post-commit join
+        // defines the buckets, as it always did for the first member of a meta group.
+        ColocateTableIndex.GroupId colocateGroupId = table.getShardGroupIds().isEmpty() ? null
+                : colocateTableIndex.getMetaGroupColocateGroupId(table.getId());
         long metaGroupId = colocateGroupId == null ? 0 : colocateGroupId.grpId;
         List<Long> shardIds = stateMgr.getStarOSAgent().createShards(bucketNum,
                 table.getPartitionFilePathInfo(physicalPartitionId),
@@ -5200,6 +5228,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         long tableId = MetaUtils.getSessionAwareTable(context, db, dbTbl).getId();
         Locker locker = new Locker();
         OlapTable olapTable = null;
+        ColocateTableIndex.GroupId metaGroupColocateGroupId;
         if (!locker.lockTableAndCheckDbExist(db, tableId, LockType.READ)) {
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
         }
@@ -5224,6 +5253,8 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             }
 
             copiedTbl = AnalyzerUtils.getShadowCopyTable(olapTable);
+            // Same as addPartitions: the new partitions' shards are pinned to this meta group outside the lock.
+            metaGroupColocateGroupId = colocateTableIndex.getMetaGroupColocateGroupId(olapTable.getId());
         } finally {
             locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
         }
@@ -5311,6 +5342,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             if (metaChanged) {
                 throw new DdlException("Table[" + copiedTbl.getName() + "]'s meta has been changed. try again.");
             }
+            checkIfColocateMetaGroupChange(olapTable, metaGroupColocateGroupId, copiedTbl.getName());
 
             // write edit log
             TruncateTableInfo info = new TruncateTableInfo(db.getId(), olapTable.getId(), newPartitions,

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
@@ -363,7 +363,7 @@ public class StarOSAgentTest {
 
         new Expectations(client) {
             {
-                client.createShard("1", (List<CreateShardInfo>) any);
+                client.createShard("1", (List<CreateShardInfo>) any, anyLong);
                 result = shards;
                 client.createShardGroup("1", (List<CreateShardGroupInfo>) any);
                 result = groups;

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoCluster.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoCluster.java
@@ -212,8 +212,8 @@ public class PseudoCluster {
 
         @Override
         public List<Long> createShards(int numShards, FilePathInfo pathInfo, FileCacheInfo cacheInfo,
-                                       long groupId, List<Long> matchShardIds, Map<String, String> properties,
-                                       ComputeResource computeResource)
+                                       List<Long> groupIds, List<Long> matchShardIds, Map<String, String> properties,
+                                       long metaGroupId, ComputeResource computeResource)
                 throws DdlException {
             List<Long> shardIds = new ArrayList<>();
             for (int i = 0; i < numShards; i++) {

--- a/fe/fe-core/src/test/java/com/starrocks/server/LakeColocateShardMetaGroupTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LakeColocateShardMetaGroupTest.java
@@ -1,0 +1,88 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.server;
+
+import com.staros.proto.FileCacheInfo;
+import com.staros.proto.FilePathInfo;
+import com.starrocks.catalog.ColocateTableIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.DdlException;
+import com.starrocks.lake.StarOSAgent;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import com.starrocks.warehouse.cngroup.ComputeResource;
+import mockit.Invocation;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class LakeColocateShardMetaGroupTest {
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(true, RunMode.SHARED_DATA);
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase("test_colo_mg").useDatabase("test_colo_mg");
+    }
+
+    @Test
+    public void testNewPartitionShardsJoinMetaGroupAtCreation() throws Exception {
+        List<Long> capturedMetaGroupIds = new ArrayList<>();
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Long> createShards(Invocation invocation, int numShards, FilePathInfo pathInfo,
+                                           FileCacheInfo cacheInfo, List<Long> groupIds, List<Long> matchShardIds,
+                                           Map<String, String> properties, long metaGroupId,
+                                           ComputeResource computeResource) throws DdlException {
+                capturedMetaGroupIds.add(metaGroupId);
+                return invocation.proceed(numShards, pathInfo, cacheInfo, groupIds, matchShardIds,
+                        properties, metaGroupId, computeResource);
+            }
+        };
+
+        starRocksAssert.withTable("CREATE TABLE test_colo_mg.cm1 (k1 int, k2 int)"
+                + " PARTITION BY RANGE(k1) (PARTITION p1 VALUES LESS THAN ('10'))"
+                + " DISTRIBUTED BY HASH(k2) BUCKETS 3"
+                + " PROPERTIES('colocate_with' = 'cg_mg_ut')");
+        OlapTable table = (OlapTable) starRocksAssert.getTable("test_colo_mg", "cm1");
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        Assertions.assertTrue(colocateTableIndex.isMetaGroupColocateTable(table.getId()));
+        long grpId = colocateTableIndex.getGroup(table.getId()).grpId;
+
+        // A new partition of the colocate table: its shards must be created with the meta group,
+        // so the very first placement already honors the colocation constraint.
+        capturedMetaGroupIds.clear();
+        starRocksAssert.ddl("ALTER TABLE test_colo_mg.cm1 ADD PARTITION p2 VALUES LESS THAN ('20')");
+        Assertions.assertEquals(List.of(grpId), capturedMetaGroupIds);
+
+        // Control: a non-colocate table's new partition carries no meta group.
+        starRocksAssert.withTable("CREATE TABLE test_colo_mg.cm2 (k1 int, k2 int)"
+                + " PARTITION BY RANGE(k1) (PARTITION p1 VALUES LESS THAN ('10'))"
+                + " DISTRIBUTED BY HASH(k2) BUCKETS 3");
+        capturedMetaGroupIds.clear();
+        starRocksAssert.ddl("ALTER TABLE test_colo_mg.cm2 ADD PARTITION p2 VALUES LESS THAN ('20')");
+        Assertions.assertEquals(List.of(0L), capturedMetaGroupIds);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/server/LakeColocateShardMetaGroupTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LakeColocateShardMetaGroupTest.java
@@ -17,9 +17,11 @@ package com.starrocks.server;
 import com.staros.proto.FileCacheInfo;
 import com.staros.proto.FilePathInfo;
 import com.starrocks.catalog.ColocateTableIndex;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.DdlException;
 import com.starrocks.lake.StarOSAgent;
+import com.starrocks.load.PartitionUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
@@ -34,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class LakeColocateShardMetaGroupTest {
     private static ConnectContext connectContext;
@@ -84,5 +87,156 @@ public class LakeColocateShardMetaGroupTest {
         capturedMetaGroupIds.clear();
         starRocksAssert.ddl("ALTER TABLE test_colo_mg.cm2 ADD PARTITION p2 VALUES LESS THAN ('20')");
         Assertions.assertEquals(List.of(0L), capturedMetaGroupIds);
+    }
+
+    @Test
+    public void testAddPartitionRetriesWhenColocationChangesDuringShardCreation() throws Exception {
+        List<Long> capturedMetaGroupIds = new ArrayList<>();
+        AtomicBoolean decolocated = new AtomicBoolean(false);
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Long> createShards(Invocation invocation, int numShards, FilePathInfo pathInfo,
+                                           FileCacheInfo cacheInfo, List<Long> groupIds, List<Long> matchShardIds,
+                                           Map<String, String> properties, long metaGroupId,
+                                           ComputeResource computeResource) throws DdlException {
+                capturedMetaGroupIds.add(metaGroupId);
+                List<Long> shardIds = invocation.proceed(numShards, pathInfo, cacheInfo, groupIds, matchShardIds,
+                        properties, metaGroupId, computeResource);
+                // Race a de-colocation into the lock-free window of ADD PARTITION: the shards above are
+                // already pinned to the colocate meta group when the table leaves the group.
+                if (metaGroupId != 0 && decolocated.compareAndSet(false, true)) {
+                    try {
+                        starRocksAssert.alterTableProperties(
+                                "ALTER TABLE test_colo_mg.cm3 SET ('colocate_with' = '')");
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+                return shardIds;
+            }
+        };
+
+        starRocksAssert.withTable("CREATE TABLE test_colo_mg.cm3 (k1 int, k2 int)"
+                + " PARTITION BY RANGE(k1) (PARTITION p1 VALUES LESS THAN ('10'))"
+                + " DISTRIBUTED BY HASH(k2) BUCKETS 3"
+                + " PROPERTIES('colocate_with' = 'cg_mg_race')");
+        OlapTable table = (OlapTable) starRocksAssert.getTable("test_colo_mg", "cm3");
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        long grpId = colocateTableIndex.getGroup(table.getId()).grpId;
+
+        // The commit re-validates the colocation snapshot taken before shard creation and rejects the
+        // DDL instead of committing shards pinned to a meta group the table no longer belongs to.
+        capturedMetaGroupIds.clear();
+        Exception e = Assertions.assertThrows(Exception.class,
+                () -> starRocksAssert.ddl("ALTER TABLE test_colo_mg.cm3 ADD PARTITION p2 VALUES LESS THAN ('20')"));
+        Assertions.assertTrue(e.getMessage().contains("colocation has been changed"), e.getMessage());
+        Assertions.assertEquals(List.of(grpId), capturedMetaGroupIds);
+        Assertions.assertTrue(decolocated.get());
+        Assertions.assertNull(table.getPartition("p2"));
+        Assertions.assertFalse(colocateTableIndex.isColocateTable(table.getId()));
+
+        // The retry sees the table's current, non-colocate state and creates the shards without a meta group.
+        capturedMetaGroupIds.clear();
+        starRocksAssert.ddl("ALTER TABLE test_colo_mg.cm3 ADD PARTITION p2 VALUES LESS THAN ('20')");
+        Assertions.assertEquals(List.of(0L), capturedMetaGroupIds);
+        Assertions.assertNotNull(table.getPartition("p2"));
+    }
+
+    @Test
+    public void testTempPartitionCreationRejectedWhenColocationChangesDuringShardCreation() throws Exception {
+        List<Long> capturedMetaGroupIds = new ArrayList<>();
+        AtomicBoolean decolocated = new AtomicBoolean(false);
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Long> createShards(Invocation invocation, int numShards, FilePathInfo pathInfo,
+                                           FileCacheInfo cacheInfo, List<Long> groupIds, List<Long> matchShardIds,
+                                           Map<String, String> properties, long metaGroupId,
+                                           ComputeResource computeResource) throws DdlException {
+                capturedMetaGroupIds.add(metaGroupId);
+                List<Long> shardIds = invocation.proceed(numShards, pathInfo, cacheInfo, groupIds, matchShardIds,
+                        properties, metaGroupId, computeResource);
+                if (metaGroupId != 0 && decolocated.compareAndSet(false, true)) {
+                    try {
+                        starRocksAssert.alterTableProperties(
+                                "ALTER TABLE test_colo_mg.cm5 SET ('colocate_with' = '')");
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+                return shardIds;
+            }
+        };
+
+        starRocksAssert.withTable("CREATE TABLE test_colo_mg.cm5 (k1 int, k2 int)"
+                + " PARTITION BY RANGE(k1) (PARTITION p1 VALUES LESS THAN ('10'))"
+                + " DISTRIBUTED BY HASH(k2) BUCKETS 3"
+                + " PROPERTIES('colocate_with' = 'cg_mg_tmp')");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test_colo_mg");
+        OlapTable table = (OlapTable) starRocksAssert.getTable("test_colo_mg", "cm5");
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        long grpId = colocateTableIndex.getGroup(table.getId()).grpId;
+        List<Long> sourcePartitionIds = List.of(table.getPartition("p1").getId());
+        connectContext.setThreadLocalInfo();
+
+        // The temp partitions of INSERT OVERWRITE / OPTIMIZE take the same lock-free path: the shards are
+        // pinned to the meta group, then committed under the WRITE lock, where the colocation is re-validated.
+        capturedMetaGroupIds.clear();
+        DdlException e = Assertions.assertThrows(DdlException.class,
+                () -> PartitionUtils.createAndAddTempPartitionsForTable(db, table, "_tmp", sourcePartitionIds,
+                        List.of(GlobalStateMgr.getCurrentState().getNextId()), null,
+                        WarehouseManager.DEFAULT_RESOURCE));
+        Assertions.assertTrue(e.getMessage().contains("colocation has been changed"), e.getMessage());
+        Assertions.assertEquals(List.of(grpId), capturedMetaGroupIds);
+        Assertions.assertTrue(decolocated.get());
+        Assertions.assertTrue(table.getTempPartitions().isEmpty());
+        Assertions.assertFalse(colocateTableIndex.isColocateTable(table.getId()));
+
+        // The retry sees the table's current, non-colocate state and creates the shards without a meta group.
+        capturedMetaGroupIds.clear();
+        PartitionUtils.createAndAddTempPartitionsForTable(db, table, "_tmp", sourcePartitionIds,
+                List.of(GlobalStateMgr.getCurrentState().getNextId()), null, WarehouseManager.DEFAULT_RESOURCE);
+        Assertions.assertEquals(List.of(0L), capturedMetaGroupIds);
+        Assertions.assertEquals(1, table.getTempPartitions().size());
+    }
+
+    @Test
+    public void testFirstPartitionOfColocateTableCreatedWithoutPartitions() throws Exception {
+        List<Long> capturedMetaGroupIds = new ArrayList<>();
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Long> createShards(Invocation invocation, int numShards, FilePathInfo pathInfo,
+                                           FileCacheInfo cacheInfo, List<Long> groupIds, List<Long> matchShardIds,
+                                           Map<String, String> properties, long metaGroupId,
+                                           ComputeResource computeResource) throws DdlException {
+                capturedMetaGroupIds.add(metaGroupId);
+                return invocation.proceed(numShards, pathInfo, cacheInfo, groupIds, matchShardIds,
+                        properties, metaGroupId, computeResource);
+            }
+        };
+
+        // A hash colocate lake table created without any partition (the shape of dynamic partitioning
+        // or a partitioned colocate MV): it joins the colocate group with no shard group, so its meta
+        // group has no bucket yet and StarOS would reject a create-time join.
+        starRocksAssert.withTable("CREATE TABLE test_colo_mg.cm4 (k1 int, k2 int)"
+                + " PARTITION BY RANGE(k1) ()"
+                + " DISTRIBUTED BY HASH(k2) BUCKETS 3"
+                + " PROPERTIES('colocate_with' = 'cg_mg_empty')");
+        OlapTable table = (OlapTable) starRocksAssert.getTable("test_colo_mg", "cm4");
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        long grpId = colocateTableIndex.getGroup(table.getId()).grpId;
+        Assertions.assertTrue(colocateTableIndex.isMetaGroupColocateTable(table.getId()));
+        Assertions.assertTrue(table.getShardGroupIds().isEmpty());
+
+        // The very first partition is created without the join; its post-commit join defines the buckets.
+        capturedMetaGroupIds.clear();
+        starRocksAssert.ddl("ALTER TABLE test_colo_mg.cm4 ADD PARTITION p1 VALUES LESS THAN ('10')");
+        Assertions.assertEquals(List.of(0L), capturedMetaGroupIds);
+        Assertions.assertNotNull(table.getPartition("p1"));
+
+        // From then on the table has a shard group, so the create-time join is requested and honored.
+        capturedMetaGroupIds.clear();
+        starRocksAssert.ddl("ALTER TABLE test_colo_mg.cm4 ADD PARTITION p2 VALUES LESS THAN ('20')");
+        Assertions.assertEquals(List.of(grpId), capturedMetaGroupIds);
+        Assertions.assertNotNull(table.getPartition("p2"));
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Shards of a new physical partition of a hash colocate lake table are created without any colocation placement information. They only get pulled onto the colocate-aligned workers when their shard groups join the StarOS meta group, which happens after the data has been written (`InsertOverwriteJobRunner` post-commit work, or the background `StarMgrMetaSyncer`). StarOS then migrates every shard of the new partition right after its load finished, orphaning the write-through data cache (and, in shared-data deployments with cache replication, its replica copy) on the original workers.

In a production case (nightly full-table `INSERT OVERWRITE` into unpartitioned colocate tables on a 40-CN cluster), each overwrite recreated all shards, the shards were re-placed ~70 seconds later, and the compaction dispatched in between even ran on the node that no longer owned the shard. Every query hitting the new partition read almost entire tablets from object storage (12.8s vs 432ms for the same query minutes later), showing up as unexplained "cache eviction" for weeks.

## What I'm doing:

- Depends on StarRocks/staros#1303, which lets `CreateShardInfo` carry a `meta_group_id`: StarOS appends each new shard to the meta group's anonymous group of its bucket position at creation — same effect as the later `UpdateMetaGroup` join, without creating any extra shard group. The very first placement then already honors the colocation constraint (the scheduler's PACK affinity scoring sees the membership), and the later wholesale join is a no-op for placement.
- `LocalMetastore.createLakeTablets`: for meta-group colocate tables, pass the colocate group id as the meta group id to `StarOSAgent.createShards`. The lookup goes through a new single-read-lock helper `ColocateTableIndex.getMetaGroupColocateGroupId` (no TOCTOU between check and get; returns null on concurrent de-colocation), and needs no explicit hash-distribution gate since only hash colocate lake tables ever join a StarOS meta group. Non-colocate tables and range-colocate tables (which already create aligned PACK groups) are unchanged.
- The join is requested only when the table already has a shard group. StarOS honors the create-time join only once the meta group has buckets (some shard group has joined it) and rejects it otherwise, and a hash colocate lake table created without any partition (`PARTITION BY RANGE (...) ()` with dynamic partitioning, a partitioned colocate MV) gets its meta group created empty. Its first partition is therefore created without the join and its post-commit join defines the buckets, as it always did for the first member of a meta group; every later partition is joined at creation. Verified on a shared-data cluster: `RANGE () ()` + `ADD PARTITION`, a dynamic-partition colocate table and a partitioned colocate MV all create their first partition, the next one is pinned.
- `StarOSAgent.createShards`: new overloads carrying `metaGroupId`; existing signatures delegate with `Constant.DEFAULT_ID` and stay unchanged for all other callers.
- An earlier revision of this PR pinned each new shard to the same-bucket tablet of an existing partition via `PlacementPreference` (`PACK` + `WITH_SHARD`). That approach was dropped: it records one anonymous pair group per shard per partition generation, so high-churn overwrite workloads pile up a large number of small groups. The meta-group-at-creation approach creates no groups at all.
- `LocalMetastore.addPartitions` / `truncateTable` and `PartitionUtils.createAndAddTempPartitionsForTable` (the temp partitions of INSERT OVERWRITE / OPTIMIZE): the tablets are created outside the table lock, so a concurrent `ALTER TABLE ... SET ('colocate_with' = ...)` in that window could leave the new shards pinned to a meta group the table no longer belongs to (the post-commit `updateLakeTableColocationInfo` only knows the table's current group). All three paths now snapshot the meta group id before the lock-free creation and re-validate it under the WRITE lock before commit (`LocalMetastore.checkIfColocateMetaGroupChange`); a mismatch fails the DDL with "try again" like `checkIfMetaChange`, and `StarMgrMetaSyncer` reclaims the shards of the failed attempt.
- UT: `LakeColocateShardMetaGroupTest` runs against the embedded StarManager and asserts that a new partition of a colocate table passes the group's meta group id to `createShards` (and that a non-colocate table passes none), that an ADD PARTITION or a temp partition creation racing with a de-colocation is rejected at commit and succeeds on retry without a meta group, and that the first partition of a colocate table created without partitions passes no meta group while its second one does. `StarOSAgentTest` / `PseudoCluster` mocks moved to the `createShard` overload that carries the meta group id.

## Verification

Noise-free A/B on a 2-CN shared-data dev cluster (fix vs the same build with the `createLakeTablets` gate neutralized), with `tablet_sched_disable_balance = true` so no background scheduler can mask or repair anything, against a colocate group whose anchor layout was a non-trivial per-bucket mix `[CN1, CN2, CN1, CN2]`:

- Baseline: `INSERT OVERWRITE` created the 4 new shards by load-based placement — 2 of 4 buckets landed against the anchor layout — and 7 seconds after the load finished exactly those two misplaced shards were swapped to their aligned workers (paired `Remove shard`/`Add shard` in the CN logs): the freshly written cache is orphaned right after every load. Notably this post-join migration fires even with the balance/background checks disabled, so no operational switch avoids it.
- With the fix (FE + staros#1303): all 4 shards were created bucket-aligned at t0 — including two placed onto the busier node, which no load heuristic would do — and nothing moved for the whole 300s observation window (zero `Remove shard` events).

NOTE: staros#1303 shipped in staros 4.2-rc4, which `main` already depends on.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4






