### PR TITLE
[Refactor] Remove unused order_by_types parameter from sort context factories

### DIFF
--- a/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
@@ -383,8 +383,7 @@ LocalPartitionTopnContextFactory::LocalPartitionTopnContextFactory(
         std::vector<bool> is_asc_order, std::vector<bool> is_null_first, const std::vector<TExpr>& t_partition_exprs,
         bool enable_pre_agg, const std::vector<TExpr>& t_pre_agg_exprs,
         const std::vector<TSlotId>& t_pre_agg_output_slot_id, int64_t offset, int64_t limit, std::string sort_keys,
-        const std::vector<OrderByType>& order_by_types, bool has_outer_join_child,
-        const std::vector<RuntimeFilterBuildDescriptor*>&)
+        bool has_outer_join_child, const std::vector<RuntimeFilterBuildDescriptor*>&)
         : _topn_type(topn_type),
           _sort_exprs(sort_exprs),
           _is_asc_order(std::move(is_asc_order)),

--- a/be/src/exec/pipeline/sort/local_partition_topn_context.h
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.h
@@ -176,8 +176,7 @@ public:
                                      std::vector<bool> is_null_first, const std::vector<TExpr>& t_partition_exprs,
                                      bool enable_pre_agg, const std::vector<TExpr>& t_pre_agg_exprs,
                                      const std::vector<TSlotId>& t_pre_agg_output_slot_id, int64_t offset,
-                                     int64_t limit, std::string sort_keys,
-                                     const std::vector<OrderByType>& order_by_types, bool has_outer_join_child,
+                                     int64_t limit, std::string sort_keys, bool has_outer_join_child,
                                      const std::vector<RuntimeFilterBuildDescriptor*>& rfs);
 
     Status prepare(RuntimeState* state);

--- a/be/src/exec/pipeline/sort/sort_context.cpp
+++ b/be/src/exec/pipeline/sort/sort_context.cpp
@@ -180,7 +180,7 @@ SortContextFactory::SortContextFactory(RuntimeState* state, const TTopNType::typ
                                        [[maybe_unused]] const std::vector<TExpr>& t_pre_agg_exprs,
                                        [[maybe_unused]] const std::vector<TSlotId>& t_pre_agg_output_slot_id,
                                        int64_t offset, int64_t limit, const std::string& sort_keys,
-                                       const std::vector<OrderByType>& order_by_types, bool has_outer_join_child,
+                                       [[maybe_unused]] bool has_outer_join_child,
                                        const std::vector<RuntimeFilterBuildDescriptor*>& build_runtime_filters)
         : _state(state),
           _topn_type(topn_type),

--- a/be/src/exec/pipeline/sort/sort_context.h
+++ b/be/src/exec/pipeline/sort/sort_context.h
@@ -128,8 +128,7 @@ public:
                        const std::vector<bool>& is_null_first, const std::vector<TExpr>& partition_exprs,
                        bool enable_pre_agg, const std::vector<TExpr>& t_pre_agg_exprs,
                        const std::vector<TSlotId>& t_pre_agg_output_slot_id, int64_t offset, int64_t limit,
-                       const std::string& sort_keys, const std::vector<OrderByType>& order_by_types,
-                       bool has_outer_join_child,
+                       const std::string& sort_keys, bool has_outer_join_child,
                        const std::vector<RuntimeFilterBuildDescriptor*>& build_runtime_filters);
 
     SortContextPtr create(int32_t idx);

--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -224,7 +224,7 @@ StatusOr<pipeline::OpFactories> TopNNode::_decompose_to_pipeline(pipeline::Pipel
             runtime_state(), _tnode.sort_node.topn_type, need_merge, _sort_exec_exprs.lhs_ordering_expr_ctxs(),
             _is_asc_order, _is_null_first, _tnode.sort_node.partition_exprs, enable_pre_agg,
             _tnode.sort_node.pre_agg_exprs, _tnode.sort_node.pre_agg_output_slot_id, _offset, partition_limit,
-            _sort_keys, _order_by_types, has_outer_join_child, _build_runtime_filters);
+            _sort_keys, has_outer_join_child, _build_runtime_filters);
 
     // Create a shared RefCountedRuntimeFilterCollector
     auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(2, std::move(this->runtime_filter_collector()));


### PR DESCRIPTION
## Why I'm doing:

`order_by_types` is a dead constructor parameter on both sort context factories, and it has never actually been read:

- It was introduced with partition topn (#6118) as `_order_by_types` on `LocalPartitionTopnContextFactory` / `LocalPartitionTopnContext`, but was only stored and forwarded — `ChunksSorterTopn` never took it, so it never affected behavior.
- #12812 ("Fix clang complains 3") removed the dead members, and removed the parameter from `LocalPartitionTopnContext`, but left it in `LocalPartitionTopnContextFactory`'s signature.
- #18551 unified both factory signatures so `TopNNode::_decompose_to_pipeline` could dispatch over them as a template parameter, which copied the already-dead `order_by_types` into `SortContextFactory` as well. It is unused there too — note the sibling parameters in that constructor already carry `[[maybe_unused]]`, and `order_by_types` was simply missed.

Unlike `is_merging`, this parameter is not needed to keep the two factories signature-compatible for the templated dispatch, since neither side uses it.

## What I'm doing:

Removing `const std::vector<OrderByType>& order_by_types` from the constructors of `SortContextFactory` and `LocalPartitionTopnContextFactory`, and dropping the corresponding argument at the single construction site in `TopNNode::_decompose_to_pipeline`.

`TopNNode::_order_by_types` itself is kept: it is still initialized in `TopNNode::init()` and passed to the sink operator factories (`PartitionSortSinkOperatorFactory` / `LocalPartitionTopnSinkOperatorFactory`), which do use it to build the sorters.

While here, `SortContextFactory`'s `has_outer_join_child` is marked `[[maybe_unused]]` for consistency with the sibling parameters in the same constructor. That one must stay in the signature: `LocalPartitionTopnContextFactory` really does use it (it drives `_has_nullable_key` for the partitioner, added by #56432), and both factories go through the same template instantiation.

No behavior change — this only removes parameters that were never read. `python3 build-support/check_be_module_boundaries.py --mode full` is clean.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
