### PR TITLE
[BugFix] Fold binary constant casts from the bytes, not byte[].toString()

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
@@ -40,11 +40,13 @@ import org.apache.commons.lang3.StringUtils;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
+import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -523,6 +525,10 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
             return Optional.empty();
         }
 
+        if (type.getPrimitiveType().isBinaryType()) {
+            return castBinaryTo(desc);
+        }
+
         String childString = toString();
         if (getType().isBoolean()) {
             childString = getBoolean() ? "1" : "0";
@@ -622,8 +628,47 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
         } catch (Exception e) {
             return Optional.empty();
         }
-        
+
         return Optional.ofNullable(res);
+    }
+
+    /**
+     * Fold a cast whose source is a BINARY/VARBINARY constant.
+     * <p>
+     * The value of such a constant is a {@code byte[]}, so {@link #toString()} yields the JVM default
+     * {@code [B@<identityHashCode>}: it must never be used as the source value of a cast, otherwise the
+     * identity hash gets baked into the plan as a real value and the result is both wrong and different
+     * on every run.
+     * <p>
+     * The BE implements binary -> string as a raw passthrough of the underlying column
+     * (VectorizedCastToStringExpr in be/src/exprs/cast_expr_tpl.hpp: VARBINARY and VARCHAR share the same
+     * physical BinaryColumn, so the cast is the identity, with neither hex encoding nor length truncation).
+     * FE folding has to produce exactly the same bytes.
+     */
+    private Optional<ConstantOperator> castBinaryTo(Type desc) {
+        byte[] bytes = isNull() ? null : getBinary();
+        if (bytes == null) {
+            return Optional.empty();
+        }
+
+        if (desc.isChar() || desc.isVarchar()) {
+            // The FE carries string constants as java Strings and ships them to the BE as UTF-8, so folding
+            // is only byte-exact when the bytes are valid UTF-8. Otherwise decoding substitutes U+FFFD and
+            // the folded value would no longer match what the BE computes, so leave the cast to the BE.
+            String decoded = new String(bytes, StandardCharsets.UTF_8);
+            if (!Arrays.equals(decoded.getBytes(StandardCharsets.UTF_8), bytes)) {
+                return Optional.empty();
+            }
+            return Optional.of(ConstantOperator.createChar(decoded, desc));
+        }
+
+        if (desc.getPrimitiveType().isBinaryType()) {
+            // binary -> binary is the identity, the target length is not applied (the BE does not truncate).
+            return Optional.of(ConstantOperator.createBinary(bytes, desc));
+        }
+
+        // The BE only supports casting a binary value to a string, so don't fold anything else either.
+        return Optional.empty();
     }
 
     public Optional<ConstantOperator> successor() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/operator/ConstantOperatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/operator/ConstantOperatorTest.java
@@ -15,14 +15,20 @@
 package com.starrocks.sql.optimizer.operator.operator;
 
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.type.CharType;
 import com.starrocks.type.DateType;
 import com.starrocks.type.FloatType;
 import com.starrocks.type.IntegerType;
