### PR TITLE
[BugFix] Surface an actionable error when INSERT external auto refresh fails

### DIFF
--- a/docs/en/sql-reference/System_variable.md
+++ b/docs/en/sql-reference/System_variable.md
@@ -732,6 +732,13 @@ Default value: `true`, which means global RF is enabled. If this feature is disa
 * **Default**: true
 * **Introduced in**: v3.3.20, v3.4.9, v3.5.8, v4.0.2
 
+### enable_insert_select_external_auto_refresh
+
+* **Description**: Whether an INSERT INTO ... SELECT or INSERT OVERWRITE ... SELECT statement that reads from a filesystem-backed external catalog table automatically triggers a refresh of the source table's cached metadata before query planning, so that the load reads the freshest data. How a refresh failure surfaces depends on the connector: connectors that report refresh failures (for example, Hive, Hudi, and Delta Lake) fail the statement with an error that shows how to disable the refresh (for example, when the metastore denies access), while some connectors log and ignore refresh failures. If the source table itself no longer exists in the metastore, the error says so instead, and disabling the refresh does not help. Set this variable to `false` to skip the refresh and plan with the cached metadata, which matches the behavior of a plain SELECT. Note that task runs created by SUBMIT TASK do not inherit the submitting session's variables. To disable the refresh for a task, use `SET GLOBAL`, or place a `SET_VAR` hint immediately after the SUBMIT keyword, for example, `SUBMIT /*+ SET_VAR(enable_insert_select_external_auto_refresh=false) */ TASK ...`.
+* **Default**: true
+* **Data type**: Boolean
+* **Introduced in**: v3.5.8, v4.0.1, v4.1.0
+
 ### enable_insert_strict
 
 * **Description**: Whether to enable strict mode while loading data using INSERT from files(). Valid values: `true` and `false` (Default). When strict mode is enabled, the system loads only qualified rows. It filters out unqualified rows and returns details about the unqualified rows. For more information, see [Strict mode](../loading/strict_mode.md). In versions earlier than v3.4.0, when `enable_insert_strict` is set to `true`, the INSERT jobs fails when there is an unqualified rows.

--- a/docs/ja/sql-reference/System_variable.md
+++ b/docs/ja/sql-reference/System_variable.md
@@ -613,6 +613,13 @@ StarRocks は 2 種類の RF を提供します：ローカル RF とグロー�
 * **デフォルト値**：true
 * **導入バージョン**：v3.3.20、v3.4.9、v3.5.8、v4.0.2
 
+### enable_insert_select_external_auto_refresh
+
+* **説明**: INSERT INTO ... SELECT または INSERT OVERWRITE ... SELECT ステートメントがファイルシステムベースの External Catalog テーブルから読み取る際に、クエリプランニングの前にソーステーブルのメタデータキャッシュのリフレッシュを自動的にトリガーして最新データを読み取るかどうか。リフレッシュ失敗時の動作は Connector に依存します。リフレッシュ失敗を報告する Connector（例えば Hive、Hudi、Delta Lake）では、ステートメントはリフレッシュを無効にする方法を案内するエラーで失敗します（例えばメタストアがアクセスを拒否した場合）。一部の Connector はリフレッシュ失敗をログに記録して無視します。ソーステーブル自体がメタストアに存在しなくなっている場合は、エラーはその旨を報告し、リフレッシュを無効にしても解決しません。この変数を `false` に設定するとリフレッシュをスキップし、キャッシュされたメタデータでプランニングします（通常の SELECT と同じ動作）。なお、SUBMIT TASK で作成されたタスクの実行は、送信セッションの変数を継承しません。タスクでリフレッシュを無効にするには、`SET GLOBAL` を使用するか、SUBMIT キーワードの直後に `SET_VAR` ヒントを置いてください。例：`SUBMIT /*+ SET_VAR(enable_insert_select_external_auto_refresh=false) */ TASK ...`。
+* **デフォルト**: true
+* **データ型**: Boolean
+* **導入バージョン**: v3.5.8, v4.0.1, v4.1.0
+
 ### enable_insert_strict
 
 * **説明**: Files() からの INSERT を使用してデータをロードする際に厳密モードを有効にするかどうか。有効な値: `true` および `false`（デフォルト）。厳密モードが有効な場合、システムは資格のある行のみをロードします。不適格な行をフィルタリングし、不適格な行の詳細を返します。詳細は [Strict mode](../loading/strict_mode.md) を参照してください。v3.4.0 より前のバージョンでは、`enable_insert_strict` が `true` に設定されている場合、不適格な行があると INSERT ジョブが失敗します。

