### PR TITLE
[BugFix] Register the pipe_driver_queue_len metric

### DIFF
--- a/be/src/exec_primitive/pipeline/primitives/pipeline_metrics.cpp
+++ b/be/src/exec_primitive/pipeline/primitives/pipeline_metrics.cpp
@@ -183,6 +183,7 @@ void PipelineExecutorMetrics::register_all_metrics(MetricRegistry* registry) {
     }
     _registry = registry;
     poller_metrics.register_all_metrics(registry);
+    driver_queue_metrics.register_all_metrics(registry);
     driver_executor_metrics.register_all_metrics(registry);
     scan_executor_metrics.register_all_metrics(registry, "scan");
     connector_scan_executor_metrics.register_all_metrics(registry, "connector_scan");


### PR DESCRIPTION
## Why I'm doing:

The `pipe_driver_queue_len` metric has been missing from the BE `/metrics` output since v3.5.0, while it is still documented in the monitoring metrics docs. Users cannot monitor the number of ready drivers waiting in the driver queues.

Root cause: the pipeline metrics refactor in #53490 introduced `DriverQueueMetrics::register_all_metrics()` for this gauge, but `PipelineExecutorMetrics::register_all_metrics()` never calls it. The gauge itself is still correctly incremented/decremented by `QuerySharedDriverQueue` and `WorkGroupDriverQueue`; it is just never registered to the metric registry, so it never appears in the `/metrics` output.

## What I'm doing:

Call `driver_queue_metrics.register_all_metrics(registry)` in `PipelineExecutorMetrics::register_all_metrics()`, next to the other pipeline metric registrations. After this one-line fix, `starrocks_be_pipe_driver_queue_len` shows up in the BE `/metrics` output again.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
