### PR TITLE
[Feature] Support configurable SSL keystore and truststore types

### DIFF
--- a/conf/fe.conf
+++ b/conf/fe.conf
@@ -42,6 +42,22 @@ rpc_port = 9020
 query_port = 9030
 edit_log_port = 9010
 
+# SSL authentication auto-detects JKS/PKCS12 when ssl_keystore_type or
+# ssl_truststore_type is empty. To use formats such as BCFKS, set the
+# corresponding type and provider explicitly.
+# ssl_keystore_location = ${STARROCKS_HOME}/conf/starrocks-keystore.jks
+# ssl_keystore_type =
+# ssl_keystore_provider =
+# ssl_keystore_password =
+# ssl_key_password =
+# ssl_truststore_location =
+# ssl_truststore_type =
+# ssl_truststore_provider =
+# ssl_truststore_password =
+# ssl_security_provider_class =
+# ssl_security_provider_name =
+# ssl_security_provider_path =
+
 # Enable jaeger tracing by setting jaeger_grpc_endpoint
 # jaeger_grpc_endpoint = http://localhost:14250
 

--- a/docs/en/administration/configuration/FE_parameters/log_server_meta.md
+++ b/docs/en/administration/configuration/FE_parameters/log_server_meta.md
@@ -990,6 +990,69 @@ This topic introduces the following types of FE configurations:
 - Description: The port on which the HTTPS server in the FE node listens.
 - Introduced in: v4.0
 
+### `ssl_keystore_type`
+
+- Default: `""`
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: The keystore type used by FE SSL and HTTPS. If this value is empty, StarRocks automatically tries the JVM default keystore type, JKS, and PKCS12. Set this value explicitly for other keystore formats, such as BCFKS.
+- Introduced in: -
+
+### `ssl_keystore_provider`
+
+- Default: `""`
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: The security provider used to load the SSL keystore. Leave it empty to use the provider selected by the JVM. Set this value when the configured keystore type must be loaded by a specific provider, such as `BCFIPS`.
+- Introduced in: -
+
+### `ssl_truststore_type`
+
+- Default: `""`
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: The truststore type used by MySQL SSL. If this value is empty, StarRocks automatically tries the JVM default keystore type, JKS, and PKCS12. Set this value explicitly for other truststore formats, such as BCFKS.
+- Introduced in: -
+
+### `ssl_truststore_provider`
+
+- Default: `""`
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: The security provider used to load the SSL truststore for MySQL SSL. Leave it empty to use the provider selected by the JVM. Set this value when the configured truststore type must be loaded by a specific provider, such as `BCFIPS`.
+- Introduced in: -
+
+### `ssl_security_provider_class`
+
+- Default: `""`
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: The security provider class registered before StarRocks loads the SSL keystore or truststore. Leave it empty if the required provider is already registered by the JVM.
+- Introduced in: -
+
+### `ssl_security_provider_name`
+
+- Default: `""`
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: The expected security provider name. If this value is set and a provider with the same name already exists, StarRocks reuses it. If StarRocks registers `ssl_security_provider_class`, the registered provider name must match this value.
+- Introduced in: -
+
+### `ssl_security_provider_path`
+
+- Default: `""`
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: The path of the security provider JAR. Multiple paths can be separated by the system path separator. Leave it empty if the provider class is already available in the FE classpath.
+- Introduced in: -
+
 ### `max_mysql_service_task_threads_num`
 
 - Default: 4096

--- a/docs/en/administration/user_privs/ssl_authentication.md
+++ b/docs/en/administration/user_privs/ssl_authentication.md
@@ -16,16 +16,45 @@ From v3.4.1 onwards, StarRocks supports secure connections encrypted by SSL. Unl
 To enable SSL authentication in StarRocks, configure the following parameters in the FE configuration file **fe.conf**:
 
 - `ssl_keystore_location`: Specifies the path to the keystore file that stores the SSL certificate and key.
+- `ssl_keystore_type`: The keystore type. Default value: empty, which means StarRocks automatically detects JKS and PKCS12. Set this parameter explicitly for formats such as BCFKS.
+- `ssl_keystore_provider`: The security provider used to load the keystore. This parameter is optional.
 - `ssl_keystore_password`: The password for accessing the keystore file. StarRocks requires this password to read the keystore file.
 - `ssl_key_password`: The password for accessing the key. StarRocks requires this password to retrieve the key from the keystore.
