### PR TITLE
[BugFix] upgrade staros to v4.0.7

### DIFF
--- a/docker/dockerfiles/dev-env/dev-env.Dockerfile
+++ b/docker/dockerfiles/dev-env/dev-env.Dockerfile
@@ -22,7 +22,7 @@ ARG predownload_thirdparty=false
 ARG thirdparty_url=https://cdn-thirdparty.starrocks.com/starrocks-thirdparty-main-20250731.tar
 ARG commit_id
 # check thirdparty/starlet-artifacts-version.sh, to get the right tag
-ARG starlet_tag=v4.0.6
+ARG starlet_tag=v4.0.7
 # build for which linux distro: centos7|ubuntu
 ARG distro=ubuntu
 # Token to access artifacts in private github repositories.

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -73,7 +73,7 @@ under the License.
         <paimon.version>1.3.1</paimon.version>
         <delta-kernel.version>4.0.0rc1</delta-kernel.version>
         <iceberg.version>1.10.0</iceberg.version>
-        <staros.version>4.0.5</staros.version>
+        <staros.version>4.0.7</staros.version>
         <!-- hadoop-azure requires no more than jetty10+ -->
         <!-- https://stackoverflow.com/questions/66713254/spark-wasb-and-jetty-11 -->
         <jetty.version>9.4.58.v20250814</jetty.version>

--- a/thirdparty/starlet-artifacts-version.sh
+++ b/thirdparty/starlet-artifacts-version.sh
@@ -9,4 +9,4 @@
 #   https://hub.docker.com/r/starrocks/starlet-artifacts-centos7/tags
 #
 # Update the following tag when STARLET releases a new version.
-export STARLET_ARTIFACTS_TAG=v4.0.6
+export STARLET_ARTIFACTS_TAG=v4.0.7


### PR DESCRIPTION
Moves the FE starclient/starmanager jar 4.0.5 -> 4.0.7 and the starlet artifacts tag v4.0.6 -> v4.0.7, in thirdparty/starlet-artifacts-version.sh and the dev-env Dockerfile default, so the Java and C++ sides land on the same staros release.

On the Java side this picks up two CVE fixes:
* gRPC Java goes to 1.76.0 (CVE-2025-55163)
* protobuf-java 3.16.1 -> 3.25.5 (CVE-2024-7254)
* jackson managed centrally at 2.21.4

Starlet bump fixes a prefetch discard in AsyncBufferInputStream::seek()

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
