### PR TITLE
[BugFix] Treat a slot with no parent tuple as bound by nothing

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ExprUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ExprUtils.java
@@ -196,6 +196,14 @@ public class ExprUtils {
         if (slotRef.isFromLambda()) {
             return true;
         }
+        // A slot the planner materialises for an intermediate expression -- the cast wrapping
+        // array_length() inside a lambda body, for one -- carries no column and never joins a tuple,
+        // so its descriptor has no parent. Such a slot is bound by no tuple at all. Say that instead
+        // of dereferencing the absent parent: TopN runtime-filter construction walks into nested
+        // lambda bodies and reaches exactly these slots.
+        if (slotRef.getDesc().getParent() == null) {
+            return false;
+        }
         for (TupleId tupleId : tupleIds) {
             if (tupleId.equals(slotRef.getDesc().getParent().getId())) {
                 return true;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LambdaTopNRuntimeFilterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LambdaTopNRuntimeFilterTest.java
@@ -1,0 +1,47 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import org.junit.jupiter.api.Test;
+
+public class LambdaTopNRuntimeFilterTest extends PlanTestBase {
+
+    // ORDER BY plus LIMIT builds a TopN node, whose runtime-filter construction asks whether each
+    // expression is bound by a set of tuples. That walk descends into the nested lambda body and meets
+    // the slot the planner materialised for the cast around array_length() -- a slot with no column
+    // that never joined a tuple. Dereferencing its absent parent threw
+    // "Cannot invoke TupleDescriptor.getId() because SlotDescriptor.getParent() is null".
+    private static final String NESTED_LAMBDA =
+            "array_map(a -> array_map(b -> array_length(a) + b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]])";
+
+    @Test
+    public void testNestedLambdaUnderTopN() throws Exception {
+        // Needs all of: ORDER BY, LIMIT, and an inner lambda referencing the outer parameter.
+        getFragmentPlan("SELECT " + NESTED_LAMBDA + " ORDER BY 1 LIMIT 1");
+        getFragmentPlan("SELECT " + NESTED_LAMBDA + " ORDER BY " + NESTED_LAMBDA + " DESC LIMIT 7, 100");
+        getFragmentPlan("SELECT " + NESTED_LAMBDA + " ORDER BY 1 ASC LIMIT 100 OFFSET 7");
+    }
+
+    @Test
+    public void testNeighbouringShapesStillPlan() throws Exception {
+        // Each one drops a single ingredient, and none of them ever reached the null parent.
+        getFragmentPlan("SELECT " + NESTED_LAMBDA);
+        getFragmentPlan("SELECT " + NESTED_LAMBDA + " ORDER BY 1");
+        getFragmentPlan("SELECT " + NESTED_LAMBDA + " LIMIT 1");
+        getFragmentPlan("SELECT array_map(a -> array_map(b -> b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]]) "
+                + "ORDER BY 1 LIMIT 1");
+        getFragmentPlan("SELECT array_map(a -> a + 1, ARRAY<TINYINT>[1,2]) ORDER BY 1 LIMIT 1");
+    }
+}

--- a/test/sql/test_array_fn/R/test_nested_lambda_topn
+++ b/test/sql/test_array_fn/R/test_nested_lambda_topn
@@ -1,0 +1,36 @@
+-- name: test_nested_lambda_topn
+select array_map(a -> array_map(b -> array_length(a) + b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]]) order by 1 limit 1;
+-- result:
+[[3,4]]
+-- !result
+select array_map(a -> array_map(b -> array_length(a) + b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]]) order by array_map(a -> array_map(b -> array_length(a) + b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]]) desc limit 7, 100;
+-- result:
+-- !result
+select array_map(a -> array_map(b -> array_length(a) + b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]]) order by 1 asc limit 100 offset 7;
+-- result:
+-- !result
+select array_map(a -> array_map(b -> array_length(a) + b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]]);
+-- result:
+[[3,4]]
+-- !result
+select array_map(a -> array_map(b -> array_length(a) + b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]]) order by 1;
+-- result:
+[[3,4]]
+-- !result
+select array_map(a -> array_map(b -> array_length(a) + b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]]) limit 1;
+-- result:
+[[3,4]]
+-- !result
+select array_map(a -> array_map(b -> b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]]) order by 1 limit 1;
+-- result:
+[[1,2]]
+-- !result
+select array_map(a -> a + 1, ARRAY<TINYINT>[1,2]) order by 1 limit 1;
+-- result:
+[2,3]
+-- !result
+select x, array_map(a -> array_map(b -> array_length(a) + b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]]) from (select 3 as x union all select 1 union all select 2) t order by x desc limit 2;
+-- result:
+3	[[3,4]]
+2	[[3,4]]
+-- !result

