### PR TITLE
[BugFix] Assign column unique ids when creating materialized views (backport #77681)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -627,6 +627,9 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         this.dbId = dbId;
         this.refreshScheme = refreshScheme;
         this.active = true;
+
+        // Assign unique ids for columns
+        initUniqueId();
     }
 
     // Used for sync mv
@@ -2666,6 +2669,19 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                 outputColumns.add(schema.get(index));
             }
             return outputColumns;
+        }
+    }
+
+    /**
+     * To support fast schema evolution, we need to init unique id for each column in base schema.
+     */
+    public void initUniqueId() {
+        List<Column> baseSchema = getBaseSchema();
+        if (baseSchema != null && !baseSchema.isEmpty()
+                && baseSchema.get(0).getUniqueId() == Column.COLUMN_UNIQUE_ID_INIT_VALUE) {
+            for (Column column : baseSchema) {
+                column.setUniqueId(incAndGetMaxColUniqueId());
+            }
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3147,6 +3147,11 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         materializedView.setIndexMeta(baseIndexId, mvName, baseSchema, schemaVersion, schemaHash,
                 shortKeyColumnCount, baseIndexStorageType, stmt.getKeysType());
 
+        // Assign unique ids for columns after index meta is set up, so that getBaseSchema() returns
+        // the actual columns. The initUniqueId() call in the MV constructor is a no-op because it
+        // runs before setIndexMeta(), when getBaseSchema() returns an empty list.
+        materializedView.initUniqueId();
+
         // validate hint
         Map<String, String> optHints = Maps.newHashMap();
         if (stmt.isExistQueryScopeHint()) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -61,6 +61,7 @@ import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -1653,5 +1654,30 @@ public class MaterializedViewTest extends StarRocksTestBase {
             }
         };
         Assertions.assertTrue(mv.isStalenessSatisfied());
+    }
+
+    @Test
+    public void testMVColumnUniqueIdAssignedOnCreate() throws Exception {
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv_uid_test\n" +
+                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                "REFRESH ASYNC\n" +
+                "PROPERTIES (\"replication_num\" = \"1\")\n" +
+                "AS SELECT k1, k2, sum(v1) as total FROM base_t1 GROUP BY k1, k2;");
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView mv = (MaterializedView) GlobalStateMgr.getCurrentState()
+                .getLocalMetastore().getTable(db.getFullName(), "mv_uid_test");
+
+        List<Column> schema = mv.getBaseSchema();
+        Assertions.assertEquals(3, schema.size());
+        Set<Integer> uniqueIds = new HashSet<>();
+        for (Column col : schema) {
+            Assertions.assertTrue(col.getUniqueId() > Column.COLUMN_UNIQUE_ID_INIT_VALUE,
+                    "Column " + col.getName() + " should have a valid unique id, but got " + col.getUniqueId());
+            Assertions.assertTrue(uniqueIds.add(col.getUniqueId()),
+                    "Duplicate column unique id " + col.getUniqueId() + " found for column " + col.getName());
+        }
+        Assertions.assertEquals(schema.size() - 1, mv.getMaxColUniqueId());
+        starRocksAssert.dropMaterializedView("mv_uid_test");
     }
 }


### PR DESCRIPTION
Manual backport of #77681 to branch-3.5. The automatic cherry-pick (#77731) failed because the tail of `MaterializedViewTest.java` diverged between the two branches; the conflict was only in diff context, the change itself applies verbatim (47 insertions, byte-identical to #77681).

## Why I'm doing:

Async materialized views are created with every column's unique id left at `-1` (`COLUMN_UNIQUE_ID_INIT_VALUE`) — unlike regular OLAP tables, whose columns get unique ids assigned in `OlapTableFactory`.

The predicate-columns tracking (`PredicateColumnsMgr`) keys columns by `(db_id, table_id, column_unique_id)`. For an async MV, all columns collapse into a single `(-1)` entry, and resolving it back via `Table.getColumnByUniqueId(-1)` always returns the **first** schema column. As a result, the auto statistics collection's predicate-column strategy only ever collects the first column of the MV; after each refresh (INSERT OVERWRITE swaps partition ids and orphans the per-partition statistics), every other column — including join keys — is left with UNKNOWN statistics, which badly breaks join-order planning (observed in production: a query regressed from minutes to 1h35m after upgrading from 3.3 to 3.5).

## What I'm doing:

Partial backport of #67915 (`MaterializedView.initUniqueId()` + constructor call) and #71072 (invoke `initUniqueId()` after `setIndexMeta()` in `LocalMetastore.createMaterializedView`, where `getBaseSchema()` returns the actual columns) onto branch-3.5:

- `MaterializedView.initUniqueId()`: assign sequential unique ids to base schema columns, guarded to be idempotent (only when the first column is still `-1`) — verbatim from branch-4.1.
- Call it at the end of the `MaterializedView(long id, long dbId, ...)` constructor (covers `LakeMaterializedView` too) and after `setIndexMeta()` in `createMaterializedView` (the load-bearing call; the constructor call is a no-op at creation time because `getBaseSchema()` is empty before `setIndexMeta()`).
- UT: `testMVColumnUniqueIdAssignedOnCreate` asserts a freshly created async MV has valid, duplicate-free column unique ids and a correct `maxColUniqueId`.

Deliberately **not** ported (they belong to the ALTER MV fast-schema-evolution feature, not this fix): the `getUseFastSchemaEvolution()` `false → true` flip, `ALTER MATERIALIZED VIEW ADD/DROP COLUMN` (grammar/AST/`AlterMVJobExecutor`/edit-log changes), and any backfill of existing MVs on reload (matches upstream behavior). Assigning unique ids while FSE stays off is harmless — it mirrors `OlapTableFactory`'s behavior for non-FSE tables.

With this change, newly created (or rebuilt) MVs on 3.5 get proper column unique ids, so predicate-column tracking and auto statistics collection work correctly for them.

Fixes #N/A

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
