### PR TITLE
[BugFix] Fill Analytor::_fns before prepare can fail half-way

### DIFF
--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -488,6 +488,13 @@ Status Aggregator::prepare(RuntimeState* state, RuntimeProfile* runtime_profile)
     _is_merge_funcs.resize(agg_size);
     _agg_fn_types = _params->agg_fn_types;
 
+    // Save the TFunction objects up front: close() walks _agg_functions/_agg_fn_ctxs and indexes _fns with
+    // the same index, so _fns must be filled before any error return below can leave prepare half-done.
+    _fns.reserve(agg_size);
+    for (int i = 0; i < agg_size; ++i) {
+        _fns.emplace_back(aggregate_functions[i].nodes[0].fn);
+    }
+
     for (int i = 0; i < agg_size; ++i) {
         const TExpr& desc = aggregate_functions[i];
         const TFunction& fn = desc.nodes[0].fn;
@@ -575,12 +582,6 @@ Status Aggregator::prepare(RuntimeState* state, RuntimeProfile* runtime_profile)
         }
         state->obj_pool()->add(_agg_fn_ctxs[i]);
         _agg_fn_ctxs[i]->set_mem_usage_counter(&_agg_state_mem_usage);
-    }
-
-    // save TFunction object
-    _fns.reserve(_agg_fn_ctxs.size());
-    for (int i = 0; i < _agg_fn_ctxs.size(); ++i) {
-        _fns.emplace_back(aggregate_functions[i].nodes[0].fn);
     }
 
     // prepare for spiller

--- a/be/src/exec/analytor.cpp
+++ b/be/src/exec/analytor.cpp
@@ -18,6 +18,7 @@
 #include <ios>
 #include <memory>
 
+#include "base/failpoint/fail_point.h"
 #include "base/utility/defer_op.h"
 #include "column/chunk.h"
 #include "column/column_helper.h"
@@ -199,6 +200,13 @@ Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* 
     _agg_states_offsets.resize(agg_size);
     _partition_size_required_function_index.resize(0);
 
+    // Save the TFunction objects up front: close() walks _agg_fn_ctxs and indexes _fns with the same
+    // index, so _fns must be filled before any error return below can leave prepare half-done.
+    _fns.reserve(agg_size);
+    for (int i = 0; i < agg_size; ++i) {
+        _fns.emplace_back(analytic_node.analytic_functions[i].nodes[0].fn);
+    }
+
     bool has_outer_join_child = analytic_node.__isset.has_outer_join_child && analytic_node.has_outer_join_child;
 
     _should_set_partition_size = false;
@@ -346,6 +354,11 @@ Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* 
         }
     }
 
+    // Fails prepare after the aggregate FunctionContexts have been created, so that the analytor is
+    // destroyed (and closed) in a half-prepared state.
+    FAIL_POINT_TRIGGER_EXECUTE(analytor_prepare_failed,
+                               { return Status::InternalError("injected failure in Analytor::prepare"); });
+
     RETURN_IF_ERROR(ExprFactory::create_expr_trees(_pool, analytic_node.partition_exprs, &_partition_ctxs, state));
     _partition_columns.resize(_partition_ctxs.size());
     for (size_t i = 0; i < _partition_ctxs.size(); i++) {
@@ -422,11 +435,6 @@ Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* 
     }
     if (_range_end_boundary.expr_ctx != nullptr) {
         RETURN_IF_ERROR(ExprExecutor::prepare(_range_end_boundary.expr_ctx, state));
-    }
-
-    _fns.reserve(_agg_fn_ctxs.size());
-    for (int i = 0; i < _agg_fn_ctxs.size(); ++i) {
-        _fns.emplace_back(_tnode.analytic_node.analytic_functions[i].nodes[0].fn);
     }
 
     return _prepare_processing_mode(state, runtime_profile);
