### PR TITLE
[BugFix] Resolve the delta column group of an extended column through its root column

### DIFF
--- a/be/src/storage/extends_column_utils.h
+++ b/be/src/storage/extends_column_utils.h
@@ -20,4 +20,21 @@ namespace starrocks {
 StatusOr<TabletSchemaCSPtr> extend_schema_by_access_paths(const TabletSchemaCSPtr& tablet_schema, size_t next_unique_id,
                                                           const std::vector<ColumnAccessPathPtr>& access_paths);
 
+// The unique id under which `column`'s data is actually stored, which is the id a delta column group
+// is keyed by (see DeltaColumnGroup::get_column_idx).
+//
+// An extended column is a JSON subfield materialized by the JSONV2 path rewrite (the column appended
+// by extend_schema_by_access_paths above). It owns no storage: it is derived from its root JSON
+// column at read time, and the unique id it carries is synthetic, allocated above every real column
+// id so that it can never collide with one. Looking a delta column group up by that synthetic id
+// therefore always misses, so the subfield would be read from the base segment and silently return
+// the value a column-mode partial update has already replaced. Resolve to the root column instead.
+inline ColumnUID storage_column_uid(const TabletColumn& column) {
+    const auto* extended_info = column.extended_info();
+    if (extended_info != nullptr && extended_info->source_column_uid >= 0) {
+        return extended_info->source_column_uid;
+    }
+    return column.unique_id();
 }
+
+} // namespace starrocks

--- a/be/src/storage/meta_reader.cpp
+++ b/be/src/storage/meta_reader.cpp
@@ -27,6 +27,7 @@
 #include "common/config_exec_fwd.h"
 #include "common/status.h"
 #include "fs/fs_factory.h"
+#include "storage/extends_column_utils.h"
 #include "storage/olap_common.h"
 #include "storage/rowset/column_iterator.h"
 #include "storage/rowset/column_reader.h"
@@ -231,13 +232,23 @@ StatusOr<std::unique_ptr<ColumnIterator>> SegmentMetaCollecter::_new_dcg_column_
         const TabletColumn& column, std::string* filename, FileEncryptionInfo* encryption_info,
         ColumnAccessPath* path) {
     // build column iter from delta column group
-    ASSIGN_OR_RETURN(auto dcg_segment, _get_dcg_segment(column.unique_id()));
+    ASSIGN_OR_RETURN(auto dcg_segment, _get_dcg_segment(storage_column_uid(column)));
     if (dcg_segment != nullptr) {
         if (filename != nullptr) {
             *filename = dcg_segment->file_name();
         }
         if (encryption_info != nullptr && dcg_segment->encryption_info()) {
             *encryption_info = *dcg_segment->encryption_info();
+        }
+        if (column.is_extended()) {
+            // Same as SegmentIterator::_new_dcg_column_iterator: an extended column has no reader of
+            // its own in the .cols segment, it must be rebuilt from the root JSON column.
+            //
+            // This site must stay in step with the scan path. The global dictionary for a JSON string
+            // subfield is collected here, through a [_META_] scan; if the scan read the .cols overlay
+            // while dictionary collection still read the base segment, the value the scan returns
+            // would be absent from the dictionary and the query would fail to decode it.
+            return dcg_segment->new_column_iterator_or_default(column, path);
         }
         return dcg_segment->new_column_iterator(column, path);
     }

--- a/be/src/storage/meta_reader.h
+++ b/be/src/storage/meta_reader.h
@@ -174,15 +174,19 @@ private:
     size_t _collect_column_size_recursive(ColumnReader* col_reader);
     int64_t _collect_column_compressed_size_recursive(ColumnReader* col_reader);
     SegmentSharedPtr _segment;
+    // Declared before _column_iterators on purpose: a column iterator can hold raw pointers into the
+    // segment and the file it was built from (a delta column group column reads from a .cols segment
+    // and its own file), and members are destroyed in reverse declaration order, so the iterators must
+    // die first. SegmentIterator gets the same ordering explicitly in close().
+    std::unordered_map<std::string, SegmentSharedPtr> _dcg_segments;
+    std::unordered_map<ColumnId, std::unique_ptr<RandomAccessFile>> _column_files;
+    std::unique_ptr<RandomAccessFile> _read_file;
     std::vector<std::unique_ptr<ColumnIterator>> _column_iterators;
     std::vector<bool> _is_default_value_column_by_cid;
     const SegmentMetaCollecterParams* _params = nullptr;
     int32_t _tablet_id;
     int32_t _rss_id;
-    std::unique_ptr<RandomAccessFile> _read_file;
     OlapReaderStatistics _stats;
-    std::unordered_map<std::string, SegmentSharedPtr> _dcg_segments;
-    std::unordered_map<ColumnId, std::unique_ptr<RandomAccessFile>> _column_files;
     // For delta column group
     DeltaColumnGroupList _dcgs;
 };

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -55,6 +55,7 @@
 #include "storage/column_predicate_inverted_index_fallback.h"
 #include "storage/column_predicate_rewriter.h"
 #include "storage/del_vector.h"
+#include "storage/extends_column_utils.h"
 #include "storage/index/index_descriptor.h"
 #include "storage/index/inverted/inverted_index_option.h"
 #include "storage/index/vector/tenann/del_id_filter.h"
