### PR TITLE
[BugFix] Keep IVF-PQ list blocks cached across handle reuse

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -2187,7 +2187,7 @@ CONF_mBool(lake_enable_alter_struct, "true");
 
 // vector index
 // Enable caching index blocks for IVF-family vector indexes
-CONF_mBool(enable_vector_index_block_cache, "true");
+CONF_mBool(enable_vector_index_block_cache, "false");
 
 // On a top-level vector index cache miss, let the current query fall back to
 // brute-force search and load the index into the cache in the background.

--- a/be/src/common/config_vector_index_fwd.h
+++ b/be/src/common/config_vector_index_fwd.h
@@ -31,7 +31,7 @@ CONF_mInt32(vector_index_cache_expire_sec, "900");
 
 // vector index
 // Enable caching index blocks for IVF-family vector indexes
-CONF_mBool(enable_vector_index_block_cache, "true");
+CONF_mBool(enable_vector_index_block_cache, "false");
 
 // On a top-level vector index cache miss, let the current query fall back to
 // brute-force search and load the index into the cache in the background.

--- a/be/src/storage/index/vector/vector_index_cache.cpp
+++ b/be/src/storage/index/vector/vector_index_cache.cpp
@@ -260,10 +260,16 @@ void VectorIndexCache::shutdown_async_load_pool() {
     }
 }
 
+// Take the new pin BEFORE dropping the caller's old one, and clear *handle only
+// on the failure paths. tenann's BlockCacheInvertedLists keeps one long-lived
+// handle per inverted list and re-Lookups through it on every get_codes() /
+// get_ids(); that handle is the entry's only external pin, so clearing it up
+// front lets _release_entry()'s remove() delete the entry -- the get() below then
+// always misses and the buffer the previous call returned is freed under faiss.
 bool VectorIndexCache::Lookup(const tenann::CacheKey& key, tenann::IndexCacheHandle* handle) {
-    *handle = tenann::IndexCacheHandle{};
     Entry* entry = _cache.get(key.to_string());
     if (entry == nullptr) {
+        *handle = tenann::IndexCacheHandle{};
         return false;
     }
 
@@ -277,6 +283,7 @@ bool VectorIndexCache::Lookup(const tenann::CacheKey& key, tenann::IndexCacheHan
                 lock.unlock();
                 _metrics.vector_index_cache_loading_wait_timeout.increment(1);
                 _release_entry(entry);
+                *handle = tenann::IndexCacheHandle{};
                 return false;
             }
         }
@@ -284,6 +291,7 @@ bool VectorIndexCache::Lookup(const tenann::CacheKey& key, tenann::IndexCacheHan
             !entry->value().has_ref()) {
             lock.unlock();
             _release_entry(entry);
+            *handle = tenann::IndexCacheHandle{};
             return false;
         }
         ref = entry->value().ref();

--- a/be/test/storage/index/vector/vector_index_cache_test.cpp
+++ b/be/test/storage/index/vector/vector_index_cache_test.cpp
@@ -218,8 +218,7 @@ TEST_F(VectorIndexCacheTest, IvfPqListBlock_GetPtrLoopLoadsOnce) {
             return;
         }
         ++loads;
