### PR TITLE
[BugFix] Fix NLJoin null-aware anti join losing probe rows when a joined chunk has no matched rows

### DIFF
--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
@@ -354,7 +354,7 @@ Status NLJoinProbeOperator::_eval_nullaware_anti_conjuncts(const ChunkPtr& chunk
                 bool all_zero = false;
                 ColumnHelper::merge_two_filters(column, filter->get(), &all_zero);
                 if (all_zero) {
-                    chunk->set_num_rows(0);
+                    break;
                 }
             }
         }

--- a/test/sql/test_nest_loop_join/R/test_nljoin_naaj_unmatched_probe_rows
+++ b/test/sql/test_nest_loop_join/R/test_nljoin_naaj_unmatched_probe_rows
@@ -1,0 +1,27 @@
+-- name: test_nljoin_naaj_unmatched_probe_rows
+create table naaj_probe_${uuid0} (k int)
+duplicate key(k)
+distributed by hash(k) buckets 1
+properties("replication_num" = "1");
+-- result:
+-- !result
+insert into naaj_probe_${uuid0} values (10), (10), (3);
+-- result:
+-- !result
+create table naaj_build_${uuid0} (c int)
+duplicate key(c)
+distributed by hash(c) buckets 2
+properties("replication_num" = "1");
+-- result:
+-- !result
+insert into naaj_build_${uuid0} values (null), (10);
+-- result:
+-- !result
+select count(*) from naaj_probe_${uuid0} p where 10 not in (select c from naaj_build_${uuid0} b where b.c != p.k);
+-- result:
+2
+-- !result
+select count(*) from naaj_probe_${uuid0} p where 3 not in (select c from naaj_build_${uuid0} b where b.c != p.k);
+-- result:
+3
+-- !result

--- a/test/sql/test_nest_loop_join/T/test_nljoin_naaj_unmatched_probe_rows
+++ b/test/sql/test_nest_loop_join/T/test_nljoin_naaj_unmatched_probe_rows
@@ -1,0 +1,19 @@
+-- name: test_nljoin_naaj_unmatched_probe_rows
+
+create table naaj_probe_${uuid0} (k int)
+duplicate key(k)
+distributed by hash(k) buckets 1
+properties("replication_num" = "1");
+
+insert into naaj_probe_${uuid0} values (10), (10), (3);
+
+create table naaj_build_${uuid0} (c int)
+duplicate key(c)
+distributed by hash(c) buckets 2
+properties("replication_num" = "1");
+
+insert into naaj_build_${uuid0} values (null), (10);
+
+select count(*) from naaj_probe_${uuid0} p where 10 not in (select c from naaj_build_${uuid0} b where b.c != p.k);
+
+select count(*) from naaj_probe_${uuid0} p where 3 not in (select c from naaj_build_${uuid0} b where b.c != p.k);


### PR DESCRIPTION
## Why I'm doing:

In NLJoin null-aware left anti join, `_eval_nullaware_anti_conjuncts` calls
`chunk->set_num_rows(0)` when the match filter turns all-zero. For an anti join,
all-zero means the probe rows are unmatched and must be output, but the cleared
chunk skips the emission step (guarded by `chunk->num_rows() > 0`), so `NOT IN`
queries silently lose rows on multi-BE clusters.

## What I'm doing:

Replace `chunk->set_num_rows(0)` with `break`, so the all-zero filter still
reaches the anti-join emission step and the unmatched probe rows are emitted.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
