### PR TITLE
[BugFix] Stop a JSON subfield aggregate from failing on an aggregate table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PreAggregateTurnOnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PreAggregateTurnOnRule.java
@@ -339,6 +339,17 @@ public class PreAggregateTurnOnRule implements TreeRewriteRule {
                                                 Column column,
                                                 PhysicalOlapScanOperator scan) {
             String queryAggFuncName = queryAggFunc.getFnName();
+            if (column.getAggregationType() == null) {
+                // A scan column without an aggregation type is not a stored column of this table. The JSON
+                // subfield pushdown adds a synthetic column per `get_json_xxx(col, '<constant path>')` to the
+                // scan, and a derived subfield carries no aggregation semantics of its own -- nothing can be
+                // pre-aggregated through it, so turn pre-aggregation off. Reading the missing type instead
+                // threw, and the raw NullPointerException reached the client as ERROR 1064 for every
+                // aggregate over a JSON subfield of an AGGREGATE KEY table. Key columns never get here; they
+                // are handled by the caller.
+                scan.setTurnOffReason("Column " + column.getName() + " has no aggregate type");
+                return true;
+            }
             if (FunctionSet.HLL_UNION_AGG.equalsIgnoreCase(queryAggFuncName) ||
                     FunctionSet.HLL_RAW_AGG.equalsIgnoreCase(queryAggFuncName)) {
                 return false;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggTableTest.java
@@ -168,6 +168,32 @@ public class AggTableTest extends PlanTestBase {
     }
 
     @Test
+    public void testAggregateOverJsonSubfieldOfAggTable() throws Exception {
+        // The JSON path pushdown rewrites get_json_xxx(col, '<constant path>') into a synthetic subfield
+        // column on the scan, and a synthetic subfield has no aggregation type. This rule compares the
+        // query's aggregate against every scanned column's aggregation type, so it dereferenced null and
+        // the raw NullPointerException reached the client as ERROR 1064 -- only for AGGREGATE KEY tables,
+        // which are the ones that run this rule at all. Nothing can be pre-aggregated through a derived
+        // subfield, so the scan turns pre-aggregation off.
+        starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `agg_json` (\n" +
+                "  `k` int(11) NULL,\n" +
+                "  `v` json REPLACE\n" +
+                ") ENGINE=OLAP\n" +
+                "AGGREGATE KEY(`k`)\n" +
+                "DISTRIBUTED BY HASH(`k`) BUCKETS 1\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");");
+
+        String plan = getFragmentPlan("select sum(get_json_int(v, '$.a')) from agg_json");
+        assertContains(plan, "TABLE: agg_json");
+        assertContains(plan, "PREAGGREGATION: OFF");
+
+        // A key-column aggregate on the same table still pre-aggregates.
+        assertContains(getFragmentPlan("select max(k) from agg_json"), "PREAGGREGATION: ON");
+    }
+
+    @Test
     public void testMultiDistinctCountWithSum() throws Exception {
         starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `reproduce` (\n" +
                 "  `id` int(11) NULL COMMENT \"\",\n" +

--- a/test/sql/test_json/R/test_json_path_rewrite_agg_table_preagg.sql
+++ b/test/sql/test_json/R/test_json_path_rewrite_agg_table_preagg.sql
@@ -1,0 +1,93 @@
+-- name: test_json_path_rewrite_agg_table_preagg
+drop database if exists test_json_path_rewrite_agg_table_preagg;
+-- result:
+-- !result
+CREATE DATABASE test_json_path_rewrite_agg_table_preagg;
+-- result:
+-- !result
+USE test_json_path_rewrite_agg_table_preagg;
+-- result:
+-- !result
+CREATE TABLE agg_json (
+  `k` int NULL,
+  `v` json REPLACE
+) ENGINE=OLAP
+AGGREGATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO agg_json VALUES (1, parse_json('{"a":1,"b":"x"}')), (2, parse_json('{"a":2,"b":"y"}'));
+-- result:
+-- !result
+INSERT INTO agg_json VALUES (1, parse_json('{"a":1,"b":"x"}')), (2, parse_json('{"a":2,"b":"y"}'));
+-- result:
+-- !result
+SELECT sum(get_json_int(v, '$.a')) FROM agg_json;
+-- result:
+3
+-- !result
+SELECT max(get_json_int(v, '$.a')) FROM agg_json;
+-- result:
+2
+-- !result
+SELECT count(get_json_int(v, '$.a')) FROM agg_json;
+-- result:
+2
+-- !result
+SELECT min(get_json_string(v, '$.b')) FROM agg_json;
+-- result:
+x
+-- !result
+SELECT sum(get_json_int(v, '$.a')) FROM agg_json WHERE k = 2;
+-- result:
+2
+-- !result
+SELECT k, get_json_int(v, '$.a'), get_json_string(v, '$.b') FROM agg_json ORDER BY k;
+-- result:
+1	1	x
+2	2	y
+-- !result
+SELECT sum(json_length(v)) FROM agg_json;
+-- result:
+4
+-- !result
+SELECT max(k) FROM agg_json;
+-- result:
+2
+-- !result
+CREATE TABLE agg_json_superseded (
+  `k` int NULL,
+  `v` json REPLACE
+) ENGINE=OLAP
+AGGREGATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 4
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO agg_json_superseded VALUES
+  (1, parse_json('{"a":1}')), (2, parse_json('{"a":2}')), (3, parse_json('{"a":3}'));
+-- result:
+-- !result
+INSERT INTO agg_json_superseded VALUES
+  (1, parse_json('{"a":100}')), (3, parse_json('{"a":300}'));
+-- result:
+-- !result
+SELECT sum(get_json_int(v, '$.a')) FROM agg_json_superseded;
+-- result:
+402
+-- !result
+SELECT max(get_json_int(v, '$.a')) FROM agg_json_superseded;
+-- result:
+300
+-- !result
+SELECT count(*) FROM agg_json_superseded;
+-- result:
+3
+-- !result
+SELECT k, get_json_int(v, '$.a') FROM agg_json_superseded ORDER BY k;
+-- result:
+1	100
+2	2
+3	300
+-- !result

--- a/test/sql/test_json/T/test_json_path_rewrite_agg_table_preagg.sql
+++ b/test/sql/test_json/T/test_json_path_rewrite_agg_table_preagg.sql
@@ -1,0 +1,64 @@
+-- name: test_json_path_rewrite_agg_table_preagg
+-- Regression: aggregating a JSON subfield of an AGGREGATE KEY table used to fail in the FE.
+--
+-- The JSON path pushdown rewrites get_json_xxx(col, '<constant path>') into a synthetic subfield column
+-- and attaches it to the scan. Only AGGREGATE KEY tables run PreAggregateTurnOnRule, which compares the
+-- query's aggregate against each scanned column's aggregation type -- and a synthetic subfield has none,
+-- so the rule dereferenced null and the raw NullPointerException reached the client as ERROR 1064. A
+-- derived subfield carries no aggregation semantics of its own, so pre-aggregation is simply turned off.
+--
+-- Nothing here can be worked around with a session variable: cbo_prune_json_subfield gates
+-- PruneSubfieldRule, not this rewrite. The same queries against a DUPLICATE table were always fine,
+-- which is why this needs an aggregate table to reproduce.
+drop database if exists test_json_path_rewrite_agg_table_preagg;
+CREATE DATABASE test_json_path_rewrite_agg_table_preagg;
+USE test_json_path_rewrite_agg_table_preagg;
+
+CREATE TABLE agg_json (
+  `k` int NULL,
+  `v` json REPLACE
+) ENGINE=OLAP
+AGGREGATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- The same values twice, so two rowsets have to be merged on read while the REPLACE result stays
+-- deterministic whichever row wins.
+INSERT INTO agg_json VALUES (1, parse_json('{"a":1,"b":"x"}')), (2, parse_json('{"a":2,"b":"y"}'));
+INSERT INTO agg_json VALUES (1, parse_json('{"a":1,"b":"x"}')), (2, parse_json('{"a":2,"b":"y"}'));
+
+-- Each of these used to return ERROR 1064 with a raw NullPointerException message.
+SELECT sum(get_json_int(v, '$.a')) FROM agg_json;
+SELECT max(get_json_int(v, '$.a')) FROM agg_json;
+SELECT count(get_json_int(v, '$.a')) FROM agg_json;
+SELECT min(get_json_string(v, '$.b')) FROM agg_json;
+SELECT sum(get_json_int(v, '$.a')) FROM agg_json WHERE k = 2;
+
+-- Projecting the same subfield always worked; the two forms have to agree.
+SELECT k, get_json_int(v, '$.a'), get_json_string(v, '$.b') FROM agg_json ORDER BY k;
+
+-- Controls: an aggregate that the rewrite does not touch, and a key-column aggregate.
+SELECT sum(json_length(v)) FROM agg_json;
+SELECT max(k) FROM agg_json;
+
+-- The loads above carry identical values, which pins that no row is counted twice but not that a
+-- superseded value stays out of the answer. Load different values for the same keys so the three
+-- possible outcomes are all distinguishable: 402 when the merge is honoured, 406 if the rows are
+-- aggregated unmerged, and 6 if the superseded values win.
+CREATE TABLE agg_json_superseded (
+  `k` int NULL,
+  `v` json REPLACE
+) ENGINE=OLAP
+AGGREGATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 4
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO agg_json_superseded VALUES
+  (1, parse_json('{"a":1}')), (2, parse_json('{"a":2}')), (3, parse_json('{"a":3}'));
+INSERT INTO agg_json_superseded VALUES
+  (1, parse_json('{"a":100}')), (3, parse_json('{"a":300}'));
+
+SELECT sum(get_json_int(v, '$.a')) FROM agg_json_superseded;
+SELECT max(get_json_int(v, '$.a')) FROM agg_json_superseded;
+SELECT count(*) FROM agg_json_superseded;
+SELECT k, get_json_int(v, '$.a') FROM agg_json_superseded ORDER BY k;


### PR DESCRIPTION
## Why I'm doing:

The JSON path pushdown rewrites get_json_xxx(col, '<constant path>') into a synthetic subfield column and attaches it to the scan. Those synthetic columns have no aggregation type -- they are derived values, not stored columns of the table. PreAggregateTurnOnRule compares the query's aggregate against the aggregation type of every column the scan reads, so it dereferenced null and the raw NullPointerException reached the client:

    create table t (k int, v json replace) aggregate key(k)
      distributed by hash(k) buckets 1 properties("replication_num" = "1");
    insert into t values (1, parse_json('{"a":1}'));

    select sum(get_json_int(v, '$.a')) from t;
    -- ERROR 1064 (HY000): Cannot invoke "com.starrocks.sql.ast.AggregateType.name()"
    --   because the return value of "com.starrocks.catalog.Column.getAggregationType()" is null

Only AGGREGATE KEY tables run this rule, which is why the same queries against a DUPLICATE table were always fine, and why any aggregate over a JSON subfield of an aggregate table hit it: sum, max, count and min alike. cbo_prune_json_subfield does not help -- it gates PruneSubfieldRule, not this rewrite -- so there was no way to run the query at all short of rewriting it.

Nothing can be pre-aggregated through a derived subfield, so turn pre-aggregation off when a scanned column has no aggregation type. That matches what the rule already decides once a type is known: a REPLACE column against SUM does not match, and an AGG_STATE_UNION column has no AggStateDesc on a synthetic subfield, so both fall through to the same answer. Key columns never reach here; the caller handles them separately.

The SQL test loads the same keys twice with different values so the answer is not just crash-free but right: 402 is the merged answer, 406 would mean the rows were aggregated unmerged, and 6 would mean the superseded values won. A SUM column and a key column in the same table keep PREAGGREGATION: ON, which the plan test pins.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
