### PR TITLE
[Tool] reverse executor: handle main AND branch (mirror forward); rename to repo-sync.yml

### DIFF
--- a/.github/workflows/cd-scan-pending.yml
+++ b/.github/workflows/cd-scan-pending.yml
@@ -3,7 +3,7 @@ name: CD SCAN PENDING PRS
 # Reverse-sync ordering release loop. Mirror of celerdata-enterprise's
 # sync-scan-pending.yml, direction reversed (runs on StarRocks; releases pending
 # cd-sync PRs once their file-overlapping predecessors merge). Triggered on a
-# 30-min cron and by cd-repo-sync.yml (workflow_dispatch after each executor run).
+# 30-min cron and by repo-sync.yml (workflow_dispatch after each executor run).
 
 on:
   schedule:

--- a/.github/workflows/cd-sync-pipeline.yml
+++ b/.github/workflows/cd-sync-pipeline.yml
@@ -1,11 +1,11 @@
 name: CD SYNC CI PIPELINE
 
-# CI gate for reverse-sync PRs (title "(cd-sync #N)", label cd-sync) opened on
-# StarRocks main by repo-sync.yml. Mirror of celerdata-enterprise's
-# sync-ci-pipeline.yml, trimmed for v1: BUILD chain only (no UT), auto-merge on
-# green. Runs on [self-hosted, normal] (mirrors ci-pipeline's heavy-job pool;
-# the tiny [sync] pool is reserved for the executor + ci-sync trigger).
-# Requires SR-side secret: PAT.
+# CI gate for reverse-sync PRs (identified by head branch `<base>-cd-sync-pr-<N>`; the
+# executor desensitizes the title/label so there is no "(cd-sync #N)" / `cd-sync` marker)
+# opened on StarRocks main / branch-4.1 / branch-4.0 by repo-sync.yml. Mirror of
+# celerdata-enterprise's sync-ci-pipeline.yml, trimmed for v1: BUILD chain only (no UT),
+# auto-merge on green. Runs on [self-hosted, normal] (mirrors ci-pipeline's heavy-job pool;
+# the tiny [sync] pool is reserved for the executor + ci-sync trigger). Requires secret: PAT.
 
 on:
   pull_request_target:
@@ -14,6 +14,8 @@ on:
       - synchronize
     branches:
       - main
+      - branch-4.1
+      - branch-4.0
 
 concurrency:
   group: ${{ github.event.number }}-cd-sync-checker
@@ -53,9 +55,11 @@ jobs:
   cd-sync-checker:
     runs-on: [self-hosted, normal]
     needs: pr-label
+    # Identify a reverse-sync PR by its head branch `<base>-cd-sync-pr-<N>` — the executor
+    # DESENSITIZES the title/label (no "(cd-sync #N)" marker, no `cd-sync` label; see
+    # repo-sync.yml REVERSE_SCRUB), so the head branch is the stable discriminator.
     if: >
-      contains(github.event.pull_request.title, '(cd-sync #') &&
-      contains(needs.pr-label.outputs.labels, 'cd-sync') &&
+      contains(github.head_ref, '-cd-sync-pr-') &&
       !contains(needs.pr-label.outputs.labels, 'pending') &&
       !contains(needs.pr-label.outputs.labels, 'force-check')
     name: RUN CHECKER
@@ -282,8 +286,7 @@ jobs:
     runs-on: [self-hosted, normal]
     if: >
       always() &&
-      contains(github.event.pull_request.title, '(cd-sync #') &&
-      contains(needs.pr-label.outputs.labels, 'cd-sync') &&
+      contains(github.head_ref, '-cd-sync-pr-') &&
       !contains(needs.pr-label.outputs.labels, 'conflict') &&
       !contains(needs.pr-label.outputs.labels, 'pending') &&
       !contains(needs.pr-label.outputs.labels, 'ERROR') &&

--- a/.github/workflows/cd-sync-pipeline.yml
+++ b/.github/workflows/cd-sync-pipeline.yml
@@ -1,7 +1,7 @@
 name: CD SYNC CI PIPELINE
 
 # CI gate for reverse-sync PRs (title "(cd-sync #N)", label cd-sync) opened on
-# StarRocks main by cd-repo-sync.yml. Mirror of celerdata-enterprise's
+# StarRocks main by repo-sync.yml. Mirror of celerdata-enterprise's
 # sync-ci-pipeline.yml, trimmed for v1: BUILD chain only (no UT), auto-merge on
 # green. Runs on [self-hosted, normal] (mirrors ci-pipeline's heavy-job pool;
 # the tiny [sync] pool is reserved for the executor + ci-sync trigger).

--- a/.github/workflows/cd-sync-pipeline.yml
+++ b/.github/workflows/cd-sync-pipeline.yml
@@ -1,8 +1,9 @@
 name: CD SYNC CI PIPELINE
 
-# CI gate for reverse-sync PRs (identified by head branch `<base>-cd-sync-pr-<N>`; the
-# executor desensitizes the title/label so there is no "(cd-sync #N)" / `cd-sync` marker)
-# opened on StarRocks main / branch-4.1 / branch-4.0 by repo-sync.yml. Mirror of
+# CI gate for reverse-sync PRs (identified by the `sync` label — on StarRocks only the
+# reverse sync opens `sync`-labeled PRs; the executor desensitizes the rest so there is no
+# "(cd-sync #N)" title / `cd-sync` label) opened on StarRocks main / branch-4.1 /
+# branch-4.0 by repo-sync.yml. Mirror of
 # celerdata-enterprise's sync-ci-pipeline.yml, trimmed for v1: BUILD chain only (no UT),
 # auto-merge on green. Runs on [self-hosted, normal] (mirrors ci-pipeline's heavy-job pool;
 # the tiny [sync] pool is reserved for the executor + ci-sync trigger). Requires secret: PAT.
