### PR TITLE
[Enhancement] Support MV on iceberg table with partition evolution when live manifests are aligned with current spec

### DIFF
--- a/docs/en/administration/configuration/FE_parameters/user_query_loading.md
+++ b/docs/en/administration/configuration/FE_parameters/user_query_loading.md
@@ -390,6 +390,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: When this item is set to `true`, StarRocks will attempt to automatically repair materialized view base-table metadata when a base external table is dropped and recreated or its table identifier changes. The repair flow can update the materialized view's base table information, collect partition-level repair information for external table partitions, and drive partition refresh decisions for async auto-refresh materialized views while honoring `autoRefreshPartitionsLimit`. Currently the automated repair supports Hive external tables; unsupported table types will cause the materialized view to be set inactive and a repair exception. Partition information collection is non-blocking and failures are logged.
 - Introduced in: v3.3.19, v3.4.8, v3.5.6
 
+### `enable_mv_on_iceberg_table_with_partition_evolution`
+
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether to allow creating and refreshing materialized views on Iceberg base tables that have undergone partition evolution (i.e. keep multiple partition specs in the table metadata). By default, StarRocks rejects both `CREATE MATERIALIZED VIEW` and MV refresh whenever the base Iceberg table has more than one partition spec, throwing `Do not support create materialized view when base iceberg table ... has done partition evolution`. When this switch is set to `true`, the restriction is relaxed: as long as every **live manifest** under the current snapshot of the Iceberg table is already aligned with the current partition spec (typically after `REWRITE DATA` / `REWRITE MANIFESTS` has rewritten all historical-spec data to the latest spec), StarRocks will allow the MV to be created and refreshed. If any live manifest still references a non-current partition spec, both CREATE and refresh still fail with the partition-evolution error to prevent silently reading inconsistent data.
+- Introduced in: -
+
 ### `enable_predicate_columns_collection`
 
 - Default: true

--- a/docs/ja/administration/configuration/FE_parameters/user_query_loading.md
+++ b/docs/ja/administration/configuration/FE_parameters/user_query_loading.md
@@ -381,6 +381,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：この項目が `true` に設定されている場合、StarRocks は、基底外部テーブルが削除され再作成されたり、テーブル識別子が変更されたりした場合に、マテリアライズドビューの基底テーブルメタデータを自動的に修復しようとします。修復フローは、マテリアライズドビューの基底テーブル情報を更新し、外部テーブルパーティションのパーティションレベルの修復情報を収集し、`autoRefreshPartitionsLimit` を尊重しながら非同期自動更新マテリアライズドビューのパーティション更新決定を駆動することができます。現在、自動修復は Hive 外部テーブルをサポートしています。サポートされていないテーブルタイプでは、マテリアライズドビューが非アクティブに設定され、修復例外が発生します。パーティション情報収集は非ブロッキングであり、失敗はログに記録されます。
 - 導入時期：v3.3.19, v3.4.8, v3.5.6
 
+### `enable_mv_on_iceberg_table_with_partition_evolution`
+
+- デフォルト：false
+- タイプ：Boolean
+- 単位：-
+- 変更可能：Yes
+- 説明：Partition Evolution が発生した（つまりテーブルメタデータに複数の partition spec が保持されている）Iceberg 基底テーブル上でマテリアライズドビューの作成と更新を許可するかどうか。デフォルトでは、Iceberg 基底テーブルの `specs()` の数が 1 を超える場合、StarRocks は `CREATE MATERIALIZED VIEW` およびマテリアライズドビューの更新の両方を拒否し、`Do not support create materialized view when base iceberg table ... has done partition evolution` エラーをスローします。この項目を `true` に設定すると、この制限が緩和されます：Iceberg テーブルの現在の snapshot 配下のすべての live manifest の partition spec id が、テーブルの currentSpec に一致している場合（通常は `REWRITE DATA` / `REWRITE MANIFESTS` で過去の spec のデータをすべて最新の spec に書き換えた後の状態）、StarRocks は対応するマテリアライズドビューの作成と更新を許可します。現在の spec 以外を参照している live manifest がまだ残っている場合、作成と更新は引き続き Partition Evolution 関連のエラーで失敗し、spec をまたいだ不整合なデータの読み取りを防ぎます。
+- 導入時期：-
+
 ### `enable_predicate_columns_collection`
 
 - デフォルト：true

--- a/docs/zh/administration/configuration/FE_parameters/user_query_loading.md
+++ b/docs/zh/administration/configuration/FE_parameters/user_query_loading.md
@@ -390,6 +390,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 当此项设置为 `true` 时，StarRocks 将尝试在基外部表被删除并重新创建或其表标识符更改时自动修复物化视图基表元数据。修复流程可以更新物化视图的基表信息，收集外部表分区的分区级修复信息，并推动异步自动刷新物化视图的分区刷新决策，同时遵守 `autoRefreshPartitionsLimit`。目前自动修复支持 Hive 外部表；不支持的表类型将导致物化视图设置为非活动状态并引发修复异常。分区信息收集是非阻塞的，失败将被记录。
 - 引入版本: v3.3.19, v3.4.8, v3.5.6
 
+### `enable_mv_on_iceberg_table_with_partition_evolution`
+
+- 默认值: false
+- 类型: Boolean
+- 单位: -
+- 是否可变: Yes
+- 描述: 是否允许在发生过 Partition Evolution（即表元数据中保留了多个 partition spec）的 Iceberg 基表上创建和刷新物化视图。默认情况下，只要 Iceberg 基表的 `specs()` 数量大于 1，StarRocks 就会拒绝 `CREATE MATERIALIZED VIEW` 和物化视图刷新，并抛出 `Do not support create materialized view when base iceberg table ... has done partition evolution` 错误。当此项设置为 `true` 时，该限制会被放宽：只要 Iceberg 表当前 snapshot 中所有存活 manifest 的 partition spec id 都等于表的 currentSpec（一般是在执行过 `REWRITE DATA` / `REWRITE MANIFESTS` 将历史 spec 的数据全部重写到最新 spec 后的状态），StarRocks 就允许创建和刷新对应的物化视图。如果仍存在指向非当前 spec 的存活 manifest，创建和刷新仍然会以 Partition Evolution 相关错误失败，以避免读到跨 spec 的不一致数据。
+- 引入版本: -
+
 ### `enable_predicate_columns_collection`
 
 - 默认值: true

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -68,12 +68,14 @@ import com.starrocks.thrift.TTableType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.Type;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.NullOrder;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SortDirection;
 import org.apache.iceberg.SortField;
 import org.apache.iceberg.SortOrder;
