### PR TITLE
[Enhancement] Collect the scan conjunct lists the dict rewriter already rewrites

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -46,6 +46,7 @@ import com.starrocks.sql.optimizer.base.HashDistributionSpec;
 import com.starrocks.sql.optimizer.base.Ordering;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.ScanOperatorPredicates;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEConsumeOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEProduceOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator;
@@ -1381,13 +1382,28 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         return false;
     }
 
+    private static void addScanConjuncts(List<ScalarOperator> predicates, ScanOperatorPredicates scanPredicates) {
+        predicates.addAll(scanPredicates.getNoEvalPartitionConjuncts());
+        predicates.addAll(scanPredicates.getNonPartitionConjuncts());
+        predicates.addAll(scanPredicates.getMinMaxConjuncts());
+    }
+
     private void collectPredicate(Operator operator, DecodeInfo info) {
-        if (operator.getPredicate() == null) {
+        List<ScalarOperator> predicates = Lists.newArrayList();
+        if (operator.getPredicate() != null) {
+            predicates.add(operator.getPredicate());
+        }
+        if (operator instanceof PhysicalHiveScanOperator hiveScan) {
+            addScanConjuncts(predicates, hiveScan.getScanOperatorPredicates());
+        } else if (operator instanceof PhysicalIcebergScanOperator icebergScan) {
+            addScanConjuncts(predicates, icebergScan.getScanOperatorPredicates());
+        }
+        if (predicates.isEmpty()) {
             return;
         }
         DictExpressionCollector dictExpressionCollector = new DictExpressionCollector(info.outputStringColumns,
                 structManager);
-        dictExpressionCollector.collect(operator.getPredicate());
+        predicates.forEach(dictExpressionCollector::collect);
 
         info.outputStringColumns.getStream().forEach(c -> {
             List<ScalarOperator> expressions = dictExpressionCollector.getDictExpressions(c);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergDictScanConjunctsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergDictScanConjunctsTest.java
@@ -1,0 +1,110 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.common.FeConstants;
+import com.starrocks.sql.optimizer.statistics.ColumnDict;
+import com.starrocks.sql.optimizer.statistics.IRelaxDictManager;
+import mockit.Expectations;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Optional;
+
+/**
+ * The min/max conjuncts of a lake scan are built by OptExternalPartitionPruner during logical
+ * optimization, separately from the scan's own predicate, so DecodeCollector has to collect them
+ * explicitly for the dictionary rewrite to reach them. These tests pin that down for each shape
+ * buildMinMaxConjunct produces: a bound equal to the source predicate (range), and bounds that are
+ * equal to nothing that was collected (= and IN).
+ */
+public class IcebergDictScanConjunctsTest extends ConnectorPlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        ConnectorPlanTestBase.beforeClass();
+        FeConstants.USE_MOCK_DICT_MANAGER = true;
+        connectContext.getSessionVariable().setEnableLowCardinalityOptimize(true);
+        connectContext.getSessionVariable().setUseLowCardinalityOptimizeV2(true);
+        connectContext.getSessionVariable().setUseLowCardinalityOptimizeOnLake(true);
+        // The lake rewrite only runs for queries: DecodeCollector gates the iceberg/hive scan
+        // visitors on isQuery, and buildPlan() in the harness does not go through the production
+        // setIsQuery(...) path.
+        connectContext.getState().setIsQuery(true);
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        FeConstants.USE_MOCK_DICT_MANAGER = false;
+        connectContext.getSessionVariable().setEnableLowCardinalityOptimize(false);
+        connectContext.getSessionVariable().setUseLowCardinalityOptimizeV2(false);
+        connectContext.getSessionVariable().setUseLowCardinalityOptimizeOnLake(false);
+        connectContext.getState().setIsQuery(false);
+    }
+
+    private void mockDataColumnDict() {
+        IRelaxDictManager dictManager = IRelaxDictManager.getInstance();
+        // Only the presence of a dict matters: checkConnectorGlobalDict needs getGlobalDict to return
+        // one, and nothing compares its contents against the predicate constants.
+        ColumnDict columnDict = new ColumnDict(ImmutableMap.of(ByteBuffer.wrap("a".getBytes()), 1), 0, 0);
+
+        new Expectations(dictManager) {
+            {
+                dictManager.hasGlobalDict(anyString, "data");
+                result = true;
+                minTimes = 0;
+
+                dictManager.getGlobalDict(anyString, "data");
+                result = Optional.of(columnDict);
+                minTimes = 0;
+            }
+        };
+    }
+
+    // An equality predicate is normalized into two bounds with a different binary type (LE/GE), so
+    // neither is equal to the collected conjunct and neither could be found in the expression map
+    // by structural coincidence.
+    @Test
+    public void testEqualityMinMaxConjunctsUseDict() throws Exception {
+        mockDataColumnDict();
+        String plan = getVerboseExplain("select count(*) from iceberg0.unpartitioned_db.t0 where data = 'a'");
+        assertContains(plan, "MIN/MAX PREDICATES: DictDecode(");
+        assertContains(plan, "[<place-holder> <= 'a']");
+        assertContains(plan, "[<place-holder> >= 'a']");
+    }
+
+    // IN is normalized into >= min and <= max over constants that appear nowhere in the predicate.
+    @Test
+    public void testInPredicateMinMaxConjunctsUseDict() throws Exception {
+        mockDataColumnDict();
+        String plan = getVerboseExplain("select count(*) from iceberg0.unpartitioned_db.t0 where data in ('a', 'b')");
+        assertContains(plan, "MIN/MAX PREDICATES: DictDecode(");
+        assertContains(plan, "[<place-holder> >= 'a']");
+        assertContains(plan, "[<place-holder> <= 'b']");
+    }
+
+    // A range bound is built with the same binary type and children as the source predicate, so it
+    // used to be rewritten only because it was equal to the collected conjunct. Guards that shape.
+    @Test
+    public void testRangeMinMaxConjunctUsesDict() throws Exception {
+        mockDataColumnDict();
+        String plan = getVerboseExplain("select count(*) from iceberg0.unpartitioned_db.t0 where data > 'a'");
+        assertContains(plan, "MIN/MAX PREDICATES: DictDecode(");
+        assertContains(plan, "[<place-holder> > 'a']");
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

`DecodeRewriter.rewriteScanPredicate` pushes every list on `ScanOperatorPredicates` — `noEvalPartitionConjuncts`, `nonPartitionConjuncts` and `minMaxConjuncts` — through `ExprReplacer`, but `DecodeCollector` only ever collects `operator.getPredicate()`. Those expressions are therefore never registered as dictionary expressions, so replacer can only replace the column ref, not the expression.

A min/max bound only gets a dictionary rewrite today when it happens to be `equals` to a conjunct that *was* collected. `OptExternalPartitionPruner.buildMinMaxConjunct` builds a fresh operator:

```java
        return new BinaryPredicateOperator(type, columnRefOperator, right);
```

so a range predicate (`a >= 'x'`) produces a bound structurally equal to the scan's own conjunct and matches it in the expression map, while the bounds derived from `=` and `IN` do not match anything:

| source predicate | synthesized bounds | equal to a collected conjunct? |
|---|---|---|
| `a >= 'x'` | `a >= 'x'` | yes — rewritten by coincidence |
| `a = 'x'` | `a <= 'x'`, `a >= 'x'` | no — different binary type |
| `a IN ('b','q','z')` | `a >= 'b'`, `a <= 'z'` | no — constants appear nowhere |

So a lake query with `a = 'x'` or `a IN (…)` on a dict-encoded column evaluates its min/max bounds on decoded strings rather than on dictionary codes, and the range case only works by accident — an accident any rule that reshapes the scan predicate between logical and physical rewrite would take away.

## What I'm doing:

Collect the three conjunct lists in `DecodeCollector.collectPredicate`, alongside `operator.getPredicate()`, for the two scan types the low-cardinality pass encodes (`PhysicalHiveScanOperator`, `PhysicalIcebergScanOperator`). They go through the same `DictExpressionCollector`, so all three bound shapes are now rewritten deliberately instead of relying on a structural match.

One consequence worth noting for review: `saveDictExpr` also feeds the profitability counters, so registering these expressions adds a little weight in favour of encoding a column that appears only in scan conjuncts.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
