### PR TITLE
[BugFix] Fix table qualification in connector views for absent default-catalog and CTE references

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveView.java
@@ -67,7 +67,7 @@ public class HiveView extends ConnectorView {
             if (Strings.isNullOrEmpty(name.getCatalog()) &&
                     Strings.isNullOrEmpty(name.getDb()) &&
                     cteRelationNames.contains(name.getTbl())) {
-                return;
+                continue;
             }
 
             tableRelation.getName().setCatalog(catalogName);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergView.java
@@ -46,7 +46,7 @@ public class IcebergView extends ConnectorView {
             if (Strings.isNullOrEmpty(name.getCatalog()) &&
                     Strings.isNullOrEmpty(name.getDb()) &&
                     cteRelationNames.contains(name.getTbl())) {
-                return;
+                continue;
             }
 
             // iceberg view query statement with external catalog which created by starrocks must have catalog name

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergView.java
@@ -51,7 +51,10 @@ public class IcebergView extends ConnectorView {
 
             // iceberg view query statement with external catalog which created by starrocks must have catalog name
             if (Strings.isNullOrEmpty(name.getCatalog())) {
-                name.setCatalog(defaultCatalogName);
+                // iceberg view's default-catalog is optional
+                // When default-catalog is null or not set, the catalog in which the view is stored must
+                // be used as the default catalog.
+                name.setCatalog(Strings.isNullOrEmpty(defaultCatalogName) ? this.catalogName : defaultCatalogName);
             }
 
             if (Strings.isNullOrEmpty(tableRelation.getName().getDb())) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PaimonView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PaimonView.java
@@ -35,7 +35,7 @@ public class PaimonView extends ConnectorView {
             if (Strings.isNullOrEmpty(name.getCatalog()) &&
                     Strings.isNullOrEmpty(name.getDb()) &&
                     cteRelationNames.contains(name.getTbl())) {
-                return;
+                continue;
             }
 
             if (Strings.isNullOrEmpty(name.getCatalog())) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/HiveViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/HiveViewTest.java
@@ -18,7 +18,6 @@ import com.google.common.collect.Lists;
 import com.starrocks.sql.ast.TableRelation;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/HiveViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/HiveViewTest.java
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.collect.Lists;
+import com.starrocks.sql.ast.TableRelation;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class HiveViewTest {
+    @Test
+    public void testQualifiesRelationsAfterCteReference() {
+        // A leading CTE reference must not short-circuit qualification of the remaining real tables
+        HiveView view = new HiveView(1L, "hive_catalog", "sample_db", "test_view",
+                Collections.emptyList(), "SELECT * FROM t", HiveView.Type.Hive);
+        TableRelation cteRelation = new TableRelation(new TableName(null, null, "cte"));
+        TableRelation tableRelation = new TableRelation(new TableName(null, null, "t"));
+        List<TableRelation> relations = Lists.newArrayList(cteRelation, tableRelation);
+
+        view.formatRelations(relations, Lists.newArrayList("cte"));
+
+        assertNull(cteRelation.getName().getCatalog());
+        assertEquals("hive_catalog", tableRelation.getName().getCatalog());
+        assertEquals("sample_db", tableRelation.getName().getDb());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergViewTest.java
@@ -1,0 +1,88 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.collect.Lists;
+import com.starrocks.sql.ast.TableRelation;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class IcebergViewTest {
+
+    private IcebergView newView(String defaultCatalogName, String defaultDbName) {
+        return new IcebergView(1L, "iceberg_catalog", "sales", "test_view",
+                Collections.emptyList(), "ignored", defaultCatalogName, defaultDbName,
+                "hdfs://path/to/view", null);
+    }
+
+    @Test
+    public void testFallsBackToOwnCatalogWhenDefaultCatalogAbsent() {
+        // The Iceberg view spec makes default-catalog optional: "When default-catalog is null or
+        // not set, the catalog in which the view is stored must be used as the default catalog."
+        // Resolution must not depend on the session's current catalog.
+        IcebergView view = newView(null, "sales");
+        TableRelation relation = new TableRelation(new TableName(null, "sales", "orders"));
+
+        view.formatRelations(Lists.newArrayList(relation), new ArrayList<>());
+
+        assertEquals("iceberg_catalog", relation.getName().getCatalog());
+        assertEquals("sales", relation.getName().getDb());
+    }
+
+    @Test
+    public void testSingleIdentifierUsesDefaultNamespace() {
+        IcebergView view = newView("catalog_from_metadata", "ns_from_metadata");
+        TableRelation relation = new TableRelation(new TableName(null, null, "orders"));
+
+        view.formatRelations(Lists.newArrayList(relation), new ArrayList<>());
+
+        assertEquals("catalog_from_metadata", relation.getName().getCatalog());
+        assertEquals("ns_from_metadata", relation.getName().getDb());
+    }
+
+    @Test
+    public void testSkipsCteRelation() {
+        IcebergView view = newView(null, "sales");
+        TableRelation relation = new TableRelation(new TableName(null, null, "cte"));
+
+        view.formatRelations(Lists.newArrayList(relation), Lists.newArrayList("cte"));
+
+        assertNull(relation.getName().getCatalog());
+        assertNull(relation.getName().getDb());
+    }
+
+    @Test
+    public void testQualifiesRelationsAfterCteReference() {
+        // A leading CTE reference must not short-circuit qualification of the remaining real
+        // tables, e.g. a view body like: WITH cte AS (SELECT 1) SELECT * FROM cte, orders
+        IcebergView view = newView(null, "sales");
+        TableRelation cteRelation = new TableRelation(new TableName(null, null, "cte"));
+        TableRelation tableRelation = new TableRelation(new TableName(null, null, "orders"));
+        List<TableRelation> relations = Lists.newArrayList(cteRelation, tableRelation);
+
+        view.formatRelations(relations, Lists.newArrayList("cte"));
+
+        assertNull(cteRelation.getName().getCatalog());
+        assertNull(cteRelation.getName().getDb());
+        assertEquals("iceberg_catalog", tableRelation.getName().getCatalog());
+        assertEquals("sales", tableRelation.getName().getDb());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/PaimonViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/PaimonViewTest.java
@@ -78,6 +78,24 @@ public class PaimonViewTest {
     }
 
     @Test
+    public void testFormatRelationsQualifiesTablesAfterCte() {
+        // A leading CTE reference must not short-circuit qualification of the remaining real tables
+        PaimonView view = new PaimonView(1L, "paimon_catalog", "sample_db", "my_view",
+                Collections.emptyList(), "WITH cte AS (SELECT 1) SELECT * FROM cte, t");
+
+        TableRelation cteRelation = new TableRelation(new TableName(null, null, "cte"));
+        TableRelation tableRelation = new TableRelation(new TableName(null, null, "t"));
+        List<TableRelation> relations = Lists.newArrayList(cteRelation, tableRelation);
+
+        view.formatRelations(relations, Lists.newArrayList("cte"));
+
+        assertNull(cteRelation.getName().getCatalog());
+        assertNull(cteRelation.getName().getDb());
+        assertEquals("paimon_catalog", tableRelation.getName().getCatalog());
+        assertEquals("sample_db", tableRelation.getName().getDb());
+    }
+
+    @Test
     public void testFormatRelationsWithDbButNoCatalog() {
         // Table reference with db but no catalog should get paimon catalog
         PaimonView view = new PaimonView(1L, "paimon_catalog", "sample_db", "my_view",


### PR DESCRIPTION
## Why I'm doing:

Two bugs in how connector (external catalog) views qualify the table references inside their view body:

1. **Iceberg view: `default-catalog` absent.** `default-catalog` is an optional field in the [Iceberg view spec](https://iceberg.apache.org/view-spec/#view-metadata). When a view's metadata does not record it (common for views created by other engines or directly via the Iceberg API), unqualified table references in the view body were left unqualified and silently fell back to the session's **current** catalog. As a result, `SELECT * FROM iceberg_catalog.db.v` from `default_catalog` failed with `database not found`, while the exact same view worked after `SET CATALOG iceberg_catalog`. The spec mandates the fallback: *"When default-catalog is null or not set, the catalog in which the view is stored must be used as the default catalog."*

2. **CTE reference short-circuits qualification.** `formatRelations` in `HiveView` / `IcebergView` / `PaimonView` used `return` instead of `continue` when skipping a CTE reference, so a view body like `WITH cte AS (...) SELECT * FROM cte, t` skipped qualification of every table after the CTE reference, causing the same session-dependent resolution failure.

## What I'm doing:

- When an Iceberg view records no `default-catalog`, qualify unqualified table references with the catalog the view is stored in, instead of leaving them to the session fallback.
- Skip only the CTE relation itself (`continue`) instead of aborting the whole qualification loop (`return`), in Hive/Iceberg/Paimon views.
- Add unit tests covering both fixes.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