+- `ssl_truststore_location`: Specifies the path to the truststore file. This parameter is optional.
+- `ssl_truststore_type`: The truststore type for MySQL SSL. Default value: empty, which means StarRocks automatically detects JKS and PKCS12. Set this parameter explicitly for formats such as BCFKS.
+- `ssl_truststore_provider`: The security provider used to load the truststore for MySQL SSL. This parameter is optional.
+- `ssl_truststore_password`: The password for accessing the truststore file. This parameter is required when `ssl_truststore_location` is set.
+- `ssl_security_provider_class`: The security provider class to register before loading the keystore or truststore. This parameter is optional.
+- `ssl_security_provider_name`: The expected provider name. This parameter is optional.
+- `ssl_security_provider_path`: The provider JAR path. This parameter is optional. If the provider JAR has already been added to the FE classpath, you do not need to set this parameter.
 - `ssl_force_secure_transport`: Whether to force SSL authentication. Default value: `FALSE`. If this item is set to `TRUE`, the system will reject connections that are not encrypted with SSL.
 
 Example:
 
 ```Properties
 ssl_keystore_location = // Path to the keystore file  
+ssl_keystore_type =
 ssl_keystore_password = // Password for the keystore file  
 ssl_key_password = // Password for accessing the key  
+```
+
+To load a BCFKS keystore and truststore with the Bouncy Castle FIPS provider, put the provider JAR in the FE classpath, for example `$STARROCKS_HOME/lib`, or configure `ssl_security_provider_path`, and then add the following configurations. These parameters configure keystore and truststore loading only. They do not by themselves guarantee that the TLS engine uses a FIPS-validated JSSE provider.
+
+```Properties
+ssl_keystore_location = /path/to/starrocks-keystore.bcfks
+ssl_keystore_type = BCFKS
+ssl_keystore_provider = BCFIPS
+ssl_keystore_password = // Password for the keystore file
+ssl_key_password = // Password for accessing the key
+
+ssl_truststore_location = /path/to/starrocks-truststore.bcfks
+ssl_truststore_type = BCFKS
+ssl_truststore_provider = BCFIPS
+ssl_truststore_password = // Password for the truststore file
+
+ssl_security_provider_class = org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider
+ssl_security_provider_name = BCFIPS
+ssl_security_provider_path = /path/to/bc-fips.jar
 ```
 
 ### Generate SSL certificate

--- a/docs/ja/administration/configuration/FE_parameters/log_server_meta.md
+++ b/docs/ja/administration/configuration/FE_parameters/log_server_meta.md
@@ -981,6 +981,69 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：FE ノードの HTTPS サーバーがリッスンするポート。
 - 導入時期：v4.0
 
+### `ssl_keystore_type`
+
+- デフォルト：`""`
+- タイプ：String
+- 単位：-
+- 変更可能：No
+- 説明：FE SSL および HTTPS で使用するキーストアタイプ。この値が空の場合、StarRocks は JVM デフォルトのキーストアタイプ、JKS、PKCS12 を自動的に試行します。BCFKS などの他のキーストア形式を使用する場合は、この値を明示的に設定します。
+- 導入時期：-
+
+### `ssl_keystore_provider`
+
+- デフォルト：`""`
+- タイプ：String
+- 単位：-
+- 変更可能：No
+- 説明：SSL キーストアのロードに使用するセキュリティ provider。空のままにすると、JVM が選択した provider を使用します。設定したキーストアタイプを `BCFIPS` などの特定 provider でロードする必要がある場合に設定します。
+- 導入時期：-
+
+### `ssl_truststore_type`
+
+- デフォルト：`""`
+- タイプ：String
+- 単位：-
+- 変更可能：No
+- 説明：MySQL SSL で使用するトラストストアタイプ。この値が空の場合、StarRocks は JVM デフォルトのキーストアタイプ、JKS、PKCS12 を自動的に試行します。BCFKS などの他のトラストストア形式を使用する場合は、この値を明示的に設定します。
+- 導入時期：-
+
+### `ssl_truststore_provider`
+
+- デフォルト：`""`
+- タイプ：String
+- 単位：-
+- 変更可能：No
+- 説明：MySQL SSL トラストストアのロードに使用するセキュリティ provider。空のままにすると、JVM が選択した provider を使用します。設定したトラストストアタイプを `BCFIPS` などの特定 provider でロードする必要がある場合に設定します。
+- 導入時期：-
+
+### `ssl_security_provider_class`
+
+- デフォルト：`""`
+- タイプ：String
+- 単位：-
+- 変更可能：No
+- 説明：StarRocks が SSL キーストアまたはトラストストアをロードする前に登録するセキュリティ provider クラス。必要な provider が JVM によってすでに登録されている場合は空のままにします。
+- 導入時期：-
+
+### `ssl_security_provider_name`
+
+- デフォルト：`""`
+- タイプ：String
+- 単位：-
+- 変更可能：No
+- 説明：期待されるセキュリティ provider 名。この値が設定され、同じ名前の provider がすでに存在する場合、StarRocks はそれを再利用します。StarRocks が `ssl_security_provider_class` を登録する場合、登録された provider 名はこの値と一致する必要があります。
+- 導入時期：-
+
+### `ssl_security_provider_path`
+
+- デフォルト：`""`
+- タイプ：String
+- 単位：-
+- 変更可能：No
+- 説明：セキュリティ provider JAR のパス。複数のパスはシステムのパス区切り文字で区切ることができます。provider クラスがすでに FE classpath で利用可能な場合は空のままにします。
+- 導入時期：-
+
 ### `max_mysql_service_task_threads_num`
 
 - デフォルト：4096

--- a/docs/ja/administration/user_privs/ssl_authentication.md
+++ b/docs/ja/administration/user_privs/ssl_authentication.md
@@ -15,16 +15,45 @@ v3.4.1以降、StarRocks は SSL で暗号化されたセキュアな接続を�
 StarRocks で SSL 認証を有効にするには、FE 構成ファイル **fe.conf** で以下のパラメータを構成します：
 
 - `ssl_keystore_location`：SSL 証明書とキーを格納するキーストアファイルへのパスを指定します。
