### PR TITLE
[BugFix] Read the values themselves when a struct-subfield predicate is evaluated by rowid

### DIFF
--- a/be/src/storage/rowset/column_iterator.h
+++ b/be/src/storage/rowset/column_iterator.h
@@ -277,6 +277,9 @@ public:
         return next_batch(range, dst);
     }
 
+    // Fills in the subfields that were left unmaterialized in an already-populated column, so an
+    // iterator without subfields of its own has nothing to do. Do NOT use it to read a column from
+    // scratch: see fetch_values_by_rowid_for_predicate_evaluate.
     virtual Status fetch_subfield_by_rowid(const rowid_t* rowids, size_t size, Column* values) { return Status::OK(); }
 
     virtual Status null_count(size_t* count) { return Status::OK(); };

--- a/be/src/storage/rowset/fill_subfield_iterator.cpp
+++ b/be/src/storage/rowset/fill_subfield_iterator.cpp
@@ -40,6 +40,17 @@ Status FillSubfieldIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t
     return _column_iter->fetch_subfield_by_rowid(rowids, size, values);
 }
 
+Status FillSubfieldIterator::fetch_values_by_rowid_for_predicate_evaluate(const Column& rowids, Column* values) {
+    // Two callers reach this iterator by rowid and want opposite things of it.
+    // _finish_late_materialization passes a column that already holds its rows and only needs the
+    // subfields nobody has read yet, which is what fetch_values_by_rowid delegates to
+    // fetch_subfield_by_rowid for. Predicate evaluation instead empties the column first and needs the
+    // values themselves: routing it through fetch_subfield_by_rowid leaves an already-materialized
+    // leaf field untouched -- a scalar iterator inherits a fetch_subfield_by_rowid that does nothing --
+    // and the caller rejects the short column with "col size not equal to ordinal col size".
+    return _column_iter->fetch_values_by_rowid(rowids, values);
+}
+
 ordinal_t FillSubfieldIterator::num_rows() const {
     return _column_iter->num_rows();
 }

--- a/be/src/storage/rowset/fill_subfield_iterator.h
+++ b/be/src/storage/rowset/fill_subfield_iterator.h
@@ -42,6 +42,8 @@ public:
 
     Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) override;
 
+    Status fetch_values_by_rowid_for_predicate_evaluate(const Column& rowids, Column* values) override;
+
     Status seek_to_first() override;
 
     Status seek_to_ordinal(ordinal_t ord) override;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -3312,10 +3312,10 @@ Status SegmentIterator::_evaluate_late_materialize_read_other_columns(vector<row
         if (ordinals->size() != col->size()) {
             // Name the column and the iterator: which iterator short-read is the whole diagnosis here,
             // and the message is all a production incident leaves behind.
-            return Status::Corruption(strings::Substitute(
-                    "_predicate_evaluate_late_materialize col size not equal to ordinal col size: "
-                    "column_id=$0 iterator=$1 ordinals=$2 col=$3",
-                    current_column_id, cur_iter->name(), ordinals->size(), col->size()));
+            return Status::Corruption(
+                    strings::Substitute("_predicate_evaluate_late_materialize col size not equal to ordinal col size: "
+                                        "column_id=$0 iterator=$1 ordinals=$2 col=$3",
+                                        current_column_id, cur_iter->name(), ordinals->size(), col->size()));
         }
         may_has_del_row |= (col->delete_state() != DEL_NOT_SATISFIED);
 

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -3300,17 +3300,22 @@ Status SegmentIterator::_evaluate_late_materialize_read_other_columns(vector<row
         current_columns.emplace_back(col);
 
         col->resize(0);
+        ColumnIterator* cur_iter = _context->_column_ids_to_column_iterators[current_column_id];
         {
             SCOPED_RAW_TIMER(&_opts.stats->late_materialize_ns);
             // for dict column, no matter it's global or local
             // we should get its local dict values in predicate evaluation which is same as next_batch
             // because the corresponding predicates are already rewritten by local dictionary
-            ColumnIterator* cur_iter = _context->_column_ids_to_column_iterators[current_column_id];
             cur_iter->reserve_col(chunk_size, col);
             RETURN_IF_ERROR(cur_iter->fetch_values_by_rowid_for_predicate_evaluate(*ordinals, col));
         }
         if (ordinals->size() != col->size()) {
-            return Status::Corruption("_predicate_evaluate_late_materialize col size not equal to ordinal col size");
+            // Name the column and the iterator: which iterator short-read is the whole diagnosis here,
+            // and the message is all a production incident leaves behind.
+            return Status::Corruption(strings::Substitute(
+                    "_predicate_evaluate_late_materialize col size not equal to ordinal col size: "
+                    "column_id=$0 iterator=$1 ordinals=$2 col=$3",
+                    current_column_id, cur_iter->name(), ordinals->size(), col->size()));
         }
         may_has_del_row |= (col->delete_state() != DEL_NOT_SATISFIED);
 

--- a/be/test/storage/rowset/struct_column_rw_test.cpp
+++ b/be/test/storage/rowset/struct_column_rw_test.cpp
@@ -29,6 +29,7 @@
 #include "storage/rowset/column_iterator.h"
 #include "storage/rowset/column_reader.h"
 #include "storage/rowset/column_writer.h"
+#include "storage/rowset/fill_subfield_iterator.h"
 #include "storage/rowset/map_column_iterator.h"
 #include "storage/rowset/segment.h"
 #include "storage/tablet_schema_helper.h"
@@ -284,6 +285,31 @@ protected:
                 ASSERT_TRUE(st.ok());
                 ASSERT_EQ(src_column->size(), rows_read);
 
+                ASSERT_EQ("{f1:1}", dst_column->debug_item(0));
+            }
+
+            // The predicate-evaluation path: a predicate on a struct subfield reads that column by
+            // rowid through a FillSubfieldIterator, and the caller empties the column first, so every
+            // rowid has to come back as a row. Routing this through fetch_subfield_by_rowid leaves an
+            // already-materialized leaf field untouched -- a scalar iterator inherits a
+            // fetch_subfield_by_rowid that does nothing -- and the segment iterator then rejects the
+            // short column with "col size not equal to ordinal col size".
+            {
+                auto st = iter->seek_to_first();
+                ASSERT_TRUE(st.ok()) << st.to_string();
+
+                auto dst_f1_column = Int32Column::create();
+                MutableColumns dst_columns;
+                dst_columns.emplace_back(std::move(dst_f1_column));
+                auto dst_column = StructColumn::create(std::move(dst_columns), {"f1"});
+
+                auto rowid_column = FixedLengthColumn<rowid_t>::create();
+                rowid_column->append(0);
+
+                FillSubfieldIterator fill_iter(0, path.get(), iter.get());
+                st = fill_iter.fetch_values_by_rowid_for_predicate_evaluate(*rowid_column, dst_column.get());
+                ASSERT_TRUE(st.ok()) << st.to_string();
+                ASSERT_EQ(rowid_column->size(), dst_column->size());
                 ASSERT_EQ("{f1:1}", dst_column->debug_item(0));
             }
         }

