### PR TITLE
[BugFix] Encode the segment short key from its sort-key columns instead of the whole row

### DIFF
--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -51,6 +51,7 @@
 #include "fs/fs.h"          // FileSystem
 #include "gen_cpp/lake_types.pb.h"
 #include "gen_cpp/segment.pb.h"
+#include "runtime/current_thread.h"
 #include "storage/base/short_key_index.h"
 #include "storage/chunk_variant_helper.h"
 #include "storage/full_sort_key_codec.h"
@@ -521,6 +522,29 @@ Status SegmentWriter::_write_raw_data(const std::vector<Slice>& slices) {
     return Status::OK();
 }
 
+// Sort-key positions only: materializing the whole row allocates tens of GB when a value column holds a huge ARRAY.
+Status SegmentWriter::_append_sort_key_index_entry(const Chunk& chunk, size_t row) {
+    TRY_CATCH_BAD_ALLOC({
+        std::vector<Datum> values(chunk.num_columns());
+        for (uint32_t idx : _sort_column_indexes) {
+            // SeekTuple encodes an out-of-range sort column as NULL; leave the slot unset rather than indexing OOB.
+            if (idx < values.size()) {
+                values[idx] = chunk.get_column_by_index(idx)->get(row);
+            }
+        }
+        SeekTuple tuple(*chunk.schema(), std::move(values));
+        // The legacy truncated short key index is ALWAYS built (footer field 9).
+        size_t keys = _tablet_schema->num_short_key_columns();
+        RETURN_IF_ERROR(_index_builder->add_item(tuple.short_key_encode(keys, _sort_column_indexes, 0)));
+        // When enabled, ADDITIONALLY record the full untruncated sort key at the SAME block boundary.
+        if (_full_sort_key_index) {
+            RETURN_IF_ERROR(
+                    _full_sort_key_index_builder->add_item(tuple.full_sort_key_encode(_sort_column_indexes, 0)));
+        }
+    });
+    return Status::OK();
+}
+
 Status SegmentWriter::append_chunk(const Chunk& chunk) {
     size_t chunk_num_rows = chunk.num_rows();
     size_t chunk_num_columns = chunk.num_columns();
@@ -558,16 +582,7 @@ Status SegmentWriter::append_chunk(const Chunk& chunk) {
         for (size_t i = 0; i < chunk_num_rows; i++) {
             // At the begin of one block, so add a short key index entry
             if ((_num_rows_written % _opts.num_rows_per_block) == 0) {
-                SeekTuple tuple(*chunk.schema(), chunk.get(i).datums());
-                // The legacy truncated short key index is ALWAYS built (footer field 9).
-                size_t keys = _tablet_schema->num_short_key_columns();
-                RETURN_IF_ERROR(_index_builder->add_item(tuple.short_key_encode(keys, _sort_column_indexes, 0)));
-                // When enabled, ADDITIONALLY record the full untruncated sort key for the SAME block
-                // boundary -> shared block geometry with the legacy index.
-                if (_full_sort_key_index) {
-                    RETURN_IF_ERROR(_full_sort_key_index_builder->add_item(
-                            tuple.full_sort_key_encode(_sort_column_indexes, 0)));
-                }
+                RETURN_IF_ERROR(_append_sort_key_index_entry(chunk, i));
             }
             // Sort-key sample: take one tuple every _sort_key_sample_row_interval
             // rows. Samples are at 0-indexed rows interval, 2*interval, 3*interval,

--- a/be/src/storage/rowset/segment_writer.h
+++ b/be/src/storage/rowset/segment_writer.h
@@ -196,6 +196,9 @@ private:
     void _init_column_meta(ColumnMetaPB* meta, uint32_t column_id, const TabletColumn& column);
     void _verify_footer();
 
+    // Encodes and records the index entry for the block starting at |row|.
+    Status _append_sort_key_index_entry(const Chunk& chunk, size_t row);
+
     // Check global dictionary validity for a single column writer
     void _check_column_global_dict_valid(ColumnWriter* column_writer, uint32_t column_index);
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -374,6 +374,7 @@ SET(DW_TEST_FILES
     ./storage/rowset/segment_iterator_test.cpp
     ./storage/rowset/segment_rewriter_test.cpp
     ./storage/rowset/segment_test.cpp
+    ./storage/rowset/segment_writer_short_key_encode_test.cpp
     ./storage/rowset/segment_writer_sort_key_sampling_test.cpp
     ./storage/rowset/series_column_iterator_test.cpp
     ./storage/rowset/struct_column_rw_test.cpp

--- a/be/test/storage/rowset/segment_writer_short_key_encode_test.cpp
+++ b/be/test/storage/rowset/segment_writer_short_key_encode_test.cpp
@@ -1,0 +1,397 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <new>
+#include <string>
+#include <vector>
+
+#include "base/testutil/assert.h"
+#include "base/utility/defer_op.h"
+#include "column/chunk.h"
+#include "column/chunk_factory.h"
+#include "column/datum_tuple.h"
+#include "column/fixed_length_column.h"
+#include "common/config_rowset_fwd.h"
+#include "fs/fs_memory.h"
+#include "gen_cpp/segment.pb.h"
+#include "gutil/strings/substitute.h"
+#include "storage/base/short_key_index.h"
+#include "storage/chunk_helper.h"
+#include "storage/rowset/page_io.h"
+#include "storage/rowset/segment.h"
+#include "storage/rowset/segment_options.h"
+#include "storage/rowset/segment_writer.h"
+#include "storage/seek_tuple.h"
+#include "storage/tablet_schema.h"
+#include "storage/tablet_schema_helper.h"
+#include "storage_primitive/chunk_iterator.h"
+#include "storage_primitive/storage_stats.h"
+
+namespace starrocks {
+
+// Materializing this column throws, standing in for the huge ARRAY value whose Datum vector used to
+// abort BE from SegmentWriter::append_chunk(). Every other Column method behaves like an INT column,
+// so it survives the column writers; ColumnFactory::accept() resolves to the
+// FixedLengthColumnBase<int32_t> visitor overload.
+class ThrowOnGetInt32Column final
+        : public CowFactory<ColumnFactory<FixedLengthColumnBase<int32_t>, ThrowOnGetInt32Column>, ThrowOnGetInt32Column,
+                            Column> {
+public:
+    using SuperClass = CowFactory<ColumnFactory<FixedLengthColumnBase<int32_t>, ThrowOnGetInt32Column>,
+                                  ThrowOnGetInt32Column, Column>;
+    ThrowOnGetInt32Column() = default;
+
+    Datum get(size_t) const override { throw std::bad_alloc(); }
+
+    MutableColumnPtr clone_empty() const override { return this->create(); }
+
+    MutableColumnPtr clone() const override {
+        auto p = clone_empty();
+        p->append(*this, 0, this->size());
+        return p;
+    }
+};
+
+static ColumnPB create_varchar_key_pb(int32_t id, int length, int index_length) {
+    ColumnPB col;
+    col.set_unique_id(id);
+    col.set_name(std::to_string(id));
+    col.set_type("VARCHAR");
+    col.set_is_key(true);
+    col.set_is_nullable(true);
+    col.set_length(length);
+    col.set_index_length(index_length);
+    return col;
+}
+
+// One index entry per block; a small block keeps the fixtures tiny while still covering several blocks.
+static constexpr uint32_t kRowsPerBlock = 4;
+static constexpr int64_t kNumRows = 14;
+
+class SegmentWriterShortKeyEncodeTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        _fs = std::make_shared<MemoryFileSystem>();
+        ASSERT_OK(_fs->create_dir(kDir));
+    }
+
+    std::unique_ptr<SegmentWriter> new_writer(uint32_t seg_id, const std::shared_ptr<TabletSchema>& schema) {
+        SegmentWriterOptions opts;
+        opts.num_rows_per_block = kRowsPerBlock;
+        std::string filename = strings::Substitute("$0/seg_$1.dat", kDir, seg_id);
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(filename));
+        return std::make_unique<SegmentWriter>(std::move(wfile), seg_id, schema, opts);
+    }
+
+    SegmentFooterPB read_segment_footer(const std::string& filename) {
+        ASSIGN_OR_ABORT(auto read_file, _fs->new_random_access_file(filename));
+        SegmentFooterPB seg_footer;
+        auto footer_size_or = Segment::parse_segment_footer(read_file.get(), &seg_footer, nullptr, nullptr);
+        CHECK(footer_size_or.ok()) << footer_size_or.status().to_string();
+        return seg_footer;
+    }
+
+    // Decode all key entries of an index page. |full| selects the SORT_KEY_PAGE footer variant.
+    std::vector<std::string> read_index_entries(const std::string& filename, const PagePointerPB& page, bool full) {
+        ASSIGN_OR_ABORT(auto read_file, _fs->new_random_access_file(filename));
+        PageReadOptions opts;
+        opts.read_file = read_file.get();
+        opts.page_pointer = PagePointer(page);
+        opts.codec = nullptr; // index pages are not compressed
+        OlapReaderStatistics stats;
+        opts.stats = &stats;
+
+        PageHandle handle;
+        Slice body;
+        PageFooterPB page_footer;
+        CHECK(PageIO::read_and_decompress_page(opts, &handle, &body, &page_footer).ok());
+
+        ShortKeyIndexDecoder decoder;
+        if (full) {
+            CHECK(decoder.parse(body, page_footer.sort_key_page_footer()).ok());
+        } else {
+            CHECK(decoder.parse(body, page_footer.short_key_page_footer()).ok());
+        }
+        std::vector<std::string> keys;
+        for (uint32_t i = 0; i < decoder.num_items(); ++i) {
+            keys.emplace_back(decoder.key(i).to_string());
+        }
+        return keys;
+    }
+
+    // Golden encodings produced the way the writer used to: materialize the WHOLE row, then encode.
+    std::vector<std::string> golden_entries(const Chunk& chunk, const TabletSchema& schema,
+                                            const std::vector<uint32_t>& sort_column_indexes, bool full) {
+        std::vector<std::string> keys;
+        for (size_t row = 0; row < chunk.num_rows(); row += kRowsPerBlock) {
+            SeekTuple tuple(*chunk.schema(), chunk.get(row).datums());
+            keys.emplace_back(full ? tuple.full_sort_key_encode(sort_column_indexes, 0)
+                                   : tuple.short_key_encode(schema.num_short_key_columns(), sort_column_indexes, 0));
+        }
+        return keys;
+    }
+
+    // Write |chunk| through append_chunk() and assert every index entry equals the whole-row golden.
+    void expect_entries_match_golden(uint32_t seg_id, const std::shared_ptr<TabletSchema>& schema, const Chunk& chunk,
+                                     const std::vector<uint32_t>& expected_sort_column_indexes) {
+        auto w = new_writer(seg_id, schema);
+        ASSERT_OK(w->init(true));
+        // The writer indexes chunk columns with its own local indexes, never tablet schema indexes.
+        ASSERT_EQ(expected_sort_column_indexes, w->_sort_column_indexes);
+        ASSERT_OK(w->append_chunk(chunk));
+        uint64_t file_size = 0;
+        uint64_t index_size = 0;
+        uint64_t footer_position = 0;
+        ASSERT_OK(w->finalize(&file_size, &index_size, &footer_position));
+
+        SegmentFooterPB seg_footer = read_segment_footer(w->segment_path());
+        ASSERT_TRUE(seg_footer.has_short_key_index_page());
+        EXPECT_EQ(golden_entries(chunk, *schema, w->_sort_column_indexes, /*full=*/false),
+                  read_index_entries(w->segment_path(), seg_footer.short_key_index_page(), /*full=*/false));
+
+        ASSERT_EQ(config::enable_full_sort_key_index, seg_footer.has_full_sort_key_index_page());
+        if (seg_footer.has_full_sort_key_index_page()) {
+            EXPECT_EQ(golden_entries(chunk, *schema, w->_sort_column_indexes, /*full=*/true),
+                      read_index_entries(w->segment_path(), seg_footer.full_sort_key_index_page(), /*full=*/true));
+        }
+    }
+
+    std::shared_ptr<TabletSchema> make_schema(const std::vector<ColumnPB>& cols, int num_short_key_columns) {
+        auto unique = TabletSchemaHelper::create_tablet_schema(cols, num_short_key_columns);
+        return std::shared_ptr<TabletSchema>(std::move(unique));
+    }
+
+    // Row |i| is NULL whenever i % 4 == 0, so every block boundary of a single-key schema is NULL.
+    ChunkUniquePtr make_int_key_chunk(const std::shared_ptr<TabletSchema>& schema, bool null_at_block_start) {
+        auto s = ChunkHelper::convert_schema(schema);
+        auto chunk = ChunkFactory::new_chunk(s, kNumRows);
+        auto cols = chunk->columns();
+        for (int64_t i = 0; i < kNumRows; ++i) {
+            const bool null = null_at_block_start && (i % kRowsPerBlock == 0);
+            cols[0]->as_mutable_ptr()->append_datum(null ? Datum() : Datum(static_cast<int32_t>(i)));
+            for (size_t c = 1; c < cols.size(); ++c) {
+                cols[c]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * 10)));
+            }
+        }
+        return chunk;
+    }
+
+    std::shared_ptr<MemoryFileSystem> _fs;
+    const std::string kDir = "/short_key_encode_test";
+};
+
+// ---------------------------------------------------------------------------
+// Encoding equivalence: the entries written from the sort-key columns alone must be byte-identical to
+// the ones the whole-row SeekTuple produced, for every key shape -- including NULL keys, VARCHAR
+// truncation, a short key shorter than the sort key, and a sort key that is not a physical prefix.
+// ---------------------------------------------------------------------------
+TEST_F(SegmentWriterShortKeyEncodeTest, entries_match_whole_row_golden_single_int_key) {
+    auto schema = make_schema({create_int_key_pb(1), create_int_value_pb(2)}, /*num_short_key_columns=*/1);
+    auto chunk = make_int_key_chunk(schema, /*null_at_block_start=*/false);
+    expect_entries_match_golden(0, schema, *chunk, {0});
+}
+
+TEST_F(SegmentWriterShortKeyEncodeTest, entries_match_whole_row_golden_null_keys) {
+    auto schema = make_schema({create_int_key_pb(1), create_int_value_pb(2)}, /*num_short_key_columns=*/1);
+    auto chunk = make_int_key_chunk(schema, /*null_at_block_start=*/true);
+    expect_entries_match_golden(0, schema, *chunk, {0});
+}
+
+TEST_F(SegmentWriterShortKeyEncodeTest, entries_match_whole_row_golden_short_key_shorter_than_sort_key) {
+    auto schema = make_schema({create_int_key_pb(1), create_int_key_pb(2), create_int_value_pb(3)},
+                              /*num_short_key_columns=*/1);
+    auto chunk = make_int_key_chunk(schema, /*null_at_block_start=*/false);
+    expect_entries_match_golden(0, schema, *chunk, {0, 1});
+}
+
+TEST_F(SegmentWriterShortKeyEncodeTest, entries_match_whole_row_golden_non_prefix_sort_key) {
+    auto schema = make_schema({create_int_key_pb(1), create_int_key_pb(2), create_int_value_pb(3)},
+                              /*num_short_key_columns=*/2);
+    schema->set_sort_key_idxes({1, 0});
+    auto chunk = make_int_key_chunk(schema, /*null_at_block_start=*/false);
+    expect_entries_match_golden(0, schema, *chunk, {1, 0});
+}
+
+TEST_F(SegmentWriterShortKeyEncodeTest, entries_match_whole_row_golden_varchar_key_truncated) {
+    auto schema = make_schema({create_varchar_key_pb(1, /*length=*/32, /*index_length=*/4), create_int_value_pb(2)},
+                              /*num_short_key_columns=*/1);
+    auto s = ChunkHelper::convert_schema(schema);
+    auto chunk = ChunkFactory::new_chunk(s, kNumRows);
+    auto cols = chunk->columns();
+    for (int64_t i = 0; i < kNumRows; ++i) {
+        // Longer than index_length, so the short key is truncated while the full sort key is not.
+        std::string v = strings::Substitute("key_that_is_long_$0", i);
+        cols[0]->as_mutable_ptr()->append_datum(Datum(Slice(v)));
+        cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+    }
+    expect_entries_match_golden(0, schema, *chunk, {0});
+}
+
+// The full sort key index (footer field 11) is encoded from the same SeekTuple, so it must match the
+// whole-row golden too. Runs the shapes whose full and truncated encodings differ.
+TEST_F(SegmentWriterShortKeyEncodeTest, entries_match_whole_row_golden_with_full_sort_key_index) {
+    const bool old_enable = config::enable_full_sort_key_index;
+    config::enable_full_sort_key_index = true;
+    DeferOp restore([&] { config::enable_full_sort_key_index = old_enable; });
+
+    auto int_schema = make_schema({create_int_key_pb(1), create_int_key_pb(2), create_int_value_pb(3)},
+                                  /*num_short_key_columns=*/1);
+    expect_entries_match_golden(0, int_schema, *make_int_key_chunk(int_schema, /*null_at_block_start=*/true), {0, 1});
+
+    auto varchar_schema =
+            make_schema({create_varchar_key_pb(1, /*length=*/32, /*index_length=*/4), create_int_value_pb(2)},
+                        /*num_short_key_columns=*/1);
+    auto s = ChunkHelper::convert_schema(varchar_schema);
+    auto chunk = ChunkFactory::new_chunk(s, kNumRows);
+    auto cols = chunk->columns();
+    for (int64_t i = 0; i < kNumRows; ++i) {
+        std::string v = strings::Substitute("key_that_is_long_$0", i);
+        cols[0]->as_mutable_ptr()->append_datum(Datum(Slice(v)));
+        cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+    }
+    expect_entries_match_golden(1, varchar_schema, *chunk, {0});
+}
+
+// ---------------------------------------------------------------------------
+// Vertical writer, key-columns pass: the sort key is the third tablet column, but the pass writes it
+// alone, so the writer must index the chunk with its local index 0 -- never the tablet index 2.
+// ---------------------------------------------------------------------------
+TEST_F(SegmentWriterShortKeyEncodeTest, vertical_writer_key_pass_uses_chunk_local_indexes) {
+    auto schema = make_schema({create_int_key_pb(1), create_int_key_pb(2), create_int_value_pb(3)},
+                              /*num_short_key_columns=*/1);
+    schema->set_sort_key_idxes({2});
+
+    auto w = new_writer(0, schema);
+    ASSERT_OK(w->init(std::vector<uint32_t>{2}, true));
+    ASSERT_EQ(std::vector<uint32_t>({0}), w->_sort_column_indexes);
+
+    auto sort_key_schema = ChunkHelper::convert_schema(schema, std::vector<ColumnId>{2});
+    auto sort_key_chunk = ChunkFactory::new_chunk(sort_key_schema, kNumRows);
+    for (int64_t i = 0; i < kNumRows; ++i) {
+        sort_key_chunk->columns()[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+    }
+    ASSERT_OK(w->append_chunk(*sort_key_chunk));
+    uint64_t index_size = 0;
+    ASSERT_OK(w->finalize_columns(&index_size));
+
+    // Second pass: the remaining columns, written without keys.
+    ASSERT_OK(w->init(std::vector<uint32_t>{0, 1}, false));
+    auto value_schema = ChunkHelper::convert_schema(schema, std::vector<ColumnId>{0, 1});
+    auto value_chunk = ChunkFactory::new_chunk(value_schema, kNumRows);
+    for (int64_t i = 0; i < kNumRows; ++i) {
+        value_chunk->columns()[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+        value_chunk->columns()[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i)));
+    }
+    ASSERT_OK(w->append_chunk(*value_chunk));
+    ASSERT_OK(w->finalize_columns(&index_size));
+    uint64_t file_size = 0;
+    ASSERT_OK(w->finalize_footer(&file_size));
+
+    SegmentFooterPB seg_footer = read_segment_footer(w->segment_path());
+    ASSERT_TRUE(seg_footer.has_short_key_index_page());
+    EXPECT_EQ(golden_entries(*sort_key_chunk, *schema, {0}, /*full=*/false),
+              read_index_entries(w->segment_path(), seg_footer.short_key_index_page(), /*full=*/false));
+    if (seg_footer.has_full_sort_key_index_page()) {
+        EXPECT_EQ(golden_entries(*sort_key_chunk, *schema, {0}, /*full=*/true),
+                  read_index_entries(w->segment_path(), seg_footer.full_sort_key_index_page(), /*full=*/true));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Value columns are never materialized: a column that throws when materialized sits at a value
+// position, so the pre-fix whole-row path (asserted to throw below) would have died here.
+// ---------------------------------------------------------------------------
+TEST_F(SegmentWriterShortKeyEncodeTest, value_column_is_never_materialized) {
+    auto schema = make_schema({create_int_key_pb(1), create_int_value_pb(2)}, /*num_short_key_columns=*/1);
+    auto s = ChunkHelper::convert_schema(schema);
+    auto chunk = ChunkFactory::new_chunk(s, 1);
+    chunk->columns()[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(7)));
+    auto trap = ThrowOnGetInt32Column::create();
+    trap->append_datum(Datum(static_cast<int32_t>(7)));
+    chunk->columns()[1] = std::move(trap);
+    ASSERT_EQ(1U, chunk->num_rows());
+    ASSERT_THROW(chunk->get(0), std::bad_alloc);
+
+    auto w = new_writer(0, schema);
+    ASSERT_OK(w->init(true));
+    ASSERT_EQ(std::vector<uint32_t>({0}), w->_sort_column_indexes);
+    ASSERT_OK(w->_append_sort_key_index_entry(*chunk, 0));
+}
+
+// ---------------------------------------------------------------------------
+// A bad_alloc raised while materializing a sort-key column must come back as a Status, not kill BE.
+// ---------------------------------------------------------------------------
+TEST_F(SegmentWriterShortKeyEncodeTest, bad_alloc_on_sort_key_column_returns_memory_limit_exceeded) {
+    auto schema = make_schema({create_int_key_pb(1), create_int_value_pb(2)}, /*num_short_key_columns=*/1);
+    auto s = ChunkHelper::convert_schema(schema);
+    auto chunk = ChunkFactory::new_chunk(s, 1);
+    auto trap = ThrowOnGetInt32Column::create();
+    trap->append_datum(Datum(static_cast<int32_t>(7)));
+    chunk->columns()[0] = std::move(trap);
+    chunk->columns()[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(7)));
+
+    auto w = new_writer(0, schema);
+    ASSERT_OK(w->init(true));
+    ASSERT_EQ(std::vector<uint32_t>({0}), w->_sort_column_indexes);
+    Status st = w->_append_sort_key_index_entry(*chunk, 0);
+    EXPECT_TRUE(st.is_mem_limit_exceeded()) << st.to_string();
+}
+
+// ---------------------------------------------------------------------------
+// Reading back what was written: the short key index still resolves block boundaries, so
+// lower_bound/upper_bound land on the same blocks the whole-row encoding produced.
+// ---------------------------------------------------------------------------
+TEST_F(SegmentWriterShortKeyEncodeTest, short_key_index_stays_seekable) {
+    auto schema = make_schema({create_int_key_pb(1), create_int_value_pb(2)}, /*num_short_key_columns=*/1);
+    auto chunk = make_int_key_chunk(schema, /*null_at_block_start=*/false);
+
+    auto w = new_writer(0, schema);
+    ASSERT_OK(w->init(true));
+    ASSERT_OK(w->append_chunk(*chunk));
+    uint64_t file_size = 0;
+    uint64_t index_size = 0;
+    uint64_t footer_position = 0;
+    ASSERT_OK(w->finalize(&file_size, &index_size, &footer_position));
+
+    std::vector<std::string> entries =
+            read_index_entries(w->segment_path(), read_segment_footer(w->segment_path()).short_key_index_page(),
+                               /*full=*/false);
+    ASSERT_EQ(static_cast<size_t>((kNumRows + kRowsPerBlock - 1) / kRowsPerBlock), entries.size());
+    // Entries are the keys of rows 0, 4, 8, 12 and must stay strictly increasing for seeks to work.
+    for (size_t i = 1; i < entries.size(); ++i) {
+        EXPECT_LT(entries[i - 1], entries[i]);
+    }
+
+    ASSIGN_OR_ABORT(auto segment, Segment::open(_fs, FileInfo{w->segment_path()}, 0, schema));
+    ASSERT_EQ(kNumRows, segment->num_rows());
+    SegmentReadOptions read_opts;
+    read_opts.fs = _fs;
+    OlapReaderStatistics stats;
+    read_opts.stats = &stats;
+    auto read_schema = ChunkHelper::convert_schema(schema);
+    ASSIGN_OR_ABORT(auto iter, segment->new_iterator(read_schema, read_opts));
+    auto read_chunk = ChunkFactory::new_chunk(read_schema, kNumRows);
+    ASSERT_OK(iter->get_next(read_chunk.get()));
+    ASSERT_EQ(kNumRows, read_chunk->num_rows());
+    for (int64_t i = 0; i < kNumRows; ++i) {
+        EXPECT_EQ(i, read_chunk->get(i)[0].get_int32());
+        EXPECT_EQ(i * 10, read_chunk->get(i)[1].get_int32());
+    }
+    iter->close();
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

A single `INSERT` can make a BE process **abort** (uncaught exception, not the OOM killer), taking
down every concurrent query and load on that node. The client only sees the misleading
`ERROR 5609: Backend node not found`.

`SegmentWriter::append_chunk()` encodes one short key index entry per block boundary. To do that it
called `Chunk::get(row)`, which materializes **every column of the row** into a `DatumTuple`, even
though only the first 1–3 sort-key columns are used for the encoding. When a value column holds a
huge ARRAY, that single allocation is enormous: measured 128 GB
(`137438953472 bytes` for one row of `2^31` `tinyint` elements — 64 bytes per element once
materialized as `Datum`). `operator new` throws `std::bad_alloc`, and nothing on the memtable flush
path catches it, so `std::terminate` → `abort`.

Reproduced on a 187 GB host (100 GB+ available at crash time):

```sql
create table t8_single (k int, a array<tinyint>)
  duplicate key(k) distributed by hash(k) buckets 1 properties("replication_num"="1");
insert into t8_single
  select 1, array_concat(array_repeat(cast(1 as tinyint), 2147483647), [cast(1 as tinyint)]);
```

Evidence from the crash:

```
W mem_hook.cpp:130] large memory alloc, query_id:00000000-... acquire:137438953472 bytes,
                    is_bad_alloc_caught: 0
be.out: operator new -> __cxa_throw -> std::terminate -> abort
        starrocks::ArrayColumn::get -> starrocks::NullableColumn::get -> starrocks::Chunk::get
        -> starrocks::SegmentWriter::append_chunk -> HorizontalRowsetWriter::_flush_chunk
        -> MemTable::flush -> MemtableFlushTask::run
```

The trigger threshold is high — one row must materialize to more than the allocatable memory — so
normal workloads (even millions of ARRAY elements per row) never reach it. But it is reachable from
plain SQL and it kills the whole node, so it is an availability defect rather than a tuning issue.

## What I'm doing:

Encode the index entry from the sort-key columns only, and guard the remaining allocations:

1. `SegmentWriter::_append_sort_key_index_entry()` fills a `Datum` vector at the sort-key positions
   via `chunk.get_column_by_index(idx)->get(row)` and leaves value columns untouched. The vector keeps
   the chunk's column count, so `SeekTuple`'s indexing, bound checks and padding rule are unchanged
   and both encoders (`short_key_encode` for footer field 9 and `full_sort_key_encode` for field 11)
   produce byte-identical keys. The read path already uses this per-column pattern — see
   `build_variant_tuple_from_chunk_row()` in `storage/chunk_variant_helper.cpp` (also called from
   `append_chunk`) and the short-key-only chunk built by `segment_iterator.cpp`.
2. The whole encode-and-record block is wrapped in `TRY_CATCH_BAD_ALLOC`, so a `bad_alloc` from any
   remaining allocation (the Datum vector, `KeyCoder::encode_ascending`, `encoded_key` growth,
   `ShortKeyIndexBuilder::add_item` buffers) becomes a `MemoryLimitExceeded` status instead of
   aborting the process. This is deliberately scoped to the short-key block only: `append_chunk` has
   already mutated the column writers by that point, and widening the catch would require settling
   the writers' post-exception discard/retry contract first. Note that the flush thread has no query
   context, so the message is typically the generic `Mem usage has exceed the limit of BE` without a
   tracker name or byte count.

Indexes are indexed with the writer's chunk-local sort column indexes (`_sort_column_indexes`), never
tablet schema indexes; the vertical writer's key-columns pass is covered by a test that makes the two
differ.

New tests in `be/test/storage/rowset/segment_writer_short_key_encode_test.cpp`:

- encoding equivalence against the old whole-row `SeekTuple` encoding, comparing the decoded index
  page entries byte for byte: single INT key, NULL keys at every block boundary, short key shorter
  than the sort key, non-prefix sort key, VARCHAR short-key truncation, and both index pages with
  `enable_full_sort_key_index` on;
- vertical-writer key-columns pass where the sort key's chunk-local index (0) differs from its tablet
  index (2);
- a column that throws when materialized, placed at a value position: writing succeeds (the old path
  is asserted to throw on the same chunk);
- the same column at the sort-key position: `append_chunk`'s helper returns `MemoryLimitExceeded` and
  the process stays alive;
- segment reopen with a full scan, verifying the short key index still resolves block boundaries.

End-to-end verification of the original 2^31-element `INSERT` against a rebuilt cluster has not been
run; the fix is covered by the unit tests above.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
