### PR TITLE
[BugFix] Expand a constant argument in encode_sort_key

### DIFF
--- a/be/src/exprs_ext/utility/utility_functions.cpp
+++ b/be/src/exprs_ext/utility/utility_functions.cpp
@@ -504,14 +504,6 @@ struct EncoderVisitor : public ColumnVisitorAdapter<EncoderVisitor> {
         return status;
     }
 
-    // Const: forward to data
-    Status do_visit(const ConstColumn& column) {
-        for (size_t i = 0; i < column.size(); i++) {
-            RETURN_IF_ERROR(column.data_column()->accept(this));
-        }
-        return Status::OK();
-    }
-
     // Strings/binary
     template <typename T>
     Status do_visit(const BinaryColumnBase<T>& column) {
@@ -600,6 +592,14 @@ StatusOr<ColumnPtr> UtilityFunctions::encode_sort_key(FunctionContext* context, 
     size_t num_rows = columns[0]->size();
     auto result = ColumnBuilder<TYPE_VARBINARY>(num_rows);
 
+    // The visitor writes one buffer per row while a ConstColumn's data column holds a single element, so a
+    // constant argument has to become a per-row column first -- otherwise only row 0 receives that key.
+    Columns key_columns;
+    key_columns.reserve(num_args);
+    for (const auto& column : columns) {
+        key_columns.emplace_back(ColumnHelper::unpack_and_duplicate_const_column(num_rows, column));
+    }
+
     std::vector<std::string> buffs(num_rows);
     detail::EncoderVisitor visitor;
     visitor.buffs = &buffs;
@@ -610,13 +610,13 @@ StatusOr<ColumnPtr> UtilityFunctions::encode_sort_key(FunctionContext* context, 
         // For example, a nullable column that contains no null values may be converted
         // to a non-nullable column during processing. To ensure consistency in the sort key
         // encoding, we explicitly add NOT_NULL markers for every row.
-        if (!columns[j]->is_nullable()) {
+        if (!key_columns[j]->is_nullable()) {
             for (auto& buff : buffs) {
                 buff.append(NOT_NULL_MARKER, 1);
             }
         }
         visitor.is_last_field = (j + 1 == num_args);
-        RETURN_IF_ERROR(columns[j]->accept(&visitor));
+        RETURN_IF_ERROR(key_columns[j]->accept(&visitor));
 
         // Add a separator between each column
         if (j < num_args - 1) {

--- a/be/test/exprs/utility_functions_test.cpp
+++ b/be/test/exprs/utility_functions_test.cpp
@@ -391,4 +391,77 @@ TEST_F(UtilityFunctionsTest, encodeSortKeyStringEscaping) {
     ASSERT_NE(k0.to_string(), k1.to_string());
 }
 
+TEST_F(UtilityFunctionsTest, encodeSortKeyConstColumn) {
+    FunctionContext* ctx = FunctionContext::create_test_context();
+    auto ptr = std::unique_ptr<FunctionContext>(ctx);
+
+    // Size > 1: a one-row constant column encodes correctly even with the defect present.
+    constexpr int kRows = 4096;
+
+    auto const_case_ids = Int64Column::create();
+    auto column_case_ids = Int64Column::create();
+    auto column_case_tag = Int64Column::create();
+    for (int i = 0; i < kRows; i++) {
+        const_case_ids->append(i + 1);
+        column_case_ids->append(i + 1);
+        column_case_tag->append(7);
+    }
+
+    Columns const_case;
+    const_case.emplace_back(ColumnHelper::create_const_column<TYPE_BIGINT>(7, kRows));
+    const_case.emplace_back(const_case_ids);
+
+    Columns column_case;
+    column_case.emplace_back(column_case_tag);
+    column_case.emplace_back(column_case_ids);
+
+    ASSIGN_OR_ASSERT_FAIL(ColumnPtr const_out, UtilityFunctions::encode_sort_key(ctx, const_case));
+    ASSIGN_OR_ASSERT_FAIL(ColumnPtr column_out, UtilityFunctions::encode_sort_key(ctx, column_case));
+
+    auto* const_bin = ColumnHelper::cast_to_raw<TYPE_VARBINARY>(const_out);
+    auto* column_bin = ColumnHelper::cast_to_raw<TYPE_VARBINARY>(column_out);
+    ASSERT_EQ(kRows, const_bin->size());
+    ASSERT_EQ(kRows, column_bin->size());
+
+    for (int i = 0; i < kRows; i++) {
+        ASSERT_EQ(column_bin->get_slice(i).to_string(), const_bin->get_slice(i).to_string()) << "row " << i;
+    }
+}
+
+TEST_F(UtilityFunctionsTest, encodeSortKeyConstNullColumn) {
+    FunctionContext* ctx = FunctionContext::create_test_context();
+    auto ptr = std::unique_ptr<FunctionContext>(ctx);
+
+    constexpr int kRows = 4096;
+
+    auto const_case_ids = Int64Column::create();
+    auto column_case_ids = Int64Column::create();
+    auto column_case_tag = NullableColumn::create(Int64Column::create(), NullColumn::create());
+    for (int i = 0; i < kRows; i++) {
+        const_case_ids->append(i + 1);
+        column_case_ids->append(i + 1);
+        column_case_tag->append_nulls(1);
+    }
+
+    Columns const_case;
+    const_case.emplace_back(ColumnHelper::create_const_null_column(kRows));
+    const_case.emplace_back(const_case_ids);
+
+    Columns column_case;
+    column_case.emplace_back(column_case_tag);
+    column_case.emplace_back(column_case_ids);
+
+    ASSIGN_OR_ASSERT_FAIL(ColumnPtr const_out, UtilityFunctions::encode_sort_key(ctx, const_case));
+    ASSIGN_OR_ASSERT_FAIL(ColumnPtr column_out, UtilityFunctions::encode_sort_key(ctx, column_case));
+
+    auto* const_bin = ColumnHelper::cast_to_raw<TYPE_VARBINARY>(const_out);
+    auto* column_bin = ColumnHelper::cast_to_raw<TYPE_VARBINARY>(column_out);
+    ASSERT_EQ(kRows, const_bin->size());
+    ASSERT_EQ(kRows, column_bin->size());
+
+    for (int i = 0; i < kRows; i++) {
+        ASSERT_EQ(column_bin->get_slice(i).to_string(), const_bin->get_slice(i).to_string()) << "row " << i;
+    }
+}
+
 } // namespace starrocks

--- a/test/sql/test_function/R/test_encode_row_id
+++ b/test/sql/test_function/R/test_encode_row_id
@@ -159,3 +159,25 @@ select FROM_BINARY(ENCODE_SORT_KEY(v1, v2, v3, NULL), 'hex') from t1;
 -- result:
 [REGEX]E:.*
 -- !result
+create table t2 (id int not null, tag bigint not null, stag varchar(16) not null) duplicate key(id) distributed by hash(id) buckets 1 properties ("replication_num" = "1");
+-- result:
+-- !result
+insert into t2 select generate_series, 7, 'STARROCKS' from TABLE(generate_series(1, 5000));
+-- result:
+-- !result
+select count(*), sum(case when a = b then 0 else 1 end) from (select FROM_BINARY(ENCODE_SORT_KEY(cast(7 as bigint), id), 'hex') a, FROM_BINARY(ENCODE_SORT_KEY(tag, id), 'hex') b from t2) x;
+-- result:
+5000	0
+-- !result
+select count(*), sum(case when a = b then 0 else 1 end) from (select FROM_BINARY(ENCODE_SORT_KEY('STARROCKS', id), 'hex') a, FROM_BINARY(ENCODE_SORT_KEY(stag, id), 'hex') b from t2) x;
+-- result:
+5000	0
+-- !result
+select count(distinct length(FROM_BINARY(ENCODE_SORT_KEY(cast(7 as bigint), id), 'hex'))) from t2;
+-- result:
+1
+-- !result
+select count(distinct length(FROM_BINARY(ENCODE_SORT_KEY(NULL, id), 'hex'))) from t2;
+-- result:
+1
+-- !result

--- a/test/sql/test_function/T/test_encode_row_id
+++ b/test/sql/test_function/T/test_encode_row_id
@@ -44,3 +44,12 @@ select FROM_BINARY(ENCODE_SORT_KEY(NULL, v1, v2, v3), 'hex') from t1;
 select FROM_BINARY(ENCODE_SORT_KEY(v1, NULL, v2, v3), 'hex') from t1;
 select FROM_BINARY(ENCODE_SORT_KEY(v1, v2, NULL, v3), 'hex') from t1;
 select FROM_BINARY(ENCODE_SORT_KEY(v1, v2, v3, NULL), 'hex') from t1;
+
+-- Needs one chunk wider than a row: 3 rows over several tablets encode correctly even when broken.
+create table t2 (id int not null, tag bigint not null, stag varchar(16) not null) duplicate key(id) distributed by hash(id) buckets 1 properties ("replication_num" = "1");
+insert into t2 select generate_series, 7, 'STARROCKS' from TABLE(generate_series(1, 5000));
+
+select count(*), sum(case when a = b then 0 else 1 end) from (select FROM_BINARY(ENCODE_SORT_KEY(cast(7 as bigint), id), 'hex') a, FROM_BINARY(ENCODE_SORT_KEY(tag, id), 'hex') b from t2) x;
+select count(*), sum(case when a = b then 0 else 1 end) from (select FROM_BINARY(ENCODE_SORT_KEY('STARROCKS', id), 'hex') a, FROM_BINARY(ENCODE_SORT_KEY(stag, id), 'hex') b from t2) x;
+select count(distinct length(FROM_BINARY(ENCODE_SORT_KEY(cast(7 as bigint), id), 'hex'))) from t2;
+select count(distinct length(FROM_BINARY(ENCODE_SORT_KEY(NULL, id), 'hex'))) from t2;


### PR DESCRIPTION
## Why I'm doing:

`encode_sort_key` builds one buffer per row and lets `EncoderVisitor` write into `buffs[i]`, but its `ConstColumn` overload forwarded to a data column that holds a **single** element, once per logical row:

```cpp
Status do_visit(const ConstColumn& column) {
    for (size_t i = 0; i < column.size(); i++) {
        RETURN_IF_ERROR(column.data_column()->accept(this));   // data_column()->size() == 1
    }
    return Status::OK();
}
```

Every inner visit writes to `buffs[0]`. So a literal argument landed in the first row of each chunk repeated *chunk-size* times, and **never in any other row**.

`ENCODE_SORT_KEY(<literal>, col)` on a 5,000-row table, compared against a stored column holding the same value — `buckets 1` so the rows share one chunk:

| | rows compared | rows that differ | encoded length |
|---|---|---|---|
| literal vs stored column | 5,000 | **5,000** | 3 distinct lengths, max **32,775 bytes** |
| stored column (reference) | 5,000 | — | uniform 15 bytes |

32,775 is `4096 × 8 + framing` — the constant written 4,096 times into row 0 of a full chunk.

**Why it was invisible.** The defect scales with chunk width, not row count. The recorded cases in `test_encode_row_id` use a 3-row table spread over several tablets, so each chunk holds one row, `ConstColumn::size()` is 1, the loop runs once and the output is correct. The existing BE unit tests pass materialized columns only. Confirmed on `main`: the same statement is correct at 3 rows and wrong at 5,000.

**Blast radius.** Losing a key is worse than the length blowup that reveals it. The row id of a retractable incremental MV over a UNION ALL is `encode(branch ordinal, keys)`, where the ordinal exists solely to keep equal keys in different branches apart; with the ordinal silently dropped, two branches collapse onto one `__ROW_ID__`. That path is currently routed to `encode_fingerprint_sha256`, whose constant handling is correct (verified: 200,000 rows, literal vs stored column, zero differences), so **no released behavior and no persisted data depend on the broken encoding**. This is a latent correctness bug plus a wrong answer for anyone calling the function directly.

## What I'm doing:

Expand constants at the function entry, the same rule `Aggregator::evaluate_agg_input_column` follows and the same fix shape as the `_state` combinator's constant bug:

```cpp
Columns key_columns;
key_columns.reserve(num_args);
for (const auto& column : columns) {
    key_columns.emplace_back(ColumnHelper::unpack_and_duplicate_const_column(num_rows, column));
}
```

Every argument of `encode_sort_key` is a data argument read per row, so all of them are expanded — unlike the aggregate combinators there is no trailing argument that has to stay constant.

The now-unreachable `ConstColumn` overload is removed rather than repaired: the writes are row-indexed, so a one-element data column cannot be encoded there, and falling through to the unsupported-type catch-all keeps a future caller that skips the expansion loud instead of silently dropping a key.

Fixes #issue: none filed — found while measuring `encode_sort_key` for #77751 and reported here directly.

### Verification

Built and deployed on a real cluster; every assertion below was first run against an unpatched BE of the same commit to confirm it actually fails there.

* **BE UT** — two cases in `UtilityFunctionsTest`, a constant `BIGINT` and a constant `NULL` over a 4,096-row batch, each asserting the constant arm encodes byte-for-byte like the equivalent per-row column. Both fail before the change and pass after it.
* **SQL regression** (`test_encode_row_id`) — 5,000 rows in one bucket; literal vs stored column for `BIGINT` and `VARCHAR`, plus length uniformity for a literal and for a literal `NULL`. On an unpatched BE these return `5000 / 5000`, `5000 / 5000`, `3`, `3`; the recorded values are `5000 / 0`, `5000 / 0`, `1`, `1`.
* **No change where it already worked** — the existing recorded cases are unaffected, because their one-row chunks were already correct; re-ran them on the patched build and the goldens match unchanged.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5

`branch-4.1` and `branch-4.0` carry the identical visitor, at `be/src/exprs/utility_functions.cpp` instead of `be/src/exprs_ext/utility/utility_functions.cpp`, so the auto-backport will need the path resolved by hand. `branch-3.5` does not have `encode_sort_key` and is unaffected.
