### PR TITLE
[BugFix] Keep array_agg's nullable result column consistent when finalize fails

### DIFF
--- a/be/src/exprs/agg/array_agg.h
+++ b/be/src/exprs/agg/array_agg.h
@@ -515,8 +515,14 @@ public:
 
     // finalize each state->column to a [nullable] array
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
+        // The null flag of the current row is appended before the array row itself is built, so an
+        // error path may return with `to` half-written: its null column holds one more entry than
+        // its data column. Roll back to the row count observed on entry before appending the
+        // placeholder row, otherwise append_default() would widen the gap instead of closing it.
+        const size_t orig_num_rows = to != nullptr ? to->size() : 0;
         auto defer = DeferOp([&]() {
             if (ctx->has_error() && to != nullptr) {
+                to->resize(orig_num_rows);
                 to->append_default();
             }
         });

--- a/be/test/exprs/agg/aggregate_test.cpp
+++ b/be/test/exprs/agg/aggregate_test.cpp
@@ -2175,6 +2175,55 @@ TEST_F(AggregateTest, test_array_aggV2) {
     }
 }
 
+// finalize_to_column() appends the null flag of the current row before the array row is built, so a
+// cancellation detected while sorting the order-by columns used to leave the nullable result column
+// with one more null flag than array rows, and the error placeholder appended on top of it.
+TEST_F(AggregateTest, test_array_aggV2_cancelled_keeps_nullable_result_consistent) {
+    std::vector<TypeDescriptor> arg_types = {TypeDescriptor::from_logical_type(TYPE_VARCHAR),
+                                             TypeDescriptor::from_logical_type(TYPE_INT)};
+    auto return_type = TypeDescriptor::from_logical_type(TYPE_ARRAY);
+    std::unique_ptr<RuntimeState> runtime_state = std::make_unique<RuntimeState>();
+    std::unique_ptr<FunctionContext> local_ctx(FunctionContext::create_test_context(std::move(arg_types), return_type));
+    std::vector<bool> is_asc_order{true};
+    std::vector<bool> nulls_first{true};
+    local_ctx->set_is_asc_order(is_asc_order);
+    local_ctx->set_nulls_first(nulls_first);
+    local_ctx->set_runtime_state(runtime_state.get());
+
+    const AggregateFunction* array_agg_func = get_aggregate_function("array_agg2", TYPE_BIGINT, TYPE_ARRAY, false);
+    auto state = ManagedAggrState::create(local_ctx.get(), array_agg_func);
+
+    auto char_type = TypeDescriptor::create_varchar_type(30);
+    MutableColumnPtr char_column = ColumnHelper::create_column(char_type, true);
+    char_column->append_datum("a");
+    char_column->append_datum("b");
+
+    MutableColumnPtr int_column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_INT), true);
+    int_column->append_datum(2);
+    int_column->append_datum(1);
+
+    std::vector<const Column*> raw_columns{char_column.get(), int_column.get()};
+    array_agg_func->update_batch_single_state(local_ctx.get(), int_column->size(), raw_columns.data(), state->state());
+
+    TypeDescriptor type_array_char;
+    type_array_char.type = LogicalType::TYPE_ARRAY;
+    type_array_char.children.emplace_back(LogicalType::TYPE_VARCHAR);
+    // a nullable result column is what the aggregator hands over when the output slot is nullable
+    MutableColumnPtr res_array_col = ColumnHelper::create_column(type_array_char, true);
+    res_array_col->append_datum(DatumArray{Slice("kept")});
+
+    local_ctx->state()->set_is_cancelled(true);
+    array_agg_func->finalize_to_column(local_ctx.get(), state->state(), res_array_col.get());
+    ASSERT_TRUE(local_ctx->has_error());
+
+    // exactly one placeholder row for this state, and null/data columns still agree
+    auto* nullable_col = down_cast<NullableColumn*>(res_array_col.get());
+    ASSERT_EQ(2, nullable_col->null_column()->size());
+    ASSERT_EQ(2, nullable_col->data_column()->size());
+    ASSERT_EQ(2, res_array_col->size());
+    ASSERT_TRUE(res_array_col->is_null(1));
+}
+
 TEST_F(AggregateTest, test_array_aggV2_multi_order_by) {
     // Test array_agg2 with multiple ORDER BY columns
     // array_agg(varchar_col order by int_col, varchar_col2)


### PR DESCRIPTION
## Why I'm doing:

ArrayAggAggregateFunctionV2::finalize_to_column() appends the null flag of the row it is about to produce long before it appends the array row itself. A cancellation detected while sorting the order-by columns, or a failing sort_and_tie_columns(), returns in between and leaves the nullable result column with one more entry in its null column than in its data column. The DeferOp then calls append_default(), which grows the data column first and the null column second, turning the gap into a CHECK failure in NullableColumn::append_nulls() that kills the BE:

  Check failed: _null_column->size() == _data_column->size() (5 vs. 4)

```
*** SIGABRT (@0x226b47) received by PID 2255687 (TID 0x7f1835a2c6c0) LWP(2256401) from PID 2255687; stack trace: ***
    @         0x32df86c7 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7f1b2d825ed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)
    @         0x32df7ec6 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f1b2d7c9330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @     0x7f1b2d822b2c pthread_kill
    @     0x7f1b2d7c927e gsignal
    @     0x7f1b2d7ac8ff abort
    @         0x1cbce05a starrocks::failure_function()
    @         0x32debfdd google::LogMessage::Fail()
    @         0x32ded0c4 google::LogMessageFatal::~LogMessageFatal()
    @         0x2db3bea7 starrocks::NullableColumn::append_nulls(unsigned long)
    @         0x2db47359 starrocks::NullableColumn::append_default()
    @         0x2867fe96 starrocks::ArrayAggAggregateFunctionV2<starrocks::ArrayAggAggregateStateV2>::finalize_to_column(starrocks::FunctionContext*, unsigned char const*, starrocks::Column*) const::{lambda()#1}::operator()() const
    @         0x286f3aa6 starrocks::DeferOp<starrocks::ArrayAggAggregateFunctionV2<starrocks::ArrayAggAggregateStateV2>::finalize_to_column(starrocks::FunctionContext*, unsigned char const*, starrocks::Column*) const::{lambda()#1}>::~DeferOp()
    @         0x28681911 starrocks::ArrayAggAggregateFunctionV2<starrocks::ArrayAggAggregateStateV2>::finalize_to_column(starrocks::FunctionContext*, unsigned char const*, starrocks::Column*) const
    @         0x28681e32 starrocks::AggregateFunctionBatchHelper<starrocks::ArrayAggAggregateStateV2, starrocks::ArrayAggAggregateFunctionV2<starrocks::ArrayAggAggregateStateV2> >::batch_finalize(starrocks::FunctionContext*, unsigned long, std::vector<unsigned char*, starrocks::Co@

```

Record the row count on entry and roll back to it before appending the placeholder row, so any error path leaves the column consistent. This also keeps the row count right when the context already carried an error on entry: previously every remaining state appended both a complete row and a placeholder one.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
