### PR TITLE
[BugFix] Map a range predicate onto a partition expression only when it is monotonic

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
@@ -387,8 +387,11 @@ public class ColumnFilterConverter {
             // Equality is exempt: a = c implies f(a) = f(c) for any f. This is the same condition
             // ListPartitionPruner.deduceExtraConjuncts applies to the LIST-partition rewrite.
             BinaryType binaryType = ((BinaryPredicateOperator) predicate).getBinaryType();
+            // Check the whole rewritten expression, not the CallOperator getCallOperator() digs out
+            // of it: that helper strips the enclosing cast, and a cast is exactly what can break the
+            // order -- cast(bill as bigint) maps '99845' to 99845, which sorts the other way round.
             if (!binaryType.isEqual()
-                    && !OperatorFunctionChecker.onlyContainMonotonicFunctions(callOperator).first) {
+                    && !OperatorFunctionChecker.onlyContainMonotonicFunctions(translate).first) {
                 return predicate;
             }
             ScalarOperator evaluation = ScalarOperatorEvaluator.INSTANCE.evaluation(callOperator);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
@@ -55,6 +55,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.LargeInPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.OperatorFunctionChecker;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorEvaluator;
@@ -376,6 +377,18 @@ public class ColumnFilterConverter {
             ScalarOperator translate = SqlToScalarOperatorTranslator.translate(predicateExpr);
             CallOperator callOperator = AnalyzerUtils.getCallOperator(translate);
             if (callOperator == null) {
+                return predicate;
+            }
+            // The rewrite keeps the comparison operator and only maps the constant through the
+            // partition expression, so it holds only where that expression preserves order. For a
+            // non-monotonic one -- substr(), a varchar-to-integer cast -- a row whose source value
+            // satisfies the original predicate can carry a partition value that does not satisfy the
+            // rewritten one, and its partition is pruned away, so the row goes silently missing.
+            // Equality is exempt: a = c implies f(a) = f(c) for any f. This is the same condition
+            // ListPartitionPruner.deduceExtraConjuncts applies to the LIST-partition rewrite.
+            BinaryType binaryType = ((BinaryPredicateOperator) predicate).getBinaryType();
+            if (!binaryType.isEqual()
+                    && !OperatorFunctionChecker.onlyContainMonotonicFunctions(callOperator).first) {
                 return predicate;
             }
             ScalarOperator evaluation = ScalarOperatorEvaluator.INSTANCE.evaluation(callOperator);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/OperatorFunctionChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/OperatorFunctionChecker.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.optimizer.operator.scalar;
 
 import com.starrocks.common.Pair;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorEvaluator;
+import com.starrocks.type.Type;
 
 import java.util.function.Predicate;
 
@@ -41,6 +42,22 @@ public class OperatorFunctionChecker {
             return Pair.create(true, "");
         }
 
+        @Override
+        public Pair<Boolean, String> visitCastOperator(CastOperator cast, Void context) {
+            Pair<Boolean, String> result = cast.getChild(0).accept(this, null);
+            if (!result.first) {
+                return result;
+            }
+            // Only some type pairs keep the order. Crossing between strings and numbers or dates
+            // does not: '99845' sorts after '998425506019' while 99845 is far below 998425506019,
+            // so a range predicate mapped through such a cast prunes partitions that hold matching
+            // rows. A narrowing numeric cast wraps or saturates and breaks the order the same way.
+            if (!isOrderPreservingCast(cast.fromType(), cast.getType())) {
+                return Pair.create(false, cast.toString());
+            }
+            return Pair.create(true, "");
+        }
+
         public Pair<Boolean, String> visitCall(CallOperator call, Void context) {
             for (ScalarOperator child : call.getChildren()) {
                 Pair<Boolean, String> result = child.accept(this, null);
@@ -54,6 +71,35 @@ public class OperatorFunctionChecker {
                 return Pair.create(false, call.getFnName());
             }
         }
+    }
+
+    private static int integerRank(Type type) {
+        if (type.isTinyint()) {
+            return 1;
+        } else if (type.isSmallint()) {
+            return 2;
+        } else if (type.isInt()) {
+            return 3;
+        } else if (type.isBigint()) {
+            return 4;
+        } else if (type.isLargeIntType()) {
+            return 5;
+        }
+        return -1;
+    }
+
+    private static boolean isOrderPreservingCast(Type from, Type to) {
+        if (from.equals(to)) {
+            return true;
+        }
+        int fromRank = integerRank(from);
+        int toRank = integerRank(to);
+        if (fromRank > 0 && toRank > 0) {
+            // widening within the integer family keeps every value and its order
+            return toRank >= fromRank;
+        }
+        // DATE and DATETIME order the same way; DATETIME -> DATE truncates, which is non-decreasing
+        return (from.isDate() && to.isDatetime()) || (from.isDatetime() && to.isDate());
     }
 
     public static Pair<Boolean, String> onlyContainPredicates(ScalarOperator scalarOperator,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/OperatorFunctionChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/OperatorFunctionChecker.java
@@ -26,9 +26,13 @@ import java.util.function.Predicate;
 public class OperatorFunctionChecker {
     static class FunctionCheckerVisitor extends ScalarOperatorVisitor<Pair<Boolean, String>, Void> {
         private final Predicate<CallOperator> predicate;
+        // A cast is checked separately from the call predicate: whether a cast is acceptable depends
+        // on what the caller is asking. Every cast is FE-evaluable, but only some keep the order.
+        private final Predicate<CastOperator> castPredicate;
 
-        public FunctionCheckerVisitor(Predicate<CallOperator> predicate) {
+        public FunctionCheckerVisitor(Predicate<CallOperator> predicate, Predicate<CastOperator> castPredicate) {
             this.predicate = predicate;
+            this.castPredicate = castPredicate;
         }
 
         @Override
@@ -48,11 +52,7 @@ public class OperatorFunctionChecker {
             if (!result.first) {
                 return result;
             }
-            // Only some type pairs keep the order. Crossing between strings and numbers or dates
-            // does not: '99845' sorts after '998425506019' while 99845 is far below 998425506019,
-            // so a range predicate mapped through such a cast prunes partitions that hold matching
-            // rows. A narrowing numeric cast wraps or saturates and breaks the order the same way.
-            if (!isOrderPreservingCast(cast.fromType(), cast.getType())) {
+            if (!castPredicate.test(cast)) {
                 return Pair.create(false, cast.toString());
             }
             return Pair.create(true, "");
@@ -88,6 +88,18 @@ public class OperatorFunctionChecker {
         return -1;
     }
 
+    /**
+     * Only some type pairs keep the order. Crossing between strings and numbers or dates does not:
+     * '99845' sorts after '998425506019' while 99845 is far below 998425506019, so a range predicate
+     * mapped through such a cast prunes partitions that hold matching rows. A narrowing numeric cast
+     * wraps or saturates and breaks the order the same way.
+     * <p>
+     * This is a question about monotonicity alone. Equality maps soundly through any deterministic
+     * function -- a = c implies f(a) = f(c) whatever f does to the order -- so the FE-constant check,
+     * which is what the callers use to license the equality rewrite, must not apply it. See
+     * ListPartitionPruner.deduceExtraConjuncts, which gates on FE-constant-ness first and only
+     * demands monotonicity for the non-equality case.
+     */
     private static boolean isOrderPreservingCast(Type from, Type to) {
         if (from.equals(to)) {
             return true;
@@ -102,13 +114,20 @@ public class OperatorFunctionChecker {
         return (from.isDate() && to.isDatetime()) || (from.isDatetime() && to.isDate());
     }
 
+    /**
+     * Checks the calls only. Casts are accepted whatever the predicate says, so a caller that cares
+     * about the order values come out in - anything driving partition pruning off a range predicate -
+     * wants onlyContainMonotonicFunctions instead of passing a monotonicity predicate through here.
+     */
     public static Pair<Boolean, String> onlyContainPredicates(ScalarOperator scalarOperator,
                                                               Predicate<CallOperator> predicate) {
-        return scalarOperator.accept(new FunctionCheckerVisitor(predicate), null);
+        return scalarOperator.accept(new FunctionCheckerVisitor(predicate, cast -> true), null);
     }
 
     public static Pair<Boolean, String> onlyContainMonotonicFunctions(ScalarOperator scalarOperator) {
-        return onlyContainPredicates(scalarOperator, call -> ScalarOperatorEvaluator.INSTANCE.isMonotonicFunction(call));
+        return scalarOperator.accept(
+                new FunctionCheckerVisitor(call -> ScalarOperatorEvaluator.INSTANCE.isMonotonicFunction(call),
+                        cast -> isOrderPreservingCast(cast.fromType(), cast.getType())), null);
     }
 
     public static Pair<Boolean, String> onlyContainFEConstantFunctions(ScalarOperator scalarOperator) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluator.java
@@ -31,7 +31,6 @@ import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.function.MetaFunctions;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
-import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.type.PrimitiveType;
@@ -225,9 +224,10 @@ public enum ScalarOperatorEvaluator {
     }
 
     public boolean isMonotonicFunction(CallOperator call) {
-        if (call instanceof CastOperator) {
-            return true;
-        }
+        // A cast used to be declared monotonic here unconditionally, which is wrong: crossing between
+        // strings and numbers reorders values. Casts are decided by OperatorFunctionChecker's
+        // visitCastOperator, which knows which type pairs keep the order; one arriving here has no
+        // invoker to look up and comes out non-monotonic, which is the safe answer.
         FunctionSignature signature;
         if (call.getFunction() != null) {
             Function fn = call.getFunction();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/scalar/OperatorFunctionCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/scalar/OperatorFunctionCheckerTest.java
@@ -1,0 +1,72 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.operator.scalar;
+
+import com.starrocks.common.Pair;
+import com.starrocks.type.DateType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.Type;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class OperatorFunctionCheckerTest {
+    private static CastOperator cast(Type from, Type to) {
+        return new CastOperator(to, new ColumnRefOperator(1, from, "c1", true));
+    }
+
+    /**
+     * A cast between strings and numbers reorders values: '99845' sorts after '998425506019' while
+     * 99845 is far below 998425506019. Mapping a range predicate through it prunes partitions that
+     * hold matching rows, so it is not monotonic.
+     */
+    @Test
+    public void testNonOrderPreservingCastIsNotMonotonic() {
+        Pair<Boolean, String> result =
+                OperatorFunctionChecker.onlyContainMonotonicFunctions(cast(VarcharType.VARCHAR, IntegerType.BIGINT));
+        assertFalse(result.first);
+        assertTrue(result.second.contains("cast"), result.second);
+
+        assertFalse(OperatorFunctionChecker.onlyContainMonotonicFunctions(cast(IntegerType.BIGINT, IntegerType.INT)).first,
+                "a narrowing integer cast wraps or saturates");
+    }
+
+    @Test
+    public void testOrderPreservingCastIsMonotonic() {
+        assertTrue(OperatorFunctionChecker.onlyContainMonotonicFunctions(cast(IntegerType.INT, IntegerType.BIGINT)).first);
+        assertTrue(OperatorFunctionChecker.onlyContainMonotonicFunctions(cast(DateType.DATE, DateType.DATETIME)).first);
+        assertTrue(OperatorFunctionChecker.onlyContainMonotonicFunctions(cast(DateType.DATETIME, DateType.DATE)).first);
+        assertTrue(OperatorFunctionChecker.onlyContainMonotonicFunctions(cast(IntegerType.BIGINT, IntegerType.BIGINT)).first);
+    }
+
+    /**
+     * The order a cast puts values in is a question about monotonicity alone. Equality maps soundly
+     * through any deterministic function, and the callers license the equality rewrite off the
+     * FE-constant check (see ListPartitionPruner.deduceExtraConjuncts, which gates on FE-constant
+     * first and only demands monotonicity for the non-equality case). So the FE-constant check must
+     * accept a cast the monotonicity check rejects -- otherwise `c1 = '99845'` stops deducing
+     * `c2 = 99845` for a generated column `c2 AS cast(c1 as bigint)` and every partition is scanned,
+     * and an MV retention condition containing such a cast is rejected outright by
+     * PartitionSelector.validateRetentionConditionPredicate.
+     */
+    @Test
+    public void testFEConstantCheckAcceptsAnyCast() {
+        assertTrue(OperatorFunctionChecker.onlyContainFEConstantFunctions(cast(VarcharType.VARCHAR, IntegerType.BIGINT)).first);
+        assertTrue(OperatorFunctionChecker.onlyContainFEConstantFunctions(cast(IntegerType.BIGINT, IntegerType.INT)).first);
+        assertTrue(OperatorFunctionChecker.onlyContainFEConstantFunctions(cast(VarcharType.VARCHAR, DateType.DATE)).first);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -419,6 +419,48 @@ public class PartitionPruneTest extends PlanTestBase {
     }
 
     @Test
+    public void testRangeExprPruneSkipsNonMonotonicExpr() throws Exception {
+        // The partition expression maps a varchar onto a bigint through substr() and a cast, and neither
+        // step preserves the string order: '99845' sorts after '998425506019' while its partition value
+        // (845) is far below the constant's (8425506019). Mapping a range predicate onto the partition
+        // expression would prune p1 away and the rows in it would go silently missing, so a range
+        // predicate must not prune at all here.
+        starRocksAssert.withTable("CREATE TABLE `t_bill_detail` (\n" +
+                "    `bill_code` varchar(200) NOT NULL DEFAULT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`bill_code`)\n" +
+                "PARTITION BY RANGE(cast(substr(bill_code, 3, 11) as bigint))\n" +
+                "(\n" +
+                "    PARTITION p1 VALUES [(\"0\"), (\"5000000\")),\n" +
+                "    PARTITION p2 VALUES [(\"20000000\"), (\"3021712368984\"))\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(`bill_code`) BUCKETS 3\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");");
+
+        starRocksAssert.query("select count(*) from t_bill_detail where bill_code > '998425506019' ")
+                .explainContains("partitions=2/2");
+        starRocksAssert.query("select count(*) from t_bill_detail where bill_code <= '998425506019' ")
+                .explainContains("partitions=2/2");
+        // equality maps soundly through any function -- a = c implies f(a) = f(c) -- and still prunes
+        starRocksAssert.query("select count(*) from t_bill_detail where bill_code = '9984517' ")
+                .explainContains("partitions=1/2");
+
+        // a monotonic partition expression keeps pruning range predicates
+        starRocksAssert.withTable("CREATE TABLE `t_daily_range` (\n" +
+                "    `dt` datetime NOT NULL COMMENT \"\",\n" +
+                "    `id` int(11) NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`dt`, `id`)\n" +
+                "PARTITION BY date_trunc('day', `dt`)(\n" +
+                " START (\"2025-04-28\") END (\"2025-04-30\") EVERY (INTERVAL 1 DAY)\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(`id`) BUCKETS 1\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");");
+        starRocksAssert.query("select count(*) from t_daily_range where dt >= '2025-04-29 00:00:00' ")
+                .explainContains("partitions=1/2");
+    }
+
+    @Test
     public void testMinMaxPrune_Check() throws Exception {
         starRocksAssert.withTable("create table t5_dup " +
                 "(c1 datetime NOT NULL, c2 int) " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -419,6 +419,30 @@ public class PartitionPruneTest extends PlanTestBase {
     }
 
     @Test
+    public void testGeneratedColumnPruneSkipsNonOrderPreservingCast() throws Exception {
+        // A varchar-to-bigint cast does not preserve the order: '99845' sorts after '998425506019'
+        // as a string while 99845 is far below 998425506019 as a number. Mapping a range predicate
+        // on c1 through that cast would prune the partition holding '99845' and lose the row.
+        // getCallOperator() unwraps the enclosing cast, so the check has to look at the whole
+        // expression, not at the call it digs out.
+        starRocksAssert.withTable("CREATE TABLE t_gen_cast (" +
+                " c1 varchar(64) NOT NULL," +
+                " c2 bigint NULL AS cast(c1 as bigint) " +
+                " ) " +
+                " DUPLICATE KEY(c1) " +
+                " PARTITION BY (c2) " +
+                " PROPERTIES('replication_num'='1')");
+        starRocksAssert.ddl("ALTER TABLE t_gen_cast ADD PARTITION p1 VALUES IN ('99845')");
+        starRocksAssert.ddl("ALTER TABLE t_gen_cast ADD PARTITION p2 VALUES IN ('998425506019')");
+        starRocksAssert.ddl("ALTER TABLE t_gen_cast ADD PARTITION p3 VALUES IN ('1234567')");
+
+        starRocksAssert.query("select count(*) from t_gen_cast where c1 > '998425506019' ")
+                .explainContains("partitions=3/3");
+        starRocksAssert.query("select count(*) from t_gen_cast where c1 <= '998425506019' ")
+                .explainContains("partitions=3/3");
+    }
+
+    @Test
     public void testRangeExprPruneSkipsNonMonotonicExpr() throws Exception {
         // The partition expression maps a varchar onto a bigint through substr() and a cast, and neither
         // step preserves the string order: '99845' sorts after '998425506019' while its partition value

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -440,6 +440,38 @@ public class PartitionPruneTest extends PlanTestBase {
                 .explainContains("partitions=3/3");
         starRocksAssert.query("select count(*) from t_gen_cast where c1 <= '998425506019' ")
                 .explainContains("partitions=3/3");
+
+        // Equality maps soundly through any deterministic function, order or no order: c1 = '99845'
+        // holds exactly for the rows whose c2 is cast('99845' as bigint). Restricting the cast must
+        // not cost the equality deduction its pruning.
+        starRocksAssert.query("select count(*) from t_gen_cast where c1 = '99845' ")
+                .explainContains("partitions=1/3");
+    }
+
+    @Test
+    public void testGeneratedColumnPruneSkipsCaseWhen() throws Exception {
+        // A guard, not a regression test: nothing here is known to be broken today.
+        //
+        // FunctionCheckerVisitor only intercepts CastOperator. CaseWhenOperator is also a
+        // CallOperator, but ScalarOperatorVisitor routes it to visitCaseWhenOperator, which the
+        // checker does not override, so it falls through to visit() and is accepted as monotonic
+        // even though this CASE inverts the order. What keeps the deduction harmless is further
+        // down: substituting the constant leaves a CASE expression rather than a constant, and the
+        // pruner can only match a constant against the partition value map, so it gives up. Should
+        // that expression ever fold, "c1 > 100" would deduce "c2 >= 1" and keep no partition at all
+        // while every matching row lives in p0. This asserts it stays at 2/2.
+        starRocksAssert.withTable("CREATE TABLE t_gen_case (" +
+                " c1 int NOT NULL," +
+                " c2 tinyint NULL AS (case when c1 > 100 then 0 else 1 end) " +
+                " ) " +
+                " DUPLICATE KEY(c1) " +
+                " PARTITION BY (c2) " +
+                " PROPERTIES('replication_num'='1')");
+        starRocksAssert.ddl("ALTER TABLE t_gen_case ADD PARTITION p0 VALUES IN ('0')");
+        starRocksAssert.ddl("ALTER TABLE t_gen_case ADD PARTITION p1 VALUES IN ('1')");
+
+        starRocksAssert.query("select count(*) from t_gen_case where c1 > 100 ")
+                .explainContains("partitions=2/2");
     }
 
     @Test

--- a/test/sql/test_partition_by_expr/R/test_range_partition_prune_nonmonotonic
+++ b/test/sql/test_partition_by_expr/R/test_range_partition_prune_nonmonotonic
@@ -1,0 +1,43 @@
+-- name: test_range_partition_prune_nonmonotonic
+CREATE TABLE bill_detail (
+        bill_code varchar(200) NOT NULL DEFAULT ""
+)
+PRIMARY KEY(bill_code)
+PARTITION BY RANGE(cast(substr(bill_code, 3, 11) as bigint))
+(PARTITION p1 VALUES [('0'), ('5000000')),
+PARTITION p2 VALUES [('20000000'), ('3021712368984')))
+DISTRIBUTED BY HASH(bill_code) BUCKETS 3
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into bill_detail values('JT2921712368984'),('9984517'),('9992868'),('9995472'),('998425506019'),('1234567'),('99845');
+-- result:
+-- !result
+select count(*) from bill_detail;
+-- result:
+7
+-- !result
+select bill_code from bill_detail where bill_code > '998425506019' order by bill_code;
+-- result:
+99845
+9984517
+9992868
+9995472
+JT2921712368984
+-- !result
+select bill_code from bill_detail where not (bill_code > '998425506019') order by bill_code;
+-- result:
+1234567
+998425506019
+-- !result
+select bill_code from bill_detail where bill_code = '9984517';
+-- result:
+9984517
+-- !result
+select count(*) from (
+        (select * from bill_detail where bill_code > '998425506019')
+        union all (select * from bill_detail where not (bill_code > '998425506019'))
+        union all (select * from bill_detail where (bill_code > '998425506019') is null)) t;
+-- result:
+7
+-- !result

--- a/test/sql/test_partition_by_expr/T/test_range_partition_prune_nonmonotonic
+++ b/test/sql/test_partition_by_expr/T/test_range_partition_prune_nonmonotonic
@@ -1,0 +1,23 @@
+-- name: test_range_partition_prune_nonmonotonic
+CREATE TABLE bill_detail (
+        bill_code varchar(200) NOT NULL DEFAULT ""
+)
+PRIMARY KEY(bill_code)
+PARTITION BY RANGE(cast(substr(bill_code, 3, 11) as bigint))
+(PARTITION p1 VALUES [('0'), ('5000000')),
+PARTITION p2 VALUES [('20000000'), ('3021712368984')))
+DISTRIBUTED BY HASH(bill_code) BUCKETS 3
+PROPERTIES ("replication_num" = "1");
+-- neither substr() nor the cast preserves the string order of bill_code: '99845' sorts after
+-- '998425506019' while its partition value (845) is far below the constant's (8425506019)
+insert into bill_detail values('JT2921712368984'),('9984517'),('9992868'),('9995472'),('998425506019'),('1234567'),('99845');
+select count(*) from bill_detail;
+select bill_code from bill_detail where bill_code > '998425506019' order by bill_code;
+select bill_code from bill_detail where not (bill_code > '998425506019') order by bill_code;
+-- equality maps soundly through any function -- a = c implies f(a) = f(c) -- and still prunes
+select bill_code from bill_detail where bill_code = '9984517';
+-- ternary logic partitioning: the three branches must add up to the whole table
+select count(*) from (
+        (select * from bill_detail where bill_code > '998425506019')
+        union all (select * from bill_detail where not (bill_code > '998425506019'))
+        union all (select * from bill_detail where (bill_code > '998425506019') is null)) t;


### PR DESCRIPTION
## Why I'm doing:

A table partitioned by an expression lets ColumnFilterConverter.convertPredicate rewrite a predicate on the source column into one on the partition expression, so that RangePartitionPruner can prune with it:

    partition by range(cast(substr(bill_code, 3, 11) as bigint))
    bill_code > '998425506019'   =>   <partition value> > 8425506019

The rewrite keeps the comparison operator and only maps the constant, so it holds only where the expression preserves order. substr() and a varchar-to-bigint cast do not: '99845' sorts after '998425506019' while its partition value (845) is far below the constant's (8425506019). The partition holding such rows is pruned away and they go silently missing:

    insert into bill_detail values('JT2921712368984'),('9984517'),('9992868'),
                                  ('9995472'),('998425506019'),('1234567'),('99845');
    select count(*) from bill_detail;                                   -- 7
    select count(*) from bill_detail where bill_code > '998425506019';  -- 1, should be 5
    -- explain: partitions=1/5

Found by a TLP (ternary logic partitioning) oracle: for a 3999-row table the three branches where p / where not p / where p is null added up to 3996 rows.

Require the partition expression to be monotonic before mapping a non-equality predicate onto it -- the same condition ListPartitionPruner.deduceExtraConjuncts already applies to the LIST-partition rewrite, and the behaviour test_equal_prune already expects there (dt > '20200101' keeps partitions=3/3 under `partition by substring(dt, 1, 4)`, while dt = '20200101' still prunes to 1/3). Equality is exempt: a = c implies f(a) = f(c) for any f, so it keeps pruning.

DROP PARTITIONS WHERE goes through the same converter, but it prunes with the negated condition to pick the partitions to keep, so a more conservative prune there can only delete fewer partitions, never more.

Tests: PartitionPruneTest#testRangeExprPruneSkipsNonMonotonicExpr covers both the non-monotonic expression (no pruning for a range predicate, pruning for equality) and a monotonic one (date_trunc still prunes), plus a SQL test that reproduces the wrong result end to end.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
