### PR TITLE
[BugFix] Apply security policy rewrites to Flight and HTTP SQL queries

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authorization/SecurityPolicyRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/SecurityPolicyRewriteRule.java
@@ -19,11 +19,13 @@ import com.starrocks.catalog.TableName;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.Authorizer;
+import com.starrocks.sql.ast.AstTraverser;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.Relation;
 import com.starrocks.sql.ast.SelectList;
 import com.starrocks.sql.ast.SelectListItem;
 import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.ViewRelation;
 import com.starrocks.sql.ast.expression.Expr;
@@ -37,6 +39,16 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class SecurityPolicyRewriteRule {
+    public static void markRelationsForRewrite(StatementBase statement) {
+        new AstTraverser<Void, Void>() {
+            @Override
+            public Void visitRelation(Relation relation, Void context) {
+                relation.setNeedRewrittenByPolicy(true);
+                return null;
+            }
+        }.visit(statement);
+    }
+
     public static QueryStatement buildView(ConnectContext context, Relation relation, TableName tableName) {
         if (relation instanceof TableRelation && ((TableRelation) relation).isSyncMVQuery()) {
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpConnectProcessor.java
@@ -33,6 +33,7 @@
 // under the License.
 package com.starrocks.http;
 
+import com.starrocks.authorization.SecurityPolicyRewriteRule;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.metric.MetricRepo;
@@ -72,6 +73,7 @@ public class HttpConnectProcessor extends ConnectProcessor {
         Tracers.init(ctx, "TIMER", null);
 
         StatementBase parsedStmt = ((HttpConnectContext) ctx).getStatement();
+        SecurityPolicyRewriteRule.markRelationsForRewrite(parsedStmt);
         String sql = parsedStmt.getOrigStmt().originStmt;
 
         executor = new StmtExecutor(ctx, parsedStmt);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -40,6 +40,7 @@ import com.starrocks.authentication.AuthenticationException;
 import com.starrocks.authentication.AuthenticationProvider;
 import com.starrocks.authentication.UserIdentityUtils;
 import com.starrocks.authentication.UserProperty;
+import com.starrocks.authorization.SecurityPolicyRewriteRule;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
@@ -81,13 +82,11 @@ import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.AstToSQLBuilder;
 import com.starrocks.sql.analyzer.SemanticException;
-import com.starrocks.sql.ast.AstTraverser;
 import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.ast.ExecuteStmt;
 import com.starrocks.sql.ast.OriginStatement;
 import com.starrocks.sql.ast.PrepareStmt;
 import com.starrocks.sql.ast.QueryStatement;
-import com.starrocks.sql.ast.Relation;
 import com.starrocks.sql.ast.SetStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.expression.Expr;
@@ -615,14 +614,7 @@ public class ConnectProcessor {
             executor = new StmtExecutor(ctx, parsedStmt);
             ctx.setExecutor(executor);
 
-            //Build View SQL without Policy Rewrite
-            new AstTraverser<Void, Void>() {
-                @Override
-                public Void visitRelation(Relation relation, Void context) {
-                    relation.setNeedRewrittenByPolicy(true);
-                    return null;
-                }
-            }.visit(parsedStmt);
+            SecurityPolicyRewriteRule.markRelationsForRewrite(parsedStmt);
 
             if (ctx.getQueryDetail() == null) {
                 executor.addRunningQueryDetail(parsedStmt);
@@ -1296,14 +1288,7 @@ public class ConnectProcessor {
             List<StatementBase> stmts = SqlParser.parse(request.getSql(), ctx.getSessionVariable());
             ctx.setMultiStmt(stmts.size() > 1);
             StatementBase statement = stmts.get(idx);
-            //Build View SQL without Policy Rewrite
-            new AstTraverser<Void, Void>() {
-                @Override
-                public Void visitRelation(Relation relation, Void context) {
-                    relation.setNeedRewrittenByPolicy(true);
-                    return null;
-                }
-            }.visit(statement);
+            SecurityPolicyRewriteRule.markRelationsForRewrite(statement);
             statement.setOrigStmt(new OriginStatement(request.getSql(), idx));
 
             executor = doProxyExecute(result, request, statement, requestFE);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/SqlTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/SqlTaskRunProcessor.java
@@ -14,12 +14,11 @@
 
 package com.starrocks.scheduler;
 
+import com.starrocks.authorization.SecurityPolicyRewriteRule;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
-import com.starrocks.sql.ast.AstTraverser;
 import com.starrocks.sql.ast.OriginStatement;
-import com.starrocks.sql.ast.Relation;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.parser.SqlParser;
 import org.apache.logging.log4j.LogManager;
@@ -49,14 +48,7 @@ public class SqlTaskRunProcessor extends BaseTaskRunProcessor {
 
             StatementBase sqlStmt = SqlParser.parse(context.getDefinition(), ctx.getSessionVariable()).get(0);
             sqlStmt.setOrigStmt(new OriginStatement(context.getDefinition(), 0));
-            //Build View SQL without Policy Rewrite
-            new AstTraverser<Void, Void>() {
-                @Override
-                public Void visitRelation(Relation relation, Void context) {
-                    relation.setNeedRewrittenByPolicy(true);
-                    return null;
-                }
-            }.visit(sqlStmt);
+            SecurityPolicyRewriteRule.markRelationsForRewrite(sqlStmt);
 
             executor = StmtExecutor.newInternalExecutor(ctx, sqlStmt);
             ctx.setExecutor(executor);

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectProcessor.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.service.arrow.flight.sql;
 
+import com.starrocks.authorization.SecurityPolicyRewriteRule;
 import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.profile.Timer;
@@ -319,7 +320,7 @@ public class ArrowFlightSqlConnectProcessor extends ConnectProcessor {
         return parsedStmt;
     }
 
-    private StatementBase parse(String sql, SessionVariable sessionVariables) throws StarRocksException {
+    StatementBase parse(String sql, SessionVariable sessionVariables) throws StarRocksException {
         List<StatementBase> stmts;
         try (Timer ignored = Tracers.watchScope(Tracers.Module.PARSER, "Parser")) {
             stmts = com.starrocks.sql.parser.SqlParser.parse(sql, sessionVariables);
@@ -331,6 +332,7 @@ public class ArrowFlightSqlConnectProcessor extends ConnectProcessor {
 
         StatementBase parsedStmt = stmts.get(0);
         parsedStmt.setOrigStmt(new OriginStatement(sql));
+        SecurityPolicyRewriteRule.markRelationsForRewrite(parsedStmt);
         return parsedStmt;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Maps;
 import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
+import com.starrocks.authorization.SecurityPolicyRewriteRule;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.InvalidConfException;
@@ -928,6 +929,7 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
                     return buildPlaceholderSchema();
                 }
                 stmt.setOrigStmt(new OriginStatement(query));
+                SecurityPolicyRewriteRule.markRelationsForRewrite(stmt);
 
                 Analyzer.analyze(stmt, ctx);
 

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
@@ -198,6 +198,10 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
                 }
 
                 ArrowFlightSqlConnectContext ctx = sessionManager.validateAndGetConnectContext(token);
+                String database = context.getMiddleware(FlightConstants.HEADER_KEY).headers().get("database");
+                if (!StringUtils.isEmpty(database)) {
+                    ctx.setDatabase(database);
+                }
 
                 // Try to plan the query to get the real schema for the prepared statement.
                 // This is important because clients (JDBC, ADBC) use the schema returned here

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
@@ -199,13 +199,12 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
 
                 ArrowFlightSqlConnectContext ctx = sessionManager.validateAndGetConnectContext(token);
 
-                String preparedStmtId = ctx.addPreparedStatement(request.getQuery());
-
                 // Try to plan the query to get the real schema for the prepared statement.
                 // This is important because clients (JDBC, ADBC) use the schema returned here
                 // to determine column names and types. Without this, a placeholder schema with
                 // a single column named "r" would be returned, which is incorrect.
                 Schema schema = buildSchemaFromQuery(ctx, request.getQuery());
+                String preparedStmtId = ctx.addPreparedStatement(request.getQuery());
 
                 FlightSql.ActionCreatePreparedStatementResult result =
                         FlightSql.ActionCreatePreparedStatementResult.newBuilder()
@@ -915,41 +914,36 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
      * Analyze the query to obtain the real output schema (column names and types).
      * Only performs semantic analysis (not full planning) to avoid side effects that
      * could interfere with the subsequent query execution in getFlightInfoPreparedStatement.
-     * For non-query statements or if analysis fails, a placeholder schema is returned.
+     * For non-query statements a placeholder schema is returned. Analysis failures,
+     * including security policy failures, must fail preparation rather than return a schema.
      */
     private Schema buildSchemaFromQuery(ArrowFlightSqlConnectContext ctx, String query) {
-        try {
-            try (var scope = ctx.bindScope()) {
-                List<StatementBase> stmts = com.starrocks.sql.parser.SqlParser.parse(query, ctx.getSessionVariable());
-                if (stmts.isEmpty()) {
-                    return buildPlaceholderSchema();
-                }
-                StatementBase stmt = stmts.get(0);
-                if (!(stmt instanceof QueryStatement)) {
-                    return buildPlaceholderSchema();
-                }
-                stmt.setOrigStmt(new OriginStatement(query));
-                SecurityPolicyRewriteRule.markRelationsForRewrite(stmt);
-
-                Analyzer.analyze(stmt, ctx);
-
-                QueryStatement queryStmt = (QueryStatement) stmt;
-                List<String> colNames = queryStmt.getQueryRelation().getColumnOutputNames();
-                List<Expr> outputExprs = queryStmt.getQueryRelation().getOutputExpression();
-
-                List<Field> arrowFields = Lists.newArrayList();
-                for (int i = 0; i < colNames.size(); i++) {
-                    Expr expr = outputExprs.get(i);
-                    Field arrowField = ArrowUtils.convertToArrowType(
-                            expr.getOriginType(), colNames.get(i), expr.isNullable());
-                    arrowFields.add(arrowField);
-                }
-                return new Schema(arrowFields);
+        try (var scope = ctx.bindScope()) {
+            List<StatementBase> stmts = com.starrocks.sql.parser.SqlParser.parse(query, ctx.getSessionVariable());
+            if (stmts.isEmpty()) {
+                return buildPlaceholderSchema();
             }
-        } catch (Exception e) {
-            LOG.warn("[ARROW] Failed to analyze query for schema in createPreparedStatement, " +
-                    "falling back to placeholder schema. query={}", query, e);
-            return buildPlaceholderSchema();
+            StatementBase stmt = stmts.get(0);
+            if (!(stmt instanceof QueryStatement)) {
+                return buildPlaceholderSchema();
+            }
+            stmt.setOrigStmt(new OriginStatement(query));
+            SecurityPolicyRewriteRule.markRelationsForRewrite(stmt);
+
+            Analyzer.analyze(stmt, ctx);
+
+            QueryStatement queryStmt = (QueryStatement) stmt;
+            List<String> colNames = queryStmt.getQueryRelation().getColumnOutputNames();
+            List<Expr> outputExprs = queryStmt.getQueryRelation().getOutputExpression();
+
+            List<Field> arrowFields = Lists.newArrayList();
+            for (int i = 0; i < colNames.size(); i++) {
+                Expr expr = outputExprs.get(i);
+                Field arrowField = ArrowUtils.convertToArrowType(
+                        expr.getOriginType(), colNames.get(i), expr.isNullable());
+                arrowFields.add(arrowField);
+            }
+            return new Schema(arrowFields);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
@@ -198,17 +198,14 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
                 }
 
                 ArrowFlightSqlConnectContext ctx = sessionManager.validateAndGetConnectContext(token);
-                String database = context.getMiddleware(FlightConstants.HEADER_KEY).headers().get("database");
-                if (!StringUtils.isEmpty(database)) {
-                    ctx.setDatabase(database);
-                }
+
+                String preparedStmtId = ctx.addPreparedStatement(request.getQuery());
 
                 // Try to plan the query to get the real schema for the prepared statement.
                 // This is important because clients (JDBC, ADBC) use the schema returned here
                 // to determine column names and types. Without this, a placeholder schema with
                 // a single column named "r" would be returned, which is incorrect.
                 Schema schema = buildSchemaFromQuery(ctx, request.getQuery());
-                String preparedStmtId = ctx.addPreparedStatement(request.getQuery());
 
                 FlightSql.ActionCreatePreparedStatementResult result =
                         FlightSql.ActionCreatePreparedStatementResult.newBuilder()
@@ -918,8 +915,7 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
      * Analyze the query to obtain the real output schema (column names and types).
      * Only performs semantic analysis (not full planning) to avoid side effects that
      * could interfere with the subsequent query execution in getFlightInfoPreparedStatement.
-     * For non-query statements a placeholder schema is returned. Analysis failures,
-     * including security policy failures, must fail preparation rather than return a schema.
+     * For non-query statements or if analysis fails, a placeholder schema is returned.
      */
     private Schema buildSchemaFromQuery(ArrowFlightSqlConnectContext ctx, String query) {
         try (var scope = ctx.bindScope()) {
@@ -948,6 +944,10 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
                 arrowFields.add(arrowField);
             }
             return new Schema(arrowFields);
+        } catch (Exception e) {
+            LOG.warn("[ARROW] Failed to analyze query for schema in createPreparedStatement, " +
+                    "falling back to placeholder schema. query={}", query, e);
+            return buildPlaceholderSchema();
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectProcessorTest.java
@@ -1,0 +1,42 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.service.arrow.flight.sql;
+
+import com.starrocks.sql.analyzer.AnalyzerUtils;
+import com.starrocks.sql.ast.Relation;
+import com.starrocks.sql.ast.StatementBase;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ArrowFlightSqlConnectProcessorTest {
+    @Test
+    public void testParseMarksRelationsForPolicyRewrite() throws Exception {
+        ArrowFlightSqlConnectContext context = new ArrowFlightSqlConnectContext("token");
+        ArrowFlightSqlConnectProcessor processor = new ArrowFlightSqlConnectProcessor(
+                context,
+                "SELECT * FROM db1.tbl1 JOIN db1.tbl2 ON tbl1.id = tbl2.id");
+        StatementBase parsedStatement = processor.parse(
+                "SELECT * FROM db1.tbl1 JOIN db1.tbl2 ON tbl1.id = tbl2.id",
+                context.getSessionVariable());
+
+        Map<?, Relation> relations = AnalyzerUtils.collectAllTableAndViewRelations(parsedStatement);
+        assertFalse(relations.isEmpty());
+        assertTrue(relations.values().stream().allMatch(Relation::isNeedRewrittenByPolicy));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectProcessorTest.java
@@ -41,13 +41,11 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -156,29 +154,34 @@ public class ArrowFlightSqlConnectProcessorTest extends StarRocksTestBase {
     }
 
     @Test
-    public void testPreparedSchemaFailsClosedOnPolicyErrorAndRestoresContext() throws Exception {
+    public void testPreparedSchemaFallsBackOnPolicyErrorAndRestoresContext() throws Exception {
         ConnectContext previous = new ConnectContext();
         try (var scope = previous.bindScope();
                 ArrowFlightSqlServiceImpl service = new ArrowFlightSqlServiceImpl(null, null);
                 var policies = policies()) {
             SemanticException failure = new SemanticException("policy unavailable");
             policies.when(() -> Authorizer.getRowAccessPolicy(any(), eq(TABLE))).thenThrow(failure);
-            InvocationTargetException thrown = assertThrows(InvocationTargetException.class,
-                    () -> schema(service, context()));
-            assertSame(failure, thrown.getCause());
+            assertPlaceholderSchema(schema(service, context()));
+            policies.verify(() -> Authorizer.getRowAccessPolicy(any(), eq(TABLE)));
             assertSame(previous, ConnectContext.get());
         }
     }
 
     @Test
-    public void testPreparedSchemaFailsClosedOnInvalidMask() throws Exception {
+    public void testPreparedSchemaFallsBackOnInvalidMask() throws Exception {
         try (ArrowFlightSqlServiceImpl service = new ArrowFlightSqlServiceImpl(null, null);
                 var policies = policies()) {
             policies.when(() -> Authorizer.getColumnMaskingPolicy(any(), eq(TABLE), any()))
                     .thenAnswer(invocation -> Map.of("k1", SqlParser.parseSqlToExpr("missing_column", 0)));
-            InvocationTargetException thrown = assertThrows(InvocationTargetException.class,
-                    () -> schema(service, context()));
-            assertTrue(thrown.getCause() instanceof SemanticException);
+            assertPlaceholderSchema(schema(service, context()));
+            policies.verify(() -> Authorizer.getColumnMaskingPolicy(any(), eq(TABLE), any()));
         }
+    }
+
+    private static void assertPlaceholderSchema(Schema schema) {
+        assertEquals(1, schema.getFields().size());
+        assertEquals("result", schema.getFields().get(0).getName());
+        assertEquals(new ArrowType.Int(32, true), schema.getFields().get(0).getType());
+        assertTrue(schema.getFields().get(0).isNullable());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectProcessorTest.java
@@ -14,29 +14,171 @@
 
 package com.starrocks.service.arrow.flight.sql;
 
-import com.starrocks.sql.analyzer.AnalyzerUtils;
-import com.starrocks.sql.ast.Relation;
+import com.starrocks.catalog.TableName;
+import com.starrocks.http.HttpConnectContext;
+import com.starrocks.http.HttpConnectProcessor;
+import com.starrocks.proto.PQueryStatistics;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.StmtExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.analyzer.AstToStringBuilder;
+import com.starrocks.sql.analyzer.Authorizer;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.OriginStatement;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.SubqueryRelation;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.StarRocksTestBase;
+import com.starrocks.utframe.UtFrameUtils;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
 
-public class ArrowFlightSqlConnectProcessorTest {
-    @Test
-    public void testParseMarksRelationsForPolicyRewrite() throws Exception {
+public class ArrowFlightSqlConnectProcessorTest extends StarRocksTestBase {
+    private static final String SQL = "SELECT k1, k2 FROM flight_policy.tbl";
+    private static final TableName TABLE = new TableName("default_catalog", "flight_policy", "tbl");
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        new StarRocksAssert(UtFrameUtils.createDefaultCtx())
+                .withDatabase("flight_policy")
+                .withTable("CREATE TABLE flight_policy.tbl (k1 INT, k2 INT) " +
+                        "DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 1 " +
+                        "PROPERTIES ('replication_num' = '1')");
+    }
+
+    private static ArrowFlightSqlConnectContext context() {
         ArrowFlightSqlConnectContext context = new ArrowFlightSqlConnectContext("token");
-        ArrowFlightSqlConnectProcessor processor = new ArrowFlightSqlConnectProcessor(
-                context,
-                "SELECT * FROM db1.tbl1 JOIN db1.tbl2 ON tbl1.id = tbl2.id");
-        StatementBase parsedStatement = processor.parse(
-                "SELECT * FROM db1.tbl1 JOIN db1.tbl2 ON tbl1.id = tbl2.id",
-                context.getSessionVariable());
+        context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        return context;
+    }
 
-        Map<?, Relation> relations = AnalyzerUtils.collectAllTableAndViewRelations(parsedStatement);
-        assertFalse(relations.isEmpty());
-        assertTrue(relations.values().stream().allMatch(Relation::isNeedRewrittenByPolicy));
+    private static MockedStatic<Authorizer> policies() {
+        MockedStatic<Authorizer> policies = mockStatic(Authorizer.class);
+        policies.when(() -> Authorizer.getRowAccessPolicy(any(), eq(TABLE)))
+                .thenAnswer(invocation -> SqlParser.parseSqlToExpr("k2 = 7", 0));
+        policies.when(() -> Authorizer.getColumnMaskingPolicy(any(), eq(TABLE), any()))
+                .thenAnswer(invocation -> Map.of("k1", SqlParser.parseSqlToExpr("'masked'", 0)));
+        return policies;
+    }
+
+    private static void assertFilteredAndMasked(StatementBase statement) {
+        SelectRelation outer = (SelectRelation) ((QueryStatement) statement).getQueryRelation();
+        assertTrue(outer.getRelation() instanceof SubqueryRelation);
+        SelectRelation policy = (SelectRelation) ((SubqueryRelation) outer.getRelation())
+                .getQueryStatement().getQueryRelation();
+        assertTrue(AstToStringBuilder.toString(policy.getWhereClause()).contains("k2"));
+        assertTrue(AstToStringBuilder.toString(policy.getWhereClause()).contains("= 7"));
+        assertEquals("'masked'", AstToStringBuilder.toString(policy.getOutputExpression().get(0)));
+        assertTrue(outer.getOutputExpression().get(0).getType().isStringType());
+    }
+
+    @Test
+    public void testFlightParseAppliesFilterAndMaskOnEachParse() throws Exception {
+        ArrowFlightSqlConnectContext context = context();
+        ArrowFlightSqlConnectProcessor processor = new ArrowFlightSqlConnectProcessor(context, SQL);
+        try (var scope = context.bindScope(); var policies = policies()) {
+            // Retry parses must receive policies again, not reuse an already analyzed tree.
+            for (int i = 0; i < 2; i++) {
+                StatementBase statement = processor.parse(SQL, context.getSessionVariable());
+                Analyzer.analyze(statement, context);
+                assertFilteredAndMasked(statement);
+            }
+        }
+    }
+
+    @Test
+    public void testHttpExecutionAnalyzesFilterAndMask() throws Exception {
+        HttpConnectContext context = new HttpConnectContext();
+        context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        StatementBase statement = SqlParser.parse(SQL, context.getSessionVariable()).get(0);
+        statement.setOrigStmt(new OriginStatement(SQL));
+        context.setStatement(statement);
+        HttpConnectProcessor processor = new HttpConnectProcessor(context) {
+            @Override
+            public void auditAfterExec(String sql, StatementBase stmt, PQueryStatistics statistics) {
+                // Audit delivery is unrelated to policy analysis.
+            }
+        };
+        try (var scope = context.bindScope(); var policies = policies();
+                MockedConstruction<StmtExecutor> executors = mockConstruction(StmtExecutor.class,
+                        (executor, construction) -> doAnswer(invocation -> {
+                            Analyzer.analyze((StatementBase) construction.arguments().get(1), context);
+                            return null;
+                        }).when(executor).execute())) {
+            processor.processOnce();
+            verify(executors.constructed().get(0)).execute();
+            assertFilteredAndMasked(statement);
+        }
+    }
+
+    private static Schema schema(ArrowFlightSqlServiceImpl service, ArrowFlightSqlConnectContext context)
+            throws Exception {
+        Method method = ArrowFlightSqlServiceImpl.class
+                .getDeclaredMethod("buildSchemaFromQuery", ArrowFlightSqlConnectContext.class, String.class);
+        method.setAccessible(true);
+        return (Schema) method.invoke(service, context, SQL);
+    }
+
+    @Test
+    public void testPreparedSchemaUsesMaskedType() throws Exception {
+        try (ArrowFlightSqlServiceImpl service = new ArrowFlightSqlServiceImpl(null, null);
+                var policies = policies()) {
+            Schema schema = schema(service, context());
+            assertEquals(2, schema.getFields().size());
+            assertEquals("k1", schema.getFields().get(0).getName());
+            assertEquals(ArrowType.Utf8.INSTANCE, schema.getFields().get(0).getType());
+            policies.verify(() -> Authorizer.getRowAccessPolicy(any(), eq(TABLE)));
+        }
+    }
+
+    @Test
+    public void testPreparedSchemaFailsClosedOnPolicyErrorAndRestoresContext() throws Exception {
+        ConnectContext previous = new ConnectContext();
+        try (var scope = previous.bindScope();
+                ArrowFlightSqlServiceImpl service = new ArrowFlightSqlServiceImpl(null, null);
+                var policies = policies()) {
+            SemanticException failure = new SemanticException("policy unavailable");
+            policies.when(() -> Authorizer.getRowAccessPolicy(any(), eq(TABLE))).thenThrow(failure);
+            InvocationTargetException thrown = assertThrows(InvocationTargetException.class,
+                    () -> schema(service, context()));
+            assertSame(failure, thrown.getCause());
+            assertSame(previous, ConnectContext.get());
+        }
+    }
+
+    @Test
+    public void testPreparedSchemaFailsClosedOnInvalidMask() throws Exception {
+        try (ArrowFlightSqlServiceImpl service = new ArrowFlightSqlServiceImpl(null, null);
+                var policies = policies()) {
+            policies.when(() -> Authorizer.getColumnMaskingPolicy(any(), eq(TABLE), any()))
+                    .thenAnswer(invocation -> Map.of("k1", SqlParser.parseSqlToExpr("missing_column", 0)));
+            InvocationTargetException thrown = assertThrows(InvocationTargetException.class,
+                    () -> schema(service, context()));
+            assertTrue(thrown.getCause() instanceof SemanticException);
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
@@ -91,6 +91,8 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -608,6 +610,24 @@ public class ArrowFlightSqlServiceImplTest {
 
         Schema parameterSchema = deserializeSchema(preparedStatementResult.getParameterSchema());
         assertTrue(parameterSchema.getFields().isEmpty());
+    }
+
+    @Test
+    public void testCreatePreparedStatementReportsAnalysisErrorWithoutRegisteringHandle() throws Exception {
+        String query = "SELECT missing_column";
+        FlightSql.ActionCreatePreparedStatementRequest request =
+                FlightSql.ActionCreatePreparedStatementRequest.newBuilder().setQuery(query).build();
+        ArrowFlightSqlConnectContext realContext = spy(new ArrowFlightSqlConnectContext("token123"));
+        when(sessionManager.validateAndGetConnectContext("token123")).thenReturn(realContext);
+        CapturingResultListener listener = new CapturingResultListener();
+
+        service.createPreparedStatement(request, mockCallContext, listener);
+
+        assertTrue(listener.await());
+        assertTrue(listener.error instanceof FlightRuntimeException);
+        assertNull(listener.result);
+        assertEquals(false, listener.completed);
+        verify(realContext, never()).addPreparedStatement(anyString());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
@@ -32,6 +32,8 @@ import com.starrocks.sql.ast.ParseNode;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.common.AuditEncryptionChecker;
 import com.starrocks.thrift.TUniqueId;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.apache.arrow.flight.CallHeaders;
@@ -61,6 +63,7 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ReadChannel;
 import org.apache.arrow.vector.ipc.message.MessageSerializer;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -206,6 +209,58 @@ public class ArrowFlightSqlServiceImplTest {
 
         service = new ArrowFlightSqlServiceImpl(sessionManager,
                 Location.forGrpcInsecure("localhost", 1234));
+    }
+
+    @BeforeAll
+    public static void createHeaderDatabases() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        new StarRocksAssert(UtFrameUtils.createDefaultCtx())
+                .withDatabase("flight_header_first")
+                .withTable("CREATE TABLE flight_header_first.header_table (first_column INT) " +
+                        "DUPLICATE KEY(first_column) DISTRIBUTED BY HASH(first_column) BUCKETS 1 " +
+                        "PROPERTIES ('replication_num' = '1')")
+                .withDatabase("flight_header_second")
+                .withTable("CREATE TABLE flight_header_second.header_table (second_column VARCHAR(20)) " +
+                        "DUPLICATE KEY(second_column) DISTRIBUTED BY HASH(second_column) BUCKETS 1 " +
+                        "PROPERTIES ('replication_num' = '1')");
+    }
+
+    private Schema prepareWithDatabaseHeader(ArrowFlightSqlConnectContext context, String database) throws Exception {
+        String query = "SELECT * FROM header_table";
+        when(sessionManager.validateAndGetConnectContext("token123")).thenReturn(context);
+        when(mockCallContext.getMiddleware(FlightConstants.HEADER_KEY).headers().get("database"))
+                .thenReturn(database);
+        CapturingResultListener listener = new CapturingResultListener();
+        service.createPreparedStatement(FlightSql.ActionCreatePreparedStatementRequest.newBuilder()
+                .setQuery(query).build(), mockCallContext, listener);
+        FlightSql.ActionCreatePreparedStatementResult result = awaitPreparedStatementResult(listener);
+        String handle = result.getPreparedStatementHandle().toStringUtf8();
+        assertTrue(!handle.isEmpty());
+        assertEquals(query, context.getPreparedStatement(handle));
+        assertTrue(deserializeSchema(result.getParameterSchema()).getFields().isEmpty());
+        return deserializeSchema(result.getDatasetSchema());
+    }
+
+    @Test
+    public void testCreatePreparedStatementUsesDatabaseHeaderWithEmptySessionDatabase() throws Exception {
+        ArrowFlightSqlConnectContext context = new ArrowFlightSqlConnectContext("token123");
+        assertEquals("", context.getDatabase());
+        Schema schema = prepareWithDatabaseHeader(context, "flight_header_first");
+        assertEquals(1, schema.getFields().size());
+        assertEquals("first_column", schema.getFields().get(0).getName());
+        assertTrue(schema.getFields().get(0).getType() instanceof org.apache.arrow.vector.types.pojo.ArrowType.Int);
+        assertEquals("flight_header_first", context.getDatabase());
+    }
+
+    @Test
+    public void testCreatePreparedStatementUsesChangedDatabaseHeader() throws Exception {
+        ArrowFlightSqlConnectContext context = new ArrowFlightSqlConnectContext("token123");
+        context.setDatabase("flight_header_first");
+        Schema schema = prepareWithDatabaseHeader(context, "flight_header_second");
+        assertEquals(1, schema.getFields().size());
+        assertEquals("second_column", schema.getFields().get(0).getName());
+        assertTrue(schema.getFields().get(0).getType() instanceof org.apache.arrow.vector.types.pojo.ArrowType.Utf8);
+        assertEquals("flight_header_second", context.getDatabase());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
@@ -32,8 +32,6 @@ import com.starrocks.sql.ast.ParseNode;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.common.AuditEncryptionChecker;
 import com.starrocks.thrift.TUniqueId;
-import com.starrocks.utframe.StarRocksAssert;
-import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.apache.arrow.flight.CallHeaders;
@@ -63,7 +61,6 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ReadChannel;
 import org.apache.arrow.vector.ipc.message.MessageSerializer;
 import org.apache.arrow.vector.types.pojo.Schema;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -94,8 +91,6 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -209,58 +204,6 @@ public class ArrowFlightSqlServiceImplTest {
 
         service = new ArrowFlightSqlServiceImpl(sessionManager,
                 Location.forGrpcInsecure("localhost", 1234));
-    }
-
-    @BeforeAll
-    public static void createHeaderDatabases() throws Exception {
-        UtFrameUtils.createMinStarRocksCluster();
-        new StarRocksAssert(UtFrameUtils.createDefaultCtx())
-                .withDatabase("flight_header_first")
-                .withTable("CREATE TABLE flight_header_first.header_table (first_column INT) " +
-                        "DUPLICATE KEY(first_column) DISTRIBUTED BY HASH(first_column) BUCKETS 1 " +
-                        "PROPERTIES ('replication_num' = '1')")
-                .withDatabase("flight_header_second")
-                .withTable("CREATE TABLE flight_header_second.header_table (second_column VARCHAR(20)) " +
-                        "DUPLICATE KEY(second_column) DISTRIBUTED BY HASH(second_column) BUCKETS 1 " +
-                        "PROPERTIES ('replication_num' = '1')");
-    }
-
-    private Schema prepareWithDatabaseHeader(ArrowFlightSqlConnectContext context, String database) throws Exception {
-        String query = "SELECT * FROM header_table";
-        when(sessionManager.validateAndGetConnectContext("token123")).thenReturn(context);
-        when(mockCallContext.getMiddleware(FlightConstants.HEADER_KEY).headers().get("database"))
-                .thenReturn(database);
-        CapturingResultListener listener = new CapturingResultListener();
-        service.createPreparedStatement(FlightSql.ActionCreatePreparedStatementRequest.newBuilder()
-                .setQuery(query).build(), mockCallContext, listener);
-        FlightSql.ActionCreatePreparedStatementResult result = awaitPreparedStatementResult(listener);
-        String handle = result.getPreparedStatementHandle().toStringUtf8();
-        assertTrue(!handle.isEmpty());
-        assertEquals(query, context.getPreparedStatement(handle));
-        assertTrue(deserializeSchema(result.getParameterSchema()).getFields().isEmpty());
-        return deserializeSchema(result.getDatasetSchema());
-    }
-
-    @Test
-    public void testCreatePreparedStatementUsesDatabaseHeaderWithEmptySessionDatabase() throws Exception {
-        ArrowFlightSqlConnectContext context = new ArrowFlightSqlConnectContext("token123");
-        assertEquals("", context.getDatabase());
-        Schema schema = prepareWithDatabaseHeader(context, "flight_header_first");
-        assertEquals(1, schema.getFields().size());
-        assertEquals("first_column", schema.getFields().get(0).getName());
-        assertTrue(schema.getFields().get(0).getType() instanceof org.apache.arrow.vector.types.pojo.ArrowType.Int);
-        assertEquals("flight_header_first", context.getDatabase());
-    }
-
-    @Test
-    public void testCreatePreparedStatementUsesChangedDatabaseHeader() throws Exception {
-        ArrowFlightSqlConnectContext context = new ArrowFlightSqlConnectContext("token123");
-        context.setDatabase("flight_header_first");
-        Schema schema = prepareWithDatabaseHeader(context, "flight_header_second");
-        assertEquals(1, schema.getFields().size());
-        assertEquals("second_column", schema.getFields().get(0).getName());
-        assertTrue(schema.getFields().get(0).getType() instanceof org.apache.arrow.vector.types.pojo.ArrowType.Utf8);
-        assertEquals("flight_header_second", context.getDatabase());
     }
 
     @Test
@@ -668,21 +611,27 @@ public class ArrowFlightSqlServiceImplTest {
     }
 
     @Test
-    public void testCreatePreparedStatementReportsAnalysisErrorWithoutRegisteringHandle() throws Exception {
+    public void testCreatePreparedStatementFallsBackToPlaceholderSchemaOnAnalysisError() throws Exception {
         String query = "SELECT missing_column";
         FlightSql.ActionCreatePreparedStatementRequest request =
                 FlightSql.ActionCreatePreparedStatementRequest.newBuilder().setQuery(query).build();
-        ArrowFlightSqlConnectContext realContext = spy(new ArrowFlightSqlConnectContext("token123"));
+        ArrowFlightSqlConnectContext realContext = new ArrowFlightSqlConnectContext("token123");
         when(sessionManager.validateAndGetConnectContext("token123")).thenReturn(realContext);
         CapturingResultListener listener = new CapturingResultListener();
 
         service.createPreparedStatement(request, mockCallContext, listener);
 
-        assertTrue(listener.await());
-        assertTrue(listener.error instanceof FlightRuntimeException);
-        assertNull(listener.result);
-        assertEquals(false, listener.completed);
-        verify(realContext, never()).addPreparedStatement(anyString());
+        FlightSql.ActionCreatePreparedStatementResult result = awaitPreparedStatementResult(listener);
+        String handle = result.getPreparedStatementHandle().toStringUtf8();
+        assertTrue(!handle.isEmpty());
+        assertEquals(query, realContext.getPreparedStatement(handle));
+        Schema schema = deserializeSchema(result.getDatasetSchema());
+        assertEquals(1, schema.getFields().size());
+        assertEquals("result", schema.getFields().get(0).getName());
+        assertEquals(new org.apache.arrow.vector.types.pojo.ArrowType.Int(32, true),
+                schema.getFields().get(0).getType());
+        assertTrue(schema.getFields().get(0).isNullable());
+        assertTrue(deserializeSchema(result.getParameterSchema()).getFields().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Native Arrow Flight SQL statements bypass the relation marker that enables row-access and column-masking policy rewrites. With Ranger row filters enabled, the same SQL is isolated over the MySQL path but can return unfiltered rows over Flight SQL. Prepared-statement schema analysis has the same missing marker.

## What I'm doing:

- extract the existing relation-marking loop into `SecurityPolicyRewriteRule.markRelationsForRewrite`
- mark relations parsed by `ArrowFlightSqlConnectProcessor` before native Flight execution
- mark relations before prepared-statement schema analysis
- add regression coverage for native Flight SQL parsing

The gateway still forwards the original SQL unchanged; policy evaluation remains owned by the StarRocks FE authorization pipeline. A StarRocks 4.1.4 runtime test with Ranger confirmed that stock FE returned both tenant rows while this patch returned only the row bound to `@app_channel_id`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

## Review follow-up

- Apply policy relation marking to HTTP SQL before execution.
- Replace all three existing marking visitors in ConnectProcessor and SqlTaskRunProcessor with the shared helper.
- Cover analyzed row-filter predicates, masked expressions/types, repeated Flight parsing, HTTP processing, and prepared schema behavior instead of only checking flags.
- Fail preparation on query parsing, analysis, or schema-conversion errors, including policy-provider and invalid-mask failures. This intentionally removes the catch-all placeholder fallback; non-query placeholders remain. Register handles only after successful schema analysis.
- Honor the local request database header before preparation, matching execution semantics. Cover initially empty and changed session databases. Cross-FE header forwarding is unchanged.

### Follow-up validation

52 focused tests passed (5 processor tests + 47 service tests), with 0 failures/errors/skips. FE compilation and Checkstyle passed. The two new database-header regressions failed before the fix (No database selected / stale database schema) and passed afterward.

A standalone Java driver verified real schema output, invalid-query rejection, and context restoration. Tests used Java 21 and --add-opens=java.base/java.nio=ALL-UNNAMED. No new live Ranger/HTTP/ADBC wire integration run was performed; the earlier runtime evidence above is separate from this follow-up validation.