### PR TITLE
[BugFix] Lower-case GIN index property keys so they reach the BE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/IndexAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/IndexAnalyzer.java
@@ -44,6 +44,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -173,6 +174,8 @@ public class IndexAnalyzer {
                     "The inverted index is disabled, enable it by setting FE config `enable_experimental_gin` to true");
         }
 
+        lowerCasePropertyKeys(properties);
+
         if (properties.containsKey(INVERTED_INDEX_IMP_LIB_KEY)) {
             String impValue = properties.get(INVERTED_INDEX_IMP_LIB_KEY);
             if (!(CLUCENE.name().equalsIgnoreCase(impValue) || BUILTIN.name().equalsIgnoreCase(impValue))) {
@@ -199,6 +202,23 @@ public class IndexAnalyzer {
 
         // add default properties
         addDefaultProperties(properties);
+    }
+
+    // BE finds the GIN properties by exact lower-case key, so any other spelling must be folded before storing.
+    private static void lowerCasePropertyKeys(Map<String, String> properties) {
+        if (properties.keySet().stream().allMatch(key -> key.equals(key.toLowerCase(Locale.ROOT)))) {
+            return;
+        }
+        Map<String, String> lowerCased = new LinkedHashMap<>();
+        for (Entry<String, String> entry : properties.entrySet()) {
+            String key = entry.getKey().toLowerCase(Locale.ROOT);
+            if (lowerCased.containsKey(key)) {
+                throw new SemanticException("Duplicated index property for GIN after lower-casing the key: " + key);
+            }
+            lowerCased.put(key, entry.getValue());
+        }
+        properties.clear();
+        properties.putAll(lowerCased);
     }
 
     private static void addDefaultProperties(Map<String, String> properties) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/GINIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/GINIndexTest.java
@@ -53,6 +53,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import static com.starrocks.common.InvertedIndexParams.CommonIndexParamKey.IMP_LIB;
 
@@ -153,6 +154,77 @@ public class GINIndexTest extends PlanTestBase {
                 () -> IndexAnalyzer.checkInvertedIndexValid(c2, new HashMap<String, String>() {{
                     put(IMP_LIB.name().toLowerCase(Locale.ROOT), InvertedIndexImpType.BUILTIN.name());
                 }}, KeysType.DUP_KEYS));
+    }
+
+    @Test
+    public void testCheckInvertedIndexLowerCasesPropertyKeys() {
+        Column c = new Column("f2", StringType.STRING, true);
+
+        Map<String, String> upperCaseKey = new HashMap<>();
+        upperCaseKey.put(IMP_LIB.name().toUpperCase(Locale.ROOT), InvertedIndexImpType.BUILTIN.name().toLowerCase(Locale.ROOT));
+        Assertions.assertDoesNotThrow(() -> IndexAnalyzer.checkInvertedIndexValid(c, upperCaseKey, KeysType.DUP_KEYS));
+        Assertions.assertEquals(InvertedIndexImpType.BUILTIN.name().toLowerCase(Locale.ROOT),
+                upperCaseKey.get(IMP_LIB.name().toLowerCase(Locale.ROOT)));
+        Assertions.assertFalse(upperCaseKey.containsKey(IMP_LIB.name().toUpperCase(Locale.ROOT)));
+
+        // Values stay untouched: only keys are case-folded.
+        Map<String, String> mixedCaseKeys = new HashMap<>();
+        mixedCaseKeys.put("Imp_Lib", InvertedIndexImpType.BUILTIN.name().toUpperCase(Locale.ROOT));
+        mixedCaseKeys.put(IndexAnalyzer.INVERTED_INDEX_PARSER_KEY.toUpperCase(Locale.ROOT),
+                IndexAnalyzer.INVERTED_INDEX_PARSER_ENGLISH);
+        Assertions.assertDoesNotThrow(() -> IndexAnalyzer.checkInvertedIndexValid(c, mixedCaseKeys, KeysType.DUP_KEYS));
+        Assertions.assertEquals(InvertedIndexImpType.BUILTIN.name().toUpperCase(Locale.ROOT),
+                mixedCaseKeys.get(IMP_LIB.name().toLowerCase(Locale.ROOT)));
+        Assertions.assertEquals(IndexAnalyzer.INVERTED_INDEX_PARSER_ENGLISH,
+                mixedCaseKeys.get(IndexAnalyzer.INVERTED_INDEX_PARSER_KEY));
+
+        // dict_gram_num needs the folding (BE uses an exact find()); lower_case only pins the stored spelling.
+        Map<String, String> upperCaseIndexParams = new HashMap<>();
+        upperCaseIndexParams.put(IMP_LIB.name().toUpperCase(Locale.ROOT),
+                InvertedIndexImpType.BUILTIN.name().toLowerCase(Locale.ROOT));
+        upperCaseIndexParams.put(IndexParamsKey.DICT_GRAM_NUM.name().toUpperCase(Locale.ROOT), "4");
+        upperCaseIndexParams.put(IndexParamsKey.PARSER.name().toUpperCase(Locale.ROOT),
+                IndexAnalyzer.INVERTED_INDEX_PARSER_ENGLISH);
+        upperCaseIndexParams.put(IndexAnalyzer.INVERTED_INDEX_LOWER_CASE_KEY.toUpperCase(Locale.ROOT), "true");
+        Assertions.assertDoesNotThrow(
+                () -> IndexAnalyzer.checkInvertedIndexValid(c, upperCaseIndexParams, KeysType.DUP_KEYS));
+        Assertions.assertEquals("4", upperCaseIndexParams.get(IndexAnalyzer.INVERTED_INDEX_DICT_GRAM_NUM_KEY));
+        Assertions.assertEquals("true", upperCaseIndexParams.get(IndexAnalyzer.INVERTED_INDEX_LOWER_CASE_KEY));
+        Assertions.assertTrue(upperCaseIndexParams.keySet().stream()
+                .allMatch(key -> key.equals(key.toLowerCase(Locale.ROOT))));
+
+        Map<String, String> collidingKeys = new HashMap<>();
+        collidingKeys.put(IMP_LIB.name().toUpperCase(Locale.ROOT), InvertedIndexImpType.BUILTIN.name().toLowerCase(Locale.ROOT));
+        collidingKeys.put(IMP_LIB.name().toLowerCase(Locale.ROOT), InvertedIndexImpType.CLUCENE.name().toLowerCase(Locale.ROOT));
+        ExceptionChecker.expectThrowsWithMsg(SemanticException.class,
+                "Duplicated index property for GIN after lower-casing the key: " + IMP_LIB.name().toLowerCase(Locale.ROOT),
+                () -> IndexAnalyzer.checkInvertedIndexValid(c, collidingKeys, KeysType.DUP_KEYS));
+    }
+
+    @Test
+    public void testUpperCaseImpLibReachesBeAsLowerCaseKey() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE `t_upper_case_imp_lib` (\n" +
+                "  `k` int NOT NULL COMMENT \"\",\n" +
+                "  `v` varchar(50) NOT NULL COMMENT \"\",\n" +
+                "  INDEX gin_v (`v`) USING GIN(\"IMP_LIB\" = \"builtin\", \"PARSER\" = \"english\", " +
+                "\"DICT_GRAM_NUM\" = \"4\")\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k`)\n" +
+                "DISTRIBUTED BY HASH(`k`) BUCKETS 1\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");");
+
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable("test", "t_upper_case_imp_lib");
+        TOlapTableIndex olapIndex = table.getIndexes().get(0).toThrift();
+        // BE fails the load with "Can not get inverted imp type" unless the key lands here exactly as imp_lib.
+        Assertions.assertEquals(InvertedIndexImpType.BUILTIN.name().toLowerCase(Locale.ROOT),
+                olapIndex.getCommon_properties().get(IMP_LIB.name().toLowerCase(Locale.ROOT)));
+        Assertions.assertEquals(IndexAnalyzer.INVERTED_INDEX_PARSER_ENGLISH,
+                olapIndex.getIndex_properties().get(IndexAnalyzer.INVERTED_INDEX_PARSER_KEY));
+        // BE reads the gram num with an exact find() as well, so an upper-case key silently disables the dictionary.
+        Assertions.assertEquals("4", olapIndex.getIndex_properties().get(IndexAnalyzer.INVERTED_INDEX_DICT_GRAM_NUM_KEY));
+        Assertions.assertTrue(olapIndex.getExtra_properties().isEmpty());
+        starRocksAssert.dropTable("t_upper_case_imp_lib");
     }
 
     @Test

