### PR TITLE
[Enhancement] Auto-materialize CTE when inlining would bloat the scalar expression

### DIFF
--- a/docs/en/sql-reference/System_variable.md
+++ b/docs/en/sql-reference/System_variable.md
@@ -287,6 +287,14 @@ Used for MySQL client compatibility. No practical usage.
 * **Data Type**: int
 * **Introduced in**: v3.5.3
 
+### cbo_cte_force_reuse_inlined_node_count
+
+* **Description**: Session-scoped threshold that lets the optimizer automatically materialize a Common Table Expression (CTE) instead of inlining it when inlining would blow up its scalar expression. In RelationTransformer.buildCTEAnchorAndProducer, for a CTE that would otherwise be inlined, the planner estimates the size of its output expression **after inlining** — expanding every un-materialized CTE it references (cascaded), while a materialized CTE or a base column counts as a single node. If that estimated inlined node count is greater than this threshold and the threshold is greater than `0`, the CTE is force-materialized. This turns the `Expression too complex` failure of deeply nested CTE chains into a bounded materialization, without any manual `[materialized]` hint. Set it below `max_scalar_operator_flat_children`. Setting the value to `0` disables this optimization.
+* **Scope**: Session
+* **Default**: `0`
+* **Data Type**: int
+* **Introduced in**: -
+
 ### cbo_cte_reuse
 
 * **Description**: Controls whether the optimizer may rewrite multi-distinct aggregate queries by reusing a Common Table Expression (CTE) (the CBO CTE‑reuse rewrite). When enabled, the planner (RewriteMultiDistinctRule) may choose a CTE-based rewrite for multi-column distincts, skewed aggregations, or when statistics indicate the CTE rewrite is more efficient; it also respects the `prefer_cte_rewrite` hint. When disabled, CTE-based rewrite is not allowed and the planner will attempt the multi-function rewrite; if a query requires CTE (for example, multi-column DISTINCT or functions that cannot be handled by multi-function rewrite) the planner will raise a user error. Note: the effective setting checked by the optimizer is the logical AND of this flag and the pipeline engine flag — i.e. `isCboCteReuse()` returns this variable AND `enablePipelineEngine`, so CTE reuse is only effective when `enablePipelineEngine` is on.

--- a/docs/zh/sql-reference/System_variable.md
+++ b/docs/zh/sql-reference/System_variable.md
@@ -270,6 +270,14 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 * **数据类型**: int
 * **引入版本**: v3.5.3
 
+### cbo_cte_force_reuse_inlined_node_count
+
+* **描述**: 会话级阈值。当内联某个公用表表达式（CTE）会导致其标量表达式膨胀时，让优化器自动改为物化该 CTE 而不是内联。在 RelationTransformer.buildCTEAnchorAndProducer 中，对于本应被内联的 CTE，规划器会预估其内联**展开后**的输出表达式大小——递归展开它引用的每一个未物化 CTE（级联），而已物化的 CTE 或基表列各记为一个节点。如果该预估的内联节点数大于此阈值且阈值大于 `0`，则强制物化该 CTE。这样可以把深层嵌套 CTE 链的 `Expression too complex` 报错转化为一次有界的物化，且无需手动添加 `[materialized]` hint。该值应设置为小于 `max_scalar_operator_flat_children`。将该值设置为 `0` 可禁用此优化。
+* **范围**: Session
+* **默认值**: `0`
+* **数据类型**: int
+* **引入版本**: -
+
 ### cbo_cte_reuse
 
 * **描述**: 控制优化器是否可以通过重用 Common Table Expression (CTE) 重写 multi-distinct 聚合查询（CBO 的 CTE‑reuse 重写）。启用时，Planner ）可能会为多列 DISTINCT、偏斜聚合或当统计信息表明 CTE 重写更高效时选择基于 CTE 的重写；此配置项也会尊重 `prefer_cte_rewrite` hint。禁用时，不允许基于 CTE 的重写，Planner 将尝试 multi-function 重写；如果查询需要 CTE（例如，多列 DISTINCT 或 multi-function 重写无法处理的函数），Planner 将抛出错误。注意：只有在 Pipeline Engine 打开时 CTE 重用才生效。

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -522,6 +522,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CBO_CTE_REUSE_RATE_V2 = "cbo_cte_reuse_rate_v2";
     public static final String PREFER_CTE_REWRITE = "prefer_cte_rewrite";
     public static final String CBO_CTE_FORCE_REUSE_NODE_COUNT = "cbo_cte_force_reuse_node_count";
