### PR TITLE
[Enhancement] Bump hadoop-cos to 3.4.1-8.3.31 and cos_api-bundle to 5.6.244.4

### DIFF
--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -131,8 +131,9 @@ subprojects {
             implementation("com.opencsv:opencsv:5.7.1")
             implementation("com.oracle.database.jdbc:ojdbc10:19.18.0.0")
             implementation("com.oracle.database.nls:orai18n:19.18.0.0")
-            implementation("com.qcloud.cos:hadoop-cos:3.3.0-8.3.2")
-            implementation("com.qcloud:chdfs_hadoop_plugin_network:3.2")
+            // transitively supplies cos_api-bundle, chdfs_hadoop_plugin_network,
+            // cos-sts-java and ofs-sdk-definition; do not redeclare them
+            implementation("com.qcloud.cos:hadoop-cos:3.4.1-8.3.31")
             implementation("com.squareup.okhttp3:okhttp:4.10.0")
             // keep on the same train as okhttp (tencentcloud-sdk declares 3.12.x)
             implementation("com.squareup.okhttp3:logging-interceptor:4.10.0")

--- a/fe/fe-core/build.gradle.kts
+++ b/fe/fe-core/build.gradle.kts
@@ -109,8 +109,9 @@ dependencies {
     implementation("com.opencsv:opencsv")
     implementation("com.oracle.database.jdbc:ojdbc10")
     implementation("com.oracle.database.nls:orai18n")
+    // transitively supplies cos_api-bundle, chdfs_hadoop_plugin_network,
+    // cos-sts-java and ofs-sdk-definition; do not redeclare them
     implementation("com.qcloud.cos:hadoop-cos")
-    implementation("com.qcloud:chdfs_hadoop_plugin_network")
     implementation("com.squareup.okhttp3:okhttp")
     implementation("com.squareup.okio:okio")
     implementation("com.starrocks:spark-dpp")

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -609,15 +609,11 @@ under the License.
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.qcloud.cos/hadoop-cos -->
+        <!-- Transitively supplies cos_api-bundle, chdfs_hadoop_plugin_network,
+             cos-sts-java and ofs-sdk-definition; do not redeclare them. -->
         <dependency>
             <groupId>com.qcloud.cos</groupId>
             <artifactId>hadoop-cos</artifactId>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/com.qcloud/chdfs_hadoop_plugin_network -->
-        <dependency>
-            <groupId>com.qcloud</groupId>
-            <artifactId>chdfs_hadoop_plugin_network</artifactId>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-azure-datalake -->

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -1093,10 +1093,15 @@ under the License.
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/com.qcloud.cos/hadoop-cos -->
+            <!-- Transitively supplies the COS client stack at the versions it was
+                 released with: cos_api-bundle, chdfs_hadoop_plugin_network,
+                 cos-sts-java and ofs-sdk-definition. Do not redeclare them here;
+                 bumping this one version is enough (also update the cos_api-bundle
+                 waiver filename in trivy.yaml). -->
             <dependency>
                 <groupId>com.qcloud.cos</groupId>
                 <artifactId>hadoop-cos</artifactId>
-                <version>3.3.0-8.3.2</version>
+                <version>3.4.1-8.3.31</version>
             </dependency>
 
             <!-- hadoop-cos pulls tencentcloud-sdk 3.1.213 whose okhttp 2.7.5 is EOL;
@@ -1110,13 +1115,6 @@ under the License.
                 <groupId>com.tencentcloudapi</groupId>
                 <artifactId>tencentcloud-sdk-java-common</artifactId>
                 <version>3.1.1471</version>
-            </dependency>
-
-            <!-- https://mvnrepository.com/artifact/com.qcloud/chdfs_hadoop_plugin_network -->
-            <dependency>
-                <groupId>com.qcloud</groupId>
-                <artifactId>chdfs_hadoop_plugin_network</artifactId>
-                <version>3.2</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-azure-datalake -->

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -1096,8 +1096,7 @@ under the License.
             <!-- Transitively supplies the COS client stack at the versions it was
                  released with: cos_api-bundle, chdfs_hadoop_plugin_network,
                  cos-sts-java and ofs-sdk-definition. Do not redeclare them here;
-                 bumping this one version is enough (also update the cos_api-bundle
-                 waiver filename in trivy.yaml). -->
+                 bumping this one version is enough -->
             <dependency>
                 <groupId>com.qcloud.cos</groupId>
                 <artifactId>hadoop-cos</artifactId>

--- a/fs_brokers/apache_hdfs_broker/src/hadoop-cos-shaded/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/src/hadoop-cos-shaded/pom.xml
@@ -31,7 +31,7 @@ under the License.
     </parent>
 
     <artifactId>hadoop-cos-shaded</artifactId>
-    <version>3.3.0-8.3.7</version>
+    <version>3.4.1-8.3.31</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -40,23 +40,22 @@ under the License.
 
     <dependencies>
         <!-- https://mvnrepository.com/artifact/com.qcloud.cos/hadoop-cos -->
+        <!-- Transitively supplies cos_api-bundle, chdfs_hadoop_plugin_network,
+             cos-sts-java and ofs-sdk-definition at the versions it was released
+             with; do not redeclare them. cosn-ranger-interface is provided-scope
+             upstream, so it stays declared explicitly below. The org.json
+             exclusion targets the stale 20180130 pulled in via cos-sts-java;
+             a patched version is re-declared below. -->
         <dependency>
             <groupId>com.qcloud.cos</groupId>
             <artifactId>hadoop-cos</artifactId>
-            <version>3.3.3-8.3.10</version>
+            <version>3.4.1-8.3.31</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.json</groupId>
                     <artifactId>json</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/com.qcloud/cos_api-bundle -->
-        <dependency>
-            <groupId>com.qcloud</groupId>
-            <artifactId>cos_api-bundle</artifactId>
-            <version>5.6.137.2</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.qcloud/cosn-ranger-interface -->
@@ -71,13 +70,6 @@ under the License.
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20231013</version>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/com.qcloud/chdfs_hadoop_plugin_network -->
-        <dependency>
-            <groupId>com.qcloud</groupId>
-            <artifactId>chdfs_hadoop_plugin_network</artifactId>
-            <version>3.5</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.qcloud/hadoop-ranger-client-for-hadoop -->

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -19,7 +19,7 @@ scan:
     # spark core
     - "**/spark-core_2.12-3.5.7.jar"
     # tencent cos_api
-    - "**/cos_api-bundle-5.6.137.2.jar"
+    - "**/cos_api-bundle-5.6.244.4.jar"
     # gcs connector hadoop3
     - "**/gcs-connector-hadoop3-2.2.26-shaded.jar"
     # parquet hadoop bundle


### PR DESCRIPTION
## Why I'm doing:

cos_api-bundle 5.6.137.2 runs one `IdleConnectionMonitorThread` per COSClient, and any abnormal exit of that thread (interrupt, OOM, runtime exception in the sweep) shuts down the live HTTP connection pool in its `finally` block. The broken `CosFileSystem` instance stays in the Hadoop FileSystem cache (FE never closes it), so every subsequent hive metadata refresh on a `cosn://` location fails permanently with `IllegalStateException: Connection pool shut down` until the FE restarts. Observed in production: a follower FE logged ~137k such errors in 5 minutes and never self-healed for hours.

hadoop-cos 8.3.22+ enables the cos java sdk's singleton `IdleConnectionMonitor` (tencentyun/hadoop-cos#171), which decouples connection-pool lifetime from the monitor thread — a monitor death no longer kills pools of live clients.

The old pins were also stale relative to `hadoop.version` 3.4.3: FE pinned the hadoop 3.3.0 flavor and the broker the 3.3.3 flavor. hadoop-cos publishes no 3.4.3 flavor, so 3.4.1-8.3.31 (the newest 3.4.1-flavor release) is the closest match.

## What I'm doing:

- fe: bump hadoop-cos `3.3.0-8.3.2` -> `3.4.1-8.3.31` (pom + gradle mirror)
- broker `hadoop-cos-shaded`: bump hadoop-cos `3.3.3-8.3.10` -> `3.4.1-8.3.31`; module version now follows the hadoop-cos version (it names the shipped shaded jar)
- fe and broker: drop the explicit `cos_api-bundle` and `chdfs_hadoop_plugin_network` declarations and let hadoop-cos supply them transitively at the versions it was released with (cos_api-bundle `5.6.244.4`, chdfs `3.6`); added comments on the hadoop-cos declarations documenting what it supplies transitively
- trivy.yaml: update the cos_api-bundle skip-files entry to the new jar name (verified with trivy 0.74: the new bundle still embeds jackson 2.14.1 and reports 4 HIGH findings, so the waiver must stay; the class-level exposure is limited to parsing COS/STS server responses)
- kept as-is (verified still required):
  - tencentcloud-sdk kms/common pins at `3.1.1471`: the new hadoop-cos still pulls kms `3.1.213` / common `3.1.1193`, which trip the `com.tencentcloudapi:*:[,3.1.1471)` enforcer ban if unpinned
  - broker `org.json` exclusion + re-declared `20231013`: `cos-sts-java` (still a compile dep of hadoop-cos) pulls the stale `org.json:20180130`, and its API uses `org.json.JSONObject` at runtime
  - broker `cosn-ranger-interface` explicit declaration: provided-scope upstream, not transitive
  - broker shade relocation and metadata filters: they match by coordinate and were verified against the new jars

Verified: FE `dependency:tree` resolves the expected versions with no conflicts, enforcer banned-dependencies passes on all FE modules, fe-core compiles, and the broker shaded jar builds with the jackson-core metadata filter still effective.

Fixes #N/A

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)