--- a/docs/zh/sql-reference/System_variable.md
+++ b/docs/zh/sql-reference/System_variable.md
@@ -619,6 +619,13 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 * **默认值**：true
 * **引入版本**：v3.3.20、v3.4.9、v3.5.8、v4.0.2
 
+### enable_insert_select_external_auto_refresh
+
+* **描述**：INSERT INTO ... SELECT 或 INSERT OVERWRITE ... SELECT 语句从基于文件系统的 External Catalog 表读取数据时，是否在查询规划前自动触发对源表元数据缓存的刷新，以保证导入读取最新数据。刷新失败的表现取决于 Connector：会上报刷新失败的 Connector（例如 Hive、Hudi、Delta Lake）会使语句报错，且错误信息中会说明如何关闭刷新（例如元数据服务拒绝访问时）；部分 Connector 则只记录日志并忽略刷新失败。如果源表本身已不存在于元数据服务中，错误信息会直接说明该表已不存在，此时关闭刷新也无济于事。将该变量设置为 `false` 可跳过刷新，直接使用缓存的元数据进行规划（与普通 SELECT 行为一致）。注意：SUBMIT TASK 创建的任务在执行时不会继承提交会话的变量。如需为任务关闭刷新，请使用 `SET GLOBAL`，或在 SUBMIT 关键字后紧跟 `SET_VAR` Hint，例如 `SUBMIT /*+ SET_VAR(enable_insert_select_external_auto_refresh=false) */ TASK ...`。
+* **默认值**：true
+* **数据类型**：Boolean
+* **引入版本**：v3.5.8、v4.0.1、v4.1.0
+
 ### enable_insert_strict
 
 * 描述：是否在使用 INSERT from FILES() 导入数据时启用严格模式。有效值：`true` 和 `false`（默认值）。启用严格模式时，系统仅导入合格的数据行，过滤掉不合格的行，并返回不合格行的详细信息。更多信息请参见 [严格模式](../loading/strict_mode.md)。在早于 v3.4.0 的版本中，当 `enable_insert_strict` 设置为 `true` 时，INSERT 作业会在出现不合格行时失败。

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -47,7 +47,9 @@ import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
@@ -109,7 +111,9 @@ import com.starrocks.type.IntegerType;
 import com.starrocks.type.NullType;
 import com.starrocks.type.Type;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -2177,9 +2181,45 @@ public class QueryAnalyzer {
 
         private Table refreshFilesystemExternalTable(String catalogName, String dbName,
                                                      TableName tableName, Table resolvedTable) {
-            metadataMgr.refreshTable(catalogName, dbName, resolvedTable, Lists.newArrayList(), false);
+            try {
+                metadataMgr.refreshTable(catalogName, dbName, resolvedTable, Lists.newArrayList(), false);
+            } catch (StarRocksConnectorException e) {
+                // Rethrow with the same type so the failure keeps its error classification; only the
+                // message changes. The connector's own message and root cause stay in the cause chain,
+                // which StmtExecutor unwinds into the client-facing error, so they are not repeated here.
+                String qualifiedName = catalogName + "." + dbName + "." + tableName.getTbl();
+                if (isDroppedTableRefreshFailure(e)) {
+                    // Say so instead of advising to plan from the stale cached object of a dropped table.
+                    throw new StarRocksConnectorException(
+                            "External table " + qualifiedName + " no longer exists in the metastore.", e);
+                }
+                throw new StarRocksConnectorException(String.format(
+                        "Auto refresh of external table %s before INSERT failed. To plan with the cached "
+                                + "metadata instead, run `SET %s = false` (task runs created by SUBMIT TASK do not "
+                                + "inherit session variables, so use SET GLOBAL or a SET_VAR hint right after SUBMIT).",
+                        qualifiedName, SessionVariable.ENABLE_INSERT_SELECT_EXTERNAL_AUTO_REFRESH), e);
+            }
             Table refreshedTable = metadataMgr.getTable(session, catalogName, dbName, tableName.getTbl());
             return refreshedTable != null ? refreshedTable : resolvedTable;
+        }
+
+        /**
+         * The Hive and Delta Lake caching metastores react to the metastore reporting the table as gone
+         * (a NoSuchObjectException, which the reflective RPC client delivers as the target of an
+         * InvocationTargetException) by invalidating their cached table entry and rethrowing the RPC
+         * failure wrapped in one more StarRocksConnectorException. That rewrap is the signal recognized
+         * here. Later RPCs of the same refresh (partition names, statistics) can also surface a
+         * NoSuchObjectException, but without the rewrap and without invalidating the cache, so scanning
+         * the whole cause chain for the exception type would misreport a live table as dropped. A catalog
+         * with the metastore cache disabled has no entry to invalidate, so a drop there also arrives
+         * without the rewrap and gets the disable-the-refresh advice, which is still correct in that setup.
+         */
+        private static boolean isDroppedTableRefreshFailure(StarRocksConnectorException e) {
+            if (!(e.getCause() instanceof StarRocksConnectorException rpcFailure)) {
+                return false;
+            }
+            return rpcFailure.getCause() instanceof InvocationTargetException invocation
+                    && invocation.getTargetException() instanceof NoSuchObjectException;
         }
 
         @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerExternalTablesLockTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerExternalTablesLockTest.java
@@ -17,7 +17,9 @@ package com.starrocks.sql;
 import com.starrocks.catalog.JDBCResource;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.util.LogUtil;
 import com.starrocks.connector.MockedMetadataMgr;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.MockedHiveMetadata;
 import com.starrocks.connector.jdbc.MockedJDBCMetadata;
 import com.starrocks.qe.ConnectContext;
@@ -26,9 +28,12 @@ import com.starrocks.sql.analyzer.PlannerMetaLocker;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.utframe.UtFrameUtils;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -138,10 +143,13 @@ public class StatementPlannerExternalTablesLockTest extends ConnectorPlanTestBas
     private static class FailingRefreshHiveMetadata extends MockedHiveMetadata {
         private final AtomicInteger getTableCalls;
         private final AtomicInteger refreshCalls;
+        private final RuntimeException refreshFailure;
 
-        private FailingRefreshHiveMetadata(AtomicInteger getTableCalls, AtomicInteger refreshCalls) {
+        private FailingRefreshHiveMetadata(AtomicInteger getTableCalls, AtomicInteger refreshCalls,
+                                           RuntimeException refreshFailure) {
             this.getTableCalls = getTableCalls;
             this.refreshCalls = refreshCalls;
+            this.refreshFailure = refreshFailure;
         }
 
         @Override
@@ -153,7 +161,7 @@ public class StatementPlannerExternalTablesLockTest extends ConnectorPlanTestBas
         @Override
         public void refreshTable(String srDbName, Table table, List<String> partitionNames, boolean onlyCachedPartitions) {
             refreshCalls.incrementAndGet();
-            throw new RuntimeException("mock refresh failure");
+            throw refreshFailure;
         }
     }
 
@@ -488,23 +496,107 @@ public class StatementPlannerExternalTablesLockTest extends ConnectorPlanTestBas
                 "filesystem external table should be resolved before and after refresh, but not during locked analysis");
     }
 
