### PR TITLE
[BugFix] Read the last conf line when the file has no trailing newline

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -65,7 +65,7 @@ read_var_from_conf() {
 }
 
 export_env_from_conf() {
-    while read line; do
+    while read line || [[ -n "$line" ]]; do
         envline=`echo $line | sed 's/[[:blank:]]*=[[:blank:]]*/=/g' | sed 's/^[[:blank:]]*//g' | grep -E "^[[:upper:]]([[:upper:]]|_|[[:digit:]])*="`
         envline=`eval "echo $envline"`
         if [[ $envline == *"="* ]]; then


### PR DESCRIPTION
## Why I'm doing:

`export_env_from_conf()` in `bin/common.sh` loses the last line of a conf file
when that file does not end with a newline.

`read` returns a non-zero exit status when it hits EOF without a line
delimiter, so `while read line` exits *after* having already stored the final
line in `$line` — the loop body never runs for it. Concretely, with a
`be.conf`/`fe.conf` whose last line is `MY_VAR=hello` and no trailing newline,
that variable is silently never exported, and the process starts with a
partially applied configuration. Editors and generators that omit the final
newline make this easy to hit, and the failure is silent — no warning, just a
missing env var.

Reproduction:

```bash
printf 'JAVA_OPTS="-Xmx1g"\nMY_LAST_VAR=hello' > t.conf   # no trailing newline
while read line; do echo "got:[$line]"; done < t.conf
# got:[JAVA_OPTS="-Xmx1g"]        <- MY_LAST_VAR is dropped
```

## What I'm doing:

Guard the loop condition with `|| [[ -n "$line" ]]` so a final unterminated
line is still processed:

```bash
while read line || [[ -n "$line" ]]; do
```

With the fix, the same reproduction prints both lines. Files that do end with a
newline are unaffected: `$line` is empty when `read` fails, so the loop still
terminates immediately.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