--- a/test/sql/test_inverted_index/R/test_gin_property_key_case
+++ b/test/sql/test_inverted_index/R/test_gin_property_key_case
@@ -1,0 +1,98 @@
+-- name: test_gin_property_key_case @slow
+ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
+-- result:
+-- !result
+CREATE DATABASE db_${uuid0};
+-- result:
+-- !result
+USE db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t_gin_upper_key` (
+  `k` int(11) NOT NULL COMMENT "",
+  `v` varchar(50) NOT NULL COMMENT "",
+  INDEX gin_v (`v`) USING GIN("IMP_LIB" = "builtin", "PARSER" = "english", "DICT_GRAM_NUM" = "4")
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+SHOW CREATE TABLE t_gin_upper_key;
+-- result:
+t_gin_upper_key	CREATE TABLE `t_gin_upper_key` (
+  `k` int(11) NOT NULL COMMENT "",
+  `v` varchar(50) NOT NULL COMMENT "",
+  INDEX gin_v (`v`) USING GIN("dict_gram_num" = "4", "imp_lib" = "builtin", "parser" = "english") COMMENT ''
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "false",
+"replication_num" = "1"
+);
+-- !result
+INSERT INTO t_gin_upper_key VALUES (1, 'hello world'), (2, 'goodbye world');
+-- result:
+-- !result
+SELECT k, v FROM t_gin_upper_key WHERE v MATCH 'hello' ORDER BY k;
+-- result:
+1	hello world
+-- !result
+SELECT k, v FROM t_gin_upper_key ORDER BY k;
+-- result:
+1	hello world
+2	goodbye world
+-- !result
+CREATE TABLE `t_gin_alter_upper_key` (
+  `k` int(11) NOT NULL COMMENT "",
+  `v` varchar(50) NOT NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+CREATE INDEX gin_v ON t_gin_alter_upper_key (v) USING GIN("IMP_LIB" = "builtin", "PARSER" = "english");
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SHOW CREATE TABLE t_gin_alter_upper_key;
+-- result:
+t_gin_alter_upper_key	CREATE TABLE `t_gin_alter_upper_key` (
+  `k` int(11) NOT NULL COMMENT "",
+  `v` varchar(50) NOT NULL COMMENT "",
+  INDEX gin_v (`v`) USING GIN("imp_lib" = "builtin", "parser" = "english") COMMENT ''
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1 
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "false",
+"replication_num" = "1"
+);
+-- !result
+INSERT INTO t_gin_alter_upper_key VALUES (1, 'hello world'), (2, 'goodbye world');
+-- result:
+-- !result
+SELECT k, v FROM t_gin_alter_upper_key WHERE v MATCH 'goodbye' ORDER BY k;
+-- result:
+2	goodbye world
+-- !result
+DROP DATABASE db_${uuid0} FORCE;
+-- result:
+-- !result

--- a/test/sql/test_inverted_index/T/test_gin_property_key_case
+++ b/test/sql/test_inverted_index/T/test_gin_property_key_case
@@ -1,0 +1,51 @@
+-- name: test_gin_property_key_case @slow
+ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
+CREATE DATABASE db_${uuid0};
+USE db_${uuid0};
+
+-- Upper-case property keys used to reach the BE verbatim: imp_lib made every load fail with
+-- "Can not get inverted imp type", dict_gram_num was silently dropped.
+CREATE TABLE `t_gin_upper_key` (
+  `k` int(11) NOT NULL COMMENT "",
+  `v` varchar(50) NOT NULL COMMENT "",
+  INDEX gin_v (`v`) USING GIN("IMP_LIB" = "builtin", "PARSER" = "english", "DICT_GRAM_NUM" = "4")
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+
+SHOW CREATE TABLE t_gin_upper_key;
+
+INSERT INTO t_gin_upper_key VALUES (1, 'hello world'), (2, 'goodbye world');
+
+SELECT k, v FROM t_gin_upper_key WHERE v MATCH 'hello' ORDER BY k;
+
+SELECT k, v FROM t_gin_upper_key ORDER BY k;
+
+-- ALTER TABLE ADD INDEX goes through the same analyzer entry point.
+CREATE TABLE `t_gin_alter_upper_key` (
+  `k` int(11) NOT NULL COMMENT "",
+  `v` varchar(50) NOT NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+
+CREATE INDEX gin_v ON t_gin_alter_upper_key (v) USING GIN("IMP_LIB" = "builtin", "PARSER" = "english");
+function: wait_alter_table_finish()
+
+SHOW CREATE TABLE t_gin_alter_upper_key;
+
+INSERT INTO t_gin_alter_upper_key VALUES (1, 'hello world'), (2, 'goodbye world');
+
+SELECT k, v FROM t_gin_alter_upper_key WHERE v MATCH 'goodbye' ORDER BY k;
+
+DROP DATABASE db_${uuid0} FORCE;


### PR DESCRIPTION
Fixes #77817

## Why I'm doing:

`USING GIN("IMP_LIB" = "builtin")` is accepted by CREATE TABLE and then breaks every INSERT
into that table with `Can not get inverted imp type`.

The SQL parser hands the analyzer a case-insensitive property map
(`TreeMap<>(String.CASE_INSENSITIVE_ORDER)`), so every FE-side check finds `IMP_LIB` and the
DDL is accepted. That map only makes *lookup* case-insensitive, though — it stores the key
exactly as the user spelled it. `Index.toThrift()` then classifies the property with an
upper-cased key but copies it into the thrift map **under the original spelling**, so
`common_properties` ends up holding `IMP_LIB`. The BE looks the key up with an exact
`find("imp_lib")` and fails.

`imp_lib` is the one that fails loudly. `"DICT_GRAM_NUM"="4"` goes through the same exact-key
lookup (`get_gram_num_from_properties`) and is **silently** dropped back to `-1`, so the
builtin dictionary gram is quietly disabled on a table the user believes has it, with no
error anywhere.

`parser` and `lower_case` are not affected at runtime: the BE matches those two
case-insensitively. This change only normalizes the spelling they are stored under.

## What I'm doing:

Fold the GIN index property keys to lower case once, at the top of `checkInvertedIndexValid`,
and run all later checks and the stored map off the normalized keys. The BE side is
untouched: exact lower-case lookup is the contract, and this makes the FE honour it.

If two keys collide after folding (e.g. `"IMP_LIB"` and `"imp_lib"` together, reachable
through the analyzer API even though the SQL parser's case-insensitive map already dedups
them), the statement is rejected with a `SemanticException` naming the key instead of one
value silently winning.

Scope boundaries:

- The BE keeps its exact-key lookups. Making `get_inverted_imp_type` and
  `get_gram_num_from_properties` case-insensitive, like the parser and lower_case readers
  already are, is a reasonable follow-up, but it is not needed once the FE never stores a
  non-lower-case key.
- Tables that were already created with an upper-case key are NOT repaired by this change;
  their stored index property keeps the old spelling and the index has to be dropped and
  recreated. No metadata migration is done here.
- No BE change.

Tests:

- `GINIndexTest.testCheckInvertedIndexLowerCasesPropertyKeys` — upper-case `IMP_LIB`,
  mixed-case keys with upper-case values (values must stay untouched), upper-case
  `IMP_LIB`/`DICT_GRAM_NUM`/`PARSER`/`LOWER_CASE` together, and the colliding-key rejection.
- `GINIndexTest.testUpperCaseImpLibReachesBeAsLowerCaseKey` — goes through the real parser and
  asserts the thrift maps the BE receives carry `imp_lib`, `parser` and `dict_gram_num`.
- `test/sql/test_inverted_index/{T,R}/test_gin_property_key_case` — end-to-end, covering both
  the inline `CREATE TABLE` index and `CREATE INDEX ... USING GIN`: `SHOW CREATE TABLE` must
  show lower-cased keys, the INSERT must succeed and `MATCH` must return the right rows.
  Verified that this case fails on the unfixed FE and passes with the fix.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
