### PR TITLE
[UT] Stabilize lake persistent index fileset test

### DIFF
--- a/be/test/storage/lake/lake_persistent_index_fileset_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_fileset_test.cpp
@@ -630,6 +630,7 @@ TEST_F(LakePersistentIndexFilesetTest, test_index_basic_read_write) {
         ASSERT_EQ(values[i], get_values[i]);
     }
 
+    ASSERT_OK(index->sync_flush_all_memtables(60 * 1000 * 1000)); // Wait up to 60s
     config::l0_max_mem_usage = l0_max_mem_usage;
 }
 


### PR DESCRIPTION
## Why I'm doing:

`LakePersistentIndexFilesetTest.test_index_basic_read_write` lowers `l0_max_mem_usage` to force asynchronous persistent-index memtable flushes, but the test can finish before a background flush completes. During fixture teardown, the worker may still access the test's `TabletManager` and crash in `TabletManager::sst_location()`.

Observed failure: https://github.com/StarRocks/starrocks/actions/runs/31622444709/job/94200748358?pr=77696

## What I'm doing:

Wait for all persistent-index memtables to finish flushing before the test exits, using the same 60-second timeout as the neighboring fileset tests. This keeps the `TabletManager` alive until the asynchronous work completes.

Validation completed:

- `git diff --check`
- `python3 build-support/check_be_module_boundaries.py --mode full`
- `python3 build-support/render_be_agents.py --check`

The focused BE UT will be validated by PR CI.

Fixes: N/A

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
