### PR TITLE
[Enhancement] Extend grouping sets pushdown to support AVG and COUNT to optimized tpcds-q22

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownAggregateGroupingSetsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownAggregateGroupingSetsRule.java
@@ -193,11 +193,15 @@ public class PushDownAggregateGroupingSetsRule extends TransformationRule {
             ScalarOperator arg = call.getChild(0);
             Type argType = arg.getType();
 
-            // AVG accumulates BOOLEAN/integer inputs as a double internally (see AvgDoubleLTGuard in the
-            // BE), not as the argument's native type; decomposing via the native-typed SUM (e.g. plain
-            // BIGINT sum) would overflow in cases the original avg wouldn't, so sum over a double-cast
-            // argument instead to keep the same accumulator width. Float/decimal args already have a
-            // SUM overload with matching (or wider, for decimal) accumulation, so they're summed as-is.
+            // AVG accumulates integer inputs as a double internally (see AvgDoubleLTGuard in the BE), not
+            // as the argument's native type; decomposing via the native-typed SUM (e.g. plain BIGINT sum)
+            // would overflow in cases the original avg wouldn't, so sum over a double-cast argument
+            // instead to keep the same accumulator width. Float/decimal args already have a SUM overload
+            // with matching (or wider, for decimal) accumulation, so they're summed as-is.
+            //
+            // Note isFixedPointType() is TINYINT..LARGEINT and excludes BOOLEAN, so avg(bool) is summed
+            // as-is through sum(BOOLEAN) -> BIGINT. That is deliberate: 0/1 inputs cannot overflow a
+            // BIGINT accumulator, so the cast would only add plan noise.
             ScalarOperator sumArg = argType.isFixedPointType() ? new CastOperator(FloatType.DOUBLE, arg, true) : arg;
 
             Function sumFn = ExprUtils.getBuiltinFunction(FunctionSet.SUM, new Type[] {sumArg.getType()},
@@ -435,16 +439,21 @@ public class PushDownAggregateGroupingSetsRule extends TransformationRule {
         List<List<Long>> groupingIds = repeat.getGroupingIds().stream()
                 .map(s -> s.subList(0, subGroups)).collect(Collectors.toList());
 
-        ScalarOperator predicate = null;
+        // NOTE: keep the repeat predicate and the aggregate (HAVING) predicate in separate variables.
+        // Sharing one variable makes the repeat predicate leak onto the aggregate whenever the aggregate
+        // has no HAVING of its own; that happens to be idempotent today only because the leaked predicate
+        // references grouping columns whose values the re-aggregation does not change.
+        ScalarOperator repeatPredicate = null;
         if (null != repeat.getPredicate()) {
             Map<ColumnRefOperator, ScalarOperator> replaceMap = Maps.newHashMap(outputs);
             nullRefs.forEach(c -> replaceMap.put(c, ConstantOperator.createNull(c.getType())));
 
             ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(replaceMap);
-            predicate = rewriter.rewrite(repeat.getPredicate());
+            repeatPredicate = rewriter.rewrite(repeat.getPredicate());
 
             ScalarOperatorRewriter r = new ScalarOperatorRewriter();
-            predicate = r.rewrite(predicate, List.of(new FoldConstantsRule(), new SimplifiedPredicateRule()));
+            repeatPredicate =
+                    r.rewrite(repeatPredicate, List.of(new FoldConstantsRule(), new SimplifiedPredicateRule()));
         }
 
         LogicalRepeatOperator newRepeat = LogicalRepeatOperator.builder()
@@ -452,7 +461,7 @@ public class PushDownAggregateGroupingSetsRule extends TransformationRule {
                 .setRepeatColumnRefList(repeatRefs)
                 .setGroupingIds(groupingIds)
                 .setHasPushDown(true)
-                .setPredicate(predicate)
+                .setPredicate(repeatPredicate)
                 .build();
 
         // aggregate; avg(x)'s sum/count must be re-summed (never re-averaged) to stay correct across
@@ -494,6 +503,13 @@ public class PushDownAggregateGroupingSetsRule extends TransformationRule {
                 // level must re-SUM the finer levels' partial counts, not re-COUNT them (which would
                 // count the number of partial-count rows instead of summing their values). Reuse the
                 // same rollup-function mapping already used by the MV-rewrite path and by pdagg.
+                //
+                // That mapping lives in UNSAFE_REWRITE_ROLLUP_FUNCTION_MAP, whose contract is
+                // `count(col) = coalesce(sum(col), 0)` - the MV path needs the coalesce because it may
+                // roll up over an empty match. Here the coalesce is provably unnecessary: the value
+                // being re-summed is a count produced by the CTE, so it is never NULL, and an
+                // aggregation group always holds at least one row - therefore this sum() can never
+                // return NULL. Do not drop that reasoning when touching this branch.
                 String rollupFnName = AggregateFunctionRollupUtils.getRollupFunctionName(v, false);
                 String fnName = rollupFnName != null ? rollupFnName : v.getFnName();
 
@@ -507,6 +523,15 @@ public class PushDownAggregateGroupingSetsRule extends TransformationRule {
                             k.getType(), v.getType());
                 }
 
+                // The rolled-up call keeps the original aggregation's output type, which only holds while
+                // every rollup mapping is type-preserving over its own output (count->sum is: sum(BIGINT)
+                // is BIGINT). Other entries in the mapping are not - bitmap_agg->bitmap_union and
+                // array_agg_distinct->array_unique_agg both change the type - so fail loudly here rather
+                // than silently emitting a CallOperator whose declared type contradicts its function.
+                Preconditions.checkState(aggFunc.getReturnType().matchesType(k.getType()),
+                        "rollup function %s returns %s but the aggregation output column is %s",
+                        fnName, aggFunc.getReturnType(), k.getType());
+
                 aggregations.put(x,
                         new CallOperator(fnName, k.getType(), Lists.newArrayList(outputs.get(k)), aggFunc));
                 outputs.put(k, x);
@@ -516,17 +541,18 @@ public class PushDownAggregateGroupingSetsRule extends TransformationRule {
         List<ColumnRefOperator> groupings = aggregate.getGroupingKeys().stream()
                 .filter(c -> !nullRefs.contains(c)).map(outputs::get).collect(Collectors.toList());
 
+        ScalarOperator havingPredicate = null;
         if (null != aggregate.getPredicate()) {
             Map<ColumnRefOperator, ScalarOperator> replaceMap = Maps.newHashMap(outputs);
             nullRefs.forEach(c -> replaceMap.put(c, ConstantOperator.createNull(c.getType())));
             ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(replaceMap);
-            predicate = rewriter.rewrite(aggregate.getPredicate());
+            havingPredicate = rewriter.rewrite(aggregate.getPredicate());
         }
         LogicalAggregationOperator newAggregate = LogicalAggregationOperator.builder()
                 .setAggregations(aggregations)
                 .setGroupingKeys(groupings)
                 .setType(AggType.GLOBAL)
-                .setPredicate(predicate)
+                .setPredicate(havingPredicate)
                 .setPartitionByColumns(groupings)
                 .build();
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownAggregateGroupingSetsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownAggregateGroupingSetsRule.java
@@ -38,6 +38,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalRepeatOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
@@ -49,6 +50,7 @@ import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.common.AggregateFunctionRollupUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.common.AggregatePushDownUtils;
 import com.starrocks.sql.optimizer.statistics.Statistics;
+import com.starrocks.type.FloatType;
 import com.starrocks.type.Type;
 
 import java.util.Collections;
@@ -187,15 +189,31 @@ public class PushDownAggregateGroupingSetsRule extends TransformationRule {
                 return;
             }
             ScalarOperator arg = call.getChild(0);
-            Function sumFn = ExprUtils.getBuiltinFunction(FunctionSet.SUM, new Type[] {arg.getType()},
+            Type argType = arg.getType();
+
+            // AVG accumulates BOOLEAN/integer inputs as a double internally (see AvgDoubleLTGuard in the
+            // BE), not as the argument's native type; decomposing via the native-typed SUM (e.g. plain
+            // BIGINT sum) would overflow in cases the original avg wouldn't, so sum over a double-cast
+            // argument instead to keep the same accumulator width. Float/decimal args already have a
+            // SUM overload with matching (or wider, for decimal) accumulation, so they're summed as-is.
+            ScalarOperator sumArg = argType.isFixedPointType() ? new CastOperator(FloatType.DOUBLE, arg, true) : arg;
+
+            Function sumFn = ExprUtils.getBuiltinFunction(FunctionSet.SUM, new Type[] {sumArg.getType()},
                     Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
-            Function countFn = ExprUtils.getBuiltinFunction(FunctionSet.COUNT, new Type[] {arg.getType()},
+            Function countFn = ExprUtils.getBuiltinFunction(FunctionSet.COUNT, new Type[] {argType},
                     Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
             Preconditions.checkState(sumFn instanceof AggregateFunction);
             Preconditions.checkState(countFn instanceof AggregateFunction);
 
+            if (sumArg.getType().isDecimalOfAnyVersion()) {
+                // the registered SUM signature is a wildcard decimal type; rectify it to the concrete
+                // argument precision/scale before use, same as the rollup level below and the analyzer path.
+                sumFn = DecimalV3FunctionAnalyzer.rectifyAggregationFunction((AggregateFunction) sumFn,
+                        sumArg.getType(), sumArg.getType());
+            }
+
             CallOperator sumCall = new CallOperator(FunctionSet.SUM, sumFn.getReturnType(),
-                    Lists.newArrayList(arg), sumFn);
+                    Lists.newArrayList(sumArg), sumFn);
             CallOperator countCall = new CallOperator(FunctionSet.COUNT, countFn.getReturnType(),
                     Lists.newArrayList(arg), countFn);
             ColumnRefOperator sumRef = factory.create(sumCall, sumCall.getType(), sumCall.isNullable());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownAggregateGroupingSetsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownAggregateGroupingSetsRule.java
@@ -42,7 +42,6 @@ import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorUtil;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.rewrite.scalar.FoldConstantsRule;
@@ -52,7 +51,9 @@ import com.starrocks.sql.optimizer.rule.transformation.materialization.common.Ag
 import com.starrocks.sql.optimizer.rule.transformation.materialization.common.AggregatePushDownUtils;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.type.FloatType;
+import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -207,12 +208,19 @@ public class PushDownAggregateGroupingSetsRule extends TransformationRule {
             Preconditions.checkState(countFn instanceof AggregateFunction);
 
             if (sumArg.getType().isDecimalOfAnyVersion()) {
-                // decimal SUM always widens its accumulator to DECIMAL128(38, scale) - narrowing the
-                // return type to the argument's own (possibly DECIMAL32/64) precision would both mismatch
-                // the BE's registered decimal_sum signature and lose the accumulator width SUM needs to
-                // avoid overflow. Reuse the canonical decimal-SUM synthesis helper instead of rectifying
-                // by hand, so this stays in sync with how MV rewrite already builds a decimal SUM.
-                sumFn = ScalarOperatorUtil.findSumFn(new Type[] {sumArg.getType()});
+                // decimal SUM always widens its accumulator - to DECIMAL128(38, scale) for decimal32/64/128
+                // inputs, or DECIMAL256(76, scale) for decimal256 inputs, since the BE registers a
+                // dedicated decimal256->decimal256 decimal_sum mapping (see
+                // aggregate_resolver_sumcount.cpp's SumDispatcher). Narrowing to the argument's own
+                // precision - or always widening to DECIMAL128 regardless of input width, as
+                // ScalarOperatorUtil.findSumFn does - would both mismatch the BE's registered accumulator.
+                ScalarType decimalArgType = (ScalarType) sumArg.getType();
+                int widePrecision = decimalArgType.isDecimal256() ? 76 : 38;
+                AggregateFunction decimalSumFn = (AggregateFunction) sumFn.copy();
+                decimalSumFn.setArgsType(new Type[] {decimalArgType});
+                decimalSumFn.setRetType(TypeFactory.createDecimalV3NarrowestType(widePrecision,
+                        decimalArgType.getScalarScale()));
+                sumFn = decimalSumFn;
             }
 
             CallOperator sumCall = new CallOperator(FunctionSet.SUM, sumFn.getReturnType(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownAggregateGroupingSetsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownAggregateGroupingSetsRule.java
@@ -46,6 +46,8 @@ import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.rewrite.scalar.FoldConstantsRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedPredicateRule;
 import com.starrocks.sql.optimizer.rule.RuleType;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.common.AggregateFunctionRollupUtils;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.common.AggregatePushDownUtils;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.type.Type;
 
@@ -68,7 +70,7 @@ import java.util.stream.Collectors;
  */
 public class PushDownAggregateGroupingSetsRule extends TransformationRule {
     private static final List<String> SUPPORT_AGGREGATE_FUNCTIONS = Lists.newArrayList(FunctionSet.MAX,
-            FunctionSet.MIN, FunctionSet.SUM);
+            FunctionSet.MIN, FunctionSet.SUM, FunctionSet.AVG, FunctionSet.COUNT);
 
     public PushDownAggregateGroupingSetsRule() {
         super(RuleType.TF_PUSHDOWN_AGG_GROUPING_SET,
@@ -89,6 +91,20 @@ public class PushDownAggregateGroupingSetsRule extends TransformationRule {
                 .allMatch(agg -> SUPPORT_AGGREGATE_FUNCTIONS.contains(agg.getFnName()) &&
                         !agg.isDistinct() && agg.getUsedColumns().cardinality() <= 1)) {
             return false;
+        }
+
+        if (aggregate.getPredicate() != null) {
+            // AVG is decomposed into sum/count and only recombined into a final avg value by a Project
+            // above the re-aggregation (see buildSubRepeatConsume); a HAVING predicate directly on the
+            // aggregation output can't be safely re-evaluated against the pre-divide sum/count columns,
+            // so skip push down whenever the predicate touches an AVG output column.
+            List<ColumnRefOperator> avgOutputRefs = aggregate.getAggregations().entrySet().stream()
+                    .filter(e -> FunctionSet.AVG.equals(e.getValue().getFnName()))
+                    .map(Map.Entry::getKey)
+                    .collect(Collectors.toList());
+            if (aggregate.getPredicate().getUsedColumns().containsAny(avgOutputRefs)) {
+                return false;
+            }
         }
 
         List<ColumnRefOperator> allRepeatRefs = repeatOperator.getRepeatColumnRef()
@@ -115,23 +131,78 @@ public class PushDownAggregateGroupingSetsRule extends TransformationRule {
         ColumnRefFactory factory = context.getColumnRefFactory();
         int cteId = context.getCteContext().getNextCteId();
 
+        // AVG can't be re-invoked on an already-aggregated value (unlike sum/min/max), so decompose
+        // each avg(x) into sum(x)/count(x) once up-front; every builder below consults this map to
+        // know which aggregations need the sum+count treatment instead of a plain pass-through/re-agg.
+        Map<ColumnRefOperator, AvgDecomposition> avgDecompositions = buildAvgDecompositions(factory, aggregate);
+
         // cte produce and push down aggregate
         context.getCteContext().addForceCTE(cteId);
-        OptExpression cteProduce = buildCTEProduce(context, input, cteId);
+        OptExpression cteProduce = buildCTEProduce(context, input, cteId, avgDecompositions);
 
         // new grouping sets consume
         Map<ColumnRefOperator, ColumnRefOperator> consumeOutputs1 = Maps.newHashMap();
-        OptExpression subRepeatConsume = buildSubRepeatConsume(factory, consumeOutputs1, aggregate, repeat, cteId);
+        OptExpression subRepeatConsume =
+                buildSubRepeatConsume(factory, consumeOutputs1, aggregate, repeat, cteId, avgDecompositions);
 
         // select consume
         Map<ColumnRefOperator, ColumnRefOperator> consumeOutputs2 = Maps.newHashMap();
-        OptExpression selectConsume = buildSelectConsume(factory, consumeOutputs2, aggregate, repeat, cteId);
+        OptExpression selectConsume =
+                buildSelectConsume(factory, consumeOutputs2, aggregate, repeat, cteId, avgDecompositions);
 
         // union all
         OptExpression union =
                 buildUnionAll(aggregate, consumeOutputs1, subRepeatConsume, consumeOutputs2, selectConsume);
 
         return Lists.newArrayList(OptExpression.create(new LogicalCTEAnchorOperator(cteId), cteProduce, union));
+    }
+
+    /**
+     * avg(x) can't be recombined across rollup levels by re-invoking avg() on already-averaged values
+     * (unlike sum/min/max, which are self-recombining) - weighting would be wrong whenever finer groups
+     * have different sizes. So every avg(x) is computed as sum(x)/count(x) instead: the finest-grain CTE
+     * produces sum(x) and count(x), coarser rollup levels re-aggregate with sum(sum(x))/sum(count(x)),
+     * and the final avg value is recovered via a division Project wherever it's consumed.
+     */
+    public static final class AvgDecomposition {
+        final ColumnRefOperator sumRef;
+        final CallOperator sumCall;
+        final ColumnRefOperator countRef;
+        final CallOperator countCall;
+
+        private AvgDecomposition(ColumnRefOperator sumRef, CallOperator sumCall,
+                                 ColumnRefOperator countRef, CallOperator countCall) {
+            this.sumRef = sumRef;
+            this.sumCall = sumCall;
+            this.countRef = countRef;
+            this.countCall = countCall;
+        }
+    }
+
+    private Map<ColumnRefOperator, AvgDecomposition> buildAvgDecompositions(ColumnRefFactory factory,
+                                                                            LogicalAggregationOperator aggregate) {
+        Map<ColumnRefOperator, AvgDecomposition> result = Maps.newHashMap();
+        aggregate.getAggregations().forEach((colRef, call) -> {
+            if (!FunctionSet.AVG.equals(call.getFnName())) {
+                return;
+            }
+            ScalarOperator arg = call.getChild(0);
+            Function sumFn = ExprUtils.getBuiltinFunction(FunctionSet.SUM, new Type[] {arg.getType()},
+                    Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+            Function countFn = ExprUtils.getBuiltinFunction(FunctionSet.COUNT, new Type[] {arg.getType()},
+                    Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+            Preconditions.checkState(sumFn instanceof AggregateFunction);
+            Preconditions.checkState(countFn instanceof AggregateFunction);
+
+            CallOperator sumCall = new CallOperator(FunctionSet.SUM, sumFn.getReturnType(),
+                    Lists.newArrayList(arg), sumFn);
+            CallOperator countCall = new CallOperator(FunctionSet.COUNT, countFn.getReturnType(),
+                    Lists.newArrayList(arg), countFn);
+            ColumnRefOperator sumRef = factory.create(sumCall, sumCall.getType(), sumCall.isNullable());
+            ColumnRefOperator countRef = factory.create(countCall, countCall.getType(), countCall.isNullable());
+            result.put(colRef, new AvgDecomposition(sumRef, sumCall, countRef, countCall));
+        });
+        return result;
     }
 
     private OptExpression buildUnionAll(LogicalAggregationOperator aggregate,
@@ -154,7 +225,8 @@ public class PushDownAggregateGroupingSetsRule extends TransformationRule {
         return OptExpression.create(union, repeatConsume, selectConsume);
     }
 
-    private OptExpression buildCTEProduce(OptimizerContext context, OptExpression input, int cteId) {
+    private OptExpression buildCTEProduce(OptimizerContext context, OptExpression input, int cteId,
+                                          Map<ColumnRefOperator, AvgDecomposition> avgDecompositions) {
         OptExpression repeatInput = input.inputAt(0);
         LogicalAggregationOperator aggregate = (LogicalAggregationOperator) input.getOp();
         LogicalRepeatOperator repeat = (LogicalRepeatOperator) repeatInput.getOp();
@@ -181,11 +253,24 @@ public class PushDownAggregateGroupingSetsRule extends TransformationRule {
             partitionRefs = allGroupByRefs;
         }
 
-        // replace output columns
+        // replace output columns; avg(x) is computed as sum(x)/count(x) here so the finest grain still
+        // produces a correct avg (nothing rewritten yet), but the underlying sum/count are what coarser
+        // rollup levels actually need to re-aggregate correctly (see buildSubRepeatConsume).
+        Map<ColumnRefOperator, CallOperator> cteAggregations = Maps.newHashMap();
+        aggregate.getAggregations().forEach((colRef, call) -> {
+            AvgDecomposition decomposition = avgDecompositions.get(colRef);
+            if (decomposition != null) {
+                cteAggregations.put(decomposition.sumRef, decomposition.sumCall);
+                cteAggregations.put(decomposition.countRef, decomposition.countCall);
+            } else {
+                cteAggregations.put(colRef, call);
+            }
+        });
+
         LogicalAggregationOperator.Builder builder = LogicalAggregationOperator.builder();
         builder.setType(AggType.GLOBAL)
                 .setGroupingKeys(allGroupByRefs)
-                .setAggregations(aggregate.getAggregations())
+                .setAggregations(cteAggregations)
                 .setPartitionByColumns(partitionRefs);
         LogicalAggregationOperator allColumnRefsAggregate = builder.build();
         // cte produce
@@ -201,16 +286,34 @@ public class PushDownAggregateGroupingSetsRule extends TransformationRule {
     private OptExpression buildSelectConsume(ColumnRefFactory factory,
                                              Map<ColumnRefOperator, ColumnRefOperator> outputs,
                                              LogicalAggregationOperator aggregate, LogicalRepeatOperator repeat,
-                                             int cteId) {
+                                             int cteId, Map<ColumnRefOperator, AvgDecomposition> avgDecompositions) {
 
         Map<ColumnRefOperator, ScalarOperator> projectMap = Maps.newHashMap();
         // consume
         Map<ColumnRefOperator, ColumnRefOperator> cteColumnRefs = Maps.newHashMap();
-        for (ColumnRefOperator input : aggregate.getAggregations().keySet()) {
-            ColumnRefOperator cteOutput = factory.create(input, input.getType(), input.isNullable());
-            cteColumnRefs.put(cteOutput, input);
-            outputs.put(input, cteOutput);
-            projectMap.put(cteOutput, cteOutput);
+        for (Map.Entry<ColumnRefOperator, CallOperator> entry : aggregate.getAggregations().entrySet()) {
+            ColumnRefOperator input = entry.getKey();
+            AvgDecomposition decomposition = avgDecompositions.get(input);
+            if (decomposition != null) {
+                // finest grain already has a correct avg (sum/count are exact, no rollup happened yet),
+                // so just recompute avg = sum/count from the CTE's sum/count columns.
+                ColumnRefOperator sumConsume = factory.create(decomposition.sumRef, decomposition.sumRef.getType(),
+                        decomposition.sumRef.isNullable());
+                ColumnRefOperator countConsume = factory.create(decomposition.countRef,
+                        decomposition.countRef.getType(), decomposition.countRef.isNullable());
+                cteColumnRefs.put(sumConsume, decomposition.sumRef);
+                cteColumnRefs.put(countConsume, decomposition.countRef);
+
+                ColumnRefOperator avgOutput = factory.create(input, input.getType(), input.isNullable());
+                outputs.put(input, avgOutput);
+                projectMap.put(avgOutput,
+                        AggregatePushDownUtils.createAvgBySumCount(entry.getValue(), sumConsume, countConsume));
+            } else {
+                ColumnRefOperator cteOutput = factory.create(input, input.getType(), input.isNullable());
+                cteColumnRefs.put(cteOutput, input);
+                outputs.put(input, cteOutput);
+                projectMap.put(cteOutput, cteOutput);
+            }
         }
         for (ColumnRefOperator input : aggregate.getGroupingKeys()) {
             if (!repeat.getOutputGrouping().contains(input)) {
@@ -250,17 +353,33 @@ public class PushDownAggregateGroupingSetsRule extends TransformationRule {
     public OptExpression buildSubRepeatConsume(ColumnRefFactory factory,
                                                 Map<ColumnRefOperator, ColumnRefOperator> outputs,
                                                 LogicalAggregationOperator aggregate, LogicalRepeatOperator repeat,
-                                                int cteId) {
+                                                int cteId, Map<ColumnRefOperator, AvgDecomposition> avgDecompositions) {
         int subGroups = repeat.getRepeatColumnRef().size() - 1;
         List<ColumnRefOperator> nullRefs = Lists.newArrayList(repeat.getRepeatColumnRef().get(subGroups));
         repeat.getRepeatColumnRef().stream().limit(subGroups).forEach(nullRefs::removeAll);
 
-        // consume
+        // consume; for avg(x), consume its sum(x)/count(x) columns instead of the (non-existent as a
+        // CTE output) avg column itself - tracked in avgSumConsume/avgCountConsume, kept out of `outputs`
+        // since `outputs` must end up holding the final recombined avg value, not an intermediate one.
+        Map<ColumnRefOperator, ColumnRefOperator> avgSumConsume = Maps.newHashMap();
+        Map<ColumnRefOperator, ColumnRefOperator> avgCountConsume = Maps.newHashMap();
         Map<ColumnRefOperator, ColumnRefOperator> cteColumnRefs = Maps.newHashMap();
         for (ColumnRefOperator input : aggregate.getAggregations().keySet()) {
-            ColumnRefOperator cteOutput = factory.create(input, input.getType(), input.isNullable());
-            cteColumnRefs.put(cteOutput, input);
-            outputs.put(input, cteOutput);
+            AvgDecomposition decomposition = avgDecompositions.get(input);
+            if (decomposition != null) {
+                ColumnRefOperator sumConsume = factory.create(decomposition.sumRef, decomposition.sumRef.getType(),
+                        decomposition.sumRef.isNullable());
+                ColumnRefOperator countConsume = factory.create(decomposition.countRef,
+                        decomposition.countRef.getType(), decomposition.countRef.isNullable());
+                cteColumnRefs.put(sumConsume, decomposition.sumRef);
+                cteColumnRefs.put(countConsume, decomposition.countRef);
+                avgSumConsume.put(input, sumConsume);
+                avgCountConsume.put(input, countConsume);
+            } else {
+                ColumnRefOperator cteOutput = factory.create(input, input.getType(), input.isNullable());
+                cteColumnRefs.put(cteOutput, input);
+                outputs.put(input, cteOutput);
+            }
         }
         for (ColumnRefOperator input : aggregate.getGroupingKeys()) {
             if (!repeat.getOutputGrouping().contains(input) && !nullRefs.contains(input)) {
@@ -307,22 +426,62 @@ public class PushDownAggregateGroupingSetsRule extends TransformationRule {
                 .setPredicate(predicate)
                 .build();
 
-        // aggregate
+        // aggregate; avg(x)'s sum/count must be re-summed (never re-averaged) to stay correct across
+        // rollup levels of unequal weight, so both are tracked here and only recombined into avg by the
+        // final Project below.
         Map<ColumnRefOperator, CallOperator> aggregations = Maps.newHashMap();
+        Map<ColumnRefOperator, ColumnRefOperator> avgSumRolledUp = Maps.newHashMap();
+        Map<ColumnRefOperator, ColumnRefOperator> avgCountRolledUp = Maps.newHashMap();
         aggregate.getAggregations().forEach((k, v) -> {
-            ColumnRefOperator x = factory.create(k, k.getType(), k.isNullable());
-            Function aggFunc = ExprUtils.getBuiltinFunction(v.getFnName(), new Type[] {k.getType()},
-                    Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+            AvgDecomposition decomposition = avgDecompositions.get(k);
+            if (decomposition != null) {
+                ColumnRefOperator sumConsumeRef = avgSumConsume.get(k);
+                ColumnRefOperator countConsumeRef = avgCountConsume.get(k);
 
-            Preconditions.checkState(aggFunc instanceof AggregateFunction);
-            if (k.getType().isDecimalOfAnyVersion()) {
-                aggFunc = DecimalV3FunctionAnalyzer.rectifyAggregationFunction((AggregateFunction) aggFunc, k.getType(),
-                        v.getType());
+                Function sumFn = ExprUtils.getBuiltinFunction(FunctionSet.SUM,
+                        new Type[] {sumConsumeRef.getType()}, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+                Preconditions.checkState(sumFn instanceof AggregateFunction);
+                if (sumConsumeRef.getType().isDecimalOfAnyVersion()) {
+                    sumFn = DecimalV3FunctionAnalyzer.rectifyAggregationFunction((AggregateFunction) sumFn,
+                            sumConsumeRef.getType(), sumConsumeRef.getType());
+                }
+                ColumnRefOperator rolledUpSum =
+                        factory.create(sumConsumeRef, sumConsumeRef.getType(), sumConsumeRef.isNullable());
+                aggregations.put(rolledUpSum, new CallOperator(FunctionSet.SUM, sumConsumeRef.getType(),
+                        Lists.newArrayList(sumConsumeRef), sumFn));
+
+                Function countFn = ExprUtils.getBuiltinFunction(FunctionSet.SUM,
+                        new Type[] {countConsumeRef.getType()}, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+                Preconditions.checkState(countFn instanceof AggregateFunction);
+                ColumnRefOperator rolledUpCount =
+                        factory.create(countConsumeRef, countConsumeRef.getType(), countConsumeRef.isNullable());
+                aggregations.put(rolledUpCount, new CallOperator(FunctionSet.SUM, countConsumeRef.getType(),
+                        Lists.newArrayList(countConsumeRef), countFn));
+
+                avgSumRolledUp.put(k, rolledUpSum);
+                avgCountRolledUp.put(k, rolledUpCount);
+            } else {
+                // sum/min/max are self-recombining (same function name); count is not - the coarser
+                // level must re-SUM the finer levels' partial counts, not re-COUNT them (which would
+                // count the number of partial-count rows instead of summing their values). Reuse the
+                // same rollup-function mapping already used by the MV-rewrite path and by pdagg.
+                String rollupFnName = AggregateFunctionRollupUtils.getRollupFunctionName(v, false);
+                String fnName = rollupFnName != null ? rollupFnName : v.getFnName();
+
+                ColumnRefOperator x = factory.create(k, k.getType(), k.isNullable());
+                Function aggFunc = ExprUtils.getBuiltinFunction(fnName, new Type[] {k.getType()},
+                        Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+
+                Preconditions.checkState(aggFunc instanceof AggregateFunction);
+                if (k.getType().isDecimalOfAnyVersion()) {
+                    aggFunc = DecimalV3FunctionAnalyzer.rectifyAggregationFunction((AggregateFunction) aggFunc,
+                            k.getType(), v.getType());
+                }
+
+                aggregations.put(x,
+                        new CallOperator(fnName, k.getType(), Lists.newArrayList(outputs.get(k)), aggFunc));
+                outputs.put(k, x);
             }
-
-            aggregations.put(x,
-                    new CallOperator(v.getFnName(), k.getType(), Lists.newArrayList(outputs.get(k)), aggFunc));
-            outputs.put(k, x);
         });
 
         List<ColumnRefOperator> groupings = aggregate.getGroupingKeys().stream()
@@ -346,6 +505,15 @@ public class PushDownAggregateGroupingSetsRule extends TransformationRule {
         Map<ColumnRefOperator, ScalarOperator> projection = Maps.newHashMap();
         aggregations.keySet().forEach(k -> projection.put(k, k));
         groupings.forEach(k -> projection.put(k, k));
+
+        avgSumRolledUp.forEach((origAvgRef, rolledUpSum) -> {
+            ColumnRefOperator rolledUpCount = avgCountRolledUp.get(origAvgRef);
+            CallOperator origAvgCall = aggregate.getAggregations().get(origAvgRef);
+            ColumnRefOperator avgOutput = factory.create(origAvgRef, origAvgRef.getType(), origAvgRef.isNullable());
+            projection.put(avgOutput,
+                    AggregatePushDownUtils.createAvgBySumCount(origAvgCall, rolledUpSum, rolledUpCount));
+            outputs.put(origAvgRef, avgOutput);
+        });
 
         for (ColumnRefOperator nullRef : nullRefs) {
             ColumnRefOperator m = factory.create(nullRef, nullRef.getType(), true);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownAggregateGroupingSetsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownAggregateGroupingSetsRule.java
@@ -186,6 +186,21 @@ public class PushDownAggregateGroupingSetsRule extends TransformationRule {
     private Map<ColumnRefOperator, AvgDecomposition> buildAvgDecompositions(ColumnRefFactory factory,
                                                                             LogicalAggregationOperator aggregate) {
         Map<ColumnRefOperator, AvgDecomposition> result = Maps.newHashMap();
+
+        // An avg(x) decomposition frequently duplicates an aggregation the query already asks for:
+        // `avg(x), count(x)` needs a single count(x), and two avg() over the same argument need a single
+        // sum/count pair. Index what is already available by call, so a synthesized part can bind to an
+        // existing output column instead of adding a redundant one to the CTE. Reuse is driven purely by
+        // CallOperator equality, so it never fires across genuinely different expressions - notably when
+        // the analyzer has wrapped avg's argument in a scale-capping CAST, avg's arg is not equal to the
+        // bare column a sibling count(x) reads, and the two correctly stay separate.
+        Map<CallOperator, ColumnRefOperator> reusable = Maps.newHashMap();
+        aggregate.getAggregations().forEach((colRef, call) -> {
+            if (!FunctionSet.AVG.equals(call.getFnName())) {
+                reusable.putIfAbsent(call, colRef);
+            }
+        });
+
         aggregate.getAggregations().forEach((colRef, call) -> {
             if (!FunctionSet.AVG.equals(call.getFnName())) {
                 return;
@@ -211,13 +226,19 @@ public class PushDownAggregateGroupingSetsRule extends TransformationRule {
             Preconditions.checkState(sumFn instanceof AggregateFunction);
             Preconditions.checkState(countFn instanceof AggregateFunction);
 
-            if (sumArg.getType().isDecimalOfAnyVersion()) {
-                // decimal SUM always widens its accumulator - to DECIMAL128(38, scale) for decimal32/64/128
-                // inputs, or DECIMAL256(76, scale) for decimal256 inputs, since the BE registers a
-                // dedicated decimal256->decimal256 decimal_sum mapping (see
+            if (sumArg.getType().isDecimalV3()) {
+                // DecimalV3 SUM always widens its accumulator - to DECIMAL128(38, scale) for
+                // decimal32/64/128 inputs, or DECIMAL256(76, scale) for decimal256 inputs, since the BE
+                // registers a dedicated decimal256->decimal256 decimal_sum mapping (see
                 // aggregate_resolver_sumcount.cpp's SumDispatcher). Narrowing to the argument's own
                 // precision - or always widening to DECIMAL128 regardless of input width, as
                 // ScalarOperatorUtil.findSumFn does - would both mismatch the BE's registered accumulator.
+                //
+                // This must test isDecimalV3(), NOT isDecimalOfAnyVersion(): legacy DECIMALV2 is a
+                // separate BE implementation registered as sum(DECIMALV2) -> DECIMALV2, so handing it a
+                // DecimalV3 return type makes the BE reject the plan outright with
+                // "Invalid agg function plan: sum with (arg type DECIMALV2, ..., result type DECIMAL128)".
+                // DECIMALV2 keeps the natively resolved SUM signature instead.
                 ScalarType decimalArgType = (ScalarType) sumArg.getType();
                 int widePrecision = decimalArgType.isDecimal256() ? 76 : 38;
                 AggregateFunction decimalSumFn = (AggregateFunction) sumFn.copy();
@@ -231,8 +252,10 @@ public class PushDownAggregateGroupingSetsRule extends TransformationRule {
                     Lists.newArrayList(sumArg), sumFn);
             CallOperator countCall = new CallOperator(FunctionSet.COUNT, countFn.getReturnType(),
                     Lists.newArrayList(arg), countFn);
-            ColumnRefOperator sumRef = factory.create(sumCall, sumCall.getType(), sumCall.isNullable());
-            ColumnRefOperator countRef = factory.create(countCall, countCall.getType(), countCall.isNullable());
+            ColumnRefOperator sumRef =
+                    reusable.computeIfAbsent(sumCall, c -> factory.create(c, c.getType(), c.isNullable()));
+            ColumnRefOperator countRef =
+                    reusable.computeIfAbsent(countCall, c -> factory.create(c, c.getType(), c.isNullable()));
             result.put(colRef, new AvgDecomposition(sumRef, sumCall, countRef, countCall));
         });
         return result;
@@ -316,6 +339,27 @@ public class PushDownAggregateGroupingSetsRule extends TransformationRule {
     /*
      * selec *, (grouping_id, grouping_set) fom cte1
      */
+    /**
+     * Create (or reuse) the consume-side column that reads one CTE output column.
+     *
+     * A single CTE output can now be wanted by more than one aggregation - an avg(x) decomposition and a
+     * sibling count(x) bind to the same column once buildAvgDecompositions dedupes them. Reading it twice
+     * would still be correct but would add a redundant consume column, so requests are cached by CTE
+     * output ref. The cache is what makes this order-independent: aggregations are iterated from a
+     * HashMap, so either the avg branch or the plain branch may run first, and both must end up with the
+     * same consume ref rather than whichever one happened to be created first.
+     */
+    private ColumnRefOperator consumeOf(ColumnRefFactory factory,
+                                        Map<ColumnRefOperator, ColumnRefOperator> cteColumnRefs,
+                                        Map<ColumnRefOperator, ColumnRefOperator> consumed,
+                                        ColumnRefOperator cteOutput) {
+        return consumed.computeIfAbsent(cteOutput, output -> {
+            ColumnRefOperator consume = factory.create(output, output.getType(), output.isNullable());
+            cteColumnRefs.put(consume, output);
+            return consume;
+        });
+    }
+
     private OptExpression buildSelectConsume(ColumnRefFactory factory,
                                              Map<ColumnRefOperator, ColumnRefOperator> outputs,
                                              LogicalAggregationOperator aggregate, LogicalRepeatOperator repeat,
@@ -324,26 +368,22 @@ public class PushDownAggregateGroupingSetsRule extends TransformationRule {
         Map<ColumnRefOperator, ScalarOperator> projectMap = Maps.newHashMap();
         // consume
         Map<ColumnRefOperator, ColumnRefOperator> cteColumnRefs = Maps.newHashMap();
+        Map<ColumnRefOperator, ColumnRefOperator> consumed = Maps.newHashMap();
         for (Map.Entry<ColumnRefOperator, CallOperator> entry : aggregate.getAggregations().entrySet()) {
             ColumnRefOperator input = entry.getKey();
             AvgDecomposition decomposition = avgDecompositions.get(input);
             if (decomposition != null) {
                 // finest grain already has a correct avg (sum/count are exact, no rollup happened yet),
                 // so just recompute avg = sum/count from the CTE's sum/count columns.
-                ColumnRefOperator sumConsume = factory.create(decomposition.sumRef, decomposition.sumRef.getType(),
-                        decomposition.sumRef.isNullable());
-                ColumnRefOperator countConsume = factory.create(decomposition.countRef,
-                        decomposition.countRef.getType(), decomposition.countRef.isNullable());
-                cteColumnRefs.put(sumConsume, decomposition.sumRef);
-                cteColumnRefs.put(countConsume, decomposition.countRef);
+                ColumnRefOperator sumConsume = consumeOf(factory, cteColumnRefs, consumed, decomposition.sumRef);
+                ColumnRefOperator countConsume = consumeOf(factory, cteColumnRefs, consumed, decomposition.countRef);
 
                 ColumnRefOperator avgOutput = factory.create(input, input.getType(), input.isNullable());
                 outputs.put(input, avgOutput);
                 projectMap.put(avgOutput,
                         AggregatePushDownUtils.createAvgBySumCount(entry.getValue(), sumConsume, countConsume));
             } else {
-                ColumnRefOperator cteOutput = factory.create(input, input.getType(), input.isNullable());
-                cteColumnRefs.put(cteOutput, input);
+                ColumnRefOperator cteOutput = consumeOf(factory, cteColumnRefs, consumed, input);
                 outputs.put(input, cteOutput);
                 projectMap.put(cteOutput, cteOutput);
             }
@@ -397,21 +437,14 @@ public class PushDownAggregateGroupingSetsRule extends TransformationRule {
         Map<ColumnRefOperator, ColumnRefOperator> avgSumConsume = Maps.newHashMap();
         Map<ColumnRefOperator, ColumnRefOperator> avgCountConsume = Maps.newHashMap();
         Map<ColumnRefOperator, ColumnRefOperator> cteColumnRefs = Maps.newHashMap();
+        Map<ColumnRefOperator, ColumnRefOperator> consumed = Maps.newHashMap();
         for (ColumnRefOperator input : aggregate.getAggregations().keySet()) {
             AvgDecomposition decomposition = avgDecompositions.get(input);
             if (decomposition != null) {
-                ColumnRefOperator sumConsume = factory.create(decomposition.sumRef, decomposition.sumRef.getType(),
-                        decomposition.sumRef.isNullable());
-                ColumnRefOperator countConsume = factory.create(decomposition.countRef,
-                        decomposition.countRef.getType(), decomposition.countRef.isNullable());
-                cteColumnRefs.put(sumConsume, decomposition.sumRef);
-                cteColumnRefs.put(countConsume, decomposition.countRef);
-                avgSumConsume.put(input, sumConsume);
-                avgCountConsume.put(input, countConsume);
+                avgSumConsume.put(input, consumeOf(factory, cteColumnRefs, consumed, decomposition.sumRef));
+                avgCountConsume.put(input, consumeOf(factory, cteColumnRefs, consumed, decomposition.countRef));
             } else {
-                ColumnRefOperator cteOutput = factory.create(input, input.getType(), input.isNullable());
-                cteColumnRefs.put(cteOutput, input);
-                outputs.put(input, cteOutput);
+                outputs.put(input, consumeOf(factory, cteColumnRefs, consumed, input));
             }
         }
         for (ColumnRefOperator input : aggregate.getGroupingKeys()) {
@@ -470,31 +503,42 @@ public class PushDownAggregateGroupingSetsRule extends TransformationRule {
         Map<ColumnRefOperator, CallOperator> aggregations = Maps.newHashMap();
         Map<ColumnRefOperator, ColumnRefOperator> avgSumRolledUp = Maps.newHashMap();
         Map<ColumnRefOperator, ColumnRefOperator> avgCountRolledUp = Maps.newHashMap();
+        // Consume columns shared by several aggregations (see consumeOf) must be re-aggregated once, not
+        // once per consumer. Keyed by consume ref, and safe to key on that alone: sharing only happens
+        // when the underlying CTE column is the very same call, and every rollup over such a column is a
+        // SUM either way - avg's partials are summed, and count rolls up to sum too. Like consumeOf this
+        // has to be a cache rather than an ordering assumption, since the two branches run in HashMap
+        // order.
+        Map<ColumnRefOperator, ColumnRefOperator> rolledUp = Maps.newHashMap();
         aggregate.getAggregations().forEach((k, v) -> {
             AvgDecomposition decomposition = avgDecompositions.get(k);
             if (decomposition != null) {
                 ColumnRefOperator sumConsumeRef = avgSumConsume.get(k);
                 ColumnRefOperator countConsumeRef = avgCountConsume.get(k);
 
-                Function sumFn = ExprUtils.getBuiltinFunction(FunctionSet.SUM,
-                        new Type[] {sumConsumeRef.getType()}, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
-                Preconditions.checkState(sumFn instanceof AggregateFunction);
-                if (sumConsumeRef.getType().isDecimalOfAnyVersion()) {
-                    sumFn = DecimalV3FunctionAnalyzer.rectifyAggregationFunction((AggregateFunction) sumFn,
-                            sumConsumeRef.getType(), sumConsumeRef.getType());
-                }
-                ColumnRefOperator rolledUpSum =
-                        factory.create(sumConsumeRef, sumConsumeRef.getType(), sumConsumeRef.isNullable());
-                aggregations.put(rolledUpSum, new CallOperator(FunctionSet.SUM, sumConsumeRef.getType(),
-                        Lists.newArrayList(sumConsumeRef), sumFn));
+                ColumnRefOperator rolledUpSum = rolledUp.computeIfAbsent(sumConsumeRef, ref -> {
+                    Function sumFn = ExprUtils.getBuiltinFunction(FunctionSet.SUM,
+                            new Type[] {ref.getType()}, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+                    Preconditions.checkState(sumFn instanceof AggregateFunction);
+                    if (ref.getType().isDecimalOfAnyVersion()) {
+                        sumFn = DecimalV3FunctionAnalyzer.rectifyAggregationFunction((AggregateFunction) sumFn,
+                                ref.getType(), ref.getType());
+                    }
+                    ColumnRefOperator out = factory.create(ref, ref.getType(), ref.isNullable());
+                    aggregations.put(out, new CallOperator(FunctionSet.SUM, ref.getType(),
+                            Lists.newArrayList(ref), sumFn));
+                    return out;
+                });
 
-                Function countFn = ExprUtils.getBuiltinFunction(FunctionSet.SUM,
-                        new Type[] {countConsumeRef.getType()}, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
-                Preconditions.checkState(countFn instanceof AggregateFunction);
-                ColumnRefOperator rolledUpCount =
-                        factory.create(countConsumeRef, countConsumeRef.getType(), countConsumeRef.isNullable());
-                aggregations.put(rolledUpCount, new CallOperator(FunctionSet.SUM, countConsumeRef.getType(),
-                        Lists.newArrayList(countConsumeRef), countFn));
+                ColumnRefOperator rolledUpCount = rolledUp.computeIfAbsent(countConsumeRef, ref -> {
+                    Function countFn = ExprUtils.getBuiltinFunction(FunctionSet.SUM,
+                            new Type[] {ref.getType()}, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+                    Preconditions.checkState(countFn instanceof AggregateFunction);
+                    ColumnRefOperator out = factory.create(ref, ref.getType(), ref.isNullable());
+                    aggregations.put(out, new CallOperator(FunctionSet.SUM, ref.getType(),
+                            Lists.newArrayList(ref), countFn));
+                    return out;
+                });
 
                 avgSumRolledUp.put(k, rolledUpSum);
                 avgCountRolledUp.put(k, rolledUpCount);
@@ -513,27 +557,30 @@ public class PushDownAggregateGroupingSetsRule extends TransformationRule {
                 String rollupFnName = AggregateFunctionRollupUtils.getRollupFunctionName(v, false);
                 String fnName = rollupFnName != null ? rollupFnName : v.getFnName();
 
-                ColumnRefOperator x = factory.create(k, k.getType(), k.isNullable());
-                Function aggFunc = ExprUtils.getBuiltinFunction(fnName, new Type[] {k.getType()},
-                        Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+                ColumnRefOperator x = rolledUp.computeIfAbsent(outputs.get(k), ref -> {
+                    ColumnRefOperator out = factory.create(k, k.getType(), k.isNullable());
+                    Function aggFunc = ExprUtils.getBuiltinFunction(fnName, new Type[] {k.getType()},
+                            Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
 
-                Preconditions.checkState(aggFunc instanceof AggregateFunction);
-                if (k.getType().isDecimalOfAnyVersion()) {
-                    aggFunc = DecimalV3FunctionAnalyzer.rectifyAggregationFunction((AggregateFunction) aggFunc,
-                            k.getType(), v.getType());
-                }
+                    Preconditions.checkState(aggFunc instanceof AggregateFunction);
+                    if (k.getType().isDecimalOfAnyVersion()) {
+                        aggFunc = DecimalV3FunctionAnalyzer.rectifyAggregationFunction((AggregateFunction) aggFunc,
+                                k.getType(), v.getType());
+                    }
 
-                // The rolled-up call keeps the original aggregation's output type, which only holds while
-                // every rollup mapping is type-preserving over its own output (count->sum is: sum(BIGINT)
-                // is BIGINT). Other entries in the mapping are not - bitmap_agg->bitmap_union and
-                // array_agg_distinct->array_unique_agg both change the type - so fail loudly here rather
-                // than silently emitting a CallOperator whose declared type contradicts its function.
-                Preconditions.checkState(aggFunc.getReturnType().matchesType(k.getType()),
-                        "rollup function %s returns %s but the aggregation output column is %s",
-                        fnName, aggFunc.getReturnType(), k.getType());
+                    // The rolled-up call keeps the original aggregation's output type, which only holds
+                    // while every rollup mapping is type-preserving over its own output (count->sum is:
+                    // sum(BIGINT) is BIGINT). Other entries in the mapping are not - bitmap_agg->
+                    // bitmap_union and array_agg_distinct->array_unique_agg both change the type - so
+                    // fail loudly here rather than silently emitting a CallOperator whose declared type
+                    // contradicts its function.
+                    Preconditions.checkState(aggFunc.getReturnType().matchesType(k.getType()),
+                            "rollup function %s returns %s but the aggregation output column is %s",
+                            fnName, aggFunc.getReturnType(), k.getType());
 
-                aggregations.put(x,
-                        new CallOperator(fnName, k.getType(), Lists.newArrayList(outputs.get(k)), aggFunc));
+                    aggregations.put(out, new CallOperator(fnName, k.getType(), Lists.newArrayList(ref), aggFunc));
+                    return out;
+                });
                 outputs.put(k, x);
             }
         });

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownAggregateGroupingSetsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownAggregateGroupingSetsRule.java
@@ -42,6 +42,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorUtil;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.rewrite.scalar.FoldConstantsRule;
@@ -206,10 +207,12 @@ public class PushDownAggregateGroupingSetsRule extends TransformationRule {
             Preconditions.checkState(countFn instanceof AggregateFunction);
 
             if (sumArg.getType().isDecimalOfAnyVersion()) {
-                // the registered SUM signature is a wildcard decimal type; rectify it to the concrete
-                // argument precision/scale before use, same as the rollup level below and the analyzer path.
-                sumFn = DecimalV3FunctionAnalyzer.rectifyAggregationFunction((AggregateFunction) sumFn,
-                        sumArg.getType(), sumArg.getType());
+                // decimal SUM always widens its accumulator to DECIMAL128(38, scale) - narrowing the
+                // return type to the argument's own (possibly DECIMAL32/64) precision would both mismatch
+                // the BE's registered decimal_sum signature and lose the accumulator width SUM needs to
+                // avoid overflow. Reuse the canonical decimal-SUM synthesis helper instead of rectifying
+                // by hand, so this stays in sync with how MV rewrite already builds a decimal SUM.
+                sumFn = ScalarOperatorUtil.findSumFn(new Type[] {sumArg.getType()});
             }
 
             CallOperator sumCall = new CallOperator(FunctionSet.SUM, sumFn.getReturnType(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/common/AggregatePushDownUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/common/AggregatePushDownUtils.java
@@ -40,6 +40,7 @@ import com.starrocks.sql.optimizer.rule.transformation.materialization.Aggregate
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.PredicateSplit;
 import com.starrocks.sql.optimizer.rule.tree.pdagg.AggregatePushDownContext;
+import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeFactory;
@@ -367,9 +368,18 @@ public class AggregatePushDownUtils {
         Type argType = avgFunc.getChild(0).getType();
         if (argType.isDecimalV3()) {
             // There is not need to apply ImplicitCastRule to divide operator of decimal types.
-            // but we should cast BIGINT-typed countColRef into DECIMAL(38,0).
-            ScalarType decimal128p38s0 = TypeFactory.createDecimalV3NarrowestType(38, 0);
-            newAvg.getChildren().set(1, new CastOperator(decimal128p38s0, newAvg.getChild(1), true));
+            // but we should cast BIGINT-typed countColRef into a decimal.
+            //
+            // The cast width must match the DIVIDE's own decimal type, not a fixed DECIMAL128: the BE
+            // dispatches division on the expression's type (VectorizedDivArithmeticExpr<TYPE_DECIMAL256>
+            // for a DECIMAL256 result) and reads BOTH operands at that width. Handing it a DECIMAL128
+            // count where it expects a DECIMAL256 one reinterprets the column's memory and silently
+            // returns garbage - avg(decimal(76,10)) came back as 0 for every row.
+            int countPrecision = avgFunc.getType().isDecimal256()
+                    ? PrimitiveType.getMaxPrecisionOfDecimal(PrimitiveType.DECIMAL256)
+                    : PrimitiveType.getMaxPrecisionOfDecimal(PrimitiveType.DECIMAL128);
+            ScalarType countType = TypeFactory.createDecimalV3NarrowestType(countPrecision, 0);
+            newAvg.getChildren().set(1, new CastOperator(countType, newAvg.getChild(1), true));
         } else {
             final ScalarOperatorRewriter scalarRewriter = new ScalarOperatorRewriter();
             newAvg = (CallOperator) scalarRewriter.rewrite(newAvg, Lists.newArrayList(new ImplicitCastRule()));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
@@ -342,11 +342,17 @@ public class GroupingSetsTest extends PlanTestBase {
             // decimal128 return type registered on the builtin SUM signature
             String sql = "select t1b, t1c, t1d, avg(id_decimal) " +
                     "   from test_all_type group by rollup(t1b, t1c, t1d)";
-            String plan = getFragmentPlan(sql);
+            String plan = getVerboseExplain(sql);
+            // id_decimal is DECIMAL64(10,2); the synthesized sum must widen its result to
+            // DECIMAL128(38, 2) - the BE's registered decimal_sum accumulator width - not stay
+            // narrowed to the argument's own DECIMAL64 precision
             assertContains(plan, "  1:AGGREGATE (update serialize)\n" +
                     "  |  STREAMING\n" +
-                    "  |  output: sum(10: id_decimal), count(10: id_decimal)\n" +
-                    "  |  group by: 2: t1b, 3: t1c, 4: t1d");
+                    "  |  aggregate: sum[([10: id_decimal, DECIMAL64(10,2), true]); args: DECIMAL64; " +
+                    "result: DECIMAL128(38,2); args nullable: true; result nullable: true], " +
+                    "count[([10: id_decimal, DECIMAL64(10,2), true]); args: DECIMAL64; result: BIGINT; " +
+                    "args nullable: true; result nullable: false]\n" +
+                    "  |  group by: [2: t1b, SMALLINT, true], [3: t1c, INT, true], [4: t1d, BIGINT, true]");
         } finally {
             connectContext.getSessionVariable().setCboPushDownGroupingSet(false);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
@@ -334,6 +334,34 @@ public class GroupingSetsTest extends PlanTestBase {
     }
 
     @Test
+    public void testPushDownGroupingSetUnsupportedFn() throws Exception {
+        connectContext.getSessionVariable().setCboPushDownGroupingSet(true);
+        try {
+            // SUPPORT_AGGREGATE_FUNCTIONS is a whitelist of functions that can be recombined across
+            // rollup levels. Widening it (as AVG/COUNT did) must not turn it into an allow-everything:
+            // a function outside the list still has to fall back to REPEAT over the raw rows.
+            String unsupportedFn = "select t1b, t1c, t1d, stddev(t1g) " +
+                    "   from test_all_type group by rollup(t1b, t1c, t1d)";
+            assertContains(getFragmentPlan(unsupportedFn), "  1:REPEAT_NODE\n" +
+                    "  |  repeat: repeat 3 lines [[], [2], [2, 3], [2, 3, 4]]\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode");
+
+            // DISTINCT is excluded for every whitelisted function too: count(distinct x) cannot be
+            // recombined by re-summing partial counts, since the same value may repeat across the
+            // finer groups being rolled up.
+            String distinctCount = "select t1b, t1c, t1d, count(distinct t1g) " +
+                    "   from test_all_type group by rollup(t1b, t1c, t1d)";
+            assertContains(getFragmentPlan(distinctCount), "  1:REPEAT_NODE\n" +
+                    "  |  repeat: repeat 3 lines [[], [2], [2, 3], [2, 3, 4]]\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode");
+        } finally {
+            connectContext.getSessionVariable().setCboPushDownGroupingSet(false);
+        }
+    }
+
+    @Test
     public void testPushDownGroupingSetAvgDecimal() throws Exception {
         connectContext.getSessionVariable().setCboPushDownGroupingSet(true);
         try {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
@@ -283,16 +283,97 @@ public class GroupingSetsTest extends PlanTestBase {
     }
 
     @Test
-    public void testPushDownGroupingSetErrorFn() throws Exception {
+    public void testPushDownGroupingSetAvg() throws Exception {
         connectContext.getSessionVariable().setCboPushDownGroupingSet(true);
         try {
-            String sql = "select t1b, t1c, t1d, count(t1g) " +
+            String sql = "select t1b, t1c, t1d, avg(t1g) " +
                     "   from test_all_type group by rollup(t1b, t1c, t1d)";
+            String plan = getFragmentPlan(sql);
+            // finest grain computes sum/count instead of avg, so coarser rollup levels can be
+            // re-aggregated correctly (re-summing, not re-averaging)
+            assertContains(plan, "  1:AGGREGATE (update serialize)\n" +
+                    "  |  STREAMING\n" +
+                    "  |  output: sum(7: t1g), count(7: t1g)\n" +
+                    "  |  group by: 2: t1b, 3: t1c, 4: t1d");
+            // REPEAT_NODE now runs on the already-aggregated (t1b, t1c) result, not on raw rows
+            assertContains(plan, "  7:REPEAT_NODE\n" +
+                    "  |  repeat: repeat 2 lines [[], [17], [17, 18]]");
+            // coarser rollup levels re-sum the sum/count columns, never re-average them
+            assertContains(plan, "  3:AGGREGATE (merge finalize)\n" +
+                    "  |  output: sum(13: sum), count(14: count)\n" +
+                    "  |  group by: 2: t1b, 3: t1c, 4: t1d");
+            assertContains(plan, "  10:AGGREGATE (merge finalize)\n" +
+                    "  |  output: sum(20: sum), sum(21: count)\n" +
+                    "  |  group by: 17: t1b, 18: t1c, 19: GROUPING_ID");
+            // avg is recovered via division wherever it's consumed
+            assertContains(plan, "CAST(20: sum AS DOUBLE) / CAST(21: count AS DOUBLE)");
+            assertContains(plan, "CAST(24: sum AS DOUBLE) / CAST(25: count AS DOUBLE)");
+        } finally {
+            connectContext.getSessionVariable().setCboPushDownGroupingSet(false);
+        }
+    }
+
+    @Test
+    public void testPushDownGroupingSetAvgWithHavingNotPushedDown() throws Exception {
+        connectContext.getSessionVariable().setCboPushDownGroupingSet(true);
+        try {
+            // a HAVING predicate directly on the avg() output can't be safely re-evaluated against the
+            // pre-divide sum/count columns of a re-aggregated rollup level, so push down must not fire
+            String sql = "select t1b, t1c, t1d, avg(t1g) " +
+                    "   from test_all_type group by rollup(t1b, t1c, t1d) having avg(t1g) > 10";
             String plan = getFragmentPlan(sql);
             assertContains(plan, "  1:REPEAT_NODE\n" +
                     "  |  repeat: repeat 3 lines [[], [2], [2, 3], [2, 3, 4]]\n" +
                     "  |  \n" +
                     "  0:OlapScanNode");
+        } finally {
+            connectContext.getSessionVariable().setCboPushDownGroupingSet(false);
+        }
+    }
+
+    @Test
+    public void testPushDownGroupingSetCount() throws Exception {
+        connectContext.getSessionVariable().setCboPushDownGroupingSet(true);
+        try {
+            String sql = "select t1b, t1c, t1d, count(t1g) " +
+                    "   from test_all_type group by rollup(t1b, t1c, t1d)";
+            String plan = getFragmentPlan(sql);
+            // finest grain: an ordinary count, nothing to recombine yet
+            assertContains(plan, "  1:AGGREGATE (update serialize)\n" +
+                    "  |  STREAMING\n" +
+                    "  |  output: count(7: t1g)\n" +
+                    "  |  group by: 2: t1b, 3: t1c, 4: t1d");
+            // REPEAT now runs on the already-aggregated (t1b, t1c) result, not on raw rows
+            assertContains(plan, "  7:REPEAT_NODE\n" +
+                    "  |  repeat: repeat 2 lines [[], [14], [14, 15]]");
+            // coarser rollup levels re-SUM the finer levels' partial counts, never re-COUNT them
+            assertContains(plan, "  8:AGGREGATE (update serialize)\n" +
+                    "  |  STREAMING\n" +
+                    "  |  output: sum(13: count)\n" +
+                    "  |  group by: 14: t1b, 15: t1c, 16: GROUPING_ID");
+            assertContains(plan, "  10:AGGREGATE (merge finalize)\n" +
+                    "  |  output: sum(17: count)\n" +
+                    "  |  group by: 14: t1b, 15: t1c, 16: GROUPING_ID");
+        } finally {
+            connectContext.getSessionVariable().setCboPushDownGroupingSet(false);
+        }
+    }
+
+    @Test
+    public void testPushDownGroupingSetCountWithHaving() throws Exception {
+        connectContext.getSessionVariable().setCboPushDownGroupingSet(true);
+        try {
+            // unlike avg, a re-summed count IS directly the correct final value (no division needed),
+            // so HAVING count(t1g) > 10 can safely push down and filter on the re-summed column.
+            String sql = "select t1b, t1c, t1d, count(t1g) " +
+                    "   from test_all_type group by rollup(t1b, t1c, t1d) having count(t1g) > 10";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  10:AGGREGATE (merge finalize)\n" +
+                    "  |  output: sum(17: count)\n" +
+                    "  |  group by: 14: t1b, 15: t1c, 16: GROUPING_ID\n" +
+                    "  |  having: 17: count > 10");
+            assertContains(plan, "  15:SELECT\n" +
+                    "  |  predicates: 19: count > 10");
         } finally {
             connectContext.getSessionVariable().setCboPushDownGroupingSet(false);
         }
@@ -448,7 +529,9 @@ public class GroupingSetsTest extends PlanTestBase {
             public OptExpression buildSubRepeatConsume(ColumnRefFactory factory,
                                                        Map<ColumnRefOperator, ColumnRefOperator> outputs,
                                                        LogicalAggregationOperator aggregate, LogicalRepeatOperator repeat,
-                                                       int cteId) {
+                                                       int cteId,
+                                                       Map<ColumnRefOperator, PushDownAggregateGroupingSetsRule.AvgDecomposition>
+                                                               avgDecompositions) {
                 int subGroups = repeat.getRepeatColumnRef().size() - 1;
                 List<ColumnRefOperator> nullRefs = Lists.newArrayList(repeat.getRepeatColumnRef().get(subGroups));
                 repeat.getRepeatColumnRef().stream().limit(subGroups).forEach(nullRefs::removeAll);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
@@ -359,6 +359,42 @@ public class GroupingSetsTest extends PlanTestBase {
     }
 
     @Test
+    public void testPushDownGroupingSetAvgDecimal256() throws Exception {
+        connectContext.getSessionVariable().setCboPushDownGroupingSet(true);
+        starRocksAssert.withTable("CREATE TABLE test_decimal256_avg (\n" +
+                "  `k1` int NULL,\n" +
+                "  `k2` int NULL,\n" +
+                "  `k3` int NULL,\n" +
+                "  `k4` int NULL,\n" +
+                "  `v` decimal(76, 10) NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k1`)\n" +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");");
+        try {
+            // v is DECIMAL256(76,10); the BE registers a dedicated decimal256->decimal256 decimal_sum
+            // mapping (unlike decimal32/64/128, which all widen to DECIMAL128), so the synthesized sum
+            // must stay in DECIMAL256, not get force-widened down to DECIMAL128
+            String sql = "select k1, k2, k3, k4, avg(v) " +
+                    "   from test_decimal256_avg group by rollup(k1, k2, k3, k4)";
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "  1:AGGREGATE (update finalize)\n" +
+                    "  |  aggregate: sum[([5: v, DECIMAL256(76,10), true]); args: DECIMAL256; " +
+                    "result: DECIMAL256(76,10); args nullable: true; result nullable: true], " +
+                    "count[([5: v, DECIMAL256(76,10), true]); args: DECIMAL256; result: BIGINT; " +
+                    "args nullable: true; result nullable: false]");
+            // the rolled-up sum must also stay in DECIMAL256, never narrow to DECIMAL128
+            assertContains(plan, "sum[([16: sum, DECIMAL256(76,10), true]); args: DECIMAL256; " +
+                    "result: DECIMAL256(76,10); args nullable: true; result nullable: true]");
+        } finally {
+            connectContext.getSessionVariable().setCboPushDownGroupingSet(false);
+            starRocksAssert.dropTable("test_decimal256_avg");
+        }
+    }
+
+    @Test
     public void testPushDownGroupingSetCount() throws Exception {
         connectContext.getSessionVariable().setCboPushDownGroupingSet(true);
         try {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
@@ -333,6 +333,41 @@ public class GroupingSetsTest extends PlanTestBase {
         }
     }
 
+    private static int countMatches(String haystack, String needle) {
+        int n = 0;
+        for (int i = haystack.indexOf(needle); i >= 0; i = haystack.indexOf(needle, i + needle.length())) {
+            n++;
+        }
+        return n;
+    }
+
+    @Test
+    public void testPushDownGroupingSetAvgReusesExistingAggregations() throws Exception {
+        connectContext.getSessionVariable().setCboPushDownGroupingSet(true);
+        try {
+            // avg(x) is computed as sum(x)/count(x). When the query already asks for count(x), the
+            // decomposition must bind to that existing output column instead of adding a second,
+            // identical count to the CTE - and the coarser level must then re-aggregate it once
+            // rather than once per consumer.
+            String withSiblingCount = "select t1b, t1c, t1d, avg(t1g), count(t1g) " +
+                    "   from test_all_type group by rollup(t1b, t1c, t1d)";
+            String plan = getFragmentPlan(withSiblingCount);
+            Assertions.assertEquals(1, countMatches(plan, "count(7: t1g)"),
+                    "avg's count(t1g) should reuse the query's own count(t1g), plan:\n" + plan);
+
+            // two avg() over the same argument likewise need only one sum/count pair
+            String twoAvgs = "select t1b, t1c, t1d, avg(t1g), avg(t1g) " +
+                    "   from test_all_type group by rollup(t1b, t1c, t1d)";
+            String twoAvgsPlan = getFragmentPlan(twoAvgs);
+            Assertions.assertEquals(1, countMatches(twoAvgsPlan, "count(7: t1g)"),
+                    "duplicate avg() should share one count, plan:\n" + twoAvgsPlan);
+            Assertions.assertEquals(1, countMatches(twoAvgsPlan, "sum(CAST(7: t1g AS DOUBLE))"),
+                    "duplicate avg() should share one sum, plan:\n" + twoAvgsPlan);
+        } finally {
+            connectContext.getSessionVariable().setCboPushDownGroupingSet(false);
+        }
+    }
+
     @Test
     public void testPushDownGroupingSetUnsupportedFn() throws Exception {
         connectContext.getSessionVariable().setCboPushDownGroupingSet(true);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
@@ -290,10 +290,11 @@ public class GroupingSetsTest extends PlanTestBase {
                     "   from test_all_type group by rollup(t1b, t1c, t1d)";
             String plan = getFragmentPlan(sql);
             // finest grain computes sum/count instead of avg, so coarser rollup levels can be
-            // re-aggregated correctly (re-summing, not re-averaging)
+            // re-aggregated correctly (re-summing, not re-averaging); the BIGINT arg is summed as
+            // DOUBLE to match avg's own double accumulator and avoid overflow a plain BIGINT sum risks
             assertContains(plan, "  1:AGGREGATE (update serialize)\n" +
                     "  |  STREAMING\n" +
-                    "  |  output: sum(7: t1g), count(7: t1g)\n" +
+                    "  |  output: sum(CAST(7: t1g AS DOUBLE)), count(7: t1g)\n" +
                     "  |  group by: 2: t1b, 3: t1c, 4: t1d");
             // REPEAT_NODE now runs on the already-aggregated (t1b, t1c) result, not on raw rows
             assertContains(plan, "  7:REPEAT_NODE\n" +
@@ -305,9 +306,10 @@ public class GroupingSetsTest extends PlanTestBase {
             assertContains(plan, "  10:AGGREGATE (merge finalize)\n" +
                     "  |  output: sum(20: sum), sum(21: count)\n" +
                     "  |  group by: 17: t1b, 18: t1c, 19: GROUPING_ID");
-            // avg is recovered via division wherever it's consumed
-            assertContains(plan, "CAST(20: sum AS DOUBLE) / CAST(21: count AS DOUBLE)");
-            assertContains(plan, "CAST(24: sum AS DOUBLE) / CAST(25: count AS DOUBLE)");
+            // avg is recovered via division wherever it's consumed; sum is already DOUBLE, so only
+            // count needs the cast
+            assertContains(plan, "20: sum / CAST(21: count AS DOUBLE)");
+            assertContains(plan, "24: sum / CAST(25: count AS DOUBLE)");
         } finally {
             connectContext.getSessionVariable().setCboPushDownGroupingSet(false);
         }
@@ -326,6 +328,25 @@ public class GroupingSetsTest extends PlanTestBase {
                     "  |  repeat: repeat 3 lines [[], [2], [2, 3], [2, 3, 4]]\n" +
                     "  |  \n" +
                     "  0:OlapScanNode");
+        } finally {
+            connectContext.getSessionVariable().setCboPushDownGroupingSet(false);
+        }
+    }
+
+    @Test
+    public void testPushDownGroupingSetAvgDecimal() throws Exception {
+        connectContext.getSessionVariable().setCboPushDownGroupingSet(true);
+        try {
+            // avg(DECIMAL) decomposes into sum(DECIMAL)/count(DECIMAL); the synthesized sum must be
+            // rectified to the argument's concrete precision/scale rather than keeping the wildcard
+            // decimal128 return type registered on the builtin SUM signature
+            String sql = "select t1b, t1c, t1d, avg(id_decimal) " +
+                    "   from test_all_type group by rollup(t1b, t1c, t1d)";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  1:AGGREGATE (update serialize)\n" +
+                    "  |  STREAMING\n" +
+                    "  |  output: sum(10: id_decimal), count(10: id_decimal)\n" +
+                    "  |  group by: 2: t1b, 3: t1c, 4: t1d");
         } finally {
             connectContext.getSessionVariable().setCboPushDownGroupingSet(false);
         }

--- a/test/sql/test_grouping_sets/R/test_grouping_sets_pushdown
+++ b/test/sql/test_grouping_sets/R/test_grouping_sets_pushdown
@@ -1,0 +1,162 @@
+-- name: test_grouping_sets_pushdown
+drop table if exists gs_pushdown_src;
+-- result:
+-- !result
+CREATE TABLE `gs_pushdown_src` (
+    `k1` varchar(20),
+    `k2` varchar(20),
+    `k3` varchar(20),
+    `v_big` bigint,
+    `v_int` int,
+    `v_dec` decimal(27,9),
+    `v_dbl` double,
+    `v_bool` boolean
+) DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+PROPERTIES ( "replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO gs_pushdown_src VALUES
+ ('a','x','p',  10,  1,  1.500000000,  1.5, 1)
+,('a','x','p',  20,  2,  2.500000000,  2.5, 0)
+,('a','x','q',  30,  3,  3.500000000,  3.5, 1)
+,('a','y','p',   7,  7,  7.250000000,  7.25, 1)
+,('b','x','p', 100, 10, 10.125000000, 10.125, 0)
+,('b','y','q',NULL,NULL,NULL,NULL,NULL)
+,('b','y','q',NULL,  5,  5.000000000,  5.0, 1)
+,('c',NULL,'p', 40,  4,  4.750000000,  4.75, 0)
+,('c',NULL,NULL,50,  5,  5.250000000,  5.25, 1)
+,(NULL,'x','p', 60,  6,  6.125000000,  6.125, 0)
+,(NULL,NULL,NULL,70, 7,  7.875000000,  7.875, 1);
+-- result:
+-- !result
+set cbo_push_down_groupingset = false;
+-- result:
+-- !result
+create table gs_res_off_1 properties("replication_num"="1") as
+select k1, k2, k3,
+       avg(v_big) a_big, count(v_big) c_big, count(*) c_star,
+       sum(v_big) s_big, max(v_int) mx, min(v_int) mn,
+       avg(v_dec) a_dec, round(avg(v_dbl), 6) a_dbl, avg(v_bool) a_bool,
+       grouping(k1) g1, grouping_id(k1, k2) gid
+from gs_pushdown_src group by rollup(k1, k2, k3);
+-- result:
+-- !result
+set cbo_push_down_groupingset = true;
+-- result:
+-- !result
+create table gs_res_on_1 properties("replication_num"="1") as
+select k1, k2, k3,
+       avg(v_big) a_big, count(v_big) c_big, count(*) c_star,
+       sum(v_big) s_big, max(v_int) mx, min(v_int) mn,
+       avg(v_dec) a_dec, round(avg(v_dbl), 6) a_dbl, avg(v_bool) a_bool,
+       grouping(k1) g1, grouping_id(k1, k2) gid
+from gs_pushdown_src group by rollup(k1, k2, k3);
+-- result:
+-- !result
+select (select count(*) from gs_res_off_1) - (select count(*) from gs_res_on_1) cnt_diff,
+       (select count(*) from ((select * from gs_res_off_1) except (select * from gs_res_on_1)) d) only_off,
+       (select count(*) from ((select * from gs_res_on_1) except (select * from gs_res_off_1)) d) only_on;
+-- result:
+0	0	0
+-- !result
+set cbo_push_down_groupingset = false;
+-- result:
+-- !result
+create table gs_res_off_2 properties("replication_num"="1") as
+select k1, k2, k3, count(v_big) c, avg(v_big) a
+from gs_pushdown_src group by cube(k1, k2, k3) having count(v_big) > 1;
+-- result:
+-- !result
+set cbo_push_down_groupingset = true;
+-- result:
+-- !result
+create table gs_res_on_2 properties("replication_num"="1") as
+select k1, k2, k3, count(v_big) c, avg(v_big) a
+from gs_pushdown_src group by cube(k1, k2, k3) having count(v_big) > 1;
+-- result:
+-- !result
+select (select count(*) from gs_res_off_2) - (select count(*) from gs_res_on_2) cnt_diff,
+       (select count(*) from ((select * from gs_res_off_2) except (select * from gs_res_on_2)) d) only_off,
+       (select count(*) from ((select * from gs_res_on_2) except (select * from gs_res_off_2)) d) only_on;
+-- result:
+0	0	0
+-- !result
+set cbo_push_down_groupingset = false;
+-- result:
+-- !result
+create table gs_res_off_3 properties("replication_num"="1") as
+select * from (
+  select grouping(k1, k2) aa, k1, k2, k3, avg(v_big) a, count(v_big) c
+  from gs_pushdown_src group by rollup(k1, k2, k3)
+) t where aa = 1;
+-- result:
+-- !result
+set cbo_push_down_groupingset = true;
+-- result:
+-- !result
+create table gs_res_on_3 properties("replication_num"="1") as
+select * from (
+  select grouping(k1, k2) aa, k1, k2, k3, avg(v_big) a, count(v_big) c
+  from gs_pushdown_src group by rollup(k1, k2, k3)
+) t where aa = 1;
+-- result:
+-- !result
+select (select count(*) from gs_res_off_3) - (select count(*) from gs_res_on_3) cnt_diff,
+       (select count(*) from ((select * from gs_res_off_3) except (select * from gs_res_on_3)) d) only_off,
+       (select count(*) from ((select * from gs_res_on_3) except (select * from gs_res_off_3)) d) only_on;
+-- result:
+0	0	0
+-- !result
+set cbo_push_down_groupingset = false;
+-- result:
+-- !result
+create table gs_res_off_4 properties("replication_num"="1") as
+select k1, k2, k3, avg(v_big) a
+from gs_pushdown_src group by rollup(k1, k2, k3) having avg(v_big) > 20;
+-- result:
+-- !result
+set cbo_push_down_groupingset = true;
+-- result:
+-- !result
+create table gs_res_on_4 properties("replication_num"="1") as
+select k1, k2, k3, avg(v_big) a
+from gs_pushdown_src group by rollup(k1, k2, k3) having avg(v_big) > 20;
+-- result:
+-- !result
+select (select count(*) from gs_res_off_4) - (select count(*) from gs_res_on_4) cnt_diff,
+       (select count(*) from ((select * from gs_res_off_4) except (select * from gs_res_on_4)) d) only_off,
+       (select count(*) from ((select * from gs_res_on_4) except (select * from gs_res_off_4)) d) only_on;
+-- result:
+0	0	0
+-- !result
+set cbo_push_down_groupingset = true;
+-- result:
+-- !result
+drop table gs_res_off_1;
+-- result:
+-- !result
+drop table gs_res_on_1;
+-- result:
+-- !result
+drop table gs_res_off_2;
+-- result:
+-- !result
+drop table gs_res_on_2;
+-- result:
+-- !result
+drop table gs_res_off_3;
+-- result:
+-- !result
+drop table gs_res_on_3;
+-- result:
+-- !result
+drop table gs_res_off_4;
+-- result:
+-- !result
+drop table gs_res_on_4;
+-- result:
+-- !result
+drop table gs_pushdown_src;
+-- result:
+-- !result

--- a/test/sql/test_grouping_sets/R/test_grouping_sets_pushdown
+++ b/test/sql/test_grouping_sets/R/test_grouping_sets_pushdown
@@ -140,26 +140,28 @@ CREATE TABLE `gs_dec_src_${uuid0}` (
     `d32` decimal(9,2),
     `d64` decimal(18,4),
     `d128` decimal(38,10),
-    `d256` decimal(76,10)
+    `d256` decimal(76,10),
+    `dv2` decimalv2(20,5)
 ) DUPLICATE KEY(`k1`)
 DISTRIBUTED BY HASH(`k1`) BUCKETS 3
 PROPERTIES ( "replication_num" = "1");
 -- result:
 -- !result
 INSERT INTO gs_dec_src_${uuid0} VALUES
- (1,1,1, 1.25, 1.5005, 1.0000000001, 10.5)
-,(1,1,2, 2.50, 2.2500, 2.0000000002, 20.25)
-,(1,2,1, 3.75, 3.1250, 3.0000000003, 30.125)
-,(2,1,1, 4.00, 4.0625, 4.0000000004, 40.0625)
-,(2,2,2, 5.10, 5.9375, 5.0000000005, 1234567890123456789012345678901234.5)
-,(2,2,2, NULL, NULL, NULL, NULL);
+ (1,1,1, 1.25, 1.5005, 1.0000000001, 10.5, 10.5)
+,(1,1,2, 2.50, 2.2500, 2.0000000002, 20.25, 20.25)
+,(1,2,1, 3.75, 3.1250, 3.0000000003, 30.125, 30.125)
+,(2,1,1, 4.00, 4.0625, 4.0000000004, 40.0625, 40.0625)
+,(2,2,2, 5.10, 5.9375, 5.0000000005, 1234567890123456789012345678901234.5, 50.5)
+,(2,2,2, NULL, NULL, NULL, NULL, NULL);
 -- result:
 -- !result
 set cbo_push_down_groupingset = false;
 -- result:
 -- !result
 create table gs_dec_off_${uuid0} properties("replication_num"="1") as
-select k1, k2, k3, avg(d32) a32, avg(d64) a64, avg(d128) a128, avg(d256) a256
+select k1, k2, k3, avg(d32) a32, avg(d64) a64, avg(d128) a128, avg(d256) a256,
+       avg(dv2) av2, sum(dv2) sv2, count(dv2) cv2
 from gs_dec_src_${uuid0} group by rollup(k1, k2, k3);
 -- result:
 -- !result
@@ -167,7 +169,8 @@ set cbo_push_down_groupingset = true;
 -- result:
 -- !result
 create table gs_dec_on_${uuid0} properties("replication_num"="1") as
-select k1, k2, k3, avg(d32) a32, avg(d64) a64, avg(d128) a128, avg(d256) a256
+select k1, k2, k3, avg(d32) a32, avg(d64) a64, avg(d128) a128, avg(d256) a256,
+       avg(dv2) av2, sum(dv2) sv2, count(dv2) cv2
 from gs_dec_src_${uuid0} group by rollup(k1, k2, k3);
 -- result:
 -- !result

--- a/test/sql/test_grouping_sets/R/test_grouping_sets_pushdown
+++ b/test/sql/test_grouping_sets/R/test_grouping_sets_pushdown
@@ -1,8 +1,8 @@
 -- name: test_grouping_sets_pushdown
-drop table if exists gs_pushdown_src;
+drop table if exists gs_pushdown_src_${uuid0};
 -- result:
 -- !result
-CREATE TABLE `gs_pushdown_src` (
+CREATE TABLE `gs_pushdown_src_${uuid0}` (
     `k1` varchar(20),
     `k2` varchar(20),
     `k3` varchar(20),
@@ -16,7 +16,7 @@ DISTRIBUTED BY HASH(`k1`) BUCKETS 3
 PROPERTIES ( "replication_num" = "1");
 -- result:
 -- !result
-INSERT INTO gs_pushdown_src VALUES
+INSERT INTO gs_pushdown_src_${uuid0} VALUES
  ('a','x','p',  10,  1,  1.500000000,  1.5, 1)
 ,('a','x','p',  20,  2,  2.500000000,  2.5, 0)
 ,('a','x','q',  30,  3,  3.500000000,  3.5, 1)
@@ -33,130 +33,186 @@ INSERT INTO gs_pushdown_src VALUES
 set cbo_push_down_groupingset = false;
 -- result:
 -- !result
-create table gs_res_off_1 properties("replication_num"="1") as
+create table gs_res_off_1_${uuid0} properties("replication_num"="1") as
 select k1, k2, k3,
        avg(v_big) a_big, count(v_big) c_big, count(*) c_star,
        sum(v_big) s_big, max(v_int) mx, min(v_int) mn,
        avg(v_dec) a_dec, round(avg(v_dbl), 6) a_dbl, avg(v_bool) a_bool,
        grouping(k1) g1, grouping_id(k1, k2) gid
-from gs_pushdown_src group by rollup(k1, k2, k3);
+from gs_pushdown_src_${uuid0} group by rollup(k1, k2, k3);
 -- result:
 -- !result
 set cbo_push_down_groupingset = true;
 -- result:
 -- !result
-create table gs_res_on_1 properties("replication_num"="1") as
+create table gs_res_on_1_${uuid0} properties("replication_num"="1") as
 select k1, k2, k3,
        avg(v_big) a_big, count(v_big) c_big, count(*) c_star,
        sum(v_big) s_big, max(v_int) mx, min(v_int) mn,
        avg(v_dec) a_dec, round(avg(v_dbl), 6) a_dbl, avg(v_bool) a_bool,
        grouping(k1) g1, grouping_id(k1, k2) gid
-from gs_pushdown_src group by rollup(k1, k2, k3);
+from gs_pushdown_src_${uuid0} group by rollup(k1, k2, k3);
 -- result:
 -- !result
-select (select count(*) from gs_res_off_1) - (select count(*) from gs_res_on_1) cnt_diff,
-       (select count(*) from ((select * from gs_res_off_1) except (select * from gs_res_on_1)) d) only_off,
-       (select count(*) from ((select * from gs_res_on_1) except (select * from gs_res_off_1)) d) only_on;
+select (select count(*) from gs_res_off_1_${uuid0}) - (select count(*) from gs_res_on_1_${uuid0}) cnt_diff,
+       (select count(*) from ((select * from gs_res_off_1_${uuid0}) except (select * from gs_res_on_1_${uuid0})) d) only_off,
+       (select count(*) from ((select * from gs_res_on_1_${uuid0}) except (select * from gs_res_off_1_${uuid0})) d) only_on;
 -- result:
 0	0	0
 -- !result
 set cbo_push_down_groupingset = false;
 -- result:
 -- !result
-create table gs_res_off_2 properties("replication_num"="1") as
+create table gs_res_off_2_${uuid0} properties("replication_num"="1") as
 select k1, k2, k3, count(v_big) c, avg(v_big) a
-from gs_pushdown_src group by cube(k1, k2, k3) having count(v_big) > 1;
+from gs_pushdown_src_${uuid0} group by cube(k1, k2, k3) having count(v_big) > 1;
 -- result:
 -- !result
 set cbo_push_down_groupingset = true;
 -- result:
 -- !result
-create table gs_res_on_2 properties("replication_num"="1") as
+create table gs_res_on_2_${uuid0} properties("replication_num"="1") as
 select k1, k2, k3, count(v_big) c, avg(v_big) a
-from gs_pushdown_src group by cube(k1, k2, k3) having count(v_big) > 1;
+from gs_pushdown_src_${uuid0} group by cube(k1, k2, k3) having count(v_big) > 1;
 -- result:
 -- !result
-select (select count(*) from gs_res_off_2) - (select count(*) from gs_res_on_2) cnt_diff,
-       (select count(*) from ((select * from gs_res_off_2) except (select * from gs_res_on_2)) d) only_off,
-       (select count(*) from ((select * from gs_res_on_2) except (select * from gs_res_off_2)) d) only_on;
+select (select count(*) from gs_res_off_2_${uuid0}) - (select count(*) from gs_res_on_2_${uuid0}) cnt_diff,
+       (select count(*) from ((select * from gs_res_off_2_${uuid0}) except (select * from gs_res_on_2_${uuid0})) d) only_off,
+       (select count(*) from ((select * from gs_res_on_2_${uuid0}) except (select * from gs_res_off_2_${uuid0})) d) only_on;
 -- result:
 0	0	0
 -- !result
 set cbo_push_down_groupingset = false;
 -- result:
 -- !result
-create table gs_res_off_3 properties("replication_num"="1") as
+create table gs_res_off_3_${uuid0} properties("replication_num"="1") as
 select * from (
   select grouping(k1, k2) aa, k1, k2, k3, avg(v_big) a, count(v_big) c
-  from gs_pushdown_src group by rollup(k1, k2, k3)
+  from gs_pushdown_src_${uuid0} group by rollup(k1, k2, k3)
 ) t where aa = 1;
 -- result:
 -- !result
 set cbo_push_down_groupingset = true;
 -- result:
 -- !result
-create table gs_res_on_3 properties("replication_num"="1") as
+create table gs_res_on_3_${uuid0} properties("replication_num"="1") as
 select * from (
   select grouping(k1, k2) aa, k1, k2, k3, avg(v_big) a, count(v_big) c
-  from gs_pushdown_src group by rollup(k1, k2, k3)
+  from gs_pushdown_src_${uuid0} group by rollup(k1, k2, k3)
 ) t where aa = 1;
 -- result:
 -- !result
-select (select count(*) from gs_res_off_3) - (select count(*) from gs_res_on_3) cnt_diff,
-       (select count(*) from ((select * from gs_res_off_3) except (select * from gs_res_on_3)) d) only_off,
-       (select count(*) from ((select * from gs_res_on_3) except (select * from gs_res_off_3)) d) only_on;
+select (select count(*) from gs_res_off_3_${uuid0}) - (select count(*) from gs_res_on_3_${uuid0}) cnt_diff,
+       (select count(*) from ((select * from gs_res_off_3_${uuid0}) except (select * from gs_res_on_3_${uuid0})) d) only_off,
+       (select count(*) from ((select * from gs_res_on_3_${uuid0}) except (select * from gs_res_off_3_${uuid0})) d) only_on;
 -- result:
 0	0	0
 -- !result
 set cbo_push_down_groupingset = false;
 -- result:
 -- !result
-create table gs_res_off_4 properties("replication_num"="1") as
+create table gs_res_off_4_${uuid0} properties("replication_num"="1") as
 select k1, k2, k3, avg(v_big) a
-from gs_pushdown_src group by rollup(k1, k2, k3) having avg(v_big) > 20;
+from gs_pushdown_src_${uuid0} group by rollup(k1, k2, k3) having avg(v_big) > 20;
 -- result:
 -- !result
 set cbo_push_down_groupingset = true;
 -- result:
 -- !result
-create table gs_res_on_4 properties("replication_num"="1") as
+create table gs_res_on_4_${uuid0} properties("replication_num"="1") as
 select k1, k2, k3, avg(v_big) a
-from gs_pushdown_src group by rollup(k1, k2, k3) having avg(v_big) > 20;
+from gs_pushdown_src_${uuid0} group by rollup(k1, k2, k3) having avg(v_big) > 20;
 -- result:
 -- !result
-select (select count(*) from gs_res_off_4) - (select count(*) from gs_res_on_4) cnt_diff,
-       (select count(*) from ((select * from gs_res_off_4) except (select * from gs_res_on_4)) d) only_off,
-       (select count(*) from ((select * from gs_res_on_4) except (select * from gs_res_off_4)) d) only_on;
+select (select count(*) from gs_res_off_4_${uuid0}) - (select count(*) from gs_res_on_4_${uuid0}) cnt_diff,
+       (select count(*) from ((select * from gs_res_off_4_${uuid0}) except (select * from gs_res_on_4_${uuid0})) d) only_off,
+       (select count(*) from ((select * from gs_res_on_4_${uuid0}) except (select * from gs_res_off_4_${uuid0})) d) only_on;
+-- result:
+0	0	0
+-- !result
+drop table if exists gs_dec_src_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `gs_dec_src_${uuid0}` (
+    `k1` int,
+    `k2` int,
+    `k3` int,
+    `d32` decimal(9,2),
+    `d64` decimal(18,4),
+    `d128` decimal(38,10),
+    `d256` decimal(76,10)
+) DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+PROPERTIES ( "replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO gs_dec_src_${uuid0} VALUES
+ (1,1,1, 1.25, 1.5005, 1.0000000001, 10.5)
+,(1,1,2, 2.50, 2.2500, 2.0000000002, 20.25)
+,(1,2,1, 3.75, 3.1250, 3.0000000003, 30.125)
+,(2,1,1, 4.00, 4.0625, 4.0000000004, 40.0625)
+,(2,2,2, 5.10, 5.9375, 5.0000000005, 1234567890123456789012345678901234.5)
+,(2,2,2, NULL, NULL, NULL, NULL);
+-- result:
+-- !result
+set cbo_push_down_groupingset = false;
+-- result:
+-- !result
+create table gs_dec_off_${uuid0} properties("replication_num"="1") as
+select k1, k2, k3, avg(d32) a32, avg(d64) a64, avg(d128) a128, avg(d256) a256
+from gs_dec_src_${uuid0} group by rollup(k1, k2, k3);
+-- result:
+-- !result
+set cbo_push_down_groupingset = true;
+-- result:
+-- !result
+create table gs_dec_on_${uuid0} properties("replication_num"="1") as
+select k1, k2, k3, avg(d32) a32, avg(d64) a64, avg(d128) a128, avg(d256) a256
+from gs_dec_src_${uuid0} group by rollup(k1, k2, k3);
+-- result:
+-- !result
+select (select count(*) from gs_dec_off_${uuid0}) - (select count(*) from gs_dec_on_${uuid0}) cnt_diff,
+       (select count(*) from ((select * from gs_dec_off_${uuid0}) except (select * from gs_dec_on_${uuid0})) d) only_off,
+       (select count(*) from ((select * from gs_dec_on_${uuid0}) except (select * from gs_dec_off_${uuid0})) d) only_on;
 -- result:
 0	0	0
 -- !result
 set cbo_push_down_groupingset = true;
 -- result:
 -- !result
-drop table gs_res_off_1;
+drop table gs_dec_off_${uuid0};
 -- result:
 -- !result
-drop table gs_res_on_1;
+drop table gs_dec_on_${uuid0};
 -- result:
 -- !result
-drop table gs_res_off_2;
+drop table gs_dec_src_${uuid0};
 -- result:
 -- !result
-drop table gs_res_on_2;
+drop table gs_res_off_1_${uuid0};
 -- result:
 -- !result
-drop table gs_res_off_3;
+drop table gs_res_on_1_${uuid0};
 -- result:
 -- !result
-drop table gs_res_on_3;
+drop table gs_res_off_2_${uuid0};
 -- result:
 -- !result
-drop table gs_res_off_4;
+drop table gs_res_on_2_${uuid0};
 -- result:
 -- !result
-drop table gs_res_on_4;
+drop table gs_res_off_3_${uuid0};
 -- result:
 -- !result
-drop table gs_pushdown_src;
+drop table gs_res_on_3_${uuid0};
+-- result:
+-- !result
+drop table gs_res_off_4_${uuid0};
+-- result:
+-- !result
+drop table gs_res_on_4_${uuid0};
+-- result:
+-- !result
+drop table gs_pushdown_src_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_grouping_sets/T/test_grouping_sets_pushdown
+++ b/test/sql/test_grouping_sets/T/test_grouping_sets_pushdown
@@ -134,24 +134,27 @@ CREATE TABLE `gs_dec_src_${uuid0}` (
     `d32` decimal(9,2),
     `d64` decimal(18,4),
     `d128` decimal(38,10),
-    `d256` decimal(76,10)
+    `d256` decimal(76,10),
+    `dv2` decimalv2(20,5)
 ) DUPLICATE KEY(`k1`)
 DISTRIBUTED BY HASH(`k1`) BUCKETS 3
 PROPERTIES ( "replication_num" = "1");
 INSERT INTO gs_dec_src_${uuid0} VALUES
- (1,1,1, 1.25, 1.5005, 1.0000000001, 10.5)
-,(1,1,2, 2.50, 2.2500, 2.0000000002, 20.25)
-,(1,2,1, 3.75, 3.1250, 3.0000000003, 30.125)
-,(2,1,1, 4.00, 4.0625, 4.0000000004, 40.0625)
-,(2,2,2, 5.10, 5.9375, 5.0000000005, 1234567890123456789012345678901234.5)
-,(2,2,2, NULL, NULL, NULL, NULL);
+ (1,1,1, 1.25, 1.5005, 1.0000000001, 10.5, 10.5)
+,(1,1,2, 2.50, 2.2500, 2.0000000002, 20.25, 20.25)
+,(1,2,1, 3.75, 3.1250, 3.0000000003, 30.125, 30.125)
+,(2,1,1, 4.00, 4.0625, 4.0000000004, 40.0625, 40.0625)
+,(2,2,2, 5.10, 5.9375, 5.0000000005, 1234567890123456789012345678901234.5, 50.5)
+,(2,2,2, NULL, NULL, NULL, NULL, NULL);
 set cbo_push_down_groupingset = false;
 create table gs_dec_off_${uuid0} properties("replication_num"="1") as
-select k1, k2, k3, avg(d32) a32, avg(d64) a64, avg(d128) a128, avg(d256) a256
+select k1, k2, k3, avg(d32) a32, avg(d64) a64, avg(d128) a128, avg(d256) a256,
+       avg(dv2) av2, sum(dv2) sv2, count(dv2) cv2
 from gs_dec_src_${uuid0} group by rollup(k1, k2, k3);
 set cbo_push_down_groupingset = true;
 create table gs_dec_on_${uuid0} properties("replication_num"="1") as
-select k1, k2, k3, avg(d32) a32, avg(d64) a64, avg(d128) a128, avg(d256) a256
+select k1, k2, k3, avg(d32) a32, avg(d64) a64, avg(d128) a128, avg(d256) a256,
+       avg(dv2) av2, sum(dv2) sv2, count(dv2) cv2
 from gs_dec_src_${uuid0} group by rollup(k1, k2, k3);
 select (select count(*) from gs_dec_off_${uuid0}) - (select count(*) from gs_dec_on_${uuid0}) cnt_diff,
        (select count(*) from ((select * from gs_dec_off_${uuid0}) except (select * from gs_dec_on_${uuid0})) d) only_off,

--- a/test/sql/test_grouping_sets/T/test_grouping_sets_pushdown
+++ b/test/sql/test_grouping_sets/T/test_grouping_sets_pushdown
@@ -1,0 +1,131 @@
+-- name: test_grouping_sets_pushdown
+-- PushDownAggregateGroupingSetsRule (cbo_push_down_groupingset, ON by default) pre-aggregates to the
+-- finest grain and expands the small result for coarser rollup levels, instead of running REPEAT over
+-- the raw rows. MAX/MIN/SUM are self-recombining so re-applying the same function is trivially correct;
+-- AVG and COUNT are not, and are rewritten (avg -> sum/count with a final divide, count -> re-summed
+-- partial counts). Those rewrites can produce a wrong VALUE while still producing a plausible PLAN, so
+-- this case is a differential oracle on rows: same query with the rule off vs on must return identical
+-- result sets. Plan-shape assertions for the same queries live in GroupingSetsTest.java.
+drop table if exists gs_pushdown_src;
+CREATE TABLE `gs_pushdown_src` (
+    `k1` varchar(20),
+    `k2` varchar(20),
+    `k3` varchar(20),
+    `v_big` bigint,
+    `v_int` int,
+    `v_dec` decimal(27,9),
+    `v_dbl` double,
+    `v_bool` boolean
+) DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+PROPERTIES ( "replication_num" = "1");
+
+-- Rows are shaped to break a naive rewrite:
+--  * groups (a,x,*) hold 3 rows while (a,y,*) holds 1, so re-averaging the per-group averages at the
+--    coarser level gives a different answer than averaging the underlying rows.
+--  * group (b,y,q) has v_big entirely NULL, so its partial sum is NULL and its partial count is 0;
+--    the coarser level must still fold that in as "contributes nothing", not as NULL or as a zero mean.
+--  * genuine NULL group keys collide with the NULLs REPEAT pads the rolled-up columns with.
+INSERT INTO gs_pushdown_src VALUES
+ ('a','x','p',  10,  1,  1.500000000,  1.5, 1)
+,('a','x','p',  20,  2,  2.500000000,  2.5, 0)
+,('a','x','q',  30,  3,  3.500000000,  3.5, 1)
+,('a','y','p',   7,  7,  7.250000000,  7.25, 1)
+,('b','x','p', 100, 10, 10.125000000, 10.125, 0)
+,('b','y','q',NULL,NULL,NULL,NULL,NULL)
+,('b','y','q',NULL,  5,  5.000000000,  5.0, 1)
+,('c',NULL,'p', 40,  4,  4.750000000,  4.75, 0)
+,('c',NULL,NULL,50,  5,  5.250000000,  5.25, 1)
+,(NULL,'x','p', 60,  6,  6.125000000,  6.125, 0)
+,(NULL,NULL,NULL,70, 7,  7.875000000,  7.875, 1);
+
+-- ---------------------------------------------------------------------------
+-- 1. AVG / COUNT / mixed aggregates over ROLLUP.
+--    v_dbl is rounded because the rewrite changes the summation order of a double accumulator; a real
+--    logic error moves the value far more than 6 decimal places, so this does not weaken the check.
+-- ---------------------------------------------------------------------------
+set cbo_push_down_groupingset = false;
+create table gs_res_off_1 properties("replication_num"="1") as
+select k1, k2, k3,
+       avg(v_big) a_big, count(v_big) c_big, count(*) c_star,
+       sum(v_big) s_big, max(v_int) mx, min(v_int) mn,
+       avg(v_dec) a_dec, round(avg(v_dbl), 6) a_dbl, avg(v_bool) a_bool,
+       grouping(k1) g1, grouping_id(k1, k2) gid
+from gs_pushdown_src group by rollup(k1, k2, k3);
+set cbo_push_down_groupingset = true;
+create table gs_res_on_1 properties("replication_num"="1") as
+select k1, k2, k3,
+       avg(v_big) a_big, count(v_big) c_big, count(*) c_star,
+       sum(v_big) s_big, max(v_int) mx, min(v_int) mn,
+       avg(v_dec) a_dec, round(avg(v_dbl), 6) a_dbl, avg(v_bool) a_bool,
+       grouping(k1) g1, grouping_id(k1, k2) gid
+from gs_pushdown_src group by rollup(k1, k2, k3);
+select (select count(*) from gs_res_off_1) - (select count(*) from gs_res_on_1) cnt_diff,
+       (select count(*) from ((select * from gs_res_off_1) except (select * from gs_res_on_1)) d) only_off,
+       (select count(*) from ((select * from gs_res_on_1) except (select * from gs_res_off_1)) d) only_on;
+
+-- ---------------------------------------------------------------------------
+-- 2. CUBE, and HAVING on a COUNT output. HAVING on COUNT is expected to push down (a re-summed count
+--    is already the final value); HAVING on AVG must NOT push down (the pre-divide sum/count columns
+--    are not the real value yet) - either way the rows must match the rule-off baseline.
+-- ---------------------------------------------------------------------------
+set cbo_push_down_groupingset = false;
+create table gs_res_off_2 properties("replication_num"="1") as
+select k1, k2, k3, count(v_big) c, avg(v_big) a
+from gs_pushdown_src group by cube(k1, k2, k3) having count(v_big) > 1;
+set cbo_push_down_groupingset = true;
+create table gs_res_on_2 properties("replication_num"="1") as
+select k1, k2, k3, count(v_big) c, avg(v_big) a
+from gs_pushdown_src group by cube(k1, k2, k3) having count(v_big) > 1;
+select (select count(*) from gs_res_off_2) - (select count(*) from gs_res_on_2) cnt_diff,
+       (select count(*) from ((select * from gs_res_off_2) except (select * from gs_res_on_2)) d) only_off,
+       (select count(*) from ((select * from gs_res_on_2) except (select * from gs_res_off_2)) d) only_on;
+
+-- ---------------------------------------------------------------------------
+-- 3. AVG under a filter on grouping() applied above the rollup - the exact shape that regressed twice
+--    before (#49928 lost the repeat predicate, #58831 copied the having predicate without remapping).
+--    The rule fires here, so this exercises predicate remapping across the CTE/union split with an
+--    aggregate that no longer exists as a CTE output column.
+-- ---------------------------------------------------------------------------
+set cbo_push_down_groupingset = false;
+create table gs_res_off_3 properties("replication_num"="1") as
+select * from (
+  select grouping(k1, k2) aa, k1, k2, k3, avg(v_big) a, count(v_big) c
+  from gs_pushdown_src group by rollup(k1, k2, k3)
+) t where aa = 1;
+set cbo_push_down_groupingset = true;
+create table gs_res_on_3 properties("replication_num"="1") as
+select * from (
+  select grouping(k1, k2) aa, k1, k2, k3, avg(v_big) a, count(v_big) c
+  from gs_pushdown_src group by rollup(k1, k2, k3)
+) t where aa = 1;
+select (select count(*) from gs_res_off_3) - (select count(*) from gs_res_on_3) cnt_diff,
+       (select count(*) from ((select * from gs_res_off_3) except (select * from gs_res_on_3)) d) only_off,
+       (select count(*) from ((select * from gs_res_on_3) except (select * from gs_res_off_3)) d) only_on;
+
+-- ---------------------------------------------------------------------------
+-- 4. HAVING directly on an AVG output. check() refuses to push down here; the rows must still match
+--    the baseline, and this pins the guard so that relaxing it later cannot silently change results.
+-- ---------------------------------------------------------------------------
+set cbo_push_down_groupingset = false;
+create table gs_res_off_4 properties("replication_num"="1") as
+select k1, k2, k3, avg(v_big) a
+from gs_pushdown_src group by rollup(k1, k2, k3) having avg(v_big) > 20;
+set cbo_push_down_groupingset = true;
+create table gs_res_on_4 properties("replication_num"="1") as
+select k1, k2, k3, avg(v_big) a
+from gs_pushdown_src group by rollup(k1, k2, k3) having avg(v_big) > 20;
+select (select count(*) from gs_res_off_4) - (select count(*) from gs_res_on_4) cnt_diff,
+       (select count(*) from ((select * from gs_res_off_4) except (select * from gs_res_on_4)) d) only_off,
+       (select count(*) from ((select * from gs_res_on_4) except (select * from gs_res_off_4)) d) only_on;
+
+set cbo_push_down_groupingset = true;
+drop table gs_res_off_1;
+drop table gs_res_on_1;
+drop table gs_res_off_2;
+drop table gs_res_on_2;
+drop table gs_res_off_3;
+drop table gs_res_on_3;
+drop table gs_res_off_4;
+drop table gs_res_on_4;
+drop table gs_pushdown_src;

--- a/test/sql/test_grouping_sets/T/test_grouping_sets_pushdown
+++ b/test/sql/test_grouping_sets/T/test_grouping_sets_pushdown
@@ -6,8 +6,8 @@
 -- partial counts). Those rewrites can produce a wrong VALUE while still producing a plausible PLAN, so
 -- this case is a differential oracle on rows: same query with the rule off vs on must return identical
 -- result sets. Plan-shape assertions for the same queries live in GroupingSetsTest.java.
-drop table if exists gs_pushdown_src;
-CREATE TABLE `gs_pushdown_src` (
+drop table if exists gs_pushdown_src_${uuid0};
+CREATE TABLE `gs_pushdown_src_${uuid0}` (
     `k1` varchar(20),
     `k2` varchar(20),
     `k3` varchar(20),
@@ -26,7 +26,7 @@ PROPERTIES ( "replication_num" = "1");
 --  * group (b,y,q) has v_big entirely NULL, so its partial sum is NULL and its partial count is 0;
 --    the coarser level must still fold that in as "contributes nothing", not as NULL or as a zero mean.
 --  * genuine NULL group keys collide with the NULLs REPEAT pads the rolled-up columns with.
-INSERT INTO gs_pushdown_src VALUES
+INSERT INTO gs_pushdown_src_${uuid0} VALUES
  ('a','x','p',  10,  1,  1.500000000,  1.5, 1)
 ,('a','x','p',  20,  2,  2.500000000,  2.5, 0)
 ,('a','x','q',  30,  3,  3.500000000,  3.5, 1)
@@ -45,24 +45,24 @@ INSERT INTO gs_pushdown_src VALUES
 --    logic error moves the value far more than 6 decimal places, so this does not weaken the check.
 -- ---------------------------------------------------------------------------
 set cbo_push_down_groupingset = false;
-create table gs_res_off_1 properties("replication_num"="1") as
+create table gs_res_off_1_${uuid0} properties("replication_num"="1") as
 select k1, k2, k3,
        avg(v_big) a_big, count(v_big) c_big, count(*) c_star,
        sum(v_big) s_big, max(v_int) mx, min(v_int) mn,
        avg(v_dec) a_dec, round(avg(v_dbl), 6) a_dbl, avg(v_bool) a_bool,
        grouping(k1) g1, grouping_id(k1, k2) gid
-from gs_pushdown_src group by rollup(k1, k2, k3);
+from gs_pushdown_src_${uuid0} group by rollup(k1, k2, k3);
 set cbo_push_down_groupingset = true;
-create table gs_res_on_1 properties("replication_num"="1") as
+create table gs_res_on_1_${uuid0} properties("replication_num"="1") as
 select k1, k2, k3,
        avg(v_big) a_big, count(v_big) c_big, count(*) c_star,
        sum(v_big) s_big, max(v_int) mx, min(v_int) mn,
        avg(v_dec) a_dec, round(avg(v_dbl), 6) a_dbl, avg(v_bool) a_bool,
        grouping(k1) g1, grouping_id(k1, k2) gid
-from gs_pushdown_src group by rollup(k1, k2, k3);
-select (select count(*) from gs_res_off_1) - (select count(*) from gs_res_on_1) cnt_diff,
-       (select count(*) from ((select * from gs_res_off_1) except (select * from gs_res_on_1)) d) only_off,
-       (select count(*) from ((select * from gs_res_on_1) except (select * from gs_res_off_1)) d) only_on;
+from gs_pushdown_src_${uuid0} group by rollup(k1, k2, k3);
+select (select count(*) from gs_res_off_1_${uuid0}) - (select count(*) from gs_res_on_1_${uuid0}) cnt_diff,
+       (select count(*) from ((select * from gs_res_off_1_${uuid0}) except (select * from gs_res_on_1_${uuid0})) d) only_off,
+       (select count(*) from ((select * from gs_res_on_1_${uuid0}) except (select * from gs_res_off_1_${uuid0})) d) only_on;
 
 -- ---------------------------------------------------------------------------
 -- 2. CUBE, and HAVING on a COUNT output. HAVING on COUNT is expected to push down (a re-summed count
@@ -70,16 +70,16 @@ select (select count(*) from gs_res_off_1) - (select count(*) from gs_res_on_1) 
 --    are not the real value yet) - either way the rows must match the rule-off baseline.
 -- ---------------------------------------------------------------------------
 set cbo_push_down_groupingset = false;
-create table gs_res_off_2 properties("replication_num"="1") as
+create table gs_res_off_2_${uuid0} properties("replication_num"="1") as
 select k1, k2, k3, count(v_big) c, avg(v_big) a
-from gs_pushdown_src group by cube(k1, k2, k3) having count(v_big) > 1;
+from gs_pushdown_src_${uuid0} group by cube(k1, k2, k3) having count(v_big) > 1;
 set cbo_push_down_groupingset = true;
-create table gs_res_on_2 properties("replication_num"="1") as
+create table gs_res_on_2_${uuid0} properties("replication_num"="1") as
 select k1, k2, k3, count(v_big) c, avg(v_big) a
-from gs_pushdown_src group by cube(k1, k2, k3) having count(v_big) > 1;
-select (select count(*) from gs_res_off_2) - (select count(*) from gs_res_on_2) cnt_diff,
-       (select count(*) from ((select * from gs_res_off_2) except (select * from gs_res_on_2)) d) only_off,
-       (select count(*) from ((select * from gs_res_on_2) except (select * from gs_res_off_2)) d) only_on;
+from gs_pushdown_src_${uuid0} group by cube(k1, k2, k3) having count(v_big) > 1;
+select (select count(*) from gs_res_off_2_${uuid0}) - (select count(*) from gs_res_on_2_${uuid0}) cnt_diff,
+       (select count(*) from ((select * from gs_res_off_2_${uuid0}) except (select * from gs_res_on_2_${uuid0})) d) only_off,
+       (select count(*) from ((select * from gs_res_on_2_${uuid0}) except (select * from gs_res_off_2_${uuid0})) d) only_on;
 
 -- ---------------------------------------------------------------------------
 -- 3. AVG under a filter on grouping() applied above the rollup - the exact shape that regressed twice
@@ -88,44 +88,85 @@ select (select count(*) from gs_res_off_2) - (select count(*) from gs_res_on_2) 
 --    aggregate that no longer exists as a CTE output column.
 -- ---------------------------------------------------------------------------
 set cbo_push_down_groupingset = false;
-create table gs_res_off_3 properties("replication_num"="1") as
+create table gs_res_off_3_${uuid0} properties("replication_num"="1") as
 select * from (
   select grouping(k1, k2) aa, k1, k2, k3, avg(v_big) a, count(v_big) c
-  from gs_pushdown_src group by rollup(k1, k2, k3)
+  from gs_pushdown_src_${uuid0} group by rollup(k1, k2, k3)
 ) t where aa = 1;
 set cbo_push_down_groupingset = true;
-create table gs_res_on_3 properties("replication_num"="1") as
+create table gs_res_on_3_${uuid0} properties("replication_num"="1") as
 select * from (
   select grouping(k1, k2) aa, k1, k2, k3, avg(v_big) a, count(v_big) c
-  from gs_pushdown_src group by rollup(k1, k2, k3)
+  from gs_pushdown_src_${uuid0} group by rollup(k1, k2, k3)
 ) t where aa = 1;
-select (select count(*) from gs_res_off_3) - (select count(*) from gs_res_on_3) cnt_diff,
-       (select count(*) from ((select * from gs_res_off_3) except (select * from gs_res_on_3)) d) only_off,
-       (select count(*) from ((select * from gs_res_on_3) except (select * from gs_res_off_3)) d) only_on;
+select (select count(*) from gs_res_off_3_${uuid0}) - (select count(*) from gs_res_on_3_${uuid0}) cnt_diff,
+       (select count(*) from ((select * from gs_res_off_3_${uuid0}) except (select * from gs_res_on_3_${uuid0})) d) only_off,
+       (select count(*) from ((select * from gs_res_on_3_${uuid0}) except (select * from gs_res_off_3_${uuid0})) d) only_on;
 
 -- ---------------------------------------------------------------------------
 -- 4. HAVING directly on an AVG output. check() refuses to push down here; the rows must still match
 --    the baseline, and this pins the guard so that relaxing it later cannot silently change results.
 -- ---------------------------------------------------------------------------
 set cbo_push_down_groupingset = false;
-create table gs_res_off_4 properties("replication_num"="1") as
+create table gs_res_off_4_${uuid0} properties("replication_num"="1") as
 select k1, k2, k3, avg(v_big) a
-from gs_pushdown_src group by rollup(k1, k2, k3) having avg(v_big) > 20;
+from gs_pushdown_src_${uuid0} group by rollup(k1, k2, k3) having avg(v_big) > 20;
 set cbo_push_down_groupingset = true;
-create table gs_res_on_4 properties("replication_num"="1") as
+create table gs_res_on_4_${uuid0} properties("replication_num"="1") as
 select k1, k2, k3, avg(v_big) a
-from gs_pushdown_src group by rollup(k1, k2, k3) having avg(v_big) > 20;
-select (select count(*) from gs_res_off_4) - (select count(*) from gs_res_on_4) cnt_diff,
-       (select count(*) from ((select * from gs_res_off_4) except (select * from gs_res_on_4)) d) only_off,
-       (select count(*) from ((select * from gs_res_on_4) except (select * from gs_res_off_4)) d) only_on;
+from gs_pushdown_src_${uuid0} group by rollup(k1, k2, k3) having avg(v_big) > 20;
+select (select count(*) from gs_res_off_4_${uuid0}) - (select count(*) from gs_res_on_4_${uuid0}) cnt_diff,
+       (select count(*) from ((select * from gs_res_off_4_${uuid0}) except (select * from gs_res_on_4_${uuid0})) d) only_off,
+       (select count(*) from ((select * from gs_res_on_4_${uuid0}) except (select * from gs_res_off_4_${uuid0})) d) only_on;
+
+-- ---------------------------------------------------------------------------
+-- 5. AVG over the full range of DECIMAL widths. avg(decimal) is decomposed into sum/count and put back
+--    together by a DIVIDE, and the BE dispatches that DIVIDE on its own decimal width, reading BOTH
+--    operands at that width - so the synthesized count operand has to be cast to a matching width.
+--    Getting that wrong does not fail: it reinterprets the column and silently returns 0 for every row,
+--    which no plan assertion can see. DECIMAL256 (precision > 38) is the case that actually regressed.
+-- ---------------------------------------------------------------------------
+drop table if exists gs_dec_src_${uuid0};
+CREATE TABLE `gs_dec_src_${uuid0}` (
+    `k1` int,
+    `k2` int,
+    `k3` int,
+    `d32` decimal(9,2),
+    `d64` decimal(18,4),
+    `d128` decimal(38,10),
+    `d256` decimal(76,10)
+) DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+PROPERTIES ( "replication_num" = "1");
+INSERT INTO gs_dec_src_${uuid0} VALUES
+ (1,1,1, 1.25, 1.5005, 1.0000000001, 10.5)
+,(1,1,2, 2.50, 2.2500, 2.0000000002, 20.25)
+,(1,2,1, 3.75, 3.1250, 3.0000000003, 30.125)
+,(2,1,1, 4.00, 4.0625, 4.0000000004, 40.0625)
+,(2,2,2, 5.10, 5.9375, 5.0000000005, 1234567890123456789012345678901234.5)
+,(2,2,2, NULL, NULL, NULL, NULL);
+set cbo_push_down_groupingset = false;
+create table gs_dec_off_${uuid0} properties("replication_num"="1") as
+select k1, k2, k3, avg(d32) a32, avg(d64) a64, avg(d128) a128, avg(d256) a256
+from gs_dec_src_${uuid0} group by rollup(k1, k2, k3);
+set cbo_push_down_groupingset = true;
+create table gs_dec_on_${uuid0} properties("replication_num"="1") as
+select k1, k2, k3, avg(d32) a32, avg(d64) a64, avg(d128) a128, avg(d256) a256
+from gs_dec_src_${uuid0} group by rollup(k1, k2, k3);
+select (select count(*) from gs_dec_off_${uuid0}) - (select count(*) from gs_dec_on_${uuid0}) cnt_diff,
+       (select count(*) from ((select * from gs_dec_off_${uuid0}) except (select * from gs_dec_on_${uuid0})) d) only_off,
+       (select count(*) from ((select * from gs_dec_on_${uuid0}) except (select * from gs_dec_off_${uuid0})) d) only_on;
 
 set cbo_push_down_groupingset = true;
-drop table gs_res_off_1;
-drop table gs_res_on_1;
-drop table gs_res_off_2;
-drop table gs_res_on_2;
-drop table gs_res_off_3;
-drop table gs_res_on_3;
-drop table gs_res_off_4;
-drop table gs_res_on_4;
-drop table gs_pushdown_src;
+drop table gs_dec_off_${uuid0};
+drop table gs_dec_on_${uuid0};
+drop table gs_dec_src_${uuid0};
+drop table gs_res_off_1_${uuid0};
+drop table gs_res_on_1_${uuid0};
+drop table gs_res_off_2_${uuid0};
+drop table gs_res_on_2_${uuid0};
+drop table gs_res_off_3_${uuid0};
+drop table gs_res_on_3_${uuid0};
+drop table gs_res_off_4_${uuid0};
+drop table gs_res_on_4_${uuid0};
+drop table gs_pushdown_src_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
For `GROUP BY ROLLUP/GROUPING SETS` with more than 3 levels, StarRocks already has a CBO rule (`PushDownAggregateGroupingSetsRule`) that avoids exploding raw rows before aggregating: it pre-aggregates to the finest grain first, then expands the smaller result for the coarser rollup levels. But the rule's function whitelist only covered `MAX/MIN/SUM`, because those are "self-recombining" (`sum(sum(x))` is valid, `avg(avg(x))` is not). Any rollup query using `AVG` or `COUNT` silently fell back to the old, expensive plan — REPEAT running on the full pre-aggregation row count.

Verified against a real TPC-DS SF100 profile (Q22, `avg(...)` over a 4-column rollup): before this change, REPEAT sat directly on ~156M join-output rows; the rule simply never fired for this query.

## What I'm doing:
- Extend the whitelist to include `AVG` and `COUNT`.
- **AVG**: not self-recombining, so it's decomposed into `sum(x)` + `count(x)` at the finest grain; coarser rollup levels re-aggregate by summing both parts (never re-averaging, which would be wrong across unequal-size groups); the final avg is recovered via division wherever it's consumed.
- **COUNT**: also not self-recombining (a coarser level must re-`SUM` the finer levels' partial counts, not re-`COUNT` them). Reuses the existing `AggregateFunctionRollupUtils` COUNT→SUM rollup mapping instead of inventing a new one.
- Added a `HAVING` guard: a predicate directly on an AVG output can't be pushed down safely (the pre-division sum/count columns aren't the real value yet), so that case is excluded. COUNT doesn't need this guard — its re-summed value is already the correct final count, so `HAVING count(...) > N` pushes down safely.

```
before (any rollup, e.g. avg/count):          after (AVG/COUNT now included):
  Aggregate(avg/count)                          CTE: Aggregate(sum,count) -- finest grain, small
       |                                             |             \
    REPEAT  <- explodes full row count               |              REPEAT (small) -> re-agg(sum,sum)
       |                                              |                    |
     Join                                        Union <---------- select finest level (sum/count -> divide)
```

- Updated `GroupingSetsTest`: new plan-shape assertions for AVG and COUNT, the AVG `HAVING` exclusion, COUNT `HAVING` pushdown, and a JMockit mock signature fix (the rewritten method gained a new parameter that the mock needed to match).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
