### PR TITLE
[BugFix] Skip the publish-time segment rewrite for a delete-only lake write

### DIFF
--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -36,6 +36,7 @@
 #include "storage/lake/meta_file.h"
 #include "storage/lake/rowset.h"
 #include "storage/lake/tablet_range_helper.h"
+#include "storage/lake/txn_log_applier.h"
 #include "storage/lake/update_manager.h"
 #include "storage/lake/vector_index_utils.h"
 #include "storage/olap_common.h"
@@ -495,13 +496,19 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
     ASSIGN_OR_RETURN(auto fs, FileSystemFactory::CreateSharedFromString(root_path));
     std::shared_ptr<TabletSchema> tablet_schema = std::make_shared<TabletSchema>(params.metadata->schema());
     // get rowset schema
-    // Segments count as "there is something to rewrite" alongside num_rows. On a split cross
-    // publish that count is apportioned per sibling, so a row-mode partial update whose segments
-    // hold this tablet's rows can still arrive with num_rows == 0; returning on the count alone
-    // would leave the partial segment (only the updated columns) attached without its unmodified
-    // columns rewritten in.
+    // Whether there is anything to rewrite is exactly "does this rowset hold rows", so ask the shared
+    // predicate rather than either count on its own. The rowset counter is apportioned per sibling on
+    // a split cross publish, so a row-mode partial update whose segments hold this tablet's rows can
+    // arrive with num_rows == 0; returning on it alone would leave the partial segment (only the
+    // updated columns) attached without its unmodified columns rewritten in. Merely counting segments
+    // is not enough either: a DELETE-only write is also a "partial update" (its write schema is just
+    // the primary key columns) and it emits one segment per flush that is empty by construction --
+    // the segment exists only to reserve the del file's op_offset. Rewriting those is pointless IO,
+    // and fatal once ORDER BY puts value columns into a primary key table's sort key, because the
+    // rewrite writes the unmodified (value-only) column set and SegmentWriter::init then demands the
+    // whole sort key be present in it.
     if (!params.op_write.has_txn_meta() || params.op_write.rewrite_segments_meta_size() == 0 ||
-        (rowset_meta.num_rows() == 0 && rowset_meta.segment_metas_size() == 0)) {
+        !rowset_holds_rows(rowset_meta)) {
         return Status::OK();
     }
     RETURN_ERROR_IF_FALSE(params.op_write.rewrite_segments_meta_size() == rowset_meta.segment_metas_size());

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -44,6 +44,32 @@
 
 namespace starrocks::lake {
 
+// Does this rowset hold any rows? The rowset-level count alone cannot answer it: a split cross
+// publish apportions that count across the siblings, so a rowset whose segments hold this tablet's
+// rows can arrive with num_rows == 0 and be mistaken for empty. The per-segment counts are not
+// apportioned, so they settle it -- and they also keep a genuinely empty write (segments written,
+// no rows in them) out, which the segment count alone would not.
+//
+// The last clause covers a legacy rowset whose segment_metas were back-filled by
+// normalize_*_after_load from the deprecated parallel arrays, which carry no per-segment count:
+// nothing proves it empty, so it is kept.
+bool rowset_holds_rows(const RowsetMetadataPB& rowset) {
+    if (rowset.num_rows() > 0) {
+        return true;
+    }
+    if (rowset.segment_metas_size() == 0) {
+        return false;
+    }
+    bool any_segment_counted = false;
+    for (const auto& segment_meta : rowset.segment_metas()) {
+        if (segment_meta.num_rows() > 0) {
+            return true;
+        }
+        any_segment_counted |= segment_meta.has_num_rows();
+    }
+    return !any_segment_counted;
+}
+
 namespace {
 
 // Non-clearing archival of the tablet's current schema before a new schema is installed: map every
@@ -200,32 +226,6 @@ Status update_metadata_schema(const TxnLogPB_OpWrite& op_write, int64_t txn_id,
     tablet_meta->mutable_schema()->Clear();
     new_schema->to_schema_pb(tablet_meta->mutable_schema());
     return Status::OK();
-}
-
-// Does this rowset hold any rows? The rowset-level count alone cannot answer it: a split cross
-// publish apportions that count across the siblings, so a rowset whose segments hold this tablet's
-// rows can arrive with num_rows == 0 and be mistaken for empty. The per-segment counts are not
-// apportioned, so they settle it -- and they also keep a genuinely empty write (segments written,
-// no rows in them) out, which the segment count alone would not.
-//
-// The last clause covers a legacy rowset whose segment_metas were back-filled by
-// normalize_*_after_load from the deprecated parallel arrays, which carry no per-segment count:
-// nothing proves it empty, so it is kept.
-bool rowset_holds_rows(const RowsetMetadataPB& rowset) {
-    if (rowset.num_rows() > 0) {
-        return true;
-    }
-    if (rowset.segment_metas_size() == 0) {
-        return false;
-    }
-    bool any_segment_counted = false;
-    for (const auto& segment_meta : rowset.segment_metas()) {
-        if (segment_meta.num_rows() > 0) {
-            return true;
-        }
-        any_segment_counted |= segment_meta.has_num_rows();
-    }
-    return !any_segment_counted;
 }
 
 // Build rssid_remap for DCG application during replication.

--- a/be/src/storage/lake/txn_log_applier.h
+++ b/be/src/storage/lake/txn_log_applier.h
@@ -24,11 +24,17 @@
 namespace starrocks {
 class TxnLogPB;
 class TabletMetadataPB;
+class RowsetMetadataPB;
 } // namespace starrocks
 
 namespace starrocks::lake {
 
 class Tablet;
+
+// Does this rowset hold any rows? Neither the rowset-level count nor the segment count alone can
+// answer it -- see the definition for why. Callers use it to decide whether an op_write carries
+// anything at all.
+bool rowset_holds_rows(const RowsetMetadataPB& rowset);
 
 class TxnLogApplier {
 public:

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -288,7 +288,13 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
             sort_column_idx_by_column_index[column_index] = i;
         }
     }
-    if (!sort_column_idx_by_column_index.empty()) {
+    // Only a key-columns pass builds the short key / full sort key index out of these positions (see
+    // the `if (_has_key)` branch of append_chunk), so only it needs the whole sort key present. A
+    // value-only pass -- a partial-update segment rewrite, or a vertical writer's value column group
+    // -- never touches _sort_column_indexes, and demanding the full sort key there is a false alarm:
+    // fatal once ORDER BY puts value columns into a primary key table's sort key, since the pass then
+    // holds SOME sort key columns (map non-empty) but not the key ones.
+    if (has_key && !sort_column_idx_by_column_index.empty()) {
         for (auto& column_idx : _tablet_schema->sort_key_idxes()) {
             auto iter = sort_column_idx_by_column_index.find(column_idx);
             if (iter != sort_column_idx_by_column_index.end()) {

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -1747,6 +1747,208 @@ protected:
     Chunk::SlotHashMap _slot_cid_map;
 };
 
+// `ORDER BY` may put value columns into a primary key table's sort key while still keeping a key
+// column in it, e.g. PRIMARY KEY(c0) ORDER BY(c1, c0). A DELETE on such a table reaches the writer
+// as a "partial update" (its write schema is just the key columns), and its publish must not try to
+// rewrite the empty segment that the delete-only flush emits: the rewrite would write the unmodified
+// columns (c1, c2) alone, a column set that holds SOME sort key columns but not c0.
+class LakeSortKeyWithValueColumnDeleteTest : public TestBase {
+public:
+    LakeSortKeyWithValueColumnDeleteTest() : TestBase(kTestDirectory) {
+        _tablet_metadata = std::make_shared<TabletMetadata>();
+        _tablet_metadata->set_id(next_id());
+        _tablet_metadata->set_version(1);
+        _tablet_metadata->set_next_rowset_id(1);
+        //
+        //  | column | type | KEY | NULL | SORTKEY |
+        //  +--------+------+-----+------+---------+
+        //  |   c0   |  INT | YES |  NO  |   YES   |
+        //  |   c1   |  INT | NO  |  YES |   YES   |
+        //  |   c2   |  INT | NO  |  YES |   NO    |
+        auto schema = _tablet_metadata->mutable_schema();
+        schema->set_id(next_id());
+        schema->set_num_short_key_columns(1);
+        schema->set_keys_type(PRIMARY_KEYS);
+        schema->set_num_rows_per_row_block(65535);
+        auto c0 = schema->add_column();
+        {
+            c0->set_unique_id(next_id());
+            c0->set_name("c0");
+            c0->set_type("INT");
+            c0->set_is_key(true);
+            c0->set_is_nullable(false);
+        }
+        auto c1 = schema->add_column();
+        {
+            c1->set_unique_id(next_id());
+            c1->set_name("c1");
+            c1->set_type("INT");
+            c1->set_is_key(false);
+            c1->set_is_nullable(true);
+            c1->set_aggregation("REPLACE");
+        }
+        auto c2 = schema->add_column();
+        {
+            c2->set_unique_id(next_id());
+            c2->set_name("c2");
+            c2->set_type("INT");
+            c2->set_is_key(false);
+            c2->set_is_nullable(true);
+            c2->set_aggregation("REPLACE");
+        }
+        // ORDER BY(c1, c0): a value column first, the key column second. The delete's rewrite column
+        // set (c1, c2) therefore intersects the sort key without covering it.
+        schema->add_sort_key_idxes(1);
+        schema->add_sort_key_idxes(0);
+        _tablet_schema = TabletSchema::create(*schema);
+        _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+
+        // A DELETE hands the writer the key columns plus the trailing __op marker.
+        _delete_slots.emplace_back(0, "c0", TypeDescriptor{LogicalType::TYPE_INT});
+        _delete_slots.emplace_back(1, "__op", TypeDescriptor{LogicalType::TYPE_TINYINT});
+        for (auto& slot : _delete_slots) {
+            _delete_slot_pointers.emplace_back(&slot);
+        }
+    }
+
+    void SetUp() override {
+        clear_and_init_test_dir();
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    }
+
+    void TearDown() override {
+        EXPECT_TRUE(_update_mgr->TEST_check_primary_index_cache_ref(_tablet_metadata->id(), 1));
+        StorageEngine::instance()->wait_storage_cleanup_tasks();
+        remove_test_dir_or_die();
+    }
+
+    Chunk generate_full_data(int64_t chunk_size) {
+        auto c0 = Int32Column::create();
+        auto c1 = Int32Column::create();
+        auto c2 = Int32Column::create();
+        for (int i = 0; i < chunk_size; i++) {
+            c0->append(i);
+            c1->append(i * 3);
+            c2->append(i * 7);
+        }
+        Chunk::SlotHashMap slot_cid_map;
+        slot_cid_map[0] = 0;
+        slot_cid_map[1] = 1;
+        slot_cid_map[2] = 2;
+        return Chunk({std::move(c0), std::move(c1), std::move(c2)}, slot_cid_map);
+    }
+
+    Chunk generate_delete_data(int64_t chunk_size) {
+        auto c0 = Int32Column::create();
+        auto cop = Int8Column::create();
+        for (int i = 0; i < chunk_size; i++) {
+            c0->append(i);
+            cop->append(TOpType::DELETE);
+        }
+        Chunk::SlotHashMap slot_cid_map;
+        slot_cid_map[0] = 0;
+        slot_cid_map[1] = 1;
+        return Chunk({std::move(c0), std::move(cop)}, slot_cid_map);
+    }
+
+    int64_t read_rows(int64_t tablet_id, int64_t version) {
+        ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+        auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata, *_schema);
+        CHECK_OK(reader->prepare());
+        CHECK_OK(reader->open(TabletReaderParams()));
+        auto chunk = ChunkFactory::new_chunk(*_schema, 128);
+        int64_t rows = 0;
+        while (true) {
+            auto st = reader->get_next(chunk.get());
+            if (st.is_end_of_file()) {
+                break;
+            }
+            CHECK_OK(st);
+            rows += chunk->num_rows();
+            chunk->reset();
+        }
+        return rows;
+    }
+
+protected:
+    constexpr static const char* const kTestDirectory = "test_lake_sort_key_with_value_column_delete";
+    constexpr static const int kChunkSize = 12;
+
+    std::shared_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<Schema> _schema;
+    int64_t _partition_id = 4562;
+    std::vector<SlotDescriptor> _delete_slots;
+    std::vector<SlotDescriptor*> _delete_slot_pointers;
+};
+
+TEST_F(LakeSortKeyWithValueColumnDeleteTest, test_delete_publish) {
+    auto tablet_id = _tablet_metadata->id();
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+    int64_t version = 1;
+
+    // Load the rows with a full-schema write.
+    {
+        auto chunk = generate_full_data(kChunkSize);
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto dw, DeltaWriterBuilder()
+                                         .set_tablet_manager(_tablet_mgr.get())
+                                         .set_tablet_id(tablet_id)
+                                         .set_txn_id(txn_id)
+                                         .set_partition_id(_partition_id)
+                                         .set_mem_tracker(_mem_tracker.get())
+                                         .set_schema_id(_tablet_schema->id())
+                                         .build());
+        ASSERT_OK(dw->open());
+        ASSERT_OK(dw->write(chunk, indexes.data(), indexes.size()));
+        ASSERT_OK(dw->finish_with_txnlog());
+        dw->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
+
+    // Delete every row. The delete-only flush emits a 0-row segment plus a del file, and the txn log
+    // carries partial-update metadata for it; publishing must skip the rewrite of that empty segment
+    // instead of failing with "is sort key but not find while init segment writer".
+    {
+        auto chunk = generate_delete_data(kChunkSize);
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto dw, DeltaWriterBuilder()
+                                         .set_tablet_manager(_tablet_mgr.get())
+                                         .set_tablet_id(tablet_id)
+                                         .set_txn_id(txn_id)
+                                         .set_partition_id(_partition_id)
+                                         .set_mem_tracker(_mem_tracker.get())
+                                         .set_schema_id(_tablet_schema->id())
+                                         .set_slot_descriptors(&_delete_slot_pointers)
+                                         .build());
+        ASSERT_OK(dw->open());
+        ASSERT_OK(dw->write(chunk, indexes.data(), indexes.size()));
+        ASSERT_OK(dw->finish_with_txnlog());
+        dw->close();
+
+        // The regression only bites when the txn log really does look like a partial update with an
+        // empty segment to rewrite -- assert that shape so the test cannot silently stop covering it.
+        ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_log(tablet_id, txn_id));
+        const auto& op_write = txn_log->op_write();
+        ASSERT_TRUE(op_write.has_txn_meta());
+        ASSERT_GT(op_write.rewrite_segments_meta_size(), 0);
+        ASSERT_EQ(0, op_write.rowset().num_rows());
+        ASSERT_GT(op_write.rowset().segment_metas_size(), 0);
+        for (const auto& segment_meta : op_write.rowset().segment_metas()) {
+            ASSERT_EQ(0, segment_meta.num_rows());
+        }
+
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    ASSERT_EQ(0, read_rows(tablet_id, version));
+}
+
 TEST_F(LakeIncompleteSortKeyPartialUpdateTest, test_incomplete_sort_key) {
     auto chunk0 = generate_data(kChunkSize, 0, 3);
     auto indexes = std::vector<uint32_t>(kChunkSize);

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -2049,6 +2049,85 @@ TEST_P(LakePartialUpdateTest, test_partial_update_retry_rewrite_check) {
     ASSERT_EQ(kChunkSize, check(version + 1, [](int c0, int c1, int c2) { return (c0 * 5 == c1) && (c0 * 4 == c2); }));
 }
 
+// The other half of the guard in RowsetUpdateState::rewrite_segment: a row-mode partial update whose
+// rowset-level num_rows has been apportioned to 0 by a split cross publish must STILL be rewritten,
+// because its segments do hold this tablet's rows. Emulate the apportionment by zeroing the txn log's
+// rowset counter while leaving the per-segment counts alone -- exactly what
+// tablet_reshard_helper::update_rowset_data_stats does to a sibling.
+//
+// c2 is the assertion that has teeth: it is not in the partial write, so it only survives if the
+// rewrite merged the unmodified columns back in. Skipping the rewrite would attach a segment holding
+// c0 and c1 alone.
+TEST_P(LakePartialUpdateTest, test_partial_update_rewrite_with_apportioned_num_rows) {
+    if (GetParam().enable_persistent_index) return;
+    if (GetParam().partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) return;
+    auto chunk0 = generate_data(kChunkSize, 0, false, 3);
+    auto chunk1 = generate_data(kChunkSize, 0, true, 5);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
+
+    auto txn_id = next_id();
+    {
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+    }
+
+    // Apportion the rowset counter down to 0, leaving the per-segment counts as the only witness
+    // that this rowset holds rows.
+    {
+        ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_log(tablet_id, txn_id));
+        auto apportioned = std::make_shared<TxnLogPB>(*txn_log);
+        auto* rowset = apportioned->mutable_op_write()->mutable_rowset();
+        ASSERT_GT(rowset->num_rows(), 0);
+        ASSERT_GT(rowset->segment_metas_size(), 0);
+        rowset->set_num_rows(0);
+        int64_t segment_rows = 0;
+        for (const auto& segment_meta : rowset->segment_metas()) {
+            segment_rows += segment_meta.num_rows();
+        }
+        ASSERT_GT(segment_rows, 0) << "the per-segment counts must survive the apportionment";
+        ASSERT_OK(_tablet_mgr->put_txn_log(apportioned));
+        _tablet_mgr->prune_metacache();
+    }
+
+    ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+    ASSERT_EQ(kChunkSize, check(version + 1, [](int c0, int c1, int c2) { return (c0 * 5 == c1) && (c0 * 4 == c2); }));
+}
+
 TEST_P(LakePartialUpdateTest, test_write_multi_segment_by_diff_val_mem_limit) {
     auto chunk0 = generate_data(kChunkSize, 0, false, 3);
     auto chunk1 = generate_data(kChunkSize, 0, true, 5);

--- a/be/test/storage/lake/txn_log_applier_test.cpp
+++ b/be/test/storage/lake/txn_log_applier_test.cpp
@@ -248,6 +248,28 @@ TEST(TxnLogApplierBatchTest, NonPrimaryKeySingleLogUncountedSegmentIsKept) {
     EXPECT_EQ(1, meta->rowsets(0).segment_metas_size());
 }
 
+// The primary key applier's skip predicate moved the same way, so check it did not broaden: an
+// op_write that really is empty -- a segment was written but holds no rows, no del files, no delete
+// predicate -- must still be skipped. Note the delete-only case never depended on this predicate;
+// dels_meta_size() > 0 short circuits it.
+//
+// The assertion has teeth because the skip returns BEFORE prepare_primary_index(): had the predicate
+// let this through, publish would go on to open "seg_empty", which does not exist.
+TEST(TxnLogApplierBatchTest, PrimaryKeySingleLogEmptySegmentIsSkipped) {
+    Tablet tablet(StorageEnv::GetInstance()->lake_tablet_manager(), 30010);
+    auto meta = build_pk_metadata(30010);
+    auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+    auto log = make_op_write_log(30010, 60, /*num_rows=*/0, /*data_size=*/0, {"seg_empty"});
+    log->mutable_op_write()->mutable_rowset()->mutable_segment_metas(0)->set_num_rows(0);
+    ASSERT_EQ(0, log->op_write().dels_meta_size());
+    ASSERT_FALSE(log->op_write().rowset().has_delete_predicate());
+
+    Status st = applier->apply(*log);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    EXPECT_EQ(0, meta->rowsets_size());
+}
+
 TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchMergeSparseSegmentIdStep) {
     Tablet tablet(StorageEnv::GetInstance()->lake_tablet_manager(), 10004);
     auto meta = build_non_pk_metadata(10004);


### PR DESCRIPTION
## Why I'm doing:

Fixes StarRocks/StarRocksTest#11953.

On a shared-data primary key table whose `ORDER BY` includes value columns, every `DELETE` fails to publish, deterministically and forever. FE retries publish in a loop, the transaction never leaves `COMMITTED`, the client's `DELETE` never returns, and the table becomes permanently unwritable (reads still work, data is intact, but there is no recovery short of dropping the table).

The failure is only visible inside the transaction:

```
SHOW PROC '/transactions/<db>/running':
  TransactionStatus  COMMITTED
  Reason             Fail to publish version for tablets:[[872401, 872403, 872402]], error msg:
                     column[0]: c1 is sort key but not find while init segment writer
```

Note which column the error names: `c1`, a **key** column. Only a value-only column subset can explain that, and the one writer that gets such a subset at publish time is the partial-update segment rewrite.

Four things stack up:

1. A `DELETE` reaches `DeltaWriterImpl` as a partial update -- its write schema is just the primary key columns -- so `build_txn_log` unconditionally emits `txn_meta` with `partial_update_column_unique_ids` plus one `rewrite_segments_meta` entry per segment.
2. A delete-only flush still produces a segment: `TabletWriterSink::flush_chunk_with_deletes` writes the (empty) upsert chunk on purpose, so the 0-row segment occupies the slot that the del file's `op_offset` refers to and in-transaction upsert/delete ordering is preserved. So `segment_metas_size() >= 1` while `num_rows() == 0`.
3. #77511 changed `RowsetUpdateState::rewrite_segment`'s early return from `num_rows() == 0` to `num_rows() == 0 && segment_metas_size() == 0`, so that a split cross publish -- where the per-sibling row count is apportioned and can round to 0 -- still rewrites segments that do hold this tablet's rows. A delete-only rowset always carries a segment, so it stopped early-returning and started actually rewriting.
4. The rewrite writes the *unmodified* columns, i.e. value columns only. `SegmentWriter::init` then arms its sort-key completeness check (the value subset does contain some sort key columns) and fails on the key column that is not in this pass.

Before #77511 the delete-only rowset early-returned on `num_rows() == 0` and `DELETE` published normally. Timeline matches: this job's archived builds #49-#53 (newest `main-aafb966`, 2026-08-05) ran the same case with 0 hits of `is sort key but not find`; build #54 (`main-c00146a`, 2026-08-19) is the first occurrence.

`ORDER BY` with only key columns does not trigger it: the value-only subset then contains no sort key column, the check never arms, and the (pointless) rewrite silently succeeds. Shared-nothing is unaffected -- `RowsetWriter` has an explicit delete-only short circuit (`_flush_chunk_state != FlushChunkState::DELETE`) that the lake path has no counterpart for.

Affected: OSS main (`d24e5dc4b73`) and branch-4.1 (backport #77957, `c023ed704fa`). branch-4.0 and branch-3.5 do not carry the commit and are not affected.

## What I'm doing:

**`RowsetUpdateState::rewrite_segment`** -- "is there anything to rewrite" is exactly "does this rowset hold rows", which `rowset_holds_rows` already answers for the two txn log appliers. Use it instead of trusting either count on its own: it consults the per-segment counts (which are *not* apportioned by a cross publish) and so keeps #77511's fix while restoring the early return for a delete-only write, whose segments are all empty. Lift the predicate out of the anonymous namespace in `txn_log_applier.cpp` and declare it in the header for the new caller.

**`SegmentWriter::init`** -- gate the sort-key completeness check on `has_key`. Only a key-columns pass builds the short key / full sort key index out of those positions (see the `if (_has_key)` branch of `append_chunk`), so only it needs the whole sort key present. A value-only pass -- a partial-update segment rewrite, or a vertical writer's value column group -- never reads `_sort_column_indexes`, so demanding coverage there is a false alarm. Today the vertical writer only escapes it because `split_column_into_groups` happens to put every sort key column in the first group; this makes the invariant explicit instead of incidental.

For the record, one thing the issue flagged as a suspected wider blast radius turns out **not** to be a bug: row-mode partial update on such a table is rejected up front by `DeltaWriterImpl::check_partial_update_with_sort_key` with `partial update on table with sort key must provide all sort key columns`, and that same guard deliberately whitelists an all-`DELETE` chunk. So the delete-only path is meant to work, which is what #77511 broke.

## Tests

`LakeSortKeyWithValueColumnDeleteTest.test_delete_publish` -- `PRIMARY KEY(c0) ORDER BY(c1, c0)`, full-schema load, publish, then delete every row and publish. It also asserts the txn log's shape (has `txn_meta`, has `rewrite_segments_meta`, rowset `num_rows == 0`, every segment `num_rows == 0`) so the test cannot silently stop covering the scenario. Without the fix it hits `column[0]: c0 is sort key but not find while init segment writer`.

While here: #77511 moved three predicates the same way and only one of the three (the non-PK applier) had a test. Filling the other two in, since this PR is touching that guard:

- `test_partial_update_rewrite_with_apportioned_num_rows` -- the positive side of `rewrite_segment`, which was never covered: a row-mode partial update whose rowset counter has been apportioned to 0 must still be rewritten. The test emulates the apportionment by zeroing the txn log's rowset `num_rows` while leaving the per-segment counts alone, exactly what `update_rowset_data_stats` does to a sibling. `c2` is the witness -- it is not in the partial write, so it only survives if the rewrite merged the unmodified columns back in.
- `PrimaryKeySingleLogEmptySegmentIsSkipped` -- the PK applier's skip predicate did not broaden: a genuinely empty write is still skipped. The assertion has teeth because the skip returns before `prepare_primary_index()`, so letting it through would try to open a segment file that does not exist.

Two things noted while auditing the rest of #77511's call sites, neither a defect in this PR's scope:

- `replication_txn_manager.cpp:472` builds `segment_metas` with only `filename` and `encryption_meta`, so every transcoded (shared-nothing to shared-data) op_write lands in `rowset_holds_rows`' "no per-segment count was recorded, so nothing proves it empty" branch. That branch is therefore live on the replication path today, not just on legacy on-disk data. The direction is safe (keep rather than drop) and it in fact fixes a latent drop there, but it is untested.
- `build_rssid_remap` must model the appliers' predicates exactly -- a drift silently shifts every downstream rssid in the replication DCG remap. It now uses the same helper as both appliers, which is the point, but it has no test; it sits in an anonymous namespace and can only be reached through applying an `OpReplication`. Worth a follow-up rather than growing this PR.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
