### PR TITLE
[BugFix] Fix empty Sql Statement in profile by supporting CTAS deparse

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
@@ -1177,13 +1177,21 @@ public class AST2StringVisitor implements AstVisitorExtendInterface<String, Void
                 return "PARTITION BY (" + partitionItems + ")";
             }
             if (org.apache.commons.collections4.CollectionUtils.isNotEmpty(listPartitionDesc.getPartitionColNames())) {
+                // The LIST keyword is what separates explicit list partitioning from automatic
+                // partitioning (AstBuilder sets autoPartitionTable only when LIST is absent), so
+                // emitting it for an automatic-partition table would deparse to a different table.
+                if (listPartitionDesc.isAutoPartitionTable()) {
+                    return "PARTITION BY (" + joinBackQuoted(listPartitionDesc.getPartitionColNames()) + ")";
+                }
                 return "PARTITION BY LIST(" + joinBackQuoted(listPartitionDesc.getPartitionColNames()) + ")";
             }
         }
         if (partitionDesc instanceof RangePartitionDesc) {
             RangePartitionDesc rangePartitionDesc = (RangePartitionDesc) partitionDesc;
             if (org.apache.commons.collections4.CollectionUtils.isNotEmpty(rangePartitionDesc.getPartitionColNames())) {
-                return "PARTITION BY RANGE(" + joinBackQuoted(rangePartitionDesc.getPartitionColNames()) + ")";
+                // The grammar requires parentheses after RANGE(cols); keep an empty pair so the
+                // output stays parseable while the partition definitions are omitted.
+                return "PARTITION BY RANGE(" + joinBackQuoted(rangePartitionDesc.getPartitionColNames()) + ") ()";
             }
         }
         return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
@@ -19,6 +19,7 @@ import com.google.common.base.Strings;
 import com.starrocks.authorization.ObjectType;
 import com.starrocks.authorization.PEntryObject;
 import com.starrocks.authorization.PrivilegeType;
+import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.TableName;
 import com.starrocks.common.util.ParseUtil;
@@ -1096,8 +1097,16 @@ public class AST2StringVisitor implements AstVisitorExtendInterface<String, Void
                 tableRef.getTableName(), tableRef.getPos());
         sb.append(tableName.toSql());
 
+        // The parenthesized clause carries column names, index definitions, or both.
+        List<String> parenthesizedItems = new ArrayList<>();
         if (org.apache.commons.collections4.CollectionUtils.isNotEmpty(stmt.getColumnNames())) {
-            sb.append(" (").append(joinBackQuoted(stmt.getColumnNames())).append(")");
+            stmt.getColumnNames().forEach(c -> parenthesizedItems.add(ParseUtil.backquote(c)));
+        }
+        if (org.apache.commons.collections4.CollectionUtils.isNotEmpty(createStmt.getIndexDefs())) {
+            createStmt.getIndexDefs().forEach(d -> parenthesizedItems.add(d.toSql()));
+        }
+        if (!parenthesizedItems.isEmpty()) {
+            sb.append(" (").append(String.join(",", parenthesizedItems)).append(")");
         }
 
         String engineName = createStmt.getEngineName();
