### PR TITLE
[BugFix] Fix lake replication file copy admission

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -243,15 +243,16 @@ CONF_mInt64(lake_replication_slow_log_ms, "30000");
 CONF_mInt64(lake_replication_read_buffer_size, "16777216"); // 16MB
 // Maximum retry count for non-segment file copy during lake-to-lake replication
 CONF_mInt32(lake_replication_max_file_copy_retry, "3");
+// Maximum number of files copied concurrently for one tablet during lake-to-lake replication.
+CONF_mInt32(lake_replication_max_parallel_files_per_tablet, "4");
 // Minimum number of files required to enable parallel copy in lake-to-lake replication.
 // Set to 0 to force disable parallel copy.
 CONF_mInt32(lake_replication_parallel_copy_min_file_count, "2");
-// Number of threads in the dedicated thread pool for per-file copy in lake-to-lake replication.
-// 0 means cpu_cores * 4 (matches replication_threads default semantics); negative means -value * cpu_cores.
-// This pool is intentionally separate from the agent-task replicate_snapshot pool so that per-file
-// copy sub-tasks can be awaited from the outer task without tripping the thread-pool self-deadlock
-// guard. The pool is built once at startup; CN restart is required to change its size.
-CONF_Int32(lake_replication_file_copy_threads, "0");
+// Number of threads in the dedicated thread pool used by lake replication for per-file copy.
+// The fixed default bounds per-copy read buffers independently of CPU count. 0 means
+// cpu_cores * 4. Negative means -value * cpu_cores. The pool is built once at startup;
+// CN restart is required to change its size.
+CONF_Int32(lake_replication_file_copy_threads, "16");
 
 // The log dir.
 CONF_String(sys_log_dir, "${STARROCKS_HOME}/log");

--- a/be/src/common/config_agent_fwd.h
+++ b/be/src/common/config_agent_fwd.h
@@ -107,12 +107,11 @@ CONF_Int32(sleep_one_second, "1");
 // The count of thread to replication
 CONF_mInt32(replication_threads, "0");
 
-// Number of threads in the dedicated thread pool for per-file copy in lake-to-lake replication.
-// 0 means cpu_cores * 4 (matches replication_threads default semantics); negative means -value * cpu_cores.
-// This pool is intentionally separate from the agent-task replicate_snapshot pool so that per-file
-// copy sub-tasks can be awaited from the outer task without tripping the thread-pool self-deadlock
-// guard. The pool is built once at startup; CN restart is required to change its size.
-CONF_Int32(lake_replication_file_copy_threads, "0");
+// Number of threads in the dedicated thread pool used by lake replication for per-file copy.
+// The fixed default bounds per-copy read buffers independently of CPU count. 0 means
+// cpu_cores * 4. Negative means -value * cpu_cores. The pool is built once at startup;
+// CN restart is required to change its size.
+CONF_Int32(lake_replication_file_copy_threads, "16");
 
 CONF_Int32(max_batch_publish_latency_ms, "100");
 

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -864,6 +864,7 @@
         "lake_replication_slow_log_ms",
         "lake_replication_read_buffer_size",
         "lake_replication_max_file_copy_retry",
+        "lake_replication_max_parallel_files_per_tablet",
         "lake_replication_parallel_copy_min_file_count",
         "enable_lake_segment_metadata_filter",
         "enable_lake_prepared_split_pre_refinement",

--- a/be/src/common/config_lake_fwd.h
+++ b/be/src/common/config_lake_fwd.h
@@ -29,6 +29,9 @@ CONF_mInt64(lake_replication_read_buffer_size, "16777216"); // 16MB
 // Maximum retry count for non-segment file copy during lake-to-lake replication
 CONF_mInt32(lake_replication_max_file_copy_retry, "3");
 
+// Maximum number of files copied concurrently for one tablet during lake-to-lake replication.
+CONF_mInt32(lake_replication_max_parallel_files_per_tablet, "4");
+
 // Minimum number of files required to enable parallel copy in lake-to-lake replication.
 // Set to 0 to force disable parallel copy.
 CONF_mInt32(lake_replication_parallel_copy_min_file_count, "2");

