### PR TITLE
[BugFix] Preserve dependency ordering in TransactionGraph.remove

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -321,7 +321,13 @@ public class GlobalTransactionMgr implements MemoryTrackable {
      * @throws StarRocksException
      * @throws TransactionCommitFailedException
      * @note it is necessary to optimize the `lock` mechanism and `lock` scope resulting from wait lock long time
-     * @note callers should get db.write lock before call this api
+     * @note Unlike commitAndPublishTransaction and commitPreparedTransaction, this variant takes NO lock of its
+     * own: the caller must hold a WRITE lock on every table the txn writes (in practice
+     * lockTable[s]WithIntensiveDbLock, as CompactionScheduler / BrokerLoadJob / SparkLoadJob / ReplicationJob
+     * do) across this whole call. That lock is not only for metadata safety -- it is what keeps partition
+     * version allocation and TransactionGraph.add() in the same order per table. Committing without it builds
+     * the publish dependency graph in the wrong order, which fails silently here and surfaces later as stuck
+     * or thrashing version publishing. See TransactionGraph.add() for the full contract.
      */
     @NotNull
     public VisibleStateWaiter commitTransaction(long dbId, long transactionId,

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionGraph.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionGraph.java
@@ -32,20 +32,29 @@ import java.util.stream.Collectors;
  * store transactions' dependency relationships
  * this class is used in DatabaseTransactionMgr and all methods are protected by mgr's lock
  * so this class does not require additional synchronization
+ * <p>
+ * Mutual exclusion is not the only thing this class needs from its callers: add() also carries an
+ * ordering contract that the mgr lock alone does not provide. See add().
  */
 public class TransactionGraph {
     private static final Logger LOG = LogManager.getLogger(TransactionGraph.class);
 
     static class Node {
         long txnId;
+        // position in add order. Each table's writer chain is ordered by seq, not by txnId: txn
+        // ids are assigned at begin time but nodes are added at commit time, and txns may commit
+        // out of txn id order. See add() for why add order is the order that matters here, and
+        // what the caller must do to keep it aligned with partition version order.
+        long seq;
         List<Long> writeTableIds;
         // transactions this txn depends
         Set<Node> ins;
         // transactions depending on this txn
         Set<Node> outs;
 
-        Node(long txnId, List<Long> writeTableIds) {
+        Node(long txnId, long seq, List<Long> writeTableIds) {
             this.txnId = txnId;
+            this.seq = seq;
             this.writeTableIds = writeTableIds;
         }
 
@@ -92,6 +101,8 @@ public class TransactionGraph {
     // tableid -> txnId that lastly write this table
     private Map<Long, Node> lastTableWriter = new HashMap<>();
 
+    private long nextSeq = 0;
+
     public TransactionGraph() {
     }
 
@@ -99,12 +110,38 @@ public class TransactionGraph {
         return nodes.size();
     }
 
+    // Ordering contract: for every table, add() must be called in the order in which the txns'
+    // partition versions were allocated. Each table's writer chain, and the seq that identifies
+    // positions on it, are defined by the order of these calls -- so if the calls arrive out of
+    // version order the chain is built wrong and seq faithfully records the wrong order. Nothing
+    // here can detect that.
+    //
+    // The mgr lock does NOT give this. Version allocation (unprotectedCommitPreparedTransaction)
+    // and this add() run in two SEPARATE mgr write-lock windows with an edit-log write between
+    // them, and EditLog.logEditGated runs the WAL apply action outside any lock, so two commits
+    // can reach add() out of allocation order.
+    //
+    // What gives it is a WRITE lock on every table the txn writes, held for the whole commit so it
+    // spans both windows. Two writers of the same table are therefore serialized end to end, so
+    // per table:
+    //     version allocation order == add order == seq order
+    // Txns that share no table may reorder freely; chains are per table, so that is harmless.
+    // Journal replay is single threaded (GlobalStateMgr "replayer" daemon) and replays a given
+    // table's txns in that same order, so a follower rebuilds an equivalent chain.
+    //
+    // That lock is taken by GlobalTransactionMgr.commitTransactionUnderDatabaseWLock and
+    // commitPreparedTransactionUnderIntensiveDbLock -- but NOT by the public
+    // GlobalTransactionMgr.commitTransaction(dbId, ...), which delegates locking to its callers.
+    // Every such caller locks for itself today (CompactionScheduler, BrokerLoadJob, SparkLoadJob,
+    // ReplicationJob); a new one that forgets would corrupt the chains here with no failure at the
+    // call site. Narrowing the lock scope on any commit path breaks this the same silent way.
+    // Keep the lock scope, or give this class its own ordering key.
     public void add(long txnId, List<Long> writeTableIds) {
         if (nodes.containsKey(txnId)) {
             LOG.warn("add an already exist txn:{}", txnId);
             return;
         }
-        Node node = new Node(txnId, writeTableIds);
+        Node node = new Node(txnId, nextSeq++, writeTableIds);
         for (long tableId : writeTableIds) {
             Node previous = lastTableWriter.put(tableId, node);
             if (previous != null) {
@@ -125,28 +162,80 @@ public class TransactionGraph {
             return;
         }
         if (node.ins != null && !node.ins.isEmpty()) {
-            LOG.warn("remove txn " + txnId + " with dependency: " + node.ins + " this may happen during FE upgrading");
-            for (Node dep : node.ins) {
-                dep.outs.remove(node);
-            }
+            // Happens when publish readiness is not decided by this graph, e.g. single
+            // (partition-version based) publish finishing a txn before its predecessors,
+            // or during FE upgrading.
+            LOG.warn("remove txn {} with dependency: {}", txnId, node.ins);
         }
         nodes.remove(txnId);
         nodesWithoutIns.remove(node);
+
+        // Removing a node in the middle of a table's writer chain must not lose ordering:
+        // splice the chain by linking the immediate predecessor to the immediate successor
+        // of every table this node writes, and let lastTableWriter fall back to the
+        // predecessor so a later add() of the same table still picks up the dependency.
+        // Only same-table edges are added; cross-table shortcuts would break the walk in
+        // getTxnsWithTxnDependencyBatch(), which assumes a single-table node has at most
+        // one out edge, pointing to the next writer of that table.
         for (long tableId : node.writeTableIds) {
-            Node holder = lastTableWriter.get(tableId);
-            if (holder == node) {
-                lastTableWriter.remove(tableId);
+            Node prev = latestWriterAmong(node.ins, tableId);
+            Node next = earliestWriterAmong(node.outs, tableId);
+            if (prev != null && next != null) {
+                prev.addOuts(next);
+                next.addIns(prev);
+            }
+            if (lastTableWriter.get(tableId) == node) {
+                if (prev != null) {
+                    lastTableWriter.put(tableId, prev);
+                } else {
+                    lastTableWriter.remove(tableId);
+                }
             }
         }
-        if (node.outs == null) {
-            return;
-        }
-        for (Node next : node.outs) {
-            next.ins.remove(node);
-            if (next.ins.isEmpty()) {
-                nodesWithoutIns.add(next);
+
+        if (node.ins != null) {
+            for (Node in : node.ins) {
+                in.outs.remove(node);
             }
         }
+        if (node.outs != null) {
+            for (Node out : node.outs) {
+                out.ins.remove(node);
+                if (out.ins.isEmpty()) {
+                    nodesWithoutIns.add(out);
+                }
+            }
+        }
+    }
+
+    // Among candidates, the writer of tableId added to the graph last. When called with the
+    // ins of a node writing tableId, this is that node's immediate predecessor on tableId's
+    // writer chain: every writer of tableId in the ins lies on the chain before the node,
+    // and the chain is ordered by seq.
+    private static Node latestWriterAmong(Set<Node> candidates, long tableId) {
+        Node result = null;
+        if (candidates != null) {
+            for (Node n : candidates) {
+                if (n.writeTableIds.contains(tableId) && (result == null || n.seq > result.seq)) {
+                    result = n;
+                }
+            }
+        }
+        return result;
+    }
+
+    // Symmetric to latestWriterAmong: with the outs of a node writing tableId, the writer of
+    // tableId added first is that node's immediate successor on tableId's writer chain.
+    private static Node earliestWriterAmong(Set<Node> candidates, long tableId) {
+        Node result = null;
+        if (candidates != null) {
+            for (Node n : candidates) {
+                if (n.writeTableIds.contains(tableId) && (result == null || n.seq < result.seq)) {
+                    result = n;
+                }
+            }
+        }
+        return result;
     }
 
     public List<Long> getTxnsWithoutDependency() {

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionGraphTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionGraphTest.java
@@ -66,9 +66,96 @@ public class TransactionGraphTest {
         graph.remove(3);
         graph.remove(4);
         assertEquals(graph.size(), 4);
-        expectNextBatch(graph, Lists.newArrayList(1L, 2L, 5L, 6L));
+        // removing the middle writers must keep txn5/txn6 ordered after txn1/txn2
+        expectNextBatch(graph, Lists.newArrayList(1L, 2L));
+        expectNextBatch(graph, Lists.newArrayList(5L, 6L));
         assertEquals(graph.size(), 0);
         assertEquals(graph.getTxnsWithoutDependency().size(), 0);
+    }
+
+    @Test
+    public void testRemoveTailKeepsLastTableWriter() {
+        TransactionGraph graph = new TransactionGraph();
+        graph.add(1, Lists.newArrayList(1L));
+        graph.add(2, Lists.newArrayList(1L));
+        // the tail of table 1's chain becomes visible first, e.g. via single publish
+        graph.remove(2);
+        // a new writer of table 1 must still depend on the remaining txn1
+        graph.add(3, Lists.newArrayList(1L));
+        expectNextBatch(graph, Lists.newArrayList(1L));
+        expectNextBatch(graph, Lists.newArrayList(3L));
+        assertEquals(0, graph.size());
+    }
+
+    @Test
+    public void testRemoveMiddleNodeKeepsOrdering() {
+        TransactionGraph graph = new TransactionGraph();
+        graph.add(1, Lists.newArrayList(1L));
+        graph.add(2, Lists.newArrayList(1L));
+        graph.add(3, Lists.newArrayList(1L));
+        graph.remove(2);
+        // txn3 must still wait for txn1
+        assertEquals(Lists.newArrayList(1L), graph.getTxnsWithoutDependency());
+        // the single-table batch walk follows the spliced chain 1 -> 3
+        assertEquals(Lists.newArrayList(1L, 3L), graph.getTxnsWithTxnDependencyBatch(1, 5, 1));
+        graph.remove(1);
+        expectNextBatch(graph, Lists.newArrayList(3L));
+        assertEquals(0, graph.size());
+    }
+
+    @Test
+    public void testRemoveMiddleNodeWithMultipleSuccessors() {
+        // table1: txn1 -> txn2 -> txn3 -> txn4
+        // table2:         txn2 ---------> txn4
+        TransactionGraph graph = new TransactionGraph();
+        graph.add(1, Lists.newArrayList(1L));
+        graph.add(2, Lists.newArrayList(1L, 2L));
+        graph.add(3, Lists.newArrayList(1L));
+        graph.add(4, Lists.newArrayList(1L, 2L));
+        graph.remove(2);
+        // table1 is spliced to txn1 -> txn3; txn4's table2 dependency on txn2 is satisfied
+        // but its table1 dependency on txn3 remains
+        expectNextBatch(graph, Lists.newArrayList(1L));
+        expectNextBatch(graph, Lists.newArrayList(3L));
+        expectNextBatch(graph, Lists.newArrayList(4L));
+        assertEquals(0, graph.size());
+    }
+
+    @Test
+    public void testRemoveWithMultiplePredecessorsOnSameTable() {
+        // table1: txn1 -> txn2 -> txn3
+        // table2: txn1 ---------> txn3
+        // txn3's ins contain two writers of table1; the fallback for lastTableWriter must
+        // pick the immediate one (txn2), not txn1
+        TransactionGraph graph = new TransactionGraph();
+        graph.add(1, Lists.newArrayList(1L, 2L));
+        graph.add(2, Lists.newArrayList(1L));
+        graph.add(3, Lists.newArrayList(1L, 2L));
+        graph.remove(3);
+        graph.add(4, Lists.newArrayList(1L));
+        expectNextBatch(graph, Lists.newArrayList(1L));
+        expectNextBatch(graph, Lists.newArrayList(2L));
+        expectNextBatch(graph, Lists.newArrayList(4L));
+        assertEquals(0, graph.size());
+    }
+
+    @Test
+    public void testRemoveWithOutOfOrderTxnIds() {
+        // txns enter the graph in commit order, which can differ from txn id order:
+        // table1: txn5 -> txn2 -> txn7
+        // table2: txn5 ---------> txn7
+        // the fallback for table1's last writer must pick txn2 (added last), not txn5
+        // (the larger txn id)
+        TransactionGraph graph = new TransactionGraph();
+        graph.add(5, Lists.newArrayList(1L, 2L));
+        graph.add(2, Lists.newArrayList(1L));
+        graph.add(7, Lists.newArrayList(1L, 2L));
+        graph.remove(7);
+        graph.add(9, Lists.newArrayList(1L));
+        expectNextBatch(graph, Lists.newArrayList(5L));
+        expectNextBatch(graph, Lists.newArrayList(2L));
+        expectNextBatch(graph, Lists.newArrayList(9L));
+        assertEquals(0, graph.size());
     }
 
     @Test


### PR DESCRIPTION
When a txn is removed from the graph while its predecessors are still in it, remove() corrupted the graph in two ways:

1. lastTableWriter was dropped instead of falling back to the removed node's immediate predecessor on that table's chain, so a later add() of the same table produced a node with no dependency edge.
2. The removed node's predecessors were never re-linked to its successors, so a successor became dependency-free too early.

Batch publish then scheduled txns ahead of unpublished earlier writers of the same table and got blocked.

Trigger conditions: a shared-data cluster running single publish (lake_enable_batch_publish_version = false) selects ready txns from getCommittedTxnList() by per-partition visible version and ignores the graph, so a txn writing different partitions can become VISIBLE and be removed while earlier committed writers of the same table are still in the graph. Enabling batch publish afterwards (it is on by default, so any cluster that had it disabled and turns it back on) makes the publish daemon schedule from the corrupted graph. The same out-of-order removal can occur when an FE upgrade switches publish modes with committed txns in flight.

Fix remove() to splice every table's writer chain around the removed node: link the immediate predecessor to the immediate successor and let lastTableWriter fall back to the predecessor. The immediate neighbors are identified by an add-order sequence number, not txnId, because txn ids are assigned at begin time while chains are ordered by commit time.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
