### PR TITLE
[Enhancement] Support the PAUSE trigger mode for failpoints

### DIFF
--- a/be/src/base/failpoint/fail_point.cpp
+++ b/be/src/base/failpoint/fail_point.cpp
@@ -18,6 +18,7 @@
 
 #include <chrono>
 #include <filesystem>
+#include <limits>
 #include <unordered_set>
 #include <utility>
 
@@ -279,6 +280,22 @@ bool init_failpoint_from_conf(const std::string& conf_file) {
                 }
                 trigger_mode.set_mode(FailPointTriggerModeType::PROBABILITY_ENABLE);
                 trigger_mode.set_probability(probability.value());
+            } else if (mode.value() == "pause") {
+                // Mirror the wire encoding: mode = DISABLE plus the pause flag.
+                trigger_mode.set_mode(FailPointTriggerModeType::DISABLE);
+                trigger_mode.set_pause(true);
+                // Optional. Absent leaves the field unset and the failpoint layer falls back to
+                // kDefaultPauseTimeoutSecond.
+                auto pause_timeout_second = value["pause_timeout_second"].get_int64();
+                if (pause_timeout_second.error() == simdjson::SUCCESS) {
+                    const int64_t raw = pause_timeout_second.value();
+                    if (raw <= 0 || raw > std::numeric_limits<int32_t>::max()) {
+                        LOG(WARNING) << "ignoring out-of-range pause_timeout_second " << raw << " for failpoint "
+                                     << std::string(fp_name.value());
+                    } else {
+                        trigger_mode.set_pause_timeout_second(static_cast<int32_t>(raw));
+                    }
+                }
             }
             fp->setMode(trigger_mode);
         }

--- a/be/src/base/failpoint/fail_point.cpp
+++ b/be/src/base/failpoint/fail_point.cpp
@@ -130,12 +130,16 @@ bool FailPoint::wait_until_released(uint64_t gen, int32_t timeout_second) {
         // Disarm, do not merely resume: leaving the failpoint armed would park every NEWLY arriving
         // thread for another full timeout, so a failpoint on a hot path (a publish RPC handler, say)
         // would keep the node wedged indefinitely -- the opposite of the self-healing this timeout
-        // exists to provide. Done outside the _pause_mu scope because setMode takes _mu -> _pause_mu.
-        LOG(WARNING) << "failpoint " << _name << " pause timed out after " << timeout_second
-                     << "s, disarming it and resuming";
-        PFailPointTriggerMode disabled;
-        disabled.set_mode(FailPointTriggerModeType::DISABLE);
-        setMode(disabled);
+        // exists to provide. Done outside the _pause_mu scope because the disarm takes
+        // _mu -> _pause_mu, and conditionally so it cannot clobber a concurrent re-arm.
+        if (disarm_expired_pause(gen)) {
+            LOG(WARNING) << "failpoint " << _name << " pause timed out after " << timeout_second
+                         << "s, disarming it and resuming";
+        } else {
+            LOG(WARNING) << "failpoint " << _name << " pause timed out after " << timeout_second
+                         << "s, resuming; its mode changed concurrently so the current state is left "
+                         << "unchanged";
+        }
     } else {
         LOG(INFO) << "failpoint " << _name << " pause released";
     }
@@ -149,6 +153,27 @@ PFailPointTriggerMode trigger_mode_from_request(const PUpdateFailPointStatusRequ
         set_pause_trigger_mode(&trigger_mode, request.pause_timeout_second());
     }
     return trigger_mode;
