### PR TITLE
[Refactor] Remove dead workgroup locals left by the spill-to-remote-storage rework

### DIFF
--- a/be/src/exec/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/aggregate/aggregate_blocking_node.cpp
@@ -46,7 +46,6 @@ StatusOr<pipeline::OpFactories> AggregateBlockingNode::_decompose_to_pipeline(pi
                                                                               bool per_bucket_optimize) {
     using namespace pipeline;
 
-    auto workgroup = context->fragment_context()->workgroup();
     auto degree_of_parallelism = context->source_operator(ops_with_sink)->degree_of_parallelism();
     auto spill_channel_factory = std::make_shared<SpillProcessChannelFactory>(degree_of_parallelism);
     if (std::is_same_v<SinkFactory, SpillableAggregateBlockingSinkOperatorFactory> ||

--- a/be/src/exec/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/aggregate/distinct_blocking_node.cpp
@@ -45,7 +45,6 @@ StatusOr<pipeline::OpFactories> DistinctBlockingNode::_decompose_to_pipeline(pip
                                                                              bool per_bucket_optimize) {
     using namespace pipeline;
 
-    auto workgroup = context->fragment_context()->workgroup();
     auto degree_of_parallelism = context->source_operator(ops_with_sink)->degree_of_parallelism();
     auto spill_channel_factory = std::make_shared<SpillProcessChannelFactory>(degree_of_parallelism);
 

--- a/be/src/exec/cross_join_node.cpp
+++ b/be/src/exec/cross_join_node.cpp
@@ -157,7 +157,6 @@ StatusOr<pipeline::OpFactories> CrossJoinNode::_decompose_to_pipeline(pipeline::
     std::copy(conjunct_ctxs().begin(), conjunct_ctxs().end(), std::back_inserter(context_params.filters));
 
     size_t num_right_partitions = context->source_operator(right_ops)->degree_of_parallelism();
-    auto workgroup = context->fragment_context()->workgroup();
     auto spill_process_factory_ptr = std::make_shared<SpillProcessChannelFactory>(num_right_partitions);
     context_params.spill_process_factory_ptr = spill_process_factory_ptr;
 

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -217,7 +217,6 @@ StatusOr<pipeline::OpFactories> HashJoinNode::_decompose_to_pipeline(pipeline::P
 
     size_t num_right_partitions = context->source_operator(rhs_operators)->degree_of_parallelism();
 
-    auto workgroup = context->fragment_context()->workgroup();
     auto build_side_spill_channel_factory = std::make_shared<SpillProcessChannelFactory>(num_right_partitions);
 
     if (runtime_state()->enable_spill() && runtime_state()->enable_hash_join_spill() &&

--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -197,8 +197,6 @@ StatusOr<pipeline::OpFactories> TopNNode::_decompose_to_pipeline(pipeline::Pipel
 
     // spill components
     // TODO: avoid create spill channel when when disable spill
-
-    auto workgroup = context->fragment_context()->workgroup();
     auto spill_channel_factory = std::make_shared<SpillProcessChannelFactory>(degree_of_parallelism);
 
     // spill process operator

--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -196,7 +196,7 @@ StatusOr<pipeline::OpFactories> TopNNode::_decompose_to_pipeline(pipeline::Pipel
     auto degree_of_parallelism = context->source_operator(ops_sink_with_sort)->degree_of_parallelism();
 
     // spill components
-    // TODO: avoid create spill channel when when disable spill
+    // TODO: avoid creating spill channel when spill is disabled
     auto spill_channel_factory = std::make_shared<SpillProcessChannelFactory>(degree_of_parallelism);
 
     // spill process operator


### PR DESCRIPTION
## Why I'm doing:

#40094 (spill to remote storage) removed `spill::IOTaskExecutor` — the only consumer of a fragment's `workgroup` — from several `_decompose_to_pipeline` paths, but left the now-unused local variable behind in each of them.

## What I'm doing:

Remove the dead `auto workgroup = context->fragment_context()->workgroup();` local from:
- `TopNNode::_decompose_to_pipeline`
- `CrossJoinNode::_decompose_to_pipeline`
- `HashJoinNode::_decompose_to_pipeline`
- `AggregateBlockingNode::_decompose_to_pipeline`
- `DistinctBlockingNode::_decompose_to_pipeline`

Searched the rest of `be/src` and `be/test` for the same pattern (`fragment_context()->workgroup()` / `fragment_ctx->workgroup()`); no other unused instances remain.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4