### PR TITLE
[Tool] cd-repo-sync: align reverse-sync head branch name to the forward format

### DIFF
--- a/.github/workflows/cd-repo-sync.yml
+++ b/.github/workflows/cd-repo-sync.yml
@@ -23,10 +23,11 @@ run-name: Repo Sync(${{ inputs.COMMIT_ID }} [${{ inputs.BRANCH }}])
 # internal issue refs/hosts), and the label set is just `sync` + `SHA:<commit>` (NO
 # `cd-sync`). The reverse pipeline / pending scan / merge-kick identify a reverse PR by the
 # `sync` label (on StarRocks only the reverse sync opens `sync`-labeled PRs); the SHA label
-# is for source recovery. The CD PR NUMBER never appears on the SR PR: the head branch /
-# run-name are keyed by the source COMMIT (already public via the SHA label), and the SR
-# PR's URL is commented back onto the CD source PR instead (the linkage lives on the
-# private side only).
+# is for source recovery. The head branch mirrors the forward sync format
+# `<branch>-sync-pr-<CD PR id>` (aligned with CelerData repo-sync.yml) so both directions
+# read consistently — this does put the CD PR number in the (public) SR branch name; the
+# run-name still shows the source COMMIT, and the SR PR's URL is commented back onto the CD
+# source PR (linkage on the private side).
 #
 # Runner pools (mirror of the forward's three): sync-normal = glue (pr-info, both
 # machines), sync-main / sync-branch = one machine each (executor serialization).
@@ -116,8 +117,8 @@ jobs:
 
       - name: Clean Branches
         env:
-          source_branch: ${{ inputs.BRANCH }}-cd-sync-${{ inputs.COMMIT_ID }}
-          destination_branch: ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.COMMIT_ID }}
+          source_branch: ${{ inputs.BRANCH }}-sync-${{ inputs.PR_ID }}
+          destination_branch: ${{ inputs.BRANCH }}-sync-pr-${{ inputs.PR_ID }}
         run: |
           curl -s -X DELETE -u username:${{secrets.GITHUB_TOKEN}} https://api.github.com/repos/${{ github.repository }}/git/refs/heads/${{ env.source_branch }}
           curl -s -X DELETE -u username:${{secrets.GITHUB_TOKEN}} https://api.github.com/repos/${{ github.repository }}/git/refs/heads/${{ env.destination_branch }}
@@ -125,7 +126,7 @@ jobs:
       - name: sync repo to branch
         env:
           source_branch: ${{ inputs.BRANCH }}
-          destination_branch: ${{ inputs.BRANCH }}-cd-sync-${{ inputs.COMMIT_ID }}
+          destination_branch: ${{ inputs.BRANCH }}-sync-${{ inputs.PR_ID }}
           github_token: ${{ secrets.SYNC_PAT }}
         run: |
           source_repo_dir=${source_repo#*/}
@@ -145,7 +146,7 @@ jobs:
         run: |
           git pull
           git checkout ${{ inputs.BRANCH }}
-          pr_branch=${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.COMMIT_ID }}
+          pr_branch=${{ inputs.BRANCH }}-sync-pr-${{ inputs.PR_ID }}
           git branch ${pr_branch} ${{ inputs.BRANCH }}
           git checkout ${pr_branch}
           git push -u origin ${pr_branch}
@@ -175,7 +176,7 @@ jobs:
           cd ${{ github.workspace }}/elastic-service
           ./lib/run_cherry_pick.sh --pr ${{ inputs.PR_ID }}
           cd ${{ github.workspace }}
-          git push -u origin ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.COMMIT_ID }}
+          git push -u origin ${{ inputs.BRANCH }}-sync-pr-${{ inputs.PR_ID }}
 
       - name: Create pull request
         id: create_pr
@@ -187,7 +188,7 @@ jobs:
           # pending scan and merge-kick identify a reverse PR by the `sync` label (on
           # StarRocks only the reverse sync opens `sync`-labeled PRs).
           PR_LABEL: sync,${{ steps.cherry-pick.outputs.LABEL }}${{ steps.cherry-pick.outputs.CONFLICT_LABEL }}
-          HEAD: ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.COMMIT_ID }}
+          HEAD: ${{ inputs.BRANCH }}-sync-pr-${{ inputs.PR_ID }}
           # Native title (already scrubbed by get_pr_info.py): no "(cd-sync #N)" marker.
           TITLE: "${{ needs.pr-info.outputs.title }}"
           # Mirror the forward flow (repo-sync.yml): carry the source PR's full body
@@ -209,7 +210,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.SYNC_PAT }}
           PR_LABEL: sync,${{ steps.cherry-pick.outputs.LABEL }},pending
-          HEAD: ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.COMMIT_ID }}
+          HEAD: ${{ inputs.BRANCH }}-sync-pr-${{ inputs.PR_ID }}
           TITLE: "${{ needs.pr-info.outputs.title }}"
           BODY: "Previous prs: ${{ steps.previous-check.outputs.CONFLICT_PRS }}"
           REVIEWER: ${{ needs.pr-info.outputs.assignees }}
@@ -311,8 +312,8 @@ jobs:
 
       - name: Clean Branches
         env:
