### PR TITLE
[Doc] Document the range-colocate checker params and s3_use_native_sdk_for_glob

### DIFF
--- a/docs/en/administration/configuration/FE_parameters/shared_lake_other.md
+++ b/docs/en/administration/configuration/FE_parameters/shared_lake_other.md
@@ -248,6 +248,15 @@ This topic introduces the following types of FE configurations:
 - Description: Whether to use the native SDK to access Azure Blob Storage, thus allowing authentication with Managed Identities and Service Principals. If this item is set to `false`, only authentication with Shared Key and SAS Token is allowed.
 - Introduced in: v3.4.4
 
+### `s3_use_native_sdk_for_glob`
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether to use the native AWS S3 SDK to resolve glob paths in the FILES() table function for S3 and S3-compatible object stores (`s3`, `s3a`, `s3n`, `oss`, `cosn`, `ks3`, `obs`, and `tos`). When this item is set to `true`, the longest literal prefix of a wildcard is pushed down to S3 `ListObjectsV2` instead of listing the whole parent prefix through Hadoop `globStatus`, which is much faster when the prefix holds many objects but few of them match. Set this item to `false` to fall back to the Hadoop `globStatus` path.
+- Introduced in: v4.1.4
+
 ### `cloud_native_hdfs_url`
 
 - Default: Empty string

--- a/docs/en/administration/configuration/FE_parameters/stats_storage.md
+++ b/docs/en/administration/configuration/FE_parameters/stats_storage.md
@@ -617,6 +617,33 @@ This topic introduces the following types of FE configurations:
 - Description: The maximum retention time of historical tablet SPLIT/MERGE jobs.
 - Introduced in: v4.1.0
 
+### `tablet_reshard_colocate_checker_membership_batch_size`
+
+- Default: 1000
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: The maximum number of tablets that the range-colocate checker sends to StarOS in a single `getShardInfo` membership-read batch RPC on shared-data clusters. Values less than `1` are treated as `1`.
+- Introduced in: v4.1.3
+
+### `tablet_reshard_colocate_checker_convergence_batch_size`
+
+- Default: 64
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: The maximum number of PACK shard groups that the range-colocate checker sends to StarOS in a single `queryShardGroupStable` placement-convergence batch RPC. Each group's stability check is computed server-side, so a smaller batch bounds per-RPC latency, and the full result is assembled across repeated calls. Values less than `1` are treated as `1`.
+- Introduced in: v4.1.3
+
+### `tablet_reshard_colocate_checker_convergence_cache_ttl_ms`
+
+- Default: 1000
+- Type: Long
+- Unit: Milliseconds
+- Is mutable: Yes
+- Description: The TTL of the range-colocate checker's placement-convergence negative cache. Within this window, a PACK shard group that StarOS last reported as not yet converged is not re-queried, which throttles the per-tick `queryShardGroupStable` load while the group is still migrating. Only not-converged results are cached, so a stale entry can only delay the group's flip to stable by up to this window, never cause a premature flip. Values less than or equal to `0` disable the cache.
+- Introduced in: v4.1.3
+
 ### `enable_tablet_pre_split_for_insert_from_files`
 
 - Default: true

--- a/docs/ja/administration/configuration/FE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/configuration/FE_parameters/shared_lake_other.md
@@ -249,6 +249,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：Azure Blob Storage にアクセスするためにネイティブ SDK を使用するかどうか。これにより、マネージド ID およびサービスプリンシパルでの認証が可能になります。この項目が `false` に設定されている場合、共有キーと SAS トークンでの認証のみが許可されます。
 - 導入時期：v3.4.4
 
