### PR TITLE
[BugFix] Remove committed merge-conflict markers from the starlet upload threshold sync (backport #77984)

### DIFF
--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -472,9 +472,6 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
         }
         UPDATE_STARLET_CONFIG(s3_use_list_objects_v1, fslib_s3client_use_list_objects_v1);
         UPDATE_STARLET_CONFIG(starlet_delete_files_max_key_in_batch, delete_files_max_key_in_batch);
-<<<<<<< HEAD
-=======
-        UPDATE_STARLET_CONFIG(starlet_cache_replication_timeout_ms, write_cache_rpc_timeout_ms);
         UPDATE_STARLET_CONFIG(starlet_fslib_s3_max_single_part_size, fslib_s3_max_single_part_size);
         UPDATE_STARLET_CONFIG(starlet_fslib_s3_min_upload_part_size, fslib_s3_min_upload_part_size);
         UPDATE_STARLET_CONFIG(starlet_fslib_gs_max_single_part_size, fslib_gs_max_single_part_size);
@@ -482,7 +479,6 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
                               fslib_azure_storage_max_single_part_size);
         UPDATE_STARLET_CONFIG(starlet_fslib_azure_storage_min_upload_part_size,
                               fslib_azure_storage_min_upload_part_size);
->>>>>>> 15c20357c80 ([Enhancement] Make starlet object-store upload thresholds configurable at runtime (backport #60610) (#60744))
 #undef UPDATE_STARLET_CONFIG
 
 #ifndef BUILD_FORMAT_LIB

--- a/be/src/service/staros_worker.cpp
+++ b/be/src/service/staros_worker.cpp
@@ -560,11 +560,7 @@ void init_staros_worker(const std::shared_ptr<starcache::StarCache>& star_cache)
         FLAGS_fslib_s3client_request_timeout_ms = static_cast<int32_t>(config::object_storage_request_timeout_ms);
     }
     fslib::FLAGS_delete_files_max_key_in_batch = config::starlet_delete_files_max_key_in_batch;
-<<<<<<< HEAD
-=======
-    fslib::FLAGS_write_cache_rpc_timeout_ms = config::starlet_cache_replication_timeout_ms;
     apply_starlet_upload_threshold_configs();
->>>>>>> 15c20357c80 ([Enhancement] Make starlet object-store upload thresholds configurable at runtime (backport #60610) (#60744))
 
     fslib::FLAGS_use_star_cache = config::starlet_use_star_cache;
     fslib::FLAGS_star_cache_async_init = config::starlet_star_cache_async_init;


### PR DESCRIPTION
## Why I'm doing:

The enterprise-to-OSS sync that produced #78018 committed **unresolved conflict markers** into the
branch instead of failing, so `branch-4.1-cd-sync-pr-15c2035` currently carries literal
`<<<<<<< HEAD` / `=======` / `>>>>>>>` lines in two BE source files. GitHub still reports #78018 as
`MERGEABLE`, so the breakage is invisible from the PR page, but the branch does not compile.

That branch is covered by the `branch-4.1*` protection rule, so the fix cannot be pushed to it
directly — hence this PR, which targets the sync branch rather than `branch-4.1`.

## What I'm doing:

Resolving both conflicts, keeping only what exists in this repository:

- keep the five `starlet_fslib_*_part_size` lines, which are what #78018 is actually about;
- drop `starlet_cache_replication_timeout_ms` / `fslib::FLAGS_write_cache_rpc_timeout_ms`, which is
  enterprise-only and has no config definition here (#78018 does not add one either).

Net effect is 8 deleted lines in `be/src/http/action/update_config_action.cpp` and
`be/src/service/staros_worker.cpp`. Once this lands on the sync branch, #78018's diff is clean and
carries exactly the upload-threshold change it advertises.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
