### PR TITLE
[BugFix] Apply a cross-published del file only to the keys the child owns

### DIFF
--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -18,7 +18,9 @@
 #include "base/phmap/phmap.h"
 #include "base/time/time.h"
 #include "base/utility/defer_op.h"
+#include "column/binary_column.h"
 #include "column/chunk_factory.h"
+#include "column/column_helper.h"
 #include "column/raw_data_visitor.h"
 #include "column/serde/column_array_serde.h"
 #include "common/stack_util.h"
@@ -37,7 +39,6 @@
 #include "storage/lake/update_manager.h"
 #include "storage/lake/vector_index_utils.h"
 #include "storage/olap_common.h"
-#include "storage/primary_index.h"
 #include "storage/rowset/segment_rewriter.h"
 #include "storage/rowset/segment_writer.h"
 #include "storage/tablet_schema.h"
@@ -918,31 +919,65 @@ static Status clip_deletes_to_tablet_range(const RowsetUpdateStateParams& params
         return Status::OK();
     }
 
+    // Resolve a per-key accessor WITHOUT materializing a Slice array. Building one (e.g. via
+    // PrimaryIndex::build_persistent_keys) would cost ~16 bytes per key on top of the already-resident
+    // decoded column -- ~160 MB for a 10M-key delete -- and would not be counted in _memory_usage. That
+    // is worst exactly on the large-delete path, whose prebuilt tombstone sstable exists to bound
+    // publish memory in the first place.
     const size_t num_keys = deletes->size();
-    Buffer<Slice> key_slices;
-    key_slices.reserve(num_keys);
-    // A non-binary PK column is fixed width, so every key is type_size() bytes; build_persistent_keys
-    // ignores the size argument for the binary case.
-    ASSIGN_OR_RETURN(const Slice* keys,
-                     PrimaryIndex::build_persistent_keys(*deletes, deletes->type_size(), 0, num_keys, &key_slices));
+    const Column* data_column = ColumnHelper::get_data_column(deletes);
+    const LargeBinaryColumn* large_binary_column = nullptr;
+    const BinaryColumn* binary_column = nullptr;
+    const uint8_t* fixed_width_data = nullptr;
+    size_t fixed_width_key_size = 0;
+    if (data_column->is_large_binary()) {
+        large_binary_column = down_cast<const LargeBinaryColumn*>(data_column);
+    } else if (data_column->is_binary()) {
+        binary_column = down_cast<const BinaryColumn*>(data_column);
+    } else {
+        // A non-binary PK column is fixed width: keys sit back to back, type_size() bytes each.
+        RawDataVisitor visitor;
+        RETURN_IF_ERROR(data_column->accept(&visitor));
+        fixed_width_data = visitor.result();
+        fixed_width_key_size = data_column->type_size();
+    }
+    auto key_at = [&](size_t i) -> Slice {
+        if (large_binary_column != nullptr) {
+            return large_binary_column->get_slice(i);
+        }
+        if (binary_column != nullptr) {
+            return binary_column->get_slice(i);
+        }
+        return Slice(fixed_width_data + i * fixed_width_key_size, fixed_width_key_size);
+    };
 
     const Slice lower(seek_range.seek_key);
     const Slice upper(seek_range.stop_key);
-    Filter selection(num_keys, 1);
-    size_t num_kept = 0;
+    // The selection buffer is allocated lazily, on the first out-of-range key. A tablet whose del file
+    // is entirely inside its own range -- every non-split tablet, and any child that owns all the keys
+    // it was handed -- therefore pays no allocation at all, only the comparisons.
+    Filter selection;
+    size_t num_dropped = 0;
     for (size_t i = 0; i < num_keys; i++) {
+        const Slice key = key_at(i);
         // [seek_key, stop_key): lower inclusive, upper exclusive (see SstSeekRange).
-        const bool in_range = (seek_range.seek_key.empty() || keys[i].compare(lower) >= 0) &&
-                              (seek_range.stop_key.empty() || keys[i].compare(upper) < 0);
-        selection[i] = in_range ? 1 : 0;
-        num_kept += in_range ? 1 : 0;
+        const bool in_range = (seek_range.seek_key.empty() || key.compare(lower) >= 0) &&
+                              (seek_range.stop_key.empty() || key.compare(upper) < 0);
+        if (in_range) {
+            continue;
+        }
+        if (selection.empty()) {
+            selection.assign(num_keys, 1);
+        }
+        selection[i] = 0;
+        ++num_dropped;
     }