@@ -1114,7 +1123,9 @@ public class AST2StringVisitor implements AstVisitorExtendInterface<String, Void
         }
 
         if (StringUtils.isNotEmpty(createStmt.getComment())) {
-            sb.append(" COMMENT \"").append(createStmt.getComment()).append("\"");
+            sb.append(" COMMENT \"")
+                    .append(CatalogUtils.addEscapeCharacter(createStmt.getComment()))
+                    .append("\"");
         }
 
         if (createStmt.getPartitionDesc() != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
@@ -37,6 +37,9 @@ import com.starrocks.sql.ast.CreateCatalogStmt;
 import com.starrocks.sql.ast.CreateResourceStmt;
 import com.starrocks.sql.ast.CreateRoutineLoadStmt;
 import com.starrocks.sql.ast.CreateStorageVolumeStmt;
+import com.starrocks.sql.ast.CreateTableAsSelectStmt;
+import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.sql.ast.CreateTemporaryTableStmt;
 import com.starrocks.sql.ast.CreateUserStmt;
 import com.starrocks.sql.ast.DataDescription;
 import com.starrocks.sql.ast.DeleteStmt;
@@ -45,6 +48,7 @@ import com.starrocks.sql.ast.DropMaterializedViewStmt;
 import com.starrocks.sql.ast.ExceptRelation;
 import com.starrocks.sql.ast.ExecuteStmt;
 import com.starrocks.sql.ast.ExportStmt;
+import com.starrocks.sql.ast.ExpressionPartitionDesc;
 import com.starrocks.sql.ast.FileTableFunctionRelation;
 import com.starrocks.sql.ast.GrantPrivilegeStmt;
 import com.starrocks.sql.ast.GrantRoleStmt;
@@ -54,15 +58,19 @@ import com.starrocks.sql.ast.HintNode;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.IntersectRelation;
 import com.starrocks.sql.ast.JoinRelation;
+import com.starrocks.sql.ast.KeysDesc;
+import com.starrocks.sql.ast.ListPartitionDesc;
 import com.starrocks.sql.ast.LoadStmt;
 import com.starrocks.sql.ast.NormalizedTableFunctionRelation;
 import com.starrocks.sql.ast.OrderByElement;
 import com.starrocks.sql.ast.ParseNode;
+import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.sql.ast.PivotAggregation;
 import com.starrocks.sql.ast.PivotRelation;
 import com.starrocks.sql.ast.PivotValue;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.RangePartitionDesc;
 import com.starrocks.sql.ast.RefreshConnectionsStmt;
 import com.starrocks.sql.ast.Relation;
 import com.starrocks.sql.ast.SelectList;
@@ -1069,6 +1077,111 @@ public class AST2StringVisitor implements AstVisitorExtendInterface<String, Void
         if (StringUtils.isNotEmpty(label)) {
             sb.append("WITH LABEL `").append(label).append("` ");
         }
+    }
+
+    @Override
+    public String visitCreateTableAsSelectStatement(CreateTableAsSelectStmt stmt, Void context) {
+        StringBuilder sb = new StringBuilder();
+        CreateTableStmt createStmt = stmt.getCreateTableStmt();
+        sb.append("CREATE ");
+        if (createStmt instanceof CreateTemporaryTableStmt) {
+            sb.append("TEMPORARY ");
+        }
+        sb.append("TABLE ");
+        if (createStmt.isSetIfNotExists()) {
+            sb.append("IF NOT EXISTS ");
+        }
+        TableRef tableRef = createStmt.getTableRef();
+        TableName tableName = new TableName(tableRef.getCatalogName(), tableRef.getDbName(),
+                tableRef.getTableName(), tableRef.getPos());
+        sb.append(tableName.toSql());
+
+        if (org.apache.commons.collections4.CollectionUtils.isNotEmpty(stmt.getColumnNames())) {
+            sb.append(" (").append(joinBackQuoted(stmt.getColumnNames())).append(")");
+        }
+
+        String engineName = createStmt.getEngineName();
+        if (!Strings.isNullOrEmpty(engineName) && !createStmt.isOlapEngine()) {
+            sb.append(" ENGINE = ").append(engineName);
+        }
+
+        // The analyzer derives a key desc when the user didn't write one; only print explicit ones.
+        KeysDesc keysDesc = createStmt.getKeysDesc();
+        if (keysDesc != null && !keysDesc.isKeysColumnsDerived()
+                && org.apache.commons.collections4.CollectionUtils.isNotEmpty(keysDesc.getKeysColumnNames())) {
+            sb.append(" ").append(keysDesc.getKeysType().toSql())
+                    .append("(").append(joinBackQuoted(keysDesc.getKeysColumnNames())).append(")");
+        }
+
+        if (StringUtils.isNotEmpty(createStmt.getComment())) {
+            sb.append(" COMMENT \"").append(createStmt.getComment()).append("\"");
+        }
+
+        if (createStmt.getPartitionDesc() != null) {
+            String partitionSql = partitionDescToSql(createStmt.getPartitionDesc());
+            if (!Strings.isNullOrEmpty(partitionSql)) {
+                sb.append(" ").append(partitionSql);
+            }
+        }
+
+        if (createStmt.getDistributionDesc() != null) {
+            sb.append(" ").append(createStmt.getDistributionDesc());
+        }
+
+        if (org.apache.commons.collections4.CollectionUtils.isNotEmpty(createStmt.getOrderByElements())) {
+            String orderByColumns = createStmt.getOrderByElements().stream()
+                    .map(e -> visit(e.getExpr()))
+                    .collect(Collectors.joining(","));
+            sb.append(" ORDER BY (").append(orderByColumns).append(")");
+        }
+
+        Map<String, String> properties = createStmt.getProperties();
+        if (properties != null && !properties.isEmpty()) {
+            sb.append(" PROPERTIES (")
+                    .append(new PrintableMap<>(properties, "=", true, false, options.isHideCredential()))
+                    .append(")");
+        }
+
+        sb.append(" AS ").append(visit(stmt.getQueryStatement(), context));
+        return sb.toString();
+    }
+
+    /**
+     * {@link PartitionDesc#toSql()} is unimplemented across its subclasses, so render the
+     * PARTITION BY clause here. Partition definitions (VALUES IN / range items) are omitted:
+     * this output is for display (profile, audit log, digest), not for re-execution.
+     * Returns null for descriptors that cannot be rendered, so the caller skips the clause.
+     */
+    private String partitionDescToSql(PartitionDesc partitionDesc) {
+        if (partitionDesc instanceof ExpressionPartitionDesc) {
+            return "PARTITION BY " + visit(((ExpressionPartitionDesc) partitionDesc).getExpr());
+        }
+        if (partitionDesc instanceof ListPartitionDesc) {
+            ListPartitionDesc listPartitionDesc = (ListPartitionDesc) partitionDesc;
+            if (org.apache.commons.collections4.CollectionUtils.isNotEmpty(listPartitionDesc.getMultiDescList())) {
+                // PARTITION BY (c1, c2) or PARTITION BY (date_trunc('day', dt), c1)
+                String partitionItems = listPartitionDesc.getMultiDescList().stream()
+                        .map(this::visit)
+                        .collect(Collectors.joining(","));
+                return "PARTITION BY (" + partitionItems + ")";
+            }
+            if (org.apache.commons.collections4.CollectionUtils.isNotEmpty(listPartitionDesc.getPartitionColNames())) {
+                return "PARTITION BY LIST(" + joinBackQuoted(listPartitionDesc.getPartitionColNames()) + ")";
+            }
+        }
+        if (partitionDesc instanceof RangePartitionDesc) {
+            RangePartitionDesc rangePartitionDesc = (RangePartitionDesc) partitionDesc;
+            if (org.apache.commons.collections4.CollectionUtils.isNotEmpty(rangePartitionDesc.getPartitionColNames())) {
+                return "PARTITION BY RANGE(" + joinBackQuoted(rangePartitionDesc.getPartitionColNames()) + ")";
+            }
+        }
+        return null;
+    }
+
+    private static String joinBackQuoted(List<String> names) {
+        return names.stream()
+                .map(ParseUtil::backquote)
+                .collect(Collectors.joining(","));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AstToSQLBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AstToSQLBuilderTest.java
@@ -391,6 +391,15 @@ public class AstToSQLBuilderTest {
                         "CREATE TABLE `t4` PARTITION BY RANGE(`dt`) DISTRIBUTED BY HASH(dt) AS SELECT `dt`\nFROM `t0`"},
                 {"CREATE TABLE t5 ORDER BY (v1) AS SELECT v1, v2 FROM t0",
                         "CREATE TABLE `t5` ORDER BY (`v1`) AS SELECT `v1`, `v2`\nFROM `t0`"},
+                {"CREATE TABLE t7 (c1, c2, INDEX idx1 (c1) USING BITMAP) AS SELECT v1, v2 FROM t0",
+                        "CREATE TABLE `t7` (`c1`,`c2`,INDEX idx1 (`c1`) USING BITMAP COMMENT '') " +
+                                "AS SELECT `v1`, `v2`\nFROM `t0`"},
+                // Index definitions alone must not drop the parenthesized clause.
+                {"CREATE TABLE t8 (INDEX idx1 (c1) USING BITMAP) AS SELECT v1 AS c1 FROM t0",
+                        "CREATE TABLE `t8` (INDEX idx1 (`c1`) USING BITMAP COMMENT '') AS SELECT `v1` AS `c1`\nFROM `t0`"},
+                // A double quote inside the comment must be escaped to keep the output legal SQL.
+                {"CREATE TABLE t9 COMMENT 'say \"hello\"' AS SELECT v1 FROM t0",
+                        "CREATE TABLE `t9` COMMENT \"say \\\"hello\\\"\" AS SELECT `v1`\nFROM `t0`"},
         };
         for (String[] c : cases) {
             StatementBase stmt = SqlParser.parseSingleStatement(c[0], SqlModeHelper.MODE_DEFAULT);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AstToSQLBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AstToSQLBuilderTest.java
@@ -363,4 +363,51 @@ public class AstToSQLBuilderTest {
         Assertions.assertDoesNotThrow(() -> Analyzer.analyze(again, AnalyzeTestUtil.getConnectContext()),
                 () -> "deparsed form no longer analyzes: " + temp);
     }
+
+    @Test
+    public void testCreateTableAsSelect() {
+        // CTAS used to have no deparse visitor and fell through to visitNode() which returns an empty
+        // string, so the profile and audit log of a CTAS in a multi-statement request showed no SQL.
+        String[][] cases = {
+                {"CREATE TABLE t1 AS SELECT v1, v2 FROM t0",
+                        "CREATE TABLE `t1` AS SELECT `v1`, `v2`\nFROM `t0`"},
+                {"CREATE TABLE IF NOT EXISTS db1.t1 (c1, c2) COMMENT \"test ctas\" " +
+                        "DISTRIBUTED BY HASH(c1) BUCKETS 8 " +
+                        "PROPERTIES('replication_num'='1') AS SELECT v1, v2 FROM t0 WHERE v1 > 1",
+                        "CREATE TABLE IF NOT EXISTS `db1`.`t1` (`c1`,`c2`) COMMENT \"test ctas\" " +
+                                "DISTRIBUTED BY HASH(c1) BUCKETS 8 " +
+                                "PROPERTIES (\"replication_num\" = \"1\") AS SELECT `v1`, `v2`\nFROM `t0`\nWHERE `v1` > 1"},
+                {"CREATE TEMPORARY TABLE t2 AS SELECT v1 FROM t0",
+                        "CREATE TEMPORARY TABLE `t2` AS SELECT `v1`\nFROM `t0`"},
+                {"CREATE TABLE t3 PRIMARY KEY (c1) DISTRIBUTED BY HASH(c1) AS SELECT v1 AS c1 FROM t0",
+                        "CREATE TABLE `t3` PRIMARY KEY(`c1`) DISTRIBUTED BY HASH(c1) AS SELECT `v1` AS `c1`\nFROM `t0`"},
+                {"CREATE TABLE t4 PARTITION BY (dt) AS SELECT dt, v1 FROM t0",
+                        "CREATE TABLE `t4` PARTITION BY LIST(`dt`) AS SELECT `dt`, `v1`\nFROM `t0`"},
+                {"CREATE TABLE t4 PARTITION BY date_trunc('day', dt) AS SELECT dt, v1 FROM t0",
+                        "CREATE TABLE `t4` PARTITION BY date_trunc('day', `dt`) AS SELECT `dt`, `v1`\nFROM `t0`"},
+                {"CREATE TABLE t4 PARTITION BY RANGE(dt) " +
+                        "(START ('2021-01-01') END ('2021-01-10') EVERY (INTERVAL 1 DAY)) " +
+                        "DISTRIBUTED BY HASH(dt) AS SELECT dt FROM t0",
+                        "CREATE TABLE `t4` PARTITION BY RANGE(`dt`) DISTRIBUTED BY HASH(dt) AS SELECT `dt`\nFROM `t0`"},
+                {"CREATE TABLE t5 ORDER BY (v1) AS SELECT v1, v2 FROM t0",
+                        "CREATE TABLE `t5` ORDER BY (`v1`) AS SELECT `v1`, `v2`\nFROM `t0`"},
+        };
+        for (String[] c : cases) {
+            StatementBase stmt = SqlParser.parseSingleStatement(c[0], SqlModeHelper.MODE_DEFAULT);
+            Assertions.assertEquals(c[1], AstToSQLBuilder.toSQL(stmt), c[0]);
+            // Regression: the fallback path used to hand out the visitor's empty string as-is.
+            Assertions.assertEquals(c[1], AstToSQLBuilder.toSQLOrDefault(stmt, c[0]), c[0]);
+        }
+    }
+
+    @Test
+    public void testCreateTableAsSelectHidesCredentials() {
+        String sql = "CREATE TABLE t6 PROPERTIES ('aws.s3.access_key'='abc', 'aws.s3.secret_key'='def') " +
+                "AS SELECT v1 FROM t0";
+        StatementBase stmt = SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
+        Assertions.assertEquals(
+                "CREATE TABLE `t6` PROPERTIES (\"aws.s3.access_key\" = \"***\", \"aws.s3.secret_key\" = \"***\") " +
+                        "AS SELECT `v1`\nFROM `t0`",
+                AstToSQLBuilder.toSQL(stmt));
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AstToSQLBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AstToSQLBuilderTest.java
@@ -381,14 +381,22 @@ public class AstToSQLBuilderTest {
                         "CREATE TEMPORARY TABLE `t2` AS SELECT `v1`\nFROM `t0`"},
                 {"CREATE TABLE t3 PRIMARY KEY (c1) DISTRIBUTED BY HASH(c1) AS SELECT v1 AS c1 FROM t0",
                         "CREATE TABLE `t3` PRIMARY KEY(`c1`) DISTRIBUTED BY HASH(c1) AS SELECT `v1` AS `c1`\nFROM `t0`"},
+                // Automatic partitioning: the LIST keyword must not appear, or the output re-parses
+                // as explicit list partitioning (a different table).
                 {"CREATE TABLE t4 PARTITION BY (dt) AS SELECT dt, v1 FROM t0",
-                        "CREATE TABLE `t4` PARTITION BY LIST(`dt`) AS SELECT `dt`, `v1`\nFROM `t0`"},
+                        "CREATE TABLE `t4` PARTITION BY (`dt`) AS SELECT `dt`, `v1`\nFROM `t0`"},
+                // An explicit LIST clause is folded into a RangePartitionDesc by AstBuilder#visitPartitionDesc
+                // (the LIST/RANGE branch), dropping the list definitions, so the deparse reflects that AST.
+                {"CREATE TABLE t4 PARTITION BY LIST(dt) (PARTITION p1 VALUES IN ('2021-01-01')) " +
+                        "DISTRIBUTED BY HASH(dt) AS SELECT dt FROM t0",
+                        "CREATE TABLE `t4` PARTITION BY RANGE(`dt`) () DISTRIBUTED BY HASH(dt) AS SELECT `dt`\nFROM `t0`"},
                 {"CREATE TABLE t4 PARTITION BY date_trunc('day', dt) AS SELECT dt, v1 FROM t0",
                         "CREATE TABLE `t4` PARTITION BY date_trunc('day', `dt`) AS SELECT `dt`, `v1`\nFROM `t0`"},
+                // The grammar requires parentheses after RANGE(cols), so an empty pair is kept.
                 {"CREATE TABLE t4 PARTITION BY RANGE(dt) " +
                         "(START ('2021-01-01') END ('2021-01-10') EVERY (INTERVAL 1 DAY)) " +
                         "DISTRIBUTED BY HASH(dt) AS SELECT dt FROM t0",
-                        "CREATE TABLE `t4` PARTITION BY RANGE(`dt`) DISTRIBUTED BY HASH(dt) AS SELECT `dt`\nFROM `t0`"},
+                        "CREATE TABLE `t4` PARTITION BY RANGE(`dt`) () DISTRIBUTED BY HASH(dt) AS SELECT `dt`\nFROM `t0`"},
                 {"CREATE TABLE t5 ORDER BY (v1) AS SELECT v1, v2 FROM t0",
                         "CREATE TABLE `t5` ORDER BY (`v1`) AS SELECT `v1`, `v2`\nFROM `t0`"},
                 {"CREATE TABLE t7 (c1, c2, INDEX idx1 (c1) USING BITMAP) AS SELECT v1, v2 FROM t0",
@@ -403,9 +411,13 @@ public class AstToSQLBuilderTest {
         };
         for (String[] c : cases) {
             StatementBase stmt = SqlParser.parseSingleStatement(c[0], SqlModeHelper.MODE_DEFAULT);
-            Assertions.assertEquals(c[1], AstToSQLBuilder.toSQL(stmt), c[0]);
+            String serializedSql = AstToSQLBuilder.toSQL(stmt);
+            Assertions.assertEquals(c[1], serializedSql, c[0]);
             // Regression: the fallback path used to hand out the visitor's empty string as-is.
             Assertions.assertEquals(c[1], AstToSQLBuilder.toSQLOrDefault(stmt, c[0]), c[0]);
+            // The deparsed form must stay legal SQL even where partition definitions are omitted.
+            Assertions.assertDoesNotThrow(() -> SqlParser.parseSingleStatement(serializedSql, SqlModeHelper.MODE_DEFAULT),
+                    c[0]);
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

When the SQL shown in the query profile or audit log is rebuilt from the AST, a CTAS statement came out as an **empty string**, so the web UI `/query` page and `SHOW PROFILELIST` showed a blank `Sql Statement` for it.

Root cause: `CreateTableAsSelectStmt` has no deparse visitor in `AST2StringVisitor`, so `AstToSQLBuilder.toSQL()` falls through to `AST2SQLVisitor#visitNode`, which returns `""`. `toSQLOrDefault()` only falls back to the origin text on exception, so the empty string is written to the profile as-is.

This is hit whenever the AST-rebuild path is taken, e.g. a CTAS inside a multi-statement request (`ctx.isMultiStmt() == true`):

```sql
delimiter $$
SET enable_profile = true;
CREATE TABLE dst AS SELECT k1, v1 FROM src;
SELECT LAST_QUERY_ID()$$
```

## What I'm doing:

Implement `visitCreateTableAsSelectStatement` in `AST2StringVisitor` so CTAS deparses to legal SQL. It covers `TEMPORARY`, `IF NOT EXISTS`, the column name list, `ENGINE` (default olap omitted), key desc (analyzer-derived key descs omitted), `COMMENT`, `PARTITION BY`, `DISTRIBUTED BY`, `ORDER BY`, and `PROPERTIES` (credentials masked via `PrintableMap`), followed by the deparsed query.

`PartitionDesc#toSql()` is unimplemented across all its subclasses (the base throws `UnsupportedOperationException`), so the `PARTITION BY` clause is rendered locally per subclass; partition definitions (`VALUES IN` / `START ... END ... EVERY`) are omitted since this output is for display (profile, audit log, digest), not re-execution.

Example:

```
IN : CREATE TABLE IF NOT EXISTS db1.t1 (c1, c2) COMMENT "test ctas" DISTRIBUTED BY HASH(c1) BUCKETS 8 PROPERTIES('replication_num'='1') AS SELECT v1, v2 FROM t0 WHERE v1 > 1
OUT: CREATE TABLE IF NOT EXISTS `db1`.`t1` (`c1`,`c2`) COMMENT "test ctas" DISTRIBUTED BY HASH(c1) BUCKETS 8 PROPERTIES ("replication_num" = "1") AS SELECT `v1`, `v2` FROM `t0` WHERE `v1` > 1
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)