### PR TITLE
[BugFix] Force single-stage aggregation for histogram() to prevent BE crash

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -34,6 +34,8 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.JoinOperator;
 import com.starrocks.sql.ast.KeysType;
+import com.starrocks.sql.common.ErrorType;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.common.TypeManager;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.LogicalProperty;
@@ -749,6 +751,11 @@ public class Utils {
 
     public static boolean couldGenerateMultiStageAggregate(LogicalProperty inputLogicalProperty,
                                                            Operator inputOp, Operator childOp) {
+        // 0. Safety: prevent functions that crash in multi-stage (must run before any hint/override logic).
+        if (cannotGenerateMultiStageAggregate(inputOp)) {
+            return false;
+        }
+
         // 1. check if must generate multi stage aggregate.
         if (mustGenerateMultiStageAggregate(inputOp, childOp)) {
             return true;
@@ -792,6 +799,35 @@ public class Utils {
                 if (tablet != null) {
                     return tablet.getFuzzyRowCount() > maxTabletRows;
                 }
+            }
+        }
+        return false;
+    }
+
+    public static boolean cannotGenerateMultiStageAggregate(Operator inputOp) {
+        Map<ColumnRefOperator, CallOperator> aggs = Maps.newHashMap();
+        List<ColumnRefOperator> groupingKeys = Lists.newArrayList();
+
+        if (OperatorType.LOGICAL_AGGR.equals(inputOp.getOpType())) {
+            LogicalAggregationOperator aggOp = (LogicalAggregationOperator) inputOp;
+            aggs = aggOp.getAggregations();
+            groupingKeys = aggOp.getGroupingKeys();
+        } else if (OperatorType.PHYSICAL_HASH_AGG.equals(inputOp.getOpType())) {
+            PhysicalHashAggregateOperator aggOp = (PhysicalHashAggregateOperator) inputOp;
+            aggs = aggOp.getAggregations();
+            groupingKeys = aggOp.getGroupBys();
+        }
+
+        for (CallOperator callOperator : aggs.values()) {
+            String fnName = callOperator.getFnName();
+            if (FunctionSet.HISTOGRAM.equalsIgnoreCase(fnName) ||
+                    FunctionSet.HISTOGRAM_HLL_NDV.equalsIgnoreCase(fnName)) {
+                if (!groupingKeys.isEmpty()) {
+                    throw new StarRocksPlannerException(
+                            fnName + "() does not support GROUP BY",
+                            ErrorType.USER_ERROR);
+                }
+                return true;
             }
         }
         return false;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -822,11 +822,6 @@ public class Utils {
             String fnName = callOperator.getFnName();
             if (FunctionSet.HISTOGRAM.equalsIgnoreCase(fnName) ||
                     FunctionSet.HISTOGRAM_HLL_NDV.equalsIgnoreCase(fnName)) {
-                if (callOperator.isDistinct()) {
-                    throw new StarRocksPlannerException(
-                            fnName + "() does not support DISTINCT",
-                            ErrorType.USER_ERROR);
-                }
                 if (!groupingKeys.isEmpty()) {
                     throw new StarRocksPlannerException(
                             fnName + "() does not support GROUP BY",

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -822,6 +822,11 @@ public class Utils {
             String fnName = callOperator.getFnName();
             if (FunctionSet.HISTOGRAM.equalsIgnoreCase(fnName) ||
                     FunctionSet.HISTOGRAM_HLL_NDV.equalsIgnoreCase(fnName)) {
+                if (callOperator.isDistinct()) {
+                    throw new StarRocksPlannerException(
+                            fnName + "() does not support DISTINCT",
+                            ErrorType.USER_ERROR);
+                }
                 if (!groupingKeys.isEmpty()) {
                     throw new StarRocksPlannerException(
                             fnName + "() does not support GROUP BY",

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -3638,4 +3638,21 @@ public class AggregateTest extends PlanTestBase {
         assertContains(plan, "group by: 1: v1, 2: v2, 3: v3");
         assertContains(plan, "output: sum(1: v1)");
     }
+
+    @Test
+    public void testHistogramForcedSingleStage() throws Exception {
+        String sql = "select histogram(v1, 10, 1.0) from t0";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "AGGREGATE (update finalize)");
+        assertNotContains(plan, "update serialize");
+        assertNotContains(plan, "merge finalize");
+    }
+
+    @Test
+    public void testHistogramWithGroupByThrowsError() throws Exception {
+        String sql = "select v2, histogram(v1, 10, 1.0) from t0 group by v2";
+        StarRocksPlannerException exception = assertThrows(StarRocksPlannerException.class,
+                () -> getFragmentPlan(sql));
+        assertThat(exception.getMessage(), containsString("histogram() does not support GROUP BY"));
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -3655,4 +3655,20 @@ public class AggregateTest extends PlanTestBase {
                 () -> getFragmentPlan(sql));
         assertThat(exception.getMessage(), containsString("histogram() does not support GROUP BY"));
     }
+
+    @Test
+    public void testHistogramWithDistinctThrowsError() throws Exception {
+        String sql = "select histogram(distinct v1, 10, 1.0) from t0";
+        StarRocksPlannerException exception = assertThrows(StarRocksPlannerException.class,
+                () -> getFragmentPlan(sql));
+        assertThat(exception.getMessage(), containsString("histogram() does not support DISTINCT"));
+    }
+
+    @Test
+    public void testHistogramWithDistinctAndGroupByThrowsError() throws Exception {
+        String sql = "select v2, histogram(distinct v1, 10, 1.0) from t0 group by v2";
+        StarRocksPlannerException exception = assertThrows(StarRocksPlannerException.class,
+                () -> getFragmentPlan(sql));
+        assertThat(exception.getMessage(), containsString("histogram() does not support DISTINCT"));
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -3655,20 +3655,4 @@ public class AggregateTest extends PlanTestBase {
                 () -> getFragmentPlan(sql));
         assertThat(exception.getMessage(), containsString("histogram() does not support GROUP BY"));
     }
-
-    @Test
-    public void testHistogramWithDistinctThrowsError() throws Exception {
-        String sql = "select histogram(distinct v1, 10, 1.0) from t0";
-        StarRocksPlannerException exception = assertThrows(StarRocksPlannerException.class,
-                () -> getFragmentPlan(sql));
-        assertThat(exception.getMessage(), containsString("histogram() does not support DISTINCT"));
-    }
-
-    @Test
-    public void testHistogramWithDistinctAndGroupByThrowsError() throws Exception {
-        String sql = "select v2, histogram(distinct v1, 10, 1.0) from t0 group by v2";
-        StarRocksPlannerException exception = assertThrows(StarRocksPlannerException.class,
-                () -> getFragmentPlan(sql));
-        assertThat(exception.getMessage(), containsString("histogram() does not support DISTINCT"));
-    }
 }


### PR DESCRIPTION
## Why I'm doing:
`histogram()` crashes every BE when called directly in SQL. Its BE implementation never implemented `serialize_to_column`, but the FE planner still picks 2-stage aggregation by default, which calls it and CHECK-fails → SIGABRT.

histogram is not a public aggregate function, and only calls without GROUP BY are supported.

## What I'm doing:
Added a check in `Utils.couldGenerateMultiStageAggregate()` (step 0, before any hint/session-variable override) for `histogram`/`histogram_hll_ndv`:
- No GROUP BY: forces single-stage aggregation, which fixes the crash.
- With GROUP BY: throws a clear FE error instead of an unverified plan.

FE-only fix, no BE code touched. Added regression tests for both cases.

Fixes #77993

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?
- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:
- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5