@@ -55,11 +56,12 @@ jobs:
   cd-sync-checker:
     runs-on: [self-hosted, normal]
     needs: pr-label
-    # Identify a reverse-sync PR by its head branch `<base>-cd-sync-pr-<N>` — the executor
-    # DESENSITIZES the title/label (no "(cd-sync #N)" marker, no `cd-sync` label; see
-    # repo-sync.yml REVERSE_SCRUB), so the head branch is the stable discriminator.
+    # Identify a reverse-sync PR by the `sync` label. On StarRocks only the reverse sync
+    # opens `sync`-labeled PRs (the forward SR->CD sync opens them on CelerData), so the
+    # label alone is a sufficient, stable discriminator — the executor desensitizes the
+    # title/label otherwise (no "(cd-sync #N)" / `cd-sync`), and the `sync` label is kept.
     if: >
-      contains(github.head_ref, '-cd-sync-pr-') &&
+      contains(needs.pr-label.outputs.labels, 'sync') &&
       !contains(needs.pr-label.outputs.labels, 'pending') &&
       !contains(needs.pr-label.outputs.labels, 'force-check')
     name: RUN CHECKER
@@ -286,7 +288,7 @@ jobs:
     runs-on: [self-hosted, normal]
     if: >
       always() &&
-      contains(github.head_ref, '-cd-sync-pr-') &&
+      contains(needs.pr-label.outputs.labels, 'sync') &&
       !contains(needs.pr-label.outputs.labels, 'conflict') &&
       !contains(needs.pr-label.outputs.labels, 'pending') &&
       !contains(needs.pr-label.outputs.labels, 'ERROR') &&

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -12,9 +12,9 @@ run-name: Repo Sync(#${{ inputs.PR_ID }} [${{ inputs.BRANCH }}])
 # Desensitize (REVERSE_SCRUB=1, StarRocks is public): the PR reads like a native upstream
 # contribution — title/body scrubbed (CelerData->StarRocks, no "(cd-sync #N)" marker, no
 # internal issue refs/hosts), and the label set is just `sync` + `SHA:<commit>` (NO
-# `cd-sync`). The reverse pipeline / pending scan identify a reverse PR by its head branch
-# `<base>-cd-sync-pr-<N>` (the internal handle, not surfaced as a title/label) and the SHA
-# label; the forward anti-loop keys on the `sync` label.
+# `cd-sync`). The reverse pipeline / pending scan / merge-kick identify a reverse PR by the
+# `sync` label (on StarRocks only the reverse sync opens `sync`-labeled PRs); the SHA label
+# is for source recovery. The head branch name is a normal internal handle (not a marker).
 #
 # Runner prerequisites (SR-side self-hosted sync runner):
 #   - /var/lib/starrocks           : target working copy (StarRocks)
@@ -167,9 +167,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.SYNC_PAT }}
           # Desensitized (REVERSE_SCRUB): keep only `sync` (forward anti-loop) + the SHA
-          # label (source recovery for serialization); DROP `cd-sync`. The reverse pipeline
-          # and pending scan identify a reverse PR by its head branch `<base>-cd-sync-pr-<N>`
-          # and the SHA label — not the `cd-sync` label or a title marker.
+          # label (source recovery for serialization); DROP `cd-sync`. The reverse pipeline,
+          # pending scan and merge-kick identify a reverse PR by the `sync` label (on
+          # StarRocks only the reverse sync opens `sync`-labeled PRs).
           PR_LABEL: sync,${{ steps.cherry-pick.outputs.LABEL }}${{ steps.cherry-pick.outputs.CONFLICT_LABEL }}
           HEAD: ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.PR_ID }}
           # Native title (already scrubbed by get_pr_info.py): no "(cd-sync #N)" marker.

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -1,5 +1,5 @@
 name: Repo Sync
-run-name: Repo Sync(#${{ inputs.PR_ID }} [${{ inputs.BRANCH }}])
+run-name: Repo Sync(${{ inputs.COMMIT_ID }} [${{ inputs.BRANCH }}])
 
 # Reverse sync executor: cherry-pick a CelerData open-source PR's commit onto the
 # StarRocks branch of the SAME name (main / branch-4.1 / branch-4.0 / …) and open a
@@ -14,7 +14,10 @@ run-name: Repo Sync(#${{ inputs.PR_ID }} [${{ inputs.BRANCH }}])
 # internal issue refs/hosts), and the label set is just `sync` + `SHA:<commit>` (NO
 # `cd-sync`). The reverse pipeline / pending scan / merge-kick identify a reverse PR by the
 # `sync` label (on StarRocks only the reverse sync opens `sync`-labeled PRs); the SHA label
-# is for source recovery. The head branch name is a normal internal handle (not a marker).
+# is for source recovery. The CD PR NUMBER never appears on the SR PR: the head branch /
+# run-name are keyed by the source COMMIT (already public via the SHA label), and the SR
+# PR's URL is commented back onto the CD source PR instead (the linkage lives on the
+# private side only).
 #
 # Runner prerequisites (SR-side self-hosted sync runner):
 #   - /var/lib/starrocks           : target working copy (StarRocks)
@@ -100,8 +103,8 @@ jobs:
 
       - name: Clean Branches
         env:
-          source_branch: ${{ inputs.BRANCH }}-cd-sync-${{ inputs.PR_ID }}
-          destination_branch: ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.PR_ID }}
+          source_branch: ${{ inputs.BRANCH }}-cd-sync-${{ inputs.COMMIT_ID }}
+          destination_branch: ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.COMMIT_ID }}
         run: |
           curl -s -X DELETE -u username:${{secrets.GITHUB_TOKEN}} https://api.github.com/repos/${{ github.repository }}/git/refs/heads/${{ env.source_branch }}
           curl -s -X DELETE -u username:${{secrets.GITHUB_TOKEN}} https://api.github.com/repos/${{ github.repository }}/git/refs/heads/${{ env.destination_branch }}
