### PR TITLE
[BugFix] Name an OLAP scan's sort key columns by column id, not by column name

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -1115,7 +1115,8 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
                 if (expr instanceof SlotRef) {
                     // check key columns
                     SlotId cid = ((SlotRef) expr).getSlotId();
-                    String columnName = desc.getSlot(cid.asInt()).getColumn().getName();
+                    // keyColumnNames holds column ids, so compare ids here too
+                    String columnName = desc.getSlot(cid.asInt()).getColumn().getColumnId().getId();
                     if (!keyColumnNames.isEmpty() && keyColumnNames.get(0).equals(columnName)) {
                         sortKeyAscHint = outputAscHint;
                     }
@@ -1161,10 +1162,14 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
                     columnsDesc.add(tColumn);
                 }
                 // process schema has order by columns
+                // Name these by the column id, not by Column#getName: BE matches them against the
+                // slots, whose col_name is the id (SlotDescriptor#toThrift), so a renamed column
+                // would match nothing - build_scan_keys would stop at it and no short-key range
+                // would be built for the query at all.
                 if (indexMeta.getSortKeyIdxes() != null) {
                     for (Integer sortKeyIdx : indexMeta.getSortKeyIdxes()) {
                         Column col = indexMeta.getSchema().get(sortKeyIdx);
-                        keyColumnNames.add(col.getName());
+                        keyColumnNames.add(col.getColumnId().getId());
                         keyColumnTypes.add(TypeSerializer.toThrift(col.getPrimitiveType()));
                     }
                 } else {
@@ -1173,7 +1178,7 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
                             continue;
                         }
 
-                        keyColumnNames.add(col.getName());
+                        keyColumnNames.add(col.getColumnId().getId());
                         keyColumnTypes.add(TypeSerializer.toThrift(col.getPrimitiveType()));
                     }
                 }
@@ -1702,6 +1707,9 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
                 if (!col.isKey()) {
                     break;
                 }
