### PR TITLE
[DO NOT MERGE] build vehicle for #77759 cluster validation

### DIFF
--- a/be/cmake_modules/ThirdParty.cmake
+++ b/be/cmake_modules/ThirdParty.cmake
@@ -403,7 +403,7 @@ set_target_properties(simdutf PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib
 add_library(velocypack STATIC IMPORTED)
 set_target_properties(velocypack PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libvelocypack.a)
 
-starrocks_resolve_thirdparty_library(HTTP_CLIENT_CURL_LIBRARY libopentelemetry_http_client_curl.a)
+starrocks_resolve_thirdparty_library(HTTP_CLIENT_CURL_LIBRARY libhttp_client_curl.a)
 add_library(http_client_curl STATIC IMPORTED GLOBAL)
 set_target_properties(http_client_curl PROPERTIES IMPORTED_LOCATION ${HTTP_CLIENT_CURL_LIBRARY})
 

--- a/be/src/storage/extends_column_utils.h
+++ b/be/src/storage/extends_column_utils.h
@@ -20,4 +20,21 @@ namespace starrocks {
 StatusOr<TabletSchemaCSPtr> extend_schema_by_access_paths(const TabletSchemaCSPtr& tablet_schema, size_t next_unique_id,
                                                           const std::vector<ColumnAccessPathPtr>& access_paths);
 
+// The unique id under which `column`'s data is actually stored, which is the id a delta column group
+// is keyed by (see DeltaColumnGroup::get_column_idx).
+//
+// An extended column is a JSON subfield materialized by the JSONV2 path rewrite (the column appended
+// by extend_schema_by_access_paths above). It owns no storage: it is derived from its root JSON
+// column at read time, and the unique id it carries is synthetic, allocated above every real column
+// id so that it can never collide with one. Looking a delta column group up by that synthetic id
+// therefore always misses, so the subfield would be read from the base segment and silently return
+// the value a column-mode partial update has already replaced. Resolve to the root column instead.
+inline ColumnUID storage_column_uid(const TabletColumn& column) {
+    const auto* extended_info = column.extended_info();
+    if (extended_info != nullptr && extended_info->source_column_uid >= 0) {
+        return extended_info->source_column_uid;
+    }
+    return column.unique_id();
 }
+
+} // namespace starrocks

--- a/be/src/storage/meta_reader.cpp
+++ b/be/src/storage/meta_reader.cpp
@@ -27,6 +27,7 @@
 #include "common/config_exec_fwd.h"
 #include "common/status.h"
 #include "fs/fs_factory.h"
+#include "storage/extends_column_utils.h"
 #include "storage/olap_common.h"
 #include "storage/rowset/column_iterator.h"
 #include "storage/rowset/column_reader.h"
@@ -231,13 +232,23 @@ StatusOr<std::unique_ptr<ColumnIterator>> SegmentMetaCollecter::_new_dcg_column_
         const TabletColumn& column, std::string* filename, FileEncryptionInfo* encryption_info,
         ColumnAccessPath* path) {
     // build column iter from delta column group
-    ASSIGN_OR_RETURN(auto dcg_segment, _get_dcg_segment(column.unique_id()));
+    ASSIGN_OR_RETURN(auto dcg_segment, _get_dcg_segment(storage_column_uid(column)));
     if (dcg_segment != nullptr) {
         if (filename != nullptr) {
             *filename = dcg_segment->file_name();
         }
         if (encryption_info != nullptr && dcg_segment->encryption_info()) {
             *encryption_info = *dcg_segment->encryption_info();
+        }
+        if (column.is_extended()) {
+            // Same as SegmentIterator::_new_dcg_column_iterator: an extended column has no reader of
+            // its own in the .cols segment, it must be rebuilt from the root JSON column.
+            //
+            // This site must stay in step with the scan path. The global dictionary for a JSON string
+            // subfield is collected here, through a [_META_] scan; if the scan read the .cols overlay
+            // while dictionary collection still read the base segment, the value the scan returns
+            // would be absent from the dictionary and the query would fail to decode it.
+            return dcg_segment->new_column_iterator_or_default(column, path);
         }
         return dcg_segment->new_column_iterator(column, path);
     }

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -55,6 +55,7 @@
 #include "storage/column_predicate_inverted_index_fallback.h"
 #include "storage/column_predicate_rewriter.h"
 #include "storage/del_vector.h"
+#include "storage/extends_column_utils.h"
 #include "storage/index/index_descriptor.h"
 #include "storage/index/inverted/inverted_index_option.h"
 #include "storage/index/vector/tenann/del_id_filter.h"
@@ -1911,13 +1912,20 @@ StatusOr<std::unique_ptr<ColumnIterator>> SegmentIterator::_new_dcg_column_itera
                                                                                     FileEncryptionInfo* encryption_info,
                                                                                     ColumnAccessPath* path) {
     // build column iter from delta column group
-    ASSIGN_OR_RETURN(auto dcg_segment, _get_dcg_segment(column.unique_id()));
+    ASSIGN_OR_RETURN(auto dcg_segment, _get_dcg_segment(storage_column_uid(column)));
     if (dcg_segment != nullptr) {
         if (filename != nullptr) {
             *filename = dcg_segment->file_name();
         }
         if (encryption_info != nullptr && dcg_segment->encryption_info()) {
             *encryption_info = *dcg_segment->encryption_info();
+        }
+        if (column.is_extended()) {
+            // The .cols segment holds the root JSON column, never the synthetic subfield column, so go
+            // through the `_or_default` entry point: it dispatches on is_extended() and rebuilds the
+            // subfield from the root column this segment does hold. new_column_iterator() would look
+            // the synthetic id up directly and fail with NotFound.
+            return dcg_segment->new_column_iterator_or_default(column, path);
         }
         return dcg_segment->new_column_iterator(column, path);
     }

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -16,6 +16,7 @@
 
 #include <functional>
 #include <iostream>
+#include <limits>
 #include <memory>
 
 #include "base/testutil/assert.h"
@@ -30,6 +31,7 @@
 #include "runtime/mem_pool.h"
 #include "runtime/mem_tracker.h"
 #include "storage/chunk_helper.h"
+#include "storage/extends_column_utils.h"
 #include "storage/meta_reader.h"
 #include "storage/olap_common.h"
 #include "storage/rowset/rowset_factory.h"
@@ -47,6 +49,7 @@
 #include "storage_primitive/column_predicate_factory.h"
 #include "storage_primitive/empty_iterator.h"
 #include "storage_primitive/union_iterator.h"
+#include "types/json_value.h"
 
 namespace starrocks {
 
@@ -1973,6 +1976,241 @@ TEST_P(RowsetColumnPartialUpdateTest, partial_update_with_clucene_gin_index_chec
     }
 }
 #endif
+
+// ------------------------------------------------------------------------------------------------
+// JSON subfield read through an extended column, after a column-mode partial update.
+//
+// The JSONV2 path rewrite (session variable cbo_json_v2_rewrite, on by default) replaces
+// get_json_int(j, '$.x') with a read of an *extended* column: a synthetic subfield column that owns
+// no storage, carries a synthetic unique id, and points back at its root JSON column through
+// ExtendedColumnInfo. A column-mode partial update writes the new value of `j` into a .cols delta
+// column group keyed by the ROOT column's unique id, so the read must resolve the group through the
+// root id. Resolving it through the extended column's own (synthetic) id matches nothing, and the
+// subfield is then served from the base segment -- silently returning the value the update replaced.
+// ------------------------------------------------------------------------------------------------
+
+static std::string make_json(int64_t x) {
+    return R"({"x": )" + std::to_string(x) + "}";
+}
+
+static TabletSharedPtr create_json_tablet(std::vector<TabletSharedPtr>* tablets, int64_t tablet_id,
+                                          int32_t schema_hash) {
+    TCreateTabletReq request;
+    request.tablet_id = tablet_id;
+    request.__set_version(1);
+    request.__set_version_hash(0);
+    request.tablet_schema.schema_hash = schema_hash;
+    request.tablet_schema.short_key_column_count = 1;
+    request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+    request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+    TColumn pk;
+    pk.column_name = "pk";
+    pk.__set_is_key(true);
+    pk.column_type.type = TPrimitiveType::BIGINT;
+    request.tablet_schema.columns.push_back(pk);
+
+    TColumn j;
+    j.column_name = "j";
+    j.__set_is_key(false);
+    j.__set_is_allow_null(true);
+    j.column_type.type = TPrimitiveType::JSON;
+    request.tablet_schema.columns.push_back(j);
+
+    TColumn v;
+    v.column_name = "v";
+    v.__set_is_key(false);
+    v.column_type.type = TPrimitiveType::INT;
+    request.tablet_schema.columns.push_back(v);
+
+    auto st = StorageEngine::instance()->create_tablet(request);
+    CHECK(st.ok()) << st.to_string();
+    auto tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    tablets->push_back(tablet);
+    return tablet;
+}
+
+// Fills a writer context that is common to the full and the partial-update rowset below.
+static RowsetWriterContext json_writer_context(const TabletSharedPtr& tablet) {
+    RowsetWriterContext writer_context;
+    writer_context.rowset_id = StorageEngine::instance()->next_rowset_id();
+    writer_context.tablet_id = tablet->tablet_id();
+    writer_context.tablet_schema_hash = tablet->schema_hash();
+    writer_context.partition_id = 0;
+    writer_context.rowset_path_prefix = tablet->schema_hash_path();
+    writer_context.rowset_state = COMMITTED;
+    writer_context.version.first = 0;
+    writer_context.version.second = 0;
+    writer_context.segments_overlap = NONOVERLAPPING;
+    return writer_context;
+}
+
+// Writes one row per key: (pk, {"x": x_of(pk)}, pk).
+static RowsetSharedPtr create_json_rowset(const TabletSharedPtr& tablet, const std::vector<int64_t>& keys,
+                                          const std::function<int64_t(int64_t)>& x_of) {
+    RowsetWriterContext writer_context = json_writer_context(tablet);
+    writer_context.tablet_schema = tablet->tablet_schema();
+    std::unique_ptr<RowsetWriter> writer;
+    CHECK_OK(RowsetFactory::create_rowset_writer(writer_context, &writer));
+
+    auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
+    auto chunk = ChunkFactory::new_chunk(schema, keys.size());
+    auto cols = chunk->columns();
+    // JsonColumn::append_datum keeps only a view of the JsonValue until the chunk copies it, so the
+    // values have to stay alive until flush_chunk.
+    std::vector<JsonValue> json_values;
+    json_values.reserve(keys.size());
+    for (int64_t key : keys) {
+        json_values.emplace_back(JsonValue::parse(make_json(x_of(key))).value());
+    }
+    for (size_t i = 0; i < keys.size(); i++) {
+        cols[0]->as_mutable_ptr()->append_datum(Datum(keys[i]));
+        cols[1]->as_mutable_ptr()->append_datum(Datum(&json_values[i]));
+        cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)keys[i]));
+    }
+    CHECK_OK(writer->flush_chunk(*chunk));
+    return *writer->build();
+}
+
+// Column-mode partial update carrying only (pk, j), which lands as a .cols delta column group.
+static RowsetSharedPtr create_json_partial_rowset(const TabletSharedPtr& tablet, const std::vector<int64_t>& keys,
+                                                  const std::function<int64_t(int64_t)>& x_of,
+                                                  const std::shared_ptr<TabletSchema>& partial_schema,
+                                                  const std::vector<int32_t>& column_indexes) {
+    RowsetWriterContext writer_context = json_writer_context(tablet);
+    writer_context.tablet_schema = partial_schema;
+    writer_context.referenced_column_ids = column_indexes;
+    writer_context.full_tablet_schema = tablet->tablet_schema();
+    writer_context.is_partial_update = true;
+    writer_context.partial_update_mode = PartialUpdateMode::COLUMN_UPDATE_MODE;
+    std::unique_ptr<RowsetWriter> writer;
+    CHECK_OK(RowsetFactory::create_rowset_writer(writer_context, &writer));
+
+    auto schema = ChunkHelper::convert_schema(partial_schema);
+    auto chunk = ChunkFactory::new_chunk(schema, keys.size());
+    auto cols = chunk->columns();
+    std::vector<JsonValue> json_values;
+    json_values.reserve(keys.size());
+    for (int64_t key : keys) {
+        json_values.emplace_back(JsonValue::parse(make_json(x_of(key))).value());
+    }
+    for (size_t i = 0; i < keys.size(); i++) {
+        cols[0]->as_mutable_ptr()->append_datum(Datum(keys[i]));
+        cols[1]->as_mutable_ptr()->append_datum(Datum(&json_values[i]));
+    }
+    CHECK_OK(writer->flush_chunk(*chunk));
+
+    RowsetSharedPtr partial_rowset = *writer->build();
+    partial_rowset->set_schema(tablet->tablet_schema());
+    return partial_rowset;
+}
+
+// Builds the access path the FE emits for get_json_int(j, '$.x'): a ROOT node named after the JSON
+// column with one FIELD child per subfield, with `extended` set on the root (ColumnAccessPath
+// .createLinearPath + setExtended on the FE side).
+static ColumnAccessPathPtr make_extended_json_path(const std::string& root_column, const std::string& field,
+                                                   LogicalType value_type) {
+    TColumnAccessPath tleaf;
+    tleaf.__set_type(TAccessPathType::FIELD);
+    tleaf.__set_from_predicate(false);
+    tleaf.__set_extended(false);
+    tleaf.__set_type_desc(TypeDescriptor(value_type).to_thrift());
+
+    TColumnAccessPath troot;
+    troot.__set_type(TAccessPathType::ROOT);
+    troot.__set_from_predicate(false);
+    troot.__set_extended(true);
+    troot.__set_type_desc(TypeDescriptor(value_type).to_thrift());
+    troot.__set_children({tleaf});
+
+    std::vector<std::string> resolved = {root_column, field};
+    size_t resolve_index = 0;
+    auto resolver = [&](const TColumnAccessPath&) -> StatusOr<std::string> {
+        CHECK_LT(resolve_index, resolved.size());
+        return resolved[resolve_index++];
+    };
+    auto res = ColumnAccessPath::create(troot, resolver);
+    CHECK(res.ok()) << res.status();
+    return std::move(res).value();
+}
+
+// Reads the tablet through the JSONV2-extended schema, exactly as OlapChunkSource does, and checks
+// the subfield column against `expected_x`. Also re-checks the whole JSON column, which reads the
+// overlay through the root column's own unique id and was therefore never affected.
+static void check_json_subfield(const TabletSharedPtr& tablet, int64_t version, size_t expected_rows,
+                                const std::function<int64_t(int64_t)>& expected_x) {
+    std::vector<ColumnAccessPathPtr> paths;
+    // The extended TabletColumn keeps a raw pointer to this path, so it has to outlive the read.
+    paths.emplace_back(make_extended_json_path("j", "x", TYPE_BIGINT));
+    ASSERT_EQ("j.x", paths[0]->linear_path());
+    ASSERT_TRUE(paths[0]->is_extended());
+
+    // Same seed as next_uniq_id(): above every real column id, so the synthetic id cannot collide.
+    ASSIGN_OR_ABORT(auto extended_schema,
+                    extend_schema_by_access_paths(tablet->tablet_schema(),
+                                                  std::numeric_limits<int32_t>::max() - 1000000, paths));
+    ASSERT_EQ(tablet->tablet_schema()->num_columns() + 1, extended_schema->num_columns());
+    const size_t subfield_cid = extended_schema->num_columns() - 1;
+    ASSERT_TRUE(extended_schema->column(subfield_cid).is_extended());
+
+    Schema schema = ChunkHelper::convert_schema(extended_schema);
+    TabletReader reader(tablet, Version(0, version), extended_schema, schema);
+    auto iter = create_tablet_iterator(reader, schema);
+    ASSERT_TRUE(iter != nullptr);
+
+    auto chunk = ChunkFactory::new_chunk(iter->schema(), 100);
+    size_t rows = 0;
+    while (true) {
+        auto st = iter->get_next(chunk.get());
+        if (st.is_end_of_file()) {
+            break;
+        }
+        ASSERT_OK(st);
+        for (size_t r = 0; r < chunk->num_rows(); r++) {
+            const int64_t pk = chunk->columns()[0]->get(r).get_int64();
+            JsonValue expected_json = JsonValue::parse(make_json(expected_x(pk))).value();
+            ASSERT_FALSE(chunk->columns()[1]->is_null(r)) << "pk=" << pk;
+            EXPECT_EQ(expected_json, *chunk->columns()[1]->get(r).get_json()) << "pk=" << pk;
+            ASSERT_FALSE(chunk->columns()[subfield_cid]->is_null(r)) << "pk=" << pk;
+            EXPECT_EQ(expected_x(pk), chunk->columns()[subfield_cid]->get(r).get_int64()) << "pk=" << pk;
+        }
+        rows += chunk->num_rows();
+        chunk->reset();
+    }
+    ASSERT_EQ(expected_rows, rows);
+}
+
+TEST_P(RowsetColumnPartialUpdateTest, partial_update_json_read_through_extended_column) {
+    const int N = 100;
+    auto tablet = create_json_tablet(&_tablets, rand(), rand());
+    auto base_x = [](int64_t pk) { return pk; };
+    auto updated_x = [](int64_t pk) { return pk + 1000; };
+
+    std::vector<int64_t> keys(N);
+    for (int i = 0; i < N; i++) {
+        keys[i] = i;
+    }
+
+    int64_t version = 1;
+    std::vector<RowsetSharedPtr> rowsets{create_json_rowset(tablet, keys, base_x)};
+    commit_rowsets(tablet, rowsets, version);
+    check_json_subfield(tablet, version, N, base_x);
+
+    // Column-mode partial update of the JSON column only.
+    std::vector<int32_t> column_indexes = {0, 1};
+    std::shared_ptr<TabletSchema> partial_schema = TabletSchema::create(tablet->tablet_schema(), column_indexes);
+    RowsetSharedPtr partial_rowset =
+            create_json_partial_rowset(tablet, keys, updated_x, partial_schema, column_indexes);
+    auto st = tablet->rowset_commit(++version, partial_rowset, 10000);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    // The update must have landed as a delta column group rather than a rewrite, otherwise the read
+    // below would exercise nothing.
+    ASSERT_GT(StorageEngine::instance()->update_manager()->get_delta_column_group_file_size_by_tablet_id(
+                      tablet->tablet_id()),
+              0);
+
+    check_json_subfield(tablet, version, N, updated_x);
+}
 
 INSTANTIATE_TEST_SUITE_P(RowsetColumnPartialUpdateTest, RowsetColumnPartialUpdateTest,
                          ::testing::Values(RowsetColumnPartialUpdateParam{1}, RowsetColumnPartialUpdateParam{1024},

--- a/test/sql/test_partial_update_column_mode/R/test_partial_update_json_subfield
+++ b/test/sql/test_partial_update_column_mode/R/test_partial_update_json_subfield
@@ -1,0 +1,47 @@
+-- name: test_partial_update_json_subfield
+-- A column-mode partial update writes the new value of the JSON column into a delta column group.
+-- get_json_* is rewritten by the optimizer into a read of an extended subfield column
+-- (cbo_json_v2_rewrite, on by default), which must resolve that delta column group through the root
+-- JSON column; resolving it through the extended column's own synthetic id finds nothing and the
+-- subfield is then silently served from the base segment, i.e. the value the update replaced.
+CREATE table tab1 (
+      pk BIGINT NOT NULL,
+      j JSON,
+      v BIGINT
+)
+ENGINE=OLAP
+PRIMARY KEY(`pk`)
+DISTRIBUTED BY HASH(`pk`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into tab1 values (1, parse_json('{"x": 1, "y": "aaa"}'), 1), (2, parse_json('{"x": 2, "y": "aaa"}'), 2);
+-- result:
+-- !result
+set partial_update_mode = 'column';
+-- result:
+-- !result
+update tab1 set j = parse_json('{"x": 9, "y": "bbb"}') where pk = 1;
+-- result:
+-- !result
+set partial_update_mode = 'auto';
+-- result:
+-- !result
+select pk, get_json_int(j, '$.x'), get_json_string(j, '$.y'), cast(j as varchar) from tab1 order by pk;
+-- result:
+1	9	bbb	{"x": 9, "y": "bbb"}
+2	2	aaa	{"x": 2, "y": "aaa"}
+-- !result
+set cbo_json_v2_rewrite = false;
+-- result:
+-- !result
+select pk, get_json_int(j, '$.x'), get_json_string(j, '$.y') from tab1 order by pk;
+-- result:
+1	9	bbb
+2	2	aaa
+-- !result
+set cbo_json_v2_rewrite = true;
+-- result:
+-- !result

--- a/test/sql/test_partial_update_column_mode/T/test_partial_update_json_subfield
+++ b/test/sql/test_partial_update_column_mode/T/test_partial_update_json_subfield
@@ -1,0 +1,25 @@
+-- name: test_partial_update_json_subfield
+-- A column-mode partial update writes the new value of the JSON column into a delta column group.
+-- get_json_* is rewritten by the optimizer into a read of an extended subfield column
+-- (cbo_json_v2_rewrite, on by default), which must resolve that delta column group through the root
+-- JSON column; resolving it through the extended column's own synthetic id finds nothing and the
+-- subfield is then silently served from the base segment, i.e. the value the update replaced.
+CREATE table tab1 (
+      pk BIGINT NOT NULL,
+      j JSON,
+      v BIGINT
+)
+ENGINE=OLAP
+PRIMARY KEY(`pk`)
+DISTRIBUTED BY HASH(`pk`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into tab1 values (1, parse_json('{"x": 1, "y": "aaa"}'), 1), (2, parse_json('{"x": 2, "y": "aaa"}'), 2);
+set partial_update_mode = 'column';
+update tab1 set j = parse_json('{"x": 9, "y": "bbb"}') where pk = 1;
+set partial_update_mode = 'auto';
+select pk, get_json_int(j, '$.x'), get_json_string(j, '$.y'), cast(j as varchar) from tab1 order by pk;
+set cbo_json_v2_rewrite = false;
+select pk, get_json_int(j, '$.x'), get_json_string(j, '$.y') from tab1 order by pk;
+set cbo_json_v2_rewrite = true;


### PR DESCRIPTION
> **Temporary — do not review, do not merge. This PR will be closed as soon as the build finishes.**

This is a build vehicle only. The real change is **#77759**; this branch carries a byte-identical patch
(364 changed lines, verified line by line) on an older base.

**Why it exists:** the internal build platform's thirdparty image predates #77417 (opentelemetry-cpp
1.2.0 → 1.9.1, merged 2026-08-11), which renamed the expected artifact:

```
-starrocks_resolve_thirdparty_library(HTTP_CLIENT_CURL_LIBRARY libhttp_client_curl.a)
+starrocks_resolve_thirdparty_library(HTTP_CLIENT_CURL_LIBRARY libopentelemetry_http_client_curl.a)
```

So every build of current `main` there dies at link time with

```
make[2]: *** No rule to make target
  '/var/local/thirdparty/installed//lib64/libopentelemetry_http_client_curl.a',
  needed by '/root/starrocks/be/output/lib/starrocks_be'.  Stop.
```

Confirmed with a control build of unmodified `main` (`a677b094dc2`), which fails identically.

This branch is based on `584ff4666dd` — the commit immediately before that bump — so it links against
the image as it stands, producing a binary that can be deployed to a test cluster to validate #77759.
