### PR TITLE
[BugFix] Silence expected tablet reshard history lookup warnings

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
@@ -514,7 +514,6 @@ public class MergeTabletJob extends TabletReshardJob {
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             item.setDb_name("");
-            LOG.warn("Failed to get database name for tablet reshard job. {}", this);
         } else {
             item.setDb_name(db.getFullName());
         }
@@ -523,7 +522,6 @@ public class MergeTabletJob extends TabletReshardJob {
         Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(dbId, tableId);
         if (table == null) {
             item.setTable_name("");
-            LOG.warn("Failed to get table name for tablet reshard job. {}", this);
         } else {
             item.setTable_name(table.getName());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -550,7 +550,6 @@ public class SplitTabletJob extends TabletReshardJob {
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             item.setDb_name("");
-            LOG.warn("Failed to get database name for tablet reshard job. {}", this);
         } else {
             item.setDb_name(db.getFullName());
         }
@@ -559,7 +558,6 @@ public class SplitTabletJob extends TabletReshardJob {
         Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(dbId, tableId);
         if (table == null) {
             item.setTable_name("");
-            LOG.warn("Failed to get table name for tablet reshard job. {}", this);
         } else {
             item.setTable_name(table.getName());
         }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardJobMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardJobMgrTest.java
@@ -27,21 +27,46 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.MergeTabletClause;
 import com.starrocks.thrift.TTabletReshardJobsItem;
+import com.starrocks.thrift.TTabletReshardJobsResponse;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class TabletReshardJobMgrTest {
     // A JMockit @Mock for a static method must itself be static, so it cannot capture a local of the
     // enclosing test method; the counters it writes live here instead. Reset before each test.
     private static final AtomicInteger NODE_COUNT_RESOLUTIONS = new AtomicInteger();
+
+    private static class WarnCounterAppender extends AbstractAppender {
+        private final AtomicInteger warnCount = new AtomicInteger();
+
+        WarnCounterAppender() {
+            super("tablet-reshard-warn-counter", null, null);
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            if (event.getLevel() == Level.WARN) {
+                warnCount.incrementAndGet();
+            }
+        }
+
+        int getWarnCount() {
+            return warnCount.get();
+        }
+    }
 
     private static void stubCountingNodeCount() {
         new MockUp<TabletReshardUtils>() {
@@ -303,6 +328,49 @@ public class TabletReshardJobMgrTest {
         jobMgr.addTabletReshardJob(job2);
 
         Assertions.assertEquals(2, jobMgr.getAllJobsInfo().getItems().size());
+    }
+
+    @Test
+    public void testGetTabletReshardJobsInfoDoesNotWarnForDroppedMetadata() {
+        TabletReshardJobMgr jobMgr = new TabletReshardJobMgr();
+        long splitJobId = 101L;
+        long mergeJobId = 102L;
+        SplitTabletJob splitJob = new SplitTabletJob(splitJobId, -1L, -1L, Map.of());
+        splitJob.jobState = TabletReshardJob.JobState.FINISHED;
+        jobMgr.tabletReshardJobs.put(splitJobId, splitJob);
+        MergeTabletJob mergeJob = new MergeTabletJob(mergeJobId, reshardDb.getId(), -1L, Map.of());
+        mergeJob.jobState = TabletReshardJob.JobState.FINISHED;
+        jobMgr.tabletReshardJobs.put(mergeJobId, mergeJob);
+
+        WarnCounterAppender appender = new WarnCounterAppender();
+        org.apache.logging.log4j.core.Logger splitLogger =
+                (org.apache.logging.log4j.core.Logger) LogManager.getLogger(SplitTabletJob.class);
+        org.apache.logging.log4j.core.Logger mergeLogger =
+                (org.apache.logging.log4j.core.Logger) LogManager.getLogger(MergeTabletJob.class);
+        appender.start();
+        splitLogger.addAppender(appender);
+        mergeLogger.addAppender(appender);
+
+        TTabletReshardJobsResponse response;
+        try {
+            response = jobMgr.getAllJobsInfo();
+        } finally {
+            splitLogger.removeAppender(appender);
+            mergeLogger.removeAppender(appender);
+            appender.stop();
+        }
+
+        Assertions.assertEquals(0, appender.getWarnCount(),
+                "dropped metadata is expected for retained history jobs and must not produce warnings");
+        Assertions.assertEquals(2, response.getItemsSize());
+        TTabletReshardJobsItem splitItem = response.getItems().stream()
+                .filter(item -> item.getJob_id() == splitJobId).findFirst().orElseThrow();
+        Assertions.assertEquals("", splitItem.getDb_name());
+        Assertions.assertEquals("", splitItem.getTable_name());
+        TTabletReshardJobsItem mergeItem = response.getItems().stream()
+                .filter(item -> item.getJob_id() == mergeJobId).findFirst().orElseThrow();
+        Assertions.assertEquals(reshardDb.getFullName(), mergeItem.getDb_name());
+        Assertions.assertEquals("", mergeItem.getTable_name());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Retained tablet reshard history jobs can outlive their database or table. Every query of `information_schema.tablet_reshard_jobs` currently treats the expected missing metadata as an error and emits up to two WARN logs per history job, amplifying routine monitoring queries into severe FE log growth.

## What I'm doing:

- Stop logging WARN when a retained split or merge history job can no longer resolve its database or table name.
- Preserve the history row, IDs, response status, and existing empty `DB_NAME` / `TABLE_NAME` values.
- Add a manager-level regression test that covers both split and merge history jobs and captures their real Log4j WARN output.

Fixes StarRocks/StarRocksTest#11940

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
