### PR TITLE
[UT] Fix FrameOfReferencePageTest column type mismatch in copy_one

### DIFF
--- a/be/test/storage/rowset/frame_of_reference_page_test.cpp
+++ b/be/test/storage/rowset/frame_of_reference_page_test.cpp
@@ -58,10 +58,10 @@ class FrameOfReferencePageTest : public testing::Test {
 public:
     template <LogicalType type, class PageDecoderType>
     void copy_one(PageDecoderType* decoder, StorageCppType<type>* ret) {
-        LogicalType ltype = scalar_field_type_to_logical_type(type);
-        TypeDescriptor index_type(ltype);
-        // TODO(alvinz): To reuse this colum
-        auto column = ColumnHelper::create_column(index_type, false);
+        // Must build a storage-typed column (e.g. TYPE_DATETIME_V1 -> Int64Column) to match
+        // GetStorageContainer<type>, not the query-typed column (e.g. TYPE_DATETIME -> TimestampColumn)
+        // that scalar_field_type_to_logical_type() + ColumnHelper::create_column() would produce.
+        auto column = ChunkFactory::column_from_field_type(type, false);
         size_t n = 1;
         ASSERT_TRUE(decoder->next_batch(&n, column.get()).ok());
         ASSERT_EQ(1, n);


### PR DESCRIPTION
## Why I'm doing:

```
❯ [ RUN      ] FrameOfReferencePageTest.TestInt64BlockEncoderSequence                                                                                                                                                                    
  I20260819 08:06:16.818483 +0000 140405497049920 frame_of_reference_page_test.cpp:81]  FrameOfReference Encoded size for 10000 values: 2045, original size:80000                                                                        
  I20260819 08:06:16.819879 +0000 140405497049920 frame_of_reference_page_test.cpp:123]  FrameOfReference Encoded size for 10000 values: 2045, original size:80000                                                                       
  I20260819 08:06:16.843804 +0000 140405497049920 frame_of_reference_page_test.cpp:81]  FrameOfReference Encoded size for 10000 values: 2045, original size:80000                                                                        
  F20260819 08:06:16.844425 +0000 140405497049920 column_helper.h:459]  Check failed: result Cast failed for column:  (expected type: N9starrocks17FixedLengthColumnIlEE, actual type: timestamp)                                        
      @         0x26860a5d  google::LogMessage::Fail()                                                                                                                                                                                   
      @         0x26861b44  google::LogMessageFatal::~LogMessageFatal()                                                                                                                                                                  
      @         0x1adf464d  starrocks::FixedLengthColumn<long> const* starrocks::ColumnHelper::as_raw_column<starrocks::FixedLengthColumn<long> >(starrocks::Column const*)                                                              
      @         0x1aed0c2e  starrocks::GetStorageContainer<(starrocks::LogicalType)15>::get_data(starrocks::Column const*)                                                                                                               
      @         0x1b017dbd  starrocks::GetStorageContainer<(starrocks::LogicalType)15>::get_data(starrocks::Column const*, unsigned long)                                                                                                
      @         0x1b01806d  void starrocks::FrameOfReferencePageTest::copy_one<(starrocks::LogicalType)15, starrocks::FrameOfReferencePageDecoder<(starrocks::LogicalType)15>                                                            
  >(starrocks::FrameOfReferencePageDecoder<(starrocks::LogicalType)15>, starrocks::StorageTypeTraits<(starrocks@                                                                                                                         
      @         0x1b010c6f  void starrocks::FrameOfReferencePageTest::test_encode_decode_page_template<(starrocks::LogicalType)15, starrocks::FrameOfReferencePageBuilder<(starrocks::LogicalType)15>,                                   
  starrocks::FrameOfReferencePageDecoder<(starrocks::LogicalType)15> >(starrocks::Stora@                                                                                                                                                 
      @         0x1b00710e  starrocks::FrameOfReferencePageTest_TestInt64BlockEncoderSequence_Test::TestBody()                                                                                                                           
      @         0x295bd161  void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test, void (testing::Test::)(), char const)                                                                        
      @         0x295b0636  testing::Test::Run()                                                                                                                                                                                         
      @         0x295b079e  testing::TestInfo::Run()                                                                                                                                                                                     
      @         0x295b0887  testing::TestSuite::Run()                                                                                                                                                                                    
      @         0x295b0dd4  testing::internal::UnitTestImpl::RunAllTests()                                                                                                                                                               
      @         0x295b0fb3  testing::UnitTest::Run()                                                                                                                                                                                     
      @         0x19df5d38  RUN_ALL_TESTS()                                                                                                                                                                                              
      @         0x19df0f55  starrocks::init_test_env(int, char**, std::unique_ptr<starrocks::SchemaScannerFactory, std::default_delete<starrocks::SchemaScannerFactory> >)                                                               
      @         0x19df191f  main                                                                                                                                                                                                         
      @     0x7fb2b3f391ca  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9)                                                                                                                                                                
      @     0x7fb2b3f3928b  __libc_start_main                                                                                                                                                                                            
      @         0x19def025  _start
```

`FrameOfReferencePageTest.TestInt64BlockEncoderSequence` (and other cases using
`copy_one()`) crashes with a `CHECK failed` fatal log, e.g. for `TYPE_DATETIME_V1`:

```
F ... column_helper.h:459]  Check failed: result Cast failed for column:  (expected type: N9starrocks17FixedLengthColumnIlEE, actual type: timestamp)
```

`copy_one()` converts the storage `LogicalType` (e.g. `TYPE_DATETIME_V1`) to
its query `LogicalType` (`TYPE_DATETIME`) via `scalar_field_type_to_logical_type()`
before building the column with `ColumnHelper::create_column()`. That produces
a `TimestampColumn`, but `GetStorageContainer<type>::get_data()` expects the
storage-typed column (`Int64Column` for `TYPE_DATETIME_V1`/`TYPE_DATE_V1`),
so `as_raw_column` fails its type-safety check and aborts.

This code path (`GetStorageContainer`/`as_raw_column` with a strict type
check) was introduced by #71577 on `main` only, so this crash does not
reproduce on branch-4.1/4.0/3.5 and does not need backporting there.

## What I'm doing:

Build the column the same way the rest of the test does — via
`ChunkFactory::column_from_field_type(type, false)` using the storage type
directly — so it matches what `GetStorageContainer<type>` expects.

Test-only change; no production code touched.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5