### PR TITLE
[BugFix] Synchronize TabletMeta binlog/flat_json config access

### DIFF
--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1581,12 +1581,13 @@ void Tablet::build_tablet_report_info(TTabletInfo* tablet_info) {
         tablet_info->__set_enable_persistent_index(_tablet_meta->get_enable_persistent_index());
         tablet_info->__set_primary_index_cache_expire_sec(_tablet_meta->get_primary_index_cache_expire_sec());
         tablet_info->__set_tablet_schema_version(_max_version_schema->schema_version());
-        if (_tablet_meta->get_binlog_config() != nullptr) {
-            tablet_info->__set_binlog_config_version(_tablet_meta->get_binlog_config()->version);
+        // Snapshot each config once: a concurrent ALTER may replace it between the null check
+        // and the dereference.
+        if (auto binlog_config = _tablet_meta->get_binlog_config(); binlog_config != nullptr) {
+            tablet_info->__set_binlog_config_version(binlog_config->version);
         }
-        if (_tablet_meta->get_flat_json_config() != nullptr) {
-            tablet_info->__set_flat_json_config_version(
-                    _tablet_meta->get_flat_json_config()->get_flat_json_config_version());
+        if (auto flat_json_config = _tablet_meta->get_flat_json_config(); flat_json_config != nullptr) {
+            tablet_info->__set_flat_json_config_version(flat_json_config->get_flat_json_config_version());
         }
         if (_updates == nullptr) {
             int64_t max_version = _timestamped_version_tracker.get_max_continuous_version();

--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -442,8 +442,10 @@ void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb, bool skip_tablet_schem
         tablet_meta_pb->mutable_updates()->CopyFrom(*_updatesPB);
     }
 
-    if (_binlog_config != nullptr) {
-        _binlog_config->to_pb(tablet_meta_pb->mutable_binlog_config());
+    // Take a snapshot through the accessor: a concurrent ALTER may replace the config between
+    // the null check and the dereference.
+    if (auto binlog_config = get_binlog_config(); binlog_config != nullptr) {
+        binlog_config->to_pb(tablet_meta_pb->mutable_binlog_config());
         BinlogLsnPB* lsn = tablet_meta_pb->mutable_binlog_min_lsn();
         lsn->set_version(_binlog_min_lsn.version());
         lsn->set_seq_id(_binlog_min_lsn.seq_id());
@@ -456,8 +458,8 @@ void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb, bool skip_tablet_schem
         _source_schema->to_schema_pb(tablet_meta_pb->mutable_source_schema());
     }
 
-    if (_flat_json_config != nullptr) {
-        _flat_json_config->to_pb(tablet_meta_pb->mutable_flat_json_config());
+    if (auto flat_json_config = get_flat_json_config(); flat_json_config != nullptr) {
+        flat_json_config->to_pb(tablet_meta_pb->mutable_flat_json_config());
     }
 }
 

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -219,17 +219,29 @@ public:
         _primary_index_cache_expire_sec = primary_index_cache_expire_sec;
     }
 
-    std::shared_ptr<BinlogConfig> get_binlog_config() { return _binlog_config; }
+    std::shared_ptr<BinlogConfig> get_binlog_config() const {
+        std::shared_lock rdlock(_config_lock);
+        return _binlog_config;
+    }
 
-    std::shared_ptr<FlatJsonConfig> get_flat_json_config() { return _flat_json_config; }
+    std::shared_ptr<FlatJsonConfig> get_flat_json_config() const {
+        std::shared_lock rdlock(_config_lock);
+        return _flat_json_config;
+    }
 
+    // Build the new config fully before publishing it, so that a concurrent reader can never
+    // observe a half-initialized one.
     void set_binlog_config(const BinlogConfig& new_config) {
-        _binlog_config = std::make_shared<BinlogConfig>();
-        _binlog_config->update(new_config);
+        auto config = std::make_shared<BinlogConfig>();
+        config->update(new_config);
+        std::unique_lock wrlock(_config_lock);
+        _binlog_config = std::move(config);
     }
 
     void set_flat_json_config(const FlatJsonConfig& new_config) {
-        _flat_json_config = std::make_shared<FlatJsonConfig>(new_config);
+        auto config = std::make_shared<FlatJsonConfig>(new_config);
+        std::unique_lock wrlock(_config_lock);
+        _flat_json_config = std::move(config);
     }
 
     BinlogLsn get_binlog_min_lsn() { return _binlog_min_lsn; }
@@ -293,6 +305,16 @@ private:
     // can be serialized with tablet meta automatically
     TabletUpdates* _updates = nullptr;
 
+    // Guards _binlog_config and _flat_json_config only.
+    //
+    // ALTER TABLE ... SET ("binlog_enable"=...) / ("flat_json.enable"=...) replaces these two
+    // wholesale from an agent thread, while load (DeltaWriter::_init), compaction
+    // (CompactionUtils::construct_output_rowset_writer), query (TabletReader) and the tablet
+    // report read them concurrently. The writer holds Tablet::_meta_lock but none of those
+    // readers do, so the shared_ptr members themselves need their own synchronization:
+    // concurrently copying and assigning the same shared_ptr object is a data race, and the
+    // control block can be freed between a reader loading it and incrementing its refcount.
+    mutable std::shared_mutex _config_lock;
     std::shared_ptr<BinlogConfig> _binlog_config;
     std::shared_ptr<FlatJsonConfig> _flat_json_config;
 

--- a/be/test/storage/tablet_meta_test.cpp
+++ b/be/test/storage/tablet_meta_test.cpp
@@ -36,7 +36,10 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <string>
+#include <thread>
+#include <vector>
 
 #include "storage/olap_common.h"
 #include "storage/rowset/rowset_meta.h"
@@ -334,6 +337,77 @@ TEST(TabletMetaTest, sum_rowset_data_disk_size_multiple_rowsets) {
 
     ASSERT_EQ(300u, sum_rowset_data_disk_size(*tablet_meta));
     ASSERT_EQ(333u, tablet_meta->tablet_footprint());
+}
+
+// ALTER TABLE ... SET ("binlog_enable"=...) / ("flat_json.enable"=...) replaces these configs
+// from an agent thread while load, compaction, query and report threads read them, and those
+// readers hold no tablet lock. Two things must hold:
+//   1. a reader never observes a half-initialized config (set_binlog_config used to publish an
+//      empty BinlogConfig and only then fill it in, so version 0 was observable);
+//   2. copying and assigning the shared_ptr members does not race (an ASAN build turns the old
+//      code's control-block use-after-free into a hard failure here).
+// Every published config is self-describing -- each field is derived from its version -- so a
+// reader can tell a whole config from a mix of two.
+// NOLINTNEXTLINE
+TEST(TabletMetaTest, test_concurrent_config_update) {
+    auto tablet_meta = std::make_shared<TabletMeta>();
+
+    constexpr int64_t kVersions = 2000;
+    constexpr int kReaders = 4;
+
+    auto make_binlog_config = [](int64_t v) {
+        BinlogConfig config;
+        config.update(v, (v % 2) == 0, v * 10, v * 100);
+        return config;
+    };
+    auto make_flat_json_config = [](int64_t v) {
+        FlatJsonConfig config((v % 2) == 0, v * 0.001, v * 0.002, static_cast<int>(v));
+        config.set_flat_json_config_version(v);
+        return config;
+    };
+
+    tablet_meta->set_binlog_config(make_binlog_config(1));
+    tablet_meta->set_flat_json_config(make_flat_json_config(1));
+
+    std::atomic<bool> stop{false};
+    std::atomic<int> failures{0};
+    std::vector<std::thread> readers;
+    readers.reserve(kReaders);
+    for (int i = 0; i < kReaders; i++) {
+        readers.emplace_back([&]() {
+            while (!stop.load(std::memory_order_relaxed)) {
+                auto binlog = tablet_meta->get_binlog_config();
+                if (binlog == nullptr || binlog->version < 1 || binlog->binlog_enable != ((binlog->version % 2) == 0) ||
+                    binlog->binlog_ttl_second != binlog->version * 10 ||
+                    binlog->binlog_max_size != binlog->version * 100) {
+                    failures.fetch_add(1);
+                }
+                auto flat_json = tablet_meta->get_flat_json_config();
+                if (flat_json == nullptr) {
+                    failures.fetch_add(1);
+                    continue;
+                }
+                int64_t version = flat_json->get_flat_json_config_version();
+                if (version < 1 || flat_json->is_flat_json_enabled() != ((version % 2) == 0) ||
+                    flat_json->get_flat_json_max_column_max() != static_cast<int>(version)) {
+                    failures.fetch_add(1);
+                }
+            }
+        });
+    }
+
+    for (int64_t version = 2; version <= kVersions; version++) {
+        tablet_meta->set_binlog_config(make_binlog_config(version));
+        tablet_meta->set_flat_json_config(make_flat_json_config(version));
+    }
+    stop.store(true);
+    for (auto& reader : readers) {
+        reader.join();
+    }
+
+    ASSERT_EQ(0, failures.load());
+    ASSERT_EQ(kVersions, tablet_meta->get_binlog_config()->version);
+    ASSERT_EQ(kVersions, tablet_meta->get_flat_json_config()->get_flat_json_config_version());
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

ALTER TABLE ... SET ("binlog_enable"=...) or ("flat_json.enable"=...) replaces TabletMeta::_binlog_config / _flat_json_config from an agent thread, while load (DeltaWriter::_init), compaction (CompactionUtils::construct_output_rowset_writer), query (TabletReader) and the tablet report read them. The writer holds Tablet::_meta_lock but none of those readers do, so the two shared_ptr members were copied and assigned concurrently with no synchronization at all.

That is a data race on the shared_ptr object itself: a reader can load the old control block and then increment its refcount after the writer has already released it and freed the config, which writes into freed memory and hands back a pointer to a destroyed config. A single ALTER fans out to every tablet on every BE, so it is one dice roll per tablet against whatever load or compaction is running.

set_binlog_config additionally published an empty BinlogConfig and filled it in afterwards, so a reader could observe version 0 with default values even without any pointer-level race.

Guard both members with a dedicated shared_mutex, and build each new config fully before publishing it. Route the remaining check-then-dereference sites in TabletMeta::to_meta_pb and Tablet::build_tablet_report_info through the accessor so they work on a stable snapshot.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
