### PR TITLE
[BugFix] Name a partition column's key range by column id, not by column name

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1167,7 +1167,10 @@ public class PlanFragmentBuilder {
                 partitionValues *= rangeSize;
     
                 kr.setColumn_type(TypeSerializer.toThrift(col.getType().getPrimitiveType()));
-                kr.setColumn_name(col.getName());
+                // BE indexes the tuple's slots by col_name, which is the column id, so name the range by
+                // the id as well: a renamed partition column would otherwise be skipped and its
+                // scan ranges never pruned.
+                kr.setColumn_name(col.getColumnId().getId());
                 if (isNullPartition) {
                     kr.setHas_null(true);
                 }
@@ -1211,7 +1214,10 @@ public class PlanFragmentBuilder {
 
                 TKeyRange kr = new TKeyRange();
                 kr.setColumn_type(TypeSerializer.toThrift(col.getType().getPrimitiveType()));
-                kr.setColumn_name(col.getName());
+                // BE indexes the tuple's slots by col_name, which is the column id, so name the range by
+                // the id as well: a renamed partition column would otherwise be skipped and its
+                // scan ranges never pruned.
+                kr.setColumn_name(col.getColumnId().getId());
                 List<TExpr> l = Lists.newArrayList();
                 partitionValuesList.forEach(v -> l.add(ExprToThrift.treeToThrift(v)));
                 kr.setList_values(l);
@@ -1242,7 +1248,10 @@ public class PlanFragmentBuilder {
 
                 TKeyRange kr = new TKeyRange();
                 kr.setColumn_type(TypeSerializer.toThrift(col.getType().getPrimitiveType()));
-                kr.setColumn_name(col.getName());
+                // BE indexes the tuple's slots by col_name, which is the column id, so name the range by
+                // the id as well: a renamed partition column would otherwise be skipped and its
+                // scan ranges never pruned.
+                kr.setColumn_name(col.getColumnId().getId());
                 List<TExpr> l = Lists.newArrayList();
                 for (var values : partitionValuesList) {
                     Preconditions.checkState(values.size() == partitionCols.size());

--- a/fe/fe-core/src/test/java/com/starrocks/planner/PartitionKeyRangeColumnIdTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/PartitionKeyRangeColumnIdTest.java
@@ -1,0 +1,95 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.Pair;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.thrift.TInternalScanRange;
+import com.starrocks.thrift.TKeyRange;
+import com.starrocks.thrift.TScanRangeLocations;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+/**
+ * A scan range carries the value range of each partition column it was cut by, and BE's dynamic
+ * partition pruning evaluates the partition conjuncts against those values to drop scan ranges the
+ * predicate cannot match. It finds the column those values belong to in a map keyed by the slot's
+ * col_name - the storage-side column id - so the range has to name the column by its id as well.
+ */
+public class PartitionKeyRangeColumnIdTest {
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        FeConstants.runningUnitTest = true;
+        UtFrameUtils.createMinStarRocksCluster();
+        connectContext = UtFrameUtils.createDefaultCtx();
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase("test_pkr").useDatabase("test_pkr")
+                .withTable("create table pkr(dt date not null, v int) duplicate key(dt)" +
+                        " partition by range(dt) (" +
+                        "  partition p1 values [('2026-01-01'), ('2026-01-02'))," +
+                        "  partition p2 values [('2026-01-02'), ('2026-01-03')))" +
+                        " distributed by hash(v) buckets 1 properties('replication_num' = '1');");
+    }
+
+    @Test
+    public void testPartitionKeyRangeNamesTheColumnById() throws Exception {
+        // dayofmonth() is not something FE can prune partitions by, so both partitions survive into
+        // the plan and BE gets a chance to drop their scan ranges - the case this naming decides.
+        String sql = "select v from test_pkr.pkr where dayofmonth(%s) = 1";
+        Assertions.assertEquals(List.of("dt", "dt"), rangeColumnNames(String.format(sql, "dt")));
+
+        starRocksAssert.ddl("alter table pkr rename column dt to dt_new");
+        try {
+            Assertions.assertEquals(List.of("dt", "dt"), rangeColumnNames(String.format(sql, "dt_new")),
+                    "a partition column range must name its column by the id, which the rename left "
+                            + "alone, or BE's column_name_to_slot lookup misses it and prunes nothing");
+        } finally {
+            starRocksAssert.ddl("alter table pkr rename column dt_new to dt");
+        }
+    }
+
+    private static List<String> rangeColumnNames(String sql) throws Exception {
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
+        Pair<String, ExecPlan> plan = UtFrameUtils.getPlanAndFragment(connectContext, sql);
+        List<String> names = Lists.newArrayList();
+        for (ScanNode scanNode : plan.second.getScanNodes()) {
+            for (TScanRangeLocations locations : scanNode.getScanRangeLocations(0)) {
+                TInternalScanRange range = locations.getScan_range().getInternal_scan_range();
+                if (range == null || range.getPartition_column_ranges() == null) {
+                    continue;
+                }
+                for (TKeyRange keyRange : range.getPartition_column_ranges()) {
+                    names.add(keyRange.getColumn_name());
+                }
+            }
+        }
+        Assertions.assertFalse(names.isEmpty(), "the plan must carry partition column ranges at all");
+        return names;
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

A scan range carries the value range of each partition column it was cut by, and BE's dynamic partition pruning (OlapScanNode::convert_scan_range_to_morsel_queue_builder -> prune_scan_ranges_by_partition_conjuncts) evaluates the partition conjuncts against those values to drop scan ranges the predicate cannot match. It finds the column those values belong to in column_name_to_slot, keyed by the slot's col_name - which SlotDescriptor sends as Column#getColumnId - while FE named the range with Column#getName. A rename changes the name and deliberately leaves the id alone, so the lookup misses, the loop simply continues, and the whole pruning silently does nothing for that column.

It matters exactly where FE cannot prune the partitions itself, e.g. a non-monotonic predicate on the partition column. On a cluster, 30 daily partitions, 300k rows, "where dayofmonth(dt) = 15" (FE keeps partitions=30/30 for all three stages):

                      TabletCount   MorselsCount   RawRowsRead
    original name     2             2              20,000
    renamed           30            30             300,000
    renamed back      2             2              20,000

15x the rows read, scaling with the number of partitions - a year of daily partitions with a monthly pattern is ~30x. Every stage returns the same 10000 rows; only the reading is wasteful.

The added test asserts that a plan's partition column ranges still name the column by its id after a rename, and fails without this change.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