@@ -109,7 +112,7 @@ jobs:
       - name: sync repo to branch
         env:
           source_branch: ${{ inputs.BRANCH }}
-          destination_branch: ${{ inputs.BRANCH }}-cd-sync-${{ inputs.PR_ID }}
+          destination_branch: ${{ inputs.BRANCH }}-cd-sync-${{ inputs.COMMIT_ID }}
           github_token: ${{ secrets.SYNC_PAT }}
         run: |
           source_repo_dir=${source_repo#*/}
@@ -129,7 +132,7 @@ jobs:
         run: |
           git pull
           git checkout ${{ inputs.BRANCH }}
-          pr_branch=${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.PR_ID }}
+          pr_branch=${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.COMMIT_ID }}
           git branch ${pr_branch} ${{ inputs.BRANCH }}
           git checkout ${pr_branch}
           git push -u origin ${pr_branch}
@@ -159,7 +162,7 @@ jobs:
           cd ${{ github.workspace }}/elastic-service
           ./lib/run_cherry_pick.sh --pr ${{ inputs.PR_ID }}
           cd ${{ github.workspace }}
-          git push -u origin ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.PR_ID }}
+          git push -u origin ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.COMMIT_ID }}
 
       - name: Create pull request
         id: create_pr
@@ -171,7 +174,7 @@ jobs:
           # pending scan and merge-kick identify a reverse PR by the `sync` label (on
           # StarRocks only the reverse sync opens `sync`-labeled PRs).
           PR_LABEL: sync,${{ steps.cherry-pick.outputs.LABEL }}${{ steps.cherry-pick.outputs.CONFLICT_LABEL }}
-          HEAD: ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.PR_ID }}
+          HEAD: ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.COMMIT_ID }}
           # Native title (already scrubbed by get_pr_info.py): no "(cd-sync #N)" marker.
           TITLE: "${{ needs.pr-info.outputs.title }}"
           # Mirror the forward flow (repo-sync.yml): carry the source PR's full body
@@ -193,7 +196,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.SYNC_PAT }}
           PR_LABEL: sync,${{ steps.cherry-pick.outputs.LABEL }},pending
-          HEAD: ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.PR_ID }}
+          HEAD: ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.COMMIT_ID }}
           TITLE: "${{ needs.pr-info.outputs.title }}"
           BODY: "Previous prs: ${{ steps.previous-check.outputs.CONFLICT_PRS }}"
           REVIEWER: ${{ needs.pr-info.outputs.assignees }}
@@ -202,7 +205,9 @@ jobs:
           cd ${{ github.workspace }}/elastic-service
           ./scripts/create_sync_repo.sh
 
-      # Write back the marker onto the CelerData SOURCE PR for idempotency.
+      # Write back onto the CelerData SOURCE PR: the marker label (idempotency /
+      # provenance) AND the created SR PR's URL as a comment — the CD->SR linkage lives
+      # ONLY on the private CD side (the public SR PR never carries the CD PR number).
       - name: Mark source PR
         if: always() && steps.create_pr.outcome == 'success'
         env:
@@ -216,6 +221,13 @@ jobs:
           gh api -X POST \
             "repos/${{ inputs.SOURCE_REPO }}/issues/${{ inputs.PR_ID }}/labels" \
             -f "labels[]=${MARK}" || echo "::warning::failed to add ${MARK} to ${{ inputs.SOURCE_REPO }}#${{ inputs.PR_ID }}"
