### PR TITLE
[Enhancement] Scan every partition for direct-value partition columns during SAMPLE analyze on external tables for tpcds-q50

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
@@ -104,6 +104,14 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
 
     private final String catalogName;
     protected List<String> partitionNames;
+    // Full partition list for the table, independent of which partitions this job actually scans data
+    // for (`partitionNames`, which for a SAMPLE job is only the sampled subset). Defaults to
+    // `partitionNames`: a FULL job's `partitionNames` already covers every partition (or the caller's
+    // explicit scope, which this job's own scan already matches). ExternalSampleStatisticsCollectJob
+    // overrides this to the table's true full partition list, so it can scan direct-value partition
+    // columns (see StatisticUtils#isDirectValuePartitionColumn) across every partition while other
+    // columns stay within the sampled subset - see its buildCollectSQLList override.
+    protected List<String> allPartitionNames;
     private final List<String> sqlBuffer = Lists.newArrayList();
     private final List<List<Expr>> rowsBuffer = Lists.newArrayList();
     // Per-partition total row count from connector metadata (Iceberg PARTITIONS table), used to extrapolate a
@@ -128,6 +136,7 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
         super(db, table, columnNames, columnTypes, type, scheduleType, properties);
         this.catalogName = catalogName;
         this.partitionNames = partitionNames;
+        this.allPartitionNames = partitionNames;
     }
 
     @Override
@@ -217,32 +226,7 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
         String status = "SUCCESS";
         String failureReason = "";
         try {
-            long finishedSQLNum = 0;
-            int parallelism = Math.max(1, context.getSessionVariable().getStatisticCollectParallelism());
-            List<List<String>> collectSQLList = buildCollectSQLList(parallelism);
-            long totalCollectSQL = collectSQLList.size();
-
-            // Each element is one self-contained CTE query for a (partition, column-group): all columns in the
-            // group share a single partition scan. They cannot be merged (only one WITH per statement), so
-            // each runs on its own. The collect parallelism now drives per-query pipeline dop: a single-element
-            // group is given dop = parallelism to use enough cpu cores.
-            for (List<String> sqlUnion : collectSQLList) {
-                if (sqlUnion.size() < parallelism) {
-                    context.getSessionVariable().setPipelineDop(parallelism / sqlUnion.size());
-                } else {
-                    context.getSessionVariable().setPipelineDop(1);
-                }
-
-                String sql = Joiner.on(" UNION ALL ").join(sqlUnion);
-
-                collectStatisticSync(sql, context, analyzeStatus);
-                finishedSQLNum++;
-                analyzeStatus.setProgress(finishedSQLNum * 100 / totalCollectSQL);
-                GlobalStateMgr.getCurrentState().getAnalyzeMgr().replayAddAnalyzeStatus(analyzeStatus);
-            }
-
-            flushInsertStatisticsData(context, true);
-            cleanupStaleRawKeyedRows(context, jobId);
+            runCollectPhases(context, analyzeStatus, jobId);
         } catch (Exception e) {
             status = "FAILED";
             failureReason = e.getMessage();
@@ -259,6 +243,49 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
                     status, System.currentTimeMillis() - startMs,
                     partitionNames.size(), columnNames.size(), failureReason);
         }
+    }
+
+    // Runs the job's collection SQL to completion, force-flushing and cleaning up stale raw-keyed rows
+    // once every query succeeds. Extracted out of collect() so ExternalSampleStatisticsCollectJob can
+    // override it to run direct-value and sampled-partition columns as two independent phases (see its
+    // override) instead of one flat query list - each phase gets its own force-flush and, for the
+    // direct-value phase, an immediate ColumnStatsMeta commit, so a later phase's failure can't
+    // retroactively erase an earlier phase's already-successful results (see PR #60703 review
+    // discussion).
+    protected void runCollectPhases(ConnectContext context, AnalyzeStatus analyzeStatus, long jobId) throws Exception {
+        int parallelism = Math.max(1, context.getSessionVariable().getStatisticCollectParallelism());
+        List<List<String>> collectSQLList = buildCollectSQLList(parallelism);
+        executeCollectSQLList(collectSQLList, context, analyzeStatus, 0, collectSQLList.size(), parallelism);
+        flushInsertStatisticsData(context, true);
+        cleanupStaleRawKeyedRows(context, jobId);
+    }
+
+    // Runs every CTE query in `collectSQLList` (in order). `finishedSQLNum`/`totalCollectSQL` let a
+    // caller running multiple phases report smooth overall progress instead of resetting to 0% at the
+    // start of each phase. Returns the updated finishedSQLNum so the caller can chain further phases.
+    //
+    // Each element is one self-contained CTE query for a (partition, column-group): all columns in the
+    // group share a single partition scan. They cannot be merged (only one WITH per statement), so
+    // each runs on its own. The collect parallelism now drives per-query pipeline dop: a single-element
+    // group is given dop = parallelism to use enough cpu cores.
+    protected long executeCollectSQLList(List<List<String>> collectSQLList, ConnectContext context,
+                                         AnalyzeStatus analyzeStatus, long finishedSQLNum, long totalCollectSQL,
+                                         int parallelism) throws Exception {
+        for (List<String> sqlUnion : collectSQLList) {
+            if (sqlUnion.size() < parallelism) {
+                context.getSessionVariable().setPipelineDop(parallelism / sqlUnion.size());
+            } else {
+                context.getSessionVariable().setPipelineDop(1);
+            }
+
+            String sql = Joiner.on(" UNION ALL ").join(sqlUnion);
+
+            collectStatisticSync(sql, context, analyzeStatus);
+            finishedSQLNum++;
+            analyzeStatus.setProgress(finishedSQLNum * 100 / totalCollectSQL);
+            GlobalStateMgr.getCurrentState().getAnalyzeMgr().replayAddAnalyzeStatus(analyzeStatus);
+        }
+        return finishedSQLNum;
     }
 
     // Resolves a scan cap: an explicit ANALYZE ... PROPERTIES value wins over the global Config default;