+### `s3_use_native_sdk_for_glob`
+
+- デフォルト：true
+- タイプ：Boolean
+- 単位：-
+- 変更可能：Yes
+- 説明：S3 および S3 互換オブジェクトストア (`s3`、`s3a`、`s3n`、`oss`、`cosn`、`ks3`、`obs`、`tos`) について、FILES() テーブル関数内の glob パスの解決にネイティブ AWS S3 SDK を使用するかどうか。この項目が `true` に設定されている場合、ワイルドカードの最長リテラルプレフィックスが S3 `ListObjectsV2` にプッシュダウンされ、Hadoop `globStatus` で親プレフィックス全体を列挙する必要がなくなります。プレフィックス配下のオブジェクトが多く、一致するものが少ない場合はこちらのほうが大幅に高速です。`false` に設定すると Hadoop `globStatus` の経路にフォールバックします。
+- 導入時期：v4.1.4
+
 ### `cloud_native_hdfs_url`
 
 - デフォルト：Empty string

--- a/docs/ja/administration/configuration/FE_parameters/stats_storage.md
+++ b/docs/ja/administration/configuration/FE_parameters/stats_storage.md
@@ -617,6 +617,33 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：過去のタブレット SPLIT/MERGE ジョブの最大保持期間。
 - 導入時期：v4.1.0
 
+### `tablet_reshard_colocate_checker_membership_batch_size`
+
+- デフォルト：1000
+- タイプ：Int
+- 単位：-
+- 変更可能：Yes
+- 説明：共有データクラスタにおいて、range-colocate チェッカーが 1 回の `getShardInfo` メンバーシップ読み取りバッチ RPC で StarOS に送信するタブレットの最大数。`1` 未満の値は `1` として扱われます。
+- 導入時期：v4.1.3
+
+### `tablet_reshard_colocate_checker_convergence_batch_size`
+
+- デフォルト：64
+- タイプ：Int
+- 単位：-
+- 変更可能：Yes
+- 説明：range-colocate チェッカーが 1 回の `queryShardGroupStable` 配置収束バッチ RPC で StarOS に送信する PACK シャードグループの最大数。各グループの安定性チェックはサーバー側で計算されるため、バッチを小さくすると RPC 1 回あたりのレイテンシを抑えられ、完全な結果は複数回の呼び出しにわたって組み立てられます。`1` 未満の値は `1` として扱われます。
+- 導入時期：v4.1.3
+
+### `tablet_reshard_colocate_checker_convergence_cache_ttl_ms`
+
+- デフォルト：1000
+- タイプ：Long
+- 単位：Milliseconds
+- 変更可能：Yes
+- 説明：range-colocate チェッカーの配置収束ネガティブキャッシュの TTL。このウィンドウ内では、StarOS が直前に「未収束」と報告した PACK シャードグループは再問い合わせされず、そのグループが移行中である間の 1 ティックあたりの `queryShardGroupStable` 負荷を抑えます。キャッシュされるのは未収束の結果のみであるため、古いエントリはグループが安定状態に切り替わるのを最大このウィンドウ分だけ遅らせるだけで、早すぎる切り替えを引き起こすことはありません。`0` 以下の値はキャッシュを無効にします。
+- 導入時期：v4.1.3
+
 ### `enable_tablet_pre_split_for_insert_from_files`
 
 - デフォルト：true

--- a/docs/zh/administration/configuration/FE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/configuration/FE_parameters/shared_lake_other.md
@@ -249,6 +249,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 是否使用原生 SDK 访问 Azure Blob Storage，从而允许使用托管标识和服务主体进行身份验证。如果此项设置为 `false`，则仅允许使用共享密钥和 SAS Token 进行身份验证。
 - 引入版本: v3.4.4
 
+### `s3_use_native_sdk_for_glob`
+
+- 默认值: true
+- 类型: Boolean
+- 单位: -
+- 是否可变: Yes
+- 描述: 对于 S3 及兼容 S3 协议的对象存储（`s3`、`s3a`、`s3n`、`oss`、`cosn`、`ks3`、`obs` 和 `tos`），是否使用原生 AWS S3 SDK 解析 FILES() 表函数中的通配符路径。设置为 `true` 时，通配符前最长的字面前缀会被下推到 S3 `ListObjectsV2`，而不是通过 Hadoop `globStatus` 列举整个父前缀。当前缀下对象很多但匹配项很少时，前者要快得多。设置为 `false` 时回退到 Hadoop `globStatus` 路径。
+- 引入版本: v4.1.4
+
 ### `cloud_native_hdfs_url`
 
 - 默认值: 空字符串

