### PR TITLE
[BugFix] Avoid dropping the final exec state report when the report thread pool is full

### DIFF
--- a/be/src/exec/pipeline/exec_state_reporter.cpp
+++ b/be/src/exec/pipeline/exec_state_reporter.cpp
@@ -340,7 +340,7 @@ void ExecStateReporter::report_exec_state(QueryContext* query_ctx, FragmentConte
     // and is retried as much as possible to ensure success.
     // Otherwise, it may result in the ingestion status getting stuck.
     bool priority = done && fragment_ctx->runtime_state()->query_options().query_type == TQueryType::LOAD;
-    submit(std::move(report_task), priority);
+    submit(std::move(report_task), priority, done);
     VLOG(2) << "[Driver] Submit exec state report task. fragment_instance_id=" << print_id(instance_id)
             << ", query_id=" << print_id(query_id) << ", is_done=" << done;
 }
@@ -380,11 +380,28 @@ ExecStateReporter::~ExecStateReporter() {
     _metrics->unmonitor_priority_reporter(_priority_thread_pool.get());
 }
 
-void ExecStateReporter::submit(std::function<void()>&& report_task, bool priority) {
+void ExecStateReporter::submit(std::function<void()>&& report_task, bool priority, bool is_done_report) {
     if (priority) {
         (void)_priority_thread_pool->submit_func(std::move(report_task));
+        return;
+    }
+    Status st = _thread_pool->submit_func(report_task);
+    if (st.ok()) {
+        return;
+    }
+    if (is_done_report) {
+        // A dropped final (done) report leaves the FE coordinator unaware that the fragment
+        // instance has finished: the query stays RUNNING and keeps holding its query queue
+        // slots until the query timeout expires. This was fixed for ingestion by routing done
+        // reports to the priority thread pool (#36688), but done reports of non-LOAD queries
+        // went back to the discardable bounded pool later (#63132). Never drop a done report:
+        // escalate it to the priority thread pool (unbounded queue) only when the bounded pool
+        // rejects it, so the priority pool is not flooded in the common case.
+        LOG(WARNING) << "exec state report thread pool is full, escalate the done report to "
+                     << "the priority thread pool: " << st.to_string();
+        (void)_priority_thread_pool->submit_func(std::move(report_task));
     } else {
-        (void)_thread_pool->submit_func(std::move(report_task));
+        VLOG(1) << "exec state report thread pool is full, discard the non-done report: " << st.to_string();
     }
 }
 

--- a/be/src/exec/pipeline/exec_state_reporter.h
+++ b/be/src/exec/pipeline/exec_state_reporter.h
@@ -43,7 +43,7 @@ public:
 
     void report_exec_state(QueryContext* query_ctx, FragmentContext* fragment_ctx, const Status& status, bool done);
 
-    void submit(std::function<void()>&& report_task, bool priority = false);
+    void submit(std::function<void()>&& report_task, bool priority = false, bool is_done_report = false);
 
     void bind_cpus(const CpuUtil::CpuIds& cpuids) const;
 


### PR DESCRIPTION
## Why I'm doing:

The final (done) exec state report of a non-LOAD query is submitted to the bounded `exec_state_report` thread pool (queue size 1000), and the submission result is discarded (`(void)`). When the queue is full, the done report is silently lost. The FE coordinator then never learns that the fragment instance finished: the coordinator thread stays blocked in `ResultReceiver.getNext` waiting for `fetch_data`, the query stays RUNNING with frozen CPUTime, and its query queue slots stay allocated until the query timeout expires. We observed single SELECTs holding hundreds of slots for 20+ minutes on 4.1.3 in production.

This is a regression of the guarantee introduced by #36688 ("Fix exec state report lost lead to ingestion status getting stuck", done reports routed to a dedicated unbounded pool). #63132 later restricted the priority pool to ingestion-only done reports — a reasonable protection for the priority pool, but it made done reports of non-LOAD queries droppable again, and the stuck-status consequence applies to every query type.

## What I'm doing:

Never drop a done report, while keeping the common-case routing of #63132 intact:

- `ExecStateReporter::submit` now checks the submission result of the bounded pool.
- Only when the bounded pool rejects a **done** report, escalate that report to the priority (unbounded) thread pool, with a WARNING log.
- Non-done (periodic profile) reports keep the existing best-effort behavior.

This way the priority pool is still not flooded by profile-carrying SELECT reports in the normal case (#63132's concern), and done reports are never lost (#36688's guarantee).

Fixes #77844

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
