### PR TITLE
[BugFix] Reserve the virtual column names so no table column can shadow them

### DIFF
--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
@@ -162,7 +162,7 @@ col_name col_type [agg_type] [NULL | NOT NULL] [DEFAULT "default_value"] [AUTO_I
 
 ### `col_name`
 
-Note that normally you cannot create a column whose name is initiated with `__op` or `__row` because these name formats are reserved for special purposes in StarRocks and creating such columns may result in undefined behavior. If you do need to create such column, set the FE dynamic parameter [`allow_system_reserved_names`](../../../administration/configuration/FE_parameters/FE_parameters.md#allow_system_reserved_names) to `TRUE`.
+Note that normally you cannot create a column whose name is initiated with `__op` or `__row` because these name formats are reserved for special purposes in StarRocks and creating such columns may result in undefined behavior. For native tables, the names of virtual columns (`_tablet_id_`, `_segment_id_`, `_rss_id_`, `_source_id_`, `_row_id_`, `_rowset_id_`, and `_dynamic_rssid_`) are reserved as well, because a table column of the same name shadows the virtual column and makes both of them impossible to reference in a query. External tables do not expose virtual columns, so they may keep such a column name. If you do need to create such column, set the FE dynamic parameter [`allow_system_reserved_names`](../../../administration/configuration/FE_parameters/FE_parameters.md#allow_system_reserved_names) to `TRUE`.
 
 ### `col_type`
 

--- a/docs/ja/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
+++ b/docs/ja/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
@@ -161,7 +161,7 @@ col_name col_type [agg_type] [NULL | NOT NULL] [DEFAULT "default_value"] [AUTO_I
 
 ### `col_name`
 
-通常、`__op` または `__row` で始まる名前のカラムは作成できません。これらの名前形式はStarRocksで特別な目的のために予約されており、そのようなカラムを作成すると未定義の動作を引き起こす可能性があるためです。どうしてもそのようなカラムを作成する必要がある場合は、FE動的パラメータ[`allow_system_reserved_names`](../../../administration/configuration/FE_parameters/FE_parameters.md#allow_system_reserved_names) を `TRUE` に設定してください。
+通常、`__op` または `__row` で始まる名前のカラムは作成できません。これらの名前形式はStarRocksで特別な目的のために予約されており、そのようなカラムを作成すると未定義の動作を引き起こす可能性があるためです。ネイティブテーブルでは、仮想カラムの名前（`_tablet_id_`、`_segment_id_`、`_rss_id_`、`_source_id_`、`_row_id_`、`_rowset_id_`、`_dynamic_rssid_`）も同様に予約されています。同名のテーブルカラムは仮想カラムを隠してしまい、クエリではどちらも参照できなくなるためです。外部テーブルは仮想カラムを公開しないため、この制限は適用されません。どうしてもそのようなカラムを作成する必要がある場合は、FE動的パラメータ[`allow_system_reserved_names`](../../../administration/configuration/FE_parameters/FE_parameters.md#allow_system_reserved_names) を `TRUE` に設定してください。
 
 ### `col_type`
 

--- a/docs/zh/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
+++ b/docs/zh/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md
@@ -162,7 +162,7 @@ col_name col_type [agg_type] [NULL | NOT NULL] [DEFAULT "default_value"] [AUTO_I
 
 ### `col_name`
 
-请注意，通常您不能创建以 `__op` 或 `__row` 开头的列名，因为这些名称格式在 StarRocks 中保留用于特殊目的，创建此类列可能会导致未定义的行为。如果您确实需要创建此类列，请将 FE 动态参数[`allow_system_reserved_names`](../../../administration/configuration/FE_parameters/FE_parameters.md#allow_system_reserved_names) 设置为 `TRUE`。
+请注意，通常您不能创建以 `__op` 或 `__row` 开头的列名，因为这些名称格式在 StarRocks 中保留用于特殊目的，创建此类列可能会导致未定义的行为。对于内表，虚拟列的名称（`_tablet_id_`、`_segment_id_`、`_rss_id_`、`_source_id_`、`_row_id_`、`_rowset_id_` 和 `_dynamic_rssid_`）同样是保留名称，因为同名的表列会遮蔽虚拟列，导致两者在查询中都无法被引用。外部表不提供虚拟列，因此可以保留此类列名。如果您确实需要创建此类列，请将 FE 动态参数[`allow_system_reserved_names`](../../../administration/configuration/FE_parameters/FE_parameters.md#allow_system_reserved_names) 设置为 `TRUE`。
 
 ### `col_type`
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -1130,6 +1130,9 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
         }
 
         FeNameFormat.checkColumnName(clause.getNewColName());
+        if (table != null && table.isNativeTableOrMaterializedView()) {
+            FeNameFormat.checkVirtualColumnNameNotUsed(clause.getNewColName());
+        }
         return null;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ColumnDefAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ColumnDefAnalyzer.java
@@ -85,6 +85,9 @@ public class ColumnDefAnalyzer {
             throw new AnalysisException("No column name or column type in column definition");
         }
         FeNameFormat.checkColumnName(name, isPartitionColumn);
+        if (isOlap) {
+            FeNameFormat.checkVirtualColumnNameNotUsed(name);
+        }
 
         // When string type length is not assigned, it needs to be assigned to 1.
         if (typeDef.getType().isScalarType()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FeNameFormat.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.analyzer;
 import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
 import com.starrocks.alter.SchemaChangeHandler;
+import com.starrocks.catalog.VirtualColumnRegistry;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
@@ -58,12 +59,17 @@ public class FeNameFormat {
 
     public static final Set<String> FORBIDDEN_COLUMN_NAMES;
 
+    // Only native tables expose the virtual columns, so only their columns can shadow one.
+    private static final Set<String> VIRTUAL_COLUMN_NAMES;
+
     static {
         FORBIDDEN_COLUMN_NAMES = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
         FORBIDDEN_COLUMN_NAMES.add("__op");
         FORBIDDEN_COLUMN_NAMES.add("__row");
         // see RewriteSimpleAggToHDFSScanRule
         FORBIDDEN_COLUMN_NAMES.add("___count___");
+        VIRTUAL_COLUMN_NAMES = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
+        VirtualColumnRegistry.getAllDefinitions().forEach(def -> VIRTUAL_COLUMN_NAMES.add(def.getName()));
         String allowedSpecialCharacters = "";
         for (Character c : SPECIAL_CHARACTERS_IN_DB_NAME) {
             allowedSpecialCharacters += c;
@@ -135,6 +141,14 @@ public class FeNameFormat {
                         "Column name [" + columnName + "] starts with " + FeConstants.GENERATED_PARTITION_COLUMN_PREFIX +
                                 " is a system reserved name. Please choose a different one.");
             }
+        }
+    }
+
+    // A real column of that name shadows the virtual one, which leaves every reference to either ambiguous.
+    public static void checkVirtualColumnNameNotUsed(String columnName) {
+        if (!Config.allow_system_reserved_names && VIRTUAL_COLUMN_NAMES.contains(columnName)) {
+            throw new SemanticException(
+                    "Column name [" + columnName + "] is a system reserved name. Please choose a different one.");
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -668,6 +668,7 @@ public class MaterializedViewAnalyzer {
                         continue;
                     }
                     FeNameFormat.checkColumnName(colName);
+                    FeNameFormat.checkVirtualColumnNameNotUsed(colName);
                 }
             }
             List<Column> mvColumns = Lists.newArrayList();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -2130,6 +2130,56 @@ public class CreateTableTest extends StarRocksTestBase {
     }
 
     @Test
+    public void testVirtualColumnNameIsReserved() {
+        StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.useDatabase("test");
+
+        String rowId = "create table tbl_row_id(k1 int, `_row_id_` varchar(20)) duplicate key(k1)" +
+                " distributed by hash(k1) properties(\"replication_num\"=\"1\");";
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "Getting analyzing error." +
+                        " Detail message: Column name [_row_id_] is a system reserved name." +
+                        " Please choose a different one.",
+                () -> starRocksAssert.withTable(rowId));
+
+        // The registry drives the reserved set, so every virtual column is covered, and matching ignores case.
+        String tabletId = "create table tbl_tablet_id(k1 int, `_TABLET_ID_` bigint) duplicate key(k1)" +
+                " distributed by hash(k1) properties(\"replication_num\"=\"1\");";
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "Column name [_TABLET_ID_] is a system reserved name",
+                () -> starRocksAssert.withTable(tabletId));
+
+        ExceptionChecker.expectThrowsNoException(() -> createTable(
+                "create table test.tbl_add_row_id(k1 int) duplicate key(k1)" +
+                        " distributed by hash(k1) properties(\"replication_num\"=\"1\");"));
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
+                "Column name [_row_id_] is a system reserved name",
+                () -> alterTableWithNewParser(
+                        "ALTER TABLE test.tbl_add_row_id ADD COLUMN `_row_id_` varchar(20)"));
+
+        // Only native tables expose the virtual columns, so an external schema may keep such a column name.
+        ExceptionChecker.expectThrowsNoException(() -> createTable(
+                "CREATE TABLE test.tbl_external_row_id (\n" +
+                        "k1 INT,\n" +
+                        "`_row_id_` VARCHAR(20)\n" +
+                        ") ENGINE=mysql\n" +
+                        "PROPERTIES (\n" +
+                        "\"host\" = \"127.0.0.1\",\n" +
+                        "\"port\" = \"3306\",\n" +
+                        "\"user\" = \"mysql_user\",\n" +
+                        "\"password\" = \"mysql_password\",\n" +
+                        "\"database\" = \"test\",\n" +
+                        "\"table\" = \"ods_order\"\n" +
+                        ");"));
+
+        // allow_system_reserved_names is the escape hatch for a table that already carries such a column.
+        Config.allow_system_reserved_names = true;
+        try {
+            ExceptionChecker.expectThrowsNoException(() -> starRocksAssert.withTable(rowId));
+        } finally {
+            Config.allow_system_reserved_names = false;
+        }
+    }
+
+    @Test
     public void testDefaultValueHasEscapeString() throws Exception {
         StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
         starRocksAssert.useDatabase("test");


### PR DESCRIPTION
## Why I'm doing:

A table column may be created with the name of a virtual column, and doing so leaves both of them
unreachable. `OlapTable#getColumn` resolves real columns before falling back to `VirtualColumnRegistry`,
while `QueryAnalyzer` adds every virtual column to the scope unconditionally, so the scope ends up holding
two fields of the same name and any reference is rejected:

```sql
CREATE TABLE t (id bigint NOT NULL, `_row_id_` varchar(64) NOT NULL, v varchar(255) NOT NULL)
DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");

SELECT _row_id_ FROM t;
-- ERROR 1064 (HY000): Getting analyzing error. Detail message: Column '_row_id_' is ambiguous.
```

So the DDL succeeds and produces a column that can never be selected, filtered on, or grouped by. Nothing
else in the code guards against the collision either: the planner rewrite that injects virtual column refs
(`OlapScanLazyMaterializationSupport`) looks them up by name and would reuse such a real column, and on the
BE side `extend_schema_by_virtual_columns` appends the virtual column to a schema that already holds that
name, after which `Schema::get_field_index_by_name` returns the first match.

## What I'm doing:

Reserving the virtual column names through `FeNameFormat#checkVirtualColumnNameNotUsed`. The names come
from `VirtualColumnRegistry`, so a virtual column added later is reserved without touching this code, and
the set is case-insensitive, so `_ROW_ID_` is rejected as well. `allow_system_reserved_names` bypasses the
check, as it does for `__op`, `__row` and `___count___`.

The check is applied only where the table actually exposes the virtual columns, which is the same condition
`QueryAnalyzer#getVirtualColumns` uses to publish them:

- `ColumnDefAnalyzer#analyze` calls it under its existing `isOlap` flag, which covers CREATE TABLE with the
  OLAP engine plus ADD COLUMN / MODIFY COLUMN;
- `AlterTableClauseAnalyzer#visitColumnRenameClause` calls it when the table it holds is a native table or a
  materialized view;
- `MaterializedViewAnalyzer` calls it for an MV's own column list.

An external table keeps the name: it never publishes virtual columns, so no reference to a remote column
called `_source_id_` or `_row_id_` can become ambiguous, and rejecting the name would make such a schema
impossible to map or to re-create after an upgrade. The names are kept out of the public
`FeNameFormat#FORBIDDEN_COLUMN_NAMES` set for the same reason: its three other readers give it unrelated
meanings (a name reserved for primary key tables in `OlapTableFactory` and `SchemaChangeHandler`, a column
without internal statistics in `MetadataMgr`).

```sql
CREATE TABLE t (id bigint, `_row_id_` varchar(20)) DUPLICATE KEY(id)
DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");
-- ERROR 1064 (HY000): Getting analyzing error. Detail message: Column name [_row_id_] is a system
-- reserved name. Please choose a different one.
```

Tables that already carry such a column keep working: metadata replay does not run the analyzer, so they
still load and stay queryable, and `allow_system_reserved_names` remains the escape hatch for re-creating
one.

Verified on a live cluster: `CREATE TABLE` with `_row_id_`, `_ROW_ID_`, `_tablet_id_` or `_dynamic_rssid_`,
`ALTER TABLE ... ADD COLUMN _row_id_`, `ALTER TABLE ... RENAME COLUMN id TO _row_id_` and an MV declaring a
`_row_id_` column are all rejected; `CREATE EXTERNAL TABLE ... ENGINE=mysql` with a `_row_id_` column is
created and shows up in `DESC`; `allow_system_reserved_names = true` still allows the column on a native
table; a table created with such a column before the change still returns rows; and `count(_row_id_)` on an
ordinary table still works.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

DDL that names a column after a virtual column is now rejected instead of accepted. Existing tables are
unaffected, and `allow_system_reserved_names` bypasses the check as it does for the other reserved names.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

No backport: virtual columns only exist on main, so there is no name to reserve on the release branches.
