### PR TITLE
[Enhancement] Upgrade StarOS and starlet to v4.2-rc4

### DIFF
--- a/docker/dockerfiles/dev-env/dev-env.Dockerfile
+++ b/docker/dockerfiles/dev-env/dev-env.Dockerfile
@@ -24,7 +24,7 @@ ARG predownload_thirdparty=false
 ARG thirdparty_url=https://cdn-thirdparty.starrocks.com/starrocks-thirdparty-main-20260526.tar
 ARG commit_id
 # check thirdparty/starlet-artifacts-version.sh, to get the right tag
-ARG starlet_tag=v4.2-rc3
+ARG starlet_tag=v4.2-rc4
 # build for which linux distro: centos7|ubuntu|rocky9
 ARG distro=ubuntu
 # Token to access artifacts in private github repositories.

--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -79,7 +79,7 @@ subprojects {
         set("protobuf-java.version", "3.25.5")
         set("puppycrawl.version", "10.21.1")
         set("spark.version", "3.5.7")
-        set("staros.version", "4.2-rc3")
+        set("staros.version", "4.2-rc4")
         set("thrift.version", "0.24.0")
         set("tomcat.version", "8.5.70")
         set("lz4-java.version", "1.10.1")

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -82,7 +82,7 @@ under the License.
         <fluss.version>0.9.1-incubating</fluss.version>
         <delta-kernel.version>4.3.0</delta-kernel.version>
         <iceberg.version>1.10.0</iceberg.version>
-        <staros.version>4.2-rc3</staros.version>
+        <staros.version>4.2-rc4</staros.version>
         <!-- hadoop-azure requires no more than jetty10+ -->
         <!-- https://stackoverflow.com/questions/66713254/spark-wasb-and-jetty-11 -->
         <jetty.version>9.4.58.v20250814</jetty.version>

--- a/thirdparty/starlet-artifacts-version.sh
+++ b/thirdparty/starlet-artifacts-version.sh
@@ -9,4 +9,4 @@
 #   https://hub.docker.com/r/starrocks/starlet-artifacts-centos7/tags
 #
 # Update the following tag when STARLET releases a new version.
-export STARLET_ARTIFACTS_TAG=v4.2-rc3
+export STARLET_ARTIFACTS_TAG=v4.2-rc4


### PR DESCRIPTION
Move the staros java artifacts and the starlet BE artifacts from v4.2-rc3 to v4.2-rc4, covering the five commits released in that tag.

The change StarRocks benefits from the following changes:

* S3ReadOnlyFile::size() answering from ReadOptions::file_size instead of issuing a HeadObject on every open.
* adds shard-group placement-score aggregation and PACK-group replica sampling to the scheduler
* on-demand shard info RPC metrics in starlet, and a
* CreateShardRequest.meta_group_id field with a matching three-argument StarClient.createShard overload that lets shards join a meta group at creation time.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr