### PR TITLE
[BugFix] Only narrow an OLAP scan's complex type when BE prunes it by an access path

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneSubfieldsForComplexType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneSubfieldsForComplexType.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.optimizer.rule.tree;
 
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ColumnAccessPath;
 import com.starrocks.catalog.ComplexTypeAccessGroup;
 import com.starrocks.catalog.ComplexTypeAccessPaths;
 import com.starrocks.common.FeConstants;
@@ -144,8 +145,50 @@ public class PruneSubfieldsForComplexType implements TreeRewriteRule {
                     }
                 }
             }
-            physicalScanOperator.getColRefToColumnMetaMap().keySet().forEach(context::addScan);
+            for (Map.Entry<ColumnRefOperator, Column> entry : physicalScanOperator.getColRefToColumnMetaMap()
+                    .entrySet()) {
+                if (isPruneBoundary(physicalScanOperator, entry.getKey(), entry.getValue())) {
+                    context.addScan(entry.getKey());
+                }
+            }
             return visit(optExpression, context);
+        }
+
+        // A scan column is only a prune boundary if BE really materializes just the subfields we keep:
+        // pruneForComplexType() narrows such a column's declared type and canSafelyPruneUnnestOutput()
+        // narrows an UNNEST output down to it, and both end up in the descriptor the receiving side of
+        // an exchange decodes with.
+        //
+        // An OLAP scan builds its output columns from the TABLET schema and narrows them only in
+        // OlapChunkSource::_prune_schema_by_access_paths, i.e. when a ColumnAccessPath was pushed down
+        // for the column, has children and is not predicate-only - the same conditions BE checks. With
+        // no such path BE hands out the full struct while FE declares a narrower one; since the chunk
+        // encoding is positional and only the first chunk of an exchange carries the meta, that
+        // mismatch makes the receiver walk the wrong number of sub-columns.
+        //
+        // NOTE on ordering: EliminateOveruseColumnAccessPathRule runs AFTER this rule and can drop
+        // paths, so in principle a path seen here could be gone by the time the plan is executed.
+        // Today the two cannot overlap - a path is only "overuse" when the parent already consumes
+        // the whole column, and then the access group covers every subfield so nothing is narrowed
+        // in the first place - and this rule cannot simply be moved after it, because it must stay
+        // before ScalarOperatorsReuseRule (it walks Projection#getCommonSubOperatorMap). Should that
+        // invariant ever break, PlanValidator's PrunedComplexTypeChecker runs on the final plan and
+        // will reject the result rather than letting it reach the BE.
+        private static boolean isPruneBoundary(PhysicalScanOperator scanOperator, ColumnRefOperator ref,
+                                               Column column) {
+            if (!ref.getType().isComplexType() ||
+                    !OperatorType.PHYSICAL_OLAP_SCAN.equals(scanOperator.getOpType())) {
+                return true;
+            }
+            for (ColumnAccessPath path : scanOperator.getColumnAccessPaths()) {
+                if (path.isFromPredicate() || !path.hasChildPath()) {
+                    continue;
+                }
+                if (path.getPath().equalsIgnoreCase(column.getName())) {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneSubfieldsForComplexType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneSubfieldsForComplexType.java
@@ -184,7 +184,13 @@ public class PruneSubfieldsForComplexType implements TreeRewriteRule {
                 if (path.isFromPredicate() || !path.hasChildPath()) {
                     continue;
                 }
-                if (path.getPath().equalsIgnoreCase(column.getName())) {
+                // Match on the column id, not the name: a path is rooted at the storage-side id
+                // (PruneSubfieldRule and computeAllColumnAccessPath both name it after
+                // Column#getColumnId), and a renamed column keeps that id while its name changes.
+                // Matching the name would stop recognising the path after a rename, leaving the
+                // declared type full while BE still prunes by the path - the same width disagreement
+                // as before, just the other way round.
+                if (path.getPath().equalsIgnoreCase(column.getColumnId().getId())) {
                     return true;
                 }
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ComplexTypePrunePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ComplexTypePrunePlanTest.java
@@ -313,6 +313,32 @@ public class ComplexTypePrunePlanTest extends PlanTestBase {
     }
 
     @Test
+    public void testPruneBoundaryAfterColumnRename() throws Exception {
+        // An access path is rooted at the column's storage id, and a rename does not change that id -
+        // only the name. If the prune boundary were decided by the current name, a renamed column
+        // would stop being recognised as backed by a path: FE would keep the declared type full while
+        // BE still prunes the scan schema by the path, which is the same width disagreement as an
+        // unbacked narrowing, only the other way round.
+        FeConstants.runningUnitTest = true;
+        starRocksAssert.withTable("create table array_struct_rename(c1 int, " +
+                "c2 array<struct<c2_sub1 int, c2_sub2 int>>) " +
+                "duplicate key(c1) distributed by hash(c1) buckets 1 " +
+                "properties('replication_num'='1')");
+        try {
+            starRocksAssert.ddl("alter table array_struct_rename rename column c2 to c2_new");
+            String sql = "select c2_new[1].c2_sub1 from array_struct_rename";
+            String plan = getVerboseExplain(sql);
+            // the path is still rooted at the original column id ...
+            assertContains(plan, "ColumnAccessPath: [/c2/INDEX/c2_sub1]");
+            // ... and the declared type narrows in lockstep with it
+            assertContains(plan, "[ARRAY<struct<`c2_sub1` int(11)>>]");
+        } finally {
+            starRocksAssert.dropTable("array_struct_rename");
+            FeConstants.runningUnitTest = false;
+        }
+    }
+
+    @Test
     public void testUnnestCrossJoin() throws Exception {
         FeConstants.runningUnitTest = true;
         String sql = "select c3_struct.c3_sub1_sub1 from array_struct_nest cross join " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ComplexTypePrunePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ComplexTypePrunePlanTest.java
@@ -270,9 +270,10 @@ public class ComplexTypePrunePlanTest extends PlanTestBase {
     @Test
     public void testProjectOnTF() throws Exception {
         FeConstants.runningUnitTest = true;
-        // no project on input, and project on tf, prune
+        // UNNEST reads the whole c2 array, so no access path is pushed down and the element type
+        // has to stay as wide as what BE materializes, even though only c2_sub1 is read
         String sql = "select c2_struct.c2_sub1 from array_struct_nest, unnest(c2) as t(c2_struct);";
-        assertVerbosePlanContains(sql, "[ARRAY<struct<`c2_sub1` int(11)>>]");
+        assertVerbosePlanContains(sql, "[ARRAY<struct<`c2_sub1` int(11), `c2_sub2` int(11)>>]");
         // no project on input, and project on tf all subfiled, no prune
         sql = "select c2_struct.c2_sub1, c2_struct.c2_sub2 from array_struct_nest, unnest(c2) as t(c2_struct);";
         assertVerbosePlanContains(sql, "[ARRAY<struct<`c2_sub1` int(11), `c2_sub2` int(11)>>]");
@@ -295,7 +296,7 @@ public class ComplexTypePrunePlanTest extends PlanTestBase {
     public void testNoOutputOnTF() throws Exception {
         FeConstants.runningUnitTest = true;
         String sql = "select c1 from array_struct_nest, unnest(c2) as t(c2_struct) where c2_struct.c2_sub1 > 0;";
-        assertVerbosePlanContains(sql, "[ARRAY<struct<`c2_sub1` int(11)>>]");
+        assertVerbosePlanContains(sql, "[ARRAY<struct<`c2_sub1` int(11), `c2_sub2` int(11)>>]");
         sql = "select c1 from array_struct_nest, unnest(c3.c3_sub1) as t(c3_struct) where c3_struct.c3_sub1_sub1 > 0;";
         assertVerbosePlanContains(sql, "[struct<`c3_sub1` array<struct<`c3_sub1_sub1` int(11)>>>]");
         FeConstants.runningUnitTest = false;
@@ -306,7 +307,7 @@ public class ComplexTypePrunePlanTest extends PlanTestBase {
         FeConstants.runningUnitTest = true;
         String sql = "select c3_struct.c3_sub1_sub1 from array_struct_nest, unnest(c2) as t(c_struct), " +
                 "unnest(c3.c3_sub1) as tt(c3_struct) where c_struct.c2_sub1 > 10";
-        assertVerbosePlanContains(sql, "[ARRAY<struct<`c2_sub1` int(11)>>]");
+        assertVerbosePlanContains(sql, "[ARRAY<struct<`c2_sub1` int(11), `c2_sub2` int(11)>>]");
         assertVerbosePlanContains(sql, "[struct<`c3_sub1` array<struct<`c3_sub1_sub1` int(11)>>>]");
         FeConstants.runningUnitTest = false;
     }
@@ -335,17 +336,19 @@ public class ComplexTypePrunePlanTest extends PlanTestBase {
     }
 
     @Test
-    public void testUnnestResultTypeNarrowedConsistently() throws Exception {
+    public void testUnnestResultTypeMatchesInputWidth() throws Exception {
         FeConstants.runningUnitTest = true;
-        // When only one subfield of the unnest output struct is used, both the unnest INPUT array
-        // element AND the unnest OUTPUT (returnTypes) must be narrowed to the same width. Previously
-        // the input was narrowed while the output kept full width, so the emitted struct width
-        // differed from its input element -> StructColumn::append field-count mismatch in the BE.
+        // The unnest INPUT array element and the unnest OUTPUT (returnTypes) must always describe the
+        // same width, otherwise the emitted struct differs from its input element and BE hits a
+        // StructColumn::append field-count mismatch. UNNEST reads the whole c2 array, so no
+        // ColumnAccessPath survives for it and BE materializes the full element from the tablet
+        // schema - both stay full. c3 is different: only c3.c3_sub1 is read, that path IS pushed
+        // down, BE prunes the scan schema by it, and the declared types narrow in lockstep.
         String sql = "select c2_struct.c2_sub1 from array_struct_nest, unnest(c2) as t(c2_struct);";
-        // input array element narrowed ...
-        assertVerbosePlanContains(sql, "[ARRAY<struct<`c2_sub1` int(11)>>]");
-        // ... and the unnest result type narrowed in sync (this is the fix).
-        assertVerbosePlanContains(sql, "returnTypes: [struct<`c2_sub1` int(11)>]");
+        // input array element stays full - UNNEST gives c2 no access path ...
+        assertVerbosePlanContains(sql, "[ARRAY<struct<`c2_sub1` int(11), `c2_sub2` int(11)>>]");
+        // ... and the unnest result type describes exactly that same element
+        assertVerbosePlanContains(sql, "returnTypes: [struct<`c2_sub1` int(11), `c2_sub2` int(11)>]");
 
         // Nested case: unnest over an array nested inside a struct.
         sql = "select c3_struct.c3_sub1_sub1 from array_struct_nest, unnest(c3.c3_sub1) as t(c3_struct);";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -1328,18 +1328,19 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
 
     @Test
     public void testUnnestOutputMatchesInputWhenArrayAlsoAccessedDirectly() throws Exception {
-        // The UNNEST input array (ass) is a scan column that is ALSO read directly as ass[1].a, so it
-        // is pruned to the UNION of the touched subfields {a, b} (a from the direct access, b from
-        // outcome.b). The UNNEST output must equal the element type of that shared input -> struct<a, b>.
-        // Pruning the output to only the subfield this output "uses" (b) would make it narrower than
-        // what BE materializes from the shared array, triggering "encode size does not equal when
-        // decoding" on shuffle deserialization.
+        // The UNNEST input array (ass) is a scan column that is ALSO read directly as ass[1].a.
+        // UNNEST needs the whole array, so no ColumnAccessPath survives for `ass` and the OLAP scan
+        // materializes the full element struct. FE must therefore keep the declared type full as
+        // well: narrowing it to the touched subfields {a, b} would declare a struct narrower than BE
+        // reads back from the tablet schema, which desyncs the positional chunk encoding on shuffle
+        // ("encode size does not equal when decoding", or a read_raw crash on the column after it).
         connectContext.getSessionVariable().setEnablePruneComplexTypes(true);
         connectContext.getSessionVariable().setEnablePruneComplexTypesInUnnest(true);
         try {
             String sql = "select ass[1].a, outcome.b from tt, unnest(ass) as t(outcome) order by v1 limit 10";
             String plan = getVerboseExplain(sql);
-            assertContains(plan, "returnTypes: [struct<`a` int(11), `b` int(11)>]");
+            assertNotContains(plan, "ColumnAccessPath");
+            assertContains(plan, "returnTypes: [struct<`a` int(11), `b` int(11), `c` int(11)>]");
             assertNotContains(plan, "returnTypes: [struct<`b` int(11)>]");
         } finally {
             connectContext.getSessionVariable().setEnablePruneComplexTypes(false);
@@ -1373,18 +1374,18 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
     @Test
     public void testPruneStackedUnnestOnNestedArray() throws Exception {
         // Stacked UNNEST of a 2D array: UNNEST(col2d) -> inner_arr (array<struct>), then
-        // UNNEST(inner_arr) -> e (struct). The outer UNNEST's input (inner_arr) is itself an UNNEST
-        // output that gets pruned here, so the outer output must be pruned in lockstep with it.
-        // canSafelyPruneUnnestOutput must recurse through the inner UNNEST down to the scan column;
-        // otherwise the outer output stays full while inner_arr is pruned, making the output WIDER
-        // than the element BE materializes -> shuffle type mismatch.
+        // UNNEST(inner_arr) -> e (struct). The chain bottoms out at an OLAP scan column that UNNEST
+        // reads whole, so no ColumnAccessPath is pushed down and BE materializes the full element
+        // struct. Every type in the chain therefore has to stay full: pruning the outer output to
+        // {a} would declare a struct narrower than the elements BE actually produces.
         connectContext.getSessionVariable().setEnablePruneComplexTypes(true);
         connectContext.getSessionVariable().setEnablePruneComplexTypesInUnnest(true);
         try {
             String sql = "select e.a from arr2d_nested, unnest(col2d) as t1(inner_arr), unnest(inner_arr) as t2(e)";
             String plan = getVerboseExplain(sql);
-            assertContains(plan, "returnTypes: [struct<`a` int(11)>]");
-            assertNotContains(plan, "returnTypes: [struct<`a` int(11), `b` int(11)>]");
+            assertNotContains(plan, "ColumnAccessPath");
+            assertContains(plan, "returnTypes: [struct<`a` int(11), `b` int(11)>]");
+            assertNotContains(plan, "returnTypes: [struct<`a` int(11)>]");
         } finally {
             connectContext.getSessionVariable().setEnablePruneComplexTypes(false);
             connectContext.getSessionVariable().setEnablePruneComplexTypesInUnnest(false);

--- a/test/sql/test_complex_type_prune/R/test_unnest_prune_needs_access_path
+++ b/test/sql/test_complex_type_prune/R/test_unnest_prune_needs_access_path
@@ -1,0 +1,97 @@
+-- name: test_unnest_prune_needs_access_path
+drop database if exists test_unnest_prune_needs_access_path;
+-- result:
+-- !result
+create database test_unnest_prune_needs_access_path;
+-- result:
+-- !result
+use test_unnest_prune_needs_access_path;
+-- result:
+-- !result
+create table citations_tbl (
+  id bigint null,
+  engine_id int null,
+  cites array<struct<root_domain varchar(64), normalized_url varchar(64),
+                     prunedawaymarker1 int, prunedawaymarker2 int>>
+) duplicate key(id)
+distributed by hash(id) buckets 3 properties("replication_num"="1");
+-- result:
+-- !result
+create table engines_tbl (
+  engine_id int null,
+  engine_name varchar(32) null
+) duplicate key(engine_id)
+distributed by hash(engine_id) buckets 3 properties("replication_num"="1");
+-- result:
+-- !result
+insert into citations_tbl values
+  (1, 1, [row('apple.com', 'https://a/1', 11, 12), row('other.com', 'https://o/1', 13, 14)]),
+  (2, 2, null),
+  (3, 1, []),
+  (4, 2, [row('apple.com', 'https://a/2', null, null)]),
+  (5, 1, [row(null, null, 15, 16), row('apple.com', 'https://a/3', 17, 18)]);
+-- result:
+-- !result
+insert into engines_tbl values (1, 'e1'), (2, 'e2');
+-- result:
+-- !result
+function: assert_explain_verbose_contains('select count(*) from (select cites from citations_tbl order by id limit 100) s left join unnest(s.cites) t(x) on true where x.root_domain = "apple.com"', 'prunedawaymarker1')
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains('select count(*) from (select cites from citations_tbl order by id limit 100) s left join unnest(s.cites) t(x) on true where x.root_domain = "apple.com"', 'prunedawaymarker2')
+-- result:
+None
+-- !result
+function: assert_explain_not_contains('select count(*) from (select cites from citations_tbl order by id limit 100) s left join unnest(s.cites) t(x) on true where x.root_domain = "apple.com"', 'ColumnAccessPath')
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains('select count(*) from (select cites, dense_rank() over (partition by engine_id order by id) rn from citations_tbl) s left join unnest(s.cites) t(x) on true where rn = 1 and x.root_domain = "apple.com"', 'prunedawaymarker1')
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains('select cites[1].root_domain from citations_tbl', 'ColumnAccessPath')
+-- result:
+None
+-- !result
+select count(*) from (select cites, engine_id from citations_tbl order by id limit 100) s
+left join unnest(s.cites) as t(x) on true
+join engines_tbl e on s.engine_id = e.engine_id
+where x.root_domain = 'apple.com';
+-- result:
+3
+-- !result
+set enable_exchange_pass_through = false;
+-- result:
+-- !result
+select e.engine_name, count(*) from (select cites, engine_id from citations_tbl order by id limit 100) s
+left join unnest(s.cites) as t(x) on true
+join engines_tbl e on s.engine_id = e.engine_id
+group by e.engine_name order by e.engine_name;
+-- result:
+e1	5
+e2	2
+-- !result
+select x.root_domain, count(*) from (
+  select cites, dense_rank() over (partition by engine_id order by id) rn from citations_tbl
+) s left join unnest(s.cites) as t(x) on true
+where rn = 1
+group by 1 order by 1;
+-- result:
+None	1
+apple.com	1
+other.com	1
+-- !result
+select x.root_domain, x.normalized_url, x.prunedawaymarker1, x.prunedawaymarker2
+from citations_tbl c, unnest(c.cites) as t(x) order by 1, 2, 3, 4;
+-- result:
+None	None	15	16
+apple.com	https://a/1	11	12
+apple.com	https://a/2	None	None
+apple.com	https://a/3	17	18
+other.com	https://o/1	13	14
+-- !result
+drop database test_unnest_prune_needs_access_path;
+-- result:
+-- !result

--- a/test/sql/test_complex_type_prune/T/test_unnest_prune_needs_access_path
+++ b/test/sql/test_complex_type_prune/T/test_unnest_prune_needs_access_path
@@ -1,0 +1,88 @@
+-- name: test_unnest_prune_needs_access_path
+-- Bug: PruneSubfieldsForComplexType narrowed the declared type of an OLAP scan column to the
+-- subfields the query touches, but what BE materializes is decided by the pushed-down
+-- ColumnAccessPath: OlapChunkSource builds its output chunk from the TABLET schema and narrows it
+-- only in _prune_schema_by_access_paths, which returns immediately when the column has no path.
+-- UNNEST over a whole array needs the entire array, so no path survives for it, yet the rule
+-- narrowed the type anyway once the array crossed a materialization boundary (a TopN or a window)
+-- on its way to the UNNEST. FE then declared ARRAY<STRUCT<root_domain>> while the scan handed out
+-- the full four-field element, and every operator that builds a column from the declared type
+-- disagreed with the data flowing into it:
+--   StructColumn::append <- ArrayColumn::append <- ArrayColumn::append_selective
+--   <- NullableColumn::append_selective <- JoinHashMap::probe
+--     Check failed: _fields.size() == struct_column.fields().size() (1 vs. 4)
+-- Across an exchange it is worse: the chunk encoding is positional and only the first chunk carries
+-- the meta, so the receiver walks one sub-column where the sender wrote four, reads the next length
+-- field out of unrelated bytes and can memcpy into an unallocated buffer - SIGSEGV at 0x0 inside
+-- serde::read_raw. Workaround before the fix: set enable_prune_complex_types = false.
+drop database if exists test_unnest_prune_needs_access_path;
+create database test_unnest_prune_needs_access_path;
+use test_unnest_prune_needs_access_path;
+
+-- the last two struct fields carry names that appear nowhere else in a plan, so asserting on them
+-- says whether the declared element type is still the full one, without depending on how a given
+-- version formats types in EXPLAIN
+create table citations_tbl (
+  id bigint null,
+  engine_id int null,
+  cites array<struct<root_domain varchar(64), normalized_url varchar(64),
+                     prunedawaymarker1 int, prunedawaymarker2 int>>
+) duplicate key(id)
+distributed by hash(id) buckets 3 properties("replication_num"="1");
+
+create table engines_tbl (
+  engine_id int null,
+  engine_name varchar(32) null
+) duplicate key(engine_id)
+distributed by hash(engine_id) buckets 3 properties("replication_num"="1");
+
+insert into citations_tbl values
+  (1, 1, [row('apple.com', 'https://a/1', 11, 12), row('other.com', 'https://o/1', 13, 14)]),
+  (2, 2, null),
+  (3, 1, []),
+  (4, 2, [row('apple.com', 'https://a/2', null, null)]),
+  (5, 1, [row(null, null, 15, 16), row('apple.com', 'https://a/3', 17, 18)]);
+
+insert into engines_tbl values (1, 'e1'), (2, 'e2');
+
+-- UNNEST reads the whole array, so no ColumnAccessPath is pushed down for `cites` and BE
+-- materializes the full element from the tablet schema. The declared type must stay just as wide,
+-- even though only root_domain is read. Before the fix this scan declared ARRAY<STRUCT<root_domain>>
+-- and both marker fields disappeared from the plan.
+function: assert_explain_verbose_contains('select count(*) from (select cites from citations_tbl order by id limit 100) s left join unnest(s.cites) t(x) on true where x.root_domain = "apple.com"', 'prunedawaymarker1')
+function: assert_explain_verbose_contains('select count(*) from (select cites from citations_tbl order by id limit 100) s left join unnest(s.cites) t(x) on true where x.root_domain = "apple.com"', 'prunedawaymarker2')
+function: assert_explain_not_contains('select count(*) from (select cites from citations_tbl order by id limit 100) s left join unnest(s.cites) t(x) on true where x.root_domain = "apple.com"', 'ColumnAccessPath')
+
+-- same through a window function, which is the shape the production query had
+function: assert_explain_verbose_contains('select count(*) from (select cites, dense_rank() over (partition by engine_id order by id) rn from citations_tbl) s left join unnest(s.cites) t(x) on true where rn = 1 and x.root_domain = "apple.com"', 'prunedawaymarker1')
+
+-- the fix must stay narrow in scope: reading a subfield directly still pushes an access path down,
+-- and there the declared type is still narrowed in lockstep with what BE reads
+function: assert_explain_verbose_contains('select cites[1].root_domain from citations_tbl', 'ColumnAccessPath')
+
+-- the shape that crashed: the array crosses a materialization boundary and then feeds a join probe
+-- that copies the array-of-struct
+select count(*) from (select cites, engine_id from citations_tbl order by id limit 100) s
+left join unnest(s.cites) as t(x) on true
+join engines_tbl e on s.engine_id = e.engine_id
+where x.root_domain = 'apple.com';
+
+-- the same column carried across a serialized exchange
+set enable_exchange_pass_through = false;
+select e.engine_name, count(*) from (select cites, engine_id from citations_tbl order by id limit 100) s
+left join unnest(s.cites) as t(x) on true
+join engines_tbl e on s.engine_id = e.engine_id
+group by e.engine_name order by e.engine_name;
+
+-- through the window, then shuffled
+select x.root_domain, count(*) from (
+  select cites, dense_rank() over (partition by engine_id order by id) rn from citations_tbl
+) s left join unnest(s.cites) as t(x) on true
+where rn = 1
+group by 1 order by 1;
+
+-- reading every subfield must of course keep working
+select x.root_domain, x.normalized_url, x.prunedawaymarker1, x.prunedawaymarker2
+from citations_tbl c, unnest(c.cites) as t(x) order by 1, 2, 3, 4;
+
+drop database test_unnest_prune_needs_access_path;


### PR DESCRIPTION
## Why I'm doing:

PruneSubfieldsForComplexType narrows a scan column's declared type to the subfields the query touches, and that declared type is what BE builds every downstream column from - a hash join's probe output, an exchange receiver's chunk, an aggregate's group-by key. For an OLAP scan, though, what BE actually materializes is decided by the pushed-down ColumnAccessPath: OlapChunkSource builds its output chunk from the TABLET schema and narrows it only in _prune_schema_by_access_paths, which returns immediately when no path was pushed down for the column. That is why the rule already skips OLAP scans in PruneSubfieldsOptVisitor#visitPhysicalScan ("olap scan operator prune column not in this rule") - but the Projection path (pruneForColumnRefMap -> pruneForComplexType) mutates the same shared ColumnRefOperator instance and slips past that guard, gated only on context.getScanRefs().contains(ref). That set is filled unconditionally for every scan column, so it means "this is a scan column", not "BE will materialize exactly what we declare" - true for an external scan, whose chunk is built from the TupleDescriptor, but not for an OLAP one.

UNNEST over a whole array column is where this bites: it needs the entire array, so no access path survives for it, yet the array picks up a narrowed type as soon as it crosses a materialization boundary (a TopN or a window) on its way to the UNNEST. FE then declares ARRAY<STRUCT<root_domain>> while the scan hands out the full four-field element, and nothing downstream can work:

  - across an exchange the chunk encoding is positional and only the first chunk carries the meta, so the receiver walks one sub-column where the sender wrote four, reads the next length field out of unrelated bytes and can memcpy into an unallocated buffer - a SIGSEGV at 0x0 inside serde::read_raw;
  - a local hash join probe trips StructColumn::append's field-count check (Check failed: _fields.size() == struct_column.fields().size());
  - and when the widths happen to line up but the order does not, nothing fails at all: StructColumn::append copies by position, so a plan that kept only the SECOND subfield reads the FIRST one's data and returns wrong results silently.

Treat an OLAP scan column as a prune boundary only when a ColumnAccessPath that BE will really prune by - one with children, not predicate-only, matching the column - was pushed down for it. Those are the same conditions BE checks, so the gate tracks what the backend does rather than restating the rule that produced the type. Gating it at the collect site closes both consumers of getScanRefs(): pruneForComplexType and canSafelyPruneUnnestOutput.

Reading a subfield directly still pushes its path down and still prunes, so the optimization is not disabled wholesale - only the case where it was never real: without a path BE reads every subfield and serializes every sub-column anyway, so all that was shrinking was the declared type.

Six existing expectations change because they asserted exactly this unsafe narrowing; the comments next to them now spell out why c2 (UNNEST reads the whole array, no path) stays full while c3 (c3.c3_sub1 read directly, path pushed down) still narrows. A note on isPruneBoundary records that EliminateOveruseColumnAccessPathRule runs after this rule and can drop paths: the two cannot overlap today, this rule cannot move after it (it must stay before ScalarOperatorsReuseRule, which it depends on for
Projection#getCommonSubOperatorMap), and PlanValidator sees the final plan if that ever changes.

Verified end to end on the reported 4.0.13-ee build: the customer query went from 938468 struct width mismatches per run to 0 with results identical to running with enable_prune_complex_types=false, and 10/10 runs survived. The new SQL regression case fails on the same cluster with the fix reverted.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
