### PR TITLE
[BugFix] upgrade staros to v3.5.6

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -72,7 +72,7 @@ under the License.
         <paimon.version>1.2.0</paimon.version>
         <delta-kernel.version>4.0.0rc1</delta-kernel.version>
         <iceberg.version>1.9.0</iceberg.version>
-        <staros.version>3.5.4</staros.version>
+        <staros.version>3.5.6</staros.version>
         <!-- hadoop-azure requires no more than jetty10+ -->
         <!-- https://stackoverflow.com/questions/66713254/spark-wasb-and-jetty-11 -->
         <jetty.version>9.4.58.v20250814</jetty.version>


### PR DESCRIPTION
Picks up the two Java-side CVE fixes released in staros v3.5.6

v3.5.6 upgrades gRPC Java to 1.76.0 (CVE-2025-55163, also avoiding the 1.75.0 shaded-Netty transport corruption) and hardens StarManager image loading to validate footer framing and reject oversized footers before allocation. It also aligns the staros Java dependency versions with what StarRocks resolves in fe/pom.xml: protobuf-java 3.16.1 -> 3.25.5 (CVE-2024-7254), jackson-core/-annotations/-databind managed centrally at 2.21.4 instead of starmanager's hardcoded 2.13.4.2, and test-scoped commons-io 2.11.0 -> 2.16.1 (CVE-2024-47554).

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

