### PR TITLE
[Feature] Serve reads from a virtual parent while an UNSHARE compaction makes the children private

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -52,8 +52,10 @@
 #include "storage/lake/metacache.h"
 #include "storage/lake/options.h"
 #include "storage/lake/tablet.h"
+#include "storage/lake/tablet_merger.h"
 #include "storage/lake/tablet_metadata.h"
 #include "storage/lake/tablet_reshard.h"
+#include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/transactions.h"
 #include "storage/lake/update_manager.h"
 #include "storage/lake/vacuum.h"
@@ -245,6 +247,9 @@ LakeServiceImpl::~LakeServiceImpl() = default;
 // in the txn-log apply path (OSS read of txn_log, broken segment, ...),
 // which no_op_publish=true bypasses entirely (transactions.cpp:320).
 DEFINE_FAIL_POINT(lake_publish_version_rpc_fail);
+// Forces the query-side parent alias back to the pre-fix behaviour (merge the primary-index
+// sstables too), so the cost of that merge can be measured against the same data.
+DEFINE_FAIL_POINT(lake_parent_alias_force_sstable_merge);
 
 void LakeServiceImpl::publish_version(::google::protobuf::RpcController* controller,
                                       const ::starrocks::PublishVersionRequest* request,
@@ -705,6 +710,86 @@ static void collect_expected_metadata_tablet_ids(const AggregatePublishVersionRe
     }
 }
 
+// Build the query-only parent metadata after all child publishes have succeeded.
+// merge_tablet is also the range-tablet merge primitive, so it already provides
+// rowset-family deduplication and PK delvec union. Phase one intentionally rejects
+// DCG/IDG instead of copying incomplete metadata into a query-visible parent.
+static Status build_parent_tablet_metadata(lake::TabletManager* tablet_mgr,
+                                           const AggregatePublishVersionRequest& request,
+                                           std::map<int64_t, TabletMetadata>* tablet_metas) {
+    if (request.parent_tablet_publish_infos().empty()) {
+        return Status::OK();
+    }
+    if (request.publish_reqs().empty() || request.publish_reqs(0).txn_infos().empty()) {
+        return Status::InvalidArgument("parent tablet publish requires transaction info");
+    }
+
+    const auto& publish_req = request.publish_reqs(0);
+    const auto& txn_info = publish_req.txn_infos(publish_req.txn_infos_size() - 1);
+    const int64_t new_version = publish_req.new_version();
+    for (const auto& parent_info : request.parent_tablet_publish_infos()) {
+        if (!parent_info.has_parent_tablet_id() || parent_info.child_tablet_ids_size() < 1) {
+            return Status::InvalidArgument("parent tablet publish requires one parent and at least one child");
+        }
+
+        std::vector<TabletMetadataPtr> child_metas;
+        child_metas.reserve(parent_info.child_tablet_ids_size());
+        MergingTabletInfoPB merging_info;
+        merging_info.set_new_tablet_id(parent_info.parent_tablet_id());
+        for (int64_t child_id : parent_info.child_tablet_ids()) {
+            if (child_id == parent_info.parent_tablet_id()) {
+                return Status::InvalidArgument("parent tablet id cannot also be a child tablet id");
+            }
+            auto it = tablet_metas->find(child_id);
+            if (it == tablet_metas->end()) {
+                return Status::NotFound(fmt::format("missing child tablet {} metadata for parent {}", child_id,
+                                                    parent_info.parent_tablet_id()));
+            }
+            const auto& child = it->second;
+            if (child.version() != new_version) {
+                return Status::InvalidArgument(
+                        fmt::format("child tablet {} metadata version {} does not match publish version {}", child_id,
+                                    child.version(), new_version));
+            }
+            if ((child.has_dcg_meta() && !child.dcg_meta().dcgs().empty()) ||
+                (child.has_idg_meta() && !child.idg_meta().idgs().empty())) {
+                return Status::NotSupported("parent tablet publish does not support DCG or IDG metadata yet");
+            }
+            child_metas.emplace_back(std::make_shared<TabletMetadata>(child));
+            merging_info.add_old_tablet_ids(child_id);
+        }
+
+        bool force_sstable_merge = false;
+        FAIL_POINT_TRIGGER_EXECUTE(lake_parent_alias_force_sstable_merge, { force_sstable_merge = true; });
+        const int64_t merge_begin_us = butil::gettimeofday_us();
+
+        MutableTabletMetadataPtr parent_meta;
+        if (child_metas.size() == 1) {
+            // An untouched sibling is represented by an IdenticalTablet in the new index. Its
+            // query parent only needs an id-adjusted copy; no rowset/delvec aggregation is needed.
+            parent_meta = std::make_shared<TabletMetadata>(*child_metas.front());
+            parent_meta->set_id(parent_info.parent_tablet_id());
+        } else {
+            ASSIGN_OR_RETURN(parent_meta,
+                             lake::merge_tablet(tablet_mgr, child_metas, merging_info, new_version, txn_info,
+                                                /*skip_sstable_merge=*/!force_sstable_merge));
+        }
+        // This runs on the publish critical path once per parent per version, so keep its cost
+        // visible: it is what wedged loads before the sstable merge was dropped from it.
+        const int64_t merge_cost_us = butil::gettimeofday_us() - merge_begin_us;
+        LOG(INFO) << "build parent tablet alias, parent=" << parent_info.parent_tablet_id()
+                  << " children=" << child_metas.size() << " version=" << new_version
+                  << " sstable_merge=" << (force_sstable_merge ? "on" : "off") << " cost=" << merge_cost_us << "us";
+        // The parent is a read alias, never the owner of child files. Mark every
+        // inherited reference shared so retiring the parent cannot delete a file
+        // that remains live in a child. Its merged delvec is reclaimed through the
+        // shared-file vacuum path once the parent disappears from retained bundles.
+        lake::tablet_reshard_helper::set_all_data_files_shared(parent_meta.get());
+        (*tablet_metas)[parent_info.parent_tablet_id()] = std::move(*parent_meta);
+    }
+    return Status::OK();
+}
+
 struct AggregatePublishContext {
     bthread::Mutex mutex;
     bool has_failure{false};
@@ -720,11 +805,18 @@ struct AggregatePublishContext {
 
     using PublishRequestCtx = RequestContext<PublishVersionResponse>;
     std::vector<PublishRequestCtx> publish_request_ctx;
+    // "host:port txn=.. tablets=.." per sub-request, filled before any dispatch so the completion
+    // callback can name the peer it is reporting on without racing the dispatch loop.
+    std::vector<std::string> sub_desc;
 
     AggregatePublishContext() : begin_us(butil::gettimeofday_us()) {}
 
     void handle_failure(const std::string& error) {
         std::lock_guard l(mutex);
+        // Log here: the FE's own RPC budget equals the one this aggregator hands each sub-request,
+        // so a sub-request failure is reported back after the FE has already timed out and the
+        // reason never reaches it. Without this line the failure is invisible on both sides.
+        LOG(WARNING) << "aggregate publish sub-request failed: " << error;
         has_failure = true;
         publish_status = Status::InternalError(error);
     }
@@ -778,7 +870,7 @@ struct AggregatePublishContext {
         publish_request_ctx.clear();
     }
 
-    void put_aggregate_metadata(ExecEnv* env) {
+    void put_aggregate_metadata(ExecEnv* env, const AggregatePublishVersionRequest& request) {
         if (!has_failure) {
             auto thread_pool = env->lake_services().put_aggregate_metadata_thread_pool;
             if (UNLIKELY(thread_pool == nullptr)) {
@@ -788,9 +880,12 @@ struct AggregatePublishContext {
                 auto task = std::make_shared<CancellableRunnable>(
                         [&] {
                             DeferOp defer([&] { latch.count_down(); });
-                            publish_status =
-                                    StorageEnv::GetInstance()->lake_tablet_manager()->put_bundle_tablet_metadata(
-                                            tablet_metas, expected_tablet_ids);
+                            auto* tablet_mgr = StorageEnv::GetInstance()->lake_tablet_manager();
+                            publish_status = build_parent_tablet_metadata(tablet_mgr, request, &tablet_metas);
+                            if (publish_status.ok()) {
+                                publish_status =
+                                        tablet_mgr->put_bundle_tablet_metadata(tablet_metas, expected_tablet_ids);
+                            }
                             if (!publish_status.ok()) {
                                 g_aggregate_publish_version_failed_tasks << 1;
                                 LOG(WARNING) << "Fail to write bundle tablet metadata: " << publish_status;
@@ -817,18 +912,28 @@ struct AggregatePublishContext {
     }
 };
 
-static void aggregate_publish_cb(brpc::Controller* cntl, PublishVersionResponse* resp, AggregatePublishContext* ctx) {
+// A sub-publish this slow is on course to burn the whole shared 60s budget; name it while we still can.
+static constexpr int64_t kSlowSubRequestUs = 20 * 1000 * 1000;
+static const std::string kUnknownSubRequest = "unknown sub-request";
+
+static void aggregate_publish_cb(brpc::Controller* cntl, PublishVersionResponse* resp, AggregatePublishContext* ctx,
+                                 int sub_index) {
     // no need to release cntl and resp.
     // the resource will be release after all publish_request finished.
     DeferOp defer([&]() { ctx->count_down(); });
+    const std::string& desc =
+            sub_index < static_cast<int>(ctx->sub_desc.size()) ? ctx->sub_desc[sub_index] : kUnknownSubRequest;
     if (cntl->Failed()) {
-        ctx->handle_failure("link rpc channel failed");
+        ctx->handle_failure(fmt::format("[{}] rpc failed after {}us: errcode={} {}", desc, cntl->latency_us(),
+                                        cntl->ErrorCode(), cntl->ErrorText()));
     } else if (resp->status().status_code() != 0) {
         std::string msg;
         for (const auto& str : resp->status().error_msgs()) {
             msg += str;
         }
-        ctx->handle_failure(msg);
+        ctx->handle_failure(fmt::format("[{}] returned error after {}us: {}", desc, cntl->latency_us(), msg));
+    } else if (cntl->latency_us() > kSlowSubRequestUs) {
+        LOG(WARNING) << "aggregate publish sub-request slow: [" << desc << "] took " << cntl->latency_us() << "us";
     }
     ctx->aggregate_response(resp);
 }
@@ -843,6 +948,16 @@ void LakeServiceImpl::aggregate_publish_version(::google::protobuf::RpcControlle
     // Collected up front, over every sub-request: the loop below stops dispatching once one of
     // them fails, and the expected set must describe the whole publish either way.
     collect_expected_metadata_tablet_ids(*request, &ctx.expected_tablet_ids);
+
+    // Fill every description first: a callback may fire while this loop is still dispatching, and
+    // appending to the vector then would reallocate under it.
+    ctx.sub_desc.reserve(request->publish_reqs_size());
+    for (int i = 0; i < request->publish_reqs_size(); ++i) {
+        const auto& node = request->compute_nodes(i);
+        const auto& req = request->publish_reqs(i);
+        ctx.sub_desc.push_back(fmt::format("{}:{} txns={} tablets={}", node.host(), node.brpc_port(),
+                                           get_txn_ids_string(&req), JoinInts(req.tablet_ids(), ",")));
+    }
 
     for (int i = 0; i < request->publish_reqs_size(); ++i) {
         if (ctx.has_failure) {
@@ -871,13 +986,13 @@ void LakeServiceImpl::aggregate_publish_version(::google::protobuf::RpcControlle
         auto* cntl_ptr = ctx.publish_request_ctx.back().cntl.get();
         auto* resp_ptr = ctx.publish_request_ctx.back().resp.get();
         (*res)->publish_version(cntl_ptr, &single_req, resp_ptr,
-                                brpc::NewCallback(aggregate_publish_cb, cntl_ptr, resp_ptr, &ctx));
+                                brpc::NewCallback(aggregate_publish_cb, cntl_ptr, resp_ptr, &ctx, i));
     }
 
     // wait for publish task finish
     ctx.wait();
     // write aggregate metadata
-    ctx.put_aggregate_metadata(_env);
+    ctx.put_aggregate_metadata(_env, *request);
 
     ctx.publish_status.to_protobuf(response->mutable_status());
 }
@@ -1600,7 +1715,84 @@ struct AggregateCompactContext {
         }
     }
 
-    void write_combined_txn_log(ExecEnv* env) {
+    Status validate_unshare_result(lake::TabletManager* tablet_mgr, const AggregateCompactRequest& request) {
+        const bool has_unshare_request = std::any_of(request.requests().begin(), request.requests().end(),
+                                                     [](const CompactRequest& req) { return req.unshare_segments(); });
+        const bool has_default_request = std::any_of(request.requests().begin(), request.requests().end(),
+                                                     [](const CompactRequest& req) { return !req.unshare_segments(); });
+        if (has_unshare_request && has_default_request) {
+            return Status::InvalidArgument("aggregate compaction cannot mix UNSHARE and default modes");
+        }
+        if (!has_unshare_request) {
+            return Status::OK();
+        }
+
+        std::unordered_map<int64_t, const TxnLogPB*> tablet_to_log;
+        for (const auto& log : combined_txn_log.txn_logs()) {
+            if (!tablet_to_log.emplace(log.tablet_id(), &log).second) {
+                return Status::Corruption(fmt::format("duplicate unshare txn log for tablet {}", log.tablet_id()));
+            }
+        }
+
+        for (const auto& compact_request : request.requests()) {
+            if (compact_request.allow_partial_success() || !compact_request.skip_write_txnlog()) {
+                return Status::InvalidArgument(
+                        "UNSHARE aggregate compaction requires allow_partial_success=false and skip_write_txnlog=true");
+            }
+            for (int64_t tablet_id : compact_request.tablet_ids()) {
+                auto log_it = tablet_to_log.find(tablet_id);
+                if (log_it == tablet_to_log.end()) {
+                    return Status::Corruption(fmt::format("missing unshare txn log for tablet {}", tablet_id));
+                }
+                const auto* txn_log = log_it->second;
+                // A tablet that took the parallel path reports one OpParallelCompaction holding
+                // every subtask's OpCompaction instead of a single top-level one. Both shapes are
+                // valid UNSHARE output, so validate against the flattened subtask list.
+                std::vector<const TxnLogPB::OpCompaction*> compactions;
+                if (txn_log->has_op_compaction()) {
+                    compactions.push_back(&txn_log->op_compaction());
+                } else if (txn_log->has_op_parallel_compaction()) {
+                    for (const auto& subtask : txn_log->op_parallel_compaction().subtask_compactions()) {
+                        compactions.push_back(&subtask);
+                    }
+                    if (compactions.empty()) {
+                        return Status::Corruption(fmt::format(
+                                "unshare txn log for tablet {} has an empty parallel compaction", tablet_id));
+                    }
+                } else {
+                    return Status::Corruption(fmt::format(
+                            "unshare txn log for tablet {} has neither op_compaction nor op_parallel_compaction",
+                            tablet_id));
+                }
+
+                std::unordered_set<uint32_t> selected;
+                for (const auto* compaction : compactions) {
+                    for (const auto& segment : compaction->output_rowset().segment_metas()) {
+                        if (segment.shared()) {
+                            return Status::Corruption(fmt::format(
+                                    "unshare output for tablet {} still contains a shared segment", tablet_id));
+                        }
+                    }
+                    selected.insert(compaction->input_rowsets().begin(), compaction->input_rowsets().end());
+                }
+
+                ASSIGN_OR_RETURN(auto metadata, tablet_mgr->get_tablet_metadata(tablet_id, compact_request.version()));
+                for (const auto& rowset : metadata->rowsets()) {
+                    const bool contains_shared =
+                            std::any_of(rowset.segment_metas().begin(), rowset.segment_metas().end(),
+                                        [](const SegmentMetadataPB& segment) { return segment.shared(); });
+                    if (contains_shared && !selected.contains(rowset.id())) {
+                        return Status::Corruption(
+                                fmt::format("unshare result for tablet {} did not rewrite shared rowset {}", tablet_id,
+                                            rowset.id()));
+                    }
+                }
+            }
+        }
+        return Status::OK();
+    }
+
+    void write_combined_txn_log(ExecEnv* env, const AggregateCompactRequest& request) {
         if (final_status.ok()) {
             VLOG(2) << "Write combined txn log. pb=" << combined_txn_log.ShortDebugString();
             auto thread_pool = env->execution_services().put_combined_txn_log_thread_pool;
@@ -1611,7 +1803,11 @@ struct AggregateCompactContext {
                 auto task = std::make_shared<CancellableRunnable>(
                         [&] {
                             DeferOp defer([&] { latch.count_down(); });
-                            final_status = starrocks::write_combined_txn_log(combined_txn_log);
+                            auto* tablet_mgr = StorageEnv::GetInstance()->lake_tablet_manager();
+                            final_status = validate_unshare_result(tablet_mgr, request);
+                            if (final_status.ok()) {
+                                final_status = starrocks::write_combined_txn_log(combined_txn_log);
+                            }
                         },
                         [&] {
                             final_status = Status::Cancelled("write combined_txn_log task has been cancelled");
@@ -1717,7 +1913,7 @@ void LakeServiceImpl::aggregate_compact(::google::protobuf::RpcController* contr
     ac_context.wait();
 
     // write combined txn log
-    ac_context.write_combined_txn_log(_env);
+    ac_context.write_combined_txn_log(_env, *request);
 
     // fill response
     ac_context.final_status.to_protobuf(response->mutable_status());

--- a/be/src/storage/lake/cloud_native_index_compaction_task.cpp
+++ b/be/src/storage/lake/cloud_native_index_compaction_task.cpp
@@ -33,7 +33,12 @@ Status CloudNativeIndexCompactionTask::execute(CancelFunc cancel_func, ThreadPoo
         op_compaction->set_compact_version(_tablet.metadata()->version());
     }
     RETURN_IF_ERROR(cancel_func());
-    RETURN_IF_ERROR(execute_index_major_compaction(txn_log.get()));
+    // An empty UNSHARE pick means this sibling already owns only private files.
+    // It must still contribute a successful no-op txn log to the all-sibling
+    // aggregate transaction, but it must not opportunistically rewrite SSTs.
+    if (!_context->is_unshare) {
+        RETURN_IF_ERROR(execute_index_major_compaction(txn_log.get()));
+    }
     _context->progress.update(100);
     TEST_ERROR_POINT("CloudNativeIndexCompactionTask::execute::1");
     if (_context->skip_write_txnlog) {

--- a/be/src/storage/lake/compaction_policy.cpp
+++ b/be/src/storage/lake/compaction_policy.cpp
@@ -613,7 +613,20 @@ StatusOr<CompactionAlgorithm> CompactionPolicy::choose_compaction_algorithm(cons
 
 StatusOr<CompactionPolicyPtr> CompactionPolicy::create(TabletManager* tablet_mgr,
                                                        std::shared_ptr<const TabletMetadataPB> tablet_metadata,
-                                                       bool force_base_compaction) {
+                                                       bool force_base_compaction, bool is_unshare) {
+    if (is_unshare) {
+        if (tablet_metadata->schema().keys_type() != PRIMARY_KEYS) {
+            return Status::NotSupported("unshare compaction only supports primary-key tablets");
+        }
+        if (!tablet_metadata->has_range()) {
+            return Status::InvalidArgument("unshare compaction requires a tablet range");
+        }
+        if ((tablet_metadata->has_dcg_meta() && !tablet_metadata->dcg_meta().dcgs().empty()) ||
+            (tablet_metadata->has_idg_meta() && !tablet_metadata->idg_meta().idgs().empty())) {
+            return Status::NotSupported("unshare compaction does not support DCG or IDG metadata yet");
+        }
+        return std::make_shared<UnshareCompactionPolicy>(tablet_mgr, std::move(tablet_metadata));
+    }
     if (tablet_metadata->schema().keys_type() == PRIMARY_KEYS) {
         return std::make_shared<PrimaryCompactionPolicy>(tablet_mgr, std::move(tablet_metadata), force_base_compaction);
     } else if (config::enable_size_tiered_compaction_strategy) {

--- a/be/src/storage/lake/compaction_policy.h
+++ b/be/src/storage/lake/compaction_policy.h
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "common/statusor.h"
+#include "gen_cpp/lake_service.pb.h"
 #include "storage/compaction_utils.h"
 
 namespace starrocks {
@@ -42,7 +43,7 @@ public:
 
     static StatusOr<CompactionPolicyPtr> create(TabletManager* tablet_mgr,
                                                 std::shared_ptr<const TabletMetadataPB> tablet_metadata,
-                                                bool force_base_compaction);
+                                                bool force_base_compaction, bool is_unshare = false);
 
     static bool is_real_time_compaction_strategy(const std::shared_ptr<const TabletMetadataPB>& metadata);
 

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -340,9 +340,9 @@ void CompactionScheduler::compact(::google::protobuf::RpcController* controller,
 
     std::vector<std::unique_ptr<CompactionTaskContext>> contexts_vec;
     for (auto tablet_id : request->tablet_ids()) {
-        auto context = std::make_unique<CompactionTaskContext>(request->txn_id(), tablet_id, request->version(),
-                                                               request->force_base_compaction(),
-                                                               request->skip_write_txnlog(), cb);
+        auto context = std::make_unique<CompactionTaskContext>(
+                request->txn_id(), tablet_id, request->version(), request->force_base_compaction(),
+                request->skip_write_txnlog(), cb, 0, 0, request->unshare_segments());
         contexts_vec.push_back(std::move(context));
         // DO NOT touch `context` from here!
     }
@@ -402,9 +402,10 @@ void CompactionScheduler::process_parallel_compaction(const CompactRequest* requ
     };
 
     for (auto tablet_id : request->tablet_ids()) {
-        auto result = _parallel_mgr->create_parallel_tasks(
-                tablet_id, request->txn_id(), request->version(), request->parallel_config(), callback,
-                request->force_base_compaction(), _threads.get(), acquire_token, release_token);
+        auto result = _parallel_mgr->create_parallel_tasks(tablet_id, request->txn_id(), request->version(),
+                                                           request->parallel_config(), callback,
+                                                           request->force_base_compaction(), _threads.get(),
+                                                           acquire_token, release_token, request->unshare_segments());
 
         if (result.ok() && result.value() > 0) {
             // Parallel compaction tasks created successfully
@@ -422,9 +423,9 @@ void CompactionScheduler::process_parallel_compaction(const CompactRequest* requ
                 VLOG(1) << "Parallel compaction not applicable for tablet " << tablet_id
                         << ", falling back to normal compaction";
             }
-            auto context = std::make_unique<CompactionTaskContext>(request->txn_id(), tablet_id, request->version(),
-                                                                   request->force_base_compaction(),
-                                                                   request->skip_write_txnlog(), callback);
+            auto context = std::make_unique<CompactionTaskContext>(
+                    request->txn_id(), tablet_id, request->version(), request->force_base_compaction(),
+                    request->skip_write_txnlog(), callback, 0, 0, request->unshare_segments());
             context->enqueue_time_sec = ::time(nullptr);
 
             {

--- a/be/src/storage/lake/compaction_task.cpp
+++ b/be/src/storage/lake/compaction_task.cpp
@@ -37,6 +37,12 @@ CompactionTask::CompactionTask(VersionedTablet tablet, std::vector<std::shared_p
           _tablet_schema(std::move(tablet_schema)) {}
 
 Status CompactionTask::execute_index_major_compaction(TxnLogPB* txn_log) {
+    if (_context->is_unshare) {
+        // UNSHARE rewrites shared data files only. Rebuilding/major-compacting the
+        // cloud-native PK index in the same transaction adds substantial I/O and is
+        // unnecessary for the atomic query-layout cutover.
+        return Status::OK();
+    }
     if (_tablet.get_schema()->keys_type() == KeysType::PRIMARY_KEYS) {
         SCOPED_RAW_TIMER(&_context->stats->pk_sst_merge_ns);
         auto metadata = _tablet.metadata();

--- a/be/src/storage/lake/compaction_task_context.h
+++ b/be/src/storage/lake/compaction_task_context.h
@@ -22,6 +22,7 @@
 #include <string>
 
 #include "common/status.h"
+#include "gen_cpp/lake_service.pb.h"
 #include "gen_cpp/lake_types.pb.h"
 #include "storage_primitive/olap_tuple.h"
 
@@ -143,12 +144,13 @@ struct CompactionTaskContext : public butil::LinkNode<CompactionTaskContext> {
     // Constructor for normal compaction
     explicit CompactionTaskContext(int64_t txn_id_, int64_t tablet_id_, int64_t version_, bool force_base_compaction_,
                                    bool skip_write_txnlog_, std::shared_ptr<CompactionTaskCallback> cb_,
-                                   int64_t table_id_ = 0, int64_t partition_id_ = 0)
+                                   int64_t table_id_ = 0, int64_t partition_id_ = 0, bool is_unshare_ = false)
             : txn_id(txn_id_),
               tablet_id(tablet_id_),
               version(version_),
               force_base_compaction(force_base_compaction_),
               skip_write_txnlog(skip_write_txnlog_),
+              is_unshare(is_unshare_),
               callback(std::move(cb_)),
               table_id(table_id_),
               partition_id(partition_id_) {}
@@ -158,9 +160,9 @@ struct CompactionTaskContext : public butil::LinkNode<CompactionTaskContext> {
                                                                      int64_t version_, bool force_base_compaction_,
                                                                      bool skip_write_txnlog_,
                                                                      std::shared_ptr<CompactionTaskCallback> cb_,
-                                                                     int32_t subtask_id_) {
+                                                                     int32_t subtask_id_, bool is_unshare_ = false) {
         auto ctx = std::make_unique<CompactionTaskContext>(txn_id_, tablet_id_, version_, force_base_compaction_,
-                                                           skip_write_txnlog_, std::move(cb_));
+                                                           skip_write_txnlog_, std::move(cb_), 0, 0, is_unshare_);
         ctx->subtask_id = subtask_id_;
         return ctx;
     }
@@ -176,6 +178,7 @@ struct CompactionTaskContext : public butil::LinkNode<CompactionTaskContext> {
     const int64_t version;
     const bool force_base_compaction;
     const bool skip_write_txnlog;
+    const bool is_unshare;
     std::atomic<int64_t> start_time{0};
     std::atomic<int64_t> finish_time{0};
     // Monotonic timestamps for adding the elapsed part of the current attempt

--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -27,6 +27,7 @@
 #include "storage/chunk_helper.h"
 #include "storage/compaction_utils.h"
 #include "storage/lake/rowset.h"
+#include "storage/lake/tablet_range_helper.h"
 #include "storage/lake/tablet_reader.h"
 #include "storage/lake/tablet_write_log_manager.h"
 #include "storage/lake/tablet_writer.h"
@@ -133,6 +134,12 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
     std::vector<uint64_t> rssid_rowids;
     rssid_rowids.reserve(chunk_size);
 
+    // Built once: only the encode-and-compare depends on the chunk.
+    std::optional<PrimaryKeyRangeFilter> pk_range_filter;
+    if (_context->is_unshare && _tablet_schema->has_separate_sort_key()) {
+        ASSIGN_OR_RETURN(pk_range_filter, PrimaryKeyRangeFilter::create(_tablet.metadata()->range(), _tablet_schema));
+    }
+
     const bool enable_light_pk_compaction_publish = StorageEngine::instance()->enable_light_pk_compaction_publish();
     while (true) {
         if (UNLIKELY(StorageEngine::instance()->bg_worker_stopped())) {
@@ -164,6 +171,26 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
         {
             SCOPED_RAW_TIMER(&_context->stats->chunk_transform_ns);
             ChunkHelper::padding_char_columns(char_field_indexes, schema, _tablet_schema, chunk.get());
+
+            if (pk_range_filter.has_value()) {
+                ASSIGN_OR_RETURN(auto filter, pk_range_filter->build(*chunk));
+                if (!rssid_rowids.empty()) {
+                    DCHECK_EQ(rssid_rowids.size(), filter.size());
+                    size_t output_index = 0;
+                    for (size_t i = 0; i < rssid_rowids.size(); ++i) {
+                        if (filter[i]) {
+                            rssid_rowids[output_index++] = rssid_rowids[i];
+                        }
+                    }
+                    rssid_rowids.resize(output_index);
+                }
+                chunk->filter(filter);
+            }
+        }
+        if (chunk->num_rows() == 0) {
+            chunk->reset();
+            rssid_rowids.clear();
+            continue;
         }
         {
             SCOPED_RAW_TIMER(&_context->stats->writer_write_ns);

--- a/be/src/storage/lake/primary_key_compaction_policy.cpp
+++ b/be/src/storage/lake/primary_key_compaction_policy.cpp
@@ -14,10 +14,13 @@
 
 #include "storage/lake/primary_key_compaction_policy.h"
 
+#include <algorithm>
+
 #include "common/config_compaction_fwd.h"
 #include "common/config_storage_fwd.h"
 #include "gutil/strings/join.h"
 #include "storage/lake/update_manager.h"
+#include "storage/tablet_schema.h"
 
 namespace starrocks::lake {
 
@@ -137,6 +140,29 @@ StatusOr<std::unique_ptr<PKSizeTieredLevel>> PrimaryCompactionPolicy::pick_max_l
 
 StatusOr<std::vector<RowsetPtr>> PrimaryCompactionPolicy::pick_rowsets() {
     return pick_rowsets(_tablet_metadata, nullptr);
+}
+
+StatusOr<std::vector<RowsetPtr>> UnshareCompactionPolicy::pick_rowsets() {
+    std::vector<RowsetPtr> input_rowsets;
+    for (int i = 0; i < _tablet_metadata->rowsets_size(); ++i) {
+        const auto& rowset = _tablet_metadata->rowsets(i);
+        const bool contains_shared_segment =
+                std::any_of(rowset.segment_metas().begin(), rowset.segment_metas().end(),
+                            [](const SegmentMetadataPB& segment) { return segment.shared(); });
+        if (contains_shared_segment) {
+            input_rowsets.emplace_back(
+                    std::make_shared<Rowset>(_tablet_mgr, _tablet_metadata, i, 0 /* compaction_segment_limit */));
+        }
+    }
+    return input_rowsets;
+}
+
+StatusOr<CompactionAlgorithm> UnshareCompactionPolicy::choose_compaction_algorithm(
+        const std::vector<RowsetPtr>& rowsets) {
+    if (rowsets.empty()) {
+        return CLOUD_NATIVE_INDEX_COMPACTION;
+    }
+    return CompactionPolicy::choose_compaction_algorithm(rowsets);
 }
 
 // Return true if segment number meet the requirement of min input
@@ -481,6 +507,37 @@ StatusOr<std::vector<RowsetPtr>> PrimaryCompactionPolicy::pick_base_rowsets(
 
 StatusOr<std::vector<RowsetPtr>> PrimaryCompactionPolicy::pick_rowsets(
         const std::shared_ptr<const TabletMetadataPB>& tablet_metadata, std::vector<bool>* has_dels) {
+    // Everyday compaction has to stay off the files a split left shared, for a tablet whose rows are
+    // not in sort-key order.
+    //
+    // Such a child reads a shared segment whole: Rowset::set_segment_tablet_range withholds the
+    // tablet range because it has no rowid interval in sort-key space, and the row-level
+    // PrimaryKeyRangeFilter is only built for the UNSHARE compaction. So an ordinary compaction here
+    // would merge the siblings' rows into its output and mark that output private -- and
+    // UnshareCompactionPolicy only picks rowsets that still carry a shared segment, so the
+    // contaminated rowset is never rewritten and those rows go on to be served by the wrong child
+    // after cutover.
+    //
+    // The window is bounded: the UNSHARE transaction is scheduled with the split and, once it
+    // commits, no rowset carries a shared segment and this guard stops matching. Waiting is what the
+    // design trades for the split being metadata-only.
+    // Tested cheapest-first: only a ranged tablet whose sort key is not the primary key can ever be
+    // in this state, and both of those are schema properties. The segment walk below is
+    // O(rowsets x segments), so it must not run for every ordinary ranged tablet.
+    if (tablet_metadata->has_range() && TabletSchema::create(tablet_metadata->schema())->has_separate_sort_key()) {
+        const bool carries_shared_segment =
+                std::any_of(tablet_metadata->rowsets().begin(), tablet_metadata->rowsets().end(),
+                            [](const RowsetMetadataPB& rowset) {
+                                return std::any_of(rowset.segment_metas().begin(), rowset.segment_metas().end(),
+                                                   [](const SegmentMetadataPB& segment) { return segment.shared(); });
+                            });
+        if (carries_shared_segment) {
+            VLOG(2) << "skip ordinary compaction while a split's shared segments await UNSHARE, tablet="
+                    << tablet_metadata->id() << " version=" << tablet_metadata->version();
+            return std::vector<RowsetPtr>{};
+        }
+    }
+
     // Base compaction reclaims space from delete-bearing rowsets. Trigger it when a manual
     // ALTER TABLE ... COMPACT requested a base compaction, or when the tablet has accumulated
     // enough deletes to be worth reclaiming -- either as a fraction of its rows

--- a/be/src/storage/lake/primary_key_compaction_policy.h
+++ b/be/src/storage/lake/primary_key_compaction_policy.h
@@ -152,4 +152,18 @@ private:
     int64_t _get_data_size(const std::shared_ptr<const TabletMetadataPB>& tablet_metadata);
 };
 
+// One-shot policy used after a range-tablet split. A rowset is the metadata and
+// conflict-resolution unit, so a rowset containing any shared segment must be
+// rewritten in full. This deliberately bypasses every normal score, size and
+// input-count gate. Rowset readers apply the child tablet range only to shared
+// segments; private segments in a mixed rowset are already child-local.
+class UnshareCompactionPolicy final : public CompactionPolicy {
+public:
+    explicit UnshareCompactionPolicy(TabletManager* tablet_mgr, std::shared_ptr<const TabletMetadataPB> tablet_metadata)
+            : CompactionPolicy(tablet_mgr, std::move(tablet_metadata), false) {}
+
+    StatusOr<std::vector<RowsetPtr>> pick_rowsets() override;
+    StatusOr<CompactionAlgorithm> choose_compaction_algorithm(const std::vector<RowsetPtr>& rowsets) override;
+};
+
 } // namespace starrocks::lake

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -153,6 +153,14 @@ Rowset::~Rowset() {
 }
 
 StatusOr<std::optional<SeekRange>> Rowset::get_seek_range() const {
+    // Range-distributed PK tablets with ORDER BY != PK persist their tablet/rowset
+    // boundaries in PK space while segment pages are ordered by the independent sort key.
+    // Such a boundary is not a contiguous segment seek range. Parent-tablet reads therefore
+    // read a deduplicated shared segment in full; UNSHARE applies the PK range row-by-row.
+    if (_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS && _tablet_schema->has_separate_sort_key()) {
+        return std::optional<SeekRange>{};
+    }
+
     const TabletRangePB* range_pb = nullptr;
     if (_metadata->has_range()) {
         range_pb = &_metadata->range();
@@ -715,8 +723,12 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
     seg_options.lake_io_opts.fs = seg_options.fs;
     seg_options.lake_io_opts.location_provider = _tablet_mgr->location_provider();
     seg_options.is_primary_keys = true;
-    seg_options.delvec_loader =
-            std::make_shared<LakeDelvecLoader>(_tablet_mgr, builder, true /*fill cache*/, seg_options.lake_io_opts);
+    // The caller already supplied the complete tablet metadata used to build this rowset. Reuse it
+    // for delvec lookup instead of reading the same version back from object storage. This is
+    // required by aggregate publish: query-parent synthesis flushes child PK indexes before the
+    // new-version bundle has been persisted, so that version exists only in the RPC response here.
+    seg_options.delvec_loader = std::make_shared<LakeDelvecLoader>(_tablet_mgr, builder, true /*fill cache*/,
+                                                                   seg_options.lake_io_opts, _tablet_metadata);
     seg_options.dcg_loader = std::make_shared<LakeDeltaColumnGroupLoader>(_tablet_metadata);
     seg_options.idg_loader = std::make_shared<LakeIndexDeltaGroupLoader>(_tablet_metadata);
     seg_options.version = version;

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -1555,8 +1555,9 @@ StatusOr<CompactionTaskPtr> TabletManager::compact(CompactionTaskContext* contex
 
     ASSIGN_OR_RETURN(auto tablet, get_tablet(context->tablet_id, context->version));
     const auto& tablet_metadata = tablet.metadata();
-    ASSIGN_OR_RETURN(auto compaction_policy,
-                     CompactionPolicy::create(this, tablet_metadata, context->force_base_compaction));
+    ASSIGN_OR_RETURN(
+            auto compaction_policy,
+            CompactionPolicy::create(this, tablet_metadata, context->force_base_compaction, context->is_unshare));
     ASSIGN_OR_RETURN(auto input_rowsets, compaction_policy->pick_rowsets());
     return compact(context, std::move(input_rowsets));
 }
@@ -1583,8 +1584,9 @@ StatusOr<CompactionTaskPtr> TabletManager::compact(CompactionTaskContext* contex
 
     ASSIGN_OR_RETURN(auto tablet, get_tablet(context->tablet_id, context->version));
     auto tablet_metadata = tablet.metadata();
-    ASSIGN_OR_RETURN(auto compaction_policy,
-                     CompactionPolicy::create(this, tablet_metadata, context->force_base_compaction));
+    ASSIGN_OR_RETURN(
+            auto compaction_policy,
+            CompactionPolicy::create(this, tablet_metadata, context->force_base_compaction, context->is_unshare));
     ASSIGN_OR_RETURN(auto algorithm, compaction_policy->choose_compaction_algorithm(input_rowsets));
     std::vector<uint32_t> input_rowsets_id;
     size_t total_input_rowsets_file_size = 0;

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -3073,7 +3073,7 @@ void reconcile_vector_index_built_version(const std::vector<TabletMergeContext>&
 StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
                                                 const std::vector<TabletMetadataPtr>& old_tablet_metadatas,
                                                 const MergingTabletInfoPB& merging_tablet, int64_t new_version,
-                                                const TxnInfoPB& txn_info) {
+                                                const TxnInfoPB& txn_info, bool skip_sstable_merge) {
     if (old_tablet_metadatas.empty()) {
         return Status::InvalidArgument("No old tablet metadata to merge");
     }
@@ -3171,7 +3171,12 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
                                       new_tablet_metadata.get()));
     }
 
-    RETURN_IF_ERROR(merge_sstables(tablet_manager, merge_contexts, new_tablet_metadata.get()));
+    if (skip_sstable_merge) {
+        // Read-only alias: leave it without a primary index rather than paying the rebuild.
+        new_tablet_metadata->clear_sstable_meta();
+    } else {
+        RETURN_IF_ERROR(merge_sstables(tablet_manager, merge_contexts, new_tablet_metadata.get()));
+    }
 
     // Phase 4: Finalize
     update_next_rowset_id(new_tablet_metadata.get());

--- a/be/src/storage/lake/tablet_merger.h
+++ b/be/src/storage/lake/tablet_merger.h
@@ -24,9 +24,14 @@ namespace starrocks::lake {
 
 class TabletManager;
 
+// |skip_sstable_merge| drops the primary-index sstable merge from the result. Only pass true for a
+// read-only alias such as the query-side parent an ORDER BY != PK split keeps alive: rewriting the
+// inherited multi-rssid sstables costs a parse+remap+reserialize of every index entry, and nothing
+// that reads such an alias consults the persistent index -- scans need rowsets and delvecs only,
+// while upserts go to the writable child layout. A real MERGE must never set it.
 StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
                                                 const std::vector<TabletMetadataPtr>& old_tablet_metadatas,
                                                 const MergingTabletInfoPB& merging_tablet, int64_t new_version,
-                                                const TxnInfoPB& txn_info);
+                                                const TxnInfoPB& txn_info, bool skip_sstable_merge = false);
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -14,6 +14,8 @@
 
 #include "storage/lake/tablet_parallel_compaction_manager.h"
 
+#include <fmt/format.h>
+
 #include <algorithm>
 #include <sstream>
 #include <utility>
@@ -337,7 +339,7 @@ TabletParallelCompactionManager::TabletParallelCompactionManager(TabletManager* 
 TabletParallelCompactionManager::~TabletParallelCompactionManager() = default;
 
 StatusOr<std::vector<RowsetPtr>> TabletParallelCompactionManager::pick_rowsets_for_compaction(
-        int64_t tablet_id, int64_t txn_id, int64_t version, bool force_base_compaction) {
+        int64_t tablet_id, int64_t txn_id, int64_t version, bool force_base_compaction, bool is_unshare) {
     // Get tablet metadata
     ASSIGN_OR_RETURN(auto tablet, _tablet_mgr->get_tablet(tablet_id, version));
     const auto& metadata = tablet.metadata();
@@ -358,7 +360,7 @@ StatusOr<std::vector<RowsetPtr>> TabletParallelCompactionManager::pick_rowsets_f
             << " first_10_rowset_ids=[" << JoinInts(first_rowset_ids, ",") << "]";
 
     // Get all rowsets to compact using standard pick_rowsets()
-    ASSIGN_OR_RETURN(auto policy, CompactionPolicy::create(_tablet_mgr, metadata, force_base_compaction));
+    ASSIGN_OR_RETURN(auto policy, CompactionPolicy::create(_tablet_mgr, metadata, force_base_compaction, is_unshare));
     auto all_rowsets_or = policy->pick_rowsets();
     if (!all_rowsets_or.ok() || all_rowsets_or.value().empty()) {
         return Status::NotFound(strings::Substitute(
@@ -443,6 +445,7 @@ std::vector<std::vector<RowsetPtr>> TabletParallelCompactionManager::split_rowse
 StatusOr<std::shared_ptr<TabletParallelCompactionState>>
 TabletParallelCompactionManager::create_and_register_tablet_state(int64_t tablet_id, int64_t txn_id, int64_t version,
                                                                   int32_t max_parallel, int64_t max_bytes,
+                                                                  bool is_unshare,
                                                                   std::shared_ptr<CompactionTaskCallback> callback,
                                                                   const ReleaseTokenFunc& release_token) {
     std::string state_key = make_state_key(tablet_id, txn_id);
@@ -461,6 +464,7 @@ TabletParallelCompactionManager::create_and_register_tablet_state(int64_t tablet
     state->tablet_id = tablet_id;
     state->txn_id = txn_id;
     state->version = version;
+    state->is_unshare = is_unshare;
     state->max_parallel = max_parallel;
     state->max_bytes_per_subtask = max_bytes;
     state->callback = std::move(callback);
@@ -636,7 +640,7 @@ StatusOr<int> TabletParallelCompactionManager::submit_subtasks(
 StatusOr<int> TabletParallelCompactionManager::create_parallel_tasks(
         int64_t tablet_id, int64_t txn_id, int64_t version, const TabletParallelConfig& config,
         std::shared_ptr<CompactionTaskCallback> callback, bool force_base_compaction, ThreadPool* thread_pool,
-        const AcquireTokenFunc& acquire_token, const ReleaseTokenFunc& release_token) {
+        const AcquireTokenFunc& acquire_token, const ReleaseTokenFunc& release_token, bool is_unshare) {
     // Validate configuration
     // max_parallel comes from table property (via FE)
     // max_bytes comes from BE config if FE passes 0
@@ -683,7 +687,8 @@ StatusOr<int> TabletParallelCompactionManager::create_parallel_tasks(
     }
 
     // Step 1: Pick rowsets for compaction
-    ASSIGN_OR_RETURN(auto all_rowsets, pick_rowsets_for_compaction(tablet_id, txn_id, version, force_base_compaction));
+    ASSIGN_OR_RETURN(auto all_rowsets,
+                     pick_rowsets_for_compaction(tablet_id, txn_id, version, force_base_compaction, is_unshare));
     size_t total_rowsets_count = all_rowsets.size();
 
     // Use the unified grouping algorithm that supports both large rowset splitting
@@ -691,7 +696,13 @@ StatusOr<int> TabletParallelCompactionManager::create_parallel_tasks(
     // are segment-based and do not depend on primary index, so this works for all table
     // types (PK, duplicate key, unique key, aggregate key).
     // Step 2: Create subtask groups (handles both large rowset split and small rowset grouping)
-    auto subtask_groups = _create_subtask_groups(tablet_id, std::move(all_rowsets), max_parallel, max_bytes);
+    auto subtask_groups = is_unshare
+                                  ? _create_unshare_subtask_groups(tablet_id, all_rowsets, max_parallel, max_bytes)
+                                  : _create_subtask_groups(tablet_id, std::move(all_rowsets), max_parallel, max_bytes);
+
+    if (is_unshare && !subtask_groups.empty()) {
+        RETURN_IF_ERROR(_validate_unshare_group_coverage(all_rowsets, subtask_groups));
+    }
 
     if (subtask_groups.empty()) {
         VLOG(1) << "Parallel compaction: tablet=" << tablet_id << " txn=" << txn_id
@@ -703,8 +714,9 @@ StatusOr<int> TabletParallelCompactionManager::create_parallel_tasks(
             << " subtask groups from " << total_rowsets_count << " rowsets";
 
     // Step 3: Create and register tablet state
-    ASSIGN_OR_RETURN(auto state_ptr, create_and_register_tablet_state(tablet_id, txn_id, version, max_parallel,
-                                                                      max_bytes, std::move(callback), release_token));
+    ASSIGN_OR_RETURN(auto state_ptr,
+                     create_and_register_tablet_state(tablet_id, txn_id, version, max_parallel, max_bytes, is_unshare,
+                                                      std::move(callback), release_token));
 
     // Step 4: Submit subtasks
     return submit_subtasks_from_groups(state_ptr, std::move(subtask_groups), force_base_compaction, thread_pool,
@@ -966,6 +978,23 @@ StatusOr<TxnLogPB> TabletParallelCompactionManager::get_merged_txn_log(int64_t t
                   [](const std::unique_ptr<CompactionTaskContext>& a, const std::unique_ptr<CompactionTaskContext>& b) {
                       return a->subtask_id < b->subtask_id;
                   });
+
+        if (state->is_unshare) {
+            if (state->expected_unshare_subtask_count <= 0 ||
+                static_cast<int32_t>(state->completed_subtasks.size()) != state->expected_unshare_subtask_count) {
+                return Status::InternalError(strings::Substitute(
+                        "Incomplete parallel UNSHARE: tablet_id=$0, txn_id=$1, completed=$2, expected=$3", tablet_id,
+                        txn_id, state->completed_subtasks.size(), state->expected_unshare_subtask_count));
+            }
+            for (const auto& ctx : state->completed_subtasks) {
+                if (!ctx->status.ok() || ctx->txn_log == nullptr || !ctx->txn_log->has_op_compaction()) {
+                    return Status::InternalError(strings::Substitute(
+                            "Parallel UNSHARE subtask failed: tablet_id=$0, txn_id=$1, subtask_id=$2, status=$3",
+                            tablet_id, txn_id, ctx->subtask_id,
+                            ctx->status.ok() ? "missing compaction txn log" : ctx->status.to_string()));
+                }
+            }
+        }
 
         // Build a map from subtask_id to status for quick lookup
         std::unordered_map<int32_t, bool> subtask_success_map;
@@ -1391,7 +1420,9 @@ StatusOr<TxnLogPB> TabletParallelCompactionManager::get_merged_txn_log(int64_t t
 
     // Execute SST compaction once after all subtasks complete.
     // Store results in OpParallelCompaction (not in individual subtask OpCompactions).
-    RETURN_IF_ERROR(execute_sst_compaction_for_parallel(tablet_id, version, op_parallel));
+    if (!state->is_unshare) {
+        RETURN_IF_ERROR(execute_sst_compaction_for_parallel(tablet_id, version, op_parallel));
+    }
 
     return merged_log;
 }
@@ -1454,7 +1485,8 @@ void TabletParallelCompactionManager::execute_subtask(int64_t tablet_id, int64_t
     // and can be merged later in on_subtask_complete
     // Pass subtask_id so that rows_mapper files use subtask-specific filenames
     auto context = CompactionTaskContext::create_for_subtask(txn_id, tablet_id, version, force_base_compaction,
-                                                             true /* skip_write_txnlog */, state->callback, subtask_id);
+                                                             true /* skip_write_txnlog */, state->callback, subtask_id,
+                                                             state->is_unshare);
 
     auto start_time = ::time(nullptr);
     auto start_time_ns = MonotonicNanos();
@@ -1863,6 +1895,184 @@ std::vector<SubtaskGroup> TabletParallelCompactionManager::_group_small_rowsets(
     return groups;
 }
 
+std::vector<SubtaskGroup> TabletParallelCompactionManager::_create_unshare_subtask_groups(
+        int64_t tablet_id, const std::vector<RowsetPtr>& rowsets, int32_t max_parallel, int64_t max_bytes_per_subtask) {
+    if (rowsets.empty() || max_parallel <= 1 || max_bytes_per_subtask <= 0) {
+        return {};
+    }
+
+    int64_t total_bytes = 0;
+    int32_t max_physical_parts = 0;
+    for (const auto& rowset : rowsets) {
+        total_bytes += rowset->data_size();
+        // Segment-range compaction keeps at least two segments in each part. A
+        // one-part rowset is represented by a NORMAL group and is still rewritten.
+        max_physical_parts += std::max<int32_t>(1, rowset->num_segments() / 2);
+    }
+    int32_t target_parts = static_cast<int32_t>((total_bytes + max_bytes_per_subtask - 1) / max_bytes_per_subtask);
+    target_parts = std::min({max_parallel, max_physical_parts, target_parts});
+    if (target_parts <= 1) {
+        VLOG(1) << "Parallel UNSHARE fallback: tablet=" << tablet_id << ", rowsets=" << rowsets.size()
+                << ", bytes=" << total_bytes << ", max_parallel=" << max_parallel;
+        return {};
+    }
+
+    std::vector<SubtaskGroup> groups;
+    if (static_cast<int32_t>(rowsets.size()) >= target_parts) {
+        // There are enough rowsets to parallelize without splitting a rowset. Keep
+        // metadata order and form exactly target_parts whole-rowset groups.
+        int64_t remaining_bytes = total_bytes;
+        int32_t remaining_groups = target_parts;
+        SubtaskGroup current;
+        current.type = SubtaskType::NORMAL;
+        for (size_t i = 0; i < rowsets.size(); ++i) {
+            const auto& rowset = rowsets[i];
+            current.rowsets.push_back(rowset);
+            current.total_bytes += rowset->data_size();
+            remaining_bytes -= rowset->data_size();
+
+            const size_t remaining_rowsets = rowsets.size() - i - 1;
+            const int64_t target_bytes =
+                    remaining_groups > 0 ? (current.total_bytes + remaining_bytes) / remaining_groups : 0;
+            if (remaining_groups > 1 && remaining_rowsets >= static_cast<size_t>(remaining_groups - 1) &&
+                current.total_bytes >= target_bytes) {
+                groups.push_back(std::move(current));
+                current = SubtaskGroup();
+                current.type = SubtaskType::NORMAL;
+                --remaining_groups;
+            }
+        }
+        if (!current.rowsets.empty()) {
+            groups.push_back(std::move(current));
+        }
+    } else {
+        // Start with one part per rowset, then give extra slots to the rowset
+        // with the largest remaining bytes per part.
+        std::vector<int32_t> part_counts(rowsets.size(), 1);
+        int32_t assigned_parts = static_cast<int32_t>(rowsets.size());
+        while (assigned_parts < target_parts) {
+            size_t best = rowsets.size();
+            double best_score = -1;
+            for (size_t i = 0; i < rowsets.size(); ++i) {
+                int32_t max_parts = std::max<int32_t>(1, rowsets[i]->num_segments() / 2);
+                if (part_counts[i] >= max_parts) {
+                    continue;
+                }
+                double score = static_cast<double>(rowsets[i]->data_size()) / part_counts[i];
+                if (score > best_score) {
+                    best = i;
+                    best_score = score;
+                }
+            }
+            if (best == rowsets.size()) {
+                break;
+            }
+            ++part_counts[best];
+            ++assigned_parts;
+        }
+
+        for (size_t i = 0; i < rowsets.size(); ++i) {
+            const auto& rowset = rowsets[i];
+            const int32_t part_count = part_counts[i];
+            if (part_count == 1) {
+                SubtaskGroup group;
+                group.type = SubtaskType::NORMAL;
+                group.rowsets.push_back(rowset);
+                group.total_bytes = rowset->data_size();
+                groups.push_back(std::move(group));
+                continue;
+            }
+
+            const int32_t total_segments = rowset->num_segments();
+            int32_t segment_start = 0;
+            for (int32_t part = 0; part < part_count; ++part) {
+                int32_t remaining_segments = total_segments - segment_start;
+                int32_t remaining_parts = part_count - part;
+                int32_t segments_in_part = (remaining_segments + remaining_parts - 1) / remaining_parts;
+                int32_t segment_end = segment_start + segments_in_part;
+
+                SubtaskGroup group;
+                group.type = SubtaskType::LARGE_ROWSET_PART;
+                group.large_rowset = rowset;
+                group.large_rowset_id = rowset->id();
+                group.segment_start = segment_start;
+                group.segment_end = segment_end;
+                group.total_bytes =
+                        part + 1 == part_count
+                                ? rowset->data_size() - (rowset->data_size() * segment_start / total_segments)
+                                : rowset->data_size() * segments_in_part / total_segments;
+                groups.push_back(std::move(group));
+                segment_start = segment_end;
+            }
+        }
+    }
+
+    VLOG(1) << "Parallel UNSHARE: tablet=" << tablet_id << " created " << groups.size() << " physical subtasks for "
+            << rowsets.size() << " shared rowsets, bytes=" << total_bytes;
+    return groups;
+}
+
+Status TabletParallelCompactionManager::_validate_unshare_group_coverage(const std::vector<RowsetPtr>& rowsets,
+                                                                         const std::vector<SubtaskGroup>& groups) {
+    struct Coverage {
+        int32_t segment_count = 0;
+        bool whole_rowset = false;
+        std::vector<std::pair<int32_t, int32_t>> segment_ranges;
+    };
+    std::unordered_map<uint32_t, Coverage> coverage;
+    for (const auto& rowset : rowsets) {
+        if (!coverage.emplace(rowset->id(), Coverage{rowset->num_segments(), false, {}}).second) {
+            return Status::InternalError(fmt::format("duplicate UNSHARE input rowset {}", rowset->id()));
+        }
+    }
+
+    for (const auto& group : groups) {
+        if (group.type == SubtaskType::RANGE_SPLIT) {
+            return Status::InternalError("parallel UNSHARE must not use sort-key range subtasks");
+        }
+        if (group.type == SubtaskType::NORMAL) {
+            for (const auto& rowset : group.rowsets) {
+                auto it = coverage.find(rowset->id());
+                if (it == coverage.end() || it->second.whole_rowset || !it->second.segment_ranges.empty()) {
+                    return Status::InternalError(
+                            fmt::format("UNSHARE rowset {} is missing or covered more than once", rowset->id()));
+                }
+                it->second.whole_rowset = true;
+            }
+            continue;
+        }
+
+        auto it = coverage.find(group.large_rowset_id);
+        if (it == coverage.end() || group.large_rowset == nullptr ||
+            group.large_rowset->id() != group.large_rowset_id || it->second.whole_rowset || group.segment_start < 0 ||
+            group.segment_start >= group.segment_end || group.segment_end > it->second.segment_count) {
+            return Status::InternalError(
+                    fmt::format("invalid UNSHARE segment coverage for rowset {}", group.large_rowset_id));
+        }
+        it->second.segment_ranges.emplace_back(group.segment_start, group.segment_end);
+    }
+
+    for (auto& [rowset_id, item] : coverage) {
+        if (item.whole_rowset) {
+            continue;
+        }
+        std::sort(item.segment_ranges.begin(), item.segment_ranges.end());
+        int32_t next_segment = 0;
+        for (const auto& [begin, end] : item.segment_ranges) {
+            if (begin != next_segment) {
+                return Status::InternalError(fmt::format(
+                        "parallel UNSHARE rowset {} has a gap/overlap before segment {}", rowset_id, begin));
+            }
+            next_segment = end;
+        }
+        if (next_segment != item.segment_count) {
+            return Status::InternalError(fmt::format("parallel UNSHARE rowset {} covers {} of {} segments", rowset_id,
+                                                     next_segment, item.segment_count));
+        }
+    }
+    return Status::OK();
+}
+
 std::vector<SubtaskGroup> TabletParallelCompactionManager::_create_subtask_groups(int64_t tablet_id,
                                                                                   std::vector<RowsetPtr> rowsets,
                                                                                   int32_t max_parallel,
@@ -2006,6 +2216,11 @@ StatusOr<int> TabletParallelCompactionManager::submit_subtasks_from_groups(
     // the original rowset, dropping segments that never got a subtask.
     int32_t total_groups = static_cast<int32_t>(groups.size());
     int32_t tokens_acquired = 0;
+
+    if (state_ptr->is_unshare) {
+        std::lock_guard<std::mutex> lock(state_ptr->mutex);
+        state_ptr->expected_unshare_subtask_count = total_groups;
+    }
 
     for (int32_t i = 0; i < total_groups; i++) {
         if (!acquire_token()) {
@@ -2239,7 +2454,8 @@ void TabletParallelCompactionManager::execute_subtask_segment_range(int64_t tabl
 
     // Create compaction context
     auto context = CompactionTaskContext::create_for_subtask(txn_id, tablet_id, version, force_base_compaction,
-                                                             true /* skip_write_txnlog */, state->callback, subtask_id);
+                                                             true /* skip_write_txnlog */, state->callback, subtask_id,
+                                                             state->is_unshare);
 
     auto start_time = ::time(nullptr);
     auto start_time_ns = MonotonicNanos();
@@ -2688,7 +2904,8 @@ void TabletParallelCompactionManager::execute_subtask_range_split(
     }
 
     auto context = CompactionTaskContext::create_for_subtask(txn_id, tablet_id, version, force_base_compaction,
-                                                             true /* skip_write_txnlog */, state->callback, subtask_id);
+                                                             true /* skip_write_txnlog */, state->callback, subtask_id,
+                                                             state->is_unshare);
 
     auto start_time = ::time(nullptr);
     auto start_time_ns = MonotonicNanos();

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.h
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.h
@@ -108,6 +108,7 @@ struct TabletParallelCompactionState {
     int64_t tablet_id = 0;
     int64_t txn_id = 0;
     int64_t version = 0;
+    bool is_unshare = false;
 
     // Rowsets currently being compacted (to avoid conflicts)
     // Key: rowset_id, Value: reference count (number of subtasks using this rowset)
@@ -160,6 +161,10 @@ struct TabletParallelCompactionState {
     // the split is incomplete and must be treated as failed.
     int32_t expected_range_split_count = 0;
 
+    // UNSHARE is all-or-nothing across every physical subtask. Recorded before
+    // submission so a partial thread-pool submission cannot be published.
+    int32_t expected_unshare_subtask_count = 0;
+
     // Mutex for thread-safe access
     mutable std::mutex mutex;
 
@@ -190,7 +195,7 @@ public:
                                         const TabletParallelConfig& config,
                                         std::shared_ptr<CompactionTaskCallback> callback, bool force_base_compaction,
                                         ThreadPool* thread_pool, const AcquireTokenFunc& acquire_token,
-                                        const ReleaseTokenFunc& release_token);
+                                        const ReleaseTokenFunc& release_token, bool is_unshare = false);
 
     // Get tablet's parallel state (for testing/monitoring)
     // Returns shared_ptr to ensure the state remains valid while being used.
@@ -245,7 +250,7 @@ private:
 
     // Pick rowsets for compaction using CompactionPolicy
     StatusOr<std::vector<RowsetPtr>> pick_rowsets_for_compaction(int64_t tablet_id, int64_t txn_id, int64_t version,
-                                                                 bool force_base_compaction);
+                                                                 bool force_base_compaction, bool is_unshare);
 
     // Split rowsets into groups for parallel compaction
     // Returns empty vector if no valid groups can be formed
@@ -258,7 +263,7 @@ private:
     // Returns nullptr if state already exists
     StatusOr<std::shared_ptr<TabletParallelCompactionState>> create_and_register_tablet_state(
             int64_t tablet_id, int64_t txn_id, int64_t version, int32_t max_parallel, int64_t max_bytes,
-            std::shared_ptr<CompactionTaskCallback> callback, const ReleaseTokenFunc& release_token);
+            bool is_unshare, std::shared_ptr<CompactionTaskCallback> callback, const ReleaseTokenFunc& release_token);
 
     // Submit subtasks to thread pool
     // Returns the number of subtasks successfully submitted
@@ -368,6 +373,15 @@ private:
     std::vector<SubtaskGroup> _create_subtask_groups(int64_t tablet_id, std::vector<RowsetPtr> rowsets,
                                                      int32_t max_parallel, int64_t max_bytes_per_subtask);
 
+    // UNSHARE must rewrite every selected shared rowset atomically. This planner
+    // partitions the physical rowset/segment work without using sort-key ranges and
+    // never drops an input merely because a one-rowset group is normally compacted.
+    std::vector<SubtaskGroup> _create_unshare_subtask_groups(int64_t tablet_id, const std::vector<RowsetPtr>& rowsets,
+                                                             int32_t max_parallel, int64_t max_bytes_per_subtask);
+
+    static Status _validate_unshare_group_coverage(const std::vector<RowsetPtr>& rowsets,
+                                                   const std::vector<SubtaskGroup>& groups);
+
     // Merge multiple subtask LCRM files into a single LCRM file for the merged compaction.
     // This enables the light publish path (SST ingestion) for large rowset split compaction.
     Status _merge_subtask_lcrm_files(int64_t tablet_id, int64_t txn_id, const std::vector<FileMetaPB>& lcrm_files,
@@ -408,6 +422,11 @@ private:
     FRIEND_TEST(TabletParallelCompactionManagerTest, test_create_range_split_groups_error_paths);
     FRIEND_TEST(TabletParallelCompactionManagerTest, test_range_split_vlog_paths);
     FRIEND_TEST(TabletParallelCompactionManagerTest, test_create_parallel_tasks_range_split);
+    FRIEND_TEST(TabletParallelCompactionManagerTest, test_create_unshare_groups_cover_all_segments);
+    FRIEND_TEST(TabletParallelCompactionManagerTest, test_create_unshare_groups_degenerate_inputs);
+    FRIEND_TEST(TabletParallelCompactionManagerTest, test_create_unshare_groups_pack_whole_rowsets);
+    FRIEND_TEST(TabletParallelCompactionManagerTest, test_create_unshare_groups_mixed_part_counts);
+    FRIEND_TEST(TabletParallelCompactionManagerTest, test_validate_unshare_coverage_rejects_a_missing_rowset);
 
     TabletManager* _tablet_mgr;
 

--- a/be/src/storage/lake/tablet_range_helper.cpp
+++ b/be/src/storage/lake/tablet_range_helper.cpp
@@ -24,6 +24,7 @@
 #include "column/schema.h"
 #include "common/logging.h"
 #include "fmt/format.h"
+#include "runtime/current_thread.h"
 #include "storage/chunk_helper.h"
 #include "storage/datum_variant.h"
 #include "storage/types.h"
@@ -379,6 +380,58 @@ StatusOr<SstSeekRange> TabletRangeHelper::create_sst_seek_range_from(const Table
     }
 
     return sst_seek_range;
+}
+
+StatusOr<PrimaryKeyRangeFilter> PrimaryKeyRangeFilter::create(const TabletRangePB& tablet_range_pb,
+                                                              const TabletSchemaCSPtr& tablet_schema) {
+    RETURN_IF(tablet_schema == nullptr, Status::InvalidArgument("tablet schema is null"));
+    RETURN_IF(tablet_schema->keys_type() != KeysType::PRIMARY_KEYS,
+              Status::InvalidArgument("PK range filter requires a primary-key tablet"));
+    ASSIGN_OR_RETURN(auto encoding_type, tablet_schema->primary_key_encoding_type_or_error());
+    // The comparison below is a bytewise Slice::compare against the encoded bounds, which only
+    // matches key order under the order-preserving big-endian encoding.
+    RETURN_IF(encoding_type != PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2,
+              Status::InvalidArgument("Big-endian encoding is required for a PK range filter"));
+
+    PrimaryKeyRangeFilter f;
+    ASSIGN_OR_RETURN(f._seek_range, TabletRangeHelper::create_sst_seek_range_from(tablet_range_pb, tablet_schema));
+    f._pkey_schema = ChunkHelper::convert_schema(tablet_schema, TabletRangeHelper::range_key_idxes(*tablet_schema));
+    f._encoding_type = encoding_type;
+    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(f._pkey_schema, &f._encoded_keys, encoding_type));
+    return f;
+}
+
+StatusOr<Filter> PrimaryKeyRangeFilter::build(const Chunk& chunk) {
+    const size_t num_rows = chunk.num_rows();
+    if (num_rows == 0) {
+        return Filter{};
+    }
+    _encoded_keys->resize(0);
+    // A wide or long primary key can make this allocation fail, and PrimaryKeyEncoder::encode returns
+    // void -- so without the macro a memory-limit breach unwinds out of a compaction worker instead
+    // of coming back as a retryable Status. This filter runs over every chunk of an UNSHARE rewrite.
+    TRY_CATCH_BAD_ALLOC(
+            PrimaryKeyEncoder::encode(_pkey_schema, chunk, 0, num_rows, _encoded_keys.get(), _encoding_type));
+    RETURN_IF(!_encoded_keys->is_binary(), Status::InternalError("V2-encoded primary key must be binary"));
+
+    const auto& binary_keys = down_cast<BinaryColumn&>(*_encoded_keys);
+    RETURN_IF(binary_keys.size() != num_rows,
+              Status::InternalError("encoded primary key count differs from the chunk row count"));
+    const Slice seek_key(_seek_range.seek_key);
+    const Slice stop_key(_seek_range.stop_key);
+    Filter filter;
+    TRY_CATCH_BAD_ALLOC(filter.assign(num_rows, 1));
+    for (size_t i = 0; i < num_rows; ++i) {
+        const Slice key = binary_keys.get_slice(i);
+        if (!_seek_range.seek_key.empty() && key.compare(seek_key) < 0) {
+            filter[i] = 0;
+            continue;
+        }
+        if (!_seek_range.stop_key.empty() && key.compare(stop_key) >= 0) {
+            filter[i] = 0;
+        }
+    }
+    return filter;
 }
 
 StatusOr<TabletRangePB> TabletRangeHelper::convert_t_range_to_pb_range(const TTabletRange& t_range) {

--- a/be/src/storage/lake/tablet_range_helper.h
+++ b/be/src/storage/lake/tablet_range_helper.h
@@ -118,4 +118,26 @@ public:
                                             const TabletRangePB& new_range);
 };
 
+// Row selection over a tablet's PK-space half-open range. This is intentionally a row filter rather
+// than a segment seek: a tablet with ORDER BY != PK has segments ordered by the sort key, so its PK
+// range cannot be mapped to a contiguous rowid span.
+//
+// Everything except the encode-and-compare is decided by (range, schema) alone, so it is computed
+// once here instead of per chunk -- an UNSHARE compaction runs this over thousands of chunks.
+// Not thread-safe: the encoder's output column is reused, so give each compaction task its own.
+class PrimaryKeyRangeFilter {
+public:
+    static StatusOr<PrimaryKeyRangeFilter> create(const TabletRangePB& tablet_range_pb,
+                                                  const TabletSchemaCSPtr& tablet_schema);
+
+    // Returns one byte per row of |chunk|: 1 to keep, 0 to drop. Empty for an empty chunk.
+    StatusOr<Filter> build(const Chunk& chunk);
+
+private:
+    SstSeekRange _seek_range;
+    Schema _pkey_schema;
+    PrimaryKeyEncodingType _encoding_type = PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2;
+    MutableColumnPtr _encoded_keys;
+};
+
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -303,7 +303,7 @@ TabletReader::TabletReader(TabletManager* tablet_mgr, std::shared_ptr<const Tabl
 
 TabletReader::TabletReader(TabletManager* tablet_mgr, std::shared_ptr<const TabletMetadataPB> metadata, Schema schema,
                            std::vector<RowsetPtr> rowsets, bool is_key, RowSourceMaskBuffer* mask_buffer,
-                           std::shared_ptr<const TabletSchema> tablet_schema)
+                           std::shared_ptr<const TabletSchema> tablet_schema, RowSourceMaskBuffer* selection_buffer)
         : ChunkIterator(std::move(schema)),
           _tablet_mgr(tablet_mgr),
           _tablet_metadata(std::move(metadata)),
@@ -312,7 +312,8 @@ TabletReader::TabletReader(TabletManager* tablet_mgr, std::shared_ptr<const Tabl
           _rowsets(std::move(rowsets)),
           _is_vertical_merge(true),
           _is_key(is_key),
-          _mask_buffer(mask_buffer) {
+          _mask_buffer(mask_buffer),
+          _selection_buffer(selection_buffer) {
     DCHECK(_mask_buffer);
 }
 
@@ -559,6 +560,12 @@ Status TabletReader::do_get_next(Chunk* chunk, std::vector<RowSourceMask>* sourc
         return Status::EndOfFile("split morsel");
     }
     RETURN_IF_ERROR(_collect_iter->get_next(chunk, source_masks));
+    if (_is_key && _selection_buffer != nullptr && source_masks->empty() && chunk->num_rows() > 0) {
+        // A one-child heap merge returns the child iterator directly, which does not
+        // produce source masks. UNSHARE still needs one mask per physical row so value
+        // groups can replay the selection stream.
+        source_masks->insert(source_masks->end(), chunk->num_rows(), RowSourceMask{0, false});
+    }
     return Status::OK();
 }
 
@@ -566,6 +573,9 @@ Status TabletReader::do_get_next(Chunk* chunk, std::vector<RowSourceMask>* sourc
                                  std::vector<uint64_t>* rssid_rowids) {
     DCHECK(_is_vertical_merge);
     RETURN_IF_ERROR(_collect_iter->get_next(chunk, source_masks, rssid_rowids));
+    if (_is_key && _selection_buffer != nullptr && source_masks->empty() && chunk->num_rows() > 0) {
+        source_masks->insert(source_masks->end(), chunk->num_rows(), RowSourceMask{0, false});
+    }
     return Status::OK();
 }
 
@@ -1117,7 +1127,7 @@ Status TabletReader::init_collector(const TabletReaderParams& params) {
         // SegmentIterator  ...    SegmentIterator
         //
         if (_is_vertical_merge && !_is_key) {
-            _collect_iter = new_mask_merge_iterator(seg_iters, _mask_buffer);
+            _collect_iter = new_mask_merge_iterator(seg_iters, _mask_buffer, _selection_buffer);
         } else {
             _collect_iter = new_heap_merge_iterator(
                     seg_iters,
@@ -1178,7 +1188,7 @@ Status TabletReader::init_collector(const TabletReaderParams& params) {
             RuntimeProfile::Counter* aggr_timer = ADD_TIMER(p, "Aggr");
 
             if (_is_vertical_merge && !_is_key) {
-                _collect_iter = new_mask_merge_iterator(seg_iters, _mask_buffer);
+                _collect_iter = new_mask_merge_iterator(seg_iters, _mask_buffer, _selection_buffer);
             } else {
                 _collect_iter = new_heap_merge_iterator(seg_iters);
             }
@@ -1191,7 +1201,7 @@ Status TabletReader::init_collector(const TabletReaderParams& params) {
             _collect_iter = timed_chunk_iterator(_collect_iter, aggr_timer);
         } else {
             if (_is_vertical_merge && !_is_key) {
-                _collect_iter = new_mask_merge_iterator(seg_iters, _mask_buffer);
+                _collect_iter = new_mask_merge_iterator(seg_iters, _mask_buffer, _selection_buffer);
             } else {
                 _collect_iter = new_heap_merge_iterator(seg_iters);
             }

--- a/be/src/storage/lake/tablet_reader.h
+++ b/be/src/storage/lake/tablet_reader.h
@@ -75,7 +75,7 @@ public:
                  std::vector<RowsetPtr> rowsets, std::shared_ptr<const TabletSchema> tablet_schema);
     TabletReader(TabletManager* tablet_mgr, std::shared_ptr<const TabletMetadataPB> metadata, Schema schema,
                  std::vector<RowsetPtr> rowsets, bool is_key, RowSourceMaskBuffer* mask_buffer,
-                 std::shared_ptr<const TabletSchema> tablet_schema);
+                 std::shared_ptr<const TabletSchema> tablet_schema, RowSourceMaskBuffer* selection_buffer = nullptr);
     ~TabletReader() override;
 
     DISALLOW_COPY_AND_MOVE(TabletReader);
@@ -169,6 +169,7 @@ private:
     bool _is_vertical_merge = false;
     bool _is_key = false;
     RowSourceMaskBuffer* _mask_buffer = nullptr;
+    RowSourceMaskBuffer* _selection_buffer = nullptr;
 
     std::shared_ptr<VersionedTablet> _tablet;
 

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -14,6 +14,8 @@
 
 #include "storage/lake/vertical_compaction_task.h"
 
+#include <fmt/format.h>
+
 #include <algorithm>
 #include <numeric>
 #include <unordered_set>
@@ -33,6 +35,7 @@
 #include "storage/compaction_utils.h"
 #include "storage/lake/rowset.h"
 #include "storage/lake/tablet_metadata.h"
+#include "storage/lake/tablet_range_helper.h"
 #include "storage/lake/tablet_reader.h"
 #include "storage/lake/tablet_write_log_manager.h"
 #include "storage/lake/tablet_writer.h"
@@ -72,6 +75,10 @@ Status VerticalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush
     DCHECK(!store_paths.empty());
     auto mask_buffer = std::make_unique<RowSourceMaskBuffer>(_tablet.id(), store_paths.begin()->path);
     auto source_masks = std::make_unique<std::vector<RowSourceMask>>();
+    const bool pk_range_filter = _context->is_unshare && _tablet_schema->has_separate_sort_key();
+    auto selection_buffer =
+            pk_range_filter ? std::make_unique<RowSourceMaskBuffer>(_tablet.id(), store_paths.begin()->path) : nullptr;
+    auto selection_masks = pk_range_filter ? std::make_unique<std::vector<RowSourceMask>>() : nullptr;
 
     uint32_t max_rows_per_segment =
             CompactionUtils::get_segment_max_rows(config::max_segment_file_size, _total_num_rows, _total_data_size);
@@ -101,7 +108,8 @@ Status VerticalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush
     // Separate-sort-key PK tables with eager index build: the PK columns are non-sort columns and
     // would otherwise land in value groups where the eager SST writer (which only sees the key group)
     // cannot reach them. Move them into the key group so compaction builds the PK-index SST eagerly.
-    const bool pk_in_key_group = writer->enable_pk_index_eager_build() && _tablet_schema->has_separate_sort_key();
+    const bool pk_in_key_group =
+            (writer->enable_pk_index_eager_build() || pk_range_filter) && _tablet_schema->has_separate_sort_key();
     if (pk_in_key_group) {
         move_pk_columns_into_key_group(&column_groups);
     }
@@ -121,12 +129,16 @@ Status VerticalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush
             // read mask buffer from the beginning
             SCOPED_RAW_TIMER(&_context->stats->mask_io_ns);
             RETURN_IF_ERROR(mask_buffer->flip_to_read());
+            if (selection_buffer != nullptr) {
+                RETURN_IF_ERROR(selection_buffer->flip_to_read());
+            }
         }
         int64_t column_group_ns = 0;
         {
             SCOPED_RAW_TIMER(&column_group_ns);
             RETURN_IF_ERROR(compact_column_group(is_key, i, column_group_size, column_groups[i], writer,
-                                                 mask_buffer.get(), source_masks.get(), cancel_func, pk_in_key_group));
+                                                 mask_buffer.get(), source_masks.get(), selection_buffer.get(),
+                                                 selection_masks.get(), cancel_func, pk_in_key_group));
         }
         if (is_key) {
             _context->stats->vertical_key_group_ns += column_group_ns;
@@ -232,12 +244,11 @@ StatusOr<int32_t> VerticalCompactionTask::calculate_chunk_size_for_column_group(
                                                 total_mem_footprint, _total_input_segs);
 }
 
-Status VerticalCompactionTask::compact_column_group(bool is_key, int column_group_index, size_t column_group_size,
-                                                    const std::vector<uint32_t>& column_group,
-                                                    std::unique_ptr<TabletWriter>& writer,
-                                                    RowSourceMaskBuffer* mask_buffer,
-                                                    std::vector<RowSourceMask>* source_masks,
-                                                    const CancelFunc& cancel_func, bool pk_in_key_group) {
+Status VerticalCompactionTask::compact_column_group(
+        bool is_key, int column_group_index, size_t column_group_size, const std::vector<uint32_t>& column_group,
+        std::unique_ptr<TabletWriter>& writer, RowSourceMaskBuffer* mask_buffer,
+        std::vector<RowSourceMask>* source_masks, RowSourceMaskBuffer* selection_buffer,
+        std::vector<RowSourceMask>* selection_masks, const CancelFunc& cancel_func, bool pk_in_key_group) {
     int32_t chunk_size = 0;
     Schema schema;
     {
@@ -260,7 +271,7 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
         }
     }
     TabletReader reader(_tablet.tablet_manager(), _tablet.metadata(), schema, _input_rowsets, is_key, mask_buffer,
-                        _tablet_schema);
+                        _tablet_schema, selection_buffer);
     {
         SCOPED_RAW_TIMER(&_context->stats->reader_prepare_ns);
         RETURN_IF_ERROR(reader.prepare());
@@ -307,6 +318,13 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
     std::vector<uint64_t> rssid_rowids;
     rssid_rowids.reserve(chunk_size);
 
+    // Built once: only the encode-and-compare depends on the chunk. Only the key group carries the
+    // PK columns, so only it filters; the value groups replay the selection stream instead.
+    std::optional<PrimaryKeyRangeFilter> pk_range_filter;
+    if (is_key && selection_buffer != nullptr) {
+        ASSIGN_OR_RETURN(pk_range_filter, PrimaryKeyRangeFilter::create(_tablet.metadata()->range(), _tablet_schema));
+    }
+
     VLOG(3) << "Compact column group. tablet: " << _tablet.id() << ", column group: " << column_group_index
             << ", reader chunk size: " << chunk_size;
 
@@ -344,8 +362,52 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
         {
             SCOPED_RAW_TIMER(&_context->stats->chunk_transform_ns);
             ChunkHelper::padding_char_columns(char_field_indexes, schema, _tablet_schema, chunk.get());
+            if (is_key && selection_buffer != nullptr) {
+                // The key group is ordered as [sort-key columns, then any PK columns that
+                // are not already sort keys]. Project the PK columns into tablet-key order
+                // before encoding them for the child-tablet range check.
+                Filter filter;
+                {
+                    // Keep this projection in a nested scope: it shares column pointers with
+                    // |chunk|, so it must be destroyed before chunk->filter() mutates them.
+                    Chunk pk_chunk;
+                    for (uint32_t pk_column = 0; pk_column < _tablet_schema->num_key_columns(); ++pk_column) {
+                        auto it = std::find(column_group.begin(), column_group.end(), pk_column);
+                        if (it == column_group.end()) {
+                            return Status::InternalError(
+                                    fmt::format("vertical UNSHARE key group does not contain PK column {}", pk_column));
+                        }
+                        size_t chunk_index = static_cast<size_t>(std::distance(column_group.begin(), it));
+                        pk_chunk.append_column(chunk->get_column_by_index(chunk_index), static_cast<SlotId>(pk_column));
+                    }
+                    ASSIGN_OR_RETURN(filter, pk_range_filter->build(pk_chunk));
+                }
+                if (source_masks->size() != filter.size()) {
+                    return Status::InternalError(
+                            fmt::format("vertical UNSHARE source-mask size {} differs from filter size {}",
+                                        source_masks->size(), filter.size()));
+                }
+                selection_masks->clear();
+                selection_masks->reserve(filter.size());
+                for (uint8_t selected : filter) {
+                    selection_masks->emplace_back(static_cast<uint16_t>(selected != 0 ? 1 : 0), false);
+                }
+                RETURN_IF_ERROR(selection_buffer->write(*selection_masks));
+
+                if (!rssid_rowids.empty()) {
+                    DCHECK_EQ(rssid_rowids.size(), filter.size());
+                    size_t output_index = 0;
+                    for (size_t row = 0; row < rssid_rowids.size(); ++row) {
+                        if (filter[row]) {
+                            rssid_rowids[output_index++] = rssid_rowids[row];
+                        }
+                    }
+                    rssid_rowids.resize(output_index);
+                }
+                chunk->filter(filter);
+            }
         }
-        {
+        if (chunk->num_rows() > 0) {
             SCOPED_RAW_TIMER(&_context->stats->writer_write_ns);
             if (rssid_rowids.empty()) {
                 RETURN_IF_ERROR(writer->write_columns(*chunk, column_group, is_key));
@@ -384,6 +446,9 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
     if (is_key) {
         SCOPED_RAW_TIMER(&_context->stats->mask_io_ns);
         RETURN_IF_ERROR(mask_buffer->flush());
+        if (selection_buffer != nullptr) {
+            RETURN_IF_ERROR(selection_buffer->flush());
+        }
     }
     return Status::OK();
 }

--- a/be/src/storage/lake/vertical_compaction_task.h
+++ b/be/src/storage/lake/vertical_compaction_task.h
@@ -50,9 +50,10 @@ private:
     Status compact_column_group(bool is_key, int column_group_index, size_t num_column_groups,
                                 const std::vector<uint32_t>& column_group, std::unique_ptr<TabletWriter>& writer,
                                 RowSourceMaskBuffer* mask_buffer, std::vector<RowSourceMask>* source_masks,
+                                RowSourceMaskBuffer* selection_buffer, std::vector<RowSourceMask>* selection_masks,
                                 const CancelFunc& cancel_func, bool pk_in_key_group);
 
-    // For a separate-sort-key PK table with eager PK-index SST build, move the PK columns (tablet
+    // For a separate-sort-key PK table with eager PK-index SST build or UNSHARE filtering, move the PK columns (tablet
     // column ids [0, num_key) not already in the sort key) out of the value groups and into the key
     // group (group 0), appended after the sort-key columns. Empty value groups are dropped. This lets
     // the eager SST writer, which only sees the key group, read the PK columns.

--- a/be/src/storage_primitive/merge_iterator.cpp
+++ b/be/src/storage_primitive/merge_iterator.cpp
@@ -470,8 +470,12 @@ ChunkIteratorPtr new_heap_merge_iterator(const std::vector<ChunkIteratorPtr>& ch
 // The order of rows is determinate by mask sequence.
 class MaskMergeIterator final : public MergeIterator {
 public:
-    explicit MaskMergeIterator(std::vector<ChunkIteratorPtr> children, RowSourceMaskBuffer* mask_buffer)
-            : MergeIterator(std::move(children)), _chunks(_children.size()), _mask_buffer(mask_buffer) {
+    explicit MaskMergeIterator(std::vector<ChunkIteratorPtr> children, RowSourceMaskBuffer* mask_buffer,
+                               RowSourceMaskBuffer* selection_buffer)
+            : MergeIterator(std::move(children)),
+              _chunks(_children.size()),
+              _mask_buffer(mask_buffer),
+              _selection_buffer(selection_buffer) {
         DCHECK(_mask_buffer);
     }
 
@@ -483,6 +487,11 @@ protected:
 private:
     std::vector<MergingChunk> _chunks;
     RowSourceMaskBuffer* _mask_buffer = nullptr;
+    // Optional row-selection stream aligned one-to-one with _mask_buffer. A non-zero
+    // source number means keep the row; zero means consume it from the source iterator
+    // without appending it. Vertical UNSHARE compaction records this stream while
+    // processing the key group and replays it for every value group.
+    RowSourceMaskBuffer* _selection_buffer = nullptr;
 };
 
 inline Status MaskMergeIterator::do_get_next(Chunk* chunk, std::vector<RowSourceMask>* source_masks) {
@@ -496,6 +505,12 @@ inline Status MaskMergeIterator::do_get_next(Chunk* chunk, std::vector<RowSource
     if (!st_or.ok()) {
         return st_or.status();
     }
+    if (_selection_buffer != nullptr) {
+        ASSIGN_OR_RETURN(bool selection_remaining, _selection_buffer->has_remaining());
+        if (selection_remaining != st_or.value()) {
+            return Status::InternalError("row-source mask and selection buffers have different lengths");
+        }
+    }
     while (st_or.value() && rows < _chunk_size) {
         RowSourceMask mask = _mask_buffer->current();
         uint16_t child = mask.get_source_num();
@@ -506,10 +521,38 @@ inline Status MaskMergeIterator::do_get_next(Chunk* chunk, std::vector<RowSource
         }
         DCHECK_GT(min_chunk.remaining_rows(), 0);
 
+        // A filtered row is still represented in the source mask so every value-group
+        // child advances over exactly the same physical rows as the key group. It is not
+        // emitted to the output chunk.
+        if (_selection_buffer != nullptr && _selection_buffer->current().get_source_num() == 0) {
+            min_chunk.advance(1);
+            _mask_buffer->advance();
+            _selection_buffer->advance();
+            if (min_chunk.remaining_rows() == 0) {
+                st = fill(child);
+                if (!st.ok() && !st.is_end_of_file()) {
+                    return st;
+                }
+            }
+            st_or = _mask_buffer->has_remaining();
+            if (!st_or.ok()) {
+                return st_or.status();
+            }
+            ASSIGN_OR_RETURN(bool selection_remaining, _selection_buffer->has_remaining());
+            if (selection_remaining != st_or.value()) {
+                return Status::InternalError("row-source mask and selection buffers have different lengths");
+            }
+            continue;
+        }
+
         size_t offset = min_chunk.compared_row();
         size_t min_chunk_num_rows = min_chunk._chunk->num_rows();
         size_t append_row_num = 0;
         size_t max_same_source_count = _mask_buffer->max_same_source_count(child, min_chunk.remaining_rows());
+        if (_selection_buffer != nullptr) {
+            max_same_source_count = std::min(max_same_source_count, _selection_buffer->max_same_source_count(
+                                                                            /*source=*/1, max_same_source_count));
+        }
         if (max_same_source_count == min_chunk_num_rows) {
             DCHECK(offset == 0);
             // all rows in |min_chunk| are from the same source chunk and |min_chunk|'s current offset is 0,
@@ -521,6 +564,9 @@ inline Status MaskMergeIterator::do_get_next(Chunk* chunk, std::vector<RowSource
                         source_masks->emplace_back(_mask_buffer->current());
                     }
                     _mask_buffer->advance();
+                    if (_selection_buffer != nullptr) {
+                        _selection_buffer->advance();
+                    }
                 }
                 return fill(child);
             } else {
@@ -546,6 +592,9 @@ inline Status MaskMergeIterator::do_get_next(Chunk* chunk, std::vector<RowSource
                 source_masks->emplace_back(_mask_buffer->current());
             }
             _mask_buffer->advance();
+            if (_selection_buffer != nullptr) {
+                _selection_buffer->advance();
+            }
         }
 
         DCHECK_LE(rows, _chunk_size);
@@ -560,6 +609,12 @@ inline Status MaskMergeIterator::do_get_next(Chunk* chunk, std::vector<RowSource
         st_or = _mask_buffer->has_remaining();
         if (!st_or.ok()) {
             return st_or.status();
+        }
+        if (_selection_buffer != nullptr) {
+            ASSIGN_OR_RETURN(bool selection_remaining, _selection_buffer->has_remaining());
+            if (selection_remaining != st_or.value()) {
+                return Status::InternalError("row-source mask and selection buffers have different lengths");
+            }
         }
     }
     if (!st.ok()) {
@@ -601,12 +656,12 @@ inline Status MaskMergeIterator::fill(size_t child) {
 }
 
 ChunkIteratorPtr new_mask_merge_iterator(const std::vector<ChunkIteratorPtr>& children,
-                                         RowSourceMaskBuffer* mask_buffer) {
-    if (children.size() == 1) {
+                                         RowSourceMaskBuffer* mask_buffer, RowSourceMaskBuffer* selection_buffer) {
+    if (children.size() == 1 && selection_buffer == nullptr) {
         return children[0];
     }
-    DCHECK(children.size() > 1 && children.size() <= RowSourceMask::MAX_SOURCES);
-    return std::make_shared<MaskMergeIterator>(children, mask_buffer);
+    DCHECK(!children.empty() && children.size() <= RowSourceMask::MAX_SOURCES);
+    return std::make_shared<MaskMergeIterator>(children, mask_buffer, selection_buffer);
 }
 
 } // namespace starrocks

--- a/be/src/storage_primitive/merge_iterator.h
+++ b/be/src/storage_primitive/merge_iterator.h
@@ -48,6 +48,7 @@ ChunkIteratorPtr new_heap_merge_iterator(const std::vector<ChunkIteratorPtr>& ch
 // new_mask_merge_iterator create a merge iterator based on source masks.
 // the order of rows is determined by mask sequence.
 ChunkIteratorPtr new_mask_merge_iterator(const std::vector<ChunkIteratorPtr>& children,
-                                         RowSourceMaskBuffer* mask_buffer);
+                                         RowSourceMaskBuffer* mask_buffer,
+                                         RowSourceMaskBuffer* selection_buffer = nullptr);
 
 } // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -159,6 +159,7 @@ set(EXEC_FILES
 if (NOT APPLE)
     list(APPEND EXEC_FILES
         ./gutil/sysinfo-test.cc
+        ./service/lake_service_parent_view_test.cpp
         ./service/lake_service_test.cpp
     )
 endif ()

--- a/be/test/service/lake_service_parent_view_test.cpp
+++ b/be/test/service/lake_service_parent_view_test.cpp
@@ -1,0 +1,328 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Aggregate publish assembling the query-side parent of a split family.
+//
+// Deliberately NOT in lake_service_test.cpp: that fixture's destructor runs fs::remove_all over a
+// root every one of its tests shares, and these cases publish real parent metadata through a live
+// brpc service. Sharing the root made them perturb unrelated tests in that file. This fixture owns
+// its own root and tears down only that.
+
+#include <brpc/controller.h>
+#include <brpc/server.h>
+#include <butil/endpoint.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <memory>
+
+#include "base/testutil/assert.h"
+#include "base/testutil/id_generator.h"
+#include "data_workflows/load/tablet_writer/load_channel_mgr.h"
+#include "exec/exec_env.h"
+#include "fs/fs_util.h"
+#include "platform/platform_env.h"
+#include "runtime/runtime_env.h"
+#include "service/service_be/lake_service.h"
+#include "storage/lake/fixed_location_provider.h"
+#include "storage/lake/join_path.h"
+#include "storage/lake/location_provider.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_metadata.h"
+#include "storage/lake/test_util.h"
+#include "storage/storage_env.h"
+#include "storage/tablet_schema.h"
+#include "storage/variant_tuple.h"
+
+namespace starrocks {
+
+using ::testing::_;
+using ::testing::Invoke;
+
+class MockParentViewLakeService : public starrocks::LakeService {
+public:
+    MOCK_METHOD4(publish_version, void(::google::protobuf::RpcController*, const ::starrocks::PublishVersionRequest*,
+                                       ::starrocks::PublishVersionResponse*, ::google::protobuf::Closure* done));
+};
+
+class ParentViewTestBase : public testing::Test {
+public:
+    ParentViewTestBase()
+            : _location_provider(std::make_shared<lake::FixedLocationProvider>(kRootLocation)),
+              _tablet_mgr(StorageEnv::GetInstance()->lake_tablet_manager()),
+              _load_channel_mgr(std::make_unique<LoadChannelMgr>(_tablet_mgr,
+                                                                 RuntimeEnv::GetInstance()->diagnose_daemon(),
+                                                                 PlatformEnv::GetInstance()->brpc_stub_cache())),
+              _lake_service(ExecEnv::GetInstance(), StorageEnv::GetInstance()->lake_tablet_manager(),
+                            _load_channel_mgr.get()) {
+        CHECK_OK(_load_channel_mgr->init(RuntimeEnv::GetInstance()->load_mem_tracker()));
+        // The tablet manager is a process-wide singleton: point it at this fixture's own root and put
+        // the previous provider back on the way out, or every test that runs afterwards resolves its
+        // files under a directory this fixture has already deleted.
+        _backup_location_provider = _tablet_mgr->TEST_set_location_provider(_location_provider);
+        CHECK_OK(FileSystem::Default()->create_dir_recursive(kRootLocation));
+        CHECK_OK(FileSystem::Default()->create_dir_recursive(
+                lake::join_path(kRootLocation, lake::kMetadataDirectoryName)));
+        CHECK_OK(FileSystem::Default()->create_dir_recursive(
+                lake::join_path(kRootLocation, lake::kTxnLogDirectoryName)));
+        CHECK_OK(FileSystem::Default()->create_dir_recursive(
+                lake::join_path(kRootLocation, lake::kSegmentDirectoryName)));
+    }
+
+    ~ParentViewTestBase() override {
+        (void)_tablet_mgr->TEST_set_location_provider(_backup_location_provider);
+        (void)fs::remove_all(kRootLocation);
+    }
+
+protected:
+    void init_server_with_mock(MockParentViewLakeService* mock_service, brpc::Server* server, int* port_out) {
+        brpc::ServerOptions options;
+        options.num_threads = 1;
+        ASSERT_EQ(server->AddService(mock_service, brpc::SERVER_DOESNT_OWN_SERVICE), 0);
+        ASSERT_EQ(server->Start(0, &options), 0);
+        *port_out = server->listen_address().port;
+    }
+
+    AggregatePublishVersionRequest build_default_agg_request(int port) {
+        AggregatePublishVersionRequest request;
+        auto* compute_node = request.add_compute_nodes();
+        compute_node->set_host("127.0.0.1");
+        compute_node->set_brpc_port(port);
+        request.add_publish_reqs()->set_timeout_ms(5000);
+        return request;
+    }
+
+    TuplePB generate_sort_key(int value) {
+        VariantTuple tuple;
+        tuple.append(DatumVariant(get_type_info(LogicalType::TYPE_INT), Datum(value)));
+        TuplePB tuple_pb;
+        tuple.to_proto(&tuple_pb);
+        return tuple_pb;
+    }
+
+    constexpr static const char* const kRootLocation = "./lake_service_parent_view_test";
+    std::shared_ptr<lake::FixedLocationProvider> _location_provider;
+    std::shared_ptr<lake::LocationProvider> _backup_location_provider;
+    lake::TabletManager* _tablet_mgr = nullptr;
+    std::unique_ptr<LoadChannelMgr> _load_channel_mgr;
+    LakeServiceImpl _lake_service;
+};
+
+// The validation build_parent_tablet_metadata does before it assembles anything. Each case is a way
+// the FE could describe a split family that cannot be turned into a readable parent, and every one of
+// them has to fail the aggregate publish rather than persist a half-built parent that queries would
+// then be pinned to.
+class AggregateParentViewTest : public ParentViewTestBase {
+protected:
+    // Drives one aggregate publish whose child publish succeeds and returns |child| for
+    // |child_tablet_id|, with the parent family described by |configure|. Returns the response status
+    // code, so a caller asserts on the failure rather than on a thrown status.
+    int publish_with_parent(int64_t child_tablet_id, int64_t version,
+                            const std::function<void(AggregatePublishVersionRequest*)>& configure,
+                            const std::shared_ptr<TabletMetadataPB>& child, bool expect_child_publish) {
+        brpc::Server server;
+        MockParentViewLakeService mock_service;
+        int port = 0;
+        init_server_with_mock(&mock_service, &server, &port);
+
+        auto request = build_default_agg_request(port);
+        auto* publish_req = request.mutable_publish_reqs(0);
+        publish_req->set_new_version(version);
+        publish_req->add_tablet_ids(child_tablet_id);
+        publish_req->add_txn_infos()->set_txn_id(12345);
+        configure(&request);
+
+        auto respond = [&](::google::protobuf::RpcController*, const PublishVersionRequest*,
+                           PublishVersionResponse* resp, ::google::protobuf::Closure* done) {
+            resp->mutable_status()->set_status_code(0);
+            if (child != nullptr) {
+                (*resp->mutable_tablet_metas())[child_tablet_id].CopyFrom(*child);
+            }
+            done->Run();
+        };
+        if (expect_child_publish) {
+            EXPECT_CALL(mock_service, publish_version(_, _, _, _)).WillOnce(Invoke(respond));
+        } else {
+            EXPECT_CALL(mock_service, publish_version(_, _, _, _)).WillRepeatedly(Invoke(respond));
+        }
+
+        PublishVersionResponse response;
+        brpc::Controller cntl;
+        google::protobuf::Closure* done = brpc::NewCallback([]() {});
+        _lake_service.aggregate_publish_version(&cntl, &request, &response, done);
+        const int code = response.status().status_code();
+
+        server.Stop(0);
+        server.Join();
+        return code;
+    }
+
+    std::shared_ptr<TabletMetadataPB> make_child(int64_t id, int64_t version) {
+        auto child = lake::generate_simple_tablet_metadata(PRIMARY_KEYS);
+        child->set_id(id);
+        child->set_version(version);
+        child->mutable_range()->mutable_lower_bound()->CopyFrom(generate_sort_key(0));
+        child->mutable_range()->set_lower_bound_included(true);
+        child->mutable_range()->mutable_upper_bound()->CopyFrom(generate_sort_key(10));
+        child->mutable_range()->set_upper_bound_included(false);
+        return child;
+    }
+};
+
+// A family with no children at all describes nothing to assemble from.
+TEST_F(AggregateParentViewTest, test_rejects_a_family_without_children) {
+    const int64_t kChild = next_id();
+    const int64_t kParent = next_id();
+    constexpr int64_t kVersion = 81;
+    const int code = publish_with_parent(
+            kChild, kVersion,
+            [&](AggregatePublishVersionRequest* request) {
+                request->add_parent_tablet_publish_infos()->set_parent_tablet_id(kParent);
+            },
+            make_child(kChild, kVersion), /*expect_child_publish=*/false);
+    EXPECT_NE(0, code) << "a parent with no children must not publish";
+}
+
+// The parent is a read alias over its children; naming it as one of them is incoherent and would make
+// the assembly read its own half-written output.
+TEST_F(AggregateParentViewTest, test_rejects_a_parent_that_is_also_its_own_child) {
+    const int64_t kTablet = next_id();
+    constexpr int64_t kVersion = 81;
+    const int code = publish_with_parent(
+            kTablet, kVersion,
+            [&](AggregatePublishVersionRequest* request) {
+                auto* info = request->add_parent_tablet_publish_infos();
+                info->set_parent_tablet_id(kTablet);
+                info->add_child_tablet_ids(kTablet);
+            },
+            make_child(kTablet, kVersion), /*expect_child_publish=*/false);
+    EXPECT_NE(0, code) << "a tablet cannot be both the parent and a child";
+}
+
+// A child whose publish returned no metadata cannot contribute its half of the parent. Assembling
+// from what did arrive would publish a parent that is missing a key range.
+TEST_F(AggregateParentViewTest, test_rejects_a_missing_child_metadata) {
+    const int64_t kChild = next_id();
+    const int64_t kAbsentChild = next_id();
+    const int64_t kParent = next_id();
+    constexpr int64_t kVersion = 81;
+    const int code = publish_with_parent(
+            kChild, kVersion,
+            [&](AggregatePublishVersionRequest* request) {
+                auto* info = request->add_parent_tablet_publish_infos();
+                info->set_parent_tablet_id(kParent);
+                info->add_child_tablet_ids(kChild);
+                info->add_child_tablet_ids(kAbsentChild);
+            },
+            make_child(kChild, kVersion), /*expect_child_publish=*/true);
+    EXPECT_NE(0, code) << "a child that reported no metadata must fail the family";
+}
+
+// DCG/IDG sidecars are not merged into the parent view yet, so a child carrying one must be refused
+// rather than silently dropped from the assembled parent.
+TEST_F(AggregateParentViewTest, test_rejects_dcg_metadata_on_a_child) {
+    const int64_t kChild = next_id();
+    const int64_t kParent = next_id();
+    constexpr int64_t kVersion = 81;
+    auto child = make_child(kChild, kVersion);
+    (*child->mutable_dcg_meta()->mutable_dcgs())[1].add_column_files("child.cols");
+    const int code = publish_with_parent(
+            kChild, kVersion,
+            [&](AggregatePublishVersionRequest* request) {
+                auto* info = request->add_parent_tablet_publish_infos();
+                info->set_parent_tablet_id(kParent);
+                info->add_child_tablet_ids(kChild);
+            },
+            child, /*expect_child_publish=*/true);
+    EXPECT_NE(0, code) << "a DCG sidecar has no place in the parent view yet";
+}
+
+TEST_F(AggregateParentViewTest, test_aggregate_publish_builds_query_parent_in_same_bundle) {
+    brpc::Server server;
+    MockParentViewLakeService mock_service;
+    int port = 0;
+    init_server_with_mock(&mock_service, &server, &port);
+
+    // Drawn from next_id() rather than fixed: this binary runs ~2000 tests in one process and every
+    // fixture draws from the same counter, so a hard-coded tablet id is eventually handed out to
+    // somebody else and the two tests corrupt each other's metadata.
+    const int64_t kParentTabletId = next_id();
+    const int64_t kChildTabletId1 = next_id();
+    const int64_t kChildTabletId2 = next_id();
+    const int64_t kIdenticalParentTabletId = next_id();
+    const int64_t kIdenticalChildTabletId = next_id();
+    constexpr int64_t kVersion = 79;
+    auto request = build_default_agg_request(port);
+    auto* publish_req = request.mutable_publish_reqs(0);
+    publish_req->set_new_version(kVersion);
+    publish_req->add_tablet_ids(kChildTabletId1);
+    publish_req->add_tablet_ids(kChildTabletId2);
+    publish_req->add_tablet_ids(kIdenticalChildTabletId);
+    publish_req->add_txn_infos()->set_txn_id(12345);
+    auto* parent_info = request.add_parent_tablet_publish_infos();
+    parent_info->set_parent_tablet_id(kParentTabletId);
+    parent_info->add_child_tablet_ids(kChildTabletId1);
+    parent_info->add_child_tablet_ids(kChildTabletId2);
+    auto* identical_parent_info = request.add_parent_tablet_publish_infos();
+    identical_parent_info->set_parent_tablet_id(kIdenticalParentTabletId);
+    identical_parent_info->add_child_tablet_ids(kIdenticalChildTabletId);
+
+    auto child1 = lake::generate_simple_tablet_metadata(PRIMARY_KEYS);
+    child1->set_id(kChildTabletId1);
+    child1->set_version(kVersion);
+    child1->mutable_range()->mutable_lower_bound()->CopyFrom(generate_sort_key(0));
+    child1->mutable_range()->set_lower_bound_included(true);
+    child1->mutable_range()->mutable_upper_bound()->CopyFrom(generate_sort_key(10));
+    child1->mutable_range()->set_upper_bound_included(false);
+    auto child2 = std::make_shared<TabletMetadataPB>(*child1);
+    child2->set_id(kChildTabletId2);
+    child2->mutable_range()->mutable_lower_bound()->CopyFrom(generate_sort_key(10));
+    child2->mutable_range()->mutable_upper_bound()->CopyFrom(generate_sort_key(20));
+    auto identical_child = std::make_shared<TabletMetadataPB>(*child1);
+    identical_child->set_id(kIdenticalChildTabletId);
+    identical_child->mutable_range()->mutable_lower_bound()->CopyFrom(generate_sort_key(30));
+    identical_child->mutable_range()->mutable_upper_bound()->CopyFrom(generate_sort_key(40));
+
+    EXPECT_CALL(mock_service, publish_version(_, _, _, _))
+            .WillOnce(Invoke([&](::google::protobuf::RpcController*, const PublishVersionRequest*,
+                                 PublishVersionResponse* resp, ::google::protobuf::Closure* done) {
+                resp->mutable_status()->set_status_code(0);
+                (*resp->mutable_tablet_metas())[kChildTabletId1].CopyFrom(*child1);
+                (*resp->mutable_tablet_metas())[kChildTabletId2].CopyFrom(*child2);
+                (*resp->mutable_tablet_metas())[kIdenticalChildTabletId].CopyFrom(*identical_child);
+                done->Run();
+            }));
+
+    PublishVersionResponse response;
+    brpc::Controller cntl;
+    google::protobuf::Closure* done = brpc::NewCallback([]() {});
+    _lake_service.aggregate_publish_version(&cntl, &request, &response, done);
+
+    ASSERT_EQ(0, response.status().status_code());
+    ASSIGN_OR_ABORT(auto parent, _tablet_mgr->get_single_tablet_metadata(kParentTabletId, kVersion));
+    EXPECT_EQ(kParentTabletId, parent->id());
+    EXPECT_EQ(kVersion, parent->version());
+    EXPECT_EQ(0, parent->range().lower_bound().values(0).value().compare("0"));
+    EXPECT_EQ(0, parent->range().upper_bound().values(0).value().compare("20"));
+    ASSIGN_OR_ABORT(auto identical_parent, _tablet_mgr->get_single_tablet_metadata(kIdenticalParentTabletId, kVersion));
+    EXPECT_EQ(kIdenticalParentTabletId, identical_parent->id());
+    EXPECT_EQ(0, identical_parent->range().lower_bound().values(0).value().compare("30"));
+    EXPECT_EQ(0, identical_parent->range().upper_bound().values(0).value().compare("40"));
+
+    server.Stop(0);
+    server.Join();
+}
+
+} // namespace starrocks

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -21,6 +21,7 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <functional>
 #include <memory>
 #include <string>
 #include <utility>

--- a/be/test/storage/lake/compaction_policy_test.cpp
+++ b/be/test/storage/lake/compaction_policy_test.cpp
@@ -25,6 +25,7 @@
 #include "storage/lake/join_path.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/tablet_schema.h"
 #include "test_util.h"
 
 namespace starrocks::lake {
@@ -736,6 +737,144 @@ TEST_F(LakeCompactionPolicyTest, test_pk_base_compaction_triggers) {
                     CompactionPolicy::create(_tablet_mgr.get(), metadata, false /* force_base_compaction */));
     ASSIGN_OR_ABORT(auto cumulative_rowsets, cumulative_policy->pick_rowsets());
     EXPECT_TRUE(cumulative_rowsets.empty());
+}
+
+TEST_F(LakeCompactionPolicyTest, test_unshare_picks_complete_shared_rowsets_only) {
+    auto metadata = generate_simple_tablet_metadata(PRIMARY_KEYS);
+    metadata->set_version(2);
+    metadata->mutable_range();
+
+    auto add_rowset = [&](uint32_t id, std::initializer_list<bool> shared_segments) {
+        auto* rowset = metadata->add_rowsets();
+        rowset->set_id(id);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        rowset->set_overlapped(shared_segments.size() > 1);
+        for (bool shared : shared_segments) {
+            auto* segment = rowset->add_segment_metas();
+            segment->set_filename("rowset_" + std::to_string(id) + "_segment_" +
+                                  std::to_string(rowset->segment_metas_size()));
+            segment->set_shared(shared);
+        }
+    };
+    add_rowset(1, {false});
+    add_rowset(2, {true});
+    add_rowset(3, {false, true, false});
+    add_rowset(4, {false, false});
+
+    ASSIGN_OR_ABORT(auto policy, CompactionPolicy::create(_tablet_mgr.get(), metadata, false, true));
+    ASSIGN_OR_ABORT(auto rowsets, policy->pick_rowsets());
+    ASSERT_EQ(2, rowsets.size());
+    EXPECT_EQ(2, rowsets[0]->id());
+    EXPECT_EQ(3, rowsets[1]->id());
+    // A mixed rowset is selected as one complete Rowset object, never as an
+    // individual shared-segment slice.
+    EXPECT_EQ(3, rowsets[1]->num_segments());
+}
+
+TEST_F(LakeCompactionPolicyTest, test_unshare_rejects_unsupported_metadata) {
+    auto non_pk = generate_simple_tablet_metadata(DUP_KEYS);
+    non_pk->mutable_range();
+    EXPECT_FALSE(CompactionPolicy::create(_tablet_mgr.get(), non_pk, false, true).ok());
+
+    auto no_range = generate_simple_tablet_metadata(PRIMARY_KEYS);
+    EXPECT_FALSE(CompactionPolicy::create(_tablet_mgr.get(), no_range, false, true).ok());
+
+    auto dcg = generate_simple_tablet_metadata(PRIMARY_KEYS);
+    dcg->mutable_range();
+    (*dcg->mutable_dcg_meta()->mutable_dcgs())[1].add_column_files("dcg.cols");
+    auto dcg_status = CompactionPolicy::create(_tablet_mgr.get(), dcg, false, true);
+    ASSERT_FALSE(dcg_status.ok());
+    EXPECT_TRUE(dcg_status.status().is_not_supported());
+
+    auto idg = generate_simple_tablet_metadata(PRIMARY_KEYS);
+    idg->mutable_range();
+    (*idg->mutable_idg_meta()->mutable_idgs())[1].add_entries()->set_index_file("idg.idx");
+    auto idg_status = CompactionPolicy::create(_tablet_mgr.get(), idg, false, true);
+    ASSERT_FALSE(idg_status.ok());
+    EXPECT_TRUE(idg_status.status().is_not_supported());
+}
+
+// The guard that keeps everyday compaction off a split's inherited files. Without it an ordinary
+// compaction on an ORDER BY != PK child reads the shared segments whole (the tablet range is
+// withheld for that shape and the row filter is only built for UNSHARE), folds the siblings' rows
+// into a private output, and UNSHARE then skips that rowset because it no longer carries a shared
+// segment -- so those rows are served by the wrong child after cutover.
+// Its own on-disk root, not LakeCompactionPolicyTest's. The test binary runs each case in its own
+// process but several at once from the same working directory, and every fixture in that family
+// clears the same RELATIVE directory in SetUp -- so one process's clear_and_init_test_dir() deletes
+// the meta/ another has just created. Adding cases to the shared root widens that window.
+class OrdinaryCompactionSharedWindowTest : public TestBase {
+public:
+    OrdinaryCompactionSharedWindowTest() : TestBase(kOwnTestDirectory) {}
+
+protected:
+    constexpr static const char* const kOwnTestDirectory = "test_ordinary_compaction_shared_window";
+
+    void SetUp() override { clear_and_init_test_dir(); }
+    void TearDown() override { remove_test_dir_ignore_error(); }
+
+    // Delete-bearing rowsets plus force_base_compaction below, so that WITHOUT the guard the picker
+    // is guaranteed to select all of them. Otherwise an empty result would not distinguish "the
+    // guard blocked it" from "the size-tiered policy had nothing worth merging", and the test would
+    // pass for the wrong reason.
+    MutableTabletMetadataPtr make_metadata(bool separate_sort_key, bool shared_segment) {
+        constexpr int64_t kBig = 100 * 1024 * 1024;
+        auto metadata = generate_simple_tablet_metadata(PRIMARY_KEYS);
+        metadata->set_version(2);
+        metadata->mutable_range();
+        // c0 is the only key column; ORDER BY the value column c1 is what makes the sort key
+        // separate from the primary key -- the shape whose range has no rowid interval.
+        if (separate_sort_key) {
+            metadata->mutable_schema()->add_sort_key_idxes(1);
+        }
+        for (uint32_t id = 1; id <= 2; ++id) {
+            auto* rowset = metadata->add_rowsets();
+            rowset->set_id(id);
+            rowset->set_overlapped(false);
+            rowset->set_num_rows(4000000);
+            rowset->set_num_dels(3200000);
+            rowset->set_data_size(kBig);
+            auto* segment = rowset->add_segment_metas();
+            segment->set_filename("rowset_" + std::to_string(id) + "_segment_0");
+            segment->set_num_rows(4000000);
+            segment->set_shared(shared_segment);
+        }
+        return metadata;
+    }
+
+    std::vector<RowsetPtr> pick(const MutableTabletMetadataPtr& metadata) {
+        auto policy_or = CompactionPolicy::create(_tablet_mgr.get(), metadata, /*force_base_compaction=*/true,
+                                                  /*is_unshare=*/false);
+        CHECK(policy_or.ok()) << policy_or.status();
+        auto rowsets_or = policy_or.value()->pick_rowsets();
+        CHECK(rowsets_or.ok()) << rowsets_or.status();
+        return std::move(rowsets_or.value());
+    }
+};
+
+// The control: nothing shared, so the guard does not apply and the picker takes both rowsets. This
+// is what makes the two assertions below meaningful.
+TEST_F(OrdinaryCompactionSharedWindowTest, test_picks_normally_when_no_segment_is_shared) {
+    auto metadata = make_metadata(/*separate_sort_key=*/true, /*shared_segment=*/false);
+    ASSERT_TRUE(TabletSchema::create(metadata->schema())->has_separate_sort_key());
+    EXPECT_EQ(2, pick(metadata).size()) << "the guard must not outlive the shared window";
+}
+
+// The fix itself: ordinary compaction must not touch a split's inherited files, because it would
+// fold the siblings' rows into a private output that the UNSHARE pass then skips.
+TEST_F(OrdinaryCompactionSharedWindowTest, test_blocked_while_shared_segments_await_unshare) {
+    auto metadata = make_metadata(/*separate_sort_key=*/true, /*shared_segment=*/true);
+    EXPECT_TRUE(pick(metadata).empty()) << "ordinary compaction must wait for UNSHARE";
+}
+
+// A plain split keeps the range in sort-key space, so _apply_tablet_range still narrows to a rowid
+// interval and ordinary compaction is not reading whole shared segments. Blocking here would stall
+// every ranged primary-key table that ever split, for nothing.
+TEST_F(OrdinaryCompactionSharedWindowTest, test_does_not_block_when_the_sort_key_is_the_primary_key) {
+    auto metadata = make_metadata(/*separate_sort_key=*/false, /*shared_segment=*/true);
+    ASSERT_FALSE(TabletSchema::create(metadata->schema())->has_separate_sort_key());
+    EXPECT_EQ(2, pick(metadata).size()) << "the guard is only for the shape whose range has no rowid interval";
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/persistent_index_sstable_test.cpp
+++ b/be/test/storage/lake/persistent_index_sstable_test.cpp
@@ -124,6 +124,36 @@ TEST_F(PersistentIndexSstableTest, test_generate_sst_seek_and_check) {
     delete iter;
 }
 
+TEST_F(PersistentIndexSstableTest, test_sample_data_keys_returns_complete_keys) {
+    constexpr int kNumKeys = 10000;
+    const std::string filename = "test_sample_data_keys.sst";
+    ASSIGN_OR_ABORT(auto file, fs::new_writable_file(lake::join_path(kTestDir, filename)));
+    phmap::btree_map<std::string, IndexValueWithVer, std::less<>> entries;
+    for (int i = 0; i < kNumKeys; ++i) {
+        entries.emplace(fmt::format("sample_key_{:016X}", i), std::make_pair(100, IndexValue(i)));
+    }
+
+    uint64_t file_size = 0;
+    PersistentIndexSstableRangePB range;
+    ASSERT_OK(PersistentIndexSstable::build_sstable(entries, file.get(), &file_size, &range));
+
+    ASSIGN_OR_ABORT(auto read_file, fs::new_random_access_file(lake::join_path(kTestDir, filename)));
+    PersistentIndexSstablePB sstable_pb;
+    sstable_pb.set_filename(filename);
+    sstable_pb.set_filesize(file_size);
+    sstable_pb.mutable_range()->CopyFrom(range);
+    auto sstable = std::make_unique<PersistentIndexSstable>();
+    ASSERT_OK(sstable->init(std::move(read_file), sstable_pb, nullptr, false));
+
+    std::vector<std::string> samples;
+    // Empty bounds are unbounded on that side, i.e. sample the whole table.
+    ASSERT_OK(sstable->sample_data_keys(&samples, Slice(), Slice(), 1));
+    ASSERT_FALSE(samples.empty());
+    for (const auto& sample : samples) {
+        EXPECT_NE(entries.end(), entries.find(sample)) << "sampled an index separator rather than a data key";
+    }
+}
+
 TEST_F(PersistentIndexSstableTest, test_merge) {
     std::vector<sstable::Iterator*> list;
     std::vector<std::unique_ptr<RandomAccessFile>> read_files;

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -37,6 +37,7 @@
 #include "fs/fs_util.h"
 #include "runtime/mem_tracker.h"
 #include "storage/chunk_helper.h"
+#include "storage/datum_variant.h"
 #include "storage/lake/compaction_policy.h"
 #include "storage/lake/compaction_test_utils.h"
 #include "storage/lake/delta_writer.h"
@@ -53,6 +54,8 @@
 #include "storage/rows_mapper.h"
 #include "storage/storage_env.h"
 #include "storage/tablet_schema.h"
+#include "storage/types.h"
+#include "storage/variant_tuple.h"
 
 namespace starrocks::lake {
 
@@ -378,6 +381,93 @@ TEST_P(LakePrimaryKeyCompactionTest, test3) {
     EXPECT_EQ(new_tablet_metadata->rowsets(0).num_dels(), 0);
     EXPECT_EQ(2, new_tablet_metadata->compaction_inputs_size());
     EXPECT_FALSE(new_tablet_metadata->has_prev_garbage_version());
+}
+
+// The UNSHARE rewrite is the only place a tablet range is used as a row-level predicate, and it is
+// the cutover that makes a split child's data private. If the filter is not applied, the child keeps
+// its siblings' rows and serves them after cutover; if it is applied to the wrong rows, it drops its
+// own. Nothing else in this file drives it: the filter is gated on is_unshare AND a sort key that is
+// not the primary key, which is the shape whose rows are scattered through every segment.
+TEST_P(LakePrimaryKeyCompactionTest, test_unshare_compaction_keeps_only_the_rows_in_range) {
+    // c0 is the key, c1 the value; ORDER BY c1 makes the sort key separate from the primary key.
+    auto metadata = generate_simple_tablet_metadata(PRIMARY_KEYS);
+    metadata->set_enable_persistent_index(GetParam().enable_persistent_index);
+    metadata->set_persistent_index_type(GetParam().persistent_index_type);
+    metadata->mutable_schema()->set_primary_key_encoding_type(PK_ENCODING_TYPE_V2);
+    metadata->mutable_schema()->add_sort_key_idxes(1);
+
+    // Keep [kRangeLow, kRangeHigh) of the key space. generate_data writes c0 = i + shift*kChunkSize,
+    // so two chunks cover [0, 2*kChunkSize).
+    constexpr int kRangeLow = 5;
+    constexpr int kRangeHigh = 17;
+    auto to_tuple = [](int value) {
+        VariantTuple tuple;
+        tuple.append(DatumVariant(get_type_info(LogicalType::TYPE_INT), Datum(value)));
+        TuplePB tuple_pb;
+        tuple.to_proto(&tuple_pb);
+        return tuple_pb;
+    };
+    auto* range = metadata->mutable_range();
+    range->mutable_lower_bound()->CopyFrom(to_tuple(kRangeLow));
+    range->set_lower_bound_included(true);
+    range->mutable_upper_bound()->CopyFrom(to_tuple(kRangeHigh));
+    range->set_upper_bound_included(false);
+
+    const int64_t tablet_id = metadata->id();
+    auto tablet_schema = TabletSchema::create(metadata->schema());
+    ASSERT_TRUE(tablet_schema->has_separate_sort_key());
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*metadata));
+
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (uint32_t i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+    int64_t version = 1;
+    for (int shift = 0; shift < 2; ++shift) {
+        auto chunk = generate_data(kChunkSize, shift);
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(tablet_schema->id())
+                                                   .set_profile(&_dummy_runtime_profile)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // What a split leaves behind: the children inherit the parent's files, so every segment is
+    // shared until the UNSHARE rewrite makes each child's copy private.
+    ASSIGN_OR_ABORT(auto before, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    auto shared = std::make_shared<TabletMetadataPB>(*before);
+    int64_t rows_before = 0;
+    for (auto& rowset : *shared->mutable_rowsets()) {
+        rows_before += rowset.num_rows();
+        for (auto& segment : *rowset.mutable_segment_metas()) {
+            segment.set_shared(true);
+        }
+    }
+    ASSERT_EQ(2 * kChunkSize, rows_before);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*shared));
+
+    auto txn_id = next_id();
+    auto task_context =
+            std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr, 0 /* table_id */,
+                                                    0 /* partition_id */, true /* is_unshare */);
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
+    ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+
+    ASSIGN_OR_ABORT(auto compaction_log, _tablet_mgr->get_txn_log(tablet_id, txn_id));
+    ASSERT_TRUE(compaction_log->has_op_compaction());
+    EXPECT_EQ(kRangeHigh - kRangeLow, compaction_log->op_compaction().output_rowset().num_rows())
+            << "the rewrite must keep exactly the keys in [" << kRangeLow << ", " << kRangeHigh << ")";
 }
 
 TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy) {

--- a/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
+++ b/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
@@ -278,6 +278,154 @@ TEST_F(TabletParallelCompactionManagerTest, test_metrics_initial_value) {
     EXPECT_EQ(0, _manager->completed_subtasks());
 }
 
+// Builds |rowset_count| shared rowsets of |segments_per_rowset| segments, each |segment_bytes| big.
+// Returned by value alongside the metadata that owns them.
+static std::vector<RowsetPtr> make_shared_rowsets(TabletManager* tablet_mgr, const MutableTabletMetadataPtr& metadata,
+                                                  int rowset_count, int segments_per_rowset, int64_t segment_bytes) {
+    std::vector<RowsetPtr> rowsets;
+    for (int rowset_id = 0; rowset_id < rowset_count; ++rowset_id) {
+        auto* rowset = metadata->add_rowsets();
+        rowset->set_id(rowset_id);
+        rowset->set_num_rows(segments_per_rowset * 100);
+        rowset->set_data_size(segments_per_rowset * segment_bytes);
+        rowset->set_overlapped(false);
+        for (int segment = 0; segment < segments_per_rowset; ++segment) {
+            auto* segment_meta = rowset->add_segment_metas();
+            segment_meta->set_filename(fmt::format("unshare_{}_{}", rowset_id, segment));
+            segment_meta->set_size(segment_bytes);
+            segment_meta->set_shared(true);
+        }
+        rowsets.push_back(std::make_shared<Rowset>(tablet_mgr, metadata, rowset_id, 0));
+    }
+    return rowsets;
+}
+
+// The planner refuses to plan at all rather than returning a partial cover. UNSHARE is
+// all-or-nothing, so "no groups" is the safe answer and the caller falls back to the serial path.
+TEST_F(TabletParallelCompactionManagerTest, test_create_unshare_groups_degenerate_inputs) {
+    auto metadata = generate_simple_tablet_metadata(PRIMARY_KEYS);
+    metadata->set_id(90101);
+    metadata->set_version(2);
+    auto rowsets = make_shared_rowsets(_tablet_mgr.get(), metadata, 2, 4, 100);
+
+    EXPECT_TRUE(_manager->_create_unshare_subtask_groups(metadata->id(), {}, 4, 200).empty()) << "no rowsets";
+    EXPECT_TRUE(_manager->_create_unshare_subtask_groups(metadata->id(), rowsets, 1, 200).empty()) << "no parallelism";
+    EXPECT_TRUE(_manager->_create_unshare_subtask_groups(metadata->id(), rowsets, 4, 0).empty()) << "no byte budget";
+    // Budget larger than the whole tablet: one part is enough, so there is nothing to parallelise.
+    EXPECT_TRUE(_manager->_create_unshare_subtask_groups(metadata->id(), rowsets, 4, 1 << 20).empty())
+            << "a single part covers everything";
+}
+
+// More rowsets than parts: each group takes whole rowsets and never splits one, so every group is
+// NORMAL and the cover is still exact.
+TEST_F(TabletParallelCompactionManagerTest, test_create_unshare_groups_pack_whole_rowsets) {
+    auto metadata = generate_simple_tablet_metadata(PRIMARY_KEYS);
+    metadata->set_id(90102);
+    metadata->set_version(2);
+    auto rowsets = make_shared_rowsets(_tablet_mgr.get(), metadata, 6, 2, 100);
+
+    auto groups = _manager->_create_unshare_subtask_groups(metadata->id(), rowsets, 3, 400);
+    ASSERT_FALSE(groups.empty());
+    EXPECT_LE(groups.size(), 3u);
+    EXPECT_TRUE(std::all_of(groups.begin(), groups.end(),
+                            [](const SubtaskGroup& group) { return group.type == SubtaskType::NORMAL; }));
+    EXPECT_TRUE(_manager->_validate_unshare_group_coverage(rowsets, groups).ok());
+
+    size_t covered = 0;
+    for (const auto& group : groups) {
+        covered += group.rowsets.size();
+    }
+    EXPECT_EQ(rowsets.size(), covered) << "every rowset must land in exactly one group";
+}
+
+// A rowset that only warrants one part is emitted as NORMAL rather than as a one-part
+// LARGE_ROWSET_PART, while its outsized sibling is still split. Both shapes in one plan.
+TEST_F(TabletParallelCompactionManagerTest, test_create_unshare_groups_mixed_part_counts) {
+    auto metadata = generate_simple_tablet_metadata(PRIMARY_KEYS);
+    metadata->set_id(90103);
+    metadata->set_version(2);
+    std::vector<RowsetPtr> rowsets;
+    // rowset 0 is tiny (1 segment), rowset 1 is 8x bigger and must be carved up.
+    for (int rowset_id = 0; rowset_id < 2; ++rowset_id) {
+        const int segments = rowset_id == 0 ? 1 : 8;
+        auto* rowset = metadata->add_rowsets();
+        rowset->set_id(rowset_id);
+        rowset->set_num_rows(segments * 100);
+        rowset->set_data_size(segments * 100);
+        rowset->set_overlapped(false);
+        for (int segment = 0; segment < segments; ++segment) {
+            auto* segment_meta = rowset->add_segment_metas();
+            segment_meta->set_filename(fmt::format("mixed_{}_{}", rowset_id, segment));
+            segment_meta->set_size(100);
+            segment_meta->set_shared(true);
+        }
+        rowsets.push_back(std::make_shared<Rowset>(_tablet_mgr.get(), metadata, rowset_id, 0));
+    }
+
+    auto groups = _manager->_create_unshare_subtask_groups(metadata->id(), rowsets, 4, 200);
+    ASSERT_FALSE(groups.empty());
+    EXPECT_TRUE(_manager->_validate_unshare_group_coverage(rowsets, groups).ok())
+            << "a mixed plan must still cover every segment exactly once";
+}
+
+// Coverage validation has to reject a plan that drops a whole rowset, not just one with a
+// gap/overlap inside a rowset -- dropping one is exactly how sibling rows would survive UNSHARE.
+TEST_F(TabletParallelCompactionManagerTest, test_validate_unshare_coverage_rejects_a_missing_rowset) {
+    auto metadata = generate_simple_tablet_metadata(PRIMARY_KEYS);
+    metadata->set_id(90104);
+    metadata->set_version(2);
+    auto rowsets = make_shared_rowsets(_tablet_mgr.get(), metadata, 2, 4, 100);
+
+    auto groups = _manager->_create_unshare_subtask_groups(metadata->id(), rowsets, 4, 200);
+    ASSERT_FALSE(groups.empty());
+    ASSERT_TRUE(_manager->_validate_unshare_group_coverage(rowsets, groups).ok());
+
+    groups.pop_back();
+    EXPECT_FALSE(_manager->_validate_unshare_group_coverage(rowsets, groups).ok());
+}
+
+TEST_F(TabletParallelCompactionManagerTest, test_create_unshare_groups_cover_all_segments) {
+    auto metadata = generate_simple_tablet_metadata(PRIMARY_KEYS);
+    metadata->set_id(90001);
+    metadata->set_version(2);
+    std::vector<RowsetPtr> rowsets;
+    for (uint32_t rowset_id = 0; rowset_id < 2; ++rowset_id) {
+        auto* rowset = metadata->add_rowsets();
+        rowset->set_id(rowset_id);
+        rowset->set_num_rows(600);
+        rowset->set_data_size(600);
+        rowset->set_overlapped(false);
+        for (int segment = 0; segment < 6; ++segment) {
+            auto* segment_meta = rowset->add_segment_metas();
+            segment_meta->set_filename(fmt::format("unshare_{}_{}", rowset_id, segment));
+            segment_meta->set_size(100);
+            segment_meta->set_shared(true);
+        }
+        rowsets.push_back(std::make_shared<Rowset>(_tablet_mgr.get(), metadata, rowset_id, 0));
+    }
+
+    auto groups = _manager->_create_unshare_subtask_groups(metadata->id(), rowsets, 4, 200);
+    ASSERT_EQ(4, groups.size());
+    EXPECT_TRUE(_manager->_validate_unshare_group_coverage(rowsets, groups).ok());
+    EXPECT_TRUE(std::all_of(groups.begin(), groups.end(),
+                            [](const SubtaskGroup& group) { return group.type == SubtaskType::LARGE_ROWSET_PART; }));
+
+    groups.front().segment_start = 1;
+    auto invalid = _manager->_validate_unshare_group_coverage(rowsets, groups);
+    EXPECT_FALSE(invalid.ok());
+    EXPECT_TRUE(invalid.message().find("gap/overlap") != std::string::npos);
+
+    const int64_t txn_id = 90002;
+    auto state_or = _manager->create_and_register_tablet_state(metadata->id(), txn_id, metadata->version(), 4, 200,
+                                                               true, nullptr, [](bool /*success*/) {});
+    ASSERT_TRUE(state_or.ok());
+    state_or.value()->expected_unshare_subtask_count = 2;
+    auto merged_log = _manager->get_merged_txn_log(metadata->id(), txn_id);
+    EXPECT_FALSE(merged_log.ok());
+    EXPECT_TRUE(merged_log.status().message().find("Incomplete parallel UNSHARE") != std::string::npos);
+    _manager->cleanup_tablet(metadata->id(), txn_id);
+}
+
 TEST_F(TabletParallelCompactionManagerTest, test_on_subtask_complete_not_exist) {
     int64_t tablet_id = 12345;
     int64_t txn_id = 67890;

--- a/be/test/storage/lake/tablet_range_helper_test.cpp
+++ b/be/test/storage/lake/tablet_range_helper_test.cpp
@@ -17,8 +17,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <array>
+
 #include "base/testutil/assert.h"
 #include "column/binary_column.h"
+#include "column/chunk_factory.h"
 #include "column/column_helper.h"
 #include "column/raw_data_visitor.h"
 #include "gen_cpp/AgentService_types.h"
@@ -230,6 +233,63 @@ TEST(TabletRangeHelperTest, test_range_key_idxes) {
     // Every other key model keeps the historical sort-key boundary semantics.
     schema_pb.set_keys_type(DUP_KEYS);
     EXPECT_EQ(std::vector<ColumnId>({2, 0}), TabletRangeHelper::range_key_idxes(*TabletSchema::create(schema_pb)));
+}
+
+TEST(TabletRangeHelperTest, test_primary_key_range_filter_with_separate_sort_key) {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(PRIMARY_KEYS);
+    schema_pb.set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
+    const std::array<std::string, 3> column_names = {"c0", "c1", "c2"};
+    for (int i = 0; i < 3; ++i) {
+        auto* column = schema_pb.add_column();
+        column->set_name(column_names[i]);
+        column->set_type("INT");
+        column->set_is_key(i < 2);
+        column->set_is_nullable(false);
+    }
+    schema_pb.add_sort_key_idxes(2);
+    auto tablet_schema = TabletSchema::create(schema_pb);
+
+    TabletRangePB range;
+    range.mutable_lower_bound()->CopyFrom(make_int_tuple_pb(2));
+    *range.mutable_lower_bound()->add_values() = make_int_tuple_pb(0).values(0);
+    range.set_lower_bound_included(true);
+    range.mutable_upper_bound()->CopyFrom(make_int_tuple_pb(4));
+    *range.mutable_upper_bound()->add_values() = make_int_tuple_pb(0).values(0);
+    range.set_upper_bound_included(false);
+
+    auto chunk = ChunkFactory::new_chunk(ChunkHelper::convert_schema(tablet_schema), 4);
+    const std::vector<std::pair<int32_t, int32_t>> keys = {{1, 9}, {2, 0}, {3, 5}, {4, 0}};
+    for (const auto& [c0, c1] : keys) {
+        chunk->get_column_raw_ptr_by_index(0)->append_datum(Datum(c0));
+        chunk->get_column_raw_ptr_by_index(1)->append_datum(Datum(c1));
+        chunk->get_column_raw_ptr_by_index(2)->append_datum(Datum(100));
+    }
+
+    ASSIGN_OR_ABORT(auto pk_filter, PrimaryKeyRangeFilter::create(range, tablet_schema));
+    ASSIGN_OR_ABORT(auto filter, pk_filter.build(*chunk));
+    ASSERT_EQ(4, filter.size());
+    EXPECT_EQ(0, filter[0]);
+    EXPECT_EQ(1, filter[1]);
+    EXPECT_EQ(1, filter[2]);
+    EXPECT_EQ(0, filter[3]);
+
+    // The same instance is reused chunk after chunk during a compaction: a second call must not be
+    // polluted by the encoded keys of the first.
+    auto chunk2 = ChunkFactory::new_chunk(ChunkHelper::convert_schema(tablet_schema), 2);
+    for (const auto& [c0, c1] : std::vector<std::pair<int32_t, int32_t>>{{0, 0}, {2, 5}}) {
+        chunk2->get_column_raw_ptr_by_index(0)->append_datum(Datum(c0));
+        chunk2->get_column_raw_ptr_by_index(1)->append_datum(Datum(c1));
+        chunk2->get_column_raw_ptr_by_index(2)->append_datum(Datum(100));
+    }
+    ASSIGN_OR_ABORT(auto filter2, pk_filter.build(*chunk2));
+    ASSERT_EQ(2, filter2.size());
+    EXPECT_EQ(0, filter2[0]);
+    EXPECT_EQ(1, filter2[1]);
+
+    ASSIGN_OR_ABORT(auto empty,
+                    pk_filter.build(*ChunkFactory::new_chunk(ChunkHelper::convert_schema(tablet_schema), 0)));
+    EXPECT_TRUE(empty.empty());
 }
 
 // NULL on a non-nullable PK column is treated as type-minimum (MIN sentinel from FE).

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -11807,6 +11807,32 @@ TEST_F(LakeTabletReshardTest, test_reshard_flush_stamps_fresh_sstable_with_new_v
                "incremental snapshot keyed on version>pre_version would skip it (data loss)";
 }
 
+// Aggregate publish builds query-parent metadata before persisting the new-version bundle. Its
+// child metadata therefore exists only in memory while merge_sstables flushes each child's PK
+// index. The rebuild must use that supplied metadata for delvec lookup instead of trying to read
+// the not-yet-created bundle from object storage.
+TEST_F(LakeTabletReshardTest, test_reshard_flush_uses_unpersisted_in_memory_metadata) {
+    set_failpoint_mode("skip_lake_pk_index_flush", FailPointTriggerModeType::DISABLE);
+    const int64_t in_memory_version = 11;
+    const int64_t tablet_id = next_id();
+    prepare_tablet_dirs(tablet_id);
+
+    constexpr int kNumRows = 16;
+    const std::string seg_name = "seg_unpersisted_bundle.dat";
+    const uint64_t seg_size = write_two_column_segment(tablet_id, seg_name, kNumRows, [](int r) { return r * 10; });
+    auto meta = make_single_segment_pk_tablet(tablet_id, in_memory_version, seg_name, seg_size, kNumRows);
+
+    // Deliberately do not call put_tablet_metadata(meta): this models the metadata returned by the
+    // per-tablet aggregate-publish RPC before the coordinator writes the partition bundle.
+    ASSERT_TRUE(_tablet_manager->get_tablet_metadata(tablet_id, in_memory_version).status().is_not_found());
+
+    ASSIGN_OR_ABORT(auto flushed, _update_manager->flush_pk_memtable(meta, in_memory_version));
+    ASSERT_NE(flushed, nullptr);
+    EXPECT_EQ(in_memory_version, flushed->version());
+    ASSERT_EQ(1, flushed->sstable_meta().sstables_size());
+    EXPECT_EQ(in_memory_version, flushed->sstable_meta().sstables(0).generation_version());
+}
+
 // Same rebuild-from-segment source, driven through the real split publish path,
 // guarding that tablet_splitter passes new_version to flush_pk_memtable.
 TEST_F(LakeTabletReshardTest, test_split_publish_stamps_fresh_sstable_with_new_version) {

--- a/be/test/storage_primitive/merge_iterator_test.cpp
+++ b/be/test/storage_primitive/merge_iterator_test.cpp
@@ -368,6 +368,187 @@ TEST_F(MergeIteratorTest, mask_merge_boundary_test) {
     }
 }
 
+TEST_F(MergeIteratorTest, mask_merge_with_selection) {
+    auto sub1 = std::make_shared<VectorChunkIterator>(_schema, COL_INT(std::vector<int32_t>{1, 3, 5}));
+    auto sub2 = std::make_shared<VectorChunkIterator>(_schema, COL_INT(std::vector<int32_t>{2, 4, 6}));
+
+    std::vector<RowSourceMask> source_masks;
+    for (uint16_t source : std::vector<uint16_t>{0, 1, 0, 1, 0, 1}) {
+        source_masks.emplace_back(source, false);
+    }
+    std::vector<RowSourceMask> selections;
+    for (uint16_t selected : std::vector<uint16_t>{0, 1, 1, 0, 0, 1}) {
+        selections.emplace_back(selected, false);
+    }
+
+    RowSourceMaskBuffer mask_buffer(0, config::storage_root_path);
+    ASSERT_TRUE(mask_buffer.write(source_masks).ok());
+    ASSERT_TRUE(mask_buffer.flush().ok());
+    ASSERT_TRUE(mask_buffer.flip_to_read().ok());
+    RowSourceMaskBuffer selection_buffer(0, config::storage_root_path);
+    ASSERT_TRUE(selection_buffer.write(selections).ok());
+    ASSERT_TRUE(selection_buffer.flush().ok());
+    ASSERT_TRUE(selection_buffer.flip_to_read().ok());
+
+    auto iter = new_mask_merge_iterator(std::vector<ChunkIteratorPtr>{sub1, sub2}, &mask_buffer, &selection_buffer);
+    ASSERT_TRUE(iter->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS).ok());
+
+    std::vector<int32_t> actual;
+    auto chunk = ChunkFactory::new_chunk(iter->schema(), config::vector_chunk_size);
+    while (iter->get_next(chunk.get()).ok()) {
+        const auto& column = chunk->get_column_by_index(0);
+        for (size_t i = 0; i < column->size(); ++i) {
+            actual.push_back(column->get(i).get_int32());
+        }
+        chunk->reset();
+    }
+    EXPECT_EQ((std::vector<int32_t>{2, 3, 6}), actual);
+}
+
+// Regression for the branch the mixed-selection case above cannot reach. With every row selected,
+// max_same_source_count equals the whole chunk, so do_get_next takes the `swap_chunk` shortcut and
+// returns `fill(child)` -- the call that also observes the child's EOF. MaskMergeIterator::fill
+// swallows that EOF and returns OK, so the swapped rows must still be delivered on this call and the
+// EOF must surface only on the next one. Getting that wrong silently truncates the last chunk of an
+// UNSHARE rewrite.
+TEST_F(MergeIteratorTest, mask_merge_single_child_all_selected_defers_eof) {
+    auto sub = std::make_shared<VectorChunkIterator>(_schema, COL_INT(std::vector<int32_t>{1, 2, 3, 4}));
+    std::vector<RowSourceMask> source_masks(4, RowSourceMask{0, false});
+    std::vector<RowSourceMask> selections(4, RowSourceMask{1, false});
+
+    RowSourceMaskBuffer mask_buffer(0, config::storage_root_path);
+    ASSERT_TRUE(mask_buffer.write(source_masks).ok());
+    ASSERT_TRUE(mask_buffer.flush().ok());
+    ASSERT_TRUE(mask_buffer.flip_to_read().ok());
+    RowSourceMaskBuffer selection_buffer(0, config::storage_root_path);
+    ASSERT_TRUE(selection_buffer.write(selections).ok());
+    ASSERT_TRUE(selection_buffer.flush().ok());
+    ASSERT_TRUE(selection_buffer.flip_to_read().ok());
+
+    auto iter = new_mask_merge_iterator(std::vector<ChunkIteratorPtr>{sub}, &mask_buffer, &selection_buffer);
+    ASSERT_TRUE(iter->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS).ok());
+
+    auto chunk = ChunkFactory::new_chunk(iter->schema(), config::vector_chunk_size);
+    auto st = iter->get_next(chunk.get());
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ASSERT_EQ(4, chunk->num_rows()) << "the whole-chunk swap must deliver its rows, not drop them with the EOF";
+    for (int i = 0; i < 4; ++i) {
+        EXPECT_EQ(i + 1, chunk->get_column_by_index(0)->get(i).get_int32());
+    }
+
+    chunk->reset();
+    ASSERT_TRUE(iter->get_next(chunk.get()).is_end_of_file()) << "EOF belongs to the call after the last rows";
+    EXPECT_EQ(0, chunk->num_rows());
+}
+
+// The two buffers are read in lockstep, one entry per row. If they disagree on how many rows remain,
+// the merge would silently pair a row with another row's verdict, so it must fail instead. This is
+// the check on entry; the one below covers the same disagreement discovered mid-skip.
+TEST_F(MergeIteratorTest, mask_merge_rejects_selection_shorter_than_mask) {
+    auto sub = std::make_shared<VectorChunkIterator>(_schema, COL_INT(std::vector<int32_t>{1, 2, 3, 4}));
+    std::vector<RowSourceMask> source_masks(4, RowSourceMask{0, false});
+    std::vector<RowSourceMask> selections(2, RowSourceMask{1, false}); // two rows short
+
+    RowSourceMaskBuffer mask_buffer(0, config::storage_root_path);
+    ASSERT_TRUE(mask_buffer.write(source_masks).ok());
+    ASSERT_TRUE(mask_buffer.flush().ok());
+    ASSERT_TRUE(mask_buffer.flip_to_read().ok());
+    RowSourceMaskBuffer selection_buffer(0, config::storage_root_path);
+    ASSERT_TRUE(selection_buffer.write(selections).ok());
+    ASSERT_TRUE(selection_buffer.flush().ok());
+    ASSERT_TRUE(selection_buffer.flip_to_read().ok());
+
+    auto iter = new_mask_merge_iterator(std::vector<ChunkIteratorPtr>{sub}, &mask_buffer, &selection_buffer);
+    ASSERT_TRUE(iter->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS).ok());
+    auto chunk = ChunkFactory::new_chunk(iter->schema(), config::vector_chunk_size);
+
+    Status st = Status::OK();
+    for (int i = 0; i < 4 && st.ok(); ++i) {
+        chunk->reset();
+        st = iter->get_next(chunk.get());
+        if (st.is_end_of_file()) break;
+    }
+    ASSERT_FALSE(st.ok()) << "a truncated selection stream must not merge silently";
+    EXPECT_TRUE(st.message().find("different lengths") != std::string::npos) << st.to_string();
+}
+
+// Every row unselected: the skip path runs to the end of the chunk, and the iterator must report EOF
+// rather than emit an empty chunk as if it were data.
+TEST_F(MergeIteratorTest, mask_merge_all_rows_unselected_yields_eof) {
+    auto sub = std::make_shared<VectorChunkIterator>(_schema, COL_INT(std::vector<int32_t>{1, 2, 3, 4}));
+    std::vector<RowSourceMask> source_masks(4, RowSourceMask{0, false});
+    std::vector<RowSourceMask> selections(4, RowSourceMask{0, false});
+
+    RowSourceMaskBuffer mask_buffer(0, config::storage_root_path);
+    ASSERT_TRUE(mask_buffer.write(source_masks).ok());
+    ASSERT_TRUE(mask_buffer.flush().ok());
+    ASSERT_TRUE(mask_buffer.flip_to_read().ok());
+    RowSourceMaskBuffer selection_buffer(0, config::storage_root_path);
+    ASSERT_TRUE(selection_buffer.write(selections).ok());
+    ASSERT_TRUE(selection_buffer.flush().ok());
+    ASSERT_TRUE(selection_buffer.flip_to_read().ok());
+
+    auto iter = new_mask_merge_iterator(std::vector<ChunkIteratorPtr>{sub}, &mask_buffer, &selection_buffer);
+    ASSERT_TRUE(iter->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS).ok());
+    auto chunk = ChunkFactory::new_chunk(iter->schema(), config::vector_chunk_size);
+    auto st = iter->get_next(chunk.get());
+    ASSERT_TRUE(st.is_end_of_file()) << st.to_string();
+    EXPECT_EQ(0, chunk->num_rows());
+}
+
+// The unselected rows sit at the END of the chunk, so the skip loop is what exhausts it. The rows
+// before them must still come out, and the exhaustion must not be mistaken for a failure.
+TEST_F(MergeIteratorTest, mask_merge_trailing_unselected_rows_still_emit_the_prefix) {
+    auto sub = std::make_shared<VectorChunkIterator>(_schema, COL_INT(std::vector<int32_t>{1, 2, 3, 4}));
+    std::vector<RowSourceMask> source_masks(4, RowSourceMask{0, false});
+    std::vector<RowSourceMask> selections{RowSourceMask{1, false}, RowSourceMask{1, false}, RowSourceMask{0, false},
+                                          RowSourceMask{0, false}};
+
+    RowSourceMaskBuffer mask_buffer(0, config::storage_root_path);
+    ASSERT_TRUE(mask_buffer.write(source_masks).ok());
+    ASSERT_TRUE(mask_buffer.flush().ok());
+    ASSERT_TRUE(mask_buffer.flip_to_read().ok());
+    RowSourceMaskBuffer selection_buffer(0, config::storage_root_path);
+    ASSERT_TRUE(selection_buffer.write(selections).ok());
+    ASSERT_TRUE(selection_buffer.flush().ok());
+    ASSERT_TRUE(selection_buffer.flip_to_read().ok());
+
+    auto iter = new_mask_merge_iterator(std::vector<ChunkIteratorPtr>{sub}, &mask_buffer, &selection_buffer);
+    ASSERT_TRUE(iter->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS).ok());
+    auto chunk = ChunkFactory::new_chunk(iter->schema(), config::vector_chunk_size);
+    ASSERT_TRUE(iter->get_next(chunk.get()).ok());
+    ASSERT_EQ(2, chunk->num_rows());
+    EXPECT_EQ(1, chunk->get_column_by_index(0)->get(0).get_int32());
+    EXPECT_EQ(2, chunk->get_column_by_index(0)->get(1).get_int32());
+
+    chunk->reset();
+    EXPECT_TRUE(iter->get_next(chunk.get()).is_end_of_file());
+}
+
+TEST_F(MergeIteratorTest, mask_merge_single_child_with_selection) {
+    auto sub = std::make_shared<VectorChunkIterator>(_schema, COL_INT(std::vector<int32_t>{1, 2, 3, 4}));
+    std::vector<RowSourceMask> source_masks(4, RowSourceMask{0, false});
+    std::vector<RowSourceMask> selections{RowSourceMask{0, false}, RowSourceMask{1, false}, RowSourceMask{0, false},
+                                          RowSourceMask{1, false}};
+
+    RowSourceMaskBuffer mask_buffer(0, config::storage_root_path);
+    ASSERT_TRUE(mask_buffer.write(source_masks).ok());
+    ASSERT_TRUE(mask_buffer.flush().ok());
+    ASSERT_TRUE(mask_buffer.flip_to_read().ok());
+    RowSourceMaskBuffer selection_buffer(0, config::storage_root_path);
+    ASSERT_TRUE(selection_buffer.write(selections).ok());
+    ASSERT_TRUE(selection_buffer.flush().ok());
+    ASSERT_TRUE(selection_buffer.flip_to_read().ok());
+
+    auto iter = new_mask_merge_iterator(std::vector<ChunkIteratorPtr>{sub}, &mask_buffer, &selection_buffer);
+    ASSERT_TRUE(iter->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS).ok());
+    auto chunk = ChunkFactory::new_chunk(iter->schema(), config::vector_chunk_size);
+    ASSERT_TRUE(iter->get_next(chunk.get()).ok());
+    ASSERT_EQ(2, chunk->num_rows());
+    EXPECT_EQ(2, chunk->get_column_by_index(0)->get(0).get_int32());
+    EXPECT_EQ(4, chunk->get_column_by_index(0)->get(1).get_int32());
+}
+
 TEST_F(MergeIteratorTest, mask_merge_exhausted_iterator) {
     std::vector<int32_t> v1{1, 2}; // Only 2 elements
     std::vector<int32_t> v2{10, 11};

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -102,6 +102,17 @@ message ComputeNodePB {
 message AggregatePublishVersionRequest {
     repeated ComputeNodePB compute_nodes = 1;
     repeated PublishVersionRequest publish_reqs = 2;
+    // Transitional read metadata for an ORDER BY range-tablet split. The aggregator
+    // rebuilds each parent from the already-published child metadata and stores the
+    // result in the same bundle. Omitted by the final unshare-compaction publish,
+    // which is the atomic cutover to reading the children directly.
+    repeated ParentTabletPublishInfoPB parent_tablet_publish_infos = 3;
+}
+
+message ParentTabletPublishInfoPB {
+    optional int64 parent_tablet_id = 1;
+    // One child means an identical-tablet replacement; multiple children mean a split family.
+    repeated int64 child_tablet_ids = 2;
 }
 
 message AbortTxnRequest {
@@ -168,6 +179,9 @@ message CompactRequest {
     
     // Configuration for per-tablet parallel compaction
     optional TabletParallelConfig parallel_config = 13;
+    // Rewrites every complete rowset containing at least one explicitly shared
+    // segment. Used once after a range-tablet split to make all child files private.
+    optional bool unshare_segments = 14 [default = false];
 }
 
 message AggregateCompactRequest {

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -660,6 +660,10 @@ message TxnInfoPB {
     // W == 1 empty fast-path to a partition that is empty at W > 1 (e.g. a repeat online rewrite of an
     // empty range partition). When false, the source op_write MUST exist and is loaded as before.
     optional bool shadow_rewrite_source_empty = 14;
+    // Marks the partition-wide compaction that removes split-shared segments. This is copied from the
+    // persisted compaction transaction attachment so aggregate publish can omit the query-only parent
+    // metadata even after an FE leader failover (when the in-memory compaction job no longer exists).
+    optional bool unshare_compaction = 15;
 }
 
 message SplittingTabletInfoPB {


### PR DESCRIPTION
## Why I'm doing:

Part of #77653 (stage OB-3). A range-tablet split is metadata-only, so both children start out pointing at the parent's files. When the sort key is the primary key that is harmless — each child's key range is also a contiguous run of rows in every file. Decouple the two keys and it stops being true: a child's rows are scattered through every file, so a child cannot read a shared file without also reading its sibling's rows.

The design constraint is that a query never pays read amplification, at any moment, including the window right after a split.

## What I'm doing:

**Reads are served from a virtual parent.** The parent becomes a frozen read-only view assembled from the children's metadata — segments de-duplicated by file identity, delvecs OR-ed, DCG overlays unioned. A file inherited by both children appears once and is read once, unfiltered. The de-dup is sound because the children's key ranges are disjoint, so what they mark on a shared segment can never be the same rowid. Aggregate publish rebuilds that view from the already-published child metadata (`parent_tablet_publish_infos`) and stores it in the same bundle.

The parent is a read alias, so it gets no primary index of its own. Rebuilding one walked every index entry on every publish and blew past the publish RPC budget, after which the FE retried from scratch and the split never settled.

**Cutover is the UNSHARE compaction** (`CompactRequest.unshare_segments`): one partition-scoped transaction that reads each inherited file in sort-key order, keeps only the rows whose primary key falls in the child's range, and writes both children's outputs atomically. `TxnInfoPB.unshare_compaction` is declared here as part of the proto surface but is **not read or written yet**: aggregate publish currently decides purely on whether `parent_tablet_publish_infos` is empty. Populating it from the persisted compaction commit attachment — which is what makes the cutover survive an FE leader failover — is FE work and lands with OB-4. Once it commits, the children's metadata references no inherited file — the condition is derivable from committed metadata and needs no state bit.

The rewrite is parallel by construction: `create_parallel_tasks` plans UNSHARE work with a partitioner that never drops an input and validates that the groups cover every segment, and the merged txn log is withheld unless every expected subtask completed. UNSHARE is all-or-nothing, so a partial submission must not publish.

This is the only place in the design where a range is used as a row-level predicate, and it is free there: the rewrite reads every file end to end anyway.

Fixes #77653

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

Nothing reaches this code until the FE gate arrives in OB-4 (`tablet_reshard_enable_pk_order_by`, default off).

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

Range distribution / tablet reshard is main-only, so no backport is needed.

---

#77654 has merged, so this branch is rebased straight onto `main` and carries nothing but its own commit.

