### PR TITLE
[Tool] DO NOT MERGE: build vehicle for #77994 + #78016 soak validation

### DIFF
--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -3019,8 +3019,48 @@ Status merge_sstables(TabletManager* tablet_manager, std::vector<TabletMergeCont
     return Status::OK();
 }
 
-void update_next_rowset_id(TabletMetadataPB* metadata) {
-    uint32_t max_end = 1; // invariant: next_rowset_id >= 1
+// Every rowset owns the rssid range [id, id + get_rowset_id_step(rowset)). Two rowsets sharing
+// an rssid make the merged tablet unreadable in a way that only shows up later, at publish or
+// PK-index rebuild time, so verify the invariant before the merged metadata escapes.
+Status check_rowset_rssid_spans_disjoint(const TabletMetadataPB& metadata) {
+    // (span_start -> rowset id), walked in id order so only adjacent spans need comparing.
+    std::map<uint32_t, std::pair<uint32_t, uint32_t>> spans; // start -> (end_exclusive, rowset_id)
+    for (const auto& rowset : metadata.rowsets()) {
+        const uint32_t start = rowset.id();
+        const uint32_t end = start + get_rowset_id_step(rowset);
+        auto [iter, inserted] = spans.try_emplace(start, std::make_pair(end, rowset.id()));
+        if (!inserted) {
+            return Status::Corruption(fmt::format(
+                    "tablet merge produced two rowsets at the same id: tablet={} rowset_id={}", metadata.id(), start));
+        }
+    }
+    uint32_t prev_end = 0;
+    uint32_t prev_id = 0;
+    bool have_prev = false;
+    for (const auto& [start, end_and_id] : spans) {
+        const auto& [end, rowset_id] = end_and_id;
+        if (have_prev && start < prev_end) {
+            return Status::Corruption(fmt::format(
+                    "tablet merge produced overlapping rssid spans: tablet={} rowset {} ends at {} but rowset {} "
+                    "starts at {}",
+                    metadata.id(), prev_id, prev_end, rowset_id, start));
+        }
+        prev_end = end;
+        prev_id = rowset_id;
+        have_prev = true;
+    }
+    return Status::OK();
+}
+
+// |floor| is the highest id space any contributing old tablet had already consumed, projected
+// into the merged space. Without it this function derives the watermark purely from what the
+// merged output still HOLDS, which can sit BELOW what an input had already handed out: a merge
+// that retains only segment_idx 0 of an ancestor rowset lowers the watermark to id+1, a later
+// local write on the merged tablet takes id+1, and a subsequent merge that reunites a same-uid
+// sibling carrying segment_idx 1 and 2 expands that rowset back over the local one -- two
+// rowsets in ONE context sharing an rssid, which no per-context offset can separate.
+void update_next_rowset_id(TabletMetadataPB* metadata, uint32_t floor) {
+    uint32_t max_end = std::max<uint32_t>(1, floor); // invariant: next_rowset_id >= 1
     for (const auto& rowset : metadata->rowsets()) {
         max_end = std::max(max_end, rowset.id() + get_rowset_id_step(rowset));
     }
@@ -3234,7 +3274,27 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
     RETURN_IF_ERROR(merge_sstables(tablet_manager, merge_contexts, new_tablet_metadata.get()));
 
     // Phase 4: Finalize
-    update_next_rowset_id(new_tablet_metadata.get());
+    //
+    // Never let the watermark regress below what a contributing old tablet already handed out:
+    // ids stay monotone across reshards, so a later local write cannot land inside an ancestor
+    // rowset's span that a partial merge is no longer holding. See update_next_rowset_id.
+    uint32_t consumed_id_floor = 1;
+    for (const auto& ctx : merge_contexts) {
+        const int64_t projected = static_cast<int64_t>(ctx.metadata()->next_rowset_id()) + ctx.rssid_offset();
+        consumed_id_floor = std::max<uint32_t>(
+                consumed_id_floor,
+                static_cast<uint32_t>(std::clamp<int64_t>(projected, 1, std::numeric_limits<uint32_t>::max())));
+    }
+    update_next_rowset_id(new_tablet_metadata.get(), consumed_id_floor);
+
+    // Fail closed rather than publish a self-overlapping rssid space. The reservations above
+    // keep newly written metadata clear, but a tablet whose metadata was produced before that
+    // was true can still arrive here with a local rowset sitting inside an ancestor span that
+    // this merge's union re-expands, and no per-context offset can separate two rowsets of the
+    // SAME context. Emitting it would corrupt the merged tablet silently: meta_file.cpp keys
+    // segment_id_to_rowset on rssid, so one rowset shadows the other and a publish either
+    // resolves a key to a rowset that no longer owns it or fails with "unexpected segment id".
+    RETURN_IF_ERROR(check_rowset_rssid_spans_disjoint(*new_tablet_metadata));
 
     // No re-share here: the merged tablet OWNS its segments via the same ownership-transfer
     // model that the identical-tablet and split paths already use. The source old tablets

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -75,6 +75,8 @@ bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_rebuild_total("tablet_merge_l
 bvar::Adder<int64_t> g_tablet_merge_legacy_sstable_rebuild_dropped_entries(
         "tablet_merge_legacy_sstable_rebuild_dropped_entries");
 bvar::Adder<int64_t> g_tablet_merge_non_shared_sstable_rebuild_total("tablet_merge_non_shared_sstable_rebuild_total");
+bvar::Adder<int64_t> g_tablet_merge_non_shared_sstable_rebuild_dropped_entries(
+        "tablet_merge_non_shared_sstable_rebuild_dropped_entries");
 
 } // namespace
 
@@ -2543,13 +2545,24 @@ Status rebuild_non_shared_legacy_sstable(TabletManager* tablet_manager, int64_t 
     // post-merge watermark. Per-entry update_max_encoded_rss_rowid_from
     // only widens this initial value as non-tombstone entries are
     // written.
+    // An entry whose rssid projects below the merged id space references a rowset this old
+    // tablet no longer carries (see below); the watermark can sit there too, on a file whose
+    // newest referenced rowset has since been compacted away. Start uninitialized in that case
+    // and let the surviving entries widen it, instead of failing the whole merge.
     const uint32_t source_max_high = extract_rss_rowid_high(src_pb.max_rss_rowid());
-    ASSIGN_OR_RETURN(uint32_t projected_max_high, ctx.map_rssid(source_max_high));
-    uint64_t max_encoded_rss_rowid =
-            encode_rss_rowid(projected_max_high, extract_rss_rowid_low(src_pb.max_rss_rowid()));
-    bool max_encoded_initialized = true;
+    uint64_t max_encoded_rss_rowid = 0;
+    bool max_encoded_initialized = false;
+    if (auto projected_max_high = ctx.map_rssid(source_max_high); projected_max_high.ok()) {
+        max_encoded_rss_rowid =
+                encode_rss_rowid(projected_max_high.value(), extract_rss_rowid_low(src_pb.max_rss_rowid()));
+        max_encoded_initialized = true;
+    } else if (static_cast<int64_t>(source_max_high) + ctx.rssid_offset() >= 0) {
+        // Only the below-the-floor direction is expected; anything else stays fatal.
+        return projected_max_high.status();
+    }
 
     uint64_t kept_entry_count = 0;
+    uint64_t dropped_value_count = 0;
     for (; source_iterator->Valid(); source_iterator->Next()) {
         const Slice entry_key = source_iterator->key();
         const Slice entry_raw_value = source_iterator->value();
@@ -2557,9 +2570,13 @@ Status rebuild_non_shared_legacy_sstable(TabletManager* tablet_manager, int64_t 
         if (!values_pb.ParseFromArray(entry_raw_value.data, static_cast<int>(entry_raw_value.size))) {
             return Status::InternalError("Failed to parse non-shared sstable value during rebuild");
         }
+        IndexValuesWithVerPB kept_pb;
         for (auto& index_value_ref : *values_pb.mutable_values()) {
             auto* index_value = &index_value_ref;
-            if (is_index_tombstone(*index_value)) continue; // preserve sentinel as-is
+            if (is_index_tombstone(*index_value)) {
+                *kept_pb.add_values() = *index_value; // preserve sentinel as-is
+                continue;
+            }
             const int64_t lifted_rssid =
                     static_cast<int64_t>(index_value->rssid()) + static_cast<int64_t>(source_rssid_offset);
             if (lifted_rssid < 0 || lifted_rssid > static_cast<int64_t>(std::numeric_limits<uint32_t>::max())) {
@@ -2567,24 +2584,48 @@ Status rebuild_non_shared_legacy_sstable(TabletManager* tablet_manager, int64_t 
                         "non-shared rebuild: lifted rssid out of uint32 range: stored={} src_offset={} lifted={}",
                         index_value->rssid(), source_rssid_offset, lifted_rssid));
             }
-            ASSIGN_OR_RETURN(uint32_t final_rssid, ctx.map_rssid(static_cast<uint32_t>(lifted_rssid)));
-            index_value->set_rssid(final_rssid);
+            auto final_rssid = ctx.map_rssid(static_cast<uint32_t>(lifted_rssid));
+            if (!final_rssid.ok()) {
+                // ctx.rssid_offset() is next_rowset_id - min_carried_id, so a negative projection
+                // means this entry's rssid sits strictly below the smallest rowset id this old
+                // tablet carries into the merged tablet: the rowset was compacted away and no
+                // segment in the merged metadata can ever resolve the entry. Drop it, exactly as
+                // rebuild_legacy_shared_sstable already drops its out-of-range entries -- failing
+                // instead aborts the merge publish, which the FE then retries forever and the
+                // table stays pinned in TABLET_RESHARD with no abort path.
+                if (lifted_rssid + ctx.rssid_offset() >= 0) {
+                    return final_rssid.status(); // above the space: still fatal
+                }
+                ++dropped_value_count;
+                continue;
+            }
+            index_value->set_rssid(final_rssid.value());
+            *kept_pb.add_values() = *index_value;
         }
-        update_max_encoded_rss_rowid_from(values_pb, &max_encoded_rss_rowid, &max_encoded_initialized);
-        const std::string serialized_entry = values_pb.SerializeAsString();
+        if (kept_pb.values_size() == 0) {
+            // Every version of this key referenced an erased rowset.
+            continue;
+        }
+        update_max_encoded_rss_rowid_from(kept_pb, &max_encoded_rss_rowid, &max_encoded_initialized);
+        const std::string serialized_entry = kept_pb.SerializeAsString();
         RETURN_IF_ERROR(output_writer.table_builder->Add(entry_key, Slice(serialized_entry)));
         ++kept_entry_count;
     }
     RETURN_IF_ERROR(source_iterator->status());
 
+    if (dropped_value_count > 0) {
+        g_tablet_merge_non_shared_sstable_rebuild_dropped_entries << static_cast<int64_t>(dropped_value_count);
+    }
+
     if (kept_entry_count == 0) {
-        // Defensive: SeekToFirst returned Valid() above, so this should
-        // be unreachable, but covers the case where every Add() somehow
-        // got skipped without an error.
+        // Every entry referenced an erased rowset. The cleanup guard deletes the partial
+        // output; leaving out_pb empty tells the caller to drop the sstable from the merged
+        // metadata, matching rebuild_legacy_shared_sstable's all-dropped path.
         return Status::OK();
     }
 
-    RETURN_IF_ERROR(finalize_legacy_rebuild_output(output_writer, max_encoded_rss_rowid, out_pb));
+    RETURN_IF_ERROR(
+            finalize_legacy_rebuild_output(output_writer, max_encoded_initialized ? max_encoded_rss_rowid : 0, out_pb));
     cleanup_partial_output.cancel();
     g_tablet_merge_non_shared_sstable_rebuild_total << 1;
     return Status::OK();

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -2766,6 +2766,50 @@ ClampedLiftedRange clamp_lifted_range_to_uint32(int32_t source_rssid_offset, uin
     return range;
 }
 
+// The rssid step a canonical rowset actually occupies once update_canonical has folded its
+// same-uid duplicates in, indexed by the plan's output index.
+//
+// get_rowset_id_step() answers for one rowset's own segment list, but union_segments_by_idx
+// keys the union on segment_idx, and a multi-level split hands same-uid siblings DISJOINT
+// pruned segment subsets (compute_rowset_segment_ownership keeps shared=true regardless of
+// overlap count). A duplicate can therefore contribute a segment_idx ABOVE anything in the
+// canonical's own list: canonical {idx 0} + sibling {idx 1, 2} occupies three rssids, not one.
+// Reserving only the canonical's own step lets the next input's lifted ids land inside that
+// span, so two rowsets share an rssid -- which surfaces as the PK index rebuild reaching the
+// same key from two different physical segments under one rssid and failing the merge publish
+// forever with "insert found duplicate key".
+//
+// Duplicates from ANY input widen their canonical, including inputs at or above the
+// upper_exclusive the ceiling is being computed for: the union happens in Phase 2, long after
+// every offset is fixed, so the reservation cannot depend on input order.
+std::vector<uint32_t> compute_post_union_rowset_id_steps(const std::vector<TabletMergeContext>& merge_contexts,
+                                                         const RowsetEmissionPlan& emission_plan) {
+    size_t num_outputs = 0;
+    for (const auto& per_source : emission_plan) {
+        for (const auto& decision : per_source) {
+            if (decision.canonical_index >= 0) {
+                num_outputs = std::max(num_outputs, static_cast<size_t>(decision.canonical_index) + 1);
+            }
+        }
+    }
+    // invariant: every rowset occupies at least one id, matching get_rowset_id_step()
+    std::vector<uint32_t> steps(num_outputs, 1);
+    for (size_t j = 0; j < emission_plan.size(); ++j) {
+        const auto& metadata = *merge_contexts[j].metadata();
+        for (int rowset_index = 0; rowset_index < metadata.rowsets_size(); ++rowset_index) {
+            const auto& decision = emission_plan[j][rowset_index];
+            if (decision.canonical_index < 0) continue;
+            const auto& rowset = metadata.rowsets(rowset_index);
+            // A deduped delete predicate keeps projecting its own id (projects_via_rssid_offset)
+            // and carries no segments, so it never widens the canonical it dedups against.
+            if (!decision.emit && rowset.has_delete_predicate()) continue;
+            auto& step = steps[decision.canonical_index];
+            step = std::max(step, get_rowset_id_step(rowset));
+        }
+    }
+    return steps;
+}
+
 // Returns the highest (rowset.id + step + ctx.rssid_offset) seen across
 // merge_contexts[0..upper_exclusive), or |base_next_rowset_id| if higher.
 // Phase 1 in merge_tablet uses this as the watermark for ctx[i]'s
@@ -2775,26 +2819,36 @@ ClampedLiftedRange clamp_lifted_range_to_uint32(int32_t source_rssid_offset, uin
 // Only rowsets that project through their own ctx's rssid_offset are counted, the
 // same set compute_rssid_offset derives the floor from. A discarded duplicate's ids
 // resolve to the canonical rowset instead, which an earlier ctx already contributed
-// to this ceiling, so reserving room for it here would lift later inputs over an
-// unoccupied hole -- with three or more siblings whose id counters have diverged that
-// alone can push map_rssid past UINT32_MAX.
+// to this ceiling, so reserving a separate span for it here would lift later inputs over
+// an unoccupied hole -- with three or more siblings whose id counters have diverged that
+// alone can push map_rssid past UINT32_MAX. What the discarded duplicate does still do is
+// widen the canonical's own span through union_segments_by_idx, which |post_union_steps|
+// accounts for; that grows no hole because the canonical really occupies those ids.
 //
 // Each uint32_t addend is widened to int64_t before the addition to avoid
 // uint32_t wrap when rowset.id() approaches UINT32_MAX — wrap there would
 // under-estimate the watermark and let later old tablets reuse occupied rssids.
 uint32_t compute_cumulative_rowset_id_ceiling(const std::vector<TabletMergeContext>& merge_contexts,
-                                              const RowsetEmissionPlan& emission_plan, size_t upper_exclusive,
+                                              const RowsetEmissionPlan& emission_plan,
+                                              const std::vector<uint32_t>& post_union_steps, size_t upper_exclusive,
                                               uint32_t base_next_rowset_id) {
     uint32_t ceiling = base_next_rowset_id;
     for (size_t j = 0; j < upper_exclusive; ++j) {
         const auto& metadata = *merge_contexts[j].metadata();
         for (int rowset_index = 0; rowset_index < metadata.rowsets_size(); ++rowset_index) {
+            const auto& decision = emission_plan[j][rowset_index];
             const auto& rowset = metadata.rowsets(rowset_index);
-            if (!projects_via_rssid_offset(emission_plan[j][rowset_index], rowset)) continue;
+            if (!projects_via_rssid_offset(decision, rowset)) continue;
 
-            const int64_t end_wide = static_cast<int64_t>(rowset.id()) +
-                                     static_cast<int64_t>(get_rowset_id_step(rowset)) +
-                                     merge_contexts[j].rssid_offset();
+            // An emitted rowset is the canonical of its dedup group, so it must reserve the
+            // group's post-union span. A discarded delete predicate projects only its own id.
+            const bool use_group_step = decision.emit && decision.canonical_index >= 0 &&
+                                        static_cast<size_t>(decision.canonical_index) < post_union_steps.size();
+            const uint32_t step =
+                    use_group_step ? post_union_steps[decision.canonical_index] : get_rowset_id_step(rowset);
+
+            const int64_t end_wide =
+                    static_cast<int64_t>(rowset.id()) + static_cast<int64_t>(step) + merge_contexts[j].rssid_offset();
             const uint32_t end =
                     static_cast<uint32_t>(std::clamp<int64_t>(end_wide, 0, std::numeric_limits<uint32_t>::max()));
             ceiling = std::max(ceiling, end);
@@ -3114,10 +3168,16 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
     // earlier ctxs[0..i-1]'s projected rowset ids; compute_rssid_offset
     // then derives ctx[i].rssid_offset against that watermark so its
     // projected ids land strictly above every earlier ctx's.
+    //
+    // Computed once, over every input: Phase 2's union_segments_by_idx can widen a
+    // canonical rowset's segment_idx span with segments from a duplicate in ANY input, so
+    // each canonical must reserve its post-union span before any offset is fixed.
+    const std::vector<uint32_t> post_union_steps =
+            compute_post_union_rowset_id_steps(merge_contexts, rowset_emission_plan);
     for (size_t i = 1; i < merge_contexts.size(); ++i) {
-        const uint32_t cumulative_ceiling =
-                compute_cumulative_rowset_id_ceiling(merge_contexts, rowset_emission_plan, /*upper_exclusive=*/i,
-                                                     merge_contexts.front().metadata()->next_rowset_id());
+        const uint32_t cumulative_ceiling = compute_cumulative_rowset_id_ceiling(
+                merge_contexts, rowset_emission_plan, post_union_steps, /*upper_exclusive=*/i,
+                merge_contexts.front().metadata()->next_rowset_id());
         new_tablet_metadata->set_next_rowset_id(cumulative_ceiling);
         const int64_t rssid_offset =
                 compute_rssid_offset(*new_tablet_metadata, merge_contexts, rowset_emission_plan, i);

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -12362,5 +12362,190 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_reserves_canonical_post_union_
     EXPECT_GT(merged->next_rowset_id(), max_occupied);
 }
 
+// The same-context half of the reservation problem (Codex review on #77994).
+//
+// A merge that retains only segment_idx 0 of an ancestor rowset used to let update_next_rowset_id
+// recompute the watermark from what the output still HOLDS -- id+1 -- losing the memory of the
+// ancestor's wider span. A local write on the merged tablet then took id+1, and a later merge that
+// reunited a same-uid sibling carrying segment_idx 1 and 2 expanded that rowset back over the local
+// one. Both then live in the SAME merge context, which shares one rssid_offset, so no ceiling
+// widening can separate them.
+//
+// Guarantee 1 (prevention): the merged watermark never regresses below what any contributing old
+// tablet already handed out, so the local write lands above the ancestor span in the first place.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_next_rowset_id_never_regresses) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t sibling_a = next_id();
+    const int64_t sibling_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(sibling_a);
+    prepare_tablet_dirs(sibling_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    constexpr uint32_t kAncestorRowsetId = 10;
+    // The ancestor rowset had 3 segments, so both children's next_rowset_id already cleared 13.
+    constexpr uint32_t kAncestorNextRowsetId = kAncestorRowsetId + 3;
+    const std::string kSharedSegmentPrefix = "ancestor_seg_";
+
+    auto build_child = [&](int64_t tablet_id, std::vector<uint32_t> retained_idx) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(kAncestorNextRowsetId);
+        set_primary_key_schema(meta.get(), 1001);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(kAncestorRowsetId);
+        rowset->set_version(base_version);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(128);
+        rowset->set_overlapped(false);
+        for (uint32_t idx : retained_idx) {
+            auto* sm = rowset->add_segment_metas();
+            sm->set_filename(fmt::format("{}{}.dat", kSharedSegmentPrefix, idx));
+            sm->set_size(128);
+            sm->set_segment_idx(idx);
+            sm->set_shared(true);
+        }
+        stamp_physical_identity_uid(rowset, kSharedSegmentPrefix); // same uid => dedup
+        (*meta->mutable_rowset_to_schema())[kAncestorRowsetId] = 1001;
+        return meta;
+    };
+
+    // A partial merge: this pair only carries segment_idx 0, so the output holds one rssid.
+    auto meta_a = build_child(sibling_a, {0});
+    auto meta_b = build_child(sibling_b, {0});
+    ASSERT_OK(put_tablet_metadata(meta_a));
+    ASSERT_OK(put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(sibling_a);
+    merging_tablet.add_old_tablet_ids(sibling_b);
+    merging_tablet.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(2);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(2);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto it = tablet_metadatas.find(merged_tablet);
+    ASSERT_TRUE(it != tablet_metadatas.end());
+    const auto& merged = it->second;
+
+    // Before the fix this was kAncestorRowsetId + 1 == 11: the ancestor's segment_idx 1 and 2 were
+    // no longer held by the output, so the watermark forgot them and the next local write would
+    // take id 11 -- inside the span a later re-merge re-expands.
+    EXPECT_GE(merged->next_rowset_id(), kAncestorNextRowsetId)
+            << "merged watermark regressed below what the inputs already consumed";
+}
+
+// Guarantee 2 (fail closed): metadata written before guarantee 1 existed can still arrive with a
+// local rowset inside an ancestor span that this merge's union re-expands. Publishing it would
+// corrupt the merged tablet silently, so the merge must refuse instead.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_same_context_rssid_overlap) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t sibling_a = next_id();
+    const int64_t sibling_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(sibling_a);
+    prepare_tablet_dirs(sibling_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    constexpr uint32_t kAncestorRowsetId = 10;
+    const std::string kSharedSegmentPrefix = "ancestor_seg_";
+    auto add_shared_segment = [&](RowsetMetadataPB* rowset, uint32_t segment_idx) {
+        auto* sm = rowset->add_segment_metas();
+        sm->set_filename(fmt::format("{}{}.dat", kSharedSegmentPrefix, segment_idx));
+        sm->set_size(128);
+        sm->set_segment_idx(segment_idx);
+        sm->set_shared(true);
+    };
+
+    // ctx[0]: keeps ancestor segment_idx 0 AND -- the legacy state -- a local rowset that a
+    // regressed watermark handed id 11, right inside the ancestor's span.
+    auto meta_a = std::make_shared<TabletMetadataPB>();
+    meta_a->set_id(sibling_a);
+    meta_a->set_version(base_version);
+    meta_a->set_next_rowset_id(kAncestorRowsetId + 2);
+    set_primary_key_schema(meta_a.get(), 1001);
+    {
+        auto* rowset = meta_a->add_rowsets();
+        rowset->set_id(kAncestorRowsetId);
+        rowset->set_version(base_version);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(128);
+        rowset->set_overlapped(false);
+        add_shared_segment(rowset, 0);
+        stamp_physical_identity_uid(rowset, kSharedSegmentPrefix);
+        (*meta_a->mutable_rowset_to_schema())[kAncestorRowsetId] = 1001;
+
+        auto* local = meta_a->add_rowsets();
+        local->set_id(kAncestorRowsetId + 1); // collides once the union restores segment_idx 1
+        local->set_version(base_version);
+        local->set_num_rows(5);
+        local->set_data_size(64);
+        local->set_overlapped(false);
+        auto* sm = local->add_segment_metas();
+        sm->set_filename("sibling_a_local.dat");
+        sm->set_size(64);
+        lake::tablet_reshard_helper::set_rowset_uid(local); // distinct uid => never deduped
+        (*meta_a->mutable_rowset_to_schema())[kAncestorRowsetId + 1] = 1001;
+    }
+
+    // ctx[1]: the same-uid sibling holding ancestor segment_idx 1 and 2.
+    auto meta_b = std::make_shared<TabletMetadataPB>();
+    meta_b->set_id(sibling_b);
+    meta_b->set_version(base_version);
+    meta_b->set_next_rowset_id(kAncestorRowsetId + 3);
+    set_primary_key_schema(meta_b.get(), 1001);
+    {
+        auto* rowset = meta_b->add_rowsets();
+        rowset->set_id(kAncestorRowsetId);
+        rowset->set_version(base_version);
+        rowset->set_num_rows(20);
+        rowset->set_data_size(256);
+        rowset->set_overlapped(false);
+        add_shared_segment(rowset, 1);
+        add_shared_segment(rowset, 2);
+        stamp_physical_identity_uid(rowset, kSharedSegmentPrefix);
+        (*meta_b->mutable_rowset_to_schema())[kAncestorRowsetId] = 1001;
+    }
+
+    ASSERT_OK(put_tablet_metadata(meta_a));
+    ASSERT_OK(put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(sibling_a);
+    merging_tablet.add_old_tablet_ids(sibling_b);
+    merging_tablet.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(2);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(2);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    auto st = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges);
+
+    // Before the fix this returned OK and emitted metadata where the canonical's folded
+    // segment_idx 1 and ctx[0]'s local rowset both claimed rssid 11.
+    ASSERT_FALSE(st.ok()) << "merge must refuse to publish a self-overlapping rssid space";
+    EXPECT_TRUE(st.message().find("overlapping rssid spans") != std::string::npos ||
+                st.message().find("same id") != std::string::npos)
+            << "unexpected error: " << st.to_string();
+}
+
 // =============================================================================
 } // namespace starrocks

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -12212,5 +12212,155 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_mixed_legacy_and_full_key
     EXPECT_EQ(0, totals[3].num_dels);
 }
 
+// A canonical rowset must reserve the rssid span it occupies AFTER update_canonical folds its
+// same-uid duplicates in, not just the span its own segment list needs.
+//
+// A multi-level split hands same-uid siblings DISJOINT pruned subsets of the ancestor's
+// segments, so the sibling can own a HIGHER segment_idx than the canonical does. Phase 2's
+// union_segments_by_idx folds those segments into the canonical, widening its
+// segment_idx range -- but Phase 1 reserved only get_rowset_id_step(canonical), because
+// projects_via_rssid_offset excludes the discarded duplicate. The next input's ids were then
+// lifted to just above the too-small reservation and landed INSIDE the canonical's real span,
+// so two rowsets in the merged metadata share an rssid.
+//
+// Both production symptoms follow from that collision, because meta_file.cpp keys
+// segment_id_to_rowset on rssid: the loser's segments stop being reachable, so publishing an
+// upsert whose index entry points at them fails with "unexpected segment id", and a later
+// PK-index rebuild reaches one key from two different physical segments under one rssid and
+// fails with "insert found duplicate key". Either one pins the reshard job forever.
+//
+// Layout: ctx[0] keeps ancestor segment_idx 0, ctx[1] keeps segment_idx 1 and 2 of the SAME
+// uid, and ctx[1] also owns a second, independent rowset that must not be lifted into the
+// canonical's [id .. id+2] span.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_reserves_canonical_post_union_rssid_span) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t sibling_a = next_id();
+    const int64_t sibling_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(sibling_a);
+    prepare_tablet_dirs(sibling_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    constexpr uint32_t kSharedRowsetId = 10;
+    const std::string kSharedSegmentPrefix = "ancestor_seg_";
+
+    // One ancestor segment of the shared rowset, kept by whichever child owns its key slice.
+    auto add_shared_segment = [&](RowsetMetadataPB* rowset, uint32_t segment_idx) {
+        auto* sm = rowset->add_segment_metas();
+        sm->set_filename(fmt::format("{}{}.dat", kSharedSegmentPrefix, segment_idx));
+        sm->set_size(128);
+        sm->set_segment_idx(segment_idx);
+        sm->set_shared(true);
+    };
+
+    // ctx[0]: retains ancestor segment_idx 0 only -> get_rowset_id_step() == 1.
+    auto meta_a = std::make_shared<TabletMetadataPB>();
+    meta_a->set_id(sibling_a);
+    meta_a->set_version(base_version);
+    meta_a->set_next_rowset_id(kSharedRowsetId + 1);
+    set_primary_key_schema(meta_a.get(), 1001);
+    {
+        auto* rowset = meta_a->add_rowsets();
+        rowset->set_id(kSharedRowsetId);
+        rowset->set_version(base_version);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(128);
+        rowset->set_overlapped(false);
+        add_shared_segment(rowset, 0);
+        // same uid across siblings => the merge dedups them onto one canonical
+        stamp_physical_identity_uid(rowset, kSharedSegmentPrefix);
+        (*meta_a->mutable_rowset_to_schema())[kSharedRowsetId] = 1001;
+    }
+
+    // ctx[1]: retains ancestor segment_idx 1 and 2 of the SAME uid, so the union widens the
+    // canonical to three rssids. Its own second rowset sits right above its shared copy.
+    auto meta_b = std::make_shared<TabletMetadataPB>();
+    meta_b->set_id(sibling_b);
+    meta_b->set_version(base_version);
+    meta_b->set_next_rowset_id(kSharedRowsetId + 4);
+    set_primary_key_schema(meta_b.get(), 1001);
+    {
+        auto* rowset = meta_b->add_rowsets();
+        rowset->set_id(kSharedRowsetId);
+        rowset->set_version(base_version);
+        rowset->set_num_rows(20);
+        rowset->set_data_size(256);
+        rowset->set_overlapped(false);
+        add_shared_segment(rowset, 1);
+        add_shared_segment(rowset, 2);
+        stamp_physical_identity_uid(rowset, kSharedSegmentPrefix);
+        (*meta_b->mutable_rowset_to_schema())[kSharedRowsetId] = 1001;
+    }
+    {
+        auto* rowset = meta_b->add_rowsets();
+        rowset->set_id(kSharedRowsetId + 3);
+        rowset->set_version(base_version);
+        rowset->set_num_rows(5);
+        rowset->set_data_size(64);
+        rowset->set_overlapped(false);
+        auto* sm = rowset->add_segment_metas();
+        sm->set_filename("sibling_b_local.dat");
+        sm->set_size(64);
+        lake::tablet_reshard_helper::set_rowset_uid(rowset); // distinct uid => never deduped
+        (*meta_b->mutable_rowset_to_schema())[kSharedRowsetId + 3] = 1001;
+    }
+
+    ASSERT_OK(put_tablet_metadata(meta_a));
+    ASSERT_OK(put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(sibling_a);
+    merging_tablet.add_old_tablet_ids(sibling_b);
+    merging_tablet.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(2);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(2);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto it = tablet_metadatas.find(merged_tablet);
+    ASSERT_TRUE(it != tablet_metadatas.end());
+    const auto& merged = it->second;
+
+    // The two shared copies dedup into one canonical carrying all three ancestor segments.
+    const RowsetMetadataPB* canonical = nullptr;
+    for (const auto& rowset : merged->rowsets()) {
+        if (rowset.segment_metas_size() == 3) {
+            canonical = &rowset;
+            break;
+        }
+    }
+    ASSERT_TRUE(canonical != nullptr) << "the union must fold all three ancestor segments into one rowset";
+
+    // Every rssid in the merged metadata must be owned by exactly one rowset -- the invariant
+    // meta_file.cpp's segment_id_to_rowset and the PK index rebuild both rely on. Before the
+    // fix, sibling_b's local rowset was lifted onto kSharedRowsetId + 1, colliding with the
+    // canonical's ancestor segment_idx 1.
+    std::map<uint32_t, uint32_t> rssid_owner; // rssid -> owning rowset id
+    for (const auto& rowset : merged->rowsets()) {
+        for (int i = 0; i < rowset.segment_metas_size(); ++i) {
+            const uint32_t rssid = lake::get_rssid(rowset, i);
+            auto [iter, inserted] = rssid_owner.try_emplace(rssid, rowset.id());
+            EXPECT_TRUE(inserted) << "rssid " << rssid << " is claimed by rowset " << iter->second << " and by rowset "
+                                  << rowset.id();
+        }
+    }
+
+    // next_rowset_id must clear every occupied rssid so later writes never reuse one.
+    uint32_t max_occupied = 0;
+    for (const auto& [rssid, owner] : rssid_owner) {
+        max_occupied = std::max(max_occupied, rssid);
+    }
+    EXPECT_GT(merged->next_rowset_id(), max_occupied);
+}
+
 // =============================================================================
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

**Do not review or merge — validation vehicle only.** This is #77994 and #78016 stacked so TSP can
build one binary carrying both, which is needed to reach the failure that sits *behind* them.

#78016 alone moves the merge soak from wedging at 6 splits / 6 merges to surviving 34; without it a
cluster run never reaches the 27–34 merge range where the remaining
`unexpected segment id: <rssid> tablet id: <merged tablet>` wedge appears. Building the two PRs
separately therefore cannot test whether #77994's watermark/fail-closed half affects that wedge.

Contents, unmodified from their own PRs:
- #77994 `[BugFix] Reserve a canonical rowset's post-union rssid span during tablet merge` (+ the
  review follow-up covering the canonical's own context)
- #78016 `[BugFix] Drop dead index entries instead of failing a non-shared sstable rebuild`

Will be closed once the soak result is recorded.

## What I'm doing:

Nothing new. See the two PRs above.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool
