### PR TITLE
[BugFix] Drop dead index entries instead of failing a non-shared sstable rebuild

### DIFF
--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -75,6 +75,8 @@ bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_rebuild_total("tablet_merge_l
 bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_rebuild_dropped_entries(
         "tablet_merge_legacy_sstable_rebuild_dropped_entries");
 bvar::Adder<int64_t> g_tablet_merge_non_shared_sstable_rebuild_total("tablet_merge_non_shared_sstable_rebuild_total");
+bvar::Adder<int64_t> g_tablet_merge_non_shared_sstable_rebuild_dropped_entries(
+        "tablet_merge_non_shared_sstable_rebuild_dropped_entries");
 
 } // namespace
 
@@ -2543,13 +2545,24 @@ Status rebuild_non_shared_legacy_sstable(TabletManager* tablet_manager, int64_t 
     // post-merge watermark. Per-entry update_max_encoded_rss_rowid_from
     // only widens this initial value as non-tombstone entries are
     // written.
+    // An entry whose rssid projects below the merged id space references a rowset this old
+    // tablet no longer carries (see below); the watermark can sit there too, on a file whose
+    // newest referenced rowset has since been compacted away. Start uninitialized in that case
+    // and let the surviving entries widen it, instead of failing the whole merge.
     const uint32_t source_max_high = extract_rss_rowid_high(src_pb.max_rss_rowid());
-    ASSIGN_OR_RETURN(uint32_t projected_max_high, ctx.map_rssid(source_max_high));
-    uint64_t max_encoded_rss_rowid =
-            encode_rss_rowid(projected_max_high, extract_rss_rowid_low(src_pb.max_rss_rowid()));
-    bool max_encoded_initialized = true;
+    uint64_t max_encoded_rss_rowid = 0;
+    bool max_encoded_initialized = false;
+    if (auto projected_max_high = ctx.map_rssid(source_max_high); projected_max_high.ok()) {
+        max_encoded_rss_rowid =
+                encode_rss_rowid(projected_max_high.value(), extract_rss_rowid_low(src_pb.max_rss_rowid()));
+        max_encoded_initialized = true;
+    } else if (static_cast<int64_t>(source_max_high) + ctx.rssid_offset() >= 0) {
+        // Only the below-the-floor direction is expected; anything else stays fatal.
+        return projected_max_high.status();
+    }
 
     uint64_t kept_entry_count = 0;
+    uint64_t dropped_value_count = 0;
     for (; source_iterator->Valid(); source_iterator->Next()) {
         const Slice entry_key = source_iterator->key();
         const Slice entry_raw_value = source_iterator->value();
@@ -2557,9 +2570,13 @@ Status rebuild_non_shared_legacy_sstable(TabletManager* tablet_manager, int64_t 
         if (!values_pb.ParseFromArray(entry_raw_value.data, static_cast<int>(entry_raw_value.size))) {
             return Status::InternalError("Failed to parse non-shared sstable value during rebuild");
         }
+        IndexValuesWithVerPB kept_pb;
         for (auto& index_value_ref : *values_pb.mutable_values()) {
             auto* index_value = &index_value_ref;
-            if (is_index_tombstone(*index_value)) continue; // preserve sentinel as-is
+            if (is_index_tombstone(*index_value)) {
+                *kept_pb.add_values() = *index_value; // preserve sentinel as-is
+                continue;
+            }
             const int64_t lifted_rssid =
                     static_cast<int64_t>(index_value->rssid()) + static_cast<int64_t>(source_rssid_offset);
             if (lifted_rssid < 0 || lifted_rssid > static_cast<int64_t>(std::numeric_limits<uint32_t>::max())) {
@@ -2567,24 +2584,48 @@ Status rebuild_non_shared_legacy_sstable(TabletManager* tablet_manager, int64_t 
                         "non-shared rebuild: lifted rssid out of uint32 range: stored={} src_offset={} lifted={}",
                         index_value->rssid(), source_rssid_offset, lifted_rssid));
             }
-            ASSIGN_OR_RETURN(uint32_t final_rssid, ctx.map_rssid(static_cast<uint32_t>(lifted_rssid)));
-            index_value->set_rssid(final_rssid);
+            auto final_rssid = ctx.map_rssid(static_cast<uint32_t>(lifted_rssid));
+            if (!final_rssid.ok()) {
+                // ctx.rssid_offset() is next_rowset_id - min_carried_id, so a negative projection
+                // means this entry's rssid sits strictly below the smallest rowset id this old
+                // tablet carries into the merged tablet: the rowset was compacted away and no
+                // segment in the merged metadata can ever resolve the entry. Drop it, exactly as
+                // rebuild_legacy_shared_sstable already drops its out-of-range entries -- failing
+                // instead aborts the merge publish, which the FE then retries forever and the
+                // table stays pinned in TABLET_RESHARD with no abort path.
+                if (lifted_rssid + ctx.rssid_offset() >= 0) {
+                    return final_rssid.status(); // above the space: still fatal
+                }
+                ++dropped_value_count;
+                continue;
+            }
+            index_value->set_rssid(final_rssid.value());
+            *kept_pb.add_values() = *index_value;
         }
-        update_max_encoded_rss_rowid_from(values_pb, &max_encoded_rss_rowid, &max_encoded_initialized);
-        const std::string serialized_entry = values_pb.SerializeAsString();
+        if (kept_pb.values_size() == 0) {
+            // Every version of this key referenced an erased rowset.
+            continue;
+        }
+        update_max_encoded_rss_rowid_from(kept_pb, &max_encoded_rss_rowid, &max_encoded_initialized);
+        const std::string serialized_entry = kept_pb.SerializeAsString();
         RETURN_IF_ERROR(output_writer.table_builder->Add(entry_key, Slice(serialized_entry)));
         ++kept_entry_count;
     }
     RETURN_IF_ERROR(source_iterator->status());
 
+    if (dropped_value_count > 0) {
+        g_tablet_merge_non_shared_sstable_rebuild_dropped_entries << static_cast<int64_t>(dropped_value_count);
+    }
+
     if (kept_entry_count == 0) {
-        // Defensive: SeekToFirst returned Valid() above, so this should
-        // be unreachable, but covers the case where every Add() somehow
-        // got skipped without an error.
+        // Every entry referenced an erased rowset. The cleanup guard deletes the partial
+        // output; leaving out_pb empty tells the caller to drop the sstable from the merged
+        // metadata, matching rebuild_legacy_shared_sstable's all-dropped path.
         return Status::OK();
     }
 
-    RETURN_IF_ERROR(finalize_legacy_rebuild_output(output_writer, max_encoded_rss_rowid, out_pb));
+    RETURN_IF_ERROR(
+            finalize_legacy_rebuild_output(output_writer, max_encoded_initialized ? max_encoded_rss_rowid : 0, out_pb));
     cleanup_partial_output.cancel();
     g_tablet_merge_non_shared_sstable_rebuild_total << 1;
     return Status::OK();

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -12212,5 +12212,162 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_mixed_legacy_and_full_key
     EXPECT_EQ(0, totals[3].num_dels);
 }
 
