### PR TITLE
[Tool] ci-sync: inject MS_PAT for the mirrorship fan-out dispatch

### DIFF
--- a/.github/workflows/ci-sync.yml
+++ b/.github/workflows/ci-sync.yml
@@ -16,6 +16,7 @@ jobs:
     env:
       PR_NUMBER: ${{ github.event.number }}
       GH_TOKEN: ${{ secrets.PAT2 }}
+      MS_PAT: ${{ secrets.MS_PAT }}
     steps:
       - name: commit_sha
         id: commit_sha


### PR DESCRIPTION
## Why I'm doing:
The SR→mirrorship fan-out in `run-repo-sync.sh` (added earlier) dispatches to the private `MirrorshipOrg/mirrorship-enterprise`, but it ran under `secrets.PAT2` (the CelerData sync token), which has no access to the mirrorship org — so the dispatch failed with "Could not resolve to a Repository" and mirrorship never received the sync (best-effort, so CelerData sync was unaffected).

## What I'm doing:
Inject a dedicated `MS_PAT` (a token that can trigger workflows on `MirrorshipOrg/mirrorship-enterprise`) into the `sync` job env so `run-repo-sync.sh`'s `[Sync MS]` block can use it. Pairs with `StarRocks/ci-tool` PR that switches the mirrorship dispatch to `GH_TOKEN="${MS_PAT}"`. Requires the `MS_PAT` repo secret to be set.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
