### PR TITLE
[BugFix] Preserve TopN projection when eliminating sort columns with equality predicates

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/EliminateSortColumnWithEqualityPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/EliminateSortColumnWithEqualityPredicateRule.java
@@ -34,6 +34,7 @@ import com.starrocks.sql.optimizer.rule.RuleType;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class EliminateSortColumnWithEqualityPredicateRule extends TransformationRule {
@@ -62,6 +63,22 @@ public class EliminateSortColumnWithEqualityPredicateRule extends Transformation
         }
 
         if (reservedOrdering.isEmpty()) {
+            // if topn has projection, we should merge topn's projection into scan's projection
+            // partial cherry-pick from https://github.com/StarRocks/starrocks/pull/58345
+            if (topn.getProjection() != null) {
+                if (scan.getProjection() == null) {
+                    scan.setProjection(topn.getProjection());
+                } else {
+                    Map<ColumnRefOperator, ScalarOperator> scanProjectMap = scan.getProjection().getColumnRefMap();
+                    topn.getProjection().getColumnRefMap().forEach(((columnRefOperator, scalarOperator) -> {
+                        if (!scanProjectMap.containsKey(columnRefOperator)) {
+                            scanProjectMap.put(columnRefOperator, scalarOperator);
+                        }
+
+                    }));
+                }
+            }
+
             if (topn.hasLimit()) {
                 // Eliminating the sort removes the only operator that would force a global merge.
                 // This rule runs after the limit split/merge rules, so emitting an init-phase limit

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/EliminateSortColumnWithEqualityPredicateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/EliminateSortColumnWithEqualityPredicateTest.java
@@ -123,4 +123,34 @@ public class EliminateSortColumnWithEqualityPredicateTest extends PlanTestBase {
                 "     offset: 10\n" +
                 "     limit: 30");
     }
+
+    @Test
+    public void testEliminateSortKeepsProjectionHoistedUponTopn() throws Exception {
+        // Regression for the planning error: HoistHeavyCostExprsUponTopnRule hoists the heavy
+        // decimal128 divide into a project above the TopN, which is later merged into the TopN
+        // operator as its projection. When every ORDER BY column is pinned by an equality
+        // predicate, this rule eliminates the TopN; the TopN's projection (holding the divide)
+        // must be merged into the scan's projection instead of being dropped, otherwise plan
+        // translation fails with "Cannot convert ColumnRefOperator to Expr".
+        starRocksAssert.withTable("CREATE TABLE `t_eliminate_sort_hoist` (\n" +
+                "  `k1` varchar(60) NOT NULL,\n" +
+                "  `v1` decimal(28, 8) NULL,\n" +
+                "  `v2` decimal(28, 8) NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k1`)\n" +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 4\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");");
+        try {
+            // v1 and v2 must also be selected as plain columns, otherwise the hoist rule bails out
+            // (the heavy expr's inputs must be pass-through outputs of the project below the TopN)
+            String sql = "select k1, v1, v2, v1 / v2 from t_eliminate_sort_hoist " +
+                    "where k1 = '2026-06' order by k1 limit 10";
+            String plan = getVerboseExplain(sql);
+            // the sort is eliminated, and the hoisted divide is computed by the scan's projection
+            assertContains(plan, "[2: v1, DECIMAL128(28,8), true] / [3: v2, DECIMAL128(28,8), true]");
+            assertNotContains(plan, "TOP-N");
+        } finally {
+            starRocksAssert.dropTable("t_eliminate_sort_hoist");
+        }
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

On branch-3.5 , a query combining a `decimal128`/`largeint` divide in the select list with `ORDER BY <column pinned by an equality predicate> LIMIT N` fails at planning time:

```
Getting analyzing error. Detail message: Cannot convert ColumnRefOperator to Expr,
please check the input expression: 14: expr.
```

Minimal repro:

```sql
CREATE TABLE t (k1 varchar(60) NOT NULL, v1 decimal(28, 8), v2 decimal(28, 8))
DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 4;

SELECT k1, v1, v2, v1 / v2 FROM t WHERE k1 = '2026-06' ORDER BY k1 LIMIT 10;
```

Root cause — an interaction of two rules:

1. `HoistHeavyCostExprsUponTopnRule` (#55417) hoists the heavy divide into a project **above** the TopN so it is only evaluated for the top N rows; `MergeProjectWithChildRule` later merges that project into the TopN operator as its `projection`.
2. `EliminateSortColumnWithEqualityPredicateRule` (#54177) then eliminates the TopN because every ORDER BY column is pinned by an equality predicate — but it drops the TopN's `projection` on the floor. The hoisted divide loses its only definition, and plan translation fails when it finds the column mapped to itself with no child producing it.

main is not affected: #58345 added the "merge the TopN's projection into the scan's projection" logic to this rule. That PR was backported to branch-3.5-cc (#70879) but never to branch-3.5, and the later #75581 backport of #74983 only carried the global-limit fix (the projection-merge lines were context in that diff, not part of it).

Workaround for affected versions: `SET_VAR(cbo_disabled_rules='TF_HOIST_HEAVY_COST_UPON_TOPN')`.

## What I'm doing:

- Partial cherry-pick of the `EliminateSortColumnWithEqualityPredicateRule` hunk from #58345 (without the DeferProjectAfterTopN feature itself): before eliminating the sort, merge the TopN's projection into the scan's projection, only adding entries the scan does not already define.
- Add a regression test that reproduces the customer query shape; it fails with the error above before the fix and passes after. Upstream has no coverage for this path (the #58345 tests only cover DeferProjectAfterTopN scenarios), so the test is new.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