@@ -279,6 +281,33 @@ public class IcebergTable extends Table {
     public boolean hasPartitionTransformedEvolution() {
         return (!isV2Format() && getReadSpec().fields().stream().anyMatch(field -> field.transform().isVoid())) ||
                 (isV2Format() && getReadSpec().specId() > 0);
+    }
+
+    public boolean isCurrentSnapshotAllOnCurrentSpec() {
+        org.apache.iceberg.Table t = getNativeTable();
+        if (t.specs().size() <= 1) {
+            return true;
+        }
+
+        Snapshot snapshot = t.currentSnapshot();
+        if (snapshot == null) {
+            return true;
+        }
+
+        int currentSpecId = t.spec().specId();
+        try {
+            for (ManifestFile manifest : snapshot.allManifests(t.io())) {
+                if (manifest.partitionSpecId() != currentSpecId) {
+                    return false;
+                }
+            }
+
+            return true;
+        } catch (Exception e) {
+            LOG.warn("Failed to check manifests for iceberg table {}, fall back to strict partition-evolution check",
+                    getName(), e);
+            return false;
+        }
     }
 
     public boolean isV2Format() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -30,6 +30,7 @@ import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergApiConverter;
 import com.starrocks.connector.iceberg.IcebergCatalogType;
 import com.starrocks.connector.iceberg.IcebergTableOperation;
+import com.starrocks.connector.iceberg.IcebergUtil;
 import com.starrocks.connector.iceberg.cost.IcebergMetricsReporter;
 import com.starrocks.connector.iceberg.procedure.AddFilesProcedure;
 import com.starrocks.connector.iceberg.procedure.CherryPickSnapshotProcedure;
@@ -68,7 +69,6 @@ import com.starrocks.thrift.TTableType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.Type;
 import org.apache.iceberg.BaseTable;
-import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.NullOrder;
 import org.apache.iceberg.PartitionField;
@@ -296,13 +296,7 @@ public class IcebergTable extends Table {
 
         int currentSpecId = t.spec().specId();
         try {
-            for (ManifestFile manifest : snapshot.allManifests(t.io())) {
-                if (manifest.partitionSpecId() != currentSpecId) {
-                    return false;
-                }
-            }
-
-            return true;
+            return IcebergUtil.isSnapshotAllOnSpec(snapshot, t.io(), currentSpecId);
         } catch (Exception e) {
             LOG.warn("Failed to check manifests for iceberg table {}, fall back to strict partition-evolution check",
                     getName(), e);

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -4219,6 +4219,12 @@ public class Config extends ConfigBase {
             "all external table partition types")
     public static boolean enable_mv_list_partition_for_external_table = false;
 
+    @ConfField(mutable = true, comment = "Whether to allow creating/refreshing materialized view on iceberg base " +
+            "table that has undergone partition evolution (i.e. has multiple partition specs in history). " +
+            "When enabled, create-mv analyze phase will skip the spec-size check, and mv refresh phase will only " +
+            "fail when there is any live manifest whose partition spec id is not equal to the current spec id.")
+    public static boolean enable_mv_on_iceberg_table_with_partition_evolution = false;
+
     /**
      * The refresh partition number when refreshing materialized view at once by default.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionUtils.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.FeConstants;
@@ -30,17 +31,21 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.expression.BinaryPredicate;
 import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.ExprToSql;
 import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
 import com.starrocks.sql.ast.expression.IntLiteral;
 import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.ast.expression.LiteralExprFactory;
 import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.type.Type;
 import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Term;
 import org.apache.iceberg.types.Types;
@@ -253,6 +258,65 @@ public class IcebergPartitionUtils {
                 transform == IcebergPartitionTransform.HOUR ||
                 transform == IcebergPartitionTransform.BUCKET ||
                 transform == IcebergPartitionTransform.TRUNCATE;
+    }
+
+    public static boolean checkPartitionTransformCompatibleWithSpec(IcebergTable table,
+                                                                    Expr partitionByExpr,
+                                                                    SlotRef slotRef) {
+        Table icebergTable = table.getNativeTable();
+        PartitionSpec partitionSpec = icebergTable.spec();
+        for (PartitionField partitionField : partitionSpec.fields()) {
+            String partitionColumnName = icebergTable.schema().findColumnName(partitionField.sourceId());
+            if (partitionColumnName.equalsIgnoreCase(slotRef.getColumnName())) {
+                IcebergPartitionTransform transform =
+                        IcebergPartitionTransform.fromString(partitionField.transform().toString());
+                switch (transform) {
+                    case YEAR:
+                    case MONTH:
+                    case DAY:
+                    case HOUR:
+                        if (!isDateTruncWithUnit(partitionByExpr, transform.name())) {
+                            throw new StarRocksConnectorException("Materialized view partition expr %s " +
+                                    "must be the same with base table partition transform %s, please use date_trunc" +
+                                    "(<transform>, <partition_colum_name>) instead.",
+                                    ExprToSql.toSql(partitionByExpr), transform.name());
+                        }
+
+                        return true;
+                    case IDENTITY:
+                        if (!(partitionByExpr instanceof SlotRef) && !MvUtils.isStr2Date(partitionByExpr) &&
+                                !MvUtils.isFuncCallExpr(partitionByExpr, FunctionSet.DATE_TRUNC)) {
+                            throw new StarRocksConnectorException("Materialized view partition expr %s: " +
+                                    "only support ref partition column for transform %s, please use " +
+                                    "<partition_column_name> instead.",
+                                    ExprToSql.toSql(partitionByExpr), transform.name());
+                        }
+
+                        return false;
+                    default:
+                        throw new StarRocksConnectorException("Do not support materialized view when " +
+                                "base iceberg table partition transform is: " + transform.name());
+                }
+            }
+        }
+
+        throw new StarRocksConnectorException("Materialized view partition expr %s is no longer compatible with " +
+                "base Iceberg table current partition spec: partition column %s is not found in current " +
+                "partition spec.", ExprToSql.toSql(partitionByExpr), slotRef.getColumnName());
+    }
+
+    private static boolean isDateTruncWithUnit(Expr partitionExpr, String timeUnit) {
+        if (MvUtils.isFuncCallExpr(partitionExpr, FunctionSet.DATE_TRUNC)) {
+            FunctionCallExpr functionCallExpr = (FunctionCallExpr) partitionExpr;
+            if (!(functionCallExpr.getChild(0) instanceof StringLiteral)) {
+                return false;
+            }
+
+            StringLiteral stringLiteral = (StringLiteral) functionCallExpr.getChild(0);
+            return stringLiteral.getStringValue().equalsIgnoreCase(timeUnit);
+        }
+
+        return false;
     }
 
     public static LocalDateTime addDateTimeInterval(LocalDateTime dateTime, IcebergPartitionTransform transform) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
@@ -46,6 +46,7 @@ import org.apache.iceberg.util.LocationUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -93,6 +94,21 @@ public final class IcebergUtil {
                     .build();
         } else {
             return CloseableIterable.withNoopClose(snapshot.allManifests(fileIO));
+        }
+    }
+
+    public static boolean isSnapshotAllOnSpec(Snapshot snapshot, FileIO fileIO, int specId) {
+        try (CloseableIterable<ManifestFile> manifests = readManifests(snapshot, fileIO)) {
+            for (ManifestFile manifest : manifests) {
+                if (manifest.partitionSpecId() != specId) {
+                    return false;
+                }
+            }
+
+            return true;
+        } catch (IOException e) {
+            throw new StarRocksConnectorException("Unable to read manifests for snapshot " +
+                    snapshot.snapshotId(), e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
@@ -76,6 +76,8 @@ public final class IcebergUtil {
                     "content",
                     "partition_spec_id",
                     "added_snapshot_id",
+                    "added_files_count",
+                    "existing_files_count",
                     "deleted_data_files_count");
 
     /**
@@ -100,7 +102,8 @@ public final class IcebergUtil {
     public static boolean isSnapshotAllOnSpec(Snapshot snapshot, FileIO fileIO, int specId) {
         try (CloseableIterable<ManifestFile> manifests = readManifests(snapshot, fileIO)) {
             for (ManifestFile manifest : manifests) {
-                if (manifest.partitionSpecId() != specId) {
+                if (manifest.partitionSpecId() != specId
+                        && (manifest.hasAddedFiles() || manifest.hasExistingFiles())) {
                     return false;
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessor.java
@@ -43,6 +43,8 @@ import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.connector.PartitionUtil;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.iceberg.IcebergPartitionUtils;
 import com.starrocks.metric.IMaterializedViewMetricsEntity;
 import com.starrocks.mv.refresh.pct.MVPCTRefreshPlanner;
 import com.starrocks.mv.refresh.pct.MVPCTRefreshSynchronizer;
@@ -66,7 +68,6 @@ import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.MaterializedViewAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
-import com.starrocks.sql.analyzer.mv.IcebergTablePartitionHandler;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.PartitionRef;
 import com.starrocks.sql.ast.expression.Expr;
@@ -823,10 +824,10 @@ public abstract class MVRefreshProcessor {
 
         try {
             for (int i = 0; i < exprs.size(); i++) {
-                IcebergTablePartitionHandler.checkPartitionTransformCompatibleWithSpec(
+                IcebergPartitionUtils.checkPartitionTransformCompatibleWithSpec(
                         icebergTable, exprs.get(i), slots.get(i));
             }
-        } catch (SemanticException e) {
+        } catch (StarRocksConnectorException e) {
             throw new DmlException("Materialized view %s.%s refresh failed: base Iceberg table %s partition "
                             + "transform has evolved and is no longer compatible with the materialized view's "
                             + "partition expression: %s",

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessor.java
@@ -66,8 +66,11 @@ import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.MaterializedViewAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.analyzer.mv.IcebergTablePartitionHandler;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.PartitionRef;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.common.PCellSetMapping;
 import com.starrocks.sql.common.PCellSortedSet;
@@ -755,11 +758,22 @@ public abstract class MVRefreshProcessor {
                 // Non-partitioned MVs do full refresh without base partition mapping.
                 if (table instanceof IcebergTable && !mv.getPartitionInfo().isUnPartitioned()) {
                     IcebergTable icebergTable = (IcebergTable) table;
-                    if (icebergTable.getNativeTable().specs().size() > 1) {
-                        throw new DmlException("Materialized view %s.%s refresh failed: base Iceberg table %s " +
-                                        "has undergone partition evolution (%d partition specs), which is not supported",
-                                db.getFullName(), mv.getName(), table.getName(),
-                                icebergTable.getNativeTable().specs().size());
+                    org.apache.iceberg.Table nativeTable = icebergTable.getNativeTable();
+                    if (nativeTable.specs().size() > 1) {
+                        // Only fail the refresh when either the user has NOT opted in, or the current snapshot's
+                        // live manifests still reference non-current partition specs (i.e. old-spec data is still
+                        // visible). If old-spec data has been fully rewritten to the current spec, the refresh is
+                        // safe to proceed even though historical specs remain in metadata.
+                        boolean allowByConfig = Config.enable_mv_on_iceberg_table_with_partition_evolution
+                                && icebergTable.isCurrentSnapshotAllOnCurrentSpec();
+                        if (!allowByConfig) {
+                            throw new DmlException("Materialized view %s.%s refresh failed: base Iceberg table %s " +
+                                            "has undergone partition evolution (%d partition specs), which is not supported",
+                                    db.getFullName(), mv.getName(), table.getName(),
+                                    nativeTable.specs().size());
+                        }
+
+                        checkIcebergPartitionTransformStillCompatible(icebergTable);
                     }
                 }
 
@@ -785,6 +799,39 @@ public abstract class MVRefreshProcessor {
         }
         logger.info("collect base table snapshot infos cost: {} ms", stopwatch.elapsed(TimeUnit.MILLISECONDS));
         return tables;
+    }
+
+    private void checkIcebergPartitionTransformStillCompatible(IcebergTable icebergTable) {
+        Map<Table, List<Expr>> refBaseTableExprs = mv.getRefBaseTablePartitionExprs(false);
+        Map<Table, List<SlotRef>> refBaseTableSlots = mv.getRefBaseTablePartitionSlots();
+        if (refBaseTableExprs == null || refBaseTableExprs.isEmpty()
+                || refBaseTableSlots == null || refBaseTableSlots.isEmpty()) {
+            return;
+        }
+
+        List<Expr> exprs = refBaseTableExprs.get(icebergTable);
+        List<SlotRef> slots = refBaseTableSlots.get(icebergTable);
+        if (exprs == null || exprs.isEmpty() || slots == null || slots.isEmpty()) {
+            return;
+        }
+
+        if (exprs.size() != slots.size()) {
+            throw new DmlException("Materialized view %s.%s refresh failed: base Iceberg table %s partition "
+                            + "expressions and slots are inconsistent, expr size: %d, slot size: %d",
+                    db.getFullName(), mv.getName(), icebergTable.getName(), exprs.size(), slots.size());
+        }
+
+        try {
+            for (int i = 0; i < exprs.size(); i++) {
+                IcebergTablePartitionHandler.checkPartitionTransformCompatibleWithSpec(
+                        icebergTable, exprs.get(i), slots.get(i));
+            }
+        } catch (SemanticException e) {
+            throw new DmlException("Materialized view %s.%s refresh failed: base Iceberg table %s partition "
+                            + "transform has evolved and is no longer compatible with the materialized view's "
+                            + "partition expression: %s",
+                    db.getFullName(), mv.getName(), icebergTable.getName(), e.getMessage());
+        }
     }
 
     public void updatePCTMVToRefreshInfoIntoTaskRun(PCellSortedSet finalMvToRefreshedPartitions,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -255,8 +255,12 @@ public class MaterializedViewAnalyzer {
             if (!allowIcebergPartitionEvolution && table instanceof IcebergTable) {
                 IcebergTable icebergTable = (IcebergTable) table;
                 if (icebergTable.getNativeTable().specs().size() > 1) {
-                    throw new SemanticException("Do not support create materialized view when base iceberg table " +
-                            table.getName() + " has done partition evolution", tableName.getPos());
+                    boolean allowByConfig = Config.enable_mv_on_iceberg_table_with_partition_evolution
+                            && icebergTable.isCurrentSnapshotAllOnCurrentSpec();
+                    if (!allowByConfig) {
+                        throw new SemanticException("Do not support create materialized view when base iceberg table " +
+                                table.getName() + " has done partition evolution", tableName.getPos());
+                    }
                 }
             }
             if (!FeConstants.isReplayFromQueryDump && !isSupportedExternalTables(table)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IcebergTablePartitionHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IcebergTablePartitionHandler.java
@@ -14,19 +14,13 @@
 
 package com.starrocks.sql.analyzer.mv;
 
-import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.common.Config;
-import com.starrocks.connector.iceberg.IcebergPartitionTransform;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.iceberg.IcebergPartitionUtils;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.expression.Expr;
-import com.starrocks.sql.ast.expression.ExprToSql;
-import com.starrocks.sql.ast.expression.FunctionCallExpr;
 import com.starrocks.sql.ast.expression.SlotRef;
-import com.starrocks.sql.ast.expression.StringLiteral;
-import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
-import org.apache.iceberg.PartitionField;
-import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
 
 /**
@@ -54,64 +48,16 @@ public class IcebergTablePartitionHandler implements MVBaseTablePartitionHandler
             }
         }
 
-        boolean withTransform = checkPartitionTransformCompatibleWithSpec(table, partitionByExpr, slotRef);
+        boolean withTransform;
+        try {
+            withTransform = IcebergPartitionUtils.checkPartitionTransformCompatibleWithSpec(
+                    table, partitionByExpr, slotRef);
+        } catch (StarRocksConnectorException e) {
+            throw new SemanticException(e.getMessage());
+        }
+
         if (withTransform) {
             context.getStatement().setRefBaseTablePartitionWithTransform(true);
         }
-    }
-
-    public static boolean checkPartitionTransformCompatibleWithSpec(IcebergTable table,
-                                                                    Expr partitionByExpr,
-                                                                    SlotRef slotRef) {
-        Table icebergTable = table.getNativeTable();
-        PartitionSpec partitionSpec = icebergTable.spec();
-        for (PartitionField partitionField : partitionSpec.fields()) {
-            String partitionColumnName = icebergTable.schema().findColumnName(partitionField.sourceId());
-            if (partitionColumnName.equalsIgnoreCase(slotRef.getColumnName())) {
-                IcebergPartitionTransform transform =
-                        IcebergPartitionTransform.fromString(partitionField.transform().toString());
-                switch (transform) {
-                    case YEAR:
-                    case MONTH:
-                    case DAY:
-                    case HOUR:
-                        if (!isDateTruncWithUnit(partitionByExpr, transform.name())) {
-                            throw new SemanticException("Materialized view partition expr %s " +
-                                    "must be the same with base table partition transform %s, please use date_trunc" +
-                                    "(<transform>, <partition_colum_name>) instead.",
-                                    ExprToSql.toSql(partitionByExpr), transform.name());
-                        }
-                        return true;
-                    case IDENTITY:
-                        if (!(partitionByExpr instanceof SlotRef) && !MvUtils.isStr2Date(partitionByExpr) &&
-                                !MvUtils.isFuncCallExpr(partitionByExpr, FunctionSet.DATE_TRUNC)) {
-                            throw new SemanticException("Materialized view partition expr %s: " +
-                                    "only support ref partition column for transform %s, please use " +
-                                    "<partition_column_name> instead.",
-                                    ExprToSql.toSql(partitionByExpr), transform.name());
-                        }
-                        return false;
-                    default:
-                        throw new SemanticException("Do not support create materialized view when " +
-                                "base iceberg table partition transform is: " + transform.name());
-                }
-            }
-        }
-
-        throw new SemanticException("Materialized view partition expr %s is no longer compatible with " +
-                "base Iceberg table current partition spec: partition column %s is not found in current " +
-                "partition spec.", ExprToSql.toSql(partitionByExpr), slotRef.getColumnName());
-    }
-
-    private static boolean isDateTruncWithUnit(Expr partitionExpr, String timeUnit) {
-        if (MvUtils.isFuncCallExpr(partitionExpr, FunctionSet.DATE_TRUNC)) {
-            FunctionCallExpr functionCallExpr = (FunctionCallExpr) partitionExpr;
-            if (!(functionCallExpr.getChild(0) instanceof StringLiteral)) {
-                return false;
-            }
-            StringLiteral stringLiteral = (StringLiteral) functionCallExpr.getChild(0);
-            return stringLiteral.getStringValue().equalsIgnoreCase(timeUnit);
-        }
-        return false;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IcebergTablePartitionHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IcebergTablePartitionHandler.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.analyzer.mv;
 
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.IcebergTable;
+import com.starrocks.common.Config;
 import com.starrocks.connector.iceberg.IcebergPartitionTransform;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.expression.Expr;
@@ -26,6 +27,7 @@ import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Table;
 
 /**
  * Handler for Iceberg tables.
@@ -42,12 +44,27 @@ public class IcebergTablePartitionHandler implements MVBaseTablePartitionHandler
         MVBaseTablePartitionHandler.checkPartitionColumnWithBaseTable(slotRef, table);
 
         // Iceberg-specific: partition evolution and transform validation
-        org.apache.iceberg.Table icebergTable = table.getNativeTable();
-        PartitionSpec partitionSpec = icebergTable.spec();
+        Table icebergTable = table.getNativeTable();
         if (icebergTable.specs().size() > 1) {
-            throw new SemanticException("Do not support create materialized view when " +
-                    "base iceberg table has partition evolution");
+            boolean allowByConfig = Config.enable_mv_on_iceberg_table_with_partition_evolution
+                    && table.isCurrentSnapshotAllOnCurrentSpec();
+            if (!allowByConfig) {
+                throw new SemanticException("Do not support create materialized view when " +
+                        "base iceberg table has partition evolution");
+            }
         }
+
+        boolean withTransform = checkPartitionTransformCompatibleWithSpec(table, partitionByExpr, slotRef);
+        if (withTransform) {
+            context.getStatement().setRefBaseTablePartitionWithTransform(true);
+        }
+    }
+
+    public static boolean checkPartitionTransformCompatibleWithSpec(IcebergTable table,
+                                                                    Expr partitionByExpr,
+                                                                    SlotRef slotRef) {
+        Table icebergTable = table.getNativeTable();
+        PartitionSpec partitionSpec = icebergTable.spec();
         for (PartitionField partitionField : partitionSpec.fields()) {
             String partitionColumnName = icebergTable.schema().findColumnName(partitionField.sourceId());
             if (partitionColumnName.equalsIgnoreCase(slotRef.getColumnName())) {
@@ -64,8 +81,7 @@ public class IcebergTablePartitionHandler implements MVBaseTablePartitionHandler
                                     "(<transform>, <partition_colum_name>) instead.",
                                     ExprToSql.toSql(partitionByExpr), transform.name());
                         }
-                        context.getStatement().setRefBaseTablePartitionWithTransform(true);
-                        break;
+                        return true;
                     case IDENTITY:
                         if (!(partitionByExpr instanceof SlotRef) && !MvUtils.isStr2Date(partitionByExpr) &&
                                 !MvUtils.isFuncCallExpr(partitionByExpr, FunctionSet.DATE_TRUNC)) {
@@ -74,14 +90,17 @@ public class IcebergTablePartitionHandler implements MVBaseTablePartitionHandler
                                     "<partition_column_name> instead.",
                                     ExprToSql.toSql(partitionByExpr), transform.name());
                         }
-                        break;
+                        return false;
                     default:
                         throw new SemanticException("Do not support create materialized view when " +
                                 "base iceberg table partition transform is: " + transform.name());
                 }
-                break;
             }
         }
+
+        throw new SemanticException("Materialized view partition expr %s is no longer compatible with " +
+                "base Iceberg table current partition spec: partition column %s is not found in current " +
+                "partition spec.", ExprToSql.toSql(partitionByExpr), slotRef.getColumnName());
     }
 
     private static boolean isDateTruncWithUnit(Expr partitionExpr, String timeUnit) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
@@ -554,26 +554,82 @@ public class IcebergTableTest extends TableTestBase {
     }
 
     @Test
+    public void testIsCurrentSnapshotAllOnCurrentSpecAfterRewriteDataOntoCurrentSpec() {
+        // Append a data file under the original SPEC_B, then evolve the partition spec (drop
+        // "k2") so the default spec id changes.
+        mockedNativeTableB.newAppend().appendFile(FILE_B_1).commit();
+        int oldSpecId = mockedNativeTableB.spec().specId();
+        mockedNativeTableB.updateSpec().removeField("k2").commit();
+        PartitionSpec newSpec = mockedNativeTableB.spec();
+        Assertions.assertNotEquals(oldSpecId, newSpec.specId());
+
+        // REWRITE DATA onto the current spec. The commit keeps an old-spec manifest containing
+        // only DELETED entries (written with the file's original spec id), which Iceberg scans
+        // ignore because it has no live files.
+        DataFile rewrittenFile = DataFiles.builder(newSpec)
+                .withPath("/path/to/data-b-rewritten.parquet")
+                .withFileSizeInBytes(10)
+                .withRecordCount(2)
+                .build();
+        mockedNativeTableB.newRewrite()
+                .deleteFile(FILE_B_1)
+                .addFile(rewrittenFile)
+                .commit();
+
+        IcebergTable table = IcebergTable.builder()
+                .setId(5)
+                .setSrTableName("tb")
+                .setCatalogName("cat")
+                .setCatalogDBName("db")
+                .setCatalogTableName("tb")
+                .setFullSchema(new ArrayList<>())
+                .setNativeTable(mockedNativeTableB)
+                .setIcebergProperties(new HashMap<>())
+                .build();
+
+        // Sanity: the snapshot still lists an old-spec manifest, but it holds no live files.
+        List<ManifestFile> manifests = mockedNativeTableB.currentSnapshot()
+                .allManifests(mockedNativeTableB.io());
+        Assertions.assertTrue(manifests.stream().anyMatch(m -> m.partitionSpecId() == oldSpecId));
+        Assertions.assertTrue(manifests.stream()
+                .filter(m -> m.partitionSpecId() == oldSpecId)
+                .noneMatch(m -> m.hasAddedFiles() || m.hasExistingFiles()));
+
+        // Every live data file is on the current spec -> aligned.
+        Assertions.assertTrue(table.isCurrentSnapshotAllOnCurrentSpec());
+    }
+
+    @Test
     public void testIsCurrentSnapshotAllOnCurrentSpecMixedManifestsReturnsFalse() {
-        IcebergTable table = buildIcebergTableWithMockedSnapshot(1, new int[] {1, 0}, false);
+        IcebergTable table = buildIcebergTableWithMockedSnapshot(1, new int[] {1, 0},
+                new boolean[] {true, true}, false);
         Assertions.assertFalse(table.isCurrentSnapshotAllOnCurrentSpec());
     }
 
     @Test
     public void testIsCurrentSnapshotAllOnCurrentSpecMultipleManifestsAllMatchReturnsTrue() {
-        IcebergTable table = buildIcebergTableWithMockedSnapshot(1, new int[] {1, 1, 1}, false);
+        IcebergTable table = buildIcebergTableWithMockedSnapshot(1, new int[] {1, 1, 1},
+                new boolean[] {true, true, true}, false);
+        Assertions.assertTrue(table.isCurrentSnapshotAllOnCurrentSpec());
+    }
+
+    @Test
+    public void testIsCurrentSnapshotAllOnCurrentSpecDeleteOnlyOldSpecManifestReturnsTrue() {
+        IcebergTable table = buildIcebergTableWithMockedSnapshot(1, new int[] {1, 0},
+                new boolean[] {true, false}, false);
         Assertions.assertTrue(table.isCurrentSnapshotAllOnCurrentSpec());
     }
 
     @Test
     public void testIsCurrentSnapshotAllOnCurrentSpecFallsBackWhenManifestReadFails() {
-        // snapshot.allManifests() throws -> catch branch returns false (conservative fallback).
-        IcebergTable table = buildIcebergTableWithMockedSnapshot(1, new int[] {}, true);
+        IcebergTable table = buildIcebergTableWithMockedSnapshot(1, new int[] {},
+                new boolean[] {}, true);
         Assertions.assertFalse(table.isCurrentSnapshotAllOnCurrentSpec());
     }
 
     private static IcebergTable buildIcebergTableWithMockedSnapshot(int currentSpecId,
                                                                     int[] manifestSpecIds,
+                                                                    boolean[] manifestHasLiveFiles,
                                                                     boolean throwOnAllManifests) {
         BaseTable nativeTable = Mockito.mock(BaseTable.class);
         // specs().size() > 1 to enter the check.
@@ -596,9 +652,11 @@ public class IcebergTableTest extends TableTestBase {
                     .thenThrow(new RuntimeException("boom"));
         } else {
             List<ManifestFile> manifests = new ArrayList<>();
-            for (int sid : manifestSpecIds) {
+            for (int i = 0; i < manifestSpecIds.length; i++) {
                 ManifestFile mf = Mockito.mock(ManifestFile.class);
-                Mockito.when(mf.partitionSpecId()).thenReturn(sid);
+                Mockito.when(mf.partitionSpecId()).thenReturn(manifestSpecIds[i]);
+                Mockito.when(mf.hasAddedFiles()).thenReturn(manifestHasLiveFiles[i]);
+                Mockito.when(mf.hasExistingFiles()).thenReturn(false);
                 manifests.add(mf);
             }
             Mockito.when(snapshot.allManifests(Mockito.any())).thenReturn(manifests);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
@@ -637,7 +637,6 @@ public class IcebergTableTest extends TableTestBase {
         specs.put(0, PartitionSpec.unpartitioned());
         specs.put(1, PartitionSpec.unpartitioned());
         Mockito.when(nativeTable.specs()).thenReturn(specs);
-
         // spec().specId() returns the "current" spec id used for comparison.
         PartitionSpec currentSpec = Mockito.mock(PartitionSpec.class);
         Mockito.when(currentSpec.specId()).thenReturn(currentSpecId);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
@@ -33,9 +33,14 @@ import com.starrocks.thrift.TTableDescriptor;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.NullOrder;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.types.Types;
@@ -453,5 +458,161 @@ public class IcebergTableTest extends TableTestBase {
         // No current snapshot (e.g. empty table) -> empty metadata, not an error.
         Mockito.when(nativeTable.currentSnapshot()).thenReturn(null);
         Assertions.assertTrue(table.getStatsCollectMetadata().isEmpty());
+    }
+
+    @Test
+    public void testIsCurrentSnapshotAllOnCurrentSpecSingleSpec() {
+        // Only one partition spec exists -> should always return true, regardless of snapshot state.
+        IcebergTable table = IcebergTable.builder()
+                .setId(1)
+                .setSrTableName("tb")
+                .setCatalogName("cat")
+                .setCatalogDBName("db")
+                .setCatalogTableName("tb")
+                .setFullSchema(new ArrayList<>())
+                .setNativeTable(mockedNativeTableB)
+                .setIcebergProperties(new HashMap<>())
+                .build();
+        Assertions.assertEquals(1, mockedNativeTableB.specs().size());
+        Assertions.assertTrue(table.isCurrentSnapshotAllOnCurrentSpec());
+    }
+
+    @Test
+    public void testIsCurrentSnapshotAllOnCurrentSpecMultiSpecNoSnapshot() {
+        // Do partition evolution before appending any data: drop the identity partition field "k2"
+        // so the table ends up with 2 partition specs (default now points to the new spec), and
+        // currentSnapshot() is null -> should be treated as "aligned with current spec".
+        mockedNativeTableB.updateSpec().removeField("k2").commit();
+
+        IcebergTable table = IcebergTable.builder()
+                .setId(2)
+                .setSrTableName("tb")
+                .setCatalogName("cat")
+                .setCatalogDBName("db")
+                .setCatalogTableName("tb")
+                .setFullSchema(new ArrayList<>())
+                .setNativeTable(mockedNativeTableB)
+                .setIcebergProperties(new HashMap<>())
+                .build();
+        Assertions.assertTrue(mockedNativeTableB.specs().size() > 1);
+        Assertions.assertNull(mockedNativeTableB.currentSnapshot());
+        Assertions.assertTrue(table.isCurrentSnapshotAllOnCurrentSpec());
+    }
+
+    @Test
+    public void testIsCurrentSnapshotAllOnCurrentSpecMultiSpecOldManifestAlive() {
+        // Append a data file under the original SPEC_B (specId=0), then evolve the partition spec
+        // (drop "k2") so the new default spec has a different specId. The current snapshot's live
+        // manifest still references the old (non-current) spec id -> return false.
+        mockedNativeTableB.newAppend().appendFile(FILE_B_1).commit();
+        int oldSpecId = mockedNativeTableB.spec().specId();
+        mockedNativeTableB.updateSpec().removeField("k2").commit();
+
+        IcebergTable table = IcebergTable.builder()
+                .setId(3)
+                .setSrTableName("tb")
+                .setCatalogName("cat")
+                .setCatalogDBName("db")
+                .setCatalogTableName("tb")
+                .setFullSchema(new ArrayList<>())
+                .setNativeTable(mockedNativeTableB)
+                .setIcebergProperties(new HashMap<>())
+                .build();
+        Assertions.assertTrue(mockedNativeTableB.specs().size() > 1);
+        Assertions.assertNotNull(mockedNativeTableB.currentSnapshot());
+        // Sanity: after evolution the default spec id has changed.
+        Assertions.assertNotEquals(oldSpecId, mockedNativeTableB.spec().specId());
+        // Old-spec manifest is still live under the current snapshot -> not all on current spec.
+        Assertions.assertFalse(table.isCurrentSnapshotAllOnCurrentSpec());
+    }
+
+    @Test
+    public void testIsCurrentSnapshotAllOnCurrentSpecMultiSpecAllManifestOnCurrentSpec() {
+        mockedNativeTableB.updateSpec().removeField("k2").commit();
+        PartitionSpec newSpec = mockedNativeTableB.spec();
+        DataFile fileOnNewSpec = DataFiles.builder(newSpec)
+                .withPath("/path/to/data-b-newspec.parquet")
+                .withFileSizeInBytes(10)
+                .withRecordCount(2)
+                .build();
+        mockedNativeTableB.newAppend().appendFile(fileOnNewSpec).commit();
+
+        IcebergTable table = IcebergTable.builder()
+                .setId(4)
+                .setSrTableName("tb")
+                .setCatalogName("cat")
+                .setCatalogDBName("db")
+                .setCatalogTableName("tb")
+                .setFullSchema(new ArrayList<>())
+                .setNativeTable(mockedNativeTableB)
+                .setIcebergProperties(new HashMap<>())
+                .build();
+        Assertions.assertTrue(mockedNativeTableB.specs().size() > 1);
+        Assertions.assertNotNull(mockedNativeTableB.currentSnapshot());
+        // All live manifests are already on the current spec -> return true.
+        Assertions.assertTrue(table.isCurrentSnapshotAllOnCurrentSpec());
+    }
+
+    @Test
+    public void testIsCurrentSnapshotAllOnCurrentSpecMixedManifestsReturnsFalse() {
+        IcebergTable table = buildIcebergTableWithMockedSnapshot(1, new int[] {1, 0}, false);
+        Assertions.assertFalse(table.isCurrentSnapshotAllOnCurrentSpec());
+    }
+
+    @Test
+    public void testIsCurrentSnapshotAllOnCurrentSpecMultipleManifestsAllMatchReturnsTrue() {
+        IcebergTable table = buildIcebergTableWithMockedSnapshot(1, new int[] {1, 1, 1}, false);
+        Assertions.assertTrue(table.isCurrentSnapshotAllOnCurrentSpec());
+    }
+
+    @Test
+    public void testIsCurrentSnapshotAllOnCurrentSpecFallsBackWhenManifestReadFails() {
+        // snapshot.allManifests() throws -> catch branch returns false (conservative fallback).
+        IcebergTable table = buildIcebergTableWithMockedSnapshot(1, new int[] {}, true);
+        Assertions.assertFalse(table.isCurrentSnapshotAllOnCurrentSpec());
+    }
+
+    private static IcebergTable buildIcebergTableWithMockedSnapshot(int currentSpecId,
+                                                                    int[] manifestSpecIds,
+                                                                    boolean throwOnAllManifests) {
+        BaseTable nativeTable = Mockito.mock(BaseTable.class);
+        // specs().size() > 1 to enter the check.
+        Map<Integer, PartitionSpec> specs = new HashMap<>();
+        specs.put(0, PartitionSpec.unpartitioned());
+        specs.put(1, PartitionSpec.unpartitioned());
+        Mockito.when(nativeTable.specs()).thenReturn(specs);
+
+        // spec().specId() returns the "current" spec id used for comparison.
+        PartitionSpec currentSpec = Mockito.mock(PartitionSpec.class);
+        Mockito.when(currentSpec.specId()).thenReturn(currentSpecId);
+        Mockito.when(nativeTable.spec()).thenReturn(currentSpec);
+
+        Snapshot snapshot = Mockito.mock(Snapshot.class);
+        Mockito.when(nativeTable.currentSnapshot()).thenReturn(snapshot);
+        Mockito.when(nativeTable.io()).thenReturn(null);
+
+        if (throwOnAllManifests) {
+            Mockito.when(snapshot.allManifests(Mockito.any()))
+                    .thenThrow(new RuntimeException("boom"));
+        } else {
+            List<ManifestFile> manifests = new ArrayList<>();
+            for (int sid : manifestSpecIds) {
+                ManifestFile mf = Mockito.mock(ManifestFile.class);
+                Mockito.when(mf.partitionSpecId()).thenReturn(sid);
+                manifests.add(mf);
+            }
+            Mockito.when(snapshot.allManifests(Mockito.any())).thenReturn(manifests);
+        }
+
+        return IcebergTable.builder()
+                .setId(100)
+                .setSrTableName("tb")
+                .setCatalogName("cat")
+                .setCatalogDBName("db")
+                .setCatalogTableName("tb")
+                .setFullSchema(new ArrayList<>())
+                .setNativeTable(nativeTable)
+                .setIcebergProperties(new HashMap<>())
+                .build();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
@@ -20,17 +20,26 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.clone.DynamicPartitionScheduler;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.connector.iceberg.MockIcebergMetadata;
 import com.starrocks.scheduler.mv.pct.MVPCTRefreshProcessor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.analyzer.mv.IcebergTablePartitionHandler;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.sql.optimizer.QueryMaterializationContext;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
@@ -45,6 +54,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.function.Executable;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -55,6 +65,9 @@ import java.util.stream.Collectors;
 
 @TestMethodOrder(MethodName.class)
 public class PartitionBasedMvRefreshProcessorIcebergTest extends MVTestBase {
+
+    private static final String EVOLVED_ICEBERG_TABLE =
+            "`iceberg0`.`partitioned_transforms_db`.`t0_date_month_identity_evolution`";
 
     @BeforeAll
     public static void beforeClass() throws Exception {
@@ -672,41 +685,190 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVTestBase {
 
     @Test
     public void testRefreshMvWithIcebergPartitionEvolution() throws Exception {
-        String mvName = "iceberg_refresh_evolution_unpartitioned_mv";
-        starRocksAssert.useDatabase("test")
-                .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`" + mvName + "`\n" +
-                        "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
-                        "REFRESH DEFERRED MANUAL\n" +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\"\n" +
-                        ")\n" +
-                        "AS SELECT id, data, ts FROM `iceberg0`.`partitioned_transforms_db`."
-                        + "`t0_date_month_identity_evolution` as a;");
-
         Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
-        MaterializedView mv = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .getTable(testDb.getFullName(), mvName));
-        Assertions.assertTrue(mv.getPartitionInfo().isUnPartitioned());
+        getEvolvedIcebergTable();
+        starRocksAssert.useDatabase("test");
 
-        triggerRefreshMv(testDb, mv);
+        // an un-partitioned mv is not affected by the base table's partition evolution.
+        String mvName = "iceberg_refresh_evolution_unpartitioned_mv";
+        starRocksAssert.withMaterializedView(mvOnEvolvedIcebergTable(mvName, null), () -> {
+            MaterializedView mv = getMv(mvName);
+            Assertions.assertTrue(mv.getPartitionInfo().isUnPartitioned());
+            triggerRefreshMv(testDb, mv);
+        });
 
-        String mvName2 = "iceberg_evolution_partitioned_mv";
+        // a partitioned mv is rejected at creation time since the user has not opted in.
+        Exception e = Assertions.assertThrows(Exception.class,
+                () -> starRocksAssert.withMaterializedView(
+                        mvOnEvolvedIcebergTable("iceberg_evolution_partitioned_mv", "date_trunc('month', ts)")),
+                "Creation should fail because the Iceberg table has partition evolution");
+        Assertions.assertTrue(String.valueOf(e.getMessage()).contains("partition evolution"),
+                "Creation should be rejected by the partition-evolution check, but got: " + e.getMessage());
+    }
+
+    @Test
+    public void testRefreshMvWithIcebergPartitionEvolutionAtRefresh() {
+        boolean originalConfig = Config.enable_mv_on_iceberg_table_with_partition_evolution;
+        Config.enable_mv_on_iceberg_table_with_partition_evolution = true;
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        IcebergTable baseTable = getEvolvedIcebergTable();
+        String mvName = "iceberg_refresh_evolution_partitioned_mv";
         try {
-            starRocksAssert.useDatabase("test")
-                    .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`" + mvName2 + "`\n" +
-                            "PARTITION BY date_trunc('month', ts)\n" +
-                            "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
-                            "REFRESH DEFERRED MANUAL\n" +
-                            "PROPERTIES (\n" +
-                            "\"replication_num\" = \"1\"\n" +
-                            ")\n" +
-                            "AS SELECT id, data, ts FROM `iceberg0`.`partitioned_transforms_db`."
-                            + "`t0_date_month_identity_evolution` as a;");
-            Assertions.fail("Should fail because Iceberg table has partition evolution");
-        } catch (Exception e) {
-            Assertions.assertTrue(e.getMessage().contains("partition evolution"));
-        }
+            starRocksAssert.useDatabase("test");
+            starRocksAssert.withMaterializedView(mvOnEvolvedIcebergTable(mvName, "date_trunc('month', ts)"), () -> {
+                MaterializedView mv = getMv(mvName);
+                // Pretend the old-spec data has been fully rewritten into the current spec, otherwise the
+                // opt-in branch is never reached.
+                new MockUp<IcebergTable>() {
+                    @Mock
+                    public boolean isCurrentSnapshotAllOnCurrentSpec() {
+                        return true;
+                    }
+                };
 
-        starRocksAssert.dropMaterializedView(mvName);
+                // 1. opted in, no old-spec data left and the transform is still compatible: refresh is allowed.
+                String allowed = refreshMvAndGetError(testDb, mv);
+                Assertions.assertFalse(allowed.contains("partition evolution")
+                                || allowed.contains("partition transform has evolved"),
+                        "Refresh should have passed the partition-evolution check, but got: " + allowed);
+
+                // 2. not opted in: the refresh is rejected by MVRefreshProcessor's spec check.
+                Config.enable_mv_on_iceberg_table_with_partition_evolution = false;
+                String rejected = refreshMvAndGetError(testDb, mv);
+                Assertions.assertTrue(rejected.contains("has undergone partition evolution"),
+                        "Refresh should be rejected by MVRefreshProcessor's spec check, but got: " + rejected);
+
+                // 3. opted in, but the base table transform has evolved away from the mv's partition expr.
+                Config.enable_mv_on_iceberg_table_with_partition_evolution = true;
+                new MockUp<MaterializedView>() {
+                    @Mock
+                    public Map<Table, List<Expr>> getRefBaseTablePartitionExprs(boolean isRefreshBaseTable) {
+                        return ImmutableMap.of(baseTable, Lists.newArrayList((Expr) null));
+                    }
+
+                    @Mock
+                    public Map<Table, List<SlotRef>> getRefBaseTablePartitionSlots() {
+                        return ImmutableMap.of(baseTable, Lists.newArrayList((SlotRef) null));
+                    }
+                };
+                new MockUp<IcebergTablePartitionHandler>() {
+                    @Mock
+                    public boolean checkPartitionTransformCompatibleWithSpec(IcebergTable table,
+                                                                             Expr partitionByExpr,
+                                                                             SlotRef slotRef) {
+                        throw new SemanticException("Materialized view partition expr date_trunc('month', ts) "
+                                + "must be the same with base table partition transform DAY");
+                    }
+                };
+                String incompatible = refreshMvAndGetError(testDb, mv);
+                Assertions.assertTrue(incompatible.contains("partition transform has evolved"),
+                        "Refresh should be rejected with an evolved-transform error, but got: " + incompatible);
+            });
+        } finally {
+            Config.enable_mv_on_iceberg_table_with_partition_evolution = originalConfig;
+        }
+    }
+
+    @Test
+    public void testRefreshMvIcebergTransformChecksAllPartitionPairsAfterEvolution() {
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        IcebergTable baseTable = getEvolvedIcebergTable();
+
+        // The mv starts with 2 partition exprs but only 1 slot, the missing slot is added later on.
+        List<Expr> exprs = Lists.newArrayList((Expr) null, (Expr) null);
+        List<SlotRef> slots = Lists.newArrayList((SlotRef) null);
+        new MockUp<MaterializedView>() {
+            @Mock
+            public String getName() {
+                return "iceberg_refresh_evolution_multi_transform_incompat";
+            }
+
+            @Mock
+            public PartitionInfo getPartitionInfo() {
+                return new SinglePartitionInfo();
+            }
+
+            @Mock
+            public Map<Table, List<Expr>> getRefBaseTablePartitionExprs(boolean isRefreshBaseTable) {
+                return ImmutableMap.of(baseTable, exprs);
+            }
+
+            @Mock
+            public Map<Table, List<SlotRef>> getRefBaseTablePartitionSlots() {
+                return ImmutableMap.of(baseTable, slots);
+            }
+        };
+
+        MaterializedView mv = new MaterializedView();
+        TaskRunContext taskRunContext = new TaskRunContext();
+        taskRunContext.setCtx(connectContext);
+        taskRunContext.setProperties(new HashMap<>());
+        MVPCTRefreshProcessor processor = new MVPCTRefreshProcessor(testDb, mv,
+                new MvTaskRunContext(taskRunContext), null, mv.getCurrentRefreshMode());
+        Executable check =
+                () -> Deencapsulation.invoke(processor, "checkIcebergPartitionTransformStillCompatible", baseTable);
+
+        // 1. inconsistent expr/slot sizes are reported rather than silently checking fewer pairs.
+        Assertions.assertTrue(Assertions.assertThrows(DmlException.class, check).getMessage()
+                .contains("expressions and slots are inconsistent"));
+
+        // 2. every expr/slot pair is validated: here only the second pair is incompatible.
+        slots.add(null);
+        int[] checkedPairs = {0};
+        new MockUp<IcebergTablePartitionHandler>() {
+            @Mock
+            public boolean checkPartitionTransformCompatibleWithSpec(IcebergTable table,
+                                                                     Expr partitionByExpr,
+                                                                     SlotRef slotRef) {
+                if (++checkedPairs[0] == 2) {
+                    throw new SemanticException("Materialized view partition expr date_trunc('day', ts) "
+                            + "must be the same with base table partition transform MONTH");
+                }
+                return false;
+            }
+        };
+
+        DmlException e = Assertions.assertThrows(DmlException.class, check);
+        Assertions.assertTrue(String.valueOf(e.getMessage()).contains("partition transform has evolved"),
+                "Refresh should be rejected with an evolved-transform error from a later partition pair, but got: "
+                        + e.getMessage());
+        Assertions.assertEquals(2, checkedPairs[0],
+                "Refresh should validate every partition expression/slot pair, not just the first one");
+    }
+
+
+
+    /**
+     * Builds a mv on the partition-evolved mock iceberg table, a null {@code partitionBy} means un-partitioned.
+     */
+    private static String mvOnEvolvedIcebergTable(String mvName, String partitionBy) {
+        return "CREATE MATERIALIZED VIEW `test`.`" + mvName + "`\n"
+                + (partitionBy == null ? "" : "PARTITION BY " + partitionBy + "\n")
+                + "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n"
+                + "REFRESH DEFERRED MANUAL\n"
+                + "PROPERTIES (\"replication_num\" = \"1\")\n"
+                + "AS SELECT id, data, ts FROM " + EVOLVED_ICEBERG_TABLE + " as a;";
+    }
+
+    private static IcebergTable getEvolvedIcebergTable() {
+        IcebergTable baseTable = (IcebergTable) GlobalStateMgr.getCurrentState().getMetadataMgr()
+                .getTable(connectContext, "iceberg0", "partitioned_transforms_db",
+                        "t0_date_month_identity_evolution");
+        Assertions.assertNotNull(baseTable);
+        Assertions.assertTrue(baseTable.getNativeTable().specs().size() > 1,
+                "mock table must have >1 partition specs to exercise the evolution branch");
+        return baseTable;
+    }
+
+    /**
+     * @return the mv refresh failure message, empty if the refresh succeeded.
+     */
+    private static String refreshMvAndGetError(Database db, MaterializedView mv) {
+        try {
+            triggerRefreshMv(db, mv);
+            return "";
+        } catch (Exception e) {
+            return String.valueOf(e.getMessage());
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
@@ -31,12 +31,12 @@ import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.RuntimeProfile;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.iceberg.IcebergPartitionUtils;
 import com.starrocks.connector.iceberg.MockIcebergMetadata;
 import com.starrocks.scheduler.mv.pct.MVPCTRefreshProcessor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
-import com.starrocks.sql.analyzer.SemanticException;
-import com.starrocks.sql.analyzer.mv.IcebergTablePartitionHandler;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.common.DmlException;
@@ -751,13 +751,14 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVTestBase {
                         return ImmutableMap.of(baseTable, Lists.newArrayList((SlotRef) null));
                     }
                 };
-                new MockUp<IcebergTablePartitionHandler>() {
+                new MockUp<IcebergPartitionUtils>() {
                     @Mock
                     public boolean checkPartitionTransformCompatibleWithSpec(IcebergTable table,
                                                                              Expr partitionByExpr,
                                                                              SlotRef slotRef) {
-                        throw new SemanticException("Materialized view partition expr date_trunc('month', ts) "
-                                + "must be the same with base table partition transform DAY");
+                        throw new StarRocksConnectorException("Materialized view partition expr "
+                                + "date_trunc('month', ts) must be the same with base table partition "
+                                + "transform DAY");
                     }
                 };
                 String incompatible = refreshMvAndGetError(testDb, mv);
@@ -815,13 +816,13 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVTestBase {
         // 2. every expr/slot pair is validated: here only the second pair is incompatible.
         slots.add(null);
         int[] checkedPairs = {0};
-        new MockUp<IcebergTablePartitionHandler>() {
+        new MockUp<IcebergPartitionUtils>() {
             @Mock
             public boolean checkPartitionTransformCompatibleWithSpec(IcebergTable table,
                                                                      Expr partitionByExpr,
                                                                      SlotRef slotRef) {
                 if (++checkedPairs[0] == 2) {
-                    throw new SemanticException("Materialized view partition expr date_trunc('day', ts) "
+                    throw new StarRocksConnectorException("Materialized view partition expr date_trunc('day', ts) "
                             + "must be the same with base table partition transform MONTH");
                 }
                 return false;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
@@ -18,6 +18,7 @@ import com.google.common.base.Joiner;
 import com.starrocks.alter.AlterJobMgr;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.Table;
@@ -25,15 +26,18 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.connector.iceberg.MockIcebergMetadata;
 import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
+import com.starrocks.sql.analyzer.mv.IcebergTablePartitionHandler;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
 import com.starrocks.sql.ast.HashDistributionDesc;
 import com.starrocks.sql.ast.RandomDistributionDesc;
 import com.starrocks.sql.ast.RangeDistributionDesc;
 import com.starrocks.sql.ast.ShowStmt;
+import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.type.IntegerType;
 import com.starrocks.utframe.StarRocksAssert;
@@ -626,6 +630,83 @@ public class MaterializedViewAnalyzerTest {
         } catch (Exception e) {
             Assertions.assertTrue(e.getMessage().contains("partition evolution"));
         }
+    }
+
+    @Test
+    public void testCreateMvOnIcebergTableWithPartitionEvolutionAllowedByConfig() throws Exception {
+        // With the new switch on, and since the mocked evolution table has no data (currentSnapshot() is null,
+        // so isCurrentSnapshotAllOnCurrentSpec() returns true), creating a partitioned MV on top of the
+        // partition-evolved iceberg table should succeed.
+        boolean originalConfig = Config.enable_mv_on_iceberg_table_with_partition_evolution;
+        Config.enable_mv_on_iceberg_table_with_partition_evolution = true;
+        String partitionedMvName = "iceberg_evolution_partitioned_mv_allowed";
+        try {
+            starRocksAssert.useDatabase("test")
+                    .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`" + partitionedMvName + "`\n" +
+                            "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                            "PARTITION BY date_trunc('month', ts)\n" +
+                            "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                            "REFRESH DEFERRED MANUAL\n" +
+                            "PROPERTIES (\n" +
+                            "\"replication_num\" = \"1\"\n" +
+                            ")\n" +
+                            "AS SELECT id, data, ts FROM `iceberg0`.`partitioned_transforms_db`."
+                            + "`t0_date_month_identity_evolution` as a;");
+            Table mv = starRocksAssert.getTable("test", partitionedMvName);
+            Assertions.assertTrue(mv instanceof MaterializedView);
+            starRocksAssert.dropMaterializedView(partitionedMvName);
+        } finally {
+            Config.enable_mv_on_iceberg_table_with_partition_evolution = originalConfig;
+        }
+    }
+
+    @Test
+    public void testCreateMvOnIcebergTableIncompatibleTransformEvenWhenAllowed() throws Exception {
+        // Even with the switch on, the MV's partition expression must still match the base iceberg table's
+        // *current* partition transform. The mocked evolution table's current default spec is month("ts"),
+        // so a MV with `date_trunc('day', ts)` must still be rejected. This is the exact protection that
+        // MVRefreshProcessor also applies at refresh time via checkPartitionTransformCompatibleWithSpec:
+        // even if all live manifests are on the current spec, an incompatible transform still fails fast.
+        boolean originalConfig = Config.enable_mv_on_iceberg_table_with_partition_evolution;
+        Config.enable_mv_on_iceberg_table_with_partition_evolution = true;
+        String partitionedMvName = "iceberg_evolution_partitioned_mv_incompat";
+        try {
+            starRocksAssert.useDatabase("test")
+                    .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`" + partitionedMvName + "`\n" +
+                            "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                            "PARTITION BY date_trunc('day', ts)\n" +
+                            "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                            "REFRESH DEFERRED MANUAL\n" +
+                            "PROPERTIES (\n" +
+                            "\"replication_num\" = \"1\"\n" +
+                            ")\n" +
+                            "AS SELECT id, data, ts FROM `iceberg0`.`partitioned_transforms_db`."
+                            + "`t0_date_month_identity_evolution` as a;");
+            Assertions.fail("Should fail because MV partition expr (day) is not compatible with base table "
+                    + "current spec transform (month)");
+        } catch (Exception e) {
+            String msg = e.getMessage() == null ? "" : e.getMessage();
+            Assertions.assertTrue(msg.contains("must be the same with base table partition transform")
+                            || msg.toUpperCase().contains("MONTH"),
+                    "Unexpected error message: " + msg);
+        } finally {
+            Config.enable_mv_on_iceberg_table_with_partition_evolution = originalConfig;
+        }
+    }
+
+    @Test
+    public void testIcebergPartitionTransformCheckRejectsMissingCurrentSpecField() {
+        IcebergTable table = (IcebergTable) GlobalStateMgr.getCurrentState().getMetadataMgr()
+                .getTable(starRocksAssert.getCtx(), MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME,
+                        MockIcebergMetadata.MOCKED_PARTITIONED_TRANSFORMS_DB_NAME,
+                        MockIcebergMetadata.MOCKED_PARTITIONED_EVOLUTION_DATE_MONTH_IDENTITY_TABLE_NAME);
+        SlotRef missingCurrentSpecSlot = new SlotRef(null, "data");
+
+        SemanticException exception = Assertions.assertThrows(SemanticException.class, () ->
+                IcebergTablePartitionHandler.checkPartitionTransformCompatibleWithSpec(
+                        table, missingCurrentSpecSlot, missingCurrentSpecSlot));
+        Assertions.assertTrue(exception.getMessage().contains("is not found in current partition spec"),
+                "Unexpected error message: " + exception.getMessage());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
@@ -26,12 +26,13 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.iceberg.IcebergPartitionUtils;
 import com.starrocks.connector.iceberg.MockIcebergMetadata;
 import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
-import com.starrocks.sql.analyzer.mv.IcebergTablePartitionHandler;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
 import com.starrocks.sql.ast.HashDistributionDesc;
 import com.starrocks.sql.ast.RandomDistributionDesc;
@@ -702,8 +703,8 @@ public class MaterializedViewAnalyzerTest {
                         MockIcebergMetadata.MOCKED_PARTITIONED_EVOLUTION_DATE_MONTH_IDENTITY_TABLE_NAME);
         SlotRef missingCurrentSpecSlot = new SlotRef(null, "data");
 
-        SemanticException exception = Assertions.assertThrows(SemanticException.class, () ->
-                IcebergTablePartitionHandler.checkPartitionTransformCompatibleWithSpec(
+        StarRocksConnectorException exception = Assertions.assertThrows(StarRocksConnectorException.class, () ->
+                IcebergPartitionUtils.checkPartitionTransformCompatibleWithSpec(
                         table, missingCurrentSpecSlot, missingCurrentSpecSlot));
         Assertions.assertTrue(exception.getMessage().contains("is not found in current partition spec"),
                 "Unexpected error message: " + exception.getMessage());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
@@ -133,7 +133,7 @@ public class MaterializedViewAnalyzerTest {
             Assertions.fail();
         } catch (Exception e) {
             Assertions.assertTrue(e.getMessage().
-                    contains("Do not support create materialized view when base iceberg table partition transform "));
+                    contains("Do not support materialized view when base iceberg table partition transform is: "));
         }
     }
 
@@ -635,9 +635,6 @@ public class MaterializedViewAnalyzerTest {
 
     @Test
     public void testCreateMvOnIcebergTableWithPartitionEvolutionAllowedByConfig() throws Exception {
-        // With the new switch on, and since the mocked evolution table has no data (currentSnapshot() is null,
-        // so isCurrentSnapshotAllOnCurrentSpec() returns true), creating a partitioned MV on top of the
-        // partition-evolved iceberg table should succeed.
         boolean originalConfig = Config.enable_mv_on_iceberg_table_with_partition_evolution;
         Config.enable_mv_on_iceberg_table_with_partition_evolution = true;
         String partitionedMvName = "iceberg_evolution_partitioned_mv_allowed";
@@ -663,11 +660,6 @@ public class MaterializedViewAnalyzerTest {
 
     @Test
     public void testCreateMvOnIcebergTableIncompatibleTransformEvenWhenAllowed() throws Exception {
-        // Even with the switch on, the MV's partition expression must still match the base iceberg table's
-        // *current* partition transform. The mocked evolution table's current default spec is month("ts"),
-        // so a MV with `date_trunc('day', ts)` must still be rejected. This is the exact protection that
-        // MVRefreshProcessor also applies at refresh time via checkPartitionTransformCompatibleWithSpec:
-        // even if all live manifests are on the current spec, an incompatible transform still fails fast.
         boolean originalConfig = Config.enable_mv_on_iceberg_table_with_partition_evolution;
         Config.enable_mv_on_iceberg_table_with_partition_evolution = true;
         String partitionedMvName = "iceberg_evolution_partitioned_mv_incompat";


### PR DESCRIPTION

## Why I'm doing:
Currently StarRocks unconditionally rejects both **CREATE MV** and **MV refresh** whenever the base iceberg table has more than one partition spec (i.e. has ever done partition evolution):

```
ER_PARSE_ERROR: Getting analyzing error. Detail message: Do not support create materialized view when base iceberg table xxxx has done partition evolution.
```

This is overly strict. In many real cases the user has already rewritten (`REWRITE DATA` /`REWRITE MANIFESTS`) all the historical-spec data files into the current spec, so only the **metadata** still keeps the historical `PartitionSpec` entries — every live manifest under the current snapshot is already on the current spec, and it is perfectly safe to build / refresh an
MV on top of it.

The current behavior forces users to either drop history or give up MV entirely on such tables.


## What I'm doing:

1. Add a new FE config switch (default `false`, backward compatible): enable_mv_on_iceberg_table_with_partition_evolution



2. Add a helper `IcebergTable#isCurrentSnapshotAllOnCurrentSpec()` which walks all manifests of the current snapshot and returns `true` iff every manifest's `partitionSpecId()` equals the  current spec id. If the table has only one spec, or has no current snapshot, it returns `true`.

3. Unify the check at all three places that used to reject partition-evolved tables:
   - `MaterializedViewAnalyzer#checkBaseTables` (CREATE MV analyze)
   - `IcebergTablePartitionHandler#checkPartitionColumn` (CREATE MV partition column check)
   - `MVRefreshProcessor#collectBaseTableSnapshotInfos` (async MV refresh)

Fixes https://github.com/StarRocks/starrocks/issues/77878

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5