### PR TITLE
[BugFix] Backquote the columns of SELECT * EXCLUDE when deparsing

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2SQLVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2SQLVisitor.java
@@ -238,7 +238,7 @@ public class AST2SQLVisitor extends AST2StringVisitor {
                     if (!item.getExcludedColumns().isEmpty()) {
                         tmp += " EXCLUDE ( ";
                         tmp += item.getExcludedColumns().stream()
-                                .map(col -> "\"" + col + "\"")
+                                .map(ParseUtil::backquote)
                                 .collect(Collectors.joining(","));
                         tmp += " ) ";
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
@@ -633,7 +633,7 @@ public class AST2StringVisitor implements AstVisitorExtendInterface<String, Void
                     selectItemLabel += " EXCLUDE ( ";
                     selectItemLabel +=
                             item.getExcludedColumns().stream()
-                                    .map(col -> "`" + col + "`")
+                                    .map(ParseUtil::backquote)
                                     .collect(Collectors.joining(","));
                     selectItemLabel += " ) ";
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AstToSQLBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AstToSQLBuilderTest.java
@@ -83,13 +83,28 @@ public class AstToSQLBuilderTest {
     public void testSelectStarExcludeToSQL() throws Exception {
         String sql = "SELECT * EXCLUDE (name, email) FROM test_exclude;";
         StatementBase stmt = SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
-        Assertions.assertEquals("SELECT * EXCLUDE ( \"name\",\"email\" ) \nFROM `test_exclude`",
+        Assertions.assertEquals("SELECT * EXCLUDE ( `name`,`email` ) \nFROM `test_exclude`",
                 AstToSQLBuilder.toSQL(stmt));
-        
+
         sql = "SELECT test_exclude.* EXCLUDE (name) FROM test_exclude";
         stmt = SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
-        Assertions.assertEquals("SELECT test_exclude.* EXCLUDE ( \"name\" ) \nFROM `test_exclude`",
+        Assertions.assertEquals("SELECT test_exclude.* EXCLUDE ( `name` ) \nFROM `test_exclude`",
                 AstToSQLBuilder.toSQL(stmt));
+    }
+
+    @Test
+    public void testSelectStarExcludeRoundTrips() throws Exception {
+        // The point of this deparser is that its output parses again. Quoting the excluded columns
+        // the way the grammar does not accept -- with double quotes -- made that false, and an
+        // assertion that only compares the printed text cannot see it.
+        for (String sql : new String[] {
+                "SELECT * EXCLUDE (name, email) FROM test_exclude",
+                "SELECT test_exclude.* EXCLUDE (name) FROM test_exclude",
+                "SELECT * EXCLUDE (`odd name`) FROM test_exclude"}) {
+            StatementBase stmt = SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
+            String printed = AstToSQLBuilder.toSQL(stmt);
+            SqlParser.parseSingleStatement(printed, SqlModeHelper.MODE_DEFAULT);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

AstToSQLBuilder exists to print an AST as SQL that parses again, and MV rewriting, query dumps and replay all rely on that. It wrapped the columns of a SELECT * EXCLUDE list in double quotes, which the grammar accepts nowhere:

    SELECT * EXCLUDE (name) FROM t;                      -- runs
    -- AstToSQLBuilder.toSQL() prints
    SELECT * EXCLUDE ( "name" ) FROM `test_exclude`      -- and parsing that says
    Unexpected input '"name"', the most similar input is {a legal identifier}

Print them with ParseUtil.backquote, the same helper the aliases a few lines below already use. AST2StringVisitor prints this clause too and had the quoting right, but hand-rolled the backquotes and so left a column name containing one to produce the same unparsable output; route it through the helper as well.

testSelectStarExcludeToSQL asserted the double-quoted text, so the deparser had a test that pinned the defect in place. Comparing printed text cannot see this class of bug at all -- the assertion is only ever as correct as the string someone wrote down. Assert the round trip instead: parse, print, and parse the printed text. That is the property this deparser owes its callers, and it fails without the fix while the text comparison passes for whatever the printer happens to emit.

Found by a deparse/reparse oracle: it round-trips every mutant through AstToSQLBuilder.toSQL() and reported this shape 100+ times across six variants.

Tests: testSelectStarExcludeRoundTrips covers a plain list, a qualified star, and a column name that needs quoting; without the fix it raises the ParsingException above.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
