### PR TITLE
[BugFix] Enforce Iceberg NOT NULL columns on the write path (backport #77589)

### DIFF
--- a/be/src/connector/iceberg_chunk_sink.cpp
+++ b/be/src/connector/iceberg_chunk_sink.cpp
@@ -100,7 +100,7 @@ StatusOr<std::unique_ptr<ConnectorChunkSink>> IcebergChunkSinkProvider::create_c
     if (boost::iequals(ctx->format, formats::PARQUET)) {
         file_writer_factory = std::make_shared<formats::ParquetFileWriterFactory>(
                 fs, ctx->compression_type, ctx->options, ctx->column_names, column_evaluators, ctx->parquet_field_ids,
-                ctx->executor, runtime_state);
+                ctx->executor, runtime_state, ctx->nullable);
     } else {
         file_writer_factory = std::make_shared<formats::UnknownFileWriterFactory>(ctx->format);
     }

--- a/be/src/connector/iceberg_chunk_sink.h
+++ b/be/src/connector/iceberg_chunk_sink.h
@@ -65,6 +65,8 @@ struct IcebergChunkSinkContext : public ConnectorChunkSinkContext {
     TCompressionType::type compression_type = TCompressionType::UNKNOWN_COMPRESSION;
     std::map<std::string, std::string> options;
     std::vector<formats::FileColumnId> parquet_field_ids;
+    // Parallel to column_names / parquet_field_ids. Empty means all columns nullable.
+    std::vector<bool> nullable;
     PriorityThreadPool* executor = nullptr;
     TCloudConfiguration cloud_conf;
     pipeline::FragmentContext* fragment_context = nullptr;

--- a/be/src/formats/parquet/chunk_writer.cpp
+++ b/be/src/formats/parquet/chunk_writer.cpp
@@ -14,6 +14,7 @@
 
 #include "formats/parquet/chunk_writer.h"
 
+#include <fmt/format.h>
 #include <parquet/file_writer.h>
 #include <parquet/schema.h>
 
@@ -59,8 +60,29 @@ Status ChunkWriter::write(Chunk* chunk) {
         ++leaf_column_idx;
     };
 
+    // Check required fields before writing any column: writing is column-at-a-time, so failing
+    // midway would leave earlier columns already appended to the row group. Only required
+    // fields are evaluated up front; optional ones cannot fail this check and stay lazy so we
+    // do not hold every evaluated column alive at once.
+    std::vector<ColumnPtr> required_columns(_type_descs.size());
     for (size_t i = 0; i < _type_descs.size(); i++) {
-        ASSIGN_OR_RETURN(auto col, _eval_func(chunk, i));
+        const auto& field = _schema->field(i);
+        if (!field->is_required()) {
+            continue;
+        }
+        ASSIGN_OR_RETURN(required_columns[i], _eval_func(chunk, i));
+        if (required_columns[i]->has_null()) {
+            return Status::DataQualityError(fmt::format("NULL value in non-nullable column '{}'", field->name()));
+        }
+    }
+
+    for (size_t i = 0; i < _type_descs.size(); i++) {
+        ColumnPtr col;
+        if (_schema->field(i)->is_required()) {
+            col = std::move(required_columns[i]);
+        } else {
+            ASSIGN_OR_RETURN(col, _eval_func(chunk, i));
+        }
         auto level_builder = LevelBuilder(_type_descs[i], _schema->field(i), _timezone, _use_legacy_decimal_encoding,
                                           _use_int96_timestamp_encoding);
         RETURN_IF_ERROR(level_builder.init());

--- a/be/src/runtime/iceberg_table_sink.cpp
+++ b/be/src/runtime/iceberg_table_sink.cpp
@@ -36,6 +36,31 @@ std::unordered_map<std::string, formats::FileColumnId> build_top_level_field_id_
     return field_ids_by_name;
 }
 
+// The Iceberg schema is the only valid source of a written column's requiredness. Slot
+// nullability is not: it describes what the feeding expression can produce, and on the
+// row-delta path UpdatePlanner derives it from that expression, so the two can disagree
+// in either direction. Unset is_optional (older FE) means nullable, so we fail towards
+// not enforcing.
+std::unordered_map<std::string, bool> build_top_level_nullable_map(const std::vector<TIcebergSchemaField>& fields) {
+    std::unordered_map<std::string, bool> nullable_by_name;
+    nullable_by_name.reserve(fields.size());
+    for (const auto& field : fields) {
+        bool nullable = !field.__isset.is_optional || field.is_optional;
+        nullable_by_name.emplace(field.name, nullable);
+    }
+    return nullable_by_name;
+}
+
+bool resolve_iceberg_sink_column_nullable(const SlotDescriptor* slot,
+                                          const std::unordered_map<std::string, bool>& nullable_by_name) {
+    auto it = nullable_by_name.find(std::string(slot->col_name()));
+    if (it != nullable_by_name.end()) {
+        return it->second;
+    }
+    // Reserved columns (_row_id, ...) are not Iceberg schema fields.
+    return slot->is_nullable();
+}
+
 Status append_iceberg_sink_column(const SlotDescriptor* slot,
                                   const std::unordered_map<std::string, formats::FileColumnId>& field_ids_by_name,
                                   std::vector<std::string>* column_names,
@@ -266,17 +291,21 @@ Status IcebergTableSink::create_data_sink_context(const TDataSink& thrift_sink, 
     // Build sink schema from the actual output tuple. TIcebergTable.columns may still contain
     // hidden metadata columns such as _file/_pos that are not written by compaction.
     auto field_ids_by_name = build_top_level_field_id_map(iceberg_table_desc->get_iceberg_schema()->fields);
+    auto nullable_by_name = build_top_level_nullable_map(iceberg_table_desc->get_iceberg_schema()->fields);
     data_sink_ctx->column_names.clear();
     data_sink_ctx->parquet_field_ids.clear();
+    data_sink_ctx->nullable.clear();
     data_sink_ctx->column_names.reserve(num_evaluators);
     data_sink_ctx->parquet_field_ids.reserve(num_evaluators);
+    data_sink_ctx->nullable.reserve(num_evaluators);
     for (size_t i = 0; i < num_evaluators; ++i) {
         RETURN_IF_ERROR(append_iceberg_sink_column((*slots)[i], field_ids_by_name, &data_sink_ctx->column_names,
                                                    &data_sink_ctx->parquet_field_ids));
+        data_sink_ctx->nullable.push_back(resolve_iceberg_sink_column_nullable((*slots)[i], nullable_by_name));
     }
 
     if (data_sink_ctx->column_names.size() != num_evaluators ||
-        data_sink_ctx->parquet_field_ids.size() != num_evaluators) {
+        data_sink_ctx->parquet_field_ids.size() != num_evaluators || data_sink_ctx->nullable.size() != num_evaluators) {
         return Status::InternalError("Iceberg sink schema metadata does not match output expressions");
     }
 

--- a/be/test/connector_sink/iceberg_table_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_table_sink_test.cpp
@@ -418,6 +418,145 @@ TEST_F(IcebergTableSinkTest, row_lineage_columns_extended_during_compaction) {
     EXPECT_EQ(sink_ctx->parquet_field_ids[2].field_id, 2147483539); // _last_updated_sequence_number reserved field ID
 }
 
+// Without this the target column's nullability never reaches the file writer, and a NOT NULL
+// Iceberg field gets written as an OPTIONAL parquet column.
+TEST_F(IcebergTableSinkTest, nullable_flags_follow_schema) {
+    TDescriptorTableBuilder table_desc_builder;
+    TSlotDescriptorBuilder slot_desc_builder;
+    auto slot1 = slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c1").column_pos(0).nullable(true).build();
+    auto slot2 =
+            slot_desc_builder.type(LogicalType::TYPE_VARCHAR).column_name("c2").column_pos(1).nullable(false).build();
+    auto slot3 = slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c3").column_pos(2).nullable(true).build();
+    TTupleDescriptorBuilder tuple_desc_builder;
+    tuple_desc_builder.add_slot(slot1);
+    tuple_desc_builder.add_slot(slot2);
+    tuple_desc_builder.add_slot(slot3);
+    tuple_desc_builder.build(&table_desc_builder);
+    DescriptorTbl* tbl = nullptr;
+    EXPECT_OK(DescriptorTbl::create(_runtime_state, &_pool, table_desc_builder.desc_tbl(), &tbl,
+                                    config::vector_chunk_size));
+    _runtime_state->set_desc_tbl(tbl);
+
+    TIcebergTable t_iceberg_table;
+    TColumn c1, c2, c3;
+    c1.__set_column_name("c1");
+    c2.__set_column_name("c2");
+    c3.__set_column_name("c3");
+    t_iceberg_table.__set_columns({c1, c2, c3});
+
+    TIcebergSchema iceberg_schema;
+    TIcebergSchemaField f1, f2, f3;
+    f1.__set_field_id(1);
+    f1.__set_name("c1");
+    f1.__set_is_optional(true);
+    f2.__set_field_id(2);
+    f2.__set_name("c2");
+    f2.__set_is_optional(false);
+    f3.__set_field_id(3);
+    f3.__set_name("c3");
+    f3.__set_is_optional(true);
+    iceberg_schema.__set_fields({f1, f2, f3});
+    t_iceberg_table.__set_iceberg_schema(iceberg_schema);
+
+    TTableDescriptor tdesc;
+    tdesc.__set_icebergTable(t_iceberg_table);
+    IcebergTableDescriptor* ice_table_desc = _pool.add(new IcebergTableDescriptor(tdesc, &_pool));
+    tbl->get_tuple_descriptor(0)->set_table_desc(ice_table_desc);
+    tbl->_tbl_desc_map[0] = ice_table_desc;
+
+    auto context = std::make_shared<pipeline::PipelineBuilderContext>(_fragment_context.get(), 1, 1, false);
+
+    TDataSink data_sink;
+    TIcebergTableSink iceberg_table_sink;
+    iceberg_table_sink.__set_location("s3://bucket/table-location");
+    data_sink.__set_iceberg_table_sink(iceberg_table_sink);
+
+    std::vector<TExpr> exprs;
+    exprs.resize(3);
+    IcebergTableSink sink(&_pool, exprs);
+    pipeline::OpFactories prev_operators{std::make_shared<pipeline::EmptySetOperatorFactory>(1, 1)};
+
+    EXPECT_OK(sink.decompose_to_pipeline(prev_operators, data_sink, context.get()));
+
+    pipeline::Pipeline* pl = const_cast<pipeline::Pipeline*>(context->last_pipeline());
+    auto connector_sink_factory = dynamic_cast<pipeline::ConnectorSinkOperatorFactory*>(pl->sink_operator_factory());
+    auto sink_ctx = dynamic_cast<connector::IcebergChunkSinkContext*>(connector_sink_factory->_sink_context.get());
+    ASSERT_NE(sink_ctx, nullptr);
+
+    ASSERT_EQ(sink_ctx->nullable.size(), 3);
+    EXPECT_TRUE(sink_ctx->nullable[0]);
+    EXPECT_FALSE(sink_ctx->nullable[1]) << "c2 is declared NOT NULL and must be written as REQUIRED";
+    EXPECT_TRUE(sink_ctx->nullable[2]);
+}
+
+// The output tuple may carry more slots than there are output expressions; the nullable vector
+// must stay aligned with the evaluators (and with column_names) rather than with the whole tuple.
+TEST_F(IcebergTableSinkTest, nullable_flags_aligned_with_evaluators_not_tuple) {
+    TDescriptorTableBuilder table_desc_builder;
+    TSlotDescriptorBuilder slot_desc_builder;
+    auto slot1 = slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c1").column_pos(0).nullable(true).build();
+    auto slot2 =
+            slot_desc_builder.type(LogicalType::TYPE_VARCHAR).column_name("c2").column_pos(1).nullable(false).build();
+    // Third slot exists in the tuple but has no matching output expression.
+    auto slot3 = slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c3").column_pos(2).nullable(false).build();
+    TTupleDescriptorBuilder tuple_desc_builder;
+    tuple_desc_builder.add_slot(slot1);
+    tuple_desc_builder.add_slot(slot2);
+    tuple_desc_builder.add_slot(slot3);
+    tuple_desc_builder.build(&table_desc_builder);
+    DescriptorTbl* tbl = nullptr;
+    EXPECT_OK(DescriptorTbl::create(_runtime_state, &_pool, table_desc_builder.desc_tbl(), &tbl,
+                                    config::vector_chunk_size));
+    _runtime_state->set_desc_tbl(tbl);
+
+    TIcebergTable t_iceberg_table;
+    TColumn c1, c2;
+    c1.__set_column_name("c1");
+    c2.__set_column_name("c2");
+    t_iceberg_table.__set_columns({c1, c2});
+
+    TIcebergSchema iceberg_schema;
+    TIcebergSchemaField f1, f2;
+    f1.__set_field_id(1);
+    f1.__set_name("c1");
+    f1.__set_is_optional(true);
+    f2.__set_field_id(2);
+    f2.__set_name("c2");
+    f2.__set_is_optional(false);
+    iceberg_schema.__set_fields({f1, f2});
+    t_iceberg_table.__set_iceberg_schema(iceberg_schema);
+
+    TTableDescriptor tdesc;
+    tdesc.__set_icebergTable(t_iceberg_table);
+    IcebergTableDescriptor* ice_table_desc = _pool.add(new IcebergTableDescriptor(tdesc, &_pool));
+    tbl->get_tuple_descriptor(0)->set_table_desc(ice_table_desc);
+    tbl->_tbl_desc_map[0] = ice_table_desc;
+
+    auto context = std::make_shared<pipeline::PipelineBuilderContext>(_fragment_context.get(), 1, 1, false);
+
+    TDataSink data_sink;
+    TIcebergTableSink iceberg_table_sink;
+    iceberg_table_sink.__set_location("s3://bucket/table-location");
+    data_sink.__set_iceberg_table_sink(iceberg_table_sink);
+
+    std::vector<TExpr> exprs;
+    exprs.resize(2); // fewer expressions than slots
+    IcebergTableSink sink(&_pool, exprs);
+    pipeline::OpFactories prev_operators{std::make_shared<pipeline::EmptySetOperatorFactory>(1, 1)};
+
+    EXPECT_OK(sink.decompose_to_pipeline(prev_operators, data_sink, context.get()));
+
+    pipeline::Pipeline* pl = const_cast<pipeline::Pipeline*>(context->last_pipeline());
+    auto connector_sink_factory = dynamic_cast<pipeline::ConnectorSinkOperatorFactory*>(pl->sink_operator_factory());
+    auto sink_ctx = dynamic_cast<connector::IcebergChunkSinkContext*>(connector_sink_factory->_sink_context.get());
+    ASSERT_NE(sink_ctx, nullptr);
+
+    EXPECT_EQ(sink_ctx->nullable.size(), sink_ctx->column_names.size());
+    ASSERT_EQ(sink_ctx->nullable.size(), 2);
+    EXPECT_TRUE(sink_ctx->nullable[0]);
+    EXPECT_FALSE(sink_ctx->nullable[1]);
+}
+
 // Test that parquet_field_ids is extended even when column_names already includes
 // row lineage columns but iceberg_schema still only contains user columns.
 TEST_F(IcebergTableSinkTest, row_lineage_field_ids_extended_when_column_names_already_present) {

--- a/be/test/formats/parquet/parquet_file_writer_test.cpp
+++ b/be/test/formats/parquet/parquet_file_writer_test.cpp
@@ -967,6 +967,62 @@ TEST_F(ParquetFileWriterTest, TestIcebergDeleteFileColumnsRequired) {
     }
 }
 
+TEST_F(ParquetFileWriterTest, TestRequiredColumnRejectsNull) {
+    std::vector type_descs{TYPE_VARCHAR_DESC, TYPE_BIGINT_DESC};
+    std::vector<std::string> column_names = {"a", "b"};
+    ASSIGN_OR_ASSERT_FAIL(auto writer, _create_writer(type_descs, {true, false}, column_names));
+
+    auto chunk = std::make_shared<Chunk>();
+    {
+        auto col0 = ColumnTestHelper::build_nullable_column<Slice>({"x", "y", "z"}, {0, 0, 0});
+        chunk->append_column(std::move(col0), chunk->num_columns());
+
+        // "b" is declared REQUIRED but carries a null in row 1
+        auto col1 = ColumnTestHelper::build_nullable_column<int64_t>({100, 0, 300}, {0, 1, 0});
+        chunk->append_column(std::move(col1), chunk->num_columns());
+    }
+
+    auto st = writer->write(chunk.get());
+    ASSERT_FALSE(st.ok()) << "writing NULL into a REQUIRED column must fail";
+    EXPECT_TRUE(st.message().find("b") != std::string::npos)
+            << "error should name the offending column, got: " << st.message();
+}
+
+TEST_F(ParquetFileWriterTest, TestRequiredColumnRejectsNullBeforeWritingAnyColumn) {
+    // "a" OPTIONAL, "b" REQUIRED: only "b" is evaluated up front, so this pins that a violation
+    // on "b" still stops "a" from reaching the row group, which would otherwise leave the
+    // writer holding a row group with mismatched column chunk lengths.
+    std::vector type_descs{TYPE_VARCHAR_DESC, TYPE_BIGINT_DESC};
+    std::vector<std::string> column_names = {"a", "b"};
+    ASSIGN_OR_ASSERT_FAIL(auto writer, _create_writer(type_descs, {true, false}, column_names));
+
+    auto good_chunk = std::make_shared<Chunk>();
+    {
+        auto col0 = ColumnTestHelper::build_column<Slice>({"x", "y", "z"});
+        good_chunk->append_column(std::move(col0), 0);
+        auto col1 = ColumnTestHelper::build_column<int64_t>({1, 2, 3});
+        good_chunk->append_column(std::move(col1), 1);
+    }
+    ASSERT_OK(writer->write(good_chunk.get()));
+    ASSERT_NE(writer->_rowgroup_writer, nullptr);
+    const int64_t buffered_before = writer->_rowgroup_writer->estimated_buffered_bytes();
+    ASSERT_GT(buffered_before, 0);
+
+    auto bad_chunk = std::make_shared<Chunk>();
+    {
+        // column "a" is perfectly valid ...
+        auto col0 = ColumnTestHelper::build_nullable_column<Slice>({"p", "q", "r"}, {0, 0, 0});
+        bad_chunk->append_column(std::move(col0), bad_chunk->num_columns());
+        // ... but column "b" is not, so nothing from this chunk may reach the row group
+        auto col1 = ColumnTestHelper::build_nullable_column<int64_t>({4, 0, 6}, {0, 1, 0});
+        bad_chunk->append_column(std::move(col1), bad_chunk->num_columns());
+    }
+    ASSERT_FALSE(writer->write(bad_chunk.get()).ok());
+
+    EXPECT_EQ(writer->_rowgroup_writer->estimated_buffered_bytes(), buffered_before)
+            << "column \"a\" of the rejected chunk leaked into the row group";
+}
+
 TEST_F(ParquetFileWriterTest, TestColumnDictionaryEncodingDisabled) {
     // Test that disabling dictionary encoding for specific column works correctly
     // This test verifies the fix for Iceberg position delete file compression issue

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -568,6 +568,7 @@ public class IcebergApiConverter {
         TIcebergSchemaField tIcebergSchemaField = new TIcebergSchemaField();
         tIcebergSchemaField.setField_id(nestedField.fieldId());
         tIcebergSchemaField.setName(nestedField.name());
+        tIcebergSchemaField.setIs_optional(nestedField.isOptional());
         if (nestedField.type().isNestedType()) {
             List<TIcebergSchemaField> children = new ArrayList<>(nestedField.type().asNestedType().fields().size());
             for (Types.NestedField child : nestedField.type().asNestedType().fields()) {

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -568,6 +568,10 @@ struct TIcebergSchemaField {
     // Refer to field name
     2: optional string name
 
+    // Mirrors Types.NestedField#isOptional(). Unset means optional: never enforce
+    // NOT NULL without an explicit signal from the Iceberg schema.
+    3: optional bool is_optional
+
     // You can fill other field properties here if you needed
     // .......
 


### PR DESCRIPTION
## Why I'm doing:

An Iceberg column declared `NOT NULL` was never enforced on the write path, while the optimizer trusted that same `NOT NULL` metadata to fold `col IS NULL` into an empty set. A NULL therefore reached storage and became invisible to the very predicate meant to find it. On the same table: `SELECT *` shows the row with a NULL, `WHERE b IS NULL` returns nothing, and `SUM(CASE WHEN b IS NULL THEN 1 ELSE 0 END)` returns 1. `EXPLAIN` confirms the scan is replaced by `0:EMPTYSET`.

```sql
SET CATALOG iceberg_catalog;
CREATE TABLE t(a int, b string not null);
INSERT INTO t VALUES(1, null);            -- accepted, no error
SELECT * FROM t;                          -- (1, NULL)
SELECT * FROM t WHERE b IS NULL;          -- empty
SELECT SUM(CASE WHEN b IS NULL THEN 1 ELSE 0 END) FROM t;  -- 1
```

The damage is not confined to StarRocks. The written parquet column was OPTIONAL while the Iceberg field was required, so the table became unreadable to other engines: Spark 4.0 with Iceberg 1.10 fails with `NullPointerException` at `UnsafeWriter.write` on a plain `SELECT *`. StarRocks also corrupted tables created by other engines the same way — Spark rejects `INSERT INTO t VALUES (2, NULL)` on its own required column, but StarRocks accepted that write into the very same table.

Fixes https://github.com/StarRocks/StarRocksTest/issues/11630.

## What I'm doing:

Deriving each written column's nullability from the Iceberg schema and rejecting NULLs in required fields before any part of the chunk is written. The optimizer rule is left untouched: it is sound once the invariant it relies on actually holds.

- Add `TIcebergSchemaField.is_optional` so the BE has an authoritative signal for requiredness, populated by FE from `org.apache.iceberg.types.Types.NestedField#isOptional()`. When the field is unset, which is what an older FE sends, the column is treated as nullable, so a mixed-version cluster simply does not enforce rather than rejecting valid writes.
- Build the sink's `nullable` vector from that schema field instead of from tuple slot nullability. Slot nullability describes what the feeding expression can produce, not what the target column allows. On the row-delta path `UpdatePlanner` derives it from the output expression (`slot.setIsNullable(outputExprs.get(index).isNullable())`), so a constant assignment makes a nullable column look required while a column read-back makes a required column look nullable — the two can be exact opposites, which is how an `UPDATE` was able to write a NULL straight back into a required column.
- Validate every column of a chunk before writing any of them. `ChunkWriter` writes one column fully before moving to the next, so a violation detected while writing column N would otherwise leave columns `0..N-1` already appended to the row group with no way to take them back.

A nullable column is unaffected and still accepts and reports NULLs. An existing table that already holds NULLs in a required column can be repaired with `ALTER TABLE t MODIFY COLUMN c <type> NULL`, which StarRocks already supports; the fix is not retroactive for such tables. Adding `NOT NULL` to an existing column stays rejected, matching Spark, which refuses `ALTER COLUMN ... SET NOT NULL` on Iceberg tables.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5


