### PR TITLE
[Enhancement] Verify snapshot file integrity on restore

### DIFF
--- a/be/src/data_workflows/snapshot/snapshot_loader.cpp
+++ b/be/src/data_workflows/snapshot/snapshot_loader.cpp
@@ -66,6 +66,12 @@
 
 namespace starrocks {
 
+// Name of the per-tablet manifest written into the remote snapshot dir. It has no '.' on purpose:
+// the remote listing splits every file name at its last '.' to recover the md5 suffix and skips
+// names without one, so the manifest is naturally ignored by the download/delete logic and only
+// ever read explicitly by name.
+static const std::string SNAPSHOT_MANIFEST_FILENAME = "__starrocks_snapshot_manifest";
+
 #ifdef BE_TEST
 inline BrokerServiceClientCache* client_cache(ExecEnv* env) {
     static BrokerServiceClientCache s_client_cache;
@@ -222,6 +228,14 @@ Status SnapshotLoader::upload(const std::map<std::string, std::string>& src_to_d
             }
         } // end for each tablet's local files
 
+        // Record the full file list of this tablet in a manifest inside its remote snapshot dir
+        if (!upload.__isset.use_broker || upload.use_broker) {
+            BrokerFileSystem fs_broker(upload.broker_addr, upload.broker_prop);
+            RETURN_IF_ERROR(_write_snapshot_manifest(&fs_broker, dest_path, local_files));
+        } else {
+            RETURN_IF_ERROR(_write_snapshot_manifest(fs.get(), dest_path, local_files));
+        }
+
         tablet_files->emplace(tablet_id, local_files_with_checksum);
         finished_num++;
         VLOG(2) << "finished to write tablet to remote. local path: " << src_path << ", remote path: " << dest_path;
@@ -309,6 +323,14 @@ Status SnapshotLoader::download(const std::map<std::string, std::string>& src_to
             ss << "get nothing from remote path: " << remote_path;
             LOG(WARNING) << ss.str();
             return Status::InternalError(ss.str());
+        }
+
+        // Check the remote listing against the manifest written at backup time
+        if (!download.__isset.use_broker || download.use_broker) {
+            BrokerFileSystem fs_broker(download.broker_addr, download.broker_prop);
+            RETURN_IF_ERROR(_verify_snapshot_manifest(&fs_broker, remote_path, remote_files));
+        } else {
+            RETURN_IF_ERROR(_verify_snapshot_manifest(fs.get(), remote_path, remote_files));
         }
 
         TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(local_tablet_id);
@@ -438,6 +460,86 @@ Status SnapshotLoader::download(const std::map<std::string, std::string>& src_to
 
     LOG(INFO) << "finished to download snapshots. job id: " << _job_id << ", task id: " << _task_id;
     return status;
+}
+
+Status SnapshotLoader::_write_snapshot_manifest(FileSystem* fs, const std::string& remote_dir,
+                                                const std::vector<std::string>& file_names) {
+    std::string manifest_path = remote_dir + "/" + SNAPSHOT_MANIFEST_FILENAME;
+    std::string content;
+    for (const std::string& name : file_names) {
+        content += name;
+        content += '\n';
+    }
+    WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+    ASSIGN_OR_RETURN(auto writable_file, fs->new_writable_file(opts, manifest_path));
+    RETURN_IF_ERROR(writable_file->append(Slice(content)));
+    RETURN_IF_ERROR(writable_file->close());
+    VLOG(2) << "wrote snapshot manifest: " << manifest_path << ", file num: " << file_names.size();
+    return Status::OK();
+}
+
+Status SnapshotLoader::_read_snapshot_manifest(FileSystem* fs, const std::string& remote_dir,
+                                               std::vector<std::string>* file_names, bool* found) {
+    *found = false;
+    file_names->clear();
+    std::string manifest_path = remote_dir + "/" + SNAPSHOT_MANIFEST_FILENAME;
+    auto maybe_file = fs->new_sequential_file(manifest_path);
+    if (!maybe_file.ok()) {
+        if (maybe_file.status().is_not_found()) {
+            // Snapshot taken before the manifest existed: nothing to verify, keep legacy behavior.
+            return Status::OK();
+        }
+        return maybe_file.status();
+    }
+    auto sequential_file = std::move(maybe_file.value());
+
+    std::string content;
+    char buf[4096];
+    while (true) {
+        ASSIGN_OR_RETURN(int64_t bytes_read, sequential_file->read(buf, sizeof(buf)));
+        if (bytes_read == 0) {
+            break;
+        }
+        content.append(buf, bytes_read);
+    }
+
+    // The manifest holds one plain file name per line.
+    for (size_t start = 0; start < content.size();) {
+        size_t end = content.find('\n', start);
+        if (end == std::string::npos) {
+            end = content.size();
+        }
+        if (end > start) {
+            file_names->emplace_back(content, start, end - start);
+        }
+        start = end + 1;
+    }
+
+    *found = true;
+    VLOG(2) << "read snapshot manifest: " << manifest_path << ", file num: " << file_names->size();
+    return Status::OK();
+}
+
+Status SnapshotLoader::_verify_snapshot_manifest(FileSystem* fs, const std::string& remote_path,
+                                                 const std::map<std::string, FileStat>& remote_files) {
+    std::vector<std::string> manifest_files;
+    bool found = false;
+    RETURN_IF_ERROR(_read_snapshot_manifest(fs, remote_path, &manifest_files, &found));
+    if (!found) {
+        // Snapshot taken before the manifest existed: keep legacy listing-based behavior.
+        return Status::OK();
+    }
+    // Every file recorded in the manifest must appear in the remote listing.
+    for (const std::string& expected_name : manifest_files) {
+        if (remote_files.find(expected_name) == remote_files.end()) {
+            std::stringstream ss;
+            ss << "snapshot file is missing in remote path: " << remote_path << "/" << expected_name
+               << ". The snapshot may be incomplete or corrupted.";
+            LOG(WARNING) << ss.str();
+            return Status::InternalError(ss.str());
+        }
+    }
+    return Status::OK();
 }
 
 Status SnapshotLoader::primary_key_move(const std::string& snapshot_path, const TabletSharedPtr& tablet,

--- a/be/src/data_workflows/snapshot/snapshot_loader.h
+++ b/be/src/data_workflows/snapshot/snapshot_loader.h
@@ -121,6 +121,23 @@ private:
 
     Status _report_every(int report_threshold, int* counter, int finished_num, int total_num, TTaskType::type type);
 
+    // Write a manifest file into the tablet's remote snapshot dir listing every uploaded file name.
+    // Called after all of a tablet's files are uploaded; the manifest is the authoritative "which
+    // files must exist" record used to detect a missing file at restore time.
+    Status _write_snapshot_manifest(FileSystem* fs, const std::string& remote_dir,
+                                    const std::vector<std::string>& file_names);
+
+    // Read the tablet's remote snapshot manifest. Sets *found to false (and returns OK) when the
+    // manifest is absent, which keeps snapshots taken before this feature on the legacy path.
+    Status _read_snapshot_manifest(FileSystem* fs, const std::string& remote_dir, std::vector<std::string>* file_names,
+                                   bool* found);
+
+    // Read the tablet's manifest and check the remote listing against it: every name recorded in
+    // the manifest must be present (per-file content integrity is covered separately by the md5
+    // check at download time). No-op (OK) when the manifest is absent (legacy snapshot).
+    Status _verify_snapshot_manifest(FileSystem* fs, const std::string& remote_path,
+                                     const std::map<std::string, FileStat>& remote_files);
+
 private:
     ExecEnv* _env;
     int64_t _job_id;

--- a/be/test/data_workflows/snapshot/snapshot_loader_test.cpp
+++ b/be/test/data_workflows/snapshot/snapshot_loader_test.cpp
@@ -22,6 +22,7 @@
 
 #include "common/system/cpu_info.h"
 #include "exec/exec_env.h"
+#include "fs/fs.h"
 
 #define private public // hack complier
 #define protected public
@@ -112,6 +113,119 @@ TEST_F(SnapshotLoaderTest, NormalCase) {
     st = loader._get_tablet_id_from_remote_path("/__tbl_10004/__part_10003/__idx_10004/__10005", &tablet_id);
     ASSERT_TRUE(st.ok());
     ASSERT_EQ(10005, tablet_id);
+}
+
+TEST_F(SnapshotLoaderTest, SnapshotManifestReadWrite) {
+    SnapshotLoader loader(_exec_env, 1L, 2L);
+    FileSystem* fs = FileSystem::Default();
+
+    const std::string dir = "./ss_manifest_test";
+    std::filesystem::remove_all(dir);
+    std::filesystem::create_directory(dir);
+
+    // no manifest in the dir yet -> found=false, still ok (legacy snapshot path)
+    {
+        std::vector<std::string> names;
+        bool found = true;
+        Status st = loader._read_snapshot_manifest(fs, dir, &names, &found);
+        ASSERT_TRUE(st.ok()) << st.message();
+        ASSERT_FALSE(found);
+        ASSERT_TRUE(names.empty());
+    }
+
+    // write a manifest then read it back verbatim, order preserved
+    {
+        std::vector<std::string> to_write = {"0_0_0.dat", "0.hdr", "0_0_1.dat"};
+        Status st = loader._write_snapshot_manifest(fs, dir, to_write);
+        ASSERT_TRUE(st.ok()) << st.message();
+
+        std::vector<std::string> names;
+        bool found = false;
+        st = loader._read_snapshot_manifest(fs, dir, &names, &found);
+        ASSERT_TRUE(st.ok()) << st.message();
+        ASSERT_TRUE(found);
+        ASSERT_EQ(to_write, names);
+    }
+
+    // the manifest file name carries no '.', so the remote listing (which keys files by the part
+    // before the last '.') never mistakes it for a data file
+    ASSERT_EQ(std::string::npos, std::string("__starrocks_snapshot_manifest").find('.'));
+
+    // an empty file list round-trips as a present-but-empty manifest
+    {
+        Status st = loader._write_snapshot_manifest(fs, dir, {});
+        ASSERT_TRUE(st.ok()) << st.message();
+
+        std::vector<std::string> names;
+        bool found = false;
+        st = loader._read_snapshot_manifest(fs, dir, &names, &found);
+        ASSERT_TRUE(st.ok()) << st.message();
+        ASSERT_TRUE(found);
+        ASSERT_TRUE(names.empty());
+    }
+
+    // a manifest whose last line has no trailing newline still parses every name
+    {
+        const std::string manifest_path = dir + "/__starrocks_snapshot_manifest";
+        WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+        auto wf_or = fs->new_writable_file(opts, manifest_path);
+        ASSERT_TRUE(wf_or.ok()) << wf_or.status().message();
+        auto wf = std::move(wf_or.value());
+        ASSERT_TRUE(wf->append(Slice("a.dat\nb.dat")).ok());
+        ASSERT_TRUE(wf->close().ok());
+
+        std::vector<std::string> names;
+        bool found = false;
+        Status st = loader._read_snapshot_manifest(fs, dir, &names, &found);
+        ASSERT_TRUE(st.ok()) << st.message();
+        ASSERT_TRUE(found);
+        ASSERT_EQ((std::vector<std::string>{"a.dat", "b.dat"}), names);
+    }
+
+    std::filesystem::remove_all(dir);
+}
+
+TEST_F(SnapshotLoaderTest, VerifySnapshotManifest) {
+    SnapshotLoader loader(_exec_env, 1L, 2L);
+    FileSystem* fs = FileSystem::Default();
+
+    const std::string dir = "./ss_verify_test";
+    std::filesystem::remove_all(dir);
+    std::filesystem::create_directory(dir);
+
+    std::map<std::string, FileStat> remote_files;
+    remote_files.emplace("0_0_0.dat", FileStat{"0_0_0.dat", "0123456789abcdef0123456789abcdef", 100});
+    remote_files.emplace("0.hdr", FileStat{"0.hdr", "fedcba9876543210fedcba9876543210", 50});
+
+    // no manifest present -> ok (legacy snapshot, nothing to verify)
+    {
+        Status st = loader._verify_snapshot_manifest(fs, dir, remote_files);
+        ASSERT_TRUE(st.ok()) << st.message();
+    }
+
+    // manifest lists exactly the files present in the remote listing -> ok
+    {
+        ASSERT_TRUE(loader._write_snapshot_manifest(fs, dir, {"0_0_0.dat", "0.hdr"}).ok());
+        Status st = loader._verify_snapshot_manifest(fs, dir, remote_files);
+        ASSERT_TRUE(st.ok()) << st.message();
+    }
+
+    // manifest lists a file missing from the remote listing -> error
+    {
+        ASSERT_TRUE(loader._write_snapshot_manifest(fs, dir, {"0_0_0.dat", "0.hdr", "0_0_1.dat"}).ok());
+        Status st = loader._verify_snapshot_manifest(fs, dir, remote_files);
+        ASSERT_FALSE(st.ok());
+        ASSERT_NE(st.message().find("missing"), std::string::npos);
+    }
+
+    // an empty manifest records no files -> nothing to check, ok
+    {
+        ASSERT_TRUE(loader._write_snapshot_manifest(fs, dir, {}).ok());
+        Status st = loader._verify_snapshot_manifest(fs, dir, remote_files);
+        ASSERT_TRUE(st.ok()) << st.message();
+    }
+
+    std::filesystem::remove_all(dir);
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

Restore has no missing-file check on the snapshot files it downloads. BE
derives the set of files to fetch purely by listing the remote tablet
directory, so if a snapshot file is missing (e.g. manually deleted, or lost in
the repository) BE simply downloads whatever remains, reports success, and the
restore commits a half-restored tablet with silently missing data. The only
guard today is "the remote directory is completely empty"; a single missing
file slips through.

## What I'm doing:

Give BE an authoritative "which files must exist" record captured at backup
time, when the data was known to be complete, and make it verify the download
against that record before the (irreversible) commit phase. This is done
entirely inside BE's `SnapshotLoader` — no FE or thrift changes.

- **Backup (upload)**: after a tablet's snapshot files are uploaded, BE writes a
  manifest file into that tablet's remote snapshot dir listing all of the
  tablet's file names (plain names, one per line). The manifest name
  (`__starrocks_snapshot_manifest`) deliberately has no `.`: the remote listing
  keys every file by the part before its last `.` (the md5 suffix) and skips
  names without one, so the manifest is naturally ignored by the download/delete
  logic and only ever read explicitly by name.
- **Restore (download)**: before commit, BE reads the manifest and checks the
  remote listing against it. A file recorded in the manifest but missing from
  the remote listing fails the restore in the DOWNLOADING phase — before any
  tablet data is overwritten — instead of silently producing a half-restored
  tablet.

Per-file content integrity is unchanged and still covered by the existing
download-time md5 check (BE recomputes each downloaded file's md5 against the
md5 carried in its remote filename); the manifest adds the missing-file
detection that layer cannot provide.

Works on both repo access paths (external broker and native FileSystem).

Graceful degradation: snapshots taken before this change have no manifest; BE
treats an absent manifest as the legacy listing-based behavior. Older BEs
restoring a newer repo also stay compatible — the dotless manifest name is
skipped by their existing remote listing just the same.

Fixes #77728

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