--- a/docs/zh/administration/configuration/FE_parameters/stats_storage.md
+++ b/docs/zh/administration/configuration/FE_parameters/stats_storage.md
@@ -617,6 +617,33 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: SPLIT/MERGE 批处理作业历史的最大保留时间。
 - 引入版本: v4.1.0
 
+### `tablet_reshard_colocate_checker_membership_batch_size`
+
+- 默认值: 1000
+- 类型: Int
+- 单位: -
+- 是否可变: Yes
+- 描述: 存算分离集群下，Range Colocate 检查器在单次 `getShardInfo` 成员关系读取批量 RPC 中发送给 StarOS 的最大 Tablet 数量。小于 `1` 的值按 `1` 处理。
+- 引入版本: v4.1.3
+
+### `tablet_reshard_colocate_checker_convergence_batch_size`
+
+- 默认值: 64
+- 类型: Int
+- 单位: -
+- 是否可变: Yes
+- 描述: Range Colocate 检查器在单次 `queryShardGroupStable` 放置收敛批量 RPC 中发送给 StarOS 的最大 PACK Shard Group 数量。每个 Group 的稳定性检查在服务端计算，因此较小的批量可以限制单次 RPC 的延迟，完整结果通过多次调用累积得到。小于 `1` 的值按 `1` 处理。
+- 引入版本: v4.1.3
+
+### `tablet_reshard_colocate_checker_convergence_cache_ttl_ms`
+
+- 默认值: 1000
+- 类型: Long
+- 单位: Milliseconds
+- 是否可变: Yes
+- 描述: Range Colocate 检查器放置收敛负缓存的 TTL。在该时间窗口内，StarOS 上次报告为尚未收敛的 PACK Shard Group 不会被重新查询，从而在该 Group 仍在迁移期间降低每轮 `queryShardGroupStable` 的负载。仅缓存未收敛的结果，因此过期条目最多只会将该 Group 转为稳定状态的时间延迟一个时间窗口，而不会导致提前转为稳定。小于或等于 `0` 的值将禁用该缓存。
+- 引入版本: v4.1.3
+
 ### `enable_tablet_pre_split_for_insert_from_files`
 
 - 默认值: true


### PR DESCRIPTION
## Why I'm doing:

While auditing the `ci-doc-param-drift` workflow I found it has never once
reported a documentation gap across 1,682 runs — it checks out the base branch
and then diffs that branch against itself, so the diff is always empty. (Fix
submitted separately.)

Re-running the checker correctly surfaced a backlog of parameters that shipped
without a reference entry. This PR covers the four that exist on **branch-4.1
and main only**.

## What I'm doing:

Adds configuration reference entries, in `en`, `zh`, and `ja`, for:

| Parameter | File | Introduced |
|---|---|---|
| `tablet_reshard_colocate_checker_membership_batch_size` | FE `stats_storage.md` | v4.1.3 |
| `tablet_reshard_colocate_checker_convergence_batch_size` | FE `stats_storage.md` | v4.1.3 |
| `tablet_reshard_colocate_checker_convergence_cache_ttl_ms` | FE `stats_storage.md` | v4.1.3 |
| `s3_use_native_sdk_for_glob` | FE `shared_lake_other.md` | v4.1.4 |

The three `tablet_reshard_colocate_checker_*` entries are placed with the other
`tablet_reshard_*` items; `s3_use_native_sdk_for_glob` sits next to
`azure_use_native_sdk`, its closest analogue.

All descriptions are derived from the `@ConfField` declarations in
`fe/fe-core/src/main/java/com/starrocks/common/Config.java` — no behavior is
described that is not in the source.

Verified: the param-drift checker no longer reports any of the four as
undocumented, and `vale` reports 0 errors / 0 warnings on both changed English
files.

Backport target is **4.1 only** — none of these parameters exist on branch-4.0
or branch-3.5.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5