### PR TITLE
[Enhancement] Build a 4K-page jemalloc variant alongside the 64K one on arm64

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1355,7 +1355,6 @@ build_jemalloc() {
         # 64K for arm architecture
         addition_opts=" --with-lg-page=16"
     else
-        # default 4K on x86 for performance
         addition_opts=" --with-lg-page=12"
     fi
     # build jemalloc with release
@@ -1367,7 +1366,13 @@ build_jemalloc() {
     mkdir -p ${TP_INSTALL_DIR}/jemalloc/lib-static/
     mv ${TP_INSTALL_DIR}/jemalloc/lib/*.so* ${TP_INSTALL_DIR}/jemalloc/lib-shared/
     mv ${TP_INSTALL_DIR}/jemalloc/lib/*.a ${TP_INSTALL_DIR}/jemalloc/lib-static/
-    # build jemalloc with debug options
+    # build jemalloc with debug options. Each subsequent ./configure below
+    # reuses this same source tree with different flags (page size,
+    # --disable-static, --enable-debug); autotools' generated Makefile
+    # doesn't reliably detect a configure-option change and rebuild the
+    # affected objects, so force a clean rebuild before every configure
+    # pass after the first.
+    make distclean
     CFLAGS="-O3 -fno-omit-frame-pointer -fPIC -g" \
     ./configure --prefix=${TP_INSTALL_DIR}/jemalloc-debug --with-jemalloc-prefix=je --enable-prof --disable-static --enable-debug --enable-fill --enable-prof --disable-cxx --disable-libdl $addition_opts
     make -j$PARALLEL
@@ -1382,15 +1387,15 @@ build_jemalloc() {
         # pair matching the host via getconf PAGESIZE.
         local page4k_opts=" --with-lg-page=12"
 
+        make distclean
         CFLAGS="-O3 -fno-omit-frame-pointer -fPIC -g" \
-        ./configure --prefix=${TP_INSTALL_DIR}/jemalloc-pg4k --with-jemalloc-prefix=je --enable-prof --disable-cxx --disable-libdl $page4k_opts
+        ./configure --prefix=${TP_INSTALL_DIR}/jemalloc-pg4k --with-jemalloc-prefix=je --enable-prof --disable-static --disable-cxx --disable-libdl $page4k_opts
         make -j$PARALLEL
         make install
-        mkdir -p ${TP_INSTALL_DIR}/jemalloc-pg4k/lib-shared/
-        mv ${TP_INSTALL_DIR}/jemalloc-pg4k/lib/*.so* ${TP_INSTALL_DIR}/jemalloc-pg4k/lib-shared/
 
+        make distclean
         CFLAGS="-O3 -fno-omit-frame-pointer -fPIC -g" \
-        ./configure --prefix=${TP_INSTALL_DIR}/jemalloc-debug-pg4k --with-jemalloc-prefix=je --enable-prof --disable-static --enable-debug --enable-fill --enable-prof --disable-cxx --disable-libdl $page4k_opts
+        ./configure --prefix=${TP_INSTALL_DIR}/jemalloc-debug-pg4k --with-jemalloc-prefix=je --enable-prof --disable-static --enable-debug --enable-fill --disable-cxx --disable-libdl $page4k_opts
         make -j$PARALLEL
         make install
     fi

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1350,10 +1350,13 @@ build_jemalloc() {
     # time one, but aborts on a larger one. If not defined, it falls back to the
     # the build system's _SC_PAGESIZE, which in many architectures can vary. Set
     # this to 64K (2^16) for arm architecture, and default 4K on x86 for performance.
-    local addition_opts=" --with-lg-page=12"
+    local addition_opts
     if [[ $MACHINE_TYPE == "aarch64" ]] ; then
-        # change to 64K for arm architecture
+        # 64K for arm architecture
         addition_opts=" --with-lg-page=16"
+    else
+        # default 4K on x86 for performance
+        addition_opts=" --with-lg-page=12"
     fi
     # build jemalloc with release
     CFLAGS="-O3 -fno-omit-frame-pointer -fPIC -g" \
@@ -1369,6 +1372,28 @@ build_jemalloc() {
     ./configure --prefix=${TP_INSTALL_DIR}/jemalloc-debug --with-jemalloc-prefix=je --enable-prof --disable-static --enable-debug --enable-fill --enable-prof --disable-cxx --disable-libdl $addition_opts
     make -j$PARALLEL
     make install
+
+    if [[ $MACHINE_TYPE == "aarch64" ]] ; then
+        # arm64 kernels vary between 4K and 64K pages depending on distro/kernel
+        # config. The 64K release/debug builds above are the safe default
+        # (work on any runtime page size <= 64K), but waste memory via larger
+        # chunk granularity on the common 4K-page case. Build matching 4K
+        # release and debug variants so downstream consumers can pick the
+        # pair matching the host via getconf PAGESIZE.
+        local page4k_opts=" --with-lg-page=12"
+
+        CFLAGS="-O3 -fno-omit-frame-pointer -fPIC -g" \
+        ./configure --prefix=${TP_INSTALL_DIR}/jemalloc-pg4k --with-jemalloc-prefix=je --enable-prof --disable-cxx --disable-libdl $page4k_opts
+        make -j$PARALLEL
+        make install
+        mkdir -p ${TP_INSTALL_DIR}/jemalloc-pg4k/lib-shared/
+        mv ${TP_INSTALL_DIR}/jemalloc-pg4k/lib/*.so* ${TP_INSTALL_DIR}/jemalloc-pg4k/lib-shared/
+
+        CFLAGS="-O3 -fno-omit-frame-pointer -fPIC -g" \
+        ./configure --prefix=${TP_INSTALL_DIR}/jemalloc-debug-pg4k --with-jemalloc-prefix=je --enable-prof --disable-static --enable-debug --enable-fill --enable-prof --disable-cxx --disable-libdl $page4k_opts
+        make -j$PARALLEL
+        make install
+    fi
 }
 
 # google benchmark


### PR DESCRIPTION
## Why I'm doing:

arm64 kernels vary between 4K and 64K pages depending on distro/kernel config. `build_jemalloc()` in `thirdparty/build-thirdparty.sh` currently always builds jemalloc for the 64K worst case on aarch64 (jemalloc aborts at runtime if the actual page size is larger than the build-time one, but tolerates a smaller one). This is safe but wastes memory via larger chunk/page granularity on the very common 4K-page arm64 case.

## What I'm doing:

On aarch64, build two additional variants alongside the existing 64K release (`jemalloc`) and debug (`jemalloc-debug`) builds:
- `jemalloc-pg4k`: 4K-page release build
- `jemalloc-debug-pg4k`: 4K-page debug build

x86_64 is unaffected (always built at 4K, unchanged). The existing 64K `jemalloc`/`jemalloc-debug` outputs and their install layout are unchanged, so nothing that currently consumes them changes behavior.

This PR only adds the extra thirdparty build outputs. It does not add any packaging or runtime selection logic in this repo — downstream build pipelines that share this thirdparty build image can pick the variant matching the host's actual page size (e.g. via `getconf PAGESIZE`) on their own.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
