### PR TITLE
[BugFix] Release per-transaction in-writing size accounting on every transaction terminal path

### DIFF
--- a/be/src/storage/txn_manager.cpp
+++ b/be/src/storage/txn_manager.cpp
@@ -353,6 +353,8 @@ Status TxnManager::publish_overwrite_txn(TPartitionId partition_id, const Tablet
                 << ", tablet_id: " << tablet->tablet_id() << ", schema_hash: " << tablet->schema_hash()
                 << ", rowset_id: " << rowset->rowset_id() << ", version: " << rowset->version();
     }
+    // The overwrite txn ends here; a stale in-flight entry would double-count its bytes.
+    tablet->remove_in_writing_data_size(transaction_id);
     tablet->erase_committed_rowset(rowset);
     std::unique_lock wrlock(_get_txn_map_lock(transaction_id));
     txn_tablet_map_t& txn_tablet_map = _get_txn_tablet_map(transaction_id);
@@ -390,8 +392,11 @@ Status TxnManager::publish_txn(TPartitionId partition_id, const TabletSharedPtr&
             StorageMetrics::instance()->update_rowset_commit_request_failed.increment(1);
             return st;
         }
+        // A failed commit leaves the rowset invisible, so delete_txn can still release the entry.
+        tablet->remove_in_writing_data_size(transaction_id);
     } else {
         auto st = tablet->add_inc_rowset(rowset, version);
+        // add_inc_rowset already made the rowset visible, so delete_txn would refuse to release the entry.
         tablet->remove_in_writing_data_size(transaction_id);
         if (!st.ok() && !st.is_already_exist()) {
             // TODO: rollback saved rowset if error?
@@ -569,8 +574,11 @@ Status TxnManager::delete_txn(KVStore* meta, TPartitionId partition_id, TTransac
                         fmt::format("Fail to delete txn because rowset is already published. tablet_id: {}, txn_id: {}",
                                     tablet_info.tablet_id, transaction_id));
             } else {
-                TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
+                // Match the incarnation the txn belongs to: a same-id replacement has its own live accounting.
+                TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, tablet_uid);
                 if (tablet != nullptr) {
+                    // This txn is discarded before publish, so nothing else will release its in-flight bytes.
+                    tablet->remove_in_writing_data_size(transaction_id);
                     tablet->erase_committed_rowset(load_info.rowset);
                 }
                 (void)RowsetMetaManager::remove(meta, tablet_uid, load_info.rowset->rowset_id());

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -4772,4 +4772,89 @@ TEST_F(TabletUpdatesTest, test_do_manual_compaction_via_task_queue) {
     EXPECT_TRUE(_tablet->verify().ok());
 }
 
+// Publishing a txn must release its in-writing accounting entry; the primary key branch used to skip it.
+TEST_F(TabletUpdatesTest, test_publish_txn_releases_in_writing_data_size) {
+    srand(GetCurrentTimeMicros());
+    _tablet = create_tablet(rand(), rand());
+    std::vector<int64_t> keys;
+    for (int i = 0; i < 100; i++) {
+        keys.emplace_back(i);
+    }
+    _tablet->updates()->stop_apply(true);
+    auto rs = create_rowset(_tablet, keys);
+    PUniqueId load_id;
+    load_id.set_hi(2000);
+    load_id.set_lo(2000);
+    const int64_t partition_id = 200;
+    const int64_t txn_id = 200;
+    ASSERT_TRUE(StorageEngine::instance()
+                        ->txn_manager()
+                        ->commit_txn(_tablet, partition_id, txn_id, load_id, rs, false, false)
+                        .ok());
+    _tablet->add_in_writing_data_size(txn_id, 100);
+    // An unrelated txn's entry must survive: the release is per-txn, not a wholesale clear.
+    _tablet->add_in_writing_data_size(txn_id + 1000, 7);
+    ASSERT_EQ(107, _tablet->in_writing_data_size());
+    ASSERT_TRUE(
+            StorageEngine::instance()->txn_manager()->publish_txn(partition_id, _tablet, txn_id, 2, rs, 0, false).ok());
+    ASSERT_EQ(7, _tablet->in_writing_data_size());
+}
+
+// Overwrite publish (online OPTIMIZE) released nothing at all, for every keys type.
+TEST_F(TabletUpdatesTest, test_publish_overwrite_txn_releases_in_writing_data_size) {
+    srand(GetCurrentTimeMicros());
+    _tablet = create_tablet(rand(), rand());
+    std::vector<int64_t> keys;
+    for (int i = 0; i < 100; i++) {
+        keys.emplace_back(i);
+    }
+    _tablet->updates()->stop_apply(true);
+    auto rs = create_rowset(_tablet, keys);
+    PUniqueId load_id;
+    load_id.set_hi(2001);
+    load_id.set_lo(2001);
+    const int64_t partition_id = 201;
+    const int64_t txn_id = 201;
+    ASSERT_TRUE(StorageEngine::instance()
+                        ->txn_manager()
+                        ->commit_txn(_tablet, partition_id, txn_id, load_id, rs, false, false)
+                        .ok());
+    _tablet->add_in_writing_data_size(txn_id, 100);
+    // An unrelated txn's entry must survive: the release is per-txn, not a wholesale clear.
+    _tablet->add_in_writing_data_size(txn_id + 1000, 7);
+    ASSERT_EQ(107, _tablet->in_writing_data_size());
+    ASSERT_TRUE(StorageEngine::instance()
+                        ->txn_manager()
+                        ->publish_overwrite_txn(partition_id, _tablet, txn_id, 2, rs, 0)
+                        .ok());
+    ASSERT_EQ(7, _tablet->in_writing_data_size());
+}
+
+// A txn committed then discarded (quorum lost, cancel) is cleared here, the only release chance left.
+TEST_F(TabletUpdatesTest, test_delete_txn_releases_in_writing_data_size) {
+    srand(GetCurrentTimeMicros());
+    _tablet = create_tablet(rand(), rand());
+    std::vector<int64_t> keys;
+    for (int i = 0; i < 100; i++) {
+        keys.emplace_back(i);
+    }
+    _tablet->updates()->stop_apply(true);
+    auto rs = create_rowset(_tablet, keys);
+    PUniqueId load_id;
+    load_id.set_hi(2002);
+    load_id.set_lo(2002);
+    const int64_t partition_id = 202;
+    const int64_t txn_id = 202;
+    ASSERT_TRUE(StorageEngine::instance()
+                        ->txn_manager()
+                        ->commit_txn(_tablet, partition_id, txn_id, load_id, rs, false, false)
+                        .ok());
+    _tablet->add_in_writing_data_size(txn_id, 100);
+    // An unrelated txn's entry must survive: the release is per-txn, not a wholesale clear.
+    _tablet->add_in_writing_data_size(txn_id + 1000, 7);
+    ASSERT_EQ(107, _tablet->in_writing_data_size());
+    ASSERT_TRUE(StorageEngine::instance()->txn_manager()->delete_txn(partition_id, _tablet, txn_id).ok());
+    ASSERT_EQ(7, _tablet->in_writing_data_size());
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

`Tablet` keeps a per-transaction accounting map of bytes still being written
(`_in_writing_txn_size`, `be/src/storage/tablet.h:483`). `DeltaWriter` adds to it on every flush
(`be/src/storage/delta_writer.cpp:543`, `:623`, `:648`, `:667` — none of them gated on keys type),
and the entry is meant to be erased once the transaction reaches a terminal state
(`Tablet::remove_in_writing_data_size`, `be/src/storage/tablet.cpp:1831`, an `erase(txn_id)`).
There is no wholesale cleanup for this map on the shared-nothing side, so every terminal path has
to release its own entry.

Only two of the terminal paths did. Full audit:

| Terminal path | Released before | Released after |
| --- | --- | --- |
| `DeltaWriter::_garbage_collection` — aborted before commit (`delta_writer.cpp:106`) | yes | yes |
| `TxnManager::publish_txn` — non-primary-key branch | yes | yes (unchanged) |
| `TxnManager::publish_txn` — primary-key branch (`tablet->updates() != nullptr`) | **no** | yes |
| `TxnManager::publish_overwrite_txn` — both branches | **no** | yes |
| `TxnManager::delete_txn` — committed, then discarded before publish | **no** | yes |
| `TxnManager::commit_txn` — failed to save the committed rowset meta | no, and not needed: the writer turns `kAborted` and `_garbage_collection` releases it | unchanged |
| `TxnManager::force_rollback_tablet_related_txns` — tablet dropped | no, and not needed: the `Tablet` object is destroyed and the map goes with it | unchanged |

Impact, stated per defect rather than in aggregate:

- **Primary key publish.** The only reader of `in_writing_data_size()` is the immutable-tablet
  check in `DeltaWriter` (`delta_writer.cpp:230`), short-circuited by
  `_opt.immutable_tablet_size > 0`. That size comes from the automatic bucket size
  (`be/src/data_sink/tablet/tablet_sink_index_channel.cpp:272`), which requires RANDOM
  distribution, while primary key tables are restricted to HASH distribution. So on primary key
  tables the stale entries are never read: the effect is a map that grows for the lifetime of the
  process, not incorrect behavior.
- **Overwrite publish, and discard-after-commit.** These two paths are not keys-type specific. On
  a table with RANDOM distribution and automatic bucketing the threshold is non-zero, so stale
  entries are double-counted on top of `data_size()` and can mark a tablet immutable earlier than
  it should be.

## What I'm doing:

Release the per-transaction entry on every terminal path that was missing it. The placement inside
`publish_txn` follows what the abort path can still repair, so no existing behavior changes:

- `TxnManager::publish_txn`, primary-key branch: release after a successful `rowset_commit`. A
  failed commit leaves the rowset invisible (the primary key path never calls
  `Rowset::make_visible`), so if the transaction is cleared afterwards `delete_txn` accepts it and
  releases the entry there.
- `TxnManager::publish_txn`, non-primary-key branch: keep the existing call where it is, i.e.
  before the `add_inc_rowset` error check. `Tablet::add_inc_rowset` makes the rowset visible
  (`tablet.cpp:591`) before binlog preparation and rowset-meta persistence can fail, and
  `delete_txn` refuses any rowset whose version is already positive — so a durable failure here
  has no second chance to release, and the release must stay unconditional.
- `TxnManager::publish_overwrite_txn`: add the call where both branches join — neither had it. The
  primary-key branch's early return is covered by `delete_txn` for the same reason as above.
- `TxnManager::delete_txn`: add the call where a committed-but-unpublished rowset is discarded, and
  resolve the tablet by `tablet_uid` as well as id. The wrapper's caller
  (`StorageEngine::clear_transaction_task`) already looks the tablet up by uid precisely because a
  same-id replacement is a different incarnation; releasing by transaction id on the wrong
  incarnation would erase live accounting that belongs to it.

Tests: three cases in `be/test/storage/tablet_updates_test.cpp`, one per fixed path. Each seeds an
extra entry for an unrelated transaction and asserts it survives, pinning the per-transaction
semantics so the fix cannot regress into a wholesale clear. Verified negatively as well: with the
production change reverted, all three fail.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