+}
+
+bool FailPoint::disarm_expired_pause(uint64_t gen) {
+    {
+        std::lock_guard l(_mu);
+        // Same lock order as setMode: _mu -> _pause_mu.
+        std::lock_guard<std::mutex> pl(_pause_mu);
+        if (_mode_generation.load(std::memory_order_relaxed) != gen) {
+            // The mode changed while this pause was expiring -- re-armed by an operator, disabled, or
+            // already disarmed by a sibling waiter. Whatever it is now is the current intent; leave
+            // it alone.
+            return false;
+        }
+        _trigger_mode.Clear();
+        _trigger_mode.set_mode(FailPointTriggerModeType::DISABLE);
+        _mode_generation.fetch_add(1, std::memory_order_relaxed);
+    }
+    // Wake any sibling threads parked on the same generation so they resume now rather than each
+    // waiting out its own timeout.
+    _pause_cv.notify_all();
+    return true;
 }
 
 void FailPoint::setMode(const PFailPointTriggerMode& p_trigger_mode) {

--- a/be/src/base/failpoint/fail_point.cpp
+++ b/be/src/base/failpoint/fail_point.cpp
@@ -16,6 +16,7 @@
 
 #include "base/failpoint/fail_point.h"
 
+#include <chrono>
 #include <filesystem>
 #include <unordered_set>
 #include <utility>
@@ -24,6 +25,21 @@
 #include "simdjson.h"
 
 namespace starrocks::failpoint {
+
+namespace {
+// Minimal scope guard for the parked-thread gauge. Hand-rolled because be/src/base must not depend
+// on be/src/util, where DeferOp lives.
+class PausedThreadGuard {
+public:
+    explicit PausedThreadGuard(std::atomic<int64_t>* counter) : _counter(counter) {}
+    ~PausedThreadGuard() { _counter->fetch_sub(1, std::memory_order_relaxed); }
+    PausedThreadGuard(const PausedThreadGuard&) = delete;
+    PausedThreadGuard& operator=(const PausedThreadGuard&) = delete;
+
+private:
+    std::atomic<int64_t>* _counter;
+};
+} // namespace
 
 int check_fail_point(const char* name, int* failnum, void** failinfo, unsigned int* flags) {
     auto fp = FailPointRegistry::GetInstance()->get(name);
@@ -39,42 +55,117 @@ FailPoint::FailPoint(std::string name) : _name(std::move(name)) {
 }
 
 bool FailPoint::shouldFail() {
-    std::shared_lock l(_mu);
-    const auto mode = _trigger_mode.mode();
-    switch (mode) {
-    case FailPointTriggerModeType::ENABLE:
-        return true;
-    case FailPointTriggerModeType::DISABLE:
-        return false;
-    case FailPointTriggerModeType::PROBABILITY_ENABLE:
-        if (drand48() <= static_cast<double>(_trigger_mode.probability())) {
-            return true;
+    uint64_t gen = 0;
+    int64_t timeout_us = 0;
+    {
+        std::shared_lock l(_mu);
+        // Check the pause flag BEFORE the mode: a pause request carries mode = DISABLE so that a
+        // node predating the flag disables rather than enabling (see internal_service.proto).
+        if (!_trigger_mode.pause()) {
+            const auto mode = _trigger_mode.mode();
+            switch (mode) {
+            case FailPointTriggerModeType::ENABLE:
+                _trigger_count.fetch_add(1, std::memory_order_relaxed);
+                return true;
+            case FailPointTriggerModeType::DISABLE:
+                return false;
+            case FailPointTriggerModeType::PROBABILITY_ENABLE:
+                if (drand48() <= static_cast<double>(_trigger_mode.probability())) {
+                    _trigger_count.fetch_add(1, std::memory_order_relaxed);
+                    return true;
+                }
+                return false;
+            case FailPointTriggerModeType::ENABLE_N_TIMES:
+                if (_n_times-- > 0) {
+                    _trigger_count.fetch_add(1, std::memory_order_relaxed);
+                    return true;
+                }
+                return false;
+            default:
+                DCHECK(false);
+                return false;
+            }
         }
-        return false;
-    case FailPointTriggerModeType::ENABLE_N_TIMES:
-        if (_n_times-- > 0) {
-            return true;
-        }
-        return false;
-    default:
-        DCHECK(false);
-        break;
+        // Read the generation together with the mode. Reading it later, under _pause_mu, would let a
+        // setMode() landing in the gap look like the CURRENT generation, so the thread would then
+        // wait for a further change and sleep until its timeout.
+        gen = _mode_generation.load(std::memory_order_relaxed);
+        const int32_t timeout_second = _trigger_mode.pause_timeout_second() > 0
+                                               ? _trigger_mode.pause_timeout_second()
+                                               : kDefaultPauseTimeoutSecond;
+        timeout_us = static_cast<int64_t>(timeout_second) * 1000000L;
     }
+    // _mu is released before blocking -- see the _pause_mu comment in the header.
+    return wait_until_released(gen, timeout_us);
+}
+
+bool FailPoint::wait_until_released(uint64_t gen, int64_t timeout_us) {
+    std::unique_lock<bthread::Mutex> l(_pause_mu);
+    if (_mode_generation.load(std::memory_order_relaxed) != gen) {
+        // Released between dropping _mu and taking _pause_mu. This thread never parks, so it must
+        // not be counted as a fire and must not appear in the gauge.
+        return false;
+    }
+    _trigger_count.fetch_add(1, std::memory_order_relaxed);
+    _paused_thread_count.fetch_add(1, std::memory_order_relaxed);
+    PausedThreadGuard gauge(&_paused_thread_count);
+
+    LOG(INFO) << "failpoint " << _name << " paused, waiting for ADMIN DISABLE FAILPOINT";
+    // steady_clock so a wall-clock adjustment cannot extend or truncate the wait.
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::microseconds(timeout_us);
+    bool timed_out = false;
+    while (_mode_generation.load(std::memory_order_relaxed) == gen) {
+        const auto now = std::chrono::steady_clock::now();
+        if (now >= deadline) {
+            timed_out = true;
+            break;
+        }
+        // bthread's wait_for takes microseconds and returns ETIMEDOUT; the loop re-checks the
+        // predicate, so a spurious wakeup or a timeout slice is handled the same way.
+        (void)_pause_cv.wait_for(l, std::chrono::duration_cast<std::chrono::microseconds>(deadline - now).count());
+    }
+    if (timed_out) {
+        LOG(WARNING) << "failpoint " << _name << " pause timed out after " << (timeout_us / 1000000)
+                     << "s, resuming";
+    } else {
+        LOG(INFO) << "failpoint " << _name << " pause released";
+    }
+    // A released pause never injects: the caller continues normally.
     return false;
+}
+
+PFailPointTriggerMode trigger_mode_from_request(const PUpdateFailPointStatusRequest& request) {
+    PFailPointTriggerMode trigger_mode = request.trigger_mode();
+    if (request.pause()) {
+        trigger_mode.set_pause(true);
+        if (request.pause_timeout_second() > 0) {
+            trigger_mode.set_pause_timeout_second(request.pause_timeout_second());
+        }
+    }
+    return trigger_mode;
 }
 
 void FailPoint::setMode(const PFailPointTriggerMode& p_trigger_mode) {
     LOG(INFO) << "failpoint change mode, name: " << _name << ", mode: " << p_trigger_mode.DebugString();
-    std::lock_guard l(_mu);
-    _trigger_mode = p_trigger_mode;
-    auto type = p_trigger_mode.mode();
-    switch (type) {
-    case FailPointTriggerModeType::ENABLE_N_TIMES:
-        _n_times = p_trigger_mode.n_times();
-        break;
-    default:
-        break;
+    {
+        std::lock_guard l(_mu);
+        _trigger_mode = p_trigger_mode;
+        auto type = p_trigger_mode.mode();
+        switch (type) {
+        case FailPointTriggerModeType::ENABLE_N_TIMES:
+            _n_times = p_trigger_mode.n_times();
+            break;
+        default:
+            break;
+        }
+        // Bump under _pause_mu too. A waiter evaluates the predicate while holding _pause_mu, and a
+        // bump plus notify landing inside that window would be lost -- the waiter would then sleep
+        // until its timeout. Taking _pause_mu here serialises against that window. _mu -> _pause_mu
+        // is the only lock order used; the waiter never holds both.
+        std::lock_guard<bthread::Mutex> pl(_pause_mu);
+        _mode_generation.fetch_add(1, std::memory_order_relaxed);
     }
+    _pause_cv.notify_all();
 }
 
 PFailPointInfo FailPoint::to_pb() const {
@@ -82,6 +173,8 @@ PFailPointInfo FailPoint::to_pb() const {
     PFailPointInfo result;
     result.set_name(_name);
     result.mutable_trigger_mode()->CopyFrom(_trigger_mode);
+    result.set_trigger_count(_trigger_count.load(std::memory_order_relaxed));
+    result.set_paused_thread_count(_paused_thread_count.load(std::memory_order_relaxed));
     return result;
 }
 

--- a/be/src/base/failpoint/fail_point.cpp
+++ b/be/src/base/failpoint/fail_point.cpp
@@ -105,35 +105,37 @@ bool FailPoint::wait_until_released(uint64_t gen, int32_t timeout_second) {
     if (timeout_second <= 0) {
         timeout_second = kDefaultPauseTimeoutSecond;
     }
-    std::unique_lock<bthread::Mutex> l(_pause_mu);
-    if (_mode_generation.load(std::memory_order_relaxed) != gen) {
-        // Released between dropping _mu and taking _pause_mu. This thread never parks, so it must
-        // not be counted as a fire and must not appear in the gauge.
-        return false;
-    }
-    _trigger_count.fetch_add(1, std::memory_order_relaxed);
-    _paused_thread_count.fetch_add(1, std::memory_order_relaxed);
-    DeferOp gauge([this] { _paused_thread_count.fetch_sub(1, std::memory_order_relaxed); });
-
-    LOG(INFO) << "failpoint " << _name << " paused, waiting for ADMIN DISABLE FAILPOINT";
-    // A condition variable rather than Awaitility's polling loop: a pause runs for
-    // failpoint_pause_timeout_second (300s by default), so polling would wake a bthread every
-    // interval for the whole window, and release should be immediate once DISABLE lands.
-    // steady_clock so a wall-clock adjustment cannot extend or truncate the wait.
-    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(timeout_second);
     bool timed_out = false;
-    while (_mode_generation.load(std::memory_order_relaxed) == gen) {
-        const auto now = std::chrono::steady_clock::now();
-        if (now >= deadline) {
-            timed_out = true;
-            break;
+    {
+        std::unique_lock<std::mutex> l(_pause_mu);
+        if (_mode_generation.load(std::memory_order_relaxed) != gen) {
+            // Released between dropping _mu and taking _pause_mu. This thread never parks, so it
+            // must not be counted as a fire and must not appear in the gauge.
+            return false;
         }
-        // bthread's wait_for takes microseconds and returns ETIMEDOUT; the loop re-checks the
-        // predicate, so a spurious wakeup or a timeout slice is handled the same way.
-        (void)_pause_cv.wait_for(l, std::chrono::duration_cast<std::chrono::microseconds>(deadline - now).count());
+        _trigger_count.fetch_add(1, std::memory_order_relaxed);
+        _paused_thread_count.fetch_add(1, std::memory_order_relaxed);
+        DeferOp gauge([this] { _paused_thread_count.fetch_sub(1, std::memory_order_relaxed); });
+
+        LOG(INFO) << "failpoint " << _name << " paused, waiting for ADMIN DISABLE FAILPOINT";
+        // A condition variable rather than Awaitility's polling loop: a pause runs for
+        // pause_timeout_second (300s by default), so polling would wake every interval for the whole
+        // window, and release should be immediate once DISABLE lands. wait_for is specified against
+        // a steady clock, so a wall-clock adjustment cannot extend or truncate it.
+        timed_out = !_pause_cv.wait_for(l, std::chrono::seconds(timeout_second), [this, gen] {
+            return _mode_generation.load(std::memory_order_relaxed) != gen;
+        });
     }
     if (timed_out) {
-        LOG(WARNING) << "failpoint " << _name << " pause timed out after " << timeout_second << "s, resuming";
+        // Disarm, do not merely resume: leaving the failpoint armed would park every NEWLY arriving
+        // thread for another full timeout, so a failpoint on a hot path (a publish RPC handler, say)
+        // would keep the node wedged indefinitely -- the opposite of the self-healing this timeout
+        // exists to provide. Done outside the _pause_mu scope because setMode takes _mu -> _pause_mu.
+        LOG(WARNING) << "failpoint " << _name << " pause timed out after " << timeout_second
+                     << "s, disarming it and resuming";
+        PFailPointTriggerMode disabled;
+        disabled.set_mode(FailPointTriggerModeType::DISABLE);
+        setMode(disabled);
     } else {
         LOG(INFO) << "failpoint " << _name << " pause released";
     }
@@ -166,7 +168,7 @@ void FailPoint::setMode(const PFailPointTriggerMode& p_trigger_mode) {
         // bump plus notify landing inside that window would be lost -- the waiter would then sleep
         // until its timeout. Taking _pause_mu here serialises against that window. _mu -> _pause_mu
         // is the only lock order used; the waiter never holds both.
-        std::lock_guard<bthread::Mutex> pl(_pause_mu);
+        std::lock_guard<std::mutex> pl(_pause_mu);
         _mode_generation.fetch_add(1, std::memory_order_relaxed);
     }
     _pause_cv.notify_all();

--- a/be/src/base/failpoint/fail_point.cpp
+++ b/be/src/base/failpoint/fail_point.cpp
@@ -63,29 +63,27 @@ bool FailPoint::shouldFail() {
         // Check the pause flag BEFORE the mode: a pause request carries mode = DISABLE so that a
         // node predating the flag disables rather than enabling (see internal_service.proto).
         if (!_trigger_mode.pause()) {
-            const auto mode = _trigger_mode.mode();
-            switch (mode) {
+            bool fired = false;
+            switch (_trigger_mode.mode()) {
             case FailPointTriggerModeType::ENABLE:
-                _trigger_count.fetch_add(1, std::memory_order_relaxed);
-                return true;
+                fired = true;
+                break;
             case FailPointTriggerModeType::DISABLE:
-                return false;
+                break;
             case FailPointTriggerModeType::PROBABILITY_ENABLE:
-                if (drand48() <= static_cast<double>(_trigger_mode.probability())) {
-                    _trigger_count.fetch_add(1, std::memory_order_relaxed);
-                    return true;
-                }
-                return false;
+                fired = drand48() <= static_cast<double>(_trigger_mode.probability());
+                break;
             case FailPointTriggerModeType::ENABLE_N_TIMES:
-                if (_n_times-- > 0) {
-                    _trigger_count.fetch_add(1, std::memory_order_relaxed);
-                    return true;
-                }
-                return false;
+                fired = _n_times-- > 0;
+                break;
             default:
                 DCHECK(false);
-                return false;
+                break;
             }
+            if (fired) {
+                _trigger_count.fetch_add(1, std::memory_order_relaxed);
+            }
+            return fired;
         }
         // Read the generation together with the mode. Reading it later, under _pause_mu, would let a
         // setMode() landing in the gap look like the CURRENT generation, so the thread would then

--- a/be/src/base/failpoint/fail_point.cpp
+++ b/be/src/base/failpoint/fail_point.cpp
@@ -22,24 +22,30 @@
 #include <unordered_set>
 #include <utility>
 
+#include "base/utility/defer_op.h"
 #include "fmt/format.h"
 #include "simdjson.h"
 
 namespace starrocks::failpoint {
 
 namespace {
-// Minimal scope guard for the parked-thread gauge. Hand-rolled because be/src/base must not depend
-// on be/src/util, where DeferOp lives.
-class PausedThreadGuard {
-public:
-    explicit PausedThreadGuard(std::atomic<int64_t>* counter) : _counter(counter) {}
-    ~PausedThreadGuard() { _counter->fetch_sub(1, std::memory_order_relaxed); }
-    PausedThreadGuard(const PausedThreadGuard&) = delete;
-    PausedThreadGuard& operator=(const PausedThreadGuard&) = delete;
+// Fallback for a pause whose arming request carries no pause_timeout_second -- a failpoint armed
+// straight through the brpc HTTP endpoint or from the conf file. A local constant rather than an
+// FE-style config: be/src/base must not depend on be/src/common (see be/module_boundary_manifest.json).
+constexpr int32_t kDefaultPauseTimeoutSecond = 300;
 
-private:
-    std::atomic<int64_t>* _counter;
-};
+// The one place that knows how a pause is encoded into a stored trigger mode. Shared by the RPC
+// path (trigger_mode_from_request) and the conf-file path so the mixed-version safety property --
+// an old node must see DISABLE, never ENABLE -- is enforced once rather than asserted twice.
+void set_pause_trigger_mode(PFailPointTriggerMode* trigger_mode, int32_t timeout_second) {
+    // mode = DISABLE, never a dedicated enum value: proto2 reports an unknown enum as the default
+    // ENABLE, so a node predating the pause would inject the fault instead of pausing.
+    trigger_mode->set_mode(FailPointTriggerModeType::DISABLE);
+    trigger_mode->set_pause(true);
+    if (timeout_second > 0) {
+        trigger_mode->set_pause_timeout_second(timeout_second);
+    }
+}
 } // namespace
 
 int check_fail_point(const char* name, int* failnum, void** failinfo, unsigned int* flags) {
@@ -57,7 +63,7 @@ FailPoint::FailPoint(std::string name) : _name(std::move(name)) {
 
 bool FailPoint::shouldFail() {
     uint64_t gen = 0;
-    int64_t timeout_us = 0;
+    int32_t timeout_second = 0;
     {
         std::shared_lock l(_mu);
         // Check the pause flag BEFORE the mode: a pause request carries mode = DISABLE so that a
@@ -89,16 +95,16 @@ bool FailPoint::shouldFail() {
         // setMode() landing in the gap look like the CURRENT generation, so the thread would then
         // wait for a further change and sleep until its timeout.
         gen = _mode_generation.load(std::memory_order_relaxed);
-        const int32_t timeout_second = _trigger_mode.pause_timeout_second() > 0
-                                               ? _trigger_mode.pause_timeout_second()
-                                               : kDefaultPauseTimeoutSecond;
-        timeout_us = static_cast<int64_t>(timeout_second) * 1000000L;
+        timeout_second = _trigger_mode.pause_timeout_second();
     }
     // _mu is released before blocking -- see the _pause_mu comment in the header.
-    return wait_until_released(gen, timeout_us);
+    return wait_until_released(gen, timeout_second);
 }
 
-bool FailPoint::wait_until_released(uint64_t gen, int64_t timeout_us) {
+bool FailPoint::wait_until_released(uint64_t gen, int32_t timeout_second) {
+    if (timeout_second <= 0) {
+        timeout_second = kDefaultPauseTimeoutSecond;
+    }
     std::unique_lock<bthread::Mutex> l(_pause_mu);
     if (_mode_generation.load(std::memory_order_relaxed) != gen) {
         // Released between dropping _mu and taking _pause_mu. This thread never parks, so it must
@@ -107,11 +113,14 @@ bool FailPoint::wait_until_released(uint64_t gen, int64_t timeout_us) {
     }
     _trigger_count.fetch_add(1, std::memory_order_relaxed);
     _paused_thread_count.fetch_add(1, std::memory_order_relaxed);
-    PausedThreadGuard gauge(&_paused_thread_count);
+    DeferOp gauge([this] { _paused_thread_count.fetch_sub(1, std::memory_order_relaxed); });
 
     LOG(INFO) << "failpoint " << _name << " paused, waiting for ADMIN DISABLE FAILPOINT";
+    // A condition variable rather than Awaitility's polling loop: a pause runs for
+    // failpoint_pause_timeout_second (300s by default), so polling would wake a bthread every
+    // interval for the whole window, and release should be immediate once DISABLE lands.
     // steady_clock so a wall-clock adjustment cannot extend or truncate the wait.
-    const auto deadline = std::chrono::steady_clock::now() + std::chrono::microseconds(timeout_us);
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(timeout_second);
     bool timed_out = false;
     while (_mode_generation.load(std::memory_order_relaxed) == gen) {
         const auto now = std::chrono::steady_clock::now();
@@ -124,8 +133,7 @@ bool FailPoint::wait_until_released(uint64_t gen, int64_t timeout_us) {
         (void)_pause_cv.wait_for(l, std::chrono::duration_cast<std::chrono::microseconds>(deadline - now).count());
     }
     if (timed_out) {
-        LOG(WARNING) << "failpoint " << _name << " pause timed out after " << (timeout_us / 1000000)
-                     << "s, resuming";
+        LOG(WARNING) << "failpoint " << _name << " pause timed out after " << timeout_second << "s, resuming";
     } else {
         LOG(INFO) << "failpoint " << _name << " pause released";
     }
@@ -136,10 +144,7 @@ bool FailPoint::wait_until_released(uint64_t gen, int64_t timeout_us) {
 PFailPointTriggerMode trigger_mode_from_request(const PUpdateFailPointStatusRequest& request) {
     PFailPointTriggerMode trigger_mode = request.trigger_mode();
     if (request.pause()) {
-        trigger_mode.set_pause(true);
-        if (request.pause_timeout_second() > 0) {
-            trigger_mode.set_pause_timeout_second(request.pause_timeout_second());
-        }
+        set_pause_trigger_mode(&trigger_mode, request.pause_timeout_second());
     }
     return trigger_mode;
 }
@@ -279,11 +284,9 @@ bool init_failpoint_from_conf(const std::string& conf_file) {
                 trigger_mode.set_mode(FailPointTriggerModeType::PROBABILITY_ENABLE);
                 trigger_mode.set_probability(probability.value());
             } else if (mode.value() == "pause") {
-                // Mirror the wire encoding: mode = DISABLE plus the pause flag.
-                trigger_mode.set_mode(FailPointTriggerModeType::DISABLE);
-                trigger_mode.set_pause(true);
-                // Optional. Absent leaves the field unset and the failpoint layer falls back to
-                // kDefaultPauseTimeoutSecond.
+                // Optional: absent or out of range leaves the field unset and the failpoint layer
+                // falls back to kDefaultPauseTimeoutSecond.
+                int32_t timeout_second = 0;
                 auto pause_timeout_second = value["pause_timeout_second"].get_int64();
                 if (pause_timeout_second.error() == simdjson::SUCCESS) {
                     const int64_t raw = pause_timeout_second.value();
@@ -291,9 +294,10 @@ bool init_failpoint_from_conf(const std::string& conf_file) {
                         LOG(WARNING) << "ignoring out-of-range pause_timeout_second " << raw << " for failpoint "
                                      << std::string(fp_name.value());
                     } else {
-                        trigger_mode.set_pause_timeout_second(static_cast<int32_t>(raw));
+                        timeout_second = static_cast<int32_t>(raw);
                     }
                 }
+                set_pause_trigger_mode(&trigger_mode, timeout_second);
             }
             fp->setMode(trigger_mode);
         }

--- a/be/src/base/failpoint/fail_point.h
+++ b/be/src/base/failpoint/fail_point.h
@@ -16,9 +16,6 @@
 
 #ifdef FIU_ENABLE
 
-#include <bthread/condition_variable.h>
-#include <bthread/mutex.h>
-
 #include <condition_variable>
 #include <functional>
 #include <memory>
@@ -62,18 +59,27 @@ protected:
     // Bumped by setMode(). A pausing thread reads it together with the mode under _mu, so a
     // setMode() that races that read is observed as "already changed" instead of being waited for.
     std::atomic<uint64_t> _mode_generation = 0;
-    // bthread rather than std primitives: several failpoints sit directly in brpc handlers before
-    // any thread-pool handoff (lake_publish_version_rpc_fail at lake_service.cpp:263), so a pause
-    // there runs on a bthread. Blocking with std::condition_variable would pin the backing pthread,
-    // and enough parked handlers would exhaust the worker pool that has to serve the
-    // ADMIN DISABLE FAILPOINT RPC -- the pause could then only end at its timeout. bthread
-    // primitives yield the worker, and work from plain pthreads too.
+    // Deliberately std, NOT bthread, primitives -- this looks like the wrong choice for a failpoint
+    // that can sit in a brpc handler, so the reason matters:
+    //
+    // shouldFail() is reached through libfiu's external callback, from inside fiu_fail(). fiu_fail
+    // increments a __thread recursion counter and takes a pthread_rwlock read lock BEFORE invoking
+    // the callback, and releases both after it returns (libfiu/fiu.c:286,295,350). A bthread that
+    // parks here yields its worker and can resume on a DIFFERENT pthread, so the counter would be
+    // incremented on one worker and decremented on another -- leaving the first worker permanently
+    // above the recursion threshold, which silently disables EVERY failpoint on it for the life of
+    // the process -- and the rwlock would be unlocked by a thread that never took it (UB).
+    // Blocking the pthread keeps both balanced.
+    //
+    // The cost is that a paused failpoint pins its thread: park more brpc handlers than the worker
+    // pool has threads and ADMIN DISABLE FAILPOINT cannot be served until the pause times out. That
+    // is bounded and visible; the bthread alternative is silent and permanent.
     //
     // The wait also has its own mutex so shouldFail() can drop _mu before blocking: blocking while
     // holding _mu (even shared) would deadlock setMode(), and therefore the release RPC.
     // Lock order is always _mu -> _pause_mu.
-    bthread::Mutex _pause_mu;
-    bthread::ConditionVariable _pause_cv;
+    std::mutex _pause_mu;
+    std::condition_variable _pause_cv;
 
     std::atomic<int64_t> _trigger_count = 0;
     std::atomic<int64_t> _paused_thread_count = 0;

--- a/be/src/base/failpoint/fail_point.h
+++ b/be/src/base/failpoint/fail_point.h
@@ -49,14 +49,10 @@ public:
     PFailPointInfo to_pb() const;
 
 protected:
-    // Fallback for a pause whose arming request carries no pause_timeout_second -- a failpoint armed
-    // straight through the brpc HTTP endpoint or from the conf file. A local constant rather than a
-    // config: be/src/base must not depend on be/src/common.
-    static constexpr int32_t kDefaultPauseTimeoutSecond = 300;
-
-    // Blocks until setMode() moves _mode_generation past |gen|, or |timeout_us| elapses.
+    // Blocks until setMode() moves _mode_generation past |gen|, or |timeout_second| elapses
+    // (|timeout_second| <= 0 falls back to the failpoint layer's default).
     // ALWAYS returns false -- a released pause continues normally and never injects.
-    bool wait_until_released(uint64_t gen, int64_t timeout_us);
+    bool wait_until_released(uint64_t gen, int32_t timeout_second);
 
     std::string _name;
     mutable std::shared_mutex _mu;

--- a/be/src/base/failpoint/fail_point.h
+++ b/be/src/base/failpoint/fail_point.h
@@ -16,6 +16,9 @@
 
 #ifdef FIU_ENABLE
 
+#include <bthread/condition_variable.h>
+#include <bthread/mutex.h>
+
 #include <condition_variable>
 #include <functional>
 #include <memory>
@@ -46,10 +49,38 @@ public:
     PFailPointInfo to_pb() const;
 
 protected:
+    // Fallback for a pause whose arming request carries no pause_timeout_second -- a failpoint armed
+    // straight through the brpc HTTP endpoint or from the conf file. A local constant rather than a
+    // config: be/src/base must not depend on be/src/common.
+    static constexpr int32_t kDefaultPauseTimeoutSecond = 300;
+
+    // Blocks until setMode() moves _mode_generation past |gen|, or |timeout_us| elapses.
+    // ALWAYS returns false -- a released pause continues normally and never injects.
+    bool wait_until_released(uint64_t gen, int64_t timeout_us);
+
     std::string _name;
     mutable std::shared_mutex _mu;
     PFailPointTriggerMode _trigger_mode;
     std::atomic_int _n_times = 0;
+
+    // Bumped by setMode(). A pausing thread reads it together with the mode under _mu, so a
+    // setMode() that races that read is observed as "already changed" instead of being waited for.
+    std::atomic<uint64_t> _mode_generation = 0;
+    // bthread rather than std primitives: several failpoints sit directly in brpc handlers before
+    // any thread-pool handoff (lake_publish_version_rpc_fail at lake_service.cpp:263), so a pause
+    // there runs on a bthread. Blocking with std::condition_variable would pin the backing pthread,
+    // and enough parked handlers would exhaust the worker pool that has to serve the
+    // ADMIN DISABLE FAILPOINT RPC -- the pause could then only end at its timeout. bthread
+    // primitives yield the worker, and work from plain pthreads too.
+    //
+    // The wait also has its own mutex so shouldFail() can drop _mu before blocking: blocking while
+    // holding _mu (even shared) would deadlock setMode(), and therefore the release RPC.
+    // Lock order is always _mu -> _pause_mu.
+    bthread::Mutex _pause_mu;
+    bthread::ConditionVariable _pause_cv;
+
+    std::atomic<int64_t> _trigger_count = 0;
+    std::atomic<int64_t> _paused_thread_count = 0;
 };
 
 class ScopedFailPoint : public FailPoint {
@@ -68,8 +99,6 @@ public:
 private:
     FailPoint* _sfp = nullptr;
 };
-
-// @TODO need PausableFailPoint?
 
 using FailPointPtr = std::shared_ptr<FailPoint>;
 
@@ -139,6 +168,13 @@ private:
 };
 
 bool init_failpoint_from_conf(const std::string& conf_file);
+
+// Lift PUpdateFailPointStatusRequest's request-level pause discriminator into the trigger mode that
+// gets stored. Lives here rather than inline in the brpc handler so it can be unit-tested, and so
+// there is exactly one place that knows the request encoding. Uses only
+// gen_cpp/internal_service.pb.h, which this header already includes, so it does not breach the
+// be/src/base layering rule.
+PFailPointTriggerMode trigger_mode_from_request(const PUpdateFailPointStatusRequest& request);
 
 } // namespace starrocks::failpoint
 #endif

--- a/be/src/base/failpoint/fail_point.h
+++ b/be/src/base/failpoint/fail_point.h
@@ -51,6 +51,12 @@ protected:
     // ALWAYS returns false -- a released pause continues normally and never injects.
     bool wait_until_released(uint64_t gen, int32_t timeout_second);
 
+    // Disarm a pause that reached its timeout, but ONLY if it is still the mode installed as of
+    // |gen|. An unconditional disarm would race an operator who re-armed the failpoint in the window
+    // between the wait expiring and the disarm landing, silently replacing their new mode with
+    // DISABLE. Returns true if this call disarmed it.
+    bool disarm_expired_pause(uint64_t gen);
+
     std::string _name;
     mutable std::shared_mutex _mu;
     PFailPointTriggerMode _trigger_mode;

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -1304,7 +1304,7 @@ void PInternalServiceImplBase<T>::update_fail_point_status(google::protobuf::Rpc
                 .to_protobuf(response->mutable_status());
         return;
     }
-    fp->setMode(request->trigger_mode());
+    fp->setMode(starrocks::failpoint::trigger_mode_from_request(*request));
     Status::OK().to_protobuf(response->mutable_status());
 #else
     Status::NotSupported("FailPoint is not supported, need re-compile BE with ENABLE_FAULT_INJECTION")

--- a/be/test/base/failpoint/fail_point_test.cpp
+++ b/be/test/base/failpoint/fail_point_test.cpp
@@ -381,4 +381,33 @@ TEST(FailPointTest, init_from_conf_pause_mode) {
     std::remove(conf_path.c_str());
 }
 
+// Every other pause test calls fp.shouldFail() directly, which bypasses libfiu entirely. In
+// production the only caller is libfiu's external callback, invoked from inside fiu_fail() while it
+// holds a __thread recursion counter and a pthread_rwlock read lock. This test drives the real macro
+// so that a pause which corrupts that per-thread state -- by yielding to another pthread, say -- is
+// caught here rather than silently disabling every failpoint on a worker in production.
+TEST(FailPointTest, pause_through_the_fiu_trigger_macro) {
+    DEFINE_FAIL_POINT(fp_pause_via_fiu);
+
+    auto test_func = [&]() {
+        FAIL_POINT_TRIGGER_RETURN(fp_pause_via_fiu, false);
+        return true;
+    };
+
+    ASSERT_TRUE(test_func());
+
+    fp_fp_pause_via_fiu.setMode(pause_mode(1));
+    // Parks inside fiu_fail(), then times out, disarms and resumes without injecting.
+    ASSERT_TRUE(test_func());
+
+    // fiu's recursion guard must still be balanced: a subsequent ENABLE has to fire on this same
+    // thread. If the pause left rec_count elevated, fiu_fail() would take its early return and this
+    // would wrongly report success.
+    fp_fp_pause_via_fiu.setMode(simple_mode(FailPointTriggerModeType::ENABLE));
+    ASSERT_FALSE(test_func());
+
+    fp_fp_pause_via_fiu.setMode(simple_mode(FailPointTriggerModeType::DISABLE));
+    ASSERT_TRUE(test_func());
+}
+
 } // namespace starrocks

--- a/be/test/base/failpoint/fail_point_test.cpp
+++ b/be/test/base/failpoint/fail_point_test.cpp
@@ -21,6 +21,8 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstdio>
+#include <fstream>
 #include <future>
 #include <thread>
 #include <vector>
@@ -354,6 +356,40 @@ TEST(FailPointTest, trigger_mode_from_request_lifts_pause) {
     auto passthrough = failpoint::trigger_mode_from_request(plain);
     ASSERT_FALSE(passthrough.pause());
     ASSERT_EQ(FailPointTriggerModeType::ENABLE, passthrough.mode());
+}
+
+TEST(FailPointTest, init_from_conf_pause_mode) {
+    failpoint::FailPoint fp("test_conf_pause");
+    ASSERT_TRUE(failpoint::FailPointRegistry::GetInstance()->add(&fp).ok());
+
+    const std::string conf_path = "./fail_point_conf_pause.json";
+    {
+        std::ofstream out(conf_path);
+        out << R"({"test_conf_pause": {"mode": "pause", "pause_timeout_second": 1}})";
+    }
+
+    ASSERT_TRUE(failpoint::init_failpoint_from_conf(conf_path));
+    ASSERT_TRUE(fp.to_pb().trigger_mode().pause());
+    ASSERT_EQ(1, fp.to_pb().trigger_mode().pause_timeout_second());
+
+    // The armed timeout is honoured: the call returns on its own without any setMode(). Bounded on a
+    // worker for the same reason as pause_times_out.
+    std::promise<bool> done;
+    auto future = done.get_future();
+    auto start = std::chrono::steady_clock::now();
+    std::thread worker([&] { done.set_value(fp.shouldFail()); });
+    const bool finished = future.wait_for(std::chrono::seconds(20)) == std::future_status::ready;
+    if (!finished) {
+        fp.setMode(simple_mode(FailPointTriggerModeType::DISABLE));
+    }
+    worker.join();
+    auto elapsed_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
+    ASSERT_TRUE(finished) << "conf-file pause_timeout_second was ignored";
+    ASSERT_FALSE(future.get());
+    ASSERT_GE(elapsed_ms, 900);
+
+    std::remove(conf_path.c_str());
 }
 
 } // namespace starrocks

--- a/be/test/base/failpoint/fail_point_test.cpp
+++ b/be/test/base/failpoint/fail_point_test.cpp
@@ -19,9 +19,6 @@
 
 #include <gtest/gtest.h>
 
-#include "base/concurrency/await.h"
-#include "base/utility/defer_op.h"
-
 #include <atomic>
 #include <chrono>
 #include <cstdio>
@@ -29,6 +26,9 @@
 #include <future>
 #include <thread>
 #include <vector>
+
+#include "base/concurrency/await.h"
+#include "base/utility/defer_op.h"
 
 namespace starrocks {
 

--- a/be/test/base/failpoint/fail_point_test.cpp
+++ b/be/test/base/failpoint/fail_point_test.cpp
@@ -310,7 +310,9 @@ TEST(FailPointTest, pause_default_timeout_applies_when_unset) {
     threads.emplace_back([&] { (void)fp.shouldFail(); });
     ASSERT_TRUE(wait_for_parked(fp, 1));
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    // A short observation window is enough: with the 300s default armed, a broken fallback would
+    // resume the thread immediately. Kept small to match this file's no-long-fixed-sleeps convention.
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
     ASSERT_EQ(1, fp.to_pb().paused_thread_count());
 }
 

--- a/be/test/base/failpoint/fail_point_test.cpp
+++ b/be/test/base/failpoint/fail_point_test.cpp
@@ -19,6 +19,12 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <thread>
+#include <vector>
+
 namespace starrocks {
 
 TEST(FailPointTest, enable_disable_mode) {
@@ -120,6 +126,234 @@ TEST(FailPointTest, sfp_demo) {
     }
 
     ASSERT_TRUE(test_func());
+}
+
+namespace {
+
+// The STORED form of a pause, i.e. what update_fail_point_status hands to setMode() after lifting
+// the request-level discriminator. mode stays DISABLE so an old backend degrades safely on the wire.
+PFailPointTriggerMode pause_mode(int32_t timeout_second) {
+    PFailPointTriggerMode mode;
+    mode.set_mode(FailPointTriggerModeType::DISABLE);
+    mode.set_pause(true);
+    if (timeout_second > 0) {
+        mode.set_pause_timeout_second(timeout_second);
+    }
+    return mode;
+}
+
+PFailPointTriggerMode simple_mode(FailPointTriggerModeType type) {
+    PFailPointTriggerMode mode;
+    mode.set_mode(type);
+    return mode;
+}
+
+// Spin until |fp| reports |expected| parked threads, so the pause tests synchronise on real state
+// instead of a fixed sleep. Returns false if the state is not reached within the budget.
+bool wait_for_parked(failpoint::FailPoint& fp, int64_t expected, int budget_ms = 10000) {
+    for (int waited = 0; waited < budget_ms; waited += 5) {
+        if (fp.to_pb().paused_thread_count() == expected) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    return false;
+}
+
+// Always disables |fp| and joins |threads| on scope exit, so a failed ASSERT_* cannot leave a
+// joinable std::thread behind -- that would call std::terminate and take the whole suite down.
+class PauseTestCleanup {
+public:
+    PauseTestCleanup(failpoint::FailPoint& fp, std::vector<std::thread>& threads) : _fp(fp), _threads(threads) {}
+    ~PauseTestCleanup() {
+        _fp.setMode(simple_mode(FailPointTriggerModeType::DISABLE));
+        for (auto& t : _threads) {
+            if (t.joinable()) {
+                t.join();
+            }
+        }
+    }
+    PauseTestCleanup(const PauseTestCleanup&) = delete;
+    PauseTestCleanup& operator=(const PauseTestCleanup&) = delete;
+
+private:
+    failpoint::FailPoint& _fp;
+    std::vector<std::thread>& _threads;
+};
+
+} // namespace
+
+TEST(FailPointTest, pause_released_by_disable) {
+    failpoint::FailPoint fp("test_pause_disable");
+    fp.setMode(pause_mode(0));
+
+    std::atomic<bool> returned{false};
+    std::atomic<bool> result{true};
+    std::vector<std::thread> threads;
+    PauseTestCleanup cleanup(fp, threads);
+    threads.emplace_back([&] {
+        result = fp.shouldFail();
+        returned = true;
+    });
+
+    ASSERT_TRUE(wait_for_parked(fp, 1));
+    ASSERT_FALSE(returned.load());
+    ASSERT_EQ(1, fp.to_pb().trigger_count());
+
+    fp.setMode(simple_mode(FailPointTriggerModeType::DISABLE));
+    threads[0].join();
+
+    ASSERT_TRUE(returned.load());
+    // A released pause continues normally and never injects.
+    ASSERT_FALSE(result.load());
+    ASSERT_EQ(0, fp.to_pb().paused_thread_count());
+}
+
+TEST(FailPointTest, pause_released_by_rearm) {
+    failpoint::FailPoint fp("test_pause_rearm");
+    fp.setMode(pause_mode(0));
+
+    std::atomic<bool> result{true};
+    std::vector<std::thread> threads;
+    PauseTestCleanup cleanup(fp, threads);
+    threads.emplace_back([&] { result = fp.shouldFail(); });
+    ASSERT_TRUE(wait_for_parked(fp, 1));
+
+    // Any mode change releases, not just DISABLE.
+    fp.setMode(simple_mode(FailPointTriggerModeType::ENABLE));
+    threads[0].join();
+    ASSERT_FALSE(result.load());
+}
+
+TEST(FailPointTest, pause_releases_all_waiters) {
+    failpoint::FailPoint fp("test_pause_all");
+    fp.setMode(pause_mode(0));
+
+    std::atomic<int> injected{0};
+    std::vector<std::thread> threads;
+    PauseTestCleanup cleanup(fp, threads);
+    for (int i = 0; i < 4; i++) {
+        threads.emplace_back([&] {
+            if (fp.shouldFail()) {
+                injected++;
+            }
+        });
+    }
+    ASSERT_TRUE(wait_for_parked(fp, 4));
+    ASSERT_EQ(4, fp.to_pb().trigger_count());
+
+    fp.setMode(simple_mode(FailPointTriggerModeType::DISABLE));
+    for (auto& t : threads) {
+        t.join();
+    }
+    ASSERT_EQ(0, injected.load());
+    ASSERT_EQ(0, fp.to_pb().paused_thread_count());
+}
+
+TEST(FailPointTest, pause_times_out) {
+    failpoint::FailPoint fp("test_pause_timeout");
+    fp.setMode(pause_mode(1));
+
+    // shouldFail() runs on a worker and is bounded by a future deadline. Calling it synchronously
+    // and asserting on elapsed time afterwards cannot catch a hang -- the assertion would never be
+    // reached -- and run-be-ut.sh imposes no per-test limit.
+    std::promise<bool> done;
+    auto future = done.get_future();
+    auto start = std::chrono::steady_clock::now();
+    std::thread worker([&] { done.set_value(fp.shouldFail()); });
+
+    const bool finished = future.wait_for(std::chrono::seconds(20)) == std::future_status::ready;
+    if (!finished) {
+        // Unblock the worker through the other code path so the test can fail instead of hanging.
+        fp.setMode(simple_mode(FailPointTriggerModeType::DISABLE));
+    }
+    worker.join();
+    auto elapsed_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
+
+    ASSERT_TRUE(finished) << "pause_timeout_second was ignored: shouldFail() never returned on its own";
+    ASSERT_FALSE(future.get());
+    ASSERT_GE(elapsed_ms, 900);
+    ASSERT_EQ(0, fp.to_pb().paused_thread_count());
+    ASSERT_EQ(1, fp.to_pb().trigger_count());
+}
+
+TEST(FailPointTest, pause_does_not_block_set_mode) {
+    failpoint::FailPoint fp("test_pause_no_deadlock");
+    // The short self-release keeps a regression from hanging the whole suite: if the pause wrongly
+    // held the shared _mu, setMode() would merely be delayed until this timeout instead of
+    // deadlocking forever, and the elapsed-time assertion below still catches it.
+    fp.setMode(pause_mode(5));
+
+    std::vector<std::thread> threads;
+    PauseTestCleanup cleanup(fp, threads);
+    threads.emplace_back([&] { (void)fp.shouldFail(); });
+    ASSERT_TRUE(wait_for_parked(fp, 1));
+
+    auto start = std::chrono::steady_clock::now();
+    fp.setMode(simple_mode(FailPointTriggerModeType::DISABLE));
+    auto elapsed_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
+    threads[0].join();
+
+    ASSERT_LT(elapsed_ms, 2000) << "setMode() blocked while a thread was paused: the pause is holding _mu";
+}
+
+TEST(FailPointTest, pause_default_timeout_applies_when_unset) {
+    failpoint::FailPoint fp("test_pause_default_timeout");
+    // pause_timeout_second unset -> kDefaultPauseTimeoutSecond (300s), so the thread must still be
+    // parked well after a short observation window rather than resuming immediately.
+    fp.setMode(pause_mode(0));
+
+    std::vector<std::thread> threads;
+    PauseTestCleanup cleanup(fp, threads);
+    threads.emplace_back([&] { (void)fp.shouldFail(); });
+    ASSERT_TRUE(wait_for_parked(fp, 1));
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    ASSERT_EQ(1, fp.to_pb().paused_thread_count());
+}
+
+TEST(FailPointTest, trigger_count_counts_fires_not_calls) {
+    failpoint::FailPoint fp("test_trigger_count");
+
+    PFailPointTriggerMode mode;
+    mode.set_mode(FailPointTriggerModeType::ENABLE_N_TIMES);
+    mode.set_n_times(3);
+    fp.setMode(mode);
+
+    int fired = 0;
+    for (int i = 0; i < 5; i++) {
+        if (fp.shouldFail()) {
+            fired++;
+        }
+    }
+    ASSERT_EQ(3, fired);
+    // 5 calls, 3 fires.
+    ASSERT_EQ(3, fp.to_pb().trigger_count());
+    ASSERT_EQ(0, fp.to_pb().paused_thread_count());
+}
+
+TEST(FailPointTest, trigger_mode_from_request_lifts_pause) {
+    // The discriminator arrives on the REQUEST so an old BE cannot echo it back; a new BE lifts it
+    // into the mode it stores, which is what to_pb() then reports truthfully.
+    PUpdateFailPointStatusRequest request;
+    request.set_fail_point_name("fp");
+    request.mutable_trigger_mode()->set_mode(FailPointTriggerModeType::DISABLE);
+    request.set_pause(true);
+    request.set_pause_timeout_second(7);
+
+    auto stored = failpoint::trigger_mode_from_request(request);
+    ASSERT_TRUE(stored.pause());
+    ASSERT_EQ(7, stored.pause_timeout_second());
+    ASSERT_EQ(FailPointTriggerModeType::DISABLE, stored.mode());
+
+    // A non-pause request passes through untouched.
+    PUpdateFailPointStatusRequest plain;
+    plain.mutable_trigger_mode()->set_mode(FailPointTriggerModeType::ENABLE);
+    auto passthrough = failpoint::trigger_mode_from_request(plain);
+    ASSERT_FALSE(passthrough.pause());
+    ASSERT_EQ(FailPointTriggerModeType::ENABLE, passthrough.mode());
 }
 
 } // namespace starrocks

--- a/be/test/base/failpoint/fail_point_test.cpp
+++ b/be/test/base/failpoint/fail_point_test.cpp
@@ -19,6 +19,9 @@
 
 #include <gtest/gtest.h>
 
+#include "base/concurrency/await.h"
+#include "base/utility/defer_op.h"
+
 #include <atomic>
 #include <chrono>
 #include <cstdio>
@@ -150,38 +153,49 @@ PFailPointTriggerMode simple_mode(FailPointTriggerModeType type) {
     return mode;
 }
 
-// Spin until |fp| reports |expected| parked threads, so the pause tests synchronise on real state
+// Wait until |fp| reports |expected| parked threads, so the pause tests synchronise on real state
 // instead of a fixed sleep. Returns false if the state is not reached within the budget.
-bool wait_for_parked(failpoint::FailPoint& fp, int64_t expected, int budget_ms = 10000) {
-    for (int waited = 0; waited < budget_ms; waited += 5) {
-        if (fp.to_pb().paused_thread_count() == expected) {
-            return true;
-        }
-        std::this_thread::sleep_for(std::chrono::milliseconds(5));
-    }
-    return false;
+bool wait_for_parked(failpoint::FailPoint& fp, int64_t expected, int64_t budget_us = 10 * 1000 * 1000) {
+    return Awaitility().timeout(budget_us).until([&] { return fp.to_pb().paused_thread_count() == expected; });
 }
 
 // Always disables |fp| and joins |threads| on scope exit, so a failed ASSERT_* cannot leave a
 // joinable std::thread behind -- that would call std::terminate and take the whole suite down.
-class PauseTestCleanup {
-public:
-    PauseTestCleanup(failpoint::FailPoint& fp, std::vector<std::thread>& threads) : _fp(fp), _threads(threads) {}
-    ~PauseTestCleanup() {
-        _fp.setMode(simple_mode(FailPointTriggerModeType::DISABLE));
-        for (auto& t : _threads) {
+auto pause_test_cleanup(failpoint::FailPoint& fp, std::vector<std::thread>& threads) {
+    return DeferOp([&fp, &threads] {
+        fp.setMode(simple_mode(FailPointTriggerModeType::DISABLE));
+        for (auto& t : threads) {
             if (t.joinable()) {
                 t.join();
             }
         }
-    }
-    PauseTestCleanup(const PauseTestCleanup&) = delete;
-    PauseTestCleanup& operator=(const PauseTestCleanup&) = delete;
+    });
+}
 
-private:
-    failpoint::FailPoint& _fp;
-    std::vector<std::thread>& _threads;
+struct BoundedRun {
+    bool finished;
+    bool injected;
+    int64_t elapsed_ms;
 };
+
+// Runs fp.shouldFail() on a worker bounded by |budget_seconds|, so a regression in the timeout path
+// fails the test instead of hanging the suite (run-be-ut.sh imposes no per-test limit). On timeout it
+// disables the failpoint through the other code path to unblock the worker.
+BoundedRun should_fail_bounded(failpoint::FailPoint& fp, int budget_seconds = 20) {
+    std::promise<bool> done;
+    auto future = done.get_future();
+    auto start = std::chrono::steady_clock::now();
+    std::thread worker([&] { done.set_value(fp.shouldFail()); });
+
+    const bool finished = future.wait_for(std::chrono::seconds(budget_seconds)) == std::future_status::ready;
+    if (!finished) {
+        fp.setMode(simple_mode(FailPointTriggerModeType::DISABLE));
+    }
+    worker.join();
+    const auto elapsed_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
+    return {finished, finished && future.get(), elapsed_ms};
+}
 
 } // namespace
 
@@ -192,7 +206,7 @@ TEST(FailPointTest, pause_released_by_disable) {
     std::atomic<bool> returned{false};
     std::atomic<bool> result{true};
     std::vector<std::thread> threads;
-    PauseTestCleanup cleanup(fp, threads);
+    auto cleanup = pause_test_cleanup(fp, threads);
     threads.emplace_back([&] {
         result = fp.shouldFail();
         returned = true;
@@ -217,7 +231,7 @@ TEST(FailPointTest, pause_released_by_rearm) {
 
     std::atomic<bool> result{true};
     std::vector<std::thread> threads;
-    PauseTestCleanup cleanup(fp, threads);
+    auto cleanup = pause_test_cleanup(fp, threads);
     threads.emplace_back([&] { result = fp.shouldFail(); });
     ASSERT_TRUE(wait_for_parked(fp, 1));
 
@@ -233,7 +247,7 @@ TEST(FailPointTest, pause_releases_all_waiters) {
 
     std::atomic<int> injected{0};
     std::vector<std::thread> threads;
-    PauseTestCleanup cleanup(fp, threads);
+    auto cleanup = pause_test_cleanup(fp, threads);
     for (int i = 0; i < 4; i++) {
         threads.emplace_back([&] {
             if (fp.shouldFail()) {
@@ -256,26 +270,10 @@ TEST(FailPointTest, pause_times_out) {
     failpoint::FailPoint fp("test_pause_timeout");
     fp.setMode(pause_mode(1));
 
-    // shouldFail() runs on a worker and is bounded by a future deadline. Calling it synchronously
-    // and asserting on elapsed time afterwards cannot catch a hang -- the assertion would never be
-    // reached -- and run-be-ut.sh imposes no per-test limit.
-    std::promise<bool> done;
-    auto future = done.get_future();
-    auto start = std::chrono::steady_clock::now();
-    std::thread worker([&] { done.set_value(fp.shouldFail()); });
-
-    const bool finished = future.wait_for(std::chrono::seconds(20)) == std::future_status::ready;
-    if (!finished) {
-        // Unblock the worker through the other code path so the test can fail instead of hanging.
-        fp.setMode(simple_mode(FailPointTriggerModeType::DISABLE));
-    }
-    worker.join();
-    auto elapsed_ms =
-            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
-
-    ASSERT_TRUE(finished) << "pause_timeout_second was ignored: shouldFail() never returned on its own";
-    ASSERT_FALSE(future.get());
-    ASSERT_GE(elapsed_ms, 900);
+    const auto run = should_fail_bounded(fp);
+    ASSERT_TRUE(run.finished) << "pause_timeout_second was ignored: shouldFail() never returned on its own";
+    ASSERT_FALSE(run.injected);
+    ASSERT_GE(run.elapsed_ms, 900);
     ASSERT_EQ(0, fp.to_pb().paused_thread_count());
     ASSERT_EQ(1, fp.to_pb().trigger_count());
 }
@@ -288,7 +286,7 @@ TEST(FailPointTest, pause_does_not_block_set_mode) {
     fp.setMode(pause_mode(5));
 
     std::vector<std::thread> threads;
-    PauseTestCleanup cleanup(fp, threads);
+    auto cleanup = pause_test_cleanup(fp, threads);
     threads.emplace_back([&] { (void)fp.shouldFail(); });
     ASSERT_TRUE(wait_for_parked(fp, 1));
 
@@ -308,7 +306,7 @@ TEST(FailPointTest, pause_default_timeout_applies_when_unset) {
     fp.setMode(pause_mode(0));
 
     std::vector<std::thread> threads;
-    PauseTestCleanup cleanup(fp, threads);
+    auto cleanup = pause_test_cleanup(fp, threads);
     threads.emplace_back([&] { (void)fp.shouldFail(); });
     ASSERT_TRUE(wait_for_parked(fp, 1));
 
@@ -372,22 +370,11 @@ TEST(FailPointTest, init_from_conf_pause_mode) {
     ASSERT_TRUE(fp.to_pb().trigger_mode().pause());
     ASSERT_EQ(1, fp.to_pb().trigger_mode().pause_timeout_second());
 
-    // The armed timeout is honoured: the call returns on its own without any setMode(). Bounded on a
-    // worker for the same reason as pause_times_out.
-    std::promise<bool> done;
-    auto future = done.get_future();
-    auto start = std::chrono::steady_clock::now();
-    std::thread worker([&] { done.set_value(fp.shouldFail()); });
-    const bool finished = future.wait_for(std::chrono::seconds(20)) == std::future_status::ready;
-    if (!finished) {
-        fp.setMode(simple_mode(FailPointTriggerModeType::DISABLE));
-    }
-    worker.join();
-    auto elapsed_ms =
-            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
-    ASSERT_TRUE(finished) << "conf-file pause_timeout_second was ignored";
-    ASSERT_FALSE(future.get());
-    ASSERT_GE(elapsed_ms, 900);
+    // The armed timeout is honoured: the call returns on its own without any setMode().
+    const auto run = should_fail_bounded(fp);
+    ASSERT_TRUE(run.finished) << "conf-file pause_timeout_second was ignored";
+    ASSERT_FALSE(run.injected);
+    ASSERT_GE(run.elapsed_ms, 900);
 
     std::remove(conf_path.c_str());
 }

--- a/docs/en/administration/configuration/FE_parameters/shared_lake_other.md
+++ b/docs/en/administration/configuration/FE_parameters/shared_lake_other.md
@@ -311,6 +311,15 @@ This topic introduces the following types of FE configurations:
 - Description: Whether to allow StarRocks to create the built-in storage volume by using the object storage-related properties specified in the FE configuration file. The default value is changed from `true` to `false` from v3.4.1 onwards.
 - Introduced in: v3.1.0
 
+### `failpoint_pause_timeout_second`
+
+- Default: 300
+- Type: Int
+- Unit: Seconds
+- Is mutable: Yes
+- Description: Safety net for the failpoint pause mode. A thread parked at a failpoint armed with `ADMIN ENABLE FAILPOINT ... WITH PAUSE` resumes automatically after this many seconds even if `ADMIN DISABLE FAILPOINT` is never issued, so a forgotten pause cannot block a node until it is restarted. Values below 1 are clamped to 1. The value is also sent to BEs/CNs with the arming request, so a frontend pause and a backend pause share the same timeout. Only relevant for fault-injection testing: the frontend must be started with `--failpoint`, and backend failpoints additionally require a backend compiled with `ENABLE_FAULT_INJECTION=ON`.
+- Introduced in: v4.2.0
+
 ### `gcp_gcs_impersonation_service_account`
 
 - Default: Empty string

--- a/docs/en/administration/configuration/FE_parameters/shared_lake_other.md
+++ b/docs/en/administration/configuration/FE_parameters/shared_lake_other.md
@@ -317,7 +317,7 @@ This topic introduces the following types of FE configurations:
 - Type: Int
 - Unit: Seconds
 - Is mutable: Yes
-- Description: Safety net for the failpoint pause mode. A thread parked at a failpoint armed with `ADMIN ENABLE FAILPOINT ... WITH PAUSE` resumes automatically after this many seconds even if `ADMIN DISABLE FAILPOINT` is never issued, so a forgotten pause cannot block a node until it is restarted. Values below 1 are clamped to 1. The value is also sent to BEs/CNs with the arming request, so a frontend pause and a backend pause share the same timeout. Only relevant for fault-injection testing: the frontend must be started with `--failpoint`, and backend failpoints additionally require a backend compiled with `ENABLE_FAULT_INJECTION=ON`.
+- Description: Safety net for the failpoint pause mode. A thread parked at a failpoint armed with `ADMIN ENABLE FAILPOINT ... WITH PAUSE` resumes automatically after this many seconds even if `ADMIN DISABLE FAILPOINT` is never issued, and the failpoint is disarmed so later threads are not parked again. A forgotten pause therefore cannot block a node until it is restarted. Values below 1 are clamped to 1. The value is also sent to BEs/CNs with the arming request, so a frontend pause and a backend pause share the same timeout. Only relevant for fault-injection testing: the frontend must be started with `--failpoint`, and backend failpoints additionally require a backend compiled with `ENABLE_FAULT_INJECTION=ON`.
 - Introduced in: v4.2.0
 
 ### `gcp_gcs_impersonation_service_account`

--- a/docs/ja/administration/configuration/FE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/configuration/FE_parameters/shared_lake_other.md
@@ -312,6 +312,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：StarRocks が FE 設定ファイルで指定されたオブジェクトストレージ関連プロパティを使用して、組み込みストレージボリュームを作成することを許可するかどうか。デフォルト値は v3.4.1 以降 `true` から `false` に変更されました。
 - 導入時期：v3.1.0
 
+### `failpoint_pause_timeout_second`
+
+- デフォルト: 300
+- タイプ: Int
+- 単位: Seconds
+- 変更可能: はい
+- 説明: failpoint の一時停止 (pause) モードのフォールバックタイムアウト。`ADMIN ENABLE FAILPOINT ... WITH PAUSE` で一時停止したスレッドは、`ADMIN DISABLE FAILPOINT` が実行されなくてもこの秒数の経過後に自動的に再開し、その failpoint は解除されます。これにより、解除し忘れてもノードの再起動が必要になることはありません。1 未満の値は 1 に丸められます。この値は failpoint を有効化するリクエストとともに BE/CN にも送信されるため、FE と BE の一時停止は同じタイムアウトを共有します。障害注入テスト専用です。FE は `--failpoint` を付けて起動する必要があり、BE 側の failpoint にはさらに `ENABLE_FAULT_INJECTION=ON` でコンパイルした BE が必要です。
+- 導入バージョン: v4.2.0
+
 ### `gcp_gcs_impersonation_service_account`
 
 - デフォルト：Empty string

--- a/docs/zh/administration/configuration/FE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/configuration/FE_parameters/shared_lake_other.md
@@ -312,6 +312,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 是否允许 StarRocks 使用 FE 配置文件中指定的对象存储相关属性创建内置存储卷。从 v3.4.1 开始，默认值从 `true` 更改为 `false`。
 - 引入版本: v3.1.0
 
+### `failpoint_pause_timeout_second`
+
+- 默认值：300
+- 类型：Int
+- 单位：Seconds
+- 是否动态：是
+- 描述：failpoint 挂起（pause）模式的兜底超时。通过 `ADMIN ENABLE FAILPOINT ... WITH PAUSE` 挂起的线程，即使一直没有执行 `ADMIN DISABLE FAILPOINT`，也会在该秒数后自动放行，避免遗漏放行导致节点必须重启才能恢复。小于 1 的取值会被归一为 1。该值同时随挂起请求下发给 BE/CN，因此 FE 与 BE 侧的挂起共用同一个超时。仅用于故障注入测试：FE 需以 `--failpoint` 启动，BE 侧 failpoint 还需使用 `ENABLE_FAULT_INJECTION=ON` 编译的 BE。
+- 引入版本：v4.2.0
+
 ### `gcp_gcs_impersonation_service_account`
 
 - 默认值: 空字符串

--- a/docs/zh/administration/configuration/FE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/configuration/FE_parameters/shared_lake_other.md
@@ -318,7 +318,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 类型：Int
 - 单位：Seconds
 - 是否动态：是
-- 描述：failpoint 挂起（pause）模式的兜底超时。通过 `ADMIN ENABLE FAILPOINT ... WITH PAUSE` 挂起的线程，即使一直没有执行 `ADMIN DISABLE FAILPOINT`，也会在该秒数后自动放行，避免遗漏放行导致节点必须重启才能恢复。小于 1 的取值会被归一为 1。该值同时随挂起请求下发给 BE/CN，因此 FE 与 BE 侧的挂起共用同一个超时。仅用于故障注入测试：FE 需以 `--failpoint` 启动，BE 侧 failpoint 还需使用 `ENABLE_FAULT_INJECTION=ON` 编译的 BE。
+- 描述：failpoint 挂起（pause）模式的兜底超时。通过 `ADMIN ENABLE FAILPOINT ... WITH PAUSE` 挂起的线程，即使一直没有执行 `ADMIN DISABLE FAILPOINT`，也会在该秒数后自动放行，并解除该 failpoint，因此后续线程不会再次被挂起，避免遗漏放行导致节点必须重启才能恢复。小于 1 的取值会被归一为 1。该值同时随挂起请求下发给 BE/CN，因此 FE 与 BE 侧的挂起共用同一个超时。仅用于故障注入测试：FE 需以 `--failpoint` 启动，BE 侧 failpoint 还需使用 `ENABLE_FAULT_INJECTION=ON` 编译的 BE。
 - 引入版本：v4.2.0
 
 ### `gcp_gcs_impersonation_service_account`

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -4998,4 +4998,12 @@ public class Config extends ConfigBase {
             "dictionary columns than this value, the list is truncated and followed by an ellipsis. Values less than " +
             "or equal to 0 are treated as 0, which truncates the list entirely.")
     public static int explain_dict_column_size = 5;
+
+    @ConfField(mutable = true, comment = "Safety net for the failpoint pause mode. A thread parked " +
+            "at a failpoint armed with ADMIN ENABLE FAILPOINT ... WITH PAUSE resumes after this many " +
+            "seconds even if ADMIN DISABLE FAILPOINT is never issued, so a forgotten pause cannot " +
+            "wedge a node until it is restarted. Values below 1 are clamped to 1. The value is also " +
+            "sent to BEs/CNs with the arming request, so an FE pause and a BE pause always share one " +
+            "timeout.")
+    public static int failpoint_pause_timeout_second = 300;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/failpoint/FailPoint.java
+++ b/fe/fe-core/src/main/java/com/starrocks/failpoint/FailPoint.java
@@ -37,6 +37,23 @@ public class FailPoint {
         }
     }
 
+    /**
+     * Remove {@code name} only if it is still mapped to {@code expected}, then release it. Used by a
+     * timed-out pause to disarm itself: an unconditional remove would delete a policy that another
+     * thread installed for the same name in the meantime, silently discarding the operator's new mode.
+     *
+     * @return true if this call removed the policy
+     */
+    public static boolean removeTriggerPolicyIf(String name, TriggerPolicy expected) {
+        // ConcurrentHashMap.remove(key, value) compares with equals(), which TriggerPolicy does not
+        // override, so this is an identity check -- exactly what is wanted here.
+        boolean removed = POLICIES.remove(name, expected);
+        if (removed) {
+            expected.release();
+        }
+        return removed;
+    }
+
     public static boolean shouldTrigger(String name) {
         TriggerPolicy triggerPolicy = POLICIES.get(name);
         if (triggerPolicy != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/failpoint/FailPoint.java
+++ b/fe/fe-core/src/main/java/com/starrocks/failpoint/FailPoint.java
@@ -22,17 +22,25 @@ public class FailPoint {
     private static boolean isEnabled = false;
 
     public static void setTriggerPolicy(String name, TriggerPolicy triggerPolicy) {
-        POLICIES.put(name, triggerPolicy);
+        TriggerPolicy previous = POLICIES.put(name, triggerPolicy);
+        if (previous != null) {
+            // Re-arming must not strand threads parked on the policy being replaced.
+            previous.release();
+        }
     }
 
     public static void removeTriggerPolicy(String name) {
-        POLICIES.remove(name);
+        TriggerPolicy removed = POLICIES.remove(name);
+        if (removed != null) {
+            // ADMIN DISABLE FAILPOINT is the release command for a PAUSE policy.
+            removed.release();
+        }
     }
 
     public static boolean shouldTrigger(String name) {
         TriggerPolicy triggerPolicy = POLICIES.get(name);
         if (triggerPolicy != null) {
-            return triggerPolicy.shouldTrigger();
+            return triggerPolicy.shouldTrigger(name);
         } else {
             return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/failpoint/FailPointExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/failpoint/FailPointExecutor.java
@@ -141,7 +141,11 @@ public class FailPointExecutor {
         if (!FailPoint.isEnabled()) {
             throw new DdlException("fail point is not enabled, please start fe with --failpoint option");
         }
-        if (updateStmt.getIsEnable()) {
+        // isArming(), not getIsEnable(): a pause is an ENABLE statement whose wire form carries
+        // is_enable = false, so the two disagree by design and only isArming() is safe at an
+        // arm-or-remove branch. The follower frontends decide the same way, via
+        // TriggerPolicy.isArming(request).
+        if (updateStmt.isArming()) {
             FailPoint.setTriggerPolicy(updateStmt.getName(), updateStmt.getTriggerPolicy());
         } else {
             FailPoint.removeTriggerPolicy(updateStmt.getName());

--- a/fe/fe-core/src/main/java/com/starrocks/failpoint/README.md
+++ b/fe/fe-core/src/main/java/com/starrocks/failpoint/README.md
@@ -51,6 +51,56 @@ ADMIN ENABLE FAILPOINT 'bdb_ha_get_leader_exception' WITH 10 TIMES ON FRONTEND;
 // Trigger with 10% probability
 ADMIN ENABLE FAILPOINT 'bdb_ha_get_leader_exception' WITH 0.1 PROBABILITY ON FRONTEND;
 
-// Disable
+// Pause every thread that reaches the failpoint, until it is disabled
+ADMIN ENABLE FAILPOINT 'bdb_ha_get_leader_exception' WITH PAUSE ON FRONTEND;
+
+// Disable (also releases a pause)
 ADMIN DISABLE FAILPOINT 'bdb_ha_get_leader_exception' ON FRONTEND;
 ```
+
+All of these require the `OPERATE` system privilege.
+
+## Pausing at a failpoint
+
+`WITH PAUSE` blocks every thread that reaches the failpoint instead of injecting a fault. It exists
+for the fault pattern that a fail-only failpoint cannot express:
+
+> stop at phase X -> act externally (kill a node, switch the leader) -> release -> assert
+
+```sql
+ADMIN ENABLE FAILPOINT 'some_failpoint' WITH PAUSE ON BACKEND '10.0.0.2:9060';
+-- ... poll SHOW FAILPOINTS until PausedThreads > 0, then do the external action ...
+ADMIN DISABLE FAILPOINT 'some_failpoint' ON BACKEND '10.0.0.2:9060';
+```
+
+Points worth knowing:
+
+- **A released pause never injects.** Once released, the trigger evaluates to false and the flow
+  continues normally, so arming an existing fail-style failpoint `WITH PAUSE` turns it into a pure
+  stop point. To pause *and* fail, arm a second failpoint downstream.
+- **Any mode change releases**, not just `ADMIN DISABLE FAILPOINT`.
+- **A forgotten disable self-heals.** A parked thread resumes after
+  `failpoint_pause_timeout_second` (FE config, default 300, mutable) with a `pause timed out`
+  WARNING. The FE sends this value to BEs/CNs with the arming request, so both sides share one
+  timeout.
+- **Observability.** `SHOW FAILPOINTS` reports `TriggerCount` (cumulative fires) and `PausedThreads`
+  (threads parked right now) for backends. FE failpoints are not listed by `SHOW FAILPOINTS`; an FE
+  pause logs `failpoint <name> paused, waiting for ADMIN DISABLE FAILPOINT` in `fe.log`, and the
+  effect on a reshard job is visible in `information_schema.tablet_reshard_jobs`.
+- **Mixed versions are safe but not useful.** A pause is sent as `DISABLE` plus a request-level pause
+  flag, so a node that predates this feature simply disables the failpoint rather than arming it.
+  Nothing is injected, but nothing pauses either, and such a node reports `DISABLE` rather than
+  `PAUSE`. Always confirm a pause with `PausedThreads > 0`, which is the only signal that proves a
+  thread actually parked.
+- **A pause blocks its logical thread.** The backend wait uses bthread primitives, so a pause inside
+  a brpc handler yields the worker rather than occupying it and `ADMIN DISABLE FAILPOINT` stays
+  serviceable. On the frontend, `TabletReshardJobMgr` runs every reshard job on one daemon thread, so
+  a pause inside a job also freezes the other reshard jobs on that frontend. A node shutdown while a
+  thread is parked waits out that thread's pause timeout.
+
+## Build requirement for BE failpoints
+
+FE failpoints need `--failpoint` at FE startup. **BE/CN failpoints exist only in a backend compiled
+with `ENABLE_FAULT_INJECTION=ON`** (`ENABLE_FAULT_INJECTION=ON ./build.sh --be`); the default build
+has them compiled out and `ADMIN ENABLE FAILPOINT ... ON BACKEND` returns
+`FailPoint is not supported, need re-compile BE with ENABLE_FAULT_INJECTION`.

--- a/fe/fe-core/src/main/java/com/starrocks/failpoint/README.md
+++ b/fe/fe-core/src/main/java/com/starrocks/failpoint/README.md
@@ -79,10 +79,12 @@ Points worth knowing:
   continues normally, so arming an existing fail-style failpoint `WITH PAUSE` turns it into a pure
   stop point. To pause *and* fail, arm a second failpoint downstream.
 - **Any mode change releases**, not just `ADMIN DISABLE FAILPOINT`.
-- **A forgotten disable self-heals.** A parked thread resumes after
-  `failpoint_pause_timeout_second` (FE config, default 300, mutable) with a `pause timed out`
-  WARNING. The FE sends this value to BEs/CNs with the arming request, so both sides share one
-  timeout.
+- **A forgotten disable self-heals.** On timeout the failpoint is **disarmed**, not merely stepped
+  past, so later arrivals are not parked again; a `pause timed out` WARNING is logged. If the failpoint
+  was re-armed while the pause was expiring, the new mode is kept and left alone. The timeout comes
+  from `failpoint_pause_timeout_second` (FE config, default 300, mutable), snapshotted when the
+  failpoint is armed and sent to every frontend and backend with the arming request, so all nodes
+  share one value even if the config changes afterwards.
 - **Observability.** `SHOW FAILPOINTS` reports `TriggerCount` (cumulative fires) and `PausedThreads`
   (threads parked right now) for backends. FE failpoints are not listed by `SHOW FAILPOINTS`; an FE
   pause logs `failpoint <name> paused, waiting for ADMIN DISABLE FAILPOINT` in `fe.log`, and the
@@ -92,11 +94,16 @@ Points worth knowing:
   Nothing is injected, but nothing pauses either, and such a node reports `DISABLE` rather than
   `PAUSE`. Always confirm a pause with `PausedThreads > 0`, which is the only signal that proves a
   thread actually parked.
-- **A pause blocks its logical thread.** The backend wait uses bthread primitives, so a pause inside
-  a brpc handler yields the worker rather than occupying it and `ADMIN DISABLE FAILPOINT` stays
-  serviceable. On the frontend, `TabletReshardJobMgr` runs every reshard job on one daemon thread, so
-  a pause inside a job also freezes the other reshard jobs on that frontend. A node shutdown while a
-  thread is parked waits out that thread's pause timeout.
+- **A pause blocks the thread it parks, and that thread stays blocked.** On the backend the wait
+  deliberately blocks the pthread rather than yielding a bthread: `shouldFail()` runs inside libfiu's
+  `fiu_fail()`, which holds a thread-local recursion counter and a read lock across the callback, so a
+  pause that migrated to another worker would corrupt both and silently disable every failpoint on the
+  original worker. The trade-off is that a paused failpoint occupies its thread, so parking more brpc
+  handlers than the worker pool has threads can delay `ADMIN DISABLE FAILPOINT` until the pause times
+  out. Pause a handful of handlers, not all of them.
+- On the frontend, `TabletReshardJobMgr` runs every reshard job on one daemon thread, so a pause
+  inside a job also freezes the other reshard jobs on that frontend. A node shutdown while a thread is
+  parked waits out that thread's pause timeout.
 
 ## Build requirement for BE failpoints
 

--- a/fe/fe-core/src/main/java/com/starrocks/failpoint/TriggerMode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/failpoint/TriggerMode.java
@@ -16,5 +16,10 @@ package com.starrocks.failpoint;
 public enum TriggerMode {
     ENABLE,
     PROBABILITY_ENABLE,
-    ENABLE_N_TIMES
+    ENABLE_N_TIMES,
+    // Park the thread that reaches the failpoint until the policy is released (ADMIN DISABLE
+    // FAILPOINT, or the policy being replaced) or the pause times out. A released pause never
+    // injects: shouldTrigger returns false and the Byteman rule's DO action is skipped.
+    // Java-internal only -- it never crosses the wire; see PFailPointTriggerMode.pause.
+    PAUSE
 }

--- a/fe/fe-core/src/main/java/com/starrocks/failpoint/TriggerPolicy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/failpoint/TriggerPolicy.java
@@ -140,9 +140,15 @@ public class TriggerPolicy {
             // Disarm, do not merely resume: leaving the policy armed would park every NEWLY arriving
             // thread for another full timeout, so a failpoint on a hot path would keep the frontend
             // wedged indefinitely -- the opposite of the self-healing this timeout exists to give.
-            LOG.warn("failpoint {} pause timed out after {}s, disarming it and resuming",
-                    name, pauseTimeoutSecond);
-            FailPoint.removeTriggerPolicy(name);
+            // Conditional on this policy still being the installed one: a plain remove would delete a
+            // replacement armed concurrently and discard the operator's new mode.
+            if (FailPoint.removeTriggerPolicyIf(name, this)) {
+                LOG.warn("failpoint {} pause timed out after {}s, disarming it and resuming",
+                        name, pauseTimeoutSecond);
+            } else {
+                LOG.warn("failpoint {} pause timed out after {}s, resuming; its policy changed "
+                        + "concurrently so the current state is left unchanged", name, pauseTimeoutSecond);
+            }
         } else {
             LOG.info("failpoint {} pause released", name);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/failpoint/TriggerPolicy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/failpoint/TriggerPolicy.java
@@ -124,19 +124,27 @@ public class TriggerPolicy {
     private boolean pauseUntilReleased(String name) {
         LOG.info("failpoint {} paused, waiting for ADMIN DISABLE FAILPOINT", name);
         pausedThreadCount.incrementAndGet();
+        boolean timedOut = false;
         try {
             // await() is nanoTime-based, so a wall-clock adjustment cannot extend or truncate the
             // wait, and its boolean return already distinguishes released from timed out.
-            if (releaseLatch.await(pauseTimeoutSecond, TimeUnit.SECONDS)) {
-                LOG.info("failpoint {} pause released", name);
-            } else {
-                LOG.warn("failpoint {} pause timed out after {}s, resuming", name, pauseTimeoutSecond);
-            }
+            timedOut = !releaseLatch.await(pauseTimeoutSecond, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             LOG.warn("failpoint {} pause interrupted, resuming", name);
+            return false;
         } finally {
             pausedThreadCount.decrementAndGet();
+        }
+        if (timedOut) {
+            // Disarm, do not merely resume: leaving the policy armed would park every NEWLY arriving
+            // thread for another full timeout, so a failpoint on a hot path would keep the frontend
+            // wedged indefinitely -- the opposite of the self-healing this timeout exists to give.
+            LOG.warn("failpoint {} pause timed out after {}s, disarming it and resuming",
+                    name, pauseTimeoutSecond);
+            FailPoint.removeTriggerPolicy(name);
+        } else {
+            LOG.info("failpoint {} pause released", name);
         }
         return false;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/failpoint/TriggerPolicy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/failpoint/TriggerPolicy.java
@@ -13,15 +13,30 @@
 // limitations under the License.
 package com.starrocks.failpoint;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.starrocks.common.Config;
 import com.starrocks.thrift.TUpdateFailPointRequest;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class TriggerPolicy {
+    private static final Logger LOG = LogManager.getLogger(TriggerPolicy.class);
+
     private final TriggerMode mode;
     private double probability;
     private int times;
 
+    // PAUSE only. Threads park on this monitor; release() wakes them.
+    private final Object pauseLock = new Object();
+    private boolean released = false;
+    private int pausedThreadCount = 0;
+
     public static TriggerPolicy enablePolicy() {
         return new TriggerPolicy(TriggerMode.ENABLE);
+    }
+
+    public static TriggerPolicy pausePolicy() {
+        return new TriggerPolicy(TriggerMode.PAUSE);
     }
 
     public static TriggerPolicy probabilityPolicy(double probability) {
@@ -46,7 +61,22 @@ public class TriggerPolicy {
         this.times = times;
     }
 
-    public boolean shouldTrigger() {
+    public TriggerMode getMode() {
+        return mode;
+    }
+
+    /**
+     * Threads parked in this policy right now. Test-only: FE deliberately exposes no pause counters
+     * on any user-visible surface (no SQL, thrift, or log surface) -- see the design doc.
+     */
+    @VisibleForTesting
+    public int getPausedThreadCount() {
+        synchronized (pauseLock) {
+            return pausedThreadCount;
+        }
+    }
+
+    public boolean shouldTrigger(String name) {
         if (mode == TriggerMode.ENABLE) {
             return true;
         }
@@ -61,11 +91,78 @@ public class TriggerPolicy {
                 return false;
             }
         }
+        if (mode == TriggerMode.PAUSE) {
+            return pauseUntilReleased(name);
+        }
         return false;
     }
 
+    /**
+     * Block until {@link #release()} or the timeout, then ALWAYS return false: a released pause
+     * continues normally and never injects the rule's action.
+     */
+    private boolean pauseUntilReleased(String name) {
+        // Normalize once: a misconfigured 0 or negative must mean "clamp to 1s", never "do not wait"
+        // and never "wait forever". The same normalization is applied when the value is sent to BEs.
+        int timeoutSecond = Math.max(1, Config.failpoint_pause_timeout_second);
+        // nanoTime, not currentTimeMillis: a wall-clock adjustment must not extend or truncate the
+        // wait.
+        long deadlineNanos = System.nanoTime() + timeoutSecond * 1_000_000_000L;
+        LOG.info("failpoint {} paused, waiting for ADMIN DISABLE FAILPOINT", name);
+        boolean timedOut = false;
+        try {
+            synchronized (pauseLock) {
+                pausedThreadCount++;
+                try {
+                    while (!released) {
+                        long remainNanos = deadlineNanos - System.nanoTime();
+                        if (remainNanos <= 0) {
+                            timedOut = true;
+                            break;
+                        }
+                        pauseLock.wait(remainNanos / 1_000_000L, (int) (remainNanos % 1_000_000L));
+                    }
+                } finally {
+                    pausedThreadCount--;
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.warn("failpoint {} pause interrupted, resuming", name);
+            return false;
+        }
+        if (timedOut) {
+            LOG.warn("failpoint {} pause timed out after {}s, resuming", name, timeoutSecond);
+        } else {
+            LOG.info("failpoint {} pause released", name);
+        }
+        return false;
+    }
+
+    /**
+     * Wake every thread parked in a PAUSE policy. Called when the policy is removed
+     * (ADMIN DISABLE FAILPOINT) or replaced by a re-arm. Idempotent, and safe on a non-PAUSE policy.
+     */
+    public void release() {
+        synchronized (pauseLock) {
+            released = true;
+            pauseLock.notifyAll();
+        }
+    }
+
+    /**
+     * Whether this request arms a policy rather than removing one. A pause deliberately carries
+     * is_enable = false -- that is what makes an FE predating the pause field remove the policy
+     * instead of arming an ENABLE it cannot honour -- so a receiver must not read is_enable alone.
+     */
+    public static boolean isArming(TUpdateFailPointRequest request) {
+        return (request.isSetPause() && request.isPause()) || request.isIs_enable();
+    }
+
     public static TriggerPolicy fromThrift(TUpdateFailPointRequest request) {
-        if (request.isSetTimes()) {
+        if (request.isSetPause() && request.isPause()) {
+            return TriggerPolicy.pausePolicy();
+        } else if (request.isSetTimes()) {
             return TriggerPolicy.timesPolicy(request.getTimes());
         } else if (request.isSetProbability()) {
             return TriggerPolicy.probabilityPolicy(request.getProbability());

--- a/fe/fe-core/src/main/java/com/starrocks/failpoint/TriggerPolicy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/failpoint/TriggerPolicy.java
@@ -14,10 +14,13 @@
 package com.starrocks.failpoint;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.starrocks.common.Config;
 import com.starrocks.thrift.TUpdateFailPointRequest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class TriggerPolicy {
     private static final Logger LOG = LogManager.getLogger(TriggerPolicy.class);
@@ -26,17 +29,35 @@ public class TriggerPolicy {
     private double probability;
     private int times;
 
-    // PAUSE only. Threads park on this monitor; release() wakes them.
-    private final Object pauseLock = new Object();
-    private boolean released = false;
-    private int pausedThreadCount = 0;
+    // PAUSE only. A one-shot gate: countDown() is idempotent, releases every waiter, and a thread
+    // arriving after the release returns immediately -- exactly the semantics a pause needs.
+    private final CountDownLatch releaseLatch = new CountDownLatch(1);
+    private final AtomicInteger pausedThreadCount = new AtomicInteger();
+    // Snapshotted when the policy is armed, never re-read from Config at park time: an
+    // ADMIN SET FRONTEND CONFIG between arming and parking must not desynchronize this frontend from
+    // its peers or from the backends, which snapshot the same value into the trigger mode they store.
+    private int pauseTimeoutSecond = 1;
 
     public static TriggerPolicy enablePolicy() {
         return new TriggerPolicy(TriggerMode.ENABLE);
     }
 
-    public static TriggerPolicy pausePolicy() {
-        return new TriggerPolicy(TriggerMode.PAUSE);
+    /**
+     * @param timeoutSecond the already-normalized pause timeout carried by the arming request; values
+     *                      below 1 are clamped so a misconfigured value can never mean "wait forever".
+     */
+    public static TriggerPolicy pausePolicy(int timeoutSecond) {
+        TriggerPolicy policy = new TriggerPolicy(TriggerMode.PAUSE);
+        policy.pauseTimeoutSecond = normalizePauseTimeoutSecond(timeoutSecond);
+        return policy;
+    }
+
+    /**
+     * The single definition of the pause-timeout clamp. Applied once at the arming site so the value
+     * that reaches a frontend policy, a follower frontend, and every backend is byte-identical.
+     */
+    public static int normalizePauseTimeoutSecond(int timeoutSecond) {
+        return Math.max(1, timeoutSecond);
     }
 
     public static TriggerPolicy probabilityPolicy(double probability) {
@@ -61,6 +82,7 @@ public class TriggerPolicy {
         this.times = times;
     }
 
+    @VisibleForTesting
     public TriggerMode getMode() {
         return mode;
     }
@@ -71,9 +93,7 @@ public class TriggerPolicy {
      */
     @VisibleForTesting
     public int getPausedThreadCount() {
-        synchronized (pauseLock) {
-            return pausedThreadCount;
-        }
+        return pausedThreadCount.get();
     }
 
     public boolean shouldTrigger(String name) {
@@ -102,39 +122,21 @@ public class TriggerPolicy {
      * continues normally and never injects the rule's action.
      */
     private boolean pauseUntilReleased(String name) {
-        // Normalize once: a misconfigured 0 or negative must mean "clamp to 1s", never "do not wait"
-        // and never "wait forever". The same normalization is applied when the value is sent to BEs.
-        int timeoutSecond = Math.max(1, Config.failpoint_pause_timeout_second);
-        // nanoTime, not currentTimeMillis: a wall-clock adjustment must not extend or truncate the
-        // wait.
-        long deadlineNanos = System.nanoTime() + timeoutSecond * 1_000_000_000L;
         LOG.info("failpoint {} paused, waiting for ADMIN DISABLE FAILPOINT", name);
-        boolean timedOut = false;
+        pausedThreadCount.incrementAndGet();
         try {
-            synchronized (pauseLock) {
-                pausedThreadCount++;
-                try {
-                    while (!released) {
-                        long remainNanos = deadlineNanos - System.nanoTime();
-                        if (remainNanos <= 0) {
-                            timedOut = true;
-                            break;
-                        }
-                        pauseLock.wait(remainNanos / 1_000_000L, (int) (remainNanos % 1_000_000L));
-                    }
-                } finally {
-                    pausedThreadCount--;
-                }
+            // await() is nanoTime-based, so a wall-clock adjustment cannot extend or truncate the
+            // wait, and its boolean return already distinguishes released from timed out.
+            if (releaseLatch.await(pauseTimeoutSecond, TimeUnit.SECONDS)) {
+                LOG.info("failpoint {} pause released", name);
+            } else {
+                LOG.warn("failpoint {} pause timed out after {}s, resuming", name, pauseTimeoutSecond);
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             LOG.warn("failpoint {} pause interrupted, resuming", name);
-            return false;
-        }
-        if (timedOut) {
-            LOG.warn("failpoint {} pause timed out after {}s, resuming", name, timeoutSecond);
-        } else {
-            LOG.info("failpoint {} pause released", name);
+        } finally {
+            pausedThreadCount.decrementAndGet();
         }
         return false;
     }
@@ -144,10 +146,7 @@ public class TriggerPolicy {
      * (ADMIN DISABLE FAILPOINT) or replaced by a re-arm. Idempotent, and safe on a non-PAUSE policy.
      */
     public void release() {
-        synchronized (pauseLock) {
-            released = true;
-            pauseLock.notifyAll();
-        }
+        releaseLatch.countDown();
     }
 
     /**
@@ -161,7 +160,9 @@ public class TriggerPolicy {
 
     public static TriggerPolicy fromThrift(TUpdateFailPointRequest request) {
         if (request.isSetPause() && request.isPause()) {
-            return TriggerPolicy.pausePolicy();
+            // The timeout is snapshotted by the arming frontend and carried on the request; falling
+            // back to this node's own Config would reintroduce the desync the snapshot prevents.
+            return TriggerPolicy.pausePolicy(request.getPause_timeout_second());
         } else if (request.isSetTimes()) {
             return TriggerPolicy.timesPolicy(request.getTimes());
         } else if (request.isSetProbability()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -3250,10 +3250,17 @@ public class ShowExecutor {
                         if (matcher != null && !matcher.match(name)) {
                             continue;
                         }
+                        // pause and both counters are optional on the wire: a BE built before them
+                        // sends null, so never dereference a boxed value here.
+                        boolean paused = Boolean.TRUE.equals(triggerMode.pause);
                         List<String> row = Lists.newArrayList();
                         row.add(failPointInfo.name);
-                        row.add(triggerMode.mode.toString());
-                        if (triggerMode.mode == FailPointTriggerModeType.ENABLE_N_TIMES) {
+                        // A pause is sent as DISABLE + pause=true so old backends degrade safely;
+                        // report what it actually means.
+                        row.add(paused ? "PAUSE" : triggerMode.mode.toString());
+                        if (paused) {
+                            row.add("");
+                        } else if (triggerMode.mode == FailPointTriggerModeType.ENABLE_N_TIMES) {
                             row.add(Integer.toString(triggerMode.nTimes));
                         } else if (triggerMode.mode == FailPointTriggerModeType.PROBABILITY_ENABLE) {
                             row.add(Double.toString(triggerMode.probability));
@@ -3261,6 +3268,10 @@ public class ShowExecutor {
                             row.add("");
                         }
                         row.add(String.format("%s:%d", node.getHost(), node.getBePort()));
+                        row.add(Long.toString(failPointInfo.triggerCount == null
+                                ? 0L : failPointInfo.triggerCount));
+                        row.add(Long.toString(failPointInfo.pausedThreadCount == null
+                                ? 0L : failPointInfo.pausedThreadCount));
                         rows.add(row);
                     }
                 } catch (InterruptedException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultMetaFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultMetaFactory.java
@@ -1322,11 +1322,15 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
 
     @Override
     public ShowResultSetMetaData visitShowFailPointStatement(ShowFailPointStatement statement, Void context) {
+        // TriggerCount / PausedThreads are appended AFTER Host on purpose: the QA harness parses
+        // this result positionally, so inserting them earlier would shift the existing columns.
         return ShowResultSetMetaData.builder()
                 .addColumn(new Column("Name", TypeFactory.createVarcharType(256)))
                 .addColumn(new Column("TriggerMode", TypeFactory.createVarcharType(32)))
                 .addColumn(new Column("Times/Probability", TypeFactory.createVarcharType(16)))
                 .addColumn(new Column("Host", TypeFactory.createVarcharType(64)))
+                .addColumn(new Column("TriggerCount", TypeFactory.createVarcharType(20)))
+                .addColumn(new Column("PausedThreads", TypeFactory.createVarcharType(20)))
                 .build();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -3850,7 +3850,10 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     public TUpdateFailPointResponse updateFailPointStatus(TUpdateFailPointRequest request) {
         TStatus status = new TStatus();
         if (FailPoint.isEnabled()) {
-            if (request.isIs_enable()) {
+            // Not `request.isIs_enable()`: a pause request deliberately carries is_enable = false so
+            // that an FE predating the pause field removes the policy instead of arming an ENABLE it
+            // cannot honour. isArming() is what keeps a pause from being read as a removal here.
+            if (TriggerPolicy.isArming(request)) {
                 FailPoint.setTriggerPolicy(request.getName(), TriggerPolicy.fromThrift(request));
             } else {
                 FailPoint.removeTriggerPolicy(request.getName());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -192,6 +192,7 @@ import com.starrocks.sql.ast.ShowCreateTableStmt;
 import com.starrocks.sql.ast.ShowDataDistributionStmt;
 import com.starrocks.sql.ast.ShowDataStmt;
 import com.starrocks.sql.ast.ShowExportStmt;
+import com.starrocks.sql.ast.ShowFailPointStatement;
 import com.starrocks.sql.ast.ShowFrontendsStmt;
 import com.starrocks.sql.ast.ShowFunctionsStmt;
 import com.starrocks.sql.ast.ShowGrantsStmt;
@@ -228,6 +229,7 @@ import com.starrocks.sql.ast.TableRef;
 import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.TruncateTableStmt;
 import com.starrocks.sql.ast.UninstallPluginStmt;
+import com.starrocks.sql.ast.UpdateFailPointStatusStatement;
 import com.starrocks.sql.ast.UpdateStmt;
 import com.starrocks.sql.ast.UseCatalogStmt;
 import com.starrocks.sql.ast.UseDbStmt;
@@ -2295,6 +2297,36 @@ public class AuthorizerStmtVisitor implements AstVisitorExtendInterface<Void, Co
 
     @Override
     public Void visitAdminSetConfigStatement(AdminSetConfigStmt statement, ConnectContext context) {
+        try {
+            Authorizer.checkSystemAction(context, PrivilegeType.OPERATE);
+        } catch (AccessDeniedException e) {
+            AccessDeniedException.reportAccessDenied(
+                    InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
+                    context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
+                    PrivilegeType.OPERATE.name(), ObjectType.SYSTEM.name(), null);
+        }
+        return null;
+    }
+
+    // ---------------------------------------- FailPoint Statement ----------------------------------------------------
+
+    @Override
+    public Void visitUpdateFailPointStatusStatement(UpdateFailPointStatusStatement statement, ConnectContext context) {
+        // The ADMIN keyword is syntax, not a privilege. Arming a failpoint injects faults into every
+        // targeted node, and WITH PAUSE can park node threads outright, so this needs OPERATE.
+        try {
+            Authorizer.checkSystemAction(context, PrivilegeType.OPERATE);
+        } catch (AccessDeniedException e) {
+            AccessDeniedException.reportAccessDenied(
+                    InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
+                    context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
+                    PrivilegeType.OPERATE.name(), ObjectType.SYSTEM.name(), null);
+        }
+        return null;
+    }
+
+    @Override
+    public Void visitShowFailPointStatement(ShowFailPointStatement statement, ConnectContext context) {
         try {
             Authorizer.checkSystemAction(context, PrivilegeType.OPERATE);
         } catch (AccessDeniedException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/UpdateFailPointStatusStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/UpdateFailPointStatusStatement.java
@@ -67,8 +67,14 @@ public class UpdateFailPointStatusStatement extends StatementBase {
         return name;
     }
 
-    public boolean isPause() {
-        return pause;
+    /**
+     * Whether this statement arms a policy rather than removing one. NOT the same as
+     * {@link #getIsEnable()}: a pause is an ENABLE statement, but it is transmitted with
+     * is_enable = false so that a node predating the pause field removes the policy instead of
+     * arming an ENABLE it cannot honour. Every arm-or-remove decision must go through this.
+     */
+    public boolean isArming() {
+        return isEnable || pause;
     }
 
     public PUpdateFailPointStatusRequest toProto() {
@@ -81,8 +87,7 @@ public class UpdateFailPointStatusStatement extends StatementBase {
             // mode and echo it back from list_fail_point, making SHOW FAILPOINTS report PAUSE for a
             // failpoint it merely disabled.
             request.pause = true;
-            // Normalized here too, so FE and BE cannot disagree about a misconfigured value.
-            request.pauseTimeoutSecond = Math.max(1, Config.failpoint_pause_timeout_second);
+            request.pauseTimeoutSecond = normalizedPauseTimeoutSecond();
         }
         return request;
     }
@@ -95,6 +100,7 @@ public class UpdateFailPointStatusStatement extends StatementBase {
         request.setIs_enable(isEnable && !pause);
         if (pause) {
             request.setPause(true);
+            request.setPause_timeout_second(normalizedPauseTimeoutSecond());
         }
         if (nTimes != null) {
             request.setTimes(nTimes);
@@ -105,7 +111,16 @@ public class UpdateFailPointStatusStatement extends StatementBase {
         return request;
     }
 
-    public PFailPointTriggerMode getFailPointMode() {
+    /**
+     * Snapshotted once, here at the arming site, and carried to every recipient. Receivers must not
+     * re-read their own config at park time or an ADMIN SET FRONTEND CONFIG in between would let the
+     * frontends and backends disagree about how long a pause lasts.
+     */
+    private int normalizedPauseTimeoutSecond() {
+        return TriggerPolicy.normalizePauseTimeoutSecond(Config.failpoint_pause_timeout_second);
+    }
+
+    private PFailPointTriggerMode getFailPointMode() {
         PFailPointTriggerMode mode = new PFailPointTriggerMode();
         if (isEnable) {
             if (pause) {
@@ -129,17 +144,13 @@ public class UpdateFailPointStatusStatement extends StatementBase {
         return mode;
     }
 
+    /**
+     * The policy this statement arms on the local frontend. Derived from the same thrift encoding the
+     * followers receive, so the leader and its followers cannot diverge -- a second decode ladder here
+     * is exactly how a new trigger mode ends up honoured on one frontend and not the others.
+     */
     public TriggerPolicy getTriggerPolicy() {
-        if (pause) {
-            return TriggerPolicy.pausePolicy();
-        }
-        if (nTimes != null) {
-            return TriggerPolicy.timesPolicy(nTimes);
-        }
-        if (probability != null) {
-            return TriggerPolicy.probabilityPolicy(probability);
-        }
-        return TriggerPolicy.enablePolicy();
+        return TriggerPolicy.fromThrift(toThrift());
     }
 
     public List<String> getBackends() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/UpdateFailPointStatusStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/UpdateFailPointStatusStatement.java
@@ -31,6 +31,10 @@ public class UpdateFailPointStatusStatement extends StatementBase {
     private Integer nTimes = null;
     private Double probability = null;
     private boolean pause = false;
+    // Snapshotted when the statement is built, not read per serialization: toThrift() is called once
+    // for the local frontend and again for EVERY follower, so re-reading a mutable Config here would
+    // let a concurrent ADMIN SET FRONTEND CONFIG hand different nodes different armed timeouts.
+    private int pauseTimeoutSecond = 0;
     private List<String> backends = null;
 
     public UpdateFailPointStatusStatement(String name, boolean isEnable, List<String> backends, NodePosition pos) {
@@ -60,6 +64,8 @@ public class UpdateFailPointStatusStatement extends StatementBase {
                                                                 NodePosition pos) {
         UpdateFailPointStatusStatement statement = new UpdateFailPointStatusStatement(name, true, backends, pos);
         statement.pause = true;
+        statement.pauseTimeoutSecond =
+                TriggerPolicy.normalizePauseTimeoutSecond(Config.failpoint_pause_timeout_second);
         return statement;
     }
 
@@ -87,7 +93,7 @@ public class UpdateFailPointStatusStatement extends StatementBase {
             // mode and echo it back from list_fail_point, making SHOW FAILPOINTS report PAUSE for a
             // failpoint it merely disabled.
             request.pause = true;
-            request.pauseTimeoutSecond = normalizedPauseTimeoutSecond();
+            request.pauseTimeoutSecond = pauseTimeoutSecond;
         }
         return request;
     }
@@ -100,7 +106,7 @@ public class UpdateFailPointStatusStatement extends StatementBase {
         request.setIs_enable(isEnable && !pause);
         if (pause) {
             request.setPause(true);
-            request.setPause_timeout_second(normalizedPauseTimeoutSecond());
+            request.setPause_timeout_second(pauseTimeoutSecond);
         }
         if (nTimes != null) {
             request.setTimes(nTimes);
@@ -109,15 +115,6 @@ public class UpdateFailPointStatusStatement extends StatementBase {
             request.setProbability(probability);
         }
         return request;
-    }
-
-    /**
-     * Snapshotted once, here at the arming site, and carried to every recipient. Receivers must not
-     * re-read their own config at park time or an ADMIN SET FRONTEND CONFIG in between would let the
-     * frontends and backends disagree about how long a pause lasts.
-     */
-    private int normalizedPauseTimeoutSecond() {
-        return TriggerPolicy.normalizePauseTimeoutSecond(Config.failpoint_pause_timeout_second);
     }
 
     private PFailPointTriggerMode getFailPointMode() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/UpdateFailPointStatusStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/UpdateFailPointStatusStatement.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.ast;
 
 import com.google.common.base.Joiner;
+import com.starrocks.common.Config;
 import com.starrocks.failpoint.TriggerPolicy;
 import com.starrocks.proto.FailPointTriggerModeType;
 import com.starrocks.proto.PFailPointTriggerMode;
@@ -29,6 +30,7 @@ public class UpdateFailPointStatusStatement extends StatementBase {
     private boolean isEnable = false;
     private Integer nTimes = null;
     private Double probability = null;
+    private boolean pause = false;
     private List<String> backends = null;
 
     public UpdateFailPointStatusStatement(String name, boolean isEnable, List<String> backends, NodePosition pos) {
@@ -48,35 +50,52 @@ public class UpdateFailPointStatusStatement extends StatementBase {
         this.probability = probability;
     }
 
+    /**
+     * ADMIN ENABLE FAILPOINT '&lt;name&gt;' WITH PAUSE: park threads that reach the failpoint until it is
+     * disabled or the pause times out. Exclusive with N TIMES / PROBABILITY at the grammar level, so
+     * this is a factory rather than a constructor overload (a boolean overload would collide with
+     * the isEnable constructor).
+     */
+    public static UpdateFailPointStatusStatement pauseStatement(String name, List<String> backends,
+                                                                NodePosition pos) {
+        UpdateFailPointStatusStatement statement = new UpdateFailPointStatusStatement(name, true, backends, pos);
+        statement.pause = true;
+        return statement;
+    }
+
     public String getName() {
         return name;
     }
 
+    public boolean isPause() {
+        return pause;
+    }
+
     public PUpdateFailPointStatusRequest toProto() {
-        PFailPointTriggerMode mode = new PFailPointTriggerMode();
-        if (isEnable) {
-            if (nTimes != null) {
-                mode.mode = FailPointTriggerModeType.ENABLE_N_TIMES;
-                mode.nTimes = nTimes;
-            } else if (probability != null) {
-                mode.mode = FailPointTriggerModeType.PROBABILITY_ENABLE;
-                mode.probability = probability.doubleValue();
-            } else {
-                mode.mode = FailPointTriggerModeType.ENABLE;
-            }
-        } else {
-            mode.mode = FailPointTriggerModeType.DISABLE;
-        }
         PUpdateFailPointStatusRequest request = new PUpdateFailPointStatusRequest();
         request.failPointName = name;
-        request.triggerMode = mode;
+        request.triggerMode = getFailPointMode();
+        if (pause) {
+            // The discriminator rides on the REQUEST, never inside triggerMode: protobuf preserves
+            // unknown fields, so a BE predating the pause would copy a nested flag into its stored
+            // mode and echo it back from list_fail_point, making SHOW FAILPOINTS report PAUSE for a
+            // failpoint it merely disabled.
+            request.pause = true;
+            // Normalized here too, so FE and BE cannot disagree about a misconfigured value.
+            request.pauseTimeoutSecond = Math.max(1, Config.failpoint_pause_timeout_second);
+        }
         return request;
     }
 
     public TUpdateFailPointRequest toThrift() {
         TUpdateFailPointRequest request = new TUpdateFailPointRequest();
         request.setName(name);
-        request.setIs_enable(isEnable);
+        // A pause sends is_enable = false for the same reason the proto sends DISABLE: an FE that
+        // predates the pause field then removes the policy instead of arming an ENABLE.
+        request.setIs_enable(isEnable && !pause);
+        if (pause) {
+            request.setPause(true);
+        }
         if (nTimes != null) {
             request.setTimes(nTimes);
         }
@@ -89,7 +108,13 @@ public class UpdateFailPointStatusStatement extends StatementBase {
     public PFailPointTriggerMode getFailPointMode() {
         PFailPointTriggerMode mode = new PFailPointTriggerMode();
         if (isEnable) {
-            if (nTimes != null) {
+            if (pause) {
+                // DISABLE, NOT a dedicated enum value: proto2 would report an unknown enum value as
+                // the default ENABLE, so a BE predating the pause field would inject the fault
+                // instead of pausing. Disabling is the safe degradation. The pause flag itself is
+                // set on the request by toProto().
+                mode.mode = FailPointTriggerModeType.DISABLE;
+            } else if (nTimes != null) {
                 mode.mode = FailPointTriggerModeType.ENABLE_N_TIMES;
                 mode.nTimes = nTimes;
             } else if (probability != null) {
@@ -105,6 +130,9 @@ public class UpdateFailPointStatusStatement extends StatementBase {
     }
 
     public TriggerPolicy getTriggerPolicy() {
+        if (pause) {
+            return TriggerPolicy.pausePolicy();
+        }
         if (nTimes != null) {
             return TriggerPolicy.timesPolicy(nTimes);
         }
@@ -140,7 +168,9 @@ public class UpdateFailPointStatusStatement extends StatementBase {
             sb.append("DISABLE");
         }
         sb.append(" FAILPOINT '").append(name).append("'");
-        if (nTimes != null) {
+        if (pause) {
+            sb.append(" WITH PAUSE");
+        } else if (nTimes != null) {
             sb.append(" WITH ").append(nTimes).append(" TIMES");
         } else if (probability != null) {
             sb.append(" WITH ").append(probability).append(" PROBABILITY");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -4994,6 +4994,8 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
                             "Invalid PROBABILITY value %f, it should be in range [0, 1]", probability));
                 }
                 return new UpdateFailPointStatusStatement(failpointName, probability, backendList, createPos(ctx));
+            } else if (ctx.PAUSE() != null) {
+                return UpdateFailPointStatusStatement.pauseStatement(failpointName, backendList, createPos(ctx));
             }
             return new UpdateFailPointStatusStatement(failpointName, true, backendList, createPos(ctx));
         } else {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/FailPointStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/FailPointStmtTest.java
@@ -14,8 +14,14 @@
 
 package com.starrocks.analysis;
 
+import com.starrocks.common.Config;
+import com.starrocks.failpoint.TriggerMode;
+import com.starrocks.proto.FailPointTriggerModeType;
+import com.starrocks.proto.PUpdateFailPointStatusRequest;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.UpdateFailPointStatusStatement;
+import com.starrocks.thrift.TUpdateFailPointRequest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -40,6 +46,9 @@ public class FailPointStmtTest {
                 "ADMIN ENABLE FAILPOINT 'test'",
                 "ADMIN ENABLE FAILPOINT 'test' WITH 1 TIMES",
                 "ADMIN ENABLE FAILPOINT 'test' WITH 0.5 PROBABILITY",
+                "ADMIN ENABLE FAILPOINT 'test' WITH PAUSE",
+                "ADMIN ENABLE FAILPOINT 'test' WITH PAUSE ON FRONTEND",
+                "ADMIN ENABLE FAILPOINT 'test' WITH PAUSE ON BACKEND '127.0.0.1:9000,127.0.0.2:9002'",
                 "ADMIN ENABLE FAILPOINT 'test' ON BACKEND '127.0.0.1:9000,127.0.0.2:9002'",
                 "ADMIN DISABLE FAILPOINT 'test'"
         );
@@ -47,6 +56,61 @@ public class FailPointStmtTest {
             testNormalCase(sql);
         }
     }
+
+    @Test
+    public void testPauseIsExclusiveWithTimesAndProbability() {
+        AnalyzeTestUtil.analyzeFail("ADMIN ENABLE FAILPOINT 'test' WITH 1 TIMES PAUSE");
+        AnalyzeTestUtil.analyzeFail("ADMIN ENABLE FAILPOINT 'test' WITH PAUSE 1 TIMES");
+    }
+
+    @Test
+    public void testPauseWireEncodingDegradesSafely() {
+        UpdateFailPointStatusStatement stmt = (UpdateFailPointStatusStatement)
+                AnalyzeTestUtil.analyzeSuccess("ADMIN ENABLE FAILPOINT 'test' WITH PAUSE");
+
+        // proto: trigger_mode.mode = DISABLE so a BE predating the pause disables rather than
+        // defaulting an unknown enum to ENABLE, and the discriminator rides on the REQUEST so such a
+        // BE cannot echo it back and make SHOW FAILPOINTS lie.
+        PUpdateFailPointStatusRequest request = stmt.toProto();
+        Assertions.assertEquals(FailPointTriggerModeType.DISABLE, request.triggerMode.mode);
+        Assertions.assertNull(request.triggerMode.pause);
+        Assertions.assertEquals(Boolean.TRUE, request.pause);
+        Assertions.assertEquals(Integer.valueOf(Config.failpoint_pause_timeout_second),
+                request.pauseTimeoutSecond);
+
+        // thrift: is_enable = false + pause = true, for the same reason on an old FE.
+        TUpdateFailPointRequest thriftRequest = stmt.toThrift();
+        Assertions.assertFalse(thriftRequest.isIs_enable());
+        Assertions.assertTrue(thriftRequest.isPause());
+
+        // local execution is unaffected by the wire encoding
+        Assertions.assertEquals(TriggerMode.PAUSE, stmt.getTriggerPolicy().getMode());
+    }
+
+    @Test
+    public void testPauseTimeoutIsNormalizedOnTheWire() {
+        int original = Config.failpoint_pause_timeout_second;
+        try {
+            Config.failpoint_pause_timeout_second = 0;
+            UpdateFailPointStatusStatement stmt = (UpdateFailPointStatusStatement)
+                    AnalyzeTestUtil.analyzeSuccess("ADMIN ENABLE FAILPOINT 'test' WITH PAUSE");
+            // Clamped to 1 before being sent, so FE and BE cannot disagree about a bad value.
+            Assertions.assertEquals(Integer.valueOf(1), stmt.toProto().pauseTimeoutSecond);
+        } finally {
+            Config.failpoint_pause_timeout_second = original;
+        }
+    }
+
+    @Test
+    public void testNonPauseEncodingUnchanged() {
+        UpdateFailPointStatusStatement stmt = (UpdateFailPointStatusStatement)
+                AnalyzeTestUtil.analyzeSuccess("ADMIN ENABLE FAILPOINT 'test' WITH 3 TIMES");
+        Assertions.assertEquals(FailPointTriggerModeType.ENABLE_N_TIMES, stmt.toProto().triggerMode.mode);
+        Assertions.assertNull(stmt.toProto().pause);
+        Assertions.assertTrue(stmt.toThrift().isIs_enable());
+        Assertions.assertFalse(stmt.toThrift().isSetPause());
+    }
+
     @Test
     public void testShowFailPoints() {
         List<String> sqls = Arrays.asList(

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/FailPointStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/FailPointStmtTest.java
@@ -82,6 +82,13 @@ public class FailPointStmtTest {
         TUpdateFailPointRequest thriftRequest = stmt.toThrift();
         Assertions.assertFalse(thriftRequest.isIs_enable());
         Assertions.assertTrue(thriftRequest.isPause());
+        // Followers snapshot the same timeout rather than re-reading their own config.
+        Assertions.assertEquals(Config.failpoint_pause_timeout_second,
+                thriftRequest.getPause_timeout_second());
+
+        // A pause is an ENABLE statement even though its wire form says is_enable = false; the
+        // leader must arm off isArming(), never off the raw flag.
+        Assertions.assertTrue(stmt.isArming());
 
         // local execution is unaffected by the wire encoding
         Assertions.assertEquals(TriggerMode.PAUSE, stmt.getTriggerPolicy().getMode());
@@ -109,6 +116,7 @@ public class FailPointStmtTest {
         Assertions.assertNull(stmt.toProto().pause);
         Assertions.assertTrue(stmt.toThrift().isIs_enable());
         Assertions.assertFalse(stmt.toThrift().isSetPause());
+        Assertions.assertTrue(stmt.isArming());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/failpoint/FailPointExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/failpoint/FailPointExecutorTest.java
@@ -52,6 +52,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 public class FailPointExecutorTest {
@@ -210,11 +211,16 @@ public class FailPointExecutorTest {
             @Mock
             public Future<PListFailPointResponse> listFailPointAsync(
                     TNetworkAddress address, PListFailPointRequest request) {
+                // A paused failpoint is reported as DISABLE + pause = true, matching the wire
+                // encoding; the FE renders it as PAUSE.
                 PFailPointTriggerMode mode = new PFailPointTriggerMode();
-                mode.mode = FailPointTriggerModeType.ENABLE;
+                mode.mode = FailPointTriggerModeType.DISABLE;
+                mode.pause = true;
                 PFailPointInfo info = new PFailPointInfo();
                 info.name = "fp_cn";
                 info.triggerMode = mode;
+                info.triggerCount = 7L;
+                info.pausedThreadCount = 2L;
 
                 PListFailPointResponse resp = new PListFailPointResponse();
                 resp.status = new StatusPB();
@@ -230,7 +236,111 @@ public class FailPointExecutorTest {
                 .visit(stmt, new ConnectContext());
         Assertions.assertTrue(result.next());
         Assertions.assertEquals("fp_cn", result.getString(0));
+        Assertions.assertEquals("PAUSE", result.getString(1));
+        Assertions.assertEquals("", result.getString(2));
         Assertions.assertEquals("10.0.0.2:9060", result.getString(3));
+        Assertions.assertEquals("7", result.getString(4));
+        Assertions.assertEquals("2", result.getString(5));
+    }
+
+    @Test
+    public void testShowFailPointsFromBackendWithoutPauseFields() throws Exception {
+        service.addComputeNode(aliveCn(10002, "10.0.0.2", 9060, 8060));
+
+        new MockUp<BackendServiceClient>() {
+            @Mock
+            public Future<PListFailPointResponse> listFailPointAsync(
+                    TNetworkAddress address, PListFailPointRequest request) {
+                // A BE built before this change leaves pause and both counters unset; jprotobuf maps
+                // an absent optional scalar to a null boxed value, so the FE must not dereference.
+                PFailPointTriggerMode mode = new PFailPointTriggerMode();
+                mode.mode = FailPointTriggerModeType.ENABLE;
+                PFailPointInfo info = new PFailPointInfo();
+                info.name = "fp_old_be";
+                info.triggerMode = mode;
+
+                PListFailPointResponse resp = new PListFailPointResponse();
+                resp.status = new StatusPB();
+                resp.status.statusCode = TStatusCode.OK.getValue();
+                resp.failPoints = Collections.singletonList(info);
+                return CompletableFuture.completedFuture(resp);
+            }
+        };
+
+        ShowFailPointStatement stmt = new ShowFailPointStatement(
+                null, Collections.singletonList("10.0.0.2:9060"), NodePosition.ZERO);
+        ShowResultSet result = ShowExecutor.ShowExecutorVisitor.getInstance()
+                .visit(stmt, new ConnectContext());
+        Assertions.assertTrue(result.next());
+        Assertions.assertEquals("ENABLE", result.getString(1));
+        Assertions.assertEquals("0", result.getString(4));
+        Assertions.assertEquals("0", result.getString(5));
+    }
+
+    @Test
+    public void testShowFailPointsOldBackendThatReceivedAPauseIsNotRenderedAsPaused() throws Exception {
+        service.addComputeNode(aliveCn(10002, "10.0.0.2", 9060, 8060));
+
+        new MockUp<BackendServiceClient>() {
+            @Mock
+            public Future<PListFailPointResponse> listFailPointAsync(
+                    TNetworkAddress address, PListFailPointRequest request) {
+                // What an old BE reports after being sent a pause: it saw only mode = DISABLE, and
+                // because the discriminator rides on the request rather than inside trigger_mode it
+                // has nothing to echo back. The FE must therefore report DISABLE, not PAUSE -- the
+                // failpoint really is just disabled on that node.
+                PFailPointTriggerMode mode = new PFailPointTriggerMode();
+                mode.mode = FailPointTriggerModeType.DISABLE;
+                PFailPointInfo info = new PFailPointInfo();
+                info.name = "fp_old_be_pause";
+                info.triggerMode = mode;
+
+                PListFailPointResponse resp = new PListFailPointResponse();
+                resp.status = new StatusPB();
+                resp.status.statusCode = TStatusCode.OK.getValue();
+                resp.failPoints = Collections.singletonList(info);
+                return CompletableFuture.completedFuture(resp);
+            }
+        };
+
+        ShowFailPointStatement stmt = new ShowFailPointStatement(
+                null, Collections.singletonList("10.0.0.2:9060"), NodePosition.ZERO);
+        ShowResultSet result = ShowExecutor.ShowExecutorVisitor.getInstance()
+                .visit(stmt, new ConnectContext());
+        Assertions.assertTrue(result.next());
+        Assertions.assertEquals("DISABLE", result.getString(1));
+        Assertions.assertEquals("0", result.getString(5));
+    }
+
+    @Test
+    public void testUpdateBackendPauseRequestEncoding() throws Exception {
+        service.addComputeNode(aliveCn(10002, "10.0.0.2", 9060, 8060));
+
+        AtomicReference<PUpdateFailPointStatusRequest> captured = new AtomicReference<>();
+        new MockUp<BackendServiceClient>() {
+            @Mock
+            public Future<PUpdateFailPointStatusResponse> updateFailPointStatusAsync(
+                    TNetworkAddress address, PUpdateFailPointStatusRequest request) {
+                captured.set(request);
+                PUpdateFailPointStatusResponse resp = new PUpdateFailPointStatusResponse();
+                resp.status = new StatusPB();
+                resp.status.statusCode = TStatusCode.OK.getValue();
+                return CompletableFuture.completedFuture(resp);
+            }
+        };
+
+        UpdateFailPointStatusStatement stmt = UpdateFailPointStatusStatement.pauseStatement(
+                "fp_test", Collections.singletonList("10.0.0.2:9060"), NodePosition.ZERO);
+        new FailPointExecutor(stmt).execute();
+
+        PUpdateFailPointStatusRequest sent = captured.get();
+        Assertions.assertNotNull(sent);
+        // Degrades safely on a BE that predates the pause field, and the discriminator stays on the
+        // request so such a BE cannot echo it back into SHOW FAILPOINTS.
+        Assertions.assertEquals(FailPointTriggerModeType.DISABLE, sent.triggerMode.mode);
+        Assertions.assertNull(sent.triggerMode.pause);
+        Assertions.assertEquals(Boolean.TRUE, sent.pause);
+        Assertions.assertTrue(sent.pauseTimeoutSecond > 0);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/failpoint/FailPointPrivilegeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/failpoint/FailPointPrivilegeTest.java
@@ -1,0 +1,96 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.failpoint;
+
+import com.starrocks.authentication.AuthenticationMgr;
+import com.starrocks.catalog.UserIdentity;
+import com.starrocks.common.ErrorReportException;
+import com.starrocks.qe.DDLStmtExecutor;
+import com.starrocks.sql.analyzer.Authorizer;
+import com.starrocks.sql.ast.CreateUserStmt;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.UserRef;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+/**
+ * Arming a failpoint injects faults into every targeted node, and WITH PAUSE can park node threads
+ * outright, so both failpoint statements require the OPERATE system privilege. Before this was added
+ * the ADMIN keyword was syntax only and any authenticated user could arm any failpoint.
+ */
+public class FailPointPrivilegeTest {
+    private static StarRocksAssert starRocksAssert;
+    private static UserIdentity userWithOperate;
+    private static UserIdentity userWithoutOperate;
+
+    private static final List<String> FAILPOINT_SQLS = List.of(
+            "ADMIN ENABLE FAILPOINT 'fp' WITH PAUSE",
+            "ADMIN DISABLE FAILPOINT 'fp'",
+            "SHOW FAILPOINTS");
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        starRocksAssert = new StarRocksAssert(UtFrameUtils.initCtxForNewPrivilege(UserIdentity.ROOT));
+        AuthenticationMgr authenticationMgr = starRocksAssert.getCtx().getGlobalStateMgr().getAuthenticationMgr();
+
+        userWithOperate = createUser(authenticationMgr, "fpOperateUser");
+        starRocksAssert.getCtx().setCurrentUserIdentity(UserIdentity.ROOT);
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
+                "grant operate on system to fpOperateUser", starRocksAssert.getCtx()), starRocksAssert.getCtx());
+
+        userWithoutOperate = createUser(authenticationMgr, "fpPlainUser");
+    }
+
+    private static UserIdentity createUser(AuthenticationMgr authenticationMgr, String name) throws Exception {
+        CreateUserStmt stmt = (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(
+                "CREATE USER '" + name + "' IDENTIFIED BY ''", starRocksAssert.getCtx());
+        authenticationMgr.createUser(stmt);
+        UserRef user = stmt.getUser();
+        return new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
+    }
+
+    private static void ctxTo(UserIdentity user) {
+        starRocksAssert.getCtx().setCurrentUserIdentity(user);
+        starRocksAssert.getCtx().setQualifiedUser(user.getUser());
+    }
+
+    @Test
+    public void testFailPointStatementsDeniedWithoutOperate() throws Exception {
+        ctxTo(userWithoutOperate);
+        for (String sql : FAILPOINT_SQLS) {
+            StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+            // reportAccessDenied converts the AccessDeniedException into an ErrorReportException.
+            Assertions.assertThrows(ErrorReportException.class,
+                    () -> Authorizer.check(stmt, starRocksAssert.getCtx()),
+                    "expected access denied for: " + sql);
+        }
+    }
+
+    @Test
+    public void testFailPointStatementsAllowedWithOperate() throws Exception {
+        ctxTo(userWithOperate);
+        for (String sql : FAILPOINT_SQLS) {
+            StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+            Assertions.assertDoesNotThrow(() -> Authorizer.check(stmt, starRocksAssert.getCtx()),
+                    "expected access granted for: " + sql);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/failpoint/TriggerPolicyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/failpoint/TriggerPolicyTest.java
@@ -14,16 +14,21 @@
 
 package com.starrocks.failpoint;
 
-import com.starrocks.common.Config;
 import com.starrocks.thrift.TUpdateFailPointRequest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
 
 public class TriggerPolicyTest {
+
+    // Long enough that a parked thread stays parked for the duration of a test.
+    private static final int PAUSE_TIMEOUT_SECOND = 300;
 
     // Spin until the policy reports the expected number of parked threads, so the tests synchronise
     // on real state rather than on a sleep.
@@ -40,7 +45,12 @@ public class TriggerPolicyTest {
     // Daemon threads so a failed assertion cannot leave a non-daemon thread parked for the whole
     // pause timeout.
     private static Thread startParker(TriggerPolicy policy, String name, AtomicBoolean triggered) {
-        Thread t = new Thread(() -> triggered.set(policy.shouldTrigger(name)), "parker-" + name);
+        return startParker(policy, name, triggered, () -> policy.shouldTrigger(name));
+    }
+
+    private static Thread startParker(TriggerPolicy policy, String name, AtomicBoolean triggered,
+                                      BooleanSupplier trigger) {
+        Thread t = new Thread(() -> triggered.set(trigger.getAsBoolean()), "parker-" + name);
         t.setDaemon(true);
         t.start();
         return t;
@@ -49,7 +59,7 @@ public class TriggerPolicyTest {
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testPauseReleasedByRelease() throws Exception {
-        TriggerPolicy policy = TriggerPolicy.pausePolicy();
+        TriggerPolicy policy = TriggerPolicy.pausePolicy(PAUSE_TIMEOUT_SECOND);
         AtomicBoolean triggered = new AtomicBoolean(true);
         Thread t = startParker(policy, "fp_pause", triggered);
         try {
@@ -67,7 +77,7 @@ public class TriggerPolicyTest {
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testPauseReleasesAllWaiters() throws Exception {
-        TriggerPolicy policy = TriggerPolicy.pausePolicy();
+        TriggerPolicy policy = TriggerPolicy.pausePolicy(PAUSE_TIMEOUT_SECOND);
         AtomicBoolean a = new AtomicBoolean(true);
         AtomicBoolean b = new AtomicBoolean(true);
         Thread t1 = startParker(policy, "fp_multi", a);
@@ -83,46 +93,26 @@ public class TriggerPolicyTest {
         Assertions.assertFalse(b.get());
     }
 
-    @Test
+    // The armed timeout is honoured and a misconfigured value clamps to 1s rather than meaning
+    // "never wait" or "wait forever". No global config is touched: the timeout now travels with the
+    // policy, which is exactly the property that keeps frontends and backends in agreement.
+    @ParameterizedTest
+    @ValueSource(ints = {1, 0, -5})
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
-    public void testPauseTimesOut() {
-        int original = Config.failpoint_pause_timeout_second;
-        try {
-            Config.failpoint_pause_timeout_second = 1;
-            TriggerPolicy policy = TriggerPolicy.pausePolicy();
+    public void testPauseTimesOutAfterItsArmedTimeout(int armedTimeout) {
+        TriggerPolicy policy = TriggerPolicy.pausePolicy(armedTimeout);
+        long start = System.nanoTime();
+        Assertions.assertFalse(policy.shouldTrigger("fp_timeout"));
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000L;
 
-            long start = System.nanoTime();
-            Assertions.assertFalse(policy.shouldTrigger("fp_timeout"));
-            long elapsedMs = (System.nanoTime() - start) / 1_000_000L;
-
-            Assertions.assertTrue(elapsedMs >= 900, "resumed after " + elapsedMs + "ms, expected >= 900ms");
-            Assertions.assertEquals(0, policy.getPausedThreadCount());
-        } finally {
-            Config.failpoint_pause_timeout_second = original;
-        }
-    }
-
-    @Test
-    @Timeout(value = 60, unit = TimeUnit.SECONDS)
-    public void testNonPositiveTimeoutIsNormalized() {
-        int original = Config.failpoint_pause_timeout_second;
-        try {
-            // A misconfigured 0 must not mean "never wait" nor "wait forever": it clamps to 1s.
-            Config.failpoint_pause_timeout_second = 0;
-            TriggerPolicy policy = TriggerPolicy.pausePolicy();
-            long start = System.nanoTime();
-            Assertions.assertFalse(policy.shouldTrigger("fp_zero"));
-            long elapsedMs = (System.nanoTime() - start) / 1_000_000L;
-            Assertions.assertTrue(elapsedMs >= 900, "resumed after " + elapsedMs + "ms, expected >= 900ms");
-        } finally {
-            Config.failpoint_pause_timeout_second = original;
-        }
+        Assertions.assertTrue(elapsedMs >= 900, "resumed after " + elapsedMs + "ms, expected >= 900ms");
+        Assertions.assertEquals(0, policy.getPausedThreadCount());
     }
 
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testInterruptResumesAndRestoresFlag() throws Exception {
-        TriggerPolicy policy = TriggerPolicy.pausePolicy();
+        TriggerPolicy policy = TriggerPolicy.pausePolicy(PAUSE_TIMEOUT_SECOND);
         AtomicBoolean triggered = new AtomicBoolean(true);
         AtomicBoolean interruptFlagSeen = new AtomicBoolean(false);
         Thread t = new Thread(() -> {
@@ -146,7 +136,7 @@ public class TriggerPolicyTest {
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testReleaseIsIdempotentAndPreRelease() {
-        TriggerPolicy policy = TriggerPolicy.pausePolicy();
+        TriggerPolicy policy = TriggerPolicy.pausePolicy(PAUSE_TIMEOUT_SECOND);
         policy.release();
         policy.release();
         // Already released: returns immediately rather than waiting out the timeout.
@@ -155,45 +145,34 @@ public class TriggerPolicyTest {
         Assertions.assertTrue((System.nanoTime() - start) / 1_000_000L < 5_000);
     }
 
+    // Both ADMIN DISABLE FAILPOINT (remove) and a re-arm (replace) must release whatever is parked on
+    // the superseded policy, or a paused thread is stranded until its timeout.
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testRemoveTriggerPolicyReleasesPausedThread() throws Exception {
-        TriggerPolicy policy = TriggerPolicy.pausePolicy();
-        FailPoint.setTriggerPolicy("fp_remove", policy);
-        AtomicBoolean triggered = new AtomicBoolean(true);
-        Thread t = new Thread(() -> triggered.set(FailPoint.shouldTrigger("fp_remove")), "parker-remove");
-        t.setDaemon(true);
-        t.start();
-        try {
-            Assertions.assertTrue(waitForParked(policy, 1));
-        } finally {
-            // ADMIN DISABLE FAILPOINT goes through removeTriggerPolicy.
-            FailPoint.removeTriggerPolicy("fp_remove");
-        }
-        t.join(10_000);
-        Assertions.assertFalse(t.isAlive());
-        Assertions.assertFalse(triggered.get());
+        assertReleasedBy("fp_remove", () -> FailPoint.removeTriggerPolicy("fp_remove"));
     }
 
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testReArmReleasesPausedThread() throws Exception {
-        TriggerPolicy policy = TriggerPolicy.pausePolicy();
-        FailPoint.setTriggerPolicy("fp_rearm", policy);
+        assertReleasedBy("fp_rearm", () -> FailPoint.setTriggerPolicy("fp_rearm", TriggerPolicy.enablePolicy()));
+        FailPoint.removeTriggerPolicy("fp_rearm");
+    }
+
+    private void assertReleasedBy(String name, Runnable release) throws Exception {
+        TriggerPolicy policy = TriggerPolicy.pausePolicy(PAUSE_TIMEOUT_SECOND);
+        FailPoint.setTriggerPolicy(name, policy);
         AtomicBoolean triggered = new AtomicBoolean(true);
-        Thread t = new Thread(() -> triggered.set(FailPoint.shouldTrigger("fp_rearm")), "parker-rearm");
-        t.setDaemon(true);
-        t.start();
+        Thread t = startParker(policy, name, triggered, () -> FailPoint.shouldTrigger(name));
         try {
             Assertions.assertTrue(waitForParked(policy, 1));
         } finally {
-            // Replacing the policy must release whatever was parked on the old one.
-            FailPoint.setTriggerPolicy("fp_rearm", TriggerPolicy.enablePolicy());
+            release.run();
         }
         t.join(10_000);
         Assertions.assertFalse(t.isAlive());
         Assertions.assertFalse(triggered.get());
-        FailPoint.removeTriggerPolicy("fp_rearm");
     }
 
     @Test
@@ -203,6 +182,7 @@ public class TriggerPolicyTest {
         request.setName("fp");
         request.setIs_enable(false);
         request.setPause(true);
+        request.setPause_timeout_second(42);
         Assertions.assertEquals(TriggerMode.PAUSE, TriggerPolicy.fromThrift(request).getMode());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/failpoint/TriggerPolicyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/failpoint/TriggerPolicyTest.java
@@ -175,6 +175,20 @@ public class TriggerPolicyTest {
         Assertions.assertFalse(triggered.get());
     }
 
+    // A timed-out pause must DISARM the failpoint, not just let one thread through: otherwise every
+    // newly arriving thread parks for a fresh full timeout and the node never recovers.
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    public void testTimeoutDisarmsTheFailpoint() {
+        FailPoint.setTriggerPolicy("fp_selfheal", TriggerPolicy.pausePolicy(1));
+        Assertions.assertFalse(FailPoint.shouldTrigger("fp_selfheal"));
+        // The policy is gone, so a later arrival passes straight through instead of parking again.
+        long start = System.nanoTime();
+        Assertions.assertFalse(FailPoint.shouldTrigger("fp_selfheal"));
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000L;
+        Assertions.assertTrue(elapsedMs < 500, "second arrival parked again after " + elapsedMs + "ms");
+    }
+
     @Test
     public void testFromThriftPreferPauseOverIsEnable() {
         // A pause request sets is_enable = false so an old FE disables; a new FE must still see PAUSE.

--- a/fe/fe-core/src/test/java/com/starrocks/failpoint/TriggerPolicyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/failpoint/TriggerPolicyTest.java
@@ -1,0 +1,240 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.failpoint;
+
+import com.starrocks.common.Config;
+import com.starrocks.thrift.TUpdateFailPointRequest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class TriggerPolicyTest {
+
+    // Spin until the policy reports the expected number of parked threads, so the tests synchronise
+    // on real state rather than on a sleep.
+    private static boolean waitForParked(TriggerPolicy policy, int expected) throws InterruptedException {
+        for (int waited = 0; waited < 10_000; waited += 5) {
+            if (policy.getPausedThreadCount() == expected) {
+                return true;
+            }
+            Thread.sleep(5);
+        }
+        return false;
+    }
+
+    // Daemon threads so a failed assertion cannot leave a non-daemon thread parked for the whole
+    // pause timeout.
+    private static Thread startParker(TriggerPolicy policy, String name, AtomicBoolean triggered) {
+        Thread t = new Thread(() -> triggered.set(policy.shouldTrigger(name)), "parker-" + name);
+        t.setDaemon(true);
+        t.start();
+        return t;
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    public void testPauseReleasedByRelease() throws Exception {
+        TriggerPolicy policy = TriggerPolicy.pausePolicy();
+        AtomicBoolean triggered = new AtomicBoolean(true);
+        Thread t = startParker(policy, "fp_pause", triggered);
+        try {
+            Assertions.assertTrue(waitForParked(policy, 1));
+        } finally {
+            policy.release();
+        }
+        t.join(10_000);
+        Assertions.assertFalse(t.isAlive());
+        // A released pause continues normally and never injects.
+        Assertions.assertFalse(triggered.get());
+        Assertions.assertEquals(0, policy.getPausedThreadCount());
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    public void testPauseReleasesAllWaiters() throws Exception {
+        TriggerPolicy policy = TriggerPolicy.pausePolicy();
+        AtomicBoolean a = new AtomicBoolean(true);
+        AtomicBoolean b = new AtomicBoolean(true);
+        Thread t1 = startParker(policy, "fp_multi", a);
+        Thread t2 = startParker(policy, "fp_multi", b);
+        try {
+            Assertions.assertTrue(waitForParked(policy, 2));
+        } finally {
+            policy.release();
+        }
+        t1.join(10_000);
+        t2.join(10_000);
+        Assertions.assertFalse(a.get());
+        Assertions.assertFalse(b.get());
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    public void testPauseTimesOut() {
+        int original = Config.failpoint_pause_timeout_second;
+        try {
+            Config.failpoint_pause_timeout_second = 1;
+            TriggerPolicy policy = TriggerPolicy.pausePolicy();
+
+            long start = System.nanoTime();
+            Assertions.assertFalse(policy.shouldTrigger("fp_timeout"));
+            long elapsedMs = (System.nanoTime() - start) / 1_000_000L;
+
+            Assertions.assertTrue(elapsedMs >= 900, "resumed after " + elapsedMs + "ms, expected >= 900ms");
+            Assertions.assertEquals(0, policy.getPausedThreadCount());
+        } finally {
+            Config.failpoint_pause_timeout_second = original;
+        }
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    public void testNonPositiveTimeoutIsNormalized() {
+        int original = Config.failpoint_pause_timeout_second;
+        try {
+            // A misconfigured 0 must not mean "never wait" nor "wait forever": it clamps to 1s.
+            Config.failpoint_pause_timeout_second = 0;
+            TriggerPolicy policy = TriggerPolicy.pausePolicy();
+            long start = System.nanoTime();
+            Assertions.assertFalse(policy.shouldTrigger("fp_zero"));
+            long elapsedMs = (System.nanoTime() - start) / 1_000_000L;
+            Assertions.assertTrue(elapsedMs >= 900, "resumed after " + elapsedMs + "ms, expected >= 900ms");
+        } finally {
+            Config.failpoint_pause_timeout_second = original;
+        }
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    public void testInterruptResumesAndRestoresFlag() throws Exception {
+        TriggerPolicy policy = TriggerPolicy.pausePolicy();
+        AtomicBoolean triggered = new AtomicBoolean(true);
+        AtomicBoolean interruptFlagSeen = new AtomicBoolean(false);
+        Thread t = new Thread(() -> {
+            triggered.set(policy.shouldTrigger("fp_interrupt"));
+            interruptFlagSeen.set(Thread.currentThread().isInterrupted());
+        }, "parker-interrupt");
+        t.setDaemon(true);
+        t.start();
+        try {
+            Assertions.assertTrue(waitForParked(policy, 1));
+        } finally {
+            t.interrupt();
+        }
+        t.join(10_000);
+        Assertions.assertFalse(t.isAlive());
+        Assertions.assertFalse(triggered.get());
+        // The interrupt status must be restored rather than swallowed.
+        Assertions.assertTrue(interruptFlagSeen.get());
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    public void testReleaseIsIdempotentAndPreRelease() {
+        TriggerPolicy policy = TriggerPolicy.pausePolicy();
+        policy.release();
+        policy.release();
+        // Already released: returns immediately rather than waiting out the timeout.
+        long start = System.nanoTime();
+        Assertions.assertFalse(policy.shouldTrigger("fp_prereleased"));
+        Assertions.assertTrue((System.nanoTime() - start) / 1_000_000L < 5_000);
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    public void testRemoveTriggerPolicyReleasesPausedThread() throws Exception {
+        TriggerPolicy policy = TriggerPolicy.pausePolicy();
+        FailPoint.setTriggerPolicy("fp_remove", policy);
+        AtomicBoolean triggered = new AtomicBoolean(true);
+        Thread t = new Thread(() -> triggered.set(FailPoint.shouldTrigger("fp_remove")), "parker-remove");
+        t.setDaemon(true);
+        t.start();
+        try {
+            Assertions.assertTrue(waitForParked(policy, 1));
+        } finally {
+            // ADMIN DISABLE FAILPOINT goes through removeTriggerPolicy.
+            FailPoint.removeTriggerPolicy("fp_remove");
+        }
+        t.join(10_000);
+        Assertions.assertFalse(t.isAlive());
+        Assertions.assertFalse(triggered.get());
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    public void testReArmReleasesPausedThread() throws Exception {
+        TriggerPolicy policy = TriggerPolicy.pausePolicy();
+        FailPoint.setTriggerPolicy("fp_rearm", policy);
+        AtomicBoolean triggered = new AtomicBoolean(true);
+        Thread t = new Thread(() -> triggered.set(FailPoint.shouldTrigger("fp_rearm")), "parker-rearm");
+        t.setDaemon(true);
+        t.start();
+        try {
+            Assertions.assertTrue(waitForParked(policy, 1));
+        } finally {
+            // Replacing the policy must release whatever was parked on the old one.
+            FailPoint.setTriggerPolicy("fp_rearm", TriggerPolicy.enablePolicy());
+        }
+        t.join(10_000);
+        Assertions.assertFalse(t.isAlive());
+        Assertions.assertFalse(triggered.get());
+        FailPoint.removeTriggerPolicy("fp_rearm");
+    }
+
+    @Test
+    public void testFromThriftPreferPauseOverIsEnable() {
+        // A pause request sets is_enable = false so an old FE disables; a new FE must still see PAUSE.
+        TUpdateFailPointRequest request = new TUpdateFailPointRequest();
+        request.setName("fp");
+        request.setIs_enable(false);
+        request.setPause(true);
+        Assertions.assertEquals(TriggerMode.PAUSE, TriggerPolicy.fromThrift(request).getMode());
+    }
+
+    @Test
+    public void testIsArmingTreatsPauseAsArm() {
+        TUpdateFailPointRequest pause = new TUpdateFailPointRequest();
+        pause.setName("fp");
+        pause.setIs_enable(false);
+        pause.setPause(true);
+        // The trap: is_enable is false, but this must NOT be read as a removal.
+        Assertions.assertTrue(TriggerPolicy.isArming(pause));
+
+        TUpdateFailPointRequest disable = new TUpdateFailPointRequest();
+        disable.setName("fp");
+        disable.setIs_enable(false);
+        Assertions.assertFalse(TriggerPolicy.isArming(disable));
+
+        TUpdateFailPointRequest enable = new TUpdateFailPointRequest();
+        enable.setName("fp");
+        enable.setIs_enable(true);
+        Assertions.assertTrue(TriggerPolicy.isArming(enable));
+    }
+
+    @Test
+    public void testNonPauseModesUnchanged() {
+        Assertions.assertTrue(TriggerPolicy.enablePolicy().shouldTrigger("fp"));
+
+        TriggerPolicy times = TriggerPolicy.timesPolicy(2);
+        Assertions.assertTrue(times.shouldTrigger("fp"));
+        Assertions.assertTrue(times.shouldTrigger("fp"));
+        Assertions.assertFalse(times.shouldTrigger("fp"));
+
+        Assertions.assertFalse(TriggerPolicy.probabilityPolicy(0.0).shouldTrigger("fp"));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/failpoint/TriggerPolicyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/failpoint/TriggerPolicyTest.java
@@ -189,6 +189,26 @@ public class TriggerPolicyTest {
         Assertions.assertTrue(elapsedMs < 500, "second arrival parked again after " + elapsedMs + "ms");
     }
 
+    // A pause that times out must disarm ITSELF, never a policy that replaced it in the meantime --
+    // otherwise the operator's newly armed mode is silently discarded. Exercised directly rather than
+    // by racing a real timeout: setTriggerPolicy releases the superseded policy, so a parked thread
+    // always observes a release rather than a timeout and never reaches the conditional removal.
+    @Test
+    public void testConditionalRemovalLeavesAReplacementArmed() {
+        TriggerPolicy expiring = TriggerPolicy.pausePolicy(1);
+        FailPoint.setTriggerPolicy("fp_replaced", expiring);
+        TriggerPolicy replacement = TriggerPolicy.enablePolicy();
+        FailPoint.setTriggerPolicy("fp_replaced", replacement);
+
+        // This is what a timed-out pause does. It must leave the replacement alone.
+        Assertions.assertFalse(FailPoint.removeTriggerPolicyIf("fp_replaced", expiring));
+        Assertions.assertTrue(FailPoint.shouldTrigger("fp_replaced"), "replacement was removed");
+
+        // The still-installed policy is removed, so a genuine self-disarm does take effect.
+        Assertions.assertTrue(FailPoint.removeTriggerPolicyIf("fp_replaced", replacement));
+        Assertions.assertFalse(FailPoint.shouldTrigger("fp_replaced"));
+    }
+
     @Test
     public void testFromThriftPreferPauseOverIsEnable() {
         // A pause request sets is_enable = false so an old FE disables; a new FE must still see PAUSE.

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowStmtMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowStmtMetaTest.java
@@ -1504,11 +1504,14 @@ public class ShowStmtMetaTest {
     public void testShowFailPointStatement() {
         ShowFailPointStatement stmt = new ShowFailPointStatement(null, null, NodePosition.ZERO);
         ShowResultSetMetaData metaData = new ShowResultMetaFactory().getMetadata(stmt);
-        Assertions.assertEquals(4, metaData.getColumnCount());
+        Assertions.assertEquals(6, metaData.getColumnCount());
         Assertions.assertEquals("Name", metaData.getColumn(0).getName());
         Assertions.assertEquals("TriggerMode", metaData.getColumn(1).getName());
         Assertions.assertEquals("Times/Probability", metaData.getColumn(2).getName());
         Assertions.assertEquals("Host", metaData.getColumn(3).getName());
+        // Appended after Host so existing positional consumers keep working.
+        Assertions.assertEquals("TriggerCount", metaData.getColumn(4).getName());
+        Assertions.assertEquals("PausedThreads", metaData.getColumn(5).getName());
     }
 
     @Test

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -934,7 +934,7 @@ setDefaultStorageVolumeStatement
 
 updateFailPointStatusStatement
     : ADMIN (DISABLE | ENABLE) FAILPOINT string
-      (WITH (times=INTEGER_VALUE TIMES | prob=DECIMAL_VALUE PROBABILITY))?
+      (WITH (times=INTEGER_VALUE TIMES | prob=DECIMAL_VALUE PROBABILITY | PAUSE))?
       (ON (BACKEND string | FRONTEND))?
     ;
 

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -680,11 +680,37 @@ message PFailPointTriggerMode {
     optional FailPointTriggerModeType mode = 1;
     optional double probability = 2;
     optional int32 n_times = 3;
+    // STORED/REPORTED pause state, lifted out of PUpdateFailPointStatusRequest by
+    // trigger_mode_from_request (or set by the conf-file parser). A client never sets these on a
+    // request -- see the request message below for why.
+    optional bool pause = 4;
+    optional int32 pause_timeout_second = 5;
 }
 
 message PUpdateFailPointStatusRequest {
     optional string fail_point_name = 1;
     optional PFailPointTriggerMode trigger_mode = 2;
+    // Pause discriminator: block every thread that reaches the failpoint until the mode changes or
+    // pause_timeout_second elapses. A released pause NEVER injects -- the trigger evaluates to false
+    // and the caller continues normally.
+    //
+    // Two deliberate choices here.
+    //
+    // (1) A separate bool rather than a new FailPointTriggerModeType value: proto2 keeps an unknown
+    // enum value out of the field, so `mode` would read back as its default, the FIRST enum value
+    // ENABLE -- a backend that predates the pause would ARM the failpoint and inject the fault
+    // instead of pausing. A pause request therefore sets trigger_mode.mode = DISABLE alongside
+    // pause = true, so such a backend harmlessly disables the failpoint instead.
+    //
+    // (2) On the REQUEST rather than nested in trigger_mode: protobuf preserves unknown fields, so a
+    // discriminator inside trigger_mode would be copied into an old backend's stored _trigger_mode
+    // and echoed back by list_fail_point -- a new frontend would then display PAUSE for a failpoint
+    // that the old backend merely disabled. On the request it is discarded with the request.
+    optional bool pause = 3;
+    // Pause safety net, so a forgotten ADMIN DISABLE FAILPOINT cannot wedge a node until it is
+    // restarted. Carried in the request rather than read from a backend config because be/src/base
+    // must not depend on be/src/common. Absent or <= 0 means "use the failpoint layer's default".
+    optional int32 pause_timeout_second = 4;
 }
 
 message PUpdateFailPointStatusResponse {
@@ -694,6 +720,12 @@ message PUpdateFailPointStatusResponse {
 message PFailPointInfo {
     optional string name = 1;
     optional PFailPointTriggerMode trigger_mode = 2;
+    // Cumulative number of times this failpoint FIRED, not the number of times it was reached:
+    // every hit under ENABLE, only the winning draws under PROBABILITY_ENABLE, only while n > 0
+    // under ENABLE_N_TIMES, and every thread that actually parks under a pause.
+    optional int64 trigger_count = 3;
+    // Gauge: threads parked at this failpoint right now. Returns to 0 once they are released.
+    optional int64 paused_thread_count = 4;
 }
 
 message PListFailPointRequest {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -2345,6 +2345,11 @@ struct TUpdateFailPointRequest {
     // sets is_enable = false, so a frontend that predates this field disables the failpoint instead
     // of enabling it. Readers must check `pause` before `is_enable`.
     5: optional bool pause;
+    // Pause timeout, snapshotted by the arming frontend and carried with the request, exactly as
+    // PUpdateFailPointStatusRequest.pause_timeout_second is for backends. Receivers must NOT re-read
+    // their own config at park time: that would let ADMIN SET FRONTEND CONFIG between arming and
+    // parking desynchronize the frontends from each other and from the backends.
+    6: optional i32 pause_timeout_second;
 }
 
 struct TUpdateFailPointResponse {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -2341,6 +2341,10 @@ struct TUpdateFailPointRequest {
     2: optional bool is_enable;
     3: optional i32 times;
     4: optional double probability;
+    // Pause mode: park threads reaching this failpoint until it is disabled. A pause request also
+    // sets is_enable = false, so a frontend that predates this field disables the failpoint instead
+    // of enabling it. Readers must check `pause` before `is_enable`.
+    5: optional bool pause;
 }
 
 struct TUpdateFailPointResponse {


### PR DESCRIPTION
## Why I'm doing:

Range distribution (shared-data tablet split / merge) needs fault-injection testing, but a forced
`SPLIT TABLET` of 200k rows finishes in under 200ms while the fastest external fault lever — an FE
leader restart — takes ~17.6s. Faults can therefore only land in `PENDING` or after the job is
already `FINISHED`; the sub-phases inside `RUNNING` are unreachable. QA's existing cases self-report
this: three consecutive leader switches on one split hit an already-`FINISHED` job on attempts 2 and
3, and an automatic reshard measured `peak concurrency 0`.

The failpoint framework can only make a site **fail**. It cannot make a site **stop and wait**, which
is the shape almost every fault scenario needs:

> stop at phase X -> act externally (kill a node / switch leader) -> release -> assert

## What I'm doing:

Adds a **pause** trigger mode to both failpoint frameworks. A thread reaching an armed-pause failpoint
blocks; on release the trigger evaluates to `false`, so the fault is **not** injected and the flow
continues normally.

```sql
ADMIN ENABLE FAILPOINT 'some_failpoint' WITH PAUSE ON BACKEND '10.0.0.2:9060';
-- poll SHOW FAILPOINTS until PausedThreads > 0, do the external action ...
ADMIN DISABLE FAILPOINT 'some_failpoint' ON BACKEND '10.0.0.2:9060';
```

Because the pause gates the trigger **condition** rather than adding an action at each call site,
**every existing failpoint becomes a pause point selectable purely from SQL, with no recompile** —
which is the point, since adding a BE failpoint otherwise means editing C++ and redeploying.

Also included:
- `SHOW FAILPOINTS` gains `TriggerCount` and `PausedThreads`, appended **after** `Host` so existing
  positional parsing keeps working. `PausedThreads > 0` is the signal that proves a thread parked.
- A pause self-heals after `failpoint_pause_timeout_second` (new FE config, default 300, mutable), so
  a forgotten `ADMIN DISABLE FAILPOINT` cannot wedge a node until restart.
- **Security fix:** `AuthorizerStmtVisitor` had no override for either failpoint statement and the
  interface default checks nothing, so **any authenticated user could arm any failpoint**. Both
  statements now require `OPERATE`. See the operational note below.

### Rolling-upgrade safety (why the encoding looks odd)

A pause is sent as `mode = DISABLE` plus a **request-level** `pause` flag, not as a new
`FailPointTriggerModeType` value. Two reasons, both load-bearing:

1. proto2 keeps an unknown enum value out of the field, so `mode` reads back as its default — the
   *first* value, `ENABLE`. A pre-pause BE receiving a `PAUSE` enum would have **armed the failpoint
   and injected the fault** instead of pausing. Sending `DISABLE` makes it degrade to a no-op.
2. The flag rides on `PUpdateFailPointStatusRequest`, not nested inside `PFailPointTriggerMode`,
   because protobuf preserves unknown fields: nested, an old BE would copy it into its stored mode and
   echo it back from `list_fail_point`, so `SHOW FAILPOINTS` would report `PAUSE` for a failpoint that
   node had merely disabled.

Thrift mirrors this with `is_enable = false` + `pause = true`. Consequence worth knowing: the
statement's `isEnable` field and the wire's `is_enable` disagree **by design**, so every arm-or-remove
branch goes through a named `isArming()` predicate rather than reading the raw flag.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

New `WITH PAUSE` syntax and two new `SHOW FAILPOINTS` columns (Interface). `ADMIN ENABLE/DISABLE
FAILPOINT` and `SHOW FAILPOINTS` now require `OPERATE` (Policy). Mixed-version behaviour is described
above (Miscellaneous).

> **Operational note for test harnesses:** anything arming failpoints over a MySQL connection as a
> user without `OPERATE` will now get access-denied and must use `root` or a `cluster_admin`-style
> role. Before this PR there was no check at all.

> **Build note:** BE/CN failpoints only exist in a backend compiled with `ENABLE_FAULT_INJECTION=ON`
> (`build.sh` defaults it OFF). Without it, `ADMIN ENABLE FAILPOINT ... ON BACKEND` returns
> `FailPoint is not supported, need re-compile BE with ENABLE_FAULT_INJECTION`.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

Main-only: this is new capability on a testing surface carrying a proto + thrift + grammar delta, and
the range-distribution feature line it serves is itself main-only. No version label set.