### PR TITLE
[Doc] Document enable_lake_add_index_fast_path

### DIFF
--- a/docs/en/administration/configuration/FE_parameters/shared_lake_other.md
+++ b/docs/en/administration/configuration/FE_parameters/shared_lake_other.md
@@ -356,6 +356,14 @@ This topic introduces the following types of FE configurations:
 - Description: Time-to-live in seconds for an unused cached HDFS/ObjectStore FileSystem managed by HdfsFsManager. The FileSystemExpirationChecker (runs every 60s) calls each HdfsFs.isExpired(...) using this value; when expired the manager closes the underlying FileSystem and removes it from the cache. Accessor methods (for example `HdfsFs.getDFSFileSystem`, `getUserName`, `getConfiguration`) update the last-access timestamp, so expiry is based on inactivity. Lower values reduce idle resource holding but increase reopen overhead; higher values keep handles longer and may consume more resources.
 - Introduced in: v3.2.0
 
+### `enable_lake_add_index_fast_path`
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether to route ADD INDEX and DROP INDEX alters on shared-data tables through the metadata-only fast path, which creates no shadow index. Set this item to `false` to fall back to the regular schema change path. This item is intended as a safety valve; the fast path is the supported default.
+
 ### `lake_autovacuum_grace_period_minutes`
 
 - Default: 30

--- a/docs/ja/administration/configuration/FE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/configuration/FE_parameters/shared_lake_other.md
@@ -357,6 +357,14 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：HdfsFsManager が管理する未使用のキャッシュ HDFS/ObjectStore FileSystem の Time-to-live (秒単位)。FileSystemExpirationChecker (60 秒ごとに実行) はこの値を使用して各 HdfsFs.isExpired(...) を呼び出します。期限切れになるとマネージャーは基盤となる FileSystem を閉じ、キャッシュから削除します。アクセサーメソッド (例: `HdfsFs.getDFSFileSystem`、`getUserName`、`getConfiguration`) は最終アクセス時刻を更新するため、有効期限は非アクティブに基づいています。値が小さいとアイドルリソースの保持は減りますが、再オープンオーバーヘッドが増加します。値が大きいとハンドルが長く保持され、より多くのリソースを消費する可能性があります。
 - 導入時期：v3.2.0
 
+### `enable_lake_add_index_fast_path`
+
+- デフォルト：true
+- タイプ：Boolean
+- 単位：-
+- 変更可能：Yes
+- 説明：共有データテーブルに対する ADD INDEX および DROP INDEX の変更を、シャドウインデックスを作成しないメタデータのみの高速パスで処理するかどうか。`false` に設定すると、通常のスキーマ変更の経路にフォールバックします。この項目はセーフティバルブとして用意されており、高速パスがサポートされるデフォルトです。
+
 ### `lake_autovacuum_grace_period_minutes`
 
 - デフォルト：30

--- a/docs/zh/administration/configuration/FE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/configuration/FE_parameters/shared_lake_other.md
@@ -357,6 +357,14 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 由 HdfsFsManager 管理的未使用的缓存 HDFS/ObjectStore FileSystem 的存活时间（秒）。FileSystemExpirationChecker（每 60 秒运行一次）使用此值调用每个 HdfsFs.isExpired(...)；过期时，管理器关闭底层 FileSystem 并将其从缓存中删除。访问器方法（例如 `HdfsFs.getDFSFileSystem`、`getUserName`、`getConfiguration`）更新最后访问时间戳，因此过期基于不活动。较低的值会减少空闲资源占用，但会增加重新打开的开销；较高的值会保持句柄更长时间，并可能消耗更多资源。
 - 引入版本: v3.2.0
 
+### `enable_lake_add_index_fast_path`
+
+- 默认值: true
+- 类型: Boolean
+- 单位: -
+- 是否可变: Yes
+- 描述: 存算分离表上的 ADD INDEX 和 DROP INDEX 变更是否走仅修改元数据的快速路径（不创建影子索引）。设置为 `false` 时回退到常规的 Schema Change 路径。该项作为安全开关提供，快速路径是受支持的默认行为。
+
 ### `lake_autovacuum_grace_period_minutes`
 
 - 默认值: 30


### PR DESCRIPTION
## Why I'm doing:

While auditing the `ci-doc-param-drift` workflow I found it has never once
reported a documentation gap across 1,682 runs — it checks out the base branch
and then diffs that branch against itself, so the diff is always empty. (Fix
submitted separately.)

Re-running the checker correctly surfaced a backlog of parameters that shipped
without a reference entry. This PR covers the one that exists on **main only**.

## What I'm doing:

Adds a configuration reference entry, in `en`, `zh`, and `ja`, for
`enable_lake_add_index_fast_path` in FE `shared_lake_other.md`.

The `Introduced in` line is intentionally omitted — the parameter is not present
in any release tag yet, so there is no version number to cite. It should be
filled in when the release it ships in is settled.

Placement follows the precedent set by `enable_lake_pk_compaction_score_gate` in
the BE reference: grouped with the other lake items by topic rather than by the
`enable_` prefix.

The description is derived from the `@ConfField` declaration in
`fe/fe-core/src/main/java/com/starrocks/common/Config.java` — no behavior is
described that is not in the source.

Verified: the param-drift checker no longer reports the parameter as
undocumented, and `vale` reports 0 errors / 0 warnings on the changed English
file.

No backport — the parameter does not exist on branch-4.1, branch-4.0, or
branch-3.5.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5