### PR TITLE
[BugFix] Refresh rowset metadata cache charges after lazy loading

### DIFF
--- a/be/src/storage/rowset/metadata_cache.cpp
+++ b/be/src/storage/rowset/metadata_cache.cpp
@@ -36,6 +36,19 @@ void MetadataCache::cache_rowset(Rowset* ptr) {
     _insert(ptr->rowset_id_str(), weak_ptr, ptr->segment_memory_usage());
 }
 
+void MetadataCache::update_rowset_charge(Rowset* ptr, size_t charge) {
+    auto rowset_owner_matches = [](void* value, const void* ctx) {
+        const auto& cached = *static_cast<const std::weak_ptr<Rowset>*>(value);
+        const auto& expected = *static_cast<const std::weak_ptr<Rowset>*>(ctx);
+        // Compare ownership without locking the weak_ptr: destroying a temporary strong
+        // reference under the shard lock could destroy another Rowset and re-enter the cache.
+        return !cached.owner_before(expected) && !expected.owner_before(cached);
+    };
+    const std::string key = ptr->rowset_id_str();
+    const auto expected = ptr->weak_from_this();
+    _cache->update_charge_if(CacheKey(key), charge, rowset_owner_matches, &expected);
+}
+
 void MetadataCache::evict_rowset(Rowset* ptr) {
     _erase(ptr->rowset_id_str());
 }

--- a/be/src/storage/rowset/metadata_cache.h
+++ b/be/src/storage/rowset/metadata_cache.h
@@ -42,6 +42,11 @@ public:
     // will be called after rowset load metadata.
     void cache_rowset(Rowset* ptr);
 
+    // Update the cache charge after the rowset loads more segment metadata.
+    // Only update an entry that still belongs to this rowset.
+    // |charge| must be a stable snapshot captured by the caller.
+    void update_rowset_charge(Rowset* ptr, size_t charge);
+
     // evict this rowset manually, will be called before rowset destroy.
     void evict_rowset(Rowset* ptr);
 

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -37,6 +37,7 @@
 #include <memory>
 #include <set>
 
+#include "base/testutil/sync_point.h"
 #include "base/time/time.h"
 #include "base/utility/defer_op.h"
 #include "column/chunk_factory.h"
@@ -248,6 +249,16 @@ void Rowset::warmup_lrucache() {
         MetadataCache::instance()->refresh_rowset(this);
     }
 #endif
+}
+
+void Rowset::_update_metadata_cache_charge(size_t charge) {
+    if (config::metadata_cache_memory_limit_percent > 0 && _keys_type != PRIMARY_KEYS) {
+#ifdef BE_TEST
+        TEST_SYNC_POINT_CALLBACK("Rowset::_update_metadata_cache_charge", &charge);
+#else
+        MetadataCache::instance()->update_rowset_charge(this, charge);
+#endif
+    }
 }
 
 // this function is only used for partial update so far
@@ -731,6 +742,7 @@ void Rowset::do_close() {
 }
 
 size_t Rowset::segment_memory_usage() {
+    TEST_SYNC_POINT("Rowset::segment_memory_usage");
     size_t total = 0;
     for (const auto& segment : _segments) {
         total += segment->mem_usage();

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -255,9 +255,13 @@ void Rowset::_update_metadata_cache_charge(size_t charge) {
     if (config::metadata_cache_memory_limit_percent > 0 && _keys_type != PRIMARY_KEYS) {
 #ifdef BE_TEST
         TEST_SYNC_POINT_CALLBACK("Rowset::_update_metadata_cache_charge", &charge);
-#else
-        MetadataCache::instance()->update_rowset_charge(this, charge);
+        // Most unit tests do not create the global metadata cache. Tests that
+        // install one exercise the same charge update as production.
+        if (MetadataCache::instance() == nullptr) {
+            return;
+        }
 #endif
+        MetadataCache::instance()->update_rowset_charge(this, charge);
     }
 }
 

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -40,6 +40,7 @@
 #include <utility>
 #include <vector>
 
+#include "common/config_rowset_fwd.h"
 #include "common/statusor.h"
 #include "common/storage_define.h"
 #include "gen_cpp/olap_file.pb.h"
@@ -339,21 +340,47 @@ public:
         // if the refs by reader is 0 and the rowset is closed, should release the resouce
         uint64_t current_refs = --_refs_by_reader;
         if (current_refs == 0) {
+            bool should_update_charge = false;
+            size_t metadata_cache_charge = 0;
             {
                 std::lock_guard<std::mutex> release_lock(_lock);
                 // rejudge _refs_by_reader because we do not add lock in create reader
-                if (_refs_by_reader == 0 && _rowset_state_machine.rowset_state() == ROWSET_UNLOADING) {
-                    // first do close, then change state
-                    do_close();
-                    WARN_IF_ERROR(_rowset_state_machine.on_release(),
-                                  strings::Substitute("rowset state on_release error, $0",
-                                                      _rowset_state_machine.rowset_state()));
+                if (_refs_by_reader == 0) {
+                    if (_rowset_state_machine.rowset_state() == ROWSET_UNLOADING) {
+                        // first do close, then change state
+                        do_close();
+                        WARN_IF_ERROR(_rowset_state_machine.on_release(),
+                                      strings::Substitute("rowset state on_release error, $0",
+                                                          _rowset_state_machine.rowset_state()));
+                    } else if (_rowset_state_machine.rowset_state() == ROWSET_LOADED &&
+                               config::metadata_cache_memory_limit_percent > 0 && _keys_type != PRIMARY_KEYS) {
+                        bool has_lazy_mem_update = false;
+                        for (const auto& segment : _segments) {
+                            has_lazy_mem_update |= segment->consume_lazy_mem_update();
+                        }
+                        if (has_lazy_mem_update) {
+                            // Consume dirty flags before taking the snapshot, so a concurrent update remains dirty
+                            // for the next last-reader release instead of being cleared after this snapshot.
+                            metadata_cache_charge = segment_memory_usage();
+                            should_update_charge = true;
+                        }
+                    }
                 }
             }
             if (_rowset_state_machine.rowset_state() == ROWSET_UNLOADED) {
                 VLOG(3) << "close the rowset. rowset state from ROWSET_UNLOADING to ROWSET_UNLOADED"
                         << ", version:" << start_version() << "-" << end_version()
                         << ", tabletid:" << _rowset_meta->tablet_id();
+            }
+            // Compute the charge under |_lock|, but update MetadataCache after releasing it,
+            // because updating the charge may evict this rowset and call Rowset::close().
+            //
+            // The snapshot and cache update are intentionally not atomic. Concurrent reader
+            // cycles may apply charge updates out of order, so the cached charge is best-effort
+            // and may remain stale until another update. This affects cache eviction decisions
+            // only and is not used for object lifetime or query/data correctness.
+            if (should_update_charge) {
+                _update_metadata_cache_charge(metadata_cache_charge);
             }
         }
     }
@@ -443,6 +470,8 @@ protected:
 
 private:
     int64_t _mem_usage() const { return sizeof(Rowset) + _rowset_path.length(); }
+
+    void _update_metadata_cache_charge(size_t charge);
 
     Status _remove_delta_column_group_files(const std::shared_ptr<FileSystem>& fs);
 

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -857,6 +857,9 @@ void Segment::update_cache_size() {
             // under batch mode, only increase the _dirty_cache_counter
             _dirty_cache_counter.fetch_add(1, std::memory_order_relaxed);
         }
+    } else {
+        // Only used by share-nothing rowsets. The last reader release consumes this flag.
+        _lazy_mem_update.store(true, std::memory_order_release);
     }
 }
 

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -267,9 +267,8 @@ public:
     // read short_key_index, for data check, just used in unit test now
     Status get_short_key_index(std::vector<std::string>* sk_index_values);
 
