### PR TITLE
[Feature] Add multi-warehouse support

### DIFF
--- a/docs/en/administration/configuration/FE_parameters/shared_lake_other.md
+++ b/docs/en/administration/configuration/FE_parameters/shared_lake_other.md
@@ -311,6 +311,15 @@ This topic introduces the following types of FE configurations:
 - Description: Whether to allow StarRocks to create the built-in storage volume by using the object storage-related properties specified in the FE configuration file. The default value is changed from `true` to `false` from v3.4.1 onwards.
 - Introduced in: v3.1.0
 
+### `enable_multi_warehouse`
+
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: No
+- Description: Whether to enable multi-warehouse support: `CREATE WAREHOUSE`, `DROP WAREHOUSE`, `ALTER WAREHOUSE`, and `ALTER SYSTEM ADD COMPUTE NODE ... INTO WAREHOUSE`. Each warehouse owns its own worker group, so a session pinned with `SET warehouse = '<name>'` only schedules query fragments onto that warehouse's compute nodes — which is how you keep a query's shuffles inside a single availability zone. Requires a shared-data cluster; the statements are rejected in shared-nothing mode. Set this item identically on every FE: a follower with it disabled ignores the warehouse journal entries and its catalog silently diverges from the leader's. Do not set it back to `false` once warehouses exist, because the warehouses would disappear from the catalog while compute nodes still reference their IDs. Restart required.
+- Introduced in: v4.2.0
+
 ### `gcp_gcs_impersonation_service_account`
 
 - Default: Empty string

--- a/docs/ja/administration/configuration/FE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/configuration/FE_parameters/shared_lake_other.md
@@ -312,6 +312,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：StarRocks が FE 設定ファイルで指定されたオブジェクトストレージ関連プロパティを使用して、組み込みストレージボリュームを作成することを許可するかどうか。デフォルト値は v3.4.1 以降 `true` から `false` に変更されました。
 - 導入時期：v3.1.0
 
+### `enable_multi_warehouse`
+
+- デフォルト：false
+- タイプ：Boolean
+- 単位：-
+- 変更可能：No
+- 説明：マルチウェアハウス機能（`CREATE WAREHOUSE`、`DROP WAREHOUSE`、`ALTER WAREHOUSE`、および `ALTER SYSTEM ADD COMPUTE NODE ... INTO WAREHOUSE`）を有効にするかどうか。各ウェアハウスは独自の Worker Group を持つため、`SET warehouse = '<name>'` で固定されたセッションはそのウェアハウスの CN ノードにのみクエリフラグメントをスケジュールします。これにより、クエリのシャッフルを単一のアベイラビリティゾーン (AZ) 内に閉じ込めることができます。共有データクラスタでのみ利用可能で、共有なしモードでは関連するステートメントは拒否されます。すべての FE に同じ値を設定してください。この設定が無効な Follower はウェアハウスのジャーナルエントリを無視するため、そのカタログは Leader のものと静かに乖離します。ウェアハウスが存在する状態でこの設定を `false` に戻さないでください。ウェアハウスがカタログから消える一方で、CN ノードはその ID を参照し続けます。変更後は FE の再起動が必要です。
+- 導入時期：v4.2.0
+
 ### `gcp_gcs_impersonation_service_account`
 
 - デフォルト：Empty string

--- a/docs/zh/administration/configuration/FE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/configuration/FE_parameters/shared_lake_other.md
@@ -312,6 +312,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 是否允许 StarRocks 使用 FE 配置文件中指定的对象存储相关属性创建内置存储卷。从 v3.4.1 开始，默认值从 `true` 更改为 `false`。
 - 引入版本: v3.1.0
 
