### PR TITLE
[BugFix] Ship the lookup's global dictionary under the id the lookup asks with

### DIFF
--- a/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
+++ b/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
@@ -80,6 +80,15 @@ Status init_global_dicts_for_scan_node(RuntimeState* state, ObjectPool* pool, co
         if (iter != global_dict_map.end()) {
             auto& dict_map = iter->second.first;
             dicts->emplace(index, const_cast<GlobalDictMap*>(&dict_map));
+        } else if (slot->type().type == TYPE_INT && is_string_type(tablet_schema->column(index).type())) {
+            // The plan typed this slot as the dictionary code while storage holds the string, so the
+            // caller is asking to read it dictionary-encoded. Skipping quietly leaves the reader to
+            // return the raw string into an int column, which surfaces far away as a decode failure
+            // against a "key" that is really string bytes, or as an out-of-bounds access.
+            return Status::InternalError(fmt::format(
+                    "no global dict for slot {} ({}), which the plan reads as a dictionary code; "
+                    "query_global_dicts carries {} entries",
+                    slot->id(), slot->col_name(), global_dict_map.size()));
         }
     }
     *global_dicts = dicts;

--- a/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
+++ b/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
@@ -85,10 +85,10 @@ Status init_global_dicts_for_scan_node(RuntimeState* state, ObjectPool* pool, co
             // caller is asking to read it dictionary-encoded. Skipping quietly leaves the reader to
             // return the raw string into an int column, which surfaces far away as a decode failure
             // against a "key" that is really string bytes, or as an out-of-bounds access.
-            return Status::InternalError(fmt::format(
-                    "no global dict for slot {} ({}), which the plan reads as a dictionary code; "
-                    "query_global_dicts carries {} entries",
-                    slot->id(), slot->col_name(), global_dict_map.size()));
+            return Status::InternalError(
+                    fmt::format("no global dict for slot {} ({}), which the plan reads as a dictionary code; "
+                                "query_global_dicts carries {} entries",
+                                slot->id(), slot->col_name(), global_dict_map.size()));
         }
     }
     *global_dicts = dicts;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lazymaterialize/GlobalLateMaterializationRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lazymaterialize/GlobalLateMaterializationRewriter.java
@@ -1203,7 +1203,14 @@ public class GlobalLateMaterializationRewriter {
                         // acquire global dict
                         final Pair<Integer, ColumnDict> globalDict = handler.getGlobalDict(scan, lazyColumn);
                         if (globalDict != null) {
-                            globalDictsBuilder.put(globalDict.first, globalDict.second);
+                            // Key it by the id the lookup will actually ask with. resolve() maps the
+                            // column back into the scan's id space so the dictionary can be found on
+                            // the scan, but the lookup's slots are built from materializedLazyColumns,
+                            // which are in this operator's space. Shipping the scan-space id meant the
+                            // backend looked its slot up in a map that did not contain it, silently
+                            // skipped applying the dictionary, and read the raw string into a slot the
+                            // plan had already typed as the dictionary code.
+                            globalDictsBuilder.put(columnRef.getId(), globalDict.second);
                         }
                     }
                 }

