### PR TITLE
[BugFix] Skip policy rewrite and generated-column analysis for _CACHE_STATS_

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authorization/SecurityPolicyRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/SecurityPolicyRewriteRule.java
@@ -38,8 +38,11 @@ import java.util.stream.Collectors;
 
 public class SecurityPolicyRewriteRule {
     public static QueryStatement buildView(ConnectContext context, Relation relation, TableName tableName) {
-        if (relation instanceof TableRelation && ((TableRelation) relation).isSyncMVQuery()) {
-            return null;
+        if (relation instanceof TableRelation) {
+            TableRelation tableRelation = (TableRelation) relation;
+            if (tableRelation.isSyncMVQuery() || tableRelation.isCacheStatsQuery()) {
+                return null;
+            }
         }
 
         List<Column> columns;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -360,6 +360,12 @@ public class QueryAnalyzer {
 
         @Override
         public Void visitTable(TableRelation tableRelation, Scope scope) {
+            if (tableRelation.isCacheStatsQuery()) {
+                // The cache-stats scope contains only the virtual metadata columns,
+                // so generated-column expressions referencing real base-table
+                // columns cannot be analyzed against it.
+                return null;
+            }
             Table table = tableRelation.getTable();
             Map<Expr, SlotRef> generatedExprToColumnRef = new HashMap<>();
             for (Column column : table.getBaseSchema()) {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/CacheStatsScanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/CacheStatsScanTest.java
@@ -16,7 +16,19 @@ package com.starrocks.planner;
 
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.server.RunMode;
+import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.analyzer.Authorizer;
+import com.starrocks.sql.ast.AstTraverser;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.Relation;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.SubqueryRelation;
+import com.starrocks.sql.ast.TableRelation;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.utframe.StarRocksAssert;
@@ -24,6 +36,8 @@ import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 public class CacheStatsScanTest {
 
@@ -55,6 +69,14 @@ public class CacheStatsScanTest {
                 "  PARTITION p2 VALUES [('2024-02-01'), ('2024-03-01'))\n" +
                 ")\n" +
                 "DISTRIBUTED BY HASH(k2) BUCKETS 3");
+
+        starRocksAssert.withTable("CREATE TABLE lake_gen_t0 (\n" +
+                "  k1 bigint,\n" +
+                "  k2 bigint,\n" +
+                "  k3 bigint AS k1 + k2\n" +
+                ")\n" +
+                "DUPLICATE KEY(k1)\n" +
+                "DISTRIBUTED BY HASH(k1) BUCKETS 3");
     }
 
     private String getFragmentPlan(String sql) throws Exception {
@@ -116,5 +138,48 @@ public class CacheStatsScanTest {
         boolean hasCacheStatsScanNode = execPlan.getScanNodes().stream()
                 .anyMatch(n -> n instanceof CacheStatsScanNode);
         Assertions.assertTrue(hasCacheStatsScanNode);
+    }
+
+    @Test
+    public void testCacheStatsScanWithGeneratedColumn() throws Exception {
+        String sql = "SELECT * FROM lake_gen_t0 [_CACHE_STATS_]";
+        String plan = getFragmentPlan(sql);
+        Assertions.assertTrue(plan.contains("CacheStatsScan"), plan);
+    }
+
+    @Test
+    public void testCacheStatsScanBypassesSecurityPolicyRewrite() throws Exception {
+        Expr rowAccessExpr = SqlParser.parseSqlToExpr("k1 > 0", SqlModeHelper.MODE_DEFAULT);
+        try (MockedStatic<Authorizer> authorizerMockedStatic = Mockito.mockStatic(Authorizer.class)) {
+            authorizerMockedStatic
+                    .when(() -> Authorizer.getRowAccessPolicy(Mockito.any(), Mockito.any()))
+                    .thenReturn(rowAccessExpr);
+            authorizerMockedStatic
+                    .when(() -> Authorizer.getColumnMaskingPolicy(Mockito.any(), Mockito.any(), Mockito.any()))
+                    .thenReturn(null);
+
+            // Sanity check: the same mocked row-access policy still rewrites an
+            // ordinary query, so the bypass below is not a false positive.
+            QueryStatement normalStmt = analyzeWithPolicyRewrite("SELECT * FROM lake_t0");
+            Assertions.assertTrue(
+                    ((SelectRelation) normalStmt.getQueryRelation()).getRelation() instanceof SubqueryRelation);
+
+            QueryStatement cacheStatsStmt = analyzeWithPolicyRewrite("SELECT * FROM lake_t0 [_CACHE_STATS_]");
+            Assertions.assertTrue(
+                    ((SelectRelation) cacheStatsStmt.getQueryRelation()).getRelation() instanceof TableRelation);
+        }
+    }
+
+    private QueryStatement analyzeWithPolicyRewrite(String sql) throws Exception {
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        new AstTraverser<Void, Void>() {
+            @Override
+            public Void visitRelation(Relation relation, Void context) {
+                relation.setNeedRewrittenByPolicy(true);
+                return null;
+            }
+        }.visit(stmt);
+        Analyzer.analyze(stmt, connectContext);
+        return (QueryStatement) stmt;
     }
 }


### PR DESCRIPTION
## Why I'm doing:

`SELECT * FROM t [_CACHE_STATS_]` replaces the relation scope with only the three virtual columns (`tablet_id` / `cached_bytes` / `total_bytes`), but two analyzer paths still reference real base-table columns and fail before execution:

1. **Tables with a row-access or masking policy**: `SecurityPolicyRewriteRule.buildView` only skips sync MV queries. For a policied table it wraps the cache-stats scan in an internal projection built from real base-table columns (plus the row-access predicate), which cannot be resolved against the cache-stats-only scope:
 `ERROR 1064: Getting analyzing error. Detail message: Column 'db.tbl.tenant_id' cannot be resolved.`
2. **Tables with generated columns**: `GeneratedColumnExprMappingCollector.visitTable` analyzes every generated-column expression against the same cache-stats-only scope (this path has no try-catch), failing the same way:
 `ERROR 1064: Getting analyzing error. Detail message: Column 'k1' cannot be resolved.`

A `_CACHE_STATS_` scan is metadata-only (per-tablet cache bytes) and returns no row data, so row-access/masking policies and generated-column rewrite cannot apply to it. Verified end-to-end on a shared-data cluster: the base build reproduces both errors verbatim on a table with a row-access policy and a table with a generated column; with this fix both queries return normally at table, partition, and aggregate scope, while plain SELECTs on the same table still enforce the row-access policy (rows filtered as expected).

Reported by a customer on 4.1 (Jira RB-153).

## What I'm doing:

- `SecurityPolicyRewriteRule.buildView`: return null (skip building the policy view) for `TableRelation`s where `isCacheStatsQuery()` is true, alongside the existing `isSyncMVQuery()` skip. Table-level SELECT privilege checks are unaffected.
- `QueryAnalyzer.GeneratedColumnExprMappingCollector.visitTable`: return early for cache-stats queries so generated-column expressions are not analyzed against the virtual-columns-only scope.
- `CacheStatsScanTest`: add regression tests — a cache-stats plan over a table with a generated column, and an analyzer test that mocks a row-access policy and asserts the cache-stats relation is NOT wrapped into a `SubqueryRelation` while an ordinary query on the same table still is (guards the test against a silently inactive mock).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
 - [x] 4.2
 - [x] 4.1
 - [ ] 4.0
 - [ ] 3.5