### PR TITLE
[BugFix] Upsert and look up only the rows a cross-published child owns

### DIFF
--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -14,6 +14,9 @@
 
 #include "storage/lake/lake_primary_index.h"
 
+#include <utility>
+#include <vector>
+
 #include "base/debug/trace.h"
 #include "base/testutil/sync_point.h"
 #include "storage/chunk_helper.h"
@@ -21,10 +24,30 @@
 #include "storage/lake/lake_persistent_index.h"
 #include "storage/lake/meta_file.h"
 #include "storage/lake/rowset_update_state.h"
+#include "storage/lake/segment_pk_iterator.h"
 #include "storage/lake/tablet.h"
 #include "storage/persistent_index_parallel_publish_context.h"
 
 namespace starrocks::lake {
+
+// A cross-published chunk carries this tablet's rows AND its siblings'. SegmentPKChunkRef::owned
+// marks which are ours, as a mask over the chunk rather than a filtered copy, so row i keeps its
+// source-segment rowid physical_rowid_offset + i. These two turn that mask into the shapes the
+// primary index takes, and neither is entered at all on an ordinary publish, where `owned` is empty
+// and every row belongs here.
+
+// Absolute source-segment rowids of the owned rows, in chunk order. Must be read off the mask BEFORE
+// the column is filtered -- filtering renumbers the survivors and the correspondence is lost.
+std::vector<uint32_t> owned_rowids_of(const SegmentPKChunkRef& current) {
+    std::vector<uint32_t> rowids;
+    rowids.reserve(current.owned.size());
+    for (size_t i = 0; i < current.owned.size(); ++i) {
+        if (current.owned[i]) {
+            rowids.push_back(current.physical_rowid_offset + static_cast<uint32_t>(i));
+        }
+    }
+    return rowids;
+}
 
 Status LakePrimaryIndex::lake_load(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata, int64_t base_version,
                                    const MetaFileBuilder* builder) {
@@ -285,6 +308,29 @@ int64_t LakePrimaryIndex::publish_sst_flush_bytes() const {
 // - Each task allocates its own slot to avoid data races during parallel execution
 // - Shared state (deletes, status) is protected by mutex when updated
 // - Errors are accumulated and checked after all tasks complete
+Status LakePrimaryIndex::upsert_owned(uint32_t rssid, const SegmentPKChunkRef& current, ParallelPublishSlot* slot,
+                                      ParallelPublishContext* context) {
+    DCHECK(!current.owned.empty());
+    // Off the mask before filtering: filtering renumbers what survives, and these have to stay the
+    // rows' positions in the source segment.
+    auto owned_rowids = owned_rowids_of(current);
+    slot->pk_column->filter(current.owned);
+    if (owned_rowids.empty()) {
+        return Status::OK();
+    }
+    // One call for the whole chunk, never one per contiguous run of owned rows: ownership of a
+    // segment ordered by a separate sort key is scattered row by row, so runs degenerate towards one
+    // per row and each call redoes the inactive-memtable and SST lookup and the flush check.
+    RETURN_IF_ERROR(upsert(rssid, owned_rowids, *slot->pk_column, nullptr /* stat */, context));
+    if (context->token == nullptr) {
+        // With no token LakePersistentIndex::upsert resolves the replaced locations inline but does
+        // not drain them into context->deletes -- in the parallel case that is the submitted lambda's
+        // job, so it only happens there.
+        old_values_to_deletes(slot->old_values, context->deletes);
+    }
+    return Status::OK();
+}
+
 Status LakePrimaryIndex::parallel_get(ThreadPoolToken* token, SegmentPKIterator* segment_pk_iterator,
                                       DeletesMap* new_deletes) {
     // Prepare parallel execution infrastructure if enabled
@@ -315,8 +361,16 @@ Status LakePrimaryIndex::parallel_get(ThreadPoolToken* token, SegmentPKIterator*
             if (pk_column_st.ok()) {
                 // Query index for existing rows with these primary keys
                 slot->pk_column = std::move(pk_column_st.value());
+                // Drop the siblings' keys first. Their old locations would otherwise reach
+                // old_values_to_deletes below and be marked deleted in THIS child's delvec, and the
+                // parent view ORs the children's delvecs -- so a sibling's lookup would erase a row
+                // its owner kept. Only the values matter downstream, never their positions, so
+                // filtering in place needs no index mapping.
+                if (!current.owned.empty()) {
+                    slot->pk_column->filter(current.owned);
+                }
                 slot->old_values.resize(slot->pk_column->size(), NullIndexValue);
-                st = get(*slot->pk_column, &slot->old_values);
+                st = slot->pk_column->empty() ? Status::OK() : get(*slot->pk_column, &slot->old_values);
             } else {
                 st = pk_column_st.status();
             }
@@ -487,9 +541,13 @@ Status LakePrimaryIndex::parallel_upsert(ThreadPoolToken* token, uint32_t rssid,
                 // Store pk_column in this task's slot to avoid data races
                 slot->pk_column = std::move(pk_column_st.value());
 
-                // Submit upsert task to thread pool. Pass nullptr for deletes since we collect
-                // them in the context (not used for upsert, only for parallel_get)
-                st = upsert(rssid, current.physical_rowid_offset, *slot->pk_column, nullptr /* stat */, &context);
+                if (!current.owned.empty()) {
+                    st = upsert_owned(rssid, current, slot, &context);
+                } else {
+                    // Submit upsert task to thread pool. Pass nullptr for deletes since we collect
+                    // them in the context (not used for upsert, only for parallel_get)
+                    st = upsert(rssid, current.physical_rowid_offset, *slot->pk_column, nullptr /* stat */, &context);
+                }
                 TRACE_COUNTER_INCREMENT("parallel_upsert_cnt", 1);
             } else {
                 st = pk_column_st.status();
@@ -503,7 +561,22 @@ Status LakePrimaryIndex::parallel_upsert(ThreadPoolToken* token, uint32_t rssid,
         } else {
             // Serial mode: Execute inline with direct error propagation
             ASSIGN_OR_RETURN(MutableColumnPtr pk_column, segment_pk_iterator->encoded_pk_column(current.chunk.get()));
-            RETURN_IF_ERROR(upsert(rssid, current.physical_rowid_offset, *pk_column, context.deletes));
+            if (current.owned.empty()) {
+                // No slot here, unlike the branch below: this overload takes the DeletesMap directly
+                // and knows nothing about a context, so it buffers internally. Only the rowid-vector
+                // overload needs one -- it was written for the parallel path, where the scratch has
+                // to outlive the call in storage the context owns.
+                RETURN_IF_ERROR(upsert(rssid, current.physical_rowid_offset, *pk_column, context.deletes));
+            } else {
+                // A fresh slot per chunk, as in the parallel branch. The scratch inside it is
+                // append-only (build_persistent_keys and _build_persistent_values both emplace_back,
+                // and old_values is resized without re-initialising what is already there), so
+                // reusing one would need explicit clearing; a new slot is simply always empty.
+                context.extend_slots();
+                auto* slot = context.slots.back().get();
+                slot->pk_column = std::move(pk_column);
+                RETURN_IF_ERROR(upsert_owned(rssid, current, slot, &context));
+            }
         }
     }
     // Synchronize parallel execution if enabled

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -16,7 +16,9 @@
 
 #include <string>
 #include <unordered_map>
+#include <vector>
 
+#include "column/vectorized_fwd.h"
 #include "storage/lake/lake_persistent_index_parallel_compact_mgr.h"
 #include "storage/lake/tablet_metadata.h"
 #include "storage/lake/types_fwd.h"
@@ -25,6 +27,10 @@
 namespace starrocks {
 
 class ParallelPublishContext;
+// Declared here rather than included: persistent_index_parallel_publish_context.h is not
+// self-contained (it needs MutableColumnPtr and a complete Buffer<Slice>), so pulling it in from a
+// header breaks the include order. The .cpp has it.
+struct ParallelPublishSlot;
 
 namespace lake {
 
@@ -33,6 +39,15 @@ class MetaFileBuilder;
 class TabletManager;
 class LakePersistentIndexParallelCompactMgr;
 class SegmentPKIterator;
+
+struct SegmentPKChunkRef;
+
+// Turn SegmentPKChunkRef::owned -- the mask a cross publish puts on a chunk -- into the two shapes
+// PrimaryIndex::upsert accepts. Both are no-ops on an ordinary publish, where the mask is empty.
+//
+// owned_rowids_of: absolute source-segment rowids of the owned rows, in chunk order. Read it off the
+// mask BEFORE filtering the column; filtering renumbers the survivors.
+std::vector<uint32_t> owned_rowids_of(const SegmentPKChunkRef& current);
 
 class LakePrimaryIndex : public PrimaryIndex {
 public:
@@ -128,6 +143,19 @@ public:
     // 1. upsert into memtable. (serialize)
     // 2. parallel get from inactive memtables and sstables. (parallel)
     // 3. Call `flush_memtable`, and flush memtable into sstable when memtable is full. (serialize)
+    // Upsert only the rows |current.owned| marks as this tablet's, each keyed to the rowid it has in
+    // the SOURCE segment rather than its position among the survivors. |slot->pk_column| holds the
+    // encoded keys and is filtered in place.
+    //
+    // Cross publish only: an ordinary publish carries an empty mask and keeps the plain overload,
+    // which needs no per-row rowid vector and works on the in-memory index too.
+    //
+    // The slot belongs to the caller: it also carries the encoded column, whose bytes the index
+    // keeps referencing after this returns when the upsert runs asynchronously. Both call sites hand
+    // over a freshly extended slot, so the append-only scratch inside it always starts empty.
+    Status upsert_owned(uint32_t rssid, const SegmentPKChunkRef& current, ParallelPublishSlot* slot,
+                        ParallelPublishContext* context);
+
     Status parallel_upsert(ThreadPoolToken* token, uint32_t rssid, SegmentPKIterator* segment_pk_iterator,
                            DeletesMap* new_deletes);
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -281,6 +281,7 @@ SET(DW_TEST_FILES
     ./storage/lake/lake_delvec_loader_test.cpp
     ./storage/lake/lake_meta_reader_test.cpp
     ./storage/lake/lake_persistent_index_test.cpp
+    ./storage/lake/lake_primary_index_selection_test.cpp
     ./storage/lake/lake_primary_key_consistency_test.cpp
     ./exec/lake_connector_scan_node_test.cpp
     ./storage/lake/metacache_test.cpp

--- a/be/test/storage/lake/lake_primary_index_selection_test.cpp
+++ b/be/test/storage/lake/lake_primary_index_selection_test.cpp
@@ -1,0 +1,55 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "storage/lake/lake_primary_index.h"
+#include "storage/lake/segment_pk_iterator.h"
+
+namespace starrocks::lake {
+
+namespace {
+
+SegmentPKChunkRef make_ref(uint32_t physical_rowid_offset, std::vector<uint8_t> owned) {
+    SegmentPKChunkRef ref;
+    ref.physical_rowid_offset = physical_rowid_offset;
+    ref.owned.assign(owned.begin(), owned.end());
+    return ref;
+}
+
+} // namespace
+
+// The rowids handed to the index must be the row's position in the SOURCE SEGMENT, not its position
+// among the survivors. Getting this wrong is silent: the upsert succeeds and the index points at a
+// different row of the same segment.
+TEST(LakePrimaryIndexSelectionTest, test_owned_rowids_are_absolute_source_positions) {
+    auto ref = make_ref(/*physical_rowid_offset=*/100, {0, 1, 0, 1, 1});
+    EXPECT_EQ((std::vector<uint32_t>{101, 103, 104}), owned_rowids_of(ref));
+}
+
+// The offset is the chunk's own base, so a chunk that starts at 0 still yields plain indexes.
+TEST(LakePrimaryIndexSelectionTest, test_owned_rowids_without_an_offset) {
+    auto ref = make_ref(/*physical_rowid_offset=*/0, {1, 0, 1});
+    EXPECT_EQ((std::vector<uint32_t>{0, 2}), owned_rowids_of(ref));
+}
+
+// A sibling that owns nothing in this chunk must produce no rowids at all, so the caller can skip
+// the upsert rather than issue an empty one.
+TEST(LakePrimaryIndexSelectionTest, test_owned_rowids_when_nothing_is_owned) {
+    EXPECT_TRUE(owned_rowids_of(make_ref(7, {0, 0, 0})).empty());
+}
+
+} // namespace starrocks::lake

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -1142,6 +1142,98 @@ TEST_P(LakePrimaryKeyPublishTest, test_publish_clips_deletes_to_tablet_range) {
     EXPECT_EQ(n - kRangeUpperExclusive, read_rows(tablet_id, 3));
 }
 
+// Cross publish hands a SPLIT child the parent's whole op_write, its siblings' rows included, and
+// SegmentPKChunkRef::owned marks which of them are this child's. Both things the child feeds the
+// primary index -- the upsert, and the lookup that turns into its delvec -- have to be restricted to
+// those rows.
+//
+// The lookup side is what corrupts data: the parent view ORs the children's delvecs, so a row some
+// sibling looked up and marked deleted here vanishes from the parent view even though its owner kept
+// it. The upsert side leaves the child claiming keys outside its range, which later reads clip away
+// but which still shadow the real owner's entries in an inherited sstable.
+//
+// A real SPLIT is out of reach here, so the two things create_if_needed keys on are staged directly:
+// a tablet range covering the lower half of the keys, and an op_write whose segments are marked
+// shared. Both publishes are cross publishes of the same key set, which makes the second one's delete
+// count a direct read-out of what the first one actually indexed.
+TEST_P(LakePrimaryKeyPublishTest, test_cross_publish_indexes_only_the_rows_this_child_owns) {
+    if (GetParam().enable_transparent_data_encryption) {
+        return;
+    }
+    const int n = kChunkSize;
+    // Tablet owns (-inf, n/2); the upper half belongs to a sibling.
+    const int kOwnedRows = n / 2;
+
+    // Range distribution requires the order-preserving big-endian PK encoding; create_sst_seek_range_from
+    // rejects anything else, and the selector declines to build without it.
+    _tablet_metadata->mutable_schema()->set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
+    auto* range_pb = _tablet_metadata->mutable_range();
+    {
+        DatumVariant upper(get_type_info(LogicalType::TYPE_INT), Datum(kOwnedRows));
+        VariantTuple tuple;
+        tuple.append(upper);
+        tuple.to_proto(range_pb->mutable_upper_bound());
+        range_pb->set_upper_bound_included(false);
+    }
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    _tablet_schema = TabletSchema::create(_tablet_metadata->schema());
+    _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+
+    auto tablet_id = _tablet_metadata->id();
+    std::vector<uint32_t> indexes(n);
+    for (uint32_t i = 0; i < static_cast<uint32_t>(n); i++) {
+        indexes[i] = i;
+    }
+
+    auto cross_publish_all_keys = [&](int64_t version) {
+        auto chunk = make_op_chunk(n, /*value_shift=*/0, /*upsert=*/true, _slot_cid_map);
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .set_profile(&_dummy_runtime_profile)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*chunk, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        // What convert_txn_log_for_splitting leaves behind: the segments stay the parent's and every
+        // child publishes the same ones, so each has to select its own rows out of them.
+        ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_log(tablet_id, txn_id));
+        auto shared_log = std::make_shared<TxnLog>(*txn_log);
+        auto* rowset = shared_log->mutable_op_write()->mutable_rowset();
+        ASSERT_GT(rowset->segment_metas_size(), 0);
+        for (auto& segment_meta : *rowset->mutable_segment_metas()) {
+            segment_meta.set_shared(true);
+        }
+        ASSERT_OK(_tablet_mgr->put_txn_log(shared_log));
+        ASSERT_OK(publish_single_version(tablet_id, version, txn_id).status());
+    };
+
+    // The two publishes run the two sides of parallel_upsert, which select identically but reach the
+    // index by different overloads -- inline with the DeletesMap, or through a slot the context owns.
+    {
+        ConfigResetGuard<bool> serial(&config::enable_pk_index_parallel_execution, false);
+        cross_publish_all_keys(2);
+    }
+    {
+        ConfigResetGuard<bool> parallel(&config::enable_pk_index_parallel_execution, true);
+        cross_publish_all_keys(3);
+    }
+
+    ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(tablet_id, 3));
+    ASSERT_EQ(2, metadata->rowsets_size());
+    // v3 overwrites exactly the keys v2 put in the index. Unselected, v2 indexes all n and v3 finds
+    // all n, so this would be n.
+    EXPECT_EQ(kOwnedRows, metadata->rowsets(0).num_dels());
+    EXPECT_EQ(kOwnedRows, read_rows(tablet_id, 3));
+}
+
 // Spill path regression (kevincai review on #75366): when a single op-aware merge task emits more than one
 // upsert chunk (merged upsert rows > config::vector_chunk_size), write_one_merged_chunk must not corrupt
 // the reused merge chunk's schema. The old clone_empty_with_schema + remove_column_by_index shared then


### PR DESCRIPTION
## Why I'm doing:

Part of #77653 (stage CP-4). #77877 gave a cross-published chunk a per-row ownership mask (`SegmentPKChunkRef::owned`), but nothing read it — the mask was produced and then ignored. This drives the primary-index half of the publish from it.

Two places acted on every row of the payload, this tablet's and its siblings' alike:

- **`LakePrimaryIndex::parallel_upsert`** inserted the whole chunk, so a child's primary index ended up pointing at rows that belong to a sibling.
- **`LakePrimaryIndex::parallel_get`** looked every key up and fed the result to `old_values_to_deletes`, so a sibling's key found its old row and marked it deleted **in this child's delvec**. The parent view ORs the children's delvecs, so a non-owner's lookup erased a row its owner had kept.

That second one is also why the delvec needs no separate change in this PR: the delvec is derived from that lookup, so fixing the lookup fixes it.

## What I'm doing:

The mask is a mask, never a filtered chunk, so a row's rowid in the source segment stays `physical_rowid_offset + its index`. Both shapes `PrimaryIndex::upsert` accepts preserve that, and neither needed a new API:

- the **parallel** path reads the absolute rowids off the mask *before* filtering the encoded column (filtering renumbers the survivors), then uses the rowid-vector overload;
- the **serial** path walks maximal `[begin, end)` runs and reuses the index-range overload, whose rowid is `rowid_start + index` — so the chunk's own offset carries through untouched, and it does not depend on the rowid-vector overload, which only the cloud-native persistent index implements.

`parallel_get` just filters: its results are consumed by value, never by position, so no index mapping is needed.

**Left alone:** `batch_parallel_get_rss_rowids` consumes its results positionally by `(begin_rowid, count)`, so filtering there would misalign them. That path serves row-mode partial update and belongs to CP-5, together with condition update.

An ordinary publish carries an empty mask and takes none of these branches.

Fixes #77653

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

The mask is only ever non-empty on a SPLIT child's cross publish, which today can only arise for a range-distributed primary-key table whose sort key equals its primary key — and there the range already narrows the read exactly. This is the row-level answer the ORDER BY relaxation needs, wired ahead of it.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

Range distribution / tablet reshard is main-only, so no backport is needed.
