### PR TITLE
[Enhancement] Give a cross-published rowset a per-row ownership selection

### DIFF
--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -187,6 +187,7 @@ set(STORAGE_FILES
     lake/compaction_policy.cpp
     lake/compaction_scheduler.cpp
     lake/compaction_task.cpp
+    lake/cross_publish_context.cpp
     lake/compaction_task_context.cpp
     lake/combined_txn_log_writer.cpp
     lake/tablet_parallel_compaction_manager.cpp

--- a/be/src/storage/lake/cross_publish_context.cpp
+++ b/be/src/storage/lake/cross_publish_context.cpp
@@ -1,0 +1,122 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/cross_publish_context.h"
+
+#include "column/binary_column.h"
+#include "column/chunk.h"
+#include "runtime/current_thread.h"
+#include "storage/chunk_helper.h"
+#include "storage_primitive/primary_key_encoder.h"
+
+namespace starrocks::lake {
+
+namespace {
+
+bool carries_shared_segment(const RowsetMetadataPB& rowset) {
+    for (const auto& segment_meta : rowset.segment_metas()) {
+        if (segment_meta.shared()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace
+
+StatusOr<CrossPublishRowSelectorPtr> CrossPublishRowSelector::create_if_needed(const TabletMetadataPB& metadata,
+                                                                               const TabletSchemaCSPtr& tablet_schema,
+                                                                               const RowsetMetadataPB& rowset) {
+    if (tablet_schema == nullptr || tablet_schema->keys_type() != KeysType::PRIMARY_KEYS) {
+        return nullptr;
+    }
+    if (!metadata.has_range() || !carries_shared_segment(rowset)) {
+        return nullptr;
+    }
+    ASSIGN_OR_RETURN(auto encoding_type, tablet_schema->primary_key_encoding_type_or_error());
+    // select_encoded compares encoded keys bytewise against the encoded bounds, which only follows
+    // key order under the order-preserving big-endian encoding. Range distribution requires V2, so
+    // anything else here is a tablet that cannot be split in the first place.
+    if (encoding_type != PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2) {
+        return nullptr;
+    }
+
+    auto selector = std::make_unique<CrossPublishRowSelector>();
+    ASSIGN_OR_RETURN(selector->_seek_range,
+                     TabletRangeHelper::create_sst_seek_range_from(metadata.range(), tablet_schema));
+    // Both bounds empty is (-inf, +inf): this tablet owns everything, so there is nothing to select
+    // and the caller should keep paying nothing. Mirrors SeekRange::all_range()'s short-circuit in
+    // SegmentIterator::_apply_tablet_range.
+    if (selector->_seek_range.seek_key.empty() && selector->_seek_range.stop_key.empty()) {
+        return nullptr;
+    }
+
+    // The range is in primary-key space whatever the segments are ordered by, so the schema is the
+    // key columns in key order -- the same one RowsetUpdateState::prepare builds for its upserts.
+    std::vector<ColumnId> pk_columns;
+    pk_columns.reserve(tablet_schema->num_key_columns());
+    for (size_t i = 0; i < tablet_schema->num_key_columns(); i++) {
+        pk_columns.push_back(static_cast<ColumnId>(i));
+    }
+    selector->_pkey_schema = ChunkHelper::convert_schema(tablet_schema, pk_columns);
+    selector->_encoding_type = encoding_type;
+    return selector;
+}
+
+StatusOr<Filter> CrossPublishRowSelector::select(const Chunk& chunk) const {
+    const size_t num_rows = chunk.num_rows();
+    if (num_rows == 0) {
+        return Filter{};
+    }
+    // Local, not a member: see the note on the declaration -- a rowset's segments load concurrently
+    // and share this selector.
+    MutableColumnPtr encoded_keys;
+    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(_pkey_schema, &encoded_keys, _encoding_type));
+    // A wide or long primary key can make this allocation fail. Publish must see that as a Status it
+    // can retry, not as an exception unwinding out of the worker -- same reason
+    // SegmentPKIterator::encoded_pk_column wraps its encode.
+    TRY_CATCH_BAD_ALLOC(
+            PrimaryKeyEncoder::encode(_pkey_schema, chunk, 0, num_rows, encoded_keys.get(), _encoding_type));
+    return select_encoded(*encoded_keys);
+}
+
+StatusOr<Filter> CrossPublishRowSelector::select_encoded(const Column& encoded_keys) const {
+    const size_t num_rows = encoded_keys.size();
+    if (num_rows == 0) {
+        return Filter{};
+    }
+    RETURN_ERROR_IF_FALSE(encoded_keys.is_binary(), "V2-encoded primary key must be binary");
+    const auto& binary_keys = down_cast<const BinaryColumn&>(encoded_keys);
+
+    const Slice seek_key(_seek_range.seek_key);
+    const Slice stop_key(_seek_range.stop_key);
+    const bool has_seek = !_seek_range.seek_key.empty();
+    const bool has_stop = !_seek_range.stop_key.empty();
+
+    Filter selection;
+    TRY_CATCH_BAD_ALLOC(selection.assign(num_rows, 1));
+    for (size_t i = 0; i < num_rows; ++i) {
+        const Slice key = binary_keys.get_slice(i);
+        // create_sst_seek_range_from folds the bounds' inclusiveness into the encoding, so the
+        // half-open [seek_key, stop_key) test below is the whole of it.
+        if (has_seek && key.compare(seek_key) < 0) {
+            selection[i] = 0;
+        } else if (has_stop && key.compare(stop_key) >= 0) {
+            selection[i] = 0;
+        }
+    }
+    return selection;
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/cross_publish_context.h
+++ b/be/src/storage/lake/cross_publish_context.h
@@ -1,0 +1,96 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+#include "column/vectorized_fwd.h"
+#include "common/statusor.h"
+#include "gen_cpp/lake_types.pb.h"
+#include "storage/lake/tablet_range_helper.h"
+#include "storage/olap_common.h"
+#include "storage/tablet_schema.h"
+#include "storage_primitive/primary_key_encoding_types.h"
+
+namespace starrocks::lake {
+
+// Decides, row by row, which rows of a cross-published rowset this tablet actually owns.
+//
+// A SPLIT cross publish hands every child the parent's whole op_write payload and leaves each side to
+// work out which rows are its own. Today the tablet range answers that on the read path:
+// SegmentIterator::_apply_tablet_range turns it into a rowid interval, and _lookup_ordinal resolves
+// the bounds exactly -- the short key index only brackets the search, which then binary-searches the
+// actual rows and compares per column. So a child reading a shared segment sees precisely its own
+// rows, and this selector has nothing to add.
+//
+// That holds only while the range and the physical order live in the same key space. A primary-key
+// tablet ordered by a separate sort key has its rows scattered through the segment, no rowid interval
+// describes them, and Rowset::set_segment_tablet_range withholds the range outright -- at which point
+// the child reads every row and nothing narrows it.
+//
+// No such tablet exists yet: CreateTableAnalyzer requires a range-distributed primary-key table to
+// declare ORDER BY equal to its key columns, and OPTIMIZE -- the only clause that rewrites a sort key
+// -- is rejected on range-distributed tables. This is the row-level answer that relaxation needs,
+// built ahead of it rather than a fix for a live defect. #77653 stages the rest.
+//
+// What the shape of the answer buys, and why it is a mask rather than a filtered chunk: the chunk
+// keeps its rows and their positions, so SegmentPKChunkRef's "chunk[i] is physical rowid
+// physical_rowid_offset + i" still holds for every i, owned or not. A consumer that must name a row
+// in the segment file -- a delvec entry, an index location -- reads it straight off the index it is
+// already looping over. Compacting the chunk instead would renumber the survivors and every rowid
+// derived from them would be wrong.
+//
+// Consuming the selection (index lookup, upsert, delvec, prebuilt SSTs, condition/partial update) is
+// deliberately NOT part of this: it lands with the stages that own those paths.
+class CrossPublishRowSelector {
+public:
+    // Builds a selector iff |rowset| is actually being cross-published to a ranged primary-key
+    // tablet, i.e. it carries at least one segment the split marked `shared` and |metadata| has a
+    // range. Returns nullptr otherwise, which is the ordinary publish path and must stay free: a
+    // rowset written by this tablet's own sink is in range by construction.
+    //
+    // Derived from committed metadata rather than passed down from PublishTabletInfo on purpose --
+    // the same reasoning the design applies to the split's own cutover. A retry, a leader failover
+    // or a replayed publish reaches the same verdict without carrying a bit for it.
+    static StatusOr<std::unique_ptr<CrossPublishRowSelector>> create_if_needed(const TabletMetadataPB& metadata,
+                                                                               const TabletSchemaCSPtr& tablet_schema,
+                                                                               const RowsetMetadataPB& rowset);
+
+    // One byte per row of |chunk|: 1 if this tablet owns the row, 0 if a sibling does. Empty for an
+    // empty chunk. |chunk| holds the primary-key columns, in key order.
+    //
+    // const, and it holds no scratch of its own: RowsetUpdateState::load_segment is documented
+    // thread-safe across segment ids and every one of a rowset's iterators shares this selector, so
+    // an encode buffer kept as a member would be written by several segments at once. Allocating it
+    // per call makes sharing safe by construction rather than by discipline; the encoded bytes were
+    // allocated per chunk either way, so only the column header is re-made.
+    StatusOr<Filter> select(const Chunk& chunk) const;
+
+    // Same verdict from keys that are already V2-encoded -- the publish path encodes the primary key
+    // for its index lookup anyway, so a consumer that has that column should hand it over rather
+    // than pay a second encode.
+    StatusOr<Filter> select_encoded(const Column& encoded_keys) const;
+
+private:
+    // Every member is set once by create_if_needed and read-only afterwards, which is what lets one
+    // selector serve a rowset's segments concurrently.
+    SstSeekRange _seek_range;
+    Schema _pkey_schema;
+    PrimaryKeyEncodingType _encoding_type = PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2;
+};
+
+using CrossPublishRowSelectorPtr = std::unique_ptr<CrossPublishRowSelector>;
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -235,6 +235,8 @@ Status RowsetUpdateState::_do_load_upserts(uint32_t segment_id, const RowsetUpda
     ASSIGN_OR_RETURN(auto pk_encoding_type, params.tablet_schema->primary_key_encoding_type_or_error());
     auto& iter = _segment_iters[segment_id];
     SegmentPKIteratorPtr result = std::make_unique<SegmentPKIterator>();
+    // Before init(), which eagerly loads the first chunk: the selection is built inside _load().
+    result->set_row_selector(_row_selector.get());
     RETURN_IF_ERROR(result->init(iter, _pkey_schema, should_enable_lazy_load(params), pk_encoding_type));
     _upserts[segment_id] = std::move(result);
     _memory_usage += _upserts[segment_id]->memory_usage();
@@ -874,6 +876,11 @@ Status RowsetUpdateState::prepare(const RowsetUpdateStateParams& params) {
             pk_columns.push_back((uint32_t)i);
         }
         _pkey_schema = ChunkHelper::convert_schema(params.tablet_schema, pk_columns);
+        // Only a SPLIT child's cross publish gets one; it is nullptr on every ordinary publish and
+        // costs nothing there. Built once per rowset and reused by every segment's iterator, which
+        // is what lets it hold its encode buffer across chunks.
+        ASSIGN_OR_RETURN(_row_selector, CrossPublishRowSelector::create_if_needed(
+                                                *params.metadata, params.tablet_schema, params.op_write.rowset()));
         ASSIGN_OR_RETURN(_segment_iters, _rowset_ptr->get_each_segment_iterator(_pkey_schema, false, &_stats));
     }
     if (_column_to_expr_value.empty() && params.op_write.has_txn_meta()) {

--- a/be/src/storage/lake/rowset_update_state.h
+++ b/be/src/storage/lake/rowset_update_state.h
@@ -19,6 +19,7 @@
 #include <unordered_map>
 
 #include "gutil/macros.h"
+#include "storage/lake/cross_publish_context.h"
 #include "storage/lake/rowset.h"
 #include "storage/lake/segment_pk_iterator.h"
 #include "storage/lake/tablet.h"
@@ -28,6 +29,8 @@
 #include "storage_primitive/primary_key_encoding_types.h"
 
 namespace starrocks::lake {
+
+using CrossPublishRowSelectorPtr = std::unique_ptr<CrossPublishRowSelector>;
 
 class RssidFileInfoContainer;
 
@@ -183,6 +186,10 @@ private:
     void _reset();
 
     // one for each segment file
+    // Built once per rowset by prepare(); nullptr unless this is a SPLIT child cross-publishing a
+    // rowset whose segments the split marked shared. Outlives every _upserts iterator, which only
+    // borrows it.
+    CrossPublishRowSelectorPtr _row_selector;
     std::vector<SegmentPKIteratorPtr> _upserts;
     // one for each delete file
     MutableColumns _deletes;

--- a/be/src/storage/lake/segment_pk_iterator.cpp
+++ b/be/src/storage/lake/segment_pk_iterator.cpp
@@ -18,6 +18,7 @@
 #include "column/chunk_factory.h"
 #include "common/config_primary_key_fwd.h"
 #include "runtime/current_thread.h"
+#include "storage/lake/cross_publish_context.h"
 #include "storage/lake/pk_index_utils.h"
 #include "storage_primitive/primary_key_encoder.h"
 
@@ -67,7 +68,17 @@ Status SegmentPKIterator::_load() {
         ASSIGN_OR_RETURN(_standalone_pk_column, encoded_pk_column(_pk_column_chunk.get()));
     }
     if (_pk_column_chunk->num_rows() == 0) {
+        _owned.clear();
         return Status::OK();
+    }
+    // Decide ownership here rather than in current(): the chunk is complete at this point and this
+    // function already returns Status, so a selection that cannot be built fails the load instead of
+    // handing the caller a chunk it would process as "own every row". current() runs after the
+    // consumer loop has already committed the previous chunk, so an error raised there is too late --
+    // LakePrimaryIndex::parallel_upsert checks the iterator status only after flush_memtable() has
+    // durably written the sstable.
+    if (_row_selector != nullptr) {
+        ASSIGN_OR_RETURN(_owned, _row_selector->select(*_pk_column_chunk));
     }
     _current_rows += _pk_column_chunk->num_rows();
     _begin_rowid_offsets.push_back(_current_rows);
@@ -122,6 +133,7 @@ SegmentPKChunkRef SegmentPKIterator::current() {
     SegmentPKChunkRef ref;
     const size_t logical_rowid_offset = _begin_rowid_offsets[_current_pk_column_idx];
     ref.physical_rowid_offset = _physical_rowid_base.value_or(0) + static_cast<uint32_t>(logical_rowid_offset);
+    ref.owned = std::move(_owned);
     ref.chunk = std::move(_pk_column_chunk);
     return ref;
 }

--- a/be/src/storage/lake/segment_pk_iterator.h
+++ b/be/src/storage/lake/segment_pk_iterator.h
@@ -21,10 +21,13 @@
 #include "column/vectorized_fwd.h"
 #include "common/status.h"
 #include "common/statusor.h"
+#include "storage/olap_common.h"
 #include "storage_primitive/chunk_iterator.h"
 #include "storage_primitive/primary_key_encoding_types.h"
 
 namespace starrocks::lake {
+
+class CrossPublishRowSelector;
 
 // One chunk emitted by SegmentPKIterator::current(), carrying chunk[0]'s
 // position in the SOURCE SEGMENT FILE:
@@ -41,6 +44,14 @@ namespace starrocks::lake {
 struct SegmentPKChunkRef {
     ChunkPtr chunk;
     uint32_t physical_rowid_offset = 0;
+    // Per chunk row: 1 if this tablet owns the row, 0 if a sibling does. Empty means "every row",
+    // which is every publish except a SPLIT child's cross publish -- see CrossPublishRowSelector.
+    //
+    // A mask, never a compaction: the chunk keeps its rows and their positions, so the physical
+    // rowid of row i stays physical_rowid_offset + i whether it is owned or not. A consumer that
+    // needs the row's identity in the segment file (a delvec entry, an index location) can read it
+    // straight off the index it is already looping over.
+    Filter owned;
 };
 
 class SegmentPKIterator {
@@ -52,6 +63,14 @@ public:
     // This avoids memory spikes when many iterators are created upfront.
     Status init(const ChunkIteratorPtr& iter, const Schema& pkey_schema, bool lazy_load,
                 PrimaryKeyEncodingType encoding_type, bool defer_data_load = false);
+
+    // Marks every emitted chunk with the rows this tablet owns (SegmentPKChunkRef::owned). Only a
+    // SPLIT child's cross publish passes one; without it every row is owned and nothing is paid.
+    //
+    // Must be called BEFORE init(): init() eagerly loads the first chunk unless defer_data_load is
+    // set, and the selection is built inside _load(), so a selector installed afterwards would miss
+    // that chunk.
+    void set_row_selector(const CrossPublishRowSelector* selector) { _row_selector = selector; }
     void next();
     bool done();
     Status status();
@@ -59,6 +78,10 @@ public:
     // Returns the most-recently-loaded chunk plus chunk[0]'s physical position
     // in the source segment (see SegmentPKChunkRef doc). The returned chunk
     // is moved out — done() will report empty until the next _load().
+    //
+    // Infallible: the ownership selection is built by _load(), so a selection that cannot be built
+    // fails the load and this chunk is never handed out at all. Deciding it here instead would be too
+    // late -- a consumer commits each chunk inside the loop and checks status() only at the end.
     SegmentPKChunkRef current();
 
     // The segment-wide physical rowid base: the first physical rowid the
@@ -81,6 +104,12 @@ public:
 
 private:
     Status _load();
+
+    // Not owned: lives in the RowsetUpdateState that outlives this iterator.
+    const CrossPublishRowSelector* _row_selector = nullptr;
+    // Ownership of the chunk _load() just produced, moved out by current(). Empty when no selector
+    // is set, which every consumer reads as "own every row".
+    Filter _owned;
 
     // Iterator of this segment file.
     ChunkIteratorPtr _iter;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -306,6 +306,7 @@ SET(DW_TEST_FILES
     ./storage/lake/spill_mem_table_sink_test.cpp
     ./storage/lake/starlet_location_provider_test.cpp
     ./storage/lake/tablet_manager_test.cpp
+    ./storage/lake/cross_publish_context_test.cpp
     ./storage/lake/tablet_range_helper_test.cpp
     ./storage/lake/sst_seek_range_test.cpp
     ./storage/lake/tablet_parallel_compaction_manager_test.cpp

--- a/be/test/storage/lake/cross_publish_context_test.cpp
+++ b/be/test/storage/lake/cross_publish_context_test.cpp
@@ -1,0 +1,187 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/cross_publish_context.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <utility>
+#include <vector>
+
+#include "base/testutil/assert.h"
+#include "column/chunk.h"
+#include "column/chunk_factory.h"
+#include "storage/chunk_helper.h"
+#include "storage/datum_variant.h"
+#include "storage/tablet_range.h"
+#include "storage/tablet_schema.h"
+#include "storage/types.h"
+#include "storage/variant_tuple.h"
+#include "types/type_descriptor.h"
+
+namespace starrocks::lake {
+
+namespace {
+
+TuplePB make_int_tuple_pb(int32_t value) {
+    VariantTuple tuple;
+    tuple.append(DatumVariant(get_type_info(LogicalType::TYPE_INT), Datum(value)));
+    TuplePB tuple_pb;
+    tuple.to_proto(&tuple_pb);
+    return tuple_pb;
+}
+
+// c0 (key), c1 (key), c2 (value); V2 encoding, which is what range distribution requires.
+TabletSchemaPB make_pk_schema_pb() {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(PRIMARY_KEYS);
+    schema_pb.set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
+    const std::array<const char*, 3> names = {"c0", "c1", "c2"};
+    for (int i = 0; i < 3; ++i) {
+        auto* column = schema_pb.add_column();
+        column->set_name(names[i]);
+        column->set_type("INT");
+        column->set_is_key(i < 2);
+        column->set_is_nullable(false);
+    }
+    return schema_pb;
+}
+
+// [ (2,0), (4,0) )
+void set_range(TabletMetadataPB* metadata) {
+    auto* range = metadata->mutable_range();
+    range->mutable_lower_bound()->CopyFrom(make_int_tuple_pb(2));
+    *range->mutable_lower_bound()->add_values() = make_int_tuple_pb(0).values(0);
+    range->set_lower_bound_included(true);
+    range->mutable_upper_bound()->CopyFrom(make_int_tuple_pb(4));
+    *range->mutable_upper_bound()->add_values() = make_int_tuple_pb(0).values(0);
+    range->set_upper_bound_included(false);
+}
+
+RowsetMetadataPB make_rowset(bool shared) {
+    RowsetMetadataPB rowset;
+    auto* segment_meta = rowset.add_segment_metas();
+    segment_meta->set_filename("seg.dat");
+    segment_meta->set_num_rows(4);
+    segment_meta->set_shared(shared);
+    return rowset;
+}
+
+ChunkUniquePtr make_pk_chunk(const TabletSchemaCSPtr& tablet_schema,
+                             const std::vector<std::pair<int32_t, int32_t>>& keys) {
+    std::vector<ColumnId> pk_columns = {0, 1};
+    auto schema = ChunkHelper::convert_schema(tablet_schema, pk_columns);
+    auto chunk = ChunkFactory::new_chunk(schema, keys.size());
+    for (const auto& [c0, c1] : keys) {
+        chunk->get_column_raw_ptr_by_index(0)->append_datum(Datum(c0));
+        chunk->get_column_raw_ptr_by_index(1)->append_datum(Datum(c1));
+    }
+    return chunk;
+}
+
+} // namespace
+
+// An ordinary publish must pay nothing: a rowset this tablet's own sink produced carries no shared
+// segment, and every row in it is in range by construction.
+TEST(CrossPublishRowSelectorTest, test_no_selector_without_a_shared_segment) {
+    auto schema_pb = make_pk_schema_pb();
+    auto tablet_schema = TabletSchema::create(schema_pb);
+    TabletMetadataPB metadata;
+    set_range(&metadata);
+
+    ASSIGN_OR_ABORT(auto selector,
+                    CrossPublishRowSelector::create_if_needed(metadata, tablet_schema, make_rowset(false)));
+    EXPECT_EQ(nullptr, selector);
+}
+
+// A tablet with no range is not range-distributed, so there is nothing to select against.
+TEST(CrossPublishRowSelectorTest, test_no_selector_without_a_range) {
+    auto schema_pb = make_pk_schema_pb();
+    auto tablet_schema = TabletSchema::create(schema_pb);
+    TabletMetadataPB metadata; // no range
+
+    ASSIGN_OR_ABORT(auto selector,
+                    CrossPublishRowSelector::create_if_needed(metadata, tablet_schema, make_rowset(true)));
+    EXPECT_EQ(nullptr, selector);
+}
+
+// Only a primary-key tablet routes by a key space separate from its physical order.
+TEST(CrossPublishRowSelectorTest, test_no_selector_for_a_non_primary_key_tablet) {
+    auto schema_pb = make_pk_schema_pb();
+    schema_pb.set_keys_type(DUP_KEYS);
+    auto tablet_schema = TabletSchema::create(schema_pb);
+    TabletMetadataPB metadata;
+    set_range(&metadata);
+
+    ASSIGN_OR_ABORT(auto selector,
+                    CrossPublishRowSelector::create_if_needed(metadata, tablet_schema, make_rowset(true)));
+    EXPECT_EQ(nullptr, selector);
+}
+
+// The verdict itself, and the property the whole stage exists for: the selection is a MASK, so a
+// row's index in the chunk still names its physical rowid in the source segment. Compacting the
+// chunk instead would renumber rows 2 and 3 to 0 and 1 and every delvec entry derived from them
+// would name the wrong row.
+TEST(CrossPublishRowSelectorTest, test_selection_marks_owned_rows_without_moving_them) {
+    auto schema_pb = make_pk_schema_pb();
+    auto tablet_schema = TabletSchema::create(schema_pb);
+    TabletMetadataPB metadata;
+    set_range(&metadata);
+
+    ASSIGN_OR_ABORT(auto selector,
+                    CrossPublishRowSelector::create_if_needed(metadata, tablet_schema, make_rowset(true)));
+    ASSERT_NE(nullptr, selector);
+
+    // (1,9) below the range; (2,0) the inclusive lower bound; (3,5) inside; (4,0) the exclusive
+    // upper bound, so a sibling's.
+    auto chunk = make_pk_chunk(tablet_schema, {{1, 9}, {2, 0}, {3, 5}, {4, 0}});
+    ASSIGN_OR_ABORT(auto selection, selector->select(*chunk));
+    ASSERT_EQ(4, selection.size()) << "the mask must be as long as the chunk, not as its owned rows";
+    EXPECT_EQ(0, selection[0]);
+    EXPECT_EQ(1, selection[1]);
+    EXPECT_EQ(1, selection[2]);
+    EXPECT_EQ(0, selection[3]);
+    EXPECT_EQ(4, chunk->num_rows()) << "the chunk itself must be untouched";
+}
+
+// One selector serves every segment and every chunk of a rowset, so consecutive calls must be
+// independent of each other. They are by construction now -- select() is const and allocates its
+// encode column locally -- and this pins that: a stale buffer would leak the first chunk's keys into
+// the second chunk's comparison.
+TEST(CrossPublishRowSelectorTest, test_selection_is_not_polluted_by_the_previous_chunk) {
+    auto schema_pb = make_pk_schema_pb();
+    auto tablet_schema = TabletSchema::create(schema_pb);
+    TabletMetadataPB metadata;
+    set_range(&metadata);
+
+    ASSIGN_OR_ABORT(auto selector,
+                    CrossPublishRowSelector::create_if_needed(metadata, tablet_schema, make_rowset(true)));
+    ASSERT_NE(nullptr, selector);
+
+    auto first = make_pk_chunk(tablet_schema, {{1, 9}, {2, 0}, {3, 5}, {4, 0}});
+    ASSIGN_OR_ABORT(auto ignored, selector->select(*first));
+
+    auto second = make_pk_chunk(tablet_schema, {{0, 0}, {2, 5}});
+    ASSIGN_OR_ABORT(auto selection, selector->select(*second));
+    ASSERT_EQ(2, selection.size());
+    EXPECT_EQ(0, selection[0]);
+    EXPECT_EQ(1, selection[1]);
+
+    auto empty = make_pk_chunk(tablet_schema, {});
+    ASSIGN_OR_ABORT(auto empty_selection, selector->select(*empty));
+    EXPECT_TRUE(empty_selection.empty());
+}
+
+} // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

Part of #77653 (stage CP-3). A SPLIT cross publish hands every child the parent's whole `op_write` payload and leaves each side to work out which rows are its own. The only thing that narrows it today is the rowid interval `SegmentIterator::_apply_tablet_range` derives from the tablet range, and that is not a row-level answer for two independent reasons:

- it resolves through the **short key index**, which addresses blocks rather than rows, so the interval it returns is inclusive at both edges — the child still reads a block's worth of a sibling's rows on either side of its range;
- it is only defined at all while the range and the physical order share a key space. A primary-key tablet ordered by a separate sort key has its rows scattered through the whole segment, so `Rowset::set_segment_tablet_range` withholds the range outright (#77634) and the child reads every row.

Acting on a sibling's row is not harmless. A condition update compares it, decides the incoming row loses, and writes that rowid into *this* child's delvec; `merge_delvecs` unions the children's delvecs on the parent view, so a non-owner's verdict erases a row its owner kept.

## What I'm doing:

`CrossPublishRowSelector` answers ownership per row, and the answer is a **mask, not a filtered chunk**. The chunk keeps its rows and their positions, so `SegmentPKChunkRef`'s contract — *chunk[i] is physical rowid `physical_rowid_offset + i`* — still holds for owned and unowned rows alike. That is the property every later stage needs: a delvec entry or an index location has to name a row in the segment **file**, not a position in a compacted stream. Compacting instead would renumber the survivors and every rowid derived from them would be wrong.

The selector is built **once per rowset from committed metadata** — this tablet's range plus the `shared` mark the split stamped on the segments — rather than from `PublishTabletInfo`. Same reasoning the design applies to the split's own cutover: a retry, a leader failover or a replayed publish reaches the same verdict without carrying a bit for it. An ordinary publish carries no shared segment, gets no selector, and pays nothing.

Consuming the selection is deliberately **not** in this PR: index lookup, upsert, delvec and the prebuilt SSTs are CP-4; condition update and partial update are CP-5. This stage produces the selection and pins its contract.

Fixes #77653

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

The selection is computed and attached; nothing reads it yet.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

Range distribution / tablet reshard is main-only, so no backport is needed.

---

**Draft: carries one dependency that is not merged yet.**

Commits in order: #77744 → this PR's change. **Review the last commit only.** #77744 touches `rowset_update_state.cpp`, which this builds on, so it is carried rather than rebased around. #77511 was the other dependency and has since merged, so this branch was rebuilt on a `main` that already contains it. Once #77744 lands this branch is rebased onto `main` and promoted.

One overlap worth flagging for whoever reviews both: #77871 (OB-3) carries a `PrimaryKeyRangeFilter` in `tablet_range_helper` that does the same encode-and-compare against the same bounds, for the UNSHARE compaction's row filter. It is not shared here because it depends on `TabletRangeHelper::range_key_idxes` from #77654, which this stage must not depend on — the CP group is meant to stand on its own with no ORDER BY involved. Whichever of the two lands second should drop its copy and use the other's.