-    if (num_kept == num_keys) {
-        // Nothing to drop: leave the column untouched so the common (non-split) case pays no copy.
+    if (num_dropped == 0) {
+        // Nothing to drop: no selection buffer was ever allocated, and the column is untouched.
         return Status::OK();
     }
     deletes->filter(selection);
-    VLOG(2) << "clip_deletes_to_tablet_range tablet:" << params.metadata->id() << " kept " << num_kept << " of "
+    VLOG(2) << "clip_deletes_to_tablet_range tablet:" << params.metadata->id() << " dropped " << num_dropped << " of "
             << num_keys << " delete keys";
     return Status::OK();
 }

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -33,9 +33,11 @@
 #include "storage/lake/location_provider.h"
 #include "storage/lake/meta_file.h"
 #include "storage/lake/rowset.h"
+#include "storage/lake/tablet_range_helper.h"
 #include "storage/lake/update_manager.h"
 #include "storage/lake/vector_index_utils.h"
 #include "storage/olap_common.h"
+#include "storage/primary_index.h"
 #include "storage/rowset/segment_rewriter.h"
 #include "storage/rowset/segment_writer.h"
 #include "storage/tablet_schema.h"
@@ -876,6 +878,75 @@ Status RowsetUpdateState::prepare(const RowsetUpdateStateParams& params) {
     return Status::OK();
 }
 
