### PR TITLE
[BugFix] Keep columns read by OR-resident predicates after inverted index filtering (backport #77659)

### DIFF
--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2550,10 +2550,10 @@ Status SegmentIterator::_apply_inverted_index() {
     // ---------------------------------------------------------
     if (!erased_preds.empty()) {
         erase_column_pred_from_pred_tree(_opts.pred_tree, erased_preds);
-        const auto& new_cid_to_predicates = _opts.pred_tree.get_immediate_column_predicate_map();
 
         for (const auto& cid : erased_pred_col_ids) {
-            if (!new_cid_to_predicates.contains(cid)) {
+            // contains_column walks OR subtrees, which the immediate map hides; such a predicate still reads the column
+            if (!_opts.pred_tree.contains_column(cid)) {
                 // predicate for pred->column_id() has been total erased by
                 // inverted index filtering.These columns may can be pruned.
                 _inverted_index_ctx->prune_cols_candidate_by_inverted_index.insert(cid);

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -1849,3 +1849,56 @@ SELECT id1 FROM t_gin_like_underscore WHERE text_column LIKE "abc" ORDER BY id1;
 DROP TABLE t_gin_like_underscore;
 -- result:
 -- !result
+-- name: test_gin_or_prune_after_index_filter @native
+ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
+-- result:
+-- !result
+CREATE TABLE `t_gin_or_prune_${uuid0}` (
+  `id` bigint NOT NULL,
+  `k`  bigint NOT NULL,
+  `v`  varchar(255) NOT NULL,
+  INDEX gin_v (`v`) USING GIN ("parser" = "none")
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1
+PROPERTIES ("replication_num" = "1", "replicated_storage" = "false");
+-- result:
+-- !result
+insert into t_gin_or_prune_${uuid0} values (1, 0, "redx"), (2, 1, "redy"), (3, 1, "blue"), (4, 0, "redz");
+-- result:
+-- !result
+select id from t_gin_or_prune_${uuid0} where v like '%red%' and (v = 'redx' or k = 1) order by id;
+-- result:
+1
+2
+-- !result
+select id from t_gin_or_prune_${uuid0} where v match '%red%' and (v = 'redx' or k = 1) order by id;
+-- result:
+1
+2
+-- !result
+set enable_prune_column_after_index_filter = false;
+-- result:
+-- !result
+select id from t_gin_or_prune_${uuid0} where v like '%red%' and (v = 'redx' or k = 1) order by id;
+-- result:
+1
+2
+-- !result
+set enable_prune_column_after_index_filter = true;
+-- result:
+-- !result
+select id, v from t_gin_or_prune_${uuid0} where v like '%red%' and (v = 'redx' or k = 1) order by id;
+-- result:
+1	redx
+2	redy
+-- !result
+select id from t_gin_or_prune_${uuid0} where v like '%red%' order by id;
+-- result:
+1
+2
+4
+-- !result
+DROP TABLE t_gin_or_prune_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_inverted_index/T/test_inverted_index
+++ b/test/sql/test_inverted_index/T/test_inverted_index
@@ -1022,3 +1022,32 @@ SELECT id1 FROM t_gin_like_underscore WHERE text_column LIKE "ab%" ORDER BY id1;
 SELECT id1 FROM t_gin_like_underscore WHERE text_column LIKE "abc" ORDER BY id1;
 
 DROP TABLE t_gin_like_underscore;
+
+-- name: test_gin_or_prune_after_index_filter @native
+ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
+CREATE TABLE `t_gin_or_prune_${uuid0}` (
+  `id` bigint NOT NULL,
+  `k`  bigint NOT NULL,
+  `v`  varchar(255) NOT NULL,
+  INDEX gin_v (`v`) USING GIN ("parser" = "none")
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1
+PROPERTIES ("replication_num" = "1", "replicated_storage" = "false");
+
+insert into t_gin_or_prune_${uuid0} values (1, 0, "redx"), (2, 1, "redy"), (3, 1, "blue"), (4, 0, "redz");
+
+-- row 4 satisfies the indexed LIKE but neither OR branch, so pruning v must not drop the OR predicate
+select id from t_gin_or_prune_${uuid0} where v like '%red%' and (v = 'redx' or k = 1) order by id;
+select id from t_gin_or_prune_${uuid0} where v match '%red%' and (v = 'redx' or k = 1) order by id;
+
+set enable_prune_column_after_index_filter = false;
+select id from t_gin_or_prune_${uuid0} where v like '%red%' and (v = 'redx' or k = 1) order by id;
+set enable_prune_column_after_index_filter = true;
+
+select id, v from t_gin_or_prune_${uuid0} where v like '%red%' and (v = 'redx' or k = 1) order by id;
+
+-- no predicate survives the index, so v stays prunable
+select id from t_gin_or_prune_${uuid0} where v like '%red%' order by id;
+
+DROP TABLE t_gin_or_prune_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

Backport of #77659 to branch-4.0. **Hand-written, not a cherry-pick** — see
`## How this differs from #77659` below.

When a GIN inverted index answers a predicate, the segment iterator may prune that predicate's
column from the read set. It decides that with `PredicateTree::get_immediate_column_predicate_map()`,
which only exposes the direct children of the root AND — a predicate sitting inside an OR subtree is
invisible to it. Such a column is then wrongly pruned: it is never read, while the surviving
OR-resident predicate is still evaluated per row, so the query silently returns a wrong result set,
with no error and no log.

Repro (`enable_gin_filter` and `enable_prune_column_after_index_filter` are both on by default; the
GIN feature itself is behind `enable_experimental_gin`):

```sql
ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");

CREATE TABLE `t_gin_or_prune` (
  `id` bigint NOT NULL,
  `k`  bigint NOT NULL,
  `v`  varchar(255) NOT NULL,
  INDEX gin_v (`v`) USING GIN ("parser" = "none")
) ENGINE=OLAP
DUPLICATE KEY(`id`)
DISTRIBUTED BY HASH(`id`) BUCKETS 1
PROPERTIES ("replication_num" = "1", "replicated_storage" = "false");

insert into t_gin_or_prune values (1, 0, "redx"), (2, 1, "redy"), (3, 1, "blue"), (4, 0, "redz");

select id from t_gin_or_prune where v like '%red%' and (v = 'redx' or k = 1) order by id;
```

Expected `1, 2`; actual `1, 2, 4` — row 4 (`redz`, `k = 0`) satisfies the indexed LIKE but neither OR
branch. The same happens with `v match '%red%'`. Turning off
`enable_prune_column_after_index_filter`, or adding `v` to the projection, restores the correct
result, which pins the wrong result on the column pruning.

## What I'm doing:

Decide prunability on the whole predicate tree instead of the immediate map:
`PredicateTree::contains_column(cid)` collects column ids by walking `compound_children`, so an
OR-resident predicate keeps its column alive. The erase helper rebuilds the tree through
`PredicateTree::create()`, so the freshly assigned tree carries an empty cached column set and no
stale map can leak in.

## How this differs from #77659

`PredicateType::kGinFallback` and `InvertedIndexFallbackPredicate` do not exist on branch-4.0, so the
mainline commit cannot be cherry-picked as-is: it would apply cleanly and then fail to compile. This
was called out in #77659's own description, which left the version checkboxes empty and promised the
backports by hand.

The mainline form introduces `remaining_predicates_require_column()`, whose job is to run the
whole-tree lookup *and* exclude `kGinFallback` predicates — an `InvertedIndexFallbackPredicate`
selects rows from a pre-loaded rowid bitmap and so does not read the column. With no such predicate
type on this branch, the fix reduces to the already-present `PredicateTree::contains_column(cid)`:
the same whole-tree lookup, with nothing to exclude. `kPlaceHolder` predicates keep their column
alive here exactly as on mainline.

## Testing

The SQL regression case `test_gin_or_prune_after_index_filter` in `test/sql/test_inverted_index` is
carried over byte-for-byte from #77659: the repro query, its `match` variant, a control with
`enable_prune_column_after_index_filter = false`, a control with the column projected, and a pure-AND
control verifying that result semantics stay unchanged when no predicate survives the index.

The three BE unit tests from #77659 are not carried over — they cover
`remaining_predicates_require_column()`, which does not exist in this form, and no BE unit test on
this branch reaches `SegmentIterator::_apply_inverted_index()`.

Checked against branch-4.0 before opening: `contains_column` is public here, `column_ids()` recurses
into `compound_children()` (which is exactly what makes the OR-resident predicate visible), the erase
helper rebuilds the tree so no cached column set is reused, and clang-format-10 leaves the hunk
unchanged.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

