### PR TITLE
[Enhancement] Implement statistics propagation for CONVERT_TZ operator

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ConvertTzStatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ConvertTzStatisticUtils.java
@@ -24,6 +24,7 @@ import com.starrocks.type.VarcharType;
 
 import java.time.DateTimeException;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.zone.ZoneOffsetTransition;
 import java.time.zone.ZoneRules;
@@ -62,14 +63,23 @@ public final class ConvertTzStatisticUtils {
      * the whole input range. Around a DST transition the mapping is not monotonic in wall-clock space,
      * e.g. UTC 00:30 and 01:30 both map to Europe/Berlin 02:30 on 2024-10-27 while 00:59 maps to 02:59,
      * so converting only the endpoints would under-range the result.
+     *
+     * {@code LocalDateTime.atZone} also skips spring-forward gaps and picks one offset in fall-back
+     * overlaps, so an instant interval built from the endpoints can miss the transition entirely.
+     * If either endpoint is skipped or ambiguous in {@code fromTz}, keep the widened range.
      */
     public static boolean hasTimezoneOffsetDrift(double minValue, double maxValue,
                                                  ConstantOperator fromTz, ConstantOperator toTz) {
         try {
             ZoneId from = ZoneId.of(fromTz.getVarchar());
             ZoneId to = ZoneId.of(toTz.getVarchar());
-            Instant minInstant = Utils.getDatetimeFromLong((long) minValue).atZone(from).toInstant();
-            Instant maxInstant = Utils.getDatetimeFromLong((long) maxValue).atZone(from).toInstant();
+            LocalDateTime minLocal = Utils.getDatetimeFromLong((long) minValue);
+            LocalDateTime maxLocal = Utils.getDatetimeFromLong((long) maxValue);
+            if (isSkippedOrAmbiguous(from, minLocal) || isSkippedOrAmbiguous(from, maxLocal)) {
+                return true;
+            }
+            Instant minInstant = minLocal.atZone(from).toInstant();
+            Instant maxInstant = maxLocal.atZone(from).toInstant();
             Instant start = minInstant.isAfter(maxInstant) ? maxInstant : minInstant;
             Instant end = minInstant.isAfter(maxInstant) ? minInstant : maxInstant;
             return hasOffsetTransition(from, start, end) || hasOffsetTransition(to, start, end);
@@ -77,6 +87,10 @@ public final class ConvertTzStatisticUtils {
             // Invalid zone id or out-of-range temporal value: keep the widened range.
             return true;
         }
+    }
+
+    private static boolean isSkippedOrAmbiguous(ZoneId zone, LocalDateTime localDateTime) {
+        return zone.getRules().getValidOffsets(localDateTime).size() != 1;
     }
 
     private static boolean hasOffsetTransition(ZoneId zone, Instant start, Instant end) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ConvertTzStatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ConvertTzStatisticUtils.java
@@ -115,7 +115,7 @@ public final class ConvertTzStatisticUtils {
             ConstantOperator converted;
             try {
                 converted = ScalarOperatorFunctions.convert_tz(parsedKey.get(), fromTz.get(), toTz.get());
-            } catch (DateTimeException e) {
+            } catch (DateTimeException | SemanticException e) {
                 return Optional.empty();
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ConvertTzStatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ConvertTzStatisticUtils.java
@@ -1,0 +1,161 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.statistics;
+
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorFunctions;
+import com.starrocks.type.Type;
+import com.starrocks.type.VarcharType;
+
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.zone.ZoneOffsetTransition;
+import java.time.zone.ZoneRules;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalDouble;
+
+/**
+ * Convert_tz-specific helpers used by {@link ExpressionStatisticCalculator}.
+ * Orchestration (NDV, nulls, assembling {@link ColumnStatistic}) stays in the calculator.
+ */
+public final class ConvertTzStatisticUtils {
+    // Timezone offsets differ by at most 26 hours
+    // (see ExtractRangePredicateFromScalarApplyRule).
+    public static final double MAX_TIMEZONE_OFFSET_SECONDS = 26.0 * 3600.0;
+
+    private ConvertTzStatisticUtils() {
+    }
+
+    public static OptionalDouble convertTzDateTime(double dateTimeStat, ConstantOperator fromTz,
+                                                   ConstantOperator toTz) {
+        try {
+            ConstantOperator input = ConstantOperator.createDatetime(Utils.getDatetimeFromLong((long) dateTimeStat));
+            ConstantOperator converted = ScalarOperatorFunctions.convert_tz(input, fromTz, toTz);
+            return OptionalDouble.of(Utils.getLongFromDateTime(converted.getDatetime()));
+        } catch (DateTimeException | SemanticException e) {
+            return OptionalDouble.empty();
+        }
+    }
+
+    /**
+     * convert_tz is only a constant wall-clock shift while both zones keep the same UTC offset over
+     * the whole input range. Around a DST transition the mapping is not monotonic in wall-clock space,
+     * e.g. UTC 00:30 and 01:30 both map to Europe/Berlin 02:30 on 2024-10-27 while 00:59 maps to 02:59,
+     * so converting only the endpoints would under-range the result.
+     */
+    public static boolean hasTimezoneOffsetDrift(double minValue, double maxValue,
+                                                 ConstantOperator fromTz, ConstantOperator toTz) {
+        try {
+            ZoneId from = ZoneId.of(fromTz.getVarchar());
+            ZoneId to = ZoneId.of(toTz.getVarchar());
+            Instant minInstant = Utils.getDatetimeFromLong((long) minValue).atZone(from).toInstant();
+            Instant maxInstant = Utils.getDatetimeFromLong((long) maxValue).atZone(from).toInstant();
+            Instant start = minInstant.isAfter(maxInstant) ? maxInstant : minInstant;
+            Instant end = minInstant.isAfter(maxInstant) ? minInstant : maxInstant;
+            return hasOffsetTransition(from, start, end) || hasOffsetTransition(to, start, end);
+        } catch (DateTimeException e) {
+            // Invalid zone id or out-of-range temporal value: keep the widened range.
+            return true;
+        }
+    }
+
+    private static boolean hasOffsetTransition(ZoneId zone, Instant start, Instant end) {
+        ZoneRules rules = zone.getRules();
+        if (!rules.getOffset(start).equals(rules.getOffset(end))) {
+            return true;
+        }
+        ZoneOffsetTransition next = rules.nextTransition(start);
+        return next != null && !next.getInstant().isAfter(end);
+    }
+
+    public static Optional<Histogram> transformHistogram(CallOperator callOperator,
+                                                         ColumnStatistic childStats,
+                                                         double minValue, double maxValue,
+                                                         double rowCount) {
+        Histogram hist = childStats == null ? null : childStats.getHistogram();
+        if (hist == null || hist.getMCV().isEmpty()) {
+            return Optional.empty();
+        }
+
+        Optional<ConstantOperator> fromTz = toConstantOperator(callOperator.getChild(1));
+        Optional<ConstantOperator> toTz = toConstantOperator(callOperator.getChild(2));
+        if (fromTz.isEmpty() || toTz.isEmpty()) {
+            return Optional.empty();
+        }
+
+        final Type resultType = callOperator.getType();
+        Map<String, Long> newMcv = new HashMap<>();
+        for (Map.Entry<String, Long> entry : hist.getMCV().entrySet()) {
+            Optional<ConstantOperator> parsedKey =
+                    ConstantOperator.createVarchar(entry.getKey()).castTo(resultType);
+            if (parsedKey.isEmpty() || parsedKey.get().isNull()) {
+                return Optional.empty();
+            }
+
+            ConstantOperator converted;
+            try {
+                converted = ScalarOperatorFunctions.convert_tz(parsedKey.get(), fromTz.get(), toTz.get());
+            } catch (DateTimeException e) {
+                return Optional.empty();
+            }
+
+            Optional<ConstantOperator> keyString = converted.castTo(VarcharType.VARCHAR);
+            if (keyString.isEmpty()) {
+                return Optional.empty();
+            }
+            newMcv.merge(keyString.get().getVarchar(), entry.getValue(), Long::sum);
+        }
+
+        // Exact per-key MCV transform; keep one covering bucket for the non-MCV mass
+        // (same idea as HistogramStatisticsCollectJob.buildCollectSingleBucket in stats collection).
+        return Optional.of(buildSingleBucketHistogram(minValue, maxValue, rowCount, newMcv));
+    }
+
+    /**
+     * Build an MCV histogram with a single covering bucket for the remaining non-MCV rows.
+     * Mirrors the stats-collection fallback that stores one bucket over [min, max] with
+     * count = totalRows - sum(MCV) when a full multi-bucket histogram is unavailable.
+     */
+    public static Histogram buildSingleBucketHistogram(double minValue, double maxValue,
+                                                       double totalRows, Map<String, Long> mcv) {
+        if (Double.isInfinite(minValue) || Double.isInfinite(maxValue)
+                || Double.isNaN(minValue) || Double.isNaN(maxValue)) {
+            return new Histogram(Collections.emptyList(), mcv);
+        }
+        long mcvRows = mcv.values().stream().mapToLong(Long::longValue).sum();
+        long nonMcvRows = Math.max(0L, Math.round(totalRows) - mcvRows);
+        List<Bucket> buckets = List.of(new Bucket(minValue, maxValue, nonMcvRows, 0L));
+        return new Histogram(buckets, mcv);
+    }
+
+    private static Optional<ConstantOperator> toConstantOperator(ScalarOperator op) {
+        if (op == null || !op.isConstant() || op.isConstantNull()) {
+            return Optional.empty();
+        }
+        if (op instanceof ConstantOperator) {
+            return Optional.of((ConstantOperator) op);
+        }
+        return Optional.empty();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ConvertTzStatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ConvertTzStatisticUtils.java
@@ -89,6 +89,15 @@ public final class ConvertTzStatisticUtils {
         }
     }
 
+    public static boolean isValidTimeZone(ConstantOperator tz) {
+        try {
+            ZoneId.of(tz.getVarchar());
+            return true;
+        } catch (DateTimeException e) {
+            return false;
+        }
+    }
+
     private static boolean isSkippedOrAmbiguous(ZoneId zone, LocalDateTime localDateTime) {
         return zone.getRules().getValidOffsets(localDateTime).size() != 1;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ConvertTzStatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ConvertTzStatisticUtils.java
@@ -18,7 +18,6 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorFunctions;
 import com.starrocks.type.Type;
 import com.starrocks.type.VarcharType;
@@ -92,14 +91,14 @@ public final class ConvertTzStatisticUtils {
     public static Optional<Histogram> transformHistogram(CallOperator callOperator,
                                                          ColumnStatistic childStats,
                                                          double minValue, double maxValue,
-                                                         double rowCount) {
+                                                         double rowCount,
+                                                         Optional<ConstantOperator> fromTz,
+                                                         Optional<ConstantOperator> toTz) {
         Histogram hist = childStats == null ? null : childStats.getHistogram();
         if (hist == null || hist.getMCV().isEmpty()) {
             return Optional.empty();
         }
 
-        Optional<ConstantOperator> fromTz = toConstantOperator(callOperator.getChild(1));
-        Optional<ConstantOperator> toTz = toConstantOperator(callOperator.getChild(2));
         if (fromTz.isEmpty() || toTz.isEmpty()) {
             return Optional.empty();
         }
@@ -147,15 +146,5 @@ public final class ConvertTzStatisticUtils {
         long nonMcvRows = Math.max(0L, Math.round(totalRows) - mcvRows);
         List<Bucket> buckets = List.of(new Bucket(minValue, maxValue, nonMcvRows, 0L));
         return new Histogram(buckets, mcv);
-    }
-
-    private static Optional<ConstantOperator> toConstantOperator(ScalarOperator op) {
-        if (op == null || !op.isConstant() || op.isConstantNull()) {
-            return Optional.empty();
-        }
-        if (op instanceof ConstantOperator) {
-            return Optional.of((ConstantOperator) op);
-        }
-        return Optional.empty();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -47,14 +47,11 @@ import org.apache.logging.log4j.Logger;
 
 import java.math.BigInteger;
 import java.time.DateTimeException;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.IsoFields;
-import java.time.zone.ZoneOffsetTransition;
-import java.time.zone.ZoneRules;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -1056,54 +1053,10 @@ public class ExpressionStatisticCalculator {
 
         }
 
-        private OptionalDouble convertTzDateTime(double dateTimeStat, ConstantOperator fromTz, ConstantOperator toTz) {
-            try {
-                ConstantOperator input = ConstantOperator.createDatetime(Utils.getDatetimeFromLong((long) dateTimeStat));
-                ConstantOperator converted = ScalarOperatorFunctions.convert_tz(input, fromTz, toTz);
-                return OptionalDouble.of(Utils.getLongFromDateTime(converted.getDatetime()));
-            } catch (Exception e) {
-                return OptionalDouble.empty();
-            }
-        }
-
-        /**
-         * convert_tz is only a constant wall-clock shift while both zones keep the same UTC offset over
-         * the whole input range. Around a DST transition the mapping is not monotonic in wall-clock space,
-         * e.g. UTC 00:30 and 01:30 both map to Europe/Berlin 02:30 on 2024-10-27 while 00:59 maps to 02:59,
-         * so converting only the endpoints would under-range the result.
-         */
-        private boolean hasTimezoneOffsetDrift(double minValue, double maxValue,
-                                               ConstantOperator fromTz, ConstantOperator toTz) {
-            try {
-                ZoneId from = ZoneId.of(fromTz.getVarchar());
-                ZoneId to = ZoneId.of(toTz.getVarchar());
-                Instant minInstant = Utils.getDatetimeFromLong((long) minValue).atZone(from).toInstant();
-                Instant maxInstant = Utils.getDatetimeFromLong((long) maxValue).atZone(from).toInstant();
-                Instant start = minInstant.isAfter(maxInstant) ? maxInstant : minInstant;
-                Instant end = minInstant.isAfter(maxInstant) ? minInstant : maxInstant;
-                return hasOffsetTransition(from, start, end) || hasOffsetTransition(to, start, end);
-            } catch (DateTimeException e) {
-                // Invalid zone id or out-of-range temporal value: keep the widened range.
-                return true;
-            }
-        }
-
-        private boolean hasOffsetTransition(ZoneId zone, Instant start, Instant end) {
-            ZoneRules rules = zone.getRules();
-            if (!rules.getOffset(start).equals(rules.getOffset(end))) {
-                return true;
-            }
-            ZoneOffsetTransition next = rules.nextTransition(start);
-            return next != null && !next.getInstant().isAfter(end);
-        }
-
         private ColumnStatistic calcConvertTzStats(List<ColumnStatistic> inputs, CallOperator callOperator) {
-            // Timezone offsets differ by at most 26 hours
-            // (see ExtractRangePredicateFromScalarApplyRule).
             ColumnStatistic childStat = inputs.get(0);
             ColumnStatistic fromTzStat = inputs.get(1);
             ColumnStatistic toTzStat = inputs.get(2);
-            final double maxOffset = 26.0 * 3600.0;
 
             final double distinctValues = Math.min(rowCount,
                     childStat.getDistinctValuesCount()
@@ -1115,17 +1068,19 @@ public class ExpressionStatisticCalculator {
                     * (1.0 - fromTzStat.getNullsFraction())
                     * (1.0 - toTzStat.getNullsFraction());
 
-            double minValue = childStat.getMinValue() - maxOffset;
-            double maxValue = childStat.getMaxValue() + maxOffset;
+            double minValue = childStat.getMinValue() - ConvertTzStatisticUtils.MAX_TIMEZONE_OFFSET_SECONDS;
+            double maxValue = childStat.getMaxValue() + ConvertTzStatisticUtils.MAX_TIMEZONE_OFFSET_SECONDS;
 
             Optional<ConstantOperator> fromTz = toConstantOperator(callOperator.getChild(1));
             Optional<ConstantOperator> toTz = toConstantOperator(callOperator.getChild(2));
             if (fromTz.isPresent() && toTz.isPresent()
                     && !childStat.hasNaNValue() && !childStat.isInfiniteRange()
-                    && !hasTimezoneOffsetDrift(childStat.getMinValue(), childStat.getMaxValue(),
+                    && !ConvertTzStatisticUtils.hasTimezoneOffsetDrift(childStat.getMinValue(), childStat.getMaxValue(),
                             fromTz.get(), toTz.get())) {
-                OptionalDouble convertedMin = convertTzDateTime(childStat.getMinValue(), fromTz.get(), toTz.get());
-                OptionalDouble convertedMax = convertTzDateTime(childStat.getMaxValue(), fromTz.get(), toTz.get());
+                OptionalDouble convertedMin =
+                        ConvertTzStatisticUtils.convertTzDateTime(childStat.getMinValue(), fromTz.get(), toTz.get());
+                OptionalDouble convertedMax =
+                        ConvertTzStatisticUtils.convertTzDateTime(childStat.getMaxValue(), fromTz.get(), toTz.get());
                 if (convertedMin.isPresent() && convertedMax.isPresent()) {
                     minValue = Math.min(convertedMin.getAsDouble(), convertedMax.getAsDouble());
                     maxValue = Math.max(convertedMin.getAsDouble(), convertedMax.getAsDouble());
@@ -1138,8 +1093,8 @@ public class ExpressionStatisticCalculator {
                     .setNullsFraction(nullsFraction)
                     .setAverageRowSize(callOperator.getType().getTypeSize())
                     .setDistinctValuesCount(distinctValues)
-                    .setHistogram(transformHistogramForConvertTz(callOperator, childStat, minValue, maxValue)
-                            .orElse(null))
+                    .setHistogram(ConvertTzStatisticUtils.transformHistogram(
+                            callOperator, childStat, minValue, maxValue, rowCount).orElse(null))
                     .build();
         }
 
@@ -1556,65 +1511,6 @@ public class ExpressionStatisticCalculator {
             } else {
                 return max.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR) - min.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR) + 1;
             }
-        }
-
-        private Optional<Histogram> transformHistogramForConvertTz(CallOperator callOperator,
-                                                                  ColumnStatistic childStats,
-                                                                  double minValue, double maxValue) {
-            Histogram hist = childStats == null ? null : childStats.getHistogram();
-            if (hist == null || hist.getMCV().isEmpty()) {
-                return Optional.empty();
-            }
-
-            Optional<ConstantOperator> fromTz = toConstantOperator(callOperator.getChild(1));
-            Optional<ConstantOperator> toTz = toConstantOperator(callOperator.getChild(2));
-            if (fromTz.isEmpty() || toTz.isEmpty()) {
-                return Optional.empty();
-            }
-
-            final Type resultType = callOperator.getType();
-            Map<String, Long> newMcv = new HashMap<>();
-            for (Map.Entry<String, Long> entry : hist.getMCV().entrySet()) {
-                Optional<ConstantOperator> parsedKey =
-                        ConstantOperator.createVarchar(entry.getKey()).castTo(resultType);
-                if (parsedKey.isEmpty() || parsedKey.get().isNull()) {
-                    return Optional.empty();
-                }
-
-                ConstantOperator converted;
-                try {
-                    converted = ScalarOperatorFunctions.convert_tz(parsedKey.get(), fromTz.get(), toTz.get());
-                } catch (Exception e) {
-                    return Optional.empty();
-                }
-
-                Optional<ConstantOperator> keyString = converted.castTo(VarcharType.VARCHAR);
-                if (keyString.isEmpty()) {
-                    return Optional.empty();
-                }
-                newMcv.merge(keyString.get().getVarchar(), entry.getValue(), Long::sum);
-            }
-
-            // Exact per-key MCV transform; keep one covering bucket for the non-MCV mass
-            // (same idea as HistogramStatisticsCollectJob.buildCollectSingleBucket in stats collection).
-            return Optional.of(buildSingleBucketHistogram(minValue, maxValue, rowCount, newMcv));
-        }
-
-        /**
-         * Build an MCV histogram with a single covering bucket for the remaining non-MCV rows.
-         * Mirrors the stats-collection fallback that stores one bucket over [min, max] with
-         * count = totalRows - sum(MCV) when a full multi-bucket histogram is unavailable.
-         */
-        private Histogram buildSingleBucketHistogram(double minValue, double maxValue,
-                                                     double totalRows, Map<String, Long> mcv) {
-            if (Double.isInfinite(minValue) || Double.isInfinite(maxValue)
-                    || Double.isNaN(minValue) || Double.isNaN(maxValue)) {
-                return new Histogram(Collections.emptyList(), mcv);
-            }
-            long mcvRows = mcv.values().stream().mapToLong(Long::longValue).sum();
-            long nonMcvRows = Math.max(0L, Math.round(totalRows) - mcvRows);
-            List<Bucket> buckets = List.of(new Bucket(minValue, maxValue, nonMcvRows, 0L));
-            return new Histogram(buckets, mcv);
         }
 
         /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -1097,7 +1097,8 @@ public class ExpressionStatisticCalculator {
                     .setNullsFraction(childStat.getNullsFraction())
                     .setAverageRowSize(callOperator.getType().getTypeSize())
                     .setDistinctValuesCount(distinctValues)
-                    .setHistogram(transformHistogramForConvertTz(callOperator, childStat).orElse(null))
+                    .setHistogram(transformHistogramForConvertTz(callOperator, childStat, minValue, maxValue)
+                            .orElse(null))
                     .build();
         }
 
@@ -1517,7 +1518,8 @@ public class ExpressionStatisticCalculator {
         }
 
         private Optional<Histogram> transformHistogramForConvertTz(CallOperator callOperator,
-                                                                  ColumnStatistic childStats) {
+                                                                  ColumnStatistic childStats,
+                                                                  double minValue, double maxValue) {
             Histogram hist = childStats == null ? null : childStats.getHistogram();
             if (hist == null || hist.getMCV().isEmpty()) {
                 return Optional.empty();
@@ -1552,8 +1554,26 @@ public class ExpressionStatisticCalculator {
                 newMcv.merge(keyString.get().getVarchar(), entry.getValue(), Long::sum);
             }
 
-            // MCV only: convert_tz is not a uniform bucket shift under DST.
-            return Optional.of(new Histogram(Collections.emptyList(), newMcv));
+            // Exact per-key MCV transform; keep one covering bucket for the non-MCV mass
+            // (same idea as HistogramStatisticsCollectJob.buildCollectSingleBucket in stats collection).
+            return Optional.of(buildSingleBucketHistogram(minValue, maxValue, rowCount, newMcv));
+        }
+
+        /**
+         * Build an MCV histogram with a single covering bucket for the remaining non-MCV rows.
+         * Mirrors the stats-collection fallback that stores one bucket over [min, max] with
+         * count = totalRows - sum(MCV) when a full multi-bucket histogram is unavailable.
+         */
+        private Histogram buildSingleBucketHistogram(double minValue, double maxValue,
+                                                     double totalRows, Map<String, Long> mcv) {
+            if (Double.isInfinite(minValue) || Double.isInfinite(maxValue)
+                    || Double.isNaN(minValue) || Double.isNaN(maxValue)) {
+                return new Histogram(Collections.emptyList(), mcv);
+            }
+            long mcvRows = mcv.values().stream().mapToLong(Long::longValue).sum();
+            long nonMcvRows = Math.max(0L, Math.round(totalRows) - mcvRows);
+            List<Bucket> buckets = List.of(new Bucket(minValue, maxValue, nonMcvRows, 0L));
+            return new Histogram(buckets, mcv);
         }
 
         /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -1299,6 +1299,27 @@ public class ExpressionStatisticCalculator {
             double averageRowSize;
             double nullsFraction;
             switch (callOperator.getFnName().toLowerCase()) {
+                case FunctionSet.CONVERT_TZ:
+                    // Timezone offsets differ by at most 26 hours
+                    // (see ExtractRangePredicateFromScalarApplyRule).
+                    ColumnStatistic childStat = childColumnStatisticList.get(0);
+                    ColumnStatistic fromTzStat = childColumnStatisticList.get(1);
+                    ColumnStatistic toTzStat = childColumnStatisticList.get(2);
+                    final double maxOffset = 26.0 * 3600.0;
+
+                    distinctValues = Math.min(rowCount,
+                            childStat.getDistinctValuesCount()
+                                    * fromTzStat.getDistinctValuesCount()
+                                    * toTzStat.getDistinctValuesCount());
+
+                    return ColumnStatistic.builder()
+                            .setMinValue(childStat.getMinValue() - maxOffset)
+                            .setMaxValue(childStat.getMaxValue() + maxOffset)
+                            .setNullsFraction(childStat.getNullsFraction())
+                            .setAverageRowSize(callOperator.getType().getTypeSize())
+                            .setDistinctValuesCount(distinctValues)
+                            .setHistogram(transformHistogramForConvertTz(callOperator, childStat).orElse(null))
+                            .build();
                 case FunctionSet.COALESCE:
                     return calcCoalesceStats(childColumnStatisticList, callOperator);
                 case FunctionSet.IF:
@@ -1464,6 +1485,46 @@ public class ExpressionStatisticCalculator {
             } else {
                 return max.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR) - min.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR) + 1;
             }
+        }
+
+        private Optional<Histogram> transformHistogramForConvertTz(CallOperator callOperator,
+                                                                  ColumnStatistic childStats) {
+            Histogram hist = childStats == null ? null : childStats.getHistogram();
+            if (hist == null || hist.getMCV().isEmpty()) {
+                return Optional.empty();
+            }
+
+            Optional<ConstantOperator> fromTz = toConstantOperator(callOperator.getChild(1));
+            Optional<ConstantOperator> toTz = toConstantOperator(callOperator.getChild(2));
+            if (fromTz.isEmpty() || toTz.isEmpty()) {
+                return Optional.empty();
+            }
+
+            final Type resultType = callOperator.getType();
+            Map<String, Long> newMcv = new HashMap<>();
+            for (Map.Entry<String, Long> entry : hist.getMCV().entrySet()) {
+                Optional<ConstantOperator> parsedKey =
+                        ConstantOperator.createVarchar(entry.getKey()).castTo(resultType);
+                if (parsedKey.isEmpty() || parsedKey.get().isNull()) {
+                    return Optional.empty();
+                }
+
+                ConstantOperator converted;
+                try {
+                    converted = ScalarOperatorFunctions.convert_tz(parsedKey.get(), fromTz.get(), toTz.get());
+                } catch (Exception e) {
+                    return Optional.empty();
+                }
+
+                Optional<ConstantOperator> keyString = converted.castTo(VarcharType.VARCHAR);
+                if (keyString.isEmpty()) {
+                    return Optional.empty();
+                }
+                newMcv.merge(keyString.get().getVarchar(), entry.getValue(), Long::sum);
+            }
+
+            // MCV only: convert_tz is not a uniform bucket shift under DST.
+            return Optional.of(new Histogram(Collections.emptyList(), newMcv));
         }
 
         /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -1058,15 +1058,16 @@ public class ExpressionStatisticCalculator {
             ColumnStatistic fromTzStat = inputs.get(1);
             ColumnStatistic toTzStat = inputs.get(2);
 
-            final double distinctValues = Math.min(rowCount,
-                    childStat.getDistinctValuesCount()
-                            * fromTzStat.getDistinctValuesCount()
-                            * toTzStat.getDistinctValuesCount());
-
             final double nullsFraction = 1.0
                     - (1.0 - childStat.getNullsFraction())
                     * (1.0 - fromTzStat.getNullsFraction())
                     * (1.0 - toTzStat.getNullsFraction());
+            final double nonNullRowCount = rowCount * (1.0 - nullsFraction);
+
+            final double distinctValues = Math.min(nonNullRowCount,
+                    childStat.getDistinctValuesCount()
+                            * fromTzStat.getDistinctValuesCount()
+                            * toTzStat.getDistinctValuesCount());
 
             double minValue = childStat.getMinValue() - ConvertTzStatisticUtils.MAX_TIMEZONE_OFFSET_SECONDS;
             double maxValue = childStat.getMaxValue() + ConvertTzStatisticUtils.MAX_TIMEZONE_OFFSET_SECONDS;
@@ -1094,7 +1095,7 @@ public class ExpressionStatisticCalculator {
                     .setAverageRowSize(callOperator.getType().getTypeSize())
                     .setDistinctValuesCount(distinctValues)
                     .setHistogram(ConvertTzStatisticUtils.transformHistogram(
-                            callOperator, childStat, minValue, maxValue, rowCount).orElse(null))
+                            callOperator, childStat, minValue, maxValue, nonNullRowCount).orElse(null))
                     .build();
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -1058,6 +1058,19 @@ public class ExpressionStatisticCalculator {
             ColumnStatistic fromTzStat = inputs.get(1);
             ColumnStatistic toTzStat = inputs.get(2);
 
+            Optional<ConstantOperator> fromTz = toConstantOperator(callOperator.getChild(1));
+            Optional<ConstantOperator> toTz = toConstantOperator(callOperator.getChild(2));
+            // Invalid constant zones are not folded when the datetime is a column, but the BE
+            // returns NULL for every row (convert_tz_prepare sets is_valid=false).
+            if ((fromTz.isPresent() && !ConvertTzStatisticUtils.isValidTimeZone(fromTz.get()))
+                    || (toTz.isPresent() && !ConvertTzStatisticUtils.isValidTimeZone(toTz.get()))) {
+                return ColumnStatistic.builder()
+                        .setNullsFraction(1.0)
+                        .setAverageRowSize(callOperator.getType().getTypeSize())
+                        .setDistinctValuesCount(0)
+                        .build();
+            }
+
             final double nullsFraction = 1.0
                     - (1.0 - childStat.getNullsFraction())
                     * (1.0 - fromTzStat.getNullsFraction())
@@ -1072,8 +1085,6 @@ public class ExpressionStatisticCalculator {
             double minValue = childStat.getMinValue() - ConvertTzStatisticUtils.MAX_TIMEZONE_OFFSET_SECONDS;
             double maxValue = childStat.getMaxValue() + ConvertTzStatisticUtils.MAX_TIMEZONE_OFFSET_SECONDS;
 
-            Optional<ConstantOperator> fromTz = toConstantOperator(callOperator.getChild(1));
-            Optional<ConstantOperator> toTz = toConstantOperator(callOperator.getChild(2));
             if (fromTz.isPresent() && toTz.isPresent()
                     && !childStat.hasNaNValue() && !childStat.isInfiniteRange()
                     && !ConvertTzStatisticUtils.hasTimezoneOffsetDrift(childStat.getMinValue(), childStat.getMaxValue(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -1109,6 +1109,11 @@ public class ExpressionStatisticCalculator {
                             * fromTzStat.getDistinctValuesCount()
                             * toTzStat.getDistinctValuesCount());
 
+            final double nullsFraction = 1.0
+                    - (1.0 - childStat.getNullsFraction())
+                    * (1.0 - fromTzStat.getNullsFraction())
+                    * (1.0 - toTzStat.getNullsFraction());
+
             double minValue = childStat.getMinValue() - maxOffset;
             double maxValue = childStat.getMaxValue() + maxOffset;
 
@@ -1129,7 +1134,7 @@ public class ExpressionStatisticCalculator {
             return ColumnStatistic.builder()
                     .setMinValue(minValue)
                     .setMaxValue(maxValue)
-                    .setNullsFraction(childStat.getNullsFraction())
+                    .setNullsFraction(nullsFraction)
                     .setAverageRowSize(callOperator.getType().getTypeSize())
                     .setDistinctValuesCount(distinctValues)
                     .setHistogram(transformHistogramForConvertTz(callOperator, childStat, minValue, maxValue)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -1095,7 +1095,8 @@ public class ExpressionStatisticCalculator {
                     .setAverageRowSize(callOperator.getType().getTypeSize())
                     .setDistinctValuesCount(distinctValues)
                     .setHistogram(ConvertTzStatisticUtils.transformHistogram(
-                            callOperator, childStat, minValue, maxValue, nonNullRowCount).orElse(null))
+                            callOperator, childStat, minValue, maxValue, nonNullRowCount, fromTz, toTz)
+                            .orElse(null))
                     .build();
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -1053,6 +1053,54 @@ public class ExpressionStatisticCalculator {
 
         }
 
+        private OptionalDouble convertTzDateTime(double dateTimeStat, ConstantOperator fromTz, ConstantOperator toTz) {
+            try {
+                ConstantOperator input = ConstantOperator.createDatetime(Utils.getDatetimeFromLong((long) dateTimeStat));
+                ConstantOperator converted = ScalarOperatorFunctions.convert_tz(input, fromTz, toTz);
+                return OptionalDouble.of(Utils.getLongFromDateTime(converted.getDatetime()));
+            } catch (Exception e) {
+                return OptionalDouble.empty();
+            }
+        }
+
+        private ColumnStatistic calcConvertTzStats(List<ColumnStatistic> inputs, CallOperator callOperator) {
+            // Timezone offsets differ by at most 26 hours
+            // (see ExtractRangePredicateFromScalarApplyRule).
+            ColumnStatistic childStat = inputs.get(0);
+            ColumnStatistic fromTzStat = inputs.get(1);
+            ColumnStatistic toTzStat = inputs.get(2);
+            final double maxOffset = 26.0 * 3600.0;
+
+            final double distinctValues = Math.min(rowCount,
+                    childStat.getDistinctValuesCount()
+                            * fromTzStat.getDistinctValuesCount()
+                            * toTzStat.getDistinctValuesCount());
+
+            double minValue = childStat.getMinValue() - maxOffset;
+            double maxValue = childStat.getMaxValue() + maxOffset;
+
+            Optional<ConstantOperator> fromTz = toConstantOperator(callOperator.getChild(1));
+            Optional<ConstantOperator> toTz = toConstantOperator(callOperator.getChild(2));
+            if (fromTz.isPresent() && toTz.isPresent()
+                    && !childStat.hasNaNValue() && !childStat.isInfiniteRange()) {
+                OptionalDouble convertedMin = convertTzDateTime(childStat.getMinValue(), fromTz.get(), toTz.get());
+                OptionalDouble convertedMax = convertTzDateTime(childStat.getMaxValue(), fromTz.get(), toTz.get());
+                if (convertedMin.isPresent() && convertedMax.isPresent()) {
+                    minValue = Math.min(convertedMin.getAsDouble(), convertedMax.getAsDouble());
+                    maxValue = Math.max(convertedMin.getAsDouble(), convertedMax.getAsDouble());
+                }
+            }
+
+            return ColumnStatistic.builder()
+                    .setMinValue(minValue)
+                    .setMaxValue(maxValue)
+                    .setNullsFraction(childStat.getNullsFraction())
+                    .setAverageRowSize(callOperator.getType().getTypeSize())
+                    .setDistinctValuesCount(distinctValues)
+                    .setHistogram(transformHistogramForConvertTz(callOperator, childStat).orElse(null))
+                    .build();
+        }
+
         private ColumnStatistic calcCoalesceStats(List<ColumnStatistic> inputs, CallOperator callOperator) {
             double nullsFraction = inputs.stream()
                     .mapToDouble(ColumnStatistic::getNullsFraction)
@@ -1300,26 +1348,7 @@ public class ExpressionStatisticCalculator {
             double nullsFraction;
             switch (callOperator.getFnName().toLowerCase()) {
                 case FunctionSet.CONVERT_TZ:
-                    // Timezone offsets differ by at most 26 hours
-                    // (see ExtractRangePredicateFromScalarApplyRule).
-                    ColumnStatistic childStat = childColumnStatisticList.get(0);
-                    ColumnStatistic fromTzStat = childColumnStatisticList.get(1);
-                    ColumnStatistic toTzStat = childColumnStatisticList.get(2);
-                    final double maxOffset = 26.0 * 3600.0;
-
-                    distinctValues = Math.min(rowCount,
-                            childStat.getDistinctValuesCount()
-                                    * fromTzStat.getDistinctValuesCount()
-                                    * toTzStat.getDistinctValuesCount());
-
-                    return ColumnStatistic.builder()
-                            .setMinValue(childStat.getMinValue() - maxOffset)
-                            .setMaxValue(childStat.getMaxValue() + maxOffset)
-                            .setNullsFraction(childStat.getNullsFraction())
-                            .setAverageRowSize(callOperator.getType().getTypeSize())
-                            .setDistinctValuesCount(distinctValues)
-                            .setHistogram(transformHistogramForConvertTz(callOperator, childStat).orElse(null))
-                            .build();
+                    return calcConvertTzStats(childColumnStatisticList, callOperator);
                 case FunctionSet.COALESCE:
                     return calcCoalesceStats(childColumnStatisticList, callOperator);
                 case FunctionSet.IF:

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -1082,7 +1082,8 @@ public class ExpressionStatisticCalculator {
                 Instant start = minInstant.isAfter(maxInstant) ? maxInstant : minInstant;
                 Instant end = minInstant.isAfter(maxInstant) ? minInstant : maxInstant;
                 return hasOffsetTransition(from, start, end) || hasOffsetTransition(to, start, end);
-            } catch (Exception e) {
+            } catch (DateTimeException e) {
+                // Invalid zone id or out-of-range temporal value: keep the widened range.
                 return true;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -47,11 +47,14 @@ import org.apache.logging.log4j.Logger;
 
 import java.math.BigInteger;
 import java.time.DateTimeException;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.IsoFields;
+import java.time.zone.ZoneOffsetTransition;
+import java.time.zone.ZoneRules;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -1063,6 +1066,36 @@ public class ExpressionStatisticCalculator {
             }
         }
 
+        /**
+         * convert_tz is only a constant wall-clock shift while both zones keep the same UTC offset over
+         * the whole input range. Around a DST transition the mapping is not monotonic in wall-clock space,
+         * e.g. UTC 00:30 and 01:30 both map to Europe/Berlin 02:30 on 2024-10-27 while 00:59 maps to 02:59,
+         * so converting only the endpoints would under-range the result.
+         */
+        private boolean hasTimezoneOffsetDrift(double minValue, double maxValue,
+                                               ConstantOperator fromTz, ConstantOperator toTz) {
+            try {
+                ZoneId from = ZoneId.of(fromTz.getVarchar());
+                ZoneId to = ZoneId.of(toTz.getVarchar());
+                Instant minInstant = Utils.getDatetimeFromLong((long) minValue).atZone(from).toInstant();
+                Instant maxInstant = Utils.getDatetimeFromLong((long) maxValue).atZone(from).toInstant();
+                Instant start = minInstant.isAfter(maxInstant) ? maxInstant : minInstant;
+                Instant end = minInstant.isAfter(maxInstant) ? minInstant : maxInstant;
+                return hasOffsetTransition(from, start, end) || hasOffsetTransition(to, start, end);
+            } catch (Exception e) {
+                return true;
+            }
+        }
+
+        private boolean hasOffsetTransition(ZoneId zone, Instant start, Instant end) {
+            ZoneRules rules = zone.getRules();
+            if (!rules.getOffset(start).equals(rules.getOffset(end))) {
+                return true;
+            }
+            ZoneOffsetTransition next = rules.nextTransition(start);
+            return next != null && !next.getInstant().isAfter(end);
+        }
+
         private ColumnStatistic calcConvertTzStats(List<ColumnStatistic> inputs, CallOperator callOperator) {
             // Timezone offsets differ by at most 26 hours
             // (see ExtractRangePredicateFromScalarApplyRule).
@@ -1082,7 +1115,9 @@ public class ExpressionStatisticCalculator {
             Optional<ConstantOperator> fromTz = toConstantOperator(callOperator.getChild(1));
             Optional<ConstantOperator> toTz = toConstantOperator(callOperator.getChild(2));
             if (fromTz.isPresent() && toTz.isPresent()
-                    && !childStat.hasNaNValue() && !childStat.isInfiniteRange()) {
+                    && !childStat.hasNaNValue() && !childStat.isInfiniteRange()
+                    && !hasTimezoneOffsetDrift(childStat.getMinValue(), childStat.getMaxValue(),
+                            fromTz.get(), toTz.get())) {
                 OptionalDouble convertedMin = convertTzDateTime(childStat.getMinValue(), fromTz.get(), toTz.get());
                 OptionalDouble convertedMax = convertTzDateTime(childStat.getMaxValue(), fromTz.get(), toTz.get());
                 if (convertedMin.isPresent() && convertedMax.isPresent()) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ConvertTzStatisticUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ConvertTzStatisticUtilsTest.java
@@ -63,6 +63,13 @@ public class ConvertTzStatisticUtilsTest {
         Assertions.assertTrue(converted.isEmpty());
     }
 
+    @Test
+    public void testIsValidTimeZone() {
+        Assertions.assertTrue(ConvertTzStatisticUtils.isValidTimeZone(ConstantOperator.createVarchar("UTC")));
+        Assertions.assertTrue(ConvertTzStatisticUtils.isValidTimeZone(ConstantOperator.createVarchar("America/New_York")));
+        Assertions.assertFalse(ConvertTzStatisticUtils.isValidTimeZone(ConstantOperator.createVarchar("Not/AZone")));
+    }
+
     // ---------- hasTimezoneOffsetDrift ----------
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ConvertTzStatisticUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ConvertTzStatisticUtilsTest.java
@@ -85,6 +85,29 @@ public class ConvertTzStatisticUtilsTest {
     }
 
     @Test
+    public void testHasTimezoneOffsetDriftTrueWhenEndpointInSpringForwardGap() {
+        // America/New_York springs forward 2024-03-10 02:00 -> 03:00. 02:30 is skipped; atZone
+        // normalizes it to after the transition, so an instant-only check would miss the gap.
+        final double min = getLongFromDateTime(LocalDateTime.of(2024, 3, 10, 2, 30, 0));
+        final double max = getLongFromDateTime(LocalDateTime.of(2024, 3, 10, 3, 15, 0));
+
+        Assertions.assertTrue(ConvertTzStatisticUtils.hasTimezoneOffsetDrift(
+                min, max, ConstantOperator.createVarchar("America/New_York"),
+                ConstantOperator.createVarchar("UTC")));
+    }
+
+    @Test
+    public void testHasTimezoneOffsetDriftTrueWhenEndpointInFallBackOverlap() {
+        // America/New_York falls back 2024-11-03 02:00 -> 01:00. 01:30 is ambiguous.
+        final double min = getLongFromDateTime(LocalDateTime.of(2024, 11, 3, 1, 15, 0));
+        final double max = getLongFromDateTime(LocalDateTime.of(2024, 11, 3, 1, 45, 0));
+
+        Assertions.assertTrue(ConvertTzStatisticUtils.hasTimezoneOffsetDrift(
+                min, max, ConstantOperator.createVarchar("America/New_York"),
+                ConstantOperator.createVarchar("UTC")));
+    }
+
+    @Test
     public void testHasTimezoneOffsetDriftTrueForInvalidZone() {
         final double min = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 0, 0));
         final double max = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 12, 0, 0));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ConvertTzStatisticUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ConvertTzStatisticUtilsTest.java
@@ -142,8 +142,10 @@ public class ConvertTzStatisticUtilsTest {
         final CallOperator call = convertTzCall(
                 ConstantOperator.createVarchar(fromTz), ConstantOperator.createVarchar(toTz));
 
-        final Optional<Histogram> result =
-                ConvertTzStatisticUtils.transformHistogram(call, childStats, 1.0, 2.0, 1000);
+        final Optional<Histogram> result = ConvertTzStatisticUtils.transformHistogram(
+                call, childStats, 1.0, 2.0, 1000,
+                Optional.of(ConstantOperator.createVarchar(fromTz)),
+                Optional.of(ConstantOperator.createVarchar(toTz)));
 
         Assertions.assertTrue(result.isPresent());
         final Map<String, Long> mcv = result.get().getMCV();
@@ -163,8 +165,10 @@ public class ConvertTzStatisticUtilsTest {
         final CallOperator call = convertTzCall(
                 ConstantOperator.createVarchar("UTC"), ConstantOperator.createVarchar("Asia/Shanghai"));
 
-        Assertions.assertTrue(
-                ConvertTzStatisticUtils.transformHistogram(call, childStats, 1.0, 2.0, 1000).isEmpty());
+        Assertions.assertTrue(ConvertTzStatisticUtils.transformHistogram(
+                call, childStats, 1.0, 2.0, 1000,
+                Optional.of(ConstantOperator.createVarchar("UTC")),
+                Optional.of(ConstantOperator.createVarchar("Asia/Shanghai"))).isEmpty());
     }
 
     @Test
@@ -177,8 +181,8 @@ public class ConvertTzStatisticUtilsTest {
                 .build();
         final CallOperator call = convertTzCall(fromTzCol, toTzCol);
 
-        Assertions.assertTrue(
-                ConvertTzStatisticUtils.transformHistogram(call, childStats, 1.0, 2.0, 1000).isEmpty());
+        Assertions.assertTrue(ConvertTzStatisticUtils.transformHistogram(
+                call, childStats, 1.0, 2.0, 1000, Optional.empty(), Optional.empty()).isEmpty());
     }
 
     @Test
@@ -190,8 +194,10 @@ public class ConvertTzStatisticUtilsTest {
         final CallOperator call = convertTzCall(
                 ConstantOperator.createVarchar("UTC"), ConstantOperator.createVarchar("Asia/Shanghai"));
 
-        Assertions.assertTrue(
-                ConvertTzStatisticUtils.transformHistogram(call, childStats, 1.0, 2.0, 1000).isEmpty());
+        Assertions.assertTrue(ConvertTzStatisticUtils.transformHistogram(
+                call, childStats, 1.0, 2.0, 1000,
+                Optional.of(ConstantOperator.createVarchar("UTC")),
+                Optional.of(ConstantOperator.createVarchar("Asia/Shanghai"))).isEmpty());
     }
 
     @Test
@@ -203,8 +209,10 @@ public class ConvertTzStatisticUtilsTest {
         final CallOperator call = convertTzCall(
                 ConstantOperator.createVarchar("Not/AZone"), ConstantOperator.createVarchar("UTC"));
 
-        Assertions.assertTrue(
-                ConvertTzStatisticUtils.transformHistogram(call, childStats, 1.0, 2.0, 1000).isEmpty());
+        Assertions.assertTrue(ConvertTzStatisticUtils.transformHistogram(
+                call, childStats, 1.0, 2.0, 1000,
+                Optional.of(ConstantOperator.createVarchar("Not/AZone")),
+                Optional.of(ConstantOperator.createVarchar("UTC"))).isEmpty());
     }
 
     private static CallOperator convertTzCall(ScalarOperator fromTz, ScalarOperator toTz) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ConvertTzStatisticUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ConvertTzStatisticUtilsTest.java
@@ -1,0 +1,223 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.statistics;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorFunctions;
+import com.starrocks.type.DateType;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalDouble;
+
+import static com.starrocks.sql.optimizer.Utils.getLongFromDateTime;
+
+/**
+ * Unit tests that directly exercise the individual helpers of {@link ConvertTzStatisticUtils}.
+ * End-to-end statistics assertions (through the expression calculator) live in
+ * {@code ExpressionStatisticsCalculatorTest}.
+ */
+public class ConvertTzStatisticUtilsTest {
+
+    // ---------- convertTzDateTime ----------
+
+    @Test
+    public void testConvertTzDateTimeShiftsByZoneOffset() {
+        final double input = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 0, 0));
+        final OptionalDouble converted = ConvertTzStatisticUtils.convertTzDateTime(
+                input, ConstantOperator.createVarchar("UTC"), ConstantOperator.createVarchar("Asia/Shanghai"));
+
+        Assertions.assertTrue(converted.isPresent());
+        // Asia/Shanghai is UTC+8 year-round, so the wall clock shifts forward 8 hours.
+        Assertions.assertEquals(8 * 3600.0, converted.getAsDouble() - input, 0.001);
+    }
+
+    @Test
+    public void testConvertTzDateTimeReturnsEmptyForInvalidZone() {
+        final double input = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 0, 0));
+        final OptionalDouble converted = ConvertTzStatisticUtils.convertTzDateTime(
+                input, ConstantOperator.createVarchar("Not/AZone"), ConstantOperator.createVarchar("UTC"));
+
+        Assertions.assertTrue(converted.isEmpty());
+    }
+
+    // ---------- hasTimezoneOffsetDrift ----------
+
+    @Test
+    public void testHasTimezoneOffsetDriftFalseForConstantOffsetZones() {
+        final double min = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30));
+        final double max = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 14, 45, 0));
+
+        Assertions.assertFalse(ConvertTzStatisticUtils.hasTimezoneOffsetDrift(
+                min, max, ConstantOperator.createVarchar("UTC"), ConstantOperator.createVarchar("Asia/Shanghai")));
+    }
+
+    @Test
+    public void testHasTimezoneOffsetDriftTrueAcrossDstTransition() {
+        // Europe/Berlin falls back on 2024-10-27 at 01:00 UTC; the interval straddles that transition.
+        final double min = getLongFromDateTime(LocalDateTime.of(2024, 10, 27, 0, 30, 0));
+        final double max = getLongFromDateTime(LocalDateTime.of(2024, 10, 27, 1, 30, 0));
+
+        Assertions.assertTrue(ConvertTzStatisticUtils.hasTimezoneOffsetDrift(
+                min, max, ConstantOperator.createVarchar("UTC"), ConstantOperator.createVarchar("Europe/Berlin")));
+    }
+
+    @Test
+    public void testHasTimezoneOffsetDriftTrueForInvalidZone() {
+        final double min = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 0, 0));
+        final double max = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 12, 0, 0));
+
+        Assertions.assertTrue(ConvertTzStatisticUtils.hasTimezoneOffsetDrift(
+                min, max, ConstantOperator.createVarchar("Not/AZone"), ConstantOperator.createVarchar("UTC")));
+    }
+
+    // ---------- buildSingleBucketHistogram ----------
+
+    @Test
+    public void testBuildSingleBucketHistogramComputesNonMcvRows() {
+        final Map<String, Long> mcv = Map.of("a", 100L, "b", 200L);
+        final Histogram hist = ConvertTzStatisticUtils.buildSingleBucketHistogram(100.0, 200.0, 1000, mcv);
+
+        Assertions.assertEquals(1, hist.getBuckets().size());
+        final Bucket bucket = hist.getBuckets().get(0);
+        Assertions.assertEquals(100.0, bucket.getLower(), 0.001);
+        Assertions.assertEquals(200.0, bucket.getUpper(), 0.001);
+        Assertions.assertEquals(700L, bucket.getCount()); // 1000 - (100 + 200)
+        Assertions.assertEquals(0L, bucket.getUpperRepeats());
+        Assertions.assertEquals(2, hist.getMCV().size());
+    }
+
+    @Test
+    public void testBuildSingleBucketHistogramWithInfiniteBoundsHasNoBucket() {
+        final Map<String, Long> mcv = Map.of("a", 100L);
+        final Histogram hist = ConvertTzStatisticUtils.buildSingleBucketHistogram(
+                Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, 1000, mcv);
+
+        Assertions.assertTrue(hist.getBuckets().isEmpty());
+        Assertions.assertEquals(1, hist.getMCV().size());
+    }
+
+    @Test
+    public void testBuildSingleBucketHistogramClampsNonMcvRowsAtZero() {
+        final Map<String, Long> mcv = Map.of("a", 800L, "b", 400L); // sum 1200 > total 1000
+        final Histogram hist = ConvertTzStatisticUtils.buildSingleBucketHistogram(1.0, 2.0, 1000, mcv);
+
+        Assertions.assertEquals(0L, hist.getBuckets().get(0).getCount());
+    }
+
+    // ---------- transformHistogram ----------
+
+    @Test
+    public void testTransformHistogramConvertsMcvForConstantZones() {
+        final String fromTz = "UTC";
+        final String toTz = "Asia/Shanghai";
+        final String dt1 = "2024-01-15 10:20:30";
+        final String dt2 = "2024-01-15 14:45:00";
+        final ColumnStatistic childStats = ColumnStatistic.builder()
+                .setDistinctValuesCount(2)
+                .setHistogram(new Histogram(Collections.emptyList(), Map.of(dt1, 100L, dt2, 200L)))
+                .build();
+        final CallOperator call = convertTzCall(
+                ConstantOperator.createVarchar(fromTz), ConstantOperator.createVarchar(toTz));
+
+        final Optional<Histogram> result =
+                ConvertTzStatisticUtils.transformHistogram(call, childStats, 1.0, 2.0, 1000);
+
+        Assertions.assertTrue(result.isPresent());
+        final Map<String, Long> mcv = result.get().getMCV();
+        Assertions.assertEquals(2, mcv.size());
+        Assertions.assertEquals(100L, mcv.get(convertTzMcvKey(dt1, fromTz, toTz)));
+        Assertions.assertEquals(200L, mcv.get(convertTzMcvKey(dt2, fromTz, toTz)));
+        Assertions.assertEquals(1, result.get().getBuckets().size());
+        final Bucket bucket = result.get().getBuckets().get(0);
+        Assertions.assertEquals(1.0, bucket.getLower(), 0.001);
+        Assertions.assertEquals(2.0, bucket.getUpper(), 0.001);
+        Assertions.assertEquals(700L, bucket.getCount()); // 1000 - (100 + 200)
+    }
+
+    @Test
+    public void testTransformHistogramEmptyWhenNoMcv() {
+        final ColumnStatistic childStats = ColumnStatistic.builder().setDistinctValuesCount(2).build();
+        final CallOperator call = convertTzCall(
+                ConstantOperator.createVarchar("UTC"), ConstantOperator.createVarchar("Asia/Shanghai"));
+
+        Assertions.assertTrue(
+                ConvertTzStatisticUtils.transformHistogram(call, childStats, 1.0, 2.0, 1000).isEmpty());
+    }
+
+    @Test
+    public void testTransformHistogramEmptyWhenTimezonesNotConstant() {
+        final ColumnRefOperator fromTzCol = new ColumnRefOperator(1, VarcharType.VARCHAR, "from_tz", true);
+        final ColumnRefOperator toTzCol = new ColumnRefOperator(2, VarcharType.VARCHAR, "to_tz", true);
+        final ColumnStatistic childStats = ColumnStatistic.builder()
+                .setDistinctValuesCount(1)
+                .setHistogram(new Histogram(Collections.emptyList(), Map.of("2024-01-15 10:20:30", 100L)))
+                .build();
+        final CallOperator call = convertTzCall(fromTzCol, toTzCol);
+
+        Assertions.assertTrue(
+                ConvertTzStatisticUtils.transformHistogram(call, childStats, 1.0, 2.0, 1000).isEmpty());
+    }
+
+    @Test
+    public void testTransformHistogramEmptyWhenMcvKeyInvalid() {
+        final ColumnStatistic childStats = ColumnStatistic.builder()
+                .setDistinctValuesCount(1)
+                .setHistogram(new Histogram(Collections.emptyList(), Map.of("not-a-datetime", 100L)))
+                .build();
+        final CallOperator call = convertTzCall(
+                ConstantOperator.createVarchar("UTC"), ConstantOperator.createVarchar("Asia/Shanghai"));
+
+        Assertions.assertTrue(
+                ConvertTzStatisticUtils.transformHistogram(call, childStats, 1.0, 2.0, 1000).isEmpty());
+    }
+
+    @Test
+    public void testTransformHistogramEmptyWhenTimezoneInvalid() {
+        final ColumnStatistic childStats = ColumnStatistic.builder()
+                .setDistinctValuesCount(1)
+                .setHistogram(new Histogram(Collections.emptyList(), Map.of("2024-01-15 10:20:30", 100L)))
+                .build();
+        final CallOperator call = convertTzCall(
+                ConstantOperator.createVarchar("Not/AZone"), ConstantOperator.createVarchar("UTC"));
+
+        Assertions.assertTrue(
+                ConvertTzStatisticUtils.transformHistogram(call, childStats, 1.0, 2.0, 1000).isEmpty());
+    }
+
+    private static CallOperator convertTzCall(ScalarOperator fromTz, ScalarOperator toTz) {
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        return new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(dtCol, fromTz, toTz));
+    }
+
+    private static String convertTzMcvKey(String datetime, String fromTz, String toTz) {
+        final ConstantOperator converted = ScalarOperatorFunctions.convert_tz(
+                ConstantOperator.createVarchar(datetime).castTo(DateType.DATETIME).get(),
+                ConstantOperator.createVarchar(fromTz),
+                ConstantOperator.createVarchar(toTz));
+        return converted.castTo(VarcharType.VARCHAR).get().getVarchar();
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -2513,7 +2513,12 @@ public class ExpressionStatisticsCalculatorTest {
         final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
 
         Assertions.assertNotNull(actual.getHistogram());
-        Assertions.assertTrue(actual.getHistogram().getBuckets().isEmpty());
+        Assertions.assertEquals(1, actual.getHistogram().getBuckets().size());
+        final Bucket bucket = actual.getHistogram().getBuckets().get(0);
+        Assertions.assertEquals(actual.getMinValue(), bucket.getLower(), 0.001);
+        Assertions.assertEquals(actual.getMaxValue(), bucket.getUpper(), 0.001);
+        Assertions.assertEquals(700L, bucket.getCount()); // 1000 - (100 + 200)
+        Assertions.assertEquals(0L, bucket.getUpperRepeats());
         final Map<String, Long> mcv = actual.getHistogram().getMCV();
         Assertions.assertEquals(2, mcv.size());
         Assertions.assertEquals(100L, mcv.get(convertTzMcvKey(dt1, fromTz, toTz)));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -2442,7 +2442,7 @@ public class ExpressionStatisticsCalculatorTest {
         assertConvertTzStatRangeCovers(actual, "UTC", "Asia/Shanghai", minDt, maxDt);
         assertConvertTzStatRangeCovers(actual, "Pacific/Kiritimati", "Etc/GMT+12", minDt, maxDt);
         Assertions.assertEquals(nullsFraction, actual.getNullsFraction(), 0.001);
-        Assertions.assertEquals(4, actual.getDistinctValuesCount(), 0.001); // min(100, 2*1*2)
+        Assertions.assertEquals(4, actual.getDistinctValuesCount(), 0.001); // min(100*(1-0.1), 2*1*2)
         Assertions.assertEquals(DateType.DATETIME.getTypeSize(), actual.getAverageRowSize(), 0.001);
         Assertions.assertNull(actual.getHistogram());
     }
@@ -2482,7 +2482,47 @@ public class ExpressionStatisticsCalculatorTest {
 
         final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
 
-        Assertions.assertEquals(5, actual.getDistinctValuesCount(), 0.001); // min(5, 3*2*2)
+        Assertions.assertEquals(5, actual.getDistinctValuesCount(), 0.001); // min(5*(1-0), 3*2*2)
+    }
+
+    @Test
+    public void testConvertTzCapsDistinctValuesAtNonNullRowCount() {
+        final int rowCount = 10;
+        final double dtNulls = 0.4;
+        final ColumnRefOperator dtCol = new ColumnRefOperator(1, DateType.DATETIME, "dt", true);
+        final ColumnRefOperator fromTzCol = new ColumnRefOperator(2, VarcharType.VARCHAR, "from_tz", true);
+        final ColumnRefOperator toTzCol = new ColumnRefOperator(3, VarcharType.VARCHAR, "to_tz", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(rowCount)
+                .addColumnStatistic(dtCol, ColumnStatistic.builder()
+                        .setMinValue(getLongFromDateTime(LocalDateTime.of(2021, 1, 1, 0, 0, 0)))
+                        .setMaxValue(getLongFromDateTime(LocalDateTime.of(2021, 1, 3, 0, 0, 0)))
+                        .setNullsFraction(dtNulls)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(3)
+                        .build())
+                .addColumnStatistic(fromTzCol, ColumnStatistic.builder()
+                        .setMinValue(Double.NEGATIVE_INFINITY)
+                        .setMaxValue(Double.POSITIVE_INFINITY)
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(2)
+                        .build())
+                .addColumnStatistic(toTzCol, ColumnStatistic.builder()
+                        .setMinValue(Double.NEGATIVE_INFINITY)
+                        .setMaxValue(Double.POSITIVE_INFINITY)
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(2)
+                        .build())
+                .build();
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(dtCol, fromTzCol, toTzCol));
+
+        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
+
+        // min(10*(1-0.4), 3*2*2) = min(6, 12) = 6
+        Assertions.assertEquals(6, actual.getDistinctValuesCount(), 0.001);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -31,6 +31,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.LambdaFunctionOperator;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorFunctions;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.BooleanType;
 import com.starrocks.type.DateType;
@@ -2390,6 +2391,258 @@ public class ExpressionStatisticsCalculatorTest {
 
         // THEN
         Assertions.assertNull(result.getHistogram());
+    }
+
+    @Test
+    public void testConvertTzWidensRangeAndUsesProductOfNdvsWhenBelowRowCount() {
+        final int rowCount = 100;
+        final double dtNdv = 2;
+        final double fromTzNdv = 1;
+        final double toTzNdv = 2;
+        final double nullsFraction = 0.1;
+        final double minEpoch = getLongFromDateTime(LocalDateTime.of(2021, 1, 10, 8, 30, 0));
+        final double maxEpoch = getLongFromDateTime(LocalDateTime.of(2021, 12, 25, 23, 59, 59));
+        final double maxOffsetSec = 26.0 * 3600.0;
+
+        final ColumnRefOperator dtCol = new ColumnRefOperator(1, DateType.DATETIME, "dt", true);
+        final ColumnRefOperator fromTzCol = new ColumnRefOperator(2, VarcharType.VARCHAR, "from_tz", true);
+        final ColumnRefOperator toTzCol = new ColumnRefOperator(3, VarcharType.VARCHAR, "to_tz", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(rowCount)
+                .addColumnStatistic(dtCol, ColumnStatistic.builder()
+                        .setMinValue(minEpoch)
+                        .setMaxValue(maxEpoch)
+                        .setNullsFraction(nullsFraction)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(dtNdv)
+                        .build())
+                .addColumnStatistic(fromTzCol, ColumnStatistic.builder()
+                        .setMinValue(Double.NEGATIVE_INFINITY)
+                        .setMaxValue(Double.POSITIVE_INFINITY)
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(fromTzNdv)
+                        .build())
+                .addColumnStatistic(toTzCol, ColumnStatistic.builder()
+                        .setMinValue(Double.NEGATIVE_INFINITY)
+                        .setMaxValue(Double.POSITIVE_INFINITY)
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(toTzNdv)
+                        .build())
+                .build();
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(dtCol, fromTzCol, toTzCol));
+
+        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
+
+        Assertions.assertFalse(actual.isUnknown());
+        Assertions.assertEquals(minEpoch - maxOffsetSec, actual.getMinValue(), 0.001);
+        Assertions.assertEquals(maxEpoch + maxOffsetSec, actual.getMaxValue(), 0.001);
+        Assertions.assertEquals(nullsFraction, actual.getNullsFraction(), 0.001);
+        Assertions.assertEquals(4, actual.getDistinctValuesCount(), 0.001); // min(100, 2*1*2)
+        Assertions.assertEquals(DateType.DATETIME.getTypeSize(), actual.getAverageRowSize(), 0.001);
+        Assertions.assertNull(actual.getHistogram());
+    }
+
+    @Test
+    public void testConvertTzCapsDistinctValuesAtRowCount() {
+        final int rowCount = 5;
+        final ColumnRefOperator dtCol = new ColumnRefOperator(1, DateType.DATETIME, "dt", true);
+        final ColumnRefOperator fromTzCol = new ColumnRefOperator(2, VarcharType.VARCHAR, "from_tz", true);
+        final ColumnRefOperator toTzCol = new ColumnRefOperator(3, VarcharType.VARCHAR, "to_tz", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(rowCount)
+                .addColumnStatistic(dtCol, ColumnStatistic.builder()
+                        .setMinValue(getLongFromDateTime(LocalDateTime.of(2021, 1, 1, 0, 0, 0)))
+                        .setMaxValue(getLongFromDateTime(LocalDateTime.of(2021, 1, 3, 0, 0, 0)))
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(3)
+                        .build())
+                .addColumnStatistic(fromTzCol, ColumnStatistic.builder()
+                        .setMinValue(Double.NEGATIVE_INFINITY)
+                        .setMaxValue(Double.POSITIVE_INFINITY)
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(2)
+                        .build())
+                .addColumnStatistic(toTzCol, ColumnStatistic.builder()
+                        .setMinValue(Double.NEGATIVE_INFINITY)
+                        .setMaxValue(Double.POSITIVE_INFINITY)
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(2)
+                        .build())
+                .build();
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(dtCol, fromTzCol, toTzCol));
+
+        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
+
+        Assertions.assertEquals(5, actual.getDistinctValuesCount(), 0.001); // min(5, 3*2*2)
+    }
+
+    @Test
+    public void testConvertTzMcvPropagationWithConstantTimezones() {
+        final String fromTz = "UTC";
+        final String toTz = "Asia/Shanghai";
+        final String dt1 = "2024-01-15 10:20:30";
+        final String dt2 = "2024-01-15 14:45:00";
+        final Map<String, Long> inputMcv = Map.of(dt1, 100L, dt2, 200L);
+
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        final ColumnStatistic dtStat = ColumnStatistic.builder()
+                .setMinValue(getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30)))
+                .setMaxValue(getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 14, 45, 0)))
+                .setNullsFraction(0)
+                .setAverageRowSize(8)
+                .setDistinctValuesCount(2)
+                .setHistogram(new Histogram(Collections.emptyList(), inputMcv))
+                .build();
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(dtCol, dtStat)
+                .build();
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(
+                        dtCol,
+                        ConstantOperator.createVarchar(fromTz),
+                        ConstantOperator.createVarchar(toTz)));
+
+        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
+
+        Assertions.assertNotNull(actual.getHistogram());
+        Assertions.assertTrue(actual.getHistogram().getBuckets().isEmpty());
+        final Map<String, Long> mcv = actual.getHistogram().getMCV();
+        Assertions.assertEquals(2, mcv.size());
+        Assertions.assertEquals(100L, mcv.get(convertTzMcvKey(dt1, fromTz, toTz)));
+        Assertions.assertEquals(200L, mcv.get(convertTzMcvKey(dt2, fromTz, toTz)));
+    }
+
+    @Test
+    public void testConvertTzNoMcvWhenTimezonesAreNotConstant() {
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        final ColumnRefOperator fromTzCol = new ColumnRefOperator(1, VarcharType.VARCHAR, "from_tz", true);
+        final ColumnRefOperator toTzCol = new ColumnRefOperator(2, VarcharType.VARCHAR, "to_tz", true);
+        final Map<String, Long> inputMcv = Map.of("2024-01-15 10:20:30", 100L);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(dtCol, ColumnStatistic.builder()
+                        .setMinValue(getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30)))
+                        .setMaxValue(getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30)))
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(1)
+                        .setHistogram(new Histogram(Collections.emptyList(), inputMcv))
+                        .build())
+                .addColumnStatistic(fromTzCol, ColumnStatistic.builder()
+                        .setMinValue(Double.NEGATIVE_INFINITY)
+                        .setMaxValue(Double.POSITIVE_INFINITY)
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(2)
+                        .build())
+                .addColumnStatistic(toTzCol, ColumnStatistic.builder()
+                        .setMinValue(Double.NEGATIVE_INFINITY)
+                        .setMaxValue(Double.POSITIVE_INFINITY)
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(2)
+                        .build())
+                .build();
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(dtCol, fromTzCol, toTzCol));
+
+        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
+
+        Assertions.assertNull(actual.getHistogram());
+        Assertions.assertEquals(4, actual.getDistinctValuesCount(), 0.001); // min(1000, 1*2*2)
+    }
+
+    @Test
+    public void testConvertTzNoMcvWhenInputHasNoHistogram() {
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(dtCol, ColumnStatistic.builder()
+                        .setMinValue(getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30)))
+                        .setMaxValue(getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 14, 45, 0)))
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(2)
+                        .build())
+                .build();
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(
+                        dtCol,
+                        ConstantOperator.createVarchar("UTC"),
+                        ConstantOperator.createVarchar("Asia/Shanghai")));
+
+        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
+
+        Assertions.assertNull(actual.getHistogram());
+        Assertions.assertEquals(2, actual.getDistinctValuesCount(), 0.001);
+    }
+
+    @Test
+    public void testConvertTzNoMcvWhenTimezoneInvalid() {
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        final Map<String, Long> inputMcv = Map.of("2024-01-15 10:20:30", 100L);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(dtCol, ColumnStatistic.builder()
+                        .setMinValue(getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30)))
+                        .setMaxValue(getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30)))
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(1)
+                        .setHistogram(new Histogram(Collections.emptyList(), inputMcv))
+                        .build())
+                .build();
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(
+                        dtCol,
+                        ConstantOperator.createVarchar("Not/AZone"),
+                        ConstantOperator.createVarchar("UTC")));
+
+        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
+
+        Assertions.assertNull(actual.getHistogram());
+    }
+
+    @Test
+    public void testConvertTzNoMcvWhenMcvKeyInvalid() {
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        final Map<String, Long> inputMcv = Map.of("not-a-datetime", 100L);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(dtCol, ColumnStatistic.builder()
+                        .setMinValue(getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30)))
+                        .setMaxValue(getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30)))
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(1)
+                        .setHistogram(new Histogram(Collections.emptyList(), inputMcv))
+                        .build())
+                .build();
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(
+                        dtCol,
+                        ConstantOperator.createVarchar("UTC"),
+                        ConstantOperator.createVarchar("Asia/Shanghai")));
+
+        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
+
+        Assertions.assertNull(actual.getHistogram());
+    }
+
+    private static String convertTzMcvKey(String datetime, String fromTz, String toTz) {
+        final ConstantOperator converted = ScalarOperatorFunctions.convert_tz(
+                ConstantOperator.createVarchar(datetime).castTo(DateType.DATETIME).get(),
+                ConstantOperator.createVarchar(fromTz),
+                ConstantOperator.createVarchar(toTz));
+        return converted.castTo(VarcharType.VARCHAR).get().getVarchar();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -2486,6 +2486,77 @@ public class ExpressionStatisticsCalculatorTest {
     }
 
     @Test
+    public void testConvertTzCombinesNullsFractionFromAllArguments() {
+        // convert_tz is null if any argument is null:
+        // 1 - (1-0.2)*(1-0.5)*(1-0.4) = 1 - 0.8*0.5*0.6 = 0.76
+        final double dtNulls = 0.2;
+        final double fromTzNulls = 0.5;
+        final double toTzNulls = 0.4;
+        final double expectedNulls = 1.0 - (1.0 - dtNulls) * (1.0 - fromTzNulls) * (1.0 - toTzNulls);
+
+        final ColumnRefOperator dtCol = new ColumnRefOperator(1, DateType.DATETIME, "dt", true);
+        final ColumnRefOperator fromTzCol = new ColumnRefOperator(2, VarcharType.VARCHAR, "from_tz", true);
+        final ColumnRefOperator toTzCol = new ColumnRefOperator(3, VarcharType.VARCHAR, "to_tz", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(100)
+                .addColumnStatistic(dtCol, ColumnStatistic.builder()
+                        .setMinValue(getLongFromDateTime(LocalDateTime.of(2021, 1, 1, 0, 0, 0)))
+                        .setMaxValue(getLongFromDateTime(LocalDateTime.of(2021, 1, 3, 0, 0, 0)))
+                        .setNullsFraction(dtNulls)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(3)
+                        .build())
+                .addColumnStatistic(fromTzCol, ColumnStatistic.builder()
+                        .setMinValue(Double.NEGATIVE_INFINITY)
+                        .setMaxValue(Double.POSITIVE_INFINITY)
+                        .setNullsFraction(fromTzNulls)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(2)
+                        .build())
+                .addColumnStatistic(toTzCol, ColumnStatistic.builder()
+                        .setMinValue(Double.NEGATIVE_INFINITY)
+                        .setMaxValue(Double.POSITIVE_INFINITY)
+                        .setNullsFraction(toTzNulls)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(2)
+                        .build())
+                .build();
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(dtCol, fromTzCol, toTzCol));
+
+        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
+
+        Assertions.assertEquals(expectedNulls, actual.getNullsFraction(), 0.001);
+        Assertions.assertEquals(0.76, actual.getNullsFraction(), 0.001);
+    }
+
+    @Test
+    public void testConvertTzNullsFractionWithConstantTimezonesUsesOnlyDatetimeNulls() {
+        // Constant timezones have nullsFraction 0, so result nulls = dt nulls.
+        final double dtNulls = 0.3;
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(dtCol, ColumnStatistic.builder()
+                        .setMinValue(getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30)))
+                        .setMaxValue(getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 14, 45, 0)))
+                        .setNullsFraction(dtNulls)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(2)
+                        .build())
+                .build();
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(
+                        dtCol,
+                        ConstantOperator.createVarchar("UTC"),
+                        ConstantOperator.createVarchar("Asia/Shanghai")));
+
+        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
+
+        Assertions.assertEquals(dtNulls, actual.getNullsFraction(), 0.001);
+    }
+
+    @Test
     public void testConvertTzMcvPropagationWithConstantTimezones() {
         final String fromTz = "UTC";
         final String toTz = "Asia/Shanghai";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -2733,7 +2733,7 @@ public class ExpressionStatisticsCalculatorTest {
     }
 
     @Test
-    public void testConvertTzFallsBackToWidenedRangeWhenTimezoneInvalid() {
+    public void testConvertTzIsAllNullWhenConstantTimezoneInvalid() {
         final double minValue = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30));
         final double maxValue = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 14, 45, 0));
 