+          PR_URL="${{ steps.create_pr.outputs.pr_url }}"
+          if [[ -n "${PR_URL}" ]]; then
+            gh api -X POST \
+              "repos/${{ inputs.SOURCE_REPO }}/issues/${{ inputs.PR_ID }}/comments" \
+              -f "body=Reverse-synced to StarRocks: ${PR_URL}" \
+              || echo "::warning::failed to comment SR PR url on ${{ inputs.SOURCE_REPO }}#${{ inputs.PR_ID }}"
+          fi
 
       - name: notify
         if: always()

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -1,10 +1,13 @@
 name: Repo Sync
 run-name: Repo Sync(#${{ inputs.PR_ID }} [${{ inputs.BRANCH }}])
 
-# Reverse sync executor: cherry-pick a CelerData open-source PR's commit onto
-# StarRocks main and open a "(cd-sync #N)" PR. Mirror of celerdata-enterprise's
-# repo-sync.yml (repo-sync-main job) with direction reversed (source=CelerData,
-# target=StarRocks). Dispatched by elastic-service/lib/sync_cd_to_sr.py.
+# Reverse sync executor: cherry-pick a CelerData open-source PR's commit onto the
+# StarRocks branch of the SAME name (main / branch-4.1 / branch-4.0 / …) and open a
+# "(cd-sync #N)" PR. Full mirror of celerdata-enterprise's forward repo-sync.yml with
+# direction reversed (source=CelerData, target=StarRocks); like the forward, it handles
+# BOTH main->main AND branch->branch (BRANCH input drives it), so StarRocks release
+# branches receive shared-line fixes directly instead of relying on self-backport.
+# Dispatched by the CD-side reverse trigger (sync-cd-to-sr.yml -> reverse_sync_decide.sh).
 # (Only the workflow file/display name drops "cd". The "(cd-sync #N)" title suffix,
 #  the `cd-sync` label and the `-cd-sync-` branch prefix are functional reverse-direction
 #  markers the rest of the reverse pipeline is built around, so they are kept verbatim.)
@@ -35,17 +38,6 @@ on:
         required: true
         type: string
         default: 'CelerData/celerdata-enterprise'
-      BACKPORT_BRANCHES:
-        # Comma-separated SR release lines the source fix should also reach
-        # (e.g. "4.1,4.0"), computed by the CD-side decision hub
-        # (ci-tool reverse_sync_decide.sh: affected ∩ SR-shared-lines). Passed
-        # through to create_sync_repo.sh, which ticks the matching version
-        # checkboxes in the SR PR body so pr-checker converts them to labels and
-        # the static backport matrix fans the fix out. Empty = no self-backport.
-        description: 'SR backport lines to tick (comma-separated, e.g. 4.1,4.0)'
-        required: false
-        type: string
-        default: ''
 
 permissions:
   contents: write
@@ -75,10 +67,12 @@ jobs:
           git pull || true
           ./lib/get_pr_info.sh
 
-  cd-repo-sync-main:
-    name: CD Repo Sync - main
+  cd-repo-sync:
+    name: Repo Sync
     runs-on: [self-hosted, sync, ubuntu]
-    if: inputs.BRANCH == 'main'
+    # Handles main AND branch-X.Y (BRANCH input drives every branch reference below),
+    # mirroring the forward executor. No BRANCH gate: the CD-side trigger only dispatches
+    # for branches StarRocks actually has (main / branch-4.1 / branch-4.0).
     needs: pr-info
     env:
       GITHUB_TOKEN: ${{ secrets.SYNC_PAT }}
@@ -170,9 +164,6 @@ jobs:
           # (official template, all sections) via the file get_pr_info.py wrote in the
           # pr-info job, plus any conflict info run_cherry_pick.sh prepended to it.
           BODY_FILE: /var/local/env/body/${{ github.repository }}/${{ inputs.PR_ID }}.txt
-          # SR release lines to self-backport to (from the CD decision hub).
-          # create_sync_repo.sh ticks the matching version checkboxes in the body.
-          BACKPORT_BRANCHES: ${{ inputs.BACKPORT_BRANCHES }}
           REVIEWER: ${{ needs.pr-info.outputs.assignees }}
           BASE: ${{ inputs.BRANCH }}
         run: |
@@ -191,10 +182,6 @@ jobs:
           HEAD: ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.PR_ID }}
           TITLE: "${{ needs.pr-info.outputs.title }}(cd-sync #${{ inputs.PR_ID }})"
           BODY: "Previous prs: ${{ steps.previous-check.outputs.CONFLICT_PRS }}"
-          # Tick the checkboxes on the pending PR at creation too: they persist on the
-          # PR object, so the pending->released re-dispatch (which re-runs this executor
-          # for ORDERING only and does not carry BACKPORT_BRANCHES) needn't re-tick.
-          BACKPORT_BRANCHES: ${{ inputs.BACKPORT_BRANCHES }}
           REVIEWER: ${{ needs.pr-info.outputs.assignees }}
           BASE: ${{ inputs.BRANCH }}
         run: |

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -9,6 +9,15 @@ run-name: Repo Sync(${{ inputs.COMMIT_ID }} [${{ inputs.BRANCH }}])
 # branches receive shared-line fixes directly instead of relying on self-backport.
 # Dispatched by the CD-side reverse trigger (sync-cd-to-sr.yml -> reverse_sync_decide.sh).
 #
+# Two executor jobs (mirror of the forward's repo-sync-main / repo-sync-branch): identical
+# steps, gated by inputs.BRANCH, each pinned to a SINGLE-runner pool (sync-main = one
+# machine, sync-branch = one machine). The single-runner pool IS the serialization
+# mechanism: previous-check ordering (pr_sequence_checker_reverse, no lock) is only safe
+# when executor runs for a direction cannot overlap — queued jobs wait on the busy runner
+# and are never dropped. Splitting main from branch also keeps the main executor's
+# `sr-synced` provenance marker fast (a slow branch conflict-fix must not delay it, or
+# CD branch backports would find no marker and be conservatively skipped).
+#
 # Desensitize (REVERSE_SCRUB=1, StarRocks is public): the PR reads like a native upstream
 # contribution — title/body scrubbed (CelerData->StarRocks, no "(cd-sync #N)" marker, no
 # internal issue refs/hosts), and the label set is just `sync` + `SHA:<commit>` (NO
@@ -79,12 +88,202 @@ jobs:
           git pull || true
           ./lib/get_pr_info.sh
 
