### PR TITLE
[Doc] Document azure_adls2_oauth2_client_endpoint and lake_vacuum_enable_task_timeout

### DIFF
--- a/docs/en/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/en/administration/configuration/BE_parameters/shared_lake_other.md
@@ -228,6 +228,14 @@ This topic introduces the following types of BE configurations:
 - Is mutable: Yes
 - Description: Sub-chunk granularity for `RowsMapperIterator` pipelined reads of `.lcrm` files during light Primary Key compaction publish in a shared-data cluster. Each output segment is split into `ceil(segment_bytes / lake_rows_mapper_sub_chunk_bytes)` sub-chunks pipelined independently. Smaller values raise the achievable parallelism for few-but-large output segments at the cost of more range reads and an extra memcpy on consume. Defaults to 4 MiB to align with the starcache disk-tier block size.
 
+### lake_vacuum_enable_task_timeout
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether Vacuum tasks honor the timeout carried in the request (`VacuumRequest.timeout_ms`) and abort themselves once it elapses. Set this item to `false` to let Vacuum tasks always run to completion no matter how long the FE caller waits.
+
 ### lake_vacuum_min_batch_delete_size
 
 - Default: 200

--- a/docs/en/administration/configuration/FE_parameters/shared_lake_other.md
+++ b/docs/en/administration/configuration/FE_parameters/shared_lake_other.md
@@ -149,6 +149,15 @@ This topic introduces the following types of FE configurations:
 - Description: The endpoint of your Azure Data Lake Storage Gen2 Account, for example, `https://test.dfs.core.windows.net`.
 - Introduced in: v3.4.1
 
+### `azure_adls2_oauth2_client_endpoint`
+
+- Default: Empty string
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: The OAuth 2.0 token endpoint of the Managed Identity used to authorize requests for your Azure Data Lake Storage Gen2. Before v3.5.19, v4.0.12, and v4.1.2, this item was named `azure_adls2_oauth2_oauth2_client_endpoint`. The former name is still accepted as an alias.
+- Introduced in: v3.4.4
+
 ### `azure_adls2_oauth2_client_id`
 
 - Default: Empty string

--- a/docs/ja/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/configuration/BE_parameters/shared_lake_other.md
@@ -228,6 +228,14 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 変更可能: はい
 - 説明: 共有データクラスタでの主キーテーブル軽量コンパクション publish 時、`RowsMapperIterator` のパイプライン化された `.lcrm` 読み取りにおける sub-chunk の粒度。各出力 segment は `ceil(segment_bytes / lake_rows_mapper_sub_chunk_bytes)` 個の sub-chunk に分割され、独立してパイプライン化されます。値を小さくするほど、少数の大きな出力 segment で達成可能な並列度が上がりますが、その代わりに範囲読み取りが増え、consume 時に追加の memcpy が発生します。デフォルトは 4 MiB で、starcache のディスク層 block サイズと一致させています。
 
+### lake_vacuum_enable_task_timeout
+
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: はい
+- 説明: Vacuum タスクがリクエストに含まれるタイムアウト (`VacuumRequest.timeout_ms`) に従い、経過した時点で自身を中止するかどうか。`false` に設定すると、FE 呼び出し側がどれだけ待つかに関係なく、Vacuum タスクは常に完了まで実行されます。
+
 ### lake_vacuum_min_batch_delete_size
 
 - デフォルト: 200

--- a/docs/ja/administration/configuration/FE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/configuration/FE_parameters/shared_lake_other.md
@@ -150,6 +150,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：Azure Data Lake Storage Gen2 アカウントのエンドポイント。例: `https://test.dfs.core.windows.net`。
 - 導入時期：v3.4.1
 