+### `enable_multi_warehouse`
+
+- 默认值: false
+- 类型: Boolean
+- 单位: -
+- 是否可变: No
+- 描述: 是否启用多仓库（Warehouse）支持，即 `CREATE WAREHOUSE`、`DROP WAREHOUSE`、`ALTER WAREHOUSE` 以及 `ALTER SYSTEM ADD COMPUTE NODE ... INTO WAREHOUSE`。每个 Warehouse 拥有独立的 Worker Group，因此通过 `SET warehouse = '<name>'` 绑定的会话只会将查询 Fragment 调度到该 Warehouse 的 CN 节点上，从而将查询的 Shuffle 限制在单个可用区（AZ）内。该功能仅支持存算分离集群，在存算一体模式下相关语句会被拒绝。请在所有 FE 上设置相同的值：如果 Follower 未开启该配置，它会忽略 Warehouse 相关的日志，其元数据会与 Leader 静默地产生分歧。一旦创建了 Warehouse，请勿再将该配置改回 `false`，否则这些 Warehouse 会从元数据中消失，而 CN 节点仍然引用其 ID。修改后需重启 FE。
+- 引入版本: v4.2.0
+
 ### `gcp_gcs_impersonation_service_account`
 
 - 默认值: 空字符串

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -579,6 +579,21 @@ public class Config extends ConfigBase {
     public static String ext_dir = System.getenv("STARROCKS_HOME") + "/lib";
 
     /**
+     * Enable multi-warehouse support (CREATE/DROP/ALTER WAREHOUSE, ALTER SYSTEM ADD COMPUTE NODE ... INTO
+     * WAREHOUSE, SET warehouse = '...'). Each warehouse owns a StarMgr worker group, so queries pinned to a
+     * warehouse only ever schedule fragments onto that warehouse's compute nodes.
+     *
+     * Requires shared_data mode. Set it identically on every FE: a follower with the flag off ignores the
+     * warehouse journal entries, so its catalog would silently diverge from the leader's.
+     *
+     * This is NOT mutable and must not be flipped back to false once warehouses exist: the base
+     * WarehouseManager does not read the persisted warehouses, so they would vanish from the catalog while
+     * compute nodes still reference their ids.
+     */
+    @ConfField
+    public static boolean enable_multi_warehouse = false;
+
+    /**
      * Labels of finished or cancelled load jobs will be removed
      * 1. after *label_keep_max_second*
      * or

--- a/fe/fe-core/src/main/java/com/starrocks/extension/DefaultExtensionContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/extension/DefaultExtensionContext.java
@@ -15,20 +15,25 @@
 package com.starrocks.extension;
 
 import com.google.common.collect.Maps;
+import com.starrocks.common.Config;
 import com.starrocks.persist.gson.DefaultGsonBuilderFactory;
 import com.starrocks.persist.gson.IGsonBuilderFactory;
 import com.starrocks.qe.scheduler.slot.BaseSlotManager;
 import com.starrocks.qe.scheduler.slot.ResourceUsageMonitor;
 import com.starrocks.qe.scheduler.slot.SlotManager;
 import com.starrocks.server.WarehouseManager;
+import com.starrocks.warehouse.multi.MultiWarehouseManager;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.util.Map;
+import java.util.function.Supplier;
 
 public class DefaultExtensionContext implements ExtensionContext {
     private final Map<Class<?>, Object> capabilityMap = Maps.newHashMap();
     private final Map<Class<?>, ConstructorMetadata> constructorMetadataMap = Maps.newHashMap();
+    // Implementations that can only be chosen once Config has been loaded; see registerDefault().
+    private final Map<Class<?>, Supplier<Class<?>>> lazyImplementationMap = Maps.newHashMap();
 
     public DefaultExtensionContext() {
         registerDefault();
@@ -73,7 +78,9 @@ public class DefaultExtensionContext implements ExtensionContext {
             // Get or resolve constructor metadata
             ConstructorMetadata metadata = constructorMetadataMap.get(clazz);
             if (metadata == null) {
-                metadata = resolveConstructorInternal(clazz);
+                Supplier<Class<?>> lazyImplementation = lazyImplementationMap.get(clazz);
+                metadata = resolveConstructorInternal(
+                        lazyImplementation == null ? clazz : lazyImplementation.get());
                 constructorMetadataMap.put(clazz, metadata);
             }
 
@@ -169,10 +176,13 @@ public class DefaultExtensionContext implements ExtensionContext {
     public void registerDefault() {
         // Register constructor for ResourceUsageMonitor to enable dependency injection
         registerConstructor(ResourceUsageMonitor.class, ResourceUsageMonitor.class);
-        
-        // Register constructor for WarehouseManager to enable dependency injection
-        registerConstructor(WarehouseManager.class, WarehouseManager.class);
-        
+        // Which WarehouseManager to build depends on Config.enable_multi_warehouse, and this context is
+        // constructed from a static initializer that can run before the config file is read (GsonUtils pulls
+        // it in). So record the choice as a supplier and let the first get() resolve it, by which time
+        // Config.init() has run.
+        lazyImplementationMap.put(WarehouseManager.class,
+                () -> Config.enable_multi_warehouse ? MultiWarehouseManager.class : WarehouseManager.class);
+
         // Register constructor for BaseSlotManager to enable dependency injection
         registerConstructor(BaseSlotManager.class, SlotManager.class);
         

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/internal/RuntimeTypeAdapterTypes.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/internal/RuntimeTypeAdapterTypes.java
@@ -184,6 +184,7 @@ import com.starrocks.warehouse.DefaultWarehouse;
 import com.starrocks.warehouse.Warehouse;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import com.starrocks.warehouse.cngroup.WarehouseComputeResource;
+import com.starrocks.warehouse.multi.MultiWarehouse;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -360,7 +361,8 @@ public class RuntimeTypeAdapterTypes {
 
         final RuntimeTypeAdapterFactory<Warehouse> warehouse_type_adapter_factory = RuntimeTypeAdapterFactory
                 .of(Warehouse.class, "clazz")
-                .registerSubtype(DefaultWarehouse.class, "DefaultWarehouse");
+                .registerSubtype(DefaultWarehouse.class, "DefaultWarehouse")
+                .registerSubtype(MultiWarehouse.class, "MultiWarehouse");
         CLAZZ_TO_RUNTIME_TYPE_ADAPTOR_FACTORIES.put(Warehouse.class, warehouse_type_adapter_factory);
 
         final RuntimeTypeAdapterFactory<LoadJob> load_job_type_runtime_adapter_factory =

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/multi/MultiWarehouse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/multi/MultiWarehouse.java
@@ -1,0 +1,267 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.warehouse.multi;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReport;
+import com.starrocks.common.proc.BaseProcResult;
+import com.starrocks.common.proc.ProcResult;
+import com.starrocks.common.util.TimeUtils;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.warehouse.cngroup.AlterCnGroupStmt;
+import com.starrocks.sql.ast.warehouse.cngroup.CreateCnGroupStmt;
+import com.starrocks.sql.ast.warehouse.cngroup.DropCnGroupStmt;
+import com.starrocks.sql.ast.warehouse.cngroup.EnableDisableCnGroupStmt;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.warehouse.Warehouse;
+import com.starrocks.warehouse.WarehouseProcDir;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A user-created warehouse backed by its own StarMgr worker group.
+ *
+ * <p> Each {@code MultiWarehouse} owns exactly one worker group. Every compute node assigned to the warehouse
+ * (via {@code ALTER SYSTEM ADD COMPUTE NODE ... INTO WAREHOUSE <name>}) is registered into that group, and
+ * {@link com.starrocks.warehouse.cngroup.WarehouseComputeResourceProvider} resolves the warehouse's nodes by
+ * asking StarMgr for the members of the group.
+ */
+public class MultiWarehouse extends Warehouse {
+    @SerializedName(value = "workerGroupId")
+    private long workerGroupId;
+
+    @SerializedName(value = "properties")
+    private Map<String, String> properties;
+
+    @SerializedName(value = "createdTime")
+    private long createdTime;
+
+    @SerializedName(value = "updatedTime")
+    private long updatedTime;
+
+    public MultiWarehouse(long id, String name, String comment, long workerGroupId,
+                          Map<String, String> properties, long createdTime) {
+        super(id, name, Strings.nullToEmpty(comment));
+        this.workerGroupId = workerGroupId;
+        this.properties = properties == null ? Maps.newHashMap() : Maps.newHashMap(properties);
+        this.createdTime = createdTime;
+        this.updatedTime = createdTime;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties == null ? Maps.newHashMap() : properties;
+    }
+
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties == null ? Maps.newHashMap() : Maps.newHashMap(properties);
+    }
+
+    public long getCreatedTime() {
+        return createdTime;
+    }
+
+    public long getUpdatedTime() {
+        return updatedTime;
+    }
+
+    public void setUpdatedTime(long updatedTime) {
+        this.updatedTime = updatedTime;
+    }
+
+    @Override
+    public long getResumeTime() {
+        // SUSPEND/RESUME is not supported, so the warehouse is never resumed.
+        return -1L;
+    }
+
+    @Override
+    public Long getAnyWorkerGroupId() {
+        return workerGroupId;
+    }
+
+    @Override
+    public List<Long> getWorkerGroupIds() {
+        return ImmutableList.of(workerGroupId);
+    }
+
+    @Override
+    public void addNodeToCNGroup(ComputeNode node, String cnGroupName) throws DdlException {
+        if (!Strings.isNullOrEmpty(cnGroupName)) {
+            // NOTE: CNGROUP is not implemented, the warehouse is the only grouping level.
+            ErrorReport.reportDdlException(ErrorCode.ERR_CNGROUP_NOT_IMPLEMENTED);
+        }
+        node.setWorkerGroupId(workerGroupId);
+        node.setWarehouseId(getId());
+    }
+
+    @Override
+    public void validateRemoveNodeFromCNGroup(ComputeNode node, String cnGroupName) throws DdlException {
+        if (!Strings.isNullOrEmpty(cnGroupName)) {
+            // NOTE: CNGROUP is not implemented, the warehouse is the only grouping level.
+            ErrorReport.reportDdlException(ErrorCode.ERR_CNGROUP_NOT_IMPLEMENTED);
+        }
+    }
+
+    @Override
+    public boolean isAvailable() {
+        // The warehouse cannot be suspended, so it is always a legal scheduling target. Whether it currently
+        // has alive nodes is decided by ComputeResourceProvider#isResourceAvailable
+        return true;
+    }
+
+    /**
+     * Nodes (compute nodes and backends) currently assigned to this warehouse.
+     */
+    public List<ComputeNode> getNodes() {
+        List<ComputeNode> nodes = new ArrayList<>();
+        SystemInfoService systemInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+        if (systemInfoService == null) {
+            return nodes;
+        }
+        for (ComputeNode node : systemInfoService.getComputeNodes()) {
+            if (node.getWarehouseId() == getId()) {
+                nodes.add(node);
+            }
+        }
+        for (ComputeNode node : systemInfoService.getBackends()) {
+            if (node.getWarehouseId() == getId()) {
+                nodes.add(node);
+            }
+        }
+        return nodes;
+    }
+
+    @Override
+    public List<String> getWarehouseInfo() {
+        List<ComputeNode> nodes = getNodes();
+        boolean anyAlive = nodes.stream().anyMatch(ComputeNode::isAlive);
+        return Lists.newArrayList(
+                String.valueOf(getId()),
+                getName(),
+                anyAlive ? "AVAILABLE" : "UNAVAILABLE",
+                String.valueOf(nodes.size()),
+                String.valueOf(1L),  // CurrentClusterCount: one worker group per warehouse
+                String.valueOf(1L),  // MaxClusterCount
+                String.valueOf(1L),  // StartedClusters
+                String.valueOf(0L),  // RunningSql: not tracked per warehouse here
+                String.valueOf(0L),  // QueuedSql: not tracked per warehouse here
+                TimeUtils.longToTimeString(createdTime),
+                "",                  // ResumedOn: SUSPEND/RESUME not supported
+                TimeUtils.longToTimeString(updatedTime),
+                propertiesToString(),
+                comment);
+    }
+
+    @Override
+    public List<List<String>> getWarehouseNodesInfo() {
+        List<List<String>> rows = new ArrayList<>();
+        for (ComputeNode node : getNodes()) {
+            rows.add(Lists.newArrayList(
+                    getName(),
+                    "",  // CNGroupId: CNGROUP is not implemented
+                    String.valueOf(node.getWorkerGroupId()),
+                    String.valueOf(node.getId()),
+                    String.valueOf(getWorkerId(node)),
+                    node.getHost(),
+                    String.valueOf(node.getHeartbeatPort()),
+                    String.valueOf(node.getBePort()),
+                    String.valueOf(node.getHttpPort()),
+                    String.valueOf(node.getBrpcPort()),
+                    String.valueOf(node.getStarletPort()),
+                    TimeUtils.longToTimeString(node.getLastStartTime()),
+                    TimeUtils.longToTimeString(node.getLastUpdateMs()),
+                    String.valueOf(node.isAlive()),
+                    Strings.nullToEmpty(node.getHeartbeatErrMsg()),
+                    Strings.nullToEmpty(node.getVersion()),
+                    String.valueOf(node.getNumRunningQueries()),
+                    String.valueOf(node.getCpuCores()),
+                    String.format("%.2f", node.getMemUsedPct() * 100),
+                    String.format("%.2f", node.getCpuUsedPermille() / 10.0),
+                    ""));  // CNGroupName: CNGROUP is not implemented
+        }
+        return rows;
+    }
+
+    /**
+     * StarMgr's id for this node, or -1 when the node has not reported a starlet port yet (StarMgr only learns
+     * about it on the first heartbeat that carries one, see HeartbeatMgr).
+     */
+    private long getWorkerId(ComputeNode node) {
+        try {
+            return GlobalStateMgr.getCurrentState().getStarOSAgent().getWorkerIdByNodeId(node.getId());
+        } catch (Exception e) {
+            return -1L;
+        }
+    }
+
+    @Override
+    public ProcResult fetchResult() {
+        BaseProcResult result = new BaseProcResult();
+        result.setNames(WarehouseProcDir.WAREHOUSE_PROC_NODE_TITLE_NAMES);
+        result.addRow(getWarehouseInfo());
+        return result;
+    }
+
+    @Override
+    public void createCNGroup(CreateCnGroupStmt stmt) throws DdlException {
+        throw new DdlException("CnGroup is not implemented");
+    }
+
+    @Override
+    public void dropCNGroup(DropCnGroupStmt stmt) throws DdlException {
+        throw new DdlException("CnGroup is not implemented");
+    }
+
+    @Override
+    public void enableCNGroup(EnableDisableCnGroupStmt stmt) throws DdlException {
+        throw new DdlException("CnGroup is not implemented");
+    }
+
+    @Override
+    public void disableCNGroup(EnableDisableCnGroupStmt stmt) throws DdlException {
+        throw new DdlException("CnGroup is not implemented");
+    }
+
+    @Override
+    public void alterCNGroup(AlterCnGroupStmt stmt) throws DdlException {
+        throw new DdlException("CnGroup is not implemented");
+    }
+
+    @Override
+    public void replayInternalOpLog(String payload) {
+        // No internal op is journalled for this warehouse: CREATE/DROP/ALTER go through the dedicated
+        // OP_CREATE/DROP/ALTER_WAREHOUSE entries, and CNGROUP is not implemented.
+    }
+
+    private String propertiesToString() {
+        Map<String, String> props = getProperties();
+        if (props.isEmpty()) {
+            return "";
+        }
+        List<String> parts = new ArrayList<>(props.size());
+        props.forEach((k, v) -> parts.add(k + "=" + v));
+        return Joiner.on(",").join(parts);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/multi/MultiWarehouseExtension.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/multi/MultiWarehouseExtension.java
@@ -1,0 +1,42 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.warehouse.multi;
+
+import com.starrocks.extension.ExtensionContext;
+import com.starrocks.extension.SRModule;
+import com.starrocks.extension.StarRocksExtension;
+import com.starrocks.server.WarehouseManager;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Registers {@link MultiWarehouseManager} as the cluster's {@code WarehouseManager}.
+ *
+ * <p>This is the second way to turn multi-warehouse on, for deployments that ship extensions in
+ * {@code Config.ext_dir} rather than editing fe.conf; the first is {@code enable_multi_warehouse = true},
+ * which {@code DefaultExtensionContext} reads. Registering an instance here wins over the constructor
+ * registration, because {@code DefaultExtensionContext#get} checks explicitly registered instances first.
+ */
+@SRModule(name = "multi_warehouse")
+public class MultiWarehouseExtension implements StarRocksExtension {
+    private static final Logger LOG = LogManager.getLogger(MultiWarehouseExtension.class);
+
+    @Override
+    public void onLoad(ExtensionContext ctx) {
+        ctx.register(WarehouseManager.class, new MultiWarehouseManager());
+        LOG.info("multi_warehouse extension loaded, WarehouseManager -> {}",
+                MultiWarehouseManager.class.getName());
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/multi/MultiWarehouseManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/multi/MultiWarehouseManager.java
@@ -1,0 +1,507 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.warehouse.multi;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.staros.util.LockCloseable;
+import com.starrocks.catalog.ResourceGroup;
+import com.starrocks.catalog.ResourceGroupMgr;
+import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReport;
+import com.starrocks.lake.StarOSAgent;
+import com.starrocks.persist.DropWarehouseLog;
+import com.starrocks.persist.ImageWriter;
+import com.starrocks.persist.OperationType;
+import com.starrocks.persist.WALApplier;
+import com.starrocks.persist.metablock.SRMetaBlockEOFException;
+import com.starrocks.persist.metablock.SRMetaBlockException;
+import com.starrocks.persist.metablock.SRMetaBlockID;
+import com.starrocks.persist.metablock.SRMetaBlockReader;
+import com.starrocks.persist.metablock.SRMetaBlockWriter;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.sql.ast.warehouse.AlterWarehouseStmt;
+import com.starrocks.sql.ast.warehouse.CreateWarehouseStmt;
+import com.starrocks.sql.ast.warehouse.DropWarehouseStmt;
+import com.starrocks.sql.ast.warehouse.ResumeWarehouseStmt;
+import com.starrocks.sql.ast.warehouse.SuspendWarehouseStmt;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.warehouse.Warehouse;
+import com.starrocks.warehouse.cngroup.CRAcquireContext;
+import com.starrocks.warehouse.cngroup.ComputeResource;
+import com.starrocks.warehouse.cngroup.ComputeResourceProvider;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A {@link WarehouseManager} that really creates warehouses, instead of rejecting the DDL.
+ *
+ * <p>Each warehouse owns one StarMgr worker group. {@code CREATE WAREHOUSE} allocates the group,
+ * {@code ALTER SYSTEM ADD COMPUTE NODE ... INTO WAREHOUSE} puts nodes in it, and everything downstream
+ * (fragment placement, tablet-to-node resolution, background jobs) already routes through
+ * {@code ComputeResource}, so no scheduler change is needed.
+ *
+ * <p>Enable it with {@code enable_multi_warehouse = true} in fe.conf, or by registering it from a static
+ * extension (see {@link MultiWarehouseExtension}). It requires shared-data mode.
+ *
+ * <p>Not supported here: CNGROUPs, SUSPEND/RESUME, and changing a warehouse's worker group size after
+ * creation (the StarMgr client exposes no size update).
+ */
+public class MultiWarehouseManager extends WarehouseManager {
+    private static final Logger LOG = LogManager.getLogger(MultiWarehouseManager.class);
+
+    /**
+     * Worker group size class handed to StarMgr, e.g. "x1". The accepted values are defined by StarMgr, not
+     * by the FE; whatever StarMgr rejects surfaces as the DdlException from createWorkerGroup.
+     */
+    public static final String PROPERTY_SIZE = "size";
+    public static final String DEFAULT_SIZE = "x1";
+
+    /**
+     * Number of StarMgr worker replicas for the group.
+     */
+    public static final String PROPERTY_REPLICA_NUMBER = "replica_number";
+    public static final int DEFAULT_REPLICA_NUMBER = 1;
+
+    private static final Set<String> MUTABLE_PROPERTIES = Sets.newHashSet(PROPERTY_REPLICA_NUMBER);
+
+    public MultiWarehouseManager() {
+        super();
+    }
+
+    public MultiWarehouseManager(ComputeResourceProvider computeResourceProvider) {
+        super(computeResourceProvider, new ArrayList<>());
+    }
+
+    // ------------------------------------------------------------------------------------------------------
+    // DDL
+    // ------------------------------------------------------------------------------------------------------
+
+    /**
+     * DDL entry points are serialized on the manager: the existence check, the StarMgr call and the journal
+     * write must not interleave with a concurrent warehouse DDL on the same leader. Warehouse DDL is rare, so
+     * a coarse lock costs nothing; the in-memory maps are still guarded by the inherited {@code rwLock}.
+     */
+    @Override
+    public synchronized void createWarehouse(CreateWarehouseStmt stmt) throws DdlException {
+        checkSharedDataMode();
+
+        final String name = stmt.getWarehouseName();
+        if (warehouseExists(name)) {
+            if (stmt.isSetIfNotExists()) {
+                LOG.info("Warehouse {} already exists, skip creating", name);
+                return;
+            }
+            ErrorReport.reportDdlException(ErrorCode.ERR_WAREHOUSE_EXISTS, name);
+        }
+
+        final Map<String, String> properties = stmt.getProperties() == null
+                ? Maps.newHashMap() : Maps.newHashMap(stmt.getProperties());
+
+        // Validate on a scratch copy: the declared properties are kept verbatim on the warehouse so that
+        // SHOW WAREHOUSES and ALTER WAREHOUSE see what the user asked for.
+        final Map<String, String> scratch = Maps.newHashMap(properties);
+        final String size = extractSize(scratch);
+        final int replicaNumber = extractReplicaNumber(scratch);
+        checkNoUnknownProperties(scratch);
+
+        final long workerGroupId = getStarOSAgent().createWorkerGroup(size, replicaNumber);
+        boolean succeeded = false;
+        try {
+            final long id = allocateId();
+            final MultiWarehouse warehouse = new MultiWarehouse(id, name, stmt.getComment(), workerGroupId,
+                    properties, System.currentTimeMillis());
+            logEdit(OperationType.OP_CREATE_WAREHOUSE, warehouse, wal -> replayCreateWarehouse((Warehouse) wal));
+            succeeded = true;
+            LOG.info("Created warehouse {}, id: {}, workerGroupId: {}", name, id, workerGroupId);
+        } finally {
+            if (!succeeded) {
+                // The warehouse never became visible, so the group it would have owned is unreachable.
+                deleteWorkerGroupQuietly(workerGroupId);
+            }
+        }
+    }
+
+    @Override
+    public synchronized void dropWarehouse(DropWarehouseStmt stmt) throws DdlException {
+        checkSharedDataMode();
+
+        final String name = stmt.getWarehouseName();
+        if (DEFAULT_WAREHOUSE_NAME.equalsIgnoreCase(name)) {
+            throw new DdlException("Can't drop the " + DEFAULT_WAREHOUSE_NAME);
+        }
+
+        final Warehouse warehouse = getWarehouseAllowNull(name);
+        if (warehouse == null) {
+            if (stmt.isSetIfExists()) {
+                LOG.info("Warehouse {} does not exist, skip dropping", name);
+                return;
+            }
+            ErrorReport.reportDdlException(ErrorCode.ERR_UNKNOWN_WAREHOUSE, String.format("name: %s", name));
+            return;
+        }
+
+        final List<Long> nodeIds = new ArrayList<>();
+        for (ComputeNode node : nodesOf(warehouse)) {
+            nodeIds.add(node.getId());
+        }
+        if (!nodeIds.isEmpty()) {
+            throw new DdlException(String.format(
+                    "Warehouse %s still has %d node(s) %s. Drop them first, e.g. "
+                            + "ALTER SYSTEM DROP COMPUTE NODE \"<host>:<port>\" FROM WAREHOUSE %s",
+                    name, nodeIds.size(), nodeIds, name));
+        }
+
+        // A resource group binds warehouses by NAME (ResourceGroup#getWarehouses), and that name is only
+        // validated when the group is created or altered. Dropping a bound warehouse would therefore leave a
+        // dangling binding that silently stops matching in
+        // ResourceGroupMgr#isResourceGroupMatchWarehouse - and a group bound only to this warehouse would
+        // become unreachable with no error anywhere. Refuse instead, and name the groups to fix.
+        final List<String> boundGroups = boundResourceGroupNames(name, fetchAllResourceGroups());
+        if (!boundGroups.isEmpty()) {
+            throw new DdlException(String.format(
+                    "Warehouse %s is still bound by resource group(s) %s. Remove the binding first, e.g. "
+                            + "ALTER RESOURCE GROUP <group> SET (\"warehouses\" = \"<remaining>\"), "
+                            + "or drop those resource groups.",
+                    name, boundGroups));
+        }
+
+        final List<Long> workerGroupIds = new ArrayList<>(warehouse.getWorkerGroupIds());
+
+        // Journal first: if the StarMgr cleanup below fails, an orphaned worker group is recoverable, while a
+        // deleted group behind a still-visible warehouse would silently break every query routed to it.
+        logEdit(OperationType.OP_DROP_WAREHOUSE, new DropWarehouseLog(name),
+                wal -> replayDropWarehouse((DropWarehouseLog) wal));
+        for (Long workerGroupId : workerGroupIds) {
+            deleteWorkerGroupQuietly(workerGroupId);
+        }
+        LOG.info("Dropped warehouse {}, worker groups: {}", name, workerGroupIds);
+    }
+
+    @Override
+    public synchronized void alterWarehouse(AlterWarehouseStmt stmt) throws DdlException {
+        checkSharedDataMode();
+
+        final String name = stmt.getWarehouseName();
+        final Warehouse warehouse = getWarehouseAllowNull(name);
+        if (warehouse == null) {
+            ErrorReport.reportDdlException(ErrorCode.ERR_UNKNOWN_WAREHOUSE, String.format("name: %s", name));
+            return;
+        }
+        if (!(warehouse instanceof MultiWarehouse)) {
+            throw new DdlException("Warehouse " + name + " can not be altered");
+        }
+        final MultiWarehouse multiWarehouse = (MultiWarehouse) warehouse;
+
+        final Map<String, String> changes = stmt.getProperties() == null
+                ? Maps.newHashMap() : Maps.newHashMap(stmt.getProperties());
+        if (changes.isEmpty()) {
+            throw new DdlException("No property to alter");
+        }
+        for (String key : changes.keySet()) {
+            if (!MUTABLE_PROPERTIES.contains(key)) {
+                throw new DdlException(String.format(
+                        "Property '%s' can not be altered. Alterable properties: %s", key, MUTABLE_PROPERTIES));
+            }
+        }
+
+        final Map<String, String> merged = Maps.newHashMap(multiWarehouse.getProperties());
+        merged.putAll(changes);
+        final int replicaNumber = extractReplicaNumber(Maps.newHashMap(merged));
+        getStarOSAgent().updateWorkerGroup(multiWarehouse.getAnyWorkerGroupId(), replicaNumber);
+
+        final MultiWarehouse updated = new MultiWarehouse(multiWarehouse.getId(), multiWarehouse.getName(),
+                multiWarehouse.getComment(), multiWarehouse.getAnyWorkerGroupId(), merged,
+                multiWarehouse.getCreatedTime());
+        updated.setUpdatedTime(System.currentTimeMillis());
+        logEdit(OperationType.OP_ALTER_WAREHOUSE, updated, wal -> replayAlterWarehouse((Warehouse) wal));
+        LOG.info("Altered warehouse {}, properties: {}", name, merged);
+    }
+
+    @Override
+    public void suspendWarehouse(SuspendWarehouseStmt stmt) throws DdlException {
+        throw new DdlException("SUSPEND WAREHOUSE is not supported: a warehouse's compute nodes are managed "
+                + "with ALTER SYSTEM ADD/DROP COMPUTE NODE, not by suspending the warehouse");
+    }
+
+    @Override
+    public void resumeWarehouse(ResumeWarehouseStmt stmt) throws DdlException {
+        throw new DdlException("RESUME WAREHOUSE is not supported: a warehouse's compute nodes are managed "
+                + "with ALTER SYSTEM ADD/DROP COMPUTE NODE, not by resuming the warehouse");
+    }
+
+    // ------------------------------------------------------------------------------------------------------
+    // Background work
+    // ------------------------------------------------------------------------------------------------------
+
+    /**
+     * Honour {@code lake_background_warehouse}. The base class always returns {@code default_warehouse}, which
+     * would leave every background job (vacuum, dictionary refresh, the leader daemons, ...) without nodes once
+     * all compute nodes have been moved into user-created warehouses.
+     */
+    @Override
+    public Warehouse getBackgroundWarehouse() {
+        final Warehouse warehouse = resolveConfiguredWarehouse(
+                Config.lake_background_warehouse, "lake_background_warehouse");
+        return warehouse != null ? warehouse : super.getBackgroundWarehouse();
+    }
+
+    /**
+     * Honour {@code lake_compaction_warehouse}, mirroring the precedence documented on
+     * {@code WarehouseManager#getVectorIndexBuildComputeResource}: explicit config > default.
+     */
+    @Override
+    public ComputeResource getCompactionComputeResource(long tableId) {
+        final Warehouse warehouse = resolveConfiguredWarehouse(
+                Config.lake_compaction_warehouse, "lake_compaction_warehouse");
+        if (warehouse != null) {
+            try {
+                return acquireComputeResource(CRAcquireContext.of(warehouse.getId()));
+            } catch (Exception e) {
+                LOG.warn("Configured compaction warehouse {} is unavailable, falling back to the default resource",
+                        warehouse.getName(), e);
+            }
+        }
+        return super.getCompactionComputeResource(tableId);
+    }
+
+    /**
+     * @return the warehouse named by a config, or null when the config is unset, names the default warehouse,
+     * or names a warehouse that does not exist (logged).
+     */
+    private Warehouse resolveConfiguredWarehouse(String configuredName, String configKey) {
+        if (Strings.isNullOrEmpty(configuredName) || DEFAULT_WAREHOUSE_NAME.equalsIgnoreCase(configuredName)) {
+            return null;
+        }
+        final Warehouse warehouse = getWarehouseAllowNull(configuredName);
+        if (warehouse == null) {
+            LOG.warn("Configured warehouse {} of {} does not exist, falling back to {}",
+                    configuredName, configKey, DEFAULT_WAREHOUSE_NAME);
+        }
+        return warehouse;
+    }
+
+    // ------------------------------------------------------------------------------------------------------
+    // Replay
+    // ------------------------------------------------------------------------------------------------------
+
+    @Override
+    public void replayCreateWarehouse(Warehouse warehouse) {
+        try (LockCloseable ignored = new LockCloseable(rwLock.writeLock())) {
+            nameToWh.put(warehouse.getName(), warehouse);
+            idToWh.put(warehouse.getId(), warehouse);
+        }
+        LOG.info("Replayed create warehouse {}", warehouse);
+    }
+
+    @Override
+    public void replayDropWarehouse(DropWarehouseLog log) {
+        try (LockCloseable ignored = new LockCloseable(rwLock.writeLock())) {
+            Warehouse warehouse = nameToWh.remove(log.getWarehouseName());
+            if (warehouse != null) {
+                idToWh.remove(warehouse.getId());
+            }
+        }
+        LOG.info("Replayed drop warehouse {}", log.getWarehouseName());
+    }
+
+    @Override
+    public void replayAlterWarehouse(Warehouse warehouse) {
+        try (LockCloseable ignored = new LockCloseable(rwLock.writeLock())) {
+            nameToWh.put(warehouse.getName(), warehouse);
+            idToWh.put(warehouse.getId(), warehouse);
+        }
+        LOG.info("Replayed alter warehouse {}", warehouse);
+    }
+
+    @Override
+    public Set<String> getAllWarehouseNames() {
+        try (LockCloseable ignored = new LockCloseable(rwLock.readLock())) {
+            return Sets.newHashSet(nameToWh.keySet());
+        }
+    }
+
+    // ------------------------------------------------------------------------------------------------------
+    // Image
+    // ------------------------------------------------------------------------------------------------------
+
+    /**
+     * The default warehouse is not persisted; it is recreated by {@link #initDefaultWarehouse()} on load, the
+     * same contract the base class documents.
+     */
+    @Override
+    public void save(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
+        List<Warehouse> warehouses = new ArrayList<>();
+        try (LockCloseable ignored = new LockCloseable(rwLock.readLock())) {
+            for (Warehouse warehouse : idToWh.values()) {
+                if (warehouse.getId() != DEFAULT_WAREHOUSE_ID) {
+                    warehouses.add(warehouse);
+                }
+            }
+        }
+        SRMetaBlockWriter writer = imageWriter.getBlockWriter(SRMetaBlockID.WAREHOUSE_MGR, 1 + warehouses.size());
+        writer.writeInt(warehouses.size());
+        for (Warehouse warehouse : warehouses) {
+            writer.writeJson(warehouse);
+        }
+        writer.close();
+    }
+
+    @Override
+    public void load(SRMetaBlockReader reader)
+            throws SRMetaBlockEOFException, IOException, SRMetaBlockException {
+        // The default warehouse must exist before postImageLoad, see WarehouseManager#load.
+        initDefaultWarehouse();
+        reader.readCollection(Warehouse.class, this::replayCreateWarehouse);
+    }
+
+    // ------------------------------------------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------------------------------------------
+
+    /**
+     * Write one journal entry and apply it in-memory inside the WAL fence. Seam for tests.
+     */
+    protected void logEdit(short op, Object payload, WALApplier applier) {
+        GlobalStateMgr.getCurrentState().getEditLog().logJsonObject(op, payload, applier);
+    }
+
+    /**
+     * Allocate a catalog id. Seam for tests.
+     */
+    protected long allocateId() {
+        return GlobalStateMgr.getCurrentState().getNextId();
+    }
+
+    private static void checkSharedDataMode() throws DdlException {
+        if (!RunMode.isSharedDataMode()) {
+            throw new DdlException("Multi-warehouse is only supported in shared_data mode");
+        }
+    }
+
+    /**
+     * Every resource group currently defined, or an empty list when the manager is not available. Seam for
+     * tests. Read through the public {@code ResourceGroupMgr} API so its own lock is taken and released per
+     * call - this must not be invoked while holding {@code rwLock}, to keep the lock order one-directional.
+     */
+    protected List<ResourceGroup> fetchAllResourceGroups() {
+        final ResourceGroupMgr resourceGroupMgr = GlobalStateMgr.getCurrentState().getResourceGroupMgr();
+        if (resourceGroupMgr == null) {
+            return new ArrayList<>();
+        }
+        final List<ResourceGroup> groups = new ArrayList<>();
+        // getAllResourceGroupNames() hands back the manager's live key set, not a copy, so snapshot it before
+        // the per-name lookups below rather than iterating it across them.
+        for (String groupName : new ArrayList<>(resourceGroupMgr.getAllResourceGroupNames())) {
+            final ResourceGroup group = resourceGroupMgr.getResourceGroup(groupName);
+            if (group != null) {
+                groups.add(group);
+            }
+        }
+        return groups;
+    }
+
+    /**
+     * Names of the groups whose {@code warehouses} property references {@code warehouseName}, sorted so the
+     * error message is deterministic.
+     *
+     * <p>Matching is case-sensitive on purpose: it mirrors
+     * {@code ResourceGroupMgr#isResourceGroupMatchWarehouse}, which compares with {@code List#contains}. A
+     * binding that differs only in case never matched any query, so it is not a reference worth blocking a
+     * drop for.
+     */
+    static List<String> boundResourceGroupNames(String warehouseName, List<ResourceGroup> groups) {
+        final List<String> bound = new ArrayList<>();
+        for (ResourceGroup group : groups) {
+            final List<String> warehouses = group.getWarehouses();
+            if (warehouses != null && warehouses.contains(warehouseName)) {
+                bound.add(group.getName());
+            }
+        }
+        Collections.sort(bound);
+        return bound;
+    }
+
+    /**
+     * The StarMgr client used for worker-group operations. Seam for tests.
+     */
+    protected StarOSAgent getStarOSAgent() throws DdlException {
+        StarOSAgent agent = GlobalStateMgr.getCurrentState().getStarOSAgent();
+        if (agent == null) {
+            throw new DdlException("StarOSAgent is not available");
+        }
+        return agent;
+    }
+
+    private List<ComputeNode> nodesOf(Warehouse warehouse) {
+        if (warehouse instanceof MultiWarehouse) {
+            return ((MultiWarehouse) warehouse).getNodes();
+        }
+        return new ArrayList<>();
+    }
+
+    private void deleteWorkerGroupQuietly(long workerGroupId) {
+        try {
+            getStarOSAgent().deleteWorkerGroup(workerGroupId);
+        } catch (Exception e) {
+            LOG.warn("Failed to delete starMgr worker group {}, it may be leaked: {}",
+                    workerGroupId, e.getMessage());
+        }
+    }
+
+    private static String extractSize(Map<String, String> properties) {
+        String size = properties.remove(PROPERTY_SIZE);
+        if (Strings.isNullOrEmpty(size)) {
+            return DEFAULT_SIZE;
+        }
+        return size;
+    }
+
+    private static int extractReplicaNumber(Map<String, String> properties) throws DdlException {
+        String value = properties.remove(PROPERTY_REPLICA_NUMBER);
+        if (Strings.isNullOrEmpty(value)) {
+            return DEFAULT_REPLICA_NUMBER;
+        }
+        int replicaNumber;
+        try {
+            replicaNumber = Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            throw new DdlException("Property '" + PROPERTY_REPLICA_NUMBER + "' must be an integer, got: " + value);
+        }
+        if (replicaNumber < 1) {
+            throw new DdlException("Property '" + PROPERTY_REPLICA_NUMBER + "' must be >= 1, got: " + replicaNumber);
+        }
+        return replicaNumber;
+    }
+
+    private static void checkNoUnknownProperties(Map<String, String> leftovers) throws DdlException {
+        if (!leftovers.isEmpty()) {
+            throw new DdlException(String.format("Unknown warehouse properties: %s. Supported: %s, %s",
+                    leftovers.keySet(), PROPERTY_SIZE, PROPERTY_REPLICA_NUMBER));
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/warehouse/multi/MultiWarehouseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/warehouse/multi/MultiWarehouseTest.java
@@ -1,0 +1,442 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.warehouse.multi;
+
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.ResourceGroup;
+import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.ExceptionChecker;
+import com.starrocks.lake.StarOSAgent;
+import com.starrocks.persist.WALApplier;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.NodeMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.sql.ast.warehouse.AlterWarehouseStmt;
+import com.starrocks.sql.ast.warehouse.CreateWarehouseStmt;
+import com.starrocks.sql.ast.warehouse.DropWarehouseStmt;
+import com.starrocks.sql.ast.warehouse.ResumeWarehouseStmt;
+import com.starrocks.sql.ast.warehouse.SuspendWarehouseStmt;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.warehouse.Warehouse;
+import com.starrocks.warehouse.cngroup.ComputeResource;
+import com.starrocks.warehouse.cngroup.WarehouseComputeResourceProvider;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class MultiWarehouseTest {
+    @Mocked
+    private GlobalStateMgr globalStateMgr;
+    @Mocked
+    private NodeMgr nodeMgr;
+    @Mocked
+    private SystemInfoService systemInfo;
+
+    private TestableMultiWarehouseManager mgr;
+
+    /**
+     * A manager whose journal write applies in-memory immediately (as it does on a real leader), whose id
+     * allocation does not need a running GlobalStateMgr, and which talks to a fake StarMgr client.
+     */
+    private static class TestableMultiWarehouseManager extends MultiWarehouseManager {
+        private final AtomicLong nextId = new AtomicLong(10000L);
+        private final FakeStarOSAgent agent = new FakeStarOSAgent();
+        private List<ResourceGroup> resourceGroups = new ArrayList<>();
+
+        @Override
+        protected List<ResourceGroup> fetchAllResourceGroups() {
+            return resourceGroups;
+        }
+
+        @Override
+        protected void logEdit(short op, Object payload, WALApplier applier) {
+            applier.apply(payload);
+        }
+
+        @Override
+        protected long allocateId() {
+            return nextId.incrementAndGet();
+        }
+
+        @Override
+        protected StarOSAgent getStarOSAgent() {
+            return agent;
+        }
+    }
+
+    /**
+     * Records the worker-group calls the manager makes.
+     *
+     * <p>Hand-written rather than a JMockit mock on purpose: a {@code @Mocked StarOSAgent} stubs out every
+     * method of the class - including ones a {@code MockUp} defines - which silently turns
+     * {@code createWorkerGroup} into "return 0" and makes every warehouse share worker group 0.
+     */
+    private static class FakeStarOSAgent extends StarOSAgent {
+        @Override
+        public long createWorkerGroup(String size, int replicaNumber) {
+            CREATED_SIZES.add(size);
+            return NEXT_WORKER_GROUP_ID.incrementAndGet();
+        }
+
+        @Override
+        public void deleteWorkerGroup(long groupId) {
+            DELETED_WORKER_GROUPS.add(groupId);
+        }
+
+        @Override
+        public void updateWorkerGroup(long workerGroupId, int replicaNumber) {
+            UPDATED_REPLICA_NUMBERS.add(replicaNumber);
+        }
+    }
+
+    private static final AtomicLong NEXT_WORKER_GROUP_ID = new AtomicLong(1000L);
+    private static final List<Long> DELETED_WORKER_GROUPS = new ArrayList<>();
+    private static final List<String> CREATED_SIZES = new ArrayList<>();
+    private static final List<Integer> UPDATED_REPLICA_NUMBERS = new ArrayList<>();
+
+    @BeforeAll
+    public static void setUp() {
+        new MockUp<RunMode>() {
+            @Mock
+            boolean isSharedDataMode() {
+                return true;
+            }
+        };
+    }
+
+    @BeforeEach
+    public void before() {
+        mgr = new TestableMultiWarehouseManager();
+        mgr.initDefaultWarehouse();
+        DELETED_WORKER_GROUPS.clear();
+        CREATED_SIZES.clear();
+        UPDATED_REPLICA_NUMBERS.clear();
+    }
+
+    private static CreateWarehouseStmt createStmt(String name, Map<String, String> properties, boolean ifNotExists) {
+        return new CreateWarehouseStmt(ifNotExists, name, properties, "az-local warehouse");
+    }
+
+    @Test
+    public void testCreateWarehouse() throws DdlException {
+        mgr.createWarehouse(createStmt("warehouse_az_a", null, false));
+        Assertions.assertTrue(mgr.warehouseExists("warehouse_az_a"));
+        Warehouse warehouse = mgr.getWarehouse("warehouse_az_a");
+        Assertions.assertInstanceOf(MultiWarehouse.class, warehouse);
+        Assertions.assertEquals(1, warehouse.getWorkerGroupIds().size());
+        Assertions.assertNotEquals(StarOSAgent.DEFAULT_WORKER_GROUP_ID,
+                warehouse.getAnyWorkerGroupId().longValue());
+        Assertions.assertEquals(MultiWarehouseManager.DEFAULT_SIZE, CREATED_SIZES.get(0));
+        Assertions.assertTrue(mgr.getAllWarehouseNames().contains("warehouse_az_a"));
+        Assertions.assertTrue(mgr.getAllWarehouseNames().contains(WarehouseManager.DEFAULT_WAREHOUSE_NAME));
+
+        // Each warehouse gets its own worker group, which is what keeps AZs apart.
+        mgr.createWarehouse(createStmt("warehouse_az_b", null, false));
+        Assertions.assertNotEquals(mgr.getWarehouse("warehouse_az_a").getAnyWorkerGroupId(),
+                mgr.getWarehouse("warehouse_az_b").getAnyWorkerGroupId());
+    }
+
+    @Test
+    public void testCreateWarehouseWithProperties() throws DdlException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(MultiWarehouseManager.PROPERTY_SIZE, "x2");
+        properties.put(MultiWarehouseManager.PROPERTY_REPLICA_NUMBER, "2");
+        mgr.createWarehouse(createStmt("wh", properties, false));
+        Assertions.assertEquals("x2", CREATED_SIZES.get(0));
+        MultiWarehouse warehouse = (MultiWarehouse) mgr.getWarehouse("wh");
+        // Declared properties are kept verbatim so SHOW WAREHOUSES reflects what the user asked for.
+        Assertions.assertEquals("x2", warehouse.getProperties().get(MultiWarehouseManager.PROPERTY_SIZE));
+        Assertions.assertEquals("2", warehouse.getProperties().get(MultiWarehouseManager.PROPERTY_REPLICA_NUMBER));
+    }
+
+    @Test
+    public void testCreateWarehouseAlreadyExists() throws DdlException {
+        mgr.createWarehouse(createStmt("wh", null, false));
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "Warehouse wh already exists.",
+                () -> mgr.createWarehouse(createStmt("wh", null, false)));
+
+        // IF NOT EXISTS is a no-op and must not allocate another worker group.
+        long groupId = mgr.getWarehouse("wh").getAnyWorkerGroupId();
+        mgr.createWarehouse(createStmt("wh", null, true));
+        Assertions.assertEquals(groupId, mgr.getWarehouse("wh").getAnyWorkerGroupId().longValue());
+        Assertions.assertEquals(1, CREATED_SIZES.size());
+    }
+
+    @Test
+    public void testCreateWarehouseRejectsUnknownProperty() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("availability_zone", "eu-west-1a");
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "Unknown warehouse properties",
+                () -> mgr.createWarehouse(createStmt("wh", properties, false)));
+        Assertions.assertFalse(mgr.warehouseExists("wh"));
+        // Nothing was allocated in StarMgr, so nothing needs cleaning up.
+        Assertions.assertTrue(CREATED_SIZES.isEmpty());
+        Assertions.assertTrue(DELETED_WORKER_GROUPS.isEmpty());
+    }
+
+    @Test
+    public void testCreateWarehouseRejectsBadReplicaNumber() {
+        Map<String, String> notANumber = new HashMap<>();
+        notANumber.put(MultiWarehouseManager.PROPERTY_REPLICA_NUMBER, "many");
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "must be an integer",
+                () -> mgr.createWarehouse(createStmt("wh", notANumber, false)));
+
+        Map<String, String> zero = new HashMap<>();
+        zero.put(MultiWarehouseManager.PROPERTY_REPLICA_NUMBER, "0");
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "must be >= 1",
+                () -> mgr.createWarehouse(createStmt("wh", zero, false)));
+    }
+
+    @Test
+    public void testDropWarehouse() throws DdlException {
+        mgr.createWarehouse(createStmt("wh", null, false));
+        long groupId = mgr.getWarehouse("wh").getAnyWorkerGroupId();
+        mgr.dropWarehouse(new DropWarehouseStmt(false, "wh"));
+        Assertions.assertFalse(mgr.warehouseExists("wh"));
+        Assertions.assertEquals(List.of(groupId), DELETED_WORKER_GROUPS);
+    }
+
+    @Test
+    public void testDropWarehouseNotExists() {
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "Warehouse name: wh not exist.",
+                () -> mgr.dropWarehouse(new DropWarehouseStmt(false, "wh")));
+        ExceptionChecker.expectThrowsNoException(() -> mgr.dropWarehouse(new DropWarehouseStmt(true, "wh")));
+    }
+
+    @Test
+    public void testDropDefaultWarehouseIsRejected() {
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "Can't drop the default_warehouse",
+                () -> mgr.dropWarehouse(new DropWarehouseStmt(false, WarehouseManager.DEFAULT_WAREHOUSE_NAME)));
+    }
+
+    @Test
+    public void testDropWarehouseWithNodesIsRejected() throws DdlException {
+        mgr.createWarehouse(createStmt("wh", null, false));
+        MultiWarehouse warehouse = (MultiWarehouse) mgr.getWarehouse("wh");
+        ComputeNode node = new ComputeNode(1001L, "127.0.0.1", 9050);
+        warehouse.addNodeToCNGroup(node, null);
+        new MockUp<MultiWarehouse>() {
+            @Mock
+            public List<ComputeNode> getNodes() {
+                return List.of(node);
+            }
+        };
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "still has 1 node(s)",
+                () -> mgr.dropWarehouse(new DropWarehouseStmt(false, "wh")));
+        Assertions.assertTrue(mgr.warehouseExists("wh"));
+        Assertions.assertTrue(DELETED_WORKER_GROUPS.isEmpty());
+    }
+
+    @Test
+    public void testAlterWarehouse() throws DdlException {
+        mgr.createWarehouse(createStmt("wh", null, false));
+        Map<String, String> changes = new HashMap<>();
+        changes.put(MultiWarehouseManager.PROPERTY_REPLICA_NUMBER, "3");
+        mgr.alterWarehouse(new AlterWarehouseStmt("wh", changes));
+        Assertions.assertEquals(List.of(3), UPDATED_REPLICA_NUMBERS);
+        MultiWarehouse warehouse = (MultiWarehouse) mgr.getWarehouse("wh");
+        Assertions.assertEquals("3", warehouse.getProperties().get(MultiWarehouseManager.PROPERTY_REPLICA_NUMBER));
+        Assertions.assertTrue(warehouse.getUpdatedTime() >= warehouse.getCreatedTime());
+    }
+
+    @Test
+    public void testAlterWarehouseRejectsImmutableProperty() throws DdlException {
+        mgr.createWarehouse(createStmt("wh", null, false));
+        Map<String, String> changes = new HashMap<>();
+        changes.put(MultiWarehouseManager.PROPERTY_SIZE, "x4");
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "can not be altered",
+                () -> mgr.alterWarehouse(new AlterWarehouseStmt("wh", changes)));
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "No property to alter",
+                () -> mgr.alterWarehouse(new AlterWarehouseStmt("wh", Maps.newHashMap())));
+    }
+
+    @Test
+    public void testAlterUnknownWarehouse() {
+        Map<String, String> changes = new HashMap<>();
+        changes.put(MultiWarehouseManager.PROPERTY_REPLICA_NUMBER, "3");
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "Warehouse name: nope not exist.",
+                () -> mgr.alterWarehouse(new AlterWarehouseStmt("nope", changes)));
+    }
+
+    @Test
+    public void testSuspendResumeUnsupported() {
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "SUSPEND WAREHOUSE is not supported",
+                () -> mgr.suspendWarehouse(new SuspendWarehouseStmt("wh")));
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "RESUME WAREHOUSE is not supported",
+                () -> mgr.resumeWarehouse(new ResumeWarehouseStmt("wh")));
+    }
+
+    @Test
+    public void testNodeAssignment() throws DdlException {
+        mgr.createWarehouse(createStmt("warehouse_az_a", null, false));
+        MultiWarehouse warehouse = (MultiWarehouse) mgr.getWarehouse("warehouse_az_a");
+        ComputeNode node = new ComputeNode(1001L, "10.0.1.10", 9050);
+        warehouse.addNodeToCNGroup(node, null);
+
+        // This is the whole point: the node lands in the warehouse's worker group, so the scheduler will only
+        // pick it for sessions pinned to that warehouse.
+        Assertions.assertEquals(warehouse.getAnyWorkerGroupId().longValue(), node.getWorkerGroupId());
+        Assertions.assertEquals(warehouse.getId(), node.getWarehouseId());
+
+        // CNGROUPs are not implemented, so naming one must fail rather than silently ignore it.
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "CNGroup feature not implemented",
+                () -> warehouse.addNodeToCNGroup(node, "cngroup_1"));
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "CNGroup feature not implemented",
+                () -> warehouse.validateRemoveNodeFromCNGroup(node, "cngroup_1"));
+    }
+
+    @Test
+    public void testWarehouseInfoColumnCount() throws DdlException {
+        mgr.createWarehouse(createStmt("wh", null, false));
+        List<String> info = mgr.getWarehouse("wh").getWarehouseInfo();
+        // Must match ShowResultMetaFactory#visitShowWarehousesStatement.
+        Assertions.assertEquals(14, info.size());
+        Assertions.assertEquals("wh", info.get(1));
+        Assertions.assertEquals("az-local warehouse", info.get(13));
+    }
+
+    private static ResourceGroup resourceGroup(String name, String... warehouses) {
+        ResourceGroup group = new ResourceGroup();
+        group.setName(name);
+        if (warehouses.length > 0) {
+            group.setWarehouses(List.of(warehouses));
+        }
+        return group;
+    }
+
+    /**
+     * A resource group binds warehouses by name and only validates them at CREATE/ALTER time, so dropping a
+     * bound warehouse would leave a binding that silently stops matching.
+     */
+    @Test
+    public void testDropWarehouseBoundByResourceGroupIsRejected() throws DdlException {
+        mgr.createWarehouse(createStmt("warehouse_az_b", null, false));
+        mgr.resourceGroups = List.of(
+                resourceGroup("rg_global"), // bound to nothing: applies everywhere
+                resourceGroup("rg_az_b", "warehouse_az_b"),
+                resourceGroup("rg_both", "warehouse_az_a", "warehouse_az_b"));
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                "is still bound by resource group(s) [rg_az_b, rg_both]",
+                () -> mgr.dropWarehouse(new DropWarehouseStmt(false, "warehouse_az_b")));
+        Assertions.assertTrue(mgr.warehouseExists("warehouse_az_b"));
+        // The StarMgr worker group must survive a refused drop.
+        Assertions.assertTrue(DELETED_WORKER_GROUPS.isEmpty());
+
+        // Once the bindings are gone the drop succeeds.
+        mgr.resourceGroups = List.of(resourceGroup("rg_global"));
+        long groupId = mgr.getWarehouse("warehouse_az_b").getAnyWorkerGroupId();
+        mgr.dropWarehouse(new DropWarehouseStmt(false, "warehouse_az_b"));
+        Assertions.assertFalse(mgr.warehouseExists("warehouse_az_b"));
+        Assertions.assertEquals(List.of(groupId), DELETED_WORKER_GROUPS);
+    }
+
+    @Test
+    public void testBoundResourceGroupNames() {
+        List<ResourceGroup> groups = List.of(
+                resourceGroup("rg_none"),
+                resourceGroup("rg_b", "warehouse_az_b"),
+                resourceGroup("rg_a", "warehouse_az_a"),
+                resourceGroup("rg_ab", "warehouse_az_a", "warehouse_az_b"));
+        // Sorted, so the error message is deterministic.
+        Assertions.assertEquals(List.of("rg_a", "rg_ab"),
+                MultiWarehouseManager.boundResourceGroupNames("warehouse_az_a", groups));
+        Assertions.assertEquals(List.of("rg_ab", "rg_b"),
+                MultiWarehouseManager.boundResourceGroupNames("warehouse_az_b", groups));
+        // A group bound to nothing applies to every warehouse and never blocks a drop.
+        Assertions.assertEquals(List.of(),
+                MultiWarehouseManager.boundResourceGroupNames("warehouse_az_c", groups));
+        // Case-sensitive, mirroring ResourceGroupMgr#isResourceGroupMatchWarehouse (List#contains): a binding
+        // that differs only in case never matched a query, so it is not a reference worth blocking a drop for.
+        Assertions.assertEquals(List.of(),
+                MultiWarehouseManager.boundResourceGroupNames("WAREHOUSE_AZ_A", groups));
+    }
+
+    @Test
+    public void testBackgroundWarehouseFollowsConfig() throws DdlException {
+        mgr.createWarehouse(createStmt("wh", null, false));
+        // Default: background work stays in default_warehouse.
+        Assertions.assertEquals(WarehouseManager.DEFAULT_WAREHOUSE_NAME, mgr.getBackgroundWarehouse().getName());
+
+        String saved = Config.lake_background_warehouse;
+        try {
+            Config.lake_background_warehouse = "wh";
+            Assertions.assertEquals("wh", mgr.getBackgroundWarehouse().getName());
+            // A config pointing at a warehouse that does not exist must not break background jobs.
+            Config.lake_background_warehouse = "gone";
+            Assertions.assertEquals(WarehouseManager.DEFAULT_WAREHOUSE_NAME, mgr.getBackgroundWarehouse().getName());
+        } finally {
+            Config.lake_background_warehouse = saved;
+        }
+    }
+
+    @Test
+    public void testCompactionComputeResourceFollowsConfig() throws DdlException {
+        new MockUp<WarehouseComputeResourceProvider>() {
+            @Mock
+            public boolean isResourceAvailable(ComputeResource computeResource) {
+                return true;
+            }
+        };
+        mgr.createWarehouse(createStmt("wh", null, false));
+
+        String saved = Config.lake_compaction_warehouse;
+        try {
+            Config.lake_compaction_warehouse = "wh";
+            Assertions.assertEquals(mgr.getWarehouse("wh").getId(),
+                    mgr.getCompactionComputeResource(1L).getWarehouseId());
+            Config.lake_compaction_warehouse = WarehouseManager.DEFAULT_WAREHOUSE_NAME;
+            Assertions.assertEquals(WarehouseManager.DEFAULT_WAREHOUSE_ID,
+                    mgr.getCompactionComputeResource(1L).getWarehouseId());
+        } finally {
+            Config.lake_compaction_warehouse = saved;
+        }
+    }
+
+    /**
+     * The image and the edit log both round-trip warehouses through the abstract {@link Warehouse} type, which
+     * only works if MultiWarehouse is registered as a gson subtype.
+     */
+    @Test
+    public void testGsonRoundTrip() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(MultiWarehouseManager.PROPERTY_SIZE, "x1");
+        MultiWarehouse original = new MultiWarehouse(123L, "wh", "comment", 456L, properties, 1000L);
+        String json = GsonUtils.GSON.toJson(original);
+        Assertions.assertTrue(json.contains("MultiWarehouse"), "type discriminator missing: " + json);
+        Warehouse restored = GsonUtils.GSON.fromJson(json, Warehouse.class);
+        Assertions.assertInstanceOf(MultiWarehouse.class, restored);
+        Assertions.assertEquals(123L, restored.getId());
+        Assertions.assertEquals("wh", restored.getName());
+        Assertions.assertEquals("comment", restored.getComment());
+        Assertions.assertEquals(456L, restored.getAnyWorkerGroupId().longValue());
+        Assertions.assertEquals("x1", ((MultiWarehouse) restored).getProperties()
+                .get(MultiWarehouseManager.PROPERTY_SIZE));
+        Assertions.assertEquals(1000L, ((MultiWarehouse) restored).getCreatedTime());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

