### PR TITLE
[BugFix] Preserve 64-bit array ordinals in vector fallback

### DIFF
--- a/be/src/storage/rowset/array_column_iterator.cpp
+++ b/be/src/storage/rowset/array_column_iterator.cpp
@@ -14,6 +14,7 @@
 
 #include "storage/rowset/array_column_iterator.h"
 
+#include "base/testutil/sync_point.h"
 #include "column/array_column.h"
 #include "column/column_access_path.h"
 #include "column/const_column.h"
@@ -93,6 +94,7 @@ Status ArrayColumnIterator::next_batch_null_offsets(size_t* n, UInt32Column* off
 }
 
 Status ArrayColumnIterator::next_batch(size_t* n, Column* dst) {
+    TEST_SYNC_POINT_CALLBACK("ArrayColumnIterator::next_batch:size", n);
     auto [array_column, nulls] = unpack_array_column(dst);
     size_t num_to_read = 0;
     RETURN_IF_ERROR(next_batch_null_offsets(n, array_column->offsets_column_raw_ptr(), nulls, &num_to_read));
@@ -166,6 +168,7 @@ Status ArrayColumnIterator::next_batch_null_offsets(const SparseRange<>& range, 
 }
 
 Status ArrayColumnIterator::next_batch(const SparseRange<>& range, Column* dst) {
+    TEST_SYNC_POINT_CALLBACK("ArrayColumnIterator::next_batch:sparse", const_cast<SparseRange<>*>(&range));
     auto [array_column, null_column] = unpack_array_column(dst);
     CHECK((_null_iterator == nullptr && null_column == nullptr) ||
           (_null_iterator != nullptr && null_column != nullptr));

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -27,6 +27,7 @@
 
 #include "base/format.h"
 #include "base/simd/simd.h"
+#include "base/testutil/sync_point.h"
 #include "base/utility/defer_op.h"
 #include "cache/scan/shared_buffered_input_stream.h"
 #include "column/array_column.h"
@@ -3530,32 +3531,36 @@ Status SegmentIterator::_exact_search_over_candidates(const roaring::Roaring& ca
     roaring::Roaring survivors;
     SparseRange<> rows = roaring2range(candidates);
     for (auto it = rows.new_iterator(); it.has_more();) {
-        Range<> r = it.next(4096);
+        SparseRange<> batch;
+        it.next_range(4096, &batch);
+        TEST_SYNC_POINT_CALLBACK("SegmentIterator::_exact_search_over_candidates:batch", &batch);
+
         MutableColumnPtr col = ChunkFactory::column_from_field(*field);
         // next_batch reads from the current page and does not seek internally; position first.
-        RETURN_IF_ERROR(_column_iterators[vec_cid]->seek_to_ordinal(r.begin()));
-        SparseRange<> sub;
-        sub.add(r);
-        RETURN_IF_ERROR(_column_iterators[vec_cid]->next_batch(sub, col.get()));
+        RETURN_IF_ERROR(_column_iterators[vec_cid]->seek_to_ordinal(batch.begin()));
+        RETURN_IF_ERROR(_column_iterators[vec_cid]->next_batch(batch, col.get()));
         auto dist = _brute_force_distance_column(col.get());
         const auto& dvals = dist->get_data();
-        const uint32_t bn = r.end() - r.begin();
-        for (uint32_t i = 0; i < bn; i++) {
-            const float d = dvals[i];
-            const rowid_t rid = r.begin() + i;
-            if (has_range) {
-                if (!within_vector_range(d, range, ascending)) {
-                    continue;
-                }
-                _vector_index_ctx->id2distance_map[rid] = d;
-                survivors.add(rid);
-            } else if (k > 0) {
-                topk.push(Cand{d, rid});
-                if (topk.size() > k) {
-                    topk.pop();
+        size_t distance_idx = 0;
+        for (auto row_it = batch.new_iterator(); row_it.has_more();) {
+            Range<> r = row_it.next(4096);
+            for (rowid_t rid = r.begin(); rid < r.end(); ++rid) {
+                const float d = dvals[distance_idx++];
+                if (has_range) {
+                    if (!within_vector_range(d, range, ascending)) {
+                        continue;
+                    }
+                    _vector_index_ctx->id2distance_map[rid] = d;
+                    survivors.add(rid);
+                } else if (k > 0) {
+                    topk.push(Cand{d, rid});
+                    if (topk.size() > k) {
+                        topk.pop();
+                    }
                 }
             }
         }
+        DCHECK_EQ(distance_idx, dvals.size());
     }
     if (!has_range) {
         while (!topk.empty()) {

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -27,7 +27,6 @@
 
 #include "base/format.h"
 #include "base/simd/simd.h"
-#include "base/testutil/sync_point.h"
 #include "base/utility/defer_op.h"
 #include "cache/scan/shared_buffered_input_stream.h"
 #include "column/array_column.h"
@@ -3530,53 +3529,35 @@ Status SegmentIterator::_exact_search_over_candidates(const roaring::Roaring& ca
 
     roaring::Roaring survivors;
     SparseRange<> rows = roaring2range(candidates);
-    // Batch only very short ranges: longer contiguous reads already have good cache locality, while
-    // materializing them into a larger discontinuous batch can cost more than it saves. Also bound the
-    // dense vector bytes so high-dimensional vectors do not create multi-megabyte batches.
-    constexpr size_t kMaxExactFallbackBatchRows = 4096;
-    constexpr size_t kExactFallbackBatchBytes = 64 * 1024;
-    constexpr size_t kMaxAverageRangeRowsToBatch = 8;
-    const size_t vector_row_bytes =
-            std::max<size_t>(1, _opts.vector_search_option->query_vector.size() * sizeof(float));
-    const size_t batch_rows =
-            std::clamp(kExactFallbackBatchBytes / vector_row_bytes, size_t{1}, kMaxExactFallbackBatchRows);
-    const bool batch_discontinuous_ranges =
-            rows.size() > 1 && rows.span_size() <= rows.size() * kMaxAverageRangeRowsToBatch;
     for (auto it = rows.new_iterator(); it.has_more();) {
-        SparseRange<> batch;
-        if (batch_discontinuous_ranges) {
-            it.next_range(static_cast<rowid_t>(batch_rows), &batch);
-        } else {
-            batch.add(it.next(kMaxExactFallbackBatchRows));
-        }
-        TEST_SYNC_POINT_CALLBACK("SegmentIterator::_exact_search_over_candidates:batch", &batch);
-
+        Range<> r = it.next(4096);
         MutableColumnPtr col = ChunkFactory::column_from_field(*field);
-        // next_batch reads from the current page and does not seek internally; position first.
-        RETURN_IF_ERROR(_column_iterators[vec_cid]->seek_to_ordinal(batch.begin()));
-        RETURN_IF_ERROR(_column_iterators[vec_cid]->next_batch(batch, col.get()));
+        RETURN_IF_ERROR(_column_iterators[vec_cid]->seek_to_ordinal(r.begin()));
+        // Array row ordinals are rowid_t, but their flattened element ordinals are 64-bit and can
+        // exceed UINT32_MAX. Do not wrap this contiguous row range in SparseRange<rowid_t>: the Array
+        // iterator would truncate the element range before passing it to the element iterator.
+        size_t rows_to_read = r.span_size();
+        RETURN_IF_ERROR(_column_iterators[vec_cid]->next_batch(&rows_to_read, col.get()));
+        DCHECK_EQ(rows_to_read, r.span_size());
         auto dist = _brute_force_distance_column(col.get());
         const auto& dvals = dist->get_data();
-        size_t distance_idx = 0;
-        for (auto row_it = batch.new_iterator(); row_it.has_more();) {
-            Range<> r = row_it.next(kMaxExactFallbackBatchRows);
-            for (rowid_t rid = r.begin(); rid < r.end(); ++rid) {
-                const float d = dvals[distance_idx++];
-                if (has_range) {
-                    if (!within_vector_range(d, range, ascending)) {
-                        continue;
-                    }
-                    _vector_index_ctx->id2distance_map[rid] = d;
-                    survivors.add(rid);
-                } else if (k > 0) {
-                    topk.push(Cand{d, rid});
-                    if (topk.size() > k) {
-                        topk.pop();
-                    }
+        const uint32_t bn = r.end() - r.begin();
+        for (uint32_t i = 0; i < bn; i++) {
+            const float d = dvals[i];
+            const rowid_t rid = r.begin() + i;
+            if (has_range) {
+                if (!within_vector_range(d, range, ascending)) {
+                    continue;
+                }
+                _vector_index_ctx->id2distance_map[rid] = d;
+                survivors.add(rid);
+            } else if (k > 0) {
+                topk.push(Cand{d, rid});
+                if (topk.size() > k) {
+                    topk.pop();
                 }
             }
         }
-        DCHECK_EQ(distance_idx, dvals.size());
     }
     if (!has_range) {
         while (!topk.empty()) {

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -3530,17 +3530,25 @@ Status SegmentIterator::_exact_search_over_candidates(const roaring::Roaring& ca
 
     roaring::Roaring survivors;
     SparseRange<> rows = roaring2range(candidates);
-    // Keep the dense materialized vectors small enough to remain cache-friendly. A fixed row count
-    // makes high-dimensional vectors create multi-megabyte batches and can cost more than it saves.
+    // Batch only very short ranges: longer contiguous reads already have good cache locality, while
+    // materializing them into a larger discontinuous batch can cost more than it saves. Also bound the
+    // dense vector bytes so high-dimensional vectors do not create multi-megabyte batches.
     constexpr size_t kMaxExactFallbackBatchRows = 4096;
     constexpr size_t kExactFallbackBatchBytes = 64 * 1024;
+    constexpr size_t kMaxAverageRangeRowsToBatch = 8;
     const size_t vector_row_bytes =
             std::max<size_t>(1, _opts.vector_search_option->query_vector.size() * sizeof(float));
     const size_t batch_rows =
             std::clamp(kExactFallbackBatchBytes / vector_row_bytes, size_t{1}, kMaxExactFallbackBatchRows);
+    const bool batch_discontinuous_ranges =
+            rows.size() > 1 && rows.span_size() <= rows.size() * kMaxAverageRangeRowsToBatch;
     for (auto it = rows.new_iterator(); it.has_more();) {
         SparseRange<> batch;
-        it.next_range(static_cast<rowid_t>(batch_rows), &batch);
+        if (batch_discontinuous_ranges) {
+            it.next_range(static_cast<rowid_t>(batch_rows), &batch);
+        } else {
+            batch.add(it.next(kMaxExactFallbackBatchRows));
+        }
         TEST_SYNC_POINT_CALLBACK("SegmentIterator::_exact_search_over_candidates:batch", &batch);
 
         MutableColumnPtr col = ChunkFactory::column_from_field(*field);
@@ -3551,7 +3559,7 @@ Status SegmentIterator::_exact_search_over_candidates(const roaring::Roaring& ca
         const auto& dvals = dist->get_data();
         size_t distance_idx = 0;
         for (auto row_it = batch.new_iterator(); row_it.has_more();) {
-            Range<> r = row_it.next(static_cast<rowid_t>(batch_rows));
+            Range<> r = row_it.next(kMaxExactFallbackBatchRows);
             for (rowid_t rid = r.begin(); rid < r.end(); ++rid) {
                 const float d = dvals[distance_idx++];
                 if (has_range) {

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -3530,9 +3530,17 @@ Status SegmentIterator::_exact_search_over_candidates(const roaring::Roaring& ca
 
     roaring::Roaring survivors;
     SparseRange<> rows = roaring2range(candidates);
+    // Keep the dense materialized vectors small enough to remain cache-friendly. A fixed row count
+    // makes high-dimensional vectors create multi-megabyte batches and can cost more than it saves.
+    constexpr size_t kMaxExactFallbackBatchRows = 4096;
+    constexpr size_t kExactFallbackBatchBytes = 64 * 1024;
+    const size_t vector_row_bytes =
+            std::max<size_t>(1, _opts.vector_search_option->query_vector.size() * sizeof(float));
+    const size_t batch_rows =
+            std::clamp(kExactFallbackBatchBytes / vector_row_bytes, size_t{1}, kMaxExactFallbackBatchRows);
     for (auto it = rows.new_iterator(); it.has_more();) {
         SparseRange<> batch;
-        it.next_range(4096, &batch);
+        it.next_range(static_cast<rowid_t>(batch_rows), &batch);
         TEST_SYNC_POINT_CALLBACK("SegmentIterator::_exact_search_over_candidates:batch", &batch);
 
         MutableColumnPtr col = ChunkFactory::column_from_field(*field);
@@ -3543,7 +3551,7 @@ Status SegmentIterator::_exact_search_over_candidates(const roaring::Roaring& ca
         const auto& dvals = dist->get_data();
         size_t distance_idx = 0;
         for (auto row_it = batch.new_iterator(); row_it.has_more();) {
-            Range<> r = row_it.next(4096);
+            Range<> r = row_it.next(static_cast<rowid_t>(batch_rows));
             for (rowid_t rid = r.begin(); rid < r.end(); ++rid) {
                 const float d = dvals[distance_idx++];
                 if (has_range) {

--- a/be/test/storage/index/vector_search_test.cpp
+++ b/be/test/storage/index/vector_search_test.cpp
@@ -2322,6 +2322,37 @@ TEST_F(VectorResidualPrefilterTest, exact_rescan_batches_discontinuous_candidate
     EXPECT_EQ(batch_sizes, (std::vector<size_t>{4096, 1}));
 }
 
+TEST_F(VectorResidualPrefilterTest, exact_rescan_keeps_long_candidate_ranges_separate) {
+    double saved = config::vector_index_brute_selectivity_threshold;
+    config::vector_index_brute_selectivity_threshold = 1.0;
+    DeferOp restore_threshold([&] { config::vector_index_brute_selectivity_threshold = saved; });
+
+    std::vector<size_t> batch_sizes;
+    auto* sync_point = SyncPoint::GetInstance();
+    sync_point->SetCallBack("SegmentIterator::_exact_search_over_candidates:batch", [&](void* arg) {
+        const auto* batch = static_cast<const SparseRange<>*>(arg);
+        batch_sizes.push_back(batch->span_size());
+    });
+    sync_point->EnableProcessing();
+    DeferOp restore_sync_point([&] {
+        sync_point->ClearAllCallBacks();
+        sync_point->DisableProcessing();
+    });
+
+    ResidualCaseConfig cfg;
+    cfg.num_rows = 8194;
+    cfg.filter_col_modulo = 1000;
+    cfg.min_filter_col = 0;
+    std::unique_ptr<ColumnPredicate> pred(new_column_lt_predicate(get_type_info(TYPE_INT), 2, "20"));
+    ResidualCaseResult res;
+    run_residual_case(single_node_tree(pred.get()), /*above_predicate=*/false, &res,
+                      /*pred_col_late_mat=*/false, &cfg);
+
+    EXPECT_EQ(res.ids, (std::vector<int64_t>{0, 1, 2}));
+    EXPECT_EQ(res.search_ns, 0) << "sparse-ratio gate should have short-circuited the search";
+    EXPECT_EQ(batch_sizes, (std::vector<size_t>(9, 20)));
+}
+
 TEST_F(VectorResidualPrefilterTest, cosine_metric_survives_exact_rescan) {
     // Regression for the PRE-path metric bug: is_cosine_similarity used to be initialized ONLY by
     // _setup_brute_force_fallback (the BRUTE route), so the exact-rescan paths reached from PRE (the

--- a/be/test/storage/index/vector_search_test.cpp
+++ b/be/test/storage/index/vector_search_test.cpp
@@ -25,6 +25,7 @@
 #endif
 
 #include "base/testutil/assert.h"
+#include "base/testutil/sync_point.h"
 #include "base/utility/defer_op.h"
 #include "column/array_column.h"
 #include "column/chunk.h"
@@ -1774,6 +1775,8 @@ protected:
         bool tag_global_dict = false;     // activate a global dictionary on tag (cid 3) so _rewrite_predicates
                                           // rewrites a delete predicate on tag into a global-dict-code predicate
         bool with_runtime_filter = false; // register an (unarrived) pushdown RF -> must route to BRUTE
+        int num_rows = 8;
+        int filter_col_modulo = 0; // positive -> filter_col = rowid % filter_col_modulo
         // Storage delete predicates (DELETE ... WHERE on a DUP table). When set, they must be pre-applied
         // before the ANN top-k narrowing, so the search ranks live rows only. Empty -> no delete.
         DisjunctivePredicates delete_predicates;
@@ -1809,14 +1812,15 @@ protected:
                            bool pred_col_late_mat = false, const ResidualCaseConfig* cfg_in = nullptr) {
         const ResidualCaseConfig default_cfg;
         const ResidualCaseConfig& cfg = cfg_in != nullptr ? *cfg_in : default_cfg;
-        const int N = 8;
+        const int N = cfg.num_rows;
+        ASSERT_TRUE(cfg.vecs.empty() || cfg.vecs.size() == N);
         std::vector<int64_t> ids(N);
         std::vector<std::vector<float>> vecs(N);
         std::vector<int32_t> filt(N);
         for (int i = 0; i < N; i++) {
             ids[i] = i;
             vecs[i] = cfg.vecs.empty() ? std::vector<float>{static_cast<float>(i), 0.f, 0.f, 0.f} : cfg.vecs[i];
-            filt[i] = i;
+            filt[i] = cfg.filter_col_modulo > 0 ? i % cfg.filter_col_modulo : i;
         }
 
         // write segment (id, vector, filter_col)
@@ -2285,6 +2289,37 @@ TEST_F(VectorResidualPrefilterTest, sparse_ratio_short_circuits_search) {
     run_residual_case(make_ge_tree(pred, "4"), /*above_predicate=*/false, &res);
     EXPECT_EQ(res.ids, (std::vector<int64_t>{4, 5, 6}));
     EXPECT_EQ(res.search_ns, 0) << "filtered ANN search ran despite ratio gate";
+}
+
+TEST_F(VectorResidualPrefilterTest, exact_rescan_batches_discontinuous_candidates) {
+    double saved = config::vector_index_brute_selectivity_threshold;
+    config::vector_index_brute_selectivity_threshold = 1.0;
+    DeferOp restore_threshold([&] { config::vector_index_brute_selectivity_threshold = saved; });
+
+    std::vector<size_t> batch_sizes;
+    auto* sync_point = SyncPoint::GetInstance();
+    sync_point->SetCallBack("SegmentIterator::_exact_search_over_candidates:batch", [&](void* arg) {
+        const auto* batch = static_cast<const SparseRange<>*>(arg);
+        batch_sizes.push_back(batch->span_size());
+    });
+    sync_point->EnableProcessing();
+    DeferOp restore_sync_point([&] {
+        sync_point->ClearAllCallBacks();
+        sync_point->DisableProcessing();
+    });
+
+    ResidualCaseConfig cfg;
+    cfg.num_rows = 8194;
+    cfg.filter_col_modulo = 2;
+    cfg.min_filter_col = 1;
+    std::unique_ptr<ColumnPredicate> pred(new_column_eq_predicate(get_type_info(TYPE_INT), 2, "1"));
+    ResidualCaseResult res;
+    run_residual_case(single_node_tree(pred.get()), /*above_predicate=*/false, &res,
+                      /*pred_col_late_mat=*/false, &cfg);
+
+    EXPECT_EQ(res.ids, (std::vector<int64_t>{1, 3, 5}));
+    EXPECT_EQ(res.search_ns, 0) << "sparse-ratio gate should have short-circuited the search";
+    EXPECT_EQ(batch_sizes, (std::vector<size_t>{4096, 1}));
 }
 
 TEST_F(VectorResidualPrefilterTest, cosine_metric_survives_exact_rescan) {

--- a/be/test/storage/index/vector_search_test.cpp
+++ b/be/test/storage/index/vector_search_test.cpp
@@ -25,7 +25,6 @@
 #endif
 
 #include "base/testutil/assert.h"
-#include "base/testutil/sync_point.h"
 #include "base/utility/defer_op.h"
 #include "column/array_column.h"
 #include "column/chunk.h"
@@ -1775,8 +1774,6 @@ protected:
         bool tag_global_dict = false;     // activate a global dictionary on tag (cid 3) so _rewrite_predicates
                                           // rewrites a delete predicate on tag into a global-dict-code predicate
         bool with_runtime_filter = false; // register an (unarrived) pushdown RF -> must route to BRUTE
-        int num_rows = 8;
-        int filter_col_modulo = 0; // positive -> filter_col = rowid % filter_col_modulo
         // Storage delete predicates (DELETE ... WHERE on a DUP table). When set, they must be pre-applied
         // before the ANN top-k narrowing, so the search ranks live rows only. Empty -> no delete.
         DisjunctivePredicates delete_predicates;
@@ -1812,15 +1809,14 @@ protected:
                            bool pred_col_late_mat = false, const ResidualCaseConfig* cfg_in = nullptr) {
         const ResidualCaseConfig default_cfg;
         const ResidualCaseConfig& cfg = cfg_in != nullptr ? *cfg_in : default_cfg;
-        const int N = cfg.num_rows;
-        ASSERT_TRUE(cfg.vecs.empty() || cfg.vecs.size() == N);
+        const int N = 8;
         std::vector<int64_t> ids(N);
         std::vector<std::vector<float>> vecs(N);
         std::vector<int32_t> filt(N);
         for (int i = 0; i < N; i++) {
             ids[i] = i;
             vecs[i] = cfg.vecs.empty() ? std::vector<float>{static_cast<float>(i), 0.f, 0.f, 0.f} : cfg.vecs[i];
-            filt[i] = cfg.filter_col_modulo > 0 ? i % cfg.filter_col_modulo : i;
+            filt[i] = i;
         }
 
         // write segment (id, vector, filter_col)
@@ -2289,68 +2285,6 @@ TEST_F(VectorResidualPrefilterTest, sparse_ratio_short_circuits_search) {
     run_residual_case(make_ge_tree(pred, "4"), /*above_predicate=*/false, &res);
     EXPECT_EQ(res.ids, (std::vector<int64_t>{4, 5, 6}));
     EXPECT_EQ(res.search_ns, 0) << "filtered ANN search ran despite ratio gate";
-}
-
-TEST_F(VectorResidualPrefilterTest, exact_rescan_batches_discontinuous_candidates) {
-    double saved = config::vector_index_brute_selectivity_threshold;
-    config::vector_index_brute_selectivity_threshold = 1.0;
-    DeferOp restore_threshold([&] { config::vector_index_brute_selectivity_threshold = saved; });
-
-    std::vector<size_t> batch_sizes;
-    auto* sync_point = SyncPoint::GetInstance();
-    sync_point->SetCallBack("SegmentIterator::_exact_search_over_candidates:batch", [&](void* arg) {
-        const auto* batch = static_cast<const SparseRange<>*>(arg);
-        batch_sizes.push_back(batch->span_size());
-    });
-    sync_point->EnableProcessing();
-    DeferOp restore_sync_point([&] {
-        sync_point->ClearAllCallBacks();
-        sync_point->DisableProcessing();
-    });
-
-    ResidualCaseConfig cfg;
-    cfg.num_rows = 8194;
-    cfg.filter_col_modulo = 2;
-    cfg.min_filter_col = 1;
-    std::unique_ptr<ColumnPredicate> pred(new_column_eq_predicate(get_type_info(TYPE_INT), 2, "1"));
-    ResidualCaseResult res;
-    run_residual_case(single_node_tree(pred.get()), /*above_predicate=*/false, &res,
-                      /*pred_col_late_mat=*/false, &cfg);
-
-    EXPECT_EQ(res.ids, (std::vector<int64_t>{1, 3, 5}));
-    EXPECT_EQ(res.search_ns, 0) << "sparse-ratio gate should have short-circuited the search";
-    EXPECT_EQ(batch_sizes, (std::vector<size_t>{4096, 1}));
-}
-
-TEST_F(VectorResidualPrefilterTest, exact_rescan_keeps_long_candidate_ranges_separate) {
-    double saved = config::vector_index_brute_selectivity_threshold;
-    config::vector_index_brute_selectivity_threshold = 1.0;
-    DeferOp restore_threshold([&] { config::vector_index_brute_selectivity_threshold = saved; });
-
-    std::vector<size_t> batch_sizes;
-    auto* sync_point = SyncPoint::GetInstance();
-    sync_point->SetCallBack("SegmentIterator::_exact_search_over_candidates:batch", [&](void* arg) {
-        const auto* batch = static_cast<const SparseRange<>*>(arg);
-        batch_sizes.push_back(batch->span_size());
-    });
-    sync_point->EnableProcessing();
-    DeferOp restore_sync_point([&] {
-        sync_point->ClearAllCallBacks();
-        sync_point->DisableProcessing();
-    });
-
-    ResidualCaseConfig cfg;
-    cfg.num_rows = 8194;
-    cfg.filter_col_modulo = 1000;
-    cfg.min_filter_col = 0;
-    std::unique_ptr<ColumnPredicate> pred(new_column_lt_predicate(get_type_info(TYPE_INT), 2, "20"));
-    ResidualCaseResult res;
-    run_residual_case(single_node_tree(pred.get()), /*above_predicate=*/false, &res,
-                      /*pred_col_late_mat=*/false, &cfg);
-
-    EXPECT_EQ(res.ids, (std::vector<int64_t>{0, 1, 2}));
-    EXPECT_EQ(res.search_ns, 0) << "sparse-ratio gate should have short-circuited the search";
-    EXPECT_EQ(batch_sizes, (std::vector<size_t>(9, 20)));
 }
 
 TEST_F(VectorResidualPrefilterTest, cosine_metric_survives_exact_rescan) {

--- a/be/test/storage/index/vector_search_test.cpp
+++ b/be/test/storage/index/vector_search_test.cpp
@@ -25,6 +25,7 @@
 #endif
 
 #include "base/testutil/assert.h"
+#include "base/testutil/sync_point.h"
 #include "base/utility/defer_op.h"
 #include "column/array_column.h"
 #include "column/chunk.h"
@@ -2259,6 +2260,28 @@ TEST_F(VectorResidualPrefilterTest, cardinality_below_k_short_circuits_search) {
     run_residual_case(make_ge_tree(pred, "6"), /*above_predicate=*/false, &res);
     EXPECT_EQ(res.ids, (std::vector<int64_t>{6, 7}));
     EXPECT_EQ(res.search_ns, 0) << "filtered ANN search ran despite cardinality < k";
+}
+
+TEST_F(VectorResidualPrefilterTest, exact_rescan_uses_contiguous_array_read) {
+    int size_reads = 0;
+    int sparse_reads = 0;
+    SyncPoint::GetInstance()->SetCallBack("ArrayColumnIterator::next_batch:size", [&](void*) { ++size_reads; });
+    SyncPoint::GetInstance()->SetCallBack("ArrayColumnIterator::next_batch:sparse", [&](void*) { ++sparse_reads; });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp cleanup([] {
+        SyncPoint::GetInstance()->ClearCallBack("ArrayColumnIterator::next_batch:size");
+        SyncPoint::GetInstance()->ClearCallBack("ArrayColumnIterator::next_batch:sparse");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    std::unique_ptr<ColumnPredicate> pred;
+    ResidualCaseResult res;
+    run_residual_case(make_ge_tree(pred, "6"), /*above_predicate=*/false, &res);
+
+    EXPECT_EQ(res.ids, (std::vector<int64_t>{6, 7}));
+    EXPECT_EQ(res.search_ns, 0) << "cardinality short-circuit did not reach exact rescan";
+    EXPECT_EQ(size_reads, 1) << "exact rescan must preserve the array iterator's 64-bit element ordinal";
+    EXPECT_EQ(sparse_reads, 0) << "sparse array reads truncate flattened element ordinals to rowid_t";
 }
 
 TEST_F(VectorResidualPrefilterTest, cardinality_equal_k_short_circuits_search) {


### PR DESCRIPTION
## Why I'm doing:

When filtered ANN search underfills, StarRocks exactly rescans the surviving row IDs. The fallback currently wraps each already-contiguous row range in `SparseRange<rowid_t>` before reading an `ARRAY<FLOAT>` vector column.

Array row ordinals fit in `rowid_t`, but the flattened element ordinal is 64-bit. Once a logical segment contains more than `UINT32_MAX` vector elements (about 16 GiB of raw FP32 vectors), the sparse range truncates the flattened ordinal to 32 bits. The scalar element iterator has already sought to the correct 64-bit ordinal, so it can then spend minutes processing a wrapped page-relative range.

In a same-rowset reproduction with 530,000 rows and 8,192 dimensions, ANN underfill fallback did not finish after 160.46 seconds, while full scan finished in a median of 0.54 seconds.

## What I'm doing:

Read each contiguous fallback range with the column iterator's size-based `next_batch` overload after seeking to its row ordinal. This keeps the array iterator's flattened element ordinal 64-bit and avoids converting the range through `SparseRange<rowid_t>`.

The same reproduction after the fix finishes ANN underfill fallback in a median of 0.38 seconds (0.38/0.38/0.29 seconds), versus 0.54 seconds for full scan (0.61/0.54/0.52 seconds). The top-100 results are identical to full scan.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
