### PR TITLE
[BugFix] Set isSingleStmt in proxyExecute so forwarded statements keep origin SQL

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -1087,6 +1087,12 @@ public class ConnectProcessor {
             int idx = request.isSetStmtIdx() ? request.getStmtIdx() : 0;
 
             List<StatementBase> stmts = SqlParser.parse(request.getSql(), ctx.getSessionVariable());
+            // The proxy context is created per forwarded request, so isSingleStmt keeps its default
+            // (false) unless set here. StmtExecutor.buildTopLevelProfile and getAuditSql rebuild the
+            // SQL from the AST for non-single statements, so a forwarded single statement would show
+            // the rebuilt SQL (or an empty one for statements without a deparse visitor, e.g. CTAS)
+            // in the profile and audit log instead of the origin text.
+            ctx.setSingleStmt(stmts.size() == 1);
             StatementBase statement = stmts.get(idx);
             //Build View SQL without Policy Rewrite
             new AstTraverser<Void, Void>() {


### PR DESCRIPTION
## Why I'm doing:

On branch-3.5, the leader creates a fresh `ConnectContext` for every forwarded request (`FrontendServiceImpl.forward`), and `ConnectProcessor.proxyExecute` never sets `isSingleStmt`, so the flag keeps its default `false`. Both `StmtExecutor.buildTopLevelProfile` and `ConnectProcessor.getAuditSql` rebuild the SQL from the AST whenever the statement is not a single statement:

```java
String sql = context.isSingleStmt() ? originStmt.originStmt :
        AstToSQLBuilder.toSQLOrDefault(parsedStmt, originStmt.originStmt);
```

So **every** statement forwarded from a follower shows the AST-rebuilt SQL in the profile and audit log instead of the origin text. For statements without a deparse visitor the rebuilt SQL is an empty string (`AST2SQLBuilderVisitor#visitNode` returns `""` and `toSQLOrDefault` only falls back on exception) — CTAS is the visible case, since it is `FORWARD_WITH_SYNC` and runs its insert coordinator on the leader:

1. Connect to a **follower**, `SET enable_profile = true;`
2. `CREATE TABLE dst AS SELECT k1, v1 FROM src;` (a plain single statement)
3. The profile on the leader (web UI `/query` page, `SHOW PROFILELIST`) shows an **empty `Sql Statement`**, while the same CTAS executed directly on the leader shows it correctly.

## What I'm doing:

Set the flag in `proxyExecute` from the parsed statement count of the forwarded SQL, the same way `handleQuery` does for direct connections. The forwarded request carries the full origin SQL plus `stmtIdx`, so the leader can count the statements itself.

main is not affected: it sets `ctx.setMultiStmt(stmts.size() > 1)` in `proxyExecute` since #71194, which was not backported to branch-3.5. This is the branch-3.5-specific counterpart, kept minimal (one flag assignment) instead of backporting the whole per-stmt audit log enhancement.

Note: a CTAS inside a genuinely multi-statement request still deparses to an empty string on branch-3.5; that root cause (missing CTAS deparse visitor) is fixed on main by #77978 and can be backported separately.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