@@ -2756,9 +2756,8 @@ public class ExpressionStatisticsCalculatorTest {
 
         final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
 
-        // Invalid zone: cannot evaluate samples; range must still cover the input domain.
-        Assertions.assertTrue(actual.getMinValue() <= minValue);
-        Assertions.assertTrue(actual.getMaxValue() >= maxValue);
+        Assertions.assertEquals(1.0, actual.getNullsFraction(), 0.001);
+        Assertions.assertEquals(0, actual.getDistinctValuesCount(), 0.001);
         Assertions.assertNull(actual.getHistogram());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -2400,9 +2400,10 @@ public class ExpressionStatisticsCalculatorTest {
         final double fromTzNdv = 1;
         final double toTzNdv = 2;
         final double nullsFraction = 0.1;
-        final double minEpoch = getLongFromDateTime(LocalDateTime.of(2021, 1, 10, 8, 30, 0));
-        final double maxEpoch = getLongFromDateTime(LocalDateTime.of(2021, 12, 25, 23, 59, 59));
-        final double maxOffsetSec = 26.0 * 3600.0;
+        final LocalDateTime minDt = LocalDateTime.of(2021, 1, 10, 8, 30, 0);
+        final LocalDateTime maxDt = LocalDateTime.of(2021, 12, 25, 23, 59, 59);
+        final double minEpoch = getLongFromDateTime(minDt);
+        final double maxEpoch = getLongFromDateTime(maxDt);
 
         final ColumnRefOperator dtCol = new ColumnRefOperator(1, DateType.DATETIME, "dt", true);
         final ColumnRefOperator fromTzCol = new ColumnRefOperator(2, VarcharType.VARCHAR, "from_tz", true);
@@ -2437,8 +2438,9 @@ public class ExpressionStatisticsCalculatorTest {
         final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
 
         Assertions.assertFalse(actual.isUnknown());
-        Assertions.assertEquals(minEpoch - maxOffsetSec, actual.getMinValue(), 0.001);
-        Assertions.assertEquals(maxEpoch + maxOffsetSec, actual.getMaxValue(), 0.001);
+        // Variable zones: estimated range must cover conversions under near-extreme offsets.
+        assertConvertTzStatRangeCovers(actual, "UTC", "Asia/Shanghai", minDt, maxDt);
+        assertConvertTzStatRangeCovers(actual, "Pacific/Kiritimati", "Etc/GMT+12", minDt, maxDt);
         Assertions.assertEquals(nullsFraction, actual.getNullsFraction(), 0.001);
         Assertions.assertEquals(4, actual.getDistinctValuesCount(), 0.001); // min(100, 2*1*2)
         Assertions.assertEquals(DateType.DATETIME.getTypeSize(), actual.getAverageRowSize(), 0.001);
@@ -2523,6 +2525,10 @@ public class ExpressionStatisticsCalculatorTest {
         Assertions.assertEquals(2, mcv.size());
         Assertions.assertEquals(100L, mcv.get(convertTzMcvKey(dt1, fromTz, toTz)));
         Assertions.assertEquals(200L, mcv.get(convertTzMcvKey(dt2, fromTz, toTz)));
+        // Converted MCV inputs must lie inside the estimated/bucket range.
+        assertConvertTzStatRangeCovers(actual, fromTz, toTz,
+                LocalDateTime.of(2024, 1, 15, 10, 20, 30),
+                LocalDateTime.of(2024, 1, 15, 14, 45, 0));
     }
 
     @Test
@@ -2588,6 +2594,9 @@ public class ExpressionStatisticsCalculatorTest {
 
         Assertions.assertNull(actual.getHistogram());
         Assertions.assertEquals(2, actual.getDistinctValuesCount(), 0.001);
+        assertConvertTzStatRangeCoversEveryMinute(actual, "UTC", "Asia/Shanghai",
+                LocalDateTime.of(2024, 1, 15, 10, 20, 30),
+                LocalDateTime.of(2024, 1, 15, 14, 45, 0));
     }
 
     @Test
@@ -2643,12 +2652,13 @@ public class ExpressionStatisticsCalculatorTest {
     }
 
     @Test
-    public void testConvertTzUsesExactRangeForConstantTimezones() {
+    public void testConvertTzRangeCoversSamplesForConstantTimezones() {
         final String fromTz = "UTC";
         final String toTz = "Asia/Shanghai";
-        final double minValue = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30));
-        final double maxValue = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 14, 45, 0));
-        final double maxOffsetSec = 26.0 * 3600.0;
+        final LocalDateTime minDt = LocalDateTime.of(2024, 1, 15, 10, 20, 30);
+        final LocalDateTime maxDt = LocalDateTime.of(2024, 1, 15, 14, 45, 0);
+        final double minValue = getLongFromDateTime(minDt);
+        final double maxValue = getLongFromDateTime(maxDt);
 
         final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
         final Statistics statistics = Statistics.builder()
@@ -2668,25 +2678,59 @@ public class ExpressionStatisticsCalculatorTest {
                         ConstantOperator.createVarchar(toTz)));
 
         final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
