### PR TITLE
[Refactor] Remove single-column assumptions in low-cardinality dict rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -417,7 +417,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 context.stringRefToDefineExprMap.put(cid, stringRefToDefineExprMap.get(cid));
             }
             if (stringExpressions.containsKey(cid)) {
-                context.stringExprsMap.put(cid, stringExpressions.get(cid));
+                context.stringExpressions.addAll(stringExpressions.get(cid));
             }
         }
 
@@ -467,25 +467,32 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         context.structManager = structManager;
     }
 
-    // For SubfieldOperators, we just need to get the field column refs, not the whole columns in the struct.
-    private List<ColumnRefOperator> getColumnRefs(ScalarOperator op) {
-        if (op.isColumnRef()) {
-            return List.of((ColumnRefOperator) op);
+    private boolean checkDependOnExpr(ScalarOperator expr, Collection<Integer> checkList) {
+        if (expr instanceof ColumnRefOperator ref) {
+            return checkDependOnExpr(ref.getId(), checkList);
         }
-        if (op instanceof SubfieldOperator) {
-            SubfieldOperator subfieldOp = op.cast();
-            Map<String, ColumnRefOperator> fields = structManager.getFieldStringRefMap(subfieldOp.getChild((0)));
-            if (fields != null
-                    && subfieldOp.getFieldNames().size() == 1
-                    && fields.containsKey(subfieldOp.getFieldNames().get(0))) {
-                return List.of(fields.get(subfieldOp.getFieldNames().get(0)));
+        if (expr instanceof CallOperator call && FunctionSet.ARRAY_AGG.equals(call.getFnName())) {
+            return call.getChild(0).isColumnRef() && checkDependOnExpr(call.getChild(0), checkList);
+        }
+        if (expr.getType().isStructType()) {
+            Map<String, ColumnRefOperator> fieldsMap = structManager.getFieldStringRefMap(expr);
+            if (fieldsMap == null) {
+                return false;
             }
+            // Any structs with encoded fields should pass. We filter the fields list later.
+            return fieldsMap.values().stream().anyMatch(c -> checkDependOnExpr(c.getId(), checkList));
         }
-        List<ColumnRefOperator> result = Lists.newArrayList();
-        for (ScalarOperator child : op.getChildren()) {
-            result.addAll(getColumnRefs(child));
+        if (expr instanceof SubfieldOperator subfieldOperator) {
+            Map<String, ColumnRefOperator> fieldsMap = structManager.getFieldStringRefMap(subfieldOperator.getChild(0));
+            if (fieldsMap == null || subfieldOperator.getFieldNames().size() != 1) {
+                return false;
+            }
+            ColumnRefOperator fieldRef = fieldsMap.get(subfieldOperator.getFieldNames().get(0));
+            return fieldRef != null && checkDependOnExpr(fieldRef.getId(), checkList);
         }
-        return result;
+        // Expressions containing multiple columns must be handled by the explicit cases above; what
+        // reaches here holds a single dictionary column and constants, so any matching child is enough.
+        return expr.getChildren().stream().anyMatch(child -> checkDependOnExpr(child, checkList));
     }
 
     private boolean checkDependOnExpr(int cid, Collection<Integer> checkList) {
@@ -496,36 +503,10 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
             return false;
         }
         ScalarOperator define = stringRefToDefineExprMap.get(cid);
-        if (define instanceof CallOperator && FunctionSet.ARRAY_AGG.equals(((CallOperator) define).getFnName())) {
-            return define.getChild(0).isColumnRef() &&
-                    checkDependOnExpr(((ColumnRefOperator) define.getChild(0)).getId(), checkList);
+        if (define instanceof ColumnRefOperator defineRef && defineRef.getId() == cid) {
+            return false;
         }
-        if (define.getType().isStructType()) {
-            Map<String, ColumnRefOperator> fieldsMap = structManager.getFieldStringRefMap(define);
-            if (fieldsMap == null) {
-                return false;
-            }
-            // Any structs with encoded fields should pass. We filter the fields list later.
-            return fieldsMap.values().stream().anyMatch(c -> checkDependOnExpr(c.getId(), checkList));
-        }
-        if (define instanceof SubfieldOperator) {
-            SubfieldOperator subfieldOperator = define.cast();
-            Map<String, ColumnRefOperator> fieldsMap = structManager.getFieldStringRefMap(subfieldOperator.getChild(0));
-            if (fieldsMap == null || subfieldOperator.getFieldNames().size() != 1) {
-                return false;
-            }
-            ColumnRefOperator fieldRef = fieldsMap.get(subfieldOperator.getFieldNames().get(0));
-            return fieldRef != null && checkDependOnExpr(fieldRef.getId(), checkList);
-        }
-        for (ColumnRefOperator ref : getColumnRefs(define)) {
-            if (ref.getId() == cid) {
-                return false;
-            }
-            if (!checkDependOnExpr(ref.getId(), checkList)) {
-                return false;
-            }
-        }
-        return true;
+        return checkDependOnExpr(define, checkList);
     }
 
     void setDefineExpr(ColumnRefOperator col, ScalarOperator define, int counter) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer.rule.tree.lowcardinality;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionName;
@@ -46,7 +47,6 @@ import com.starrocks.type.VarcharType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -70,7 +70,7 @@ import static com.starrocks.sql.optimizer.rule.tree.lowcardinality.DecodeUtil.ge
  *  e. Generate the global dictionary expression
  */
 class DecodeContext {
-    private final ColumnRefFactory factory;
+    final ColumnRefFactory factory;
 
     // Global DictCache
     // string ColumnRefId -> ColumnDict
@@ -93,7 +93,7 @@ class DecodeContext {
     // select upper(a) from t0 where lower(a) = 'tt'
     // a is string column
     // upper(a), lower(a) is relation expression
-    Map<Integer, List<ScalarOperator>> stringExprsMap = Maps.newHashMap();
+    Set<ScalarOperator> stringExpressions = Sets.newIdentityHashSet();
 
     // all string aggregate expressions
     Map<Integer, List<CallOperator>> stringAggregateExprs = Maps.newHashMap();
@@ -111,7 +111,9 @@ class DecodeContext {
 
     Map<ColumnRefOperator, ScalarOperator> dictRefToDefineExprMap = Maps.newHashMap();
 
-    Map<ScalarOperator, ScalarOperator> stringExprToDictExprMap = Maps.newHashMap();
+    Map<ScalarOperator, ScalarOperator> stringExprToDictExprMap = Maps.newIdentityHashMap();
+
+    Map<ScalarOperator, ScalarOperator> stringExprToDictDefineExprMap = Maps.newIdentityHashMap();
 
     StructManager structManager;
 
@@ -136,9 +138,10 @@ class DecodeContext {
             SubfieldOperator subfieldOperator = operator.cast();
             Map<String, ColumnRefOperator> fieldsUseRefMap = structManager.getFieldStringRefMap(
                     subfieldOperator.getChild(0));
-            Preconditions.checkNotNull(fieldsUseRefMap);
-            Preconditions.checkState(subfieldOperator.getFieldNames().size() == 1
-                    && fieldsUseRefMap.containsKey(subfieldOperator.getFieldNames().get(0)));
+            if (fieldsUseRefMap == null || subfieldOperator.getFieldNames().size() != 1
+                    || !fieldsUseRefMap.containsKey(subfieldOperator.getFieldNames().get(0))) {
+                return null;
+            }
             return getUseStringRef(fieldsUseRefMap.get(subfieldOperator.getFieldNames().get(0)));
         }
         if (operator instanceof CallOperator && FunctionSet.ARRAY_AGG.equals(((CallOperator) operator).getFnName())) {
@@ -160,7 +163,6 @@ class DecodeContext {
 
     private void rewriteStringRefToDictRef() {
         // rewrite string column to dict column
-        DictExprRewrite exprRewriter = new DictExprRewrite();
         for (Integer stringId : allStringColumns) {
             if (!stringRefToDefineExprMap.containsKey(stringId)) {
                 continue;
@@ -175,12 +177,9 @@ class DecodeContext {
             ScalarOperator stringDefineExpr = stringRefToDefineExprMap.get(stringId);
             ColumnRefOperator stringRef = factory.getColumnRef(stringId);
             ColumnRefOperator dictRef = stringRefToDictRefMap.get(stringRef);
-            ColumnRefOperator useStringRef = stringRef.getType().isStructType() ? stringRef
-                    : getUseStringRef(stringDefineExpr);
-            stringExprToDictExprMap.put(stringRef, exprRewriter.decode(dictRef, stringRef, stringRef));
+            decode(stringRef);
             // return type is dict
-            ScalarOperator dictExpr = exprRewriter.define(dictRef.getType(), useStringRef, stringDefineExpr);
-            dictRefToDefineExprMap.put(dictRef, dictExpr);
+            dictRefToDefineExprMap.put(dictRef, define(stringDefineExpr));
         }
     }
 
@@ -251,18 +250,8 @@ class DecodeContext {
 
     private void rewriteStringExpressions() {
         // rewrite string expression
-        DictExprRewrite exprRewriter = new DictExprRewrite();
-        for (Integer stringId : stringExprsMap.keySet()) {
-            ColumnRefOperator stringRef = factory.getColumnRef(stringId);
-            ColumnRefOperator dictRef = stringRefToDictRefMap.get(stringRef);
-            for (ScalarOperator stringExpr : stringExprsMap.getOrDefault(stringId, Collections.emptyList())) {
-                if (stringExprToDictExprMap.containsKey(stringExpr)) {
-                    continue;
-                }
-                // return type is string, different as define expression
-                ScalarOperator dictExpr = exprRewriter.decode(dictRef, stringRef, stringExpr);
-                stringExprToDictExprMap.put(stringExpr, dictExpr);
-            }
+        for (ScalarOperator stringExpr : stringExpressions) {
+            decode(stringExpr);
         }
     }
 
@@ -340,127 +329,160 @@ class DecodeContext {
 
     }
 
-    private static Function buildFunction(String fnName, List<ScalarOperator> args) {
+    private static CallOperator buildCallOperator(CallOperator call, List<ScalarOperator> args) {
+        String fnName = call.getFnName();
+        final Function fn;
         if (fnName.equals(FunctionSet.NAMED_STRUCT)) {
             Type[] argTypes = args.stream().map(ScalarOperator::getType).toArray(Type[]::new);
-            Function fn = ExprUtils.getBuiltinFunction(fnName, argTypes, Function.CompareMode.IS_SUPERTYPE_OF).copy();
+            fn = ExprUtils.getBuiltinFunction(fnName, argTypes, Function.CompareMode.IS_SUPERTYPE_OF).copy();
             List<StructField> fields = Lists.newArrayList();
             for (int i = 0; i < args.size(); i += 2) {
                 fields.add(new StructField(((ConstantOperator) args.get(i)).getVarchar(), argTypes[i + 1]));
             }
             fn.setRetType(new StructType(fields, true));
-            return fn;
+        } else {
+            Type[] argTypes = args.stream().map(ScalarOperator::getType).toArray(Type[]::new);
+            fn = ExprUtils.getBuiltinFunction(fnName, argTypes, Function.CompareMode.IS_SUPERTYPE_OF);
         }
-        Type[] argTypes = args.stream().map(ScalarOperator::getType).toArray(Type[]::new);
-        return ExprUtils.getBuiltinFunction(fnName, argTypes, Function.CompareMode.IS_SUPERTYPE_OF);
+        return new CallOperator(fnName, fn.getReturnType(), args, fn,
+                call.isDistinct(), call.isRemovedDistinct());
     }
 
-    // define mode: means the result column is dict, DictExpr should return int/array<int> type
-    // decode mode: means the result column is string, DictExpr should return string/array<string> type
-    private class DictExprRewrite extends BaseScalarOperatorShuttle {
+    // Decodes a dictified struct by generating a new named_struct function and applying decode on all dictified fields.
+    private ScalarOperator decodeStruct(ScalarOperator dictExpression,
+                                       ScalarOperator expression) {
+        Preconditions.checkState(dictExpression.getType().isStructType());
+        StructType exprType =  (StructType) expression.getType();
+        StructType dictType = (StructType) dictExpression.getType();
+        List<ScalarOperator> newFields = Lists.newArrayList();
+        Map<String, ColumnRefOperator> fieldsStringRefMap = structManager.getFieldStringRefMap(expression);
+        Preconditions.checkNotNull(fieldsStringRefMap);
+        for (int i = 0; i < exprType.getFields().size(); ++i) {
+            String fieldName = exprType.getField(i).getName();
+            newFields.add(ConstantOperator.createVarchar(fieldName));
+            Type fieldOriginalType =  exprType.getField(i).getType();
+            Type fieldDictType = dictType.getField(i).getType();
+            ScalarOperator fieldExpr =  new SubfieldOperator(dictExpression, fieldDictType, List.of(fieldName));
+            if (fieldOriginalType.matchesType(fieldDictType)) {
+                newFields.add(fieldExpr);
+            } else {
+                ColumnRefOperator fieldStringRef = fieldsStringRefMap.get(fieldName);
+                Preconditions.checkNotNull(fieldStringRef);
+                ColumnRefOperator fieldDictRef = stringRefToDictRefMap.get(fieldStringRef);
+                Preconditions.checkNotNull(fieldDictRef);
+                newFields.add(new DictMappingOperator(
+                        fieldOriginalType,
+                        fieldDictRef,
+                        new ColumnRefOperator(
+                                fieldDictRef.getId(),
+                                fieldExpr.getType(),
+                                fieldDictRef.getName(),
+                                fieldExpr.isNullable()),
+                        fieldExpr));
+            }
+        }
+        Type[] argTypes = newFields.stream().map(ScalarOperator::getType).toArray(Type[]::new);
+        Function fn = ExprUtils.getBuiltinFunction(
+                FunctionSet.NAMED_STRUCT, argTypes, Function.CompareMode.IS_SUPERTYPE_OF).copy();
+        fn.setRetType(exprType);
+        return new CallOperator(FunctionSet.NAMED_STRUCT, fn.getReturnType(), newFields, fn);
+    }
+
+    private ScalarOperator decodeImpl(ScalarOperator expression) {
+        DictExprEncoder encoder = new DictExprEncoder();
+        ScalarOperator result = expression.accept(encoder, null);
+        if (result.getType().isStructType()) {
+            Preconditions.checkState(encoder.getAnchorOp() == null);
+            return decodeStruct(result, expression);
+        }
+        ColumnRefOperator useStringRef = getUseStringRef(expression);
+        if (useStringRef == null) {
+            // e.g. getting a non dictified field from a struct
+            return result;
+        }
+        ColumnRefOperator useDictRef = stringRefToDictRefMap.get(useStringRef);
+        Preconditions.checkNotNull(useDictRef);
+        if (useStringRef.getType().isVarchar() && encoder.getAnchorOp() == null) {
+            return new DictMappingOperator(useDictRef, expression.clone(), expression.getType());
+        } else if (result.isColumnRef() && encoder.getAnchorOp() == null) {
+            // decode array-column-ref
+            return new DictMappingOperator(useDictRef, result, expression.getType());
+        } else if (result instanceof CallOperator
+                && LOW_CARD_ARRAY_FUNCTIONS.contains(((CallOperator) result).getFnName())
+                && !supportLowCardinality(expression.getType())) {
+            Preconditions.checkState(encoder.getAnchorOp() == null);
+            return result;
+        }
+        result = encoder.processAnchor(result, expression);
+        return new DictMappingOperator(expression.getType(), useDictRef, result, encoder.getAnchorOp());
+    }
+
+    // returns a dictified form of the expression as a new expression in string domain. Uses stringExprToDictExprMap
+    // as a cache.
+    private ScalarOperator decode(ScalarOperator expression) {
+        if (stringExprToDictExprMap.containsKey(expression)) {
+            return stringExprToDictExprMap.get(expression);
+        }
+        ScalarOperator decodeExpr = decodeImpl(expression);
+        stringExprToDictExprMap.put(expression, decodeExpr);
+        return decodeExpr;
+    }
+
+    public ScalarOperator defineImpl(ScalarOperator expression) {
+        DictExprEncoder encoder = new DictExprEncoder();
+        ScalarOperator result = expression.accept(encoder, null);
+        if (expression.getType().isStructType() ||
+                expression instanceof CallOperator call
+                        && call.getFunction() instanceof AggregateFunction agg
+                        && agg.getReturnType().isStructType()) {
+            return result;
+        }
+        ColumnRefOperator useStringRef = getUseStringRef(expression);
+        if (useStringRef == null) {
+            return result;
+        }
+        ColumnRefOperator useDictRef = stringRefToDictRefMap.get(useStringRef);
+        if (useStringRef.getType().isVarchar() && encoder.getAnchorOp() == null) {
+            return new DictMappingOperator(useDictRef, expression.clone(), useDictRef.getType());
+        }
+        if (encoder.getAnchorOp() != null) {
+            if (!result.isColumnRef()) {
+                // e.g. upper(array_column[0])), need define string-expr by dict-expr
+                return new DictMappingOperator(
+                        IntegerType.INT, useDictRef, result, encoder.getAnchorOp());
+            } else {
+                // e.g. array_column[0], need define to string
+                return encoder.getAnchorOp();
+            }
+        }
+
+        return result;
+    }
+
+    // returns a dictified form of the expression as a new expression in dict domain. Uses stringExprToDictDefineExprMap
+    // as a cache.
+    public ScalarOperator define(ScalarOperator expression) {
+        if (stringExprToDictDefineExprMap.containsKey(expression)) {
+            return stringExprToDictDefineExprMap.get(expression);
+        }
+        ScalarOperator define = defineImpl(expression);
+        stringExprToDictDefineExprMap.put(expression, define);
+        return define;
+    }
+
+    // Returns a half-baked encoding of a string-typed scalar expression into its dict-encoded form.
+    // Every column ref present in stringRefToDictRefMap becomes its dict ref; there is no per-operator
+    // liveness filter here, callers decide which expressions to hand in. Supported array/struct ops are
+    // rewritten to operate on codes (int / array<int>) instead of strings.
+    // For expressions that collapse an array/struct into scalar form, anchorOp marks where the
+    // array/struct -> string transformation happens, and the returned operator carries a mock string
+    // ref in place of that transformation.
+    // The result must always be post-processed by define() or decode().
+    private class DictExprEncoder extends BaseScalarOperatorShuttle {
         // to mark special array expression: array_min/array_max/array[x]
         // their return type is string, but use low cardinality optimization, we need execute them first
         private ScalarOperator anchorOp;
-        private ColumnRefOperator anchorUseDictRef;
 
-        public ScalarOperator decodeStruct(ScalarOperator dictExpression,
-                                           ScalarOperator expression,
-                                           ColumnRefOperator useStringRef) {
-            Preconditions.checkState(dictExpression.getType().isStructType());
-            Preconditions.checkState(useStringRef.getType().isStructType());
-            StructType exprType =  (StructType) expression.getType();
-            StructType dictType = (StructType) dictExpression.getType();
-            List<ScalarOperator> newFields = Lists.newArrayList();
-            Map<String, ColumnRefOperator> fieldsStringRefMap = structManager.getFieldStringRefMap(useStringRef);
-            Preconditions.checkNotNull(fieldsStringRefMap);
-            for (int i = 0; i < exprType.getFields().size(); ++i) {
-                String fieldName = exprType.getField(i).getName();
-                newFields.add(ConstantOperator.createVarchar(fieldName));
-                Type fieldOriginalType =  exprType.getField(i).getType();
-                Type fieldDictType = dictType.getField(i).getType();
-                ScalarOperator fieldExpr =  new SubfieldOperator(dictExpression, fieldDictType, List.of(fieldName));
-                if (fieldOriginalType.matchesType(fieldDictType)) {
-                    newFields.add(fieldExpr);
-                } else {
-                    ColumnRefOperator fieldStringRef = fieldsStringRefMap.get(fieldName);
-                    Preconditions.checkNotNull(fieldStringRef);
-                    ColumnRefOperator fieldDictRef = stringRefToDictRefMap.get(fieldStringRef);
-                    Preconditions.checkNotNull(fieldDictRef);
-                    newFields.add(new DictMappingOperator(
-                            fieldOriginalType,
-                            fieldDictRef,
-                            new ColumnRefOperator(
-                                    fieldDictRef.getId(),
-                                    fieldExpr.getType(),
-                                    fieldDictRef.getName(),
-                                    fieldExpr.isNullable()),
-                            fieldExpr));
-                }
-            }
-            Type[] argTypes = newFields.stream().map(ScalarOperator::getType).toArray(Type[]::new);
-            Function fn = ExprUtils.getBuiltinFunction(
-                    FunctionSet.NAMED_STRUCT, argTypes, Function.CompareMode.IS_SUPERTYPE_OF).copy();
-            fn.setRetType(exprType);
-            return new CallOperator(FunctionSet.NAMED_STRUCT, fn.getReturnType(), newFields, fn);
-        }
-
-        public ScalarOperator decode(ColumnRefOperator useDictRef, ColumnRefOperator useStringRef,
-                                     ScalarOperator expression) {
-            anchorOp = null;
-            anchorUseDictRef = null;
-            ScalarOperator result = expression.accept(this, null);
-            if (useStringRef.getType().isVarchar() && anchorUseDictRef == null) {
-                return new DictMappingOperator(useDictRef, expression.clone(), expression.getType());
-            }
-            if (result.getType().isStructType()) {
-                Preconditions.checkState(anchorOp == null);
-                return decodeStruct(result, expression, useStringRef);
-            }
-            if (result.isColumnRef() && anchorOp == null) {
-                // decode array-column-ref
-                return new DictMappingOperator(useDictRef, result, expression.getType());
-            } else if (result instanceof CallOperator
-                    && LOW_CARD_ARRAY_FUNCTIONS.contains(((CallOperator) result).getFnName())
-                    && !supportLowCardinality(expression.getType())) {
-                Preconditions.checkState(anchorOp == null);
-                return result;
-            } else if (result instanceof SubfieldOperator) {
-                Preconditions.checkState(expression instanceof SubfieldOperator);
-                SubfieldOperator subfieldOperator = expression.cast();
-                if (subfieldOperator.getFieldNames().size() != 1 ||
-                        !structManager.getFieldStringRefMap(expression.getChild(0))
-                                .containsKey(subfieldOperator.getFieldNames().get(0))) {
-                    // Getting non dictified field from a struct
-                    return result;
-                }
-            }
-            result = processAnchor(result);
-            return new DictMappingOperator(expression.getType(), anchorUseDictRef, result, anchorOp);
-        }
-
-        public ScalarOperator define(Type type, ColumnRefOperator useStringRef, ScalarOperator expression) {
-            ColumnRefOperator useDictRef = stringRefToDictRefMap.get(useStringRef);
-            anchorOp = null;
-            anchorUseDictRef = null;
-            ScalarOperator result = expression.accept(this, null);
-            if (useStringRef.getType().isVarchar() && anchorUseDictRef == null) {
-                return new DictMappingOperator(useDictRef, expression.clone(), useDictRef.getType());
-
-            }
-            if (anchorOp != null) {
-                if (!result.isColumnRef()) {
-                    // e.g. upper(array_column[0])), need define string-expr by dict-expr
-                    return new DictMappingOperator(type, anchorUseDictRef, result, anchorOp);
-                } else {
-                    // e.g. array_column[0], need define to string
-                    return anchorOp;
-                }
-            }
-
-            return result;
-        }
-
-        // array rewrite
         @Override
         public ScalarOperator visitVariableReference(ColumnRefOperator variable, Void context) {
             return stringRefToDictRefMap.getOrDefault(variable, variable);
@@ -484,11 +506,10 @@ class DecodeContext {
                 newChildren = newChildren.stream().map(op -> op.isConstant() ?
                         dictEncodeConstant(op, dictRef.getId()) : op).collect(Collectors.toCollection(ArrayList::new));
             }
-            Function fn = buildFunction(call.getFnName(), newChildren);
-            ScalarOperator result = new CallOperator(call.getFnName(), fn.getReturnType(), newChildren, fn);
+            ScalarOperator result = buildCallOperator(call, newChildren);
 
             if (call.getType().isStringType()) {
-                return processAnchor(result);
+                return processAnchor(result, call);
             }
             return result;
         }
@@ -504,7 +525,7 @@ class DecodeContext {
             ScalarOperator result = new CollectionElementOperator(((ArrayType) newChildren.get(0)
                     .getType()).getItemType(), newChildren.get(0), newChildren.get(1), collectionElementOp.isCheckOutOfBounds());
 
-            return processAnchor(result);
+            return processAnchor(result, collectionElementOp);
         }
 
         @Override
@@ -529,9 +550,8 @@ class DecodeContext {
                 Preconditions.checkNotNull(fieldUseStringRef);
                 ColumnRefOperator childDictRef = stringRefToDictRefMap.get(fieldUseStringRef);
                 Preconditions.checkNotNull(childDictRef);
-                anchorUseDictRef = childDictRef;
                 if (operator.getType().isStringType()) {
-                    return processAnchor(result);
+                    return processAnchor(result, operator);
                 } else {
                     return result;
                 }
@@ -539,7 +559,7 @@ class DecodeContext {
             return result;
         }
 
-        private ScalarOperator processAnchor(ScalarOperator expr) {
+        private ScalarOperator processAnchor(ScalarOperator expr, ScalarOperator originalOperator) {
             if (anchorOp != null && !anchorOp.equals(expr)) {
                 return expr;
             }
@@ -549,14 +569,16 @@ class DecodeContext {
             anchorOp = expr;
             // mock use column ref, only type is used, ScalarOperatorToExpr will rewrite it
             // @todo: rewrite ScalarOperatorToExpr process when v1 is deprecated
-            if (anchorUseDictRef == null) {
-                List<ColumnRefOperator> usedColumns = expr.getColumnRefs();
-                Preconditions.checkState(!usedColumns.isEmpty());
-                anchorUseDictRef = usedColumns.get(0);
-            }
+            ColumnRefOperator anchorUseStringRef = getUseStringRef(originalOperator);
+            ColumnRefOperator anchorUseDictRef = stringRefToDictRefMap.get(anchorUseStringRef);
+            Preconditions.checkNotNull(anchorUseDictRef);
 
             return new ColumnRefOperator(anchorUseDictRef.getId(), expr.getType(),
                     anchorUseDictRef.getName(), anchorUseDictRef.isNullable());
+        }
+
+        ScalarOperator getAnchorOp() {
+            return anchorOp;
         }
     }
 
@@ -636,9 +658,7 @@ class DecodeContext {
                 return call;
             }
 
-            Function fn = buildFunction(call.getFnName(), newChildren);
-            return new CallOperator(call.getFnName(), fn.getReturnType(), newChildren, fn,
-                    call.isDistinct(), call.isRemovedDistinct());
+            return buildCallOperator(call, newChildren);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -90,18 +90,11 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
         this.sessionVariable = sessionVariable;
     }
 
-    // For structs, we only return the encoded fields collected by DecodeCollector.
-    static ColumnRefSet getUsedColumns(ScalarOperator scalarOperator, DecodeContext context) {
-        if (scalarOperator.isColumnRef()) {
-            return new ColumnRefSet(((ColumnRefOperator) scalarOperator).getId());
-        }
-        Map<String, ColumnRefOperator> structFieldsData = context.structManager.getFieldStringRefMap(scalarOperator);
-        if (structFieldsData != null) {
-            return new ColumnRefSet(structFieldsData.values());
-        }
-        ColumnRefSet result = new ColumnRefSet();
-        scalarOperator.getChildren().forEach(c -> result.union(getUsedColumns(c, context)));
-        return result;
+    // Encoding is only forbidden for a column ref whose dict column is not live here. Anything else is
+    // permitted as far as this check goes; callers establish that a dict form actually exists separately
+    // (a dict projection key, or membership in a dict-expr map).
+    static boolean encodingAllowed(ScalarOperator op, ColumnRefSet supportColumns) {
+        return !op.isColumnRef() || supportColumns.contains(op.cast());
     }
 
     public OptExpression rewrite(OptExpression optExpression) {
@@ -257,7 +250,7 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
         }
 
         // replace string predicate to dict predicate
-        JoinOnPredicateReplacer replacer = new JoinOnPredicateReplacer(context.stringRefToDictRefMap, inputs, context);
+        JoinOnPredicateReplacer replacer = new JoinOnPredicateReplacer(context.stringRefToDictRefMap, inputs);
         return predicate.accept(replacer, null);
     }
 
@@ -882,12 +875,11 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
         Map<ColumnRefOperator, ScalarOperator> newColumnRefMap = Maps.newHashMap();
         for (ColumnRefOperator key : projection.getColumnRefMap().keySet()) {
             ScalarOperator value = projection.getColumnRefMap().get(key);
-
             if (!context.stringRefToDictRefMap.containsKey(key)) {
                 newColumnRefMap.put(key, value.accept(replacer, null));
                 continue;
             }
-            if (!inputs.containsAll(getUsedColumns(value, context))) {
+            if (!encodingAllowed(value, inputs)) {
                 newColumnRefMap.put(key, value);
                 continue;
             }
@@ -937,8 +929,12 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
 
         @Override
         public Optional<ScalarOperator> preprocess(ScalarOperator scalarOperator) {
-            if (exprMapping.containsKey(scalarOperator)
-                    && supportColumns.containsAll(getUsedColumns(scalarOperator, context))) {
+            if (scalarOperator instanceof ColumnRefOperator col) {
+                // TODO(farhad-celo): Temporary hack to preserve the current behavior for the structs.
+                //  Will be removed in the next PR.
+                scalarOperator = context.factory.getColumnRef(col.getId());
+            }
+            if (exprMapping.containsKey(scalarOperator) && encodingAllowed(scalarOperator, supportColumns)) {
                 return Optional.of(exprMapping.get(scalarOperator));
             }
             return Optional.empty();
@@ -948,14 +944,11 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
     private static class JoinOnPredicateReplacer extends BaseScalarOperatorShuttle {
         private final Map<ColumnRefOperator, ColumnRefOperator> stringRefToDictRefMap;
         private final ColumnRefSet supportColumns;
-        private final DecodeContext context;
 
         public JoinOnPredicateReplacer(Map<ColumnRefOperator, ColumnRefOperator> stringRefToDictRefMap,
-                                       ColumnRefSet supportColumns,
-                                       DecodeContext context) {
+                                       ColumnRefSet supportColumns) {
             this.stringRefToDictRefMap = stringRefToDictRefMap;
             this.supportColumns = supportColumns;
-            this.context = context;
         }
 
         @Override
@@ -964,8 +957,7 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
                 return Optional.empty();
             }
 
-            if (stringRefToDictRefMap.containsKey(columnRef) && supportColumns.containsAll(
-                    getUsedColumns(columnRef, context))) {
+            if (stringRefToDictRefMap.containsKey(columnRef) && encodingAllowed(columnRef, supportColumns)) {
                 return Optional.of(stringRefToDictRefMap.get(columnRef));
             }
 


### PR DESCRIPTION
## Why I'm doing:

The low-cardinality dictionary rewrite assumes throughout that every dict-able expression is built on exactly one string column. The assumption is threaded through the code in three ways: as parameters (`decode(useDictRef, useStringRef, expression)`), as visitor state (`anchorUseDictRef` carried between calls), and as a flattened column-ref walk in `checkDependOnExpr`.

Removing it is a prerequisite for supporting multi-input array functions — `array_filter`, `array_sortby`, and `array_map` with a lambda — where an expression legitimately depends on more than one column, and on columns that are not encoded. This PR is the refactor only: no new functionality, and no behavior change intended.

## What I'm doing:

**`DecodeContext`**

- `decode()` / `define()` move out of the inner visitor to `DecodeContext` methods, each split into a cached front-end and an `*Impl`, backed by `stringExprToDictExprMap` and a new `stringExprToDictDefineExprMap`.
- Each expression's dict column is derived with `getUseStringRef(expression)` instead of being passed in by the caller. `getUseStringRef` returns `null` for a non-dictified subfield instead of asserting, since it is now called on arbitrary string expressions rather than only on already-dictified defines.
- `DictExprRewrite` becomes `DictExprEncoder` and no longer holds `anchorUseDictRef` between calls; `processAnchor(expr, originalOperator)` resolves the ref from the original operator.
- `decodeStruct` becomes a `DecodeContext` method and no longer takes `useStringRef`.
- `buildFunction` becomes `buildCallOperator`, unifying the two construction sites; the encoder's site now preserves `isDistinct` / `isRemovedDistinct` (both `false` for scalar array functions, so no functional change).
- `stringExprsMap` (`Map<Integer, List<ScalarOperator>>`) becomes a flat identity `Set<ScalarOperator>`, since the per-column key is no longer needed to interpret an entry.

**`DecodeCollector`**

- `checkDependOnExpr` dispatches on the expression, absorbing the `array_agg` / struct / subfield cases and removing the `getColumnRefs` helper.
- `initContext` fills the flat expression set.

**`DecodeRewriter`**

- `getUsedColumns(op, context)` collapses to `encodingAllowed(op, supportColumns)`, which lets `ExprReplacer` and `JoinOnPredicateReplacer` drop their `DecodeContext` dependency. In `JoinOnPredicateReplacer` the call was already guarded by `instanceof ColumnRefOperator`, where `getUsedColumns` returns just that ref's id, so the two forms are equivalent.
- `stringExprToDictExprMap` becomes an identity map, so `ExprReplacer` canonicalizes a column ref through `ColumnRefFactory` before looking it up: the refs embedded in projection expressions are distinct instances from the canonical ones the map is keyed by, and without this the per-reference rewrite that structs rely on silently stops happening. That canonicalization is marked `TODO` and goes away once struct expressions are registered as whole expressions.

This PR contains code changes in https://github.com/StarRocks/starrocks/actions/runs/31752402186/job/94633004814?pr=77772 to address the review comment. 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
