### PR TITLE
[BugFix] Do not prune subfields of aggregate-state columns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PruneSubfieldRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PruneSubfieldRule.java
@@ -18,9 +18,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnAccessPath;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.sql.ast.AggregateType;
 import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
@@ -130,7 +132,19 @@ public class PruneSubfieldRule extends TransformationRule {
             if (!normalizer.hasPath(ref)) {
                 continue;
             }
-            String columnName = scan.getColRefToColumnMetaMap().get(ref).getColumnId().getId();
+            Column column = scan.getColRefToColumnMetaMap().get(ref);
+            // An AGG_STATE_UNION column does not store the value the query sees: it stores a serialized
+            // aggregate state, and the storage layer rebuilds the value by running the aggregate function
+            // over that state. An access path asks the BE for only part of the column -- `array_length(v)`
+            // on an array_agg_distinct column asks for /v/OFFSET alone -- and the merge then runs against
+            // an array that kept its offsets and lost its elements. array_length comes back as 0 or 1
+            // instead of the real length, and on wider data the merge indexes past the element column and
+            // the BE dies in NullableColumn::null_count. A global dictionary is unusable on these columns
+            // for the same reason, see #77096.
+            if (column.getAggregationType() == AggregateType.AGG_STATE_UNION) {
+                continue;
+            }
+            String columnName = column.getColumnId().getId();
             ColumnAccessPath p = normalizer.normalizePath(ref, columnName);
 
             if (p.hasChildPath()) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -141,6 +141,16 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                 "    \"replication_num\" = \"1\"\n" +
                 ");"
         );
+        starRocksAssert.withTable("CREATE TABLE `agg_state_arr` (\n" +
+                "  `k` int NULL, \n" +
+                "  `v` array_agg_distinct(varchar(100)) \n" +
+                ") ENGINE=OLAP\n" +
+                "AGGREGATE KEY(`k`)\n" +
+                "DISTRIBUTED BY HASH(`k`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ");"
+        );
         FeConstants.runningUnitTest = false;
     }
 
@@ -363,6 +373,14 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         sql = "select array_length(a1), a1[1] from pc0";
         plan = getVerboseExplain(sql);
         assertContains(plan, "ColumnAccessPath: [/a1/ALL]");
+
+        // An AGG_STATE_UNION column stores a serialized aggregate state, and the storage layer rebuilds
+        // the array by running the aggregate function over it. Asking the BE for /v/OFFSET alone leaves
+        // the merge an array that kept its offsets and lost its elements: array_length() answers 0 or 1,
+        // and a wider merge indexes past the element column and kills the BE. No path for those columns.
+        sql = "select array_length(v) from agg_state_arr";
+        plan = getVerboseExplain(sql);
+        assertNotContains(plan, "ColumnAccessPath");
 
         sql = "select a1[map1[1]] from pc0";
         plan = getVerboseExplain(sql);

--- a/test/sql/test_agg_state/R/test_agg_state_subfield_prune.sql
+++ b/test/sql/test_agg_state/R/test_agg_state_subfield_prune.sql
@@ -1,0 +1,75 @@
+-- name: test_agg_state_subfield_prune
+SET cbo_prune_subfield = true;
+-- result:
+-- !result
+CREATE TABLE src (k INT, s VARCHAR(100))
+DISTRIBUTED BY HASH(k) BUCKETS 8
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO src
+SELECT g1.generate_series AS k,
+       concat('str_', cast((g2.generate_series % 40) AS string)) AS s
+FROM TABLE(generate_series(1, 2000)) g1, TABLE(generate_series(1, 40)) g2;
+-- result:
+-- !result
+CREATE TABLE st (k INT, v array_agg_distinct(varchar(100)))
+DISTRIBUTED BY HASH(k) BUCKETS 8
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO st SELECT k, array_agg_distinct_state(s) FROM src;
+-- result:
+-- !result
+INSERT INTO st SELECT k, array_agg_distinct_state(s) FROM src;
+-- result:
+-- !result
+SELECT count(*) AS n, sum(array_length(v)) AS total_elems FROM st;
+-- result:
+2000	80000
+-- !result
+SELECT count(*) AS n_full_arrays FROM st WHERE array_length(v) = 40;
+-- result:
+2000
+-- !result
+SELECT array_length(v) FROM st WHERE k = 1;
+-- result:
+40
+-- !result
+SELECT sum(cardinality(v)) AS total_elems FROM st;
+-- result:
+80000
+-- !result
+SELECT array_length(v), v[1] IS NOT NULL FROM st WHERE k = 1;
+-- result:
+40	1
+-- !result
+CREATE TABLE plain (k INT, v ARRAY<VARCHAR(100)>)
+DUPLICATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 8
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO plain SELECT k, array_agg(DISTINCT s) FROM src GROUP BY k;
+-- result:
+-- !result
+SELECT count(*) AS n, sum(array_length(v)) AS total_elems FROM plain;
+-- result:
+2000	80000
+-- !result
+CREATE TABLE repl (k INT, v ARRAY<VARCHAR(100)> REPLACE)
+AGGREGATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 8
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO repl SELECT k, array_agg(DISTINCT s) FROM src GROUP BY k;
+-- result:
+-- !result
+INSERT INTO repl SELECT k, array_agg(DISTINCT s) FROM src GROUP BY k;
+-- result:
+-- !result
+SELECT count(*) AS n, sum(array_length(v)) AS total_elems FROM repl;
+-- result:
+2000	80000
+-- !result