-  cd-repo-sync:
-    name: Repo Sync
-    runs-on: [self-hosted, sync, ubuntu]
-    # Handles main AND branch-X.Y (BRANCH input drives every branch reference below),
-    # mirroring the forward executor. No BRANCH gate: the CD-side trigger only dispatches
-    # for branches StarRocks actually has (main / branch-4.1 / branch-4.0).
+  repo-sync-main:
+    name: Repo Sync - main
+    runs-on: [self-hosted, sync-main]
+    # Mirror of the forward repo-sync-main: main-direction syncs only, pinned to the single sync-main runner (serialization; see header).
+    if: inputs.BRANCH == 'main'
+    needs: pr-info
+    env:
+      GITHUB_TOKEN: ${{ secrets.SYNC_PAT }}
+      GH_TOKEN: ${{ secrets.SYNC_PAT }}
+    steps:
+      - name: clean
+        run: |
+          rm -rf ${{ github.workspace }}
+          mkdir -p ${{ github.workspace }}
+
+      - name: checkout code
+        run: |
+          shopt -s dotglob
+          cp -rf /var/lib/starrocks/* ${{ github.workspace }}
+          shopt -u dotglob
+
+      - name: Clean Branches
+        env:
+          source_branch: ${{ inputs.BRANCH }}-cd-sync-${{ inputs.COMMIT_ID }}
+          destination_branch: ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.COMMIT_ID }}
+        run: |
+          curl -s -X DELETE -u username:${{secrets.GITHUB_TOKEN}} https://api.github.com/repos/${{ github.repository }}/git/refs/heads/${{ env.source_branch }}
+          curl -s -X DELETE -u username:${{secrets.GITHUB_TOKEN}} https://api.github.com/repos/${{ github.repository }}/git/refs/heads/${{ env.destination_branch }}
+
+      - name: sync repo to branch
+        env:
+          source_branch: ${{ inputs.BRANCH }}
+          destination_branch: ${{ inputs.BRANCH }}-cd-sync-${{ inputs.COMMIT_ID }}
+          github_token: ${{ secrets.SYNC_PAT }}
+        run: |
+          source_repo_dir=${source_repo#*/}
+          cp -rf /var/local/env/ci-source-code/${source_repo_dir} ${source_repo_dir}
+          cd ${source_repo_dir} && git pull
+          git checkout ${source_branch}
+          git remote set-url origin https://${github_token}@github.com/${{ github.repository }}.git
+          git push origin ${source_branch}:${destination_branch}
+
+      - name: checkout tools
+        run: |
+          cp -rf /var/lib/elastic-service ./elastic-service
+          cd elastic-service
+          git pull
+
+      - name: pr branch
+        run: |
+          git pull
+          git checkout ${{ inputs.BRANCH }}
+          pr_branch=${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.COMMIT_ID }}
+          git branch ${pr_branch} ${{ inputs.BRANCH }}
+          git checkout ${pr_branch}
+          git push -u origin ${pr_branch}
+
+      # Ordering: if a file-overlapping, earlier-merged cd-sync PR is still open,
+      # this PR must wait -> RES != True -> created as pending (see Create pending pr).
+      - name: previous check
+        id: previous-check
+        run: |
+          cd ${{ github.workspace }}/elastic-service
+          check_res=$(python3 lib/pr_sequence_checker_reverse.py new ${{ inputs.BRANCH }} ${{ inputs.PR_ID }} ${{ inputs.COMMIT_ID }})
+          echo "${check_res}"
+          conflict_prs=$(echo ${check_res} | awk -F'Files:' '{print $1}' | awk -F' ' '{print $NF}')
+          echo CONFLICT_PRS=${conflict_prs} >> $GITHUB_OUTPUT
+          res=$(echo ${check_res} | tail -n 1)
+          echo RES=${res} >> $GITHUB_OUTPUT
+
+      - name: refresh base before cherry-pick
+        run: |
+          cd ${{ github.workspace }}
+          git fetch origin ${{ inputs.BRANCH }}
+          git reset --hard origin/${{ inputs.BRANCH }}
+
+      - name: cherry pick
+        id: cherry-pick
+        run: |
+          cd ${{ github.workspace }}/elastic-service
+          ./lib/run_cherry_pick.sh --pr ${{ inputs.PR_ID }}
+          cd ${{ github.workspace }}
+          git push -u origin ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.COMMIT_ID }}
+
+      - name: Create pull request
+        id: create_pr
+        if: steps.previous-check.outputs.RES == 'True'
+        env:
+          GITHUB_TOKEN: ${{ secrets.SYNC_PAT }}
+          # Desensitized (REVERSE_SCRUB): keep only `sync` (forward anti-loop) + the SHA
+          # label (source recovery for serialization); DROP `cd-sync`. The reverse pipeline,
+          # pending scan and merge-kick identify a reverse PR by the `sync` label (on
+          # StarRocks only the reverse sync opens `sync`-labeled PRs).
+          PR_LABEL: sync,${{ steps.cherry-pick.outputs.LABEL }}${{ steps.cherry-pick.outputs.CONFLICT_LABEL }}
+          HEAD: ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.COMMIT_ID }}
+          # Native title (already scrubbed by get_pr_info.py): no "(cd-sync #N)" marker.
+          TITLE: "${{ needs.pr-info.outputs.title }}"
+          # Mirror the forward flow (repo-sync.yml): carry the source PR's full body
+          # (official template, all sections) via the file get_pr_info.py wrote in the
+          # pr-info job (scrubbed), plus any conflict info run_cherry_pick.sh prepended.
+          BODY_FILE: /var/local/env/body/${{ github.repository }}/${{ inputs.PR_ID }}.txt
+          REVIEWER: ${{ needs.pr-info.outputs.assignees }}
+          BASE: ${{ inputs.BRANCH }}
+        run: |
+          cd ${{ github.workspace }}/elastic-service
+          ./scripts/create_sync_repo.sh
+
+      # A file-overlapping predecessor is still open -> hold this PR as pending.
+      # cd-sync-pipeline.yml skips `pending` PRs; cd-scan-pending.yml releases it
+      # (removes pending + re-dispatches this workflow) once predecessors merge.
+      - name: Create pending pull request
+        id: create_pending_pr
+        if: steps.previous-check.outputs.RES != 'True'
+        env:
+          GITHUB_TOKEN: ${{ secrets.SYNC_PAT }}
+          PR_LABEL: sync,${{ steps.cherry-pick.outputs.LABEL }},pending
+          HEAD: ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.COMMIT_ID }}
+          TITLE: "${{ needs.pr-info.outputs.title }}"
+          BODY: "Previous prs: ${{ steps.previous-check.outputs.CONFLICT_PRS }}"
+          REVIEWER: ${{ needs.pr-info.outputs.assignees }}
+          BASE: ${{ inputs.BRANCH }}
+        run: |
+          cd ${{ github.workspace }}/elastic-service
+          ./scripts/create_sync_repo.sh
+
+      # Write back onto the CelerData SOURCE PR: the marker label (idempotency /
+      # provenance) AND the created SR PR's URL as a comment — the CD->SR linkage lives
+      # ONLY on the private CD side (the public SR PR never carries the CD PR number).
+      - name: Mark source PR
+        if: always() && steps.create_pr.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_PAT }}
+        run: |
+          if [[ "${{ steps.cherry-pick.outputs.CONFLICT_LABEL }}" != '' ]]; then
+            MARK="cd-sync-conflict"
+          else
+            MARK="sr-synced"
+          fi
+          gh api -X POST \
+            "repos/${{ inputs.SOURCE_REPO }}/issues/${{ inputs.PR_ID }}/labels" \
+            -f "labels[]=${MARK}" || echo "::warning::failed to add ${MARK} to ${{ inputs.SOURCE_REPO }}#${{ inputs.PR_ID }}"
+          PR_URL="${{ steps.create_pr.outputs.pr_url }}"
+          if [[ -n "${PR_URL}" ]]; then
+            gh api -X POST \
+              "repos/${{ inputs.SOURCE_REPO }}/issues/${{ inputs.PR_ID }}/comments" \
+              -f "body=Reverse-synced to StarRocks: ${PR_URL}" \
+              || echo "::warning::failed to comment SR PR url on ${{ inputs.SOURCE_REPO }}#${{ inputs.PR_ID }}"
+          fi
+
+      - name: notify
+        if: always()
+        env:
+          branch: ${{ inputs.BRANCH }}
+          source_pr: ${{ inputs.PR_ID }}
+          source_commit_id: ${{ inputs.COMMIT_ID }}
+          action_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+        run: |
+          cd ${{ github.workspace }}
+          if [[ ! -d ${{ github.workspace }}/elastic-service ]]; then
+            cp -rf /var/lib/elastic-service ./elastic-service
+          fi
+          cd elastic-service && git pull
+          if [[ "${{ steps.cherry-pick.outputs.CONFLICT_LABEL }}" != '' && "${{ steps.create_pr.outcome }}" == 'success' ]]; then
+            msg_type="conflict"
+            this_pr_url=${{ steps.create_pr.outputs.pr_url }}
+          elif [[ "${{ steps.create_pending_pr.outcome }}" == 'success' ]]; then
+            msg_type="pending"
+            this_pr_url=${{ steps.create_pending_pr.outputs.pr_url }}
+          elif [[ "${{ steps.create_pr.outcome }}" == 'success' ]]; then
+            exit 0
+          else
+            msg_type="error"
+            this_pr_url=""
+          fi
+          python3 lib/sync_notify.py ${msg_type} ${branch} ${source_pr} ${source_commit_id} ${action_url} ${this_pr_url}
+
+      # Kick the pending scan so a just-created pending PR is (re)evaluated promptly,
+      # and any now-releasable pending PR (predecessor merged) gets picked up.
+      - name: Trigger pending scan
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_PAT }}
+        run: |
+          gh workflow run cd-scan-pending.yml -R ${{ github.repository }} || true
+
+      - name: clean
+        if: always()
+        run: |
+          rm -rf ${{ github.workspace }} && mkdir -p ${{ github.workspace }}
+
+  repo-sync-branch:
+    name: Repo Sync - branch
+    runs-on: [self-hosted, sync-branch]
+    # Mirror of the forward repo-sync-branch: branch-X.Y syncs only, pinned to the single sync-branch runner. The CD-side trigger only dispatches branches StarRocks actually has (branch-4.1 / branch-4.0).
+    if: inputs.BRANCH != 'main'
     needs: pr-info
     env:
       GITHUB_TOKEN: ${{ secrets.SYNC_PAT }}

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -28,6 +28,8 @@ run-name: Repo Sync(${{ inputs.COMMIT_ID }} [${{ inputs.BRANCH }}])
 # PR's URL is commented back onto the CD source PR instead (the linkage lives on the
 # private side only).
 #