-    // for cloud native tablet metadata cache.
-    // after the segment is inserted into metadata cache, various indexes will be loaded later when used,
-    // so the segment size in the cache needs to be updated when indexes are loading.
+    // Update the cloud-native segment cache charge. For share-nothing rowsets,
+    // mark the segment dirty when its memory usage may have changed.
     void update_cache_size();
 
     bool is_default_column(const TabletColumn& column) { return !_column_readers.contains(column.unique_id()); }
@@ -289,6 +288,8 @@ public:
 
     // for ut test
     void set_num_rows(uint32_t num_rows) { _num_rows = num_rows; }
+
+    bool consume_lazy_mem_update() { return _lazy_mem_update.exchange(false, std::memory_order_acq_rel); }
 
 #ifdef BE_TEST
     static void toggle_batch_update_cache_mode(bool enabled) { _s_allow_batch_update_mode = enabled; }
@@ -408,6 +409,9 @@ private:
     lake::TabletManager* _tablet_manager = nullptr;
     // used to guarantee that segment will be opened at most once in a thread-safe way
     OnceFlag _open_once;
+
+    // for share nothing, set to true after update_cache_size() is called
+    std::atomic<bool> _lazy_mem_update{false};
 #ifdef BE_TEST
     static bool _s_allow_batch_update_mode;
 #endif