--- a/test/sql/test_late_materialization_subfield/R/test_late_materialize_struct_subfield_predicate
+++ b/test/sql/test_late_materialization_subfield/R/test_late_materialize_struct_subfield_predicate
@@ -1,0 +1,90 @@
+-- name: test_late_materialize_struct_subfield_predicate
+CREATE TABLE src (
+  v1 bigint,
+  str string,
+  s1 struct<s1 int>
+) DUPLICATE KEY(v1)
+DISTRIBUTED BY HASH(v1) BUCKETS 3
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into src values (1,'aa',named_struct('s1',1)),(2,'bb',named_struct('s1',1)),(3,'cc',named_struct('s1',1)),(4,'dd',named_struct('s1',1)),(5,'ee',named_struct('s1',1)),(6,'ff',named_struct('s1',1)),(7,'gg',named_struct('s1',1)),(8,'hh',named_struct('s1',1)),(9,'ii',named_struct('s1',1)),(10,'jj',named_struct('s1',1));
+-- result:
+-- !result
+insert into src select * from src;
+-- result:
+-- !result
+insert into src select * from src;
+-- result:
+-- !result
+insert into src select * from src;
+-- result:
+-- !result
+insert into src select * from src;
+-- result:
+-- !result
+insert into src select * from src;
+-- result:
+-- !result
+insert into src select * from src;
+-- result:
+-- !result
+insert into src select * from src;
+-- result:
+-- !result
+insert into src select * from src;
+-- result:
+-- !result
+insert into src select * from src;
+-- result:
+-- !result
+insert into src select * from src;
+-- result:
+-- !result
+insert into src select * from src;
+-- result:
+-- !result
+insert into src select * from src;
+-- result:
+-- !result
+CREATE TABLE scs (
+  v1 bigint,
+  str string,
+  s1 struct<s1 int>
+) DUPLICATE KEY(v1)
+DISTRIBUTED BY HASH(v1) BUCKETS 3
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into scs select * from src;
+-- result:
+-- !result
+select count(*) from scs;
+-- result:
+40960
+-- !result
+select v1 from scs where str = 'dd' and s1.s1 >= 1 order by v1 limit 3;
+-- result:
+4
+4
+4
+-- !result
+select v1 from scs where str = 'dd' and s1.s1 >= 2 order by v1 limit 3;
+-- result:
+-- !result
+select v1 from scs where str = 'dd' order by v1 limit 3;
+-- result:
+4
+4
+4
+-- !result
+select v1 from scs where s1.s1 >= 1 order by v1 limit 3;
+-- result:
+1
+1
+1
+-- !result
+select count(*) from scs where str = 'dd' and s1.s1 >= 1;
+-- result:
+4096
+-- !result

