### PR TITLE
[BugFix] Fix silent data loss in rewrite_data_files with WHERE clause

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergRewriteData.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergRewriteData.java
@@ -31,15 +31,19 @@ import java.util.stream.Collectors;
 
 public class IcebergRewriteData {
 
-    private IcebergConnectorScanRangeSource source;
+    // One source per data scan node. A merge-on-read plan has two mutually exclusive data branches
+    // (with / without equality deletes), so candidates must be collected from all of them.
+    private final List<IcebergConnectorScanRangeSource> sources = new ArrayList<>();
     private Map<StructLikeWrapper, List<TaskGroup>> partitionedTasks;
     private int maxScanRangeLength = 100;
     private long batchSize = 10L * 1024 * 1024 * 1024;
     private Iterator<List<TaskGroup>> outer;
     private Iterator<TaskGroup> inner = Collections.emptyIterator();
 
-    public void setSource(IcebergConnectorScanRangeSource source) {
-        this.source = source;
+    public void addSource(IcebergConnectorScanRangeSource source) {
+        if (source != null) {
+            this.sources.add(source);
+        }
     }
 
     public void setBatchSize(long batchSize) {
@@ -52,11 +56,16 @@ public class IcebergRewriteData {
 
     public void buildNewScanNodeRange(long fileSizeThreshold, boolean allFiles) {
         partitionedTasks = new HashMap<>();
-        List<FileScanTask> tasks = new ArrayList<>();
+        for (IcebergConnectorScanRangeSource source : sources) {
+            collectFromSource(source, fileSizeThreshold, allFiles);
+        }
+        this.outer = partitionedTasks.values().iterator();
+    }
+
+    private void collectFromSource(IcebergConnectorScanRangeSource source, long fileSizeThreshold, boolean allFiles) {
+        List<FileScanTask> tasks;
         do {
-            if (source != null) {
-                tasks = source.getSourceFileScanOutputs(maxScanRangeLength, fileSizeThreshold, allFiles);
-            }
+            tasks = source.getSourceFileScanOutputs(maxScanRangeLength, fileSizeThreshold, allFiles);
             for (FileScanTask task : tasks) {
                 PartitionSpec spec = task.spec();
                 StructLikeWrapper partitionWrapper = StructLikeWrapper.forType(spec.partitionType());
@@ -80,7 +89,6 @@ public class IcebergRewriteData {
                 }
             }
         } while (!tasks.isEmpty());
-        this.outer = partitionedTasks.values().iterator();
     }
 
     public boolean hasMoreTaskGroup() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergRewriteDataJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergRewriteDataJob.java
@@ -49,7 +49,11 @@ import java.util.stream.Collectors;
 
 public class IcebergRewriteDataJob {
     private static final Logger LOG = LogManager.getLogger(IcebergRewriteDataJob.class);
-    private final String insertSql;
+    // Carries the partition filter, used only to decide which files are rewritten.
+    private final String planningSql;
+    // Same statement without the filter, used to read every live row of the selected files.
+    private final String executionSql;
+    private final boolean hasPartitionFilter;
     private final boolean rewriteAll;
     private final long minFileSizeBytes;
     private final long batchSize;
@@ -142,7 +146,9 @@ public class IcebergRewriteDataJob {
         }
     }
 
-    public IcebergRewriteDataJob(String insertSql,
+    public IcebergRewriteDataJob(String planningSql,
+                                 String executionSql,
+                                 boolean hasPartitionFilter,
                                  boolean rewriteAll,
                                  long minFileSizeBytes,
                                  long batchSize,
@@ -150,7 +156,9 @@ public class IcebergRewriteDataJob {
                                  boolean writeRowLineage,
                                  ConnectContext context,
                                  AlterTableStmt stmt) {
-        this.insertSql = insertSql;
+        this.planningSql = planningSql;
+        this.executionSql = executionSql;
+        this.hasPartitionFilter = hasPartitionFilter;
         this.rewriteAll = rewriteAll;
         this.minFileSizeBytes = minFileSizeBytes;
         this.batchSize = batchSize;
@@ -162,29 +170,38 @@ public class IcebergRewriteDataJob {
 
     public void prepare() throws Exception {
         this.parsedStmt = com.starrocks.sql.parser.SqlParser
-                .parse(insertSql, context.getSessionVariable())
+                .parse(executionSql, context.getSessionVariable())
+                .get(0);
+        StatementBase planningParsedStmt = com.starrocks.sql.parser.SqlParser
+                .parse(planningSql, context.getSessionVariable())
                 .get(0);
 
-        this.rewriteStmt = new IcebergRewriteStmt((InsertStmt) parsedStmt, rewriteAll, writeRowLineage);
+        this.rewriteStmt = new IcebergRewriteStmt(
+                (InsertStmt) planningParsedStmt, rewriteAll, writeRowLineage, hasPartitionFilter);
         this.execPlan = StatementPlanner.plan(rewriteStmt, context);
+        // A merge-on-read plan splits the data scan into DATA_FILE_WITH_EQ_DELETE and DATA_FILE_WITHOUT_EQ_DELETE
+        // branches that carry the same plan node name. Both must contribute candidates, otherwise a whole branch
+        // is silently skipped. The EQ_DELETE branch is excluded on purpose: its queue holds the very same tasks as
+        // the WITH_EQ_DELETE branch, so including it would count those files twice.
         this.scanNodes = execPlan.getFragments().stream()
                 .flatMap(fragment -> fragment.collectScanNodes().values().stream())
                 .filter(scan -> scan instanceof IcebergScanNode && "IcebergScanNode".equals(scan.getPlanNodeName()))
                 .map(scan -> (IcebergScanNode) scan)
                 .collect(Collectors.toList());
 
-        IcebergScanNode targetNode = scanNodes.stream().findFirst().orElse(null);
-        if (targetNode == null) {
+        if (scanNodes.isEmpty()) {
             TableRef tableRef = ((InsertStmt) parsedStmt).getTableRef();
             TableName tableName = TableName.fromTableRef(tableRef);
-            LOG.info("No IcebergScanNode of table " + tableName + 
+            LOG.info("No IcebergScanNode of table " + tableName +
                         " found for rewrite, prepare becomes no-op.");
             return;
         }
 
-        this.baseSnapshotId = targetNode.getBaseSnapshotId().orElse(null);
+        // Every scan node of this plan reads the same table pinned to the same snapshot, so any of
+        // them reports the snapshot the rewrite was planned against.
+        this.baseSnapshotId = scanNodes.get(0).getBaseSnapshotId().orElse(null);
         this.rewriteData = new IcebergRewriteData();
-        this.rewriteData.setSource(targetNode.getSourceRange());
+        scanNodes.forEach(node -> rewriteData.addSource(node.getSourceRange()));
         this.rewriteData.setBatchSize(batchSize);
         this.rewriteData.buildNewScanNodeRange(minFileSizeBytes, rewriteAll);
     }
@@ -244,12 +261,17 @@ public class IcebergRewriteDataJob {
                     ConnectContext subCtx = buildSubConnectContext(context);
                     try (var scope = subCtx.bindScope()) {
                         IcebergRewriteStmt localStmt =
-                                new IcebergRewriteStmt((InsertStmt) parsedStmt, rewriteAll, writeRowLineage);
+                                new IcebergRewriteStmt((InsertStmt) parsedStmt, rewriteAll, writeRowLineage, hasPartitionFilter);
                         ExecPlan localPlan = StatementPlanner.plan(localStmt, subCtx);
         
+                        // Every iceberg scan node must be narrowed to this task group, including the
+                        // IcebergEqualityDeleteScanNode. rebuildScanRange() routes the task list through
+                        // IcebergRemoteSourceTrigger, so each node picks up only the files of its own MOR branch.
+                        // Leaving the equality-delete scan untouched would keep it at full-table range and apply
+                        // equality keys of other partitions to this group.
                         List<IcebergScanNode> localScanNodes = localPlan.getFragments().stream()
                                 .flatMap(f -> f.collectScanNodes().values().stream())
-                                .filter(s -> s instanceof IcebergScanNode && "IcebergScanNode".equals(s.getPlanNodeName()))
+                                .filter(s -> s instanceof IcebergScanNode)
                                 .map(s -> (IcebergScanNode) s)
                                 .collect(Collectors.toList());
         

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RewriteDataFilesProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RewriteDataFilesProcedure.java
@@ -167,7 +167,19 @@ public class RewriteDataFilesProcedure extends IcebergTableProcedure {
     private IcebergRewriteDataJob newRewriteJob(VelocityContext velCtx, boolean writeRowLineage, boolean rewriteAll,
                                                 long minFileSizeBytes, long batchSize, long batchParallelism,
                                                 ConnectContext context, AlterTableStmt stmt) {
-        return new IcebergRewriteDataJob(buildInsertSelectSql(velCtx, writeRowLineage), rewriteAll,
+        // The filter selects which files are rewritten; it must not filter rows inside those files, otherwise the
+        // non-matching rows of a partially matched file are dropped when the whole file is removed at commit time.
+        // Planning keeps the filter (so file pruning still applies), execution drops it and rewrites whole files.
+        // This mirrors Iceberg's own `TableScan.ignoreResiduals()`.
+        String planningSql = buildInsertSelectSql(velCtx, writeRowLineage);
+        VelocityContext execVelCtx = new VelocityContext();
+        execVelCtx.put("catalogName", velCtx.get("catalogName"));
+        execVelCtx.put("dbName", velCtx.get("dbName"));
+        execVelCtx.put("tableName", velCtx.get("tableName"));
+        execVelCtx.put("partitionFilterSql", null);
+        String executionSql = buildInsertSelectSql(execVelCtx, writeRowLineage);
+        boolean hasPartitionFilter = velCtx.get("partitionFilterSql") != null;
+        return new IcebergRewriteDataJob(planningSql, executionSql, hasPartitionFilter, rewriteAll,
                 minFileSizeBytes, batchSize, batchParallelism, writeRowLineage, context, stmt);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -297,6 +297,9 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.transport.TTransportException;
@@ -3358,12 +3361,24 @@ public class StmtExecutor {
             if (extra == null) {
                 extra = new IcebergMetadata.IcebergSinkExtra();
             }
+            // A rewrite removes the data files it scanned, so a delete file may only be removed along with them
+            // when it is provably dangling afterwards. Removing one that still applies to an untouched data file
+            // would resurrect the rows it deletes.
+            boolean wholeTableRewrite = ((IcebergRewriteStmt) stmt).rewriteAll()
+                    && !((IcebergRewriteStmt) stmt).hasPartitionFilter();
             for (PlanFragment fragment : execPlan.getFragments()) {
                 for (ScanNode scan : fragment.collectScanNodes().values()) {
                     if (scan instanceof IcebergScanNode && scan.getPlanNodeName().equals("IcebergScanNode")) {
-                        extra.addAppliedDeleteFiles(((IcebergScanNode) scan).getPosAppliedDeleteFiles());
-                        extra.addScannedDataFiles(((IcebergScanNode) scan).getScannedDataFiles());
-                        if (((IcebergRewriteStmt) stmt).rewriteAll()) {
+                        Set<DataFile> scannedDataFiles = ((IcebergScanNode) scan).getScannedDataFiles();
+                        extra.addScannedDataFiles(scannedDataFiles);
+                        extra.addAppliedDeleteFiles(
+                                danglingPosDeleteFiles(((IcebergScanNode) scan).getPosAppliedDeleteFiles(),
+                                        scannedDataFiles, wholeTableRewrite));
+                        // Equality deletes carry no reference to the data files they apply to; they cover every
+                        // file of their partition with a lower sequence number. Only a rewrite of the whole table
+                        // is guaranteed to have rewritten all of them. Keeping them is harmless: the files written
+                        // by the rewrite get a higher sequence number, so the deletes no longer apply to them.
+                        if (wholeTableRewrite) {
                             extra.addAppliedDeleteFiles(((IcebergScanNode) scan).getEqualAppliedDeleteFiles());
                         }
                     }
@@ -3371,6 +3386,26 @@ public class StmtExecutor {
             }
         }
         return extra;
+    }
+
+    // A position delete is file scoped when it names the single data file it applies to; deletion vectors always
+    // are. Such a file becomes dangling once that data file is rewritten, so it can be dropped with it. Position
+    // deletes without a reference span the whole partition and would still apply to data files this rewrite left
+    // untouched - unless the rewrite covered the whole table, in which case there is no untouched file left and
+    // every applied position delete, file scoped or not, is dangling.
+    private static Set<DeleteFile> danglingPosDeleteFiles(Set<DeleteFile> posDeleteFiles,
+                                                          Set<DataFile> scannedDataFiles,
+                                                          boolean wholeTableRewrite) {
+        if (wholeTableRewrite) {
+            return posDeleteFiles;
+        }
+        Set<String> rewrittenLocations = scannedDataFiles.stream()
+                .map(ContentFile::location)
+                .collect(Collectors.toSet());
+        return posDeleteFiles.stream()
+                .filter(deleteFile -> deleteFile.referencedDataFile() != null
+                        && rewrittenLocations.contains(deleteFile.referencedDataFile()))
+                .collect(Collectors.toSet());
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/IcebergRewriteStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/IcebergRewriteStmt.java
@@ -18,17 +18,26 @@ public class IcebergRewriteStmt extends InsertStmt {
 
     private final boolean rewriteAll;
     private final boolean writeRowLineage;
+    private final boolean hasPartitionFilter;
 
-    public IcebergRewriteStmt(InsertStmt base, boolean rewriteAll, boolean writeRowLineage) {
+    public IcebergRewriteStmt(InsertStmt base, boolean rewriteAll, boolean writeRowLineage,
+                              boolean hasPartitionFilter) {
         super(base.getTableRef(), base.getTargetPartitionNames(), base.getLabel(), base.getTargetColumnNames(),
                 base.getQueryStatement(), base.isOverwrite(), base.getProperties(), base.getPos());
         super.setOrigStmt(base.getOrigStmt());
         this.rewriteAll = rewriteAll;
         this.writeRowLineage = writeRowLineage;
+        this.hasPartitionFilter = hasPartitionFilter;
     }
 
     public boolean rewriteAll() {
         return rewriteAll;
+    }
+
+    // True when the rewrite was scoped by a WHERE clause. Such a rewrite covers only the files that survived
+    // pruning, so equality deletes it applied may still apply to data files left untouched.
+    public boolean hasPartitionFilter() {
+        return hasPartitionFilter;
     }
 
     public boolean writeRowLineage() {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRewriteDataJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRewriteDataJobTest.java
@@ -76,6 +76,8 @@ public class IcebergRewriteDataJobTest {
         AlterTableStmt alter = Mockito.mock(AlterTableStmt.class);
         return new IcebergRewriteDataJob(
                 "insert into t select 1",
+                "insert into t select 1",
+                false,
                 false,
                 0L,
                 10L,
@@ -122,7 +124,7 @@ public class IcebergRewriteDataJobTest {
         when(alter.getTableName()).thenReturn("t");
 
         IcebergRewriteDataJob job = new IcebergRewriteDataJob(
-                "insert into t select 1", false, 0L, 10L, 1L, false, ctx, alter);
+                "insert into t select 1", "insert into t select 1", false, false, 0L, 10L, 1L, false, ctx, alter);
 
         IcebergScanNode scanNode = mock(IcebergScanNode.class);
         Deencapsulation.setField(job, "scanNodes", Collections.singletonList(scanNode));
@@ -171,7 +173,7 @@ public class IcebergRewriteDataJobTest {
         when(sv.clone()).thenReturn(sv);
 
         IcebergRewriteDataJob job = new IcebergRewriteDataJob(
-                "insert into t select 1", false, 0L, 10L, 1L, false, ctx, alter);
+                "insert into t select 1", "insert into t select 1", false, false, 0L, 10L, 1L, false, ctx, alter);
 
         // ---- Prepare minimal fields required by execute() ----
         InsertStmt parsedInsert = mock(InsertStmt.class);
@@ -236,7 +238,7 @@ public class IcebergRewriteDataJobTest {
         Deencapsulation.setField(job, "parsedStmt", fakeInsertStmt);
         new mockit.Expectations() {
             {
-                new com.starrocks.sql.ast.IcebergRewriteStmt(fakeInsertStmt, anyBoolean, anyBoolean);
+                new com.starrocks.sql.ast.IcebergRewriteStmt(fakeInsertStmt, anyBoolean, anyBoolean, anyBoolean);
                 result = rewriteStmt;
                 minTimes = 0;
             }
@@ -303,7 +305,7 @@ public class IcebergRewriteDataJobTest {
         };
 
         IcebergRewriteDataJob job = new IcebergRewriteDataJob(
-                "insert into t select 1", false, 0L, 10L, 1L, false, ctx, alter);
+                "insert into t select 1", "insert into t select 1", false, false, 0L, 10L, 1L, false, ctx, alter);
 
         job.prepare();
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRowLineageUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRowLineageUtilsTest.java
@@ -47,7 +47,7 @@ public class IcebergRowLineageUtilsTest {
         IcebergTable icebergTable = Mockito.mock(IcebergTable.class);
         Mockito.when(icebergTable.getFormatVersion()).thenReturn(3);
 
-        IcebergRewriteStmt rewriteStmt = new IcebergRewriteStmt(newInsertStmt(), true, true);
+        IcebergRewriteStmt rewriteStmt = new IcebergRewriteStmt(newInsertStmt(), true, true, false);
 
         Assertions.assertTrue(
                 IcebergRowLineageUtils.shouldWriteRowLineageColumns(rewriteStmt, icebergTable));
@@ -58,7 +58,7 @@ public class IcebergRowLineageUtilsTest {
         IcebergTable icebergTable = Mockito.mock(IcebergTable.class);
         Mockito.when(icebergTable.getFormatVersion()).thenReturn(3);
 
-        IcebergRewriteStmt rewriteStmt = new IcebergRewriteStmt(newInsertStmt(), true, false);
+        IcebergRewriteStmt rewriteStmt = new IcebergRewriteStmt(newInsertStmt(), true, false, false);
 
         Assertions.assertFalse(
                 IcebergRowLineageUtils.shouldWriteRowLineageColumns(rewriteStmt, icebergTable));
@@ -69,7 +69,7 @@ public class IcebergRowLineageUtilsTest {
         IcebergTable icebergTable = Mockito.mock(IcebergTable.class);
         Mockito.when(icebergTable.getFormatVersion()).thenReturn(2);
 
-        IcebergRewriteStmt rewriteStmt = new IcebergRewriteStmt(newInsertStmt(), true, true);
+        IcebergRewriteStmt rewriteStmt = new IcebergRewriteStmt(newInsertStmt(), true, true, false);
 
         Assertions.assertFalse(
                 IcebergRowLineageUtils.shouldWriteRowLineageColumns(rewriteStmt, icebergTable));

--- a/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
@@ -304,7 +304,7 @@ public class IcebergScanNodeTest {
         }};
 
         IcebergRewriteData rewriteData = new IcebergRewriteData();
-        rewriteData.setSource(mockSource);
+        rewriteData.addSource(mockSource);
         rewriteData.setBatchSize(10 * 1024);
         rewriteData.setMaxScanRangeLength(5);
 
@@ -603,6 +603,90 @@ public class IcebergScanNodeTest {
         // 8. Assert
         Assertions.assertTrue(info1.isIs_rewrite());
         Assertions.assertTrue(info2.isIs_rewrite());
+    }
+
+    private IcebergMetadata.IcebergSinkExtra runFillRewriteFiles(boolean rewriteAll, boolean hasPartitionFilter,
+                                                                 Set<DeleteFile> posDeletes,
+                                                                 Set<DeleteFile> eqDeletes,
+                                                                 Set<DataFile> scannedDataFiles) throws Exception {
+        IcebergRewriteStmt rewriteStmt = Mockito.mock(IcebergRewriteStmt.class);
+        Mockito.when(rewriteStmt.rewriteAll()).thenReturn(rewriteAll);
+        Mockito.when(rewriteStmt.hasPartitionFilter()).thenReturn(hasPartitionFilter);
+
+        IcebergScanNode scanNode = Mockito.mock(IcebergScanNode.class);
+        Mockito.when(scanNode.getPlanNodeName()).thenReturn("IcebergScanNode");
+        Mockito.when(scanNode.getPosAppliedDeleteFiles()).thenReturn(posDeletes);
+        Mockito.when(scanNode.getEqualAppliedDeleteFiles()).thenReturn(eqDeletes);
+        Mockito.when(scanNode.getScannedDataFiles()).thenReturn(scannedDataFiles);
+
+        PlanFragment fragment = Mockito.mock(PlanFragment.class);
+        Mockito.when(fragment.collectScanNodes()).thenReturn(Map.of(new PlanNodeId(0), scanNode));
+        ExecPlan execPlan = Mockito.mock(ExecPlan.class);
+        Mockito.when(execPlan.getFragments()).thenReturn(new ArrayList<>(List.of(fragment)));
+
+        StmtExecutor executor = new StmtExecutor(new ConnectContext(), Mockito.mock(StatementBase.class));
+        return executor.fillRewriteFiles(rewriteStmt, execPlan, new ArrayList<>(),
+                new IcebergMetadata.IcebergSinkExtra());
+    }
+
+    private DeleteFile mockDeleteFile(String referencedDataFile) {
+        DeleteFile deleteFile = Mockito.mock(DeleteFile.class);
+        Mockito.when(deleteFile.referencedDataFile()).thenReturn(referencedDataFile);
+        return deleteFile;
+    }
+
+    private DataFile mockDataFileAt(String location) {
+        DataFile dataFile = Mockito.mock(DataFile.class);
+        Mockito.when(dataFile.location()).thenReturn(location);
+        return dataFile;
+    }
+
+    @Test
+    public void testFillRewriteFilesOnlyRemovesFileScopedPosDeletesOfRewrittenFiles() throws Exception {
+        DataFile rewritten = mockDataFileAt("oss://bucket/db/tbl/data/rewritten.parquet");
+        // Names the data file this rewrite removes -> dangling afterwards, safe to drop.
+        DeleteFile fileScopedOnRewritten = mockDeleteFile("oss://bucket/db/tbl/data/rewritten.parquet");
+        // Names a data file left untouched -> still needed.
+        DeleteFile fileScopedOnUntouched = mockDeleteFile("oss://bucket/db/tbl/data/untouched.parquet");
+        // Partition scoped: may apply to data files this rewrite did not read.
+        DeleteFile partitionScoped = mockDeleteFile(null);
+
+        IcebergMetadata.IcebergSinkExtra extra = runFillRewriteFiles(false, true,
+                Set.of(fileScopedOnRewritten, fileScopedOnUntouched, partitionScoped),
+                Set.of(), Set.of(rewritten));
+
+        Assertions.assertEquals(Set.of(fileScopedOnRewritten), extra.getAppliedDeleteFiles());
+        Assertions.assertEquals(Set.of(rewritten), extra.getScannedDataFiles());
+    }
+
+    @Test
+    public void testFillRewriteFilesRemovesAllPosDeletesOnWholeTableRewrite() throws Exception {
+        DataFile rewritten = mockDataFileAt("oss://bucket/db/tbl/data/rewritten.parquet");
+        DeleteFile fileScoped = mockDeleteFile("oss://bucket/db/tbl/data/rewritten.parquet");
+        // Partition scoped, but a whole-table rewrite leaves no untouched data file it could still apply to.
+        DeleteFile partitionScoped = mockDeleteFile(null);
+
+        IcebergMetadata.IcebergSinkExtra extra = runFillRewriteFiles(true, false,
+                Set.of(fileScoped, partitionScoped), Set.of(), Set.of(rewritten));
+
+        Assertions.assertEquals(Set.of(fileScoped, partitionScoped), extra.getAppliedDeleteFiles());
+    }
+
+    @Test
+    public void testFillRewriteFilesKeepsEqualityDeletesWhenScopedByFilter() throws Exception {
+        DataFile rewritten = mockDataFileAt("oss://bucket/db/tbl/data/rewritten.parquet");
+        DeleteFile eqDelete = mockDeleteFile(null);
+
+        // rewrite_all with a WHERE clause covers only the files that survived pruning, so an equality delete
+        // it applied may still apply to data files left untouched: dropping it would resurrect deleted rows.
+        IcebergMetadata.IcebergSinkExtra scoped = runFillRewriteFiles(true, true,
+                Set.of(), Set.of(eqDelete), Set.of(rewritten));
+        Assertions.assertTrue(scoped.getAppliedDeleteFiles().isEmpty());
+
+        // A whole-table rewrite reads every data file, so its equality deletes are all dangling.
+        IcebergMetadata.IcebergSinkExtra wholeTable = runFillRewriteFiles(true, false,
+                Set.of(), Set.of(eqDelete), Set.of(rewritten));
+        Assertions.assertEquals(Set.of(eqDelete), wholeTable.getAppliedDeleteFiles());
     }
 
     @Test
@@ -961,13 +1045,14 @@ public class IcebergScanNodeTest {
 
         new MockUp<IcebergRewriteStmt>() {
             @Mock
-            public void $init(InsertStmt base, boolean rewriteAll, boolean writeRowLineage) {
+            public void $init(InsertStmt base, boolean rewriteAll, boolean writeRowLineage, boolean hasPartitionFilter) {
                 //do nothing
             }
         };
 
         IcebergRewriteDataJob job = new IcebergRewriteDataJob(
-                "insert into t select * from t", false, 0L, 10L, 1L, false, context, alter);
+                "insert into t select * from t", "insert into t select * from t", false, false, 0L, 10L, 1L, false,
+                context, alter);
 
         job.prepare();
         Deencapsulation.setField(job, "execPlan", execPlan);
@@ -1037,7 +1122,7 @@ public class IcebergScanNodeTest {
         };
         new mockit.MockUp<IcebergRewriteStmt>() {
             @mockit.Mock
-            public void $init(InsertStmt base, boolean rewriteAll, boolean writeRowLineage) { /* no-op */ }
+            public void $init(InsertStmt base, boolean rewriteAll, boolean writeRowLineage, boolean hasPartitionFilter) { /* no-op */ }
         };
 
         StmtExecutor executor = Mockito.mock(StmtExecutor.class);
@@ -1059,7 +1144,7 @@ public class IcebergScanNodeTest {
         };
 
         IcebergRewriteDataJob job = new IcebergRewriteDataJob(
-                "insert into t select 1", false, 0L, 10L, 1L, false, context, alter);
+                "insert into t select 1", "insert into t select 1", false, false, 0L, 10L, 1L, false, context, alter);
 
         Deencapsulation.setField(job, "rewriteStmt", rewriteStmt);
         Deencapsulation.setField(job, "parsedStmt", parsedInsert);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -1123,7 +1123,7 @@ public class InsertPlanTest extends PlanTestBase {
 
         String sql = "insert into iceberg_catalog_lineage.iceberg_db.iceberg_lineage_table select 1, 2, 3, 4";
         InsertStmt insertStmt = (InsertStmt) SqlParser.parse(sql, connectContext.getSessionVariable().getSqlMode()).get(0);
-        IcebergRewriteStmt rewriteStmt = new IcebergRewriteStmt(insertStmt, true, true);
+        IcebergRewriteStmt rewriteStmt = new IcebergRewriteStmt(insertStmt, true, true, false);
 
         String actualRes = getInsertExecPlan(rewriteStmt, sql);
         Assertions.assertTrue(actualRes.contains(IcebergTable.ROW_ID), actualRes);


### PR DESCRIPTION
## Why I'm doing:

`ALTER TABLE ... EXECUTE rewrite_data_files() WHERE <filter>` on an Iceberg table silently drops rows when the filter does not fully align with partition boundaries.

Root cause: the WHERE filter was applied as a row-level predicate inside the rewrite's `INSERT ... SELECT`, but the source data files were still deleted whole at commit time. For any partition transform where a filter can select part of a file's rows without selecting the whole file (bucket transforms always, or a non-aligned range on truncate/day/month/etc.), the non-matching rows in a partially-matched file are stranded, then silently discarded when that file is removed. Reproduced deterministically: `INSERT 200 rows -> rewrite_data_files() WHERE id < 100` on a `bucket(id, 4)` table reports success but `COUNT(*)` drops from 200 to 99, with no error.

## What I'm doing:

Split the rewrite into two statements so the filter only decides which files are candidates, not which rows survive:
- a planning statement that carries the WHERE filter, used to select the files to rewrite (this is where partition pruning happens)
- an execution statement without the filter, which rewrites every selected file whole - matching how Iceberg's own rewrite actions use a file filter (`ignoreResiduals()`), never a row filter

This alone would still be unsafe for two other reasons found on the same commit path while implementing the split, both fixed in this PR:
- merge-on-read plans split the data scan into two mutually exclusive branches (with / without equality deletes); only the first branch found was used as the candidate source, silently dropping the other branch's files
- the equality-delete scan node was left at full-table range when rewriting a single task group, so it could apply another partition's equality deletes to the group being rewritten, or repeatedly scan the whole table's equality deletes
- applied delete files were unconditionally dropped once their data files were rewritten; a delete file that also covers data files this rewrite did not touch needs to stay, or rows it deleted would resurrect. Now: position deletes are dropped only when they name a data file this rewrite removed (or, for a whole-table rewrite, unconditionally, since no untouched file is left); equality deletes are kept unless the rewrite covers the whole table (rewritten files get a strictly higher sequence number, so old equality deletes never apply to them)

Fixes StarRocks/StarRocksTest#11470

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5