### PR TITLE
[Tool] reverse sync: mark sr-synced even on conflict (resolve on SR side)

### DIFF
--- a/.github/workflows/cd-repo-sync.yml
+++ b/.github/workflows/cd-repo-sync.yml
@@ -226,14 +226,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.SYNC_PAT }}
         run: |
+          # Always mark sr-synced: it is the provenance the branch-mode reverse sync
+          # reuses. A cherry-pick conflict is resolved on the StarRocks PR side, so it
+          # must NOT withhold the marker — withholding it would wrongly block this fix's
+          # CD backports from reverse-syncing. On conflict, ALSO tag cd-sync-conflict for
+          # visibility (the SR PR still needs manual conflict resolution).
+          LABEL_ARGS=(-f "labels[]=sr-synced")
           if [[ "${{ steps.cherry-pick.outputs.CONFLICT_LABEL }}" != '' ]]; then
-            MARK="cd-sync-conflict"
-          else
-            MARK="sr-synced"
+            LABEL_ARGS+=(-f "labels[]=cd-sync-conflict")
           fi
           gh api -X POST \
             "repos/${{ inputs.SOURCE_REPO }}/issues/${{ inputs.PR_ID }}/labels" \
-            -f "labels[]=${MARK}" || echo "::warning::failed to add ${MARK} to ${{ inputs.SOURCE_REPO }}#${{ inputs.PR_ID }}"
+            "${LABEL_ARGS[@]}" || echo "::warning::failed to label ${{ inputs.SOURCE_REPO }}#${{ inputs.PR_ID }}"
           PR_URL="${{ steps.create_pr.outputs.pr_url }}"
           if [[ -n "${PR_URL}" ]]; then
             gh api -X POST \
@@ -417,14 +421,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.SYNC_PAT }}
         run: |
+          # Always mark sr-synced: it is the provenance the branch-mode reverse sync
+          # reuses. A cherry-pick conflict is resolved on the StarRocks PR side, so it
+          # must NOT withhold the marker — withholding it would wrongly block this fix's
+          # CD backports from reverse-syncing. On conflict, ALSO tag cd-sync-conflict for
+          # visibility (the SR PR still needs manual conflict resolution).
+          LABEL_ARGS=(-f "labels[]=sr-synced")
           if [[ "${{ steps.cherry-pick.outputs.CONFLICT_LABEL }}" != '' ]]; then
-            MARK="cd-sync-conflict"
-          else
-            MARK="sr-synced"
+            LABEL_ARGS+=(-f "labels[]=cd-sync-conflict")
           fi
           gh api -X POST \
             "repos/${{ inputs.SOURCE_REPO }}/issues/${{ inputs.PR_ID }}/labels" \
-            -f "labels[]=${MARK}" || echo "::warning::failed to add ${MARK} to ${{ inputs.SOURCE_REPO }}#${{ inputs.PR_ID }}"
+            "${LABEL_ARGS[@]}" || echo "::warning::failed to label ${{ inputs.SOURCE_REPO }}#${{ inputs.PR_ID }}"
           PR_URL="${{ steps.create_pr.outputs.pr_url }}"
           if [[ -n "${PR_URL}" ]]; then
             gh api -X POST \


### PR DESCRIPTION
## Why I'm doing:

The reverse-sync executor (`cd-repo-sync.yml`, "Mark source PR" step) marked the CelerData source PR `sr-synced` **only on a clean cherry-pick**; on conflict it marked `cd-sync-conflict` instead. But `sr-synced` is the provenance the branch-mode reverse sync reuses (`reverse_sync_decide.sh` checks the main PR's `sr-synced` before syncing its branch backports). So a conflicted main fix — e.g. CelerData#60610 → StarRocks#77984 — left the CD PR **without** `sr-synced`, which then conservatively **blocked that fix's CD backports from reverse-syncing at all**.

A cherry-pick conflict is resolved on the StarRocks PR side (the SR PR carries the `conflict` label + conflict markers). It should not withhold the provenance marker.

## What I'm doing:

Always add `sr-synced`; on conflict **also** add `cd-sync-conflict` for visibility (the SR PR still needs manual resolution). Applied to both the `main` and `branch` executor jobs.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