+// An entry in a NON-shared legacy sstable whose rssid projects below the merged id space must be
+// dropped, not fail the merge. ctx.rssid_offset() is next_rowset_id - min_carried_id, so a negative
+// projection means the entry references a rowset id below the smallest one this old tablet carries
+// into the merged tablet: it was compacted away, no segment in the merged metadata can resolve it,
+// and returning the error instead aborts the reshard publish, which the FE retries forever.
+//
+// rebuild_legacy_shared_sstable already drops its out-of-range entries; this covers the non-shared
+// twin. Layout, chosen so the rebuild path is the one that runs:
+//   ctx[0]: canonical rowset id 10, uid U, ancestor segment_idx 0. next_rowset_id 11.
+//   ctx[1]: local rowset id 100 (own uid, sets the carried floor) + the same-uid duplicate at id
+//           101 carrying segment_idx 1, which dedups into the canonical and therefore populates
+//           shared_rssid_map -- that is what makes ctx_disagreement_keys non-empty and sends the
+//           sstable through rebuild_non_shared_legacy_sstable instead of the PB-level shift.
+//   ctx[1]'s offset is 11 - 100 = -89, so the sstable's stored rssid 50 lifts to -39 (dropped)
+//   while stored rssid 101 resolves through shared_rssid_map to the canonical (kept).
+TEST_F(LakeTabletReshardTest, test_tablet_merging_non_shared_sstable_rebuild_drops_below_floor_entry) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    constexpr uint32_t kCanonicalRowsetId = 10;
+    constexpr uint32_t kLocalRowsetId = 100;
+    constexpr uint32_t kDuplicateRowsetId = 101;
+    constexpr uint32_t kDeadStoredRssid = 50;                 // lifts below zero => dead
+    constexpr uint32_t kLiveStoredRssid = kDuplicateRowsetId; // resolves via shared_rssid_map
+    const std::string kAncestorSegPrefix = "ancestor_seg_";
+
+    auto add_shared_segment = [&](RowsetMetadataPB* rowset, uint32_t segment_idx) {
+        auto* sm = rowset->add_segment_metas();
+        sm->set_filename(fmt::format("{}{}.dat", kAncestorSegPrefix, segment_idx));
+        sm->set_size(128);
+        sm->set_segment_idx(segment_idx);
+        sm->set_shared(true);
+    };
+
+    // ctx[0]: the canonical copy of the ancestor rowset.
+    auto meta_a = std::make_shared<TabletMetadataPB>();
+    meta_a->set_id(child_a);
+    meta_a->set_version(base_version);
+    meta_a->set_next_rowset_id(kCanonicalRowsetId + 1);
+    set_primary_key_schema(meta_a.get(), 1001);
+    {
+        auto* rowset = meta_a->add_rowsets();
+        rowset->set_id(kCanonicalRowsetId);
+        rowset->set_version(base_version);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(128);
+        rowset->set_overlapped(false);
+        add_shared_segment(rowset, 0);
+        stamp_physical_identity_uid(rowset, kAncestorSegPrefix); // same uid across children => dedup
+        (*meta_a->mutable_rowset_to_schema())[kCanonicalRowsetId] = 1001;
+    }
+
+    // ctx[1]: a local rowset that fixes the carried floor at 100, the same-uid duplicate, and a
+    // non-shared sstable holding one dead entry plus one live one.
+    const std::string sst_filename = "non_shared_below_floor.sst";
+    const auto sst_path = _tablet_manager->sst_location(child_b, sst_filename);
+    const uint64_t sst_filesize = write_legacy_pk_sstable(
+            sst_path, {{"k_dead", kDeadStoredRssid, /*rowid=*/0}, {"k_live", kLiveStoredRssid, /*rowid=*/7}});
+
+    auto meta_b = std::make_shared<TabletMetadataPB>();
+    meta_b->set_id(child_b);
+    meta_b->set_version(base_version);
+    meta_b->set_next_rowset_id(kDuplicateRowsetId + 2);
+    set_primary_key_schema(meta_b.get(), 1001);
+    {
+        auto* local = meta_b->add_rowsets();
+        local->set_id(kLocalRowsetId);
+        local->set_version(base_version);
+        local->set_num_rows(5);
+        local->set_data_size(64);
+        local->set_overlapped(false);
+        auto* sm = local->add_segment_metas();
+        sm->set_filename("child_b_local.dat");
+        sm->set_size(64);
+        lake::tablet_reshard_helper::set_rowset_uid(local); // own uid => emitted, never deduped
+        (*meta_b->mutable_rowset_to_schema())[kLocalRowsetId] = 1001;
+
+        auto* duplicate = meta_b->add_rowsets();
+        duplicate->set_id(kDuplicateRowsetId);
+        duplicate->set_version(base_version);
+        duplicate->set_num_rows(10);
+        duplicate->set_data_size(128);
+        duplicate->set_overlapped(false);
+        add_shared_segment(duplicate, 1);
+        stamp_physical_identity_uid(duplicate, kAncestorSegPrefix);
+        (*meta_b->mutable_rowset_to_schema())[kDuplicateRowsetId] = 1001;
+    }
+    {
+        auto* sst = meta_b->mutable_sstable_meta()->add_sstables();
+        sst->set_filename(sst_filename);
+        sst->set_filesize(sst_filesize);
+        sst->set_rssid_offset(0);
+        // High word must reach the disagreement key so needs_rebuild fires.
+        sst->set_max_rss_rowid((static_cast<uint64_t>(kLiveStoredRssid) << 32) | 7);
+    }
+
+    ASSERT_OK(put_tablet_metadata(meta_a));
+    ASSERT_OK(put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(child_a);
+    merging_tablet.add_old_tablet_ids(child_b);
+    merging_tablet.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(2);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(2);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    // Before the fix this returned InvalidArgument("Segment id overflow during tablet merge") from
+    // rebuild_non_shared_legacy_sstable and the MERGE job never left RUNNING.
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto it = tablet_metadatas.find(merged_tablet);
+    ASSERT_TRUE(it != tablet_metadatas.end());
+    const auto& merged = it->second;
+    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
+    const auto& rebuilt = merged->sstable_meta().sstables(0);
+    EXPECT_NE(sst_filename, rebuilt.filename()) << "the rebuild must emit a fresh file";
+    EXPECT_EQ(0, rebuilt.rssid_offset()) << "rebuilt entries are pre-remapped";
+
+    ASSIGN_OR_ABORT(
+            auto rebuilt_sstable,
+            lake::PersistentIndexSstable::new_sstable(
+                    rebuilt, _tablet_manager->sst_location(merged_tablet, rebuilt.filename()),
+                    /*cache=*/nullptr, /*need_filter=*/false, /*delvec=*/nullptr, merged, _tablet_manager.get()));
+    sstable::ReadOptions read_options;
+    read_options.fill_cache = false;
+    std::unique_ptr<sstable::Iterator> iter(rebuilt_sstable->new_iterator(read_options));
+    std::map<std::string, uint32_t> rebuilt_entries;
+    for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+        IndexValuesWithVerPB values_pb;
+        ASSERT_TRUE(values_pb.ParseFromArray(iter->value().data, static_cast<int>(iter->value().size)));
+        ASSERT_GT(values_pb.values_size(), 0);
+        rebuilt_entries.emplace(iter->key().to_string(), values_pb.values(0).rssid());
+    }
+    ASSERT_OK(iter->status());
+
+    EXPECT_FALSE(rebuilt_entries.count("k_dead"))
+            << "an entry below the carried floor references an erased rowset and must be dropped";
+    ASSERT_TRUE(rebuilt_entries.count("k_live")) << "the live entry must survive the rebuild";
+    // The duplicate deduped into the canonical, so its rssid resolves into the canonical's span.
+    EXPECT_GE(rebuilt_entries["k_live"], kCanonicalRowsetId);
+    EXPECT_LE(rebuilt_entries["k_live"], kCanonicalRowsetId + 1);
+}
+
 // =============================================================================
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

