### PR TITLE
[Tool] Use JDK 21 for SonarCloud workflows

### DIFF
--- a/.github/workflows/ci-merged-sonarcloud-fe.yml
+++ b/.github/workflows/ci-merged-sonarcloud-fe.yml
@@ -29,11 +29,11 @@ jobs:
           echo ${{github.base_ref}}
           echo "branch=${{github.base_ref}}" >> $GITHUB_OUTPUT
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: 17
-          distribution: 'adopt'
+          java-version: 21
+          distribution: 'temurin'
 
       - name: Cache SonarCloud packages
         uses: actions/cache@v5

--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -288,7 +288,7 @@ jobs:
           git merge --squash --no-edit ${BRANCH} || (echo "Merge conflict, please check." && exit -1);
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         id: setup_java
         if: steps.checkout_pr.outcome == 'success'
         with:

--- a/.github/workflows/sonarcloud-be-build.yml
+++ b/.github/workflows/sonarcloud-be-build.yml
@@ -31,6 +31,13 @@ jobs:
           echo $workdir
           sed -i "s|\/root\/starrocks|$workdir|g" be/build-wrapper/build-wrapper-dump.json
 
+      - name: Set up JDK 21
+        if: steps.changes.outputs.be == 'true'
+        uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: 'temurin'
+
       - name: Run sonar-scanner
         if: steps.changes.outputs.be == 'true'
         env:


### PR DESCRIPTION
Run all SonarCloud analysis jobs with Temurin JDK 21 instead of relying on JDK 17 or an unspecified self-hosted runner Java installation. Standardize the Java setup action on v5 across the FE and BE workflows.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