StarRocks' grammar already parses `CREATE WAREHOUSE`, `DROP WAREHOUSE`, `ALTER WAREHOUSE` and
`ALTER SYSTEM ADD COMPUTE NODE ... INTO WAREHOUSE`, and `SET warehouse = '<name>'` is already wired
through `StmtExecutor`. But the base `WarehouseManager` rejects every one of those DDLs with
`"Multi-Warehouse is not implemented"`, and the only warehouse that ever exists is `default_warehouse`
on StarMgr's default worker group.

The practical consequence: in a shared-data cluster spread across availability zones, there is no way to
confine a query to the CNs of one AZ. Every MPP shuffle can cross an AZ boundary, which costs both
latency and inter-AZ network charges.

## What I'm doing:

Implementing multi-warehouse, so each user-created warehouse owns its own StarMgr worker group. Compute
nodes added with `... INTO WAREHOUSE <name>` are registered into that group, so a session pinned with
`SET warehouse = '<name>'` only ever schedules fragments onto that warehouse's nodes — which is what
keeps a query's shuffles inside a single AZ.

Nothing downstream needed changing: fragment placement, tablet-to-node resolution and background jobs
already route through `ComputeResource`.

Usage:

```sql
CREATE WAREHOUSE warehouse_az_a;
CREATE WAREHOUSE warehouse_az_b;

ALTER SYSTEM ADD COMPUTE NODE "10.0.1.10:9050" INTO WAREHOUSE warehouse_az_a;
ALTER SYSTEM ADD COMPUTE NODE "10.0.2.10:9050" INTO WAREHOUSE warehouse_az_b;

SET warehouse = 'warehouse_az_a';
SHOW NODES FROM WAREHOUSE warehouse_az_a;
```