+    public static final String CBO_CTE_FORCE_REUSE_INLINED_NODE_COUNT = "cbo_cte_force_reuse_inlined_node_count";
     public static final String CBO_CTE_FORCE_REUSE_LIMIT_WITHOUT_ORDER_BY =
             "cbo_cte_force_reuse_limit_without_order_by";
     public static final String ENABLE_SQL_DIGEST = "enable_sql_digest";
@@ -1593,6 +1594,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // When the value is 0, disable the force reuse optimization.
     @VarAttr(name = CBO_CTE_FORCE_REUSE_NODE_COUNT)
     private int cboCTEForceReuseNodeCount = 2000;
+
+    // If inlining a CTE would expand its output expression to more than this many scalar nodes
+    // (counting the cascaded expansion of every un-materialized CTE it references), force
+    // materialization of that CTE instead. This is a Calcite-bloat-style node-count cap that turns
+    // the "Expression too complex" blow-up of nested CTE chains into a bounded materialization.
+    // Should be set below max_scalar_operator_flat_children. When 0, this optimization is disabled.
+    @VarAttr(name = CBO_CTE_FORCE_REUSE_INLINED_NODE_COUNT)
+    private int cboCTEForceReuseInlinedNodeCount = 0;
 
     // If true, force CTE reuse when CTE contains LIMIT without ORDER BY to avoid unstable results.
     // When false, allow inline even if CTE has LIMIT without ORDER BY (may cause inconsistent results).
@@ -3795,6 +3804,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public int getCboCTEForceReuseNodeCount() {
         return cboCTEForceReuseNodeCount;
+    }
+
+    public int getCboCTEForceReuseInlinedNodeCount() {
+        return cboCTEForceReuseInlinedNodeCount;
+    }
+
+    public void setCboCTEForceReuseInlinedNodeCount(int cboCTEForceReuseInlinedNodeCount) {
+        this.cboCTEForceReuseInlinedNodeCount = cboCTEForceReuseInlinedNodeCount;
     }
 
     public void setCboCTEForceReuseNodeCount(int cboCTEForceReuseNodeCount) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/CTETransformerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/CTETransformerContext.java