+- `ssl_keystore_type`：キーストアタイプ。デフォルト値は空で、StarRocks が JKS と PKCS12 を自動検出することを示します。BCFKS などの形式を使用する場合は、このパラメータを明示的に設定します。
+- `ssl_keystore_provider`：キーストアのロードに使用するセキュリティ provider。このパラメータは任意です。
 - `ssl_keystore_password`：キーストアファイルにアクセスするためのパスワード。StarRocks は、キーストアファイルを読み取るためにこのパスワードを要求します。
 - `ssl_key_password`：キーにアクセスするためのパスワード。StarRocks は、キーストアからキーを取得するためにこのパスワードを要求します。
+- `ssl_truststore_location`：トラストストアファイルのパスを指定します。このパラメータは任意です。
+- `ssl_truststore_type`：MySQL SSL で使用するトラストストアタイプ。デフォルト値は空で、StarRocks が JKS と PKCS12 を自動検出することを示します。BCFKS などの形式を使用する場合は、このパラメータを明示的に設定します。
+- `ssl_truststore_provider`：MySQL SSL トラストストアのロードに使用するセキュリティ provider。このパラメータは任意です。
+- `ssl_truststore_password`：トラストストアファイルにアクセスするためのパスワード。`ssl_truststore_location` を設定する場合、このパラメータが必要です。
+- `ssl_security_provider_class`：キーストアまたはトラストストアをロードする前に登録するセキュリティ provider クラス。このパラメータは任意です。
+- `ssl_security_provider_name`：期待される provider 名。このパラメータは任意です。
+- `ssl_security_provider_path`：provider JAR のパス。このパラメータは任意です。provider JAR がすでに FE classpath に追加されている場合、このパラメータを設定する必要はありません。
 - `ssl_force_secure_transport`: SSL 認証を強制するかどうか。デフォルト値：`FALSE`。この項目を `TRUE` に設定すると、SSL で暗号化されていない接続はシステムによって拒否されます。
 
 例：
 
 ```Properties
 ssl_keystore_location = // キーストアファイルへのパス。
+ssl_keystore_type =
 ssl_keystore_password = // キーストアファイルのパスワード
 ssl_key_password = // キーにアクセスするためのパスワード
+```
+
+Bouncy Castle FIPS provider で BCFKS 形式のキーストアとトラストストアをロードするには、provider JAR を FE classpath (例: `$STARROCKS_HOME/lib`) に配置するか、`ssl_security_provider_path` を設定してから、以下の設定を追加します。これらのパラメータはキーストアとトラストストアのロードのみを構成します。これだけで TLS engine が FIPS validated JSSE provider を使用することは保証されません。
+
+```Properties
+ssl_keystore_location = /path/to/starrocks-keystore.bcfks
+ssl_keystore_type = BCFKS
+ssl_keystore_provider = BCFIPS
+ssl_keystore_password = // キーストアファイルのパスワード
+ssl_key_password = // キーにアクセスするためのパスワード
+
+ssl_truststore_location = /path/to/starrocks-truststore.bcfks
+ssl_truststore_type = BCFKS
+ssl_truststore_provider = BCFIPS
+ssl_truststore_password = // トラストストアファイルのパスワード
+
+ssl_security_provider_class = org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider
+ssl_security_provider_name = BCFIPS
+ssl_security_provider_path = /path/to/bc-fips.jar
 ```
 
 ### SSL 証明書の生成

--- a/docs/zh/administration/configuration/FE_parameters/log_server_meta.md
+++ b/docs/zh/administration/configuration/FE_parameters/log_server_meta.md
@@ -989,6 +989,69 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: FE 节点中 HTTPS 服务器监听的端口。
 - 引入版本: v4.0
 
+### `ssl_keystore_type`
+
+- 默认值: `""`
+- 类型: String
+- 单位: -
+- 是否可变: No
+- 描述: FE SSL 和 HTTPS 使用的 keystore 类型。如果该值为空，StarRocks 会自动尝试 JVM 默认 keystore 类型、JKS 和 PKCS12。如需使用 BCFKS 等其他 keystore 格式，需要显式设置该参数。
+- 引入版本: -
+
+### `ssl_keystore_provider`
+
+- 默认值: `""`
+- 类型: String
+- 单位: -
+- 是否可变: No
+- 描述: 加载 SSL keystore 时使用的安全 provider。留空表示使用 JVM 选择的 provider。当配置的 keystore 类型必须由特定 provider 加载时，例如 `BCFIPS`，需要设置该参数。
+- 引入版本: -
+
+### `ssl_truststore_type`
+
+- 默认值: `""`
+- 类型: String
+- 单位: -
+- 是否可变: No
+- 描述: MySQL SSL 使用的 truststore 类型。如果该值为空，StarRocks 会自动尝试 JVM 默认 keystore 类型、JKS 和 PKCS12。如需使用 BCFKS 等其他 truststore 格式，需要显式设置该参数。
+- 引入版本: -
+
+### `ssl_truststore_provider`
+
+- 默认值: `""`
+- 类型: String
+- 单位: -
+- 是否可变: No
+- 描述: 加载 MySQL SSL truststore 时使用的安全 provider。留空表示使用 JVM 选择的 provider。当配置的 truststore 类型必须由特定 provider 加载时，例如 `BCFIPS`，需要设置该参数。
+- 引入版本: -
+
+### `ssl_security_provider_class`
+
+- 默认值: `""`
+- 类型: String
+- 单位: -
+- 是否可变: No
+- 描述: StarRocks 加载 SSL keystore 或 truststore 前注册的安全 provider 类。如果所需 provider 已由 JVM 注册，可以留空。
+- 引入版本: -
+
+### `ssl_security_provider_name`
+
+- 默认值: `""`
+- 类型: String
+- 单位: -
+- 是否可变: No
+- 描述: 期望使用的安全 provider 名称。如果设置该值且同名 provider 已存在，StarRocks 会复用该 provider。如果 StarRocks 注册 `ssl_security_provider_class`，注册后的 provider 名称必须与该值匹配。
+- 引入版本: -
+
+### `ssl_security_provider_path`
+
+- 默认值: `""`
+- 类型: String
+- 单位: -
+- 是否可变: No
+- 描述: 安全 provider JAR 的路径。多个路径可以使用系统路径分隔符分隔。如果 provider 类已在 FE classpath 中，可以留空。
+- 引入版本: -
+
 ### `max_mysql_service_task_threads_num`
 
 - 默认值: 4096