**Main changes**

- `MultiWarehouseManager` — a `WarehouseManager` that really creates warehouses. `CREATE` allocates the
  worker group, `DROP` deletes it, `ALTER` updates its replica count. Journalled through the existing
  `OP_CREATE/DROP/ALTER_WAREHOUSE` entries and persisted in the existing `WAREHOUSE_MGR` image block.
- `MultiWarehouse` — a `Warehouse` owning exactly one worker group; registered as a gson subtype so both
  the image and the edit log can round-trip it through the abstract `Warehouse` type.
- `MultiWarehouseExtension` — optional registration path for deployments that ship extensions in
  `Config.ext_dir` rather than editing `fe.conf`.
- New FE config `enable_multi_warehouse`, **default `false`**, which selects the implementation. Existing
  clusters are unaffected until it is turned on.

**Guardrails worth reviewing**

- `DROP WAREHOUSE` refuses while compute nodes are still attached — deleting the worker group underneath a
  live CN would leave the node pointing at a group StarMgr no longer knows about.
- `DROP WAREHOUSE` also refuses while a resource group still binds the warehouse. `ResourceGroup` binds
  warehouses **by name** and only validates that name at CREATE/ALTER time, so dropping a bound warehouse
  would leave a dangling binding that silently stops matching in
  `ResourceGroupMgr#isResourceGroupMatchWarehouse` — and a group bound only to that warehouse would become
  unreachable with no error anywhere.
