### PR TITLE
[BugFix] Fixing global dict expr propagation for cases where project hides a column used in predicates 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -1400,6 +1400,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
             if (!expressions.isEmpty()) {
                 // predicate only translate to string expression
                 stringExpressions.computeIfAbsent(c, l -> Lists.newArrayList()).addAll(expressions);
+                info.usedStringColumns.union(c);
             }
         });
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -3410,4 +3410,29 @@ public class LowCardinalityTest2 extends PlanTestBase {
             Config.push_down_non_grouped_aggregate_below_union = prevConfig;
         }
     }
+
+    @Test
+    void testPredicateOnlyDictDecodeWithProjection() throws Exception {
+        String sql = """
+              WITH T1 AS ( SELECT C_USER, C_DEPT FROM low_card_t1) [MATERIALIZED]
+              SELECT C_DEPT FROM T1 WHERE C_USER = "str"
+                """;
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "Global Dict Exprs:\n" +
+                "    16: DictDefine(14: c_user, [<place-holder>])\n" +
+                "    17: DictDefine(15: c_dept, [<place-holder>])\n" +
+                "\n" +
+                "  5:Decode\n" +
+                "  |  <dict id 17> : <string id 13>\n" +
+                "  |  cardinality: 1\n" +
+                "  |  \n" +
+                "  4:Project\n" +
+                "  |  output columns:\n" +
+                "  |  17 <-> [17: c_dept, INT, true]\n" +
+                "  |  cardinality: 1\n" +
+                "  |  \n" +
+                "  3:SELECT\n" +
+                "  |  predicates: DictDecode(16: c_user, [<place-holder> = 'str'])\n" +
+                "  |  cardinality: 1", plan);
+    }
 }

--- a/test/sql/test_low_cardinality/R/test_low_cardinality_array
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality_array
@@ -412,3 +412,8 @@ select  array_contains(a1, NULL), array_contains_all(a1, array_slice(a1, 1, 2)),
 0	1	1
 0	1	1
 -- !result
+with cte as (select a1, a2 from s1) [materialized] select a1 from cte where a2[1] = 'JX' order by a1 limit 2;
+-- result:
+["Hebei","Hong Kong","Macao","Guangxi"]
+["Hong Kong","Jiangsu","Tibet","Yunnan","Fujian"]
+-- !result

--- a/test/sql/test_low_cardinality/T/test_low_cardinality_array
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality_array
@@ -343,3 +343,5 @@ select array_contains(arr, 'Hunan'), array_contains_all(arr, ['Henan', 'Tibet'])
        array_position(arr, 'Macao'), array_remove(arr, 'Henan') from cte;
 
 select  array_contains(a1, NULL), array_contains_all(a1, array_slice(a1, 1, 2)), array_contains_seq(a1, array_slice(a1, 1, 2)) from s1 order by v1 limit 2;
+
+with cte as (select a1, a2 from s1) [materialized] select a1 from cte where a2[1] = 'JX' order by a1 limit 2;


### PR DESCRIPTION
## Why I'm doing:
In the low cardinality rewrite, if a dict column is only used in the predicate and the operator has projections, the column gets dropped from DecodeInfo, which causes the GlobalDictExpr not to be propagated to the fragment and query fails with "dict column not found" error.

## What I'm doing:
Adding the columns used in predicates to DecodeInfo::usedStringColumns.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
