### PR TITLE
[BugFix] Propagate accept() status in GroupedExecutionSinkOperator::push_chunk

### DIFF
--- a/be/src/exec/pipeline/group_execution/group_operator.cpp
+++ b/be/src/exec/pipeline/group_execution/group_operator.cpp
@@ -48,7 +48,7 @@ Status GroupedExecutionSinkOperator::set_finishing(RuntimeState* state) {
 Status GroupedExecutionSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
     auto res = _exchanger->accept(chunk, _driver_sequence);
     _peak_memory_usage_counter->set(_exchanger->get_memory_usage());
-    return Status::OK();
+    return res;
 }
 
 Status GroupedExecutionSinkFactory::prepare(RuntimeState* state) {


### PR DESCRIPTION
## Why I'm doing:

`GroupedExecutionSinkOperator::push_chunk` captures the `Status` returned by
`LocalExchanger::accept()` into `res` but always returns `Status::OK()`
afterward, silently swallowing any error the exchanger reports (e.g. spill
failures, closed-exchanger states). The sibling `LocalExchangeSinkOperator::push_chunk`
already returns this value correctly (see `local_exchange_sink_operator.cpp`),
so `GroupedExecutionSinkOperator` was inconsistent with the established pattern.

## What I'm doing:

Return the captured `res` instead of unconditionally returning `Status::OK()`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5