@@ -280,6 +307,14 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
     // sample can be extrapolated back to the full partition. Only meaningful when a budget is active and the
     // connector exposes exact per-partition row counts cheaply - currently Iceberg (PARTITIONS metadata table).
     // Other connectors / no-budget runs return empty, and statistics are then stored as raw sample values.
+    //
+    // Uses allPartitionNames, not partitionNames: for a SAMPLE job, direct-value partition columns (see
+    // StatisticUtils#isDirectValuePartitionColumn) are scanned across every partition in allPartitionNames,
+    // not just the sampled partitionNames subset - looking up only partitionNames here would leave every
+    // "extra" partition's total unknown, silently skipping extrapolation (and under-reporting row_count)
+    // for any of them that a scan-budget cap truncates. allPartitionNames always covers partitionNames too
+    // (it's a superset - see ExternalSampleStatisticsCollectJob's constructor), so this is a strict widening,
+    // never a behavior change for a plain FULL job where the two lists are already identical.
     private Map<String, Long> buildPartitionTotalRowCounts(long bytesCap, long filesCap, long rowsCap, long jobId) {
         boolean budgetActive = bytesCap > 0 || filesCap > 0 || rowsCap > 0;
         if (!budgetActive) {
@@ -288,7 +323,7 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
         try {
             // Connector-agnostic: each PartitionTraits decides whether it can supply per-partition totals
             // (Iceberg does via the PARTITIONS metadata table; others return empty -> no extrapolation).
-            return ConnectorPartitionTraits.build(table).getPartitionRowCounts(partitionNames);
+            return ConnectorPartitionTraits.build(table).getPartitionRowCounts(allPartitionNames);
         } catch (Exception e) {
             // Never fail collection over missing extrapolation input: fall back to raw sample values.
             LOG.warn("[ExternalStats] failed to fetch partition row counts for extrapolation | jobId={} " +
@@ -356,7 +391,7 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
     // row is never double-counted even if this cleanup fails - it just wastes a bit of space until
     // the next collection retries it. Best-effort: must never fail a job whose actual stats write
     // already succeeded.
-    private void cleanupStaleRawKeyedRows(ConnectContext context, long jobId) {
+    protected void cleanupStaleRawKeyedRows(ConnectContext context, long jobId) {
         String rawTableUuid = table.getUUID();
         boolean ok = new StatisticExecutor().dropExternalStatRawPartitions(context, rawTableUuid, partitionNames, columnNames);
         if (!ok) {
@@ -366,34 +401,50 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
     }
 
     protected List<List<String>> buildCollectSQLList(int parallelism) {
-        // Collect a partition in a single scan by wrapping the read in a CTE (base_cte_table) shared by every
-        // column's aggregate branch. Columns are split into groups so a wide table does not build one CTE
-        // multicast to hundreds of consumers (inflating query/plan size and the memory held for the
-        // materialized partition); each group scans the partition once, so total scans are
-        // partitions x ceil(columns / columnsPerScan). The group size mirrors the internal sample path
-        // (ColumnSampleManager.splitPrimitiveTypeStats): max(2, statistic_collect_parallelism), i.e. at least
-        // two columns share a scan. Each group is a self-contained CTE query and two CTE queries cannot be
-        // UNION ALL'd (one WITH per statement), so the outer group size is fixed to 1; parallelism only sets
-        // per-query pipeline dop in the execute loop.
+        return buildCollectSQLListForColumns(partitionNames, columnNames, columnTypes, parallelism);
+    }
+
+    // Builds one CTE query per (partition, column-batch) for the given partitions/columns. Extracted out
+    // of buildCollectSQLList so ExternalSampleStatisticsCollectJob can independently scan direct-value
+    // partition columns (see StatisticUtils#isDirectValuePartitionColumn) across every partition while
+    // non-partition columns stay within the sampled subset - see its buildCollectSQLList override.
+    //
+    // Collect a partition in a single scan by wrapping the read in a CTE (base_cte_table) shared by every
+    // column's aggregate branch. Columns are split into groups so a wide table does not build one CTE
+    // multicast to hundreds of consumers (inflating query/plan size and the memory held for the
+    // materialized partition); each group scans the partition once, so total scans are
+    // partitions x ceil(columns / columnsPerScan). The group size mirrors the internal sample path
+    // (ColumnSampleManager.splitPrimitiveTypeStats): max(2, statistic_collect_parallelism), i.e. at least
+    // two columns share a scan. Each group is a self-contained CTE query and two CTE queries cannot be
+    // UNION ALL'd (one WITH per statement), so the outer group size is fixed to 1; parallelism only sets
+    // per-query pipeline dop in the execute loop.
+    protected List<List<String>> buildCollectSQLListForColumns(List<String> partitionsToScan,
+                                                               List<String> scanColumnNames,
+                                                               List<Type> scanColumnTypes, int parallelism) {
+        if (scanColumnNames.isEmpty()) {
+            return Collections.emptyList();
+        }
         int columnsPerScan = Math.max(2, parallelism);
         List<String> totalQuerySQL = new ArrayList<>();
-        for (String partitionName : partitionNames) {
+        for (String partitionName : partitionsToScan) {
             if (DO_NOT_COLLECT_PARTITIONS.contains(partitionName)) {
                 LOG.info("Skip collect full statistics for partition: {} in table: {}",
                         partitionName, table.getName());
                 continue;
             }
-            for (int start = 0; start < columnNames.size(); start += columnsPerScan) {
-                int end = Math.min(columnNames.size(), start + columnsPerScan);
-                totalQuerySQL.add(buildPartitionCTESQL(table, partitionName, start, end));
+            for (int start = 0; start < scanColumnNames.size(); start += columnsPerScan) {
+                int end = Math.min(scanColumnNames.size(), start + columnsPerScan);
+                totalQuerySQL.add(buildPartitionCTESQL(table, partitionName,
+                        scanColumnNames.subList(start, end), scanColumnTypes.subList(start, end)));
             }
         }
 
         return Lists.partition(totalQuerySQL, 1);
     }
 
-    // Builds one CTE query that collects columns [startCol, endCol) of a single partition in a shared scan.
-    private String buildPartitionCTESQL(Table table, String partitionName, int startCol, int endCol) {
+    // Builds one CTE query that collects `batchColumnNames` of a single partition in a shared scan.
+    private String buildPartitionCTESQL(Table table, String partitionName, List<String> batchColumnNames,
+                                        List<Type> batchColumnTypes) {
         Collection<String> nullValues = resolveNullValues(table);
         String partitionPredicate = table.isUnPartitioned() ? "1=1" :
                 Joiner.on(" AND ").join(generatePartitionPredicates(table, partitionName, nullValues));
@@ -402,12 +453,12 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
         // non-collection). Non-statable columns emit constant sketches and need nothing beyond COUNT(1).
         List<String> projection = new ArrayList<>();
         List<String> unionSelects = new ArrayList<>();
-        for (int i = startCol; i < endCol; i++) {
-            Type columnType = columnTypes.get(i);
+        for (int i = 0; i < batchColumnNames.size(); i++) {
+            Type columnType = batchColumnTypes.get(i);
             if (columnType.canStatistic() && !columnType.isCollectionType()) {
-                projection.add(StatisticUtils.quoting(table, columnNames.get(i)));
+                projection.add(StatisticUtils.quoting(table, batchColumnNames.get(i)));
             }
-            unionSelects.add(buildColumnSelectFromCTE(table, partitionName, columnNames.get(i), columnType));
+            unionSelects.add(buildColumnSelectFromCTE(table, partitionName, batchColumnNames.get(i), columnType));
         }
 
         VelocityContext context = new VelocityContext();
@@ -590,7 +641,7 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
         flushInsertStatisticsData(context, false);
     }
 
-    private void flushInsertStatisticsData(ConnectContext context, boolean force) throws Exception {
+    protected void flushInsertStatisticsData(ConnectContext context, boolean force) throws Exception {
         // hll serialize to hex, about 32kb
         long bufferSize = 33L * 1024 * rowsBuffer.size();
         if (bufferSize < Config.statistic_full_collect_buffer && !force) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJob.java
@@ -18,22 +18,28 @@ import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.type.Type;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCollectJob {
-    private final int allPartitionSize;
+    private static final Logger LOG = LogManager.getLogger(ExternalSampleStatisticsCollectJob.class);
 
     public ExternalSampleStatisticsCollectJob(String catalogName, Database db, Table table, List<String> partitionNames,
                                               List<String> columnNames, List<Type> columnTypes,
                                               StatsConstants.AnalyzeType type, StatsConstants.ScheduleType scheduleType,
-                                              Map<String, String> properties, int allPartitionSize) {
+                                              Map<String, String> properties, List<String> allPartitionNames) {
         super(catalogName, db, table, partitionNames, columnNames, columnTypes, type, scheduleType, properties);
-        this.allPartitionSize = allPartitionSize;
+        this.allPartitionNames = allPartitionNames;
     }
 
     public Set<Long> getSampledPartitionsHashValue() {
@@ -42,7 +48,87 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
     }
 
     public int getAllPartitionSize() {
-        return allPartitionSize;
+        return allPartitionNames.size();
+    }
+
+    // Hash set of every partition in the table (not just the sampled subset - contrast with
+    // getSampledPartitionsHashValue). Used to give direct-value partition columns (see
+    // StatisticUtils#isDirectValuePartitionColumn) an honest "sampled == all" partition record in
+    // ColumnStatsMeta, so the standard SAMPLE row-count extrapolation formula
+    // (rowCount / sampledPartitionSize * allPartitionSize) naturally comes out to a 1x no-op for them,
+    // instead of needing a special read-time bypass.
+    public Set<Long> getAllPartitionsHashValue() {
+        HashFunction hashFunction = Hashing.murmur3_128();
+        return allPartitionNames.stream().map(s -> hashFunction.hashUnencodedChars(s).asLong()).collect(Collectors.toSet());
+    }
+
+    // Direct-value partition columns (see StatisticUtils#isDirectValuePartitionColumn) get their exact
+    // NDV by scanning every partition instead of just the sampled subset - this is metadata-cheap (one
+    // value per partition, partition-pruned) and the merged HLL that comes out of a full scan is already
+    // exact, so it needs no sample extrapolation. All other columns keep the normal sampled-partition
+    // behavior.
+    //
+    // The two groups are run as two independent phases, each force-flushed on its own: if the
+    // direct-value phase finishes fully, its ColumnStatsMeta is committed (with full-coverage partition
+    // counts) immediately, before the sampled-column phase even starts - so a later failure in that
+    // second phase can't retroactively erase an already-successful full-partition scan (see PR #60703
+    // review discussion). If the direct-value phase itself fails partway through, ColumnStatsMeta for
+    // those columns simply isn't updated this run - the existing (possibly still-SAMPLE, possibly
+    // absent) metadata stays in effect and gets correctly re-extrapolated as usual, never
+    // over-multiplied, until the next successful ANALYZE.
+    @Override
+    protected void runCollectPhases(ConnectContext context, AnalyzeStatus analyzeStatus, long jobId) throws Exception {
+        List<String> directValueColumnNames = new ArrayList<>();
+        List<Type> directValueColumnTypes = new ArrayList<>();
+        List<String> restColumnNames = new ArrayList<>();
+        List<Type> restColumnTypes = new ArrayList<>();
+        for (int i = 0; i < columnNames.size(); i++) {
+            String columnName = columnNames.get(i);
+            if (StatisticUtils.isDirectValuePartitionColumn(table, columnName)) {
+                directValueColumnNames.add(columnName);
+                directValueColumnTypes.add(columnTypes.get(i));
+            } else {
+                restColumnNames.add(columnName);
+                restColumnTypes.add(columnTypes.get(i));
+            }
+        }
+
+        int parallelism = Math.max(1, context.getSessionVariable().getStatisticCollectParallelism());
+        List<List<String>> directValueSQLList = buildCollectSQLListForColumns(allPartitionNames, directValueColumnNames,
+                directValueColumnTypes, parallelism);
+        List<List<String>> restSQLList = buildCollectSQLListForColumns(partitionNames, restColumnNames, restColumnTypes,
+                parallelism);
+        long totalCollectSQL = directValueSQLList.size() + restSQLList.size();
+
+        long finishedSQLNum = 0;
+        if (!directValueColumnNames.isEmpty()) {
+            finishedSQLNum = executeCollectSQLList(directValueSQLList, context, analyzeStatus, finishedSQLNum,
+                    totalCollectSQL, parallelism);
+            flushInsertStatisticsData(context, true);
+            commitDirectValueColumnsFully(directValueColumnNames);
+        }
+        if (!restColumnNames.isEmpty()) {
+            executeCollectSQLList(restSQLList, context, analyzeStatus, finishedSQLNum, totalCollectSQL, parallelism);
+        }
+        flushInsertStatisticsData(context, true);
+        cleanupStaleRawKeyedRows(context, jobId);
+    }
+
+    // Best-effort early commit of ColumnStatsMeta for columns whose full-partition scan just succeeded
+    // (see runCollectPhases): records their sampled-partition set as ALL partitions, so the standard
+    // extrapolation formula naturally becomes a 1x no-op for them. Failure here is non-fatal - losing
+    // just this early-commit optimization only costs a redundant full re-scan of every partition on the
+    // next ANALYZE, not correctness (the existing metadata, whatever it says, is still handled correctly
+    // by the normal SAMPLE/FULL logic in connector.statistics.StatisticsUtils#estimateColumnStatistics).
+    private void commitDirectValueColumnsFully(List<String> directValueColumnNames) {
+        try {
+            new StatisticExecutor().commitExternalColumnStatsMeta(db, table, getCatalogName(), columnNames,
+                    directValueColumnNames, StatsConstants.AnalyzeType.SAMPLE, LocalDateTime.now(), properties,
+                    Collections.emptySet(), getAllPartitionsHashValue(), getAllPartitionSize(), true);
+        } catch (Exception e) {
+            LOG.warn("Failed to eagerly commit ColumnStatsMeta for direct-value partition columns {} on table {}",
+                    directValueColumnNames, table.getName(), e);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -689,55 +689,95 @@ public class StatisticExecutor {
                 }
             } else {
                 // for external table
-                ExternalBasicStatsMeta externalBasicStatsMeta = analyzeMgr.getExternalTableBasicStatsMeta(
-                        statsJob.getCatalogName(), db.getFullName(), table.getName());
-                if (externalBasicStatsMeta == null) {
-                    externalBasicStatsMeta = new ExternalBasicStatsMeta(statsJob.getCatalogName(), db.getFullName(),
-                            table.getName(), Lists.newArrayList(statsJob.getColumnNames()), statsJob.getAnalyzeType(),
-                            analyzeStatus.getEndTime(), statsJob.getProperties());
-                } else {
-                    externalBasicStatsMeta = externalBasicStatsMeta.clone();
-                    externalBasicStatsMeta.setUpdateTime(analyzeStatus.getEndTime());
-                    externalBasicStatsMeta.setProperties(statsJob.getProperties());
-                    externalBasicStatsMeta.setAnalyzeType(statsJob.getAnalyzeType());
-                    // set columns to the latest collect job's columns
-                    externalBasicStatsMeta.setColumns(Lists.newArrayList(statsJob.getColumnNames()));
-                }
-
                 Set<Long> sampledPartitions = new HashSet<>();
+                Set<Long> fullCoveragePartitions = Collections.emptySet();
                 int allPartitionSize = -1;
                 if (statsJob.getAnalyzeType() == StatsConstants.AnalyzeType.SAMPLE) {
                     ExternalSampleStatisticsCollectJob sampleStatsJob = (ExternalSampleStatisticsCollectJob) statsJob;
                     sampledPartitions = sampleStatsJob.getSampledPartitionsHashValue();
+                    fullCoveragePartitions = sampleStatsJob.getAllPartitionsHashValue();
                     allPartitionSize = sampleStatsJob.getAllPartitionSize();
                 }
-                for (String column : ListUtils.emptyIfNull(statsJob.getColumnNames())) {
-                    // merge sampled partitions
-                    if (externalBasicStatsMeta.getColumnStatsMetaMap().containsKey(column)) {
-                        sampledPartitions.addAll(externalBasicStatsMeta.getColumnStatsMeta(column).
-                                getSampledPartitionsHashValue());
-                    }
-                    ColumnStatsMeta meta =
-                            new ColumnStatsMeta(column, statsJob.getAnalyzeType(), analyzeStatus.getEndTime(),
-                                    sampledPartitions, allPartitionSize);
-                    externalBasicStatsMeta.addColumnStatsMeta(meta);
-                }
-                // Persist the table UUID (best-effort) so followers can invalidate the connector stats cache
-                // during journal replay without resolving external table metadata. If the UUID can't be
-                // resolved, leave it null and replay will fall back to the metadata-based path.
-                try {
-                    externalBasicStatsMeta.setTableUUID(table.getUUID());
-                } catch (Exception e) {
-                    LOG.warn("Failed to resolve table UUID for external basic stats meta, table: {}.{}.{}",
-                            statsJob.getCatalogName(), db.getFullName(), table.getName(), e);
-                }
-                GlobalStateMgr.getCurrentState().getAnalyzeMgr().addExternalBasicStatsMeta(externalBasicStatsMeta);
-                GlobalStateMgr.getCurrentState().getAnalyzeMgr()
-                        .refreshConnectorTableBasicStatisticsCache(statsJob.getCatalogName(),
-                                db.getFullName(), table.getName(), statsJob.getColumnNames(), refreshAsync);
+                commitExternalColumnStatsMeta(db, table, statsJob.getCatalogName(), statsJob.getColumnNames(),
+                        statsJob.getColumnNames(), statsJob.getAnalyzeType(), analyzeStatus.getEndTime(),
+                        statsJob.getProperties(), sampledPartitions, fullCoveragePartitions, allPartitionSize,
+                        refreshAsync);
             }
         }
         return analyzeStatus;
+    }
+
+    // Durably records ColumnStatsMeta for `columnNamesToCommit` and refreshes the connector stats cache.
+    // Normally called once, for every column in the job, only after the whole job finishes successfully
+    // (see the call site above). ExternalSampleStatisticsCollectJob also calls this directly, right after
+    // its direct-value-column phase (see StatisticUtils#isDirectValuePartitionColumn) completes, so a
+    // later failure in the sampled-column phase can't retroactively erase an already-successful
+    // full-partition scan's metadata. Safe to call twice for the same columns: addColumnStatsMeta
+    // overwrites by column name, so the final post-job call is a harmless re-write for columns already
+    // committed early.
+    //
+    // Direct-value columns are recorded with `fullCoveragePartitions` (honestly "every partition was
+    // sampled for this column") instead of the job's own `sampledPartitions` subset, and with AnalyzeType
+    // FULL. This makes the standard SAMPLE row-count extrapolation formula in
+    // connector.statistics.StatisticsUtils#estimateColumnStatistics a 1x no-op for them if it's ever
+    // reached, and lets FULL's early-return handle the common case - without any special-cased read-time
+    // bypass. Legacy metadata written before this distinction existed keeps its own (genuinely partial)
+    // sampledPartitions and is extrapolated normally, so it is never silently treated as already-complete.
+    //
+    // `allJobColumnNames` is the job's full declared column set (used for ExternalBasicStatsMeta's own
+    // bookkeeping, e.g. setColumns); `columnNamesToCommit` is the (possibly smaller) subset to actually
+    // build/store a ColumnStatsMeta entry for in this call.
+    void commitExternalColumnStatsMeta(Database db, Table table, String catalogName, List<String> allJobColumnNames,
+                                       List<String> columnNamesToCommit, StatsConstants.AnalyzeType jobAnalyzeType,
+                                       LocalDateTime updateTime, Map<String, String> properties,
+                                       Set<Long> sampledPartitions, Set<Long> fullCoveragePartitions,
+                                       int allPartitionSize, boolean refreshAsync) {
+        AnalyzeMgr analyzeMgr = GlobalStateMgr.getCurrentState().getAnalyzeMgr();
+        ExternalBasicStatsMeta externalBasicStatsMeta = analyzeMgr.getExternalTableBasicStatsMeta(
+                catalogName, db.getFullName(), table.getName());
+        if (externalBasicStatsMeta == null) {
+            externalBasicStatsMeta = new ExternalBasicStatsMeta(catalogName, db.getFullName(),
+                    table.getName(), Lists.newArrayList(allJobColumnNames), jobAnalyzeType, updateTime, properties);
+        } else {
+            externalBasicStatsMeta = externalBasicStatsMeta.clone();
+            externalBasicStatsMeta.setUpdateTime(updateTime);
+            externalBasicStatsMeta.setProperties(properties);
+            externalBasicStatsMeta.setAnalyzeType(jobAnalyzeType);
+            // set columns to the latest collect job's columns
+            externalBasicStatsMeta.setColumns(Lists.newArrayList(allJobColumnNames));
+        }
+
+        for (String column : ListUtils.emptyIfNull(columnNamesToCommit)) {
+            boolean isDirectValue = StatisticUtils.isDirectValuePartitionColumn(table, column);
+            Set<Long> columnSampledPartitions;
+            if (isDirectValue) {
+                // Full coverage should always just be full coverage - no merging with whatever
+                // (necessarily smaller) sampled-partition set a prior, non-eligible-era run recorded.
+                columnSampledPartitions = fullCoveragePartitions;
+            } else {
+                columnSampledPartitions = new HashSet<>(sampledPartitions);
+                if (externalBasicStatsMeta.getColumnStatsMetaMap().containsKey(column)) {
+                    columnSampledPartitions.addAll(externalBasicStatsMeta.getColumnStatsMeta(column).
+                            getSampledPartitionsHashValue());
+                }
+            }
+            StatsConstants.AnalyzeType columnAnalyzeType = isDirectValue ? StatsConstants.AnalyzeType.FULL : jobAnalyzeType;
+            ColumnStatsMeta meta =
+                    new ColumnStatsMeta(column, columnAnalyzeType, updateTime, columnSampledPartitions, allPartitionSize);
+            externalBasicStatsMeta.addColumnStatsMeta(meta);
+        }
+        // Persist the table UUID (best-effort) so followers can invalidate the connector stats cache
+        // during journal replay without resolving external table metadata. If the UUID can't be
+        // resolved, leave it null and replay will fall back to the metadata-based path.
+        try {
+            externalBasicStatsMeta.setTableUUID(table.getUUID());
+        } catch (Exception e) {
+            LOG.warn("Failed to resolve table UUID for external basic stats meta, table: {}.{}.{}",
+                    catalogName, db.getFullName(), table.getName(), e);
+        }
+        analyzeMgr.addExternalBasicStatsMeta(externalBasicStatsMeta);
+        analyzeMgr.refreshConnectorTableBasicStatisticsCache(catalogName, db.getFullName(), table.getName(),
+                columnNamesToCommit, refreshAsync);
     }
 
     public List<TStatisticData> executeStatisticDQL(ConnectContext context, String sql) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -70,6 +70,7 @@ import com.starrocks.type.Type;
 import com.starrocks.type.TypeFactory;
 import com.starrocks.warehouse.Warehouse;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.iceberg.PartitionField;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -340,6 +341,41 @@ public class StatisticUtils {
             return false;
         }
         return table.getPartitions().stream().noneMatch(Partition::hasData);
+    }
+
+    // True when a partition's name/value directly and losslessly encodes `columnName`'s raw value for
+    // every row in that partition. For such a column, scanning every partition (not just a sampled
+    // subset) gives an exact NDV via the normal HLL merge - see
+    // ExternalSampleStatisticsCollectJob#buildCollectSQLList, which routes exactly these columns through
+    // every partition instead of the sampled ones, and StatisticExecutor, which then records the column's
+    // AnalyzeType as FULL so read-side estimation does not apply sample extrapolation to it.
+    //
+    // - Hive/Hudi/Delta: every partition column qualifies unconditionally - these formats only support
+    //   explicit-value partitioning, there's no transform concept to worry about.
+    // - Iceberg: only a column used as an IDENTITY-transform partition field qualifies. A composite spec
+    //   (e.g. identity(region), identity(dt)) is fine - every row in a partition still shares the same
+    //   value for each individual identity field, we just parse out the specific field for this column
+    //   rather than requiring the whole spec to be exactly one field. Non-identity transforms
+    //   (year/month/day/hour/bucket/truncate) do NOT qualify: the partition value is a function of the
+    //   raw value, not the raw value itself, so many distinct raw values can share one partition value.
+    //   Spec-evolved tables are excluded: partitions written under a different historical spec may not
+    //   carry this column as an identity field at all.
+    static boolean isDirectValuePartitionColumn(Table table, String columnName) {
+        if (table == null) {
+            return false;
+        }
+        if (table.isHiveTable() || table.isHudiTable() || table.isDeltalakeTable()) {
+            return table.getPartitionColumnNames().contains(columnName);
+        }
+        if (!(table instanceof IcebergTable)) {
+            return false;
+        }
+        IcebergTable icebergTable = (IcebergTable) table;
+        if (icebergTable.isUnPartitioned() || icebergTable.hasPartitionTransformedEvolution()) {
+            return false;
+        }
+        PartitionField field = icebergTable.getPartitionField(columnName);
+        return field != null && field.transform().isIdentity();
     }
 
     public static List<ColumnDef> buildStatsColumnDef(String tableName) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
@@ -282,7 +282,7 @@ public class StatisticsCollectJobFactory {
             allPartitionNames = allPartitionNames == null ? ConnectorPartitionTraits.build(table).getPartitionNames() :
                     allPartitionNames;
             return new ExternalSampleStatisticsCollectJob(catalogName, db, table, samplePartitionNames, columnNames,
-                    columnTypes, analyzeType, scheduleType, properties, allPartitionNames.size());
+                    columnTypes, analyzeType, scheduleType, properties, allPartitionNames);
         }
 
         return new ExternalFullStatisticsCollectJob(catalogName, db, table, partitionNames, columnNames, columnTypes,

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/DirectValuePartitionColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/DirectValuePartitionColumnTest.java
@@ -1,0 +1,152 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.statistic;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.connector.iceberg.TableTestBase;
+import com.starrocks.connector.iceberg.TestTables;
+import mockit.Mock;
+import mockit.MockUp;
+import org.apache.iceberg.PartitionSpec;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.starrocks.type.IntegerType.INT;
+import static com.starrocks.type.StringType.STRING;
+
+// Iceberg identity-partition eligibility for StatisticUtils#isDirectValuePartitionColumn -
+// ExternalSampleStatisticsCollectJob routes exactly these columns through every partition instead
+// of the sampled subset (see StatisticUtilsTest for the Hive/Hudi/Delta cases, which don't need the
+// Iceberg test-table fixtures this class pulls in via TableTestBase).
+public class DirectValuePartitionColumnTest extends TableTestBase {
+
+    private IcebergTable wrap(TestTables.TestTable nativeTable, List<Column> columns) {
+        return new IcebergTable(1, nativeTable.name(), "iceberg_catalog", "resource",
+                "iceberg_db", nativeTable.name(), "", columns, nativeTable, Maps.newHashMap());
+    }
+
+    @Test
+    public void testSingleColumnIdentityPartitionIsEligible() {
+        // mockedNativeTableB: SCHEMA_B(k1 int, k2 int), SPEC_B = identity(k2)
+        List<Column> columns = Lists.newArrayList(new Column("k1", INT), new Column("k2", INT));
+        IcebergTable table = wrap(mockedNativeTableB, columns);
+        Assertions.assertTrue(StatisticUtils.isDirectValuePartitionColumn(table, "k2"));
+    }
+
+    @Test
+    public void testCompositeIdentityPartitionColumnIsEligible() {
+        // Composite identity spec: every row in a partition still shares the same value for each
+        // individual identity field, so a marginal column within it now qualifies (unlike the older,
+        // more conservative single-field-spec restriction).
+        PartitionSpec compositeSpec = PartitionSpec.builderFor(SCHEMA_H).identity("k2").identity("k3").build();
+        TestTables.TestTable compositeTable = create(SCHEMA_H, compositeSpec, "th_composite", 1);
+        List<Column> columns = Lists.newArrayList(
+                new Column("k1", STRING), new Column("k2", STRING), new Column("k3", STRING),
+                new Column("k4", STRING), new Column("k5", STRING));
+        IcebergTable table = wrap(compositeTable, columns);
+        Assertions.assertTrue(StatisticUtils.isDirectValuePartitionColumn(table, "k2"));
+        Assertions.assertTrue(StatisticUtils.isDirectValuePartitionColumn(table, "k3"));
+        Assertions.assertFalse(StatisticUtils.isDirectValuePartitionColumn(table, "k1"));
+    }
+
+    @Test
+    public void testNonIdentityTransformIsNotEligible() {
+        // mockedNativeTableD: SCHEMA_D(k1 int, ts timestamptz), SPEC_D_5 = hour(ts)
+        List<Column> columns = Lists.newArrayList(new Column("k1", INT));
+        IcebergTable table = wrap(mockedNativeTableD, columns);
+        Assertions.assertFalse(StatisticUtils.isDirectValuePartitionColumn(table, "ts"));
+    }
+
+    @Test
+    public void testUnpartitionedTableIsNotEligible() {
+        // mockedNativeTableH: SCHEMA_H, PartitionSpec.unpartitioned()
+        List<Column> columns = Lists.newArrayList(new Column("k1", STRING));
+        IcebergTable table = wrap(mockedNativeTableH, columns);
+        Assertions.assertFalse(StatisticUtils.isDirectValuePartitionColumn(table, "k1"));
+    }
+
+    @Test
+    public void testPartitionSpecEvolutionIsNotEligible() {
+        // mockedNativeTableC: SCHEMA_B(k1 int, k2 int), SPEC_B = identity(k2), format version 2
+        mockedNativeTableC.updateSpec().addField("k1").commit();
+        List<Column> columns = Lists.newArrayList(new Column("k1", INT), new Column("k2", INT));
+        IcebergTable table = wrap(mockedNativeTableC, columns);
+        Assertions.assertFalse(StatisticUtils.isDirectValuePartitionColumn(table, "k2"));
+    }
+
+    @Test
+    public void testNonIcebergNonExplicitPartitionTableIsNotEligible() {
+        Assertions.assertFalse(StatisticUtils.isDirectValuePartitionColumn(null, "k1"));
+    }
+
+    @Test
+    public void testHivePartitionColumnIsUnconditionallyEligible() {
+        new MockUp<Table>() {
+            @Mock
+            public boolean isHiveTable() {
+                return true;
+            }
+
+            @Mock
+            public List<String> getPartitionColumnNames() {
+                return ImmutableList.of("dt");
+            }
+        };
+        Table hiveTable = new Table(Table.TableType.HIVE);
+        Assertions.assertTrue(StatisticUtils.isDirectValuePartitionColumn(hiveTable, "dt"));
+        Assertions.assertFalse(StatisticUtils.isDirectValuePartitionColumn(hiveTable, "not_a_partition_col"));
+    }
+
+    @Test
+    public void testHudiPartitionColumnIsUnconditionallyEligible() {
+        new MockUp<Table>() {
+            @Mock
+            public boolean isHudiTable() {
+                return true;
+            }
+
+            @Mock
+            public List<String> getPartitionColumnNames() {
+                return ImmutableList.of("dt");
+            }
+        };
+        Table hudiTable = new Table(Table.TableType.HUDI);
+        Assertions.assertTrue(StatisticUtils.isDirectValuePartitionColumn(hudiTable, "dt"));
+    }
+
+    @Test
+    public void testDeltaLakePartitionColumnIsUnconditionallyEligible() {
+        new MockUp<Table>() {
+            @Mock
+            public boolean isDeltalakeTable() {
+                return true;
+            }
+
+            @Mock
+            public List<String> getPartitionColumnNames() {
+                return ImmutableList.of("dt");
+            }
+        };
+        Table deltaTable = new Table(Table.TableType.DELTALAKE);
+        Assertions.assertTrue(StatisticUtils.isDirectValuePartitionColumn(deltaTable, "dt"));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
Comparing TPC-DS q50 between a native StarRocks table and the same data as an Iceberg external table showed drastically different plans and a huge execution-time regression on the Iceberg side. Root cause traced back to statistics collection: `ANALYZE ... WITH SAMPLE` on an external table only scans a bounded number of partitions (`statistic_sample_collect_partition_size`, default 300) to build each column's HLL sketch. For a table like `store_sales` partitioned by `ss_sold_date_sk` (~1824 partitions), the merged HLL only ever sees the 300 sampled partitions, so the column's NDV comes out around 298 instead of the true ~1820.

That undercount cascades through the optimizer:

```
NDV(ss_sold_date_sk) = 298 (sampled)         NDV(ss_sold_date_sk) = 1820 (actual)
        │                                              │
        ▼                                              ▼
join selectivity ≈ 104/298 ≈ 35%             join selectivity ≈ 104/1820 ≈ 5.7%
        │                                              │
        ▼                                              ▼
inflated intermediate cardinality            correct intermediate cardinality
        │                                              │
        ▼                                              ▼
CBO picks PARTITIONED JOIN                   CBO picks BUCKET_SHUFFLE JOIN
        │                                              │
        ▼                                              ▼
loses runtime filters from                   runtime filters propagate normally
ticket/item/customer joins
        │
        ▼
massive shuffle at execution time
```

Row count, null count, and data size already have sample-to-full extrapolation logic (`connector/statistics/StatisticsUtils#estimateColumnStatistics`), but NDV never did — the per-partition HLL sketches are only ever unioned across the sampled subset, with no correction step.

## What I'm doing:
For a "direct-value partition column" — a column whose value a partition already records exactly and losslessly for every row inside it — route that column's collection through **every** partition instead of the sampled subset, even inside a SAMPLE job. Every other column keeps the existing sampled-partition behavior unchanged.

A column qualifies when:
- it's an Iceberg **identity-transform** partition field (composite specs are fine — `identity(region)` + `identity(dt)` both qualify individually; non-identity transforms like `year`/`month`/`bucket`/`truncate` do not, since many raw values can collapse into one partition value), or
- it's any partition column at all on Hive/Hudi/Delta tables (these formats only support explicit-value partitioning, so there's no transform to worry about).

Mechanically, `ExternalSampleStatisticsCollectJob` now splits its column list into two groups and builds two independent sets of per-partition CTE queries — one against the full partition list, one against the sampled subset — both going through the exact same SQL-generation and HLL-merge path as before:

```
ExternalSampleStatisticsCollectJob.buildCollectSQLList()
        │
        ├── direct-value partition columns ──► scan ALL partitions ──┐
        │                                                            │
        └── everything else ──► scan sampled 300 partitions ─────────┼──► same CTE/HLL SQL,
                                                                      │    same INSERT path,
                                                                      │    same external_column_statistics table
                                                                      ▼
                                                          merged HLL is now exact for
                                                          the direct-value columns
```

Since the merged HLL for these columns is now built from every partition, it's already exact — no extrapolation needed. To make the read path skip its sample-based row-count extrapolation for them, `StatisticExecutor` records their `ColumnStatsMeta` as `AnalyzeType.FULL` even though the overall job is `SAMPLE`; the existing FULL/SAMPLE branch in `estimateColumnStatistics` then does the right thing automatically, so no new schema column, override function, or bypass query was needed.

Added `DirectValuePartitionColumnTest` covering the eligibility rule: single-column and composite Iceberg identity specs, non-identity transforms, unpartitioned tables, spec evolution, and Hive/Hudi/Delta partition columns.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
