### PR TITLE
[Enhancement] Optimize peak memory of `LAG ... IGNORE NULLS`

### DIFF
--- a/be/src/bench/CMakeLists.txt
+++ b/be/src/bench/CMakeLists.txt
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ADD_BE_BENCH(${SRC_DIR}/bench/analytor_lag_bench)
 ADD_BE_BENCH(${SRC_DIR}/bench/chunks_sorter_bench)
 ADD_BE_BENCH(${SRC_DIR}/bench/agg_hash_map_bench)
 ADD_BE_BENCH(${SRC_DIR}/bench/runtime_filter_bench)

--- a/be/src/bench/analytor_lag_bench.cpp
+++ b/be/src/bench/analytor_lag_bench.cpp
@@ -14,7 +14,7 @@
 
 // Benchmark: peak input-buffer retention of `lag(col, 1) IGNORE NULLS` in the Analytor operator,
 // comparing the legacy whole-partition materializing path against the streaming + watermark-eviction
-// path (config::pipeline_analytic_enable_lag_ignore_nulls_streaming).
+// path (config::pipeline_analytic_enable_ignore_nulls_streaming).
 //
 // The headline metric is the profile counter `PeakBufferedRows` (high-water-mark of rows retained in
 // Analytor::_input_chunks), reported as a custom benchmark counter. Wall-clock time is incidental.