-          source_branch: ${{ inputs.BRANCH }}-cd-sync-${{ inputs.COMMIT_ID }}
-          destination_branch: ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.COMMIT_ID }}
+          source_branch: ${{ inputs.BRANCH }}-sync-${{ inputs.PR_ID }}
+          destination_branch: ${{ inputs.BRANCH }}-sync-pr-${{ inputs.PR_ID }}
         run: |
           curl -s -X DELETE -u username:${{secrets.GITHUB_TOKEN}} https://api.github.com/repos/${{ github.repository }}/git/refs/heads/${{ env.source_branch }}
           curl -s -X DELETE -u username:${{secrets.GITHUB_TOKEN}} https://api.github.com/repos/${{ github.repository }}/git/refs/heads/${{ env.destination_branch }}
@@ -320,7 +321,7 @@ jobs:
       - name: sync repo to branch
         env:
           source_branch: ${{ inputs.BRANCH }}
-          destination_branch: ${{ inputs.BRANCH }}-cd-sync-${{ inputs.COMMIT_ID }}
+          destination_branch: ${{ inputs.BRANCH }}-sync-${{ inputs.PR_ID }}
           github_token: ${{ secrets.SYNC_PAT }}
         run: |
           source_repo_dir=${source_repo#*/}
@@ -340,7 +341,7 @@ jobs:
         run: |
           git pull
           git checkout ${{ inputs.BRANCH }}
-          pr_branch=${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.COMMIT_ID }}
+          pr_branch=${{ inputs.BRANCH }}-sync-pr-${{ inputs.PR_ID }}
           git branch ${pr_branch} ${{ inputs.BRANCH }}
           git checkout ${pr_branch}
           git push -u origin ${pr_branch}
@@ -370,7 +371,7 @@ jobs:
           cd ${{ github.workspace }}/elastic-service
           ./lib/run_cherry_pick.sh --pr ${{ inputs.PR_ID }}
           cd ${{ github.workspace }}
-          git push -u origin ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.COMMIT_ID }}
+          git push -u origin ${{ inputs.BRANCH }}-sync-pr-${{ inputs.PR_ID }}
 
       - name: Create pull request
         id: create_pr
@@ -382,7 +383,7 @@ jobs:
           # pending scan and merge-kick identify a reverse PR by the `sync` label (on
           # StarRocks only the reverse sync opens `sync`-labeled PRs).
           PR_LABEL: sync,${{ steps.cherry-pick.outputs.LABEL }}${{ steps.cherry-pick.outputs.CONFLICT_LABEL }}
-          HEAD: ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.COMMIT_ID }}
+          HEAD: ${{ inputs.BRANCH }}-sync-pr-${{ inputs.PR_ID }}
           # Native title (already scrubbed by get_pr_info.py): no "(cd-sync #N)" marker.
           TITLE: "${{ needs.pr-info.outputs.title }}"
           # Mirror the forward flow (repo-sync.yml): carry the source PR's full body
@@ -404,7 +405,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.SYNC_PAT }}
           PR_LABEL: sync,${{ steps.cherry-pick.outputs.LABEL }},pending
-          HEAD: ${{ inputs.BRANCH }}-cd-sync-pr-${{ inputs.COMMIT_ID }}
+          HEAD: ${{ inputs.BRANCH }}-sync-pr-${{ inputs.PR_ID }}
           TITLE: "${{ needs.pr-info.outputs.title }}"
           BODY: "Previous prs: ${{ steps.previous-check.outputs.CONFLICT_PRS }}"
           REVIEWER: ${{ needs.pr-info.outputs.assignees }}


### PR DESCRIPTION
## Why I'm doing:
The reverse-sync (CD→SR) executor named its head/intermediate branches `<branch>-cd-sync[-pr]-<COMMIT_ID>`, which diverges from the forward sync's `<branch>-sync[-pr]-<PR_ID>` (CelerData `repo-sync.yml`). Keeping the two directions' branch-name formats consistent is easier to read and tool against.

## What I'm doing:
Align the reverse head/intermediate branch names to the forward format in both jobs (main / branch):
- drop the `cd-` marker: `-cd-sync-pr-` → `-sync-pr-`, `-cd-sync-` → `-sync-`
- key the branch by the source PR id instead of the commit: `${{ inputs.COMMIT_ID }}` → `${{ inputs.PR_ID }}`

10 head-branch + 4 intermediate-branch references updated; the `cd-sync-conflict` **label** and the `SHA:<commit>` **label** are unchanged.

### Safety
Reverse PRs are identified by the `sync` **label** (not the branch name) across the pipeline / pending scan / merge-kick, and the source PR is recovered from the `SHA:` label. `pr_sequence_checker_reverse.py` finds predecessors via the `sync` label + `SHA:` label and never constructs or parses the head branch name — so serialization and identification are unaffected by the rename.

### Trade-off (called out)
This puts the CD PR number into the (public) SR branch name, reversing the earlier "the CD PR number never appears on the SR PR" desensitization **for the branch name only**. The title/body remain scrubbed, the label set stays `sync` + `SHA:` (no `cd-sync`), and the run-name still shows the source commit. The header comment is updated to reflect this.

Note: `workflow_dispatch`-only file; existing already-created reverse PRs keep their old branch names — this affects future runs.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5