### PR TITLE
[BugFix] Restore GIN index directories during primary key tablet migration

### DIFF
--- a/be/src/data_workflows/clone/engine_clone_task.cpp
+++ b/be/src/data_workflows/clone/engine_clone_task.cpp
@@ -1000,25 +1000,47 @@ Status EngineCloneTask::_finish_clone_primary(Tablet* tablet, const std::string&
 
     auto fs = FileSystem::Default();
     std::set<std::string> tablet_files;
+    std::set<std::string> tablet_index_dirs;
+    auto cleanup_linked_snapshot = [&]() {
+        for (const auto& filename : tablet_files) {
+            auto st = fs->delete_file(filename);
+            LOG_IF(WARNING, !st.ok() && !st.is_not_found()) << "Fail to remove tablet file " << filename << ": " << st;
+        }
+        for (const auto& index_dir : tablet_index_dirs) {
+            auto st = fs::remove_all(index_dir);
+            LOG_IF(WARNING, !st.ok() && !st.is_not_found())
+                    << "Fail to remove tablet index directory " << index_dir << ": " << st;
+        }
+    };
+
     for (const std::string& filename : clone_files) {
         std::string from = clone_dir + "/" + filename;
         std::string to = tablet_dir + "/" + filename;
+        auto st = fs->link_file(from, to);
+        if (!st.ok()) {
+            cleanup_linked_snapshot();
+            return st;
+        }
         tablet_files.insert(to);
-        RETURN_IF_ERROR(fs->link_file(from, to));
     }
     LOG(INFO) << "Linked " << clone_files.size() << " files from " << clone_dir << " to " << tablet_dir;
+
+    auto link_index_st = SnapshotManager::instance()->link_inverted_index_directories(
+            snapshot_meta, tablet->tablet_schema(), clone_dir, tablet_dir, &tablet_index_dirs);
+    if (!link_index_st.ok()) {
+        cleanup_linked_snapshot();
+        return link_index_st;
+    }
+    LOG(INFO) << "Linked " << tablet_index_dirs.size() << " inverted index directories from " << clone_dir << " to "
+              << tablet_dir;
+
     bool need_rebuild_pk_index = _clone_req.__isset.need_rebuild_pk_index && _clone_req.need_rebuild_pk_index;
     // Note that |snapshot_meta| may be modified by `load_snapshot`.
     Status st = tablet->updates()->load_snapshot(snapshot_meta, false, false, need_rebuild_pk_index,
                                                  config::pindex_rebuild_clone_wait_seconds);
     if (!st.ok()) {
-        Status clear_st;
-        for (const std::string& filename : tablet_files) {
-            clear_st = fs::delete_file(filename);
-            if (!clear_st.ok()) {
-                LOG(WARNING) << "remove tablet file:" << filename << " failed, status:" << clear_st;
-            }
-        }
+        cleanup_linked_snapshot();
+        return st;
     }
 
     int64_t expired_stale_sweep_endtime = UnixSeconds() - config::tablet_rowset_stale_sweep_time_sec;

--- a/be/src/data_workflows/migration/engine_storage_migration_task.cpp
+++ b/be/src/data_workflows/migration/engine_storage_migration_task.cpp
@@ -544,6 +544,12 @@ Status EngineStorageMigrationTask::_finish_primary_key_migration(const TabletSha
         // don't wait rebuild pk index to finish because migration task does not support increment migration
         // and needs to be completed as soon as possible
 
+        res = SnapshotManager::instance()->restore_inverted_index_directories(schema_hash_path);
+        if (!res.ok()) {
+            need_remove_new_path = true;
+            break;
+        }
+
         // create_tablet_from_meta_snapshot does not reset rowset_seg_id in snapshot_meta. The GC progress for
         // the old tablet maybe conflict in rowset_seg_id with the new one. But it is safe because the rowset_seg_id
         // conflict in GC progress will only affect the delvector/dcg cache (delete the cache) for the new tablet but

--- a/be/src/data_workflows/snapshot/snapshot_loader.cpp
+++ b/be/src/data_workflows/snapshot/snapshot_loader.cpp
@@ -38,6 +38,7 @@
 #include <filesystem>
 #include <set>
 
+#include "base/utility/defer_op.h"
 #include "common/config_ingest_fwd.h"
 #include "common/config_rpc_client_fwd.h"
 #include "common/logging.h"
@@ -491,6 +492,8 @@ Status SnapshotLoader::primary_key_move(const std::string& snapshot_path, const 
         return Status::InternalError(ss.str());
     }
 
+    RETURN_IF_ERROR(SnapshotManager::instance()->restore_inverted_index_directories(snapshot_path));
+
     auto meta_file = strings::Substitute("$0/meta", snapshot_path);
     auto res = SnapshotManager::instance()->parse_snapshot_meta(meta_file);
     if (!res.ok()) {
@@ -503,8 +506,23 @@ Status SnapshotLoader::primary_key_move(const std::string& snapshot_path, const 
     }
     snapshot_meta.tablet_meta().set_tablet_id(tablet_id);
 
-    // Do not need to copy GIN in pk table because it does not support GIN now
-    RETURN_IF_ERROR(SnapshotManager::instance()->assign_new_rowset_id(&snapshot_meta, snapshot_path));
+    RETURN_IF_ERROR(
+            SnapshotManager::instance()->assign_new_rowset_id(&snapshot_meta, snapshot_path, tablet->tablet_schema()));
+
+    std::vector<std::string> linked_files;
+    std::set<std::string> linked_index_dirs;
+    CancelableDefer cleanup_published_files([&]() {
+        for (const auto& linked_file : linked_files) {
+            auto st = FileSystem::Default()->delete_file(linked_file);
+            LOG_IF(WARNING, !st.ok() && !st.is_not_found())
+                    << "failed to remove linked snapshot file " << linked_file << ": " << st;
+        }
+        for (const auto& index_dir : linked_index_dirs) {
+            auto st = fs::remove_all(index_dir);
+            LOG_IF(WARNING, !st.ok() && !st.is_not_found())
+                    << "failed to remove linked inverted index directory " << index_dir << ": " << st;
+        }
+    });
 
     if (overwrite) {
         // check all files in /clone and /tablet
@@ -529,26 +547,23 @@ Status SnapshotLoader::primary_key_move(const std::string& snapshot_path, const 
         }
 
         // link files one by one
-        // files in snapshot dir will be moved in snapshot clean process
-        std::vector<std::string> linked_files;
+        // files in snapshot dir will be removed in snapshot clean process
         for (const std::string& file : snapshot_files) {
             std::string full_src_path = snapshot_path + "/" + file;
             std::string full_dest_path = tablet_path + "/" + file;
             if (link(full_src_path.c_str(), full_dest_path.c_str()) != 0) {
                 LOG(WARNING) << "failed to link file from " << full_src_path << " to " << full_dest_path
                              << ", err: " << std::strerror(errno);
-
-                // clean the already linked files
-                for (auto& linked_file : linked_files) {
-                    remove(linked_file.c_str());
-                }
-
                 return Status::InternalError("move tablet failed");
             }
             linked_files.push_back(full_dest_path);
             VLOG(2) << "link file from " << full_src_path << " to " << full_dest_path;
         }
 
+        RETURN_IF_ERROR(SnapshotManager::instance()->link_inverted_index_directories(
+                snapshot_meta, tablet->tablet_schema(), snapshot_path, tablet_path, &linked_index_dirs));
+        LOG(INFO) << "linked " << linked_index_dirs.size() << " inverted index directories from " << snapshot_path
+                  << " to " << tablet_path;
     } else {
         LOG(FATAL) << "only support overwrite now";
     }
@@ -567,6 +582,7 @@ Status SnapshotLoader::primary_key_move(const std::string& snapshot_path, const 
     tablet->save_meta();
 
     RETURN_IF_ERROR(tablet->updates()->load_snapshot(snapshot_meta, true));
+    cleanup_published_files.cancel();
     tablet->updates()->remove_expired_versions(time(nullptr));
     LOG(INFO) << "Loaded snapshot of tablet " << tablet->tablet_id() << ", removing directory " << snapshot_path;
     auto st = fs::remove_all(snapshot_path);

--- a/be/src/storage/replication_txn_manager.cpp
+++ b/be/src/storage/replication_txn_manager.cpp
@@ -544,7 +544,8 @@ Status ReplicationTxnManager::replicate_remote_snapshot(const TReplicateSnapshot
     if (tablet->updates() == nullptr) {
         RETURN_IF_ERROR(convert_snapshot_for_none_primary(tablet_snapshot_dir_path, &column_unique_id_map, request));
     } else {
-        RETURN_IF_ERROR(convert_snapshot_for_primary(tablet_snapshot_dir_path, &column_unique_id_map, request));
+        RETURN_IF_ERROR(convert_snapshot_for_primary(tablet_snapshot_dir_path, &column_unique_id_map, request,
+                                                     tablet->tablet_schema()));
     }
 
     return Status::OK();
@@ -636,7 +637,10 @@ Status ReplicationTxnManager::convert_snapshot_for_none_primary(
 
 Status ReplicationTxnManager::convert_snapshot_for_primary(const std::string& tablet_snapshot_path,
                                                            std::unordered_map<uint32_t, uint32_t>* column_unique_id_map,
-                                                           const TReplicateSnapshotRequest& request) {
+                                                           const TReplicateSnapshotRequest& request,
+                                                           const TabletSchemaCSPtr& tablet_schema) {
+    RETURN_IF_ERROR(SnapshotManager::instance()->restore_inverted_index_directories(tablet_snapshot_path));
+
     std::string snapshot_meta_file_path = tablet_snapshot_path + "meta";
     ASSIGN_OR_RETURN(auto snapshot_meta, SnapshotManager::instance()->parse_snapshot_meta(snapshot_meta_file_path));
 
@@ -664,7 +668,8 @@ Status ReplicationTxnManager::convert_snapshot_for_primary(const std::string& ta
         }
     }
 
-    RETURN_IF_ERROR(SnapshotManager::instance()->assign_new_rowset_id(&snapshot_meta, tablet_snapshot_path));
+    RETURN_IF_ERROR(
+            SnapshotManager::instance()->assign_new_rowset_id(&snapshot_meta, tablet_snapshot_path, tablet_schema));
 
     RETURN_IF_ERROR(snapshot_meta.serialize_to_file(snapshot_meta_file_path));
 
@@ -860,24 +865,45 @@ Status ReplicationTxnManager::publish_snapshot_for_primary(Tablet* tablet, const
 
     auto fs = FileSystem::Default();
     std::set<std::string> tablet_files;
+    std::set<std::string> tablet_index_dirs;
+    auto cleanup_published_files = [&]() {
+        for (const auto& filename : tablet_files) {
+            auto st = fs->delete_file(filename);
+            LOG_IF(WARNING, !st.ok() && !st.is_not_found())
+                    << "Failed to remove tablet file " << filename << ": " << st;
+        }
+        for (const auto& index_dir : tablet_index_dirs) {
+            auto st = starrocks::fs::remove_all(index_dir);
+            LOG_IF(WARNING, !st.ok() && !st.is_not_found())
+                    << "Failed to remove tablet index directory " << index_dir << ": " << st;
+        }
+    };
+
     for (const std::string& filename : clone_files) {
         std::string from = snapshot_dir + "/" + filename;
         std::string to = tablet_dir + "/" + filename;
-        tablet_files.insert(to);
-        RETURN_IF_ERROR(fs->link_file(from, to));
+        auto st = fs->link_file(from, to);
+        if (!st.ok()) {
+            cleanup_published_files();
+            return st;
+        }
+        tablet_files.insert(std::move(to));
     }
     LOG(INFO) << "Linked " << clone_files.size() << " files from " << snapshot_dir << " to " << tablet_dir;
+
+    auto link_index_st = SnapshotManager::instance()->link_inverted_index_directories(
+            snapshot_meta, tablet->tablet_schema(), snapshot_dir, tablet_dir, &tablet_index_dirs);
+    if (!link_index_st.ok()) {
+        cleanup_published_files();
+        return link_index_st;
+    }
+    LOG(INFO) << "Linked " << tablet_index_dirs.size() << " inverted index directories from " << snapshot_dir << " to "
+              << tablet_dir;
 
     Status status = tablet->updates()->load_snapshot(snapshot_meta, false, true);
     if (!status.ok()) {
         LOG(WARNING) << "Failed to load snapshot of tablet " << tablet->tablet_id() << " from " << snapshot_dir;
-        Status clear_st;
-        for (const std::string& filename : tablet_files) {
-            clear_st = fs::delete_file(filename);
-            if (!clear_st.ok()) {
-                LOG(WARNING) << "Failed to remove tablet file: " << filename << ", status: " << clear_st;
-            }
-        }
+        cleanup_published_files();
     } else {
         int64_t expired_stale_sweep_endtime = UnixSeconds() - config::tablet_rowset_stale_sweep_time_sec;
         tablet->updates()->remove_expired_versions(expired_stale_sweep_endtime);

--- a/be/src/storage/replication_txn_manager.h
+++ b/be/src/storage/replication_txn_manager.h
@@ -71,7 +71,8 @@ private:
 
     Status convert_snapshot_for_primary(const std::string& tablet_snapshot_path,
                                         std::unordered_map<uint32_t, uint32_t>* column_unique_id_map,
-                                        const TReplicateSnapshotRequest& request);
+                                        const TReplicateSnapshotRequest& request,
+                                        const TabletSchemaCSPtr& tablet_schema);
 
     Status publish_snapshot(Tablet* tablet, const string& snapshot_dir, int64_t snapshot_version,
                             bool incremental_snapshot);

--- a/be/src/storage/snapshot_manager.cpp
+++ b/be/src/storage/snapshot_manager.cpp
@@ -73,6 +73,192 @@ using std::list;
 
 namespace starrocks {
 
+namespace {
+
+Status flatten_inverted_index_directories(const std::string& snapshot_dir) {
+    std::vector<std::string> snapshot_entries;
+    RETURN_IF_ERROR(FileSystem::Default()->get_children(snapshot_dir, &snapshot_entries));
+    for (const auto& entry : snapshot_entries) {
+        if (!entry.ends_with(".ivt")) {
+            continue;
+        }
+
+        const std::string index_dir = fmt::format("{}/{}", snapshot_dir, entry);
+        auto is_dir = fs::is_directory(index_dir);
+        RETURN_IF_ERROR(is_dir.status());
+        if (!is_dir.value()) {
+            continue;
+        }
+
+        std::vector<std::string> index_files;
+        RETURN_IF_ERROR(FileSystem::Default()->get_children(index_dir, &index_files));
+        const std::string flattened_prefix = entry.substr(0, entry.size() - 4);
+        for (const auto& index_file : index_files) {
+            const std::string old_name = fmt::format("{}/{}", index_dir, index_file);
+            const std::string new_name = fmt::format("{}/{}_{}", snapshot_dir, flattened_prefix, index_file);
+            RETURN_IF_ERROR(FileSystem::Default()->rename_file(old_name, new_name));
+        }
+        RETURN_IF_ERROR(FileSystem::Default()->delete_dir_recursive(index_dir));
+    }
+    return Status::OK();
+}
+
+Status restore_inverted_index_directories_impl(const std::string& clone_dir) {
+#ifndef __APPLE__
+    std::vector<std::string> clone_entries;
+    RETURN_IF_ERROR(FileSystem::Default()->get_children(clone_dir, &clone_entries));
+    for (const auto& entry : clone_entries) {
+        if (!CLucenePlugin::is_index_files(entry)) {
+            continue;
+        }
+
+        const auto first_separator = entry.find('_');
+        const auto second_separator =
+                first_separator == std::string::npos ? std::string::npos : entry.find('_', first_separator + 1);
+        const auto third_separator =
+                second_separator == std::string::npos ? std::string::npos : entry.find('_', second_separator + 1);
+        if (first_separator == std::string::npos || first_separator == 0 || second_separator == std::string::npos ||
+            second_separator == first_separator + 1 || third_separator == std::string::npos ||
+            third_separator == second_separator + 1 || third_separator + 1 == entry.size()) {
+            return Status::InternalError("invalid inverted index file name: " + entry);
+        }
+
+        const std::string index_dir = fmt::format("{}/{}.ivt", clone_dir, entry.substr(0, third_separator));
+        RETURN_IF_ERROR(fs::create_directories(index_dir));
+        RETURN_IF_ERROR(
+                FileSystem::Default()->rename_file(fmt::format("{}/{}", clone_dir, entry),
+                                                   fmt::format("{}/{}", index_dir, entry.substr(third_separator + 1))));
+    }
+#endif
+    return Status::OK();
+}
+
+struct RowsetIndexLayout {
+    std::string rowset_id;
+    int32_t num_segments;
+};
+
+// Builtin inverted indexes are stored in the segment footer and have no standalone .ivt directory. Keep the
+// property check here instead of calling is_builtin_inverted_index(), which is not available on branch-4.0.
+bool has_standalone_inverted_index(const TabletIndex& index) {
+    const auto& properties = index.common_properties();
+    const auto property = properties.find(INVERTED_IMP_KEY);
+    return property == properties.end() || !boost::iequals(property->second, "builtin");
+}
+
+Status link_inverted_index_directories_impl(const std::vector<RowsetIndexLayout>& rowset_layouts,
+                                            const TabletSchemaCSPtr& tablet_schema, const std::string& snapshot_dir,
+                                            const std::string& tablet_dir, std::set<std::string>* created_index_dirs) {
+    if (UNLIKELY(tablet_schema == nullptr)) {
+        return Status::InvalidArgument("tablet schema is null");
+    }
+    if (tablet_schema->indexes()->empty()) {
+        return Status::OK();
+    }
+
+    std::vector<std::string> created_directories;
+    std::vector<std::string> created_files;
+    CancelableDefer rollback([&]() {
+        for (auto it = created_files.rbegin(); it != created_files.rend(); ++it) {
+            auto st = FileSystem::Default()->delete_file(*it);
+            LOG_IF(WARNING, !st.ok() && !st.is_not_found())
+                    << "Fail to remove linked inverted index file " << *it << ": " << st;
+        }
+        for (auto it = created_directories.rbegin(); it != created_directories.rend(); ++it) {
+            auto st = fs::remove_all(*it);
+            LOG_IF(WARNING, !st.ok() && !st.is_not_found())
+                    << "Fail to remove linked inverted index directory " << *it << ": " << st;
+        }
+    });
+
+    for (const auto& rowset_layout : rowset_layouts) {
+        for (int segment_id = 0; segment_id < rowset_layout.num_segments; ++segment_id) {
+            for (const auto& index : *tablet_schema->indexes()) {
+                if (index.index_type() != GIN || !has_standalone_inverted_index(index)) {
+                    continue;
+                }
+
+                const std::string source = IndexDescriptor::inverted_index_file_path(
+                        snapshot_dir, rowset_layout.rowset_id, segment_id, index.index_id());
+                auto is_dir = fs::is_directory(source);
+                RETURN_IF_ERROR(is_dir.status());
+                if (!is_dir.value()) {
+                    return Status::InternalError("inverted index path is not a directory: " + source);
+                }
+
+                std::set<std::string> index_directories;
+                std::set<std::string> index_files;
+                RETURN_IF_ERROR(fs::list_dirs_files(source, &index_directories, &index_files));
+                if (!index_directories.empty()) {
+                    return Status::Corruption("inverted index directory contains nested directories: " + source);
+                }
+
+                const std::string destination = IndexDescriptor::inverted_index_file_path(
+                        tablet_dir, rowset_layout.rowset_id, segment_id, index.index_id());
+                bool created = false;
+                auto create_status = FileSystem::Default()->create_dir_if_missing(destination, &created);
+                if (!create_status.ok()) {
+                    if (create_status.is_already_exist()) {
+                        return Status::Corruption("inverted index path is not a directory: " + destination);
+                    }
+                    return create_status;
+                }
+
+                if (created) {
+                    created_directories.emplace_back(destination);
+                    for (const auto& index_file : index_files) {
+                        RETURN_IF_ERROR(
+                                FileSystem::Default()->link_file(fmt::format("{}/{}", source, index_file),
+                                                                 fmt::format("{}/{}", destination, index_file)));
+                    }
+                    continue;
+                }
+
+                std::set<std::string> destination_directories;
+                std::set<std::string> destination_files;
+                RETURN_IF_ERROR(fs::list_dirs_files(destination, &destination_directories, &destination_files));
+                if (!destination_directories.empty()) {
+                    return Status::Corruption("existing inverted index directory contains nested directories: " +
+                                              destination);
+                }
+                for (const auto& destination_file : destination_files) {
+                    if (!index_files.contains(destination_file)) {
+                        return Status::Corruption("existing inverted index directory contains an unexpected file: " +
+                                                  fmt::format("{}/{}", destination, destination_file));
+                    }
+                    ASSIGN_OR_RETURN(auto source_md5, fs::md5sum(fmt::format("{}/{}", source, destination_file)));
+                    ASSIGN_OR_RETURN(auto destination_md5,
+                                     fs::md5sum(fmt::format("{}/{}", destination, destination_file)));
+                    if (source_md5 != destination_md5) {
+                        return Status::Corruption("existing inverted index file has different content: " +
+                                                  fmt::format("{}/{}", destination, destination_file));
+                    }
+                }
+                bool completed_existing_directory = false;
+                for (const auto& index_file : index_files) {
+                    if (destination_files.contains(index_file)) {
+                        continue;
+                    }
+                    const std::string destination_file = fmt::format("{}/{}", destination, index_file);
+                    RETURN_IF_ERROR(FileSystem::Default()->link_file(fmt::format("{}/{}", source, index_file),
+                                                                     destination_file));
+                    created_files.emplace_back(destination_file);
+                    completed_existing_directory = true;
+                }
+                if (completed_existing_directory) {
+                    VLOG(2) << "Completed existing inverted index directory " << destination;
+                }
+            }
+        }
+    }
+
+    created_index_dirs->insert(created_directories.begin(), created_directories.end());
+    rollback.cancel();
+    return Status::OK();
+}
+
+} // namespace
+
 SnapshotManager* SnapshotManager::_s_instance = nullptr;
 std::mutex SnapshotManager::_mlock;
 
@@ -84,6 +270,23 @@ SnapshotManager* SnapshotManager::instance() {
         }
     }
     return _s_instance;
+}
+
+Status SnapshotManager::restore_inverted_index_directories(const std::string& snapshot_dir) {
+    return restore_inverted_index_directories_impl(snapshot_dir);
+}
+
+Status SnapshotManager::link_inverted_index_directories(const SnapshotMeta& snapshot_meta,
+                                                        const TabletSchemaCSPtr& tablet_schema,
+                                                        const std::string& snapshot_dir, const std::string& tablet_dir,
+                                                        std::set<std::string>* created_index_dirs) {
+    std::vector<RowsetIndexLayout> rowset_layouts;
+    rowset_layouts.reserve(snapshot_meta.rowset_metas().size());
+    for (const auto& rowset_meta : snapshot_meta.rowset_metas()) {
+        rowset_layouts.emplace_back(rowset_meta.rowset_id(), rowset_meta.num_segments());
+    }
+    return link_inverted_index_directories_impl(rowset_layouts, tablet_schema, snapshot_dir, tablet_dir,
+                                                created_index_dirs);
 }
 
 Status SnapshotManager::make_snapshot(const TSnapshotRequest& request, string* snapshot_path) {
@@ -184,6 +387,8 @@ Status SnapshotManager::convert_rowset_ids(const string& clone_dir, int64_t tabl
     if (!has_header_file && !has_meta_file) {
         return Status::InternalError("fail to find header or meta file");
     }
+    RETURN_IF_ERROR(restore_inverted_index_directories(clone_dir));
+
     TabletMetaPB cloned_tablet_meta_pb;
     if (has_meta_file) {
         return Status::OK();
@@ -206,37 +411,6 @@ Status SnapshotManager::convert_rowset_ids(const string& clone_dir, int64_t tabl
     new_tablet_meta_pb.set_tablet_id(tablet_id);
     new_tablet_meta_pb.set_schema_hash(schema_hash);
     auto tablet_schema = std::make_shared<const TabletSchema>(new_tablet_meta_pb.schema());
-
-    // handle inverted index file
-    std::vector<std::string> all_files;
-    std::vector<std::string> new_inverted_index_files;
-    RETURN_IF_ERROR(FileSystem::Default()->get_children(clone_dir, &all_files));
-#ifndef __APPLE__
-    for (const auto& file : all_files) {
-        if (CLucenePlugin::is_index_files(file)) {
-            auto* p1 = (char*)std::memchr(file.data(), '_', file.size());
-            auto* p2 = (char*)std::memchr(p1 + 1, '_', file.size() - (p1 - file.data() + 1));
-            auto* p3 = (char*)std::memchr(p2 + 1, '_', file.size() - (p2 - file.data() + 1));
-            if (p1 == nullptr || p2 == nullptr || p3 == nullptr) {
-                return Status::InternalError("invalid index file name: " + file);
-            }
-
-            std::string rowsetid = file.substr(0, p1 - file.data());
-            std::string segment_id = file.substr(p1 - file.data() + 1, p2 - p1 - 1);
-            std::string index_id = file.substr(p2 - file.data() + 1, p3 - p2 - 1);
-            std::string inverted_index_path = IndexDescriptor::inverted_index_file_path(
-                    clone_dir, rowsetid, std::stoi(segment_id), std::stoi(index_id));
-
-            if (!fs::path_exist(inverted_index_path)) {
-                RETURN_IF_ERROR(fs::create_directories(inverted_index_path));
-            }
-
-            std::string new_file_name = file.substr(p3 - file.data() + 1, file.data() + file.size() - p3);
-            RETURN_IF_ERROR(FileSystem::Default()->rename_file(clone_dir + "/" + file,
-                                                               inverted_index_path + "/" + new_file_name));
-        }
-    }
-#endif
 
     std::unordered_map<string, string> old_to_new_rowsetid;
 
@@ -455,6 +629,14 @@ StatusOr<std::string> SnapshotManager::snapshot_incremental(const TabletSharedPt
         }
     }
 
+    if (tablet->updates() != nullptr) {
+        if (auto st = flatten_inverted_index_directories(snapshot_dir); !st.ok()) {
+            LOG(WARNING) << "Fail to flatten inverted index directories in snapshot " << snapshot_dir << ": " << st;
+            (void)fs::remove_all(snapshot_id_path);
+            return st;
+        }
+    }
+
     return snapshot_id_path;
 }
 
@@ -521,6 +703,11 @@ StatusOr<std::string> SnapshotManager::snapshot_full(const TabletSharedPtr& tabl
 
     // 4. Build snapshot header/meta file for the non-PrimaryKey tablet.
     if (tablet->updates() != nullptr) {
+        if (auto st = flatten_inverted_index_directories(snapshot_dir); !st.ok()) {
+            LOG(WARNING) << "Fail to flatten inverted index directories in snapshot " << snapshot_dir << ": " << st;
+            (void)fs::remove_all(snapshot_id_path);
+            return st;
+        }
         return snapshot_id_path;
     }
 
@@ -552,31 +739,10 @@ StatusOr<std::string> SnapshotManager::snapshot_full(const TabletSharedPtr& tabl
     dcg_snapshot_path << snapshot_dir << "/" << tablet->tablet_id() << ".dcgs_snapshot";
     RETURN_IF_ERROR(DeltaColumnGroupListHelper::save_snapshot(dcg_snapshot_path.str(), dcg_snapshot_pb));
 
-    // handle inverted index files
-    std::vector<std::string> all_files;
-    RETURN_IF_ERROR(FileSystem::Default()->get_children(snapshot_dir, &all_files));
-    for (const auto& file : all_files) {
-        auto is_dir = fs::is_directory(snapshot_dir + "/" + file);
-        if (is_dir.ok() && is_dir.value() && file.find("ivt", 0) != std::string::npos) {
-            std::vector<std::string> index_files;
-            RETURN_IF_ERROR(FileSystem::Default()->get_children(snapshot_dir + "/" + file, &index_files));
-            for (const auto& index_file : index_files) {
-                auto* p1 = (char*)std::memchr(file.data(), '_', file.size());
-                auto* p2 = (char*)std::memchr(p1 + 1, '_', file.size() - (p1 - file.data() + 1));
-                auto* p3 = (char*)std::memchr(p2 + 1, '.', file.size() - (p2 - file.data() + 1));
-
-                std::string rowsetid = file.substr(0, p1 - file.data());
-                std::string segment_id = file.substr(p1 - file.data() + 1, p2 - p1 - 1);
-                std::string index_id = file.substr(p2 - file.data() + 1, p3 - p2 - 1);
-
-                std::string old_name = snapshot_dir + "/" + file + "/" + index_file;
-                std::string new_name =
-                        snapshot_dir + "/" + rowsetid + "_" + segment_id + "_" + index_id + "_" + index_file;
-
-                RETURN_IF_ERROR(FileSystem::Default()->rename_file(old_name, new_name));
-            }
-            RETURN_IF_ERROR(FileSystem::Default()->delete_dir_recursive(snapshot_dir + "/" + file));
-        }
+    if (auto st = flatten_inverted_index_directories(snapshot_dir); !st.ok()) {
+        LOG(WARNING) << "Fail to flatten inverted index directories in snapshot " << snapshot_dir << ": " << st;
+        (void)fs::remove_all(snapshot_id_path);
+        return st;
     }
 
     snapshot_tablet_meta->revise_inc_rs_metas(vector<RowsetMetaSharedPtr>());
@@ -675,6 +841,12 @@ StatusOr<std::string> SnapshotManager::snapshot_primary(const TabletSharedPtr& t
             (void)fs::remove_all(snapshot_id_path);
             return st;
         }
+    }
+
+    if (auto st = flatten_inverted_index_directories(snapshot_dir); !st.ok()) {
+        LOG(WARNING) << "Fail to flatten inverted index directories in snapshot " << snapshot_dir << ": " << st;
+        (void)fs::remove_all(snapshot_id_path);
+        return st;
     }
 
     return snapshot_id_path;

--- a/be/src/storage/snapshot_manager.h
+++ b/be/src/storage/snapshot_manager.h
@@ -69,6 +69,15 @@ public:
 
     Status convert_rowset_ids(const string& clone_dir, int64_t tablet_id, int32_t schema_hash);
 
+    Status restore_inverted_index_directories(const std::string& snapshot_dir);
+
+    // Existing standalone GIN index directories are verified and completed in place. Only directories created by
+    // this call are returned in |created_index_dirs|. Files added to a pre-existing directory are retained after
+    // return so callers never remove paths from a destination they do not own during rollback.
+    Status link_inverted_index_directories(const SnapshotMeta& snapshot_meta, const TabletSchemaCSPtr& tablet_schema,
+                                           const std::string& snapshot_dir, const std::string& tablet_dir,
+                                           std::set<std::string>* created_index_dirs);
+
     // Create a file named `meta` under the directory |snapshot_dir|. See the
     // comment in snapshot_manager.cpp for the details of the file format.
     // Any existing file with the name `meta` will be deleted, and a new file

--- a/be/test/data_workflows/migration/engine_storage_migration_task_test.cpp
+++ b/be/test/data_workflows/migration/engine_storage_migration_task_test.cpp
@@ -60,6 +60,7 @@
 #include "storage/chunk_helper.h"
 #include "storage/delta_writer.h"
 #ifndef __APPLE__
+#include "storage/index/index_descriptor.h"
 #include "storage/index/inverted/clucene/clucene_plugin.h"
 #endif
 #include "storage/lake/tablet_manager.h"
@@ -686,23 +687,32 @@ TEST_F(EngineStorageMigrationTaskTest, test_migrate_pk_tablet_with_clucene_gin_i
     ASSERT_EQ(tablet->data_dir(), dest_store);
     ASSERT_EQ(tablet->updates()->max_version(), 2);
 
-    std::set<std::string> destination_dirs;
     std::set<std::string> destination_files;
-    ASSERT_OK(fs::list_dirs_files(tablet->schema_hash_path(), &destination_dirs, &destination_files));
+    ASSERT_OK(fs::list_dirs_files(tablet->schema_hash_path(), nullptr, &destination_files));
     ASSERT_TRUE(std::none_of(destination_files.begin(), destination_files.end(),
                              [](const std::string& file) { return CLucenePlugin::is_index_files(file); }));
 
-    size_t index_directory_count = 0;
-    for (const auto& directory : destination_dirs) {
-        if (!directory.ends_with(".ivt")) {
-            continue;
+    std::vector<RowsetSharedPtr> applied_rowsets;
+    ASSERT_OK(tablet->updates()->get_applied_rowsets(2, &applied_rowsets));
+    ASSERT_FALSE(applied_rowsets.empty());
+
+    size_t active_index_directory_count = 0;
+    for (const auto& rowset : applied_rowsets) {
+        for (int segment_id = 0; segment_id < rowset->num_segments(); ++segment_id) {
+            for (const auto& index : *tablet->tablet_schema()->indexes()) {
+                if (index.index_type() != GIN) {
+                    continue;
+                }
+                const auto index_directory = IndexDescriptor::inverted_index_file_path(
+                        tablet->schema_hash_path(), rowset->rowset_id().to_string(), segment_id, index.index_id());
+                std::set<std::string> index_files;
+                ASSERT_OK(fs::list_dirs_files(index_directory, nullptr, &index_files));
+                ASSERT_FALSE(index_files.empty()) << index_directory;
+                ++active_index_directory_count;
+            }
         }
-        std::set<std::string> index_files;
-        ASSERT_OK(fs::list_dirs_files(tablet->schema_hash_path() + "/" + directory, nullptr, &index_files));
-        ASSERT_FALSE(index_files.empty()) << directory;
-        ++index_directory_count;
     }
-    ASSERT_GT(index_directory_count, 0);
+    ASSERT_GT(active_index_directory_count, 0);
 }
 #endif
 

--- a/be/test/data_workflows/migration/engine_storage_migration_task_test.cpp
+++ b/be/test/data_workflows/migration/engine_storage_migration_task_test.cpp
@@ -19,6 +19,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <set>
 #include <utility>
 
 #include "base/path/file_util.h"
@@ -58,6 +59,9 @@
 #include "runtime/runtime_state.h"
 #include "storage/chunk_helper.h"
 #include "storage/delta_writer.h"
+#ifndef __APPLE__
+#include "storage/index/inverted/clucene/clucene_plugin.h"
+#endif
 #include "storage/lake/tablet_manager.h"
 #include "storage/options.h"
 #include "storage/rowset/rowset_factory.h"
@@ -77,7 +81,7 @@ public:
 
     static void TearDownTestCase() { config::enable_event_based_compaction_framework = true; }
 
-    static TabletSharedPtr create_pk_tablet(int64_t tablet_id, int32_t schema_hash) {
+    static TabletSharedPtr create_pk_tablet(int64_t tablet_id, int32_t schema_hash, bool add_gin_index = false) {
         TCreateTabletReq request;
         request.tablet_id = tablet_id;
         request.__set_version(1);
@@ -102,8 +106,22 @@ public:
         TColumn k3;
         k3.column_name = "v2";
         k3.__set_is_key(false);
-        k3.column_type.type = TPrimitiveType::INT;
+        k3.column_type.type = add_gin_index ? TPrimitiveType::VARCHAR : TPrimitiveType::INT;
+        if (add_gin_index) {
+            k3.column_type.len = 65535;
+        }
         request.tablet_schema.columns.push_back(k3);
+
+        if (add_gin_index) {
+            request.tablet_schema.__isset.indexes = true;
+            request.tablet_schema.indexes.emplace_back();
+            auto& gin_index = request.tablet_schema.indexes.back();
+            gin_index.__set_index_id(1);
+            gin_index.__set_index_name("v2_gin");
+            gin_index.__set_index_type(TIndexType::GIN);
+            gin_index.__set_columns({"v2"});
+            gin_index.__set_common_properties({{"imp_lib", "clucene"}});
+        }
         auto st = StorageEngine::instance()->create_tablet(request);
         CHECK(st.ok()) << st.to_string();
         return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
@@ -633,6 +651,60 @@ TEST_F(EngineStorageMigrationTaskTest, test_migrate_empty_pk_tablet) {
     EngineStorageMigrationTask migration_task(empty_tablet_id, empty_schema_hash, dest_path, false);
     ASSERT_OK(migration_task.execute());
 }
+
+#ifndef __APPLE__
+TEST_F(EngineStorageMigrationTaskTest, test_migrate_pk_tablet_with_clucene_gin_index) {
+    constexpr int64_t tablet_id = 88888;
+    constexpr int32_t schema_hash = 8888;
+    auto* tablet_manager = StorageEngine::instance()->tablet_manager();
+
+    auto tablet = create_pk_tablet(tablet_id, schema_hash, true);
+    tablet->set_enable_persistent_index(false);
+    ASSERT_OK(tablet->rowset_commit(2, create_pk_rowset(tablet, {1, 2, 3, 4, 5})));
+
+    std::set<std::string> source_index_dirs;
+    ASSERT_OK(fs::list_dirs_files(tablet->schema_hash_path(), &source_index_dirs, nullptr));
+    ASSERT_TRUE(std::any_of(source_index_dirs.begin(), source_index_dirs.end(),
+                            [](const std::string& entry) { return entry.ends_with(".ivt"); }));
+
+    DataDir* source_store = tablet->data_dir();
+    DataDir* dest_store = nullptr;
+    for (auto* store : StorageEngine::instance()->get_stores()) {
+        if (store != source_store) {
+            dest_store = store;
+            break;
+        }
+    }
+    ASSERT_NE(dest_store, nullptr);
+    tablet.reset();
+
+    sleep(2);
+    ASSERT_OK(EngineStorageMigrationTask(tablet_id, schema_hash, dest_store, false).execute());
+
+    tablet = tablet_manager->get_tablet(tablet_id);
+    ASSERT_NE(tablet, nullptr);
+    ASSERT_EQ(tablet->data_dir(), dest_store);
+    ASSERT_EQ(tablet->updates()->max_version(), 2);
+
+    std::set<std::string> destination_dirs;
+    std::set<std::string> destination_files;
+    ASSERT_OK(fs::list_dirs_files(tablet->schema_hash_path(), &destination_dirs, &destination_files));
+    ASSERT_TRUE(std::none_of(destination_files.begin(), destination_files.end(),
+                             [](const std::string& file) { return CLucenePlugin::is_index_files(file); }));
+
+    size_t index_directory_count = 0;
+    for (const auto& directory : destination_dirs) {
+        if (!directory.ends_with(".ivt")) {
+            continue;
+        }
+        std::set<std::string> index_files;
+        ASSERT_OK(fs::list_dirs_files(tablet->schema_hash_path() + "/" + directory, nullptr, &index_files));
+        ASSERT_FALSE(index_files.empty()) << directory;
+        ++index_directory_count;
+    }
+    ASSERT_GT(index_directory_count, 0);
+}
+#endif
 
 // Verifies that rapid PK tablet re-migration (disk A->B->A) preserves the
 // new tablet's rowset metadata when GC and migration race concurrently.

--- a/be/test/storage/replication_txn_manager_test.cpp
+++ b/be/test/storage/replication_txn_manager_test.cpp
@@ -16,6 +16,9 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <set>
+
 #include "base/testutil/assert.h"
 #include "base/uuid/uuid_generator.h"
 #include "column/chunk_factory.h"
@@ -26,12 +29,17 @@
 #include "fs/fs_util.h"
 #include "gen_cpp/AgentService_types.h"
 #include "storage/chunk_helper.h"
+#include "storage/index/index_descriptor.h"
+#ifndef __APPLE__
+#include "storage/index/inverted/clucene/clucene_plugin.h"
+#endif
 #include "storage/rowset/rowset_factory.h"
 #include "storage/rowset/rowset_options.h"
 #include "storage/rowset/rowset_writer.h"
 #include "storage/rowset/rowset_writer_context.h"
 #include "storage/rowset/segment.h"
 #include "storage/tablet_manager.h"
+#include "storage/tablet_updates.h"
 #include "testutil/local_snapshot_client.h"
 
 namespace starrocks {
@@ -77,7 +85,7 @@ public:
     }
 
     TabletSharedPtr create_tablet(int64_t tablet_id, int64_t version, int32_t schema_hash,
-                                  bool multi_column_key = false) {
+                                  bool multi_column_key = false, bool with_gin = false) {
         TCreateTabletReq request;
         request.tablet_id = tablet_id;
         request.__set_version(version);
@@ -122,8 +130,26 @@ public:
         TColumn k3;
         k3.column_name = "v2";
         k3.__set_is_key(false);
-        k3.column_type.type = TPrimitiveType::INT;
+        if (with_gin) {
+            k3.column_type.type = TPrimitiveType::VARCHAR;
+            k3.column_type.len = 65535;
+            if (GetParam() == TKeysType::type::AGG_KEYS) {
+                k3.aggregation_type = TAggregationType::REPLACE;
+            }
+        } else {
+            k3.column_type.type = TPrimitiveType::INT;
+        }
         request.tablet_schema.columns.push_back(k3);
+        if (with_gin) {
+            request.tablet_schema.__isset.indexes = true;
+            request.tablet_schema.indexes.emplace_back();
+            auto& gin_index = request.tablet_schema.indexes.back();
+            gin_index.__set_index_id(1);
+            gin_index.__set_index_name("v2_gin");
+            gin_index.__set_index_type(TIndexType::GIN);
+            gin_index.__set_columns({"v2"});
+            gin_index.__set_common_properties({{"imp_lib", "clucene"}});
+        }
         auto st = StorageEngine::instance()->create_tablet(request);
         CHECK(st.ok()) << st.to_string();
         return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
@@ -181,6 +207,73 @@ public:
         }
         return *writer->build();
     }
+
+    void recreate_tablets_with_gin() {
+        auto tablet_manager = StorageEngine::instance()->tablet_manager();
+        ASSERT_OK(tablet_manager->drop_tablet(_tablet_id, kDeleteFiles));
+        ASSERT_OK(tablet_manager->drop_tablet(_src_tablet_id, kDeleteFiles));
+        ASSERT_OK(tablet_manager->delete_shutdown_tablet(_tablet_id));
+        ASSERT_OK(tablet_manager->delete_shutdown_tablet(_src_tablet_id));
+
+        auto tablet = create_tablet(_tablet_id, 1, _schema_hash, false, true);
+        auto src_tablet = create_tablet(_src_tablet_id, 1, _schema_hash, false, true);
+        std::vector<int64_t> keys{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+        for (int64_t version = 2; version <= _version; ++version) {
+            auto rowset = create_rowset(tablet, keys);
+            if (tablet->updates() == nullptr) {
+                ASSERT_OK(tablet->add_inc_rowset(rowset, version));
+            } else {
+                ASSERT_OK(tablet->rowset_commit(version, rowset));
+            }
+        }
+        for (int64_t version = 2; version <= _src_version; ++version) {
+            auto rowset = create_rowset(src_tablet, keys);
+            if (src_tablet->updates() == nullptr) {
+                ASSERT_OK(src_tablet->add_inc_rowset(rowset, version));
+            } else {
+                ASSERT_OK(src_tablet->rowset_commit(version, rowset));
+            }
+        }
+    }
+
+#ifndef __APPLE__
+    static void assert_tablet_gin_indexes(const TabletSharedPtr& tablet) {
+        std::set<std::string> files;
+        ASSERT_OK(fs::list_dirs_files(tablet->schema_hash_path(), nullptr, &files));
+        ASSERT_TRUE(std::none_of(files.begin(), files.end(),
+                                 [](const std::string& file) { return CLucenePlugin::is_index_files(file); }));
+
+        size_t index_directory_count = 0;
+        auto assert_rowset_indexes = [&](const std::string& rowset_id, int32_t num_segments) {
+            for (int32_t segment_id = 0; segment_id < num_segments; ++segment_id) {
+                const auto index_dir =
+                        IndexDescriptor::inverted_index_file_path(tablet->schema_hash_path(), rowset_id, segment_id, 1);
+                auto is_directory = fs::is_directory(index_dir);
+                ASSERT_OK(is_directory.status());
+                ASSERT_TRUE(is_directory.value()) << index_dir;
+
+                std::set<std::string> index_files;
+                ASSERT_OK(fs::list_dirs_files(index_dir, nullptr, &index_files));
+                ASSERT_FALSE(index_files.empty()) << index_dir;
+                ++index_directory_count;
+            }
+        };
+
+        if (tablet->updates() != nullptr) {
+            std::vector<RowsetSharedPtr> rowsets;
+            ASSERT_OK(tablet->updates()->get_applied_rowsets(tablet->max_version().second, &rowsets));
+            for (const auto& rowset : rowsets) {
+                ASSERT_NO_FATAL_FAILURE(assert_rowset_indexes(rowset->rowset_id().to_string(), rowset->num_segments()));
+            }
+        } else {
+            for (const auto& rowset_meta : tablet->tablet_meta()->all_rs_metas()) {
+                ASSERT_NO_FATAL_FAILURE(
+                        assert_rowset_indexes(rowset_meta->rowset_id().to_string(), rowset_meta->num_segments()));
+            }
+        }
+        ASSERT_GT(index_directory_count, 0);
+    }
+#endif
 
 protected:
     int64_t _transaction_id = 200;
@@ -386,6 +479,59 @@ TEST_P(ReplicationTxnManagerTest, test_run_normal) {
 
     StorageEngine::instance()->replication_txn_manager()->clear_expired_snapshots();
 }
+
+#ifndef __APPLE__
+TEST_P(ReplicationTxnManagerTest, test_run_normal_with_gin_index) {
+    if (GetParam() != TKeysType::type::PRIMARY_KEYS) {
+        GTEST_SKIP() << "Non-primary GIN replication is covered by the follow-up fix";
+    }
+    ASSERT_NO_FATAL_FAILURE(recreate_tablets_with_gin());
+
+    TRemoteSnapshotRequest remote_snapshot_request;
+    remote_snapshot_request.__set_transaction_id(_transaction_id);
+    remote_snapshot_request.__set_table_id(_table_id);
+    remote_snapshot_request.__set_partition_id(_partition_id);
+    remote_snapshot_request.__set_tablet_id(_tablet_id);
+    remote_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    remote_snapshot_request.__set_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_visible_version(_version);
+    remote_snapshot_request.__set_src_token(get_master_token());
+    remote_snapshot_request.__set_src_tablet_id(_src_tablet_id);
+    remote_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    remote_snapshot_request.__set_src_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_src_visible_version(_src_version);
+    remote_snapshot_request.__set_src_backends({local_snapshot_backend_for_test()});
+
+    TSnapshotInfo remote_snapshot_info;
+    ASSERT_OK(StorageEngine::instance()->replication_txn_manager()->remote_snapshot(remote_snapshot_request,
+                                                                                    &remote_snapshot_info));
+
+    TReplicateSnapshotRequest replicate_snapshot_request;
+    replicate_snapshot_request.__set_transaction_id(_transaction_id);
+    replicate_snapshot_request.__set_table_id(_table_id);
+    replicate_snapshot_request.__set_partition_id(_partition_id);
+    replicate_snapshot_request.__set_tablet_id(_tablet_id);
+    replicate_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    replicate_snapshot_request.__set_schema_hash(_schema_hash);
+    replicate_snapshot_request.__set_visible_version(_version);
+    replicate_snapshot_request.__set_src_token(get_master_token());
+    replicate_snapshot_request.__set_src_tablet_id(_src_tablet_id);
+    replicate_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    replicate_snapshot_request.__set_src_schema_hash(_schema_hash);
+    replicate_snapshot_request.__set_src_visible_version(_src_version);
+    replicate_snapshot_request.__set_src_snapshot_infos({remote_snapshot_info});
+
+    ASSERT_OK(StorageEngine::instance()->replication_txn_manager()->replicate_snapshot(replicate_snapshot_request));
+    auto tablet = StorageEngine::instance()->tablet_manager()->get_tablet(_tablet_id);
+    ASSERT_NE(tablet, nullptr);
+    ASSERT_OK(StorageEngine::instance()->replication_txn_manager()->publish_txn(_transaction_id, _partition_id, tablet,
+                                                                                _src_version));
+    ASSERT_EQ(_src_version, tablet->max_version().second);
+    ASSERT_NO_FATAL_FAILURE(assert_tablet_gin_indexes(tablet));
+
+    StorageEngine::instance()->replication_txn_manager()->clear_txn(_transaction_id);
+}
+#endif
 
 INSTANTIATE_TEST_SUITE_P(ReplicationTxnManagerTest, ReplicationTxnManagerTest,
                          testing::Values(TKeysType::type::AGG_KEYS, TKeysType::type::PRIMARY_KEYS));

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -3806,8 +3806,8 @@ TEST_F(TabletUpdatesTest, link_builtin_gin_index_skips_standalone_directory) {
     rowset_meta.set_num_segments(1);
 
     std::set<std::string> created_index_dirs;
-    ASSERT_OK(SnapshotManager::instance()->link_inverted_index_directories(
-            snapshot_meta, schema, snapshot_dir, tablet_dir, &created_index_dirs));
+    ASSERT_OK(SnapshotManager::instance()->link_inverted_index_directories(snapshot_meta, schema, snapshot_dir,
+                                                                           tablet_dir, &created_index_dirs));
     ASSERT_TRUE(created_index_dirs.empty());
     std::set<std::string> destination_dirs;
     std::set<std::string> destination_files;

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -14,6 +14,7 @@
 
 #include "storage/tablet_updates_test.h"
 
+#include <algorithm>
 #include <random>
 
 #include "base/failpoint/fail_point.h"
@@ -23,11 +24,18 @@
 #include "common/config_primary_key_fwd.h"
 #include "common/config_scan_io_fwd.h"
 #include "common/config_storage_fwd.h"
+#include "data_workflows/clone/engine_clone_task.h"
 #include "data_workflows/consistency/engine_checksum_task.h"
+#include "data_workflows/snapshot/snapshot_loader.h"
 #include "fs/fs_factory.h"
 #include "runtime/runtime_state.h"
 #include "script/script.h"
 #include "storage/chunk_helper.h"
+#include "storage/index/index_descriptor.h"
+#include "storage/index/inverted/inverted_index_common.h"
+#ifndef __APPLE__
+#include "storage/index/inverted/clucene/clucene_plugin.h"
+#endif
 #include "storage/local_primary_key_recover.h"
 #include "storage/manual_compaction.h"
 #include "storage/primary_key_dump.h"
@@ -3525,6 +3533,289 @@ TEST_F(TabletUpdatesTest, load_snapshot_primary) {
     test_load_snapshot_primary(7, {3, 4, 5});
     test_load_snapshot_primary(7, {3, 5, 7});
 }
+
+#ifndef __APPLE__
+TEST_F(TabletUpdatesTest, load_snapshot_primary_with_gin_index) {
+    srand(GetCurrentTimeMicros());
+    auto src_tablet = create_tablet(rand(), rand(), false, 0, 0, false, true);
+    auto dest_tablet = create_tablet(rand(), rand(), false, 0, 0, false, true);
+    DeferOp defer([&]() {
+        auto tablet_mgr = StorageEngine::instance()->tablet_manager();
+        (void)tablet_mgr->drop_tablet(src_tablet->tablet_id());
+        (void)tablet_mgr->drop_tablet(dest_tablet->tablet_id());
+        (void)fs::remove_all(src_tablet->schema_hash_path());
+        (void)fs::remove_all(dest_tablet->schema_hash_path());
+    });
+
+    auto add_version = [&](TabletSharedPtr& tablet, int64_t version) {
+        std::vector<int64_t> keys = {version * 10 + 1, version * 10 + 2, version * 10 + 3};
+        auto rowset = create_rowset(tablet, keys);
+        ASSERT_TRUE(tablet->rowset_commit(version, rowset).ok());
+    };
+    add_version(src_tablet, 2);
+    add_version(dest_tablet, 2);
+    add_version(src_tablet, 3);
+    add_version(src_tablet, 4);
+    add_version(dest_tablet, 4);
+
+    std::vector<int64_t> missing_version_ranges;
+    ASSERT_TRUE(dest_tablet->updates()->get_missing_version_ranges(missing_version_ranges).ok());
+    ASSERT_EQ(std::vector<int64_t>({3, 3, 5}), missing_version_ranges);
+
+    auto snapshot_path = SnapshotManager::instance()->snapshot_primary(src_tablet, missing_version_ranges, 3600);
+    ASSERT_TRUE(snapshot_path.ok()) << snapshot_path.status();
+    DeferOp snapshot_defer([&]() { (void)fs::remove_all(*snapshot_path); });
+    const std::string snapshot_dir = SnapshotManager::instance()->get_schema_hash_full_path(src_tablet, *snapshot_path);
+
+    std::set<std::string> snapshot_dirs;
+    std::set<std::string> snapshot_files;
+    ASSERT_OK(fs::list_dirs_files(snapshot_dir, &snapshot_dirs, &snapshot_files));
+    ASSERT_TRUE(snapshot_dirs.empty());
+    ASSERT_TRUE(std::any_of(snapshot_files.begin(), snapshot_files.end(),
+                            [](const std::string& file) { return file.find("_0_1_") != std::string::npos; }));
+
+    ASSERT_OK(SnapshotManager::instance()->convert_rowset_ids(snapshot_dir, src_tablet->tablet_id(),
+                                                              src_tablet->schema_hash()));
+    snapshot_dirs.clear();
+    snapshot_files.clear();
+    ASSERT_OK(fs::list_dirs_files(snapshot_dir, &snapshot_dirs, &snapshot_files));
+    ASSERT_TRUE(std::any_of(snapshot_dirs.begin(), snapshot_dirs.end(),
+                            [](const std::string& dir) { return dir.ends_with(".ivt"); }));
+
+    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(snapshot_dir + "/meta");
+    ASSERT_TRUE(snapshot_meta.ok()) << snapshot_meta.status();
+    snapshot_meta->tablet_meta().set_tablet_id(dest_tablet->tablet_id());
+    snapshot_meta->tablet_meta().set_schema_hash(dest_tablet->schema_hash());
+    for (auto& rowset_meta : snapshot_meta->rowset_metas()) {
+        rowset_meta.set_tablet_id(dest_tablet->tablet_id());
+        rowset_meta.set_tablet_schema_hash(dest_tablet->schema_hash());
+    }
+    ASSERT_OK(snapshot_meta->serialize_to_file(snapshot_dir + "/meta"));
+
+    std::set<std::string> dest_dirs_before;
+    ASSERT_OK(fs::list_dirs_files(dest_tablet->schema_hash_path(), &dest_dirs_before, nullptr));
+
+    TCloneReq clone_req;
+    clone_req.tablet_id = dest_tablet->tablet_id();
+    clone_req.schema_hash = dest_tablet->schema_hash();
+    std::vector<std::string> error_msgs;
+    std::vector<TTabletInfo> tablet_infos;
+    Status clone_status;
+    EngineCloneTask clone_task(_compaction_mem_tracker.get(), clone_req, 0, &error_msgs, &tablet_infos, &clone_status);
+    ASSERT_OK(clone_task._finish_clone_primary(dest_tablet.get(), snapshot_dir));
+    ASSERT_EQ(4, dest_tablet->updates()->max_version());
+
+    std::set<std::string> dest_dirs_after;
+    std::set<std::string> dest_files_after;
+    ASSERT_OK(fs::list_dirs_files(dest_tablet->schema_hash_path(), &dest_dirs_after, &dest_files_after));
+    ASSERT_GT(dest_dirs_after.size(), dest_dirs_before.size());
+    ASSERT_TRUE(std::none_of(dest_files_after.begin(), dest_files_after.end(),
+                             [](const std::string& file) { return CLucenePlugin::is_index_files(file); }));
+    for (const auto& dir : dest_dirs_after) {
+        if (!dir.ends_with(".ivt")) {
+            continue;
+        }
+        std::set<std::string> index_files;
+        ASSERT_OK(fs::list_dirs_files(dest_tablet->schema_hash_path() + "/" + dir, nullptr, &index_files));
+        ASSERT_FALSE(index_files.empty());
+    }
+}
+
+TEST_F(TabletUpdatesTest, restore_primary_snapshot_with_gin_index) {
+    srand(GetCurrentTimeMicros());
+    auto src_tablet = create_tablet(rand(), rand(), false, 0, 0, false, true);
+    auto dest_tablet = create_tablet(rand(), src_tablet->schema_hash(), false, 0, 0, false, true);
+    DeferOp defer([&]() {
+        auto tablet_mgr = StorageEngine::instance()->tablet_manager();
+        (void)tablet_mgr->drop_tablet(src_tablet->tablet_id());
+        (void)tablet_mgr->drop_tablet(dest_tablet->tablet_id());
+        (void)fs::remove_all(src_tablet->schema_hash_path());
+        (void)fs::remove_all(dest_tablet->schema_hash_path());
+    });
+
+    auto add_version = [&](TabletSharedPtr& tablet, int64_t version) {
+        std::vector<int64_t> keys = {version * 10 + 1, version * 10 + 2, version * 10 + 3};
+        ASSERT_OK(tablet->rowset_commit(version, create_rowset(tablet, keys)));
+    };
+    add_version(src_tablet, 2);
+    add_version(src_tablet, 3);
+    add_version(src_tablet, 4);
+    add_version(dest_tablet, 2);
+
+    auto snapshot_path = SnapshotManager::instance()->snapshot_full(src_tablet, 4, 3600);
+    ASSERT_OK(snapshot_path.status());
+    DeferOp snapshot_defer([&]() { (void)fs::remove_all(*snapshot_path); });
+    const std::string source_snapshot_dir =
+            SnapshotManager::instance()->get_schema_hash_full_path(src_tablet, *snapshot_path);
+
+    const std::string restore_root =
+            fmt::format("{}/restore_snapshot_{}", dest_tablet->data_dir()->path(), dest_tablet->tablet_id());
+    const std::string restore_parent = fmt::format("{}/{}", restore_root, dest_tablet->tablet_id());
+    const std::string restore_dir = fmt::format("{}/{}", restore_parent, dest_tablet->schema_hash());
+    ASSERT_OK(fs::create_directories(restore_parent));
+    DeferOp restore_defer([&]() { (void)fs::remove_all(restore_root); });
+    std::error_code copy_error;
+    std::filesystem::copy(source_snapshot_dir, restore_dir,
+                          std::filesystem::copy_options::recursive | std::filesystem::copy_options::overwrite_existing,
+                          copy_error);
+    ASSERT_FALSE(copy_error) << copy_error.message();
+
+    std::set<std::string> restore_dirs;
+    std::set<std::string> restore_files;
+    ASSERT_OK(fs::list_dirs_files(restore_dir, &restore_dirs, &restore_files));
+    ASSERT_TRUE(restore_dirs.empty());
+    ASSERT_TRUE(std::any_of(restore_files.begin(), restore_files.end(),
+                            [](const std::string& file) { return CLucenePlugin::is_index_files(file); }));
+
+    SnapshotLoader loader(nullptr, 1, 2);
+    ASSERT_OK(loader.primary_key_move(restore_dir, dest_tablet, true));
+    ASSERT_EQ(4, dest_tablet->updates()->max_version());
+    ASSERT_FALSE(fs::path_exist(restore_dir));
+
+    std::set<std::string> tablet_dirs;
+    std::set<std::string> tablet_files;
+    ASSERT_OK(fs::list_dirs_files(dest_tablet->schema_hash_path(), &tablet_dirs, &tablet_files));
+    ASSERT_TRUE(std::none_of(tablet_files.begin(), tablet_files.end(),
+                             [](const std::string& file) { return CLucenePlugin::is_index_files(file); }));
+
+    size_t index_directory_count = 0;
+    for (const auto& directory : tablet_dirs) {
+        if (!directory.ends_with(".ivt")) {
+            continue;
+        }
+        std::set<std::string> index_files;
+        ASSERT_OK(fs::list_dirs_files(dest_tablet->schema_hash_path() + "/" + directory, nullptr, &index_files));
+        ASSERT_FALSE(index_files.empty()) << directory;
+        ++index_directory_count;
+    }
+    ASSERT_GT(index_directory_count, 0);
+}
+
+TEST_F(TabletUpdatesTest, link_primary_snapshot_gin_indexes_is_idempotent) {
+    srand(GetCurrentTimeMicros());
+    auto tablet = create_tablet(rand(), rand(), false, 0, 0, false, true);
+    DeferOp tablet_defer([&]() {
+        auto tablet_mgr = StorageEngine::instance()->tablet_manager();
+        (void)tablet_mgr->drop_tablet(tablet->tablet_id());
+        (void)fs::remove_all(tablet->schema_hash_path());
+    });
+
+    std::vector<int64_t> keys = {21, 22, 23};
+    ASSERT_OK(tablet->rowset_commit(2, create_rowset(tablet, keys)));
+
+    auto snapshot_path = SnapshotManager::instance()->snapshot_full(tablet, 2, 3600);
+    ASSERT_OK(snapshot_path.status());
+    DeferOp snapshot_defer([&]() { (void)fs::remove_all(*snapshot_path); });
+    const std::string snapshot_dir = SnapshotManager::instance()->get_schema_hash_full_path(tablet, *snapshot_path);
+
+    ASSERT_OK(
+            SnapshotManager::instance()->convert_rowset_ids(snapshot_dir, tablet->tablet_id(), tablet->schema_hash()));
+    auto snapshot_meta = SnapshotManager::instance()->parse_snapshot_meta(snapshot_dir + "/meta");
+    ASSERT_OK(snapshot_meta.status());
+    ASSERT_OK(
+            SnapshotManager::instance()->assign_new_rowset_id(&*snapshot_meta, snapshot_dir, tablet->tablet_schema()));
+
+    const auto snapshot_rowset =
+            std::find_if(snapshot_meta->rowset_metas().begin(), snapshot_meta->rowset_metas().end(),
+                         [](const auto& rowset_meta) { return rowset_meta.num_segments() > 0; });
+    ASSERT_NE(snapshot_meta->rowset_metas().end(), snapshot_rowset);
+    const std::string source_index_dir =
+            IndexDescriptor::inverted_index_file_path(snapshot_dir, snapshot_rowset->rowset_id(), 0, 1);
+    const std::string destination_index_dir =
+            IndexDescriptor::inverted_index_file_path(tablet->schema_hash_path(), snapshot_rowset->rowset_id(), 0, 1);
+    ASSERT_TRUE(fs::path_exist(source_index_dir));
+
+    std::set<std::string> linked_index_dirs;
+    DeferOp linked_index_defer([&]() {
+        for (const auto& index_dir : linked_index_dirs) {
+            (void)fs::remove_all(index_dir);
+        }
+    });
+    ASSERT_OK(SnapshotManager::instance()->link_inverted_index_directories(
+            *snapshot_meta, tablet->tablet_schema(), snapshot_dir, tablet->schema_hash_path(), &linked_index_dirs));
+    ASSERT_FALSE(linked_index_dirs.empty());
+    ASSERT_TRUE(linked_index_dirs.contains(destination_index_dir));
+
+    const auto& existing_index_dir = destination_index_dir;
+    std::set<std::string> existing_index_files;
+    ASSERT_OK(fs::list_dirs_files(existing_index_dir, nullptr, &existing_index_files));
+    ASSERT_FALSE(existing_index_files.empty());
+    const std::string index_file_name = *existing_index_files.begin();
+    const std::string source_index_file = source_index_dir + "/" + index_file_name;
+    const std::string missing_index_file = existing_index_dir + "/" + index_file_name;
+    ASSERT_TRUE(fs::path_exist(source_index_file));
+    ASSERT_OK(FileSystem::Default()->delete_file(missing_index_file));
+    ASSERT_TRUE(fs::path_exist(source_index_file));
+
+    std::set<std::string> retried_index_dirs;
+    ASSERT_OK(SnapshotManager::instance()->link_inverted_index_directories(
+            *snapshot_meta, tablet->tablet_schema(), snapshot_dir, tablet->schema_hash_path(), &retried_index_dirs));
+    ASSERT_TRUE(retried_index_dirs.empty());
+    ASSERT_TRUE(fs::path_exist(missing_index_file));
+    ASSERT_TRUE(fs::path_exist(source_index_file));
+
+    const std::string unexpected_file = existing_index_dir + "/unexpected";
+    ASSERT_OK(FileSystem::Default()->link_file(missing_index_file, unexpected_file));
+
+    std::set<std::string> mismatched_index_dirs;
+    auto st = SnapshotManager::instance()->link_inverted_index_directories(
+            *snapshot_meta, tablet->tablet_schema(), snapshot_dir, tablet->schema_hash_path(), &mismatched_index_dirs);
+    ASSERT_TRUE(st.is_corruption()) << st;
+    ASSERT_TRUE(fs::path_exist(existing_index_dir));
+    ASSERT_TRUE(fs::path_exist(unexpected_file));
+    ASSERT_TRUE(fs::path_exist(source_index_dir));
+    ASSERT_TRUE(mismatched_index_dirs.empty());
+}
+
+TEST_F(TabletUpdatesTest, link_builtin_gin_index_skips_standalone_directory) {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(DUP_KEYS);
+    schema_pb.set_num_short_key_columns(1);
+
+    auto* key = schema_pb.add_column();
+    key->set_unique_id(1);
+    key->set_name("k1");
+    key->set_type("INT");
+    key->set_is_key(true);
+    key->set_length(4);
+
+    auto* value = schema_pb.add_column();
+    value->set_unique_id(2);
+    value->set_name("v1");
+    value->set_type("VARCHAR");
+    value->set_length(64);
+
+    auto* index = schema_pb.add_table_indices();
+    index->set_index_id(100);
+    index->set_index_name("gin_v1");
+    index->set_index_type(GIN);
+    index->add_col_unique_id(2);
+    index->set_index_properties(R"({"common_properties":{")" + INVERTED_IMP_KEY + R"(":"builtin"}})");
+    auto schema = std::make_shared<const TabletSchema>(schema_pb);
+
+    const auto root = fmt::format("{}/builtin_gin_link_test", config::storage_root_path);
+    const auto snapshot_dir = root + "/snapshot";
+    const auto tablet_dir = root + "/tablet";
+    ASSERT_OK(fs::create_directories(snapshot_dir));
+    ASSERT_OK(fs::create_directories(tablet_dir));
+    DeferOp defer([&]() { (void)fs::remove_all(root); });
+
+    SnapshotMeta snapshot_meta;
+    auto& rowset_meta = snapshot_meta.rowset_metas().emplace_back();
+    rowset_meta.set_rowset_id(StorageEngine::instance()->next_rowset_id().to_string());
+    rowset_meta.set_num_segments(1);
+
+    std::set<std::string> created_index_dirs;
+    ASSERT_OK(SnapshotManager::instance()->link_inverted_index_directories(
+            snapshot_meta, schema, snapshot_dir, tablet_dir, &created_index_dirs));
+    ASSERT_TRUE(created_index_dirs.empty());
+    std::set<std::string> destination_dirs;
+    std::set<std::string> destination_files;
+    ASSERT_OK(fs::list_dirs_files(tablet_dir, &destination_dirs, &destination_files));
+    ASSERT_TRUE(destination_dirs.empty());
+    ASSERT_TRUE(destination_files.empty());
+}
+#endif
 
 TEST_F(TabletUpdatesTest, multiple_delete_and_upsert) {
     _tablet = create_tablet(rand(), rand());

--- a/be/test/storage/tablet_updates_test.h
+++ b/be/test/storage/tablet_updates_test.h
@@ -380,7 +380,8 @@ public:
     }
 
     TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash, bool multi_column_pk = false,
-                                  int64_t schema_id = 0, int32_t schema_version = 0, bool add_v3 = false) {
+                                  int64_t schema_id = 0, int32_t schema_version = 0, bool add_v3 = false,
+                                  bool add_gin_index = false) {
         srand(GetCurrentTimeMicros());
         TCreateTabletReq request;
         request.tablet_id = tablet_id;
@@ -427,8 +428,22 @@ public:
         TColumn k3;
         k3.column_name = "v2";
         k3.__set_is_key(false);
-        k3.column_type.type = TPrimitiveType::INT;
+        k3.column_type.type = add_gin_index ? TPrimitiveType::VARCHAR : TPrimitiveType::INT;
+        if (add_gin_index) {
+            k3.column_type.len = 65535;
+        }
         request.tablet_schema.columns.emplace_back(k3);
+
+        if (add_gin_index) {
+            request.tablet_schema.__isset.indexes = true;
+            request.tablet_schema.indexes.emplace_back();
+            auto& gin_index = request.tablet_schema.indexes.back();
+            gin_index.__set_index_id(1);
+            gin_index.__set_index_name("v2_gin");
+            gin_index.__set_index_type(TIndexType::GIN);
+            gin_index.__set_columns({"v2"});
+            gin_index.__set_common_properties({{"imp_lib", "clucene"}});
+        }
 
         if (add_v3) {
             TColumn k4;


### PR DESCRIPTION
> **Depends on #76901.** This PR is intentionally stacked on the Primary Key GIN snapshot fix because it reuses the shared `SnapshotManager::restore_inverted_index_directories()` helper. Until #76901 is merged, GitHub shows the #76901 changes together with this migration-specific change. After #76901 merges, this branch will be rebased so only the migration changes remain.

## Why I'm doing:

Primary Key tablets with CLucene GIN indexes can fail during intra-node storage migration. The migration path flattens CLucene index directories into files, but does not restore them before creating the destination tablet from the metadata snapshot. The subsequent rowset ID assignment expects the `.ivt` directories and returns `NotFound`.

This can cause repeated tablet migration failures and leave the scheduler retrying the same affected tablets.

## What I'm doing:

Restore flattened inverted-index files into their `.ivt` directories in `_finish_primary_key_migration()` before calling `create_tablet_from_meta_snapshot()`. If restoration fails, abort and clean up the new destination path.

Add a regression test that:

- creates a Primary Key tablet with a CLucene GIN index;
- writes a rowset containing a real `.ivt` directory;
- migrates the tablet across storage roots through the public migration execution path;
- verifies that no flattened GIN files remain in the tablet root;
- obtains the migrated tablet's applied rowsets and verifies every active rowset/segment/GIN index has a non-empty `.ivt` directory.

Fixes #77706

## Relationship to #76900 / #76901

#76901 fixes the Primary Key snapshot clone, restore, and replication lifecycle and provides the shared GIN directory helper used here. This PR covers a separate consumer: intra-node storage migration. The issues and PRs remain separate so each execution path has its own regression test and backport record.

This issue is also distinct from #77100 / #77101, which concern builtin GIN indexes on 4.1 and do not cover the CLucene `.ivt` directory path.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] 4.1
- [x] 4.0
- [ ] 3.5

## Validation:

Validated locally against upstream `main` at `ecd4cf99f90805392b1276601017536ce52b56bb` with #76901, #76902, and this PR stacked together (validation commit `f36259fbb97`) in `starrocks/dev-env-ubuntu:latest`.

- `git diff --check upstream/main...HEAD` passed.
- `EngineStorageMigrationTaskTest.test_migrate_pk_tablet_with_clucene_gin_index`: 1/1 passed.
- `EngineCloneTaskTest.{incremental_clone_preserves_gin_indexes,full_clone_preserves_gin_indexes,backup_restore_preserves_gin_indexes}`: 3/3 passed.
- `ReplicationTxnManagerTest.test_run_normal_with_gin_index` for both AGG_KEYS and PRIMARY_KEYS parameters: 2/2 passed.
- `TabletUpdatesTest.{load_snapshot_primary_with_gin_index,restore_primary_snapshot_with_gin_index,link_primary_snapshot_gin_indexes_is_idempotent,link_builtin_gin_index_skips_standalone_directory}`: 4/4 passed.
- The migration regression test uses the public execution path and verifies the non-empty GIN directories referenced by every active applied rowset after migration; it does not use private-method access.
- A CentOS 7 / glibc 2.17 StarRocks 4.0.13 BE containing this production fix and the existing CLucene GIN fixes also compiled successfully.
