### PR TITLE
[BugFix] Lower-case GIN index property keys so they reach the BE (backport #77818)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/InvertedIndexUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/InvertedIndexUtil.java
@@ -26,8 +26,10 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.IndexDef.IndexType;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 import static com.starrocks.common.InvertedIndexParams.CommonIndexParamKey.IMP_LIB;
@@ -86,6 +88,8 @@ public class InvertedIndexUtil {
             throw new SemanticException("The inverted index is disabled, enable it by setting FE config `enable_experimental_gin` to true");
         }
 
+        lowerCasePropertyKeys(properties);
+
         String impLibKey = IMP_LIB.name().toLowerCase(Locale.ROOT);
         if (properties.containsKey(impLibKey)) {
             String impValue = properties.get(impLibKey);
@@ -105,6 +109,23 @@ public class InvertedIndexUtil {
 
         // add default properties
         addDefaultProperties(properties);
+    }
+
+    // BE finds the GIN properties by exact lower-case key, so any other spelling must be folded before storing.
+    private static void lowerCasePropertyKeys(Map<String, String> properties) {
+        if (properties.keySet().stream().allMatch(key -> key.equals(key.toLowerCase(Locale.ROOT)))) {
+            return;
+        }
+        Map<String, String> lowerCased = new LinkedHashMap<>();
+        for (Entry<String, String> entry : properties.entrySet()) {
+            String key = entry.getKey().toLowerCase(Locale.ROOT);
+            if (lowerCased.containsKey(key)) {
+                throw new SemanticException("Duplicated index property for GIN after lower-casing the key: " + key);
+            }
+            lowerCased.put(key, entry.getValue());
+        }
+        properties.clear();
+        properties.putAll(lowerCased);
     }
 
     private static void addDefaultProperties(Map<String, String> properties) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/GINIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/GINIndexTest.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
+import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.InvertedIndexParams.IndexParamsKey;
 import com.starrocks.common.InvertedIndexParams.InvertedIndexImpType;
 import com.starrocks.common.InvertedIndexParams.SearchParamsKey;
@@ -42,6 +43,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import static com.starrocks.common.InvertedIndexParams.CommonIndexParamKey.IMP_LIB;
 
@@ -127,6 +129,58 @@ public class GINIndexTest extends PlanTestBase {
                 SemanticException.class,
                 () -> InvertedIndexUtil.checkInvertedIndexValid(c2, null, KeysType.DUP_KEYS),
                 "The inverted index does not support shared data mode");
+    }
+
+    @Test
+    public void testCheckInvertedIndexLowerCasesPropertyKeys() {
+        Column c = new Column("f2", Type.STRING, true);
+
+        Map<String, String> upperCaseKey = new HashMap<>();
+        upperCaseKey.put(IMP_LIB.name().toUpperCase(Locale.ROOT), InvertedIndexImpType.CLUCENE.name().toLowerCase(Locale.ROOT));
+        Assertions.assertDoesNotThrow(() -> InvertedIndexUtil.checkInvertedIndexValid(c, upperCaseKey, KeysType.DUP_KEYS));
+        Assertions.assertEquals(InvertedIndexImpType.CLUCENE.name().toLowerCase(Locale.ROOT),
+                upperCaseKey.get(IMP_LIB.name().toLowerCase(Locale.ROOT)));
+        Assertions.assertFalse(upperCaseKey.containsKey(IMP_LIB.name().toUpperCase(Locale.ROOT)));
+
+        // Values stay untouched: only keys are case-folded.
+        Map<String, String> mixedCaseKeys = new HashMap<>();
+        mixedCaseKeys.put("Imp_Lib", InvertedIndexImpType.CLUCENE.name().toUpperCase(Locale.ROOT));
+        mixedCaseKeys.put(InvertedIndexUtil.INVERTED_INDEX_PARSER_KEY.toUpperCase(Locale.ROOT),
+                InvertedIndexUtil.INVERTED_INDEX_PARSER_ENGLISH);
+        Assertions.assertDoesNotThrow(() -> InvertedIndexUtil.checkInvertedIndexValid(c, mixedCaseKeys, KeysType.DUP_KEYS));
+        Assertions.assertEquals(InvertedIndexImpType.CLUCENE.name().toUpperCase(Locale.ROOT),
+                mixedCaseKeys.get(IMP_LIB.name().toLowerCase(Locale.ROOT)));
+        Assertions.assertEquals(InvertedIndexUtil.INVERTED_INDEX_PARSER_ENGLISH,
+                mixedCaseKeys.get(InvertedIndexUtil.INVERTED_INDEX_PARSER_KEY));
+        Assertions.assertTrue(mixedCaseKeys.keySet().stream().allMatch(key -> key.equals(key.toLowerCase(Locale.ROOT))));
+
+        Map<String, String> collidingKeys = new HashMap<>();
+        collidingKeys.put(IMP_LIB.name().toUpperCase(Locale.ROOT), InvertedIndexImpType.CLUCENE.name().toLowerCase(Locale.ROOT));
+        collidingKeys.put(IMP_LIB.name().toLowerCase(Locale.ROOT), InvertedIndexImpType.CLUCENE.name().toUpperCase(Locale.ROOT));
+        ExceptionChecker.expectThrowsWithMsg(SemanticException.class,
+                "Duplicated index property for GIN after lower-casing the key: " + IMP_LIB.name().toLowerCase(Locale.ROOT),
+                () -> InvertedIndexUtil.checkInvertedIndexValid(c, collidingKeys, KeysType.DUP_KEYS));
+    }
+
+    @Test
+    public void testUpperCaseImpLibReachesBeAsLowerCaseKey() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE `t_upper_case_imp_lib` (\n" +
+                "  `k` int NOT NULL COMMENT \"\",\n" +
+                "  `v` varchar(50) NOT NULL COMMENT \"\",\n" +
+                "  INDEX gin_v (`v`) USING GIN(\"IMP_LIB\" = \"clucene\", \"PARSER\" = \"english\")\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k`)\n" +
+                "DISTRIBUTED BY HASH(`k`) BUCKETS 1\n" +
+                "PROPERTIES (\"replication_num\" = \"1\", \"replicated_storage\" = \"false\");");
+
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable("test", "t_upper_case_imp_lib");
+        TOlapTableIndex olapIndex = table.getIndexes().get(0).toThrift();
+        // BE fails the load with "Can not get inverted imp type" unless the key lands here exactly as imp_lib.
+        Assertions.assertEquals("clucene", olapIndex.getCommon_properties().get(IMP_LIB.name().toLowerCase(Locale.ROOT)));
+        Assertions.assertEquals(InvertedIndexUtil.INVERTED_INDEX_PARSER_ENGLISH,
+                olapIndex.getIndex_properties().get(InvertedIndexUtil.INVERTED_INDEX_PARSER_KEY));
+        starRocksAssert.dropTable("t_upper_case_imp_lib");
     }
 
     @Test