--- a/docs/zh/administration/user_privs/ssl_authentication.md
+++ b/docs/zh/administration/user_privs/ssl_authentication.md
@@ -15,16 +15,45 @@ sidebar_position: 40
 要在 StarRocks 中启用 SSL 认证，需要在 FE 配置文件 **fe.conf** 中配置以下参数：
 
 - `ssl_keystore_location`：指定存储 SSL 证书和密钥的 keystore 文件路径。
+- `ssl_keystore_type`：keystore 类型。默认值为空，表示 StarRocks 自动识别 JKS 和 PKCS12。如需使用 BCFKS 等格式，需要显式配置该参数。
+- `ssl_keystore_provider`：用于加载 keystore 的安全 provider。该参数为可选项。
 - `ssl_keystore_password`：keystore 文件的访问密码，StarRocks 读取 keystore 文件时需要提供该密码。
 - `ssl_key_password`：密钥的访问密码，StarRocks 读取 keystore 文件中的密钥时需要提供该密码。
+- `ssl_truststore_location`：指定 truststore 文件路径。该参数为可选项。
+- `ssl_truststore_type`：MySQL SSL 使用的 truststore 类型。默认值为空，表示 StarRocks 自动识别 JKS 和 PKCS12。如需使用 BCFKS 等格式，需要显式配置该参数。
+- `ssl_truststore_provider`：用于加载 MySQL SSL truststore 的安全 provider。该参数为可选项。
+- `ssl_truststore_password`：truststore 文件的访问密码。配置 `ssl_truststore_location` 时需要配置该参数。
+- `ssl_security_provider_class`：加载 keystore 或 truststore 前需要注册的安全 provider 类。该参数为可选项。
+- `ssl_security_provider_name`：期望的 provider 名称。该参数为可选项。
+- `ssl_security_provider_path`：provider JAR 路径。该参数为可选项。如果 provider JAR 已添加到 FE classpath 中，则无需配置该参数。
 - `ssl_force_secure_transport`: 是否强制启用 SSL 认证，默认为 `FALSE`。如设置为 `TRUE`，则系统会拒绝未通过 SSL 加密的连接。
 
 示例：
 
 ```Properties
 ssl_keystore_location = // keystore 文件的路径
+ssl_keystore_type =
 ssl_keystore_password = // keystore 文件的密码
 ssl_key_password = // 密钥的密码
+```
+
+如果需要使用 Bouncy Castle FIPS provider 加载 BCFKS 格式的 keystore 和 truststore，可以将 provider JAR 放入 FE classpath，例如 `$STARROCKS_HOME/lib`，或配置 `ssl_security_provider_path`，然后添加如下配置。这些参数只用于配置 keystore 和 truststore 的加载方式，本身不保证 TLS engine 使用经过 FIPS 验证的 JSSE provider。
+
+```Properties
+ssl_keystore_location = /path/to/starrocks-keystore.bcfks
+ssl_keystore_type = BCFKS
+ssl_keystore_provider = BCFIPS
+ssl_keystore_password = // keystore 文件的密码
+ssl_key_password = // 密钥的密码
+
+ssl_truststore_location = /path/to/starrocks-truststore.bcfks
+ssl_truststore_type = BCFKS
+ssl_truststore_provider = BCFIPS
+ssl_truststore_password = // truststore 文件的密码
+
+ssl_security_provider_class = org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider
+ssl_security_provider_name = BCFIPS
+ssl_security_provider_path = /path/to/bc-fips.jar
 ```
 
 ### 生成 SSL 证书

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -4065,6 +4065,18 @@ public class Config extends ConfigBase {
     public static String ssl_keystore_location = "";
 
     /**
+     * the keystore type. Empty means auto detection.
+     */
+    @ConfField
+    public static String ssl_keystore_type = "";
+
+    /**
+     * the keystore security provider
+     */
+    @ConfField
+    public static String ssl_keystore_provider = "";
+
+    /**
      * the password of keystore file
      */
     @ConfField
@@ -4083,10 +4095,40 @@ public class Config extends ConfigBase {
     public static String ssl_truststore_location = "";
 
     /**
+     * the truststore type. Empty means auto detection.
+     */
+    @ConfField
+    public static String ssl_truststore_type = "";
+
+    /**
+     * the truststore security provider
+     */
+    @ConfField
+    public static String ssl_truststore_provider = "";
+
+    /**
      * the password of truststore file
      */
     @ConfField
     public static String ssl_truststore_password = "";
+
+    /**
+     * the security provider class for SSL keystore and truststore
+     */
+    @ConfField
+    public static String ssl_security_provider_class = "";
+
+    /**
+     * the security provider name for SSL keystore and truststore
+     */
+    @ConfField
+    public static String ssl_security_provider_name = "";
+
+    /**
+     * the security provider jar path for SSL keystore and truststore
+     */
+    @ConfField
+    public static String ssl_security_provider_path = "";
 
     /**
      * Allow only secure transport from clients

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/SSLUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/SSLUtil.java
@@ -1,0 +1,157 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import com.google.common.base.Strings;
+import com.starrocks.common.Config;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.Provider;
+import java.security.Security;
+
+public final class SSLUtil {
+    private static final Logger LOG = LogManager.getLogger(SSLUtil.class);
+
+    private SSLUtil() {
+    }
+
+    public static KeyStore loadKeyStore(String filepath, String keystorePassword, String storeType,
+                                        String storeProvider, String storeName) throws Exception {
+        if (Strings.isNullOrEmpty(storeType)) {
+            return loadKeyStoreAuto(filepath, keystorePassword, storeProvider, storeName);
+        }
+        return loadKeyStoreWithType(filepath, keystorePassword, storeType, storeProvider, storeName);
+    }
+
+    private static KeyStore loadKeyStoreAuto(String filepath, String keystorePassword, String storeProvider,
+                                             String storeName) throws Exception {
+        if (!Strings.isNullOrEmpty(storeProvider)) {
+            throw new GeneralSecurityException(String.format(
+                    "SSL %s type must be set when SSL %s provider '%s' is configured",
+                    storeName, storeName, storeProvider));
+        }
+
+        String defaultType = KeyStore.getDefaultType();
+        String[] candidateTypes = new String[] {defaultType, "JKS", "PKCS12"};
+        GeneralSecurityException loadException = null;
+        for (int i = 0; i < candidateTypes.length; i++) {
+            String candidateType = candidateTypes[i];
+            if (Strings.isNullOrEmpty(candidateType) || isDuplicatedCandidate(candidateTypes, i)) {
+                continue;
+            }
+            try {
+                return loadKeyStoreWithType(filepath, keystorePassword, candidateType, storeProvider, storeName);
+            } catch (Exception e) {
+                if (loadException == null) {
+                    Throwable rootCause = getRootCause(e);
+                    loadException = new GeneralSecurityException(String.format(
+                            "Failed to load SSL %s file '%s' with auto-detected type, first failure: %s",
+                            storeName, filepath, rootCause), e);
+                } else {
+                    loadException.addSuppressed(e);
+                }
+            }
+        }
+        if (loadException == null) {
+            loadException = new GeneralSecurityException(String.format(
+                    "Failed to load SSL %s file '%s' with auto-detected type: no candidate keystore types",
+                    storeName, filepath));
+        }
+        throw loadException;
+    }
+
+    private static boolean isDuplicatedCandidate(String[] candidateTypes, int currentIndex) {
+        for (int i = 0; i < currentIndex; i++) {
+            if (candidateTypes[currentIndex].equalsIgnoreCase(candidateTypes[i])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static KeyStore loadKeyStoreWithType(String filepath, String keystorePassword, String resolvedType,
+                                                 String storeProvider, String storeName) throws Exception {
+        try {
+            KeyStore keyStore = Strings.isNullOrEmpty(storeProvider) ? KeyStore.getInstance(resolvedType) :
+                    KeyStore.getInstance(resolvedType, storeProvider);
+            try (InputStream keyStoreIS = new FileInputStream(filepath)) {
+                keyStore.load(keyStoreIS, keystorePassword.toCharArray());
+            }
+            return keyStore;
+        } catch (Exception e) {
+            Throwable rootCause = getRootCause(e);
+            throw new GeneralSecurityException(String.format(
+                    "Failed to load SSL %s file '%s' with type '%s'%s, root cause: %s",
+                    storeName, filepath, resolvedType,
+                    Strings.isNullOrEmpty(storeProvider) ? "" : " and provider '" + storeProvider + "'",
+                    rootCause), e);
+        }
+    }
+
+    private static Throwable getRootCause(Throwable throwable) {
+        Throwable cause = throwable;
+        while (cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+        return cause;
+    }
+
+    public static void registerSecurityProviderIfNeeded(Class<?> callerClass) throws Exception {
+        if (Strings.isNullOrEmpty(Config.ssl_security_provider_class)) {
+            return;
+        }
+        if (!Strings.isNullOrEmpty(Config.ssl_security_provider_name) &&
+                Security.getProvider(Config.ssl_security_provider_name) != null) {
+            return;
+        }
+
+        Class<?> providerClass;
+        if (Strings.isNullOrEmpty(Config.ssl_security_provider_path)) {
+            providerClass = Class.forName(Config.ssl_security_provider_class);
+        } else {
+            String[] paths = Config.ssl_security_provider_path.split(File.pathSeparator);
+            URL[] urls = new URL[paths.length];
+            for (int i = 0; i < paths.length; i++) {
+                urls[i] = new File(paths[i]).toURI().toURL();
+            }
+            URLClassLoader classLoader = new URLClassLoader(urls, callerClass.getClassLoader());
+            providerClass = Class.forName(Config.ssl_security_provider_class, true, classLoader);
+        }
+
+        Object providerObject = providerClass.getDeclaredConstructor().newInstance();
+        if (!(providerObject instanceof Provider)) {
+            throw new GeneralSecurityException("SSL security provider class " +
+                    Config.ssl_security_provider_class + " is not a java.security.Provider");
+        }
+        Provider provider = (Provider) providerObject;
+        if (!Strings.isNullOrEmpty(Config.ssl_security_provider_name) &&
+                !Config.ssl_security_provider_name.equals(provider.getName())) {
+            throw new GeneralSecurityException("Configured SSL security provider name " +
+                    Config.ssl_security_provider_name + " does not match provider class name " + provider.getName());
+        }
+        Security.addProvider(provider);
+        LOG.info("Registered SSL security provider {} from {}", provider.getName(),
+                Strings.isNullOrEmpty(Config.ssl_security_provider_path) ? "classpath" :
+                        Config.ssl_security_provider_path);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/HttpSSLContextLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/HttpSSLContextLoader.java
@@ -16,13 +16,12 @@ package com.starrocks.http.rest;
 
 import com.google.common.base.Strings;
 import com.starrocks.common.Config;
+import com.starrocks.common.util.SSLUtil;
 import com.starrocks.http.SslUtil;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 
-import java.io.FileInputStream;
-import java.io.InputStream;
 import java.security.KeyStore;
 import java.util.Arrays;
 import javax.net.ssl.KeyManagerFactory;
@@ -43,22 +42,26 @@ public class HttpSSLContextLoader {
     }
 
     private static SslContext createSSLContext() throws Exception {
-        KeyStore keyStore = KeyStore.getInstance("JKS");
-        try (InputStream keyStoreIS = new FileInputStream(Config.ssl_keystore_location)) {
-            if (Strings.isNullOrEmpty(Config.ssl_keystore_password)) {
-                throw new IllegalArgumentException("The SSL keystore password cannot be null or empty.");
-            }
-            keyStore.load(keyStoreIS, Config.ssl_keystore_password.toCharArray());
+        SSLUtil.registerSecurityProviderIfNeeded(HttpSSLContextLoader.class);
+
+        if (Strings.isNullOrEmpty(Config.ssl_keystore_password)) {
+            throw new IllegalArgumentException("The SSL keystore password cannot be null or empty.");
         }
-        KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
         if (Config.ssl_key_password == null) {
             throw new IllegalArgumentException("SSL key password (Config.ssl_key_password) cannot be null.");
         }
+
+        KeyStore keyStore = SSLUtil.loadKeyStore(Config.ssl_keystore_location, Config.ssl_keystore_password,
+                Config.ssl_keystore_type, Config.ssl_keystore_provider, "keystore");
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
         kmf.init(keyStore, Config.ssl_key_password.toCharArray());
 
         String[] supportedCiphers = ((SSLServerSocketFactory) SSLServerSocketFactory.getDefault())
                 .getSupportedCipherSuites();
         String[] filteredCiphers = SslUtil.filterCipherSuites(supportedCiphers);
-        return SslContextBuilder.forServer(kmf).sslProvider(SslProvider.JDK).ciphers(Arrays.asList(filteredCiphers)).build();
+        return SslContextBuilder.forServer(kmf)
+                .sslProvider(SslProvider.JDK)
+                .ciphers(Arrays.asList(filteredCiphers))
+                .build();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/ssl/SSLContextLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/ssl/SSLContextLoader.java
@@ -16,12 +16,11 @@ package com.starrocks.mysql.ssl;
 
 import com.google.common.base.Strings;
 import com.starrocks.common.Config;
+import com.starrocks.common.util.SSLUtil;
 import com.starrocks.http.SslUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.FileInputStream;
-import java.io.InputStream;
 import java.security.KeyStore;
 import java.security.SecureRandom;
 import javax.net.ssl.KeyManagerFactory;
@@ -57,17 +56,18 @@ public class SSLContextLoader {
     }
 
     private static SSLContext createSSLContext() throws Exception {
-        KeyStore keyStore = KeyStore.getInstance("JKS");
-        try (InputStream keyStoreIS = new FileInputStream(Config.ssl_keystore_location)) {
-            keyStore.load(keyStoreIS, Config.ssl_keystore_password.toCharArray());
-        }
+        SSLUtil.registerSecurityProviderIfNeeded(SSLContextLoader.class);
+
+        KeyStore keyStore = SSLUtil.loadKeyStore(Config.ssl_keystore_location, Config.ssl_keystore_password,
+                Config.ssl_keystore_type, Config.ssl_keystore_provider, "keystore");
         KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
         kmf.init(keyStore, Config.ssl_key_password.toCharArray());
 
         SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
         TrustManager[] trustManagers = null;
         if (!Strings.isNullOrEmpty(Config.ssl_truststore_location)) {
-            trustManagers = createTrustManagers(Config.ssl_truststore_location, Config.ssl_truststore_password);
+            trustManagers = createTrustManagers(Config.ssl_truststore_location, Config.ssl_truststore_password,
+                    Config.ssl_truststore_type, Config.ssl_truststore_provider);
         }
         sslContext.init(kmf.getKeyManagers(), trustManagers, new SecureRandom());
 
@@ -79,11 +79,9 @@ public class SSLContextLoader {
         return SslUtil.filterCipherSuites(supportedCiphers);
     }
 
-    private static TrustManager[] createTrustManagers(String filepath, String keystorePassword) throws Exception {
-        KeyStore trustStore = KeyStore.getInstance("JKS");
-        try (InputStream trustStoreIS = new FileInputStream(filepath)) {
-            trustStore.load(trustStoreIS, keystorePassword.toCharArray());
-        }
+    private static TrustManager[] createTrustManagers(String filepath, String keystorePassword,
+                                                      String storeType, String storeProvider) throws Exception {
+        KeyStore trustStore = SSLUtil.loadKeyStore(filepath, keystorePassword, storeType, storeProvider, "truststore");
         TrustManagerFactory trustFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
         trustFactory.init(trustStore);
         return trustFactory.getTrustManagers();

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/SSLUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/SSLUtilTest.java
@@ -1,0 +1,204 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import com.starrocks.common.Config;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.Provider;
+import java.security.Security;
+
+public class SSLUtilTest {
+    private static final String PASSWORD = "starrocks";
+    private static final String TEST_PROVIDER_NAME = "StarRocksSSLUtilTestProvider";
+    private static final String MISMATCH_PROVIDER_NAME = "StarRocksSSLUtilMismatchProvider";
+
+    @TempDir
+    public Path tempDir;
+
+    @AfterEach
+    public void tearDown() {
+        Config.ssl_security_provider_class = "";
+        Config.ssl_security_provider_name = "";
+        Config.ssl_security_provider_path = "";
+        Security.removeProvider(TEST_PROVIDER_NAME);
+        Security.removeProvider(MISMATCH_PROVIDER_NAME);
+    }
+
+    @Test
+    public void testLoadKeyStoreAutoDetectsPkcs12() throws Exception {
+        Path keyStorePath = createKeyStore("PKCS12", "starrocks-keystore.p12");
+
+        KeyStore keyStore = SSLUtil.loadKeyStore(keyStorePath.toString(), PASSWORD, "", "", "keystore");
+
+        Assertions.assertNotNull(keyStore);
+        Assertions.assertEquals(0, keyStore.size());
+        Assertions.assertTrue("PKCS12".equalsIgnoreCase(keyStore.getType()));
+    }
+
+    @Test
+    public void testLoadKeyStoreAutoDetectsJks() throws Exception {
+        String compat = Security.getProperty("keystore.type.compat");
+        Security.setProperty("keystore.type.compat", "false");
+        try {
+            Path keyStorePath = createKeyStore("JKS", "starrocks-keystore.jks");
+
+            KeyStore keyStore = SSLUtil.loadKeyStore(keyStorePath.toString(), PASSWORD, "", "", "keystore");
+
+            Assertions.assertNotNull(keyStore);
+            Assertions.assertEquals(0, keyStore.size());
+            Assertions.assertTrue("JKS".equalsIgnoreCase(keyStore.getType()));
+        } finally {
+            Security.setProperty("keystore.type.compat", compat == null ? "true" : compat);
+        }
+    }
+
+    @Test
+    public void testLoadKeyStoreWithExplicitType() throws Exception {
+        Path keyStorePath = createKeyStore("PKCS12", "starrocks-keystore.p12");
+
+        KeyStore keyStore = SSLUtil.loadKeyStore(keyStorePath.toString(), PASSWORD, "PKCS12", "", "keystore");
+
+        Assertions.assertNotNull(keyStore);
+        Assertions.assertEquals(0, keyStore.size());
+    }
+
+    @Test
+    public void testLoadKeyStoreWithExplicitTypeReportsRootCause() {
+        Path keyStorePath = tempDir.resolve("missing-keystore.p12");
+
+        GeneralSecurityException e = Assertions.assertThrows(GeneralSecurityException.class,
+                () -> SSLUtil.loadKeyStore(keyStorePath.toString(), PASSWORD, "PKCS12", "", "keystore"));
+
+        Assertions.assertTrue(e.getMessage().contains("root cause: java.io.FileNotFoundException"));
+    }
+
+    @Test
+    public void testLoadKeyStoreWithExplicitProvider() throws Exception {
+        Path keyStorePath = createKeyStore("PKCS12", "starrocks-keystore.p12");
+        String providerName = KeyStore.getInstance("PKCS12").getProvider().getName();
+
+        KeyStore keyStore = SSLUtil.loadKeyStore(
+                keyStorePath.toString(), PASSWORD, "PKCS12", providerName, "keystore");
+
+        Assertions.assertNotNull(keyStore);
+        Assertions.assertEquals(0, keyStore.size());
+        Assertions.assertEquals(providerName, keyStore.getProvider().getName());
+    }
+
+    @Test
+    public void testLoadKeyStoreRequiresTypeWhenProviderConfigured() throws Exception {
+        Path keyStorePath = createKeyStore("PKCS12", "starrocks-keystore.p12");
+
+        GeneralSecurityException e = Assertions.assertThrows(GeneralSecurityException.class,
+                () -> SSLUtil.loadKeyStore(
+                        keyStorePath.toString(), PASSWORD, "", "SUN", "keystore"));
+
+        Assertions.assertTrue(e.getMessage().contains(
+                "SSL keystore type must be set when SSL keystore provider 'SUN' is configured"));
+    }
+
+    @Test
+    public void testLoadKeyStoreAutoDetectionReportsFailure() throws Exception {
+        Path keyStorePath = createKeyStore("PKCS12", "starrocks-keystore.p12");
+
+        GeneralSecurityException e = Assertions.assertThrows(GeneralSecurityException.class,
+                () -> SSLUtil.loadKeyStore(keyStorePath.toString(), "wrong-password", "", "", "keystore"));
+
+        Assertions.assertTrue(e.getMessage().contains("auto-detected type"));
+        Assertions.assertNotNull(e.getCause());
+        Assertions.assertTrue(e.getSuppressed().length > 0);
+    }
+
+    @Test
+    public void testLoadKeyStoreAutoDetectionReportsRootCauseInMessage() {
+        Path keyStorePath = tempDir.resolve("missing-keystore.p12");
+
+        GeneralSecurityException e = Assertions.assertThrows(GeneralSecurityException.class,
+                () -> SSLUtil.loadKeyStore(keyStorePath.toString(), PASSWORD, "", "", "keystore"));
+
+        Assertions.assertTrue(e.getMessage().contains("java.io.FileNotFoundException"));
+    }
+
+    @Test
+    public void testRegisterSecurityProviderSkipsExistingProvider() throws Exception {
+        Security.addProvider(new TestProvider());
+        Config.ssl_security_provider_class = "com.starrocks.common.util.NoSuchProvider";
+        Config.ssl_security_provider_name = TEST_PROVIDER_NAME;
+
+        SSLUtil.registerSecurityProviderIfNeeded(SSLUtilTest.class);
+
+        Assertions.assertNotNull(Security.getProvider(TEST_PROVIDER_NAME));
+    }
+
+    @Test
+    public void testRegisterSecurityProviderFromClasspath() throws Exception {
+        Config.ssl_security_provider_class = TestProvider.class.getName();
+        Config.ssl_security_provider_name = TEST_PROVIDER_NAME;
+
+        SSLUtil.registerSecurityProviderIfNeeded(SSLUtilTest.class);
+
+        Assertions.assertNotNull(Security.getProvider(TEST_PROVIDER_NAME));
+    }
+
+    @Test
+    public void testRegisterSecurityProviderRejectsNonProviderClass() {
+        Config.ssl_security_provider_class = NotProvider.class.getName();
+
+        GeneralSecurityException e = Assertions.assertThrows(GeneralSecurityException.class,
+                () -> SSLUtil.registerSecurityProviderIfNeeded(SSLUtilTest.class));
+
+        Assertions.assertTrue(e.getMessage().contains("is not a java.security.Provider"));
+    }
+
+    @Test
+    public void testRegisterSecurityProviderRejectsNameMismatch() {
+        Config.ssl_security_provider_class = TestProvider.class.getName();
+        Config.ssl_security_provider_name = MISMATCH_PROVIDER_NAME;
+
+        GeneralSecurityException e = Assertions.assertThrows(GeneralSecurityException.class,
+                () -> SSLUtil.registerSecurityProviderIfNeeded(SSLUtilTest.class));
+
+        Assertions.assertTrue(e.getMessage().contains("does not match provider class name"));
+    }
+
+    private Path createKeyStore(String storeType, String fileName) throws Exception {
+        KeyStore keyStore = KeyStore.getInstance(storeType);
+        keyStore.load(null, PASSWORD.toCharArray());
+
+        Path keyStorePath = tempDir.resolve(fileName);
+        try (OutputStream out = Files.newOutputStream(keyStorePath)) {
+            keyStore.store(out, PASSWORD.toCharArray());
+        }
+        return keyStorePath;
+    }
+
+    public static class TestProvider extends Provider {
+        public TestProvider() {
+            super(TEST_PROVIDER_NAME, "1.0", "Test SSL provider");
+        }
+    }
+
+    public static class NotProvider {
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/http/HttpSslContextBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/HttpSslContextBuilderTest.java
@@ -54,6 +54,11 @@ class HttpSslContextBuilderTest {
         Config.enable_https = true;
         Config.ssl_keystore_password = "pass";
         Config.ssl_key_password = "pass";
+        Config.ssl_keystore_type = "";
+        Config.ssl_keystore_provider = "";
+        Config.ssl_security_provider_class = "";
+        Config.ssl_security_provider_name = "";
+        Config.ssl_security_provider_path = "";
         File f = File.createTempFile("keystore", ".jks");
         f.deleteOnExit();
         Config.ssl_keystore_location = f.getAbsolutePath();


### PR DESCRIPTION
## Why I'm doing:

StarRocks FE SSL loading currently assumes a fixed keystore format in some paths, which causes problems in FIPS-compliant environments where BCFKS with a specific security provider such as BCFIPS may be required. It can also break compatibility for existing PKCS12 keystores when no explicit keystore type is configured.

This change makes SSL keystore and truststore loading configurable while preserving the previous auto-detection behavior for JKS and PKCS12.

## What I'm doing:

- Add configurable SSL keystore/truststore type and provider settings.
- Add optional security provider registration for SSL loading, including provider class, provider name, and provider path.
- Share SSL keystore loading logic between MySQL SSL and HTTPS SSL paths.
- Preserve backward compatibility by auto-detecting JKS and PKCS12 when the keystore/truststore type is not explicitly configured.
- Add unit tests for SSL keystore loading with auto-detected JKS/PKCS12 and explicit PKCS12.
- Update FE configuration examples and SSL authentication documentation.

Fixes [#78098](https://github.com/StarRocks/starrocks/issues/78098)

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5