### PR TITLE
[BugFix] Do not abort the BE when a zone map fails to parse

### DIFF
--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -622,8 +622,9 @@ Status ColumnReader::_parse_zone_map(const TypeInfoPtr& type_info, const ZoneMap
 
     if (zm.has_not_null()) {
         if (UNLIKELY(!zm.has_min() || !zm.has_max())) {
-            LOG(ERROR) << "Corrupted zone map protobuf detected: " << zm.ShortDebugString();
-            return Status::Corruption("Corrupted zone map data: missing min or max values");
+            // Do not print `zm`: protobuf reflection over a corrupted message faults.
+            return Status::Corruption(
+                    fmt::format("Bad file {}: zone map for column {} has no min or max", file_name(), _name));
         }
         RETURN_IF_ERROR(datum_from_string(type_info.get(), &(detail->min_value()), zm.min(), nullptr));
         RETURN_IF_ERROR(datum_from_string(type_info.get(), &(detail->max_value()), zm.max(), nullptr));
@@ -1024,7 +1025,13 @@ bool ColumnReader::segment_zone_map_filter(const std::vector<const ColumnPredica
     LogicalType lt = _get_zone_map_parse_type(predicates[0]);
     ZoneMapDetail detail;
     auto st = _parse_zone_map(lt, *_segment_zone_map, &detail);
-    CHECK(st.ok()) << st;
+    if (!st.ok()) {
+        // Degrade to NO pruning instead of failing: returning true means the segment cannot
+        // be excluded, so it is read in full and no matching row can be lost. This returns
+        // bool, so the Status has nowhere else to go.
+        LOG_EVERY_N(WARNING, 100) << "skip segment zone map pruning for column " << _name << ": " << st;
+        return true;
+    }
     auto filter = [&](const ColumnPredicate* pred) { return pred->zone_map_filter(detail); };
     return std::all_of(predicates.begin(), predicates.end(), filter);
 }

--- a/be/test/storage/rowset/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/column_reader_writer_test.cpp
@@ -71,6 +71,7 @@
 #include "storage/storage_engine.h"
 #include "storage/tablet_schema_helper.h"
 #include "storage/types.h"
+#include "storage_primitive/column_predicate_factory.h"
 #include "storage_primitive/range.h"
 #include "testutil/schema_test_helper.h"
 #include "types/date_value.h"
@@ -1327,6 +1328,56 @@ TEST_F(ColumnReaderWriterTest, read_column_with_compression_dictionary) {
     ASSERT_OK(iter->next_batch(&one_row, one.get()));
     ASSERT_EQ(1, one->size());
     ASSERT_EQ(values[kRowsPerPage * 3 + 7], one->get(0).get_slice().to_string());
+}
+
+// A segment zone map that claims to hold non-null values but carries neither `min` nor `max` is
+// rejected by _parse_zone_map. segment_zone_map_filter() has to survive that rejection: it returns
+// bool, so it cannot propagate the Status, and aborting the process is not an acceptable substitute.
+TEST_F(ColumnReaderWriterTest, test_segment_zone_map_without_min_max) {
+    auto col = ChunkFactory::column_from_field_type(TYPE_INT, false);
+    for (int32_t i = 0; i < 128; ++i) {
+        (void)col->append_numbers(&i, sizeof(int32_t));
+    }
+
+    ColumnMetaPB meta;
+    const std::string fname = strings::Substitute("$0/test_segment_zone_map_without_min_max.data", TEST_DIR);
+    auto segment = create_dummy_segment(fname);
+
+    {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(fname));
+        ColumnWriterOptions writer_opts = make_writer_opts<TYPE_INT, BIT_SHUFFLE, 2>(&meta, false);
+        TabletColumn column(STORAGE_AGGREGATE_NONE, TYPE_INT);
+        ASSIGN_OR_ABORT(auto writer, ColumnWriter::create(writer_opts, &column, wfile.get()));
+        ASSERT_OK(writer->init());
+        ASSERT_OK(writer->append(*col));
+        flush_column_writer(writer.get());
+        ASSERT_OK(wfile->close());
+    }
+
+    // The writer always emits all four fields, so drop min/max while keeping has_not_null set.
+    ColumnMetaPB corrupted_meta = meta;
+    ZoneMapPB* segment_zone_map = nullptr;
+    for (int i = 0; i < corrupted_meta.indexes_size(); ++i) {
+        if (corrupted_meta.indexes(i).type() == ZONE_MAP_INDEX) {
+            segment_zone_map = corrupted_meta.mutable_indexes(i)->mutable_zone_map_index()->mutable_segment_zone_map();
+            break;
+        }
+    }
+    ASSERT_NE(nullptr, segment_zone_map);
+    ASSERT_TRUE(segment_zone_map->has_not_null());
+    segment_zone_map->clear_min();
+    segment_zone_map->clear_max();
+
+    ASSIGN_OR_ABORT(auto reader, ColumnReader::create(&corrupted_meta, segment.get(), nullptr));
+    // _init() strips min/max only when has_not_null is false, so the crafted state must survive.
+    ASSERT_FALSE(reader->segment_zone_map()->has_min());
+
+    std::unique_ptr<ColumnPredicate> predicate(new_column_ge_predicate(get_type_info(TYPE_INT), 0, "0"));
+    std::vector<const ColumnPredicate*> predicates{predicate.get()};
+
+    // Without the production change this CHECK-aborts the process instead of returning.
+    // `true` means "cannot exclude this segment", i.e. the pruning is skipped and the segment is read.
+    ASSERT_TRUE(reader->segment_zone_map_filter(predicates));
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

#64952 added a check to `ColumnReader::_parse_zone_map` for a zone map whose `has_not_null` is set
but whose `min`/`max` are absent, described there as "defensive code to detect corrupted zonemap and
return errors instead of possibly crash". It was merged and backported to four release branches.

In production it still crashes. Two lines keep that `Status` from taking effect and abort the process
instead — one of them inside the check #64952 added. The stack below reaches `_parse_zone_map` through
`_zone_map_filter`, which propagates the `Status` (`:1006`); `segment_zone_map_filter`, which holds the
second line, is a different caller of it — reached from `segment.cpp:329` — and does not appear in that
stack. That is the path the new test exercises.

**`column_reader.cpp:625` logs `zm.ShortDebugString()`** — a protobuf reflection walk over the message
the branch has just classified as corrupted. On a damaged one the walk faults, so the process dies
before the log line is written and before `return Status::Corruption` is reached. We hit this three
times in production, always at the same fault address:

```
4.1.4 RELEASE (build 4a9848e distro centos arch x86_64)
PC: @ google::protobuf::TextFormat::Printer::Print(Message const&, TextGenerator*) const
*** SIGSEGV (@0x98) received by PID 15582 ***
    google::protobuf::Message::ShortDebugString[abi:cxx11]() const
    starrocks::ColumnReader::_parse_zone_map(TypeInfoPtr const&, ZoneMapPB const&, ZoneMapDetail*) const
    starrocks::ColumnReader::_zone_map_filter<...>
    starrocks::SegmentIterator::_get_row_ranges_by_zone_map()
    starrocks::workgroup::ScanExecutor::worker_thread()
```

`ShortDebugString()` is the only call of its kind in this file and is reachable from this branch only,
so the stack proves the branch was entered. Grepping `be.INFO`/`be.WARNING`/`be.out` on the five hosts
that crashed for `"Corrupted zone map"` returns **0 lines** — the diagnostic has never once survived.
The core from one of them (1,048 threads) had **5 scan threads inside `_parse_zone_map` at once**, so
the abort discards every concurrent scan on that BE, not just the one that tripped the branch.

**`column_reader.cpp:1027` is `CHECK(st.ok()) << st;`** — it turns the returned `Status` back into an
abort. That line predates #64952: it came from #26343 (`[Enhancement] Declare some methods with
nodiscard attribute`), where a `Status` return value had to be consumed and `CHECK` was the shortest
way. #64952 is four inserted lines in one file and touched no caller, so the two callers that
already used `RETURN_IF_ERROR` — `_zone_map_filter` (`:1006`, the path the stack above takes) and
`get_raw_zone_map` (`:958`) — propagate the new failure mode, while this third one still turns it
into an abort.

## What I'm doing:

- `_parse_zone_map`: drop the log line and report through the `Status`, naming the segment file and the
  column. This is the shape the file's only other `Bad file {}` corruption sites already use —
  `column_reader.cpp:240` and `:244`, both `Status::Corruption(fmt::format("Bad file {}: ...",
  file_name(), ...))` with no log line. The `Status` reaches the failing query, and the file path is
  what `meta_tool --operation=dump_zonemap --file=<segment>` needs to read the zone map off disk rather
  than out of the damaged copy in memory.
- `segment_zone_map_filter`: replace `CHECK(st.ok())` with a rate-limited warning and `return true`,
  the same degrade-to-no-pruning shape `column_reader.cpp:740` already uses when a bloom filter is
  unavailable. `true` means "this segment cannot be excluded", so the segment is read in full and no
  matching row can be lost; this one returns `bool`, so the `Status` has nowhere else to go, and
  `LOG_EVERY_N` keeps one bad segment from filling the log — it is consulted per column per segment
  per query (`segment.cpp:329`).

### Not in this PR

`SegmentMetaCollecter::__collect_max_or_min` (`meta_reader.cpp:602`) reads `->min()`/`->max()` after
checking only `has_not_null()`. With `min` unset that yields the field default, which
`TypeInfo::from_string` turns into `0` while returning OK (`types/type_info.cpp:221`) — a wrong bound
handed to the optimizer rather than a crash. Different symptom, so it is left out; happy to fold the
two `&&`s in here if you prefer.

Whatever corrupts the message is still unknown on our side and **this PR does not fix that**. It
changes the failure mode from "several BEs abort at once, with nothing in the log" to "one query fails
with a `Status` that names the column". Aborting in the error-handling path is a defect regardless of
what produced the corrupted object.

This is not a new error-handling policy: #64952 already settled that a zone map missing `min`/`max`
should surface as a `Status`. This PR only makes that reachable.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

`ColumnReaderWriterTest.test_segment_zone_map_without_min_max` writes an INT column, clears `min`/`max`
on the copied segment zone map while leaving `has_not_null` set, and calls `segment_zone_map_filter`.
The crafted state reaches the reader because `_init` strips `min`/`max` only when `has_not_null` is
false (`column_reader.cpp:205`), which the test asserts; with the old `CHECK` in place the call aborts.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

Both production lines are present verbatim on 4.1, 4.0 and 3.5 (`4.1:427/749`, `4.0:407/700`,
`3.5:379/662`), and `be/src/storage/rowset/column_reader.cpp` cherry-picks onto each of the three
with no conflict. 3.4 and 3.3 carry the same two lines (`3.4:377/637`, `3.3:377/624`) but are left
unchecked: their last releases were 3.4.10 (2026-01-14) and 3.3.22 (2026-01-27), and neither branch
has taken a commit in the last 30 days.

The test hunk does not travel. `be/src/storage_primitive/` is `main`-only since #75835, so on the
release branches `new_column_ge_predicate` comes from `storage/column_predicate.h`,
`column_from_field_type` is `ChunkHelper::` (`storage/chunk_helper.h`) rather than `ChunkFactory::`
(`column/chunk_factory.h`), `create_dummy_segment` takes `(fs, fname)` rather than `(fname)`, and
`make_writer_opts` does not exist at all. The auto-backports will therefore land with a conflict in
`column_reader_writer_test.cpp` only; I will resubmit each one with the test adapted to that
branch's fixture.