+import com.starrocks.type.TypeFactory;
+import com.starrocks.type.VarbinaryType;
+import com.starrocks.type.VarcharType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 public class ConstantOperatorTest {
     @Test
@@ -150,6 +156,65 @@ public class ConstantOperatorTest {
         ConstantOperator time = ConstantOperator.createTime(now.getHour() * 3600D + now.getMinute() * 60D + now.getSecond());
         ConstantOperator datetime = ConstantOperator.createDatetime(now);
         Assertions.assertEquals(datetime, time.castTo(DateType.DATETIME).get());
+    }
+
+    @Test
+    public void testCastBinaryToStringKeepsTheBytes() {
+        byte[] bytes = "zz".getBytes(StandardCharsets.UTF_8);
+        ConstantOperator binary = ConstantOperator.createBinary(bytes, VarbinaryType.VARBINARY);
+
+        // The BE casts binary to string by handing the underlying bytes over untouched, folding must agree.
+        String folded = binary.castTo(VarcharType.VARCHAR).get().getVarchar();
+        Assertions.assertEquals("zz", folded);
+        Assertions.assertFalse(folded.startsWith("[B@"), folded);
+
+        // The folded value used to be the identity hash code of the byte[], so it differed on every call.
+        Assertions.assertEquals(folded, binary.castTo(VarcharType.VARCHAR).get().getVarchar());
+        Assertions.assertEquals(binary.castTo(VarcharType.VARCHAR).get(), binary.castTo(VarcharType.VARCHAR).get());
+
+        // An equal but distinct constant, i.e. a different byte[] instance, folds to the same value.
+        ConstantOperator otherInstance =
+                ConstantOperator.createBinary("zz".getBytes(StandardCharsets.UTF_8), VarbinaryType.VARBINARY);
+        Assertions.assertEquals(folded, otherInstance.castTo(VarcharType.VARCHAR).get().getVarchar());
+
+        // CHAR and sized VARCHAR take the same path, the BE does not truncate to the target length either.
+        Assertions.assertEquals("zz", binary.castTo(CharType.CHAR).get().getVarchar());
+        Assertions.assertEquals("zz", binary.castTo(TypeFactory.createVarcharType(1)).get().getVarchar());
+    }
+
+    @Test
+    public void testCastBinaryToBinaryKeepsTheBytes() {
+        byte[] bytes = "zz".getBytes(StandardCharsets.UTF_8);
+        ConstantOperator binary = ConstantOperator.createBinary(bytes, VarbinaryType.VARBINARY);
+
+        Assertions.assertArrayEquals(bytes, binary.castTo(VarbinaryType.VARBINARY).get().getBinary());
+        Assertions.assertArrayEquals(bytes, binary.castTo(TypeFactory.createVarbinary(10)).get().getBinary());
+    }
+
+    @Test
+    public void testCastNonUtf8BinaryToStringIsNotFolded() {
+        // 0xFF is not valid UTF-8: decoding it would substitute U+FFFD and the folded constant would no
+        // longer carry the bytes the BE would produce, so the cast has to be left to the BE.
+        ConstantOperator binary = ConstantOperator.createBinary(new byte[] {(byte) 0xFF}, VarbinaryType.VARBINARY);
+        Assertions.assertEquals(Optional.empty(), binary.castTo(VarcharType.VARCHAR));
+        Assertions.assertEquals(Optional.empty(), binary.castTo(CharType.CHAR));
+    }
+
+    @Test
+    public void testCastBinaryToOtherTypesIsNotFolded() {
+        ConstantOperator binary =
+                ConstantOperator.createBinary("12".getBytes(StandardCharsets.UTF_8), VarbinaryType.VARBINARY);
+
+        // The BE only supports casting a binary value to a string, folding anything else would make the
+        // constant path disagree with the non-folded one.
+        Assertions.assertEquals(Optional.empty(), binary.castTo(IntegerType.INT));
+        Assertions.assertEquals(Optional.empty(), binary.castTo(IntegerType.BIGINT));
+        Assertions.assertEquals(Optional.empty(), binary.castTo(FloatType.DOUBLE));
+        Assertions.assertEquals(Optional.empty(), binary.castTo(DateType.DATE));
+
+        // A null binary constant used to be folded into the literal string "null".
+        Assertions.assertEquals(Optional.empty(),
+                ConstantOperator.createNull(VarbinaryType.VARBINARY).castTo(VarcharType.VARCHAR));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -27,6 +27,7 @@ import com.starrocks.type.FloatType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.TypeFactory;
+import com.starrocks.type.VarbinaryType;
 import com.starrocks.type.VarcharType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,6 +38,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -740,6 +742,19 @@ public class ScalarOperatorFunctionsTest {
                 () -> ScalarOperatorFunctions.nextDay(O_DT_20150323_092355, ConstantOperator.createVarchar("undefine_dow"))
                         .getVarchar(),
                 "undefine_dow not supported in next_day dow_string");
+    }
+
+    @Test
+    public void nextDayWithFoldedBinaryDow() {
+        // Folding cast(<varbinary> as varchar) used to yield the java default byte[] toString(), which then
+        // poisoned every function reading the folded value: next_day reported
+        // "[B@3461c8cb not supported in next_day dow_string".
+        ConstantOperator dow = ConstantOperator
+                .createBinary("Sunday".getBytes(StandardCharsets.UTF_8), VarbinaryType.VARBINARY)
+                .castTo(VarcharType.VARCHAR).get();
+        assertEquals("Sunday", dow.getVarchar());
+        assertEquals("2015-03-29T09:23:55",
+                ScalarOperatorFunctions.nextDay(O_DT_20150323_092355, dow).getDate().toString());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
@@ -191,6 +191,32 @@ public class ConstantExpressionTest extends PlanTestBase {
     }
 
     @Test
+    public void testCastBinaryToString() throws Exception {
+        // Folding used to produce the java default byte[] toString(), i.e. "[B@<identityHashCode>", which is
+        // both wrong and different on every run, while the non-folded BE path returns the bytes.
+        testFragmentPlanContainsConstExpr(
+                "select cast(cast('zz' as varbinary) as varchar);",
+                "'zz'");
+
+        testFragmentPlanContainsConstExpr(
+                "select cast(cast('zz' as varbinary) as char(10));",
+                "'zz'");
+
+        // The bogus value poisoned every function reading it, which is how the bug surfaced:
+        // "ERROR 1064: [B@3461c8cb not supported in next_day dow_string".
+        testFragmentPlanContainsConstExpr(
+                "select next_day(cast('2023-04-05' as datetime), cast(cast('Sunday' as varbinary) as varchar));",
+                "'2023-04-09'");
+
+        // A sized binary target does not change the value either. ReduceCastRule drops the intermediate cast
+        // here because matchesType() ignores the length of a varbinary, so this only guards that it stays a
+        // no-op; the binary -> binary folding itself is covered by ConstantOperatorTest.
+        testFragmentPlanContainsConstExpr(
+                "select cast(cast(cast('zz' as varbinary) as varbinary(10)) as varchar);",
+                "'zz'");
+    }
+
+    @Test
     public void testCastToDecimalLiteral() throws Exception {
         testFragmentPlanContainsConstExpr(
                 "select cast(151971657 as decimal32);",


### PR DESCRIPTION
## Why I'm doing:

FE constant folding of cast(<varbinary constant> as varchar) returned the java default Object.toString() of the byte[] that holds the value:

    select cast(cast('zz' as varbinary) as varchar);  -- [B@233c25e5

The value is an identity hash code, so it is silently wrong, differs on every run, and disagrees with the non-folded path, which the BE evaluates and which returns the real bytes. It also poisoned whatever read the folded constant, which is how the bug surfaced:

    select next_day(cast('2023-04-05' as datetime),
                    cast(cast('zz' as varbinary) as varchar));
    ERROR 1064: [B@3461c8cb not supported in next_day dow_string

ConstantOperator.castTo() derives the source value of every cast from toString(), which has no BINARY/VARBINARY branch and falls through to String.valueOf(value). The binary target branch had the same defect: it turned that same "[B@..." text back into bytes.

Fix castTo() rather than toString(). toString() is the display form of a constant and feeds EXPLAIN output plus statistics and histogram keys, while the value of a binary constant is bytes and has no faithful string form, so the two concerns have to stay apart; binary sources now read getBinary() directly.

The BE casts binary to string by handing the underlying column over untouched (VectorizedCastToStringExpr in be/src/exprs/cast_expr_tpl.hpp: VARBINARY and VARCHAR share the same BinaryColumn), with neither hex encoding nor truncation to the target length, so folding now produces exactly those bytes. Bytes that are not valid UTF-8 are left to the BE, because the java String they decode to does not encode back to them. Binary to anything but a string is no longer folded either, which is the set of casts the BE actually implements.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
