### PR TITLE
[BugFix] Drop a del file's local cache and retry when its checksum fails (backport #78022)

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -1003,10 +1003,9 @@ Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pke
             ASSIGN_OR_RETURN(ropts.encryption_info, KeyCache::instance().unwrap_encryption_meta(del.encryption_meta()));
         }
         ASSIGN_OR_RETURN(auto rf, fs::new_random_access_file(ropts, _tablet_mgr->del_location(_tablet_id, del.name())));
-        ASSIGN_OR_RETURN(auto buf, rf->read_all());
         // Verify before decoding: a corrupt del file that still deserializes cleanly would erase the
-        // wrong primary keys from the index.
-        RETURN_IF_ERROR(verify_del_file_crc32c(del, _tablet_id, buf));
+        // wrong primary keys from the index. Drops the local data cache and re-reads once on a mismatch.
+        ASSIGN_OR_RETURN(auto buf, read_and_verify_del_file(rf.get(), del, _tablet_id));
         auto pkc = pk_column->clone();
         const auto* data = reinterpret_cast<const uint8_t*>(buf.data());
         RETURN_IF_ERROR(serde::ColumnArraySerde::deserialize(data, data + buf.size(), pkc.get()));

--- a/be/src/storage/lake/lake_primary_key_recover.cpp
+++ b/be/src/storage/lake/lake_primary_key_recover.cpp
@@ -111,8 +111,8 @@ Status LakePrimaryKeyRecover::rowset_iterator(
             // so verify here before handing the handle over; it re-reads positionally from offset 0.
             // Only pays the extra read when a checksum was actually recorded.
             if (del.has_crc32c()) {
-                ASSIGN_OR_RETURN(auto buf, read_file->read_all());
-                RETURN_IF_ERROR(verify_del_file_crc32c(del, _metadata->id(), buf));
+                auto verified = read_and_verify_del_file(read_file.get(), del, _metadata->id());
+                RETURN_IF_ERROR(verified.status());
             }
             del_rfs.push_back(std::move(read_file));
         }

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -30,6 +30,8 @@
 #include "storage/lake/tablet_writer.h" // kUnknownDelOpOffset
 #include "storage/lake/update_manager.h"
 #include "storage/protobuf_file.h"
+#include "storage/rowset/page_io.h"
+#include "testutil/sync_point.h"
 #include "util/coding.h"
 #include "util/crc32c.h"
 #include "util/defer_op.h"