@@ -1670,4 +1678,7 @@ AnalytorPtr AnalytorFactory::create(int i) {
     }
     return _analytors[i];
 }
+
+DEFINE_FAIL_POINT(analytor_prepare_failed);
+
 } // namespace starrocks

--- a/test/sql/test_window_function/R/test_window_prepare_failed
+++ b/test/sql/test_window_function/R/test_window_prepare_failed
@@ -1,0 +1,39 @@
+-- name: test_window_prepare_failed @sequential
+CREATE TABLE `t0` (
+  `k` int(11) NULL,
+  `v` int(11) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t0 values (1, 1), (1, 2), (2, 3);
+-- result:
+-- !result
+admin enable failpoint 'analytor_prepare_failed';
+-- result:
+-- !result
+[UC]select k, sum(v) over(partition by k) from t0;
+[UC]select k, sum(v) over(partition by k order by v rows between 1 preceding and current row) from t0;
+[UC]select k, sum(v) over(partition by k), max(v) over(partition by k) from t0;
+admin disable failpoint 'analytor_prepare_failed';
+-- result:
+-- !result
+select k, sum(v) over(partition by k order by v) as s from t0 order by k, v;
+-- result:
+1	1
+1	3
+2	3
+-- !result
+select k, row_number() over(partition by k order by v) as rn from t0 order by k, v;
+-- result:
+1	1
+1	2
+2	1
+-- !result
+CLEANUP {
+  admin disable failpoint 'analytor_prepare_failed';
+} END CLEANUP

--- a/test/sql/test_window_function/T/test_window_prepare_failed
+++ b/test/sql/test_window_function/T/test_window_prepare_failed
@@ -1,0 +1,29 @@
+-- name: test_window_prepare_failed @sequential
+
+CREATE TABLE `t0` (
+  `k` int(11) NULL,
+  `v` int(11) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into t0 values (1, 1), (1, 2), (2, 3);
+
+-- Analytor::prepare fails after the aggregate FunctionContexts have been created, so the analytor is
+-- closed from its destructor while still half-prepared. It must report the error instead of crashing the BE.
+admin enable failpoint 'analytor_prepare_failed';
+[UC]select k, sum(v) over(partition by k) from t0;
+[UC]select k, sum(v) over(partition by k order by v rows between 1 preceding and current row) from t0;
+[UC]select k, sum(v) over(partition by k), max(v) over(partition by k) from t0;
+admin disable failpoint 'analytor_prepare_failed';
+
+-- the BE must still be alive and window functions must still work
+select k, sum(v) over(partition by k order by v) as s from t0 order by k, v;
+select k, row_number() over(partition by k order by v) as rn from t0 order by k, v;
+
+CLEANUP {
+  admin disable failpoint 'analytor_prepare_failed';
+} END CLEANUP


### PR DESCRIPTION
## Why I'm doing:

Analytor::prepare() sizes _agg_fn_ctxs up front but filled _fns only at the very end, so any error return in between left the analytor holding FunctionContexts with an empty _fns. The analytor is then closed from its destructor, where the SRJAR loop walks _agg_fn_ctxs and indexes _fns with the same index, reading past the end of an empty vector and killing the BE:

    select multi_distinct_sum(v1) over() from t;
```
query_id:019ffb0b-09ed-7910-8820-6c9009cd33bf, fragment_instance:019ffb0b-09ed-7910-8820-6c9009cd33c0, plan_node_id:-1
*** Aborted at 1786623232 (unix time) try "date -d @1786623232" if you are using GNU date ***
PC: @         0x1e1fdf4e starrocks::Analytor::close(starrocks::RuntimeState*)::{lambda()#1}::operator()() const
*** SIGSEGV (@0x58) received by PID 2921864 (TID 0x7fc2a53056c0) LWP(2922306) from PID 88; stack trace: ***
    @         0x32df4647 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7fc454fceed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)
    @         0x32df3e46 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7fc454f72330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @         0x1e1fdf4e starrocks::Analytor::close(starrocks::RuntimeState*)::{lambda()#1}::operator()() const
    @         0x1e1fe771 starrocks::Analytor::close(starrocks::RuntimeState*)
    @         0x1e1f0a76 starrocks::Analytor::~Analytor()
    @         0x1e226ca9 void std::destroy_at<starrocks::Analytor>(starrocks::Analytor*)
    @         0x1e226c8e void std::_Destroy<starrocks::Analytor>(starrocks::Analytor*)
    @         0x1e226abe std::_Sp_counted_ptr_inplace<starrocks::Analytor, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose()
    @         0x1c9ec976 std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release()
    @         0x1c9f33ba std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count()
    @         0x1d421b9a std::__shared_ptr<starrocks::Analytor, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr()
    @         0x1d421bb6 std::shared_ptr<starrocks::Analytor>::~shared_ptr()
    @         0x1e1eb4c3 void std::destroy_at<std::shared_ptr<starrocks::Analytor> >(std::shared_ptr<starrocks::Analytor>*)
    @         0x1e1e8696 void std::_Destroy<std::shared_ptr<starrocks::Analytor> >(std::shared_ptr<starrocks::Analytor>*)
    @         0x1e1e6b7b void std::_Destroy_aux<false>::__destroy<std::shared_ptr<starrocks::Analytor>*>(std::shared_ptr<starrocks::Analytor>*, std::shared_ptr<starrocks::Analytor>*)
    @         0x1e1e56f3 void std::_Destroy<std::shared_ptr<starrocks::Analytor>*>(std::shared_ptr<starrocks::Analytor>*, std::shared_ptr<starrocks::Analytor>*)
    @         0x1e1e2053 std::vector<std::shared_ptr<starrocks::Analytor>, std::allocator<std::shared_ptr<starrocks::Analytor> > >::~vector()
    @         0x1e1eff1c starrocks::AnalytorFactory::~AnalytorFactory()
    @         0x1e1eff37 void std::destroy_at<starrocks::AnalytorFactory>(starrocks::AnalytorFactory*)
    @         0x1e1efe44 void std::_Destroy<starrocks::AnalytorFactory>(starrocks::AnalytorFactory*)
    @         0x1e1ef00c std::_Sp_counted_ptr_inplace<starrocks::AnalytorFactory, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose()
    @         0x1c9ec976 std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release()
    @         0x1c9f33ba std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count()
    @         0x1e1e0fa2 std::__shared_ptr<starrocks::AnalytorFactory, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr()
    @         0x1e1e0fbe std::shared_ptr<starrocks::AnalytorFactory>::~shared_ptr()
    @         0x1e1ee9ff starrocks::pipeline::AnalyticSourceOperatorFactory::~AnalyticSourceOperatorFactory()
    @         0x1e1efee6 void std::destroy_at<starrocks::pipeline::AnalyticSourceOperatorFactory>(starrocks::pipeline::AnalyticSourceOperatorFactory*)
    @         0x1e1efe0e void std::_Destroy<starrocks::pipeline::AnalyticSourceOperatorFactory>(starrocks::pipeline::AnalyticSourceOperatorFactory*)
    @         0x1e1eeb74 std::_Sp_counted_ptr_inplace<starrocks::pipeline::AnalyticSourceOperatorFactory, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose()
    @         0x1c9ec976 std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release()

```
Here prepare() bails out with "Invalid window function plan" because the function has no window implementation in the BE, but every other error return in prepare() reaches the same crash.

Fill _fns right after the resize() block so that it always has the same size as _agg_fn_ctxs no matter where prepare() returns. Aggregator has the same shape - not reachable today because nothing returns or throws between the two loops - so fill its _fns up front as well.

Add a failpoint that fails Analytor::prepare after the FunctionContexts are created, and a SQLTest using it; the test kills the BE without this fix.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