+# Runner pools (mirror of the forward's three): sync-normal = glue (pr-info, both
+# machines), sync-main / sync-branch = one machine each (executor serialization).
 # Runner prerequisites (SR-side self-hosted sync runner):
 #   - /var/lib/starrocks           : target working copy (StarRocks)
 #   - /var/lib/elastic-service     : sync tooling
@@ -67,7 +69,10 @@ jobs:
 
   pr-info:
     name: Add PR Information
-    runs-on: [self-hosted, sync, ubuntu]
+    # sync-normal = the parallel-safe glue pool (mirror of the forward's sync-normal);
+    # both sync-sr machines carry it. The bare `sync` label was retired from these
+    # machines (it belongs to the legacy forward-trigger glue runners).
+    runs-on: [self-hosted, sync-normal]
     env:
       PR_ID: ${{ inputs.PR_ID }}
       SYNC_PAT: ${{ secrets.SYNC_PAT }}

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -72,7 +72,7 @@ jobs:
     # sync-normal = the parallel-safe glue pool (mirror of the forward's sync-normal);
     # both sync-sr machines carry it. The bare `sync` label was retired from these
     # machines (it belongs to the legacy forward-trigger glue runners).
-    runs-on: [self-hosted, sync-normal]
+    runs-on: [self-hosted, sync-normal, ubuntu]
     env:
       PR_ID: ${{ inputs.PR_ID }}
       SYNC_PAT: ${{ secrets.SYNC_PAT }}

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -3,14 +3,18 @@ run-name: Repo Sync(#${{ inputs.PR_ID }} [${{ inputs.BRANCH }}])
 
 # Reverse sync executor: cherry-pick a CelerData open-source PR's commit onto the
 # StarRocks branch of the SAME name (main / branch-4.1 / branch-4.0 / …) and open a
-# "(cd-sync #N)" PR. Full mirror of celerdata-enterprise's forward repo-sync.yml with
+# DESENSITIZED PR. Full mirror of celerdata-enterprise's forward repo-sync.yml with
 # direction reversed (source=CelerData, target=StarRocks); like the forward, it handles
 # BOTH main->main AND branch->branch (BRANCH input drives it), so StarRocks release
 # branches receive shared-line fixes directly instead of relying on self-backport.
 # Dispatched by the CD-side reverse trigger (sync-cd-to-sr.yml -> reverse_sync_decide.sh).
-# (Only the workflow file/display name drops "cd". The "(cd-sync #N)" title suffix,
-#  the `cd-sync` label and the `-cd-sync-` branch prefix are functional reverse-direction
-#  markers the rest of the reverse pipeline is built around, so they are kept verbatim.)
+#
+# Desensitize (REVERSE_SCRUB=1, StarRocks is public): the PR reads like a native upstream
+# contribution — title/body scrubbed (CelerData->StarRocks, no "(cd-sync #N)" marker, no
+# internal issue refs/hosts), and the label set is just `sync` + `SHA:<commit>` (NO
+# `cd-sync`). The reverse pipeline / pending scan identify a reverse PR by its head branch
+# `<base>-cd-sync-pr-<N>` (the internal handle, not surfaced as a title/label) and the SHA
+# label; the forward anti-loop keys on the `sync` label.
 #
 # Runner prerequisites (SR-side self-hosted sync runner):
 #   - /var/lib/starrocks           : target working copy (StarRocks)
@@ -56,6 +60,11 @@ jobs:
       PR_ID: ${{ inputs.PR_ID }}
       SYNC_PAT: ${{ secrets.SYNC_PAT }}
       SOURCE_REPO: ${{ inputs.SOURCE_REPO }}
+      # Desensitize the reverse PR: get_pr_info.py scrubs the title/body (drop the
+      # "(cd-sync #N)" marker, rebrand CelerData->StarRocks, strip internal issue refs /
+      # hosts) so the StarRocks PR reads like a native upstream contribution. StarRocks is
+      # public; do not leak the CelerData sync mechanism / internal PR numbers.
+      REVERSE_SCRUB: "1"
     outputs:
       assignees: ${{ steps.ori_pr_info.outputs.assignees }}
       title: ${{ steps.ori_pr_info.outputs.title }}
@@ -157,12 +166,17 @@ jobs:
         if: steps.previous-check.outputs.RES == 'True'
         env:
           GITHUB_TOKEN: ${{ secrets.SYNC_PAT }}
-          PR_LABEL: sync,cd-sync,${{ steps.cherry-pick.outputs.LABEL }}${{ steps.cherry-pick.outputs.CONFLICT_LABEL }}
+          # Desensitized (REVERSE_SCRUB): keep only `sync` (forward anti-loop) + the SHA
+          # label (source recovery for serialization); DROP `cd-sync`. The reverse pipeline
+          # and pending scan identify a reverse PR by its head branch `<base>-cd-sync-pr-<N>`
+          # and the SHA label — not the `cd-sync` label or a title marker.
+          PR_LABEL: sync,${{ steps.cherry-pick.outputs.LABEL }}${{ steps.cherry-pick.outputs.CONFLICT_LABEL }}
           HEAD: ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.PR_ID }}
