### PR TITLE
[BugFix] Fix incorrect length for VARCHAR field type in Paimon Catalog (backport #68383)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
@@ -509,7 +509,7 @@ public class ColumnTypeConverter {
         }
 
         public Type visit(VarCharType varCharType) {
-            return ScalarType.createDefaultCatalogString();
+            return ScalarType.createVarcharType(varCharType.getLength());
         }
 
         public Type visit(BooleanType booleanType) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonColumnConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonColumnConverterTest.java
@@ -69,9 +69,9 @@ public class PaimonColumnConverterTest {
 
     @Test
     public void testConvertVarchar() {
-        VarCharType paimonType = new VarCharType();
+        VarCharType paimonType = new VarCharType(20);
         Type result = ColumnTypeConverter.fromPaimonType(paimonType);
-        Type srType = ScalarType.createDefaultCatalogString();
+        Type srType = ScalarType.createVarcharType(20);
         Assertions.assertEquals(result, srType);
     }
 
@@ -170,7 +170,7 @@ public class PaimonColumnConverterTest {
         Type result = ColumnTypeConverter.fromPaimonType(paimonType);
         Assertions.assertTrue(result instanceof com.starrocks.catalog.MapType);
         com.starrocks.catalog.MapType srType = (com.starrocks.catalog.MapType) result;
-        Assertions.assertEquals(ScalarType.createDefaultCatalogString(), srType.getKeyType());
+        Assertions.assertEquals(ScalarType.createVarcharType(20), srType.getKeyType());
         Assertions.assertEquals(Type.DATETIME, srType.getValueType());
     }
 


### PR DESCRIPTION
## Why I'm doing:
Fixes #68382

Manual backport of #68383 to branch-3.5. The original PR was only labeled `4.1`, so Mergify auto-backported it to branch-4.1 only (#68459); branch-4.0 and branch-3.5 still carry the bug.

## What I'm doing:

Paimon `VarCharType` was always converted to `ScalarType.createDefaultCatalogString()`, discarding the declared length, so a Paimon `VARCHAR(20)` column showed up as the catalog max varchar length in StarRocks. Convert it with the real length instead.

Conflict resolution note: `main` has since moved the type factory to `com.starrocks.type.TypeFactory`, which does not exist on branch-3.5. The change is applied with the equivalent `com.starrocks.catalog.ScalarType.createVarcharType(int)` (same implementation: `new ScalarType(VARCHAR)` with the length set). No other part of the upstream refactor is pulled in.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

This PR already targets branch-3.5 directly, so no auto-backport label is set.