-    @Test
-    public void testInsertSelectFilesystemRefreshFailurePropagatesError() throws Exception {
+    /**
+     * Registers a Hive mock whose refreshTable throws {@code failure}, plans {@code sql}, and
+     * returns the thrown exception. Callers build {@code failure} in the shape the production
+     * connector produces; the mock only decides what refreshTable throws.
+     */
+    private Exception planWithFailingRefresh(String sql, RuntimeException failure,
+                                             Class<? extends Exception> expectedType) throws Exception {
         AtomicInteger getTableCalls = new AtomicInteger();
         AtomicInteger refreshCalls = new AtomicInteger();
 
         GlobalStateMgr gsm = GlobalStateMgr.getCurrentState();
         MockedMetadataMgr metadataMgr = (MockedMetadataMgr) gsm.getMetadataMgr();
         metadataMgr.registerMockedMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME,
-                new FailingRefreshHiveMetadata(getTableCalls, refreshCalls));
+                new FailingRefreshHiveMetadata(getTableCalls, refreshCalls, failure));
 
-        String sql = "insert into t0 (v1, v2) select l_orderkey, l_partkey from hive0.tpch.lineitem";
         StatementBase stmt = UtFrameUtils.parseStmtWithNewParserNotIncludeAnalyzer(sql, connectContext);
