### PR TITLE
[BugFix] Serialize EXCEPT/INTERSECT keys by row when the batch buffer would be huge

### DIFF
--- a/be/src/exec/except_hash_set.cpp
+++ b/be/src/exec/except_hash_set.cpp
@@ -14,6 +14,7 @@
 
 #include "exec/except_hash_set.h"
 
+#include "base/failpoint/fail_point.h"
 #include "exec/aggregate/agg_hash_set.h"
 #include "exec_primitive/exec_node.h"
 #include "runtime/current_thread.h"
@@ -21,6 +22,10 @@
 #include "runtime/runtime_state.h"
 
 namespace starrocks {
+
+// Forces the by-rows path regardless of how wide the rows actually are, so ordinary data can
+// exercise it: reaching the INT32_MAX bound for real needs a row of half a megabyte or more.
+DEFINE_FAIL_POINT(except_hash_set_force_by_rows);
 
 template <typename HashSet>
 Status ExceptHashSet<HashSet>::BufferState::init(RuntimeState* state) {
@@ -38,17 +43,47 @@ void ExceptHashSet<HashSet>::build_set(RuntimeState* state, const ChunkPtr& chun
     buffer_state->slice_sizes.assign(state->chunk_size(), 0);
 
     size_t cur_max_one_row_size = _get_max_serialize_size(chunk, exprs);
-    if (UNLIKELY(cur_max_one_row_size > buffer_state->max_one_row_size)) {
+    // The trigger is hoisted out of the growth check on purpose: a narrow key never widens the
+    // stride, so testing it inside would leave the failpoint unable to fire at all.
+    bool force_by_rows = false;
+    FAIL_POINT_TRIGGER_EXECUTE(except_hash_set_force_by_rows, { force_by_rows = true; });
+    if (UNLIKELY(force_by_rows || cur_max_one_row_size > buffer_state->max_one_row_size)) {
+        size_t batch_allocate_size = cur_max_one_row_size * state->chunk_size() + SLICE_MEMEQUAL_OVERFLOW_PADDING;
+        // too large, process by rows
+        if (force_by_rows || batch_allocate_size > kMaxBatchSerializeSize) {
+            // Reset the high-water mark so the next chunk is sized on its own merits instead of
+            // inheriting this row's stride and being forced down the by-rows path forever.
+            buffer_state->max_one_row_size = 0;
+            buffer_state->mem_pool.clear();
+            buffer_state->buffer =
+                    buffer_state->mem_pool.allocate(cur_max_one_row_size + SLICE_MEMEQUAL_OVERFLOW_PADDING);
+            return _build_set_by_rows(chunk, exprs, pool, chunk_size, buffer_state);
+        }
         buffer_state->max_one_row_size = cur_max_one_row_size;
         buffer_state->mem_pool.clear();
-        buffer_state->buffer = buffer_state->mem_pool.allocate(buffer_state->max_one_row_size * state->chunk_size() +
-                                                               SLICE_MEMEQUAL_OVERFLOW_PADDING);
+        buffer_state->buffer = buffer_state->mem_pool.allocate(batch_allocate_size);
     }
 
     _serialize_columns(chunk, exprs, chunk_size, buffer_state);
 
     for (size_t i = 0; i < chunk_size; ++i) {
         ExceptSliceFlag key(buffer_state->buffer + i * buffer_state->max_one_row_size, buffer_state->slice_sizes[i]);
+        _hash_set->lazy_emplace(key, [&](const auto& ctor) {
+            uint8_t* pos = pool->allocate_with_reserve(key.slice.size, SLICE_MEMEQUAL_OVERFLOW_PADDING);
+            memcpy(pos, key.slice.data, key.slice.size);
+            ctor(pos, key.slice.size);
+        });
+    }
+}
+
+// There may be additional virtual function overhead, but the bottleneck of this branch is serialization.
+template <typename HashSet>
+ALWAYS_NOINLINE void ExceptHashSet<HashSet>::_build_set_by_rows(const ChunkPtr& chunk,
+                                                                const std::vector<ExprContext*>& exprs, MemPool* pool,
+                                                                size_t chunk_size, BufferState* buffer_state) {
+    Columns key_columns = _evaluate_key_columns(chunk, exprs);
+    for (size_t i = 0; i < chunk_size; ++i) {
+        ExceptSliceFlag key(buffer_state->buffer, _serialize_one_row(key_columns, i, buffer_state));
         _hash_set->lazy_emplace(key, [&](const auto& ctor) {
             uint8_t* pos = pool->allocate_with_reserve(key.slice.size, SLICE_MEMEQUAL_OVERFLOW_PADDING);
             memcpy(pos, key.slice.data, key.slice.size);
@@ -70,10 +105,30 @@ Status ExceptHashSet<HashSet>::erase_duplicate_row(RuntimeState* state, const Ch
     buffer_state->slice_sizes.assign(state->chunk_size(), 0);
 
     size_t cur_max_one_row_size = _get_max_serialize_size(chunk, exprs);
-    if (UNLIKELY(cur_max_one_row_size > buffer_state->max_one_row_size)) {
+    // The trigger is hoisted out of the growth check on purpose: a narrow key never widens the
+    // stride, so testing it inside would leave the failpoint unable to fire at all.
+    bool force_by_rows = false;
+    FAIL_POINT_TRIGGER_EXECUTE(except_hash_set_force_by_rows, { force_by_rows = true; });
+    if (UNLIKELY(force_by_rows || cur_max_one_row_size > buffer_state->max_one_row_size)) {
+        // The padding is what build_set already reserves; both paths share this buffer and
+        // ExceptSliceFlagEqual reads past the key with SIMD, so the probe side needs it too.
+        size_t batch_allocate_size = cur_max_one_row_size * state->chunk_size() + SLICE_MEMEQUAL_OVERFLOW_PADDING;
+        // too large, process by rows
+        if (force_by_rows || batch_allocate_size > kMaxBatchSerializeSize) {
+            buffer_state->max_one_row_size = 0;
+            buffer_state->mem_pool.clear();
+            buffer_state->buffer =
+                    buffer_state->mem_pool.allocate(cur_max_one_row_size + SLICE_MEMEQUAL_OVERFLOW_PADDING);
+            if (UNLIKELY(buffer_state->buffer == nullptr)) {
+                return Status::InternalError("Mem usage has exceed the limit of BE");
+            }
+            RETURN_IF_LIMIT_EXCEEDED(state, "Except, while probe hash table.");
+            _erase_duplicate_row_by_rows(chunk, exprs, chunk_size, buffer_state);
+            return Status::OK();
+        }
         buffer_state->max_one_row_size = cur_max_one_row_size;
         buffer_state->mem_pool.clear();
-        buffer_state->buffer = buffer_state->mem_pool.allocate(buffer_state->max_one_row_size * state->chunk_size());
+        buffer_state->buffer = buffer_state->mem_pool.allocate(batch_allocate_size);
         if (UNLIKELY(buffer_state->buffer == nullptr)) {
             return Status::InternalError("Mem usage has exceed the limit of BE");
         }
@@ -91,6 +146,21 @@ Status ExceptHashSet<HashSet>::erase_duplicate_row(RuntimeState* state, const Ch
     }
 
     return Status::OK();
+}
+
+template <typename HashSet>
+ALWAYS_NOINLINE void ExceptHashSet<HashSet>::_erase_duplicate_row_by_rows(const ChunkPtr& chunk,
+                                                                          const std::vector<ExprContext*>& exprs,
+                                                                          size_t chunk_size,
+                                                                          BufferState* buffer_state) {
+    Columns key_columns = _evaluate_key_columns(chunk, exprs);
+    for (size_t i = 0; i < chunk_size; ++i) {
+        ExceptSliceFlag key(buffer_state->buffer, _serialize_one_row(key_columns, i, buffer_state));
+        auto iter = _hash_set->find(key);
+        if (iter != _hash_set->end()) {
+            iter->deleted = true;
+        }
+    }
 }
 
 template <typename HashSet>
@@ -134,6 +204,34 @@ size_t ExceptHashSet<HashSet>::_get_max_serialize_size(const ChunkPtr& chunk, co
         }
     }
     return max_size;
+}
+
+template <typename HashSet>
+Columns ExceptHashSet<HashSet>::_evaluate_key_columns(const ChunkPtr& chunk, const std::vector<ExprContext*>& exprs) {
+    Columns key_columns;
+    key_columns.reserve(exprs.size());
+    for (auto expr : exprs) {
+        key_columns.emplace_back(EVALUATE_NULL_IF_ERROR(expr, expr->root(), chunk.get()));
+    }
+    return key_columns;
+}
+
+// Mirrors _serialize_columns for a single row. The serialized key is always nullable, so a
+// non-nullable column contributes a false null byte ahead of its value -- the same layout
+// Column::serialize_batch_with_null_masks(..., nullptr, false) produces.
+template <typename HashSet>
+size_t ExceptHashSet<HashSet>::_serialize_one_row(const Columns& key_columns, size_t idx, BufferState* buffer_state) {
+    uint8_t* cursor = buffer_state->buffer;
+    for (const auto& key_column : key_columns) {
+        if (key_column->is_nullable()) {
+            cursor += key_column->serialize(idx, cursor);
+        } else {
+            constexpr bool kNotNull = false;
+            memcpy(cursor, &kNotNull, sizeof(bool));
+            cursor += sizeof(bool) + key_column->serialize(idx, cursor + sizeof(bool));
+        }
+    }
+    return cursor - buffer_state->buffer;
 }
 
 template <typename HashSet>

--- a/be/src/exec/except_hash_set.h
+++ b/be/src/exec/except_hash_set.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <limits>
+
 #include "base/phmap/phmap.h"
 #include "base/phmap/phmap_dump.h"
 #include "base/string/slice.h"
@@ -92,6 +94,24 @@ private:
     size_t _get_max_serialize_size(const ChunkPtr& chunk, const std::vector<ExprContext*>& exprs);
     void _serialize_columns(const ChunkPtr& chunk, const std::vector<ExprContext*>& exprs, size_t chunk_size,
                             BufferState* buffer_state);
+
+    // Serializing a whole chunk at once needs max_one_row_size * chunk_size bytes, which one very wide
+    // row blows up out of all proportion to the data: a single ARRAY<ARRAY<BIGINT>> of 5M sub-arrays
+    // serializes to ~70MB, and 70MB * 4096 asked the MemPool for 512GB. Past this bound the chunk is
+    // serialized one row at a time into a single-row buffer instead, exactly as
+    // AggHashMapWithSerializedKey::compute_agg_states does.
+    static constexpr size_t kMaxBatchSerializeSize = std::numeric_limits<int32_t>::max();
+
+    // Evaluates the key exprs once for the whole chunk; the caller then walks rows.
+    Columns _evaluate_key_columns(const ChunkPtr& chunk, const std::vector<ExprContext*>& exprs);
+    // Serializes row `idx` into buffer_state->buffer and returns its length. Byte-for-byte identical
+    // to what _serialize_columns writes for that row, so the two paths may be mixed across chunks.
+    size_t _serialize_one_row(const Columns& key_columns, size_t idx, BufferState* buffer_state);
+
+    void _build_set_by_rows(const ChunkPtr& chunk, const std::vector<ExprContext*>& exprs, MemPool* pool,
+                            size_t chunk_size, BufferState* buffer_state);
+    void _erase_duplicate_row_by_rows(const ChunkPtr& chunk, const std::vector<ExprContext*>& exprs, size_t chunk_size,
+                                      BufferState* buffer_state);
 
 private:
     std::unique_ptr<HashSet> _hash_set;

--- a/be/src/exec/intersect_hash_set.cpp
+++ b/be/src/exec/intersect_hash_set.cpp
@@ -14,12 +14,18 @@
 
 #include "exec/intersect_hash_set.h"
 
+#include "base/failpoint/fail_point.h"
 #include "base/phmap/phmap_dump.h"
 #include "exec/aggregate/agg_hash_set.h"
 #include "exec_primitive/exec_node.h"
 #include "runtime/runtime_state.h"
 
 namespace starrocks {
+
+// Forces the by-rows path regardless of how wide the rows actually are, so ordinary data can
+// exercise it: reaching the INT32_MAX bound for real needs a row of half a megabyte or more.
+DEFINE_FAIL_POINT(intersect_hash_set_force_by_rows);
+
 template <typename HashSet>
 Status IntersectHashSet<HashSet>::init(RuntimeState* state) {
     _hash_set = std::make_unique<HashSet>();
@@ -36,10 +42,24 @@ void IntersectHashSet<HashSet>::build_set(RuntimeState* state, const ChunkPtr& c
 
     _slice_sizes.assign(state->chunk_size(), 0);
     size_t cur_max_one_row_size = _get_max_serialize_size(chunkPtr, exprs);
-    if (UNLIKELY(cur_max_one_row_size > _max_one_row_size)) {
+    // The trigger is hoisted out of the growth check on purpose: a narrow key never widens the
+    // stride, so testing it inside would leave the failpoint unable to fire at all.
+    bool force_by_rows = false;
+    FAIL_POINT_TRIGGER_EXECUTE(intersect_hash_set_force_by_rows, { force_by_rows = true; });
+    if (UNLIKELY(force_by_rows || cur_max_one_row_size > _max_one_row_size)) {
+        size_t batch_allocate_size = cur_max_one_row_size * state->chunk_size() + SLICE_MEMEQUAL_OVERFLOW_PADDING;
+        // too large, process by rows
+        if (force_by_rows || batch_allocate_size > kMaxBatchSerializeSize) {
+            // Reset the high-water mark so the next chunk is sized on its own merits instead of
+            // inheriting this row's stride and being forced down the by-rows path forever.
+            _max_one_row_size = 0;
+            _mem_pool->clear();
+            _buffer = _mem_pool->allocate(cur_max_one_row_size + SLICE_MEMEQUAL_OVERFLOW_PADDING);
+            return _build_set_by_rows(chunkPtr, exprs, pool, chunk_size);
+        }
         _max_one_row_size = cur_max_one_row_size;
         _mem_pool->clear();
-        _buffer = _mem_pool->allocate(_max_one_row_size * state->chunk_size() + SLICE_MEMEQUAL_OVERFLOW_PADDING);
+        _buffer = _mem_pool->allocate(batch_allocate_size);
     }
 
     _serialize_columns(chunkPtr, exprs, chunk_size);
@@ -55,16 +75,50 @@ void IntersectHashSet<HashSet>::build_set(RuntimeState* state, const ChunkPtr& c
     }
 }
 
+// There may be additional virtual function overhead, but the bottleneck of this branch is serialization.
+template <typename HashSet>
+ALWAYS_NOINLINE void IntersectHashSet<HashSet>::_build_set_by_rows(const ChunkPtr& chunkPtr,
+                                                                   const std::vector<ExprContext*>& exprs,
+                                                                   MemPool* pool, size_t chunk_size) {
+    Columns key_columns = _evaluate_key_columns(chunkPtr, exprs);
+    for (size_t i = 0; i < chunk_size; ++i) {
+        IntersectSliceFlag key(_buffer, _serialize_one_row(key_columns, i));
+        _hash_set->lazy_emplace(key, [&](const auto& ctor) {
+            // we must persist the slice before insert
+            uint8_t* pos = pool->allocate_with_reserve(key.slice.size, SLICE_MEMEQUAL_OVERFLOW_PADDING);
+            memcpy(pos, key.slice.data, key.slice.size);
+            ctor(pos, key.slice.size);
+        });
+    }
+}
+
 template <typename HashSet>
 Status IntersectHashSet<HashSet>::refine_intersect_row(RuntimeState* state, const ChunkPtr& chunkPtr,
                                                        const std::vector<ExprContext*>& exprs, const int hit_times) {
     size_t chunk_size = chunkPtr->num_rows();
     _slice_sizes.assign(state->chunk_size(), 0);
     size_t cur_max_one_row_size = _get_max_serialize_size(chunkPtr, exprs);
-    if (UNLIKELY(cur_max_one_row_size > _max_one_row_size)) {
+    // The trigger is hoisted out of the growth check on purpose: a narrow key never widens the
+    // stride, so testing it inside would leave the failpoint unable to fire at all.
+    bool force_by_rows = false;
+    FAIL_POINT_TRIGGER_EXECUTE(intersect_hash_set_force_by_rows, { force_by_rows = true; });
+    if (UNLIKELY(force_by_rows || cur_max_one_row_size > _max_one_row_size)) {
+        size_t batch_allocate_size = cur_max_one_row_size * state->chunk_size() + SLICE_MEMEQUAL_OVERFLOW_PADDING;
+        // too large, process by rows
+        if (force_by_rows || batch_allocate_size > kMaxBatchSerializeSize) {
+            _max_one_row_size = 0;
+            _mem_pool->clear();
+            _buffer = _mem_pool->allocate(cur_max_one_row_size + SLICE_MEMEQUAL_OVERFLOW_PADDING);
+            if (UNLIKELY(_buffer == nullptr)) {
+                return Status::InternalError("Mem usage has exceed the limit of BE");
+            }
+            RETURN_IF_LIMIT_EXCEEDED(state, "Intersect, while probe hash table.");
+            _refine_intersect_row_by_rows(chunkPtr, exprs, chunk_size, hit_times);
+            return Status::OK();
+        }
         _max_one_row_size = cur_max_one_row_size;
         _mem_pool->clear();
-        _buffer = _mem_pool->allocate(_max_one_row_size * state->chunk_size() + SLICE_MEMEQUAL_OVERFLOW_PADDING);
+        _buffer = _mem_pool->allocate(batch_allocate_size);
         if (UNLIKELY(_buffer == nullptr)) {
             return Status::InternalError("Mem usage has exceed the limit of BE");
         }
@@ -81,6 +135,20 @@ Status IntersectHashSet<HashSet>::refine_intersect_row(RuntimeState* state, cons
         }
     }
     return Status::OK();
+}
+
+template <typename HashSet>
+ALWAYS_NOINLINE void IntersectHashSet<HashSet>::_refine_intersect_row_by_rows(const ChunkPtr& chunkPtr,
+                                                                              const std::vector<ExprContext*>& exprs,
+                                                                              size_t chunk_size, int hit_times) {
+    Columns key_columns = _evaluate_key_columns(chunkPtr, exprs);
+    for (size_t i = 0; i < chunk_size; ++i) {
+        IntersectSliceFlag key(_buffer, _serialize_one_row(key_columns, i));
+        auto iter = _hash_set->find(key);
+        if (iter != _hash_set->end() && iter->hit_times == hit_times - 1) {
+            iter->hit_times = hit_times;
+        }
+    }
 }
 
 template <typename HashSet>
@@ -125,6 +193,35 @@ size_t IntersectHashSet<HashSet>::_get_max_serialize_size(const ChunkPtr& chunkP
         }
     }
     return max_size;
+}
+
+template <typename HashSet>
+Columns IntersectHashSet<HashSet>::_evaluate_key_columns(const ChunkPtr& chunkPtr,
+                                                         const std::vector<ExprContext*>& exprs) {
+    Columns key_columns;
+    key_columns.reserve(exprs.size());
+    for (auto* expr : exprs) {
+        key_columns.emplace_back(EVALUATE_NULL_IF_ERROR(expr, expr->root(), chunkPtr.get()));
+    }
+    return key_columns;
+}
+
+// Mirrors _serialize_columns for a single row. The serialized key is always nullable, so a
+// non-nullable column contributes a false null byte ahead of its value -- the same layout
+// Column::serialize_batch_with_null_masks(..., nullptr, false) produces.
+template <typename HashSet>
+size_t IntersectHashSet<HashSet>::_serialize_one_row(const Columns& key_columns, size_t idx) {
+    uint8_t* cursor = _buffer;
+    for (const auto& key_column : key_columns) {
+        if (key_column->is_nullable()) {
+            cursor += key_column->serialize(idx, cursor);
+        } else {
+            constexpr bool kNotNull = false;
+            memcpy(cursor, &kNotNull, sizeof(bool));
+            cursor += sizeof(bool) + key_column->serialize(idx, cursor + sizeof(bool));
+        }
+    }
+    return cursor - _buffer;
 }
 
 template <typename HashSet>

--- a/be/src/exec/intersect_hash_set.h
+++ b/be/src/exec/intersect_hash_set.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <limits>
+
 #include "base/phmap/phmap.h"
 #include "base/string/slice.h"
 #include "column/chunk.h"
@@ -78,6 +80,24 @@ private:
     void _serialize_columns(const ChunkPtr& chunkPtr, const std::vector<ExprContext*>& exprs, size_t chunk_size);
 
     size_t _get_max_serialize_size(const ChunkPtr& chunkPtr, const std::vector<ExprContext*>& exprs);
+
+    // Serializing a whole chunk at once needs max_one_row_size * chunk_size bytes, which one very wide
+    // row blows up out of all proportion to the data: a single ARRAY<ARRAY<BIGINT>> of 5M sub-arrays
+    // serializes to ~70MB, and 70MB * 4096 asked the MemPool for 512GB. Past this bound the chunk is
+    // serialized one row at a time into a single-row buffer instead, exactly as
+    // AggHashMapWithSerializedKey::compute_agg_states does.
+    static constexpr size_t kMaxBatchSerializeSize = std::numeric_limits<int32_t>::max();
+
+    // Evaluates the key exprs once for the whole chunk; the caller then walks rows.
+    Columns _evaluate_key_columns(const ChunkPtr& chunkPtr, const std::vector<ExprContext*>& exprs);
+    // Serializes row `idx` into _buffer and returns its length. Byte-for-byte identical to what
+    // _serialize_columns writes for that row, so the two paths may be mixed across chunks.
+    size_t _serialize_one_row(const Columns& key_columns, size_t idx);
+
+    void _build_set_by_rows(const ChunkPtr& chunkPtr, const std::vector<ExprContext*>& exprs, MemPool* pool,
+                            size_t chunk_size);
+    void _refine_intersect_row_by_rows(const ChunkPtr& chunkPtr, const std::vector<ExprContext*>& exprs,
+                                       size_t chunk_size, int hit_times);
 
     std::unique_ptr<HashSet> _hash_set;
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -60,6 +60,7 @@ set(EXEC_FILES
         ./exec/hdfs_scan_node_test.cpp
         ./exec/lake_meta_scanner_test.cpp
         ./exec/repeat_node_test.cpp
+        ./exec/set_hash_set_test.cpp
         ./exec/sorting_test.cpp
         ./exec/table_function_node_test.cpp
         ./exec/olap_scan_prepare_test.cpp

--- a/be/test/exec/set_hash_set_test.cpp
+++ b/be/test/exec/set_hash_set_test.cpp
@@ -1,0 +1,391 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+
+#include "base/failpoint/fail_point.h"
+#include "base/testutil/assert.h"
+#include "column/column_helper.h"
+#include "common/object_pool.h"
+#include "exec/except_hash_set.h"
+#include "exec/exec_env.h"
+#include "exec/intersect_hash_set.h"
+#include "exprs/column_ref.h"
+#include "exprs/expr_context.h"
+#include "exprs/expr_executor.h"
+#include "runtime/mem_pool.h"
+#include "runtime/runtime_state.h"
+
+namespace starrocks {
+
+// EXCEPT/INTERSECT serialize a chunk's key columns into a fixed-stride buffer sized
+// max_one_row_size * state->chunk_size(). One very wide row prices the whole chunk, so past
+// INT32_MAX the operators serialize row by row into a single-row buffer instead. The two paths
+// must agree byte for byte, because one query can take both -- a chunk holding a wide value goes
+// by rows while the narrow chunks around it stay vectorized.
+class SetHashSetTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        // A default-constructed RuntimeState has no mem trackers, and RETURN_IF_LIMIT_EXCEEDED on
+        // the probe paths dereferences them.
+        TUniqueId fragment_id;
+        TQueryOptions query_options;
+        TQueryGlobals query_globals;
+        auto* exec_env = ExecEnv::GetInstance();
+        _runtime_state = std::make_shared<RuntimeState>(fragment_id, query_options, query_globals,
+                                                        &exec_env->query_execution_services(), exec_env);
+        _runtime_state->init_mem_trackers(TUniqueId());
+        _runtime_state->set_chunk_size(kChunkSize);
+        _varchar_type = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
+        _slot_ref = _pool.add(new ColumnRef(_varchar_type, 0));
+        _exprs.emplace_back(_pool.add(new ExprContext(_slot_ref)));
+        ASSERT_OK(ExprExecutor::prepare(_exprs, _runtime_state.get()));
+        ASSERT_OK(ExprExecutor::open(_exprs, _runtime_state.get()));
+    }
+
+    void TearDown() override { ExprExecutor::close(_exprs, _runtime_state.get()); }
+
+protected:
+    // A stride above this forces the by-rows path: kWideValueSize * kChunkSize > INT32_MAX.
+    static constexpr size_t kChunkSize = 4096;
+    static constexpr size_t kWideValueSize = 1024 * 1024;
+
+    ChunkPtr make_chunk(const std::vector<std::string>& values, bool nullable) {
+        auto column = ColumnHelper::create_column(_varchar_type, nullable);
+        for (const auto& value : values) {
+            column->append_datum(Datum(Slice(value)));
+        }
+        auto chunk = std::make_shared<Chunk>();
+        chunk->append_column(std::move(column), 0);
+        return chunk;
+    }
+
+    static std::string wide_value(char fill) { return std::string(kWideValueSize, fill); }
+
+    // Turning the failpoint on lets ordinary narrow data drive the by-rows path, so the two
+    // serializations can be compared on identical input instead of only on half-megabyte rows.
+    class ForceByRows {
+    public:
+        explicit ForceByRows(const std::string& name) : _name(name) {
+            auto* fp = failpoint::FailPointRegistry::GetInstance()->get(_name);
+            EXPECT_NE(nullptr, fp) << "failpoint " << _name << " is not registered";
+            set_enabled(fp, true);
+            _fp = fp;
+        }
+        ~ForceByRows() {
+            if (_fp != nullptr) {
+                set_enabled(_fp, false);
+            }
+        }
+
+    private:
+        static void set_enabled(failpoint::FailPoint* fp, bool enable) {
+            PFailPointTriggerMode mode;
+            mode.set_mode(enable ? FailPointTriggerModeType::ENABLE : FailPointTriggerModeType::DISABLE);
+            fp->setMode(mode);
+        }
+
+        std::string _name;
+        failpoint::FailPoint* _fp = nullptr;
+    };
+
+    // The set of keys the hash set ended up holding, so a by-rows build can be compared against a
+    // batch build of the same rows.
+    static std::vector<std::string> keys_of(IntersectHashSerializeSet& hash_set) {
+        std::vector<std::string> keys;
+        for (auto it = hash_set.begin(); it != hash_set.end(); ++it) {
+            keys.emplace_back(it->slice.data, it->slice.size);
+        }
+        std::sort(keys.begin(), keys.end());
+        return keys;
+    }
+
+    static std::vector<std::string> keys_of(ExceptHashSerializeSet& hash_set) {
+        std::vector<std::string> keys;
+        for (auto it = hash_set.begin(); it != hash_set.end(); ++it) {
+            keys.emplace_back(it->slice.data, it->slice.size);
+        }
+        std::sort(keys.begin(), keys.end());
+        return keys;
+    }
+
+    std::shared_ptr<RuntimeState> _runtime_state;
+    ObjectPool _pool;
+    TypeDescriptor _varchar_type;
+    ColumnRef* _slot_ref = nullptr;
+    std::vector<ExprContext*> _exprs;
+};
+
+// A chunk holding a single 1MB row would ask for 1MB * 4096 = 4GB of buffer if it were serialized
+// in one batch. It must still be inserted, and found again by a later probe.
+TEST_F(SetHashSetTest, intersect_wide_row_takes_by_rows_path) {
+    IntersectHashSerializeSet hash_set;
+    ASSERT_OK(hash_set.init(_runtime_state.get()));
+    MemPool pool;
+
+    auto wide_chunk = make_chunk({wide_value('a')}, false);
+    hash_set.build_set(_runtime_state.get(), wide_chunk, _exprs, &pool);
+    ASSERT_FALSE(hash_set.empty());
+
+    // Probing the same value marks it as hit; a different value must not match.
+    ASSERT_OK(hash_set.refine_intersect_row(_runtime_state.get(), wide_chunk, _exprs, 1));
+    size_t hit = 0;
+    for (auto it = hash_set.begin(); it != hash_set.end(); ++it) {
+        hit += (it->hit_times == 1);
+    }
+    ASSERT_EQ(1, hit);
+
+    auto other_chunk = make_chunk({wide_value('b')}, false);
+    ASSERT_OK(hash_set.refine_intersect_row(_runtime_state.get(), other_chunk, _exprs, 2));
+    for (auto it = hash_set.begin(); it != hash_set.end(); ++it) {
+        ASSERT_NE(2, it->hit_times);
+    }
+}
+
+// The regression this guards: a wide chunk is serialized by rows and a narrow one in a batch, so a
+// value inserted through one path has to be found through the other. If the two layouts disagreed
+// the lookup would silently miss.
+TEST_F(SetHashSetTest, intersect_by_rows_and_batch_layouts_agree) {
+    IntersectHashSerializeSet hash_set;
+    ASSERT_OK(hash_set.init(_runtime_state.get()));
+    MemPool pool;
+
+    // Built by rows (1MB stride), probed in a batch (narrow stride) and vice versa.
+    const std::string wide = wide_value('a');
+    hash_set.build_set(_runtime_state.get(), make_chunk({wide}, false), _exprs, &pool);
+    hash_set.build_set(_runtime_state.get(), make_chunk({"narrow"}, false), _exprs, &pool);
+
+    ASSERT_OK(hash_set.refine_intersect_row(_runtime_state.get(), make_chunk({"narrow"}, false), _exprs, 1));
+    ASSERT_OK(hash_set.refine_intersect_row(_runtime_state.get(), make_chunk({wide}, false), _exprs, 1));
+
+    size_t hit = 0;
+    for (auto it = hash_set.begin(); it != hash_set.end(); ++it) {
+        hit += (it->hit_times == 1);
+    }
+    ASSERT_EQ(2, hit);
+}
+
+// A nullable column serializes its own null byte while a non-nullable one gets a false byte
+// prepended, so both paths have to reproduce that for the keys to compare equal.
+TEST_F(SetHashSetTest, intersect_nullable_wide_row_round_trips) {
+    IntersectHashSerializeSet hash_set;
+    ASSERT_OK(hash_set.init(_runtime_state.get()));
+    MemPool pool;
+
+    auto nullable_wide = make_chunk({wide_value('a')}, true);
+    hash_set.build_set(_runtime_state.get(), nullable_wide, _exprs, &pool);
+    ASSERT_OK(hash_set.refine_intersect_row(_runtime_state.get(), nullable_wide, _exprs, 1));
+
+    size_t hit = 0;
+    for (auto it = hash_set.begin(); it != hash_set.end(); ++it) {
+        hit += (it->hit_times == 1);
+    }
+    ASSERT_EQ(1, hit);
+}
+
+TEST_F(SetHashSetTest, except_wide_row_takes_by_rows_path) {
+    ExceptHashSerializeSet hash_set;
+    ASSERT_OK(hash_set.init(_runtime_state.get()));
+    ExceptBufferState buffer_state;
+    ASSERT_OK(buffer_state.init(_runtime_state.get()));
+    MemPool pool;
+
+    auto wide_chunk = make_chunk({wide_value('a')}, false);
+    hash_set.build_set(_runtime_state.get(), wide_chunk, _exprs, &pool, &buffer_state);
+    ASSERT_EQ(1, hash_set.size());
+
+    // Erasing with the same value marks the row deleted; an unrelated value leaves it alone.
+    auto other_chunk = make_chunk({wide_value('b')}, false);
+    ASSERT_OK(hash_set.erase_duplicate_row(_runtime_state.get(), other_chunk, _exprs, &buffer_state));
+    for (auto it = hash_set.begin(); it != hash_set.end(); ++it) {
+        ASSERT_FALSE(it->deleted);
+    }
+
+    ASSERT_OK(hash_set.erase_duplicate_row(_runtime_state.get(), wide_chunk, _exprs, &buffer_state));
+    for (auto it = hash_set.begin(); it != hash_set.end(); ++it) {
+        ASSERT_TRUE(it->deleted);
+    }
+}
+
+TEST_F(SetHashSetTest, except_by_rows_and_batch_layouts_agree) {
+    ExceptHashSerializeSet hash_set;
+    ASSERT_OK(hash_set.init(_runtime_state.get()));
+    ExceptBufferState buffer_state;
+    ASSERT_OK(buffer_state.init(_runtime_state.get()));
+    MemPool pool;
+
+    const std::string wide = wide_value('a');
+    hash_set.build_set(_runtime_state.get(), make_chunk({wide}, false), _exprs, &pool, &buffer_state);
+    hash_set.build_set(_runtime_state.get(), make_chunk({"narrow"}, false), _exprs, &pool, &buffer_state);
+    ASSERT_EQ(2, hash_set.size());
+
+    // Built by rows, erased in a batch -- and the other way round.
+    ASSERT_OK(hash_set.erase_duplicate_row(_runtime_state.get(), make_chunk({"narrow"}, false), _exprs, &buffer_state));
+    ASSERT_OK(hash_set.erase_duplicate_row(_runtime_state.get(), make_chunk({wide}, false), _exprs, &buffer_state));
+
+    size_t deleted = 0;
+    for (auto it = hash_set.begin(); it != hash_set.end(); ++it) {
+        deleted += it->deleted;
+    }
+    ASSERT_EQ(2, deleted);
+}
+
+// Once a wide chunk has driven the stride up, a following narrow chunk must not inherit it: that
+// would keep every later chunk on the by-rows path for the rest of the query.
+TEST_F(SetHashSetTest, narrow_chunk_after_wide_chunk_still_matches) {
+    IntersectHashSerializeSet hash_set;
+    ASSERT_OK(hash_set.init(_runtime_state.get()));
+    MemPool pool;
+
+    hash_set.build_set(_runtime_state.get(), make_chunk({wide_value('a')}, false), _exprs, &pool);
+
+    std::vector<std::string> narrow_values;
+    narrow_values.reserve(kChunkSize);
+    for (size_t i = 0; i < kChunkSize; ++i) {
+        narrow_values.emplace_back("v" + std::to_string(i));
+    }
+    hash_set.build_set(_runtime_state.get(), make_chunk(narrow_values, false), _exprs, &pool);
+
+    ASSERT_OK(hash_set.refine_intersect_row(_runtime_state.get(), make_chunk(narrow_values, false), _exprs, 1));
+    size_t hit = 0;
+    for (auto it = hash_set.begin(); it != hash_set.end(); ++it) {
+        hit += (it->hit_times == 1);
+    }
+    ASSERT_EQ(kChunkSize, hit);
+}
+
+// The two serializations must produce the same keys for the same rows. Comparing them on ordinary
+// narrow data is only possible with the failpoint: naturally reaching the by-rows path takes a row
+// of half a megabyte, and at that size the interesting cases (nulls, empty strings, many rows in
+// one chunk) become impractical to build.
+TEST_F(SetHashSetTest, intersect_failpoint_by_rows_matches_batch) {
+    const std::vector<std::string> values = {"a", "", "bb", "ccc", std::string(1, '\0'), "a"};
+
+    IntersectHashSerializeSet batch_set;
+    ASSERT_OK(batch_set.init(_runtime_state.get()));
+    MemPool batch_pool;
+    batch_set.build_set(_runtime_state.get(), make_chunk(values, false), _exprs, &batch_pool);
+
+    IntersectHashSerializeSet by_rows_set;
+    ASSERT_OK(by_rows_set.init(_runtime_state.get()));
+    MemPool by_rows_pool;
+    {
+        ForceByRows guard("intersect_hash_set_force_by_rows");
+        by_rows_set.build_set(_runtime_state.get(), make_chunk(values, false), _exprs, &by_rows_pool);
+    }
+
+    ASSERT_EQ(keys_of(batch_set), keys_of(by_rows_set));
+
+    // And a key built one way has to be found the other way.
+    {
+        ForceByRows guard("intersect_hash_set_force_by_rows");
+        ASSERT_OK(batch_set.refine_intersect_row(_runtime_state.get(), make_chunk(values, false), _exprs, 1));
+    }
+    size_t hit = 0;
+    for (auto it = batch_set.begin(); it != batch_set.end(); ++it) {
+        hit += (it->hit_times == 1);
+    }
+    ASSERT_EQ(keys_of(batch_set).size(), hit);
+}
+
+TEST_F(SetHashSetTest, intersect_failpoint_by_rows_matches_batch_nullable) {
+    auto nullable_chunk = [this]() {
+        auto column = ColumnHelper::create_column(_varchar_type, true);
+        column->append_datum(Datum(Slice("a")));
+        column->append_nulls(1);
+        column->append_datum(Datum(Slice("")));
+        column->append_nulls(1);
+        auto chunk = std::make_shared<Chunk>();
+        chunk->append_column(std::move(column), 0);
+        return chunk;
+    };
+
+    IntersectHashSerializeSet batch_set;
+    ASSERT_OK(batch_set.init(_runtime_state.get()));
+    MemPool batch_pool;
+    batch_set.build_set(_runtime_state.get(), nullable_chunk(), _exprs, &batch_pool);
+
+    IntersectHashSerializeSet by_rows_set;
+    ASSERT_OK(by_rows_set.init(_runtime_state.get()));
+    MemPool by_rows_pool;
+    {
+        ForceByRows guard("intersect_hash_set_force_by_rows");
+        by_rows_set.build_set(_runtime_state.get(), nullable_chunk(), _exprs, &by_rows_pool);
+    }
+
+    ASSERT_EQ(keys_of(batch_set), keys_of(by_rows_set));
+}
+
+TEST_F(SetHashSetTest, except_failpoint_by_rows_matches_batch) {
+    const std::vector<std::string> values = {"a", "", "bb", "ccc", std::string(1, '\0'), "a"};
+
+    ExceptHashSerializeSet batch_set;
+    ASSERT_OK(batch_set.init(_runtime_state.get()));
+    ExceptBufferState batch_state;
+    ASSERT_OK(batch_state.init(_runtime_state.get()));
+    MemPool batch_pool;
+    batch_set.build_set(_runtime_state.get(), make_chunk(values, false), _exprs, &batch_pool, &batch_state);
+
+    ExceptHashSerializeSet by_rows_set;
+    ASSERT_OK(by_rows_set.init(_runtime_state.get()));
+    ExceptBufferState by_rows_state;
+    ASSERT_OK(by_rows_state.init(_runtime_state.get()));
+    MemPool by_rows_pool;
+    {
+        ForceByRows guard("except_hash_set_force_by_rows");
+        by_rows_set.build_set(_runtime_state.get(), make_chunk(values, false), _exprs, &by_rows_pool, &by_rows_state);
+    }
+
+    ASSERT_EQ(keys_of(batch_set), keys_of(by_rows_set));
+
+    // Built in a batch, erased by rows: every key must still be located.
+    {
+        ForceByRows guard("except_hash_set_force_by_rows");
+        ASSERT_OK(batch_set.erase_duplicate_row(_runtime_state.get(), make_chunk(values, false), _exprs, &batch_state));
+    }
+    size_t deleted = 0;
+    for (auto it = batch_set.begin(); it != batch_set.end(); ++it) {
+        deleted += it->deleted;
+    }
+    ASSERT_EQ(batch_set.size(), deleted);
+}
+
+// A full chunk through the by-rows path: the single-row buffer is rewritten for every row, so a
+// stale pointer or a missing reset would show up as lost or duplicated keys.
+TEST_F(SetHashSetTest, intersect_failpoint_by_rows_full_chunk) {
+    std::vector<std::string> values;
+    values.reserve(kChunkSize);
+    for (size_t i = 0; i < kChunkSize; ++i) {
+        values.emplace_back("value_" + std::to_string(i));
+    }
+
+    IntersectHashSerializeSet hash_set;
+    ASSERT_OK(hash_set.init(_runtime_state.get()));
+    MemPool pool;
+    {
+        ForceByRows guard("intersect_hash_set_force_by_rows");
+        hash_set.build_set(_runtime_state.get(), make_chunk(values, false), _exprs, &pool);
+        ASSERT_OK(hash_set.refine_intersect_row(_runtime_state.get(), make_chunk(values, false), _exprs, 1));
+    }
+
+    size_t hit = 0;
+    for (auto it = hash_set.begin(); it != hash_set.end(); ++it) {
+        hit += (it->hit_times == 1);
+    }
+    ASSERT_EQ(kChunkSize, hit);
+}
+
+} // namespace starrocks

--- a/test/sql/test_set_operation/R/test_by_row_serialization
+++ b/test/sql/test_set_operation/R/test_by_row_serialization
@@ -1,0 +1,96 @@
+-- name: test_set_operation_by_row_serialization @system @sequential
+CREATE TABLE `s1` (
+  `c1` int NULL,
+  `c2` varchar(64) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c1`)
+DISTRIBUTED BY HASH(`c1`) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE `s2` (
+  `c1` int NULL,
+  `c2` varchar(64) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c1`)
+DISTRIBUTED BY HASH(`c1`) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into s1 values (1, 'a'), (2, ''), (3, null), (4, 'dd'), (null, 'e');
+-- result:
+-- !result
+insert into s2 values (1, 'a'), (3, null), (5, 'ff');
+-- result:
+-- !result
+select * from (select c1, c2 from s1 intersect select c1, c2 from s2) t order by c1, c2;
+-- result:
+1	a
+3	None
+-- !result
+select * from (select c1, c2 from s1 except select c1, c2 from s2) t order by c1, c2;
+-- result:
+None	e
+2	
+4	dd
+-- !result
+admin enable failpoint 'intersect_hash_set_force_by_rows';
+-- result:
+-- !result
+admin enable failpoint 'except_hash_set_force_by_rows';
+-- result:
+-- !result
+select * from (select c1, c2 from s1 intersect select c1, c2 from s2) t order by c1, c2;
+-- result:
+1	a
+3	None
+-- !result
+select * from (select c1, c2 from s1 except select c1, c2 from s2) t order by c1, c2;
+-- result:
+None	e
+2	
+4	dd
+-- !result
+select * from (select c1, c2 from s1 intersect select c1, c2 from s2 intersect select c1, c2 from s1) t order by c1, c2;
+-- result:
+1	a
+3	None
+-- !result
+insert into s1 select generate_series, concat('v', generate_series) from table(generate_series(10, 5000));
+-- result:
+-- !result
+insert into s2 select generate_series, concat('v', generate_series) from table(generate_series(10, 5000));
+-- result:
+-- !result
+select count(*) from (select c1, c2 from s1 intersect select c1, c2 from s2) t;
+-- result:
+4993
+-- !result
+select count(*) from (select c1, c2 from s1 except select c1, c2 from s2) t;
+-- result:
+3
+-- !result
+admin disable failpoint 'intersect_hash_set_force_by_rows';
+-- result:
+-- !result
+admin disable failpoint 'except_hash_set_force_by_rows';
+-- result:
+-- !result
+select count(*) from (select c1, c2 from s1 intersect select c1, c2 from s2) t;
+-- result:
+4993
+-- !result
+select count(*) from (select c1, c2 from s1 except select c1, c2 from s2) t;
+-- result:
+3
+-- !result
+drop table s1;
+-- result:
+-- !result
+drop table s2;
+-- result:
+-- !result
+CLEANUP {
+  admin disable failpoint 'intersect_hash_set_force_by_rows';
+  admin disable failpoint 'except_hash_set_force_by_rows';
+} END CLEANUP

--- a/test/sql/test_set_operation/T/test_by_row_serialization
+++ b/test/sql/test_set_operation/T/test_by_row_serialization
@@ -1,0 +1,71 @@
+-- name: test_set_operation_by_row_serialization @system @sequential
+
+-- EXCEPT/INTERSECT serialize a chunk's key columns into a fixed-stride buffer sized
+-- max_one_row_size * chunk_size, so one very wide row prices the whole chunk: an
+-- ARRAY<ARRAY<BIGINT>> holding 5M sub-arrays serializes to ~70MB and 70MB * 4096 asked the
+-- MemPool for 512GB on a chunk that held a single row. Past INT32_MAX the operators now
+-- serialize row by row into a single-row buffer instead.
+--
+-- Reaching that bound with real data takes half a megabyte per row, which is too heavy for a
+-- regression case, so the failpoints take the branch on ordinary data. What has to hold is that
+-- both serializations produce the same keys: one query can take both paths, because a chunk
+-- holding a wide value goes by rows while the narrow chunks around it stay vectorized.
+
+CREATE TABLE `s1` (
+  `c1` int NULL,
+  `c2` varchar(64) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c1`)
+DISTRIBUTED BY HASH(`c1`) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+CREATE TABLE `s2` (
+  `c1` int NULL,
+  `c2` varchar(64) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c1`)
+DISTRIBUTED BY HASH(`c1`) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+-- Nulls and an empty string are the values whose serialized layout differs between the two
+-- paths (a nullable column writes its own null byte, a non-nullable one gets a false byte
+-- prepended), so they are the ones that would expose a mismatch.
+insert into s1 values (1, 'a'), (2, ''), (3, null), (4, 'dd'), (null, 'e');
+insert into s2 values (1, 'a'), (3, null), (5, 'ff');
+
+-- Baseline: the vectorized path.
+select * from (select c1, c2 from s1 intersect select c1, c2 from s2) t order by c1, c2;
+select * from (select c1, c2 from s1 except select c1, c2 from s2) t order by c1, c2;
+
+admin enable failpoint 'intersect_hash_set_force_by_rows';
+admin enable failpoint 'except_hash_set_force_by_rows';
+
+-- Same queries, serialized one row at a time. The results must be identical.
+select * from (select c1, c2 from s1 intersect select c1, c2 from s2) t order by c1, c2;
+select * from (select c1, c2 from s1 except select c1, c2 from s2) t order by c1, c2;
+
+-- INTERSECT over three inputs exercises refine_intersect_row's by-rows variant, which walks
+-- the hash set with hit_times rather than building it.
+select * from (select c1, c2 from s1 intersect select c1, c2 from s2 intersect select c1, c2 from s1) t order by c1, c2;
+
+-- A chunk larger than one row: the single-row buffer is rewritten for every row, so a stale
+-- pointer would show up here as lost or duplicated keys.
+insert into s1 select generate_series, concat('v', generate_series) from table(generate_series(10, 5000));
+insert into s2 select generate_series, concat('v', generate_series) from table(generate_series(10, 5000));
+select count(*) from (select c1, c2 from s1 intersect select c1, c2 from s2) t;
+select count(*) from (select c1, c2 from s1 except select c1, c2 from s2) t;
+
+admin disable failpoint 'intersect_hash_set_force_by_rows';
+admin disable failpoint 'except_hash_set_force_by_rows';
+
+-- And the vectorized path still agrees on the same, now larger, data.
+select count(*) from (select c1, c2 from s1 intersect select c1, c2 from s2) t;
+select count(*) from (select c1, c2 from s1 except select c1, c2 from s2) t;
+
+drop table s1;
+drop table s2;
+
+CLEANUP {
+  admin disable failpoint 'intersect_hash_set_force_by_rows';
+  admin disable failpoint 'except_hash_set_force_by_rows';
+} END CLEANUP


### PR DESCRIPTION
## Why I'm doing:

{Except,Intersect}HashSet size their serialization buffer as max_one_row_size * state->chunk_size(), where max_one_row_size is the widest row in the chunk. One fat row therefore prices the whole chunk: a single ARRAY<ARRAY<BIGINT>> holding 5M sub-arrays serializes to ~70MB, and 70MB * 4096 asked the MemPool for 512GB while the chunk held exactly one row. The query dies with "Memory of process exceed limit, try consume:549755813888", and on an ASan build the allocator aborts before any of that error handling runs and takes the BE down with it.

Fall back to serializing one row at a time into a single-row buffer once the batch buffer would exceed INT32_MAX, mirroring
AggHashMapWithSerializedKey::compute_agg_states. Resetting max_one_row_size to 0 on that branch matters: without it the fat row's stride sticks and every later chunk is forced down the by-rows path. The per-row layout matches _serialize_columns byte for byte -- a nullable column serializes its own null byte, a non-nullable one gets a false byte ahead of its value, as Column::serialize_batch_with_null_masks(..., nullptr, false) does -- so chunks may take either path within one query.

Also reserve SLICE_MEMEQUAL_OVERFLOW_PADDING in
ExceptHashSet::erase_duplicate_row, which shares the buffer with build_set and whose ExceptSliceFlagEqual reads past the key with SIMD.

Reaching the by-rows path for real takes half a megabyte per row, which puts nulls, empty strings, embedded NULs and a full 4096-row chunk out of practical reach -- the cases most likely to expose a layout mismatch. Add intersect_hash_set_force_by_rows and except_hash_set_force_by_rows to take the branch regardless of row width. The trigger sits outside the `cur > max_one_row_size` growth check on purpose: a narrow key never widens the stride, so testing it inside would leave the failpoint silently unable to fire. Without FIU_ENABLE the macro expands to nothing and `false || x` folds away, so release builds are unaffected.

The tests pin the property the two paths have to share: the same rows must serialize to the same keys either way. Six cases drive the natural threshold with 1MB rows, four use the failpoint to compare the layouts on ordinary data.

Found by:

  CREATE TABLE t1 (c1 INT, c2 ARRAY<BIGINT>);
  CREATE TABLE t2 (c1 INT, c2 ARRAY<ARRAY<BIGINT>>);
  INSERT INTO t1 SELECT generate_series, array_append([], generate_series)
    FROM TABLE(generate_series(1, 5000000));
  INSERT INTO t2 SELECT 1, array_agg(c2) FROM t1;
  SELECT array_length(array_distinct(t2.c2)) FROM
    (SELECT t2.c1, t2.c2 FROM t2 INTERSECT SELECT t2.c1, t2.c2 FROM t2) t2;

```
==3286242==ERROR: AddressSanitizer: out of memory: allocator is trying to allocate 0x8000000000 bytes
    #0 0x1c95563d in posix_memalign (/home/disk1/fha/sr-ws/fuzzrun/output/be/lib/starrocks_be+0x1c95563d)
    #1 0x2d647f69 in starrocks::SystemAllocator::allocate_via_malloc(unsigned long) be/src/runtime/memory/system_allocator.cpp:74
    #2 0x2d647c5a in starrocks::SystemAllocator::allocate(starrocks::MemTracker*, unsigned long) be/src/runtime/memory/system_allocator.cpp:53
    #3 0x2d64721d in starrocks::MemChunkAllocator::allocate(unsigned long, starrocks::MemChunk*) be/src/runtime/memory/mem_chunk_allocator.cpp:80
    #4 0x2d3e2474 in starrocks::MemPool::find_chunk(unsigned long, bool) be/src/runtime/mem_pool.cpp:140
    #5 0x1cd88180 in unsigned char* starrocks::MemPool::allocate<false>(long, int, int) be/src/runtime/mem_pool.h:222
    #6 0x1cd88180 in starrocks::MemPool::allocate(long) be/src/runtime/mem_pool.h:113
    #7 0x1ec4b5f2 in starrocks::ExceptHashSet<phmap::flat_hash_set<starrocks::ExceptSliceFlag, starrocks::ExceptSliceFlagHash, starrocks::ExceptSliceFlagEqual, std::allocator<starrocks::ExceptSliceFlag> > >::build_set(starrocks::R
untimeState*, std::shared_ptr<starrocks::Chunk> const&, std::vector<starrocks::ExprContext*, std::allocator<starrocks::ExprContext*> > const&, starrocks::MemPool*, starrocks::ExceptHashSet<phmap::flat_hash_set<starrocks::ExceptSli
ceFlag, starrocks::ExceptSliceFlagHash, starrocks::ExceptSliceFlagEqual, std::allocator<starrocks::ExceptSliceFlag> > >::BufferState*) be/src/exec/except_hash_set.cpp:44
    #8 0x1ec47d7c in starrocks::pipeline::ExceptContext::append_chunk_to_ht(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&, std::vector<starrocks::ExprContext*, std::allocator<starrocks::ExprContext*> > const&,
 starrocks::ExceptHashSet<phmap::flat_hash_set<starrocks::ExceptSliceFlag, starrocks::ExceptSliceFlagHash, starrocks::ExceptSliceFlagEqual, std::allocator<starrocks::ExceptSliceFlag> > >::BufferState*) be/src/exec/pipeline/set/exc
ept_context.cpp:68
    #9 0x1ec3d763 in starrocks::pipeline::ExceptBuildSinkOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&) be/src/exec/pipeline/set/except_build_sink_operator.cpp:26
    #10 0x23601a6b in starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int) be/src/exec/runtime/pipeline_driver.cpp:480
    #11 0x1e558f86 in starrocks::pipeline::GlobalDriverExecutor::_worker_thread() be/src/exec/pipeline/pipeline_driver_executor.cpp:180
    #12 0x1e557333 in operator() be/src/exec/pipeline/pipeline_driver_executor.cpp:71
    #13 0x1e55eeef in __invoke_impl<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::<lambda()>&> /opt/gcc-toolset-14/include/c++/14.3.0/bits/invoke.h:61
    #14 0x1e55e635 in __invoke_r<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::<lambda()>&> /opt/gcc-toolset-14/include/c++/14.3.0/bits/invoke.h:111
    #15 0x1e55e105 in _M_invoke /opt/gcc-toolset-14/include/c++/14.3.0/bits/std_function.h:290
    #16 0x1ca5ab21 in std::function<void ()>::operator()() const /opt/gcc-toolset-14/include/c++/14.3.0/bits/std_function.h:591
    #17 0x2e293d15 in starrocks::FunctionRunnable::run() be/src/common/thread/threadpool.cpp:68
    #18 0x2e28db1b in starrocks::ThreadPool::dispatch_thread() be/src/common/thread/threadpool.cpp:689
    #19 0x2e2aefb5 in void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /opt/gcc-toolset-14/include/
c++/14.3.0/bits/invoke.h:74

```


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
