### PR TITLE
[Tool] pr-checker: convert checkbox->label for sync PRs (reverse-synced backport)

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -122,8 +122,12 @@ jobs:
   backport-check-subtask:
     needs: title-check
     runs-on: ubuntu-latest
+    # always(): also convert checkbox -> label for SYNC PRs (unified checkbox-driven model).
+    # sync PRs skip the sync-checker -> title-check chain, so without always() this job would
+    # be skipped for them and their (AI-ticked / carried) checkboxes would never become the
+    # labels the static backport matrix reads. Relevant on SR for CD->SR reverse-synced PRs.
     if: >
-      (
+      always() && (
         startsWith(github.event.pull_request.title, '[BugFix]') ||
         startsWith(github.event.pull_request.title, '[Enhancement]') ||
         startsWith(github.event.pull_request.title, '[Doc]') ||
@@ -147,7 +151,10 @@ jobs:
           labels: ${{ matrix.version }}
 
       - name: check-done
-        if: contains(toJson(github.event.pull_request.body), '[ ] I have checked the version labels')
+        # don't gate SYNC PRs on this human-acknowledgement checkbox — they are machine
+        # generated (reverse sync is AI-ticked / injected), no human to force. Only enforce
+        # it on non-sync (author-authored) PRs.
+        if: contains(toJson(github.event.pull_request.body), '[ ] I have checked the version labels') && !contains(github.event.pull_request.labels.*.name, 'sync')
         run: |
           echo "::error::You must mark this checkbox - I have checked the version labels which the pr will be auto-backported to the target branch"
           exit 1


### PR DESCRIPTION
## Why I'm doing:
Unified checkbox-driven backport. CD->SR reverse-synced PRs carry AI-ticked version checkboxes, but pr-checker skips sync PRs so those checkboxes never became labels for the static backport matrix.

## What I'm doing:
`pr-checker.yml`: `backport-check-subtask` runs for sync PRs (`always()`) to convert checkbox->label; the human "I have checked the version labels" gate is skipped for sync PRs (machine-generated). Native PRs unchanged. SR's static backport matrix already includes sync PRs.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4