### PR TITLE
[BugFix] Guard against null ComputeNode in warehouse availability check

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
@@ -18,6 +18,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.common.ErrorCode;
@@ -112,8 +113,10 @@ public class DefaultSharedDataWorkerProvider implements WorkerProvider {
                 throw ErrorReportException.report(ErrorCode.ERR_NO_NODES_IN_WAREHOUSE, warehouse.getName());
             }
 
+            // Keep the full warehouse worker id list, including ids missing from cluster info, so backup
+            // routing can still treat those ids as primaries and choose a healthy buddy for them.
             return new DefaultSharedDataWorkerProvider(idToComputeNode, availableComputeNodes, computeResource,
-                    blacklistBackupRoutingPolicy);
+                    blacklistBackupRoutingPolicy, computeNodeIds);
         }
     }
 
@@ -129,8 +132,17 @@ public class DefaultSharedDataWorkerProvider implements WorkerProvider {
 
     /**
      * List of the compute node ids, used to select buddy node in case some of the nodes are not available.
+     * Lazily built from {@link #warehouseWorkerIds} on first use.
      */
     protected ImmutableList<Long> allComputeNodeIds;
+
+    /**
+     * Warehouse worker ids captured at snapshot time, including ids that did not resolve to a
+     * {@link ComputeNode} in {@link #id2ComputeNode}. An unresolved id must stay a member of this set so
+     * that {@code selectBackupWorker} still treats it as an eligible primary and routes it to a healthy
+     * buddy, instead of refusing to substitute at all.
+     */
+    private final ImmutableSet<Long> warehouseWorkerIds;
 
     private final Set<Long> selectedWorkerIds;
 
@@ -150,6 +162,15 @@ public class DefaultSharedDataWorkerProvider implements WorkerProvider {
                                            ImmutableMap<Long, ComputeNode> availableID2ComputeNode,
                                            ComputeResource computeResource,
                                            BlacklistBackupRoutingPolicy blacklistBackupRoutingPolicy) {
+        this(id2ComputeNode, availableID2ComputeNode, computeResource, blacklistBackupRoutingPolicy,
+                id2ComputeNode.keySet());
+    }
+
+    private DefaultSharedDataWorkerProvider(ImmutableMap<Long, ComputeNode> id2ComputeNode,
+                                           ImmutableMap<Long, ComputeNode> availableID2ComputeNode,
+                                           ComputeResource computeResource,
+                                           BlacklistBackupRoutingPolicy blacklistBackupRoutingPolicy,
+                                           Collection<Long> warehouseWorkerIds) {
         this.id2ComputeNode = id2ComputeNode;
         this.availableID2ComputeNode = availableID2ComputeNode;
         this.selectedWorkerIds = Sets.newConcurrentHashSet();
@@ -157,6 +178,7 @@ public class DefaultSharedDataWorkerProvider implements WorkerProvider {
         this.computeResource = computeResource;
         this.blacklistBackupRoutingPolicy = Preconditions.checkNotNull(blacklistBackupRoutingPolicy,
                 "blacklistBackupRoutingPolicy");
+        this.warehouseWorkerIds = ImmutableSet.copyOf(warehouseWorkerIds);
     }
 
     @Override
@@ -269,14 +291,12 @@ public class DefaultSharedDataWorkerProvider implements WorkerProvider {
      * Uses reservoir sampling (k=1) in a single pass to avoid allocating a list per call.
      */
     protected long selectBackupWorkerRandom(long workerId) {
-        if (availableID2ComputeNode.isEmpty() || !id2ComputeNode.containsKey(workerId)) {
+        if (availableID2ComputeNode.isEmpty() || !warehouseWorkerIds.contains(workerId)) {
             return -1;
         }
         if (allComputeNodeIds == null) {
             createAvailableIdList();
         }
-        Preconditions.checkNotNull(allComputeNodeIds);
-        Preconditions.checkState(allComputeNodeIds.contains(workerId));
 
         int eligibleCount = 0;
         long chosen = -1;
@@ -297,14 +317,12 @@ public class DefaultSharedDataWorkerProvider implements WorkerProvider {
      * Tries the next id in the sorted list after {@code workerId} (circular), returning the first eligible buddy.
      */
     protected long selectBackupWorkerCircular(long workerId) {
-        if (availableID2ComputeNode.isEmpty() || !id2ComputeNode.containsKey(workerId)) {
+        if (availableID2ComputeNode.isEmpty() || !warehouseWorkerIds.contains(workerId)) {
             return -1;
         }
         if (allComputeNodeIds == null) {
             createAvailableIdList();
         }
-        Preconditions.checkNotNull(allComputeNodeIds);
-        Preconditions.checkState(allComputeNodeIds.contains(workerId));
 
         int startPos = allComputeNodeIds.indexOf(workerId);
         int attempts = allComputeNodeIds.size();
@@ -353,7 +371,7 @@ public class DefaultSharedDataWorkerProvider implements WorkerProvider {
     }
 
     protected void createAvailableIdList() {
-        List<Long> ids = new ArrayList<>(id2ComputeNode.keySet());
+        List<Long> ids = new ArrayList<>(warehouseWorkerIds);
         Collections.sort(ids);
         this.allComputeNodeIds = ImmutableList.copyOf(ids);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
@@ -95,8 +95,9 @@ public class DefaultSharedDataWorkerProvider implements WorkerProvider {
             final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
             final ImmutableMap.Builder<Long, ComputeNode> builder = ImmutableMap.builder();
             final List<Long> computeNodeIds = warehouseManager.getAllComputeNodeIds(computeResource);
+            SystemInfoService clusterInfo = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
             for (Long nodeId : computeNodeIds) {
-                ComputeNode node = systemInfoService.getBackendOrComputeNode(nodeId);
+                ComputeNode node = clusterInfo.getBackendOrComputeNode(nodeId);
                 if (node == null) {
                     continue;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
@@ -94,8 +94,13 @@ public class DefaultSharedDataWorkerProvider implements WorkerProvider {
             final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
             final ImmutableMap.Builder<Long, ComputeNode> builder = ImmutableMap.builder();
             final List<Long> computeNodeIds = warehouseManager.getAllComputeNodeIds(computeResource);
-            computeNodeIds.forEach(nodeId -> builder.put(nodeId,
-                    GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendOrComputeNode(nodeId)));
+            for (Long nodeId : computeNodeIds) {
+                ComputeNode node = systemInfoService.getBackendOrComputeNode(nodeId);
+                if (node == null) {
+                    continue;
+                }
+                builder.put(nodeId, node);
+            }
             ImmutableMap<Long, ComputeNode> idToComputeNode = builder.build();
             if (LOG.isDebugEnabled()) {
                 LOG.debug("idToComputeNode: {}", idToComputeNode);
@@ -366,7 +371,8 @@ public class DefaultSharedDataWorkerProvider implements WorkerProvider {
     private static ImmutableMap<Long, ComputeNode> filterAvailableWorkers(ImmutableMap<Long, ComputeNode> workers) {
         ImmutableMap.Builder<Long, ComputeNode> builder = new ImmutableMap.Builder<>();
         for (Map.Entry<Long, ComputeNode> entry : workers.entrySet()) {
-            if (entry.getValue().isAlive() && !SimpleScheduler.isInBlocklist(entry.getKey())) {
+            ComputeNode node = entry.getValue();
+            if (node != null && node.isAlive() && !SimpleScheduler.isInBlocklist(entry.getKey())) {
                 builder.put(entry);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/cngroup/WarehouseComputeResourceProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/cngroup/WarehouseComputeResourceProvider.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -108,6 +109,7 @@ public final class WarehouseComputeResourceProvider implements ComputeResourcePr
         SystemInfoService systemInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
         List<ComputeNode> nodes = computeNodeIds.stream()
                 .map(id -> systemInfoService.getBackendOrComputeNode(id))
+                .filter(Objects::nonNull)
                 .filter(ComputeNode::isAlive).collect(Collectors.toList());
         return nodes;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
@@ -148,6 +148,23 @@ public class DefaultSharedDataWorkerProviderTest {
                 WarehouseManager.DEFAULT_RESOURCE);
     }
 
+    private WorkerProvider newWorkerProviderWithMissingNodeId(long missingId,
+                                                              BlacklistBackupRoutingPolicy blacklistBackupRoutingPolicy) {
+        List<Long> nodeIds = Lists.newArrayList(id2AllNodes.keySet());
+        nodeIds.add(missingId);
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public List<Long> getAllComputeNodeIds(ComputeResource computeResource) {
+                return nodeIds;
+            }
+        };
+        return newWorkerProvider(blacklistBackupRoutingPolicy);
+    }
+
+    private WorkerProvider newWorkerProviderWithMissingNodeId(long missingId) {
+        return newWorkerProviderWithMissingNodeId(missingId, BlacklistBackupRoutingPolicy.getDefault());
+    }
+
     private static void testUsingWorkerHelper(WorkerProvider workerProvider, Long workerId) {
         Assertions.assertTrue(workerProvider.isWorkerSelected(workerId));
         Assertions.assertTrue(workerProvider.getSelectedWorkerIds().contains(workerId));
@@ -230,6 +247,85 @@ public class DefaultSharedDataWorkerProviderTest {
         Assertions.assertFalse(workerProvider.getAllAvailableNodes().contains(99999L));
         Assertions.assertEquals(id2AllNodes.size(), workerProvider.getAllAvailableNodes().size());
         Assertions.assertEquals(1L, workerProvider.getWorkerById(1L).getId());
+    }
+
+    @Test
+    public void testSelectBackupWorkerCircularForMissingWarehouseNodeId() {
+        long missingId = 99999L;
+        WorkerProvider workerProvider = newWorkerProviderWithMissingNodeId(missingId, BlacklistBackupRoutingPolicy.CIRCULAR);
+
+        Assertions.assertFalse(workerProvider.isDataNodeAvailable(missingId));
+        long backupId = workerProvider.selectBackupWorker(missingId);
+        Assertions.assertTrue(backupId > 0);
+        Assertions.assertNotEquals(missingId, backupId);
+        Assertions.assertTrue(workerProvider.isDataNodeAvailable(backupId));
+        // stable: repeated calls for the same missing primary return the same buddy
+        Assertions.assertEquals(backupId, workerProvider.selectBackupWorker(missingId));
+        // a workerId that isn't part of the warehouse snapshot at all still yields no backup
+        Assertions.assertEquals(-1, workerProvider.selectBackupWorker(15678));
+    }
+
+    @Test
+    public void testSelectBackupWorkerRandomForMissingWarehouseNodeId() {
+        long missingId = 99999L;
+        WorkerProvider workerProvider = newWorkerProviderWithMissingNodeId(missingId, BlacklistBackupRoutingPolicy.RANDOM);
+
+        Assertions.assertFalse(workerProvider.isDataNodeAvailable(missingId));
+        for (int i = 0; i < 20; ++i) {
+            long backupId = workerProvider.selectBackupWorker(missingId);
+            Assertions.assertTrue(backupId > 0);
+            Assertions.assertNotEquals(missingId, backupId);
+            Assertions.assertTrue(id2AllNodes.containsKey(backupId));
+            Assertions.assertTrue(workerProvider.isDataNodeAvailable(backupId));
+        }
+        Assertions.assertEquals(-1, workerProvider.selectBackupWorker(15678));
+    }
+
+    @Test
+    public void testNormalBackendSelectorBackupFromMissingWarehouseNodeId() {
+        long missingId = 99999L;
+        WorkerProvider workerProvider = newWorkerProviderWithMissingNodeId(missingId);
+
+        OlapScanNode scanNode = newOlapScanNode(1, 1);
+        TScanRangeLocations locations = new TScanRangeLocations();
+        locations.setScan_range(new TScanRange().setInternal_scan_range(new TInternalScanRange().setRow_count(1)));
+        TScanRangeLocation location = new TScanRangeLocation();
+        location.setBackend_id(missingId);
+        locations.addToLocations(location);
+
+        FragmentScanRangeAssignment assignment = new FragmentScanRangeAssignment();
+        NormalBackendSelector selector = new NormalBackendSelector(scanNode, Collections.singletonList(locations),
+                assignment, workerProvider, false);
+        ExceptionChecker.expectThrowsNoException(selector::computeScanRangeAssignment);
+
+        Assertions.assertFalse(assignment.isEmpty());
+        for (long id : assignment.keySet()) {
+            Assertions.assertNotEquals(missingId, id);
+            Assertions.assertTrue(workerProvider.isDataNodeAvailable(id));
+        }
+    }
+
+    @Test
+    public void testCollocationBackendSelectorBackupFromMissingWarehouseNodeId() {
+        long missingId = 99999L;
+        WorkerProvider workerProvider = newWorkerProviderWithMissingNodeId(missingId);
+
+        OlapScanNode scanNode = newOlapScanNode(10, 1);
+        scanNode.getBucketSeqToLocations().putAll(
+                genBucketSeq2Locations(ImmutableMap.of(0, ImmutableList.of(missingId)), 1));
+
+        FragmentScanRangeAssignment assignment = new FragmentScanRangeAssignment();
+        ColocatedBackendSelector.Assignment colAssignment =
+                new ColocatedBackendSelector.Assignment(scanNode.getBucketNums(), 1, Optional.empty());
+        ColocatedBackendSelector selector =
+                new ColocatedBackendSelector(scanNode, assignment, colAssignment, false, workerProvider, 1);
+        ExceptionChecker.expectThrowsNoException(selector::computeScanRangeAssignment);
+
+        Assertions.assertFalse(assignment.isEmpty());
+        for (long id : assignment.keySet()) {
+            Assertions.assertNotEquals(missingId, id);
+            Assertions.assertTrue(workerProvider.isDataNodeAvailable(id));
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
@@ -214,6 +214,25 @@ public class DefaultSharedDataWorkerProviderTest {
     }
 
     @Test
+    public void testCaptureAvailableWorkersSkipsMissingNodeIds() {
+        List<Long> nodeIds = Lists.newArrayList(id2AllNodes.keySet());
+        nodeIds.add(99999L);
+
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public List<Long> getAllComputeNodeIds(ComputeResource computeResource) {
+                return nodeIds;
+            }
+        };
+
+        WorkerProvider workerProvider = newWorkerProvider();
+        Assertions.assertNull(workerProvider.getWorkerById(99999L));
+        Assertions.assertFalse(workerProvider.getAllAvailableNodes().contains(99999L));
+        Assertions.assertEquals(id2AllNodes.size(), workerProvider.getAllAvailableNodes().size());
+        Assertions.assertEquals(1L, workerProvider.getWorkerById(1L).getId());
+    }
+
+    @Test
     public void testSelectWorker() throws StarRocksException {
         HostBlacklist blockList = SimpleScheduler.getHostBlacklist();
         SystemInfoService sysInfo = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();

--- a/fe/fe-core/src/test/java/com/starrocks/warehouse/cngroup/WarehouseComputeResourceProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/warehouse/cngroup/WarehouseComputeResourceProviderTest.java
@@ -15,11 +15,16 @@
 package com.starrocks.warehouse.cngroup;
 
 import com.starrocks.common.ErrorReportException;
+import com.starrocks.common.StarRocksException;
+import com.starrocks.lake.StarOSAgent;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.ComputeNode;
+import com.starrocks.system.SystemInfoService;
 import com.starrocks.warehouse.Warehouse;
 import com.starrocks.warehouse.WarehouseTestBase;
+import mockit.Mock;
+import mockit.MockUp;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -107,6 +112,33 @@ public class WarehouseComputeResourceProviderTest extends WarehouseTestBase {
         } catch (ErrorReportException e) {
             assertThat(e.getMessage()).contains("Warehouse id: 1 not exist");
         }
+    }
+
+    @Test
+    public void testProviderGetAliveComputeNodesSkipsMissingNodeIds() {
+        ComputeNode aliveNode = new ComputeNode(10001L, "192.168.0.1", 9050);
+        aliveNode.setAlive(true);
+
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Long> getWorkersByWorkerGroup(long workerGroupId) throws StarRocksException {
+                return Lists.newArrayList(10001L, 99999L);
+            }
+        };
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public ComputeNode getBackendOrComputeNode(long nodeId) {
+                if (nodeId == 10001L) {
+                    return aliveNode;
+                }
+                return null;
+            }
+        };
+
+        ComputeResource computeResource = acquireDefaultWarehouseResource();
+        List<ComputeNode> result = provider.getAliveComputeNodes(computeResource);
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals(10001L, result.get(0).getId());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

`WarehouseComputeResourceProvider.getAliveComputeNodes` maps StarMgr worker ids to `ComputeNode` via `SystemInfoService.getBackendOrComputeNode`, then filters with `.filter(ComputeNode::isAlive)` directly on the mapped element:

```java
List<ComputeNode> nodes = computeNodeIds.stream()
        .map(id -> systemInfoService.getBackendOrComputeNode(id))
        .filter(ComputeNode::isAlive).collect(Collectors.toList());
```

If a worker id returned by `getWorkersByWorkerGroup` does not resolve to a `ComputeNode` on this FE (`getBackendOrComputeNode` returns `null`), `ComputeNode::isAlive` throws a `NullPointerException`. That NPE is caught by `isResourceAvailable`'s catch block and logged as a generic "failed to get alive compute nodes from starMgr" warning, and the warehouse is reported as unavailable — even when every other compute node in the group is healthy and alive. Because the exception aborts the whole stream, a single unresolvable worker id takes down availability for the entire warehouse, not just that one node.

We hit this in production: a follower FE that had just restarted was rebuilding its worker→node mapping (`StarOSAgent#getOrUpdateNodeIdByWorkerInfo`, which resolves workers by `host:starletPort`/heartbeat port and caches the result in-memory, not persisted/replicated) while a CN rolling restart was concurrently changing starlet ports/node ids. That produced one worker id that didn't resolve to a `ComputeNode`, and every query and background task on that FE started failing with `Warehouse default_warehouse is not available` until the FE was restarted again.

## What I'm doing:

Filter out `null` nodes before checking `isAlive`, so an unresolvable worker id is simply skipped instead of throwing and aborting the entire computation:

```java
List<ComputeNode> nodes = computeNodeIds.stream()
        .map(id -> systemInfoService.getBackendOrComputeNode(id))
        .filter(Objects::nonNull)
        .filter(ComputeNode::isAlive).collect(Collectors.toList());
```

Added `testProviderGetAliveComputeNodesSkipsMissingNodeIds`, which mocks `getWorkersByWorkerGroup` to return one resolvable and one unresolvable worker id, and asserts the resolvable/alive node is still returned. This test throws an NPE without the fix and passes with it.

The same class of bug lives in the query-scheduling path, so this PR also guards `DefaultSharedDataWorkerProvider.Factory.captureAvailableWorkers`: it fed `ImmutableMap.Builder.put(id, getBackendOrComputeNode(id))` directly (Guava's `ImmutableMap` rejects null values → NPE on an unresolvable id). Unresolved ids are now skipped when building the snapshot, and — so backup routing can still substitute a healthy buddy for an unresolved *primary* — the full warehouse id list is tracked separately (`allComputeNodeIds`) rather than derived from the resolved-node map. See `DefaultSharedDataWorkerProviderTest` for the added regression coverage (skip-missing snapshot + backup-routing through an unresolved primary).

## Provenance — long-standing latent bug, escalated (not introduced) by the CNResourceProvider refactor:

This is not a regression from a recent change; the crashing pattern predates the current code layout. Verified against the tree just before the CNResourceProvider refactor (parent of #59358):

- The identical unguarded `map(getBackendOrComputeNode).filter(ComputeNode::isAlive)` already lived in `WarehouseManager.getAliveComputeNodes(long, long)`. #59358 relocated this method verbatim into `WarehouseComputeResourceProvider.getAliveComputeNodes`; #59335 only changed a parameter type (`warehouseId` → `ComputeResource`). The null handling was never touched.
- `WarehouseManager.getAllComputeNodeIds` already resolved ids through `StarOSAgent.getWorkersByWorkerGroup` back then, so the "id is present in the worker group but unresolvable via `getBackendOrComputeNode`" window is equally old — it stems from the worker→node cache being a separate system of record from `SystemInfoService`.
- The sibling site fixed here, `DefaultSharedDataWorkerProvider.Factory.captureAvailableWorkers`, also predates the refactor with the same latent defect (`ImmutableMap.Builder.put(id, getBackendOrComputeNode(id))` throws on a null value).

What the refactor *did* change is severity. #59358 introduced `ComputeResourceProvider#isResourceAvailable`, which runs `getAliveComputeNodes` on the resource-acquisition path of every query/load and maps any thrown exception to `Warehouse ... is not available`. That converts a latent, potentially localized null into a self-masking, whole-warehouse outage (the production failure above). This PR therefore hardens a long-standing latent NPE across both consumers, rather than reverting a specific regression.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
