### PR TITLE
[BugFix] Match a scan's access paths by column id in DeferProjectAfterTopNRule

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/DeferProjectAfterTopNRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/DeferProjectAfterTopNRule.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.optimizer.rule.transformation;
 
 import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnAccessPath;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
@@ -35,6 +36,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 public class DeferProjectAfterTopNRule extends TransformationRule {
@@ -59,10 +61,18 @@ public class DeferProjectAfterTopNRule extends TransformationRule {
         return false;
     }
 
+    // An access path is rooted at the column's storage-side id, which a rename leaves alone while the
+    // name changes, so the roots have to be matched against the ids. Matching the ColumnRefOperator's
+    // name instead makes a renamed column - and only that column, the others still answer to their id -
+    // look as if no path were pushed down for it, so the projection reading its subfields is deferred
+    // past the TopN. The whole struct then travels through the TopN and the exchange, and the scan
+    // loses its access path as well, because no subfield expression is left above it to build one from.
     private boolean mayBenefitFromPruningSubField(OptimizerContext context,
+                                                  Map<ColumnRefOperator, Column> refToColumn,
                                                   Set<String> columnAccessPaths, ScalarOperator scalarOperator) {
         return scalarOperator.getUsedColumns().getColumnRefOperators(context.getColumnRefFactory())
-                .stream().anyMatch(columnRefOperator -> columnAccessPaths.contains(columnRefOperator.getName()));
+                .stream().map(refToColumn::get).filter(Objects::nonNull)
+                .anyMatch(column -> columnAccessPaths.contains(column.getColumnId().getId()));
     }
 
     @Override
@@ -77,6 +87,8 @@ public class DeferProjectAfterTopNRule extends TransformationRule {
         Set<String> columnsWithAccessPath = new HashSet<>();
 
         Operator projectChild = projectExpression.getInputs().get(0).getOp();
+        Map<ColumnRefOperator, Column> refToColumn = projectChild instanceof LogicalOlapScanOperator
+                ? ((LogicalOlapScanOperator) projectChild).getColRefToColumnMetaMap() : Map.of();
         if (projectChild instanceof LogicalOlapScanOperator) {
             LogicalOlapScanOperator olapScanOperator = projectChild.cast();
             List<ColumnAccessPath> columnAccessPaths = olapScanOperator.getColumnAccessPaths();
@@ -96,7 +108,7 @@ public class DeferProjectAfterTopNRule extends TransformationRule {
                 }
                 // If some columns of the expression appear in ColumnAccessPath,
                 // it may benefit from pruning subfield, in which case we should keep it.
-                return !mayBenefitFromPruningSubField(context, columnsWithAccessPath, entry.getValue());
+                return !mayBenefitFromPruningSubField(context, refToColumn, columnsWithAccessPath, entry.getValue());
             }
             return false;
         });
@@ -111,7 +123,7 @@ public class DeferProjectAfterTopNRule extends TransformationRule {
 
         projectOperator.getColumnRefMap().forEach((columnRefOperator, scalarOperator) -> {
             if (topNRequiredInputColumns.contains(columnRefOperator) ||
-                    mayBenefitFromPruningSubField(context, columnsWithAccessPath, scalarOperator)) {
+                    mayBenefitFromPruningSubField(context, refToColumn, columnsWithAccessPath, scalarOperator)) {
                 preProjectionMap.put(columnRefOperator, scalarOperator);
                 // In theory, expressions calculated in pre-project do not need to be recalculated in post-project.
                 // Here we only keep the column ref operator in postProjectionMap.

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DeferProjectAfterTopNTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DeferProjectAfterTopNTest.java
@@ -18,6 +18,34 @@ import org.junit.jupiter.api.Test;
 
 public class DeferProjectAfterTopNTest extends PlanTestBase {
 
+    /**
+     * The rule keeps a projection below the TopN when the expression may benefit from subfield
+     * pruning, and it decides that by looking the column up among the access paths pushed down for
+     * the scan - whose roots are storage-side column ids. A rename changes Column#getName and leaves
+     * that id alone, so matching on the name makes a renamed column look as if nothing pruned it: the
+     * projection is deferred, the whole struct travels through the TopN and the exchange, and the
+     * scan ends up with no access path at all because no subfield expression is left above it.
+     */
+    @Test
+    public void testSubfieldPruningSurvivesColumnRename() throws Exception {
+        starRocksAssert.withTable("create table defer_rename(k int, c struct<a int, b int>, pad varchar(64)) " +
+                "duplicate key(k) distributed by hash(k) buckets 1 properties('replication_num'='1')");
+        try {
+            String before = getVerboseExplain("select c.a, pad from defer_rename order by k limit 10");
+            assertContains(before, "ColumnAccessPath: [/c/a]");
+
+            starRocksAssert.ddl("alter table defer_rename rename column c to c_new");
+            String after = getVerboseExplain("select c_new.a, pad from defer_rename order by k limit 10");
+            // the path is rooted at the id the rename left alone ...
+            assertContains(after, "ColumnAccessPath: [/c/a]");
+            // ... and the subfield is still extracted below the TopN, so the exchange carries an int
+            // rather than the whole struct
+            assertContains(after, "4 <-> [4: c_new.a, INT, true]");
+        } finally {
+            starRocksAssert.dropTable("defer_rename");
+        }
+    }
+
     @Test
     public void testNormalCases() throws Exception {
         {


### PR DESCRIPTION
## Why I'm doing:

The rule keeps a projection below the TopN when its expression may benefit from subfield pruning, which it decides by looking the column up among the access paths pushed down for the scan. Those paths are rooted at the column's storage-side id - PruneSubfieldRule names them after Column#getColumnId - while the lookup used the ColumnRefOperator's name, which a rename changes and the id deliberately survives.

So after

    alter table t rename column c to c_new

that column (and only that column - the others still answer to their id) looks as if nothing pruned it. The projection reading c_new.a is deferred past the TopN, so the whole struct travels through the TopN and the exchange instead of the extracted int, and the scan loses its access path altogether, because no subfield expression is left above it to build one from: BE then reads every sub-column of the struct for every scanned row, not just the one the query asked for.

    before                                    after the rename
      1:Project   (below the TopN)              3:Project  (above the exchange)
      |  [2: c, struct<a,b>].a                  |  [2: c_new, struct<a,b>].a
      0:OlapScanNode                            0:OlapScanNode
         ColumnAccessPath: [/c/a]                  (no access path at all)

Results are unaffected either way; the query just reads the whole struct. The added test asserts the post-rename plan and fails without this change.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