--- a/test/sql/test_low_cardinality/R/test_lowcard_late_materialize
+++ b/test/sql/test_low_cardinality/R/test_lowcard_late_materialize
@@ -1,0 +1,95 @@
+-- name: test_lowcard_late_materialize
+CREATE TABLE `lm_dict` (
+  `k1` bigint NULL,
+  `v1` varchar(255) NULL,
+  `v2` varchar(255) NULL,
+  `v3` varchar(255) NULL,
+  `v9` varchar(255) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO lm_dict VALUES
+(1, 'a1', 'x', 'c1', 'm1'),
+(2, 'a2', 'x', 'c2', 'm2'),
+(3, 'a3', 'y', 'c3', 'm3'),
+(4, 'a4', 'y', 'c4', 'm4'),
+(5, 'a5', 'x', 'c5', 'm5'),
+(6, 'a6', 'z', 'c6', 'm6'),
+(7, 'a7', 'z', 'c7', 'm7'),
+(8, 'a8', 'x', 'c8', 'm8'),
+(9, 'a9', 'y', 'c9', 'm9'),
+(10, 'a10', 'z', 'c10', 'm10');
+-- result:
+-- !result
+select v1, count(*) from lm_dict group by v1 order by v1;
+-- result:
+a1	1
+a10	1
+a2	1
+a3	1
+a4	1
+a5	1
+a6	1
+a7	1
+a8	1
+a9	1
+-- !result
+select v2, count(*) from lm_dict group by v2 order by v2;
+-- result:
+x	4
+y	3
+z	3
+-- !result
+select v3, count(*) from lm_dict group by v3 order by v3;
+-- result:
+c1	1
+c10	1
+c2	1
+c3	1
+c4	1
+c5	1
+c6	1
+c7	1
+c8	1
+c9	1
+-- !result
+set cbo_cte_reuse_rate = 0;
+-- result:
+-- !result
+set enable_global_late_materialization = true;
+-- result:
+-- !result
+set enable_global_late_materialization_cost_based = false;
+-- result:
+-- !result
+with c as (select k1, v1, v2, v3 from lm_dict),
+     d as (select count(*) as n from c where v2 = 'x')
+select a.k1, a.v1, d.n from c a cross join d order by a.k1 limit 5;
+-- result:
+1	a1	4
+2	a2	4
+3	a3	4
+4	a4	4
+5	a5	4
+-- !result
+with c as (select k1, v1, v3 from lm_dict)
+select x.k1, x.v1, y.v3 from c x join c y on x.k1 = y.k1 order by x.k1 limit 5;
+-- result:
+1	a1	c1
+2	a2	c2
+3	a3	c3
+4	a4	c4
+5	a5	c5
+-- !result
+with c as (select k1, v1 from lm_dict)
+select x.k1, x.v1, y.v1 from c x join c y on x.k1 = y.k1 order by x.k1 limit 5;
+-- result:
+1	a1	a1
+2	a2	a2
+3	a3	a3
+4	a4	a4
+5	a5	a5
+-- !result

--- a/test/sql/test_low_cardinality/T/test_lowcard_late_materialize
+++ b/test/sql/test_low_cardinality/T/test_lowcard_late_materialize
@@ -1,0 +1,49 @@
+-- name: test_lowcard_late_materialize
+CREATE TABLE `lm_dict` (
+  `k1` bigint NULL,
+  `v1` varchar(255) NULL,
+  `v2` varchar(255) NULL,
+  `v3` varchar(255) NULL,
+  `v9` varchar(255) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+INSERT INTO lm_dict VALUES
+(1, 'a1', 'x', 'c1', 'm1'),
+(2, 'a2', 'x', 'c2', 'm2'),
+(3, 'a3', 'y', 'c3', 'm3'),
+(4, 'a4', 'y', 'c4', 'm4'),
+(5, 'a5', 'x', 'c5', 'm5'),
+(6, 'a6', 'z', 'c6', 'm6'),
+(7, 'a7', 'z', 'c7', 'm7'),
+(8, 'a8', 'x', 'c8', 'm8'),
+(9, 'a9', 'y', 'c9', 'm9'),
+(10, 'a10', 'z', 'c10', 'm10');
+-- The columns are low-cardinality, so the frontend collects a global dictionary for them and
+-- the plan rewrites them to dictionary codes. Touch them first: collection is asynchronous.
+select v1, count(*) from lm_dict group by v1 order by v1;
+select v2, count(*) from lm_dict group by v2 order by v2;
+select v3, count(*) from lm_dict group by v3 order by v3;
+-- Late materialization defers a column and fetches it back by row position. Both are on by
+-- default; the CTE has to be materialised rather than inlined, and the cost gate is turned off
+-- so the choice does not depend on statistics.
+set cbo_cte_reuse_rate = 0;
+set enable_global_late_materialization = true;
+set enable_global_late_materialization_cost_based = false;
+-- The deferred column is dictionary-encoded, so the plan types its fetch slot as INT while
+-- storage holds the string. The dictionary shipped with the lookup used to be keyed by the
+-- scan's column id rather than the id the lookup asks with, so the backend found no dictionary,
+-- silently read the raw string into that INT slot, and died -- as a decode failure against a
+-- "key" that was really string bytes, as an out-of-bounds read while sorting the fetched chunk,
+-- or as a 32-byte heap write while deserializing the fetch response.
+with c as (select k1, v1, v2, v3 from lm_dict),
+     d as (select count(*) as n from c where v2 = 'x')
+select a.k1, a.v1, d.n from c a cross join d order by a.k1 limit 5;
+-- A NOT NULL dictionary column: no NullableColumn wraps it, so nothing caught the mismatch and
+-- the fetched chunk went straight into the sort.
+with c as (select k1, v1, v3 from lm_dict)
+select x.k1, x.v1, y.v3 from c x join c y on x.k1 = y.k1 order by x.k1 limit 5;
+-- Both consumers of the shared CTE ask for the same dictionary column.
+with c as (select k1, v1 from lm_dict)
+select x.k1, x.v1, y.v1 from c x join c y on x.k1 = y.k1 order by x.k1 limit 5;


### PR DESCRIPTION
## Why I'm doing:

A late-materialized column that the low-cardinality rewrite had turned into a dictionary code killed the backend. The plan types the fetch slot as INT while storage holds the string, so the lookup has to apply the global dictionary when it reads the column back by row position -- and it could not find one.

GlobalLateMaterializationRewriter resolves the column into the scan's id space to look the dictionary up on the scan, then shipped it keyed by that scan-space id. The lookup's slots come from materializedLazyColumns and carry this operator's ids, so init_global_dicts_for_scan_node searched a map that did not contain its slot:

    query_global_dicts has 1 entries, slot ids = [38,]
    slot=41 name=v1 slotType=INT tabletIdx=1 dictFound=0

Finding nothing, it skipped applying the dictionary, and the reader returned the raw string into a column the plan had already typed as an int. That surfaced four different ways, all from this one id: a decode failure against a "key" that was really string bytes (845230433), a CHECK on a NullableColumn whose data and null columns had drifted, an out-of-bounds read while sorting the fetched chunk, and a 32-byte heap write while deserializing the fetch response.

Key the dictionary by the id the lookup asks with. With that, the same statement returns its rows and the tap reads slot ids = [41,], dictFound=1.

Also stop init_global_dicts_for_scan_node skipping in silence. When the plan types a slot as an int over a string column it is asking to read a dictionary code, and having no dictionary for it is not a case to degrade through -- the reader would hand back bytes that are not codes. Return an error naming the slot instead. It did not fire once the id was fixed; it is there so the next id-space mismatch arrives as a diagnosable error rather than as memory corruption.

Ten rows and three distinct values are enough to reproduce; the dictionary engages within about ten seconds.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