+                // Names, not ids, on purpose: this is the query cache digest, not something BE
+                // looks a column up by, and the rest of the normal form (selected_column, the
+                // partition column names) is built from names as well.
                 keyColumnNames.add(col.getName());
                 keyColumnTypes.add(TypeSerializer.toThrift(col.getPrimitiveType()));
             }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -1115,16 +1115,19 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
                 if (expr instanceof SlotRef) {
                     // check key columns
                     SlotId cid = ((SlotRef) expr).getSlotId();
-                    // keyColumnNames holds column ids, so compare ids here too
-                    String columnName = desc.getSlot(cid.asInt()).getColumn().getColumnId().getId();
-                    if (!keyColumnNames.isEmpty() && keyColumnNames.get(0).equals(columnName)) {
+                    // Identify the probe column by its storage-side id, the one handle a rename does
+                    // not change, and compare both checks below against ids as well - keyColumnNames
+                    // holds ids, and a partition column's name is just as mutable as this one's.
+                    String probeColumnId = desc.getSlot(cid.asInt()).getColumn().getColumnId().getId();
+                    if (!keyColumnNames.isEmpty() && keyColumnNames.get(0).equals(probeColumnId)) {
                         sortKeyAscHint = outputAscHint;
                     }
                     // check partition column
                     PartitionInfo partitionInfo = olapTable.getPartitionInfo();
                     if (partitionInfo instanceof RangePartitionInfo) {
                         List<Column> partitionColumns = partitionInfo.getPartitionColumns(olapTable.getIdToColumn());
-                        if (!partitionColumns.isEmpty() && partitionColumns.get(0).getName().equals(columnName)) {
+                        if (!partitionColumns.isEmpty()
+                                && partitionColumns.get(0).getColumnId().getId().equals(probeColumnId)) {
                             partitionKeyAscHint = Optional.of(outputAscHint);
                         }
                     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SortKeyColumnIdPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SortKeyColumnIdPlanTest.java
@@ -1,0 +1,83 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * BE knows a column by its storage-side id, not by its name: SlotDescriptor#toThrift sends
+ * Column#getColumnId as the slot's col_name, and TColumn#column_name - what the tablet schema is
+ * built from - is the id as well. A rename changes Column#getName and deliberately leaves that id
+ * alone, so anything FE sends BE that names a column by getName() stops matching afterwards.
+ */
+public class SortKeyColumnIdPlanTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        PlanTestBase.beforeClass();
+        starRocksAssert.withTable("create table sort_key_rename(k1 int, k2 int, v1 int) " +
+                "duplicate key(k1, k2) distributed by hash(v1) buckets 1 " +
+                "properties('replication_num'='1')");
+    }
+
+    /**
+     * sort_key_column_names feeds ChunkPredicateBuilder::build_scan_keys, which looks each name up in
+     * column_value_ranges - a map keyed by the slot's col_name, i.e. the column id - and stops at the
+     * first miss. Naming the sort key by the current column name leaves conditional_key_columns at 0
+     * for a renamed table, so no short-key range is built and the scan reads the whole block instead
+     * of the key range. The rows returned are the same; they are just read the hard way.
+     */
+    @Test
+    public void testSortKeyColumnNamesAreColumnIds() throws Exception {
+        starRocksAssert.ddl("alter table sort_key_rename rename column k1 to k1_new");
+        try {
+            String thrift = getThriftPlan("select v1 from sort_key_rename where k1_new > 1 and k2 = 1");
+            Assertions.assertTrue(thrift.contains("column_name:k1,"),
+                    "the tablet schema BE builds names this column by its id: " + scanNodeOf(thrift));
+            Assertions.assertTrue(thrift.contains("sort_key_column_names:[k1, k2]"),
+                    "sort key names must be column ids, or BE cannot match them against the slots: "
+                            + scanNodeOf(thrift));
+        } finally {
+            starRocksAssert.ddl("alter table sort_key_rename rename column k1_new to k1");
+        }
+    }
+
+    /**
+     * That same list is also compared inside FE, in assignOrderByHints, against the column behind a
+     * TopN filter's probe slot: when it is the leading key column the scan is told to read in the
+     * TopN's direction. Both sides have to speak the same language - changing only the payload would
+     * leave a name being compared against an id, and a descending TopN on a renamed key column would
+     * silently lose its hint (output_asc_hint falls back to its default true).
+     */
+    @Test
+    public void testOrderByHintSurvivesColumnRename() throws Exception {
+        assertContains(getThriftPlan("select v1 from sort_key_rename order by k1 desc limit 5"),
+                "output_asc_hint:false");
+        starRocksAssert.ddl("alter table sort_key_rename rename column k1 to k1_new");
+        try {
+            assertContains(getThriftPlan("select v1 from sort_key_rename order by k1_new desc limit 5"),
+                    "output_asc_hint:false");
+        } finally {
+            starRocksAssert.ddl("alter table sort_key_rename rename column k1_new to k1");
+        }
+    }
+
+    private static String scanNodeOf(String thrift) {
+        int i = thrift.indexOf("olap_scan_node:");
+        return i < 0 ? thrift : thrift.substring(i, Math.min(i + 600, thrift.length()));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SortKeyColumnIdPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SortKeyColumnIdPlanTest.java
@@ -32,6 +32,11 @@ public class SortKeyColumnIdPlanTest extends PlanTestBase {
         starRocksAssert.withTable("create table sort_key_rename(k1 int, k2 int, v1 int) " +
                 "duplicate key(k1, k2) distributed by hash(v1) buckets 1 " +
                 "properties('replication_num'='1')");
+        starRocksAssert.withTable("create table part_key_rename(dt date not null, v1 int) " +
+                "duplicate key(dt) partition by range(dt) (" +
+                "  partition p1 values [('2026-01-01'), ('2026-01-02'))," +
+                "  partition p2 values [('2026-01-02'), ('2026-01-03'))) " +
+                "distributed by hash(v1) buckets 1 properties('replication_num'='1')");
     }
 
     /**
@@ -73,6 +78,26 @@ public class SortKeyColumnIdPlanTest extends PlanTestBase {
                     "output_asc_hint:false");
         } finally {
             starRocksAssert.ddl("alter table sort_key_rename rename column k1_new to k1");
+        }
+    }
+
+    /**
+     * assignOrderByHints checks the same probe column twice: against the sort key, and against the
+     * table's leading partition column, which decides whether BE may schedule the partitions in the
+     * TopN's direction (partition_order_hint). The second check compares against a Column of its own,
+     * so it has to be moved to ids together with the first one - leaving it on names would mean an id
+     * being compared against a name, and a renamed partition column would silently lose that hint.
+     */
+    @Test
+    public void testPartitionOrderHintSurvivesColumnRename() throws Exception {
+        assertContains(getThriftPlan("select v1 from part_key_rename order by dt desc limit 5"),
+                "partition_order_hint:false");
+        starRocksAssert.ddl("alter table part_key_rename rename column dt to dt_new");
+        try {
+            assertContains(getThriftPlan("select v1 from part_key_rename order by dt_new desc limit 5"),
+                    "partition_order_hint:false");
+        } finally {
+            starRocksAssert.ddl("alter table part_key_rename rename column dt_new to dt");
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

A rename changes Column#getName and deliberately leaves the storage-side id alone - "All references to Column should use columnId instead of name", as Column documents - and BE knows a column by that id: SlotDescriptor#toThrift sends Column#getColumnId as the slot's col_name, and TColumn#column_name, what the tablet schema is built from, is the id as well.

OlapScanNode filled TOlapScanNode/TLakeScanNode.sort_key_column_names from getName(). BE's build_scan_keys looks each of those names up in column_value_ranges - keyed by the slot's col_name - and stops at the first miss, so after

    alter table t rename column k1 to k1_new

conditional_key_columns stays 0, no short-key range is built, and the scan reads whole blocks instead of seeking the key range. Nothing errors and the rows returned are the same; the table just quietly gets slower, from a DDL that ran weeks earlier. Renaming the leading key column disables the scan keys entirely, renaming the k-th leaves only the first k-1.

Measured on a cluster, 1.2M rows, duplicate key(k1, k2), predicate on both columns (two key columns are needed for BE to build scan keys at all, unless enable_short_key_for_one_column_filter is on):

                    ShortKeyFilterRows   RemainingAfterShortKeyFilter   RawRowsRead
    original name   1.200M (1199986)     14                             14
    renamed         0                    1.200M (1200000)               8.192K (8192)
    renamed back    1.200M (1199986)     14                             14

With this change all three stages read 14 rows, and every stage returns the same 14 rows throughout - this was never a correctness problem.

assignOrderByHints compares that same list against the column behind a TopN filter's probe slot to decide whether the scan may read in the TopN's direction, so it now compares ids too: changing only the payload would silently drop the hint for a descending TopN on a renamed key column. The second test pins exactly that, and fails if only half of this change is applied.

TNormalOlapScanNode's key_column_names is deliberately left on names: it is the query cache digest, not something BE looks a column up by, and the rest of that normal form is built from names as well.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