--- a/be/test/storage/rowset/metadata_cache_test.cpp
+++ b/be/test/storage/rowset/metadata_cache_test.cpp
@@ -352,8 +352,7 @@ TEST_F(MetadataCacheTest, update_charge_on_last_reader_release) {
     rowset->release();
     ASSERT_EQ(2, update_charge_calls);
     ASSERT_EQ(loaded_rowset_size, captured_charge);
-    ASSERT_EQ(loaded_rowset_size - initial_rowset_size,
-              metadata_cache->get_memory_usage() - initial_cache_usage);
+    ASSERT_EQ(loaded_rowset_size - initial_rowset_size, metadata_cache->get_memory_usage() - initial_cache_usage);
     ASSERT_GT(rowset->segment_memory_usage(), 0);
 
     const size_t updated_cache_usage = metadata_cache->get_memory_usage();
@@ -440,8 +439,7 @@ TEST_F(MetadataCacheTest, skip_charge_calculation_for_ineligible_rowsets) {
     int segment_memory_usage_calls = 0;
     const int32_t old_metadata_cache_memory_limit_percent = config::metadata_cache_memory_limit_percent;
     SyncPoint::GetInstance()->EnableProcessing();
-    SyncPoint::GetInstance()->SetCallBack("Rowset::segment_memory_usage",
-                                         [&](void*) { ++segment_memory_usage_calls; });
+    SyncPoint::GetInstance()->SetCallBack("Rowset::segment_memory_usage", [&](void*) { ++segment_memory_usage_calls; });
     DeferOp defer([old_metadata_cache_memory_limit_percent] {
         config::metadata_cache_memory_limit_percent = old_metadata_cache_memory_limit_percent;
         SyncPoint::GetInstance()->ClearCallBack("Rowset::segment_memory_usage");

--- a/be/test/storage/rowset/metadata_cache_test.cpp
+++ b/be/test/storage/rowset/metadata_cache_test.cpp
@@ -18,7 +18,10 @@
 #include "storage/rowset/metadata_cache.h"
 #undef private
 
+#include "base/testutil/sync_point.h"
+#include "base/utility/defer_op.h"
 #include "column/chunk_factory.h"
+#include "common/config_rowset_fwd.h"
 #include "storage/chunk_helper.h"
 #include "storage/rowset/rowset_factory.h"
 #include "storage/rowset/rowset_options.h"
@@ -144,14 +147,15 @@ public:
         return *writer->build();
     }
 
-    TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash) {
+    TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash,
+                                  TKeysType::type keys_type = TKeysType::DUP_KEYS) {
         TCreateTabletReq request;
         request.tablet_id = tablet_id;
         request.__set_version(1);
         request.__set_version_hash(0);
         request.tablet_schema.schema_hash = schema_hash;
         request.tablet_schema.short_key_column_count = 1;
-        request.tablet_schema.keys_type = TKeysType::DUP_KEYS;
+        request.tablet_schema.keys_type = keys_type;
         request.tablet_schema.storage_type = TStorageType::COLUMN;
 
         TColumn k1;
@@ -271,6 +275,192 @@ TEST_F(MetadataCacheTest, test_warmup_uses_touch_without_releasing_handle) {
     ASSERT_EQ("rowset_warmup_key", recording_cache->last_touch_key);
     ASSERT_EQ(0, recording_cache->lookup_calls);
     ASSERT_EQ(0, recording_cache->release_calls);
+}
+
+TEST_F(MetadataCacheTest, update_charge_on_last_reader_release) {
+    constexpr size_t kMetadataCacheCapacity = 10 * 1024 * 1024;
+    const size_t num_rows = 1000;
+    vector<int64_t> keys;
+    keys.reserve(num_rows);
+    for (size_t i = 0; i < num_rows; ++i) {
+        keys.push_back(i);
+    }
+
+    const int32_t old_metadata_cache_memory_limit_percent = config::metadata_cache_memory_limit_percent;
+    config::metadata_cache_memory_limit_percent = 30;
+    DeferOp restore_config([old_metadata_cache_memory_limit_percent] {
+        config::metadata_cache_memory_limit_percent = old_metadata_cache_memory_limit_percent;
+    });
+
+    auto metadata_cache = std::make_unique<MetadataCache>(kMetadataCacheCapacity);
+    auto tablet = create_tablet(1003, 10006);
+    auto rowset = create_rowset(tablet, keys);
+    ASSERT_TRUE(rowset->load().ok());
+    metadata_cache->cache_rowset(rowset.get());
+
+    const size_t initial_rowset_size = rowset->segment_memory_usage();
+    const size_t initial_cache_usage = metadata_cache->get_memory_usage();
+
+    // Segment::open() marks a share-nothing segment dirty. Verify that the
+    // dirty bit is consumed exactly once, then restore it for the Rowset-level
+    // last-reader test below.
+    ASSERT_FALSE(rowset->segments().empty());
+    auto& segment = rowset->segments().front();
+    ASSERT_TRUE(segment->consume_lazy_mem_update());
+    ASSERT_FALSE(segment->consume_lazy_mem_update());
+    segment->update_cache_size();
+
+    int update_charge_calls = 0;
+    size_t captured_charge = 0;
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("Rowset::_update_metadata_cache_charge", [&](void* arg) {
+        ++update_charge_calls;
+        captured_charge = *static_cast<size_t*>(arg);
+        metadata_cache->update_rowset_charge(rowset.get(), captured_charge);
+    });
+    DeferOp defer([] {
+        SyncPoint::GetInstance()->ClearCallBack("Rowset::_update_metadata_cache_charge");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    // Consume the dirty flag restored above. This intentionally pays for one redundant refresh
+    // per Rowset load in exchange for keeping update_cache_size() uniform.
+    rowset->acquire();
+    rowset->release();
+    ASSERT_EQ(1, update_charge_calls);
+    ASSERT_EQ(initial_rowset_size, captured_charge);
+    ASSERT_EQ(initial_cache_usage, metadata_cache->get_memory_usage());
+
+    rowset->acquire();
+    rowset->acquire();
+
+    std::vector<std::string> short_keys;
+    ASSERT_TRUE(rowset->get_segment_sk_index(&short_keys).ok());
+    const size_t loaded_rowset_size = rowset->segment_memory_usage();
+    ASSERT_GT(loaded_rowset_size, initial_rowset_size);
+    ASSERT_EQ(initial_cache_usage, metadata_cache->get_memory_usage());
+
+    rowset->release();
+    ASSERT_EQ(1, update_charge_calls);
+    ASSERT_EQ(initial_cache_usage, metadata_cache->get_memory_usage());
+
+    rowset->release();
+    ASSERT_EQ(2, update_charge_calls);
+    ASSERT_EQ(loaded_rowset_size, captured_charge);
+    ASSERT_EQ(loaded_rowset_size - initial_rowset_size,
+              metadata_cache->get_memory_usage() - initial_cache_usage);
+    ASSERT_GT(rowset->segment_memory_usage(), 0);
+
+    const size_t updated_cache_usage = metadata_cache->get_memory_usage();
+    rowset->acquire();
+    rowset->release();
+    ASSERT_EQ(2, update_charge_calls);
+    ASSERT_EQ(updated_cache_usage, metadata_cache->get_memory_usage());
+
+    // A charge refresh after the entry has been removed is a no-op.
+    metadata_cache->evict_rowset(rowset.get());
+    const size_t usage_after_evict = metadata_cache->get_memory_usage();
+    ASSERT_EQ(0, usage_after_evict);
+    metadata_cache->update_rowset_charge(rowset.get(), loaded_rowset_size);
+    ASSERT_EQ(usage_after_evict, metadata_cache->get_memory_usage());
+}
+
+TEST_F(MetadataCacheTest, update_charge_ignores_replaced_rowset) {
+    const std::vector<int64_t> keys{1, 2, 3};
+    auto tablet = create_tablet(1007, 10010);
+    auto original = create_rowset(tablet, keys);
+    ASSERT_TRUE(original->load().ok());
+    MetadataCache metadata_cache(10 * 1024 * 1024);
+    metadata_cache.cache_rowset(original.get());
+
+    std::vector<std::string> short_keys;
+    ASSERT_TRUE(original->get_segment_sk_index(&short_keys).ok());
+    const size_t original_charge = original->segment_memory_usage();
+
+    // Migration can create another Rowset object with the same ID. Its cache
+    // entry must not receive a delayed charge update from the original object.
+    RowsetSharedPtr replacement;
+    ASSERT_TRUE(RowsetFactory::create_rowset(tablet->tablet_schema(), original->rowset_path(), original->rowset_meta(),
+                                             &replacement, nullptr)
+                        .ok());
+    ASSERT_TRUE(replacement->load().ok());
+    metadata_cache.cache_rowset(replacement.get());
+    ASSERT_EQ(0, original->segment_memory_usage());
+    const size_t replacement_charge = replacement->segment_memory_usage();
+    ASSERT_GT(original_charge, replacement_charge);
+    const size_t cache_usage = metadata_cache.get_memory_usage();
+
+    metadata_cache.update_rowset_charge(original.get(), original_charge);
+    ASSERT_EQ(cache_usage, metadata_cache.get_memory_usage());
+    ASSERT_EQ(replacement_charge, replacement->segment_memory_usage());
+
+    // The replacement's own lazy metadata growth must still be accounted for.
+    ASSERT_TRUE(replacement->get_segment_sk_index(&short_keys).ok());
+    const size_t loaded_charge = replacement->segment_memory_usage();
+    ASSERT_GT(loaded_charge, replacement_charge);
+    metadata_cache.update_rowset_charge(replacement.get(), loaded_charge);
+    ASSERT_EQ(cache_usage + loaded_charge - replacement_charge, metadata_cache.get_memory_usage());
+    ASSERT_EQ(0, metadata_cache._cache->get_lookup_count());
+
+    metadata_cache.evict_rowset(replacement.get());
+    ASSERT_EQ(0, metadata_cache.get_memory_usage());
+    ASSERT_EQ(0, replacement->segment_memory_usage());
+}
+
+TEST_F(MetadataCacheTest, last_reader_release_closes_unloading_rowset) {
+    const std::vector<int64_t> keys{1, 2, 3};
+    auto tablet = create_tablet(1006, 10009);
+    auto rowset = create_rowset(tablet, keys);
+    ASSERT_TRUE(rowset->load().ok());
+    ASSERT_GT(rowset->segment_memory_usage(), 0);
+
+    rowset->acquire();
+    rowset->close();
+    // close() moves a referenced rowset to ROWSET_UNLOADING without clearing
+    // its segments. The last reader release performs the deferred close.
+    ASSERT_GT(rowset->segment_memory_usage(), 0);
+    rowset->release();
+    ASSERT_EQ(0, rowset->segment_memory_usage());
+}
+
+TEST_F(MetadataCacheTest, skip_charge_calculation_for_ineligible_rowsets) {
+    const std::vector<int64_t> keys{1, 2, 3};
+    auto dup_tablet = create_tablet(1004, 10007);
+    auto pk_tablet = create_tablet(1005, 10008, TKeysType::PRIMARY_KEYS);
+    auto dup_rowset = create_rowset(dup_tablet, keys);
+    auto pk_rowset = create_rowset(pk_tablet, keys);
+    ASSERT_TRUE(dup_rowset->load().ok());
+    ASSERT_TRUE(pk_rowset->load().ok());
+
+    int segment_memory_usage_calls = 0;
+    const int32_t old_metadata_cache_memory_limit_percent = config::metadata_cache_memory_limit_percent;
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("Rowset::segment_memory_usage",
+                                         [&](void*) { ++segment_memory_usage_calls; });
+    DeferOp defer([old_metadata_cache_memory_limit_percent] {
+        config::metadata_cache_memory_limit_percent = old_metadata_cache_memory_limit_percent;
+        SyncPoint::GetInstance()->ClearCallBack("Rowset::segment_memory_usage");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    config::metadata_cache_memory_limit_percent = 30;
+    pk_rowset->acquire();
+    pk_rowset->release();
+    ASSERT_EQ(0, segment_memory_usage_calls);
+
+    config::metadata_cache_memory_limit_percent = 0;
+    dup_rowset->acquire();
+    dup_rowset->release();
+    ASSERT_EQ(0, segment_memory_usage_calls);
+
+    config::metadata_cache_memory_limit_percent = 30;
+    dup_rowset->acquire();
+    dup_rowset->release();
+    ASSERT_EQ(1, segment_memory_usage_calls);
+
+    dup_rowset->acquire();
+    dup_rowset->release();
+    ASSERT_EQ(1, segment_memory_usage_calls);
 }
 
 TEST_F(MetadataCacheTest, test_concurrency_issue) {

--- a/be/test/storage/rowset/metadata_cache_test.cpp
+++ b/be/test/storage/rowset/metadata_cache_test.cpp
@@ -463,6 +463,130 @@ TEST_F(MetadataCacheTest, skip_charge_calculation_for_ineligible_rowsets) {
     ASSERT_EQ(1, segment_memory_usage_calls);
 }
 
+class MetadataCacheReaderTest : public MetadataCacheTest {
+public:
+    void SetUp() override {
+        MetadataCacheTest::SetUp();
+        _previous_cache = MetadataCache::_s_instance;
+        _previous_cache_percent = config::metadata_cache_memory_limit_percent;
+        _metadata_cache = std::make_unique<MetadataCache>(10 * 1024 * 1024);
+        MetadataCache::_s_instance = _metadata_cache.get();
+        config::metadata_cache_memory_limit_percent = 30;
+    }
+
+    void TearDown() override {
+        MetadataCache::_s_instance = _previous_cache;
+        config::metadata_cache_memory_limit_percent = _previous_cache_percent;
+        _metadata_cache.reset();
+        MetadataCacheTest::TearDown();
+    }
+
+protected:
+    std::unique_ptr<MetadataCache> _metadata_cache;
+    MetadataCache* _previous_cache = nullptr;
+    int32_t _previous_cache_percent = 0;
+};
+
+TEST_F(MetadataCacheReaderTest, close_refreshes_charge_only_after_last_reader) {
+    const std::vector<int64_t> keys{1, 2, 3};
+    auto tablet = create_tablet(1008, 10011);
+    auto rowset = create_rowset(tablet, keys);
+    ASSERT_TRUE(rowset->load().ok());
+    _metadata_cache->cache_rowset(rowset.get());
+    const size_t initial_rowset_size = rowset->segment_memory_usage();
+    const size_t initial_cache_usage = _metadata_cache->get_memory_usage();
+    auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
+
+    // Exercise release through TabletReader's production implementation, with
+    // two overlapping readers retaining the same rowset.
+    TabletReader first_reader(tablet, Version(0, 0), schema, std::vector<RowsetSharedPtr>{rowset});
+    ASSERT_TRUE(first_reader.prepare().ok());
+    TabletReader last_reader(tablet, Version(0, 0), schema, std::vector<RowsetSharedPtr>{rowset});
+    ASSERT_TRUE(last_reader.prepare().ok());
+    ASSERT_EQ(2, rowset->refs_by_reader());
+
+    std::vector<std::string> short_keys;
+    ASSERT_TRUE(rowset->get_segment_sk_index(&short_keys).ok());
+    const size_t loaded_rowset_size = rowset->segment_memory_usage();
+    ASSERT_GT(loaded_rowset_size, initial_rowset_size);
+
+    first_reader.close();
+    ASSERT_EQ(1, rowset->refs_by_reader());
+    ASSERT_EQ(initial_cache_usage, _metadata_cache->get_memory_usage());
+    last_reader.close();
+    ASSERT_EQ(0, rowset->refs_by_reader());
+    ASSERT_EQ(initial_cache_usage + loaded_rowset_size - initial_rowset_size, _metadata_cache->get_memory_usage());
+    ASSERT_EQ(loaded_rowset_size, rowset->segment_memory_usage());
+    ASSERT_FALSE(rowset->segments().front()->consume_lazy_mem_update());
+
+    const size_t updated_cache_usage = _metadata_cache->get_memory_usage();
+    TabletReader clean_reader(tablet, Version(0, 0), schema, std::vector<RowsetSharedPtr>{rowset});
+    ASSERT_TRUE(clean_reader.prepare().ok());
+    clean_reader.close();
+    ASSERT_EQ(0, rowset->refs_by_reader());
+    ASSERT_EQ(updated_cache_usage, _metadata_cache->get_memory_usage());
+    ASSERT_EQ(0, _metadata_cache->_cache->get_lookup_count());
+}
+
+TEST_F(MetadataCacheReaderTest, close_finishes_deferred_rowset_unload) {
+    const std::vector<int64_t> keys{1, 2, 3};
+    auto tablet = create_tablet(1009, 10012);
+    auto rowset = create_rowset(tablet, keys);
+    ASSERT_TRUE(rowset->load().ok());
+    _metadata_cache->cache_rowset(rowset.get());
+    const size_t loaded_rowset_size = rowset->segment_memory_usage();
+    ASSERT_GT(loaded_rowset_size, 0);
+    auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
+
+    TabletReader first_reader(tablet, Version(0, 0), schema, std::vector<RowsetSharedPtr>{rowset});
+    ASSERT_TRUE(first_reader.prepare().ok());
+    TabletReader last_reader(tablet, Version(0, 0), schema, std::vector<RowsetSharedPtr>{rowset});
+    ASSERT_TRUE(last_reader.prepare().ok());
+
+    // Eviction requests close(), but both readers still need the segments.
+    _metadata_cache->evict_rowset(rowset.get());
+    ASSERT_EQ(0, _metadata_cache->get_memory_usage());
+    ASSERT_EQ(loaded_rowset_size, rowset->segment_memory_usage());
+    first_reader.close();
+    ASSERT_EQ(1, rowset->refs_by_reader());
+    ASSERT_EQ(loaded_rowset_size, rowset->segment_memory_usage());
+    last_reader.close();
+    ASSERT_EQ(0, rowset->refs_by_reader());
+    ASSERT_EQ(0, rowset->segment_memory_usage());
+    ASSERT_EQ(0, _metadata_cache->get_memory_usage());
+
+    // The last close must finish the transition to UNLOADED, allowing a reload.
+    ASSERT_TRUE(rowset->load().ok());
+    ASSERT_GT(rowset->segment_memory_usage(), 0);
+}
+
+TEST_F(MetadataCacheReaderTest, charge_growth_can_evict_rowset_on_close) {
+    const std::vector<int64_t> keys{1, 2, 3};
+    auto tablet = create_tablet(1010, 10013);
+    auto rowset = create_rowset(tablet, keys);
+    ASSERT_TRUE(rowset->load().ok());
+    const size_t initial_rowset_size = rowset->segment_memory_usage();
+    const size_t initial_charge = initial_rowset_size + LRUCache::key_handle_size(CacheKey(rowset->rowset_id_str()));
+    _metadata_cache->set_capacity(initial_charge * kNumShards);
+    _metadata_cache->cache_rowset(rowset.get());
+    ASSERT_EQ(initial_charge, _metadata_cache->get_memory_usage());
+
+    auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
+    TabletReader reader(tablet, Version(0, 0), schema, std::vector<RowsetSharedPtr>{rowset});
+    ASSERT_TRUE(reader.prepare().ok());
+    std::vector<std::string> short_keys;
+    ASSERT_TRUE(rowset->get_segment_sk_index(&short_keys).ok());
+    ASSERT_GT(rowset->segment_memory_usage(), initial_rowset_size);
+    ASSERT_EQ(initial_charge, _metadata_cache->get_memory_usage());
+
+    // Refreshing the charge now exceeds the shard capacity. Its deleter calls
+    // Rowset::close(), which must run after release() drops the rowset lock.
+    reader.close();
+    ASSERT_EQ(0, rowset->refs_by_reader());
+    ASSERT_EQ(0, _metadata_cache->get_memory_usage());
+    ASSERT_EQ(0, rowset->segment_memory_usage());
+}
+
 TEST_F(MetadataCacheTest, test_concurrency_issue) {
     const size_t N = 100;
     vector<int64_t> keys;

--- a/be/test/storage/rowset/metadata_cache_test.cpp
+++ b/be/test/storage/rowset/metadata_cache_test.cpp
@@ -120,7 +120,7 @@ public:
 
     void TearDown() override {}
 
-    RowsetSharedPtr create_rowset(const TabletSharedPtr& tablet, const vector<int64_t>& keys) {
+    RowsetSharedPtr create_rowset(const TabletSharedPtr& tablet, const vector<int64_t>& keys, size_t num_segments = 1) {
         RowsetWriterContext writer_context;
         RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
         writer_context.rowset_id = rowset_id;
@@ -136,14 +136,19 @@ public:
         std::unique_ptr<RowsetWriter> writer;
         EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
         auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
-        auto chunk = ChunkFactory::new_chunk(schema, keys.size());
-        auto cols = chunk->columns();
-        for (int64_t key : keys) {
-            cols[0]->as_mutable_ptr()->append_datum(Datum(key));
-            cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(key % 100 + 1)));
-            cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)(key % 1000 + 2)));
+        for (size_t segment_id = 0; segment_id < num_segments; ++segment_id) {
+            const size_t begin = keys.size() * segment_id / num_segments;
+            const size_t end = keys.size() * (segment_id + 1) / num_segments;
+            auto chunk = ChunkFactory::new_chunk(schema, end - begin);
+            auto cols = chunk->columns();
+            for (size_t i = begin; i < end; ++i) {
+                int64_t key = keys[i];
+                cols[0]->as_mutable_ptr()->append_datum(Datum(key));
+                cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(key % 100 + 1)));
+                cols[2]->as_mutable_ptr()->append_datum(Datum((int32_t)(key % 1000 + 2)));
+            }
+            EXPECT_TRUE(writer->flush_chunk(*chunk).ok());
         }
-        EXPECT_TRUE(writer->flush_chunk(*chunk).ok());
         return *writer->build();
     }
 
@@ -475,6 +480,11 @@ public:
     }
 
     void TearDown() override {
+        if (_observing_charge_refreshes) {
+            SyncPoint::GetInstance()->DisableProcessing();
+            SyncPoint::GetInstance()->ClearCallBack("Rowset::segment_memory_usage");
+            SyncPoint::GetInstance()->ClearCallBack("Rowset::_update_metadata_cache_charge");
+        }
         MetadataCache::_s_instance = _previous_cache;
         config::metadata_cache_memory_limit_percent = _previous_cache_percent;
         _metadata_cache.reset();
@@ -482,10 +492,162 @@ public:
     }
 
 protected:
+    void observe_charge_refreshes() {
+        _observing_charge_refreshes = true;
+        SyncPoint::GetInstance()->SetCallBack("Rowset::segment_memory_usage", [&](void*) { ++_snapshot_calls; });
+        SyncPoint::GetInstance()->SetCallBack("Rowset::_update_metadata_cache_charge", [&](void* arg) {
+            ++_charge_update_calls;
+            _last_charge = *static_cast<size_t*>(arg);
+        });
+        SyncPoint::GetInstance()->EnableProcessing();
+    }
+
     std::unique_ptr<MetadataCache> _metadata_cache;
     MetadataCache* _previous_cache = nullptr;
     int32_t _previous_cache_percent = 0;
+    bool _observing_charge_refreshes = false;
+    int _snapshot_calls = 0;
+    int _charge_update_calls = 0;
+    size_t _last_charge = 0;
 };
+
+TEST_F(MetadataCacheReaderTest, segment_dirty_flags_are_consumed_independently_and_can_be_rearmed) {
+    auto tablet = create_tablet(1012, 10015);
+    auto rowset = create_rowset(tablet, {1, 2, 3, 4, 5, 6}, 2);
+    ASSERT_TRUE(rowset->load().ok());
+    ASSERT_EQ(2, rowset->segments().size());
+    const auto& first = rowset->segments()[0];
+    const auto& second = rowset->segments()[1];
+    first->consume_lazy_mem_update();
+    second->consume_lazy_mem_update();
+    ASSERT_FALSE(first->consume_lazy_mem_update());
+    ASSERT_FALSE(second->consume_lazy_mem_update());
+
+    // Multiple notifications coalesce until consumed and do not dirty a sibling.
+    first->update_cache_size();
+    first->update_cache_size();
+    ASSERT_TRUE(first->consume_lazy_mem_update());
+    ASSERT_FALSE(first->consume_lazy_mem_update());
+    ASSERT_FALSE(second->consume_lazy_mem_update());
+
+    first->update_cache_size();
+    second->update_cache_size();
+    ASSERT_TRUE(first->consume_lazy_mem_update());
+    ASSERT_TRUE(second->consume_lazy_mem_update());
+    ASSERT_FALSE(first->consume_lazy_mem_update());
+    ASSERT_FALSE(second->consume_lazy_mem_update());
+}
+
+TEST_F(MetadataCacheReaderTest, release_refreshes_all_dirty_segments_once) {
+    auto tablet = create_tablet(1013, 10016);
+    auto rowset = create_rowset(tablet, {1, 2, 3, 4, 5, 6, 7, 8, 9}, 3);
+    ASSERT_TRUE(rowset->load().ok());
+    ASSERT_EQ(3, rowset->segments().size());
+    _metadata_cache->cache_rowset(rowset.get());
+    const size_t initial_rowset_size = rowset->segment_memory_usage();
+    const size_t initial_cache_usage = _metadata_cache->get_memory_usage();
+    const auto& segments = rowset->segments();
+    for (const auto& segment : segments) {
+        segment->consume_lazy_mem_update();
+    }
+    const size_t first_size = segments[0]->mem_usage();
+    const size_t last_size = segments[2]->mem_usage();
+    observe_charge_refreshes();
+
+    rowset->acquire();
+    rowset->acquire();
+    ASSERT_TRUE(segments[0]->load_index().ok());
+    ASSERT_TRUE(segments[2]->load_index().ok());
+    const size_t loaded_rowset_size =
+            initial_rowset_size + segments[0]->mem_usage() - first_size + segments[2]->mem_usage() - last_size;
+    ASSERT_GT(loaded_rowset_size, initial_rowset_size);
+
+    rowset->release();
+    ASSERT_EQ(1, rowset->refs_by_reader());
+    ASSERT_EQ(0, _snapshot_calls);
+    ASSERT_EQ(0, _charge_update_calls);
+    ASSERT_EQ(initial_cache_usage, _metadata_cache->get_memory_usage());
+
+    rowset->release();
+    ASSERT_EQ(0, rowset->refs_by_reader());
+    ASSERT_EQ(1, _snapshot_calls);
+    ASSERT_EQ(1, _charge_update_calls);
+    ASSERT_EQ(loaded_rowset_size, _last_charge);
+    ASSERT_EQ(initial_cache_usage + loaded_rowset_size - initial_rowset_size, _metadata_cache->get_memory_usage());
+    // Finding the first dirty segment must not skip consumption of later flags.
+    for (const auto& segment : segments) {
+        ASSERT_FALSE(segment->consume_lazy_mem_update());
+    }
+
+    rowset->acquire();
+    rowset->release();
+    ASSERT_EQ(1, _snapshot_calls);
+    ASSERT_EQ(1, _charge_update_calls);
+
+    // A subsequent change in the previously clean middle segment triggers one
+    // more snapshot and publishes the complete rowset charge.
+    const size_t middle_size = segments[1]->mem_usage();
+    rowset->acquire();
+    ASSERT_TRUE(segments[1]->load_index().ok());
+    const size_t final_rowset_size = loaded_rowset_size + segments[1]->mem_usage() - middle_size;
+    ASSERT_GT(final_rowset_size, loaded_rowset_size);
+    rowset->release();
+    ASSERT_EQ(2, _snapshot_calls);
+    ASSERT_EQ(2, _charge_update_calls);
+    ASSERT_EQ(final_rowset_size, _last_charge);
+    ASSERT_EQ(initial_cache_usage + final_rowset_size - initial_rowset_size, _metadata_cache->get_memory_usage());
+    ASSERT_FALSE(segments[1]->consume_lazy_mem_update());
+}
+
+TEST_F(MetadataCacheReaderTest, unloading_release_destroys_segments_without_refreshing_dirty_charge) {
+    auto tablet = create_tablet(1014, 10017);
+    auto rowset = create_rowset(tablet, {1, 2, 3});
+    ASSERT_TRUE(rowset->load().ok());
+    _metadata_cache->cache_rowset(rowset.get());
+    std::weak_ptr<Segment> segment = rowset->segments().front();
+    rowset->acquire();
+    rowset->acquire();
+    ASSERT_TRUE(rowset->segments().front()->load_index().ok());
+    observe_charge_refreshes();
+
+    rowset->close();
+    ASSERT_EQ(2, rowset->refs_by_reader());
+    ASSERT_FALSE(segment.expired());
+    rowset->release();
+    ASSERT_EQ(1, rowset->refs_by_reader());
+    ASSERT_FALSE(segment.expired());
+    ASSERT_EQ(0, _snapshot_calls);
+    ASSERT_EQ(0, _charge_update_calls);
+
+    rowset->release();
+    ASSERT_EQ(0, rowset->refs_by_reader());
+    ASSERT_TRUE(rowset->segments().empty());
+    ASSERT_TRUE(segment.expired());
+    ASSERT_EQ(0, _snapshot_calls);
+    ASSERT_EQ(0, _charge_update_calls);
+
+    // Successful reload verifies that on_release() completed the UNLOADED transition.
+    ASSERT_TRUE(rowset->load().ok());
+    ASSERT_FALSE(rowset->segments().empty());
+}
+
+TEST_F(MetadataCacheReaderTest, loaded_empty_rowset_release_skips_charge_calculation) {
+    auto tablet = create_tablet(1015, 10018);
+    auto rowset = create_rowset(tablet, {}, 0);
+    ASSERT_EQ(0, rowset->num_segments());
+    ASSERT_TRUE(rowset->load().ok());
+    ASSERT_TRUE(rowset->segments().empty());
+    _metadata_cache->cache_rowset(rowset.get());
+    const size_t initial_cache_usage = _metadata_cache->get_memory_usage();
+    observe_charge_refreshes();
+
+    rowset->acquire();
+    rowset->release();
+    ASSERT_EQ(0, rowset->refs_by_reader());
+    ASSERT_EQ(0, _snapshot_calls);
+    ASSERT_EQ(0, _charge_update_calls);
+    ASSERT_EQ(initial_cache_usage, _metadata_cache->get_memory_usage());
+}
 
 TEST_F(MetadataCacheReaderTest, close_refreshes_charge_only_after_last_reader) {
     const std::vector<int64_t> keys{1, 2, 3};
@@ -526,6 +688,44 @@ TEST_F(MetadataCacheReaderTest, close_refreshes_charge_only_after_last_reader) {
     ASSERT_EQ(0, rowset->refs_by_reader());
     ASSERT_EQ(updated_cache_usage, _metadata_cache->get_memory_usage());
     ASSERT_EQ(0, _metadata_cache->_cache->get_lookup_count());
+}
+
+TEST_F(MetadataCacheReaderTest, disable_cache_before_charge_update) {
+    const std::vector<int64_t> keys{1, 2, 3};
+    auto tablet = create_tablet(1011, 10014);
+    auto rowset = create_rowset(tablet, keys);
+    ASSERT_TRUE(rowset->load().ok());
+    _metadata_cache->cache_rowset(rowset.get());
+    const size_t initial_cache_usage = _metadata_cache->get_memory_usage();
+
+    auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
+    TabletReader reader(tablet, Version(0, 0), schema, std::vector<RowsetSharedPtr>{rowset});
+    ASSERT_TRUE(reader.prepare().ok());
+    std::vector<std::string> short_keys;
+    ASSERT_TRUE(rowset->get_segment_sk_index(&short_keys).ok());
+
+    int snapshots = 0;
+    int charge_updates = 0;
+    SyncPoint::GetInstance()->SetCallBack("Rowset::segment_memory_usage", [&](void*) {
+        ++snapshots;
+        // The runtime setting can change after release() passes its first
+        // config check but before it publishes the charge snapshot.
+        config::metadata_cache_memory_limit_percent = 0;
+    });
+    SyncPoint::GetInstance()->SetCallBack("Rowset::_update_metadata_cache_charge", [&](void*) { ++charge_updates; });
+    DeferOp clear_callbacks([] {
+        SyncPoint::GetInstance()->DisableProcessing();
+        SyncPoint::GetInstance()->ClearCallBack("Rowset::segment_memory_usage");
+        SyncPoint::GetInstance()->ClearCallBack("Rowset::_update_metadata_cache_charge");
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+
+    reader.close();
+    ASSERT_EQ(1, snapshots);
+    ASSERT_EQ(0, charge_updates);
+    ASSERT_EQ(0, rowset->refs_by_reader());
+    ASSERT_EQ(initial_cache_usage, _metadata_cache->get_memory_usage());
+    ASSERT_FALSE(rowset->segments().empty());
 }
 
 TEST_F(MetadataCacheReaderTest, close_finishes_deferred_rowset_unload) {


### PR DESCRIPTION
## What I'm doing:
Rowset metadata cache entries kept their initial charge after lazy-loaded indexes increased segment memory usage.

Mark share-nothing segments dirty when metadata changes and refresh the cache charge when the last reader releases a loaded non-PK rowset. Skip full memory scans when segments are clean or the cache is disabled.

Reuse Cache::update_charge_if and compare weak-pointer ownership to avoid updating a different Rowset cached under the same ID. Capture memory usage under the Rowset lock and update the cache after unlocking so eviction can call close(). Keep charge accounting best-effort across concurrent reader cycles.

Add regression coverage for lazy metadata growth, last-reader and clean releases, disabled-cache and primary-key paths, deferred close, and replacement of a cached Rowset with another object sharing its ID.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