-        final double expectedMin = convertTzDateTimeValue(minValue, fromTz, toTz);
-        final double expectedMax = convertTzDateTimeValue(maxValue, fromTz, toTz);
 
-        Assertions.assertEquals(expectedMin, actual.getMinValue(), 0.001);
-        Assertions.assertEquals(expectedMax, actual.getMaxValue(), 0.001);
-        // Exact conversion must be tighter than the conservative ±26h widen.
-        Assertions.assertTrue(actual.getMinValue() > minValue - maxOffsetSec);
-        Assertions.assertTrue(actual.getMaxValue() < maxValue + maxOffsetSec);
+        assertConvertTzStatRangeCoversEveryMinute(actual, fromTz, toTz, minDt, maxDt);
         Assertions.assertEquals(2, actual.getDistinctValuesCount(), 0.001);
     }
 
     @Test
-    public void testConvertTzReordersExactRangeWhenOffsetFlipsEndpoints() {
-        // Negative overall shift (Shanghai -> UTC): both endpoints move earlier.
-        // Result min/max must still be ordered via min()/max() of the converted endpoints.
+    public void testConvertTzRangeCoversSamplesAcrossDstTransition() {
+        // Europe/Berlin falls back on 2024-10-27. Endpoint-only conversion under-ranges because
+        // UTC 00:59 -> Berlin 02:59 lies outside convert(00:30)/convert(01:30).
+        final String fromTz = "UTC";
+        final String toTz = "Europe/Berlin";
+        final LocalDateTime minDt = LocalDateTime.of(2024, 10, 27, 0, 30, 0);
+        final LocalDateTime maxDt = LocalDateTime.of(2024, 10, 27, 1, 30, 0);
+        final LocalDateTime foldPeak = LocalDateTime.of(2024, 10, 27, 0, 59, 0);
+        final double minValue = getLongFromDateTime(minDt);
+        final double maxValue = getLongFromDateTime(maxDt);
+
+        final double convertedMin = convertTzDateTimeValue(minValue, fromTz, toTz);
+        final double convertedMax = convertTzDateTimeValue(maxValue, fromTz, toTz);
+        final double convertedFoldPeak = convertTzDateTimeValue(getLongFromDateTime(foldPeak), fromTz, toTz);
+        Assertions.assertTrue(convertedFoldPeak > Math.max(convertedMin, convertedMax)
+                || convertedFoldPeak < Math.min(convertedMin, convertedMax));
+
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(dtCol, ColumnStatistic.builder()
+                        .setMinValue(minValue)
+                        .setMaxValue(maxValue)
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(3)
+                        .build())
+                .build();
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(
+                        dtCol,
+                        ConstantOperator.createVarchar(fromTz),
+                        ConstantOperator.createVarchar(toTz)));
+
+        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
+
+        assertConvertTzStatRangeCoversEveryMinute(actual, fromTz, toTz, minDt, maxDt);
+    }
+
+    @Test
+    public void testConvertTzRangeCoversSamplesWhenOffsetShiftsEarlier() {
         final String fromTz = "Asia/Shanghai";
         final String toTz = "UTC";
-        final double minValue = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30));
-        final double maxValue = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 14, 45, 0));
+        final LocalDateTime minDt = LocalDateTime.of(2024, 1, 15, 10, 20, 30);
+        final LocalDateTime maxDt = LocalDateTime.of(2024, 1, 15, 14, 45, 0);
+        final double minValue = getLongFromDateTime(minDt);
+        final double maxValue = getLongFromDateTime(maxDt);
 
         final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
         final Statistics statistics = Statistics.builder()