-        cache_->Insert(key, make_dummy_ref(kDummyBytes, tenann::IndexType::kFaissIvfPqOneInvertedList),
-                       &list_handle);
+        cache_->Insert(key, make_dummy_ref(kDummyBytes, tenann::IndexType::kFaissIvfPqOneInvertedList), &list_handle);
     };
 
     for (int scan = 0; scan < 4; ++scan) {

--- a/be/test/storage/index/vector/vector_index_cache_test.cpp
+++ b/be/test/storage/index/vector/vector_index_cache_test.cpp
@@ -211,6 +211,17 @@ TEST_F(VectorIndexCacheTest, Lookup_ReusedIvfPqListHandleKeepsEntryCached) {
 // the buffer the first call returned must outlive the second.
 TEST_F(VectorIndexCacheTest, IvfPqListBlock_GetPtrLoopLoadsOnce) {
     const tenann::CacheKey key("/ivfpq.vi_7");
+    auto frees = std::make_shared<std::atomic<int>>(0);
+    auto make_tracked_ref = [frees]() -> tenann::IndexRef {
+        void* buf = std::malloc(kDummyBytes);
+        return std::make_shared<tenann::Index>(
+                buf, tenann::IndexType::kFaissIvfPqOneInvertedList,
+                [frees](void* v) {
+                    frees->fetch_add(1, std::memory_order_relaxed);
+                    std::free(v);
+                },
+                /*explicit_bytes=*/kDummyBytes);
+    };
     tenann::IndexCacheHandle list_handle; // stands in for cache_handles[list_no]
     int loads = 0;
     auto get_ptr = [&]() {
@@ -218,7 +229,7 @@ TEST_F(VectorIndexCacheTest, IvfPqListBlock_GetPtrLoopLoadsOnce) {
             return;
         }
         ++loads;
-        cache_->Insert(key, make_dummy_ref(kDummyBytes, tenann::IndexType::kFaissIvfPqOneInvertedList), &list_handle);
+        cache_->Insert(key, make_tracked_ref(), &list_handle);
     };
 
     for (int scan = 0; scan < 4; ++scan) {
@@ -226,8 +237,11 @@ TEST_F(VectorIndexCacheTest, IvfPqListBlock_GetPtrLoopLoadsOnce) {
         const void* codes = list_handle.index_ref()->index_raw();
         get_ptr(); // get_ids()
         EXPECT_EQ(codes, list_handle.index_ref()->index_raw()) << "scan " << scan;
+        EXPECT_EQ(0, frees->load(std::memory_order_relaxed)) << "scan " << scan;
     }
     EXPECT_EQ(1, loads);
+    list_handle = tenann::IndexCacheHandle{};
+    EXPECT_EQ(1, frees->load(std::memory_order_relaxed));
 }
 
 // Guards the TTL PR's grouping rule: a list block leaves the cache as soon as

--- a/be/test/storage/index/vector/vector_index_cache_test.cpp
+++ b/be/test/storage/index/vector/vector_index_cache_test.cpp
@@ -181,6 +181,83 @@ TEST_F(VectorIndexCacheTest, Insert_ThenLookup_ReturnsSameRef) {
     EXPECT_EQ(ref.get(), h_lkp.index_ref().get());
 }
 
+// tenann's BlockCacheInvertedLists keeps one long-lived IndexCacheHandle per
+// inverted list and re-Lookups through that same handle on every access. That
+// handle is the entry's only external pin, so releasing it before the new pin is
+// taken lets _release_entry()'s DynamicCache::remove() delete the entry -- and
+// the get() right below can then never hit.
+TEST_F(VectorIndexCacheTest, Lookup_ReusedIvfPqListHandleKeepsEntryCached) {
+    const tenann::CacheKey key("/ivfpq.vi_0");
+    auto ref = make_dummy_ref(kDummyBytes, tenann::IndexType::kFaissIvfPqOneInvertedList);
+    tenann::IndexCacheHandle h;
+    cache_->Insert(key, ref, &h);
+    ASSERT_TRUE(h.valid());
+    ASSERT_EQ(1u, cache_->entry_count());
+
+    for (int i = 0; i < 3; ++i) {
+        ASSERT_TRUE(cache_->Lookup(key, &h)) << "iteration " << i;
+        EXPECT_EQ(ref.get(), h.index_ref().get()) << "iteration " << i;
+        EXPECT_EQ(1u, cache_->entry_count()) << "iteration " << i;
+    }
+
+    tenann::IndexCacheHandle bystander;
+    EXPECT_TRUE(cache_->Lookup(key, &bystander));
+    EXPECT_EQ(ref.get(), bystander.index_ref().get());
+}
+
+// Mirrors BlockCacheInvertedLists::get_ptr(): Lookup() through the list's own
+// handle, load and Insert() only on a miss. faiss reads each probed list twice
+// per scan (get_codes() then get_ids()), so a warm list must not reload -- and
+// the buffer the first call returned must outlive the second.
+TEST_F(VectorIndexCacheTest, IvfPqListBlock_GetPtrLoopLoadsOnce) {
+    const tenann::CacheKey key("/ivfpq.vi_7");
+    tenann::IndexCacheHandle list_handle; // stands in for cache_handles[list_no]
+    int loads = 0;
+    auto get_ptr = [&]() {
+        if (cache_->Lookup(key, &list_handle)) {
+            return;
+        }
+        ++loads;
+        cache_->Insert(key, make_dummy_ref(kDummyBytes, tenann::IndexType::kFaissIvfPqOneInvertedList),
+                       &list_handle);
+    };
+
+    for (int scan = 0; scan < 4; ++scan) {
+        get_ptr(); // get_codes()
+        const void* codes = list_handle.index_ref()->index_raw();
+        get_ptr(); // get_ids()
+        EXPECT_EQ(codes, list_handle.index_ref()->index_raw()) << "scan " << scan;
+    }
+    EXPECT_EQ(1, loads);
+}
+
+// Guards the TTL PR's grouping rule: a list block leaves the cache as soon as
+// its owning reader drops the last pin, instead of lingering under its own TTL.
+TEST_F(VectorIndexCacheTest, IvfPqListBlock_RemovedWhenLastPinDrops) {
+    const tenann::CacheKey key("/ivfpq.vi_3");
+    {
+        tenann::IndexCacheHandle h;
+        cache_->Insert(key, make_dummy_ref(kDummyBytes, tenann::IndexType::kFaissIvfPqOneInvertedList), &h);
+        ASSERT_EQ(1u, cache_->entry_count());
+        ASSERT_EQ(kDummyBytes, cache_->memory_usage());
+    }
+    EXPECT_EQ(0u, cache_->entry_count());
+    EXPECT_EQ(0u, cache_->memory_usage());
+
+    tenann::IndexCacheHandle fresh;
+    EXPECT_FALSE(cache_->Lookup(key, &fresh));
+}
+
+// A miss must not leave the caller holding a ref for some other key.
+TEST_F(VectorIndexCacheTest, Lookup_MissClearsPreviousHandle) {
+    tenann::IndexCacheHandle h;
+    cache_->Insert(tenann::CacheKey("/present.vi"), make_dummy_ref(), &h);
+    ASSERT_TRUE(h.valid());
+
+    EXPECT_FALSE(cache_->Lookup(tenann::CacheKey("/absent.vi"), &h));
+    EXPECT_FALSE(h.valid());
+}
+
 TEST_F(VectorIndexCacheTest, GetOrCreate_FirstCallRunsLoader) {
     int calls = 0;
     auto loader = [&]() -> tenann::IndexRef {


### PR DESCRIPTION
## Why I'm doing:

IVF-PQ vector search re-reads every probed inverted list from the `.vi` file on
every access. `BlockCacheInvertedLists` reuses one handle per list, while
`VectorIndexCache::Lookup()` cleared that handle before acquiring its replacement.
The clear dropped the list entry's last external pin, deleted the entry, and made
the following lookup miss. Faiss requests codes and row IDs separately, so this
caused repeated full-list reads and could free the codes buffer before scanning it.

Block caching was also enabled by default. IVF-PQ uses compact product-quantized
codes, so caching the whole index normally has a relatively small and predictable
memory cost. In contrast, cold per-list reads are directly visible in query
latency and can saturate disk I/O. Whole-index caching is therefore the safer
default; memory-constrained deployments can still opt in to block caching.

## What I'm doing:

`VectorIndexCache::Lookup()` now acquires the replacement pin before releasing a
reused handle and clears the handle only on failure. The regression tests verify
that repeated codes/IDs access loads a list once, keeps the first buffer alive,
removes the block when the last pin drops, and clears stale handles on misses.

This PR also changes `enable_vector_index_block_cache` from `true` to `false` by
default. The generated vector-index config forward header is updated with the
same default. User documentation will be updated in a separate documentation PR.

Verified locally:

```
python3 build-support/gen_config_fwd_headers.py --check
bash build-support/check_common_config_header_includes.sh
BUILD_TYPE=Release ./run-be-ut.sh --build-target starrocks_dw_test \
  --module starrocks_dw_test --without-java-ext \
  --gtest_filter 'VectorIndexCacheTest.*:TenANNReaderTest.*:VectorIndexSearchTest.*:SharedDataVectorIndexTest.*'
# 74 tests passed
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