--- a/test/sql/test_agg_state/T/test_agg_state_subfield_prune.sql
+++ b/test/sql/test_agg_state/T/test_agg_state_subfield_prune.sql
@@ -1,0 +1,72 @@
+-- name: test_agg_state_subfield_prune
+-- Regression for silently wrong results, and a BE crash, when subfield pruning is applied to an
+-- AGG_STATE_UNION column.
+--
+-- An agg-state column does not store the value a query reads. It stores a serialized aggregate
+-- state, and the storage layer rebuilds the value by running the aggregate function over that state
+-- while it merges rowsets. PruneSubfieldRule handed those columns a subfield access path anyway:
+-- array_length(v) needs only the length, so the scan was told to fetch /v/OFFSET and skip the
+-- elements, and the merge then ran against an array that kept its offsets and lost its elements.
+-- array_length() answered 0 or 1 instead of the real length, so the same row gave different answers
+-- depending on whether the query also projected an element. On wider data the merge indexed past the
+-- element column and killed the BE in NullableColumn::null_count(), and since compaction re-runs the
+-- same merge, the BE crash-looped after every restart. A global dictionary is unusable on these
+-- columns for the same reason, see #77096.
+--
+-- Every assertion below is order-independent: array_agg_distinct is an unordered aggregate, so only
+-- element counts are stable, never element positions. The states are built with the scalar
+-- array_agg_distinct_state() rather than the aggregate _combine(), because _state() is the spelling
+-- that exists on every branch this fix is backported to.
+SET cbo_prune_subfield = true;
+
+CREATE TABLE src (k INT, s VARCHAR(100))
+DISTRIBUTED BY HASH(k) BUCKETS 8
+PROPERTIES ("replication_num" = "1");
+
+-- 2000 groups x 40 distinct strings each = 80000 rows.
+INSERT INTO src
+SELECT g1.generate_series AS k,
+       concat('str_', cast((g2.generate_series % 40) AS string)) AS s
+FROM TABLE(generate_series(1, 2000)) g1, TABLE(generate_series(1, 40)) g2;
+
+CREATE TABLE st (k INT, v array_agg_distinct(varchar(100)))
+DISTRIBUTED BY HASH(k) BUCKETS 8
+PROPERTIES ("replication_num" = "1");
+
+-- One state per source row, loaded twice, so a key's value only exists after the storage layer
+-- unions many states across two rowsets. Each key still ends up with its 40 distinct strings.
+INSERT INTO st SELECT k, array_agg_distinct_state(s) FROM src;
+INSERT INTO st SELECT k, array_agg_distinct_state(s) FROM src;
+
+-- Length-only projections: these are the ones that used to be handed /v/OFFSET.
+SELECT count(*) AS n, sum(array_length(v)) AS total_elems FROM st;
+SELECT count(*) AS n_full_arrays FROM st WHERE array_length(v) = 40;
+SELECT array_length(v) FROM st WHERE k = 1;
+SELECT sum(cardinality(v)) AS total_elems FROM st;
+
+-- Projecting an element as well was always correct, because that plan reads the whole column. The
+-- two projections of the same row have to agree.
+SELECT array_length(v), v[1] IS NOT NULL FROM st WHERE k = 1;
+
+-- Control: a plain ARRAY column is the value it stores, so it keeps its subfield pruning and its
+-- results must be unaffected by the fix.
+CREATE TABLE plain (k INT, v ARRAY<VARCHAR(100)>)
+DUPLICATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 8
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO plain SELECT k, array_agg(DISTINCT s) FROM src GROUP BY k;
+
+SELECT count(*) AS n, sum(array_length(v)) AS total_elems FROM plain;
+
+-- Control: an ARRAY column with REPLACE aggregation lives in an aggregate table and is merged on
+-- read too, but it stores the value itself, so it was never affected either.
+CREATE TABLE repl (k INT, v ARRAY<VARCHAR(100)> REPLACE)
+AGGREGATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 8
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO repl SELECT k, array_agg(DISTINCT s) FROM src GROUP BY k;
+INSERT INTO repl SELECT k, array_agg(DISTINCT s) FROM src GROUP BY k;
+
+SELECT count(*) AS n, sum(array_length(v)) AS total_elems FROM repl;


### PR DESCRIPTION
## Why I'm doing:

```
starrocks_be: be/src/gutil/casts.h:99: To down_cast(From&) [with To = const starrocks::NullableColumn&; From = const starrocks::Column]: Assertion `dynamic_cast<ToAsPointer>(&f) != NULL' failed.
PC: @     0x7f6dcd9f6b2c pthread_kill
*** SIGABRT (@0xe79e2) received by PID 948706 (TID 0x7f6a298086c0) LWP(949530) from PID 948706; stack trace: ***
    @         0x32df4647 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7f6dcd9f9ed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)
    @         0x32df3e46 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f6dcd99d330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @     0x7f6dcd9f6b2c pthread_kill
    @     0x7f6dcd99d27e gsignal
    @     0x7f6dcd9808ff abort
    @     0x7f6dcd98081b (/usr/lib/x86_64-linux-gnu/libc.so.6+0x2881a)
    @     0x7f6dcd993517 __assert_fail
    @         0x20ef0338 starrocks::NullableColumn const& down_cast<starrocks::NullableColumn const&, starrocks::Column const>(starrocks::Column const&)
    @         0x25b52c00 starrocks::ArrayAggAggregateFunctionBase<(starrocks::LogicalType)17, true, starrocks::ArrayAggAggregateState, phmap::flat_hash_set<starrocks::SliceWithHash, starrocks::HashOnSliceWithHash, starrocks::Equal
OnSliceWithHash, std::allocator<starrocks::SliceWit@
    @         0x255edd66 starrocks::NullableAggregateFunctionBase<starrocks::AggregateFunction const*, starrocks::NullableAggregateFunctionState<starrocks::ArrayAggAggregateState<(starrocks::LogicalType)17, true, phmap::flat_hash_
set<starrocks::SliceWithHash, starrocks::HashOnSlic@
    @         0x242015c4 starrocks::AggStateUnion::merge(starrocks::FunctionContext*, starrocks::Column const*, unsigned char*, unsigned long) const
    @         0x24244678 starrocks::AggregateFunctionBatchHelper<starrocks::AggStateUnionState, starrocks::AggStateUnion>::merge_batch_single_state(starrocks::FunctionContext*, unsigned char*, starrocks::Column const*, unsigned lo
ng, unsigned long) const
    @         0x24204f1e starrocks::AggFuncBasedValueAggregator::aggregate_batch_impl(int, int, starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> const&)
    @         0x24205115 starrocks::AggFuncBasedValueAggregator::aggregate_values(int, int, unsigned int const*, bool)
    @         0x241f10ab starrocks::ChunkAggregator::aggregate()
    @         0x241e78c2 starrocks::AggregateIterator::do_get_next(starrocks::Chunk*, std::vector<starrocks::RowSourceMask, std::allocator<starrocks::RowSourceMask> >*)
    @         0x241ea5ff starrocks::AggregateIterator::do_get_next(starrocks::Chunk*)
    @         0x1cd836e1 starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x241f6b28 starrocks::TimedChunkIterator::do_get_next(starrocks::Chunk*)
    @         0x1cd836e1 starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x21f103a6 starrocks::TabletReader::do_get_next(starrocks::Chunk*)
    @         0x1cd836e1 starrocks::ChunkIterator::get_next(starrocks::Chunk*)

```

An AGG_STATE_UNION column does not store the value a query sees. It stores a serialized aggregate state, and the storage layer rebuilds the value by running the aggregate function over that state while it merges rowsets.

PruneSubfieldRule handed those columns a subfield access path anyway. For `array_length(v)` on an `array_agg_distinct(varchar)` column the path is `/v/OFFSET`, so the BE reads the array's offsets and skips its elements, and the merge then runs against an array that kept its offsets and lost its elements:

    create table src (k int, s varchar(100)) distributed by hash(k) buckets 8;
    insert into src select g1.generate_series,
                          concat('str_', cast((g2.generate_series % 40) as string))
      from table(generate_series(1,200)) g1, table(generate_series(1,40)) g2;
    create table a1 (k int, v array_agg_distinct(varchar(100)))
      distributed by hash(k) buckets 8;
    insert into a1 select k, array_agg_distinct_combine(s) from src group by k;
    insert into a1 select k, array_agg_distinct_combine(s) from src group by k;

    select k, array_length(v) from a1 where k = 1;        -- 1  0   (wrong)
    select array_length(v), v[1] from a1 where k = 1;     -- 40 str_16 (right)
    select sum(array_length(v)) from a1;                  -- 200, should be 8000

Wider data turns the wrong answer into a crash: on a 10592-row table `select count(*) from st where array_length(v) = 40` kills the BE with SIGSEGV in NullableColumn::null_count() under ArrayAggAggregateFunctionBase::merge(), and compaction re-runs the same merge, so the BE crash-loops after a restart. A plain array column, and an `array<varchar> REPLACE` column in an aggregate table, are unaffected -- the value they store is the value the query reads.

Skip access paths for AGG_STATE_UNION columns. This is the same reason a global dictionary is not usable for them, see #77096. Plain columns keep their paths, so `select array_length(a1) from pc0` still reports `[/a1/OFFSET]`.

Covered by a plan test in PruneComplexSubfieldTest and by the SQL test test_agg_state/test_agg_state_subfield_prune, which asserts element counts only (array_agg_distinct is unordered, so element positions are not stable) and keeps a plain-array and a REPLACE-array table as controls. Against an unpatched FE that case reports 2000 elements where 80000 are expected.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