@@ -1911,13 +1912,20 @@ StatusOr<std::unique_ptr<ColumnIterator>> SegmentIterator::_new_dcg_column_itera
                                                                                     FileEncryptionInfo* encryption_info,
                                                                                     ColumnAccessPath* path) {
     // build column iter from delta column group
-    ASSIGN_OR_RETURN(auto dcg_segment, _get_dcg_segment(column.unique_id()));
+    ASSIGN_OR_RETURN(auto dcg_segment, _get_dcg_segment(storage_column_uid(column)));
     if (dcg_segment != nullptr) {
         if (filename != nullptr) {
             *filename = dcg_segment->file_name();
         }
         if (encryption_info != nullptr && dcg_segment->encryption_info()) {
             *encryption_info = *dcg_segment->encryption_info();
+        }
+        if (column.is_extended()) {
+            // The .cols segment holds the root JSON column, never the synthetic subfield column, so go
+            // through the `_or_default` entry point: it dispatches on is_extended() and rebuilds the
+            // subfield from the root column this segment does hold. new_column_iterator() would look
+            // the synthetic id up directly and fail with NotFound.
+            return dcg_segment->new_column_iterator_or_default(column, path);
         }
         return dcg_segment->new_column_iterator(column, path);
     }

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -4474,6 +4474,11 @@ Status SegmentIterator::_apply_bitmap_index() {
 
         RETURN_IF_ERROR(_bitmap_index_evaluator.init([&cid_2_ucid,
                                                       this](ColumnId cid) -> StatusOr<BitmapIndexIterator*> {
+            // NOTE: deliberately the column's OWN unique id, not storage_column_uid(). An extended
+            // column (JSON subfield) owns no bitmap index, so this misses every delta column group and
+            // then finds no reader in the base segment either -- the column ends up unindexed, which is
+            // what we want. Substituting the root column's id here would apply the JSON column's index
+            // to a subfield predicate. Only the value-read path resolves through the root id.
             const ColumnUID ucid = cid_2_ucid[cid];
             // the column's index in this segment file
             ASSIGN_OR_RETURN(std::shared_ptr<Segment> segment_ptr, _get_dcg_segment(ucid));
@@ -4565,6 +4570,9 @@ Status SegmentIterator::_init_inverted_index_iterators() {
         }
 
         ColumnId cid = pair.first;
+        // Same as _apply_bitmap_index: deliberately the column's OWN unique id. An extended column
+        // (JSON subfield) owns no inverted index, so this resolves to no index rather than to the root
+        // JSON column's one. Only the value-read path uses storage_column_uid().
         ColumnUID ucid = cid_2_ucid[cid];
 
         IndexReadOptions index_opts;

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -2256,6 +2256,7 @@ TEST_P(RowsetColumnPartialUpdateTest, partial_update_json_meta_dict_reads_overla
     // prove nothing.
     SegmentSharedPtr overlaid_segment;
     uint32_t overlaid_rowsetid = 0;
+    size_t overlaid_segment_idx = 0;
     auto rowset_map = tablet->updates()->get_rowset_map();
     ASSERT_TRUE(rowset_map != nullptr);
     for (const auto& [rowset_id, rs] : *rowset_map) {
@@ -2274,6 +2275,7 @@ TEST_P(RowsetColumnPartialUpdateTest, partial_update_json_meta_dict_reads_overla
             if (!dcgs.empty()) {
                 overlaid_segment = rs->segments()[seg];
                 overlaid_rowsetid = rowset_id;
+                overlaid_segment_idx = seg;
                 break;
             }
         }
@@ -2296,7 +2298,9 @@ TEST_P(RowsetColumnPartialUpdateTest, partial_update_json_meta_dict_reads_overla
     SegmentMetaCollectOptions options;
     options.is_primary_keys = true;
     options.tablet_id = tablet->tablet_id();
-    options.segment_id = 0;
+    // Must match the segment the collecter was constructed from: init() derives the delta column
+    // group key as pk_rowsetid + segment_id.
+    options.segment_id = overlaid_segment_idx;
     options.version = version;
     options.pk_rowsetid = overlaid_rowsetid;
     options.dcg_loader = dcg_loader;

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -16,6 +16,7 @@
 
 #include <functional>
 #include <iostream>
+#include <limits>
 #include <memory>
 
 #include "base/testutil/assert.h"
@@ -30,6 +31,7 @@
 #include "runtime/mem_pool.h"
 #include "runtime/mem_tracker.h"
 #include "storage/chunk_helper.h"
+#include "storage/extends_column_utils.h"
 #include "storage/meta_reader.h"
 #include "storage/olap_common.h"
 #include "storage/rowset/rowset_factory.h"
@@ -47,6 +49,7 @@
 #include "storage_primitive/column_predicate_factory.h"
 #include "storage_primitive/empty_iterator.h"
 #include "storage_primitive/union_iterator.h"
+#include "types/json_value.h"
 
 namespace starrocks {
 
@@ -1973,6 +1976,241 @@ TEST_P(RowsetColumnPartialUpdateTest, partial_update_with_clucene_gin_index_chec
     }
 }
 #endif
+
+// ------------------------------------------------------------------------------------------------
+// JSON subfield read through an extended column, after a column-mode partial update.
+//
+// The JSONV2 path rewrite (session variable cbo_json_v2_rewrite, on by default) replaces
+// get_json_int(j, '$.x') with a read of an *extended* column: a synthetic subfield column that owns
+// no storage, carries a synthetic unique id, and points back at its root JSON column through
+// ExtendedColumnInfo. A column-mode partial update writes the new value of `j` into a .cols delta
+// column group keyed by the ROOT column's unique id, so the read must resolve the group through the
+// root id. Resolving it through the extended column's own (synthetic) id matches nothing, and the
+// subfield is then served from the base segment -- silently returning the value the update replaced.
+// ------------------------------------------------------------------------------------------------
+
+static std::string make_json(int64_t x) {
+    return R"({"x": )" + std::to_string(x) + "}";
+}
+
+static TabletSharedPtr create_json_tablet(std::vector<TabletSharedPtr>* tablets, int64_t tablet_id,
+                                          int32_t schema_hash) {
+    TCreateTabletReq request;
+    request.tablet_id = tablet_id;
+    request.__set_version(1);
+    request.__set_version_hash(0);
+    request.tablet_schema.schema_hash = schema_hash;
+    request.tablet_schema.short_key_column_count = 1;
+    request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+    request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+    TColumn pk;
+    pk.column_name = "pk";
+    pk.__set_is_key(true);
+    pk.column_type.type = TPrimitiveType::BIGINT;
+    request.tablet_schema.columns.push_back(pk);
+
+    TColumn j;
+    j.column_name = "j";
+    j.__set_is_key(false);
+    j.__set_is_allow_null(true);
+    j.column_type.type = TPrimitiveType::JSON;
+    request.tablet_schema.columns.push_back(j);
+
+    TColumn v;
+    v.column_name = "v";
+    v.__set_is_key(false);
+    v.column_type.type = TPrimitiveType::INT;
+    request.tablet_schema.columns.push_back(v);
+
+    auto st = StorageEngine::instance()->create_tablet(request);
+    CHECK(st.ok()) << st.to_string();
+    auto tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    tablets->push_back(tablet);
+    return tablet;
+}
+
+// Fills a writer context that is common to the full and the partial-update rowset below.
+static RowsetWriterContext json_writer_context(const TabletSharedPtr& tablet) {
+    RowsetWriterContext writer_context;
+    writer_context.rowset_id = StorageEngine::instance()->next_rowset_id();
+    writer_context.tablet_id = tablet->tablet_id();
+    writer_context.tablet_schema_hash = tablet->schema_hash();
+    writer_context.partition_id = 0;
+    writer_context.rowset_path_prefix = tablet->schema_hash_path();
+    writer_context.rowset_state = COMMITTED;
+    writer_context.version.first = 0;
+    writer_context.version.second = 0;
+    writer_context.segments_overlap = NONOVERLAPPING;
+    return writer_context;
+}
+
+// Writes one row per key: (pk, {"x": x_of(pk)}, pk).
+static RowsetSharedPtr create_json_rowset(const TabletSharedPtr& tablet, const std::vector<int64_t>& keys,
+                                          const std::function<int64_t(int64_t)>& x_of) {
+    RowsetWriterContext writer_context = json_writer_context(tablet);
+    writer_context.tablet_schema = tablet->tablet_schema();
+    std::unique_ptr<RowsetWriter> writer;
+    CHECK_OK(RowsetFactory::create_rowset_writer(writer_context, &writer));
+
+    auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
+    auto chunk = ChunkFactory::new_chunk(schema, keys.size());
+    auto cols = chunk->columns();
+    // JsonColumn::append_datum keeps only a view of the JsonValue until the chunk copies it, so the
+    // values have to stay alive until flush_chunk.
+    std::vector<JsonValue> json_values;
+    json_values.reserve(keys.size());
+    for (int64_t key : keys) {
+        json_values.emplace_back(JsonValue::parse(make_json(x_of(key))).value());
+    }
+    for (size_t i = 0; i < keys.size(); i++) {
+        cols[0]->as_mutable_ptr()->append_datum(Datum(keys[i]));
+        cols[1]->as_mutable_ptr()->append_datum(Datum(&json_values[i]));
+        cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)keys[i]));
+    }
+    CHECK_OK(writer->flush_chunk(*chunk));
+    return *writer->build();
+}
+
+// Column-mode partial update carrying only (pk, j), which lands as a .cols delta column group.
+static RowsetSharedPtr create_json_partial_rowset(const TabletSharedPtr& tablet, const std::vector<int64_t>& keys,
+                                                  const std::function<int64_t(int64_t)>& x_of,
+                                                  const std::shared_ptr<TabletSchema>& partial_schema,
+                                                  const std::vector<int32_t>& column_indexes) {
+    RowsetWriterContext writer_context = json_writer_context(tablet);
+    writer_context.tablet_schema = partial_schema;
+    writer_context.referenced_column_ids = column_indexes;
+    writer_context.full_tablet_schema = tablet->tablet_schema();
+    writer_context.is_partial_update = true;
+    writer_context.partial_update_mode = PartialUpdateMode::COLUMN_UPDATE_MODE;
+    std::unique_ptr<RowsetWriter> writer;
+    CHECK_OK(RowsetFactory::create_rowset_writer(writer_context, &writer));
+
+    auto schema = ChunkHelper::convert_schema(partial_schema);
+    auto chunk = ChunkFactory::new_chunk(schema, keys.size());
+    auto cols = chunk->columns();
+    std::vector<JsonValue> json_values;
+    json_values.reserve(keys.size());
+    for (int64_t key : keys) {
+        json_values.emplace_back(JsonValue::parse(make_json(x_of(key))).value());
+    }
+    for (size_t i = 0; i < keys.size(); i++) {
+        cols[0]->as_mutable_ptr()->append_datum(Datum(keys[i]));
+        cols[1]->as_mutable_ptr()->append_datum(Datum(&json_values[i]));
+    }
+    CHECK_OK(writer->flush_chunk(*chunk));
+
+    RowsetSharedPtr partial_rowset = *writer->build();
+    partial_rowset->set_schema(tablet->tablet_schema());
+    return partial_rowset;
+}
+
+// Builds the access path the FE emits for get_json_int(j, '$.x'): a ROOT node named after the JSON
+// column with one FIELD child per subfield, with `extended` set on the root (ColumnAccessPath
+// .createLinearPath + setExtended on the FE side).
+static ColumnAccessPathPtr make_extended_json_path(const std::string& root_column, const std::string& field,
+                                                   LogicalType value_type) {
+    TColumnAccessPath tleaf;
+    tleaf.__set_type(TAccessPathType::FIELD);
+    tleaf.__set_from_predicate(false);
+    tleaf.__set_extended(false);
+    tleaf.__set_type_desc(TypeDescriptor(value_type).to_thrift());
+
+    TColumnAccessPath troot;
+    troot.__set_type(TAccessPathType::ROOT);
+    troot.__set_from_predicate(false);
+    troot.__set_extended(true);
+    troot.__set_type_desc(TypeDescriptor(value_type).to_thrift());
+    troot.__set_children({tleaf});
+
+    std::vector<std::string> resolved = {root_column, field};
+    size_t resolve_index = 0;
+    auto resolver = [&](const TColumnAccessPath&) -> StatusOr<std::string> {
+        CHECK_LT(resolve_index, resolved.size());
+        return resolved[resolve_index++];
+    };
+    auto res = ColumnAccessPath::create(troot, resolver);
+    CHECK(res.ok()) << res.status();
+    return std::move(res).value();
+}
+
+// Reads the tablet through the JSONV2-extended schema, exactly as OlapChunkSource does, and checks
+// the subfield column against `expected_x`. Also re-checks the whole JSON column, which reads the
+// overlay through the root column's own unique id and was therefore never affected.
+static void check_json_subfield(const TabletSharedPtr& tablet, int64_t version, size_t expected_rows,
+                                const std::function<int64_t(int64_t)>& expected_x) {
+    std::vector<ColumnAccessPathPtr> paths;
+    // The extended TabletColumn keeps a raw pointer to this path, so it has to outlive the read.
+    paths.emplace_back(make_extended_json_path("j", "x", TYPE_BIGINT));
+    ASSERT_EQ("j.x", paths[0]->linear_path());
+    ASSERT_TRUE(paths[0]->is_extended());
+
+    // Same seed as next_uniq_id(): above every real column id, so the synthetic id cannot collide.
+    ASSIGN_OR_ABORT(auto extended_schema,
+                    extend_schema_by_access_paths(tablet->tablet_schema(),
+                                                  std::numeric_limits<int32_t>::max() - 1000000, paths));
+    ASSERT_EQ(tablet->tablet_schema()->num_columns() + 1, extended_schema->num_columns());
+    const size_t subfield_cid = extended_schema->num_columns() - 1;
+    ASSERT_TRUE(extended_schema->column(subfield_cid).is_extended());
+
+    Schema schema = ChunkHelper::convert_schema(extended_schema);
+    TabletReader reader(tablet, Version(0, version), extended_schema, schema);
+    auto iter = create_tablet_iterator(reader, schema);
+    ASSERT_TRUE(iter != nullptr);
+
+    auto chunk = ChunkFactory::new_chunk(iter->schema(), 100);
+    size_t rows = 0;
+    while (true) {
+        auto st = iter->get_next(chunk.get());
+        if (st.is_end_of_file()) {
+            break;
+        }
+        ASSERT_OK(st);
+        for (size_t r = 0; r < chunk->num_rows(); r++) {
+            const int64_t pk = chunk->columns()[0]->get(r).get_int64();
+            JsonValue expected_json = JsonValue::parse(make_json(expected_x(pk))).value();
+            ASSERT_FALSE(chunk->columns()[1]->is_null(r)) << "pk=" << pk;
+            EXPECT_EQ(expected_json, *chunk->columns()[1]->get(r).get_json()) << "pk=" << pk;
+            ASSERT_FALSE(chunk->columns()[subfield_cid]->is_null(r)) << "pk=" << pk;
+            EXPECT_EQ(expected_x(pk), chunk->columns()[subfield_cid]->get(r).get_int64()) << "pk=" << pk;
+        }
+        rows += chunk->num_rows();
+        chunk->reset();
+    }
+    ASSERT_EQ(expected_rows, rows);
+}
+
+TEST_P(RowsetColumnPartialUpdateTest, partial_update_json_read_through_extended_column) {
+    const int N = 100;
+    auto tablet = create_json_tablet(&_tablets, rand(), rand());
+    auto base_x = [](int64_t pk) { return pk; };
+    auto updated_x = [](int64_t pk) { return pk + 1000; };
+
+    std::vector<int64_t> keys(N);
+    for (int i = 0; i < N; i++) {
+        keys[i] = i;
+    }
+
+    int64_t version = 1;
+    std::vector<RowsetSharedPtr> rowsets{create_json_rowset(tablet, keys, base_x)};
+    commit_rowsets(tablet, rowsets, version);
+    check_json_subfield(tablet, version, N, base_x);
+
+    // Column-mode partial update of the JSON column only.
+    std::vector<int32_t> column_indexes = {0, 1};
+    std::shared_ptr<TabletSchema> partial_schema = TabletSchema::create(tablet->tablet_schema(), column_indexes);
+    RowsetSharedPtr partial_rowset =
+            create_json_partial_rowset(tablet, keys, updated_x, partial_schema, column_indexes);
+    auto st = tablet->rowset_commit(++version, partial_rowset, 10000);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    // The update must have landed as a delta column group rather than a rewrite, otherwise the read
+    // below would exercise nothing.
+    ASSERT_GT(StorageEngine::instance()->update_manager()->get_delta_column_group_file_size_by_tablet_id(
+                      tablet->tablet_id()),
+              0);
+
+    check_json_subfield(tablet, version, N, updated_x);
+}
 
 INSTANTIATE_TEST_SUITE_P(RowsetColumnPartialUpdateTest, RowsetColumnPartialUpdateTest,
                          ::testing::Values(RowsetColumnPartialUpdateParam{1}, RowsetColumnPartialUpdateParam{1024},

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -18,10 +18,12 @@
 #include <iostream>
 #include <limits>
 #include <memory>
+#include <set>
 
 #include "base/testutil/assert.h"
 #include "base/utility/defer_op.h"
 #include "column/chunk_factory.h"
+#include "column/column_helper.h"
 #include "column/datum_tuple.h"
 #include "common/config_compaction_fwd.h"
 #include "common/config_exec_fwd.h"
@@ -1989,8 +1991,10 @@ TEST_P(RowsetColumnPartialUpdateTest, partial_update_with_clucene_gin_index_chec
 // subfield is then served from the base segment -- silently returning the value the update replaced.
 // ------------------------------------------------------------------------------------------------
 
-static std::string make_json(int64_t x) {
-    return R"({"x": )" + std::to_string(x) + "}";
+// `tag` is constant within a rowset, so the flattened `y` sub-column is dictionary-encoded -- which is
+// what makes the [_META_] dictionary-collection path below reachable.
+static std::string make_json(int64_t x, const std::string& tag) {
+    return R"({"x": )" + std::to_string(x) + R"(, "y": ")" + tag + R"("})";
 }
 
 static TabletSharedPtr create_json_tablet(std::vector<TabletSharedPtr>* tablets, int64_t tablet_id,
@@ -2047,7 +2051,7 @@ static RowsetWriterContext json_writer_context(const TabletSharedPtr& tablet) {
 
 // Writes one row per key: (pk, {"x": x_of(pk)}, pk).
 static RowsetSharedPtr create_json_rowset(const TabletSharedPtr& tablet, const std::vector<int64_t>& keys,
-                                          const std::function<int64_t(int64_t)>& x_of) {
+                                          const std::function<int64_t(int64_t)>& x_of, const std::string& tag) {
     RowsetWriterContext writer_context = json_writer_context(tablet);
     writer_context.tablet_schema = tablet->tablet_schema();
     std::unique_ptr<RowsetWriter> writer;
@@ -2061,7 +2065,7 @@ static RowsetSharedPtr create_json_rowset(const TabletSharedPtr& tablet, const s
     std::vector<JsonValue> json_values;
     json_values.reserve(keys.size());
     for (int64_t key : keys) {
-        json_values.emplace_back(JsonValue::parse(make_json(x_of(key))).value());
+        json_values.emplace_back(JsonValue::parse(make_json(x_of(key), tag)).value());
     }
     for (size_t i = 0; i < keys.size(); i++) {
         cols[0]->as_mutable_ptr()->append_datum(Datum(keys[i]));
@@ -2076,7 +2080,7 @@ static RowsetSharedPtr create_json_rowset(const TabletSharedPtr& tablet, const s
 static RowsetSharedPtr create_json_partial_rowset(const TabletSharedPtr& tablet, const std::vector<int64_t>& keys,
                                                   const std::function<int64_t(int64_t)>& x_of,
                                                   const std::shared_ptr<TabletSchema>& partial_schema,
-                                                  const std::vector<int32_t>& column_indexes) {
+                                                  const std::vector<int32_t>& column_indexes, const std::string& tag) {
     RowsetWriterContext writer_context = json_writer_context(tablet);
     writer_context.tablet_schema = partial_schema;
     writer_context.referenced_column_ids = column_indexes;
@@ -2092,7 +2096,7 @@ static RowsetSharedPtr create_json_partial_rowset(const TabletSharedPtr& tablet,
     std::vector<JsonValue> json_values;
     json_values.reserve(keys.size());
     for (int64_t key : keys) {
-        json_values.emplace_back(JsonValue::parse(make_json(x_of(key))).value());
+        json_values.emplace_back(JsonValue::parse(make_json(x_of(key), tag)).value());
     }
     for (size_t i = 0; i < keys.size(); i++) {
         cols[0]->as_mutable_ptr()->append_datum(Datum(keys[i]));
@@ -2109,18 +2113,18 @@ static RowsetSharedPtr create_json_partial_rowset(const TabletSharedPtr& tablet,
 // column with one FIELD child per subfield, with `extended` set on the root (ColumnAccessPath
 // .createLinearPath + setExtended on the FE side).
 static ColumnAccessPathPtr make_extended_json_path(const std::string& root_column, const std::string& field,
-                                                   LogicalType value_type) {
+                                                   const TypeDescriptor& value_type) {
     TColumnAccessPath tleaf;
     tleaf.__set_type(TAccessPathType::FIELD);
     tleaf.__set_from_predicate(false);
     tleaf.__set_extended(false);
-    tleaf.__set_type_desc(TypeDescriptor(value_type).to_thrift());
+    tleaf.__set_type_desc(value_type.to_thrift());
 
     TColumnAccessPath troot;
     troot.__set_type(TAccessPathType::ROOT);
     troot.__set_from_predicate(false);
     troot.__set_extended(true);
-    troot.__set_type_desc(TypeDescriptor(value_type).to_thrift());
+    troot.__set_type_desc(value_type.to_thrift());
     troot.__set_children({tleaf});
 
     std::vector<std::string> resolved = {root_column, field};
@@ -2138,10 +2142,10 @@ static ColumnAccessPathPtr make_extended_json_path(const std::string& root_colum
 // the subfield column against `expected_x`. Also re-checks the whole JSON column, which reads the
 // overlay through the root column's own unique id and was therefore never affected.
 static void check_json_subfield(const TabletSharedPtr& tablet, int64_t version, size_t expected_rows,
-                                const std::function<int64_t(int64_t)>& expected_x) {
+                                const std::function<int64_t(int64_t)>& expected_x, const std::string& expected_tag) {
     std::vector<ColumnAccessPathPtr> paths;
     // The extended TabletColumn keeps a raw pointer to this path, so it has to outlive the read.
-    paths.emplace_back(make_extended_json_path("j", "x", TYPE_BIGINT));
+    paths.emplace_back(make_extended_json_path("j", "x", TypeDescriptor(TYPE_BIGINT)));
     ASSERT_EQ("j.x", paths[0]->linear_path());
     ASSERT_TRUE(paths[0]->is_extended());
 
@@ -2168,7 +2172,7 @@ static void check_json_subfield(const TabletSharedPtr& tablet, int64_t version, 
         ASSERT_OK(st);
         for (size_t r = 0; r < chunk->num_rows(); r++) {
             const int64_t pk = chunk->columns()[0]->get(r).get_int64();
-            JsonValue expected_json = JsonValue::parse(make_json(expected_x(pk))).value();
+            JsonValue expected_json = JsonValue::parse(make_json(expected_x(pk), expected_tag)).value();
             ASSERT_FALSE(chunk->columns()[1]->is_null(r)) << "pk=" << pk;
             EXPECT_EQ(expected_json, *chunk->columns()[1]->get(r).get_json()) << "pk=" << pk;
             ASSERT_FALSE(chunk->columns()[subfield_cid]->is_null(r)) << "pk=" << pk;
@@ -2192,15 +2196,15 @@ TEST_P(RowsetColumnPartialUpdateTest, partial_update_json_read_through_extended_
     }
 
     int64_t version = 1;
-    std::vector<RowsetSharedPtr> rowsets{create_json_rowset(tablet, keys, base_x)};
+    std::vector<RowsetSharedPtr> rowsets{create_json_rowset(tablet, keys, base_x, "old")};
     commit_rowsets(tablet, rowsets, version);
-    check_json_subfield(tablet, version, N, base_x);
+    check_json_subfield(tablet, version, N, base_x, "old");
 
     // Column-mode partial update of the JSON column only.
     std::vector<int32_t> column_indexes = {0, 1};
     std::shared_ptr<TabletSchema> partial_schema = TabletSchema::create(tablet->tablet_schema(), column_indexes);
     RowsetSharedPtr partial_rowset =
-            create_json_partial_rowset(tablet, keys, updated_x, partial_schema, column_indexes);
+            create_json_partial_rowset(tablet, keys, updated_x, partial_schema, column_indexes, "new");
     auto st = tablet->rowset_commit(++version, partial_rowset, 10000);
     ASSERT_TRUE(st.ok()) << st.to_string();
     // The update must have landed as a delta column group rather than a rewrite, otherwise the read
@@ -2209,7 +2213,118 @@ TEST_P(RowsetColumnPartialUpdateTest, partial_update_json_read_through_extended_
                       tablet->tablet_id()),
               0);
 
-    check_json_subfield(tablet, version, N, updated_x);
+    check_json_subfield(tablet, version, N, updated_x, "new");
+}
+
+// The global dictionary for a JSON string subfield is collected by a [_META_] scan through
+// SegmentMetaCollecter, which resolves delta column groups with the same code the scan path uses. If
+// dictionary collection kept reading the base segment while the scan reads the .cols overlay, the value
+// the scan returns would be absent from the dictionary. This drives that collecter directly.
+TEST_P(RowsetColumnPartialUpdateTest, partial_update_json_meta_dict_reads_overlay) {
+    const int N = 100;
+    auto tablet = create_json_tablet(&_tablets, rand(), rand());
+    auto x_of = [](int64_t pk) { return pk; };
+
+    std::vector<int64_t> keys(N);
+    for (int i = 0; i < N; i++) {
+        keys[i] = i;
+    }
+
+    int64_t version = 1;
+    std::vector<RowsetSharedPtr> rowsets{create_json_rowset(tablet, keys, x_of, "old")};
+    commit_rowsets(tablet, rowsets, version);
+
+    std::vector<int32_t> column_indexes = {0, 1};
+    std::shared_ptr<TabletSchema> partial_schema = TabletSchema::create(tablet->tablet_schema(), column_indexes);
+    RowsetSharedPtr partial_rowset =
+            create_json_partial_rowset(tablet, keys, x_of, partial_schema, column_indexes, "new");
+    auto st = tablet->rowset_commit(++version, partial_rowset, 10000);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    // The extended column for get_json_string(j, '$.y').
+    std::vector<ColumnAccessPathPtr> paths;
+    paths.emplace_back(make_extended_json_path("j", "y", TypeDescriptor::create_varchar_type(255)));
+    ASSIGN_OR_ABORT(auto extended_schema,
+                    extend_schema_by_access_paths(tablet->tablet_schema(),
+                                                  std::numeric_limits<int32_t>::max() - 1000000, paths));
+    const size_t subfield_cid = extended_schema->num_columns() - 1;
+    ASSERT_EQ(TYPE_VARCHAR, extended_schema->column(subfield_cid).type());
+
+    auto dcg_loader = std::make_shared<LocalDeltaColumnGroupLoader>(tablet->data_dir()->get_meta());
+
+    // Find the segment that actually carries an overlay -- collecting from a segment without one would
+    // prove nothing.
+    SegmentSharedPtr overlaid_segment;
+    uint32_t overlaid_rowsetid = 0;
+    auto rowset_map = tablet->updates()->get_rowset_map();
+    ASSERT_TRUE(rowset_map != nullptr);
+    for (const auto& [rowset_id, rs] : *rowset_map) {
+        if (rs == nullptr) {
+            continue;
+        }
+        // For a primary-key tablet the delta column group is keyed by the rowset-map key (the rssid
+        // base) plus the segment index -- the same arithmetic SegmentMetaCollecter::init() does.
+        ASSERT_OK(rs->load());
+        for (size_t seg = 0; seg < rs->segments().size(); seg++) {
+            DeltaColumnGroupList dcgs;
+            TabletSegmentId tsid;
+            tsid.tablet_id = tablet->tablet_id();
+            tsid.segment_id = rowset_id + seg;
+            ASSERT_OK(dcg_loader->load(tsid, version, &dcgs));
+            if (!dcgs.empty()) {
+                overlaid_segment = rs->segments()[seg];
+                overlaid_rowsetid = rowset_id;
+                break;
+            }
+        }
+        if (overlaid_segment != nullptr) {
+            break;
+        }
+    }
+    ASSERT_TRUE(overlaid_segment != nullptr) << "no segment carries a delta column group";
+
+    SegmentMetaCollecter collecter(overlaid_segment);
+    SegmentMetaCollecterParams params;
+    params.fields.emplace_back(META_DICT_MERGE);
+    params.field_type.emplace_back(LogicalType::TYPE_VARCHAR);
+    params.cids.emplace_back(subfield_cid);
+    params.read_page.emplace_back(true);
+    params.tablet_schema = extended_schema;
+    params.low_cardinality_threshold = 256;
+    params.use_page_cache = false;
+
+    SegmentMetaCollectOptions options;
+    options.is_primary_keys = true;
+    options.tablet_id = tablet->tablet_id();
+    options.segment_id = 0;
+    options.version = version;
+    options.pk_rowsetid = overlaid_rowsetid;
+    options.dcg_loader = dcg_loader;
+
+    ASSERT_OK(collecter.init(&params, options));
+    ASSERT_OK(collecter.open());
+
+    // Non-nullable, matching what MetaReader builds for META_DICT_MERGE: _collect_dict_for_column only
+    // appends to the array's offsets/elements, never to a null column.
+    auto dict_column = ColumnHelper::create_column(
+            TypeDescriptor::create_array_type(TypeDescriptor::create_varchar_type(255)), false);
+    std::vector<Column*> dsts = {dict_column.get()};
+    ASSERT_OK(collecter.collect(&dsts));
+
+    std::set<std::string> words;
+    for (size_t r = 0; r < dict_column->size(); r++) {
+        // Keep the Datum alive: get_array() hands back a reference into it, so iterating
+        // dict_column->get(r).get_array() directly would read a destroyed temporary.
+        auto row = dict_column->get(r);
+        for (const auto& word : row.get_array()) {
+            words.insert(word.get_slice().to_string());
+        }
+    }
+    // Guard against a vacuous pass: if no dictionary was collected at all, the assertions below would
+    // hold for the wrong reason.
+    ASSERT_FALSE(words.empty()) << "no dictionary collected, the check below would be vacuous";
+    EXPECT_TRUE(words.count("new") > 0) << "dictionary is missing the value the scan now returns";
+    EXPECT_TRUE(words.count("old") == 0) << "dictionary still carries the pre-update value";
 }
 
 INSTANTIATE_TEST_SUITE_P(RowsetColumnPartialUpdateTest, RowsetColumnPartialUpdateTest,

--- a/test/sql/test_partial_update_column_mode/R/test_partial_update_json_subfield
+++ b/test/sql/test_partial_update_column_mode/R/test_partial_update_json_subfield
@@ -34,6 +34,15 @@ select pk, get_json_int(j, '$.x'), get_json_string(j, '$.y'), cast(j as varchar)
 1	9	bbb	{"x": 9, "y": "bbb"}
 2	2	aaa	{"x": 2, "y": "aaa"}
 -- !result
+-- A predicate on the overlaid subfield must match the updated row too, not just the projection.
+select pk from tab1 where get_json_string(j, '$.y') = 'bbb' order by pk;
+-- result:
+1
+-- !result
+select pk from tab1 where get_json_int(j, '$.x') = 9 order by pk;
+-- result:
+1
+-- !result
 set cbo_json_v2_rewrite = false;
 -- result:
 -- !result

--- a/test/sql/test_partial_update_column_mode/R/test_partial_update_json_subfield
+++ b/test/sql/test_partial_update_column_mode/R/test_partial_update_json_subfield
@@ -1,0 +1,47 @@
+-- name: test_partial_update_json_subfield
+-- A column-mode partial update writes the new value of the JSON column into a delta column group.
+-- get_json_* is rewritten by the optimizer into a read of an extended subfield column
+-- (cbo_json_v2_rewrite, on by default), which must resolve that delta column group through the root
+-- JSON column; resolving it through the extended column's own synthetic id finds nothing and the
+-- subfield is then silently served from the base segment, i.e. the value the update replaced.
+CREATE table tab1 (
+      pk BIGINT NOT NULL,
+      j JSON,
+      v BIGINT
+)
+ENGINE=OLAP
+PRIMARY KEY(`pk`)
+DISTRIBUTED BY HASH(`pk`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into tab1 values (1, parse_json('{"x": 1, "y": "aaa"}'), 1), (2, parse_json('{"x": 2, "y": "aaa"}'), 2);
+-- result:
+-- !result
+set partial_update_mode = 'column';
+-- result:
+-- !result
+update tab1 set j = parse_json('{"x": 9, "y": "bbb"}') where pk = 1;
+-- result:
+-- !result
+set partial_update_mode = 'auto';
+-- result:
+-- !result
+select pk, get_json_int(j, '$.x'), get_json_string(j, '$.y'), cast(j as varchar) from tab1 order by pk;
+-- result:
+1	9	bbb	{"x": 9, "y": "bbb"}
+2	2	aaa	{"x": 2, "y": "aaa"}
+-- !result
+set cbo_json_v2_rewrite = false;
+-- result:
+-- !result
+select pk, get_json_int(j, '$.x'), get_json_string(j, '$.y') from tab1 order by pk;
+-- result:
+1	9	bbb
+2	2	aaa
+-- !result
+set cbo_json_v2_rewrite = true;
+-- result:
+-- !result

--- a/test/sql/test_partial_update_column_mode/T/test_partial_update_json_subfield
+++ b/test/sql/test_partial_update_column_mode/T/test_partial_update_json_subfield
@@ -1,0 +1,25 @@
+-- name: test_partial_update_json_subfield
+-- A column-mode partial update writes the new value of the JSON column into a delta column group.
+-- get_json_* is rewritten by the optimizer into a read of an extended subfield column
+-- (cbo_json_v2_rewrite, on by default), which must resolve that delta column group through the root
+-- JSON column; resolving it through the extended column's own synthetic id finds nothing and the
+-- subfield is then silently served from the base segment, i.e. the value the update replaced.
+CREATE table tab1 (
+      pk BIGINT NOT NULL,
+      j JSON,
+      v BIGINT
+)
+ENGINE=OLAP
+PRIMARY KEY(`pk`)
+DISTRIBUTED BY HASH(`pk`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into tab1 values (1, parse_json('{"x": 1, "y": "aaa"}'), 1), (2, parse_json('{"x": 2, "y": "aaa"}'), 2);
+set partial_update_mode = 'column';
+update tab1 set j = parse_json('{"x": 9, "y": "bbb"}') where pk = 1;
+set partial_update_mode = 'auto';
+select pk, get_json_int(j, '$.x'), get_json_string(j, '$.y'), cast(j as varchar) from tab1 order by pk;
+set cbo_json_v2_rewrite = false;
+select pk, get_json_int(j, '$.x'), get_json_string(j, '$.y') from tab1 order by pk;
+set cbo_json_v2_rewrite = true;

--- a/test/sql/test_partial_update_column_mode/T/test_partial_update_json_subfield
+++ b/test/sql/test_partial_update_column_mode/T/test_partial_update_json_subfield
@@ -20,6 +20,9 @@ set partial_update_mode = 'column';
 update tab1 set j = parse_json('{"x": 9, "y": "bbb"}') where pk = 1;
 set partial_update_mode = 'auto';
 select pk, get_json_int(j, '$.x'), get_json_string(j, '$.y'), cast(j as varchar) from tab1 order by pk;
+-- A predicate on the overlaid subfield must match the updated row too, not just the projection.
+select pk from tab1 where get_json_string(j, '$.y') = 'bbb' order by pk;
+select pk from tab1 where get_json_int(j, '$.x') = 9 order by pk;
 set cbo_json_v2_rewrite = false;
 select pk, get_json_int(j, '$.x'), get_json_string(j, '$.y') from tab1 order by pk;
 set cbo_json_v2_rewrite = true;


### PR DESCRIPTION
## Why I'm doing:

On a primary-key table, a column-mode partial update to a `JSON` column lands correctly on disk, but
`get_json_int(j, '$.x')` keeps returning the value the update replaced. No error, no warning, and the
row count is right. Reading the same field any other way is correct:

| expression | result | |
|---|---|---|
| `get_json_int(a, '$.x')` | `1` | **pre-update** |
| `json_query(a, '$.x')` | `9` | correct |
| `a -> 'x'` | `9` | correct |
| `cast(a as varchar)` | `{"x": 9}` | correct |

`SET cbo_json_v2_rewrite = false` makes it correct, which pins the fault to the JSONV2 path rewrite;
`enable_json_flat`, `cbo_prune_json_subfield` and `cbo_json_v2_dict_opt` make no difference, and
`partial_update_mode = row` is unaffected.

## What I'm doing:

The JSONV2 path rewrite replaces `get_json_int(j, '$.x')` with a read of an **extended column**: a
synthetic subfield column that owns no storage and is derived from its root JSON column at read time
(`extend_schema_by_access_paths`, `LakeDataSource::_extend_schema_by_access_paths`). The unique id
such a column carries is synthetic — seeded from `next_uniq_id()`, above every real column id, so it
can never collide with one.

A column-mode partial update writes the new value of the JSON column into a `.cols` delta column
group keyed by the **root** column's unique id (`DeltaColumnGroup::get_column_idx`). Both delta
column group read paths looked the group up by `column.unique_id()`, so for an extended column the
lookup missed deterministically, and the subfield was then served from the base segment:

```
_init_column_iterator_by_cid
  -> _new_dcg_column_iterator(col)          // col.unique_id() == synthetic id
     -> _get_dcg_segment(synthetic id)      // never matches -> nullptr
  -> Segment::new_column_iterator_or_default(col)  // BASE segment
     -> Segment::_new_extended_column_iterator      // pre-update value
```

The non-extended routes (`json_query`, `->`, `cast`, and `cbo_prune_json_subfield`'s pruned path)
keep the real column id, hit the delta column group, and read the `.cols` file — which is why only
`get_json_*` was wrong.

The fix resolves the lookup through `ExtendedColumnInfo::source_column_uid`, and builds the iterator
with `Segment::new_column_iterator_or_default()`, which dispatches on `is_extended()` and rebuilds
the subfield from the root column the `.cols` segment does hold. `new_column_iterator()` would look
the synthetic id up directly and return `NotFound`, i.e. changing only the lookup would turn a stale
read into a hard query failure.

`SegmentMetaCollecter` carries the identical code and **has to move in the same commit**: the global
dictionary for a JSON string subfield is collected there through a `[_META_]` scan
(`StatisticExecutor.queryDictSyncForJson`, allowed for extended columns by
`DecodeCollector.checkExtendedColumn`, with `cbo_json_v2_dict_opt` on by default). Fixing only the
scan would make it read the overlay while the dictionary still came from the base segment; the value
the scan returns would then be missing from the dictionary, encoded as code `0`
(`ColumnDecoder::_encode_string_to_global_id` does this silently) and rejected at decode time with
`Dict Decode failed`.

Scope notes:
- Both shared-data and shared-nothing scans reach the same `SegmentIterator`, so both were affected.
- `VariantPathRewriteRule` builds extended columns through the same mechanism, but it is registered only
  for `LOGICAL_ICEBERG_SCAN` (`QueryOptimizer.java:743`) and is off by default. Iceberg tables have no
  delta column groups and never reach `SegmentIterator`, so VARIANT is unaffected either way.
- Everything is a read-path change; nothing about how a partial update is written changes.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: queries that returned a stale JSON subfield now return the current value

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

### Tests

`be/test/storage/rowset_column_partial_update_test.cpp` —
`partial_update_json_read_through_extended_column`: builds a PK tablet with a JSON column, applies a
column-mode partial update, asserts a delta column group was actually produced, then reads through
the JSONV2-extended schema. Before the fix the whole-JSON column reads `{"x": 1000}` correctly while
the subfield returns `0`; after the fix both are current. `extend_schema_by_access_paths` had no
caller anywhere in `be/test` before this, and no test had ever driven an extended column through a
delta column group.

`test/sql/test_partial_update_column_mode/{T,R}/test_partial_update_json_subfield` — end to end,
including the `cbo_json_v2_rewrite = false` control.

`partial_update_json_meta_dict_reads_overlay` covers the other half of the fix: it drives
`SegmentMetaCollecter` with `META_DICT_MERGE` over a JSON string subfield after a column-mode update.
Without the `meta_reader.cpp` change it collects the pre-update value and misses the value the scan
returns. It asserts a dictionary was collected at all first, so it cannot pass vacuously.

Locally, both new cases are red before their respective halves of the fix and green after;
`RowsetColumnPartialUpdateTest`, `LakePartialUpdateTest`, `MetaReader*`, `SegmentIterator*`,
`FlatJsonColumnRW*` and `DeltaColumnGroup*` — 263 passed, 4 pre-existing skips, 0 failures.

Validated on a shared-data cluster: on the pre-fix binary `get_json_int` returned the stale value and
`WHERE get_json_string(a,'$.y')='bbb'` matched zero rows out of 70000 while two rows held that value;
on the fixed binary both are correct, untouched rows are unchanged, and a second column-mode update
layered on the existing overlay reads back correctly.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128UYRrDmr3ge68DPzXNf4Z
