### PR TITLE
[BugFix] Validate Iceberg rewrite commits from the plan-time snapshot (backport #77709)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -2784,7 +2784,22 @@ public class IcebergMetadata implements ConnectorMetadata {
         if (isRewrite && extra != null) {
             ((IcebergSinkExtra) extra).getScannedDataFiles().forEach(batchWrite::deleteFile);
             ((IcebergSinkExtra) extra).getAppliedDeleteFiles().forEach(batchWrite::deleteFile);
-            ((RewriteData) batchWrite).setSnapshotId(nativeTbl.currentSnapshot().snapshotId());
+            // Validate from the snapshot the rewrite planned against, not the one current at
+            // commit time. RewriteFiles checks for row-level deletes added to the files being
+            // replaced over the range (startingSnapshot, current]; passing the commit-time
+            // snapshot makes that range empty, so a DELETE/UPDATE that landed while the rewrite
+            // was running is never seen. Replacing its data files then strands the position
+            // deletes on paths no longer in the table, silently resurrecting deleted rows.
+            Long baseSnapshotId = ((IcebergSinkExtra) extra).getBaseSnapshotId();
+            if (baseSnapshotId == null) {
+                Snapshot currentSnapshot = nativeTbl.currentSnapshot();
+                if (currentSnapshot != null) {
+                    baseSnapshotId = currentSnapshot.snapshotId();
+                }
+            }
+            if (baseSnapshotId != null) {
+                ((RewriteData) batchWrite).setSnapshotId(baseSnapshotId);
+            }
         }
 
         // Set audit info for the commit

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergRewriteDataJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergRewriteDataJob.java
@@ -60,6 +60,10 @@ public class IcebergRewriteDataJob {
     private ExecPlan execPlan;
     private List<IcebergScanNode> scanNodes;
     private IcebergRewriteData rewriteData;
+    // Snapshot the rewrite planned against, frozen in prepare(). Every batch rewrites the
+    // file set picked there, so this is the snapshot the commit must validate from -- see
+    // the comment on IcebergSinkExtra.baseSnapshotId.
+    private Long baseSnapshotId;
     private long batchParallelism = 1;
     private StatementBase parsedStmt;
     private final ConcurrentLinkedQueue<FinishArgs> collected = new ConcurrentLinkedQueue<>();
@@ -178,6 +182,7 @@ public class IcebergRewriteDataJob {
             return;
         }
 
+        this.baseSnapshotId = targetNode.getBaseSnapshotId().orElse(null);
         this.rewriteData = new IcebergRewriteData();
         this.rewriteData.setSource(targetNode.getSourceRange());
         this.rewriteData.setBatchSize(batchSize);
@@ -283,6 +288,7 @@ public class IcebergRewriteDataJob {
                 return RewriteMetrics.EMPTY;
             }
             IcebergSinkExtra extra = new IcebergSinkExtra();
+            extra.setBaseSnapshotId(baseSnapshotId);
             List<TSinkCommitInfo> faList = Lists.newArrayList();
             for (FinishArgs fa : collected) {
                 extra.addScannedDataFiles(((IcebergSinkExtra) fa.getExtra()).getScannedDataFiles());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.IcebergPartitionKey;
@@ -3224,6 +3225,116 @@ public class IcebergMetadataTest extends TableTestBase {
         mockedNativeTableA.refresh();
         List<FileScanTask> fileScanTasks = Lists.newArrayList(mockedNativeTableA.newScan().planFiles());
         Assertions.assertFalse(fileScanTasks.isEmpty());
+    }
+
+    // Empty but present column stats, so a commit test can build a data file without
+    // asserting anything about its statistics.
+    private TIcebergColumnStats emptyColumnStats() {
+        TIcebergColumnStats stats = new TIcebergColumnStats();
+        stats.setColumn_sizes(Map.of());
+        stats.setValue_counts(Map.of());
+        stats.setNull_value_counts(Map.of());
+        stats.setLower_bounds(Map.of());
+        stats.setUpper_bounds(Map.of());
+        return stats;
+    }
+
+    private TIcebergDataFile buildRewriteOutputDataFile() {
+        TIcebergDataFile dataFile = new TIcebergDataFile();
+        dataFile.setPath(mockedNativeTableA.location() + "/data/data_bucket=0/rewritten.parquet");
+        dataFile.setFormat("parquet");
+        dataFile.setRecord_count(2);
+        dataFile.setSplit_offsets(Lists.newArrayList(4L));
+        dataFile.setPartition_path(mockedNativeTableA.location() + "/data/data_bucket=0/");
+        dataFile.setFile_size_in_bytes(512);
+        dataFile.setPartition_null_fingerprint("0");
+        dataFile.setColumn_stats(emptyColumnStats());
+        return dataFile;
+    }
+
+    @Test
+    public void testCommitRewriteDetectsDeleteLandedAfterPlanTime() throws Exception {
+        // S0 - the snapshot the rewrite planned against and read FILE_A from.
+        mockedNativeTableA.newFastAppend().appendFile(FILE_A).commit();
+        long planTimeSnapshotId = mockedNativeTableA.currentSnapshot().snapshotId();
+
+        // S1 - a concurrent UPDATE/DELETE lands a position delete over FILE_A after the
+        // rewrite planned but before it commits. Replacing FILE_A now would strand that
+        // delete on a path no longer in the table and resurrect the row it removed.
+        mockedNativeTableA.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", Lists.newArrayList(), mockedNativeTableA, Maps.newHashMap());
+
+        new Expectations(metadata) {
+            {
+                metadata.getTable((ConnectContext) any, anyString, anyString);
+                result = icebergTable;
+                minTimes = 0;
+            }
+        };
+
+        TSinkCommitInfo rewriteCommit = new TSinkCommitInfo();
+        rewriteCommit.setIs_rewrite(true);
+        rewriteCommit.setIceberg_data_file(buildRewriteOutputDataFile());
+
+        IcebergMetadata.IcebergSinkExtra extra = new IcebergMetadata.IcebergSinkExtra();
+        extra.addScannedDataFiles(Sets.newHashSet(FILE_A));
+        extra.setBaseSnapshotId(planTimeSnapshotId);
+
+        // Scoping validateFromSnapshot to the commit-time snapshot instead of the plan-time
+        // base makes the validation window empty, so this conflict commits silently and
+        // corrupts the table (StarRocksTest#11450 duplicates a row, #11396 resurrects one).
+        StarRocksConnectorException e = Assertions.assertThrows(StarRocksConnectorException.class,
+                () -> metadata.finishSink("iceberg_db", "iceberg_table",
+                        Lists.newArrayList(rewriteCommit), null, extra),
+                "rewrite must not commit over a delete that landed after it planned");
+        Assertions.assertTrue(e.getMessage().contains("found new delete for replaced data file"),
+                "expected Iceberg's replaced-data-file conflict error, got: " + e.getMessage());
+    }
+
+    @Test
+    public void testCommitRewriteFallsBackToCurrentSnapshotWhenBaseMissing() throws Exception {
+        // A rewrite whose sink extra carries no plan-time snapshot -- e.g. a plan that
+        // produced no IcebergScanNode to freeze one from. The commit must still scope
+        // validateFromSnapshot (falling back to the current snapshot) rather than skip it
+        // or fail, so an ordinary rewrite with nothing to conflict against still commits.
+        mockedNativeTableA.newFastAppend().appendFile(FILE_A).commit();
+        long snapshotBeforeRewrite = mockedNativeTableA.currentSnapshot().snapshotId();
+
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", Lists.newArrayList(), mockedNativeTableA, Maps.newHashMap());
+
+        new Expectations(metadata) {
+            {
+                metadata.getTable((ConnectContext) any, anyString, anyString);
+                result = icebergTable;
+                minTimes = 0;
+            }
+        };
+
+        TSinkCommitInfo rewriteCommit = new TSinkCommitInfo();
+        rewriteCommit.setIs_rewrite(true);
+        rewriteCommit.setIceberg_data_file(buildRewriteOutputDataFile());
+
+        IcebergMetadata.IcebergSinkExtra extra = new IcebergMetadata.IcebergSinkExtra();
+        extra.addScannedDataFiles(Sets.newHashSet(FILE_A));
+        // deliberately no setBaseSnapshotId(...)
+
+        metadata.finishSink("iceberg_db", "iceberg_table",
+                Lists.newArrayList(rewriteCommit), null, extra);
+
+        mockedNativeTableA.refresh();
+        Snapshot newSnapshot = mockedNativeTableA.currentSnapshot();
+        Assertions.assertNotNull(newSnapshot, "rewrite commit must produce a snapshot");
+        Assertions.assertNotEquals(snapshotBeforeRewrite, newSnapshot.snapshotId(),
+                "rewrite commit must advance the snapshot id past the pre-rewrite state");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

On a merge-on-read Iceberg table, a concurrent `UPDATE` or `DELETE` racing `ALTER TABLE ... EXECUTE rewrite_data_files()` could leave the table with a wrong row count while **both statements reported success**. With `UPDATE` the target row ended up duplicated (100 base rows became 101, the row present with both its old and new value); with `DELETE` the deleted row was resurrected (99 expected, 100 observed). The `DELETE` variant is the more dangerous of the two, since the extra row is data the user asked to remove.

The two share a single root cause. `RewriteFiles.validateFromSnapshot()` was handed `nativeTbl.currentSnapshot()` — the snapshot current at *commit* time — instead of the snapshot the rewrite planned against. Iceberg's `validateNoNewDeletesForDataFiles` scans the range `(startingSnapshot, current]` for row-level deletes added to the data files being replaced, so passing the commit-time snapshot makes that range empty via `SnapshotUtil.ancestorsBetween(parent, starting)` and the validation never fires. A `DELETE`/`UPDATE` that committed while the rewrite was running therefore stayed invisible, and replacing its data files stranded the position deletes on file paths no longer part of the table. Because Iceberg's `VALIDATE_ADDED_DELETE_FILES_OPERATIONS` covers both `overwrite` (produced by `UPDATE`) and `delete` (produced by `DELETE`), one fix addresses both symptoms.

The DML side of this race was already correct — `UpdatePlanner`, `DeletePlanner` and `MergeIntoPlanner` all freeze a plan-time `baseSnapshotId` and pass it through `IcebergSinkExtra`. Only the rewrite commit path was left out, which is why the reverse ordering (rewrite commits first) was correctly refused with `Cannot commit, missing data files` while the forward ordering silently corrupted the table.

## What I'm doing:

Freezing the base snapshot in `IcebergRewriteDataJob.prepare()` — where the file set to rewrite is selected — and carrying it to the commit through `IcebergSinkExtra`, reusing the mechanism the DML planners already rely on. `prepare()` is the correct place to capture it: every batch rewrites the file set chosen there via `rebuildScanRange`, whereas each batch's `localPlan` is re-planned against a fresher snapshot and would reintroduce the same defect.

`commitDataOperation` now consumes that value and keeps a fallback to the current snapshot when no plan-time snapshot is available, matching the row-delta path; the fallback also removes a latent NPE when the table has no current snapshot.

Verified on a 1 FE + 1 BE cluster against a shared Hive-metastore Iceberg catalog, comparing an unpatched build with the patched FE using an identical script and identical criteria:

| Scenario | Unpatched baseline | With this fix |
| --- | --- | --- |
| `UPDATE` × `rewrite_data_files` | 4/4 corrupt (101 rows, target row duplicated) | 0/4 corrupt, 4/4 rewrite refused |
| `DELETE` × `rewrite_data_files` | 4/4 corrupt (100 rows, deleted row back) | 0/4 corrupt, 4/4 rewrite refused, `DELETE` correctly lands 99 rows |
| `rewrite_data_files` with no concurrent DML | — | still compacts normally (3 files to 1, row count unchanged) |

The refusals carry Iceberg's `Cannot commit, found new delete for replaced data file`, confirming the validation now covers the scan-to-commit window. The no-conflict row confirms the fix does not simply reject every rewrite.

Fixes https://github.com/StarRocks/StarRocksTest/issues/11450
Fixes https://github.com/StarRocks/StarRocksTest/issues/11396

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

