### PR TITLE
[Tool] reverse sync: kick the pending-scan when a reverse-sync PR merges

### DIFF
--- a/.github/workflows/cd-scan-pending-on-merge.yml
+++ b/.github/workflows/cd-scan-pending-on-merge.yml
@@ -1,0 +1,36 @@
+name: CD SCAN PENDING (ON MERGE)
+
+# Event-driven kick for the reverse-sync pending release loop. When a reverse-sync
+# (CelerData -> StarRocks) PR MERGES, promptly run cd-scan-pending.yml so the next
+# file-overlapping `pending` PR is released without waiting for the 30-min cron.
+#
+# This mirrors the forward side, where send_pr_notification.py dispatches
+# sync-scan-pending.yml after a sync PR is merged. The reverse cd-sync-pipeline.yml is
+# a trimmed v1 (BUILD + auto-merge only, no notification hook), so the kick lives here.
+#
+# pull_request_target:closed fires on every PR close; the job `if` restricts it to a
+# merged reverse-sync PR. It keys on the executor's head-branch signature
+# `<base>-cd-sync-pr-<N>` (set unconditionally by repo-sync.yml and NOT altered by the
+# model-2 scrub, unlike the `cd-sync` label/title marker) so it fires whether or not
+# scrub is active.
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  actions: write
+
+jobs:
+  kick-scan-pending:
+    runs-on: [self-hosted, sync]
+    if: >
+      github.repository == 'StarRocks/starrocks' &&
+      github.event.pull_request.merged == true &&
+      contains(github.head_ref, '-cd-sync-pr-')
+    steps:
+      - name: dispatch cd-scan-pending
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_PAT }}
+        run: |
+          gh workflow run cd-scan-pending.yml -R ${{ github.repository }} || true

--- a/.github/workflows/cd-scan-pending-on-merge.yml
+++ b/.github/workflows/cd-scan-pending-on-merge.yml
@@ -22,7 +22,9 @@ permissions:
 
 jobs:
   kick-scan-pending:
-    runs-on: [self-hosted, sync]
+    # sync-normal = the reverse-sync glue pool (pr-info / pending-scan live there too);
+    # bare [sync] is the FORWARD trigger's pool — keep reverse work off it.
+    runs-on: [self-hosted, sync-normal]
     if: >
       github.repository == 'StarRocks/starrocks' &&
       github.event.pull_request.merged == true &&

--- a/.github/workflows/cd-scan-pending-on-merge.yml
+++ b/.github/workflows/cd-scan-pending-on-merge.yml
@@ -9,10 +9,9 @@ name: CD SCAN PENDING (ON MERGE)
 # a trimmed v1 (BUILD + auto-merge only, no notification hook), so the kick lives here.
 #
 # pull_request_target:closed fires on every PR close; the job `if` restricts it to a
-# merged reverse-sync PR. It keys on the executor's head-branch signature
-# `<base>-cd-sync-pr-<N>` (set unconditionally by repo-sync.yml and NOT altered by the
-# model-2 scrub, unlike the `cd-sync` label/title marker) so it fires whether or not
-# scrub is active.
+# merged reverse-sync PR via the `sync` label. On StarRocks only the reverse sync opens
+# `sync`-labeled PRs (the forward SR->CD sync opens them on CelerData), and the executor
+# keeps the `sync` label after desensitization — so the label is a sufficient discriminator.
 
 on:
   pull_request_target:
@@ -27,7 +26,7 @@ jobs:
     if: >
       github.repository == 'StarRocks/starrocks' &&
       github.event.pull_request.merged == true &&
-      contains(github.head_ref, '-cd-sync-pr-')
+      contains(github.event.pull_request.labels.*.name, 'sync')
     steps:
       - name: dispatch cd-scan-pending
         env:

--- a/.github/workflows/cd-scan-pending-on-merge.yml
+++ b/.github/workflows/cd-scan-pending-on-merge.yml
@@ -24,7 +24,7 @@ jobs:
   kick-scan-pending:
     # sync-normal = the reverse-sync glue pool (pr-info / pending-scan live there too);
     # bare [sync] is the FORWARD trigger's pool — keep reverse work off it.