--- a/test/sql/test_late_materialization_subfield/T/test_late_materialize_struct_subfield_predicate
+++ b/test/sql/test_late_materialization_subfield/T/test_late_materialize_struct_subfield_predicate
@@ -1,0 +1,40 @@
+-- name: test_late_materialize_struct_subfield_predicate
+CREATE TABLE src (
+  v1 bigint,
+  str string,
+  s1 struct<s1 int>
+) DUPLICATE KEY(v1)
+DISTRIBUTED BY HASH(v1) BUCKETS 3
+PROPERTIES ("replication_num" = "1");
+insert into src values (1,'aa',named_struct('s1',1)),(2,'bb',named_struct('s1',1)),(3,'cc',named_struct('s1',1)),(4,'dd',named_struct('s1',1)),(5,'ee',named_struct('s1',1)),(6,'ff',named_struct('s1',1)),(7,'gg',named_struct('s1',1)),(8,'hh',named_struct('s1',1)),(9,'ii',named_struct('s1',1)),(10,'jj',named_struct('s1',1));
+insert into src select * from src;
+insert into src select * from src;
+insert into src select * from src;
+insert into src select * from src;
+insert into src select * from src;
+insert into src select * from src;
+insert into src select * from src;
+insert into src select * from src;
+insert into src select * from src;
+insert into src select * from src;
+insert into src select * from src;
+insert into src select * from src;
+CREATE TABLE scs (
+  v1 bigint,
+  str string,
+  s1 struct<s1 int>
+) DUPLICATE KEY(v1)
+DISTRIBUTED BY HASH(v1) BUCKETS 3
+PROPERTIES ("replication_num" = "1");
+-- write every row in one statement: the scan reads the subfield predicate column by rowid only
+-- when the rows sit in one rowset, so loading them in twelve doubling steps does not exercise it
+insert into scs select * from src;
+select count(*) from scs;
+-- a predicate on a low-cardinality string column plus one on a struct subfield leaves the subfield
+-- column to be read by rowid as the second predicate column of the late-materialization order
+select v1 from scs where str = 'dd' and s1.s1 >= 1 order by v1 limit 3;
+select v1 from scs where str = 'dd' and s1.s1 >= 2 order by v1 limit 3;
+-- each predicate alone reads the column through the ordinary path
+select v1 from scs where str = 'dd' order by v1 limit 3;
+select v1 from scs where s1.s1 >= 1 order by v1 limit 3;
+select count(*) from scs where str = 'dd' and s1.s1 >= 1;


### PR DESCRIPTION
## Why I'm doing:

A predicate on a struct subfield reads its column through a FillSubfieldIterator, whose fetch_values_by_rowid delegates to ColumnIterator::fetch_subfield_by_rowid. That method fills in the subfields left unmaterialized in a column that already holds its rows, so an iterator with no subfields of its own inherits a base implementation that does nothing -- which is right for _finish_late_materialization, the caller it was written for.

Predicate evaluation is the opposite: _evaluate_late_materialize_read_other_columns empties the column first and needs the values. Routing it through the same method leaves an already-materialized leaf field untouched, and the caller then rejects the short column:

    create table t (v1 bigint, str string, s1 struct<s1 int>)
      duplicate key(v1) distributed by hash(v1) buckets 3;
    -- 40960 rows, str a 10-value low-cardinality column
    select v1 from t where str = 'dd' and s1.s1 >= 1;
    ERROR 1064 (HY000): _predicate_evaluate_late_materialize col size not equal to
                        ordinal col size

Two predicates are what it takes: the string column is the more selective one and goes first, which leaves the subfield column to be read by rowid as the second entry of the predicate order. Either predicate alone, or a third predicate that reorders them, reads the column through the ordinary path and is unaffected.

Override fetch_values_by_rowid_for_predicate_evaluate in FillSubfieldIterator so that path reads the values, and leave fetch_subfield_by_rowid alone: making its base implementation read values instead of nothing does fix this query, but then _finish_late_materialization appends a second time over rows it already had and a scan emits a chunk of 8192 rows.

Also name the column and the iterator in that Corruption status. A short read by one iterator is the whole diagnosis, and the message is all a production incident leaves behind.

Tests: struct_column_rw_test drives FillSubfieldIterator:: fetch_values_by_rowid_for_predicate_evaluate over a subfield-pruned struct column and asserts one row per rowid (zero without the fix), plus a SQL test that reproduces the failing query end to end.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
