### PR TITLE
[BugFix] Upgrade broker commons-lang3 to 3.20.0 for CVE-2025-48924

### DIFF
--- a/fs_brokers/apache_hdfs_broker/src/broker-core/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/src/broker-core/pom.xml
@@ -57,12 +57,6 @@ under the License.
             <artifactId>commons-collections</artifactId>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/commons-configuration/commons-configuration -->
-        <dependency>
-            <groupId>commons-configuration</groupId>
-            <artifactId>commons-configuration</artifactId>
-        </dependency>
-
         <!-- https://mvnrepository.com/artifact/commons-daemon/commons-daemon -->
         <dependency>
             <groupId>commons-daemon</groupId>
@@ -73,12 +67,6 @@ under the License.
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/commons-lang/commons-lang -->
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->

--- a/fs_brokers/apache_hdfs_broker/src/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/src/pom.xml
@@ -154,13 +154,6 @@ under the License.
                 <version>1.11.0</version>
             </dependency>
 
-            <!-- https://mvnrepository.com/artifact/commons-configuration/commons-configuration -->
-            <dependency>
-                <groupId>commons-configuration</groupId>
-                <artifactId>commons-configuration</artifactId>
-                <version>1.6</version>
-            </dependency>
-
             <!-- https://mvnrepository.com/artifact/commons-daemon/commons-daemon -->
             <dependency>
                 <groupId>commons-daemon</groupId>
@@ -175,18 +168,14 @@ under the License.
                 <version>2.14.0</version>
             </dependency>
 
-            <!-- https://mvnrepository.com/artifact/commons-lang/commons-lang -->
-            <dependency>
-                <groupId>commons-lang</groupId>
-                <artifactId>commons-lang</artifactId>
-                <version>2.6</version>
-            </dependency>
-
             <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
+            <!-- Keep at or above 3.18.0: it fixes CVE-2025-48924 (ClassUtils.getClass
+                 StackOverflow), and hadoop-common/commons-text/commons-configuration2
+                 need APIs added after 3.3.2 (e.g. lang3.function.FailableSupplier). -->
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.3.2</version>
+                <version>3.20.0</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/commons-logging/commons-logging -->


### PR DESCRIPTION
## Why I'm doing:

https://www.cve.org/CVERecord?id=CVE-2025-48924

## What I'm doing:

1. Upgrade commons-lang3 from 3.3.2 to 3.20.0
2. Remove unused commons-lang 2.6 and commons-configuration 1.6

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