Part of #77653. A `MERGE TABLET` on a range-distribution PK table wedges forever:

```
MERGE job 14487 stuck in RUNNING, retried every ~11s:
  Failed to publish version: Fail to publish version for tablets:[[14466,14467,14468,14469]],
  error msg: Segment id overflow during tablet merge
      be/src/storage/lake/tablet_merger.cpp:2570 value_or_err_L2570
      be/src/storage/lake/tablet_merger.cpp:2901 rebuild_non_shared_legacy_sstable(...)
      be/src/storage/lake/tablet_merger.cpp:3008 emit_non_shared_legacy_sstable_into_dest(...)
      be/src/storage/lake/tablet_merger.cpp:3234 merge_sstables(...)
```

`rebuild_non_shared_legacy_sstable` remaps each index entry's rssid through `ctx.map_rssid` and
returned the error when the projection left uint32. That error is not corruption:

```
ctx.rssid_offset() = base_metadata.next_rowset_id() - min_carried_id
mapped = rssid + rssid_offset < 0   <=>   rssid < min_carried_id - next_rowset_id
```

Since `next_rowset_id >= 1`, a negative projection means the entry's rssid sits **strictly below
the smallest rowset id this old tablet carries into the merged tablet**. That rowset was compacted
away, it is not in the merged metadata, and no segment can ever resolve the entry — it is dead.
Failing on it aborts the reshard publish, the FE retries it forever, and the table stays pinned in
`TABLET_RESHARD` with no abort path (`canAbort()` admits only `PENDING`), so the only recovery is
`DROP DATABASE ... FORCE`.