--- a/be/src/storage/lake/lake_replication_txn_manager.cpp
+++ b/be/src/storage/lake/lake_replication_txn_manager.cpp
@@ -53,11 +53,6 @@
 
 namespace starrocks::lake {
 namespace {
-// Backlog guard for shared REPLICATE_SNAPSHOT thread pool.
-// Parallel copy is disabled when queue depth exceeds num_threads * this factor
-// to avoid adding more pressure to an already saturated pool.
-constexpr int kParallelCopyMaxQueuePerThread = 8;
-
 std::unordered_set<std::string> collect_shared_file_names(const TabletMetadataPB& metadata) {
     std::unordered_set<std::string> files;
     for (const auto& rowset : metadata.rowsets()) {
@@ -472,12 +467,21 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
 
     ThreadPool* repl_pool = replicate_file_thread_pool;
     bool use_parallel = should_use_parallel_copy(filename_map.size(), repl_pool);
+    bool use_file_copy_pool = repl_pool != nullptr && repl_pool->max_threads() > 0 &&
+                              config::lake_replication_parallel_copy_min_file_count > 0;
+    size_t worker_count = 1;
+    if (use_parallel) {
+        worker_count = std::min<size_t>(filename_map.size(),
+                                        std::max(1, config::lake_replication_max_parallel_files_per_tablet));
+    }
     std::mutex mu;
     std::mutex* shared_mutex = nullptr;
     FileConverterCreatorFunc active_file_converters = file_converters;
     if (use_parallel) {
         LOG(INFO) << "Start parallel file copy, file_count: " << filename_map.size() << ", txn_id: " << txn_id
-                  << ", tablet_id: " << target_tablet_id << ", pool num_threads: " << repl_pool->num_threads()
+                  << ", tablet_id: " << target_tablet_id << ", worker_count: " << worker_count
+                  << ", pool max_threads: " << repl_pool->max_threads()
+                  << ", pool num_threads: " << repl_pool->num_threads()
                   << ", pool active_threads: " << repl_pool->active_threads()
                   << ", pool queued_tasks: " << repl_pool->num_queued_tasks();
         shared_mutex = &mu;
@@ -624,26 +628,16 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
         });
     }
     // step 4: execute tasks and collect copy metrics.
-    // Follow the ThreadPoolToken(CONCURRENT) + wait() pattern used in txn_manager.cpp.
-    if (use_parallel) {
-        auto token = repl_pool->new_token(ThreadPool::ExecutionMode::CONCURRENT);
-        std::vector<Status> task_results(tasks.size());
-        for (size_t i = 0; i < tasks.size(); i++) {
-            auto st =
-                    token->submit_func([&task_results, i, task = std::move(tasks[i])]() { task_results[i] = task(); });
-            if (!st.ok()) {
-                task_results[i] = std::move(st);
-            }
-        }
-        token->wait();
-        for (const auto& r : task_results) {
-            if (!r.ok()) {
-                LOG(WARNING) << "Parallel file copy failed, txn_id: " << txn_id << ", tablet_id: " << target_tablet_id
-                             << ", pool num_threads: " << repl_pool->num_threads()
-                             << ", pool active_threads: " << repl_pool->active_threads()
-                             << ", pool queued_tasks: " << repl_pool->num_queued_tasks() << ", error: " << r;
-                return r;
-            }
+    if (use_file_copy_pool) {
+        auto st = execute_file_copy_tasks(std::move(tasks), repl_pool, worker_count);
+        if (!st.ok()) {
+            LOG(WARNING) << "File copy through dedicated pool failed, txn_id: " << txn_id
+                         << ", tablet_id: " << target_tablet_id << ", worker_count: " << worker_count
+                         << ", pool max_threads: " << repl_pool->max_threads()
+                         << ", pool num_threads: " << repl_pool->num_threads()
+                         << ", pool active_threads: " << repl_pool->active_threads()
+                         << ", pool queued_tasks: " << repl_pool->num_queued_tasks() << ", error: " << st;
+            return st;
         }
     } else {
         for (const auto& task : tasks) {
@@ -657,8 +651,9 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
     }
     LOG(INFO) << "Replicated tablet file count: " << filename_map.size() << ", total bytes: " << total_file_size
               << ", cost: " << total_time_sec << "s, rate: " << copy_rate
-              << "MB/s, parallel: " << (use_parallel ? "true" : "false") << ", txn_id: " << txn_id
-              << ", tablet_id: " << target_tablet_id;
+              << "MB/s, file_copy_pool: " << (use_file_copy_pool ? "true" : "false")
+              << ", parallel: " << (use_parallel ? "true" : "false") << ", worker_count: " << worker_count
+              << ", txn_id: " << txn_id << ", tablet_id: " << target_tablet_id;
 
     // step 5: update metadata and write txn log.
     // Update segment sizes in tablet_metadata if there are any changes
@@ -697,14 +692,52 @@ bool LakeReplicationTxnManager::should_use_parallel_copy(size_t file_count, cons
     if (min_file_count == 0) {
         return false;
     }
+    if (config::lake_replication_max_parallel_files_per_tablet <= 1) {
+        return false;
+    }
     if (file_count < static_cast<size_t>(min_file_count)) {
         return false;
     }
-    const int num_threads = thread_pool->num_threads();
-    if (num_threads <= 0) {
+    if (thread_pool->max_threads() <= 0) {
         return false;
     }
-    return thread_pool->num_queued_tasks() <= num_threads * kParallelCopyMaxQueuePerThread;
+    return true;
+}
+
+Status LakeReplicationTxnManager::execute_file_copy_tasks(std::vector<ReplicationTask> tasks, ThreadPool* thread_pool,
+                                                          size_t max_workers) {
+    if (tasks.empty()) {
+        return Status::OK();
+    }
+    if (thread_pool == nullptr || thread_pool->max_threads() <= 0) {
+        return Status::InvalidArgument("Lake replication file copy thread pool is unavailable");
+    }
+
+    const size_t worker_count = std::min(tasks.size(), std::max<size_t>(1, max_workers));
+    auto token = thread_pool->new_token(ThreadPool::ExecutionMode::CONCURRENT);
+    std::atomic<size_t> next_task{0};
+    std::vector<Status> task_results(tasks.size());
+    Status submit_status;
+    for (size_t i = 0; i < worker_count; ++i) {
+        auto st = token->submit_func([&]() {
+            while (true) {
+                size_t task_index = next_task.fetch_add(1, std::memory_order_relaxed);
+                if (task_index >= tasks.size()) {
+                    return;
+                }
+                task_results[task_index] = tasks[task_index]();
+            }
+        });
+        if (!st.ok() && submit_status.ok()) {
+            submit_status = std::move(st);
+        }
+    }
+    token->wait();
+    RETURN_IF_ERROR(submit_status);
+    for (const auto& result : task_results) {
+        RETURN_IF_ERROR(result);
+    }
+    return Status::OK();
 }
 
 StatusOr<size_t> LakeReplicationTxnManager::copy_non_segment_file_with_retry(

--- a/be/src/storage/lake/lake_replication_txn_manager.h
+++ b/be/src/storage/lake/lake_replication_txn_manager.h
@@ -116,6 +116,10 @@ public:
     // Decide whether to use parallel copy for current tablet files.
     static bool should_use_parallel_copy(size_t file_count, const ThreadPool* thread_pool);
 
+    // Execute file copies through the CN-wide dedicated pool using at most max_workers for this tablet.
+    static Status execute_file_copy_tasks(std::vector<ReplicationTask> tasks, ThreadPool* thread_pool,
+                                          size_t max_workers);
+
 private:
     TabletManager* _tablet_manager;
 #ifdef USE_STAROS

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -484,25 +484,30 @@ private:
 
 TEST(LakeReplicationTaskRunnerTest, test_should_use_parallel_copy_basic_gate) {
     Int32ConfigGuard min_file_guard(&config::lake_replication_parallel_copy_min_file_count);
+    Int32ConfigGuard max_worker_guard(&config::lake_replication_max_parallel_files_per_tablet);
     config::lake_replication_parallel_copy_min_file_count = 2;
+    config::lake_replication_max_parallel_files_per_tablet = 4;
     EXPECT_FALSE(LakeReplicationTxnManager::should_use_parallel_copy(2, nullptr));
 
     std::unique_ptr<ThreadPool> pool;
-    ASSERT_OK(ThreadPoolBuilder("lake_par_gate")
-                      .set_min_threads(1)
-                      .set_max_threads(1)
+    ASSERT_OK(ThreadPoolBuilder("lake_repl_parallel_gate")
+                      .set_min_threads(0)
+                      .set_max_threads(4)
                       .set_max_queue_size(8)
                       .build(&pool));
+    EXPECT_EQ(0, pool->num_threads());
     EXPECT_FALSE(LakeReplicationTxnManager::should_use_parallel_copy(1, pool.get()));
     EXPECT_TRUE(LakeReplicationTxnManager::should_use_parallel_copy(2, pool.get()));
     pool->shutdown();
 }
 
-TEST(LakeReplicationTaskRunnerTest, test_should_use_parallel_copy_queue_overloaded) {
+TEST(LakeReplicationTaskRunnerTest, test_should_use_parallel_copy_ignores_queue_depth) {
     Int32ConfigGuard min_file_guard(&config::lake_replication_parallel_copy_min_file_count);
+    Int32ConfigGuard max_worker_guard(&config::lake_replication_max_parallel_files_per_tablet);
     config::lake_replication_parallel_copy_min_file_count = 2;
+    config::lake_replication_max_parallel_files_per_tablet = 4;
     std::unique_ptr<ThreadPool> pool;
-    ASSERT_OK(ThreadPoolBuilder("lake_par_overld")
+    ASSERT_OK(ThreadPoolBuilder("lake_repl_parallel_overload")
                       .set_min_threads(1)
                       .set_max_threads(1)
                       .set_max_queue_size(32)
@@ -514,7 +519,7 @@ TEST(LakeReplicationTaskRunnerTest, test_should_use_parallel_copy_queue_overload
         ASSERT_OK(pool->submit_func([&]() { block.wait(); }));
     }
 
-    EXPECT_FALSE(LakeReplicationTxnManager::should_use_parallel_copy(20, pool.get()));
+    EXPECT_TRUE(LakeReplicationTxnManager::should_use_parallel_copy(20, pool.get()));
     block.count_down();
     pool->wait();
     pool->shutdown();
@@ -529,6 +534,121 @@ TEST(LakeReplicationTaskRunnerTest, test_should_use_parallel_copy_can_disable_by
             ThreadPoolBuilder("lake_par_dis").set_min_threads(1).set_max_threads(1).set_max_queue_size(8).build(&pool));
 
     EXPECT_FALSE(LakeReplicationTxnManager::should_use_parallel_copy(100, pool.get()));
+    pool->shutdown();
+}
+
+TEST(LakeReplicationTaskRunnerTest, test_should_use_parallel_copy_can_limit_tablet_to_one_worker) {
+    Int32ConfigGuard min_file_guard(&config::lake_replication_parallel_copy_min_file_count);
+    Int32ConfigGuard max_worker_guard(&config::lake_replication_max_parallel_files_per_tablet);
+    config::lake_replication_parallel_copy_min_file_count = 2;
+    config::lake_replication_max_parallel_files_per_tablet = 1;
+
+    std::unique_ptr<ThreadPool> pool;
+    ASSERT_OK(ThreadPoolBuilder("lake_repl_one_worker")
+                      .set_min_threads(0)
+                      .set_max_threads(4)
+                      .set_max_queue_size(8)
+                      .build(&pool));
+
+    EXPECT_FALSE(LakeReplicationTxnManager::should_use_parallel_copy(100, pool.get()));
+    pool->shutdown();
+}
+
+TEST(LakeReplicationTaskRunnerTest, test_execute_file_copy_tasks_uses_pool_for_single_file) {
+    std::unique_ptr<ThreadPool> pool;
+    ASSERT_OK(ThreadPoolBuilder("lake_repl_single_file")
+                      .set_min_threads(0)
+                      .set_max_threads(2)
+                      .set_max_queue_size(8)
+                      .build(&pool));
+
+    const auto caller_thread = std::this_thread::get_id();
+    std::thread::id copy_thread;
+    std::vector<LakeReplicationTxnManager::ReplicationTask> tasks;
+    tasks.emplace_back([&]() {
+        copy_thread = std::this_thread::get_id();
+        return Status::OK();
+    });
+
+    ASSERT_OK(LakeReplicationTxnManager::execute_file_copy_tasks(std::move(tasks), pool.get(), 1));
+    EXPECT_NE(caller_thread, copy_thread);
+    pool->shutdown();
+}
+
+TEST(LakeReplicationTaskRunnerTest, test_execute_file_copy_tasks_limits_tablet_workers) {
+    std::unique_ptr<ThreadPool> pool;
+    ASSERT_OK(ThreadPoolBuilder("lake_repl_tablet_dop")
+                      .set_min_threads(0)
+                      .set_max_threads(4)
+                      .set_max_queue_size(8)
+                      .build(&pool));
+
+    CountDownLatch workers_started(2);
+    std::atomic<int> active{0};
+    std::atomic<int> max_active{0};
+    std::atomic<int> completed{0};
+    std::vector<LakeReplicationTxnManager::ReplicationTask> tasks;
+    for (int i = 0; i < 12; ++i) {
+        tasks.emplace_back([&]() {
+            int current = active.fetch_add(1, std::memory_order_relaxed) + 1;
+            int observed = max_active.load(std::memory_order_relaxed);
+            while (current > observed && !max_active.compare_exchange_weak(observed, current)) {
+            }
+            workers_started.count_down();
+            workers_started.wait();
+            completed.fetch_add(1, std::memory_order_relaxed);
+            active.fetch_sub(1, std::memory_order_relaxed);
+            return Status::OK();
+        });
+    }
+
+    ASSERT_OK(LakeReplicationTxnManager::execute_file_copy_tasks(std::move(tasks), pool.get(), 2));
+    EXPECT_EQ(12, completed.load());
+    EXPECT_EQ(2, max_active.load());
+    pool->shutdown();
+}
+
+TEST(LakeReplicationTaskRunnerTest, test_execute_file_copy_tasks_shares_global_pool_limit) {
+    std::unique_ptr<ThreadPool> pool;
+    ASSERT_OK(ThreadPoolBuilder("lake_repl_global_limit")
+                      .set_min_threads(0)
+                      .set_max_threads(3)
+                      .set_max_queue_size(16)
+                      .build(&pool));
+
+    CountDownLatch workers_started(3);
+    std::atomic<int> active{0};
+    std::atomic<int> max_active{0};
+    auto build_tasks = [&]() {
+        std::vector<LakeReplicationTxnManager::ReplicationTask> tasks;
+        for (int i = 0; i < 8; ++i) {
+            tasks.emplace_back([&]() {
+                int current = active.fetch_add(1, std::memory_order_relaxed) + 1;
+                int observed = max_active.load(std::memory_order_relaxed);
+                while (current > observed && !max_active.compare_exchange_weak(observed, current)) {
+                }
+                workers_started.count_down();
+                workers_started.wait();
+                active.fetch_sub(1, std::memory_order_relaxed);
+                return Status::OK();
+            });
+        }
+        return tasks;
+    };
+
+    Status first_status;
+    Status second_status;
+    std::thread first(
+            [&]() { first_status = LakeReplicationTxnManager::execute_file_copy_tasks(build_tasks(), pool.get(), 4); });
+    std::thread second([&]() {
+        second_status = LakeReplicationTxnManager::execute_file_copy_tasks(build_tasks(), pool.get(), 4);
+    });
+    first.join();
+    second.join();
+
+    ASSERT_OK(first_status);
+    ASSERT_OK(second_status);
+    EXPECT_EQ(3, max_active.load());
     pool->shutdown();
 }
 

--- a/docs/en/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/en/administration/configuration/BE_parameters/shared_lake_other.md
@@ -572,11 +572,29 @@ This topic introduces the following types of BE configurations:
 
 ### lake_replication_file_copy_threads
 
-- Default: 0
+- Default: 16
 - Type: Int
 - Unit: -
 - Is mutable: No
-- Description: Number of threads in the dedicated thread pool used by lake-to-lake (shared-data) cross-cluster replication for per-file copy. `0` means `cpu_cores * 4` (the same default semantics as `replication_threads`); negative values mean `-value * cpu_cores`. This pool is intentionally separate from the agent-task `replicate_snapshot` pool so that per-file copy sub-tasks can be awaited from the outer task without tripping the thread-pool self-deadlock guard. The pool is built once at startup and has no runtime resize hook, so CN restart is required to change its size.
+- Description: Number of threads in the CN-wide dedicated thread pool used by lake-to-lake (shared-data) cross-cluster replication for per-file copy. The default caps concurrent copy tasks and their read buffers independently of CPU count. `0` means `cpu_cores * 4`; negative values mean `-value * cpu_cores`. The pool is built once at startup, so CN restart is required to change its size.
+- Introduced in: v4.1.2
+
+### lake_replication_max_parallel_files_per_tablet
+
+- Default: 4
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: Maximum number of files copied concurrently for one tablet during lake-to-lake (shared-data) cross-cluster replication. All tablets share the CN-wide `lake_replication_file_copy_threads` pool, so this setting prevents one tablet from monopolizing the pool. Values less than or equal to `1` serialize file copy within each tablet.
+- Introduced in: v4.1.4
+
+### lake_replication_parallel_copy_min_file_count
+
+- Default: 2
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: Minimum number of files in a tablet required to copy that tablet's files concurrently during lake-to-lake (shared-data) cross-cluster replication. Set this parameter to `0` to disable the dedicated file copy pool and execute file copy in the calling replication task.
 - Introduced in: v4.1.2
 
 ### lake_service_max_concurrency

--- a/docs/zh/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/configuration/BE_parameters/shared_lake_other.md
@@ -569,11 +569,29 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 
 ### lake_replication_file_copy_threads
 
-- 默认值：0
+- 默认值：16
 - 类型：Int
 - 单位：-
 - 是否动态：否
-- 描述：存算分离跨集群复制（lake-to-lake replication）逐文件拷贝所使用的独立线程池大小。`0` 表示 `cpu_cores * 4`（与 `replication_threads` 默认语义一致）；负值表示 `-value * cpu_cores`。该线程池与 agent 任务的 `replicate_snapshot` 线程池刻意区分，目的是让外层任务可以安全地通过 `ThreadPoolToken::wait()` 等待逐文件拷贝子任务，而不触发线程池自死锁保护。该线程池在启动时一次性创建，无运行时 resize 入口，调整大小需重启 CN。
+- 描述：存算分离跨集群复制（lake-to-lake replication）逐文件拷贝所使用的 CN 全局独立线程池大小。默认值用于限制并发拷贝任务及其读缓冲区，不随 CPU 核数增长。`0` 表示 `cpu_cores * 4`；负值表示 `-value * cpu_cores`。该线程池在启动时一次性创建，调整大小需重启 CN。
+- 引入版本：v4.1.2
+
+### lake_replication_max_parallel_files_per_tablet
+
+- 默认值：4
+- 类型：Int
+- 单位：-
+- 是否动态：是
+- 描述：存算分离跨集群复制（lake-to-lake replication）中单个 tablet 同时拷贝文件的最大数量。所有 tablet 共用 CN 全局的 `lake_replication_file_copy_threads` 线程池，因此该配置可防止单个 tablet 独占线程池。配置值小于或等于 `1` 时，单个 tablet 内的文件串行拷贝。
+- 引入版本：v4.1.4
+
+### lake_replication_parallel_copy_min_file_count
+
+- 默认值：2
+- 类型：Int
+- 单位：-
+- 是否动态：是
+- 描述：存算分离跨集群复制（lake-to-lake replication）中，启用单个 tablet 内文件并行拷贝所需的最小文件数。设置为 `0` 时关闭独立文件拷贝线程池，由调用复制任务直接执行文件拷贝。
 - 引入版本：v4.1.2
 
 ### lake_service_max_concurrency


### PR DESCRIPTION
## Why I'm doing:

Lake replication file copy admission can bypass the dedicated CN-wide limit in two cases. A dynamic copy pool starts with zero live threads, so the previous gate never enables parallel copy on a cold pool. When its queue is busy, copy falls back to the calling replication task, allowing concurrent tablets to exceed the intended global copy limit and multiply per-file read-buffer memory.

## What I'm doing:

- Route enabled file copy through the CN-wide dedicated pool, including single-file tablets.
- Use bounded worker loops so each tablet occupies at most `lake_replication_max_parallel_files_per_tablet` workers while all tablets share `lake_replication_file_copy_threads`.
- Base cold-start admission on the configured pool capacity and let the pool provide global admission instead of falling back to inline copy based on queue depth.
- Set the default CN-wide file copy pool size to 16 and document both copy admission controls.
- Add regression tests for cold-start admission, queue saturation, per-tablet concurrency, single-file routing, and the global pool limit across tablets.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5