### PR TITLE
[BugFix] stop shipping test-scope jars in java-extensions reader libs

### DIFF
--- a/java-extensions/fluss-reader/pom.xml
+++ b/java-extensions/fluss-reader/pom.xml
@@ -140,6 +140,7 @@
                         <configuration>
                             <outputDirectory>${project.build.directory}/fluss-reader-lib</outputDirectory>
                             <overWriteIfNewer>true</overWriteIfNewer>
+                            <includeScope>runtime</includeScope>
                         </configuration>
                     </execution>
                 </executions>

--- a/java-extensions/hive-reader/pom.xml
+++ b/java-extensions/hive-reader/pom.xml
@@ -26,7 +26,6 @@
             <groupId>com.starrocks</groupId>
             <artifactId>hadoop-ext</artifactId>
             <version>1.0.0</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -119,6 +118,7 @@
                         <configuration>
                             <outputDirectory>${project.build.directory}/hive-reader-lib</outputDirectory>
                             <overWriteIfNewer>true</overWriteIfNewer>
+                            <includeScope>runtime</includeScope>
                         </configuration>
                     </execution>
                 </executions>

--- a/java-extensions/hudi-reader/pom.xml
+++ b/java-extensions/hudi-reader/pom.xml
@@ -26,7 +26,6 @@
             <groupId>com.starrocks</groupId>
             <artifactId>hadoop-ext</artifactId>
             <version>1.0.0</version>
-            <scope>provided</scope>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-client -->
@@ -182,6 +181,7 @@
                         <configuration>
                             <outputDirectory>${project.build.directory}/hudi-reader-lib</outputDirectory>
                             <overWriteIfNewer>true</overWriteIfNewer>
+                            <includeScope>runtime</includeScope>
                         </configuration>
                     </execution>
                 </executions>

--- a/java-extensions/kudu-reader/pom.xml
+++ b/java-extensions/kudu-reader/pom.xml
@@ -104,6 +104,7 @@
                         <configuration>
                             <outputDirectory>${project.build.directory}/kudu-reader-lib</outputDirectory>
                             <overWriteIfNewer>true</overWriteIfNewer>
+                            <includeScope>runtime</includeScope>
                         </configuration>
                     </execution>
                 </executions>

--- a/java-extensions/paimon-reader/pom.xml
+++ b/java-extensions/paimon-reader/pom.xml
@@ -129,6 +129,7 @@
                         <configuration>
                             <outputDirectory>${project.build.directory}/paimon-reader-lib</outputDirectory>
                             <overWriteIfNewer>true</overWriteIfNewer>
+                            <includeScope>runtime</includeScope>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Add <includeScope>runtime</includeScope> to the five reader modules whose lib dir is shipped, matching what fe/fe-server/pom.xml already does for the FE lib dir.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
