### PR TITLE
[Tool] retire backport-reconcile-shadow (superseded by pre-merge advisory; SR drops AI)

### DIFF
--- a/.github/workflows/ci-merged.yml
+++ b/.github/workflows/ci-merged.yml
@@ -67,37 +67,6 @@ jobs:
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
           python3 lib/backport_fanout_run.py --repo ${GITHUB_REPOSITORY} --pr ${PR_NUMBER} --dry-run
 
-  # Decision-10 phase B shadow: checkbox x AI-affected reconciliation, DRY-RUN.
-  # Runs on [self-hosted, ubuntu, ai] — that pool has BOTH /var/lib/ci-tool AND
-  # `claude` + the github-bugfix-versions plugin (see bugfix-version-index.yml).
-  # `claude` returns this [BugFix]'s affected release lines (branches still
-  # carrying the bug); backport_reconcile.py then prints the matrix (window /
-  # affected / checked / auto / notify) and posts NOTHING. continue-on-error so
-  # it can never affect the merge. Needs ci-tool #4934 on the runner.
-  backport-reconcile-shadow:
-    name: Backport Reconcile (dry-run shadow)
-    runs-on: [ self-hosted, ubuntu, ai ]
-    if: >
-      github.event.pull_request.merged == true &&
-      github.base_ref == 'main' &&
-      github.repository == 'StarRocks/starrocks' &&
-      startsWith(github.event.pull_request.title, '[BugFix]') &&
-      !contains(github.event.pull_request.title, '(sync #') &&
-      !contains(github.event.pull_request.labels.*.name, 'sync') &&
-      !contains(github.head_ref, '-sync-') &&
-      !contains(github.event.pull_request.title, 'cherry-pick') &&
-      !contains(github.event.pull_request.title, 'backport')
-    continue-on-error: true
-    env:
-      PR_NUMBER: ${{ github.event.number }}
-      GH_TOKEN: ${{ secrets.PAT }}
-      GITHUB_TOKEN: ${{ secrets.PAT }}
-    steps:
-      - name: reconcile dry-run (checkbox x AI affected)
-        run: |
-          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
-          ./bin/backport_reconcile.sh --repo ${GITHUB_REPOSITORY} --pr ${PR_NUMBER} --dry-run
-
   thirdparty-filter:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true


### PR DESCRIPTION
## Why I'm doing:

`backport-reconcile-shadow` (at-merge dry-run: checkbox × AI-affected) was the precursor to an at-merge AI reconcile that is no longer the plan: execution is unified on **checkbox → label → static backport matrix**, the AI-vs-checkbox comparison moved to the CelerData-side **pre-merge advisory**, and StarRocks **drops the AI side entirely** (2026-08-13 decision — the SR-side advisory was likewise not deployed). The job now only burns a `claude` run per merged `[BugFix]` and logs a matrix nobody consumes.

## What I'm doing:

Delete the `backport-reconcile-shadow` job from `ci-merged.yml`. Pure removal, zero behavior risk (the job was `continue-on-error` and never affected the merge or posted anything). It was also the last main-branch caller of the `backport_reconcile.sh` compat shim, unblocking the shim's removal in ci-tool.

Not touched: `backport-fanout-shadow` (separate mechanism) and the static `backport` matrix.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5