-          TITLE: "${{ needs.pr-info.outputs.title }}(cd-sync #${{ inputs.PR_ID }})"
+          # Native title (already scrubbed by get_pr_info.py): no "(cd-sync #N)" marker.
+          TITLE: "${{ needs.pr-info.outputs.title }}"
           # Mirror the forward flow (repo-sync.yml): carry the source PR's full body
           # (official template, all sections) via the file get_pr_info.py wrote in the
-          # pr-info job, plus any conflict info run_cherry_pick.sh prepended to it.
+          # pr-info job (scrubbed), plus any conflict info run_cherry_pick.sh prepended.
           BODY_FILE: /var/local/env/body/${{ github.repository }}/${{ inputs.PR_ID }}.txt
           REVIEWER: ${{ needs.pr-info.outputs.assignees }}
           BASE: ${{ inputs.BRANCH }}
@@ -178,9 +192,9 @@ jobs:
         if: steps.previous-check.outputs.RES != 'True'
         env:
           GITHUB_TOKEN: ${{ secrets.SYNC_PAT }}
-          PR_LABEL: sync,cd-sync,${{ steps.cherry-pick.outputs.LABEL }},pending
+          PR_LABEL: sync,${{ steps.cherry-pick.outputs.LABEL }},pending
           HEAD: ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.PR_ID }}