### PR DESCRIPTION
Backport of #77818 to `branch-3.5`.

## Why this is not a cherry-pick

The automatic backport (#77864) conflicted because the fix on main lives in
`sql/analyzer/IndexAnalyzer.java`, which does not exist on this branch. Here the same
`checkInvertedIndexValid` entry point is in `analysis/InvertedIndexUtil.java`, so the identical
key-folding is applied there. Note this branch only supports the `clucene` implementation, so the
test uses `clucene` instead of `builtin`.

## Why I'm doing:

`USING GIN("IMP_LIB" = "clucene")` is accepted by CREATE TABLE and then breaks every INSERT
into that table with `Can not get inverted imp type`.

The SQL parser hands the analyzer a case-insensitive property map
(`TreeMap<>(String.CASE_INSENSITIVE_ORDER)`), so every FE-side check finds `IMP_LIB` and the
DDL is accepted. That map only makes *lookup* case-insensitive, though — it stores the key
exactly as the user spelled it. `Index.toThrift()` then classifies the property with an
upper-cased key but copies it into the thrift map **under the original spelling**, so
`common_properties` ends up holding `IMP_LIB`. The BE looks the key up with an exact
`find("imp_lib")` (`be/src/storage/index/inverted/inverted_index_option.cpp`) and fails.

`parser` is not affected at runtime: the BE matches that one case-insensitively. This change
only normalizes the spelling it is stored under.

## What I'm doing:

Fold the GIN index property keys to lower case once, at the top of `checkInvertedIndexValid`,
and run all later checks and the stored map off the normalized keys. The BE side is
untouched: exact lower-case lookup is the contract, and this makes the FE honour it.

If two keys collide after folding (e.g. `"IMP_LIB"` and `"imp_lib"` together, reachable
through the analyzer API even though the SQL parser's case-insensitive map already dedups
them), the statement is rejected with a `SemanticException` naming the key instead of one
value silently winning.

Scope boundaries:

- The BE keeps its exact-key lookups. Making `get_inverted_imp_type` case-insensitive is a
  reasonable follow-up, but it is not needed once the FE never stores a non-lower-case key.
- Tables that were already created with an upper-case key are NOT repaired by this change;
  their stored index property keeps the old spelling and the index has to be dropped and
  recreated. No metadata migration is done here.
- `SHOW CREATE TABLE` output changes for newly created GIN indexes declared with non-lower-case
  property keys: the key is now echoed lower-cased (`"IMP_LIB"` → `"imp_lib"`), matching the
  spelling that is actually stored and shipped to the BE. This is the same visible change #77818
  made on main.
- No BE change.

## Differences from the mainline PR

- Landing site: `com/starrocks/analysis/InvertedIndexUtil.java` instead of
  `com/starrocks/sql/analyzer/IndexAnalyzer.java` (the latter does not exist on this branch).
  The inserted call site and the `lowerCasePropertyKeys` helper are identical.
- This branch supports only `InvertedIndexImpType.CLUCENE`, so the tests use `clucene`.
- This branch also rejects GIN on replicated storage, so the test table sets
  `"replicated_storage" = "false"`.
- `dict_gram_num` and `lower_case` do not exist on this branch
  (`InvertedIndexParams.IndexParamsKey` has only `PARSER` and `OMIT_TERM_FREQ_AND_POSITION`),
  so those parts of the mainline test are dropped.
- The mainline SQL regression case (`test/sql/test_inverted_index/{T,R}/test_gin_property_key_case`)
  is **not** carried over: it relies on `builtin` and `dict_gram_num`, and there is no
  3.5 cluster here matching this branch to record a `R` file against. SQL regression is covered on main
  by #77818; this backport carries the FE fix and unit tests only.

Tests:

- `GINIndexTest.testCheckInvertedIndexLowerCasesPropertyKeys` — upper-case `IMP_LIB`,
  mixed-case keys with upper-case values (values must stay untouched), and the colliding-key
  rejection.
- `GINIndexTest.testUpperCaseImpLibReachesBeAsLowerCaseKey` — goes through the real parser and
  asserts the thrift maps the BE receives carry `imp_lib` and `parser`.
- Verified both new tests fail on this branch without the fix (2 failures out of 6) and pass with it.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

