### PR TITLE
[Enhancement] Choose the scan row carrier deterministically so index-answered wide columns stay prunable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -41,6 +41,7 @@ import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableFunctionTable;
 import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.VirtualColumnRegistry;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.catalog.system.information.FeMetricsSystemTable;
 import com.starrocks.catalog.system.information.LoadTrackingLogsSystemTable;
@@ -247,6 +248,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -264,6 +266,7 @@ import static com.starrocks.catalog.Function.CompareMode.IS_NONSTRICT_SUPERTYPE_
 import static com.starrocks.sql.common.ErrorType.INTERNAL_ERROR;
 import static com.starrocks.sql.common.UnsupportedException.unsupportedException;
 import static com.starrocks.sql.optimizer.operator.scalar.ScalarOperator.isColumnEqualConstant;
+import static com.starrocks.thrift.PlanNodesConstants.ROW_ID_COLUMN_NAME;
 
 /**
  * PlanFragmentBuilder used to transform physical operator to exec plan fragment
@@ -589,7 +592,8 @@ public class PlanFragmentBuilder {
          * used in the stage after scan.
          */
         private void setUnUsedOutputColumns(PhysicalOlapScanOperator node, OlapScanNode scanNode,
-                                            List<ScalarOperator> predicates, OlapTable referenceTable) {
+                                            List<ScalarOperator> predicates, OlapTable referenceTable,
+                                            ExecPlan context) {
             SessionVariable sessionVariable = ConnectContext.get().getSessionVariable();
             if (!sessionVariable.isEnableFilterUnusedColumnsInScanStage()) {
                 return;
@@ -610,10 +614,11 @@ public class PlanFragmentBuilder {
                     .map(ColumnRefOperator::getId)
                     .collect(Collectors.toSet());
             // Empty outputColumnIds means that the expression after ScanNode does not need any column from ScanNode.
-            // However, at least one column needs to be output, so choose any column as the output column.
+            // However, at least one column needs to be output, so choose one column as the row carrier.
             if (requiredColumns.isEmpty()) {
-                if (!scanNode.getSlots().isEmpty()) {
-                    requiredColumns.add(scanNode.getSlots().get(0).getId().asInt());
+                SlotDescriptor carrier = chooseRowCarrierSlot(node, scanNode, predicates, referenceTable, context);
+                if (carrier != null) {
+                    requiredColumns.add(carrier.getId().asInt());
                 }
             }
 
@@ -649,6 +654,70 @@ public class PlanFragmentBuilder {
                     .boxed().filter(c -> !requiredColumns.contains(c))
                     .collect(Collectors.toSet());
             scanNode.setUnUsedOutputStringColumns(unUsedOutputColumnIds);
+        }
+
+        // Keeping the carrier off the wide predicate columns is what leaves them prunable after an index filter.
+        private SlotDescriptor chooseRowCarrierSlot(PhysicalOlapScanOperator node, OlapScanNode scanNode,
+                                                    List<ScalarOperator> predicates, OlapTable referenceTable,
+                                                    ExecPlan context) {
+            List<SlotDescriptor> slots = scanNode.getSlots();
+            if (slots.isEmpty()) {
+                return null;
+            }
+
+            Set<Integer> dictEncodedSlotIds = node.getGlobalDicts().stream()
+                    .map(dict -> dict.first)
+                    .collect(Collectors.toSet());
+            // Ties break on slot id so the same query always materializes the same carrier.
+            SlotDescriptor cheapest = slots.stream()
+                    .filter(slot -> isCheapRowCarrier(slot, dictEncodedSlotIds))
+                    .min(Comparator.comparingInt((SlotDescriptor slot) -> slot.getType().getTypeSize())
+                            .thenComparingInt(slot -> slot.getId().asInt()))
+                    .orElse(null);
+            if (cheapest != null) {
+                return cheapest;
+            }
+
+            SlotDescriptor rowIdCarrier = addRowIdCarrierSlot(scanNode, predicates, referenceTable, context);
+            return rowIdCarrier != null ? rowIdCarrier : slots.get(0);
+        }
+
+        private boolean isCheapRowCarrier(SlotDescriptor slot, Set<Integer> dictEncodedSlotIds) {
+            // A dict-encoded string is read as fixed-width codes, so carrying it costs no more than a scalar.
+            if (dictEncodedSlotIds.contains(slot.getId().asInt())) {
+                return true;
+            }
+            Type type = slot.getType();
+            return type.isNumericType() || type.isDateType() || type.isBoolean();
+        }
+
+        private SlotDescriptor addRowIdCarrierSlot(OlapScanNode scanNode, List<ScalarOperator> predicates,
+                                                   OlapTable referenceTable, ExecPlan context) {
+            if (!Config.enable_virtual_columns || predicates.isEmpty()) {
+                return null;
+            }
+            // Short circuit resolves every slot against the tablet schema, which holds no virtual column.
+            if (context.isShortCircuit()) {
+                return null;
+            }
+            // Query cache normalizes the scan's column list into its digest; keep a synthesized slot out of it.
+            if (ConnectContext.get().getSessionVariable().isEnableQueryCache()) {
+                return null;
+            }
+            Column rowIdColumn = VirtualColumnRegistry.getColumn(ROW_ID_COLUMN_NAME);
+            if (rowIdColumn == null) {
+                return null;
+            }
+
+            // The slot id must come from the factory; the descriptor table's own generator collides with col-ref ids.
+            ColumnRefOperator carrierRef = columnRefFactory.create(ROW_ID_COLUMN_NAME, rowIdColumn.getType(), false);
+            columnRefFactory.updateColumnRefToColumns(carrierRef, rowIdColumn, referenceTable);
+            SlotDescriptor carrier =
+                    context.getDescTbl().addSlotDescriptor(scanNode.getDesc(), new SlotId(carrierRef.getId()));
+            carrier.setColumn(rowIdColumn);
+            carrier.setIsNullable(false);
+            carrier.setIsMaterialized(true);
+            return carrier;
         }
 
         @Override
@@ -1069,10 +1138,10 @@ public class PlanFragmentBuilder {
                         "Build Exec OlapScanNode fail, scan info is invalid", INTERNAL_ERROR, e);
             }
 
-            tupleDescriptor.computeMemLayout();
+            // set unused output columns; it may add a row carrier slot, so lay out memory afterwards
+            setUnUsedOutputColumns(node, scanNode, predicates, referenceTable, context);
 
-            // set unused output columns 
-            setUnUsedOutputColumns(node, scanNode, predicates, referenceTable);
+            tupleDescriptor.computeMemLayout();
 
             // set isPreAggregation
             scanNode.setIsPreAggregation(node.isPreAggregation(), node.getTurnOffReason());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/FilterUnusedColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/FilterUnusedColumnTest.java
@@ -14,8 +14,11 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.utframe.StarRocksAssert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -96,6 +99,114 @@ public class FilterUnusedColumnTest extends PlanTestBase {
         String sql = "select 1 from tpcds_100g_date_dim as ref_0 where ref_0.d_day_name=\"dd\" limit 137";
         String plan = getThriftPlan(sql);
         assertContains(plan, "unused_output_column_name:[]");
+    }
+
+    @Test
+    public void testRowIdCarrierWhenEveryPredicateColumnIsWide() throws Exception {
+        SessionVariable sv = connectContext.getSessionVariable();
+        boolean prevDict = sv.isEnableLowCardinalityOptimize();
+        // UtFrameUtils turns virtual columns off for every FE unit test, while production defaults them on.
+        boolean prevVirtual = Config.enable_virtual_columns;
+        try {
+            // A dict-encoded string is a cheap carrier, so drop the dict to model a high-cardinality column.
+            sv.setEnableLowCardinalityOptimize(false);
+            Config.enable_virtual_columns = true;
+            String sql = "select count(*) from tpcds_100g_date_dim where d_day_name = 'dd'";
+            assertContains(getThriftPlan(sql), "unused_output_column_name:[d_day_name]");
+            assertContains(getDescTbl(sql), "colName:_row_id_");
+        } finally {
+            Config.enable_virtual_columns = prevVirtual;
+            sv.setEnableLowCardinalityOptimize(prevDict);
+        }
+    }
+
+    @Test
+    public void testCheapPredicateColumnPreferredOverRowIdCarrier() throws Exception {
+        SessionVariable sv = connectContext.getSessionVariable();
+        boolean prevDict = sv.isEnableLowCardinalityOptimize();
+        boolean prevVirtual = Config.enable_virtual_columns;
+        try {
+            sv.setEnableLowCardinalityOptimize(false);
+            Config.enable_virtual_columns = true;
+            String sql = "select count(*) from tpcds_100g_date_dim where d_dow > 1 and d_day_name = 'dd'";
+            assertContains(getThriftPlan(sql), "unused_output_column_name:[d_day_name]");
+            Assertions.assertFalse(getDescTbl(sql).contains("colName:_row_id_"));
+        } finally {
+            Config.enable_virtual_columns = prevVirtual;
+            sv.setEnableLowCardinalityOptimize(prevDict);
+        }
+    }
+
+    @Test
+    public void testRowIdCarrierGatedByVirtualColumnsConfig() throws Exception {
+        SessionVariable sv = connectContext.getSessionVariable();
+        boolean prevDict = sv.isEnableLowCardinalityOptimize();
+        boolean prevVirtual = Config.enable_virtual_columns;
+        try {
+            sv.setEnableLowCardinalityOptimize(false);
+            Config.enable_virtual_columns = false;
+            String sql = "select count(*) from tpcds_100g_date_dim where d_day_name = 'dd'";
+            assertContains(getThriftPlan(sql), "unused_output_column_name:[]");
+            Assertions.assertFalse(getDescTbl(sql).contains("colName:_row_id_"));
+        } finally {
+            Config.enable_virtual_columns = prevVirtual;
+            sv.setEnableLowCardinalityOptimize(prevDict);
+        }
+    }
+
+    @Test
+    public void testDeterministicCarrierWithoutVirtualColumns() throws Exception {
+        SessionVariable sv = connectContext.getSessionVariable();
+        boolean prevDict = sv.isEnableLowCardinalityOptimize();
+        boolean prevVirtual = Config.enable_virtual_columns;
+        try {
+            sv.setEnableLowCardinalityOptimize(false);
+            // Without a synthesized carrier the cheapest predicate column still wins, so t1a stays unread.
+            Config.enable_virtual_columns = false;
+            String sql = "select count(1) from test_all_type where t1a='a' and t1b=1 and t1c=2";
+            assertContains(getThriftPlan(sql), "unused_output_column_name:[t1a, t1c]");
+            Assertions.assertFalse(getDescTbl(sql).contains("colName:_row_id_"));
+        } finally {
+            Config.enable_virtual_columns = prevVirtual;
+            sv.setEnableLowCardinalityOptimize(prevDict);
+        }
+    }
+
+    @Test
+    public void testDictEncodedPredicateColumnCarriesRows() throws Exception {
+        SessionVariable sv = connectContext.getSessionVariable();
+        boolean prevDict = sv.isEnableLowCardinalityOptimize();
+        boolean prevVirtual = Config.enable_virtual_columns;
+        try {
+            // A dict-encoded string is read as fixed-width codes, so it carries the rows and no carrier is added.
+            sv.setEnableLowCardinalityOptimize(true);
+            Config.enable_virtual_columns = true;
+            String sql = "select count(*) from test_all_type where t1a = 'a'";
+            assertContains(getThriftPlan(sql), "unused_output_column_name:[]");
+            Assertions.assertFalse(getDescTbl(sql).contains("colName:_row_id_"));
+        } finally {
+            Config.enable_virtual_columns = prevVirtual;
+            sv.setEnableLowCardinalityOptimize(prevDict);
+        }
+    }
+
+    @Test
+    public void testRowIdCarrierGatedByQueryCache() throws Exception {
+        SessionVariable sv = connectContext.getSessionVariable();
+        boolean prevDict = sv.isEnableLowCardinalityOptimize();
+        boolean prevCache = sv.isEnableQueryCache();
+        boolean prevVirtual = Config.enable_virtual_columns;
+        try {
+            sv.setEnableLowCardinalityOptimize(false);
+            Config.enable_virtual_columns = true;
+            sv.setEnableQueryCache(true);
+            String sql = "select count(*) from tpcds_100g_date_dim where d_day_name = 'dd'";
+            assertContains(getThriftPlan(sql), "unused_output_column_name:[]");
+        } finally {
+            Config.enable_virtual_columns = prevVirtual;
+            sv.setEnableQueryCache(prevCache);
+            sv.setEnableLowCardinalityOptimize(prevDict);
+        }
     }
 
     @Test
@@ -248,9 +359,10 @@ public class FilterUnusedColumnTest extends PlanTestBase {
             assertContains(plan, "unused_output_column_name:[]");
         }
         {
+            // Nothing above the scan needs a value, so the cheapest predicate column (t1b) carries the rows.
             String sql = "select count(1) from test_all_type where t1a='a' and t1b=1 and t1c=2";
             String plan = getThriftPlan(sql);
-            assertContains(plan, "unused_output_column_name:[t1b, t1c]");
+            assertContains(plan, "unused_output_column_name:[t1a, t1c]");
         }
 
         {
@@ -266,7 +378,7 @@ public class FilterUnusedColumnTest extends PlanTestBase {
         {
             String sql = "select 1 from test_all_type where t1a='a' and t1b=1 and t1c=2";
             String plan = getThriftPlan(sql);
-            assertContains(plan, "unused_output_column_name:[t1b, t1c]");
+            assertContains(plan, "unused_output_column_name:[t1a, t1c]");
         }
     }
 
@@ -275,12 +387,12 @@ public class FilterUnusedColumnTest extends PlanTestBase {
         {
             String sql = "select count(1) from test_all_type where t1a='a' or (t1b=1 and t1c=2)";
             String plan = getThriftPlan(sql);
-            assertContains(plan, "unused_output_column_name:[t1b, t1c]");
+            assertContains(plan, "unused_output_column_name:[t1a, t1c]");
         }
         {
             String sql = "select count(1) from test_all_type where t1a='a' or (t1b=1 and t1c=2 and t1a='b')";
             String plan = getThriftPlan(sql);
-            assertContains(plan, "unused_output_column_name:[t1b, t1c]");
+            assertContains(plan, "unused_output_column_name:[t1a, t1c]");
         }
         {
             String sql = "select count(1) from test_all_type where t1a='a' or (t1b=1 and t1c=2 and t1d+t1a=3)";
@@ -321,13 +433,13 @@ public class FilterUnusedColumnTest extends PlanTestBase {
             String sql = "select /*+SET_VAR(enable_pushdown_or_predicate=false)*/ " +
                     "count(1) from test_all_type where t1a='a' or (t1b=1 and t1c=2)";
             String plan = getThriftPlan(sql);
-            assertContains(plan, "unused_output_column_name:[t1b, t1c]");
+            assertContains(plan, "unused_output_column_name:[t1a, t1c]");
         }
         {
             String sql = "select /*+SET_VAR(enable_pushdown_or_predicate=false)*/ " +
                     "count(1) from test_all_type where t1a='a' or (t1b=1 and t1c=2 and t1a='b')";
             String plan = getThriftPlan(sql);
-            assertContains(plan, "unused_output_column_name:[t1b, t1c]");
+            assertContains(plan, "unused_output_column_name:[t1a, t1c]");
         }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

`count(*) WHERE <predicate>` needs the scan to emit at least one column, because a chunk with zero columns
cannot express "N rows". Today the row carrier is picked arbitrarily -- `scanNode.getSlots().get(0)` in
`PlanFragmentBuilder#setUnUsedOutputColumns`. When the only materialized slots are predicate-only columns,
that arbitrary pick lands on a predicate column, which then stays in the scan's output schema. And a column
that is in the output schema can never be pruned after an inverted index has answered its predicate
(`SegmentIterator::_build_context`: a column is prunable only if it is *not* in the output schema), so a wide
text column keeps being read and materialized in full even though no predicate needs it any more.

Measured on a 1M-row table with a builtin GIN index on a 138-byte high-cardinality text column, 550K rows
matching, default session variables:

| query | BytesRead | CompressedBytesRead | ScanTime (3 runs) |
|---|---|---|---|
| `select count(*) from t where txt match 'taghot'` | 74.482 MB | 138.857 MB (cold cache) | 18.867 / 18.272 / 18.158 ms |
| `select max(id) from t where txt match 'taghot'` | 4.196 MB | 1.102 MB (cold) | 11.475 / 7.434 / 5.939 ms |

Both queries filter identically (`GinFilterRows` 450,000, `PredFilterRows` 0 -- the predicate really is gone).
The only difference is that `max(id)` has another column to carry the rows, so `txt` gets pruned.

The arbitrariness shows up directly: adding a redundant `AND id > 0` to the `count(*)` moves the carrier onto
`id` and the wide column is pruned. Same semantics, very different cost, decided by slot iteration order.

## What I'm doing:

Making the carrier choice deterministic, and giving it a free option when no real column is cheap:

1. Reuse the cheapest predicate column when one is cheap -- a fixed-width scalar, or a string covered by a
   global dictionary (read as fixed-width codes). Such a column has to be read for its own predicate anyway,
   so carrying the rows on it costs nothing extra. Ties break on slot id so a query always picks the same one.
2. Otherwise -- every candidate is a variable-length column -- carry the rows on the `_row_id_` virtual column,
   which already exists (`VirtualColumnRegistry` / `TRowIdColumnIterator`) and reads no file at all. The wide
   predicate columns then fall out of the output schema and become prunable through the existing
   `enable_prune_column_after_index_filter` path.

No BE change: this reuses the virtual-column plumbing and the index-filter pruning that are already there.

Injecting the synthesized carrier is skipped when `enable_virtual_columns` is off, when the scan has no
predicate, for short-circuit plans (those resolve every slot against the tablet schema, which holds no virtual
column), and when query cache is on (to keep a synthesized slot out of the digest it normalizes). The existing
`enable_filter_unused_columns_in_scan_stage` and non-preaggregation aggregate-family early returns still apply.

Same table, after the change:

| query | BytesRead | ScanTime (3 runs) |
|---|---|---|
| `select count(*) from t where txt match 'taghot'` | **0.000 B** | **4.430 / 4.728 / 3.980 ms** |

15 assorted queries (`OR`, non-pushdown expressions, partially-erased predicates on the same column, `EXISTS`,
`sum(1)`, no predicate, `max(id)`) return byte-identical results before and after.

Cases that deliberately do not change, verified on the same cluster:

| predicate column | before | after |
|---|---|---|
| low-cardinality varchar with a global dictionary (GIN on) | 19.527 / 21.912 / 20.081 ms | 21.387 / 18.492 / 18.875 ms |
| low-cardinality varchar with a global dictionary (GIN off) | 6.537 / 5.964 / 5.463 ms | 6.134 / 6.072 / 5.653 ms |
| mixed `v = '...' AND id > 2500000` | 11.442 / 11.433 / 11.322 ms | 9.969 / 12.638 / 10.437 ms |

A dictionary-encoded carrier costs 4 bytes/row, which is cheaper than the 8-byte `_row_id_` when the index does
not fire, so those columns keep carrying the rows.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

Query results are unchanged; the scan's materialized column set changes, so plans for queries that need no
column value from a scan change shape.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

No backport: this is a performance change, not a wrong-result fix, and the `_row_id_` virtual column it
relies on does not exist on 3.5 / 4.0 / 4.1.