--- a/test/sql/test_array_fn/T/test_nested_lambda_topn
+++ b/test/sql/test_array_fn/T/test_nested_lambda_topn
@@ -1,0 +1,16 @@
+-- name: test_nested_lambda_topn
+-- ORDER BY plus LIMIT builds a TopN node, and its runtime-filter construction asks whether each
+-- expression is bound by a set of tuples. That walk descends into the inner lambda and reaches the
+-- slot the planner materialised for the cast around array_length(), which belongs to no tuple.
+select array_map(a -> array_map(b -> array_length(a) + b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]]) order by 1 limit 1;
+select array_map(a -> array_map(b -> array_length(a) + b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]]) order by array_map(a -> array_map(b -> array_length(a) + b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]]) desc limit 7, 100;
+select array_map(a -> array_map(b -> array_length(a) + b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]]) order by 1 asc limit 100 offset 7;
+-- the same expression without a TopN, as a reference for the value above
+select array_map(a -> array_map(b -> array_length(a) + b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]]);
+-- neighbouring shapes: each drops one ingredient and never reached the missing parent
+select array_map(a -> array_map(b -> array_length(a) + b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]]) order by 1;
+select array_map(a -> array_map(b -> array_length(a) + b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]]) limit 1;
+select array_map(a -> array_map(b -> b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]]) order by 1 limit 1;
+select array_map(a -> a + 1, ARRAY<TINYINT>[1,2]) order by 1 limit 1;
+-- ordering still works over several rows
+select x, array_map(a -> array_map(b -> array_length(a) + b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]]) from (select 3 as x union all select 1 union all select 2) t order by x desc limit 2;


### PR DESCRIPTION
## Why I'm doing:

A TopN node builds runtime filters, and that asks whether each expression is bound by a set of tuple ids. The walk recurses through the expression tree, so for a nested lambda it descends into the inner body and meets the slot the planner materialised for an intermediate expression -- the cast around array_length() below. Such a slot carries no column and never joins a tuple, so its descriptor has no parent, and reading the parent's id threw:

    SELECT array_map(a -> array_map(b -> array_length(a) + b, a),
                     ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]])
    ORDER BY 1 LIMIT 1;

    ERROR 1064 (HY000): Cannot invoke "com.starrocks.planner.TupleDescriptor.getId()"
                        because the return value of
                        "com.starrocks.planner.SlotDescriptor.getParent()" is null

It takes all three ingredients. ORDER BY and LIMIT together make the TopN that builds the filters -- either alone plans fine. The lambda has to nest, and the inner one has to reference the outer parameter: array_map(a -> array_map(b -> b, a), ...) plans fine because nothing wraps a cast around the outer parameter. Offset, sort direction, and whether ORDER BY repeats the select expression make no difference.

isFromLambda() already exempts a lambda's own parameters, added by #31125 for the same crash shape. This slot is not one of those -- it belongs to no relation at all -- so the answer to "is it bound by these tuples" is no. Return that rather than dereferencing the parent that was never set. A runtime filter then stops at this expression instead of being pushed past it, which costs an optimisation and no rows.

Tests: LambdaTopNRuntimeFilterTest covers the three shapes that reach the null parent and, separately, five neighbouring shapes that must keep planning -- each dropping one ingredient. Without the fix the first test errors and the second still passes. Verified on a cluster as well: the eight failing variants of the shape matrix all return correct results afterwards, matching a non-TopN reference query, and RuntimeFilterTest, ArraySortLambdaTest, LambdaArgIdCollisionTest, ReproLambdaInReuseTest, PushDownTopnNTest and DeferProjectAfterTopNTest stay green (16 cases). That verification ran on baseline e4080d18bc8, not on this commit's parent.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