-
-        Assertions.assertThrows(RuntimeException.class, () -> StatementPlanner.plan(stmt, connectContext));
-        Assertions.assertEquals(1, refreshCalls.get(), "filesystem external refresh should still be attempted once");
+        Exception e = Assertions.assertThrows(expectedType, () -> StatementPlanner.plan(stmt, connectContext));
+        Assertions.assertEquals(1, refreshCalls.get(), "filesystem external refresh should be attempted once");
         Assertions.assertEquals(1, getTableCalls.get(),
                 "planner should stop after the first pre-lock resolution when refresh fails");
+        return e;
+    }
+
+    private void assertActionableRefreshError(String sql) throws Exception {
+        // Production shape for a metastore denial: HiveMetaClient.callRPC wraps the reflective
+        // InvocationTargetException (target: the metastore error) in a StarRocksConnectorException.
+        StarRocksConnectorException connectorFailure = new StarRocksConnectorException(
+                "Failed to get table [tpch.lineitem]",
+                new InvocationTargetException(new MetaException("mock metastore denial")));
+        Exception e = planWithFailingRefresh(sql, connectorFailure, StarRocksConnectorException.class);
+        Assertions.assertTrue(e.getMessage().contains("hive0.tpch.lineitem"),
+                "error should name the table: " + e.getMessage());
+        Assertions.assertTrue(e.getMessage().contains("SET enable_insert_select_external_auto_refresh = false"),
+                "error should tell the user how to disable the refresh: " + e.getMessage());
+        Assertions.assertSame(connectorFailure, e.getCause(),
+                "the connector exception should be kept as the cause, with its message and root cause");
+        // What the client sees: our line first, then the connector message and the metastore's reason once each.
+        String clientMessage = LogUtil.getUnwoundExceptionMessage(e);
+        Assertions.assertTrue(clientMessage.startsWith("Auto refresh of external table hive0.tpch.lineitem"),
+                clientMessage);
+        Assertions.assertTrue(clientMessage.contains("MetaException: mock metastore denial"), clientMessage);
+        Assertions.assertEquals(clientMessage.indexOf("Failed to get table"), clientMessage.lastIndexOf("Failed to get table"),
+                "connector message should appear exactly once: " + clientMessage);
+    }
+
+    @Test
+    public void testInsertSelectFilesystemRefreshFailurePropagatesActionableError() throws Exception {
+        assertActionableRefreshError("insert into t0 (v1, v2) select l_orderkey, l_partkey from hive0.tpch.lineitem");
+    }
+
+    @Test
+    public void testSubmitTaskInsertRefreshFailurePropagatesActionableError() throws Exception {
+        assertActionableRefreshError("submit task refresh_failure_task as " +
+                "insert into t0 (v1, v2) select l_orderkey, l_partkey from hive0.tpch.lineitem");
+    }
+
+    @Test
+    public void testInsertSelectFilesystemRefreshDroppedTableGetsNoDisableAdvice() throws Exception {
+        // Production shape for a dropped table: HiveMetaClient.callRPC's reflective invoke wraps
+        // NoSuchObjectException in InvocationTargetException, and CachingHiveMetastore rethrows it
+        // wrapped in one more StarRocksConnectorException after invalidating the cache.
+        Exception e = planWithFailingRefresh(
+                "insert into t0 (v1, v2) select l_orderkey, l_partkey from hive0.tpch.lineitem",
+                new StarRocksConnectorException("Failed to get table [tpch.lineitem], invalidated cache.",
+                        new StarRocksConnectorException("Failed to get table [tpch.lineitem]",
+                                new InvocationTargetException(new NoSuchObjectException("table not found")))),
+                StarRocksConnectorException.class);
+        Assertions.assertTrue(e.getMessage().contains("hive0.tpch.lineitem"),
+                "error should name the table: " + e.getMessage());
+        Assertions.assertTrue(e.getMessage().contains("no longer exists"),
+                "error should say the table is gone: " + e.getMessage());
+        Assertions.assertFalse(e.getMessage().contains("enable_insert_select_external_auto_refresh"),
+                "a dropped table must not be answered with disable-the-refresh advice: " + e.getMessage());
+        String clientMessage = LogUtil.getUnwoundExceptionMessage(e);
+        Assertions.assertTrue(clientMessage.contains("NoSuchObjectException: table not found"), clientMessage);
+    }
+
+    @Test
+    public void testInsertSelectFilesystemRefreshNotFoundWithoutCacheInvalidationGetsDisableAdvice() throws Exception {
+        // A NoSuchObjectException from a later RPC of the same refresh (partition names, statistics) arrives
+        // straight from callRPC, without the caching metastore's rewrap, and the cached table was not
+        // invalidated. That is not a dropped table, so the user must still get the disable advice.
+        Exception e = planWithFailingRefresh(
+                "insert into t0 (v1, v2) select l_orderkey, l_partkey from hive0.tpch.lineitem",
+                new StarRocksConnectorException("Failed to get partitionKeys on [tpch.lineitem]",
+                        new InvocationTargetException(new NoSuchObjectException("stats not found"))),
+                StarRocksConnectorException.class);
+        Assertions.assertFalse(e.getMessage().contains("no longer exists"),
+                "a live table must not be reported as dropped: " + e.getMessage());
+        Assertions.assertTrue(e.getMessage().contains("SET enable_insert_select_external_auto_refresh = false"),
+                "error should tell the user how to disable the refresh: " + e.getMessage());
+    }
+
+    @Test
+    public void testInsertSelectFilesystemRefreshNonConnectorFailureKeepsType() throws Exception {
+        // Only connector exceptions are rewritten; anything else (an FE bug, an NPE) must propagate untouched.
+        RuntimeException failure = new RuntimeException("mock refresh failure");
+        Exception e = planWithFailingRefresh(
+                "insert into t0 (v1, v2) select l_orderkey, l_partkey from hive0.tpch.lineitem",
+                failure, RuntimeException.class);
+        Assertions.assertSame(failure, e, "non-connector failure should propagate untouched");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

`INSERT INTO/OVERWRITE ... SELECT` from a filesystem-backed external catalog table auto-refreshes the source table's metadata before planning (`enable_insert_select_external_auto_refresh`, default `true`, added by #64026 to guarantee load freshness). When that refresh fails — for example, a cross-account Glue catalog denies `glue:GetTable` — the raw connector exception fails the statement with no hint that the refresh caused it or that it can be disabled, even though a plain `SELECT` from the same table works fine from cached metadata.

The trap is worse with `SUBMIT TASK`: task runs reset session variables (`TaskRun.buildTaskRunConnectContext`), so a user who found `SET enable_insert_select_external_auto_refresh = false` sees the task submit successfully and then fail at run time anyway, because the setting never reaches the task's execution context. The variable was also entirely undocumented.

## What I'm doing:

- When the pre-planning refresh in `QueryAnalyzer.ExternalTablesOnlyVisitor.refreshFilesystemExternalTable` throws a `StarRocksConnectorException`, rethrow it as a `SemanticException` (original exception attached as the cause) that names the table, preserves the connector message, and tells the user how to plan from cached metadata instead: `SET enable_insert_select_external_auto_refresh = false` (for SUBMIT TASK, `SET GLOBAL` or a `SET_VAR` hint right after `SUBMIT` — task runs do not inherit the submitting session's variables). Only connector exceptions are converted; other runtime failures (FE bugs, NPEs) keep their original type and INTERNAL_ERR classification.
- Dropped-table carve-out: when the cause chain contains Hive's `NoSuchObjectException` or Delta's `TableNotFoundException` (the connector has already invalidated its cache entry), the error instead says the table no longer exists — advising "disable the refresh" there would point the user at planning against a dropped table. Classification reuses `LogUtil.isCausedBy`.
- The freshness contract of #64026 is intentionally unchanged: a failed refresh still fails the statement; only the error quality changes. Nothing that succeeded before behaves differently, and MV refresh paths are unaffected (they explicitly disable this variable before planning).
- Document the variable (new entry in `System_variable.md`, en/zh/ja), including which connectors report refresh failures and the SUBMIT TASK propagation caveat.

Tests: updated the existing refresh-failure test to assert the actionable message (table name, variable name, connector message preserved, cause attached), plus new coverage for the SUBMIT TASK submit-time path and the dropped-table carve-out, using the production exception nesting (`StarRocksConnectorException` → `InvocationTargetException` → `NoSuchObjectException`).

Known follow-ups deliberately left out to keep this change minimal: connectors that swallow refresh failures (Iceberg, Paimon) or implement no refresh (Kudu, Fluss) never reach this error path (docs state this); a typed table-not-found exception across connectors would replace the cause-chain classification; the refresh's cost profile (full-partition reload, no per-statement dedup, submit-time + run-time double refresh for tasks) is pre-existing behavior.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5