### PR TITLE
[BugFix] Keep the merge and the per-run sort on the same NULL semantics for ARRAY/STRUCT keys

### DIFF
--- a/be/src/column/adaptive_nullable_column.h
+++ b/be/src/column/adaptive_nullable_column.h
@@ -109,6 +109,9 @@ public:
         _size = 0;
     }
 
+    // Before materialization the two internal columns are shorter than size(), so reading them directly is out.
+    bool can_access_nullable_data() const override { return _state == State::kMaterialized; }
+
     bool has_null() const override {
         switch (_state) {
         case State::kUninitialized: {

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -463,6 +463,9 @@ public:
     // current only used by adaptive_nullable_column
     virtual void materialized_nullable() const {}
 
+    // True when NullableColumn's data/null columns are readable as is; a lazily filled subclass must override to false.
+    virtual bool can_access_nullable_data() const { return false; }
+
     // If the column contains subcolumns (such as Array, Nullable, etc), do callback on them.
     // Shallow: doesn't do recursive calls; don't do call for itself.
     virtual void mutate_each_subcolumn() {}

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -94,6 +94,7 @@ public:
     void update_has_null();
 
     bool is_nullable() const override { return true; }
+    bool can_access_nullable_data() const override { return true; }
     bool is_json() const override { return _data_column->is_json(); }
     bool is_variant() const override { return _data_column->is_variant(); }
     bool is_array() const override { return _data_column->is_array(); }

--- a/be/src/compute_env/sorting/merge.h
+++ b/be/src/compute_env/sorting/merge.h
@@ -20,6 +20,7 @@
 #include <utility>
 
 #include "column/chunk.h"
+#include "column/nullable_column.h"
 #include "column/sorting/sort_permute.h"
 #include "column/sorting/sorting.h"
 #include "column/vectorized_fwd.h"
@@ -27,6 +28,108 @@
 #include "types/datum.h"
 
 namespace starrocks {
+
+// A merge input column, unpacked into the data and null columns behind it whenever that is safe, so that
+// comparing a row costs one virtual call instead of two `is_null()` plus a `compare_at` rechecking the null.
+// A view aliases the column it was built from: it must not outlive the merge call that built it, and the
+// columns it points at must not be appended to, reset or swapped while it is alive.
+struct ColumnCompareView {
+    const Column* original = nullptr;
+    // `data` is `original` and `nulls` is null unless the column was unpacked.
+    const Column* data = nullptr;
+    const NullColumn* nulls = nullptr;
+    // Snapshot of NullableColumn::has_null(), which its is_null() consults before the bitmap and which
+    // callers are free to leave stale (see BoolOrAggregateFunction::empty_result and resize()).
+    bool has_null = false;
+#ifndef NDEBUG
+    size_t debug_num_rows = 0;
+    const uint8_t* debug_null_data = nullptr;
+#endif
+
+    ColumnCompareView() = default;
+
+    // The condition is a capability, never a type name, so a new column class defaults to the general path.
+    explicit ColumnCompareView(const Column& column) : original(&column), data(&column) {
+        if (column.is_nullable() && !column.is_constant() && column.can_access_nullable_data()) {
+            const auto& nullable = down_cast<const NullableColumn&>(column);
+            data = nullable.data_column().get();
+            nulls = nullable.null_column().get();
+            has_null = nullable.has_null();
+        }
+#ifndef NDEBUG
+        debug_num_rows = column.size();
+        debug_null_data = null_data();
+#endif
+    }
+
+    const uint8_t* null_data() const { return nulls == nullptr ? nullptr : nulls->immutable_data().data(); }
+
+    // Catches a source column whose object, length or NULL flag changed behind a view still being compared
+    // with. In-place writes into the data or bitmap buffers keep every field below equal and go unnoticed.
+    bool debug_source_unchanged(const Column& column) const {
+#ifdef NDEBUG
+        return true;
+#else
+        // Compare the pointers first: a replaced inner column makes the buffer address stale to read.
+        if (original != &column) {
+            return false;
+        }
+        const ColumnCompareView current(column);
+        return data == current.data && nulls == current.nulls && has_null == current.has_null &&
+               debug_num_rows == column.size() && debug_null_data == current.null_data();
+#endif
+    }
+};
+
+// Compare one row of two columns while merging sorted runs. The returned value is in the ascending
+// space, so the caller still has to flip it by `desc.sort_order`.
+//
+// The position of a row-level NULL is decided by `desc.null_first`, which is already flipped by the
+// sort order to compensate for that final flip. The values are compared with the direction-free
+// `desc.nan_direction()` instead, because that is the hint every run was sorted with (see
+// `ColumnSorter` in column/sorting/sort_column.cpp, which leaves the direction to the sorter). Handing
+// the flipped `null_first` to the value comparison would order NULL elements nested in ARRAY/STRUCT
+// the opposite way of the per-run sort, and merging runs under a NULL semantics they were not sorted
+// with degenerates the output into a concatenation of the runs.
+inline int compare_column_row(const SortDesc& desc, const ColumnCompareView& left, size_t lhs_row,
+                              const ColumnCompareView& right, size_t rhs_row) {
+    // Both sides fall back together: comparing an unpacked column against a wrapper would mix two levels.
+    // Only this all-or-nothing fast path carries the NULL semantics below; the general path keeps whatever
+    // is_null() plus NullableColumn::compare_at() do, which still disagree on a column with a stale flag.
+    const bool unpacked = left.nulls != nullptr && right.nulls != nullptr;
+    // Reading the flag before the bitmap is the is_null() half of the old comparison, kept because the flag
+    // is the same signal ColumnSorter's `!has_null()` fast path sorted the run by. It deliberately does not
+    // follow NullableColumn::compare_at(), which reads the bitmap alone and would order a stale row against
+    // the sort that produced the run.
+    const bool lhs_null =
+            unpacked ? left.has_null && left.nulls->immutable_data()[lhs_row] != 0 : left.original->is_null(lhs_row);
+    const bool rhs_null =
+            unpacked ? right.has_null && right.nulls->immutable_data()[rhs_row] != 0 : right.original->is_null(rhs_row);
+    if (lhs_null || rhs_null) {
+        if (lhs_null && rhs_null) {
+            return 0;
+        }
+        return lhs_null ? desc.null_first : -desc.null_first;
+    }
+    if (unpacked) {
+        return left.data->compare_at(lhs_row, rhs_row, *right.data, desc.nan_direction());
+    }
+    return left.original->compare_at(lhs_row, rhs_row, *right.original, desc.nan_direction());
+}
+
+// Compare one row of two runs, column by column, stopping at the first column that orders them.
+inline int compare_run_row(const SortDescs& descs, const std::vector<ColumnCompareView>& left, size_t lhs_row,
+                           const std::vector<ColumnCompareView>& right, size_t rhs_row) {
+    for (int i = 0; i < descs.num_columns(); i++) {
+        const SortDesc desc = descs.get_column_desc(i);
+        int x = compare_column_row(desc, left[i], lhs_row, right[i], rhs_row);
+        if (x != 0) {
+            return x * desc.sort_order;
+        }
+    }
+    return 0;
+}
+
 // SortedRun represents part of sorted chunk, specified by the range
 // The chunk is sorted based on `orderby` columns
 struct SortedRun {

--- a/be/src/compute_env/sorting/merge_column.cpp
+++ b/be/src/compute_env/sorting/merge_column.cpp
@@ -42,29 +42,6 @@ struct EqualRange {
     EqualRange(Range left, Range right) : left_range(std::move(left)), right_range(std::move(right)) {}
 };
 
-// Compare one row of two columns while merging sorted runs. The returned value is in the ascending
-// space, so the caller still has to flip it by `desc.sort_order`.
-//
-// The position of a row-level NULL is decided by `desc.null_first`, which is already flipped by the
-// sort order to compensate for that final flip. The values are compared with the direction-free
-// `desc.nan_direction()` instead, because that is the hint every run was sorted with (see
-// `ColumnSorter` in column/sorting/sort_column.cpp, which leaves the direction to the sorter). Handing
-// the flipped `null_first` to the value comparison would order NULL elements nested in ARRAY/STRUCT
-// the opposite way of the per-run sort, and merging runs under a NULL semantics they were not sorted
-// with degenerates the output into a concatenation of the runs.
-static int compare_column_row(const SortDesc& desc, const Column& left, size_t lhs_row, const Column& right,
-                              size_t rhs_row) {
-    const bool lhs_null = left.is_null(lhs_row);
-    const bool rhs_null = right.is_null(rhs_row);
-    if (lhs_null || rhs_null) {
-        if (lhs_null && rhs_null) {
-            return 0;
-        }
-        return lhs_null ? desc.null_first : -desc.null_first;
-    }
-    return left.compare_at(lhs_row, rhs_row, right, desc.nan_direction());
-}
-
 // MergeTwoColumn incremental merge two columns
 class MergeTwoColumn final : public ColumnVisitorAdapter<MergeTwoColumn> {
 public:
@@ -74,6 +51,8 @@ public:
               _desc(desc),
               _left_col(left_col),
               _right_col(right_col),
+              _left_view(*left_col),
+              _right_view(*right_col),
               _equal_ranges(equal_range),
               _perm(perm) {}
 
@@ -144,17 +123,17 @@ public:
     template <class ColumnType>
     Status do_visit_slow(const ColumnType&) {
         auto cmp = [&](size_t lhs_index, size_t rhs_index) {
-            int x = compare_column_row(_desc, *_left_col, lhs_index, *_right_col, rhs_index);
+            int x = compare_column_row(_desc, _left_view, lhs_index, _right_view, rhs_index);
             if (_desc.sort_order == -1) {
                 x *= -1;
             }
             return x;
         };
         auto equal_left = [&](size_t lhs_index, size_t rhs_index) {
-            return compare_column_row(_desc, *_left_col, lhs_index, *_left_col, rhs_index) == 0;
+            return compare_column_row(_desc, _left_view, lhs_index, _left_view, rhs_index) == 0;
         };
         auto equal_right = [&](size_t lhs_index, size_t rhs_index) {
-            return compare_column_row(_desc, *_right_col, lhs_index, *_right_col, rhs_index) == 0;
+            return compare_column_row(_desc, _right_view, lhs_index, _right_view, rhs_index) == 0;
         };
         return do_merge(cmp, equal_left, equal_right);
     }
@@ -233,6 +212,9 @@ private:
     const SortDesc _desc;
     const Column* _left_col;
     const Column* _right_col;
+    // Built once per merged column, and alive only for that merge, which is what keeps them from dangling.
+    const ColumnCompareView _left_view;
+    const ColumnCompareView _right_view;
     std::vector<EqualRange>* _equal_ranges;
     Permutation* _perm;
     bool use_german_string = false;
@@ -442,7 +424,10 @@ int SortedRun::compare_row(const SortDescs& desc, const SortedRun& rhs, size_t l
     DCHECK_LT(rhs_row, rhs.range.second);
     for (int i = 0; i < desc.num_columns(); i++) {
         const SortDesc col_desc = desc.get_column_desc(i);
-        int x = compare_column_row(col_desc, *get_column(i), lhs_row, *rhs.get_column(i), rhs_row);
+        // Comparing a row here is rare enough that building the two views costs less than caching them would.
+        const ColumnCompareView lhs_view(*get_column(i));
+        const ColumnCompareView rhs_view(*rhs.get_column(i));
+        int x = compare_column_row(col_desc, lhs_view, lhs_row, rhs_view, rhs_row);
         if (x != 0) {
             return x * col_desc.sort_order;
         }

--- a/be/src/compute_env/sorting/merge_column.cpp
+++ b/be/src/compute_env/sorting/merge_column.cpp
@@ -42,14 +42,36 @@ struct EqualRange {
     EqualRange(Range left, Range right) : left_range(std::move(left)), right_range(std::move(right)) {}
 };
 
+// Compare one row of two columns while merging sorted runs. The returned value is in the ascending
+// space, so the caller still has to flip it by `desc.sort_order`.
+//
+// The position of a row-level NULL is decided by `desc.null_first`, which is already flipped by the
+// sort order to compensate for that final flip. The values are compared with the direction-free
+// `desc.nan_direction()` instead, because that is the hint every run was sorted with (see
+// `ColumnSorter` in column/sorting/sort_column.cpp, which leaves the direction to the sorter). Handing
+// the flipped `null_first` to the value comparison would order NULL elements nested in ARRAY/STRUCT
+// the opposite way of the per-run sort, and merging runs under a NULL semantics they were not sorted
+// with degenerates the output into a concatenation of the runs.
+static int compare_column_row(const SortDesc& desc, const Column& left, size_t lhs_row, const Column& right,
+                              size_t rhs_row) {
+    const bool lhs_null = left.is_null(lhs_row);
+    const bool rhs_null = right.is_null(rhs_row);
+    if (lhs_null || rhs_null) {
+        if (lhs_null && rhs_null) {
+            return 0;
+        }
+        return lhs_null ? desc.null_first : -desc.null_first;
+    }
+    return left.compare_at(lhs_row, rhs_row, right, desc.nan_direction());
+}
+
 // MergeTwoColumn incremental merge two columns
 class MergeTwoColumn final : public ColumnVisitorAdapter<MergeTwoColumn> {
 public:
     MergeTwoColumn(SortDesc desc, const Column* left_col, const Column* right_col, std::vector<EqualRange>* equal_range,
                    Permutation* perm)
             : ColumnVisitorAdapter(this),
-              _sort_order(desc.sort_order),
-              _null_first(desc.null_first),
+              _desc(desc),
               _left_col(left_col),
               _right_col(right_col),
               _equal_ranges(equal_range),
@@ -122,17 +144,17 @@ public:
     template <class ColumnType>
     Status do_visit_slow(const ColumnType&) {
         auto cmp = [&](size_t lhs_index, size_t rhs_index) {
-            int x = _left_col->compare_at(lhs_index, rhs_index, *_right_col, _null_first);
-            if (_sort_order == -1) {
+            int x = compare_column_row(_desc, *_left_col, lhs_index, *_right_col, rhs_index);
+            if (_desc.sort_order == -1) {
                 x *= -1;
             }
             return x;
         };
         auto equal_left = [&](size_t lhs_index, size_t rhs_index) {
-            return _left_col->compare_at(lhs_index, rhs_index, *_left_col, _null_first) == 0;
+            return compare_column_row(_desc, *_left_col, lhs_index, *_left_col, rhs_index) == 0;
         };
         auto equal_right = [&](size_t lhs_index, size_t rhs_index) {
-            return _right_col->compare_at(lhs_index, rhs_index, *_right_col, _null_first) == 0;
+            return compare_column_row(_desc, *_right_col, lhs_index, *_right_col, rhs_index) == 0;
         };
         return do_merge(cmp, equal_left, equal_right);
     }
@@ -141,7 +163,7 @@ public:
     Status merge_ordinary_column(const Container& left_data, const Container& right_data) {
         auto cmp = [&](size_t lhs_index, size_t rhs_index) {
             int x = SorterComparator<ValueType>::compare(left_data[lhs_index], right_data[rhs_index]);
-            if (_sort_order == -1) {
+            if (_desc.sort_order == -1) {
                 x *= -1;
             }
             return x;
@@ -192,7 +214,7 @@ public:
             DCHECK(_left_col->is_nullable() && _right_col->is_nullable());
             const auto* lhs_data = down_cast<const NullableColumn*>(_left_col)->data_column().get();
             const auto* rhs_data = down_cast<const NullableColumn*>(_right_col)->data_column().get();
-            MergeTwoColumn merge2({_sort_order, _null_first}, lhs_data, rhs_data, _equal_ranges, _perm);
+            MergeTwoColumn merge2(_desc, lhs_data, rhs_data, _equal_ranges, _perm);
             merge2.set_use_german_string(is_use_german_string());
             return lhs_data->accept(&merge2);
         }
@@ -208,8 +230,7 @@ private:
     constexpr static uint32_t kLeftIndex = 0;
     constexpr static uint32_t kRightIndex = 1;
 
-    const int _sort_order;
-    const int _null_first;
+    const SortDesc _desc;
     const Column* _left_col;
     const Column* _right_col;
     std::vector<EqualRange>* _equal_ranges;
@@ -420,9 +441,10 @@ int SortedRun::compare_row(const SortDescs& desc, const SortedRun& rhs, size_t l
     DCHECK_LT(lhs_row, range.second);
     DCHECK_LT(rhs_row, rhs.range.second);
     for (int i = 0; i < desc.num_columns(); i++) {
-        int x = get_column(i)->compare_at(lhs_row, rhs_row, *rhs.get_column(i), desc.get_column_desc(i).null_first);
+        const SortDesc col_desc = desc.get_column_desc(i);
+        int x = compare_column_row(col_desc, *get_column(i), lhs_row, *rhs.get_column(i), rhs_row);
         if (x != 0) {
-            return x * desc.get_column_desc(i).sort_order;
+            return x * col_desc.sort_order;
         }
     }
     return 0;

--- a/be/src/compute_env/sorting/merge_path.cpp
+++ b/be/src/compute_env/sorting/merge_path.cpp
@@ -197,25 +197,63 @@ void detail::_do_merge_along_merge_path(const SortDescs& descs, const InputSegme
         // Auxiliary data structure for Chunk::append
         std::pair<size_t, size_t> range;
 
-        MergeIterator(const InputSegment& input) : input(input) {}
+        // Views of `run`'s orderby columns, only valid while `run` is the one they were built from
+        std::vector<ColumnCompareView> views;
+        const size_t num_sort_columns;
+
+        MergeIterator(const InputSegment& input, size_t num_sort_columns)
+                : input(input), num_sort_columns(num_sort_columns) {
+            views.reserve(num_sort_columns);
+        }
+
+        // The only place allowed to move the run pointer, so that the views can never outlive their run.
+        // An exhausted iterator can land on an empty run, whose orderby columns were never evaluated.
+        void set_run(const SortedRun* new_run) {
+            run = new_run;
+            views.clear();
+            if (run == nullptr || run->num_rows() == 0) {
+                return;
+            }
+            DCHECK_GE(run->num_columns(), num_sort_columns);
+            for (size_t col = 0; col < num_sort_columns; col++) {
+                views.emplace_back(*run->get_column(col));
+            }
+        }
+
+        bool debug_views_match_run() const {
+            if (run == nullptr || run->num_rows() == 0) {
+                return views.empty();
+            }
+            if (views.size() != num_sort_columns) {
+                return false;
+            }
+            for (size_t col = 0; col < views.size(); col++) {
+                if (!views[col].debug_source_unchanged(*run->get_column(col))) {
+                    return false;
+                }
+            }
+            return true;
+        }
     };
 
-    MergeIterator l_it(left);
+    const size_t num_sort_columns = descs.num_columns();
+
+    MergeIterator l_it(left, num_sort_columns);
     auto l_run_opt = left.runs.get_run_idx(li);
     if (l_run_opt.has_value()) {
         l_it.run_idx = l_run_opt.value().first;
         l_it.offset = l_run_opt.value().second;
-        l_it.run = &left.runs.get_run(l_it.run_idx);
+        l_it.set_run(&left.runs.get_run(l_it.run_idx));
         DCHECK_GE(l_it.offset, l_it.run->start_index());
         DCHECK_LT(l_it.offset, l_it.run->end_index());
     }
 
-    MergeIterator r_it(right);
+    MergeIterator r_it(right, num_sort_columns);
     auto r_run_opt = right.runs.get_run_idx(ri);
     if (r_run_opt.has_value()) {
         r_it.run_idx = r_run_opt.value().first;
         r_it.offset = r_run_opt.value().second;
-        r_it.run = &right.runs.get_run(r_it.run_idx);
+        r_it.set_run(&right.runs.get_run(r_it.run_idx));
         DCHECK_GE(r_it.offset, r_it.run->start_index());
         DCHECK_LT(r_it.offset, r_it.run->end_index());
     }
@@ -252,15 +290,16 @@ void detail::_do_merge_along_merge_path(const SortDescs& descs, const InputSegme
     auto forward_iterator = [](MergeIterator& it) {
         DCHECK(it.run != nullptr);
         if (it.offset >= it.run->end_index()) {
-            it.run = nullptr;
+            const SortedRun* next = nullptr;
             do {
                 it.run_idx++;
                 if (it.run_idx >= it.input.runs.num_chunks()) {
                     break;
                 }
-                it.run = &it.input.runs.get_run(it.run_idx);
-                it.offset = it.run->start_index();
-            } while (it.run->num_rows() == 0);
+                next = &it.input.runs.get_run(it.run_idx);
+                it.offset = next->start_index();
+            } while (next->num_rows() == 0);
+            it.set_run(next);
         }
     };
 
@@ -334,7 +373,9 @@ void detail::_do_merge_along_merge_path(const SortDescs& descs, const InputSegme
             };
 
             auto compare = [&descs, &l_it, &r_it]() {
-                return l_it.run->compare_row(descs, *r_it.run, l_it.offset, r_it.offset);
+                DCHECK(l_it.debug_views_match_run());
+                DCHECK(r_it.debug_views_match_run());
+                return compare_run_row(descs, l_it.views, l_it.offset, r_it.views, r_it.offset);
             };
             if (compare() <= 0) {
                 auto satisfy = [&compare]() { return compare() <= 0; };

--- a/be/test/compute_env/sorting/sorting_test.cpp
+++ b/be/test/compute_env/sorting/sorting_test.cpp
@@ -24,10 +24,12 @@
 
 #include "base/testutil/assert.h"
 #include "base/utility/defer_op.h"
+#include "column/adaptive_nullable_column.h"
 #include "column/array_column.h"
 #include "column/chunk.h"
 #include "column/column.h"
 #include "column/column_helper.h"
+#include "column/const_column.h"
 #include "column/fixed_length_column.h"
 #include "column/nullable_column.h"
 #include "column/sorting/sort_permute.h"
@@ -314,6 +316,222 @@ TEST_F(SortRunConsistencyTest, nullable_int_keeps_null_position) {
     expect_order(type, column, asc_nulls_first(), {1, 5, 2, 0, 6, 7, 4, 3});
     expect_order(type, column, desc_nulls_last(), {3, 4, 7, 6, 0, 2, 5, 1});
     expect_order(type, column, desc_nulls_first(), {1, 3, 4, 7, 6, 0, 2, 5});
+}
+
+static MutableColumnPtr build_adaptive_int_column(AdaptiveNullableColumn::State state) {
+    auto column = AdaptiveNullableColumn::create(Int32Column::create(), NullColumn::create());
+    switch (state) {
+    case AdaptiveNullableColumn::State::kUninitialized:
+        break;
+    case AdaptiveNullableColumn::State::kNull:
+        CHECK(column->append_nulls(3));
+        break;
+    case AdaptiveNullableColumn::State::kConstant:
+        for (int i = 0; i < 3; i++) {
+            column->append_default_not_null_value();
+        }
+        break;
+    case AdaptiveNullableColumn::State::kNotConstant:
+        for (int i = 0; i < 3; i++) {
+            column->append_datum(Datum(i));
+        }
+        break;
+    case AdaptiveNullableColumn::State::kMaterialized:
+        CHECK(column->append_nulls(1));
+        column->append_datum(Datum(1));
+        break;
+    }
+    CHECK(state == column->state());
+    return column;
+}
+
+// A column is unpacked into its data and null columns only if it says both are readable as is. Everything
+// else keeps the general path, and asking must not materialize anything, because the merge asks from every
+// worker thread at once while the inputs are supposed to be read-only.
+class ColumnCompareViewTest : public testing::Test {
+protected:
+    static void expect_general_path(const Column& column) {
+        ColumnCompareView view(column);
+        EXPECT_EQ(&column, view.original);
+        EXPECT_EQ(&column, view.data);
+        EXPECT_EQ(nullptr, view.nulls);
+    }
+
+    static void expect_unpacked(const Column& column) {
+        const auto& nullable = down_cast<const NullableColumn&>(column);
+        ColumnCompareView view(column);
+        EXPECT_EQ(&column, view.original);
+        EXPECT_EQ(nullable.data_column().get(), view.data);
+        EXPECT_EQ(nullable.null_column().get(), view.nulls);
+    }
+};
+
+TEST_F(ColumnCompareViewTest, nullable_column_is_unpacked) {
+    MutableColumnPtr column = build_nullable_int_column({1, std::nullopt, 3});
+    ASSERT_TRUE(column->can_access_nullable_data());
+    expect_unpacked(*column);
+}
+
+TEST_F(ColumnCompareViewTest, plain_and_constant_columns_keep_the_general_path) {
+    MutableColumnPtr plain = build_int_column({1, 2, 3});
+    EXPECT_FALSE(plain->can_access_nullable_data());
+    expect_general_path(*plain);
+
+    // A constant NULL column reports the is_nullable() of the column it wraps, yet down_cast-ing it would be UB.
+    auto constant_null = ConstColumn::create(build_nullable_int_column({std::nullopt}), 3);
+    EXPECT_TRUE(constant_null->is_nullable());
+    EXPECT_FALSE(constant_null->can_access_nullable_data());
+    expect_general_path(*constant_null);
+
+    expect_general_path(*ConstColumn::create(build_int_column({7}), 3));
+}
+
+TEST_F(ColumnCompareViewTest, adaptive_column_is_unpacked_only_once_materialized) {
+    for (auto state : {AdaptiveNullableColumn::State::kUninitialized, AdaptiveNullableColumn::State::kNull,
+                       AdaptiveNullableColumn::State::kConstant, AdaptiveNullableColumn::State::kNotConstant}) {
+        MutableColumnPtr column = build_adaptive_int_column(state);
+        EXPECT_FALSE(column->can_access_nullable_data());
+
+        expect_general_path(*column);
+        // Building the view is the only thing asserted here: a full comparison would materialize the column.
+        EXPECT_TRUE(state == down_cast<AdaptiveNullableColumn*>(column.get())->state());
+    }
+
+    MutableColumnPtr materialized = build_adaptive_int_column(AdaptiveNullableColumn::State::kMaterialized);
+    ASSERT_TRUE(materialized->can_access_nullable_data());
+    expect_unpacked(*materialized);
+}
+
+// Several call sites write the null bitmap directly and leave has_null() false (BoolOrAggregateFunction's
+// empty_result, resize()). What the merge must agree with is the per-run sort, which skips NULL handling
+// entirely when has_null() is false -- so the comparison has to consult the flag before the bitmap, exactly
+// like is_null() does.
+TEST_F(ColumnCompareViewTest, stale_has_null_is_ordered_the_way_the_run_sort_orders_it) {
+    MutableColumnPtr owner = build_nullable_int_column({1, 2});
+    auto* nullable = down_cast<NullableColumn*>(owner.get());
+    nullable->null_column_data()[1] = 1;
+    ASSERT_FALSE(nullable->has_null());
+    ASSERT_FALSE(nullable->is_null(1)) << "is_null() consults has_null() before the bitmap";
+
+    ColumnPtr column = std::move(owner);
+    const ColumnCompareView view(*column);
+    ASSERT_NE(nullptr, view.nulls) << "the column is unpacked, so this exercises the fast path";
+
+    for (const SortDesc& desc : {SortDesc(true, true), SortDesc(false, false)}) {
+        const SortDescs descs(std::vector<int>{desc.sort_order}, std::vector<int>{desc.null_first});
+        SmallPermutation permutation = create_small_permutation(column->size());
+        const std::atomic<bool> cancel{false};
+        ASSERT_OK(sort_and_tie_columns(cancel, Columns{column}, descs, permutation));
+
+        const bool sort_puts_first_row_first = permutation[0].index_in_chunk == 0;
+        const int merged = compare_column_row(desc, view, 0, view, 1) * desc.sort_order;
+        EXPECT_EQ(sort_puts_first_row_first, merged < 0) << "sort_order: " << desc.sort_order;
+    }
+}
+
+// The two runs have to overlap to reach MergeTwoColumn at all: two disjoint runs are concatenated by
+// merge_sorted_chunks_two_way without ever comparing a row, which would leave these cases green and blind.
+class MergeTwoColumnTest : public testing::Test {
+protected:
+    using Values = std::vector<std::optional<int32_t>>;
+
+    static Values read_values(const Column& column, const std::vector<uint32_t>& rows) {
+        Values values;
+        for (uint32_t row : rows) {
+            values.emplace_back(column.is_null(row) ? std::nullopt
+                                                    : std::optional<int32_t>(column.get(row).get_int32()));
+        }
+        return values;
+    }
+
+    // Merge two single column runs, and report whether the output interleaved them, which only a row by row
+    // merge can produce.
+    static Values merge_two_runs(const SortDescs& descs, const ColumnPtr& left, const ColumnPtr& right,
+                                 bool* interleaved) {
+        auto make_run = [](const ColumnPtr& column) {
+            ChunkPtr chunk = std::make_shared<Chunk>(Columns{column}, Chunk::SlotHashMap{{0, 0}});
+            return SortedRun(chunk, Columns{column});
+        };
+
+        Permutation perm;
+        CHECK(merge_sorted_chunks_two_way(descs, make_run(left), make_run(right), &perm).ok());
+
+        Values values;
+        bool seen_right = false;
+        *interleaved = false;
+        for (const auto& item : perm) {
+            const Column& column = item.chunk_index == 0 ? *left : *right;
+            values.emplace_back(column.is_null(item.index_in_chunk)
+                                        ? std::nullopt
+                                        : std::optional<int32_t>(column.get(item.index_in_chunk).get_int32()));
+            if (item.chunk_index == 1) {
+                seen_right = true;
+            } else if (seen_right) {
+                *interleaved = true;
+            }
+        }
+        return values;
+    }
+
+    // The order the per-run sort itself produces for all the rows at once, the merge must reproduce it.
+    static Values sort_all(const SortDescs& descs, const Values& all) {
+        ColumnPtr column = build_nullable_int_column(all);
+        SmallPermutation perm = create_small_permutation(column->size());
+        const std::atomic<bool> cancel{false};
+        CHECK(sort_and_tie_columns(cancel, Columns{column}, descs, perm).ok());
+
+        std::vector<uint32_t> rows;
+        for (const auto& item : perm) {
+            rows.emplace_back(item.index_in_chunk);
+        }
+        return read_values(*column, rows);
+    }
+
+    static SortDescs desc_nulls_last() { return SortDescs(std::vector<bool>{false}, std::vector<bool>{false}); }
+    static SortDescs asc_nulls_first() { return SortDescs(std::vector<bool>{true}, std::vector<bool>{true}); }
+};
+
+TEST_F(MergeTwoColumnTest, merges_nullable_columns_the_way_the_sort_would) {
+    // Distinct values, so a single order satisfies both phases and the comparison below is unambiguous.
+    const Values left_values{9, 7, 4, std::nullopt};
+    const Values right_values{8, 6, 5, std::nullopt};
+    Values all = left_values;
+    all.insert(all.end(), right_values.begin(), right_values.end());
+
+    for (const auto& descs : {desc_nulls_last(), asc_nulls_first()}) {
+        Values left_sorted = sort_all(descs, left_values);
+        Values right_sorted = sort_all(descs, right_values);
+
+        bool interleaved = false;
+        Values merged = merge_two_runs(descs, build_nullable_int_column(left_sorted),
+                                       build_nullable_int_column(right_sorted), &interleaved);
+        EXPECT_TRUE(interleaved);
+        EXPECT_EQ(sort_all(descs, all), merged);
+    }
+}
+
+TEST_F(MergeTwoColumnTest, merges_materialized_adaptive_columns_the_way_the_sort_would) {
+    auto build_adaptive = [](const Values& values) {
+        auto column = AdaptiveNullableColumn::create(Int32Column::create(), NullColumn::create());
+        for (const auto& value : values) {
+            value.has_value() ? column->append_datum(Datum(value.value())) : (void)column->append_nulls(1);
+        }
+        column->materialized_nullable();
+        CHECK(column->can_access_nullable_data());
+        return column;
+    };
+
+    const Values left_values{9, 7, 4, std::nullopt};
+    const Values right_values{8, 6, 5, std::nullopt};
+    Values all = left_values;
+    all.insert(all.end(), right_values.begin(), right_values.end());
+
+    const SortDescs descs = desc_nulls_last();
+    bool interleaved = false;
+    Values merged = merge_two_runs(descs, build_adaptive(sort_all(descs, left_values)),
+                                   build_adaptive(sort_all(descs, right_values)), &interleaved);
+    EXPECT_TRUE(interleaved);
+    EXPECT_EQ(sort_all(descs, all), merged);
 }
 
 } // namespace

--- a/be/test/compute_env/sorting/sorting_test.cpp
+++ b/be/test/compute_env/sorting/sorting_test.cpp
@@ -16,15 +16,22 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <memory>
+#include <optional>
 #include <utility>
 #include <vector>
 
 #include "base/testutil/assert.h"
 #include "base/utility/defer_op.h"
+#include "column/array_column.h"
 #include "column/chunk.h"
 #include "column/column.h"
 #include "column/column_helper.h"
+#include "column/fixed_length_column.h"
+#include "column/nullable_column.h"
+#include "column/sorting/sort_permute.h"
+#include "column/struct_column.h"
 #include "common/config_exec_fwd.h"
 #include "compute_env/sorting/merge.h"
 #include "compute_env/sorting/sort_cursor.h"
@@ -43,6 +50,54 @@ static MutableColumnPtr build_int_column(const std::vector<int32_t>& values) {
         column->append_datum(Datum(value));
     }
     return column;
+}
+
+// A row of an ARRAY<INT> column with nullable elements, std::nullopt is a NULL element.
+using ArrayRow = std::vector<std::optional<int32_t>>;
+
+static MutableColumnPtr build_nullable_int_column(const std::vector<std::optional<int32_t>>& values) {
+    auto column = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    for (const auto& value : values) {
+        if (value.has_value()) {
+            column->append_datum(Datum(value.value()));
+        } else {
+            column->append_nulls(1);
+        }
+    }
+    return column;
+}
+
+// Build an ARRAY<INT> column with nullable elements. A row without a value is a NULL row, which makes
+// the whole column nullable.
+static MutableColumnPtr build_array_column(const std::vector<std::optional<ArrayRow>>& rows) {
+    std::vector<std::optional<int32_t>> elements;
+    auto offsets = UInt32Column::create();
+    offsets->append(0);
+    for (const auto& row : rows) {
+        if (row.has_value()) {
+            elements.insert(elements.end(), row->begin(), row->end());
+        }
+        offsets->append(elements.size());
+    }
+    MutableColumnPtr column = ArrayColumn::create(build_nullable_int_column(elements), std::move(offsets));
+
+    if (std::all_of(rows.begin(), rows.end(), [](const auto& row) { return row.has_value(); })) {
+        return column;
+    }
+    auto nulls = NullColumn::create();
+    for (const auto& row : rows) {
+        nulls->append(row.has_value() ? 0 : 1);
+    }
+    return NullableColumn::create(std::move(column), std::move(nulls));
+}
+
+// Build a STRUCT<f0 INT, f1 INT> column, both fields are nullable.
+static MutableColumnPtr build_struct_column(const std::vector<std::optional<int32_t>>& f0,
+                                            const std::vector<std::optional<int32_t>>& f1) {
+    MutableColumns fields;
+    fields.emplace_back(build_nullable_int_column(f0));
+    fields.emplace_back(build_nullable_int_column(f1));
+    return StructColumn::create(std::move(fields), std::vector<std::string>{"f0", "f1"});
 }
 
 static void clear_exprs(std::vector<ExprContext*>& exprs) {
@@ -127,6 +182,138 @@ TEST_F(SortingCoreTest, merge_sorted_chunks) {
     ASSERT_OK(merge_sorted_chunks(sort_desc, &_sort_exprs, input_chunks, &output));
     ASSERT_TRUE(output.is_sorted(sort_desc));
     ASSERT_EQ(18, output.num_rows());
+}
+
+// A sorted run is compared twice on its way out of a full sort: once while the run itself is sorted,
+// and once again while the runs are merged. Both phases must agree on where a NULL goes, otherwise the
+// merge reorders rows that were already in the right order. These tests pin that agreement down by
+// running the very same rows through one run (no merge) and through several runs (merged), and by
+// pinning the resulting order to a literal so a change of the NULL semantics cannot slip through.
+class SortRunConsistencyTest : public testing::Test {
+protected:
+    void SetUp() override { _runtime_state = create_runtime_state(); }
+
+    void TearDown() override { clear_exprs(_sort_exprs); }
+
+    // Sort every run on its own and merge the sorted runs afterwards, exactly what a full sort does
+    // once its input no longer fits into a single buffered run. `run_sizes` splits the rows into runs,
+    // a single run holding every row is the path that never merges anything.
+    // Returns the row ids in output order.
+    std::vector<int32_t> sort_and_merge(const TypeDescriptor& key_type, const ColumnPtr& key_column,
+                                        const std::vector<size_t>& run_sizes, const SortDescs& sort_desc) {
+        clear_exprs(_sort_exprs);
+        _exprs.emplace_back(std::make_unique<ColumnRef>(key_type, 0));
+        _sort_exprs.emplace_back(new ExprContext(_exprs.back().get()));
+        CHECK(ExprExecutor::prepare(_sort_exprs, _runtime_state.get()).ok());
+        CHECK(ExprExecutor::open(_sort_exprs, _runtime_state.get()).ok());
+
+        const Chunk::SlotHashMap slot_map{{0, 0}, {1, 1}};
+        const std::atomic<bool> cancel{false};
+
+        std::vector<ChunkUniquePtr> sorted_runs;
+        size_t offset = 0;
+        for (size_t run_size : run_sizes) {
+            auto key = key_column->clone_empty();
+            key->append(*key_column, offset, run_size);
+            auto row_id = Int32Column::create();
+            for (size_t i = 0; i < run_size; i++) {
+                row_id->append(static_cast<int32_t>(offset + i));
+            }
+            ChunkPtr run = std::make_shared<Chunk>(Columns{std::move(key), std::move(row_id)}, slot_map);
+
+            SmallPermutation permutation = create_small_permutation(run_size);
+            CHECK(sort_and_tie_columns(cancel, Columns{run->get_column_by_index(0)}, sort_desc, permutation).ok());
+            auto sorted_run = run->clone_empty_with_slot(run_size);
+            materialize_by_permutation_single(sorted_run.get(), run, permutation);
+            sorted_runs.emplace_back(std::move(sorted_run));
+
+            offset += run_size;
+        }
+        CHECK_EQ(key_column->size(), offset);
+
+        SortedRuns output;
+        CHECK(merge_sorted_chunks(sort_desc, &_sort_exprs, sorted_runs, &output).ok());
+        // The merged runs must be sorted by the very comparator the merge itself used.
+        EXPECT_TRUE(output.is_sorted(sort_desc));
+
+        ChunkPtr merged = output.assemble();
+        std::vector<int32_t> order;
+        for (size_t i = 0; i < merged->num_rows(); i++) {
+            order.emplace_back(merged->get_column_by_index(1)->get(i).get_int32());
+        }
+        return order;
+    }
+
+    // Every split of the same rows must produce the same order as the single run that is never merged.
+    void expect_order(const TypeDescriptor& key_type, const ColumnPtr& key_column, const SortDescs& sort_desc,
+                      const std::vector<int32_t>& expected) {
+        const size_t num_rows = key_column->size();
+        ASSERT_EQ(num_rows, expected.size());
+
+        EXPECT_EQ(expected, sort_and_merge(key_type, key_column, {num_rows}, sort_desc)) << "single run";
+        for (const auto& run_sizes : std::vector<std::vector<size_t>>{{4, 4}, {3, 5}, {2, 2, 2, 2}, {1, 2, 3, 1, 1}}) {
+            EXPECT_EQ(expected, sort_and_merge(key_type, key_column, run_sizes, sort_desc))
+                    << "runs: " << run_sizes.size();
+        }
+    }
+
+    static SortDescs asc_nulls_first() { return SortDescs(std::vector<bool>{true}, std::vector<bool>{true}); }
+    static SortDescs desc_nulls_last() { return SortDescs(std::vector<bool>{false}, std::vector<bool>{false}); }
+    static SortDescs desc_nulls_first() { return SortDescs(std::vector<bool>{false}, std::vector<bool>{true}); }
+
+    std::shared_ptr<RuntimeState> _runtime_state;
+    std::vector<std::unique_ptr<ColumnRef>> _exprs;
+    std::vector<ExprContext*> _sort_exprs;
+};
+
+// Whether a NULL is the smallest or the greatest value is `SortDesc::nan_direction()`, which the sort
+// order mirrors: ascending nulls-first and descending nulls-last both make a NULL element the smallest
+// value in ascending space, so under `DESC NULLS LAST` the rows holding a NULL element come out first.
+// No two of the eight rows below compare equal, which makes every expected order unambiguous.
+TEST_F(SortRunConsistencyTest, array) {
+    ColumnPtr column =
+            build_array_column({ArrayRow{std::nullopt}, ArrayRow{5}, ArrayRow{4}, ArrayRow{3},
+                                ArrayRow{std::nullopt, 2}, ArrayRow{7}, ArrayRow{std::nullopt, 9}, ArrayRow{8}});
+    const auto type = TypeDescriptor::create_array_type(TypeDescriptor(TYPE_INT));
+
+    expect_order(type, column, asc_nulls_first(), {0, 4, 6, 3, 2, 1, 5, 7});
+    // Before this was fixed, every run sorted the NULL elements first while the merge ordered them
+    // last, so merging several runs degenerated the output into a concatenation of the runs.
+    expect_order(type, column, desc_nulls_last(), {6, 4, 0, 7, 5, 1, 2, 3});
+}
+
+TEST_F(SortRunConsistencyTest, nullable_array) {
+    // Row 2 is a NULL row, which the null_first flag places, unlike the NULL elements of rows 0/4/6.
+    ColumnPtr column =
+            build_array_column({ArrayRow{std::nullopt}, ArrayRow{5}, std::nullopt, ArrayRow{3},
+                                ArrayRow{std::nullopt, 2}, ArrayRow{7}, ArrayRow{std::nullopt, 9}, ArrayRow{8}});
+    const auto type = TypeDescriptor::create_array_type(TypeDescriptor(TYPE_INT));
+
+    expect_order(type, column, desc_nulls_last(), {6, 4, 0, 7, 5, 1, 3, 2});
+    expect_order(type, column, desc_nulls_first(), {2, 7, 5, 1, 3, 6, 4, 0});
+}
+
+TEST_F(SortRunConsistencyTest, struct_with_null_field) {
+    // STRUCT hands the same hint down to its fields, so a NULL field is ordered like a NULL element.
+    ColumnPtr column =
+            build_struct_column({std::nullopt, 5, 3, std::nullopt, 8, std::nullopt, 7, 1}, {1, 0, 0, 2, 0, 3, 0, 0});
+    const auto type =
+            TypeDescriptor::create_struct_type({"f0", "f1"}, {TypeDescriptor(TYPE_INT), TypeDescriptor(TYPE_INT)});
+
+    expect_order(type, column, asc_nulls_first(), {0, 3, 5, 7, 2, 1, 6, 4});
+    expect_order(type, column, desc_nulls_last(), {5, 3, 0, 4, 6, 1, 2, 7});
+}
+
+// A row-level NULL of a scalar column is placed by the null_first flag alone. The per-run sort
+// partitions those rows off instead of comparing them, so the merge is the only phase reading the flag
+// and its output must not move.
+TEST_F(SortRunConsistencyTest, nullable_int_keeps_null_position) {
+    ColumnPtr column = build_nullable_int_column({5, std::nullopt, 3, 9, 8, 1, 6, 7});
+    const auto type = TypeDescriptor(TYPE_INT);
+
+    expect_order(type, column, asc_nulls_first(), {1, 5, 2, 0, 6, 7, 4, 3});
+    expect_order(type, column, desc_nulls_last(), {3, 4, 7, 6, 0, 2, 5, 1});
+    expect_order(type, column, desc_nulls_first(), {1, 3, 4, 7, 6, 0, 2, 5});
 }
 
 } // namespace

--- a/be/test/exec/sorting_test.cpp
+++ b/be/test/exec/sorting_test.cpp
@@ -713,6 +713,192 @@ TEST(MergePathTest, test1) {
     }
 }
 
+// A NULL row, and for the array an element that is NULL, which is the value the merge used to order the
+// opposite way of the per-run sort. Values are dense so both sides of the merge overlap everywhere.
+static MutableColumnPtr build_nullable_key_column(const TypeDescriptor& type_desc, bool use_array, int32_t count) {
+    MutableColumnPtr column = ColumnHelper::create_column(type_desc, true);
+    for (int32_t value = 0; value < count; value++) {
+        if (value % 17 == 0) {
+            column->append_nulls(1);
+        } else if (!use_array) {
+            column->append_datum(Datum(value));
+        } else {
+            DatumArray array;
+            array.emplace_back(value % 7 == 0 ? Datum() : Datum(value));
+            array.emplace_back(Datum(value));
+            column->append_datum(Datum(array));
+        }
+    }
+    down_cast<NullableColumn*>(column.get())->update_has_null();
+    return column;
+}
+
+static std::vector<std::string> debug_rows(const Column& column, size_t start, size_t count) {
+    std::vector<std::string> rows;
+    for (size_t i = 0; i < count; i++) {
+        rows.emplace_back(column.debug_item(start + i));
+    }
+    return rows;
+}
+
+// merge_path is the other row-by-row merge, and the only one whose iterators keep a comparison view alive
+// across run switches, so it needs its own coverage of the nullable shapes.
+static void test_merge_path_nullable(bool use_array, size_t runs_per_side, size_t processor_num,
+                                     size_t trailing_empty_runs, bool empty_run_in_the_middle, bool& success) {
+    auto runtime_state = create_runtime_state();
+    const TypeDescriptor type_desc =
+            use_array ? TypeDescriptor::create_array_type(TypeDescriptor(TYPE_INT)) : TypeDescriptor(TYPE_INT);
+    // Descending with the NULLs last is the combination that made the merge disagree with the per-run sort.
+    const SortDescs sort_descs(std::vector<bool>{false}, std::vector<bool>{false});
+
+    std::vector<ExprContext*> sort_exprs;
+    std::vector<std::unique_ptr<ColumnRef>> exprs;
+    exprs.emplace_back(std::make_unique<ColumnRef>(type_desc, 0));
+    sort_exprs.emplace_back(new ExprContext(exprs.back().get()));
+    ASSERT_OK(ExprExecutor::prepare(sort_exprs, runtime_state.get()));
+    ASSERT_OK(ExprExecutor::open(sort_exprs, runtime_state.get()));
+    DeferOp defer([&]() { clear_exprs(sort_exprs); });
+    const Chunk::SlotHashMap map{{0, 0}};
+
+    constexpr int32_t kNumRows = 512;
+    ColumnPtr unsorted = build_nullable_key_column(type_desc, use_array, kNumRows);
+    SmallPermutation permutation = create_small_permutation(unsorted->size());
+    const std::atomic<bool> cancel{false};
+    ASSERT_OK(sort_and_tie_columns(cancel, Columns{unsorted}, sort_descs, permutation));
+
+    // Both sides take every other row of the fully sorted input, which keeps each side sorted while making
+    // the two overlap over their whole range.
+    MutableColumns sides;
+    sides.emplace_back(unsorted->clone_empty());
+    sides.emplace_back(unsorted->clone_empty());
+    for (size_t i = 0; i < permutation.size(); i++) {
+        sides[i % 2]->append(*unsorted, permutation[i].index_in_chunk, 1);
+    }
+
+    // A run over an empty chunk never evaluates its orderby exprs, so its orderby columns stay empty, and
+    // reading a column off one would go out of bounds.
+    auto append_empty_run = [&](SortedRuns& runs) {
+        auto empty_chunk = std::make_shared<Chunk>(Columns{unsorted->clone_empty()}, map);
+        SortedRun empty_run(std::move(empty_chunk), &sort_exprs);
+        EXPECT_TRUE(empty_run.orderby.empty());
+        runs.chunks.emplace_back(std::move(empty_run));
+    };
+
+    std::vector<SortedRuns> input_runs(2);
+    for (size_t side = 0; side < 2; side++) {
+        const size_t rows_per_run = sides[side]->size() / runs_per_side;
+        for (size_t run = 0; run < runs_per_side; run++) {
+            const size_t start = run * rows_per_run;
+            const size_t count = (run + 1 == runs_per_side) ? sides[side]->size() - start : rows_per_run;
+            MutableColumnPtr column = sides[side]->clone_empty();
+            column->append(*sides[side], start, count);
+            auto chunk = std::make_shared<Chunk>(Columns{std::move(column)}, map);
+            input_runs[side].chunks.emplace_back(SortedRun(std::move(chunk), &sort_exprs));
+            // An empty run between two non-empty ones: the iterator has to step over it and build views for
+            // the run behind it, which is a different branch than landing on a trailing empty run.
+            if (empty_run_in_the_middle && run == 0 && runs_per_side > 1) {
+                append_empty_run(input_runs[side]);
+            }
+        }
+        // The iterator lands on these once its side is exhausted.
+        for (size_t i = 0; i < trailing_empty_runs; i++) {
+            append_empty_run(input_runs[side]);
+        }
+    }
+
+    const size_t left_len = input_runs[0].num_rows();
+    const size_t right_len = input_runs[1].num_rows();
+    merge_path::InputSegment left(std::move(input_runs[0]), 0, left_len);
+    merge_path::InputSegment right(std::move(input_runs[1]), 0, right_len);
+
+    std::vector<merge_path::OutputSegment> dests;
+    for (size_t processor_idx = 0; processor_idx < processor_num; processor_idx++) {
+        auto dest_chunk = std::make_shared<Chunk>(Columns{unsorted->clone_empty()}, map);
+        Columns dest_orderby;
+        dest_orderby.emplace_back(unsorted->clone_empty());
+        SortedRun dest_run(std::move(dest_chunk), std::move(dest_orderby));
+        dests.emplace_back(std::move(dest_run), std::vector<int32_t>{-1}, left_len + right_len);
+    }
+
+    std::vector<std::thread> threads;
+    for (size_t processor_idx = 0; processor_idx < processor_num; processor_idx++) {
+        threads.emplace_back([&sort_descs, &left, &right, &dests, processor_idx, processor_num]() {
+            merge_path::merge(sort_descs, left, right, dests[processor_idx], processor_idx, processor_num);
+        });
+    }
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    std::vector<std::string> merged;
+    std::vector<std::string> merged_orderby;
+    for (size_t processor_idx = 0; processor_idx < processor_num; processor_idx++) {
+        auto& run = dests[processor_idx].run;
+        const auto rows = debug_rows(*run.chunk->get_column_by_index(0), run.start_index(), run.num_rows());
+        merged.insert(merged.end(), rows.begin(), rows.end());
+        const auto orderby_rows = debug_rows(*run.orderby[0], run.start_index(), run.num_rows());
+        merged_orderby.insert(merged_orderby.end(), orderby_rows.begin(), orderby_rows.end());
+    }
+
+    // The merge has to reproduce the order the per-run sort produces for all the rows at once.
+    std::vector<std::string> expected;
+    for (const auto& item : permutation) {
+        expected.emplace_back(unsorted->debug_item(item.index_in_chunk));
+    }
+    ASSERT_EQ(expected, merged);
+    ASSERT_EQ(expected, merged_orderby);
+
+    success = true;
+}
+
+TEST(MergePathTest, nullable_columns) {
+    for (bool use_array : {false, true}) {
+        for (size_t runs_per_side : {1, 3, 7}) {
+            for (size_t processor_num : {1, 2, 4}) {
+                bool success = false;
+                test_merge_path_nullable(use_array, runs_per_side, processor_num, 0, false, success);
+                ASSERT_TRUE(success) << "array: " << use_array << ", runs: " << runs_per_side;
+            }
+        }
+    }
+}
+
+// Runs over empty chunks carry no orderby column at all, and the iterator walks onto the trailing ones as it
+// runs out, which is where reading a column off the run would go out of bounds.
+TEST(MergePathTest, runs_over_empty_chunks) {
+    for (bool use_array : {false, true}) {
+        for (size_t runs_per_side : {1, 3}) {
+            for (size_t trailing_empty_runs : {1, 2}) {
+                for (size_t processor_num : {1, 2, 4}) {
+                    bool success = false;
+                    test_merge_path_nullable(use_array, runs_per_side, processor_num, trailing_empty_runs, false,
+                                             success);
+                    ASSERT_TRUE(success) << "array: " << use_array << ", runs: " << runs_per_side
+                                         << ", empty runs: " << trailing_empty_runs;
+                }
+            }
+        }
+    }
+}
+
+// The other empty-run branch: the iterator steps over an empty run and has to build views for the non-empty
+// run behind it, instead of stopping on the empty one.
+TEST(MergePathTest, empty_run_between_two_non_empty_runs) {
+    for (bool use_array : {false, true}) {
+        for (size_t runs_per_side : {2, 3}) {
+            for (size_t trailing_empty_runs : {0, 1}) {
+                for (size_t processor_num : {1, 2, 4}) {
+                    bool success = false;
+                    test_merge_path_nullable(use_array, runs_per_side, processor_num, trailing_empty_runs, true,
+                                             success);
+                    ASSERT_TRUE(success) << "array: " << use_array << ", runs: " << runs_per_side
+                                         << ", empty runs: " << trailing_empty_runs;
+                }
+            }
+        }
+    }
+}
+
 TEST(SortingTest, compare) {
     // any type
     std::vector<TypeDescriptor> type_lists;

--- a/test/sql/test_sort/R/test_array_desc_multi_sorted_runs.sql
+++ b/test/sql/test_sort/R/test_array_desc_multi_sorted_runs.sql
@@ -1,0 +1,139 @@
+-- name: test_array_desc_multi_sorted_runs
+drop database if exists test_array_desc_multi_sorted_runs;
+-- result:
+-- !result
+create database test_array_desc_multi_sorted_runs;
+-- result:
+-- !result
+use test_array_desc_multi_sorted_runs;
+-- result:
+-- !result
+CREATE TABLE t_arr (
+    id INT,
+    arr ARRAY<INT>,
+    arr_nonull ARRAY<INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_arr VALUES
+    (1, [NULL], [1]),
+    (2, [5], [5]),
+    (3, [4], [4]),
+    (4, [3], [3]),
+    (5, [NULL, 2], [9, 2]),
+    (6, [7], [7]),
+    (7, [NULL, 9], [6]),
+    (8, [8], [8]),
+    (9, NULL, [2, 2]);
+-- result:
+-- !result
+SET pipeline_dop = 1;
+-- result:
+-- !result
+SET chunk_size = 2;
+-- result:
+-- !result
+SET full_sort_max_buffered_rows = 1073741824;
+-- result:
+-- !result
+SELECT id, arr FROM t_arr ORDER BY arr DESC;
+-- result:
+7	[null,9]
+5	[null,2]
+1	[null]
+8	[8]
+6	[7]
+2	[5]
+3	[4]
+4	[3]
+9	None
+-- !result
+SELECT id, arr FROM t_arr ORDER BY arr;
+-- result:
+9	None
+1	[null]
+5	[null,2]
+7	[null,9]
+4	[3]
+3	[4]
+2	[5]
+6	[7]
+8	[8]
+-- !result
+SELECT id, arr_nonull FROM t_arr ORDER BY arr_nonull DESC;
+-- result:
+5	[9,2]
+8	[8]
+6	[7]
+7	[6]
+2	[5]
+3	[4]
+4	[3]
+9	[2,2]
+1	[1]
+-- !result
+SELECT id FROM t_arr ORDER BY id DESC;
+-- result:
+9
+8
+7
+6
+5
+4
+3
+2
+1
+-- !result
+SET full_sort_max_buffered_rows = 2;
+-- result:
+-- !result
+SELECT id, arr FROM t_arr ORDER BY arr DESC;
+-- result:
+7	[null,9]
+5	[null,2]
+1	[null]
+8	[8]
+6	[7]
+2	[5]
+3	[4]
+4	[3]
+9	None
+-- !result
+SELECT id, arr FROM t_arr ORDER BY arr;
+-- result:
+9	None
+1	[null]
+5	[null,2]
+7	[null,9]
+4	[3]
+3	[4]
+2	[5]
+6	[7]
+8	[8]
+-- !result
+SELECT id, arr_nonull FROM t_arr ORDER BY arr_nonull DESC;
+-- result:
+5	[9,2]
+8	[8]
+6	[7]
+7	[6]
+2	[5]
+3	[4]
+4	[3]
+9	[2,2]
+1	[1]
+-- !result
+SELECT id FROM t_arr ORDER BY id DESC;
+-- result:
+9
+8
+7
+6
+5
+4
+3
+2
+1
+-- !result

--- a/test/sql/test_sort/T/test_array_desc_multi_sorted_runs.sql
+++ b/test/sql/test_sort/T/test_array_desc_multi_sorted_runs.sql
@@ -1,0 +1,44 @@
+-- name: test_array_desc_multi_sorted_runs
+
+drop database if exists test_array_desc_multi_sorted_runs;
+create database test_array_desc_multi_sorted_runs;
+use test_array_desc_multi_sorted_runs;
+
+-- ORDER BY an ARRAY column compares the array element by element, and the sort of every buffered run
+-- has to agree with the merge of those runs on where a NULL element goes. Run the same rows through a
+-- single run, which never merges, and through several merged runs, and check the output is the same.
+CREATE TABLE t_arr (
+    id INT,
+    arr ARRAY<INT>,
+    arr_nonull ARRAY<INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t_arr VALUES
+    (1, [NULL], [1]),
+    (2, [5], [5]),
+    (3, [4], [4]),
+    (4, [3], [3]),
+    (5, [NULL, 2], [9, 2]),
+    (6, [7], [7]),
+    (7, [NULL, 9], [6]),
+    (8, [8], [8]),
+    (9, NULL, [2, 2]);
+
+SET pipeline_dop = 1;
+SET chunk_size = 2;
+
+-- A single sorted run, the merge is never reached.
+SET full_sort_max_buffered_rows = 1073741824;
+SELECT id, arr FROM t_arr ORDER BY arr DESC;
+SELECT id, arr FROM t_arr ORDER BY arr;
+SELECT id, arr_nonull FROM t_arr ORDER BY arr_nonull DESC;
+SELECT id FROM t_arr ORDER BY id DESC;
+
+-- Five sorted runs that have to be merged. Every result above must be reproduced exactly.
+SET full_sort_max_buffered_rows = 2;
+SELECT id, arr FROM t_arr ORDER BY arr DESC;
+SELECT id, arr FROM t_arr ORDER BY arr;
+SELECT id, arr_nonull FROM t_arr ORDER BY arr_nonull DESC;
+SELECT id FROM t_arr ORDER BY id DESC;


### PR DESCRIPTION
## Why I'm doing:

`ORDER BY <ARRAY column> DESC` returns the wrong order as soon as the sort no longer fits into a single
buffered run: the output degenerates into a concatenation of the runs (see the issue for a repro).

The per-run sort and the merge disagreed on where a NULL *element* nested in an ARRAY belongs. `ColumnSorter`
hands the direction-free `SortDesc::nan_direction()` down to the element comparison, while the merge handed
`SortDesc::null_first`, which is already flipped by the sort order. Under DESC the two have opposite signs,
so the merge compared rows under a NULL semantics the runs were never sorted with, and merging sorted runs
with the wrong comparator yields the concatenation above. The same shape affects `ORDER BY <STRUCT column>
DESC` with a NULL field.

## What I'm doing:

Two commits.

**1. The fix.** The merge now decides a row-level NULL by `desc.null_first` (unchanged, bit for bit) and
compares values with `desc.nan_direction()`, the hint every run was sorted with. That is the whole
correctness change.

**2. Paying for it.** Doing both checks per row cost two extra `Column::is_null()` virtual calls, and a
non-NULL row then walked into `NullableColumn::compare_at()` which rechecks the null bitmap. On its own the
fix measured +18.5% retired instructions on the nullable scalar merge benchmark. The second commit takes that
back: each merge input column is unpacked once, outside the row loop, into a small value type holding its
data column, its null column and its `has_null()` flag, so a row comparison costs one virtual call instead of
four. **What the two commits together leave against main is +1.4% on that benchmark** - the same order as the
+2.1% the non-nullable control drifts by without touching any NULL handling at all - and on the `merge_path`
comparator the pair is a net speedup. Whether a column may be unpacked is asked through a new
`Column::can_access_nullable_data()` capability query rather than a type list, so `AdaptiveNullableColumn`
reports false until it is materialized and any future column class defaults to the general path.

Fixes #77793

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

### Behaviour, in full

- For normal columns, where `_has_null` and the null bitmap agree, this PR behaves exactly like the
  correctness fix alone.
- For a stale column that the repository's own APIs can produce (`_has_null == false` while the bitmap holds
  a 1 — `BoolOrAggregateFunction::empty_result()` writes the bitmap without setting the flag, `resize()` does
  not refresh it), the correctness fix alone mixes two NULL tests: `is_null()` consults the flag first, while
  `NullableColumn::compare_at()` reads the bitmap alone. The unpacked fast path settles on the `has_null()`
  signal, the same one `ColumnSorter` takes its no-NULL fast path from, so the merge stays consistent with
  the sort that produced each run. Output for such columns can therefore differ from the fix alone.
- This is an internal sort-consistency correction. It does not change SQL-level ASC/DESC or NULLS
  FIRST/LAST semantics, but it is an implementation behaviour difference and is disclosed here.

### Performance

Retired instructions, three binaries built from the same tree with the same benchmark patch and measured in
alternating rounds on one idle host (medians of 3 rounds, 20 fixed iterations each). The first column is what
this PR does as a whole; the other two show where that comes from - the correctness fix on its own, and how
much of it this optimization takes back:

| benchmark | **this PR vs main** | of which: the correctness fix | taken back by the optimization |
|---|---:|---:|---:|
| `BM_merge_columnwise` (non-nullable control) | +0.1% / +2.1% / +1.6% | +0.2% ... +1.8% | -0.08% ... +0.29% |
| `BM_merge_columnwise_nullable/{2,18,34}` | **+2.1% / +1.4% / +1.2%** | +10.2% / +18.5% / +16.9% | -7.4% / -14.5% / -13.5% |
| `BM_merge_columnwise_nullable_array/{2,18,34}` | **+1.2% / +3.2% / +3.5%** | +4.2% / +5.7% / +5.7% | -2.9% / -2.4% / -2.1% |
| `merge_path`, nullable scalar (temporary benchmark, not in this PR) | **-3.4% / -2.1% / -3.4%** | +2.5% / +3.7% / +2.5% | -5.7% / -5.6% / -5.8% |
| `merge_path`, nullable array | **-2.6% / -1.5% / -2.3%** | +1.3% / +1.9% / +1.3% | -3.8% / -3.4% / -3.6% |

The non-nullable control never touches the NULL handling, yet it drifts by the same +0.1% ... +2.1% against
main, so what is left on the nullable benchmarks is no longer distinguishable from that baseline drift; on the
`merge_path` comparator the PR is a net speedup. What validates the measurement itself is that same control in
the last column: +/-0.3% between two binaries that differ only by this optimization. `merge_path` has no
benchmark upstream, so its ratios were measured with a temporary one that is deliberately not part of this PR;
a counter in it confirms the measured region really crosses run boundaries.

One correction to the last column: that sweep predates the `has_null()` guard the fast path grew while
addressing review (the second bullet under Behaviour). Re-measuring the two representative cases on the
revision actually shipped here, same method and same host, gives **-12.4%** for
`BM_merge_columnwise_nullable/18` and **-5.5%** for the nullable-scalar `merge_path` case, against -14.5%
and -5.6% above: the guard costs about two points of the speedup on the scalar merge and keeps the rest.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5