-    runs-on: [self-hosted, sync-normal]
+    runs-on: [self-hosted, sync-normal, ubuntu]
     if: >
       github.repository == 'StarRocks/starrocks' &&
       github.event.pull_request.merged == true &&

--- a/.github/workflows/cd-scan-pending.yml
+++ b/.github/workflows/cd-scan-pending.yml
@@ -24,11 +24,12 @@ jobs:
 
   scan-pending-cd-pr:
     name: SCAN PENDING CD-SYNC PRS
-    # [sync, ubuntu] — NOT bare [sync]: the legacy [sync]-only runners (forward ci-sync
-    # trigger glue) have no /var/lib/elastic-service, which is exactly how the only prior
-    # run of this workflow failed (2026-08-04, landed on such a runner). The reverse-sync
-    # prereqs live on the sg-ubuntu-sync-sr machines only.
-    runs-on: [self-hosted, sync, ubuntu]
+    # sync-normal (mirror of the forward sync-scan-pending's pool) — NOT bare [sync]:
+    # the legacy [sync]-only runners (forward ci-sync trigger glue) have no
+    # /var/lib/elastic-service, which is exactly how the only prior run of this workflow
+    # failed (2026-08-04, landed on such a runner). The reverse-sync prereqs live on the
+    # sg-ubuntu-sync-sr machines, which carry sync-normal.
+    runs-on: [self-hosted, sync-normal]
     if: github.repository == 'StarRocks/starrocks'
     steps:
       - name: scan

--- a/.github/workflows/cd-scan-pending.yml
+++ b/.github/workflows/cd-scan-pending.yml
@@ -29,7 +29,7 @@ jobs:
     # /var/lib/elastic-service, which is exactly how the only prior run of this workflow
     # failed (2026-08-04, landed on such a runner). The reverse-sync prereqs live on the
     # sg-ubuntu-sync-sr machines, which carry sync-normal.
-    runs-on: [self-hosted, sync-normal]
+    runs-on: [self-hosted, sync-normal, ubuntu]
     if: github.repository == 'StarRocks/starrocks'
     steps:
       - name: scan

--- a/.github/workflows/cd-scan-pending.yml
+++ b/.github/workflows/cd-scan-pending.yml
@@ -24,7 +24,11 @@ jobs:
 
   scan-pending-cd-pr:
     name: SCAN PENDING CD-SYNC PRS
-    runs-on: [self-hosted, sync]
+    # [sync, ubuntu] — NOT bare [sync]: the legacy [sync]-only runners (forward ci-sync
+    # trigger glue) have no /var/lib/elastic-service, which is exactly how the only prior
+    # run of this workflow failed (2026-08-04, landed on such a runner). The reverse-sync
+    # prereqs live on the sg-ubuntu-sync-sr machines only.
+    runs-on: [self-hosted, sync, ubuntu]
     if: github.repository == 'StarRocks/starrocks'
     steps:
       - name: scan


### PR DESCRIPTION
## Why I'm doing:

The reverse-sync pending-release loop (`cd-scan-pending.yml`) had no immediate, merge-driven trigger — only a 30-min cron and a post-executor kick. The forward side releases a pending PR within seconds of a merge; the reverse side lagged up to 30 minutes.

## What I'm doing:

Add a small event-driven workflow that fires on `pull_request_target: closed` and, for a **merged reverse-sync PR**, dispatches the pending-scan so the next file-overlapping `pending` PR is released promptly.

The job `if` restricts the (frequent) close event to reverse-sync merges by keying on the `sync` label — on StarRocks only the reverse executor opens `sync`-labeled PRs (forward sync opens on CelerData), so the label alone identifies a reverse-sync PR. Non-matching closes skip the job (no runner used).

Also pins `cd-scan-pending.yml` itself to the `[sync, ubuntu]` pool: bare `[sync]` also matches the legacy forward-trigger glue runners without `/var/lib/elastic-service` — the workflow's only prior run (2026-08-04) landed on one and failed exactly there.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5