+// Drop the delete keys that fall outside this tablet's key range.
+//
+// A del file is cross-published verbatim to every SPLIT child: each child reads the SAME parent del
+// file and erases every key in it from its OWN primary index. The upsert side does not have this
+// problem because it is clipped at read time -- convert_txn_log_for_splitting stamps this tablet's
+// range onto op_write.rowset, and get_each_segment_iterator turns it into
+// SegmentReadOptions::tablet_range, which _apply_tablet_range resolves to a rowid range via the
+// short key index so out-of-range rows are never even read. A del file is a flat serialized PK
+// column with no index and no guaranteed key order, so it gets no such pruning and every child sees
+// every key.
+//
+// Erasing a key it does not own is not merely wasted work: the child's primary index still carries
+// the ancestor entries inherited through its shared sstables (the tablet-range gate on those runs
+// only in LakePersistentIndex::merge_sstables, i.e. at sstable compaction time), so the lookup can
+// SUCCEED and hand back a location in a rowset the split pruned away from this child. That rssid
+// then reaches MetaFileBuilder::update_num_del_stat, which finds no such rowset and fails the
+// publish with "unexpected segment id: <rssid> tablet id: <child>" -- permanently, since the load
+// txn is retried forever and the SPLIT job's CLEANING waits on it.
+//
+// Dropping them is correct, not just safe: a key outside this tablet's range belongs to a sibling by
+// definition, the same del file is cross-published to that sibling, and the sibling erases it from
+// its own index. Each child erasing only its own slice is exactly what the upsert side already does.
+//
+// Costs nothing extra in I/O: the caller has already read and decoded the whole del file, so this is
+// one pass over an in-memory column. Byte comparison is valid because create_sst_seek_range_from
+// encodes the bounds with the same PrimaryKeyEncoder and pkey_schema used to materialize this column,
+// and requires PK_ENCODING_TYPE_V2 (big-endian, order preserving) for range-distribution tables.
+static Status clip_deletes_to_tablet_range(const RowsetUpdateStateParams& params, Column* deletes) {
+    // No tablet range at all => not a range-distribution tablet, nothing to clip against.
+    if (!params.metadata->has_range() || deletes->empty()) {
+        return Status::OK();
+    }
+    ASSIGN_OR_RETURN(auto seek_range,
+                     TabletRangeHelper::create_sst_seek_range_from(params.metadata->range(), params.tablet_schema));
+    // Both bounds empty means (-inf, +inf): every key belongs here. Mirrors SeekRange::all_range()'s
+    // short-circuit in SegmentIterator::_apply_tablet_range.
+    if (seek_range.seek_key.empty() && seek_range.stop_key.empty()) {
+        return Status::OK();
+    }
+
+    const size_t num_keys = deletes->size();
+    Buffer<Slice> key_slices;
+    key_slices.reserve(num_keys);
+    // A non-binary PK column is fixed width, so every key is type_size() bytes; build_persistent_keys
+    // ignores the size argument for the binary case.
+    ASSIGN_OR_RETURN(const Slice* keys,
+                     PrimaryIndex::build_persistent_keys(*deletes, deletes->type_size(), 0, num_keys, &key_slices));
+
+    const Slice lower(seek_range.seek_key);
+    const Slice upper(seek_range.stop_key);
+    Filter selection(num_keys, 1);
+    size_t num_kept = 0;
+    for (size_t i = 0; i < num_keys; i++) {
+        // [seek_key, stop_key): lower inclusive, upper exclusive (see SstSeekRange).
+        const bool in_range = (seek_range.seek_key.empty() || keys[i].compare(lower) >= 0) &&
+                              (seek_range.stop_key.empty() || keys[i].compare(upper) < 0);
+        selection[i] = in_range ? 1 : 0;
+        num_kept += in_range ? 1 : 0;
+    }
+    if (num_kept == num_keys) {
+        // Nothing to drop: leave the column untouched so the common (non-split) case pays no copy.
+        return Status::OK();
+    }
+    deletes->filter(selection);
+    VLOG(2) << "clip_deletes_to_tablet_range tablet:" << params.metadata->id() << " kept " << num_kept << " of "
+            << num_keys << " delete keys";
+    return Status::OK();
+}
+
 Status RowsetUpdateState::load_delete(uint32_t del_id, const RowsetUpdateStateParams& params) {
     CHECK_MEM_LIMIT("RowsetUpdateState::load_delete");
     // always one file for now.
@@ -915,6 +986,9 @@ Status RowsetUpdateState::load_delete(uint32_t del_id, const RowsetUpdateStatePa
     const auto* begin = reinterpret_cast<const uint8_t*>(read_buffer.data());
     const auto* end = begin + read_buffer.size();
     RETURN_IF_ERROR(Serd::deserialize(begin, end, col.get()));
+    // Clip before accounting memory, so a heavily-pruned SPLIT child only holds its own slice of the
+    // parent's del file rather than the whole thing.
+    RETURN_IF_ERROR(clip_deletes_to_tablet_range(params, col.get()));
     _memory_usage += col->memory_usage();
     _deletes[del_id] = std::move(col);
     TRACE("end read $0-th deletes files", del_id);

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -39,6 +39,7 @@
 #include "fs/fs_util.h"
 #include "platform/key_cache.h"
 #include "storage/chunk_helper.h"
+#include "storage/datum_variant.h"
 #include "storage/del_vector.h"
 #include "storage/lake/compaction_policy.h"
 #include "storage/lake/compaction_task.h"
@@ -58,6 +59,8 @@
 #include "storage/rowset/segment_writer.h"
 #include "storage/storage_env.h"
 #include "storage/tablet_schema.h"
+#include "storage/types.h"
+#include "storage/variant_tuple.h"
 #include "testutil/chunk_assert.h"
 
 namespace starrocks::lake {
@@ -873,6 +876,76 @@ TEST_P(LakePrimaryKeyPublishTest, test_spill_delete_only_removes_keys) {
     ASSERT_EQ(n, read_rows(tablet_id, 2));
     write_one_txn(3, make_op_chunk(n, /*value_shift=*/0, /*upsert=*/false, _slot_cid_map));
     ASSERT_EQ(0, read_rows(tablet_id, 3));
+}
+
+// A del file is cross-published verbatim to every SPLIT child, so a child must erase only the keys
+// inside its own tablet range. The upsert side is clipped at read time (tablet_range -> short key
+// index -> rowid range); the del file has no index and no guaranteed key order, so publish clips it
+// explicitly in RowsetUpdateState::load_delete.
+//
+// Regression for "unexpected segment id: <rssid> tablet id: <child>": erasing a key it does not own
+// makes the child look that key up in its own primary index, which still carries the ancestor
+// entries inherited via shared sstables, so the lookup can succeed and return a location in a rowset
+// the split pruned away -- and MetaFileBuilder::update_num_del_stat then fails the publish forever.
+//
+// Here the tablet range covers only the lower half of the keys, so a delete of ALL keys must remove
+// exactly the in-range half and leave the rest untouched.
+TEST_P(LakePrimaryKeyPublishTest, test_publish_clips_deletes_to_tablet_range) {
+    if (GetParam().enable_transparent_data_encryption) {
+        return;
+    }
+    const int n = kChunkSize;
+    const int kRangeUpperExclusive = n / 2;
+
+    // Range distribution requires the order-preserving big-endian PK encoding; create_sst_seek_range_from
+    // rejects anything else.
+    _tablet_metadata->mutable_schema()->set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
+    // Tablet owns [0, n/2): a delete of every key may only take effect on that half.
+    auto* range_pb = _tablet_metadata->mutable_range();
+    {
+        DatumVariant upper(get_type_info(LogicalType::TYPE_INT), Datum(kRangeUpperExclusive));
+        VariantTuple tuple;
+        tuple.append(upper);
+        tuple.to_proto(range_pb->mutable_upper_bound());
+        range_pb->set_upper_bound_included(false);
+    }
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    _tablet_schema = TabletSchema::create(_tablet_metadata->schema());
+    _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+
+    auto tablet_id = _tablet_metadata->id();
+    std::vector<uint32_t> indexes(n);
+    for (uint32_t i = 0; i < static_cast<uint32_t>(n); i++) {
+        indexes[i] = i;
+    }
+    auto write_one_txn = [&](int64_t version, const ChunkPtr& chunk) {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .set_profile(&_dummy_runtime_profile)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*chunk, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version, txn_id).status());
+    };
+
+    // v2: all n keys land (a local write is not range-clipped: its segments are not shared and its
+    // rowset carries no range, which is what makes this a usable stand-in for the inherited state).
+    write_one_txn(2, make_op_chunk(n, /*value_shift=*/0, /*upsert=*/true, _slot_cid_map));
+    ASSERT_EQ(n, read_rows(tablet_id, 2));
+
+    // v3: delete every key. Before the fix this erased all n and, on a real SPLIT child, tripped
+    // "unexpected segment id" on an ancestor rssid the child no longer has.
+    write_one_txn(3, make_op_chunk(n, /*value_shift=*/0, /*upsert=*/false, _slot_cid_map));
+    EXPECT_EQ(n - kRangeUpperExclusive, read_rows(tablet_id, 3));
 }
 
 // Spill path regression (kevincai review on #75366): when a single op-aware merge task emits more than one


### PR DESCRIPTION
## Why I'm doing:

Part of #77653. Cross publish hands a SPLIT child the parent's whole payload and then leaves each
side to work out which rows are actually its own. Every place that gets that wrong is the same bug
wearing a different hat; this PR closes the delete side, where getting it wrong does not merely waste
work but wedges the table.

Fixes StarRocksTest#11845 — a load txn's publish on a SPLIT child tablet fails forever with
`unexpected segment id: 536 tablet id: 548708`, which wedges the SPLIT job in `CLEANING` and pins the
table in `TABLET_RESHARD` (`ALTER` rejected, `INSERT` blocked indefinitely, no recovery path).

### The asymmetry

A del file is cross-published **verbatim** to every SPLIT child: each child reads the *same parent*
del file and erases every key in it from its **own** primary index.

The upsert side does not have this problem, because it is clipped at read time:

```
convert_txn_log_for_splitting()               tablet_reshard.cpp
  update_rowset_ranges(txn_log, base->range())      stamps THIS child's range onto op_write.rowset
        ↓
Rowset::get_seek_range()                      rowset.cpp
        ↓
Rowset::get_each_segment_iterator()           seg_options.tablet_range = <child range>
        ↓
SegmentIterator::_apply_tablet_range()        short key index → contiguous rowid range
                                              → out-of-range rows are never even read
```

A del file is a flat `ColumnArraySerde` PK column: no index, and **no guaranteed key order** (the
writer only sorts when it additionally builds a tombstone sstable — see the `std::is_sorted` check in
`build_del_tombstone_sstable`). So it gets no seek-based pruning, and every child sees every key.

### Why that corrupts the publish rather than just wasting work

The child's primary index still carries the ancestor entries inherited through its **shared
sstables** — the tablet-range gate on those runs only in `LakePersistentIndex::merge_sstables`, i.e.
at sstable compaction time, not on the lookup path. So erasing a foreign key can **succeed** and hand
back a location in a rowset the split pruned away from this child. That rssid reaches
`MetaFileBuilder::update_num_del_stat`, which finds no such rowset and fails the publish — forever,
because the load txn is retried indefinitely and `SplitTabletJob.runCleaningJob` blocks on
`isPreviousTransactionsFinished` waiting for it.

### Evidence from the wedged cluster

Decoding the wedged partition's bundle metadata (partition 547059@v363):

```
parent 548582   range=(-inf..+inf)     174 rowsets, 31 of them carrying del_files
child  548708   range=(-inf..39937)    retained 31 — exactly the del_files-carrying ones
child  548709   range=[39937..79873)   retained 31 — same
child  548710   range=[79873..+inf)    retained all 174
```

The splitter keeps a del-file-carrying rowset **regardless** of whether its key range intersects the
child (its del files must be replayed for the PK index), stamping an empty clipped range when the
intersection is empty:

| tablet | tablet.range | rowset 535's range |
|---|---|---|
| parent 548582 | `(-inf..+inf)` | `[75777..+inf)` |
| child 548709 | `[39937..79873)` | `[75777..79873)` ✅ correct intersection |
| child 548710 | `[79873..+inf)` | `[79873..+inf)` ✅ |
| **child 548708** | **`(-inf..39937)`** | **`[75777..75777)`** ← empty |

Rowset **536 exists only in 548710** (`[79873..+inf)`). The failures are on the two *pruned* children
(548708 / 548709), whose ranges cannot legitimately own keys ≥ 79873 — so they should never have
resolved 536 at all. Both failed on the same parent txn log
(`tablet_id_in_metadata: 548708 / 548709, tablet_id_in_txn_log: [548582]`, 103,368 hits each), which
is also why the FE-side error printed the parent id twice.

This also explains why all observed cases were PK tables under continuous `DELETE`: no del files, no
bug.

## What I'm doing:

Clip the delete keys to the tablet's range in `RowsetUpdateState::load_delete`.

**Dropping them is correct, not just safe**: a key outside this tablet's range belongs to a sibling by
definition, the same del file is cross-published to that sibling, and the sibling erases it from its
own index. Each child erasing only its own slice is exactly what the upsert side already does.

**One clip covers both delete paths.** The memtable `erase` and the prebuilt-tombstone-sstable
`bulk_erase` both drive their reverse lookup from the same `state.deletes(del_id)` column, so
filtering at materialization fixes both.

**No extra I/O.** The caller has already done `read_all()` + full `deserialize`, so this is one pass
over an in-memory column. It also *reduces* memory: a heavily-pruned child now holds only its own
slice instead of the parent's entire del column.

**Byte comparison is valid** because `create_sst_seek_range_from` encodes the bounds with the same
`PrimaryKeyEncoder` and `pkey_schema` used to materialize this column, and requires
`PK_ENCODING_TYPE_V2` (big-endian, order preserving) for range-distribution tables — which is also
what makes the persistent index's bytewise key order well-defined in the first place.

Short-circuits before any comparison for tablets with no range (non-range-distribution) and for
unbounded ranges, mirroring `SeekRange::all_range()` in `_apply_tablet_range`.

### Deliberately NOT addressed here

* **Read amplification.** Every child still reads the *whole* parent del file from object storage;
  clipping happens after the read. Avoiding that needs the splitter to rewrite del files per child at
  prune time (a write-path change) or a del-file format with an index — both far riskier than this
  fix, and orthogonal to the correctness bug.
* **The empty-range retention itself** (`[75777..75777)` above). It is consistent with the splitter's
  "keep del-file rowsets regardless of range" rule and is not what breaks the publish; worth a
  separate look.
* **The ancestor entries in the child's inherited shared sstables.** Gating those on the *lookup*
  path (not just in `merge_sstables`) would also prevent this failure, but it touches every index
  read. The del-side clip is the targeted, symmetric fix.
* `PK_ENCODING_TYPE_V1` + a tablet range would now surface as a publish error from
  `create_sst_seek_range_from` rather than silently mis-deleting. That combination should not exist
  (FE requires V2 for range distribution) and `merge_sstables` already hard-fails the same way.

### Where this sits in #77653

The invariant this establishes — **a child may only act on the keys its range owns** — is the one the
rest of the cross-publish work builds on. The upsert side already honours it (via
`update_rowset_ranges` → `tablet_range` → `_apply_tablet_range`); this PR brings the delete side to
parity. Still open, tracked separately:

* the PK index still *accepts* a foreign-range key on lookup, so the invariant is enforced by every
  caller rather than by the index itself;
* `sort_key_min`/`sort_key_max` are compared against a range that, once ORDER BY != PK is allowed,
  lives in a different key space;
* condition update and row-mode partial update decide per child using each child's own index state,
  which diverges after the split.

This PR is self-contained and does not depend on any of them.

### Test

`test_publish_clips_deletes_to_tablet_range` gives the tablet a range covering only the lower half of
its keys, upserts all keys, then deletes **all** of them. Before this change every key was erased;
now exactly the in-range half is, and the out-of-range half is untouched.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

On a range-distribution tablet, a delete key outside the tablet's own range is no longer applied. Only
reachable for tablets that carry a range; hash-distributed tablets short-circuit and are unaffected.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

`branch-4.1` has the same unclipped `load_delete`. `branch-4.0` and `branch-3.5` do not have the
tablet reshard / range distribution feature, so they are not affected.