@@ -124,6 +126,52 @@ Status verify_del_file_crc32c(const FileMetaPB& del_meta, int64_t tablet_id, std
 
 Status verify_del_file_crc32c(const DelfileWithRowsetId& del_meta, int64_t tablet_id, std::string_view content) {
     return do_verify_del_file_crc32c(del_meta, tablet_id, content);
+}
+
+// Drop a del file's local data cache after its checksum failed to verify. Only meaningful in
+// shared-data mode, where the file is backed by remote storage and cached locally; elsewhere there is
+// no cache layer to invalidate and this reports NotSupported so the caller does not retry.
+static Status drop_corrupted_del_file_cache(const std::string& path) {
+    Status drop_status = Status::NotSupported("clear corrupted cache is only supported in shared-data mode");
+#if defined(USE_STAROS) && !defined(BUILD_FORMAT_LIB)
+    drop_status = drop_local_cache_data(path);
+#endif
+    // Outside the platform guard on purpose, so tests can drive the retry path on any build.
+    TEST_SYNC_POINT_CALLBACK("lake::drop_corrupted_del_file_cache", &drop_status);
+    return drop_status;
+}
+
+template <typename DelMetaPB>
+static StatusOr<std::string> do_read_and_verify_del_file(RandomAccessFile* rf, const DelMetaPB& del_meta,
+                                                         int64_t tablet_id) {
+    ASSIGN_OR_RETURN(auto content, rf->read_all());
+    auto st = do_verify_del_file_crc32c(del_meta, tablet_id, content);
+    if (st.ok()) {
+        return content;
+    }
+    // A del file is immutable once written, so bytes that do not match the recorded checksum are not
+    // the bytes that were written. The likeliest culprit is a corrupted block in the local data cache
+    // rather than in remote storage, so drop the cache and read once more -- the retry then reads
+    // through to the remote object. Segment pages (PageIO::read_and_decompress_page) and
+    // persistent-index sstables (PersistentIndexSstable) recover from cache corruption the same way.
+    auto drop_status = drop_corrupted_del_file_cache(rf->filename());
+    if (!drop_status.ok()) {
+        VLOG(2) << "skip clearing corrupted cache for " << rf->filename() << ": " << drop_status;
+        return st; // report the original corruption, not the drop failure
+    }
+    LOG(INFO) << "cleared corrupted cache for " << rf->filename() << ", re-reading the del file";
+    ASSIGN_OR_RETURN(content, rf->read_all());
+    RETURN_IF_ERROR(do_verify_del_file_crc32c(del_meta, tablet_id, content));
+    return content;
+}
+
+StatusOr<std::string> read_and_verify_del_file(RandomAccessFile* rf, const FileMetaPB& del_meta, int64_t tablet_id) {
+    return do_read_and_verify_del_file(rf, del_meta, tablet_id);
+}
+
+StatusOr<std::string> read_and_verify_del_file(RandomAccessFile* rf, const DelfileWithRowsetId& del_meta,
+                                               int64_t tablet_id) {
+    return do_read_and_verify_del_file(rf, del_meta, tablet_id);
 }
 
 static std::string delvec_cache_key(int64_t tablet_id, const DelvecPagePB& page) {

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -73,6 +73,16 @@ uint32_t resolve_del_op_offset(int64_t op_offset, bool column_mode, const Rowset
 Status verify_del_file_crc32c(const FileMetaPB& del_meta, int64_t tablet_id, std::string_view content);
 Status verify_del_file_crc32c(const DelfileWithRowsetId& del_meta, int64_t tablet_id, std::string_view content);
 
+// Read a del file's whole content through |rf| and verify it with verify_del_file_crc32c(). On a
+// checksum mismatch, drop the file's local data cache and read once more before failing: a del file is
+// immutable, so the bytes are most likely corrupt in the local cache rather than in remote storage, and
+// the retry reads through to the remote object. Falls back to reporting the original Corruption when
+// there is no cache to drop (non-shared-data build, or lake_clear_corrupted_cache_data turned off).
+// Segment pages and persistent-index sstables recover from cache corruption the same way.
+StatusOr<std::string> read_and_verify_del_file(RandomAccessFile* rf, const FileMetaPB& del_meta, int64_t tablet_id);
+StatusOr<std::string> read_and_verify_del_file(RandomAccessFile* rf, const DelfileWithRowsetId& del_meta,
+                                               int64_t tablet_id);
+
 class MetaFileBuilder {
 public:
     explicit MetaFileBuilder(const Tablet& tablet, std::shared_ptr<TabletMetadata> metadata_ptr);

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -911,10 +911,9 @@ Status RowsetUpdateState::load_delete(uint32_t del_id, const RowsetUpdateStatePa
         }
     }
     ASSIGN_OR_RETURN(auto read_file, fs->new_random_access_file(opts, params.tablet->del_location(path)));
-    ASSIGN_OR_RETURN(auto read_buffer, read_file->read_all());
     // Verify before decoding: a corrupt del file that still deserializes cleanly would erase the
-    // wrong primary keys.
-    RETURN_IF_ERROR(verify_del_file_crc32c(del_meta, params.tablet->id(), read_buffer));
+    // wrong primary keys. Drops the local data cache and re-reads once on a checksum mismatch.
+    ASSIGN_OR_RETURN(auto read_buffer, read_and_verify_del_file(read_file.get(), del_meta, params.tablet->id()));
     auto col = pk_column->clone();
     using Serd = serde::ColumnArraySerde;
     const auto* begin = reinterpret_cast<const uint8_t*>(read_buffer.data());

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -866,6 +866,81 @@ TEST_P(LakePrimaryKeyPublishTest, test_del_file_crc32c_detects_corruption) {
     EXPECT_TRUE(meta_v3.status().is_not_found()) << meta_v3.status();
 }
 
+// A checksum mismatch is most plausibly a corrupted block in the local data cache, not in remote
+// storage, so the read drops that cache and tries once more. Simulate exactly that: corrupt the del
+// file, then have the cache-drop hook restore the original bytes -- standing in for the retry reading
+// through to an intact remote object -- and the publish must then succeed instead of failing.
+TEST_P(LakePrimaryKeyPublishTest, test_del_file_crc32c_retries_after_dropping_cache) {
+    const int n = kChunkSize;
+    auto tablet_id = _tablet_metadata->id();
+    std::vector<uint32_t> indexes(n);
+    for (uint32_t i = 0; i < static_cast<uint32_t>(n); i++) {
+        indexes[i] = i;
+    }
+    auto write_one_txn = [&](const ChunkPtr& chunk) {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .set_profile(&_dummy_runtime_profile)
+                                                   .build());
+        CHECK_OK(delta_writer->open());
+        CHECK_OK(delta_writer->write(*chunk, indexes.data(), indexes.size()));
+        CHECK_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        return txn_id;
+    };
+
+    ASSERT_OK(publish_single_version(tablet_id, 2, write_one_txn(make_op_chunk(n, 0, true, _slot_cid_map))).status());
+    ASSERT_EQ(n, read_rows(tablet_id, 2));
+
+    auto delete_txn = write_one_txn(make_op_chunk(n, 0, /*upsert=*/false, _slot_cid_map));
+    ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_log(tablet_id, delete_txn));
+    ASSERT_GE(txn_log->op_write().dels_meta_size(), 1);
+    const std::string del_path = _tablet_mgr->del_location(tablet_id, txn_log->op_write().dels_meta(0).name());
+
+    // Keep the good bytes, then corrupt the file in place (length-preserving, as in the sibling test).
+    std::string good_bytes;
+    {
+        ASSIGN_OR_ABORT(auto rf, fs::new_random_access_file(del_path));
+        ASSIGN_OR_ABORT(good_bytes, rf->read_all());
+        ASSERT_FALSE(good_bytes.empty());
+        auto corrupted = good_bytes;
+        corrupted[corrupted.size() - 1] = static_cast<char>(corrupted[corrupted.size() - 1] ^ 0xff);
+        WritableFileOptions wopts{.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+        ASSIGN_OR_ABORT(auto wf, fs::new_writable_file(wopts, del_path));
+        ASSERT_OK(wf->append(Slice(corrupted)));
+        ASSERT_OK(wf->close());
+    }
+
+    // The drop is a no-op on a non-shared-data build, so force it to report success and, at the same
+    // moment, restore the file -- that is what dropping a corrupt cached block achieves in production.
+    int drop_calls = 0;
+    const std::string sync_point = "lake::drop_corrupted_del_file_cache";
+    SyncPoint::GetInstance()->SetCallBack(sync_point, [&](void* arg) {
+        ++drop_calls;
+        WritableFileOptions wopts{.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+        ASSIGN_OR_ABORT(auto wf, fs::new_writable_file(wopts, del_path));
+        CHECK_OK(wf->append(Slice(good_bytes)));
+        CHECK_OK(wf->close());
+        *(Status*)arg = Status::OK();
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([&]() {
+        SyncPoint::GetInstance()->ClearCallBack(sync_point);
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    ASSERT_OK(publish_single_version(tablet_id, 3, delete_txn).status());
+    EXPECT_EQ(1, drop_calls) << "the cache drop should have been attempted exactly once";
+    EXPECT_EQ(0, read_rows(tablet_id, 3)) << "the retried del file should have applied";
+}
+
 // Spill path: the op-aware parallel merge must preserve in-transaction upsert/delete order. Drive the
 // default spill path (enable_load_spill=true) with parallel merge and tiny merge batches so a key that is
 // deleted and then re-upserted across flushes resolves across merge batches; the re-upsert (higher global


### PR DESCRIPTION
Manual backport of #78022 to `branch-4.1`.

Mergify could not produce this PR: its first attempt pushed a commit with **unresolved conflict markers** to `mergify/bp/branch-4.1/pr-78022`, and every retry then failed to push a new commit to that same ref (`! [rejected] ... (fetch first)`), so it reported "No backport have been created" twice. This PR is a clean cherry-pick done by hand instead; the stale mergify branch can be deleted.

## Conflict resolution

`branch-4.1` predates the `base/` source reorganization, so the only conflict was the include block of `be/src/storage/lake/meta_file.cpp`, in two hunks:

| Hunk | Cause | Resolution |
|---|---|---|
| `base/*` block | main added `base/testutil/sync_point.h` into a block of `base/...` includes that does not exist on 4.1 | dropped that block; added `testutil/sync_point.h` (the 4.1 path) in sort order |
| `util/*` block | 4.1 has `util/coding.h` / `util/crc32c.h` / `util/starrocks_metrics.h` … where main has `storage/storage_metrics.h` | kept 4.1's `util/*` block and added the newly needed `storage/rowset/page_io.h` |

The net difference from the merged commit is exactly one line — `base/testutil/sync_point.h` becomes `testutil/sync_point.h`. Everything else is byte-identical, and the diffstat matches main's (`6 files changed, 139 insertions(+), 8 deletions(-)`).

## Prerequisites verified on branch-4.1 before pushing

- `Status drop_local_cache_data(const std::string&)` is exported from `be/src/storage/rowset/page_io.h:121`, behind the same `USE_STAROS && !BUILD_FORMAT_LIB` guard — so the cache drop reuses the existing helper here too, with no new config.
- `be/src/testutil/sync_point.h` exists (only the path differs).
- `lake_clear_corrupted_cache_data` exists in `be/src/common/config.h`.
- `util/defer_op.h` and `SyncPoint` are already used by `primary_key_publish_test.cpp`, so the new test's dependencies are present.
- clang-format clean.

## One behavioral difference from main worth knowing

`lake_clear_corrupted_cache_data` defaults to **`true` on branch-4.1** and `false` on main. The cache-drop-and-retry recovery this PR adds is therefore **active by default on 4.1**, whereas on main it is dormant until the config is turned on. That default is pre-existing and not changed here, but it means the behavior change lands immediately on 4.1.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

A del file checksum mismatch that previously failed outright can now succeed on a retry after the local data cache is dropped. Because `lake_clear_corrupted_cache_data` defaults to true on this branch, that applies without any config change.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