- `getBackgroundWarehouse()` / `getCompactionComputeResource()` now honour `lake_background_warehouse` and
  `lake_compaction_warehouse`. Without this, once every CN has been moved into a user-created warehouse,
  background jobs (vacuum, compaction, dictionary refresh, the leader daemons) would be left pointing at a
  `default_warehouse` with no nodes.
- `DefaultExtensionContext` resolves the `WarehouseManager` implementation **lazily**, on first `get()`.
  Reading `Config.enable_multi_warehouse` eagerly in `registerDefault()` is unsafe: that context is
  constructed from a static initializer that `GsonUtils` pulls in, which can run before `Config.init()` and
  would silently freeze the flag at `false`.
- `size` is immutable after creation (the StarMgr client exposes no resize call) and is rejected by
  `ALTER WAREHOUSE` with an explicit message rather than being silently ignored.

**Not implemented** (each reports so explicitly rather than failing silently): CNGROUPs, and
`SUSPEND`/`RESUME WAREHOUSE`.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

With `enable_multi_warehouse = false` (the default) behaviour is unchanged. With it enabled, the existing
`CREATE`/`DROP`/`ALTER WAREHOUSE` statements stop returning `"Multi-Warehouse is not implemented"` and
start working, and `SHOW WAREHOUSES` / `SHOW NODES FROM WAREHOUSE` return real rows.

Note for reviewers on downgrade: the config must not be flipped back to `false` once warehouses exist —
the base `WarehouseManager` does not read the persisted warehouses, so they would vanish from the catalog
while compute nodes still reference their IDs. This is called out in the config's javadoc and in the docs.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

**Tests** — `MultiWarehouseTest`, 20 cases: create (incl. `IF NOT EXISTS`, properties, unknown-property and
bad-`replica_number` rejection), drop (incl. `IF EXISTS`, default-warehouse, nodes-attached and
resource-group-bound rejections), alter (incl. immutable-property rejection), node assignment into the
warehouse's worker group, CNGROUP rejection, `SUSPEND`/`RESUME` rejection, `getWarehouseInfo()` column count
against `ShowResultMetaFactory`, background/compaction warehouse config resolution, and gson round-trip
through the abstract `Warehouse` type.

**Docs** — `enable_multi_warehouse` added to
`docs/{en,zh,ja}/administration/configuration/FE_parameters/shared_lake_other.md`.

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

Not a bugfix — no backport intended.