### PR TITLE
[BugFix] Fix NPE reading iceberg $partitions with decimal or null timestamptz partition values

### DIFF
--- a/java-extensions/iceberg-metadata-reader/pom.xml
+++ b/java-extensions/iceberg-metadata-reader/pom.xml
@@ -94,6 +94,11 @@
             <artifactId>iceberg-aws</artifactId>
             <version>${iceberg.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/IcebergMetadataColumnValue.java
+++ b/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/IcebergMetadataColumnValue.java
@@ -124,7 +124,7 @@ public class IcebergMetadataColumnValue implements ColumnValue {
 
     @Override
     public BigDecimal getDecimal() {
-        return null;
+        return (BigDecimal) fieldData;
     }
 
     @Override

--- a/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionsTableScanner.java
+++ b/java-extensions/iceberg-metadata-reader/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionsTableScanner.java
@@ -168,7 +168,8 @@ public class IcebergPartitionsTableScanner extends AbstractIcebergMetadataScanne
                 int pos = fieldIdToPos.get(fieldId);
                 Type fieldType = partitionData.getType(pos);
                 Object partitionValue = partitionData.get(pos);
-                if (partitionField.transform().isIdentity() && Types.TimestampType.withZone().equals(fieldType)) {
+                if (partitionValue != null && partitionField.transform().isIdentity()
+                        && Types.TimestampType.withZone().equals(fieldType)) {
                     partitionValue = ((long) partitionValue) / 1000;
                 }
                 reusedRecord.setField(name, partitionValue);

--- a/java-extensions/iceberg-metadata-reader/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataColumnValueTest.java
+++ b/java-extensions/iceberg-metadata-reader/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataColumnValueTest.java
@@ -1,0 +1,50 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import com.starrocks.jni.connector.ColumnValue;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class IcebergMetadataColumnValueTest {
+
+    @Test
+    public void testUnpackDecimalPartitionValues() {
+        Types.StructType partitionType = Types.StructType.of(
+                Types.NestedField.optional(1000, "d_trunc", Types.DecimalType.of(18, 4)),
+                Types.NestedField.optional(1001, "d_null", Types.DecimalType.of(18, 4)));
+        GenericRecord record = GenericRecord.create(partitionType);
+        record.setField("d_trunc", new BigDecimal("123.4500"));
+        record.setField("d_null", null);
+
+        List<ColumnValue> values = new ArrayList<>();
+        new IcebergMetadataColumnValue(record).unpackStruct(Arrays.asList(0, 1), values);
+
+        Assertions.assertEquals(2, values.size());
+        // A non-null decimal partition value must round-trip. Returning null here is what blows up
+        // as an NPE in OffHeapColumnVector.putDecimal.
+        Assertions.assertNotNull(values.get(0));
+        Assertions.assertEquals(new BigDecimal("123.4500"), values.get(0).getDecimal());
+        // A NULL partition value is represented by a null ColumnValue, which appendValue turns into appendNull.
+        Assertions.assertNull(values.get(1));
+    }
+}

--- a/java-extensions/iceberg-metadata-reader/src/test/java/com/starrocks/connector/iceberg/IcebergPartitionsTableScannerTest.java
+++ b/java-extensions/iceberg-metadata-reader/src/test/java/com/starrocks/connector/iceberg/IcebergPartitionsTableScannerTest.java
@@ -1,0 +1,79 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import org.apache.iceberg.PartitionData;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+public class IcebergPartitionsTableScannerTest {
+    private static final Schema SCHEMA =
+            new Schema(Types.NestedField.optional(1, "ts", Types.TimestampType.withZone()));
+
+    private static IcebergPartitionsTableScanner scannerFor(PartitionSpec spec) throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("required_fields", "partition_value");
+        params.put("metadata_column_names", "partition_value");
+        params.put("metadata_column_types", "struct<ts:datetime>");
+        params.put("serialized_table", "");
+        params.put("split_info", "");
+        IcebergPartitionsTableScanner scanner = new IcebergPartitionsTableScanner(4096, params);
+
+        // doOpen() needs a real deserialized table, so seed the state it would have produced instead.
+        setField(scanner, "schema", SCHEMA);
+        setField(scanner, "partitionFields", spec.fields());
+        setField(scanner, "reusedRecord", GenericRecord.create(spec.partitionType()));
+        return scanner;
+    }
+
+    private static void setField(Object target, String name, Object value) throws Exception {
+        Field field = IcebergPartitionsTableScanner.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static Object partitionValuesOf(IcebergPartitionsTableScanner scanner, PartitionData data) throws Exception {
+        Method method = IcebergPartitionsTableScanner.class
+                .getDeclaredMethod("getPartitionValues", PartitionData.class);
+        method.setAccessible(true);
+        return method.invoke(scanner, data);
+    }
+
+    @Test
+    public void testIdentityTimestampTzPartitionValues() throws Exception {
+        PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("ts").build();
+        PartitionData data = new PartitionData(spec.partitionType());
+
+        // A NULL timestamptz partition value must stay NULL. Unboxing it blows up before the value
+        // ever reaches the column vector.
+        data.set(0, null);
+        GenericRecord nullRecord = (GenericRecord) partitionValuesOf(scannerFor(spec), data);
+        Assertions.assertNull(nullRecord.getField("ts"));
+
+        // A non-null timestamptz partition value is still converted from micros to millis.
+        data.set(0, 1786000000123456L);
+        GenericRecord record = (GenericRecord) partitionValuesOf(scannerFor(spec), data);
+        Assertions.assertEquals(1786000000123L, record.getField("ts"));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

`SELECT ... FROM <iceberg_table>$partitions` fails with a `NullPointerException` from the JNI scanner whenever the table has a DECIMAL partition field, so the `$partitions` metadata table is unusable on those tables. Two independent defects produce it.

First, `IcebergMetadataColumnValue.getDecimal()` is a stub that always returns `null`. Every other `ColumnValue` implementation (`Hive`, `Hudi`, `Paimon`, `Odps`, `Kudu`, `Fluss`) returns the real value; only this one returns a constant, so `OffHeapColumnVector.putDecimal()` dereferences null:

```
Caused by: java.lang.NullPointerException: Cannot invoke "java.math.BigDecimal.setScale(int, java.math.RoundingMode)" because "value" is null
	at com.starrocks.jni.connector.OffHeapColumnVector.putDecimal(OffHeapColumnVector.java:358)
	at com.starrocks.jni.connector.OffHeapColumnVector.appendDecimal(OffHeapColumnVector.java:352)
	at com.starrocks.jni.connector.OffHeapColumnVector.appendStruct(OffHeapColumnVector.java:468)
	at com.starrocks.connector.iceberg.IcebergPartitionsTableScanner.doGetNext(IcebergPartitionsTableScanner.java:85)
```

This triggers on **non-null** decimal partition values, not on NULL ones. `unpackStruct()` already maps a null raw value to a null `ColumnValue` and `appendValue()` short-circuits that to `appendNull()`, so a table whose decimal partition values are all NULL reads fine while a table with no NULLs at all fails on every row. Null-checking `putDecimal()` would therefore not fix anything and would silently report a real partition value such as `123.4500` as `NULL`.

Second, the identity-`timestamptz` conversion in `IcebergPartitionsTableScanner.getPartitionValues()` unboxes a possibly-null value, which runs before that null-safe path:

```java
Object partitionValue = partitionData.get(pos);
if (partitionField.transform().isIdentity() && Types.TimestampType.withZone().equals(fieldType)) {
    partitionValue = ((long) partitionValue) / 1000;   // NPE when the partition value is NULL
}
```

```
Caused by: java.lang.NullPointerException: Cannot invoke "java.lang.Long.longValue()" because "partitionValue" is null
	at com.starrocks.connector.iceberg.IcebergPartitionsTableScanner.getPartitionValues(IcebergPartitionsTableScanner.java:172)
```

Only `$partitions` is affected: `$files`, `$manifests`, `$snapshots`, `$history`, `$refs` and `$metadata_log_entries` do not project the partition struct, and their bounds columns are already converted to strings.

## What I'm doing:

Fixes StarRocks/StarRocksTest#11649

Return the underlying `BigDecimal` from `IcebergMetadataColumnValue.getDecimal()` — `Type.TypeID.DECIMAL.javaClass()` is `java.math.BigDecimal`, and the FE maps an Iceberg `decimal(p, s)` partition field to a StarRocks DECIMAL of the same precision and scale, so `putDecimal()`'s `setScale(scale, UNNECESSARY)` is exact. And skip the identity-`timestamptz` micros-to-millis conversion when the partition value is NULL, leaving it for the null-safe column-vector path.

Added unit tests for both: a non-null decimal partition value must round-trip through `unpackStruct()`, and an identity-`timestamptz` partition struct must keep a NULL value NULL while still converting a non-null one. Both fail on the current code with the exact exceptions above.

Verified manually on a 1 FE + 1 BE cluster against a Hive-metastore Iceberg catalog, covering `truncate(decimal)`, `identity(decimal)` and `identity(timestamptz)` partitioning with mixed, all-NULL and no-NULL partition values plus an INT-partitioned control table. Before, the decimal cases and the NULL-`timestamptz` case raised the NPEs above on every run; after, all cases return rows with real values (`123.4500`, `777.8800`, `2026-08-13 10:00:00`) and `null` only for genuinely NULL partition values, every metadata table on every test table stays readable, and normal data queries are unchanged. Reaching the `timestamptz` path needs a table written by another engine, since StarRocks maps `DATETIME` to Iceberg `timestamp without zone`; Spark 4.0 with Iceberg 1.10 was used for that.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: `SELECT ... FROM <table>$partitions` now succeeds where it previously failed, and decimal partition values are shown with their real value.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
