### PR TITLE
[Enhancement] Support non-key expressions in tablet pre-split

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertFromTableScanContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertFromTableScanContext.java
@@ -32,7 +32,7 @@ import java.util.Objects;
 public record InsertFromTableScanContext(
         OlapTable sourceTable,
         String sourceFromSql,                       // "`db`.`tbl` `alias`" or "`db`.`tbl`"
-        Map<String, String> targetToSourceColumnNames,   // lower-cased target name -> source column name
+        Map<String, String> targetToSourceColumnNames,   // directly mapped lower-cased target name -> source name
         String wherePredicateSql,                   // nullable
         ComputeResource computeResource) implements ScanContext {
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertSelectSourceColumns.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertSelectSourceColumns.java
@@ -30,11 +30,12 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Resolves the full target-&gt;source column-name map (lower-cased target name -&gt; source column
- * name, total over the target's non-generated base columns) for a parsed
+ * Resolves the target-&gt;source column-name map (lower-cased target name -&gt; source column
+ * name) for directly mapped outputs of a parsed
  * {@code INSERT INTO <range-dist target> SELECT ... FROM <single OLAP source>}. The sampler uses
  * the map to project any index's sort key (base or rollup) and the partition columns by their
- * source-table column names.
+ * source-table column names. Non-key target columns may be arbitrary expressions and are omitted
+ * from the map.
  *
  * <p>Returns {@code null} whenever the projection cannot be cleanly and safely mapped
  * (caller then silently skips pre-split).
@@ -105,28 +106,42 @@ final class InsertSelectSourceColumns {
         } else {
             List<String[]> outputs = new ArrayList<>(items.size());
             for (SelectListItem item : items) {
-                if (item.isStar() || !(item.getExpr() instanceof SlotRef slotRef)) {
+                if (item.isStar()) {
                     return null;
                 }
-                if (slotRef.getTblName() != null
-                        && !matchesSource(slotRef.getTblName(), normalizedSourceName, sourceAlias)) {
+                String outputName = item.getAlias();
+                String sourceName = null;
+                if (item.getExpr() instanceof SlotRef slotRef) {
+                    if (slotRef.getTblName() != null
+                            && !matchesSource(slotRef.getTblName(), normalizedSourceName, sourceAlias)) {
+                        return null;
+                    }
+                    sourceName = sourceColumnMap.get(slotRef.getColName().toLowerCase());
+                    if (sourceName == null) {
+                        return null;
+                    }
+                    if (outputName == null) {
+                        outputName = slotRef.getColName();
+                    }
+                } else if (byName && outputName == null) {
+                    // The target position of an expression is unknown for BY NAME without an alias.
                     return null;
                 }
-                String sourceName = sourceColumnMap.get(slotRef.getColName().toLowerCase());
-                if (sourceName == null) {
-                    return null;
-                }
-                String outputName = item.getAlias() != null ? item.getAlias() : slotRef.getColName();
                 outputs.add(new String[] {outputName, sourceName});
             }
             if (byName) {
+                Set<String> outputNames = new HashSet<>();
                 for (String[] output : outputs) {
-                    if (targetToSource.put(output[0].toLowerCase(), output[1]) != null) {
+                    String targetName = output[0].toLowerCase();
+                    if (!outputNames.add(targetName)) {
                         return null;   // duplicate output name
+                    }
+                    if (output[1] != null) {
+                        targetToSource.put(targetName, output[1]);
                     }
                 }
                 // Exact-set match: output names must be exactly the target non-generated columns.
-                if (!targetToSource.keySet().equals(targetNames(targetCols))) {
+                if (!outputNames.equals(targetNames(targetCols))) {
                     return null;
                 }
             } else {
@@ -134,7 +149,10 @@ final class InsertSelectSourceColumns {
                     return null;
                 }
                 for (int i = 0; i < targetCols.size(); i++) {
-                    targetToSource.put(targetCols.get(i).getName().toLowerCase(), outputs.get(i)[1]);
+                    String sourceName = outputs.get(i)[1];
+                    if (sourceName != null) {
+                        targetToSource.put(targetCols.get(i).getName().toLowerCase(), sourceName);
+                    }
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertSelectSourceColumns.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertSelectSourceColumns.java
@@ -14,13 +14,16 @@
 
 package com.starrocks.alter.reshard.presplit;
 
+import com.google.common.base.Predicate;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.TableName;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.SelectListItem;
 import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.sql.ast.expression.Subquery;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -34,8 +37,8 @@ import java.util.Set;
  * name) for directly mapped outputs of a parsed
  * {@code INSERT INTO <range-dist target> SELECT ... FROM <single OLAP source>}. The sampler uses
  * the map to project any index's sort key (base or rollup) and the partition columns by their
- * source-table column names. Non-key target columns may be arbitrary expressions and are omitted
- * from the map.
+ * source-table column names. Non-key target columns may be expressions over the source relation
+ * and are omitted from the map.
  *
  * <p>Returns {@code null} whenever the projection cannot be cleanly and safely mapped
  * (caller then silently skips pre-split).
@@ -123,9 +126,14 @@ final class InsertSelectSourceColumns {
                     if (outputName == null) {
                         outputName = slotRef.getColName();
                     }
-                } else if (byName && outputName == null) {
-                    // The target position of an expression is unknown for BY NAME without an alias.
-                    return null;
+                } else {
+                    if (byName && outputName == null) {
+                        // The target position of an expression is unknown for BY NAME without an alias.
+                        return null;
+                    }
+                    if (!referencesOnlySource(item.getExpr(), sourceColumnMap, normalizedSourceName, sourceAlias)) {
+                        return null;
+                    }
                 }
                 outputs.add(new String[] {outputName, sourceName});
             }
@@ -164,6 +172,51 @@ final class InsertSelectSourceColumns {
             return null;
         }
         return Map.copyOf(targetToSource);
+    }
+
+    /**
+     * Returns {@code true} when every reference inside a non-{@link SlotRef} projection resolves to
+     * the source relation the caller already resolved and authorized.
+     *
+     * <p>The hook runs pre-analysis, so nothing the analyzer would have rejected has been rejected
+     * yet when the reshard is submitted. Every SELECT item used to be a bare source column, which
+     * made that safe implicitly; now that expressions are admitted, the same invariant is enforced
+     * explicitly -- no subquery of any shape, and every slot names a visible source column with the
+     * source's own qualifier (or none). Otherwise a projection over an unauthorized table or an
+     * unknown column would reshard the target on behalf of a statement that never runs.
+     *
+     * <p>Function calls themselves stay allowed: the sampler never evaluates a non-key projection,
+     * it only projects the mapped source columns, so the expression's own semantics cannot skew the
+     * sampled row set.
+     */
+    private static boolean referencesOnlySource(
+            Expr expr, Map<String, String> sourceColumnMap,
+            TableName normalizedSourceName, String sourceAlias) {
+        List<Expr> rejected = new ArrayList<>();
+        expr.collectAll((Predicate<Expr>) e -> isForeignReference(
+                e, sourceColumnMap, normalizedSourceName, sourceAlias), rejected);
+        return rejected.isEmpty();
+    }
+
+    private static boolean isForeignReference(
+            Expr expr, Map<String, String> sourceColumnMap,
+            TableName normalizedSourceName, String sourceAlias) {
+        // Any subquery shape (scalar, IN-subquery, EXISTS holds its Subquery as a child) reads
+        // relations the hook never resolved or authorized.
+        if (expr instanceof Subquery) {
+            return true;
+        }
+        if (expr instanceof SlotRef slot) {
+            if (slot.getTblName() != null
+                    && !matchesSource(slot.getTblName(), normalizedSourceName, sourceAlias)) {
+                return true;
+            }
+            // A null column name (e.g. a struct-subfield slot) is not resolvable against the
+            // source schema here, so treat it as foreign rather than guessing.
+            return slot.getColName() == null
+                    || !sourceColumnMap.containsKey(slot.getColName().toLowerCase());
+        }
+        return false;
     }
 
     private static Set<String> targetNames(List<Column> targetCols) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TablePreSplitSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TablePreSplitSource.java
@@ -34,7 +34,6 @@ import com.starrocks.sql.ast.SelectListItem;
 import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.expression.Expr;
-import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.common.MetaUtils;
 
 import java.util.List;
@@ -65,7 +64,7 @@ final class TablePreSplitSource implements InsertPreSplitSource {
     @Override
     public boolean matches(InsertStmt insertStmt, SelectRelation selectRelation) {
         Relation from = selectRelation.getRelation();
-        return isMappableProjection(selectRelation)
+        return hasSupportedProjectionShape(selectRelation)
                 && from instanceof TableRelation
                 && !(from instanceof FileTableFunctionRelation)
                 && isPlainTableReference((TableRelation) from);
@@ -128,14 +127,13 @@ final class TablePreSplitSource implements InsertPreSplitSource {
 
     /**
      * Verifies the projection is a bare {@code SELECT *} (single star, no
-     * qualifier / EXCLUDE / alias) OR a list of bare column references
-     * ({@code SlotRef}), with no DISTINCT and no
-     * GROUP BY / HAVING / ORDER BY / LIMIT. A WHERE clause is allowed (gated
-     * separately). Any expression projection, qualified / excluded star, or
-     * row-changing clause would decouple the sampled row-set from what the load
-     * writes.
+     * qualifier / EXCLUDE / alias) or an explicit list without stars, with no
+     * DISTINCT and no GROUP BY / HAVING / ORDER BY / LIMIT. A WHERE clause is
+     * allowed (gated separately). Expressions in the explicit list are checked
+     * later by {@link InsertSelectSourceColumns}: only target columns needed for
+     * partitioning and range distribution must be direct source-column refs.
      */
-    private static boolean isMappableProjection(SelectRelation selectRelation) {
+    private static boolean hasSupportedProjectionShape(SelectRelation selectRelation) {
         SelectList selectList = selectRelation.getSelectList();
         if (selectList == null || selectList.isDistinct()) {
             return false;
@@ -151,7 +149,7 @@ final class TablePreSplitSource implements InsertPreSplitSource {
             }
         } else {
             for (SelectListItem item : items) {
-                if (item.isStar() || !(item.getExpr() instanceof SlotRef)) {
+                if (item.isStar()) {
                     return false;
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TablePreSplitSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TablePreSplitSource.java
@@ -131,7 +131,8 @@ final class TablePreSplitSource implements InsertPreSplitSource {
      * DISTINCT and no GROUP BY / HAVING / ORDER BY / LIMIT. A WHERE clause is
      * allowed (gated separately). Expressions in the explicit list are checked
      * later by {@link InsertSelectSourceColumns}: only target columns needed for
-     * partitioning and range distribution must be direct source-column refs.
+     * partitioning and range distribution must be direct source-column refs, and
+     * an expression may reference nothing beyond the resolved source relation.
      */
     private static boolean hasSupportedProjectionShape(SelectRelation selectRelation) {
         SelectList selectList = selectRelation.getSelectList();

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookTableTest.java
@@ -43,6 +43,7 @@ import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
 import com.starrocks.sql.ast.expression.InformationFunction;
+import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.junit.jupiter.api.AfterEach;
@@ -254,16 +255,17 @@ public class InsertPreSplitHookTableTest {
     }
 
     @Test
-    public void testExpressionProjectionShortCircuits() throws Exception {
-        // INSERT INTO t SELECT col + 1 FROM src — a non-SlotRef expression item.
+    public void testExpressionProjectionMatchesTableSourceShape() {
+        // Expressions are accepted at the shape gate. prepare() later verifies
+        // that every key needed by sampling is still a direct source-column ref.
         SelectListItem exprItem = mock(SelectListItem.class);
         when(exprItem.isStar()).thenReturn(false);
         when(exprItem.getExpr()).thenReturn(mock(FunctionCallExpr.class));
 
-        InsertStmt stmt = insertStmtWithQueryRelation(
-                selectRelationWithSelectList(selectListOf(exprItem), mock(TableRelation.class)));
-        assertHookDoesNotDelegate(() ->
-                InsertPreSplitHook.maybeRunPreSplit(stmt, mockConnectContextWithSessionPreSplit(true)));
+        SelectRelation selectRelation = selectRelationWithSelectList(
+                selectListOf(exprItem), plainTableRelation());
+
+        Assertions.assertTrue(new TablePreSplitSource().matches(mock(InsertStmt.class), selectRelation));
     }
 
     @Test
@@ -529,6 +531,26 @@ public class InsertPreSplitHookTableTest {
                     "no WHERE clause must yield a null predicate SQL");
             Assertions.assertSame(fixture.sourceTable, scanContext.sourceTable(),
                     "scan context must carry the resolved OLAP source table");
+        }
+    }
+
+    @Test
+    public void prepareAllowsExpressionOnNonKeyColumn() throws Exception {
+        // target [k, v]; SELECT k, parse_json(v) FROM src. The sampler only needs
+        // target key k, so the value expression is intentionally absent from the map.
+        try (SourceFixture fixture = sourceFixture()) {
+            SelectRelation selectRelation =
+                    (SelectRelation) fixture.insertStmt.getQueryStatement().getQueryRelation();
+            SelectListItem expression = mock(SelectListItem.class);
+            when(expression.isStar()).thenReturn(false);
+            when(expression.getExpr()).thenReturn(mock(FunctionCallExpr.class));
+            SelectList projection = selectListOf(bareColumnItem("k"), expression);
+            when(selectRelation.getSelectList()).thenReturn(projection);
+
+            InsertFromTableScanContext scanContext = fixture.prepareScanContext();
+
+            Assertions.assertNotNull(scanContext);
+            Assertions.assertEquals(Map.of("k", "k"), scanContext.targetToSourceColumnNames());
         }
     }
 
@@ -885,6 +907,15 @@ public class InsertPreSplitHookTableTest {
         SelectList selectList = mock(SelectList.class);
         when(selectList.getItems()).thenReturn(List.of(items));
         return selectList;
+    }
+
+    private static SelectListItem bareColumnItem(String columnName) {
+        SlotRef slotRef = mock(SlotRef.class);
+        when(slotRef.getColName()).thenReturn(columnName);
+        SelectListItem item = mock(SelectListItem.class);
+        when(item.isStar()).thenReturn(false);
+        when(item.getExpr()).thenReturn(slotRef);
+        return item;
     }
 
     private static InsertStmt insertStmtWithQueryRelation(QueryRelation queryRelation) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertSelectSourceColumnsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertSelectSourceColumnsTest.java
@@ -18,11 +18,15 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.TableName;
 import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.SelectList;
 import com.starrocks.sql.ast.SelectListItem;
 import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
 import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.sql.ast.expression.Subquery;
+import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.type.IntegerType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -90,12 +94,25 @@ public class InsertSelectSourceColumnsTest {
         return bareItem(colName, null, null);
     }
 
+    /**
+     * A {@code parse_json(v)} projection over the source column {@code v}. The expression is a real
+     * AST node, not a mock, because the reference gate walks the tree with {@code collectAll} --
+     * a mock would silently answer "nothing rejected" for every input.
+     */
     private static SelectListItem expressionItem(String alias) {
+        return expressionItem(alias, sourceExpr(new SlotRef((TableName) null, "v")));
+    }
+
+    private static SelectListItem expressionItem(String alias, Expr expr) {
         SelectListItem item = mock(SelectListItem.class);
         when(item.isStar()).thenReturn(false);
-        when(item.getExpr()).thenReturn(mock(FunctionCallExpr.class));
+        when(item.getExpr()).thenReturn(expr);
         when(item.getAlias()).thenReturn(alias);
         return item;
+    }
+
+    private static FunctionCallExpr sourceExpr(Expr argument) {
+        return new FunctionCallExpr("parse_json", Collections.singletonList(argument));
     }
 
     private static SelectRelation bareRelation(SelectListItem... items) {
@@ -559,6 +576,103 @@ public class InsertSelectSourceColumnsTest {
 
         Map<String, String> result = InsertSelectSourceColumns.resolve(
                 insertStmt(true), rel,
+                target, source, SRC_NAME, null,
+                Collections.singletonList(col("k")),
+                Collections.emptyList());
+
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    public void expressionQualifiedWithSourceMapsRequiredColumns() {
+        // SELECT k, parse_json(src.v) -> the qualifier names the source, so the expression is fine.
+        List<Column> cols = Arrays.asList(col("k"), col("v"));
+        OlapTable target = olapTable(cols, cols, false);
+        OlapTable source = olapTable(cols, cols, false);
+
+        SelectListItem expr = expressionItem(
+                null, sourceExpr(new SlotRef(new TableName(null, null, "src"), "v")));
+        SelectRelation rel = bareRelation(bareItem("k"), expr);
+
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
+                insertStmt(false), rel,
+                target, source, SRC_NAME, null,
+                Collections.singletonList(col("k")),
+                Collections.emptyList());
+
+        Assertions.assertEquals(Map.of("k", "k"), result);
+    }
+
+    @Test
+    public void expressionOverForeignTableReturnsNull() {
+        // SELECT k, parse_json(other.v) -> the hook never resolved or authorized `other`.
+        List<Column> cols = Arrays.asList(col("k"), col("v"));
+        OlapTable target = olapTable(cols, cols, false);
+        OlapTable source = olapTable(cols, cols, false);
+
+        SelectListItem expr = expressionItem(
+                null, sourceExpr(new SlotRef(new TableName(null, null, "other"), "v")));
+        SelectRelation rel = bareRelation(bareItem("k"), expr);
+
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
+                insertStmt(false), rel,
+                target, source, SRC_NAME, null,
+                Collections.singletonList(col("k")),
+                Collections.emptyList());
+
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    public void expressionOverUnknownColumnReturnsNull() {
+        // SELECT k, parse_json(nosuch) -> analysis would reject this, so do not reshard for it.
+        List<Column> cols = Arrays.asList(col("k"), col("v"));
+        OlapTable target = olapTable(cols, cols, false);
+        OlapTable source = olapTable(cols, cols, false);
+
+        SelectListItem expr = expressionItem(null, sourceExpr(new SlotRef((TableName) null, "nosuch")));
+        SelectRelation rel = bareRelation(bareItem("k"), expr);
+
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
+                insertStmt(false), rel,
+                target, source, SRC_NAME, null,
+                Collections.singletonList(col("k")),
+                Collections.emptyList());
+
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    public void scalarSubqueryProjectionReturnsNull() {
+        // SELECT k, (SELECT ...) -> reads a relation outside the authorized source.
+        List<Column> cols = Arrays.asList(col("k"), col("v"));
+        OlapTable target = olapTable(cols, cols, false);
+        OlapTable source = olapTable(cols, cols, false);
+
+        Subquery subquery = new Subquery(mock(QueryStatement.class), NodePosition.ZERO);
+        SelectRelation rel = bareRelation(bareItem("k"), expressionItem(null, subquery));
+
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
+                insertStmt(false), rel,
+                target, source, SRC_NAME, null,
+                Collections.singletonList(col("k")),
+                Collections.emptyList());
+
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    public void nestedSubqueryInsideExpressionReturnsNull() {
+        // SELECT k, parse_json((SELECT ...)) -> the walk must reach nested nodes, not just the root.
+        List<Column> cols = Arrays.asList(col("k"), col("v"));
+        OlapTable target = olapTable(cols, cols, false);
+        OlapTable source = olapTable(cols, cols, false);
+
+        Subquery subquery = new Subquery(mock(QueryStatement.class), NodePosition.ZERO);
+        SelectRelation rel = bareRelation(bareItem("k"), expressionItem(null, sourceExpr(subquery)));
+
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
+                insertStmt(false), rel,
                 target, source, SRC_NAME, null,
                 Collections.singletonList(col("k")),
                 Collections.emptyList());

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertSelectSourceColumnsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertSelectSourceColumnsTest.java
@@ -21,6 +21,7 @@ import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.SelectList;
 import com.starrocks.sql.ast.SelectListItem;
 import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.expression.FunctionCallExpr;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.type.IntegerType;
 import org.junit.jupiter.api.Assertions;
@@ -87,6 +88,14 @@ public class InsertSelectSourceColumnsTest {
 
     private static SelectListItem bareItem(String colName) {
         return bareItem(colName, null, null);
+    }
+
+    private static SelectListItem expressionItem(String alias) {
+        SelectListItem item = mock(SelectListItem.class);
+        when(item.isStar()).thenReturn(false);
+        when(item.getExpr()).thenReturn(mock(FunctionCallExpr.class));
+        when(item.getAlias()).thenReturn(alias);
+        return item;
     }
 
     private static SelectRelation bareRelation(SelectListItem... items) {
@@ -472,24 +481,84 @@ public class InsertSelectSourceColumnsTest {
     }
 
     @Test
-    public void expressionItemReturnsNull() {
-        // SELECT k+1 -> getExpr() not SlotRef -> null
+    public void expressionOnNonKeyByPositionMapsRequiredColumns() {
+        // target [k, v]; SELECT k, parse_json(v) -> only k is needed by the sampler.
         List<Column> cols = Arrays.asList(col("k"), col("v"));
         OlapTable target = olapTable(cols, cols, false);
         OlapTable source = olapTable(cols, cols, false);
 
-        // Create an item whose getExpr() returns a non-SlotRef expression
-        SelectListItem item = mock(SelectListItem.class);
-        when(item.isStar()).thenReturn(false);
-        when(item.getExpr()).thenReturn(mock(com.starrocks.sql.ast.expression.FunctionCallExpr.class));
-
-        SelectList list = mock(SelectList.class);
-        when(list.getItems()).thenReturn(Collections.singletonList(item));
-        SelectRelation rel = mock(SelectRelation.class);
-        when(rel.getSelectList()).thenReturn(list);
+        SelectRelation rel = bareRelation(bareItem("k"), expressionItem(null));
 
         Map<String, String> result = InsertSelectSourceColumns.resolve(
                 insertStmt(false), rel,
+                target, source, SRC_NAME, null,
+                Collections.singletonList(col("k")),
+                Collections.emptyList());
+
+        Assertions.assertEquals(Map.of("k", "k"), result);
+    }
+
+    @Test
+    public void expressionOnSortKeyByPositionReturnsNull() {
+        List<Column> cols = Arrays.asList(col("k"), col("v"));
+        OlapTable target = olapTable(cols, cols, false);
+        OlapTable source = olapTable(cols, cols, false);
+
+        SelectRelation rel = bareRelation(expressionItem(null), bareItem("v"));
+
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
+                insertStmt(false), rel,
+                target, source, SRC_NAME, null,
+                Collections.singletonList(col("k")),
+                Collections.emptyList());
+
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    public void expressionOnPartitionColumnByPositionReturnsNull() {
+        List<Column> cols = Arrays.asList(col("k"), col("dt"), col("v"));
+        OlapTable target = olapTable(cols, cols, false);
+        OlapTable source = olapTable(cols, cols, false);
+
+        SelectRelation rel = bareRelation(bareItem("k"), expressionItem(null), bareItem("v"));
+
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
+                insertStmt(false), rel,
+                target, source, SRC_NAME, null,
+                Collections.singletonList(col("k")),
+                Collections.singletonList(col("dt")));
+
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    public void expressionOnNonKeyByNameUsesAlias() {
+        List<Column> cols = Arrays.asList(col("k"), col("v"));
+        OlapTable target = olapTable(cols, cols, false);
+        OlapTable source = olapTable(cols, cols, false);
+
+        SelectRelation rel = bareRelation(bareItem("k"), expressionItem("v"));
+
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
+                insertStmt(true), rel,
+                target, source, SRC_NAME, null,
+                Collections.singletonList(col("k")),
+                Collections.emptyList());
+
+        Assertions.assertEquals(Map.of("k", "k"), result);
+    }
+
+    @Test
+    public void expressionByNameWithoutAliasReturnsNull() {
+        List<Column> cols = Arrays.asList(col("k"), col("v"));
+        OlapTable target = olapTable(cols, cols, false);
+        OlapTable source = olapTable(cols, cols, false);
+
+        SelectRelation rel = bareRelation(bareItem("k"), expressionItem(null));
+
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
+                insertStmt(true), rel,
                 target, source, SRC_NAME, null,
                 Collections.singletonList(col("k")),
                 Collections.emptyList());


### PR DESCRIPTION
## Why I'm doing:

INSERT-from-table Sample-Based Tablet Pre-Split currently requires every SELECT item to be a direct `SlotRef`. As a result, harmless expressions on non-key value columns (for example `parse_json(value)`) disable pre-split for the entire load, even though the sampler only needs target partition columns and range-distribution sort keys.

Root cause: the projection mapper was total over all target columns instead of only the columns required to reproduce the sampling keys.

## What I'm doing:

- Allow expressions in explicit SELECT lists for INSERT-from-table pre-split.
- Keep a partial target-to-source map containing only direct column references.
- Continue requiring every partition column and every base/rollup range sort-key column to map to a direct source column.
- Require aliases for expression outputs under `INSERT ... BY NAME` so the target output set remains unambiguous.
- Require an admitted expression to reference nothing beyond the resolved source relation: no subquery of any shape, and every slot must name a visible source column with the source's own qualifier. The hook runs before semantic analysis, so without this an expression over an unauthorized table or an unknown column would reshard the target on behalf of a statement that never runs. Every SELECT item used to be a bare source column, which enforced that implicitly. Function calls stay eligible -- the sampler never evaluates a non-key projection, it only projects the mapped source columns.

Impact: this only expands pre-split eligibility. The actual INSERT projection and expression evaluation are unchanged. Expressions on a partition, base sort-key, or rollup sort-key column still safely fall back to loading without pre-split.

Related: #77842 adds pre-splitting for dynamic `INSERT OVERWRITE` temporary partitions. The two PRs are independently mergeable; the reported workload uses both capabilities.

## Checks:

- `./run-fe-ut.sh --test com.starrocks.alter.reshard.presplit.InsertSelectSourceColumnsTest`
- `./run-fe-ut.sh --test com.starrocks.alter.reshard.presplit.InsertPreSplitHookTableTest`
- End-to-end on a shared-data TSP cluster (1 FE + 3 CN), 300MB source, `tablet_reshard_target_size=16MB`. Every INSERT filters down to ~1% of the rows so the online auto-split (same size knob) cannot confound the tablet count; only pre-split can produce more than one tablet. Measured against a build of this PR's base commit:
  - `SELECT k1, dt, parse_json(v)` (expression on a non-key column): 1 -> 21 tablets
  - `SELECT k1, dt, v` (control, all bare columns): 21 -> 21 tablets, no regression
  - `SELECT k1 + 0, dt, v` (expression on the sort key): 1 -> 1, still skipped
  - `SELECT k1, dt, concat(v, (SELECT ...))` (expression reading another table): 1 -> 1, still skipped
  - all four write the same 30000 rows
- `git diff --check`

Fixes N/A

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
