### PR TITLE
[BugFix] Fix MV add partition failure when session time_zone is east of +08:00

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -1551,7 +1551,15 @@ public class MvUtils {
                 materializedView.getTableProperty().getProperties().get("storage_cooldown_time");
         if (storageCooldownTime != null) {
             // cast long str to time str e.g.  '1587473111000' -> '2020-04-21 15:00:00'
-            String storageCooldownTimeStr = TimeUtils.longToTimeString(Long.parseLong(storageCooldownTime));
+            // The literal is re-parsed as a DATETIME by PropertyAnalyzer.analyzeDataProperty when the
+            // partition is added, in the session time zone it was rendered in. "never cool down" is
+            // 9999-12-31 23:59:59 at +08:00, so a session zone east of that renders year 10000, which
+            // the DATETIME parser rejects and adding the partition fails. Bound the value at the latest
+            // DATETIME the session zone can express.
+            long maxExpressibleMs = TimeUtils.MAX_DATETIME.atZone(TimeUtils.getTimeZone().toZoneId())
+                    .toInstant().toEpochMilli();
+            String storageCooldownTimeStr = TimeUtils.longToTimeString(
+                    Math.min(Long.parseLong(storageCooldownTime), maxExpressibleMs));
             partitionProperties.put("storage_cooldown_time", storageCooldownTimeStr);
         }
         return partitionProperties;

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -963,6 +963,10 @@ public class MaterializedViewTest extends StarRocksTestBase {
 
     @Test
     public void testCreateMVWithCoolDownTime() throws Exception {
+        // The assertions below pin the exact "never cool down" epoch, which is only expressible as a
+        // DATETIME literal at or west of the +08:00 storage zone. Pin the session zone so the test does
+        // not depend on the machine's zone (SessionVariable defaults to TimeUtils.getSystemTimeZone()).
+        connectContext.getSessionVariable().setTimeZone("Asia/Shanghai");
         starRocksAssert.withDatabase("test").useDatabase("test")
                 .withTable("CREATE TABLE test.table1\n" +
                         "(\n" +
@@ -1029,6 +1033,44 @@ public class MaterializedViewTest extends StarRocksTestBase {
                 DataProperty.getInferredDefaultDataProperty(), false);
         Assertions.assertTrue(mockDataProperty.getCooldownTimeMs() < 253402271999000L);
         // misbehavior
+    }
+
+    @Test
+    public void testCoolDownTimeOfPartitionPropertiesEastOfStorageZone() throws Exception {
+        // The "never cool down" cooldown is stored as 9999-12-31 23:59:59 in the fixed +08:00 cluster
+        // zone, so it is not expressible as a DATETIME in a session time zone east of +08:00. Both
+        // zones are pinned here because the stored value is zone independent while the rendered
+        // literal is not: an FE reading this metadata with time_zone = Asia/Seoul used to render
+        // "+10000-01-01 00:59:59", which analyzeDataProperty rejects, so adding a partition to the MV
+        // failed and the refresh stopped making progress.
+        String originalTimeZone = connectContext.getSessionVariable().getTimeZone();
+        try {
+            connectContext.getSessionVariable().setTimeZone("Asia/Shanghai");
+            starRocksAssert.withMaterializedView("create materialized view mv_cooldown_east_of_utc8 " +
+                    "DISTRIBUTED BY HASH(`k2`) BUCKETS 3 REFRESH MANUAL PROPERTIES (" +
+                    "\"replication_num\" = \"1\"," +
+                    "\"storage_medium\" = \"SSD\"," +
+                    "\"storage_cooldown_time\" = \"9999-12-31 23:59:59\")" +
+                    "as select k2, sum(v1) as total from base_t1 group by k2;");
+            MaterializedView mv = (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getDb("test").getTable("mv_cooldown_east_of_utc8");
+            Assertions.assertEquals(String.valueOf(DataProperty.MAX_COOLDOWN_TIME_MS),
+                    mv.getTableProperty().getProperties().get("storage_cooldown_time"));
+
+            connectContext.getSessionVariable().setTimeZone("Asia/Seoul");
+            Map<String, String> partitionProperties = MvUtils.getPartitionProperties(mv);
+            Assertions.assertEquals("9999-12-31 23:59:59", partitionProperties.get("storage_cooldown_time"));
+
+            // The bounded literal still means "never cool down": every consumer compares the cooldown
+            // against the current time, and this is the furthest instant Asia/Seoul (+09:00) can name.
+            DataProperty dataProperty = PropertyAnalyzer.analyzeDataProperty(partitionProperties,
+                    DataProperty.getInferredDefaultDataProperty(), false);
+            Assertions.assertEquals(DataProperty.MAX_COOLDOWN_TIME_MS - 3600 * 1000L,
+                    dataProperty.getCooldownTimeMs());
+        } finally {
+            connectContext.getSessionVariable().setTimeZone(originalTimeZone);
+            starRocksAssert.dropMaterializedView("mv_cooldown_east_of_utc8");
+        }
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

`DataProperty.MAX_COOLDOWN_TIME_MS` (253402271999000) is the "never cool down" sentinel. It is
`9999-12-31 23:59:59` **at the fixed +08:00 storage zone**, so it is not representable as a DATETIME
wall clock in any session time zone east of +08:00.

`MvUtils.getPartitionProperties()` renders that stored epoch-ms with `TimeUtils.longToTimeString(long)`,
which formats in the **session** zone, and the result is fed straight back into `storage_cooldown_time`
of the `ADD PARTITION` the refresh generates. With `time_zone = Asia/Seoul` the literal is
`+10000-01-01 00:59:59`, so `PropertyAnalyzer.analyzeDataProperty` cannot parse it back and every
partition creation on the MV fails:

```text
com.starrocks.sql.analyzer.SemanticException: Getting analyzing error.
        at PropertyAnalyzer.analyzeDataProperty() / DateUtils.parseStrictDateTime()
Caused by: java.time.format.DateTimeParseException:
        Text '+10000-01-01 00:59:59' could not be parsed at index 12
```

Existing partitions keep refreshing, so the MV just silently stops picking up new data.

Two things make this worse than it looks:

- **It triggers on stock configuration.** With `tablet_sched_storage_cooldown_second = -1`
  (`Config.java:2125`), `DataProperty.getSsdCooldownTimeMs()` returns the sentinel, so any MV with
  `storage_medium = SSD` carries it even if the user never wrote `storage_cooldown_time`.
- **It is not `main`-only.** The same unbounded render is in tags 4.0.13 (`MvUtils:1538`) and 3.5.20
  (`:1494`), where the formatter emits `10000-01-01 00:59:59` without a sign and the fixed-width-4 year
  field rejects it just the same.

A *user-supplied* literal is not affected: `analyzeDataProperty` parses it in the session zone, so
`9999-12-31 23:59:59` entered in `Asia/Seoul` is stored as `sentinel - 1h` and renders back fine. The
bug needs the zone-independent sentinel in metadata plus a session zone east of +08:00.

Fixes #77851

## What I'm doing:

Bounding the rendered value at the latest DATETIME the session zone can express, at the one site whose
output is re-parsed:

```java
long maxExpressibleMs = TimeUtils.MAX_DATETIME.atZone(TimeUtils.getTimeZone().toZoneId())
        .toInstant().toEpochMilli();
String storageCooldownTimeStr = TimeUtils.longToTimeString(
        Math.min(Long.parseLong(storageCooldownTime), maxExpressibleMs));
```

Three notes on why this shape:

- `AnalyzerUtils.createPartitionKeyDesc()` already does the same thing when it builds an
  `AddPartitionClause`: compare against `TimeUtils.MAX_DATETIME` and saturate rather than emit a literal
  outside the type's domain (`AnalyzerUtils.java:1931`).
- The bound is **session-relative** on purpose. Rendering and parsing have to agree on the zone — using
  a fixed zone here would shift ordinary cooldown values, which is what #66360 regressed. At or west of
  +08:00 the output is therefore unchanged, and #52079's assertion that the value round-trips back to
  exactly `253402271999000` still holds. A universal bound such as `TimeUtils.MAX_UNIX_TIMESTAMP` would
  break it.
- A bounded value still means "never cool down": every consumer compares the cooldown against the
  current time, and no FE code compares it against `MAX_COOLDOWN_TIME_MS` — every reference constructs
  or assigns with it. The shift is at most 8 hours, in year 9999.

`longToTimeString(long)`'s javadoc asks round-trip callers to carry epoch-ms rather than a wall-clock
string, and I agree that is the end state. It is not reachable from this call site alone: MV partitions
are created by generating an `ADD PARTITION` clause and running it through the normal analyzer
(`MVPCTRefreshListPartitioner`), whose contract for this property is a DATETIME literal. Changing that
means widening the property syntax or giving the MV a typed cooldown — both larger than a bug fix, and
neither removes the display sites below. Happy to follow up if you would like that direction.

Test: `MaterializedViewTest.testCoolDownTimeOfPartitionPropertiesEastOfStorageZone`, next to the #52079
test. It pins **both** zones — the MV is created at `Asia/Shanghai` so the sentinel is what lands in
metadata, then the session moves to `Asia/Seoul` for the render — and asserts the literal is
`9999-12-31 23:59:59` and round-trips to a "never cool down" instant. Reverting only the `MvUtils`
change makes it fail. A single-zone test would not: created in `Asia/Seoul` the stored value is
`sentinel - 1h`, which renders back fine with or without the fix.

`testCreateMVWithCoolDownTime` now pins `Asia/Shanghai` as well. It asserts the exact sentinel epoch,
which is only expressible at or west of +08:00, so without an explicit zone it depends on the
developer's machine zone (`SessionVariable.timeZone` defaults to `TimeUtils.getSystemTimeZone()`).

Known follow-ups, deliberately not here — display only, none of them stops a refresh:
`SHOW CREATE MATERIALIZED VIEW` (`MaterializedView.java:2107`), `SHOW MATERIALIZED VIEWS` (`:2208`),
`SHOW PARTITIONS` (`PartitionsProcDir.java:395`), and BE
`information_schema.partitions_meta.COOLDOWN_TIME`. Fixing those together would justify a shared
helper, which felt out of place in a bug fix.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

branch-4.0, 3.5, 3.4 and 3.3 are affected too — the cooldown block is byte-identical there
(`4.0:1538`, `3.5:1494`, `3.4:1477`, `3.3:1437`). I left those boxes unchecked because an automatic
cherry-pick would apply cleanly and then fail to compile: `TimeUtils.MAX_DATETIME` is a `LocalDateTime`
only on `branch-4.1` and `main`, and a `java.util.Date` on the rest. Adapting it also needs care —
there `MAX_DATETIME` is parsed at a fixed +08:00, so `MAX_DATETIME.getTime()` *is*
`MAX_COOLDOWN_TIME_MS` and a naive `Math.min` would be a no-op. I'd rather send those backports by hand
once this lands.