-          TITLE: "${{ needs.pr-info.outputs.title }}(cd-sync #${{ inputs.PR_ID }})"
+          TITLE: "${{ needs.pr-info.outputs.title }}"
           BODY: "Previous prs: ${{ steps.previous-check.outputs.CONFLICT_PRS }}"
           REVIEWER: ${{ needs.pr-info.outputs.assignees }}
           BASE: ${{ inputs.BRANCH }}

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -1,10 +1,13 @@
-name: CD Repo Sync
-run-name: CD Repo Sync(#${{ inputs.PR_ID }} [${{ inputs.BRANCH }}])
+name: Repo Sync
+run-name: Repo Sync(#${{ inputs.PR_ID }} [${{ inputs.BRANCH }}])
 
 # Reverse sync executor: cherry-pick a CelerData open-source PR's commit onto
 # StarRocks main and open a "(cd-sync #N)" PR. Mirror of celerdata-enterprise's
 # repo-sync.yml (repo-sync-main job) with direction reversed (source=CelerData,
 # target=StarRocks). Dispatched by elastic-service/lib/sync_cd_to_sr.py.
+# (Only the workflow file/display name drops "cd". The "(cd-sync #N)" title suffix,
+#  the `cd-sync` label and the `-cd-sync-` branch prefix are functional reverse-direction
+#  markers the rest of the reverse pipeline is built around, so they are kept verbatim.)
 #
 # Runner prerequisites (SR-side self-hosted sync runner):
 #   - /var/lib/starrocks           : target working copy (StarRocks)
@@ -32,6 +35,17 @@ on:
         required: true
         type: string
         default: 'CelerData/celerdata-enterprise'
+      BACKPORT_BRANCHES:
+        # Comma-separated SR release lines the source fix should also reach
+        # (e.g. "4.1,4.0"), computed by the CD-side decision hub
+        # (ci-tool reverse_sync_decide.sh: affected ∩ SR-shared-lines). Passed
+        # through to create_sync_repo.sh, which ticks the matching version
+        # checkboxes in the SR PR body so pr-checker converts them to labels and
+        # the static backport matrix fans the fix out. Empty = no self-backport.
+        description: 'SR backport lines to tick (comma-separated, e.g. 4.1,4.0)'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: write
@@ -156,6 +170,9 @@ jobs:
           # (official template, all sections) via the file get_pr_info.py wrote in the
           # pr-info job, plus any conflict info run_cherry_pick.sh prepended to it.
           BODY_FILE: /var/local/env/body/${{ github.repository }}/${{ inputs.PR_ID }}.txt
+          # SR release lines to self-backport to (from the CD decision hub).
+          # create_sync_repo.sh ticks the matching version checkboxes in the body.
+          BACKPORT_BRANCHES: ${{ inputs.BACKPORT_BRANCHES }}
           REVIEWER: ${{ needs.pr-info.outputs.assignees }}
           BASE: ${{ inputs.BRANCH }}
         run: |
@@ -174,6 +191,10 @@ jobs:
           HEAD: ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.PR_ID }}
           TITLE: "${{ needs.pr-info.outputs.title }}(cd-sync #${{ inputs.PR_ID }})"
           BODY: "Previous prs: ${{ steps.previous-check.outputs.CONFLICT_PRS }}"
+          # Tick the checkboxes on the pending PR at creation too: they persist on the
+          # PR object, so the pending->released re-dispatch (which re-runs this executor
+          # for ORDERING only and does not carry BACKPORT_BRANCHES) needn't re-tick.
+          BACKPORT_BRANCHES: ${{ inputs.BACKPORT_BRANCHES }}
           REVIEWER: ${{ needs.pr-info.outputs.assignees }}
           BASE: ${{ inputs.BRANCH }}
         run: |


### PR DESCRIPTION
## Why I'm doing:

Part of the reverse-sync redesign (see `docs/superpowers/specs/2026-08-14-reverse-branch-sync-redesign.md`): the reverse CD→SR sync now **mirrors the forward** and syncs **branch→branch** (not just main→main), so StarRocks release branches receive shared-line fixes directly instead of relying on SR self-backport. This eliminates the shared-branch (4.1/4.0) divergence that main-only sync allowed.

## What I'm doing:

1. **Reverse executor handles main AND branch — split into two jobs mirroring the forward.** `repo-sync-main` / `repo-sync-branch` (identical steps, gated by `inputs.BRANCH`, every branch reference `${{ inputs.BRANCH }}`-parameterized), each pinned to a **single-runner pool** (`sync-main` / `sync-branch`, labels already applied to sg-ubuntu-sync-sr-1/2). The single-runner pool is the serialization mechanism (previous-check ordering has no lock; queued jobs wait, never dropped), and the split keeps the main executor's `sr-synced` provenance marker fast — a slow branch conflict-fix must not delay it or CD branch backports would be conservatively skipped. Cherry-picks onto the StarRocks branch of the same name and opens a desensitized PR (scrubbed title/body, labels `sync` + `SHA:<commit>`).
2. **Drop `BACKPORT_BRANCHES`.** The reverse no longer ticks SR checkboxes for self-backport — both repos' backport matrices already exclude sync PRs (`!(sync #` / `!sync` / `!-sync-`) and the body is copied verbatim, so inherited ticks are inert. This supersedes N3 (elastic-service#1391) and SR-side N4 (StarRocks#77755), which will be closed.
3. **Rename kept:** `cd-repo-sync.yml` → `repo-sync.yml`, drops the "cd" marker on the SR side.
4. **CD PR number never appears on the SR PR.** Head/mirror branch names and the run-name are keyed by the source **commit** (already public via the `SHA:<commit>` label), not the CD PR id; nothing depends on the old pattern (pipeline / pending-scan / merge-kick identify reverse PRs by the `sync` label, source recovery is SHA-label based). Instead, after creating the SR PR the executor **comments its URL onto the CD source PR** (same step/token as the `sr-synced` marker), so the CD↔SR linkage lives only on the private side.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5