### PR TITLE
[Enhancement] Pre-split dynamic overwrite temporary partitions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -59,6 +59,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -329,11 +330,12 @@ public class SplitTabletJob extends TabletReshardJob {
         // 1. Cancel previous in-flight compactions on the resharded partitions so cleaning does not wait
         //    for slow compaction, then wait for the rest. Compactions on partitions this job does not
         //    reshard are neither cancelled nor waited on (see CompactionScheduler#cancelPreviousCompactions).
-        Set<Long> ignoredCompactionTxnIds = GlobalStateMgr.getCurrentState().getCompactionMgr()
-                .cancelPreviousCompactions(endTransactionId, dbId, tableId, reshardingPhysicalPartitions.keySet());
+        Set<Long> ignoredTransactionIds = new HashSet<>(getCleanupExcludedTransactionIds());
+        ignoredTransactionIds.addAll(GlobalStateMgr.getCurrentState().getCompactionMgr()
+                .cancelPreviousCompactions(endTransactionId, dbId, tableId, reshardingPhysicalPartitions.keySet()));
         try {
             if (!GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().isPreviousTransactionsFinished(
-                    endTransactionId, dbId, List.of(tableId), ignoredCompactionTxnIds)) {
+                    endTransactionId, dbId, List.of(tableId), ignoredTransactionIds)) {
                 return;
             }
         } catch (AnalysisException e) { // Db is dropped, ignore exception

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
@@ -28,7 +28,9 @@ import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /*
  * TabletReshardJob is for tablet splitting and merging.
@@ -82,6 +84,12 @@ public abstract class TabletReshardJob implements Writable {
     @SerializedName(value = "warehouseId")
     protected Long warehouseId;
 
+    // Transactions that were opened only to reserve identifiers/metadata for the operation that
+    // requested this reshard. They have not started writing and therefore must not make CLEANING
+    // wait on the caller that is synchronously waiting for this job. Persisted for leader replay.
+    @SerializedName(value = "cleanupExcludedTransactionIds")
+    protected Set<Long> cleanupExcludedTransactionIds;
+
     public TabletReshardJob(long jobId, JobType jobType) {
         this.jobId = jobId;
         this.jobType = jobType;
@@ -106,6 +114,21 @@ public abstract class TabletReshardJob implements Writable {
      */
     public void setWarehouseId(long warehouseId) {
         this.warehouseId = warehouseId;
+    }
+
+    /**
+     * Exclude a known-not-yet-writing transaction from this job's cleanup watermark wait.
+     * Callers must set this before the job is admitted and journaled.
+     */
+    public void addCleanupExcludedTransactionId(long transactionId) {
+        if (cleanupExcludedTransactionIds == null) {
+            cleanupExcludedTransactionIds = new HashSet<>();
+        }
+        cleanupExcludedTransactionIds.add(transactionId);
+    }
+
+    protected Set<Long> getCleanupExcludedTransactionIds() {
+        return cleanupExcludedTransactionIds == null ? Set.of() : cleanupExcludedTransactionIds;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
@@ -28,9 +28,9 @@ import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /*
  * TabletReshardJob is for tablet splitting and merging.
@@ -84,11 +84,18 @@ public abstract class TabletReshardJob implements Writable {
     @SerializedName(value = "warehouseId")
     protected Long warehouseId;
 
-    // Transactions that were opened only to reserve identifiers/metadata for the operation that
-    // requested this reshard. They have not started writing and therefore must not make CLEANING
-    // wait on the caller that is synchronously waiting for this job. Persisted for leader replay.
-    @SerializedName(value = "cleanupExcludedTransactionIds")
-    protected Set<Long> cleanupExcludedTransactionIds;
+    // Transactions that were opened only to reserve identifiers/metadata for the operation that is
+    // synchronously waiting for this job, and that provably have not started writing yet. Excluding
+    // them from the CLEANING watermark wait breaks the wait cycle where CLEANING waits for the
+    // caller's transaction while the caller waits for this job.
+    //
+    // Deliberately NOT persisted, and cleared as soon as the caller stops waiting
+    // (clearCleanupExcludedTransactionIds): the exclusion is only sound while the transaction is
+    // known not to be writing. Once the caller proceeds -- or the leader changes and the caller is
+    // gone -- CLEANING must go back to waiting for that transaction, otherwise it could unregister
+    // the resharding tablets while the transaction is still writing to the old ones.
+    // volatile + concurrent set: written by the submitting session thread, read by the reshard daemon.
+    protected volatile Set<Long> cleanupExcludedTransactionIds;
 
     public TabletReshardJob(long jobId, JobType jobType) {
         this.jobId = jobId;
@@ -117,14 +124,27 @@ public abstract class TabletReshardJob implements Writable {
     }
 
     /**
-     * Exclude a known-not-yet-writing transaction from this job's cleanup watermark wait.
-     * Callers must set this before the job is admitted and journaled.
+     * Exclude a known-not-yet-writing transaction from this job's cleanup watermark wait, for as
+     * long as its owner is synchronously waiting for this job. Callers must set this before the job
+     * is admitted, and must call {@link #clearCleanupExcludedTransactionIds()} the moment they stop
+     * waiting -- see the field comment for why the exclusion cannot outlive that window.
      */
     public void addCleanupExcludedTransactionId(long transactionId) {
         if (cleanupExcludedTransactionIds == null) {
-            cleanupExcludedTransactionIds = new HashSet<>();
+            cleanupExcludedTransactionIds = ConcurrentHashMap.newKeySet();
         }
         cleanupExcludedTransactionIds.add(transactionId);
+    }
+
+    /**
+     * Drop every cleanup-wait exclusion, so CLEANING waits for those transactions again. Called
+     * once the waiting caller is about to proceed (its transaction may start writing at any moment)
+     * or has given up on this job.
+     */
+    public void clearCleanupExcludedTransactionIds() {
+        if (cleanupExcludedTransactionIds != null) {
+            cleanupExcludedTransactionIds.clear();
+        }
     }
 
     protected Set<Long> getCleanupExcludedTransactionIds() {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHook.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHook.java
@@ -175,10 +175,21 @@ public final class InsertPreSplitHook {
         if (insertStmt.isSpecifyPartitionNames() || insertStmt.isStaticKeyPartitionInsert()) {
             return false;
         }
-        if (insertStmt.getProperties() != null && !insertStmt.getProperties().isEmpty()) {
-            return false;
-        }
-        return true;
+        return !carriesLoadProperties(insertStmt);
+    }
+
+    /**
+     * Whether the statement was written with a {@code PROPERTIES(...)} clause, which can change the
+     * row set the load writes (max_filter_ratio, strict_mode, ...) relative to what the sampler saw.
+     *
+     * <p>Deliberately not {@code getProperties().isEmpty()}: {@code InsertAnalyzer#analyzeProperties}
+     * fills that map with the session defaults for max_filter_ratio / strict_mode / timeout, so after
+     * analysis it is never empty. {@link #passesCommonPreFilters} runs before analysis and would not
+     * notice, but {@link #passesDynamicOverwritePreFilters} runs after it and would reject every
+     * statement. Both ask the parse-time question so the two gates cannot drift apart.
+     */
+    private static boolean carriesLoadProperties(InsertStmt insertStmt) {
+        return !insertStmt.getUserSpecifiedPropertyKeys().isEmpty();
     }
 
     private static boolean passesDynamicOverwritePreFilters(
@@ -195,7 +206,7 @@ public final class InsertPreSplitHook {
         if (insertStmt.isSpecifyPartitionNames() || insertStmt.isStaticKeyPartitionInsert()) {
             return false;
         }
-        return insertStmt.getProperties() == null || insertStmt.getProperties().isEmpty();
+        return !carriesLoadProperties(insertStmt);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHook.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHook.java
@@ -85,6 +85,24 @@ public final class InsertPreSplitHook {
         }
     }
 
+    /**
+     * Runs the dynamic-overwrite variant after its transaction has been opened but before the
+     * load is replanned and starts writing. Fail-safe like {@link #maybeRunPreSplit}: any failure
+     * leaves the runtime auto-partition path to create or reuse the temporary partitions.
+     */
+    public static void maybeRunDynamicOverwritePreSplit(
+            InsertStmt insertStmt, ConnectContext context, long overwriteTransactionId) {
+        try {
+            if (!passesDynamicOverwritePreFilters(insertStmt, context, overwriteTransactionId)) {
+                return;
+            }
+            tryRunEligibleInsert(insertStmt, context, overwriteTransactionId);
+        } catch (Throwable unexpected) {
+            LOG.warn("Sample-Based Tablet Pre-Split (dynamic INSERT OVERWRITE) hook failed; "
+                    + "proceeding without pre-split", unexpected);
+        }
+    }
+
     private static void tryRunPreSplit(StatementBase parsedStmt, ConnectContext context)
             throws AccessDeniedException {
         if (!(parsedStmt instanceof InsertStmt insertStmt)) {
@@ -93,6 +111,12 @@ public final class InsertPreSplitHook {
         if (!passesCommonPreFilters(insertStmt, context)) {
             return;
         }
+        tryRunEligibleInsert(insertStmt, context, -1L);
+    }
+
+    private static void tryRunEligibleInsert(
+            InsertStmt insertStmt, ConnectContext context, long overwriteTransactionId)
+            throws AccessDeniedException {
         SelectRelation selectRelation = extractSelectRelation(insertStmt);
         if (selectRelation == null) {
             return;
@@ -125,8 +149,13 @@ public final class InsertPreSplitHook {
         if (prepared == null) {
             return;
         }
-        PreSplitFlow.dispatch(resolvedTable.database(), resolvedTable.olapTable(),
-                prepared, source.loadKind(), context::isKilled, context);
+        if (overwriteTransactionId > 0) {
+            PreSplitFlow.runDynamicOverwriteFlow(resolvedTable.database(), resolvedTable.olapTable(),
+                    prepared, source.loadKind(), context::isKilled, context, overwriteTransactionId);
+        } else {
+            PreSplitFlow.dispatch(resolvedTable.database(), resolvedTable.olapTable(),
+                    prepared, source.loadKind(), context::isKilled, context);
+        }
     }
 
     private static boolean passesCommonPreFilters(InsertStmt insertStmt, ConnectContext context) {
@@ -150,6 +179,23 @@ public final class InsertPreSplitHook {
             return false;
         }
         return true;
+    }
+
+    private static boolean passesDynamicOverwritePreFilters(
+            InsertStmt insertStmt, ConnectContext context, long overwriteTransactionId) {
+        if (!insertStmt.isDynamicOverwrite() || !insertStmt.hasOverwriteJob() || overwriteTransactionId <= 0) {
+            return false;
+        }
+        if (insertStmt.isExplain() && !ExplainLevel.ANALYZE.equals(insertStmt.getExplainLevel())) {
+            return false;
+        }
+        if (context.getTxnId() != 0 || insertStmt.getTxnId() != DmlStmt.INVALID_TXN_ID) {
+            return false;
+        }
+        if (insertStmt.isSpecifyPartitionNames() || insertStmt.isStaticKeyPartitionInsert()) {
+            return false;
+        }
+        return insertStmt.getProperties() == null || insertStmt.getProperties().isEmpty();
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PartitionSampleGrouper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PartitionSampleGrouper.java
@@ -97,6 +97,24 @@ public final class PartitionSampleGrouper {
     public static List<PartitionSamples> group(SampleSet samples, OlapTable table, ConnectContext ctx,
                                                long dbId, long totalFileBytes,
                                                Set<Long> sampledSecondaryIndexMetaIds) {
+        return group(samples, table, ctx, dbId, totalFileBytes, sampledSecondaryIndexMetaIds,
+                false, null);
+    }
+
+    /**
+     * Dynamic-overwrite variant. Resolves sampled values to transaction-scoped temporary
+     * partitions using the same naming convention as the runtime auto-partition RPC.
+     */
+    public static List<PartitionSamples> groupTemporary(
+            SampleSet samples, OlapTable table, ConnectContext ctx, long dbId, long totalFileBytes,
+            Set<Long> sampledSecondaryIndexMetaIds, long transactionId) {
+        return group(samples, table, ctx, dbId, totalFileBytes, sampledSecondaryIndexMetaIds,
+                true, "txn" + transactionId);
+    }
+
+    private static List<PartitionSamples> group(
+            SampleSet samples, OlapTable table, ConnectContext ctx, long dbId, long totalFileBytes,
+            Set<Long> sampledSecondaryIndexMetaIds, boolean temporaryPartition, String partitionNamePrefix) {
         List<Tuple> partitionSourceTuples = samples.getPartitionSourceTuples();
         if (partitionSourceTuples.isEmpty()) {
             // Sampler did not project partition source columns (target was unpartitioned).
@@ -164,7 +182,8 @@ public final class PartitionSampleGrouper {
         // own locking later.
         Map<String, MergedGroup> byPartitionName = new LinkedHashMap<>();
         for (RawGroup rawGroup : rawGroups.values()) {
-            AnalyzedClauseEntry entry = analyzeOnce(table, rawGroup.formattedValues, ctx);
+            AnalyzedClauseEntry entry = analyzeOnce(
+                    table, rawGroup.formattedValues, ctx, temporaryPartition, partitionNamePrefix);
             if (entry == null) {
                 PreSplitMetrics.recordEligibilitySkip(SkipReason.INVALID_PARTITION_VALUE);
                 continue;
@@ -210,7 +229,9 @@ public final class PartitionSampleGrouper {
                 long estimatedBytes = sampleRowCount == 0 ? 0L :
                         Math.round((double) group.rows.size() / sampleRowCount * totalFileBytes);
 
-                Partition partition = table.getPartition(group.partitionName);
+                Partition partition = temporaryPartition
+                        ? table.getPartition(group.partitionName, true)
+                        : table.getPartition(group.partitionName);
                 if (partition == null) {
                     resolved.add(new PartitionSamples(
                             group.formattedValues, group.partitionName, false,
@@ -313,11 +334,12 @@ public final class PartitionSampleGrouper {
      * value. Returns {@code null} if the analyzer rejects the value (caller
      * counts under {@link SkipReason#INVALID_PARTITION_VALUE}).
      */
-    private static AnalyzedClauseEntry analyzeOnce(OlapTable table, List<String> formattedValues,
-                                                   ConnectContext ctx) {
+    private static AnalyzedClauseEntry analyzeOnce(
+            OlapTable table, List<String> formattedValues, ConnectContext ctx,
+            boolean temporaryPartition, String partitionNamePrefix) {
         try {
             AddPartitionClause clause = AnalyzerUtils.getAddPartitionClauseFromPartitionValues(
-                    table, Collections.singletonList(formattedValues), false, null);
+                    table, Collections.singletonList(formattedValues), temporaryPartition, partitionNamePrefix);
             AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(table);
             analyzer.analyze(ctx, clause);
             List<PartitionDesc> resolved = clause.getResolvedPartitionDescList();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
@@ -191,8 +191,18 @@ final class PreSplitFlow {
         LOG.info("Sample-Based Tablet Pre-Split ({}, multi-partition) outcome for table {}: {}",
                 loadKind, table.getName(), outcome);
         if (outcome instanceof PreSplitOutcome.SubmittedCombined submittedCombined) {
-            TabletPreSplitCoordinator.awaitCombinedJobAllowingFallback(
-                    loadKind, table, submittedCombined.combinedJob(), shouldAbort);
+            try {
+                TabletPreSplitCoordinator.awaitCombinedJobAllowingFallback(
+                        loadKind, table, submittedCombined.combinedJob(), shouldAbort);
+            } finally {
+                // The await is fail-safe: on timeout / abort it returns while the job may still be
+                // pre-CLEANING, and the caller then goes on to plan and write with the very
+                // transaction CLEANING was told to ignore. Revoking the exclusion here keeps the
+                // watermark wait honest for exactly the window the transaction was idle -- worst
+                // case CLEANING now waits for the load, which is the pre-existing behaviour for
+                // every other in-flight transaction.
+                submittedCombined.combinedJob().clearCleanupExcludedTransactionIds();
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
@@ -131,6 +131,28 @@ final class PreSplitFlow {
 
     static void runMultiPartitionFlow(Database database, OlapTable table, Prepared prepared,
                                       LoadKind loadKind, BooleanSupplier shouldAbort, ConnectContext context) {
+        runMultiPartitionFlow(database, table, prepared, loadKind, shouldAbort, context, -1L);
+    }
+
+    /**
+     * Samples a dynamic overwrite before its write starts, pre-creates the predicted
+     * transaction-scoped temporary partitions, and splits those temporary partitions.
+     */
+    static void runDynamicOverwriteFlow(Database database, OlapTable table, Prepared prepared,
+                                        LoadKind loadKind, BooleanSupplier shouldAbort,
+                                        ConnectContext context, long overwriteTransactionId) {
+        if (!table.getPartitionInfo().isPartitioned()
+                || !Boolean.TRUE.equals(table.supportedAutomaticPartition())
+                || overwriteTransactionId <= 0) {
+            return;
+        }
+        runMultiPartitionFlow(database, table, prepared, loadKind, shouldAbort, context,
+                overwriteTransactionId);
+    }
+
+    private static void runMultiPartitionFlow(
+            Database database, OlapTable table, Prepared prepared, LoadKind loadKind,
+            BooleanSupplier shouldAbort, ConnectContext context, long overwriteTransactionId) {
         int activeComputeNodeCount = TabletReshardUtils.computeNodeCount(prepared.computeResource());
         // Try the meta tier first (row-group footer statistics, no data scan), mirroring the
         // single-partition flow's meta-tier-first routing; fall back to the exact data tier for
@@ -149,15 +171,23 @@ final class PreSplitFlow {
         // partition whose currently-resolved rollup set differs, and the coordinator re-checks the
         // same set immediately before planning each partition.
         Set<Long> sampledSecondaryIndexMetaIds = new HashSet<>(samples.getSecondaryIndexMetaIds());
-        List<PartitionSamples> groups = PartitionSampleGrouper.group(
-                samples, table, context, database.getId(), prepared.estimatedBytes(),
-                sampledSecondaryIndexMetaIds);
+        List<PartitionSamples> groups = overwriteTransactionId > 0
+                ? PartitionSampleGrouper.groupTemporary(
+                        samples, table, context, database.getId(), prepared.estimatedBytes(),
+                        sampledSecondaryIndexMetaIds, overwriteTransactionId)
+                : PartitionSampleGrouper.group(
+                        samples, table, context, database.getId(), prepared.estimatedBytes(),
+                        sampledSecondaryIndexMetaIds);
         if (groups.isEmpty()) {
             return;
         }
-        PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                database, table, groups, activeComputeNodeCount, context, prepared.computeResource(),
-                sampledSecondaryIndexMetaIds);
+        PreSplitOutcome outcome = overwriteTransactionId > 0
+                ? TabletPreSplitCoordinator.submitForTemporaryPartitionsCombined(
+                        database, table, groups, activeComputeNodeCount, context, prepared.computeResource(),
+                        sampledSecondaryIndexMetaIds, overwriteTransactionId)
+                : TabletPreSplitCoordinator.submitForPartitionsCombined(
+                        database, table, groups, activeComputeNodeCount, context, prepared.computeResource(),
+                        sampledSecondaryIndexMetaIds);
         LOG.info("Sample-Based Tablet Pre-Split ({}, multi-partition) outcome for table {}: {}",
                 loadKind, table.getName(), outcome);
         if (outcome instanceof PreSplitOutcome.SubmittedCombined submittedCombined) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinator.java
@@ -593,6 +593,30 @@ public final class TabletPreSplitCoordinator {
             Database database, OlapTable table, List<PartitionSamples> partitionSamplesList,
             int activeComputeNodeCount, ConnectContext ctx, ComputeResource loadComputeResource,
             Set<Long> sampledSecondaryIndexMetaIds) {
+        return submitForPartitionsCombined(database, table, partitionSamplesList, activeComputeNodeCount,
+                ctx, loadComputeResource, sampledSecondaryIndexMetaIds, false, -1L);
+    }
+
+    /**
+     * Dynamic-overwrite counterpart that creates and resolves transaction-scoped temporary
+     * partitions. The already-open overwrite transaction has not started writing, so it is
+     * excluded from the reshard job's cleanup watermark wait to avoid a synchronous wait cycle.
+     */
+    public static PreSplitOutcome submitForTemporaryPartitionsCombined(
+            Database database, OlapTable table, List<PartitionSamples> partitionSamplesList,
+            int activeComputeNodeCount, ConnectContext ctx, ComputeResource loadComputeResource,
+            Set<Long> sampledSecondaryIndexMetaIds, long overwriteTransactionId) {
+        Preconditions.checkArgument(overwriteTransactionId > 0,
+                "overwriteTransactionId must be positive, was %s", overwriteTransactionId);
+        return submitForPartitionsCombined(database, table, partitionSamplesList, activeComputeNodeCount,
+                ctx, loadComputeResource, sampledSecondaryIndexMetaIds, true, overwriteTransactionId);
+    }
+
+    private static PreSplitOutcome submitForPartitionsCombined(
+            Database database, OlapTable table, List<PartitionSamples> partitionSamplesList,
+            int activeComputeNodeCount, ConnectContext ctx, ComputeResource loadComputeResource,
+            Set<Long> sampledSecondaryIndexMetaIds, boolean temporaryPartition,
+            long cleanupExcludedTransactionId) {
         Objects.requireNonNull(database, "database");
         Objects.requireNonNull(table, "table");
         Objects.requireNonNull(partitionSamplesList, "partitionSamplesList");
@@ -618,7 +642,7 @@ public final class TabletPreSplitCoordinator {
             PreSplitMetrics.recordPartitionCounted();
             PreSplitOutcome perPartition = planOnePartition(
                     database, table, entry, activeComputeNodeCount, ctx,
-                    sampledSecondaryIndexMetaIds, oldTabletIdToRanges);
+                    sampledSecondaryIndexMetaIds, temporaryPartition, oldTabletIdToRanges);
             perPartitionResults.add(perPartition);
         }
 
@@ -638,6 +662,9 @@ public final class TabletPreSplitCoordinator {
             // load specifies a different `warehouse` property.
             if (loadComputeResource != null) {
                 combinedJob.setWarehouseId(loadComputeResource.getWarehouseId());
+            }
+            if (cleanupExcludedTransactionId > 0) {
+                combinedJob.addCleanupExcludedTransactionId(cleanupExcludedTransactionId);
             }
             GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().addTabletReshardJob(combinedJob);
             return new PreSplitOutcome.SubmittedCombined(combinedJob, perPartitionResults);
@@ -675,13 +702,17 @@ public final class TabletPreSplitCoordinator {
             Database database, OlapTable table, PartitionSamples entry,
             int activeComputeNodeCount, ConnectContext ctx,
             Set<Long> sampledSecondaryIndexMetaIds,
+            boolean temporaryPartition,
             Map<Long, List<TabletRange>> oldTabletIdToRanges) {
         try {
             if (!entry.existsInCatalog()) {
                 // Cheap pre-check: if the partition raced into the catalog since the grouper
                 // snapshot, skip the addPartitions call and record ALREADY_EXISTS. addPartitions
                 // would otherwise silently dedupe — we want the metric to attribute correctly.
-                if (table.getPartition(entry.partitionName()) != null) {
+                Partition existingPartition = temporaryPartition
+                        ? table.getPartition(entry.partitionName(), true)
+                        : table.getPartition(entry.partitionName());
+                if (existingPartition != null) {
                     PreSplitMetrics.recordPreCreate(PreSplitMetrics.PreCreateResult.ALREADY_EXISTS);
                 } else {
                     try {
@@ -707,7 +738,8 @@ public final class TabletPreSplitCoordinator {
             // resolved secondary index-id set that no longer equals the sampled set drops the
             // partition here rather than submitting a base-only partial.
             List<IndexPreSplitTarget> resolvedTargets =
-                    resolveUnderReadLock(database, table, entry.partitionName(), sampledSecondaryIndexMetaIds);
+                    resolveUnderReadLock(database, table, entry.partitionName(), temporaryPartition,
+                            sampledSecondaryIndexMetaIds);
             if (resolvedTargets == null) {
                 PreSplitMetrics.recordEligibilitySkip(SkipReason.PARTITION_NOT_ELIGIBLE_POST_CREATE);
                 return new PreSplitOutcome.Skipped(SkipReason.PARTITION_NOT_ELIGIBLE_POST_CREATE);
@@ -767,11 +799,14 @@ public final class TabletPreSplitCoordinator {
      * PARTITION_NOT_ELIGIBLE_POST_CREATE).
      */
     private static List<IndexPreSplitTarget> resolveUnderReadLock(
-            Database database, OlapTable table, String partitionName, Set<Long> sampledSecondaryIndexMetaIds) {
+            Database database, OlapTable table, String partitionName, boolean temporaryPartition,
+            Set<Long> sampledSecondaryIndexMetaIds) {
         Locker locker = new Locker();
         locker.lockTableWithIntensiveDbLock(database.getId(), table.getId(), LockType.READ);
         try {
-            Partition partition = table.getPartition(partitionName);
+            Partition partition = temporaryPartition
+                    ? table.getPartition(partitionName, true)
+                    : table.getPartition(partitionName);
             if (partition == null) {
                 return null;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -18,6 +18,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.starrocks.alter.reshard.presplit.InsertPreSplitHook;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
@@ -69,6 +70,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -194,10 +196,17 @@ public class InsertOverwriteJobRunner {
     private void doLoad() throws Exception {
         Preconditions.checkState(job.getJobState() == InsertOverwriteJobState.OVERWRITE_RUNNING);
         createTempPartitions();
+        preSplitDynamicOverwriteTempPartitions();
         prepareInsert();
         executeInsert();
         doCommit();
         transferTo(InsertOverwriteJobState.OVERWRITE_SUCCESS);
+    }
+
+    void preSplitDynamicOverwriteTempPartitions() {
+        if (job.isDynamicOverwrite() && job.getTxnId() > 0) {
+            InsertPreSplitHook.maybeRunDynamicOverwritePreSplit(insertStmt, context, job.getTxnId());
+        }
     }
 
     public void replayStateChange(InsertOverwriteStateChangeInfo info) {
@@ -562,32 +571,35 @@ public class InsertOverwriteJobRunner {
 
     /**
      * Get temp partitions for dynamic overwrite during GC.
-     * Handles three scenarios:
-     * 1. Normal execution: get temp partition names from TransactionState
-     * 2. After FE restart: identify temp partitions by prefix "txn{txnId}_"
-     * 3. Cancelled before prepare: no temp partitions to clean up
+     * Combines names recorded in transaction state with a catalog prefix scan. The latter is needed
+     * both after FE restart and when pre-split created a temporary partition before the BE reported it
+     * through the dynamic-partition RPC.
      */
     private List<String> getDynamicOverwriteTempPartitions(OlapTable targetTable) {
-        List<String> tmpPartitionNames = Lists.newArrayList();
-        if (insertStmt != null && job.getTxnId() > 0) {
-            // Normal execution: get temp partition names from TransactionState
-            tmpPartitionNames = getTempPartitionNamesFromTxnState();
-        } else if (job.getTxnId() > 0) {
-            // After FE restart: identify temp partitions by prefix "txn{txnId}_"
-            String tempPartitionPrefix = "txn" + job.getTxnId() + "_";
-            tmpPartitionNames = targetTable.getTempPartitions().stream()
-                    .map(Partition::getName)
-                    .filter(name -> name.startsWith(tempPartitionPrefix))
-                    .collect(Collectors.toList());
-            LOG.info("dynamic overwrite job {} (FE restarted) drop temp partitions with prefix '{}': {}",
-                    job.getJobId(), tempPartitionPrefix, tmpPartitionNames);
-        } else {
-            // Cancelled before prepare: no temp partitions to clean up
+        if (job.getTxnId() <= 0) {
             LOG.info("dynamic overwrite job {} cancelled before prepare phase, no temp partitions to clean up",
                     job.getJobId());
+            return List.of();
         }
 
-        return tmpPartitionNames;
+        Set<String> tmpPartitionNames = new LinkedHashSet<>();
+        if (insertStmt != null) {
+            try {
+                tmpPartitionNames.addAll(getTempPartitionNamesFromTxnState());
+            } catch (Exception e) {
+                LOG.warn("failed to get temp partitions from transaction {} for dynamic overwrite job {}",
+                        job.getTxnId(), job.getJobId(), e);
+            }
+        }
+
+        String tempPartitionPrefix = "txn" + job.getTxnId() + "_";
+        targetTable.getTempPartitions().stream()
+                .map(Partition::getName)
+                .filter(name -> name.startsWith(tempPartitionPrefix))
+                .forEach(tmpPartitionNames::add);
+        LOG.info("dynamic overwrite job {} drop temp partitions with prefix '{}': {}",
+                job.getJobId(), tempPartitionPrefix, tmpPartitionNames);
+        return new ArrayList<>(tmpPartitionNames);
     }
 
     // Wait until the load transaction of a dynamic overwrite job is no longer running,
@@ -791,6 +803,7 @@ public class InsertOverwriteJobRunner {
             final List<String> finalTmpPartitionNames = tmpPartitionNames;
             GlobalStateMgr.getCurrentState().getEditLog().logInsertOverwriteStateChange(info, wal -> {
                 replacePartition(targetTable, finalSourcePartitionNames, finalTmpPartitionNames);
+                dropUnusedDynamicOverwriteTempPartitions(targetTable);
             });
 
             targetTable.lastSchemaUpdateTime.set(System.nanoTime());
@@ -918,6 +931,30 @@ public class InsertOverwriteJobRunner {
         }
     }
 
+    /**
+     * Sampling and the actual load use separate source snapshots. If rows for a sampled partition
+     * disappear before the load starts, its pre-created temporary partition is never registered in
+     * transaction state and therefore is not promoted. Drop every transaction-scoped temporary
+     * partition left after the successful replacement.
+     */
+    private void dropUnusedDynamicOverwriteTempPartitions(OlapTable targetTable) {
+        if (!job.isDynamicOverwrite() || job.getTxnId() <= 0) {
+            return;
+        }
+        String tempPartitionPrefix = "txn" + job.getTxnId() + "_";
+        List<String> unusedPartitionNames = targetTable.getTempPartitions().stream()
+                .map(Partition::getName)
+                .filter(name -> name.startsWith(tempPartitionPrefix))
+                .toList();
+        for (String partitionName : unusedPartitionNames) {
+            targetTable.dropTempPartition(partitionName, true);
+        }
+        if (!unusedPartitionNames.isEmpty()) {
+            LOG.info("dynamic overwrite job {} dropped unused pre-split temp partitions: {}",
+                    job.getJobId(), unusedPartitionNames);
+        }
+    }
+
     protected void replayCommit() {
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
@@ -933,6 +970,7 @@ public class InsertOverwriteJobRunner {
                     .map(partitionId -> targetTable.getPartition(partitionId).getName())
                     .toList();
             replacePartition(targetTable, job.getSourcePartitionNames(), tmpPartitionNames);
+            dropUnusedDynamicOverwriteTempPartitions(targetTable);
         } finally {
             locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.WRITE);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -575,7 +575,7 @@ public class InsertOverwriteJobRunner {
      * both after FE restart and when pre-split created a temporary partition before the BE reported it
      * through the dynamic-partition RPC.
      */
-    private List<String> getDynamicOverwriteTempPartitions(OlapTable targetTable) {
+    List<String> getDynamicOverwriteTempPartitions(OlapTable targetTable) {
         if (job.getTxnId() <= 0) {
             LOG.info("dynamic overwrite job {} cancelled before prepare phase, no temp partitions to clean up",
                     job.getJobId());
@@ -937,7 +937,7 @@ public class InsertOverwriteJobRunner {
      * transaction state and therefore is not promoted. Drop every transaction-scoped temporary
      * partition left after the successful replacement.
      */
-    private void dropUnusedDynamicOverwriteTempPartitions(OlapTable targetTable) {
+    void dropUnusedDynamicOverwriteTempPartitions(OlapTable targetTable) {
         if (!job.isDynamicOverwrite() || job.getTxnId() <= 0) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
@@ -29,6 +29,7 @@ import com.starrocks.sql.parser.NodePosition;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -125,6 +126,12 @@ public class InsertStmt extends DmlStmt {
     // Currently only takes effect when the SELECT source is files().
     private boolean enablePushDownSchema = false;
 
+    // The property keys the statement was written with. Snapshotted here because getProperties()
+    // stops answering "what did the user ask for?" once InsertAnalyzer#analyzeProperties fills the
+    // same map with the session defaults for max_filter_ratio / strict_mode / timeout (and consumes
+    // enable_push_down_schema out of it). A caller that runs after analysis has no other way to ask.
+    private Set<String> userSpecifiedPropertyKeys = Set.of();
+
     public InsertStmt(TableRef tableRef, PartitionRef targetPartitionNames, String label, List<String> cols,
                       QueryStatement queryStatement, boolean isOverwrite, Map<String, String> insertProperties,
                       NodePosition pos) {
@@ -136,6 +143,7 @@ public class InsertStmt extends DmlStmt {
         this.targetColumnNames = cols;
         this.isOverwrite = isOverwrite;
         this.properties.putAll(insertProperties);
+        this.userSpecifiedPropertyKeys = Set.copyOf(insertProperties.keySet());
         this.tableFunctionAsTargetTable = false;
         this.tableFunctionProperties = null;
         this.blackHoleTableAsTargetTable = false;
@@ -267,6 +275,15 @@ public class InsertStmt extends DmlStmt {
 
     public boolean isEnablePushDownSchema() {
         return enablePushDownSchema;
+    }
+
+    /**
+     * The load-property keys this statement was written with, empty when it carries no
+     * {@code PROPERTIES(...)} clause. Unlike {@link #getProperties()}, the answer does not change
+     * once the statement has been analyzed.
+     */
+    public Set<String> getUserSpecifiedPropertyKeys() {
+        return userSpecifiedPropertyKeys;
     }
 
     public QueryStatement getQueryStatement() {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
@@ -757,6 +757,13 @@ public class SplitTabletJobTest {
         Assertions.assertEquals(splitJob.getReshardingPhysicalPartitions().keySet(), includePartitionIdsArg.get());
         Assertions.assertEquals(Set.of(7L, 8L, 42L), excludeTxnIdsArg.get());
         Assertions.assertEquals(TabletReshardJob.JobState.CLEANING, splitJob.getJobState());
+
+        // Once the pre-split caller stops waiting, its transaction may start writing at any moment,
+        // so the next cleaning cycle must wait for it again.
+        splitJob.clearCleanupExcludedTransactionIds();
+        splitJob.runCleaningJob();
+        Assertions.assertEquals(ignoredCompactionTxnIds, excludeTxnIdsArg.get());
+        Assertions.assertEquals(TabletReshardJob.JobState.CLEANING, splitJob.getJobState());
     }
 
     private TabletReshardJob createTabletReshardJob() throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
@@ -731,6 +731,7 @@ public class SplitTabletJobTest {
         splitJob.endTransactionId = 5000L;
 
         Set<Long> ignoredCompactionTxnIds = Set.of(7L, 8L);
+        splitJob.addCleanupExcludedTransactionId(42L);
         AtomicReference<Set<Long>> includePartitionIdsArg = new AtomicReference<>();
         AtomicReference<Set<Long>> excludeTxnIdsArg = new AtomicReference<>();
         new MockUp<CompactionMgr>() {
@@ -754,7 +755,7 @@ public class SplitTabletJobTest {
         // the returned ignored txn ids to the wait; while the wait is unsatisfied the job stays CLEANING.
         splitJob.runCleaningJob();
         Assertions.assertEquals(splitJob.getReshardingPhysicalPartitions().keySet(), includePartitionIdsArg.get());
-        Assertions.assertEquals(ignoredCompactionTxnIds, excludeTxnIdsArg.get());
+        Assertions.assertEquals(Set.of(7L, 8L, 42L), excludeTxnIdsArg.get());
         Assertions.assertEquals(TabletReshardJob.JobState.CLEANING, splitJob.getJobState());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookTableTest.java
@@ -54,6 +54,8 @@ import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
 
 import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.assertHookDoesNotDelegate;
 import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.bigintColumn;
@@ -197,8 +199,9 @@ public class InsertPreSplitHookTableTest {
         // INSERT PROPERTIES(strict_mode=true) ... — load properties are only validated by
         // InsertAnalyzer.analyzeProperties after this hook, so pre-splitting for a statement that
         // may fail property validation is wrong. Skip conservatively when any property is present.
+        // The gate reads the parse-time key set, not getProperties(), which the analyzer overwrites.
         InsertStmt stmt = simpleTableInsertStmt();
-        when(stmt.getProperties()).thenReturn(Map.of("strict_mode", "true"));
+        when(stmt.getUserSpecifiedPropertyKeys()).thenReturn(Set.of("strict_mode"));
 
         assertHookDoesNotDelegate(() ->
                 InsertPreSplitHook.maybeRunPreSplit(stmt, mockConnectContextWithSessionPreSplit(true)));
@@ -639,6 +642,134 @@ public class InsertPreSplitHookTableTest {
             flow.verify(() -> PreSplitFlow.runDynamicOverwriteFlow(
                     any(Database.class), eq(fixture.targetTable), any(PreSplitFlow.Prepared.class),
                     eq(LoadKind.INSERT_FROM_TABLE), any(), eq(fixture.context), eq(42L)), times(1));
+        }
+    }
+
+    @Test
+    public void dynamicOverwriteHookDispatchesWithAnalyzerFilledProperties() throws Exception {
+        // This hook is the one pre-split entry point that runs AFTER analysis, so getProperties()
+        // has already been filled with the session defaults InsertAnalyzer#analyzeProperties adds
+        // to every INSERT. Gating on that map instead of the parse-time key set made the whole
+        // dynamic-overwrite path a silent no-op on a real cluster.
+        try (SourceFixture fixture = sourceFixture();
+                MockedStatic<PreSplitFlow> flow = Mockito.mockStatic(PreSplitFlow.class)) {
+            when(fixture.insertStmt.isDynamicOverwrite()).thenReturn(true);
+            when(fixture.insertStmt.hasOverwriteJob()).thenReturn(true);
+            when(fixture.insertStmt.getProperties()).thenReturn(Map.of(
+                    "strict_mode", "true", "max_filter_ratio", "0.0", "timeout", "14400"));
+            when(fixture.insertStmt.getUserSpecifiedPropertyKeys()).thenReturn(Set.of());
+
+            InsertPreSplitHook.maybeRunDynamicOverwritePreSplit(fixture.insertStmt, fixture.context, 42L);
+
+            flow.verify(() -> PreSplitFlow.runDynamicOverwriteFlow(
+                    any(Database.class), eq(fixture.targetTable), any(PreSplitFlow.Prepared.class),
+                    eq(LoadKind.INSERT_FROM_TABLE), any(), eq(fixture.context), eq(42L)), times(1));
+        }
+    }
+
+    @Test
+    public void dynamicOverwriteHookSkipsUserSpecifiedProperties() throws Exception {
+        assertDynamicOverwriteHookSkips(42L, stmt -> {
+            when(stmt.isDynamicOverwrite()).thenReturn(true);
+            when(stmt.hasOverwriteJob()).thenReturn(true);
+            when(stmt.getUserSpecifiedPropertyKeys()).thenReturn(Set.of("max_filter_ratio"));
+        });
+    }
+
+    @Test
+    public void dynamicOverwriteHookSkipsNonDynamicStatement() throws Exception {
+        assertDynamicOverwriteHookSkips(42L, stmt -> {
+            when(stmt.isDynamicOverwrite()).thenReturn(false);
+            when(stmt.hasOverwriteJob()).thenReturn(true);
+        });
+    }
+
+    @Test
+    public void dynamicOverwriteHookSkipsWithoutOverwriteJob() throws Exception {
+        assertDynamicOverwriteHookSkips(42L, stmt -> {
+            when(stmt.isDynamicOverwrite()).thenReturn(true);
+            when(stmt.hasOverwriteJob()).thenReturn(false);
+        });
+    }
+
+    @Test
+    public void dynamicOverwriteHookSkipsWithoutTransactionId() throws Exception {
+        // The caller has not opened the overwrite transaction yet, so there is no txn prefix to
+        // name the temporary partitions after.
+        assertDynamicOverwriteHookSkips(0L, stmt -> {
+            when(stmt.isDynamicOverwrite()).thenReturn(true);
+            when(stmt.hasOverwriteJob()).thenReturn(true);
+        });
+    }
+
+    @Test
+    public void dynamicOverwriteHookSkipsExplain() throws Exception {
+        assertDynamicOverwriteHookSkips(42L, stmt -> {
+            when(stmt.isDynamicOverwrite()).thenReturn(true);
+            when(stmt.hasOverwriteJob()).thenReturn(true);
+            when(stmt.isExplain()).thenReturn(true);
+            when(stmt.getExplainLevel()).thenReturn(ExplainLevel.COSTS);
+        });
+    }
+
+    @Test
+    public void dynamicOverwriteHookSkipsPreSetStatementTransaction() throws Exception {
+        assertDynamicOverwriteHookSkips(42L, stmt -> {
+            when(stmt.isDynamicOverwrite()).thenReturn(true);
+            when(stmt.hasOverwriteJob()).thenReturn(true);
+            when(stmt.getTxnId()).thenReturn(99L);
+        });
+    }
+
+    @Test
+    public void dynamicOverwriteHookSkipsTargetPartitionSpec() throws Exception {
+        assertDynamicOverwriteHookSkips(42L, stmt -> {
+            when(stmt.isDynamicOverwrite()).thenReturn(true);
+            when(stmt.hasOverwriteJob()).thenReturn(true);
+            when(stmt.isSpecifyPartitionNames()).thenReturn(true);
+        });
+        assertDynamicOverwriteHookSkips(42L, stmt -> {
+            when(stmt.isDynamicOverwrite()).thenReturn(true);
+            when(stmt.hasOverwriteJob()).thenReturn(true);
+            when(stmt.isStaticKeyPartitionInsert()).thenReturn(true);
+        });
+    }
+
+    @Test
+    public void dynamicOverwriteHookSkipsExplicitSessionTransaction() throws Exception {
+        try (SourceFixture fixture = sourceFixture();
+                MockedStatic<PreSplitFlow> flow = Mockito.mockStatic(PreSplitFlow.class)) {
+            when(fixture.insertStmt.isDynamicOverwrite()).thenReturn(true);
+            when(fixture.insertStmt.hasOverwriteJob()).thenReturn(true);
+            when(fixture.context.getTxnId()).thenReturn(7L);
+
+            InsertPreSplitHook.maybeRunDynamicOverwritePreSplit(fixture.insertStmt, fixture.context, 42L);
+
+            flow.verifyNoInteractions();
+        }
+    }
+
+    @Test
+    public void dynamicOverwriteHookSwallowsUnexpectedFailure() throws Exception {
+        // Fail-safe contract: the load must still run when the hook throws.
+        InsertStmt stmt = mock(InsertStmt.class);
+        when(stmt.isDynamicOverwrite()).thenThrow(new IllegalStateException("boom"));
+
+        Assertions.assertDoesNotThrow(() -> InsertPreSplitHook.maybeRunDynamicOverwritePreSplit(
+                stmt, mockConnectContextWithSessionPreSplit(true), 42L));
+    }
+
+    /** Applies {@code stubs} to the fixture's statement and asserts the flow is never entered. */
+    private static void assertDynamicOverwriteHookSkips(
+            long overwriteTransactionId, Consumer<InsertStmt> stubs) throws Exception {
+        try (SourceFixture fixture = sourceFixture();
+                MockedStatic<PreSplitFlow> flow = Mockito.mockStatic(PreSplitFlow.class)) {
+            stubs.accept(fixture.insertStmt);
+
+            InsertPreSplitHook.maybeRunDynamicOverwritePreSplit(
+                    fixture.insertStmt, fixture.context, overwriteTransactionId);
+
+            flow.verifyNoInteractions();
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookTableTest.java
@@ -65,6 +65,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 /**
@@ -623,6 +624,21 @@ public class InsertPreSplitHookTableTest {
 
             Assertions.assertNull(fixture.prepareScanContext(),
                     "a temporary-table source must skip pre-split (ROOT sampler cannot see it)");
+        }
+    }
+
+    @Test
+    public void dynamicOverwriteHookDispatchesWithTransactionId() throws Exception {
+        try (SourceFixture fixture = sourceFixture();
+                MockedStatic<PreSplitFlow> flow = Mockito.mockStatic(PreSplitFlow.class)) {
+            when(fixture.insertStmt.isDynamicOverwrite()).thenReturn(true);
+            when(fixture.insertStmt.hasOverwriteJob()).thenReturn(true);
+
+            InsertPreSplitHook.maybeRunDynamicOverwritePreSplit(fixture.insertStmt, fixture.context, 42L);
+
+            flow.verify(() -> PreSplitFlow.runDynamicOverwriteFlow(
+                    any(Database.class), eq(fixture.targetTable), any(PreSplitFlow.Prepared.class),
+                    eq(LoadKind.INSERT_FROM_TABLE), any(), eq(fixture.context), eq(42L)), times(1));
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PartitionSampleGrouperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PartitionSampleGrouperTest.java
@@ -228,6 +228,37 @@ public class PartitionSampleGrouperTest {
     }
 
     @Test
+    public void dynamicOverwriteUsesTemporaryTransactionScopedPartitionNames() {
+        Column dateCol = new Column("d", DateType.DATE);
+        OlapTable table = stubTable(List.of(dateCol));
+        SampleSet samples = sampleSetOf(List.of(tuple(Variant.of(DateType.DATE, "2026-05-26"))));
+
+        AddPartitionClause clause = new AddPartitionClause(null, null, null, true);
+        PartitionDesc desc = mock(PartitionDesc.class);
+        when(desc.getPartitionName()).thenReturn("txn42_p20260526");
+        clause.setResolvedPartitionDescList(List.of(desc));
+
+        try (MockedStatic<AnalyzerUtils> analyzerUtils = Mockito.mockStatic(AnalyzerUtils.class);
+                MockedConstruction<AlterTableClauseAnalyzer> alterCtor =
+                        Mockito.mockConstruction(AlterTableClauseAnalyzer.class, (mockObj, ctx) -> { });
+                MockedConstruction<Locker> lockerCtor = Mockito.mockConstruction(Locker.class)) {
+            analyzerUtils.when(() -> AnalyzerUtils.getAddPartitionClauseFromPartitionValues(
+                            eq(table), eq(List.of(List.of("2026-05-26"))), eq(true), eq("txn42")))
+                    .thenReturn(clause);
+
+            List<PartitionSamples> out = PartitionSampleGrouper.groupTemporary(
+                    samples, table, null, DB_ID, TOTAL_FILE_BYTES, Set.of(), 42L);
+
+            assertEquals(1, out.size());
+            assertEquals("txn42_p20260526", out.get(0).partitionName());
+            assertFalse(out.get(0).existsInCatalog());
+            assertTrue(out.get(0).analyzedClause().isTempPartition());
+            analyzerUtils.verify(() -> AnalyzerUtils.getAddPartitionClauseFromPartitionValues(
+                    eq(table), eq(List.of(List.of("2026-05-26"))), eq(true), eq("txn42")), times(1));
+        }
+    }
+
+    @Test
     public void singlePartitionValueProducesOneGroup() {
         Column dateCol = new Column("d", DateType.DATE);
         OlapTable table = stubTable(List.of(dateCol));

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
@@ -212,6 +212,36 @@ public class PreSplitFlowTest {
     }
 
     @Test
+    public void dynamicOverwriteFlowSkipsIneligibleTargets() {
+        // Same automatic-partition gate as dispatch(), plus the transaction-id guard: a dynamic
+        // overwrite names its temporary partitions after the transaction, so there is nothing to
+        // pre-create without one.
+        Database database = mock(Database.class);
+        when(database.getId()).thenReturn(7L);
+        PreSplitFlow.Prepared prepared = preparedFor(mock(ScanContext.class));
+
+        record Case(String name, OlapTable table, long txnId) {
+        }
+        List<Case> cases = List.of(
+                new Case("unpartitioned", mockTable(false, true), 42L),
+                new Case("manually partitioned", mockTable(true, false), 42L),
+                new Case("no overwrite transaction", mockTable(true, true), 0L));
+
+        for (Case testCase : cases) {
+            try (MockedStatic<TabletReshardUtils> reshardUtils = PresplitTestSupport.stubComputeNodeCount(1);
+                    MockedStatic<PartitionSampleGrouper> grouper = Mockito.mockStatic(PartitionSampleGrouper.class);
+                    MockedStatic<TabletPreSplitCoordinator> coordinator =
+                            Mockito.mockStatic(TabletPreSplitCoordinator.class)) {
+                PreSplitFlow.runDynamicOverwriteFlow(database, testCase.table(), prepared,
+                        LoadKind.INSERT_FROM_TABLE, () -> false, mock(ConnectContext.class), testCase.txnId());
+
+                grouper.verifyNoInteractions();
+                coordinator.verifyNoInteractions();
+            }
+        }
+    }
+
+    @Test
     public void dispatchSkipsManuallyPartitioned() {
         // Partitioned + supportedAutomaticPartition() returns false (manual list/range
         // partitions) -> the hoisted automatic-partition gate skips before either submit.

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
@@ -178,6 +178,40 @@ public class PreSplitFlowTest {
     }
 
     @Test
+    public void dynamicOverwriteRevokesCleanupExclusionAfterAwait() {
+        // The await is fail-safe, so it can return with the job still pre-CLEANING while the
+        // overwrite transaction is about to start writing. The exclusion must not survive it.
+        Database database = mock(Database.class);
+        when(database.getId()).thenReturn(7L);
+        OlapTable table = mockTable(/*partitioned*/ true, /*automatic*/ true);
+        PreSplitFlow.Prepared prepared = preparedFor(mock(ScanContext.class));
+        SampleSet samples = new SampleSet(List.of(), List.of(), Estimates.ZERO);
+        TabletReshardJob combinedJob = mock(TabletReshardJob.class);
+
+        try (MockedStatic<TabletReshardUtils> reshardUtils = PresplitTestSupport.stubComputeNodeCount(1);
+                MockedStatic<PartitionSampleGrouper> grouper = Mockito.mockStatic(PartitionSampleGrouper.class);
+                MockedStatic<TabletPreSplitCoordinator> coordinator =
+                        Mockito.mockStatic(TabletPreSplitCoordinator.class);
+                MockedConstruction<ReservoirSampler> ignored = Mockito.mockConstruction(ReservoirSampler.class,
+                        (sampler, ctx) -> when(sampler.sample(any(SampleRequest.class))).thenReturn(samples))) {
+            grouper.when(() -> PartitionSampleGrouper.groupTemporary(
+                            any(SampleSet.class), any(OlapTable.class), any(ConnectContext.class),
+                            anyLong(), anyLong(), any(), eq(42L)))
+                    .thenReturn(List.of(mock(PartitionSamples.class)));
+            coordinator.when(() -> TabletPreSplitCoordinator.submitForTemporaryPartitionsCombined(
+                            any(), any(), anyList(), anyInt(), any(), any(), any(), eq(42L)))
+                    .thenReturn(new PreSplitOutcome.SubmittedCombined(combinedJob, List.of()));
+
+            PreSplitFlow.runDynamicOverwriteFlow(database, table, prepared, LoadKind.INSERT_FROM_TABLE,
+                    () -> false, mock(ConnectContext.class), 42L);
+
+            coordinator.verify(() -> TabletPreSplitCoordinator.awaitCombinedJobAllowingFallback(
+                    any(), eq(table), eq(combinedJob), any()), times(1));
+            Mockito.verify(combinedJob, times(1)).clearCleanupExcludedTransactionIds();
+        }
+    }
+
+    @Test
     public void dispatchSkipsManuallyPartitioned() {
         // Partitioned + supportedAutomaticPartition() returns false (manual list/range
         // partitions) -> the hoisted automatic-partition gate skips before either submit.

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
@@ -143,6 +143,41 @@ public class PreSplitFlowTest {
     }
 
     @Test
+    public void dynamicOverwriteRoutesThroughTemporaryPartitionFlow() {
+        Database database = mock(Database.class);
+        when(database.getId()).thenReturn(7L);
+        OlapTable table = mockTable(/*partitioned*/ true, /*automatic*/ true);
+        PreSplitFlow.Prepared prepared = preparedFor(mock(ScanContext.class));
+        SampleSet samples = new SampleSet(List.of(), List.of(), Estimates.ZERO);
+
+        try (MockedStatic<TabletReshardUtils> reshardUtils = PresplitTestSupport.stubComputeNodeCount(1);
+                MockedStatic<PartitionSampleGrouper> grouper = Mockito.mockStatic(PartitionSampleGrouper.class);
+                MockedStatic<TabletPreSplitCoordinator> coordinator =
+                        Mockito.mockStatic(TabletPreSplitCoordinator.class);
+                MockedConstruction<ReservoirSampler> ignored = Mockito.mockConstruction(ReservoirSampler.class,
+                        (sampler, ctx) -> when(sampler.sample(any(SampleRequest.class))).thenReturn(samples))) {
+            grouper.when(() -> PartitionSampleGrouper.groupTemporary(
+                            any(SampleSet.class), any(OlapTable.class), any(ConnectContext.class),
+                            anyLong(), anyLong(), any(), eq(42L)))
+                    .thenReturn(List.of(mock(PartitionSamples.class)));
+            coordinator.when(() -> TabletPreSplitCoordinator.submitForTemporaryPartitionsCombined(
+                            any(), any(), anyList(), anyInt(), any(), any(), any(), eq(42L)))
+                    .thenReturn(new PreSplitOutcome.Skipped(SkipReason.NO_USEFUL_CUTS));
+
+            PreSplitFlow.runDynamicOverwriteFlow(database, table, prepared, LoadKind.INSERT_FROM_TABLE,
+                    () -> false, mock(ConnectContext.class), 42L);
+
+            grouper.verify(() -> PartitionSampleGrouper.groupTemporary(
+                    any(SampleSet.class), eq(table), any(ConnectContext.class),
+                    eq(7L), anyLong(), any(), eq(42L)), times(1));
+            coordinator.verify(() -> TabletPreSplitCoordinator.submitForTemporaryPartitionsCombined(
+                    eq(database), eq(table), anyList(), anyInt(), any(), any(), any(), eq(42L)), times(1));
+            coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
+                    any(), any(), anyList(), anyInt(), any(), any(), any()), never());
+        }
+    }
+
+    @Test
     public void dispatchSkipsManuallyPartitioned() {
         // Partitioned + supportedAutomaticPartition() returns false (manual list/range
         // partitions) -> the hoisted automatic-partition gate skips before either submit.

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinatorMultiPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinatorMultiPartitionTest.java
@@ -237,6 +237,38 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
     }
 
     @Test
+    public void preCreatesAndSplitsTemporaryPartitionForDynamicOverwrite() throws Exception {
+        AtomicInteger addPartitionsCalls = new AtomicInteger();
+        AddPartitionClause clause = new AddPartitionClause(null, null, null, true);
+        List<PartitionSamples> entries = List.of(
+                missingEntry("txn42_pNew", clause, 100, 100L * DebugUtil.MEGABYTE));
+        TabletReshardJob combinedJob = mock(TabletReshardJob.class);
+
+        try (MockedStatic<GlobalStateMgr> gsm = mockGlobalStateMgrWithCustomMetastore(
+                (db, name, addedClause) -> {
+                    addPartitionsCalls.incrementAndGet();
+                    Assertions.assertTrue(addedClause.isTempPartition());
+                    installExistingTempPartition("txn42_pNew", 11_002L, 21_002L, 0L);
+                });
+                MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
+                MockedConstruction<Locker> ignored = noopLockerCtor()) {
+            ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = mapCaptor();
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundaries(
+                    eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
+
+            PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForTemporaryPartitionsCombined(
+                    database, table, entries, 3, freshConnectContext(), null, Set.of(), 42L);
+
+            Assertions.assertInstanceOf(PreSplitOutcome.SubmittedCombined.class, outcome);
+            Assertions.assertEquals(1, addPartitionsCalls.get());
+            Assertions.assertTrue(mapCaptor.getValue().containsKey(21_002L));
+            verify(combinedJob).addCleanupExcludedTransactionId(42L);
+            verify(GlobalStateMgr.getCurrentState().getTabletReshardJobMgr())
+                    .addTabletReshardJob(combinedJob);
+        }
+    }
+
+    @Test
     public void continuesAfterPreCreateFailure() throws Exception {
         // pBad: addPartitions throws -> Skipped(PRE_CREATE_FAILED).
         // pGood: existing, eligible -> contributes to combined submit.
@@ -1209,6 +1241,24 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 .thenReturn(List.of(baseIndex));
         when(partition.getDefaultPhysicalPartition()).thenReturn(physicalPartition);
         when(table.getPartition(name)).thenReturn(partition);
+    }
+
+    private void installExistingTempPartition(String name, long physicalPartitionId,
+                                              long tabletId, long rowCount) {
+        Partition partition = mock(Partition.class);
+        PhysicalPartition physicalPartition = mock(PhysicalPartition.class);
+        when(physicalPartition.getId()).thenReturn(physicalPartitionId);
+        MaterializedIndex baseIndex = mock(MaterializedIndex.class);
+        when(baseIndex.getMetaId()).thenReturn(BASE_INDEX_META_ID);
+        Tablet tablet = mock(Tablet.class);
+        when(tablet.getId()).thenReturn(tabletId);
+        when(baseIndex.getTablets()).thenReturn(List.of(tablet));
+        when(baseIndex.getRowCount()).thenReturn(rowCount);
+        when(physicalPartition.getIndex(BASE_INDEX_META_ID)).thenReturn(baseIndex);
+        when(physicalPartition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE))
+                .thenReturn(List.of(baseIndex));
+        when(partition.getDefaultPhysicalPartition()).thenReturn(physicalPartition);
+        when(table.getPartition(name, true)).thenReturn(partition);
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerTest.java
@@ -169,6 +169,84 @@ public class InsertOverwriteJobRunnerTest {
     }
 
     @Test
+    public void testDropUnusedDynamicOverwriteTempPartitions() {
+        // Sampling and the load use different source snapshots, so a pre-created temporary
+        // partition can end up with no rows and never be promoted. Only this transaction's
+        // leftovers may be dropped -- another concurrent overwrite owns the rest.
+        InsertOverwriteJob job = new InsertOverwriteJob(
+                301L, Mockito.mock(InsertStmt.class), 11L, 12L, WarehouseManager.DEFAULT_WAREHOUSE_ID, true);
+        job.setTxnId(42L);
+        InsertOverwriteJobRunner runner = new InsertOverwriteJobRunner(
+                job, Mockito.mock(ConnectContext.class), Mockito.mock(StmtExecutor.class));
+
+        OlapTable table = Mockito.mock(OlapTable.class);
+        Mockito.when(table.getTempPartitions()).thenReturn(Lists.newArrayList(
+                mockPartitionNamed("txn42_p20260101"),
+                mockPartitionNamed("txn7_p20260101"),
+                mockPartitionNamed("p20260101")));
+
+        runner.dropUnusedDynamicOverwriteTempPartitions(table);
+
+        Mockito.verify(table).dropTempPartition("txn42_p20260101", true);
+        Mockito.verify(table, Mockito.never()).dropTempPartition("txn7_p20260101", true);
+        Mockito.verify(table, Mockito.never()).dropTempPartition("p20260101", true);
+    }
+
+    @Test
+    public void testDropUnusedDynamicOverwriteTempPartitionsSkipsNonDynamicJob() {
+        InsertOverwriteJob job = new InsertOverwriteJob(
+                302L, Mockito.mock(InsertStmt.class), 11L, 12L, WarehouseManager.DEFAULT_WAREHOUSE_ID, false);
+        job.setTxnId(42L);
+        InsertOverwriteJobRunner runner = new InsertOverwriteJobRunner(
+                job, Mockito.mock(ConnectContext.class), Mockito.mock(StmtExecutor.class));
+
+        OlapTable table = Mockito.mock(OlapTable.class);
+
+        runner.dropUnusedDynamicOverwriteTempPartitions(table);
+
+        Mockito.verifyNoInteractions(table);
+    }
+
+    @Test
+    public void testGetDynamicOverwriteTempPartitionsFallsBackToPrefixScan() {
+        // The transaction state is gone (here: never existed), which is exactly the case that used
+        // to lose the pre-created partitions. The prefix scan must still find this transaction's
+        // temporary partitions so GC can drop them.
+        InsertOverwriteJob job = new InsertOverwriteJob(
+                303L, Mockito.mock(InsertStmt.class), 11L, 12L, WarehouseManager.DEFAULT_WAREHOUSE_ID, true);
+        job.setTxnId(4242L);
+        InsertOverwriteJobRunner runner = new InsertOverwriteJobRunner(
+                job, Mockito.mock(ConnectContext.class), Mockito.mock(StmtExecutor.class));
+
+        OlapTable table = Mockito.mock(OlapTable.class);
+        Mockito.when(table.getTempPartitions()).thenReturn(Lists.newArrayList(
+                mockPartitionNamed("txn4242_p20260101"),
+                mockPartitionNamed("txn4243_p20260101")));
+
+        Assertions.assertEquals(Lists.newArrayList("txn4242_p20260101"),
+                runner.getDynamicOverwriteTempPartitions(table));
+    }
+
+    @Test
+    public void testGetDynamicOverwriteTempPartitionsBeforePrepare() {
+        InsertOverwriteJob job = new InsertOverwriteJob(
+                304L, Mockito.mock(InsertStmt.class), 11L, 12L, WarehouseManager.DEFAULT_WAREHOUSE_ID, true);
+        InsertOverwriteJobRunner runner = new InsertOverwriteJobRunner(
+                job, Mockito.mock(ConnectContext.class), Mockito.mock(StmtExecutor.class));
+
+        OlapTable table = Mockito.mock(OlapTable.class);
+
+        Assertions.assertTrue(runner.getDynamicOverwriteTempPartitions(table).isEmpty());
+        Mockito.verifyNoInteractions(table);
+    }
+
+    private static Partition mockPartitionNamed(String name) {
+        Partition partition = Mockito.mock(Partition.class);
+        Mockito.when(partition.getName()).thenReturn(name);
+        return partition;
+    }
+
+    @Test
     public void testInsertOverwriteAbortsWhenTableStateNotNormal() throws Exception {
         // Guards against the race where an overwrite passes analysis while the table is NORMAL,
         // then the table state flips (e.g. an ALTER submits) before the job's prepare() runs.

--- a/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerTest.java
@@ -41,6 +41,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.sql.SQLException;
+import java.util.List;
 
 public class InsertOverwriteJobRunnerTest {
 
@@ -179,11 +180,14 @@ public class InsertOverwriteJobRunnerTest {
         InsertOverwriteJobRunner runner = new InsertOverwriteJobRunner(
                 job, Mockito.mock(ConnectContext.class), Mockito.mock(StmtExecutor.class));
 
-        OlapTable table = Mockito.mock(OlapTable.class);
-        Mockito.when(table.getTempPartitions()).thenReturn(Lists.newArrayList(
+        // Build the partition mocks before opening the outer when(), otherwise Mockito sees a
+        // nested stubbing and fails with UnfinishedStubbing.
+        List<Partition> tempPartitions = Lists.newArrayList(
                 mockPartitionNamed("txn42_p20260101"),
                 mockPartitionNamed("txn7_p20260101"),
-                mockPartitionNamed("p20260101")));
+                mockPartitionNamed("p20260101"));
+        OlapTable table = Mockito.mock(OlapTable.class);
+        Mockito.when(table.getTempPartitions()).thenReturn(tempPartitions);
 
         runner.dropUnusedDynamicOverwriteTempPartitions(table);
 
@@ -218,10 +222,11 @@ public class InsertOverwriteJobRunnerTest {
         InsertOverwriteJobRunner runner = new InsertOverwriteJobRunner(
                 job, Mockito.mock(ConnectContext.class), Mockito.mock(StmtExecutor.class));
 
-        OlapTable table = Mockito.mock(OlapTable.class);
-        Mockito.when(table.getTempPartitions()).thenReturn(Lists.newArrayList(
+        List<Partition> tempPartitions = Lists.newArrayList(
                 mockPartitionNamed("txn4242_p20260101"),
-                mockPartitionNamed("txn4243_p20260101")));
+                mockPartitionNamed("txn4243_p20260101"));
+        OlapTable table = Mockito.mock(OlapTable.class);
+        Mockito.when(table.getTempPartitions()).thenReturn(tempPartitions);
 
         Assertions.assertEquals(Lists.newArrayList("txn4242_p20260101"),
                 runner.getDynamicOverwriteTempPartitions(table));

--- a/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerTest.java
@@ -16,6 +16,7 @@
 package com.starrocks.load;
 
 import com.google.common.collect.Lists;
+import com.starrocks.alter.reshard.presplit.InsertPreSplitHook;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
@@ -36,6 +37,7 @@ import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.sql.SQLException;
@@ -146,6 +148,24 @@ public class InsertOverwriteJobRunnerTest {
                 WarehouseManager.DEFAULT_WAREHOUSE_ID, false);
         InsertOverwriteJobRunner runner = new InsertOverwriteJobRunner(insertOverwriteJob, connectContext, executor);
         Assertions.assertFalse(runner.isFinished());
+    }
+
+    @Test
+    public void testDynamicOverwritePreSplitRunsAfterTransactionIsAssigned() {
+        InsertStmt insertStmt = Mockito.mock(InsertStmt.class);
+        ConnectContext context = Mockito.mock(ConnectContext.class);
+        StmtExecutor executor = Mockito.mock(StmtExecutor.class);
+        InsertOverwriteJob job = new InsertOverwriteJob(
+                101L, insertStmt, 11L, 12L, WarehouseManager.DEFAULT_WAREHOUSE_ID, true);
+        job.setTxnId(42L);
+        InsertOverwriteJobRunner runner = new InsertOverwriteJobRunner(job, context, executor);
+
+        try (MockedStatic<InsertPreSplitHook> hook = Mockito.mockStatic(InsertPreSplitHook.class)) {
+            runner.preSplitDynamicOverwriteTempPartitions();
+
+            hook.verify(() -> InsertPreSplitHook.maybeRunDynamicOverwritePreSplit(
+                    insertStmt, context, 42L));
+        }
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Dynamic `INSERT OVERWRITE` creates transaction-scoped temporary automatic partitions from the BE only after the load starts writing. Sample-Based Tablet Pre-Split therefore has no target partition to split beforehand, and a large range-distributed overwrite can remain limited to one initial tablet per generated partition.

Root cause: the pre-split hook runs during the first plan, while dynamic-overwrite temporary partition names require the overwrite transaction ID and were previously materialized only by the runtime create-partition RPC.

## What I'm doing:

- Run the fail-safe pre-split hook after the dynamic-overwrite transaction is opened and before the INSERT is replanned or starts writing.
- Generate the same `txn{txnId}_...` temporary partition clauses as the runtime automatic-partition path, pre-create those temporary partitions, and split them synchronously.
- Gate the new hook on the property keys the statement was *written* with rather than on `getProperties()`. This hook is the one pre-split entry point that runs after analysis, and `InsertAnalyzer#analyzeProperties` has by then filled that map with the session defaults for `max_filter_ratio` / `strict_mode` / `timeout`, so a plain `getProperties().isEmpty()` gate rejects every statement. `InsertStmt` now snapshots the parse-time key set so the pre-analysis and post-analysis gates answer the same question.
- Exclude the opened-but-not-yet-writing overwrite transaction from the reshard job's cleanup watermark wait, so CLEANING does not wait on the caller that is synchronously waiting for the job. The exclusion is revoked the moment the await returns and is deliberately not persisted: `awaitCombinedJobAllowingFallback` is fail-safe and can return while the job is still pre-CLEANING, and from that point the transaction may start writing to the old tablets.
- Let the runtime create-partition RPC reuse the pre-split catalog partitions and publish the resulting tablet locations into transaction state.
- Scan the transaction prefix during failure GC and remove any sampled temporary partitions that are unused because the sampling and load source snapshots changed.

Impact: eligible dynamic overwrites can start writing to multiple pre-split range tablets. The hook remains fail-safe; sampling, partition creation, or reshard failures fall back to the existing runtime automatic-partition behavior.

Related: #77843 allows non-key SELECT expressions during pre-split analysis. The two PRs are independently mergeable; the reported workload uses both capabilities.

## Checks:

- `./run-fe-ut.sh --test com.starrocks.alter.reshard.presplit.PreSplitFlowTest`
- Focused FE unit tests for `PartitionSampleGrouperTest`, `TabletPreSplitCoordinatorMultiPartitionTest`, `InsertPreSplitHookTableTest`, `SplitTabletJobTest`, and `InsertOverwriteJobRunnerTest`
- End-to-end on a shared-data TSP cluster (1 FE + 3 CN), 300MB source over 4 automatic partitions, `tablet_reshard_target_size=16MB`. Every INSERT filters down to ~1% of the rows so the online auto-split (same size knob) cannot confound the tablet count; only pre-split can produce more than one tablet.
  - dynamic overwrite: 1 -> 6 tablets per partition, ~1.1k rows each, spread evenly over the 3 CNs; row count and data unchanged
  - repeating the overwrite over the already-split partitions: still 6 tablets, 0 leftover temporary partitions
  - with #77843 applied on top, `INSERT OVERWRITE ... SELECT dt, k1, parse_json(v) FROM src` also pre-splits 1 -> 6
  - `git diff --check`

Fixes N/A

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