+### `azure_adls2_oauth2_client_endpoint`
+
+- デフォルト：Empty string
+- タイプ：String
+- 単位：-
+- 変更可能：No
+- 説明：Azure Data Lake Storage Gen2 の要求を承認するために使用されるマネージド ID の OAuth 2.0 トークンエンドポイント。v3.5.19、v4.0.12、v4.1.2 より前は、この項目は `azure_adls2_oauth2_oauth2_client_endpoint` という名前でした。旧名称は現在もエイリアスとして受け付けられます。
+- 導入時期：v3.4.4
+
 ### `azure_adls2_oauth2_client_id`
 
 - デフォルト：Empty string

--- a/docs/zh/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/configuration/BE_parameters/shared_lake_other.md
@@ -225,6 +225,14 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 是否动态：是
 - 描述：存算分离集群下，主键表轻量 Compaction 发布阶段，`RowsMapperIterator` 流水化读取 `.lcrm` 文件时使用的 sub-chunk 粒度。每个输出 segment 被切分为 `ceil(segment_bytes / lake_rows_mapper_sub_chunk_bytes)` 个 sub-chunk，独立流水化。值越小，少而大的输出 segment 能获得越高的并发度，但代价是更多的范围读取和消费时一次额外的 memcpy。默认 4 MiB，与 starcache 磁盘层 block 大小对齐。
 
+### lake_vacuum_enable_task_timeout
+
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：Vacuum 任务是否遵循请求中携带的超时时间（`VacuumRequest.timeout_ms`），并在超时后自行终止。设为 `false` 时，无论 FE 调用方等待多久，Vacuum 任务都会一直运行至完成。
+
 ### lake_vacuum_min_batch_delete_size
 
 - 默认值：200

--- a/docs/zh/administration/configuration/FE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/configuration/FE_parameters/shared_lake_other.md
@@ -150,6 +150,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: Azure Data Lake Storage Gen2 账户的 endpoint，例如 `https://test.dfs.core.windows.net`。
 - 引入版本: v3.4.1
 
+### `azure_adls2_oauth2_client_endpoint`
+
+- 默认值: 空字符串
+- 类型: String
+- 单位: -
+- 是否可变: No
+- 描述: 用于授权 Azure Data Lake Storage Gen2 请求的托管标识的 OAuth 2.0 令牌 endpoint。在 v3.5.19、v4.0.12 和 v4.1.2 之前，该配置项名为 `azure_adls2_oauth2_oauth2_client_endpoint`。旧名称仍作为别名保留。
+- 引入版本: v3.4.4
+
 ### `azure_adls2_oauth2_client_id`
 
 - 默认值: 空字符串


### PR DESCRIPTION
## Why I'm doing:

While auditing the `ci-doc-param-drift` workflow I found it has never once
reported a documentation gap across 1,682 runs — it checks out the base branch
and then diffs that branch against itself, so the diff is always empty. (Fix
submitted separately.)

Re-running the checker correctly surfaced a backlog of parameters that shipped
without a reference entry. This PR covers the two that exist on **every**
supported branch.

## What I'm doing:

Adds configuration reference entries, in `en`, `zh`, and `ja`, for:

| Parameter | File | Introduced |
|---|---|---|
| `azure_adls2_oauth2_client_endpoint` | FE `shared_lake_other.md` | v3.4.4 |
| `lake_vacuum_enable_task_timeout` | BE `shared_lake_other.md` | v3.5.19 / v4.0.12 / v4.1.3 |

`azure_adls2_oauth2_client_endpoint` was named
`azure_adls2_oauth2_oauth2_client_endpoint` until v3.5.19/v4.0.12/v4.1.2
(#74581); the entry documents the current name and notes that the former name
is still accepted as an alias.

All descriptions are derived from the parameter declarations in
`fe/fe-core/src/main/java/com/starrocks/common/Config.java` and
`be/src/common/config.h` — no behavior is described that is not in the source.

Verified: the param-drift checker no longer reports either parameter as
undocumented, and `vale` reports 0 errors / 0 warnings on both changed English
files.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5