### PR TITLE
[BugFix] Register the pipe_driver_queue_len metric (backport #77890)

### DIFF
--- a/be/src/exec/pipeline/pipeline_metrics.cpp
+++ b/be/src/exec/pipeline/pipeline_metrics.cpp
@@ -122,6 +122,7 @@ void DriverExecutorMetrics::register_all_metrics(MetricRegistry* registry) {
 
 void PipelineExecutorMetrics::register_all_metrics(MetricRegistry* registry) {
     poller_metrics.register_all_metrics(registry);
+    driver_queue_metrics.register_all_metrics(registry);
     driver_executor_metrics.register_all_metrics(registry);
     scan_executor_metrics.register_all_metrics(registry, "scan");
     connector_scan_executor_metrics.register_all_metrics(registry, "connector_scan");


### PR DESCRIPTION
## Why I'm doing:

Manual backport of #77890. The automatic backport failed because `pipeline_metrics.cpp` was moved to `be/src/exec_primitive/pipeline/primitives/` on main by a refactor, while this branch still has it at `be/src/exec/pipeline/pipeline_metrics.cpp`, so the cherry-pick hit a rename conflict.

The `pipe_driver_queue_len` metric has been missing from the BE `/metrics` output since v3.5.0, while it is still documented in the monitoring metrics docs. The pipeline metrics refactor in #53490 introduced `DriverQueueMetrics::register_all_metrics()` for this gauge, but `PipelineExecutorMetrics::register_all_metrics()` never calls it, so the gauge is maintained but never registered.

## What I'm doing:

Call `driver_queue_metrics.register_all_metrics(registry)` in `PipelineExecutorMetrics::register_all_metrics()`, same one-line fix as #77890 applied to this branch's file path.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