@@ -123,4 +123,41 @@ public class CTETransformerContext {
     public boolean isForceCTE(int cteId) {
         return forceCTEList.contains(cteId);
     }
+
+    // Snapshot all mutable state so a speculative "peek" transform whose result is discarded can be
+    // rolled back (see RelationTransformer.buildCTEAnchorAndProducer). A discarded peek must not leave
+    // its CTE registrations behind: cteRefIdMapping.size() feeds isForceInline(), so leftover
+    // registrations would drift the inline/reuse decision of later CTEs.
+    public Memento save() {
+        return new Memento(cteExpressions, cteRefIdMapping, cteIdToNodeCount, uniqueId.get(), forceCTEList);
+    }
+
+    public void restore(Memento memento) {
+        cteExpressions.clear();
+        cteExpressions.putAll(memento.cteExpressions);
+        cteRefIdMapping.clear();
+        cteRefIdMapping.putAll(memento.cteRefIdMapping);
+        cteIdToNodeCount.clear();
+        cteIdToNodeCount.putAll(memento.cteIdToNodeCount);
+        uniqueId.set(memento.uniqueId);
+        forceCTEList.clear();
+        forceCTEList.addAll(memento.forceCTEList);
+    }
+
+    public static final class Memento {
+        private final Map<Integer, ExpressionMapping> cteExpressions;
+        private final Map<Integer, Integer> cteRefIdMapping;
+        private final Map<Integer, Integer> cteIdToNodeCount;
+        private final int uniqueId;
+        private final List<Integer> forceCTEList;
+
+        private Memento(Map<Integer, ExpressionMapping> cteExpressions, Map<Integer, Integer> cteRefIdMapping,
+                        Map<Integer, Integer> cteIdToNodeCount, int uniqueId, List<Integer> forceCTEList) {
+            this.cteExpressions = new HashMap<>(cteExpressions);
+            this.cteRefIdMapping = new HashMap<>(cteRefIdMapping);
+            this.cteIdToNodeCount = new HashMap<>(cteIdToNodeCount);
+            this.uniqueId = uniqueId;
+            this.forceCTEList = Lists.newArrayList(forceCTEList);
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DistributionInfo;
@@ -166,6 +167,7 @@ import java.util.stream.Collectors;
 
 import static com.starrocks.server.CatalogMgr.ResourceMappingCatalog.isResourceMappingCatalog;
 import static com.starrocks.sql.ast.CTERelation.CTEMaterializationHint.MATERIALIZED;
+import static com.starrocks.sql.ast.CTERelation.CTEMaterializationHint.NONE;
 import static com.starrocks.sql.common.ErrorType.INTERNAL_ERROR;
 import static com.starrocks.sql.common.UnsupportedException.unsupportedException;
 import static com.starrocks.sql.parser.ErrorMsgProxy.PARSER_ERROR_MSG;
@@ -221,7 +223,11 @@ public class RelationTransformer implements AstVisitorExtendInterface<LogicalPla
     public LogicalPlan transform(Relation relation) {
         if (relation instanceof QueryRelation && !((QueryRelation) relation).getCteRelations().isEmpty()) {
             QueryRelation queryRelation = (QueryRelation) relation;
-            if (queryRelation.getCteRelations().stream().noneMatch(c -> c.getRefs() > 1
+            // When cbo_cte_force_reuse_inlined_node_count is on, a single-referenced CTE may still be
+            // force-materialized to avoid inline bloat, so it must reach buildCTEAnchorAndProducer
+            // instead of being short-circuited to inline here.
+            boolean forceReuseByInlinedNode = session.getSessionVariable().getCboCTEForceReuseInlinedNodeCount() > 0;
+            if (!forceReuseByInlinedNode && queryRelation.getCteRelations().stream().noneMatch(c -> c.getRefs() > 1
                     || c.getMaterializationHint() == MATERIALIZED)) {
                 return visit(relation);
             }
@@ -256,20 +262,44 @@ public class RelationTransformer implements AstVisitorExtendInterface<LogicalPla
                 case NONE -> cteRelation.getRefs() <= 1
                         || (cteContext.isForceInline() && !cteContext.hasRegisteredCte(cteRelation.getCteMouldId()));
             };
-            if (shouldInline) {
+            // cbo_cte_force_reuse_inlined_node_count: a CTE that would be inlined is still worth
+            // materializing when inlining would blow up its scalar expression. Peek its producer and
+            // force reuse if the cascaded inlined size exceeds the threshold.
+            int forceReuseInlinedNodeCount = session.getSessionVariable().getCboCTEForceReuseInlinedNodeCount();
+            boolean peekForInlinedSize = shouldInline && cteRelation.getMaterializationHint() == NONE
+                    && forceReuseInlinedNodeCount > 0;
+            if (shouldInline && !peekForInlinedSize) {
                 continue;
             }
 
+            // Register the CTE BEFORE building the producer, exactly as the non-peek path always did,
+            // so cte-id allocation order is unchanged when the feature is off. When only peeking, take
+            // a snapshot first so a peek that decides to inline can be fully rolled back (it registers
+            // this CTE and any nested CTEs, which would otherwise drift isForceInline() for later CTEs).
+            CTETransformerContext.Memento memento = peekForInlinedSize ? cteContext.save() : null;
             int cteId = cteContext.registerCte(cteRelation.getCteMouldId());
-            if (cteRelation.getMaterializationHint() == MATERIALIZED) {
-                cteContext.addForceCTE(cteId);
-            }
             LogicalCTEAnchorOperator anchorOperator = new LogicalCTEAnchorOperator(cteId);
             LogicalCTEProduceOperator produceOperator = new LogicalCTEProduceOperator(cteId);
             LogicalPlan producerPlan =
                     new RelationTransformer(columnRefFactory, session,
                             new ExpressionMapping(new Scope(RelationId.anonymous(), new RelationFields())),
                             cteContext, mvTransformerContext).transform(cteRelation.getCteQueryStatement().getQueryRelation());
+
+            boolean forceMaterialize = cteRelation.getMaterializationHint() == MATERIALIZED;
+            if (peekForInlinedSize && estimateInlinedSize(producerPlan.getRootBuilder(),
+                    forceReuseInlinedNodeCount) > forceReuseInlinedNodeCount) {
+                forceMaterialize = true;
+                shouldInline = false;
+            }
+            if (shouldInline) {
+                // Peeked but the CTE is not expression-heavy; inline as usual: drop the producer and
+                // roll back the registration (and any nested registrations from the peek).
+                cteContext.restore(memento);
+                continue;
+            }
+            if (forceMaterialize) {
+                cteContext.addForceCTE(cteId);
+            }
             OptExprBuilder produceOptBuilder =
                     new OptExprBuilder(produceOperator, Lists.newArrayList(producerPlan.getRootBuilder()),
                             producerPlan.getRootBuilder().getExpressionMapping());
@@ -302,6 +332,70 @@ public class RelationTransformer implements AstVisitorExtendInterface<LogicalPla
         }
 
         return new Pair<>(root, anchorOptBuilder);
+    }
+
+    // Estimate the scalar node count of a CTE producer's output expression AFTER inlining -- i.e. with
+    // every un-materialized CTE it references expanded in place (cascaded). A materialized CTE (a
+    // CTEConsume leaf) or a base column is a leaf of weight 1, so the estimate is bounded by the
+    // materialization boundaries already chosen for lower CTEs. This is the "would inlining this CTE
+    // blow up?" signal, mirroring Calcite's node-count bloat budget but at the CTE-decision layer.
+    private int estimateInlinedSize(OptExprBuilder rootBuilder, int limit) {
+        Map<ColumnRefOperator, ScalarOperator> definitions = Maps.newHashMap();
+        collectColumnDefinitions(rootBuilder.getRoot(), definitions);
+        Operator rootOp = rootBuilder.getRoot().getOp();
+        Map<ColumnRefOperator, ScalarOperator> outputMap;
+        if (rootOp instanceof LogicalProjectOperator) {
+            outputMap = ((LogicalProjectOperator) rootOp).getColumnRefMap();
+        } else if (rootOp.getProjection() != null) {
+            outputMap = rootOp.getProjection().getColumnRefMap();
+        } else {
+            return 0;
+        }
+        int max = 0;
+        for (ScalarOperator expr : outputMap.values()) {
+            max = Math.max(max, expandedSize(expr, definitions, Sets.newHashSet(), limit));
+            if (max > limit) {
+                break;
+            }
+        }
+        return max;
+    }
+
+    // Collect column -> defining-expression across all projection layers in the producer subtree, so a
+    // column reference can be expanded into its definition. CTEConsume / scan output columns have no
+    // definition here and therefore stay leaves (materialization boundaries).
+    private void collectColumnDefinitions(OptExpression node, Map<ColumnRefOperator, ScalarOperator> definitions) {
+        Operator op = node.getOp();
+        if (op instanceof LogicalProjectOperator) {
+            definitions.putAll(((LogicalProjectOperator) op).getColumnRefMap());
+        } else if (op.getProjection() != null) {
+            definitions.putAll(op.getProjection().getColumnRefMap());
+        }
+        for (OptExpression child : node.getInputs()) {
+            collectColumnDefinitions(child, definitions);
+        }
+    }
+
+    private int expandedSize(ScalarOperator op, Map<ColumnRefOperator, ScalarOperator> definitions,
+                             Set<ColumnRefOperator> visiting, int limit) {
+        if (op instanceof ColumnRefOperator) {
+            ColumnRefOperator ref = (ColumnRefOperator) op;
+            ScalarOperator def = definitions.get(ref);
+            if (def == null || !visiting.add(ref)) {
+                return 1;
+            }
+            int size = expandedSize(def, definitions, visiting, limit);
+            visiting.remove(ref);
+            return size;
+        }
+        int size = 1;
+        for (ScalarOperator child : op.getChildren()) {
+            size += expandedSize(child, definitions, visiting, limit);
+            if (size > limit) {
+                break;
+            }
+        }
+        return size;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/OperatorMaxFlatChildTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/OperatorMaxFlatChildTest.java
@@ -86,4 +86,79 @@ public class OperatorMaxFlatChildTest extends PlanTestBase {
         });
     }
 
+    // A 2-layer single-referenced CTE chain reproducing "Expression too complex": each layer's CASE
+    // WHEN references the previous column 7 times, so inlining c1 into c2 multiplies the node count
+    // (~20 -> ~153). Single-referenced CTEs are inlined, then MergeTwoProjectRule collapses the
+    // projects and ReplaceColumnRefRewriter clones the expression per reference, tripping the limit.
+    @Test
+    public void testNestedCteExpressionBloat() throws Exception {
+        final int prev = Config.max_scalar_operator_flat_children;
+        Config.max_scalar_operator_flat_children = 100;
+        try {
+            String sql =
+                    "WITH \n" +
+                    "  c1 AS (SELECT CASE WHEN t1c = 1 THEN t1c + 1 WHEN t1c = 2 THEN t1c + 2 " +
+                    "                     WHEN t1c = 3 THEN t1c + 3 ELSE t1c END AS x FROM test_all_type),\n" +
+                    "  c2 AS (SELECT CASE WHEN x = 11 THEN x + 11 WHEN x = 22 THEN x + 22 " +
+                    "                     WHEN x = 33 THEN x + 33 ELSE x END AS x FROM c1)\n" +
+                    "SELECT x FROM c2";
+            assertThrows(SemanticException.class, () -> getFragmentPlan(sql));
+        } finally {
+            Config.max_scalar_operator_flat_children = prev;
+        }
+    }
+
+    // Same 2-layer chain, but c1 carries a [materialized] hint, so RelationTransformer materializes it
+    // (buildCTEAnchorAndProducer + addForceCTE) instead of inlining. c2 then references c1's output
+    // column (1 node) rather than inlining c1's CASE WHEN, so there is no project-merge bloat: at
+    // limit = 100 it does not throw and the plan shows a MultiCastDataSinks producer -- also confirming
+    // a single-referenced forced CTE survives the optimizer's inline rules.
+    @Test
+    public void testNestedCteMaterializedHintNoBloat() throws Exception {
+        final int prev = Config.max_scalar_operator_flat_children;
+        Config.max_scalar_operator_flat_children = 100;   // same tiny limit as the inline case
+        try {
+            String sql =
+                    "WITH \n" +
+                    "  c1 AS (SELECT CASE WHEN t1c = 1 THEN t1c + 1 WHEN t1c = 2 THEN t1c + 2 " +
+                    "                     WHEN t1c = 3 THEN t1c + 3 ELSE t1c END AS x FROM test_all_type) [materialized],\n" +
+                    "  c2 AS (SELECT CASE WHEN x = 11 THEN x + 11 WHEN x = 22 THEN x + 22 " +
+                    "                     WHEN x = 33 THEN x + 33 ELSE x END AS x FROM c1)\n" +
+                    "SELECT x FROM c2";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "MultiCastDataSinks");
+        } finally {
+            Config.max_scalar_operator_flat_children = prev;
+        }
+    }
+
+    // C.2 auto fix (cascading): with cbo_cte_force_reuse_inlined_node_count on, the nested-CTE chain
+    // that would blow up (each layer's CASE WHEN references the previous column 7 times, so the
+    // inlined size cascades 20 -> 153 -> 1084) is auto-materialized in RelationTransformer -- no hint.
+    // The estimator materializes c2 (its inlined size 153 > 100), which caps c3 back to ~20; nothing
+    // exceeds the 200 flat-children limit and the plan shows MultiCastDataSinks.
+    @Test
+    public void testNestedCteAutoForceReuseByInlinedNodeCount() throws Exception {
+        final int prevLimit = Config.max_scalar_operator_flat_children;
+        final int prevThreshold = connectContext.getSessionVariable().getCboCTEForceReuseInlinedNodeCount();
+        Config.max_scalar_operator_flat_children = 200;
+        connectContext.getSessionVariable().setCboCTEForceReuseInlinedNodeCount(100);
+        try {
+            String sql =
+                    "WITH \n" +
+                    "  c1 AS (SELECT CASE WHEN t1c = 1 THEN t1c + 1 WHEN t1c = 2 THEN t1c + 2 " +
+                    "                     WHEN t1c = 3 THEN t1c + 3 ELSE t1c END AS x FROM test_all_type),\n" +
+                    "  c2 AS (SELECT CASE WHEN x = 11 THEN x + 11 WHEN x = 22 THEN x + 22 " +
+                    "                     WHEN x = 33 THEN x + 33 ELSE x END AS x FROM c1),\n" +
+                    "  c3 AS (SELECT CASE WHEN x = 44 THEN x + 44 WHEN x = 55 THEN x + 55 " +
+                    "                     WHEN x = 66 THEN x + 66 ELSE x END AS x FROM c2)\n" +
+                    "SELECT x FROM c3";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "MultiCastDataSinks");
+        } finally {
+            Config.max_scalar_operator_flat_children = prevLimit;
+            connectContext.getSessionVariable().setCboCTEForceReuseInlinedNodeCount(prevThreshold);
+        }
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/transformer/CTETransformerContextTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/transformer/CTETransformerContextTest.java
@@ -1,0 +1,55 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.transformer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CTETransformerContextTest {
+
+    // save()/restore() must roll back every mutable structure so a discarded speculative "peek"
+    // transform (RelationTransformer.buildCTEAnchorAndProducer) leaves no registrations behind --
+    // otherwise cteRefIdMapping.size() would drift isForceInline() for later CTEs.
+    @Test
+    public void testSaveRestoreRollsBackRegistrations() {
+        CTETransformerContext ctx = new CTETransformerContext(10);
+        ctx.registerCte(1);
+
+        CTETransformerContext.Memento memento = ctx.save();
+
+        // Mutate everything a peek could touch.
+        int id2 = ctx.registerCte(2);
+        ctx.addForceCTE(id2);
+        ctx.recordCteNodeCount(id2, 42);
+        assertTrue(ctx.hasRegisteredCte(2));
+        assertTrue(ctx.isForceCTE(id2));
+
+        ctx.restore(memento);
+
+        // Everything after the snapshot is rolled back; everything before it survives.
+        assertTrue(ctx.hasRegisteredCte(1));
+        assertFalse(ctx.hasRegisteredCte(2));
+        assertFalse(ctx.isForceCTE(id2));
+        assertNull(ctx.getCteNodeCount(id2));
+
+        // uniqueId is restored too, so the next registration reuses the rolled-back id.
+        int id3 = ctx.registerCte(3);
+        assertEquals(id2, id3);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Nested/chained CTEs with complex `CASE WHEN` can hit `Expression too complex` (or FE OOM):
single-referenced CTEs are inlined, and `MergeTwoProjectRule` clones the referenced expression
per column reference, so the scalar-expression node count multiplies across layers
(e.g. ~20 -> ~153 -> ~1084 -> ... at ~7x per layer).

## What I'm doing:

Add session variable `cbo_cte_force_reuse_inlined_node_count` (default `0` = off). When `> 0`,
`RelationTransformer.buildCTEAnchorAndProducer` peeks a would-be-inlined CTE producer and, if the
estimated inlined size exceeds the threshold, force-materializes the CTE instead. The estimate is
cascaded: un-materialized referenced CTEs are expanded in place, while a materialized CTE (a
`CTEConsume` leaf) or a base column counts as a single node, so it captures the multiplicative
blow-up while stopping at existing materialization boundaries (with an early-exit at the threshold).

The decision is made at the CTE creation entry point (`RelationTransformer`), reusing the normal
force-CTE path, so no RBO rule is touched. A discarded peek is rolled back via a
`CTETransformerContext` snapshot/restore, and registration order is preserved, so behavior is
byte-identical when the feature is off (the default).

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

The default value `0` disables the optimization and keeps the current behavior byte-for-byte;
the new behavior is strictly opt-in.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr