### PR TITLE
[BugFix] Reduce Flat JSON vertical compaction memory usage (backport #77682)

### DIFF
--- a/be/src/storage/meta_reader.cpp
+++ b/be/src/storage/meta_reader.cpp
@@ -629,6 +629,11 @@ Status SegmentMetaCollecter::_collect_column_compressed_size(ColumnId cid, Colum
 }
 
 size_t SegmentMetaCollecter::_collect_column_size_recursive(ColumnReader* col_reader) {
+    // A Flat JSON root footprint already aggregates its sub-readers.
+    if (col_reader->is_flat_json()) {
+        return col_reader->total_mem_footprint();
+    }
+
     size_t total_mem_footprint = col_reader->total_mem_footprint();
 
     if (col_reader->sub_readers() != nullptr) {

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -216,6 +216,14 @@ Status ColumnReader::_init(ColumnMetaPB* meta, const TabletColumn* column) {
                 RETURN_IF_ERROR(res);
                 _sub_readers->emplace_back(std::move(res).value());
             }
+            // Flat JSON segments written before the root footprint was persisted have a zero root
+            // value even though their child readers have valid footprints. Recover the aggregate
+            // at read time so compaction can size chunks correctly for existing data.
+            if (_is_flat_json && _total_mem_footprint == 0) {
+                for (const auto& sub_reader : *_sub_readers) {
+                    _total_mem_footprint += sub_reader->total_mem_footprint();
+                }
+            }
             return Status::OK();
         }
         return Status::OK();

--- a/be/src/storage/rowset/json_column_compactor.cpp
+++ b/be/src/storage/rowset/json_column_compactor.cpp
@@ -201,6 +201,7 @@ Status FlatJsonColumnCompactor::finish() {
         _subcolumn_dict_valid[sub_column_key] = sub_dict_valid;
     }
 
+    _json_meta->set_total_mem_footprint(total_mem_footprint());
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/json_column_writer.cpp
+++ b/be/src/storage/rowset/json_column_writer.cpp
@@ -314,6 +314,7 @@ Status FlatJsonColumnWriter::finish() {
         }
     }
 
+    _json_meta->set_total_mem_footprint(total_mem_footprint());
     return Status::OK();
 }
 

--- a/be/src/util/json_flattener.cpp
+++ b/be/src/util/json_flattener.cpp
@@ -1024,30 +1024,31 @@ ColumnPtr JsonMerger::merge(const Columns& columns) {
     DCHECK_GE(columns.size(), 1);
     DCHECK(_src_columns.empty());
 
-    _result = NullableColumn::create(JsonColumn::create(), NullColumn::create());
-    _json_result = down_cast<JsonColumn*>(down_cast<NullableColumn*>(_result.get())->data_column().get());
-    _null_result = down_cast<NullColumn*>(down_cast<NullableColumn*>(_result.get())->null_column().get());
+    auto result = NullableColumn::create(JsonColumn::create(), NullColumn::create());
+    auto* nullable_result = down_cast<NullableColumn*>(result.get());
+    auto* json_result = down_cast<JsonColumn*>(nullable_result->data_column().get());
+    auto* null_result = down_cast<NullColumn*>(nullable_result->null_column().get());
     size_t rows = columns[0]->size();
-    _result->reserve(rows);
+    result->reserve(rows);
 
     for (auto& col : columns) {
         _src_columns.emplace_back(col.get());
     }
 
     if (_src_root->op == JsonFlatPath::OP_INCLUDE) {
-        _merge_impl<true>(rows);
+        _merge_impl<true>(rows, *json_result, *null_result);
     } else {
-        _merge_impl<false>(rows);
+        _merge_impl<false>(rows, *json_result, *null_result);
     }
 
     _src_columns.clear();
     if (_output_nullable) {
-        down_cast<NullableColumn*>(_result.get())->update_has_null();
+        nullable_result->update_has_null();
         // IMPORTANT: Check column integrity to prevent NullableColumn inconsistency
-        _result->check_or_die();
-        return _result;
+        result->check_or_die();
+        return result;
     } else {
-        auto data_column = down_cast<NullableColumn*>(_result.get())->data_column();
+        auto data_column = nullable_result->data_column();
         // IMPORTANT: Check column integrity to prevent NullableColumn inconsistency
         data_column->check_or_die();
         return data_column;
@@ -1055,7 +1056,7 @@ ColumnPtr JsonMerger::merge(const Columns& columns) {
 }
 
 template <bool IN_TREE>
-void JsonMerger::_merge_impl(size_t rows) {
+void JsonMerger::_merge_impl(size_t rows, JsonColumn& json_result, NullColumn& null_result) {
     if (_has_remain) {
         auto remain = down_cast<const JsonColumn*>(_src_columns.back());
         for (size_t i = 0; i < rows; i++) {
@@ -1067,23 +1068,23 @@ void JsonMerger::_merge_impl(size_t rows) {
                 _merge_json(_src_root.get(), &builder, i);
                 builder.close();
                 auto slice = builder.slice();
-                _json_result->append(JsonValue(slice));
-                _null_result->append(slice.isEmptyObject());
+                json_result.append(JsonValue(slice));
+                null_result.append(slice.isEmptyObject());
             } else if (!vs.isObject()) {
                 for (int k = 0; k < _src_paths.size(); k++) {
                     // check child column should be null
                     DCHECK(_src_columns[k]->is_null(i));
                 }
-                _json_result->append(JsonValue(vs));
-                _null_result->append(vs.isEmptyObject());
+                json_result.append(JsonValue(vs));
+                null_result.append(vs.isEmptyObject());
             } else {
                 vpack::Builder builder;
                 builder.add(vpack::Value(vpack::ValueType::Object));
                 _merge_json_with_remain<IN_TREE>(_src_root.get(), &vs, &builder, i);
                 builder.close();
                 auto slice = builder.slice();
-                _json_result->append(JsonValue(slice));
-                _null_result->append(slice.isEmptyObject());
+                json_result.append(JsonValue(slice));
+                null_result.append(slice.isEmptyObject());
             }
         }
     } else {
@@ -1093,8 +1094,8 @@ void JsonMerger::_merge_impl(size_t rows) {
             _merge_json(_src_root.get(), &builder, i);
             builder.close();
             auto json = builder.slice();
-            _json_result->append(JsonValue(json));
-            _null_result->append(json.isEmptyObject());
+            json_result.append(JsonValue(json));
+            null_result.append(json.isEmptyObject());
         }
     }
 }

--- a/be/src/util/json_flattener.h
+++ b/be/src/util/json_flattener.h
@@ -236,7 +236,7 @@ public:
 
 private:
     template <bool IN_TREE>
-    void _merge_impl(size_t rows);
+    void _merge_impl(size_t rows, JsonColumn& json_result, NullColumn& null_result);
 
     template <bool IN_TREE>
     void _merge_json_with_remain(const JsonFlatPath* root, const vpack::Slice* remain, vpack::Builder* builder,
@@ -257,10 +257,6 @@ private:
     std::vector<std::string> _exclude_paths;
     std::vector<std::string> _level_paths;
     bool _output_nullable = false;
-
-    ColumnPtr _result;
-    JsonColumn* _json_result;
-    NullColumn* _null_result;
 };
 
 // use read or compaction flat json

--- a/be/test/storage/meta_reader_test.cpp
+++ b/be/test/storage/meta_reader_test.cpp
@@ -25,6 +25,7 @@
 #include "fs/fs_util.h"
 #include "fs/key_cache.h"
 #include "storage/rowset/column_iterator.h"
+#include "storage/rowset/column_reader.h"
 #include "storage/rowset/segment_writer.h"
 #include "testutil/assert.h"
 
@@ -155,7 +156,7 @@ TEST_F(SegmentMetaCollecterTest, test_init_with_dcg_options) {
     EXPECT_OK(collecter2.init(&params, non_pk_options));
 }
 
-TEST_F(SegmentMetaCollecterTest, test_collect_dict_json_column_success) {
+TEST_F(SegmentMetaCollecterTest, test_collect_flat_json_meta_fields) {
     // Create a proper JSON segment with actual data
     TabletSchemaPB json_schema_pb;
     auto json_col = json_schema_pb.add_column();
@@ -204,14 +205,25 @@ TEST_F(SegmentMetaCollecterTest, test_collect_dict_json_column_success) {
     // Open the JSON segment
     FileInfo json_file_info{.path = json_segment_name, .encryption_meta = encryption_pair.encryption_meta};
     ASSIGN_OR_ABORT(auto json_segment, Segment::open(fs, json_file_info, 0, json_tablet_schema));
+    const auto* root_reader = json_segment->column(0);
+    ASSERT_NE(nullptr, root_reader);
+    ASSERT_TRUE(root_reader->is_flat_json());
+    ASSERT_NE(nullptr, root_reader->sub_readers());
 
-    // Test dictionary collection from JSON column
+    uint64_t child_mem_footprint = 0;
+    for (const auto& child : *root_reader->sub_readers()) {
+        child_mem_footprint += child->total_mem_footprint();
+    }
+    ASSERT_GT(child_mem_footprint, 0);
+    ASSERT_EQ(child_mem_footprint, root_reader->total_mem_footprint());
+
+    // Test metadata collection from a Flat JSON column.
     SegmentMetaCollecter json_collecter(json_segment);
     SegmentMetaCollecterParams params;
-    params.fields.emplace_back("dict_merge");
-    params.field_type.emplace_back(LogicalType::TYPE_ARRAY);
-    params.cids.emplace_back(0);
-    params.read_page.emplace_back(true); // Need to read page for JSON
+    params.fields = {META_DICT_MERGE, META_COLUMN_SIZE};
+    params.field_type = {LogicalType::TYPE_ARRAY, LogicalType::TYPE_BIGINT};
+    params.cids = {0, 0};
+    params.read_page = {true, false};
     params.tablet_schema = json_tablet_schema;
     params.low_cardinality_threshold = 1000;
     SegmentMetaCollectOptions options;
@@ -219,13 +231,13 @@ TEST_F(SegmentMetaCollecterTest, test_collect_dict_json_column_success) {
     EXPECT_OK(json_collecter.open());
 
     auto array_col = create_array_column();
-
-    // Test successful dictionary collection for JSON column
-    Status status = json_collecter._collect_dict(0, array_col.get(), LogicalType::TYPE_ARRAY);
-
-    ASSERT_OK(status);
+    auto column_size_col = Int64Column::create();
+    std::vector<Column*> columns{array_col.get(), column_size_col.get()};
+    ASSERT_OK(json_collecter.collect(&columns));
     EXPECT_GT(array_col->size(), 0);
     EXPECT_EQ("[['Beijing','Shanghai'], ['Alice','Bob']]", array_col->debug_string());
+    ASSERT_EQ(1, column_size_col->size());
+    EXPECT_EQ(static_cast<int64_t>(root_reader->total_mem_footprint()), column_size_col->get(0).get_int64());
 }
 
 TEST_F(SegmentMetaCollecterTest, test_collect_multiple_meta_fields) {

--- a/be/test/storage/rowset/flat_json_column_compact_test.cpp
+++ b/be/test/storage/rowset/flat_json_column_compact_test.cpp
@@ -275,7 +275,8 @@ protected:
     };
 
     // Write one JSON segment from `jsons`; segment nullability follows jsons[0]->is_nullable().
-    SegmentHandle write_segment(Columns& jsons, bool need_flat, const std::string& fname) {
+    SegmentHandle write_segment(Columns& jsons, bool need_flat, const std::string& fname, bool is_compaction = true,
+                                bool simulate_legacy_root_footprint = false) {
         SegmentHandle handle;
         handle.fs = std::make_shared<MemoryFileSystem>();
         EXPECT_TRUE(handle.fs->create_dir(TEST_DIR).ok());
@@ -297,7 +298,7 @@ protected:
         writer_opts.meta->set_compression(starrocks::LZ4_FRAME);
         writer_opts.meta->set_is_nullable(jsons[0]->is_nullable());
         writer_opts.need_zone_map = false;
-        writer_opts.is_compaction = true;
+        writer_opts.is_compaction = is_compaction;
 
         ASSIGN_OR_ABORT(auto writer, ColumnWriter::create(writer_opts, &json_tablet_column, wfile.get()));
         EXPECT_OK(writer->init());
@@ -310,6 +311,9 @@ protected:
         EXPECT_TRUE(writer->write_ordinal_index().ok());
         EXPECT_TRUE(wfile->close().ok());
 
+        if (simulate_legacy_root_footprint) {
+            handle.meta->set_total_mem_footprint(0);
+        }
         handle.segment->set_num_rows(handle.num_rows);
         auto res = ColumnReader::create(handle.meta.get(), handle.segment.get(), nullptr);
         EXPECT_TRUE(res.ok());
@@ -356,6 +360,51 @@ private:
     std::shared_ptr<TabletSchema> _dummy_segment_schema;
     std::shared_ptr<ColumnMetaPB> _meta;
 };
+
+TEST_F(FlatJsonColumnCompactTest, testFlatJsonRootTotalMemFootprint) {
+    Columns jsons = {
+            normal_json(R"({"session_id": "session-1", "messages": [{"content": "first message"}]})", false),
+            normal_json(R"({"session_id": "session-2", "messages": [{"content": "second message"}]})", false),
+    };
+
+    for (bool is_compaction : {false, true}) {
+        auto handle = write_segment(jsons, /*need_flat=*/true,
+                                    is_compaction ? "/compaction_flat_json_total_mem_footprint.data"
+                                                  : "/load_flat_json_total_mem_footprint.data",
+                                    is_compaction);
+        ASSERT_TRUE(handle.meta->json_meta().is_flat());
+        ASSERT_GT(handle.meta->children_columns_size(), 0);
+
+        uint64_t child_mem_footprint = 0;
+        for (const auto& child : handle.meta->children_columns()) {
+            child_mem_footprint += child.total_mem_footprint();
+        }
+        ASSERT_GT(child_mem_footprint, 0);
+        EXPECT_EQ(child_mem_footprint, handle.meta->total_mem_footprint());
+        EXPECT_EQ(handle.meta->total_mem_footprint(), handle.reader->total_mem_footprint());
+    }
+}
+
+TEST_F(FlatJsonColumnCompactTest, testLegacyFlatJsonRootTotalMemFootprintFallback) {
+    Columns jsons = {
+            normal_json(R"({"session_id": "session-1", "messages": [{"content": "first message"}]})", false),
+            normal_json(R"({"session_id": "session-2", "messages": [{"content": "second message"}]})", false),
+    };
+
+    auto handle = write_segment(jsons, /*need_flat=*/true, "/legacy_flat_json_total_mem_footprint.data",
+                                /*is_compaction=*/true, /*simulate_legacy_root_footprint=*/true);
+    ASSERT_TRUE(handle.meta->json_meta().is_flat());
+    ASSERT_EQ(0, handle.meta->total_mem_footprint());
+    ASSERT_TRUE(handle.reader->is_flat_json());
+    ASSERT_NE(nullptr, handle.reader->sub_readers());
+
+    uint64_t child_mem_footprint = 0;
+    for (const auto& child : *handle.reader->sub_readers()) {
+        child_mem_footprint += child->total_mem_footprint();
+    }
+    ASSERT_GT(child_mem_footprint, 0);
+    EXPECT_EQ(child_mem_footprint, handle.reader->total_mem_footprint());
+}
 
 TEST_F(FlatJsonColumnCompactTest, testJsonCompactToJson) {
     // clang-format off

--- a/be/test/util/json_flattener_test.cpp
+++ b/be/test/util/json_flattener_test.cpp
@@ -223,6 +223,25 @@ TEST_F(JsonFlattenerTest, testNormalJson) {
     EXPECT_EQ("4", result[1]->debug_item(1));
 }
 
+TEST_F(JsonFlattenerTest, mergerDoesNotRetainReturnedColumn) {
+    std::vector<std::string> paths = {"k1", "k2"};
+    std::vector<LogicalType> types = {TYPE_BIGINT, TYPE_BIGINT};
+    auto flat_columns = test_json({R"({"k1": 1, "k2": 2})", R"({"k1": 3, "k2": 4})"}, paths, types, false);
+
+    for (bool output_nullable : {false, true}) {
+        JsonMerger merger(paths, types);
+        merger.set_output_nullable(output_nullable);
+
+        auto result = merger.merge(flat_columns);
+
+        ASSERT_EQ(output_nullable, result->is_nullable());
+        ASSERT_EQ(2, result->size());
+        EXPECT_EQ(JsonValue::parse(R"({"k1": 1, "k2": 2})").value(), *result->get(0).get_json());
+        EXPECT_EQ(JsonValue::parse(R"({"k1": 3, "k2": 4})").value(), *result->get(1).get_json());
+        EXPECT_EQ(1, result->use_count());
+    }
+}
+
 TEST_F(JsonFlattenerTest, testCastNormalJson) {
     std::vector<std::string> json = {R"( {"k1": 1, "k2": 2} )", R"( {"k1": 3, "k2": [1,2,3,4]} )"};
 


### PR DESCRIPTION
Manual backport of #77682 to `branch-4.0`, replacing the conflicted and closed automatic backport #77869.

## Why I'm doing

Lake vertical compaction may reconstruct Flat JSON inputs through `JsonMergeIterator` when flattened layouts are incompatible. `JsonMerger` retained its latest output, and Flat JSON root metadata did not expose the aggregate child memory footprint. Together these issues could retain reconstructed JSON columns and make compaction choose an oversized read chunk.

## What I'm doing

- Make each `JsonMerger` result call-local and pass output columns explicitly.
- Persist the aggregate Flat JSON root footprint from load and compaction writers.
- Reconstruct a zero legacy Flat JSON root footprint from its immediate child readers.
- Avoid counting an aggregate Flat JSON root and its children twice in `column_size`.
- Add ownership, footprint persistence, legacy compatibility, and metadata accounting tests.

## Backport adaptation

`branch-4.0` still defines `JsonMerger` in `util/json_flattener.{h,cpp}`, so the main fix and ownership tests are translated to those existing files. The main-only standalone benchmark is intentionally omitted because this release branch predates the PlatformEnv/RuntimeEnv and configuration-header APIs it uses; this does not change the production fix.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