@@ -107,7 +107,7 @@ static ColumnPtr make_value_chunk_column(Pattern pattern, int64_t begin, int64_t
 static void BM_LagIgnoreNulls(benchmark::State& bstate, Pattern pattern, bool streaming) {
     for (auto _ : bstate) {
         bstate.PauseTiming();
-        config::pipeline_analytic_enable_lag_ignore_nulls_streaming = streaming;
+        config::pipeline_analytic_enable_ignore_nulls_streaming = streaming;
         // Fine-grained eviction so PeakBufferedRows reflects the algorithmic bound rather than the
         // eviction batch size (default 128 chunks would otherwise set a ~128-chunk floor).
         config::pipeline_analytic_removable_chunk_num = 4;

--- a/be/src/bench/analytor_lag_bench.cpp
+++ b/be/src/bench/analytor_lag_bench.cpp
@@ -1,0 +1,202 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Benchmark: peak input-buffer retention of `lag(col, 1) IGNORE NULLS` in the Analytor operator,
+// comparing the legacy whole-partition materializing path against the streaming + watermark-eviction
+// path (config::pipeline_analytic_enable_lag_ignore_nulls_streaming).
+//
+// The headline metric is the profile counter `PeakBufferedRows` (high-water-mark of rows retained in
+// Analytor::_input_chunks), reported as a custom benchmark counter. Wall-clock time is incidental.
+//
+// Data patterns (single partition, so the whole input is one partition):
+//   ALL_NULL        - column is entirely NULL.  Streaming: target never set -> evicts to ~chunk.
+//   DENSE           - every row non-null.        Streaming: target tracks current -> evicts to ~chunk.
+//   SPARSE          - one non-null every G rows.  Streaming: retains ~G rows (target lags one gap).
+//   HEAD_THEN_NULL  - row 0 non-null, rest NULL.  Streaming: target PINNED at 0 -> no eviction (the
+//                     documented caveat; only value-caching would fix this one).
+// Legacy (materializing) always retains the whole partition regardless of pattern.
+//
+// NOTE: exercises the real Analytor with a hand-built analytic TPlanNode. Validated by construction;
+// must be compiled/run in a StarRocks BE build. The Thrift construction is isolated in
+// thrift_bench_util.h.
+
+#include <benchmark/benchmark.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "bench/thrift_bench_util.h"
+#include "column/chunk.h"
+#include "column/column_helper.h"
+#include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
+#include "common/config_exec_flow_fwd.h"
+#include "common/config_exec_fwd.h"
+#include "common/runtime_profile.h"
+#include "exec/analytor.h"
+#include "runtime/descriptor_helper.h"
+#include "runtime/descriptors.h"
+#include "runtime/mem_pool.h"
+#include "runtime/memory/mem_chunk_allocator.h"
+#include "runtime/runtime_state.h"
+#include "types/logical_type.h"
+#include "util/cpu_info.h"
+#include "util/starrocks_metrics.h"
+
+namespace starrocks {
+
+enum Pattern { ALL_NULL = 0, DENSE = 1, SPARSE = 2, HEAD_THEN_NULL = 3 };
+
+static constexpr int64_t kRows = 1 << 20; // ~1M rows total
+static constexpr int64_t kChunk = 4096;   // rows per chunk fed to the operator
+static constexpr int64_t kSparseGap = 64; // one non-null every kSparseGap rows for SPARSE
+
+static TPlanNode make_lag_plan_node(TupleId input_tuple_id, SlotId value_slot_id, int64_t offset) {
+    const TTypeDesc int_type = bench::make_scalar_type(TPrimitiveType::INT);
+    TExpr lag = bench::make_builtin_aggregate_expr(
+            "lag", {int_type}, int_type,
+            {bench::make_slot_ref_expr(input_tuple_id, value_slot_id, int_type),
+             bench::make_bigint_literal_expr(offset), bench::make_null_literal_expr(int_type)},
+            true);
+    TAnalyticWindow window = bench::make_rows_window(
+            std::nullopt, bench::make_rows_offset_boundary(TAnalyticWindowBoundaryType::PRECEDING, offset));
+    return bench::make_analytic_plan_node({lag}, input_tuple_id, window);
+}
+
+// A nullable INT32 column for global rows [begin, begin+count) under the given pattern.
+static ColumnPtr make_value_chunk_column(Pattern pattern, int64_t begin, int64_t count) {
+    auto data = Int32Column::create();
+    auto nulls = NullColumn::create();
+    for (int64_t i = 0; i < count; ++i) {
+        const int64_t g = begin + i;
+        bool is_null;
+        switch (pattern) {
+        case ALL_NULL:
+            is_null = true;
+            break;
+        case DENSE:
+            is_null = false;
+            break;
+        case SPARSE:
+            is_null = (g % kSparseGap != 0);
+            break;
+        case HEAD_THEN_NULL:
+        default:
+            is_null = (g != 0);
+            break;
+        }
+        data->append(is_null ? 0 : static_cast<int32_t>(g));
+        nulls->append(is_null ? 1 : 0);
+    }
+    return NullableColumn::create(std::move(data), std::move(nulls));
+}
+
+static void BM_LagIgnoreNulls(benchmark::State& bstate, Pattern pattern, bool streaming) {
+    for (auto _ : bstate) {
+        bstate.PauseTiming();
+        config::pipeline_analytic_enable_lag_ignore_nulls_streaming = streaming;
+        // Fine-grained eviction so PeakBufferedRows reflects the algorithmic bound rather than the
+        // eviction batch size (default 128 chunks would otherwise set a ~128-chunk floor).
+        config::pipeline_analytic_removable_chunk_num = 4;
+
+        ObjectPool pool;
+        TDescriptorTableBuilder dtb;
+        {
+            TTupleDescriptorBuilder in_tuple;
+            in_tuple.add_slot(TSlotDescriptorBuilder().type(TYPE_INT).nullable(true).column_name("v").build());
+            in_tuple.build(&dtb);
+            TTupleDescriptorBuilder out_tuple;
+            out_tuple.add_slot(TSlotDescriptorBuilder().type(TYPE_INT).nullable(true).column_name("lag_v").build());
+            out_tuple.build(&dtb);
+        }
+        auto* state = pool.add(new RuntimeState(TUniqueId(), TQueryOptions(), TQueryGlobals(), nullptr));
+        DescriptorTbl* desc_tbl = nullptr;
+        CHECK(DescriptorTbl::create(state, &pool, dtb.desc_tbl(), &desc_tbl, config::vector_chunk_size).ok());
+        state->set_desc_tbl(desc_tbl);
+        state->init_instance_mem_tracker();
+
+        const TupleId in_tuple_id = 0;
+        const TupleId out_tuple_id = 1;
+        const SlotId col_slot_id = desc_tbl->get_tuple_descriptor(in_tuple_id)->slots()[0]->id();
+        TupleDescriptor* result_tuple = desc_tbl->get_tuple_descriptor(out_tuple_id);
+
+        TPlanNode tnode = make_lag_plan_node(in_tuple_id, col_slot_id, 1);
+        RuntimeProfile profile("Analytor");
+
+        auto analytor = std::make_shared<Analytor>(tnode, result_tuple, false);
+        CHECK(analytor->prepare(state, &pool, &profile).ok());
+        CHECK(analytor->open(state).ok());
+
+        bstate.ResumeTiming();
+
+        int64_t fed = 0;
+        while (fed < kRows) {
+            const int64_t n = std::min<int64_t>(kChunk, kRows - fed);
+            auto chunk = std::make_shared<Chunk>();
+            chunk->append_column(make_value_chunk_column(pattern, fed, n), col_slot_id);
+            CHECK(analytor->process(state, chunk).ok());
+            fed += n;
+            // Drain output so the OUTPUT buffer does not dominate; we measure INPUT retention.
+            while (ChunkPtr out = analytor->poll_chunk_buffer()) {
+                benchmark::DoNotOptimize(out);
+            }
+        }
+        CHECK(analytor->finish_process(state).ok());
+        while (ChunkPtr out = analytor->poll_chunk_buffer()) {
+            benchmark::DoNotOptimize(out);
+        }
+
+        bstate.PauseTiming();
+        auto* peak = profile.get_counter("PeakBufferedRows");
+        auto* evicted = profile.get_counter("RemoveUnusedRowsCount");
+        const double peak_rows = peak ? static_cast<double>(peak->value()) : -1;
+        bstate.counters["PeakRows"] = peak_rows;
+        // nullable int32 ~ 4 bytes data + 1 byte null flag per row
+        bstate.counters["PeakMiB"] = peak_rows * 5.0 / (1024.0 * 1024.0);
+        bstate.counters["Evictions"] = evicted ? static_cast<double>(evicted->value()) : 0;
+
+        analytor->close(state);
+        bstate.ResumeTiming();
+    }
+}
+
+BENCHMARK_CAPTURE(BM_LagIgnoreNulls, all_null_legacy, ALL_NULL, false)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(BM_LagIgnoreNulls, dense_legacy, DENSE, false)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(BM_LagIgnoreNulls, sparse_legacy, SPARSE, false)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(BM_LagIgnoreNulls, head_then_null_legacy, HEAD_THEN_NULL, false)->Unit(benchmark::kMillisecond);
+
+BENCHMARK_CAPTURE(BM_LagIgnoreNulls, all_null_streaming, ALL_NULL, true)->Unit(benchmark::kMillisecond)->Iterations(1);
+BENCHMARK_CAPTURE(BM_LagIgnoreNulls, dense_streaming, DENSE, true)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(BM_LagIgnoreNulls, sparse_streaming, SPARSE, true)->Unit(benchmark::kMillisecond);
+BENCHMARK_CAPTURE(BM_LagIgnoreNulls, head_then_null_streaming, HEAD_THEN_NULL, true)->Unit(benchmark::kMillisecond);
+
+} // namespace starrocks
+
+int main(int argc, char** argv) {
+    // Standalone benchmarks do not run the BE's GlobalEnv initialization, which normally creates
+    // the process-wide allocator used by MemPool or load config defaults. Analytor::open() allocates
+    // its aggregate state from a MemPool, and its processing mode depends on those config defaults.
+    if (!starrocks::config::init(nullptr)) return 1;
+    starrocks::CpuInfo::init();
+    starrocks::StarRocksMetrics::instance()->initialize();
+    starrocks::MemChunkAllocator::init_instance(nullptr, starrocks::config::chunk_reserved_bytes_limit);
+
+    ::benchmark::Initialize(&argc, argv);
+    if (::benchmark::ReportUnrecognizedArguments(argc, argv)) return 1;
+    ::benchmark::RunSpecifiedBenchmarks();
+    ::benchmark::Shutdown();
+    return 0;
+}

--- a/be/src/bench/thrift_bench_util.h
+++ b/be/src/bench/thrift_bench_util.h
@@ -1,0 +1,153 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "common/global_types.h"
+#include "gen_cpp/Exprs_types.h"
+#include "gen_cpp/PlanNodes_types.h"
+#include "gen_cpp/Types_types.h"
+
+namespace starrocks::bench {
+
+inline TTypeDesc make_scalar_type(TPrimitiveType::type type) {
+    TTypeDesc desc;
+    TTypeNode node;
+    node.__set_type(TTypeNodeType::SCALAR);
+    TScalarType scalar;
+    scalar.__set_type(type);
+    node.__set_scalar_type(scalar);
+    desc.types.push_back(node);
+    return desc;
+}
+
+inline TExpr make_slot_ref_expr(TupleId tuple_id, SlotId slot_id, const TTypeDesc& type, bool nullable = true) {
+    TExprNode node;
+    node.__set_node_type(TExprNodeType::SLOT_REF);
+    node.__set_type(type);
+    node.__set_num_children(0);
+    node.__set_is_nullable(nullable);
+    TSlotRef slot_ref;
+    slot_ref.__set_slot_id(slot_id);
+    slot_ref.__set_tuple_id(tuple_id);
+    node.__set_slot_ref(slot_ref);
+
+    TExpr expr;
+    expr.nodes.push_back(std::move(node));
+    return expr;
+}
+
+inline TExpr make_bigint_literal_expr(int64_t value) {
+    TExprNode node;
+    node.__set_node_type(TExprNodeType::INT_LITERAL);
+    node.__set_type(make_scalar_type(TPrimitiveType::BIGINT));
+    node.__set_num_children(0);
+    node.__set_is_nullable(false);
+    TIntLiteral literal;
+    literal.__set_value(value);
+    node.__set_int_literal(literal);
+
+    TExpr expr;
+    expr.nodes.push_back(std::move(node));
+    return expr;
+}
+
+inline TExpr make_null_literal_expr(const TTypeDesc& type) {
+    TExprNode node;
+    node.__set_node_type(TExprNodeType::NULL_LITERAL);
+    node.__set_type(type);
+    node.__set_num_children(0);
+    node.__set_is_nullable(true);
+
+    TExpr expr;
+    expr.nodes.push_back(std::move(node));
+    return expr;
+}
+
+inline TExpr make_builtin_aggregate_expr(const std::string& function_name,
+                                         const std::vector<TTypeDesc>& function_arg_types, const TTypeDesc& return_type,
+                                         const std::vector<TExpr>& arguments, bool ignore_nulls = false,
+                                         bool nullable = true) {
+    TExprNode aggregate;
+    aggregate.__set_node_type(TExprNodeType::AGG_EXPR);
+    aggregate.__set_num_children(arguments.size());
+    aggregate.__set_type(return_type);
+    aggregate.__set_has_nullable_child(nullable);
+    aggregate.__set_is_nullable(nullable);
+
+    TAggregateExpr aggregate_expr;
+    aggregate_expr.__set_is_merge_agg(false);
+    aggregate.__set_agg_expr(aggregate_expr);
+
+    TFunction function;
+    TFunctionName name;
+    name.__set_function_name(function_name);
+    function.__set_name(name);
+    function.__set_binary_type(TFunctionBinaryType::BUILTIN);
+    function.__set_arg_types(function_arg_types);
+    function.__set_ret_type(return_type);
+    function.__set_has_var_args(false);
+    function.__set_ignore_nulls(ignore_nulls);
+    aggregate.__set_fn(function);
+
+    TExpr expr;
+    expr.nodes.push_back(std::move(aggregate));
+    for (const auto& argument : arguments) {
+        expr.nodes.insert(expr.nodes.end(), argument.nodes.begin(), argument.nodes.end());
+    }
+    return expr;
+}
+
+inline TAnalyticWindowBoundary make_rows_offset_boundary(TAnalyticWindowBoundaryType::type type, int64_t offset) {
+    TAnalyticWindowBoundary boundary;
+    boundary.__set_type(type);
+    boundary.__set_rows_offset_value(offset);
+    return boundary;
+}
+
+inline TAnalyticWindow make_rows_window(const std::optional<TAnalyticWindowBoundary>& start,
+                                        const std::optional<TAnalyticWindowBoundary>& end) {
+    TAnalyticWindow window;
+    window.__set_type(TAnalyticWindowType::ROWS);
+    if (start.has_value()) {
+        window.__set_window_start(start.value());
+    }
+    if (end.has_value()) {
+        window.__set_window_end(end.value());
+    }
+    return window;
+}
+
+inline TPlanNode make_analytic_plan_node(const std::vector<TExpr>& analytic_functions, TupleId buffered_tuple_id,
+                                         const TAnalyticWindow& window, int32_t node_id = 0, int64_t limit = -1) {
+    TAnalyticNode analytic_node;
+    analytic_node.__set_window(window);
+    analytic_node.__set_buffered_tuple_id(buffered_tuple_id);
+    analytic_node.__set_analytic_functions(analytic_functions);
+
+    TPlanNode plan_node;
+    plan_node.__set_node_id(node_id);
+    plan_node.__set_node_type(TPlanNodeType::ANALYTIC_EVAL_NODE);
+    plan_node.__set_limit(limit);
+    plan_node.__set_analytic_node(analytic_node);
+    return plan_node;
+}
+
+} // namespace starrocks::bench

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1223,7 +1223,7 @@ CONF_Int32(pipeline_analytic_max_buffer_size, "128");
 CONF_Int32(pipeline_analytic_removable_chunk_num, "128");
 CONF_Bool(pipeline_analytic_enable_streaming_process, "true");
 CONF_mBool(pipeline_analytic_enable_removable_cumulative_process, "true");
-// `lag(... ) IGNORE NULLS` only looks backward, so it can be evaluated in streaming mode with
+// `window_fun(... ) IGNORE NULLS` can be evaluated in streaming mode with
 // watermark-based eviction of the input buffer instead of materializing the whole partition.
 // Set to false to fall back to the legacy whole-partition materializing behavior.
 CONF_mBool(pipeline_analytic_enable_ignore_nulls_streaming, "true");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1223,6 +1223,10 @@ CONF_Int32(pipeline_analytic_max_buffer_size, "128");
 CONF_Int32(pipeline_analytic_removable_chunk_num, "128");
 CONF_Bool(pipeline_analytic_enable_streaming_process, "true");
 CONF_mBool(pipeline_analytic_enable_removable_cumulative_process, "true");
+// `lag(... ) IGNORE NULLS` only looks backward, so it can be evaluated in streaming mode with
+// watermark-based eviction of the input buffer instead of materializing the whole partition.
+// Set to false to fall back to the legacy whole-partition materializing behavior.
+CONF_mBool(pipeline_analytic_enable_lag_ignore_nulls_streaming, "true");
 CONF_Int32(pipline_limit_max_delivery, "4096");
 
 // only used in DCHECK

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1226,7 +1226,7 @@ CONF_mBool(pipeline_analytic_enable_removable_cumulative_process, "true");
 // `lag(... ) IGNORE NULLS` only looks backward, so it can be evaluated in streaming mode with
 // watermark-based eviction of the input buffer instead of materializing the whole partition.
 // Set to false to fall back to the legacy whole-partition materializing behavior.
-CONF_mBool(pipeline_analytic_enable_lag_ignore_nulls_streaming, "true");
+CONF_mBool(pipeline_analytic_enable_ignore_nulls_streaming, "true");
 CONF_Int32(pipline_limit_max_delivery, "4096");
 
 // only used in DCHECK

--- a/be/src/common/config_exec_flow_fwd.h
+++ b/be/src/common/config_exec_flow_fwd.h
@@ -113,6 +113,11 @@ CONF_Bool(pipeline_analytic_enable_streaming_process, "true");
 
 CONF_mBool(pipeline_analytic_enable_removable_cumulative_process, "true");
 
+// `lag(... ) IGNORE NULLS` only looks backward, so it can be evaluated in streaming mode with
+// watermark-based eviction of the input buffer instead of materializing the whole partition.
+// Set to false to fall back to the legacy whole-partition materializing behavior.
+CONF_mBool(pipeline_analytic_enable_lag_ignore_nulls_streaming, "true");
+
 CONF_Int32(pipline_limit_max_delivery, "4096");
 
 // the maximum number of connections in the connection pool for a single jdbc url

--- a/be/src/common/config_exec_flow_fwd.h
+++ b/be/src/common/config_exec_flow_fwd.h
@@ -113,10 +113,10 @@ CONF_Bool(pipeline_analytic_enable_streaming_process, "true");
 
 CONF_mBool(pipeline_analytic_enable_removable_cumulative_process, "true");
 
-// `lag(... ) IGNORE NULLS` only looks backward, so it can be evaluated in streaming mode with
+// `window_fun(... ) IGNORE NULLS` can be evaluated in streaming mode with
 // watermark-based eviction of the input buffer instead of materializing the whole partition.
 // Set to false to fall back to the legacy whole-partition materializing behavior.
-CONF_mBool(pipeline_analytic_enable_lag_ignore_nulls_streaming, "true");
+CONF_mBool(pipeline_analytic_enable_ignore_nulls_streaming, "true");
 
 CONF_Int32(pipline_limit_max_delivery, "4096");
 

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -160,7 +160,7 @@
         "pipeline_analytic_removable_chunk_num",
         "pipeline_analytic_enable_streaming_process",
         "pipeline_analytic_enable_removable_cumulative_process",
-        "pipeline_analytic_enable_lag_ignore_nulls_streaming",
+        "pipeline_analytic_enable_ignore_nulls_streaming",
         "pipline_limit_max_delivery",
         "jdbc_connection_pool_size",
         "jdbc_minimum_idle_connections",

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -160,6 +160,7 @@
         "pipeline_analytic_removable_chunk_num",
         "pipeline_analytic_enable_streaming_process",
         "pipeline_analytic_enable_removable_cumulative_process",
+        "pipeline_analytic_enable_lag_ignore_nulls_streaming",
         "pipline_limit_max_delivery",
         "jdbc_connection_pool_size",
         "jdbc_minimum_idle_connections",

--- a/be/src/exec/analytor.cpp
+++ b/be/src/exec/analytor.cpp
@@ -306,7 +306,7 @@ Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* 
                 // materializing the whole partition.
                 // `lead ... IGNORE NULLS` and `first_value`/`last_value` IGNORE NULLS still require the full materialized data.
                 const bool is_lag_ignore_nulls = (fname == "lag");
-                if (!(is_lag_ignore_nulls && config::pipeline_analytic_enable_lag_ignore_nulls_streaming)) {
+                if (!(is_lag_ignore_nulls && config::pipeline_analytic_enable_ignore_nulls_streaming)) {
                     _need_partition_materializing = true;
                 }
             }

--- a/be/src/exec/analytor.cpp
+++ b/be/src/exec/analytor.cpp
@@ -295,16 +295,21 @@ Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* 
             // we should always use nullable aggregate function.
             is_input_nullable = true;
             const AggregateFunction* func = nullptr;
+            const auto& fname = fn.name.function_name;
             std::string real_fn_name = fn.name.function_name;
             if (fn.ignore_nulls) {
-                DCHECK(fn.name.function_name == "first_value" || fn.name.function_name == "last_value" ||
-                       fn.name.function_name == "lead" || fn.name.function_name == "lag");
+                DCHECK(fname == "first_value" || fname == "last_value" || fname == "lead" || fname == "lag");
                 // "in" means "ignore nulls", we use first_value_in/last_value_in instead of first_value/last_value
                 // to find right AggregateFunction to support ignore nulls.
                 real_fn_name += "_in";
-                _need_partition_materializing = true;
+                // `lag ... IGNORE NULLS` only looks backward, so it can run in streaming mode instead of
+                // materializing the whole partition.
+                // `lead ... IGNORE NULLS` and `first_value`/`last_value` IGNORE NULLS still require the full materialized data.
+                const bool is_lag_ignore_nulls = (fname == "lag");
+                if (!(is_lag_ignore_nulls && config::pipeline_analytic_enable_lag_ignore_nulls_streaming)) {
+                    _need_partition_materializing = true;
+                }
             }
-            const auto& fname = fn.name.function_name;
             auto real_arg_type = arg_type.type;
             if (fname == "max_by" || fname == "min_by" || fname == "max_by_v2" || fname == "min_by_v2") {
                 const TypeDescriptor arg1_type = TypeDescriptor::from_thrift(fn.arg_types[1]);
@@ -865,6 +870,20 @@ void Analytor::_remove_unused_rows(RuntimeState* state) {
         const int64_t referenced_position =
                 _is_range_window ? _current_row_position : std::min(_current_row_position, _get_frame_for_rows().end);
         if (_get_global_position(referenced_position) <= remove_end_position) {
+            return;
+        }
+    }
+
+    // Respect per-function look-back watermarks (e.g. `lag ... IGNORE NULLS`, whose oldest needed
+    // row can be earlier than the frame bound when NULLs are skipped).
+    for (size_t i = 0; i < _agg_functions.size(); i++) {
+        const std::optional<int64_t> min_retained_position_opt = _agg_functions[i]->get_min_retained_position(
+                _agg_fn_ctxs[i], _managed_fn_states[0]->data() + _agg_states_offsets[i]);
+
+        // We can not remove any rows that the aggregation still needs.
+        // N.B.: `remove_end_position` is exclusive, so a `<` is appropriate.
+        if (min_retained_position_opt.has_value() &&
+            _get_global_position(min_retained_position_opt.value()) < remove_end_position) {
             return;
         }
     }

--- a/be/src/exprs/agg/aggregate.h
+++ b/be/src/exprs/agg/aggregate.h
@@ -190,6 +190,16 @@ public:
     // this information should be updated as well.
     virtual void reset_state_for_contraction(FunctionContext* ctx, AggDataPtr __restrict state, size_t count) const {}
 
+    // For window functions evaluated in streaming mode whose look-back is bounded but data-dependent.
+    // Returns the earliest input row position, in the analytor's local column coordinates, that this function may still
+    // read for subsequent rows. The analytor may evict any buffered row strictly before the minimum such position across
+    // all its functions.
+    // Returns std::nullopt when the function imposes no retention requirement beyond the operator's frame-based bound.
+    virtual std::optional<int64_t> get_min_retained_position(FunctionContext* ctx,
+                                                             ConstAggDataPtr __restrict state) const {
+        return std::nullopt;
+    }
+
     virtual std::string get_name() const = 0;
 
     // State management methods:

--- a/be/src/exprs/agg/window.h
+++ b/be/src/exprs/agg/window.h
@@ -765,6 +765,29 @@ class LeadLagWindowFunction final : public ValueWindowFunction<LT, LeadLagState<
         }
     }
 
+    // `lag ... IGNORE NULLS` supports streaming eviction. Once at least one non-null value has
+    // been seen, `target_not_null_index` is the oldest buffered row the function may still read.
+    std::optional<int64_t> get_min_retained_position(FunctionContext* ctx,
+                                                     ConstAggDataPtr __restrict state) const override {
+        if constexpr (ignoreNulls && isLag) {
+            const int64_t idx = this->data(state).target_not_null_index;
+            if (idx >= 0) {
+                return idx;
+            }
+        }
+        return std::nullopt;
+    }
+
+    // Shift the index after eviction so it stays in the operator's (post-eviction) local indices.
+    void reset_state_for_contraction(FunctionContext* ctx, AggDataPtr __restrict state, size_t count) const override {
+        if constexpr (ignoreNulls && isLag) {
+            if (this->data(state).target_not_null_index >= 0) {
+                this->data(state).target_not_null_index -= count;
+                DCHECK_GE(this->data(state).target_not_null_index, 0);
+            }
+        }
+    }
+
     void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
                     size_t end) const override {
         this->get_values_helper(state, dst, start, end);

--- a/be/test/exprs/agg/window_test.cpp
+++ b/be/test/exprs/agg/window_test.cpp
@@ -1143,7 +1143,7 @@ ColumnPtr build_nullable_int_column(const std::vector<OptInt>& vals, size_t begi
 // Drive the real Analytor and return the lag output for each input row (in input order).
 std::vector<OptInt> run_analytor_lag(const std::vector<OptInt>& input, int64_t offset, bool streaming,
                                      int64_t chunk_rows) {
-    config::pipeline_analytic_enable_lag_ignore_nulls_streaming = streaming;
+    config::pipeline_analytic_enable_ignore_nulls_streaming = streaming;
     // Small eviction batch so the streaming path actually evicts/contracts many times over the run.
     config::pipeline_analytic_removable_chunk_num = 2;
 

--- a/be/test/exprs/agg/window_test.cpp
+++ b/be/test/exprs/agg/window_test.cpp
@@ -18,14 +18,31 @@
 #include <algorithm>
 #include <cmath>
 #include <memory>
+#include <optional>
+#include <random>
+#include <string>
+#include <vector>
 
 #include "column/array_column.h"
 #include "column/binary_column.h"
+#include "column/chunk.h"
 #include "column/column_builder.h"
 #include "column/column_helper.h"
+#include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
+#include "common/config_exec_flow_fwd.h"
+#include "common/config_exec_fwd.h"
+#include "common/runtime_profile.h"
+#include "exec/analytor.h"
 #include "exprs/agg/aggregate_factory.h"
+#include "gen_cpp/Exprs_types.h"
+#include "gen_cpp/PlanNodes_types.h"
+#include "gen_cpp/Types_types.h"
+#include "runtime/descriptor_helper.h"
+#include "runtime/descriptors.h"
 #include "runtime/mem_pool.h"
 #include "runtime/memory/counting_allocator.h"
+#include "runtime/runtime_state.h"
 #include "testutil/function_utils.h"
 
 namespace starrocks {
@@ -913,6 +930,357 @@ TEST_F(LagWindowTest, test_lag_large_binary_non_const_default) {
         ASSERT_FALSE(lag_state->is_null) << "row=" << row;
         Slice value = AggDataTypeTraits<TYPE_VARCHAR>::get_ref(lag_state->value);
         ASSERT_EQ(expected[row], value.to_string()) << "row=" << row;
+    }
+}
+
+TEST_F(LagWindowTest, test_lag_ignore_nulls_all_null_needs_no_retention) {
+    auto data_col = Int32Column::create();
+    auto null_col = NullColumn::create();
+    const int64_t N = 8;
+    for (int i = 0; i < N; ++i) {
+        data_col->append(0);
+        null_col->append(1); // all NULL
+    }
+    ColumnPtr value_col = NullableColumn::create(std::move(data_col), std::move(null_col));
+    auto default_col = ColumnHelper::create_const_column<TYPE_INT>(99, value_col->size());
+    const int64_t offset = 1;
+
+    Columns args = build_lag_args(value_col, offset, default_col);
+    std::vector<const Column*> raw_cols{args[0].get(), args[1].get(), args[2].get()};
+
+    const AggregateFunction* lag_func = get_aggregate_function("lag_in", TYPE_INT, TYPE_INT, true);
+    auto state = ManagedAggrState::create(ctx, lag_func);
+    lag_func->reset(ctx, args, state->state());
+
+    for (int64_t row = 0; row < N; ++row) {
+        int64_t frame_start = row - offset;
+        int64_t frame_end = frame_start + 1;
+        lag_func->update_batch_single_state_with_frame(ctx, state->state(), raw_cols.data(), 0, N, frame_start,
+                                                       frame_end);
+        ASSERT_EQ(std::nullopt, lag_func->get_min_retained_position(ctx, state->state())) << "row=" << row;
+    }
+}
+
+// With regularly-occurring non-nulls the retained watermark tracks the most recent non-null (never
+// pinned to the partition start), and reset_state_for_contraction shifts it into the operator's
+// post-eviction coordinates.
+TEST_F(LagWindowTest, test_lag_ignore_nulls_watermark_tracks_recent_nonnull) {
+    auto data_col = Int32Column::create();
+    auto null_col = NullColumn::create();
+    const int64_t N = 8;
+    for (int i = 0; i < N; ++i) {
+        if (i % 2 == 0) {
+            data_col->append((i + 1) * 10);
+            null_col->append(0);
+        } else {
+            data_col->append(0);
+            null_col->append(1);
+        }
+    }
+    ColumnPtr value_col = NullableColumn::create(std::move(data_col), std::move(null_col));
+    auto default_col = ColumnHelper::create_const_column<TYPE_INT>(99, value_col->size());
+    const int64_t offset = 1;
+
+    Columns args = build_lag_args(value_col, offset, default_col);
+    std::vector<const Column*> raw_cols{args[0].get(), args[1].get(), args[2].get()};
+
+    const AggregateFunction* lag_func = get_aggregate_function("lag_in", TYPE_INT, TYPE_INT, true);
+    auto state = ManagedAggrState::create(ctx, lag_func);
+    lag_func->reset(ctx, args, state->state());
+
+    for (int64_t row = 0; row < N; ++row) {
+        int64_t frame_start = row - offset;
+        int64_t frame_end = frame_start + 1;
+        lag_func->update_batch_single_state_with_frame(ctx, state->state(), raw_cols.data(), 0, N, frame_start,
+                                                       frame_end);
+        auto* s = reinterpret_cast<LeadLagState<TYPE_INT, /*ignoreNulls=*/true>*>(state->state());
+        auto wm = lag_func->get_min_retained_position(ctx, state->state());
+        ASSERT_EQ(s->target_not_null_index, wm) << "row=" << row;
+        ASSERT_GE(wm.value(), row - 2) << "row=" << row; // bounded near current, not pinned to 0
+    }
+
+    auto* s = reinterpret_cast<LeadLagState<TYPE_INT, /*ignoreNulls=*/true>*>(state->state());
+    int64_t before = s->target_not_null_index;
+    lag_func->reset_state_for_contraction(ctx, state->state(), 2);
+    ASSERT_EQ(before - 2, s->target_not_null_index);
+}
+
+// ===================================================================================================
+// End-to-end correctness: drive the real Analytor operator for `lag(col, offset) IGNORE NULLS` and
+// verify the emitted output column matches an independent reference implementation, with the streaming
+// + watermark-eviction path both DISABLED (legacy materializing) and ENABLED. This is what exercises
+// Analytor::_remove_unused_rows + reset_state_for_contraction under real chunking/eviction, which the
+// function-level tests above never touch.
+// ===================================================================================================
+namespace {
+
+using OptInt = std::optional<int32_t>;
+
+TTypeDesc make_scalar_ttype(TPrimitiveType::type t) {
+    TTypeDesc desc;
+    TTypeNode node;
+    node.__set_type(TTypeNodeType::SCALAR);
+    TScalarType scalar;
+    scalar.__set_type(t);
+    node.__set_scalar_type(scalar);
+    desc.types.push_back(node);
+    return desc;
+}
+
+TExprNode make_slot_ref(TupleId tuple, SlotId slot, const TTypeDesc& ttype) {
+    TExprNode node;
+    node.__set_node_type(TExprNodeType::SLOT_REF);
+    node.__set_type(ttype);
+    node.__set_num_children(0);
+    node.__set_is_nullable(true);
+    TSlotRef slot_ref;
+    slot_ref.__set_slot_id(slot);
+    slot_ref.__set_tuple_id(tuple);
+    node.__set_slot_ref(slot_ref);
+    return node;
+}
+
+TExprNode make_bigint_literal(int64_t v) {
+    TExprNode node;
+    node.__set_node_type(TExprNodeType::INT_LITERAL);
+    node.__set_type(make_scalar_ttype(TPrimitiveType::BIGINT));
+    node.__set_num_children(0);
+    node.__set_is_nullable(false);
+    TIntLiteral lit;
+    lit.__set_value(v);
+    node.__set_int_literal(lit);
+    return node;
+}
+
+TExprNode make_null_literal(const TTypeDesc& ttype) {
+    TExprNode node;
+    node.__set_node_type(TExprNodeType::NULL_LITERAL);
+    node.__set_type(ttype);
+    node.__set_num_children(0);
+    node.__set_is_nullable(true);
+    return node;
+}
+
+// lag(<slot>, offset, NULL) IGNORE NULLS, ROWS UNBOUNDED PRECEDING AND <offset> PRECEDING, single partition.
+TPlanNode make_lag_tnode(TupleId in_tuple_id, SlotId col_slot_id, int64_t offset) {
+    const TTypeDesc int_type = make_scalar_ttype(TPrimitiveType::INT);
+    TExpr fn_call;
+    TExprNode agg;
+    agg.__set_node_type(TExprNodeType::AGG_EXPR);
+    agg.__set_num_children(3);
+    agg.__set_type(int_type);
+    agg.__set_has_nullable_child(true);
+    agg.__set_is_nullable(true);
+    {
+        TAggregateExpr agg_expr;
+        agg_expr.__set_is_merge_agg(false);
+        agg.__set_agg_expr(agg_expr);
+        TFunction fn;
+        TFunctionName fn_name;
+        fn_name.__set_function_name("lag");
+        fn.__set_name(fn_name);
+        fn.__set_binary_type(TFunctionBinaryType::BUILTIN);
+        fn.__set_arg_types(std::vector<TTypeDesc>{int_type});
+        fn.__set_ret_type(int_type);
+        fn.__set_has_var_args(false);
+        fn.__set_ignore_nulls(true);
+        agg.__set_fn(fn);
+    }
+    fn_call.nodes.push_back(agg);
+    fn_call.nodes.push_back(make_slot_ref(in_tuple_id, col_slot_id, int_type));
+    fn_call.nodes.push_back(make_bigint_literal(offset));
+    fn_call.nodes.push_back(make_null_literal(int_type));
+
+    TAnalyticWindow window;
+    window.__set_type(TAnalyticWindowType::ROWS);
+    {
+        TAnalyticWindowBoundary end;
+        end.__set_type(TAnalyticWindowBoundaryType::PRECEDING);
+        end.__set_rows_offset_value(offset);
+        window.__set_window_end(end); // window_start unset => UNBOUNDED PRECEDING
+    }
+    TAnalyticNode anode;
+    anode.__set_window(window);
+    anode.__set_buffered_tuple_id(in_tuple_id);
+    anode.analytic_functions.push_back(fn_call);
+
+    TPlanNode tnode;
+    tnode.__set_node_id(0);
+    tnode.__set_node_type(TPlanNodeType::ANALYTIC_EVAL_NODE);
+    tnode.__set_limit(-1);
+    tnode.__set_analytic_node(anode);
+    return tnode;
+}
+
+// Reference: lag(x, offset) IGNORE NULLS with NULL default.
+std::vector<OptInt> ref_lag_ignore_nulls(const std::vector<OptInt>& in, int64_t offset) {
+    std::vector<OptInt> out(in.size());
+    std::vector<int32_t> seen; // non-null values strictly before current, in order
+    for (size_t i = 0; i < in.size(); ++i) {
+        if (static_cast<int64_t>(seen.size()) >= offset) {
+            out[i] = seen[seen.size() - offset];
+        } else {
+            out[i] = std::nullopt;
+        }
+        if (in[i].has_value()) {
+            seen.push_back(*in[i]);
+        }
+    }
+    return out;
+}
+
+ColumnPtr build_nullable_int_column(const std::vector<OptInt>& vals, size_t begin, size_t count) {
+    auto data = Int32Column::create();
+    auto nulls = NullColumn::create();
+    for (size_t i = 0; i < count; ++i) {
+        const OptInt& v = vals[begin + i];
+        data->append(v.has_value() ? *v : 0);
+        nulls->append(v.has_value() ? 0 : 1);
+    }
+    return NullableColumn::create(std::move(data), std::move(nulls));
+}
+
+// Drive the real Analytor and return the lag output for each input row (in input order).
+std::vector<OptInt> run_analytor_lag(const std::vector<OptInt>& input, int64_t offset, bool streaming,
+                                     int64_t chunk_rows) {
+    config::pipeline_analytic_enable_lag_ignore_nulls_streaming = streaming;
+    // Small eviction batch so the streaming path actually evicts/contracts many times over the run.
+    config::pipeline_analytic_removable_chunk_num = 2;
+
+    ObjectPool pool;
+    TDescriptorTableBuilder dtb;
+    {
+        TTupleDescriptorBuilder in_tuple;
+        in_tuple.add_slot(TSlotDescriptorBuilder().type(TYPE_INT).nullable(true).column_name("v").build());
+        in_tuple.build(&dtb);
+        TTupleDescriptorBuilder out_tuple;
+        out_tuple.add_slot(TSlotDescriptorBuilder().type(TYPE_INT).nullable(true).column_name("lag_v").build());
+        out_tuple.build(&dtb);
+    }
+    auto* state = pool.add(new RuntimeState(TUniqueId(), TQueryOptions(), TQueryGlobals(), nullptr));
+    DescriptorTbl* desc_tbl = nullptr;
+    CHECK(DescriptorTbl::create(state, &pool, dtb.desc_tbl(), &desc_tbl, config::vector_chunk_size).ok());
+    state->set_desc_tbl(desc_tbl);
+    state->init_instance_mem_tracker();
+
+    const TupleId in_tuple_id = 0;
+    const TupleId out_tuple_id = 1;
+    const SlotId col_slot_id = desc_tbl->get_tuple_descriptor(in_tuple_id)->slots()[0]->id();
+    const SlotId res_slot_id = desc_tbl->get_tuple_descriptor(out_tuple_id)->slots()[0]->id();
+    TupleDescriptor* result_tuple = desc_tbl->get_tuple_descriptor(out_tuple_id);
+
+    TPlanNode tnode = make_lag_tnode(in_tuple_id, col_slot_id, offset);
+    RuntimeProfile profile("Analytor");
+    auto analytor = std::make_shared<Analytor>(tnode, result_tuple, false);
+    CHECK(analytor->prepare(state, &pool, &profile).ok());
+    CHECK(analytor->open(state).ok());
+
+    std::vector<OptInt> out;
+    auto collect = [&](const ChunkPtr& chunk) {
+        if (chunk == nullptr) return;
+        ColumnPtr res = chunk->get_column_by_slot_id(res_slot_id);
+        for (size_t i = 0; i < res->size(); ++i) {
+            if (res->is_null(i)) {
+                out.push_back(std::nullopt);
+            } else {
+                out.push_back(static_cast<int32_t>(res->get(i).get_int32()));
+            }
+        }
+    };
+
+    size_t fed = 0;
+    while (fed < input.size()) {
+        const size_t n = std::min<size_t>(chunk_rows, input.size() - fed);
+        auto chunk = std::make_shared<Chunk>();
+        chunk->append_column(build_nullable_int_column(input, fed, n), col_slot_id);
+        CHECK(analytor->process(state, chunk).ok());
+        fed += n;
+        while (ChunkPtr o = analytor->poll_chunk_buffer()) collect(o);
+    }
+    CHECK(analytor->finish_process(state).ok());
+    while (ChunkPtr o = analytor->poll_chunk_buffer()) collect(o);
+    analytor->close(state);
+    return out;
+}
+
+std::vector<OptInt> pattern_column(int pattern, size_t n, uint32_t seed) {
+    std::vector<OptInt> v(n);
+    std::mt19937 rng(seed);
+    for (size_t i = 0; i < n; ++i) {
+        bool is_null;
+        switch (pattern) {
+        case 0: // all null
+            is_null = true;
+            break;
+        case 1: // dense
+            is_null = false;
+            break;
+        case 2: // sparse: one non-null every 64 rows
+            is_null = (i % 64 != 0);
+            break;
+        case 3: // head then long null tail (the watermark caveat case)
+            is_null = (i != 0);
+            break;
+        default: // random ~1/3 null
+            is_null = (rng() % 3 == 0);
+            break;
+        }
+        v[i] = is_null ? OptInt(std::nullopt) : OptInt(static_cast<int32_t>(i + 1));
+    }
+    return v;
+}
+
+void expect_equal(const std::vector<OptInt>& got, const std::vector<OptInt>& expected, const std::string& tag) {
+    ASSERT_EQ(expected.size(), got.size()) << tag;
+    for (size_t i = 0; i < expected.size(); ++i) {
+        ASSERT_EQ(expected[i].has_value(), got[i].has_value()) << tag << " null-mismatch at row " << i;
+        if (expected[i].has_value()) {
+            ASSERT_EQ(*expected[i], *got[i]) << tag << " value-mismatch at row " << i;
+        }
+    }
+}
+
+} // namespace
+
+// Streaming output must equal both the legacy (materializing) output and the independent reference,
+// across data shapes, offsets, and chunk sizes (which shift partition/eviction boundaries).
+TEST_F(LagWindowTest, e2e_streaming_matches_reference_and_legacy) {
+    const size_t n = 5000;
+    const int patterns[] = {0, 1, 2, 3, 4};
+    const int64_t offsets[] = {1, 2, 3};
+    const int64_t chunk_sizes[] = {1, 7, 256, 4096};
+
+    for (int p : patterns) {
+        const auto input = pattern_column(p, n, /*seed*/ 1000 + p);
+        for (int64_t off : offsets) {
+            const auto expected = ref_lag_ignore_nulls(input, off);
+            for (int64_t cs : chunk_sizes) {
+                const std::string tag =
+                        "p=" + std::to_string(p) + " off=" + std::to_string(off) + " chunk=" + std::to_string(cs);
+                expect_equal(run_analytor_lag(input, off, /*streaming*/ false, cs), expected, "legacy " + tag);
+                expect_equal(run_analytor_lag(input, off, /*streaming*/ true, cs), expected, "streaming " + tag);
+            }
+        }
+    }
+}
+
+// The exact column discussed for offset 2: NULL,NULL,1,NULL,1,NULL,1,1 (values distinguished so we can
+// see which physical non-null is picked). Verifies streaming and legacy agree with the reference.
+TEST_F(LagWindowTest, e2e_offset2_sparse_explicit) {
+    std::vector<OptInt> input{std::nullopt, std::nullopt, 10, std::nullopt, 20, std::nullopt, 30, 40};
+    const int64_t offset = 2;
+    const auto expected = ref_lag_ignore_nulls(input, offset);
+    // sanity-check the reference itself: 2nd-most-recent non-null strictly before each row.
+    // rows:          0    1    2      3     4      5     6     7
+    // value:         -    -    10     -     20     -     30    40
+    // non-nulls before row: {} {} {}   {10}  {10}  {10,20} {10,20} {10,20,30}
+    // 2nd-most-recent:  -    -    -      -     -      10     10     20
+    std::vector<OptInt> hand{std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt, 10, 10, 20};
+    expect_equal(expected, hand, "reference-self-check");
+
+    for (int64_t cs : {1, 3, 8}) {
+        expect_equal(run_analytor_lag(input, offset, false, cs), expected, "legacy cs=" + std::to_string(cs));
+        expect_equal(run_analytor_lag(input, offset, true, cs), expected, "streaming cs=" + std::to_string(cs));
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:

Currently, `LAG ... IGNORE NULLS` materializes the whole partition and keeps it in memory during all of the calculation. On a large partition (e.g. skew), this leads to memory pressure in a single BE.

## What I'm doing:
Since we only need to keep the last _N_ (offset) non-null entries, we can safely evict rows before this. This means we can enable streaming for this particular function and implement eviction to match the needed rows.

I added tests and a microbenchmark for this. The results of the microbenchmark show a -42x peak memory reduction (from 5MB to 0.11MB for 1M rows). For larger partitions the reduction should be even larger.
```
Running ./be/build_Release/src/bench/output/analytor_lag_bench
Run on (14 X 48 MHz CPU s)
Load Average: 5.82, 4.50, 3.48
------------------------------------------------------------------------------------------------------------
Benchmark                                                  Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------------------
BM_LagIgnoreNulls/all_null_legacy                       27.1 ms         27.1 ms           25 Evictions=0 PeakMiB=5 PeakRows=1048.58k
BM_LagIgnoreNulls/dense_legacy                          29.5 ms         29.5 ms           24 Evictions=0 PeakMiB=5 PeakRows=1048.58k
BM_LagIgnoreNulls/sparse_legacy                         26.8 ms         26.8 ms           26 Evictions=0 PeakMiB=5 PeakRows=1048.58k
BM_LagIgnoreNulls/head_then_null_legacy                 26.9 ms         26.9 ms           26 Evictions=0 PeakMiB=5 PeakRows=1048.58k
BM_LagIgnoreNulls/all_null_streaming/iterations:1       22.6 ms         22.5 ms            1 Evictions=63 PeakMiB=0.117188 PeakRows=24.576k
BM_LagIgnoreNulls/dense_streaming                       27.1 ms         27.1 ms           26 Evictions=63 PeakMiB=0.117188 PeakRows=24.576k
BM_LagIgnoreNulls/sparse_streaming                      24.7 ms         24.7 ms           28 Evictions=63 PeakMiB=0.117188 PeakRows=24.576k
BM_LagIgnoreNulls/head_then_null_streaming              23.6 ms         23.6 ms           26 Evictions=0 PeakMiB=5 PeakRows=1048.58k

```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5