`compute_rssid_offset` cannot avoid this by widening the floor: it derives the floor from rowset
metadata (`rowset.id`, `max_compact_input_rowset_id`, `del_files[].origin_rowset_id`), while these
rssids live *inside* the sstable's entries, which are only read later in `merge_sstables`, after
every offset is already fixed.

The sibling path already got this right — `rebuild_legacy_shared_sstable` counts and drops its
out-of-range entries (`g_tablet_merge_legacy_sstable_rebuild_dropped_entries`) and drops the whole
sstable when nothing survives. Only the non-shared path was left failing.

## What I'm doing:

Drop a value whose projection falls below the merged id space, and drop the whole sstable when
every entry goes (leaving `out_pb` empty, which is the existing "caller drops it" signal, with the
cleanup guard removing the partial output). Dropped values are counted in a new
`tablet_merge_non_shared_sstable_rebuild_dropped_entries` bvar, mirroring the shared path.

The `max_rss_rowid` watermark projection gets the same treatment: a file whose newest referenced
rowset has been compacted away now starts uninitialized and lets the surviving entries widen it,
and the finalize call reuses the shared path's `initialized ? value : 0` guard.

A projection *above* the id space stays fatal in both places — only the below-the-floor direction
is explained by an erased rowset.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

`branch-4.1` carries the same `rebuild_non_shared_legacy_sstable`. `branch-4.0` and `branch-3.5` do
not have the tablet reshard / range distribution feature.