@@ -2706,19 +2750,15 @@ public class ExpressionStatisticsCalculatorTest {
                         ConstantOperator.createVarchar(toTz)));
 
         final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
-        final double convertedMin = convertTzDateTimeValue(minValue, fromTz, toTz);
-        final double convertedMax = convertTzDateTimeValue(maxValue, fromTz, toTz);
 
-        Assertions.assertEquals(Math.min(convertedMin, convertedMax), actual.getMinValue(), 0.001);
-        Assertions.assertEquals(Math.max(convertedMin, convertedMax), actual.getMaxValue(), 0.001);
         Assertions.assertTrue(actual.getMinValue() <= actual.getMaxValue());
+        assertConvertTzStatRangeCoversEveryMinute(actual, fromTz, toTz, minDt, maxDt);
     }
 
     @Test
     public void testConvertTzFallsBackToWidenedRangeWhenTimezoneInvalid() {
         final double minValue = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30));
         final double maxValue = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 14, 45, 0));
-        final double maxOffsetSec = 26.0 * 3600.0;
 
         final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
         final Statistics statistics = Statistics.builder()
@@ -2739,14 +2779,14 @@ public class ExpressionStatisticsCalculatorTest {
 
         final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
 
-        Assertions.assertEquals(minValue - maxOffsetSec, actual.getMinValue(), 0.001);
-        Assertions.assertEquals(maxValue + maxOffsetSec, actual.getMaxValue(), 0.001);
+        // Invalid zone: cannot evaluate samples; range must still cover the input domain.
+        Assertions.assertTrue(actual.getMinValue() <= minValue);
+        Assertions.assertTrue(actual.getMaxValue() >= maxValue);
         Assertions.assertNull(actual.getHistogram());
     }
 
     @Test
     public void testConvertTzKeepsWidenedRangeWhenChildRangeIsInfinite() {
-        final double maxOffsetSec = 26.0 * 3600.0;
         final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
         final Statistics statistics = Statistics.builder()
                 .setOutputRowCount(1000)
@@ -2766,9 +2806,26 @@ public class ExpressionStatisticsCalculatorTest {
 
         final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
 
-        Assertions.assertEquals(Double.NEGATIVE_INFINITY - maxOffsetSec, actual.getMinValue(), 0.001);
-        Assertions.assertEquals(Double.POSITIVE_INFINITY + maxOffsetSec, actual.getMaxValue(), 0.001);
+        Assertions.assertTrue(actual.isInfiniteRange());
         Assertions.assertEquals(2, actual.getDistinctValuesCount(), 0.001);
+    }
+
+    private static void assertConvertTzStatRangeCovers(ColumnStatistic actual, String fromTz, String toTz,
+                                                       LocalDateTime... samples) {
+        for (LocalDateTime sample : samples) {
+            final double converted = convertTzDateTimeValue(getLongFromDateTime(sample), fromTz, toTz);
+            Assertions.assertTrue(
+                    converted >= actual.getMinValue() - 0.001 && converted <= actual.getMaxValue() + 0.001,
+                    () -> "convert_tz(" + sample + ", " + fromTz + ", " + toTz + ") = " + converted
+                            + " outside estimated range [" + actual.getMinValue() + ", " + actual.getMaxValue() + "]");
+        }
+    }
+
+    private static void assertConvertTzStatRangeCoversEveryMinute(ColumnStatistic actual, String fromTz, String toTz,
+                                                                  LocalDateTime start, LocalDateTime end) {
+        for (LocalDateTime sample = start; !sample.isAfter(end); sample = sample.plusMinutes(1)) {
+            assertConvertTzStatRangeCovers(actual, fromTz, toTz, sample);
+        }
     }
 
     private static String convertTzMcvKey(String datetime, String fromTz, String toTz) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -2637,12 +2637,149 @@ public class ExpressionStatisticsCalculatorTest {
         Assertions.assertNull(actual.getHistogram());
     }
 
+    @Test
+    public void testConvertTzUsesExactRangeForConstantTimezones() {
+        final String fromTz = "UTC";
+        final String toTz = "Asia/Shanghai";
+        final double minValue = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30));
+        final double maxValue = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 14, 45, 0));
+        final double maxOffsetSec = 26.0 * 3600.0;
+
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(dtCol, ColumnStatistic.builder()
+                        .setMinValue(minValue)
+                        .setMaxValue(maxValue)
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(2)
+                        .build())
+                .build();
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(
+                        dtCol,
+                        ConstantOperator.createVarchar(fromTz),
+                        ConstantOperator.createVarchar(toTz)));
+
+        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
+        final double expectedMin = convertTzDateTimeValue(minValue, fromTz, toTz);
+        final double expectedMax = convertTzDateTimeValue(maxValue, fromTz, toTz);
+
+        Assertions.assertEquals(expectedMin, actual.getMinValue(), 0.001);
+        Assertions.assertEquals(expectedMax, actual.getMaxValue(), 0.001);
+        // Exact conversion must be tighter than the conservative ±26h widen.
+        Assertions.assertTrue(actual.getMinValue() > minValue - maxOffsetSec);
+        Assertions.assertTrue(actual.getMaxValue() < maxValue + maxOffsetSec);
+        Assertions.assertEquals(2, actual.getDistinctValuesCount(), 0.001);
+    }
+
+    @Test
+    public void testConvertTzReordersExactRangeWhenOffsetFlipsEndpoints() {
+        // Negative overall shift (Shanghai -> UTC): both endpoints move earlier.
+        // Result min/max must still be ordered via min()/max() of the converted endpoints.
+        final String fromTz = "Asia/Shanghai";
+        final String toTz = "UTC";
+        final double minValue = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30));
+        final double maxValue = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 14, 45, 0));
+
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(dtCol, ColumnStatistic.builder()
+                        .setMinValue(minValue)
+                        .setMaxValue(maxValue)
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(2)
+                        .build())
+                .build();
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(
+                        dtCol,
+                        ConstantOperator.createVarchar(fromTz),
+                        ConstantOperator.createVarchar(toTz)));
+
+        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
+        final double convertedMin = convertTzDateTimeValue(minValue, fromTz, toTz);
+        final double convertedMax = convertTzDateTimeValue(maxValue, fromTz, toTz);
+
+        Assertions.assertEquals(Math.min(convertedMin, convertedMax), actual.getMinValue(), 0.001);
+        Assertions.assertEquals(Math.max(convertedMin, convertedMax), actual.getMaxValue(), 0.001);
+        Assertions.assertTrue(actual.getMinValue() <= actual.getMaxValue());
+    }
+
+    @Test
+    public void testConvertTzFallsBackToWidenedRangeWhenTimezoneInvalid() {
+        final double minValue = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30));
+        final double maxValue = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 14, 45, 0));
+        final double maxOffsetSec = 26.0 * 3600.0;
+
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(dtCol, ColumnStatistic.builder()
+                        .setMinValue(minValue)
+                        .setMaxValue(maxValue)
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(2)
+                        .build())
+                .build();
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(
+                        dtCol,
+                        ConstantOperator.createVarchar("Not/AZone"),
+                        ConstantOperator.createVarchar("UTC")));
+
+        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
+
+        Assertions.assertEquals(minValue - maxOffsetSec, actual.getMinValue(), 0.001);
+        Assertions.assertEquals(maxValue + maxOffsetSec, actual.getMaxValue(), 0.001);
+        Assertions.assertNull(actual.getHistogram());
+    }
+
+    @Test
+    public void testConvertTzKeepsWidenedRangeWhenChildRangeIsInfinite() {
+        final double maxOffsetSec = 26.0 * 3600.0;
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(dtCol, ColumnStatistic.builder()
+                        .setMinValue(Double.NEGATIVE_INFINITY)
+                        .setMaxValue(Double.POSITIVE_INFINITY)
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(2)
+                        .build())
+                .build();
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(
+                        dtCol,
+                        ConstantOperator.createVarchar("UTC"),
+                        ConstantOperator.createVarchar("Asia/Shanghai")));
+
+        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
+
+        Assertions.assertEquals(Double.NEGATIVE_INFINITY - maxOffsetSec, actual.getMinValue(), 0.001);
+        Assertions.assertEquals(Double.POSITIVE_INFINITY + maxOffsetSec, actual.getMaxValue(), 0.001);
+        Assertions.assertEquals(2, actual.getDistinctValuesCount(), 0.001);
+    }
+
     private static String convertTzMcvKey(String datetime, String fromTz, String toTz) {
         final ConstantOperator converted = ScalarOperatorFunctions.convert_tz(
                 ConstantOperator.createVarchar(datetime).castTo(DateType.DATETIME).get(),
                 ConstantOperator.createVarchar(fromTz),
                 ConstantOperator.createVarchar(toTz));
         return converted.castTo(VarcharType.VARCHAR).get().getVarchar();
+    }
+
+    private static double convertTzDateTimeValue(double dateTimeValue, String fromTz, String toTz) {
+        final ConstantOperator converted = ScalarOperatorFunctions.convert_tz(
+                ConstantOperator.createDatetime(Utils.getDatetimeFromLong((long) dateTimeValue)),
+                ConstantOperator.createVarchar(fromTz),
+                ConstantOperator.createVarchar(toTz));
+        return Utils.getLongFromDateTime(converted.getDatetime());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -2596,130 +2596,9 @@ public class ExpressionStatisticsCalculatorTest {
         Assertions.assertEquals(2, mcv.size());
         Assertions.assertEquals(100L, mcv.get(convertTzMcvKey(dt1, fromTz, toTz)));
         Assertions.assertEquals(200L, mcv.get(convertTzMcvKey(dt2, fromTz, toTz)));
-        // Converted MCV inputs must lie inside the estimated/bucket range.
         assertConvertTzStatRangeCovers(actual, fromTz, toTz,
                 LocalDateTime.of(2024, 1, 15, 10, 20, 30),
                 LocalDateTime.of(2024, 1, 15, 14, 45, 0));
-    }
-
-    @Test
-    public void testConvertTzNoMcvWhenTimezonesAreNotConstant() {
-        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
-        final ColumnRefOperator fromTzCol = new ColumnRefOperator(1, VarcharType.VARCHAR, "from_tz", true);
-        final ColumnRefOperator toTzCol = new ColumnRefOperator(2, VarcharType.VARCHAR, "to_tz", true);
-        final Map<String, Long> inputMcv = Map.of("2024-01-15 10:20:30", 100L);
-        final Statistics statistics = Statistics.builder()
-                .setOutputRowCount(1000)
-                .addColumnStatistic(dtCol, ColumnStatistic.builder()
-                        .setMinValue(getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30)))
-                        .setMaxValue(getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30)))
-                        .setNullsFraction(0)
-                        .setAverageRowSize(8)
-                        .setDistinctValuesCount(1)
-                        .setHistogram(new Histogram(Collections.emptyList(), inputMcv))
-                        .build())
-                .addColumnStatistic(fromTzCol, ColumnStatistic.builder()
-                        .setMinValue(Double.NEGATIVE_INFINITY)
-                        .setMaxValue(Double.POSITIVE_INFINITY)
-                        .setNullsFraction(0)
-                        .setAverageRowSize(8)
-                        .setDistinctValuesCount(2)
-                        .build())
-                .addColumnStatistic(toTzCol, ColumnStatistic.builder()
-                        .setMinValue(Double.NEGATIVE_INFINITY)
-                        .setMaxValue(Double.POSITIVE_INFINITY)
-                        .setNullsFraction(0)
-                        .setAverageRowSize(8)
-                        .setDistinctValuesCount(2)
-                        .build())
-                .build();
-        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
-                Lists.newArrayList(dtCol, fromTzCol, toTzCol));
-
-        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
-
-        Assertions.assertNull(actual.getHistogram());
-        Assertions.assertEquals(4, actual.getDistinctValuesCount(), 0.001); // min(1000, 1*2*2)
-    }
-
-    @Test
-    public void testConvertTzNoMcvWhenInputHasNoHistogram() {
-        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
-        final Statistics statistics = Statistics.builder()
-                .setOutputRowCount(1000)
-                .addColumnStatistic(dtCol, ColumnStatistic.builder()
-                        .setMinValue(getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30)))
-                        .setMaxValue(getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 14, 45, 0)))
-                        .setNullsFraction(0)
-                        .setAverageRowSize(8)
-                        .setDistinctValuesCount(2)
-                        .build())
-                .build();
-        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
-                Lists.newArrayList(
-                        dtCol,
-                        ConstantOperator.createVarchar("UTC"),
-                        ConstantOperator.createVarchar("Asia/Shanghai")));
-
-        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
-
-        Assertions.assertNull(actual.getHistogram());
-        Assertions.assertEquals(2, actual.getDistinctValuesCount(), 0.001);
-        assertConvertTzStatRangeCoversEveryMinute(actual, "UTC", "Asia/Shanghai",
-                LocalDateTime.of(2024, 1, 15, 10, 20, 30),
-                LocalDateTime.of(2024, 1, 15, 14, 45, 0));
-    }
-
-    @Test
-    public void testConvertTzNoMcvWhenTimezoneInvalid() {
-        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
-        final Map<String, Long> inputMcv = Map.of("2024-01-15 10:20:30", 100L);
-        final Statistics statistics = Statistics.builder()
-                .setOutputRowCount(1000)
-                .addColumnStatistic(dtCol, ColumnStatistic.builder()
-                        .setMinValue(getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30)))
-                        .setMaxValue(getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30)))
-                        .setNullsFraction(0)
-                        .setAverageRowSize(8)
-                        .setDistinctValuesCount(1)
-                        .setHistogram(new Histogram(Collections.emptyList(), inputMcv))
-                        .build())
-                .build();
-        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
-                Lists.newArrayList(
-                        dtCol,
-                        ConstantOperator.createVarchar("Not/AZone"),
-                        ConstantOperator.createVarchar("UTC")));
-
-        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
-
-        Assertions.assertNull(actual.getHistogram());
-    }
-
-    @Test
-    public void testConvertTzNoMcvWhenMcvKeyInvalid() {
-        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
-        final Map<String, Long> inputMcv = Map.of("not-a-datetime", 100L);
-        final Statistics statistics = Statistics.builder()
-                .setOutputRowCount(1000)
-                .addColumnStatistic(dtCol, ColumnStatistic.builder()
-                        .setMinValue(getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30)))
-                        .setMaxValue(getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30)))
-                        .setNullsFraction(0)
-                        .setAverageRowSize(8)
-                        .setDistinctValuesCount(1)
-                        .setHistogram(new Histogram(Collections.emptyList(), inputMcv))
-                        .build())
-                .build();
-        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
-                Lists.newArrayList(
-                        dtCol,
-                        ConstantOperator.createVarchar("UTC"),
-                        ConstantOperator.createVarchar("Asia/Shanghai")));
-
-        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
-
-        Assertions.assertNull(actual.getHistogram());
     }
 
     @Test
