### PR TITLE
[Enhancement] Upgrade OpenSSL to 3.5.7 and krb5 to 1.21.3

### DIFF
--- a/nix/thirdparty-archives.nix
+++ b/nix/thirdparty-archives.nix
@@ -189,10 +189,10 @@ let
       md5 = "09a8328574dab22a7df848eae6dbbf53";
       sha256 = "1apyxjd1ixy4g8xkr61p0ny8jiz8vyv1j0k4nxqkxpqrf4g2vf1d";
     };
-    "krb5-1.19.4.tar.gz" = {
-      url = "https://web.mit.edu/kerberos/dist/krb5/1.19/krb5-1.19.4.tar.gz";
-      md5 = "ef76083e58f8c49066180642d7c2814a";
-      sha256 = "1sslkcbzg4dc98957lhzchwkfnyd2shpkrip75ms5q2db8f9ixa1";
+    "krb5-1.21.3.tar.gz" = {
+      url = "https://web.mit.edu/kerberos/dist/krb5/1.21/krb5-1.21.3.tar.gz";
+      md5 = "beb34d1dfc72ba0571ce72bed03e06eb";
+      sha256 = "0ddd81431pfsqv89w31jxa2pw8gp1wavs6mjh2whiyv7mmgcv95p";
     };
     "leveldb-1.20.tar.gz" = {
       url = "https://github.com/google/leveldb/archive/v1.20.tar.gz";
@@ -254,10 +254,10 @@ let
       md5 = "86c4052adeb8447900bf33b4e2ddd1f9";
       sha256 = "13ia4a1zh9r22pnwsdi55wax9kj9y8b9b02lis0rfw269j1g0596";
     };
-    "openssl-OpenSSL_1_1_1m.tar.gz" = {
-      url = "https://github.com/openssl/openssl/archive/OpenSSL_1_1_1m.tar.gz";
-      md5 = "710c2368d28f1a25ab92e25b5b9b11ec";
-      sha256 = "0q5kvar91asbv7k203sx3rafqirf4rhqih3anz829a7hgjnj9bin";
+    "openssl-3.5.7.tar.gz" = {
+      url = "https://github.com/openssl/openssl/releases/download/openssl-3.5.7/openssl-3.5.7.tar.gz";
+      md5 = "36608cd5445f708d0c2200aea9682c35";
+      sha256 = "1s4qmjp33ai43ahlm3iw59aq86fj5hp7kxbcygwq194waa5d5h58";
     };
     "opentelemetry-cpp-v1.9.1.tar.gz" = {
       url = "https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.9.1.tar.gz";
@@ -462,7 +462,7 @@ let
     "x86_64-linux" = [
       "starrocks-clucene-2026.06.23.tar.gz"
       "libevent-24236aed01798303745470e6c498bf606e88724a.zip"
-      "openssl-OpenSSL_1_1_1m.tar.gz"
+      "openssl-3.5.7.tar.gz"
       "thrift-0.24.0.tar.gz"
       "protobuf-3.16.1.tar.gz"
       "gflags-2.2.2.tar.gz"
@@ -481,7 +481,7 @@ let
       "leveldb-1.20.tar.gz"
       "brpc-1.9.0.tar.gz"
       "rocksdb-6.22.1.zip"
-      "krb5-1.19.4.tar.gz"
+      "krb5-1.21.3.tar.gz"
       "cyrus-sasl-2.1.28.tar.gz"
       "librdkafka-2.11.0.tar.gz"
       "pulsar-client-3.3.0.tar.gz"
@@ -533,7 +533,7 @@ let
     "aarch64-linux" = [
       "starrocks-clucene-2026.06.23.tar.gz"
       "libevent-24236aed01798303745470e6c498bf606e88724a.zip"
-      "openssl-OpenSSL_1_1_1m.tar.gz"
+      "openssl-3.5.7.tar.gz"
       "thrift-0.24.0.tar.gz"
       "protobuf-3.16.1.tar.gz"
       "gflags-2.2.2.tar.gz"
@@ -552,7 +552,7 @@ let
       "leveldb-1.20.tar.gz"
       "brpc-1.9.0.tar.gz"
       "rocksdb-6.22.1.zip"
-      "krb5-1.19.4.tar.gz"
+      "krb5-1.21.3.tar.gz"
       "cyrus-sasl-2.1.28.tar.gz"
       "librdkafka-2.11.0.tar.gz"
       "pulsar-client-3.3.0.tar.gz"
@@ -602,7 +602,7 @@ let
     "aarch64-darwin" = [
       "starrocks-clucene-2026.06.23.tar.gz"
       "libevent-24236aed01798303745470e6c498bf606e88724a.zip"
-      "openssl-OpenSSL_1_1_1m.tar.gz"
+      "openssl-3.5.7.tar.gz"
       "thrift-0.24.0.tar.gz"
       "protobuf-3.16.1.tar.gz"
       "gflags-2.2.2.tar.gz"
@@ -621,7 +621,7 @@ let
       "leveldb-1.20.tar.gz"
       "brpc-1.9.0.tar.gz"
       "rocksdb-6.22.1.zip"
-      "krb5-1.19.4.tar.gz"
+      "krb5-1.21.3.tar.gz"
       "cyrus-sasl-2.1.28.tar.gz"
       "librdkafka-2.11.0.tar.gz"
       "pulsar-client-3.3.0.tar.gz"

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -94,10 +94,10 @@ LIBEVENT_SOURCE=libevent-24236aed01798303745470e6c498bf606e88724a
 LIBEVENT_MD5SUM="c6c4e7614f03754b8c67a17f68177649"
 
 # openssl
-OPENSSL_DOWNLOAD="https://github.com/openssl/openssl/archive/OpenSSL_1_1_1m.tar.gz"
-OPENSSL_NAME=openssl-OpenSSL_1_1_1m.tar.gz
-OPENSSL_SOURCE=openssl-OpenSSL_1_1_1m
-OPENSSL_MD5SUM="710c2368d28f1a25ab92e25b5b9b11ec"
+OPENSSL_DOWNLOAD="https://github.com/openssl/openssl/releases/download/openssl-3.5.7/openssl-3.5.7.tar.gz"
+OPENSSL_NAME=openssl-3.5.7.tar.gz
+OPENSSL_SOURCE=openssl-3.5.7
+OPENSSL_MD5SUM="36608cd5445f708d0c2200aea9682c35"
 
 # thrift
 THRIFT_DOWNLOAD="https://archive.apache.org/dist/thrift/0.24.0/thrift-0.24.0.tar.gz"
@@ -214,10 +214,10 @@ SASL_SOURCE=cyrus-sasl-2.1.28
 SASL_MD5SUM="7dcf3919b3085a1d09576438171bda91"
 
 # MIT Kerberos publishes release archives from web.mit.edu/kerberos/dist.
-KRB5_DOWNLOAD="https://web.mit.edu/kerberos/dist/krb5/1.19/krb5-1.19.4.tar.gz"
-KRB5_NAME=krb5-1.19.4.tar.gz
-KRB5_SOURCE=krb5-1.19.4
-KRB5_MD5SUM="ef76083e58f8c49066180642d7c2814a"
+KRB5_DOWNLOAD="https://web.mit.edu/kerberos/dist/krb5/1.21/krb5-1.21.3.tar.gz"
+KRB5_NAME=krb5-1.21.3.tar.gz
+KRB5_SOURCE=krb5-1.21.3
+KRB5_MD5SUM="beb34d1dfc72ba0571ce72bed03e06eb"
 
 # librdkafka
 LIBRDKAFKA_DOWNLOAD="https://github.com/confluentinc/librdkafka/archive/refs/tags/v2.11.0.tar.gz"


### PR DESCRIPTION
OpenSSL 1.1.1 reached end-of-life on 2023-09-11 and no longer receives public security fixes. Move the bundled copy to the 3.5 LTS line, which is supported until 2030-04-08.

krb5 has to move with it. In a static no-shared OpenSSL 3 build the legacy provider is not loaded, so EVP_rc4() and EVP_md4() return non-NULL but fail at init. krb5 1.19.4 calls EVP_rc4() unconditionally, which would break arcfour-hmac at runtime with opaque errors, while 1.21.3 leaves K5_OPENSSL_RC4 undefined and compiles the RC4 enc provider out, so arcfour is reported as an unsupported enctype instead. Kerberos arcfour-hmac-md5 stops working either way, which only affects older KDCs; modern ones default to AES enctypes.

## Why I'm doing:

## What I'm doing:

Fixes #72034

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
