### PR TITLE
[BugFix] Report data cache read stats in intermediate query statistics (backport #77696)

### DIFF
--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -256,6 +256,7 @@ std::shared_ptr<QueryStatistics> QueryContext::intermediate_query_statistic(int6
     query_statistic->add_cpu_costs(_delta_cpu_cost_ns.exchange(0));
     query_statistic->add_mem_costs(mem_cost_bytes());
     query_statistic->add_transmitted_bytes(delta_transmitted_bytes);
+    query_statistic->add_read_stats(consume_delta_read_local_cnt(), consume_delta_read_remote_cnt());
     {
         std::lock_guard l(_scan_stats_lock);
         for (const auto& [table_id, scan_stats] : _scan_stats) {

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -212,6 +212,8 @@ public:
     void incr_read_stats(int64_t read_local_cnt, int64_t read_remote_cnt) {
         _total_read_local_cnt += read_local_cnt;
         _total_read_remote_cnt += read_remote_cnt;
+        _delta_read_local_cnt += read_local_cnt;
+        _delta_read_remote_cnt += read_remote_cnt;
     }
     void update_push_rows_stats(int32_t plan_node_id, int64_t push_rows) {
         auto it = _node_exec_stats.find(plan_node_id);
@@ -262,6 +264,8 @@ public:
     int64_t get_spill_bytes() { return _total_spill_bytes; }
     int64_t get_read_local_cnt() { return _total_read_local_cnt; }
     int64_t get_read_remote_cnt() { return _total_read_remote_cnt; }
+    int64_t consume_delta_read_local_cnt() { return _delta_read_local_cnt.exchange(0); }
+    int64_t consume_delta_read_remote_cnt() { return _delta_read_remote_cnt.exchange(0); }
     int64_t get_transmitted_bytes() { return _total_transmitted_bytes; }
 
     // Query start time, used to check how long the query has been running
@@ -347,6 +351,8 @@ private:
     std::atomic<int64_t> _delta_cpu_cost_ns = 0;
     std::atomic<int64_t> _delta_scan_rows_num = 0;
     std::atomic<int64_t> _delta_scan_bytes = 0;
+    std::atomic<int64_t> _delta_read_local_cnt = 0;
+    std::atomic<int64_t> _delta_read_remote_cnt = 0;
 
     struct ScanStats {
         std::atomic<int64_t> total_scan_rows_num = 0;

--- a/be/test/exec/pipeline/query_context_manger_test.cpp
+++ b/be/test/exec/pipeline/query_context_manger_test.cpp
@@ -333,6 +333,47 @@ TEST(QueryContextManagerTest, testReadStats) {
     ctx.incr_read_stats(100, 200);
     ASSERT_EQ(100, ctx.get_read_local_cnt());
     ASSERT_EQ(200, ctx.get_read_remote_cnt());
+
+    // Deltas drain once consumed, while totals stay intact.
+    EXPECT_EQ(100, ctx.consume_delta_read_local_cnt());
+    EXPECT_EQ(200, ctx.consume_delta_read_remote_cnt());
+    EXPECT_EQ(0, ctx.consume_delta_read_local_cnt());
+    EXPECT_EQ(0, ctx.consume_delta_read_remote_cnt());
+    EXPECT_EQ(100, ctx.get_read_local_cnt());
+    EXPECT_EQ(200, ctx.get_read_remote_cnt());
+
+    ctx.incr_read_stats(2, 4);
+    EXPECT_EQ(2, ctx.consume_delta_read_local_cnt());
+    EXPECT_EQ(4, ctx.consume_delta_read_remote_cnt());
+    EXPECT_EQ(102, ctx.get_read_local_cnt());
+    EXPECT_EQ(204, ctx.get_read_remote_cnt());
+}
+
+TEST(QueryContextManagerTest, testIntermediateQueryStatisticCarriesReadStats) {
+    auto parent_mem_tracker = std::make_shared<MemTracker>(MemTrackerType::QUERY_POOL, 1073741824L, "parent", nullptr);
+    QueryContext ctx;
+    ctx.init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
+
+    ctx.incr_read_stats(100, 200);
+
+    auto intermediate_stats = ctx.intermediate_query_statistic(0);
+    ASSERT_NE(nullptr, intermediate_stats);
+    PQueryStatistics intermediate_pb;
+    intermediate_stats->to_pb(&intermediate_pb);
+    EXPECT_EQ(100, intermediate_pb.read_local_cnt());
+    EXPECT_EQ(200, intermediate_pb.read_remote_cnt());
+
+    // The delta has been drained, so a second report carries nothing.
+    auto second_intermediate_stats = ctx.intermediate_query_statistic(0);
+    ASSERT_NE(nullptr, second_intermediate_stats);
+    PQueryStatistics second_intermediate_pb;
+    second_intermediate_stats->to_pb(&second_intermediate_pb);
+    EXPECT_EQ(0, second_intermediate_pb.read_local_cnt());
+    EXPECT_EQ(0, second_intermediate_pb.read_remote_cnt());
+
+    // Totals used by the final-sink path are unaffected by delta consumption.
+    EXPECT_EQ(100, ctx.get_read_local_cnt());
+    EXPECT_EQ(200, ctx.get_read_remote_cnt());
 }
 
 // The reserve limit is the early-warning line the AUTO spill trigger probes through


### PR DESCRIPTION
Manual backport of #77696 to branch-4.0. The automatic Mergify backport (#78047) hit conflicts and was closed: on main these counters live in `QueryRuntimeState` (`be/src/compute_env/query/query_runtime_state.h`), while this branch still keeps them directly on `QueryContext` (`be/src/exec/pipeline/query_context.h`), so the change is ported onto the old layout.

## Why I'm doing:

In shared-data mode the audit log field `CacheHitRatio` (and the FE cache-hit-ratio metrics) is computed from the `read_local_cnt` / `read_remote_cnt` counters shipped from BEs. Only `QueryContext::final_query_statistic()` included these counters; `intermediate_query_statistic()` — the delta statistics that non-final-sink BEs piggyback on exchange traffic — did not carry them. Since the final-sink BE usually runs no scan, the scan-side counters of virtually every multi-node query were lost: the FE received zero counts, and `AuditEvent.calculateCacheHitRatio()` fell back to the constant `"100%"`.

Observed on a production shared-data cluster (4.1.4): a 12.8s query that read 4.75 GB from S3 (its profile shows a real IO-count hit ratio of 95.1%) was logged with `CacheHitRatio: "100%"`. In that FE's audit log, ~19200 entries carried the bare fallback `"100%"` while only ~1400 carried genuinely computed values — the single-node queries whose scan happened to run on the final-sink BE.

## What I'm doing:

- `QueryContext::incr_read_stats()` now also accumulates the increments into new `_delta_read_local_cnt` / `_delta_read_remote_cnt` counters, drained by `consume_delta_read_local_cnt()` / `consume_delta_read_remote_cnt()` (`exchange(0)`, the same pattern as the cpu-cost delta).
- `QueryContext::intermediate_query_statistic()` adds the drained deltas via `QueryStatistics::add_read_stats()`, so scan-side counts propagate through the exchange chain to the final-sink BE and on to the FE. Serialization and merging already handle these fields (`to_pb` / `to_thrift` / `merge` / `merge_pb` / FE `AuditStatisticsUtil`), so there is no protocol change.
- `final_query_statistic()` keeps using the totals; non-final-sink BEs only ever ship deltas, so nothing is double counted.
- Conflict resolution vs #77696: the delta counters and consume methods land on `QueryContext` instead of `QueryRuntimeState` (which does not exist on this branch), and the delta-drain assertions from `QueryRuntimeStateTest.TracksReadStats` are folded into the existing `QueryContextManagerTest.testReadStats`.
- UT: extended `QueryContextManagerTest.testReadStats` with the delta-drain semantics, and ported `QueryContextManagerTest.testIntermediateQueryStatisticCarriesReadStats` verifying an intermediate report carries the counts exactly once, a second report carries zero, and the totals used by the final-sink path are unaffected.

Fixes #77697

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