@@ -2728,15 +2607,13 @@ public class ExpressionStatisticsCalculatorTest {
         final String toTz = "Asia/Shanghai";
         final LocalDateTime minDt = LocalDateTime.of(2024, 1, 15, 10, 20, 30);
         final LocalDateTime maxDt = LocalDateTime.of(2024, 1, 15, 14, 45, 0);
-        final double minValue = getLongFromDateTime(minDt);
-        final double maxValue = getLongFromDateTime(maxDt);
 
         final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
         final Statistics statistics = Statistics.builder()
                 .setOutputRowCount(1000)
                 .addColumnStatistic(dtCol, ColumnStatistic.builder()
-                        .setMinValue(minValue)
-                        .setMaxValue(maxValue)
+                        .setMinValue(getLongFromDateTime(minDt))
+                        .setMaxValue(getLongFromDateTime(maxDt))
                         .setNullsFraction(0)
                         .setAverageRowSize(8)
                         .setDistinctValuesCount(2)
@@ -2762,22 +2639,13 @@ public class ExpressionStatisticsCalculatorTest {
         final String toTz = "Europe/Berlin";
         final LocalDateTime minDt = LocalDateTime.of(2024, 10, 27, 0, 30, 0);
         final LocalDateTime maxDt = LocalDateTime.of(2024, 10, 27, 1, 30, 0);
-        final LocalDateTime foldPeak = LocalDateTime.of(2024, 10, 27, 0, 59, 0);
-        final double minValue = getLongFromDateTime(minDt);
-        final double maxValue = getLongFromDateTime(maxDt);
-
-        final double convertedMin = convertTzDateTimeValue(minValue, fromTz, toTz);
-        final double convertedMax = convertTzDateTimeValue(maxValue, fromTz, toTz);
-        final double convertedFoldPeak = convertTzDateTimeValue(getLongFromDateTime(foldPeak), fromTz, toTz);
-        Assertions.assertTrue(convertedFoldPeak > Math.max(convertedMin, convertedMax)
-                || convertedFoldPeak < Math.min(convertedMin, convertedMax));
 
         final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
         final Statistics statistics = Statistics.builder()
                 .setOutputRowCount(1000)
                 .addColumnStatistic(dtCol, ColumnStatistic.builder()
-                        .setMinValue(minValue)
-                        .setMaxValue(maxValue)
+                        .setMinValue(getLongFromDateTime(minDt))
+                        .setMaxValue(getLongFromDateTime(maxDt))
                         .setNullsFraction(0)
                         .setAverageRowSize(8)
                         .setDistinctValuesCount(3)
@@ -2800,15 +2668,13 @@ public class ExpressionStatisticsCalculatorTest {
         final String toTz = "UTC";
         final LocalDateTime minDt = LocalDateTime.of(2024, 1, 15, 10, 20, 30);
         final LocalDateTime maxDt = LocalDateTime.of(2024, 1, 15, 14, 45, 0);
-        final double minValue = getLongFromDateTime(minDt);
-        final double maxValue = getLongFromDateTime(maxDt);
 
         final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
         final Statistics statistics = Statistics.builder()
                 .setOutputRowCount(1000)
                 .addColumnStatistic(dtCol, ColumnStatistic.builder()
-                        .setMinValue(minValue)
-                        .setMaxValue(maxValue)
+                        .setMinValue(getLongFromDateTime(minDt))
+                        .setMaxValue(getLongFromDateTime(maxDt))
                         .setNullsFraction(0)
                         .setAverageRowSize(8)
                         .setDistinctValuesCount(2)


### PR DESCRIPTION
## Why I'm doing:

Statistics for `CONVERT_TZ` were not implemented. This can lead to suboptimal query plans.
 
## What I'm doing:

Add statistics propagation for `CONVERT_TZ` in `ExpressionStatisticCalculator`. I am using the already existing FE implementation used for constant folding for min/max values. In cases, where it is not constant, we use the 26 hour window frame as min/max values. 

We also add MCVs calculation for `CONVERT_TZ` operator using `convert_tz` function from `ScalarOperatorFunctions` in FE. 

Add unit coverage in `ExpressionStatisticsCalculatorTest`.

Fixes #

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5