### PR TITLE
[BugFix] Decide condition update and partial update per owning child

### DIFF
--- a/be/src/storage/lake/column_mode_partial_update_handler.cpp
+++ b/be/src/storage/lake/column_mode_partial_update_handler.cpp
@@ -105,12 +105,7 @@ Status ColumnModePartialUpdateHandler::_load_update_state(const RowsetUpdateStat
 
     // Create segment iterators for update files
     OlapReaderStatistics stats;
-    // Emit every row of a shared segment and answer ownership per row instead of letting the tablet
-    // range narrow the iterator: the two branches this handler takes below -- apply the update through
-    // a DCG, or materialize the row into a new segment -- cannot be told apart from the rss_rowid
-    // alone, so it needs the mask, and the mask only exists if the rows reach the selector.
-    ASSIGN_OR_RETURN(auto segment_iters, _rowset_ptr->get_each_segment_iterator(pkey_schema, true, &stats,
-                                                                                /*apply_tablet_range=*/false));
+    ASSIGN_OR_RETURN(auto segment_iters, _rowset_ptr->get_each_segment_iterator(pkey_schema, true, &stats));
     RETURN_ERROR_IF_FALSE(segment_iters.size() == num_segments);
     // Only a SPLIT child's cross publish gets one; nullptr on every ordinary publish, and then every
     // row is owned. Held by the handler because the iterators keep referencing it.
@@ -336,10 +331,7 @@ Status ColumnModePartialUpdateHandler::_update_source_chunk_by_upt(const UptidTo
     TRACE_COUNTER_SCOPE_LATENCY_US("pcu_update_source_by_upt_us");
     // build iterators
     OlapReaderStatistics stats;
-    // Unclipped for the same reason site 1 is: the upt rowids in |upt_id_to_rowid_pairs| index into the
-    // chunk this reads, so both must address the update segment the same way.
-    ASSIGN_OR_RETURN(auto segment_iters, _rowset_ptr->get_each_segment_iterator(partial_schema, true, &stats,
-                                                                                /*apply_tablet_range=*/false));
+    ASSIGN_OR_RETURN(auto segment_iters, _rowset_ptr->get_each_segment_iterator(partial_schema, true, &stats));
     RETURN_ERROR_IF_FALSE(segment_iters.size() == _rowset_ptr->num_segments());
     // handle upt files one by one
     for (const auto& each : upt_id_to_rowid_pairs) {

--- a/be/src/storage/lake/column_mode_partial_update_handler.cpp
+++ b/be/src/storage/lake/column_mode_partial_update_handler.cpp
@@ -110,12 +110,12 @@ Status ColumnModePartialUpdateHandler::_load_update_state(const RowsetUpdateStat
     // a DCG, or materialize the row into a new segment -- cannot be told apart from the rss_rowid
     // alone, so it needs the mask, and the mask only exists if the rows reach the selector.
     ASSIGN_OR_RETURN(auto segment_iters, _rowset_ptr->get_each_segment_iterator(pkey_schema, true, &stats,
-                                                                               /*apply_tablet_range=*/false));
+                                                                                /*apply_tablet_range=*/false));
     RETURN_ERROR_IF_FALSE(segment_iters.size() == num_segments);
     // Only a SPLIT child's cross publish gets one; nullptr on every ordinary publish, and then every
     // row is owned. Held by the handler because the iterators keep referencing it.
     ASSIGN_OR_RETURN(_row_selector, CrossPublishRowSelector::create_if_needed(*params.metadata, params.tablet_schema,
-                                                                             _rowset_ptr->metadata()));
+                                                                              _rowset_ptr->metadata()));
 
     // Create lazy-load SegmentPKIterators with deferred first load.
     // defer_data_load=true avoids loading the first chunk during init(), so that
@@ -146,7 +146,7 @@ Status ColumnModePartialUpdateHandler::_load_update_state(const RowsetUpdateStat
     for (uint32_t i = 0; i < num_segments; i++) {
         _partial_update_states[i].src_rss_rowids = std::move(rss_rowids_per_segment[i]);
         _partial_update_states[i].build_rss_rowid_to_update_rowid(pk_iters[i]->physical_rowid_base(),
-                                                                 owned_per_segment[i]);
+                                                                  owned_per_segment[i]);
         _partial_update_states[i].inited = true;
     }
 
@@ -339,7 +339,7 @@ Status ColumnModePartialUpdateHandler::_update_source_chunk_by_upt(const UptidTo
     // Unclipped for the same reason site 1 is: the upt rowids in |upt_id_to_rowid_pairs| index into the
     // chunk this reads, so both must address the update segment the same way.
     ASSIGN_OR_RETURN(auto segment_iters, _rowset_ptr->get_each_segment_iterator(partial_schema, true, &stats,
-                                                                               /*apply_tablet_range=*/false));
+                                                                                /*apply_tablet_range=*/false));
     RETURN_ERROR_IF_FALSE(segment_iters.size() == _rowset_ptr->num_segments());
     // handle upt files one by one
     for (const auto& each : upt_id_to_rowid_pairs) {

--- a/be/src/storage/lake/column_mode_partial_update_handler.cpp
+++ b/be/src/storage/lake/column_mode_partial_update_handler.cpp
@@ -105,8 +105,17 @@ Status ColumnModePartialUpdateHandler::_load_update_state(const RowsetUpdateStat
 
     // Create segment iterators for update files
     OlapReaderStatistics stats;
-    ASSIGN_OR_RETURN(auto segment_iters, _rowset_ptr->get_each_segment_iterator(pkey_schema, true, &stats));
+    // Emit every row of a shared segment and answer ownership per row instead of letting the tablet
+    // range narrow the iterator: the two branches this handler takes below -- apply the update through
+    // a DCG, or materialize the row into a new segment -- cannot be told apart from the rss_rowid
+    // alone, so it needs the mask, and the mask only exists if the rows reach the selector.
+    ASSIGN_OR_RETURN(auto segment_iters, _rowset_ptr->get_each_segment_iterator(pkey_schema, true, &stats,
+                                                                               /*apply_tablet_range=*/false));
     RETURN_ERROR_IF_FALSE(segment_iters.size() == num_segments);
+    // Only a SPLIT child's cross publish gets one; nullptr on every ordinary publish, and then every
+    // row is owned. Held by the handler because the iterators keep referencing it.
+    ASSIGN_OR_RETURN(_row_selector, CrossPublishRowSelector::create_if_needed(*params.metadata, params.tablet_schema,
+                                                                             _rowset_ptr->metadata()));
 
     // Create lazy-load SegmentPKIterators with deferred first load.
     // defer_data_load=true avoids loading the first chunk during init(), so that
@@ -115,6 +124,8 @@ Status ColumnModePartialUpdateHandler::_load_update_state(const RowsetUpdateStat
     std::vector<SegmentPKIteratorPtr> pk_iters(num_segments);
     for (uint32_t i = 0; i < num_segments; i++) {
         pk_iters[i] = std::make_unique<SegmentPKIterator>();
+        // Must precede init(): the selection is built inside _load().
+        pk_iters[i]->set_row_selector(_row_selector.get());
         RETURN_IF_ERROR(pk_iters[i]->init(segment_iters[i], pkey_schema, true /*lazy_load*/, pk_encoding_type,
                                           true /*defer_data_load*/));
     }
@@ -122,8 +133,10 @@ Status ColumnModePartialUpdateHandler::_load_update_state(const RowsetUpdateStat
     // Parallel query PK index: each segment's PKs are loaded chunk-by-chunk (lazy)
     // and each chunk is queried against the index in parallel via thread pool.
     std::vector<std::vector<uint64_t>> rss_rowids_per_segment;
+    std::vector<Filter> owned_per_segment;
     RETURN_IF_ERROR(params.tablet->update_mgr()->batch_get_rss_rowids_from_pkindex(
-            params.tablet->id(), _base_version, pk_iters, &rss_rowids_per_segment, false /*need_lock*/));
+            params.tablet->id(), _base_version, pk_iters, &rss_rowids_per_segment, false /*need_lock*/,
+            &owned_per_segment));
 
     // Build rss_rowid_to_update_rowid mapping for each update segment. Pass each
     // segment's physical rowid base (range_start, captured by the iterator during
@@ -132,7 +145,8 @@ Status ColumnModePartialUpdateHandler::_load_update_state(const RowsetUpdateStat
     _partial_update_states.resize(num_segments);
     for (uint32_t i = 0; i < num_segments; i++) {
         _partial_update_states[i].src_rss_rowids = std::move(rss_rowids_per_segment[i]);
-        _partial_update_states[i].build_rss_rowid_to_update_rowid(pk_iters[i]->physical_rowid_base());
+        _partial_update_states[i].build_rss_rowid_to_update_rowid(pk_iters[i]->physical_rowid_base(),
+                                                                 owned_per_segment[i]);
         _partial_update_states[i].inited = true;
     }
 
@@ -322,7 +336,10 @@ Status ColumnModePartialUpdateHandler::_update_source_chunk_by_upt(const UptidTo
     TRACE_COUNTER_SCOPE_LATENCY_US("pcu_update_source_by_upt_us");
     // build iterators
     OlapReaderStatistics stats;
-    ASSIGN_OR_RETURN(auto segment_iters, _rowset_ptr->get_each_segment_iterator(partial_schema, true, &stats));
+    // Unclipped for the same reason site 1 is: the upt rowids in |upt_id_to_rowid_pairs| index into the
+    // chunk this reads, so both must address the update segment the same way.
+    ASSIGN_OR_RETURN(auto segment_iters, _rowset_ptr->get_each_segment_iterator(partial_schema, true, &stats,
+                                                                               /*apply_tablet_range=*/false));
     RETURN_ERROR_IF_FALSE(segment_iters.size() == _rowset_ptr->num_segments());
     // handle upt files one by one
     for (const auto& each : upt_id_to_rowid_pairs) {

--- a/be/src/storage/lake/column_mode_partial_update_handler.h
+++ b/be/src/storage/lake/column_mode_partial_update_handler.h
@@ -16,6 +16,7 @@
 
 #include <functional>
 
+#include "storage/lake/cross_publish_context.h"
 #include "storage/lake/rowset_update_state.h"
 #include "storage/lake/tablet_metadata.h"
 #include "storage/rowset_column_update_state.h"
@@ -76,6 +77,8 @@ private:
     // `_rowset_meta_ptr` contains full life cycle rowset meta in `_rowset_ptr`.
     RowsetMetadataUniquePtr _rowset_meta_ptr;
     std::unique_ptr<Rowset> _rowset_ptr;
+    // Only a SPLIT child's cross publish builds one. Outlives the SegmentPKIterators that reference it.
+    CrossPublishRowSelectorPtr _row_selector;
     int64_t _upt_memory_usage_per_row = 0;
 };
 

--- a/be/src/storage/lake/cross_publish_context.h
+++ b/be/src/storage/lake/cross_publish_context.h
@@ -29,21 +29,24 @@ namespace starrocks::lake {
 // Decides, row by row, which rows of a cross-published rowset this tablet actually owns.
 //
 // A SPLIT cross publish hands every child the parent's whole op_write payload and leaves each side to
-// work out which rows are its own. Today the tablet range answers that on the read path:
+// work out which rows are its own. The tablet range can answer that by narrowing the read:
 // SegmentIterator::_apply_tablet_range turns it into a rowid interval, and _lookup_ordinal resolves
 // the bounds exactly -- the short key index only brackets the search, which then binary-searches the
-// actual rows and compares per column. So a child reading a shared segment sees precisely its own
-// rows, and this selector has nothing to add.
+// actual rows and compares per column. That is what the READ path does, and what the publish path
+// used to do as well.
 //
-// That holds only while the range and the physical order live in the same key space. A primary-key
-// tablet ordered by a separate sort key has its rows scattered through the segment, no rowid interval
-// describes them, and Rowset::set_segment_tablet_range withholds the range outright -- at which point
-// the child reads every row and nothing narrows it.
+// Publish asks for every row instead (get_each_segment_iterator's apply_tablet_range=false) and uses
+// this selector, for two reasons. The narrowing only works while the range and the physical order live
+// in the same key space: a primary-key tablet ordered by a separate sort key has its rows scattered
+// through the segment, no rowid interval describes them, and Rowset::set_segment_tablet_range
+// withholds the range outright -- at which point a narrowing consumer silently sees every row as its
+// own. And a narrowed iterator gives the publish state fewer entries than the source segment has rows,
+// which the row-mode partial update rewrite cannot use: SegmentRewriter copies the source segment
+// whole and demands one value per row of it.
 //
-// No such tablet exists yet: CreateTableAnalyzer requires a range-distributed primary-key table to
-// declare ORDER BY equal to its key columns, and OPTIMIZE -- the only clause that rewrites a sort key
-// -- is rejected on range-distributed tables. This is the row-level answer that relaxation needs,
-// built ahead of it rather than a fix for a live defect. #77653 stages the rest.
+// So ownership is one decision, made here, per row: consumers get a mask (SegmentPKChunkRef::owned)
+// and every rowid they derive still names the row's position in the source segment. #77653 stages the
+// rest of the consumers.
 //
 // What the shape of the answer buys, and why it is a mask rather than a filtered chunk: the chunk
 // keeps its rows and their positions, so SegmentPKChunkRef's "chunk[i] is physical rowid

--- a/be/src/storage/lake/cross_publish_context.h
+++ b/be/src/storage/lake/cross_publish_context.h
@@ -29,24 +29,24 @@ namespace starrocks::lake {
 // Decides, row by row, which rows of a cross-published rowset this tablet actually owns.
 //
 // A SPLIT cross publish hands every child the parent's whole op_write payload and leaves each side to
-// work out which rows are its own. The tablet range can answer that by narrowing the read:
+// work out which rows are its own. The tablet range already answers that whenever it can:
 // SegmentIterator::_apply_tablet_range turns it into a rowid interval, and _lookup_ordinal resolves
 // the bounds exactly -- the short key index only brackets the search, which then binary-searches the
-// actual rows and compares per column. That is what the READ path does, and what the publish path
-// used to do as well.
+// actual rows and compares per column. So a child reading a shared segment, on the read path or
+// through get_each_segment_iterator on the publish path, sees precisely its own rows.
 //
-// Publish asks for every row instead (get_each_segment_iterator's apply_tablet_range=false) and uses
-// this selector, for two reasons. The narrowing only works while the range and the physical order live
-// in the same key space: a primary-key tablet ordered by a separate sort key has its rows scattered
-// through the segment, no rowid interval describes them, and Rowset::set_segment_tablet_range
-// withholds the range outright -- at which point a narrowing consumer silently sees every row as its
-// own. And a narrowed iterator gives the publish state fewer entries than the source segment has rows,
-// which the row-mode partial update rewrite cannot use: SegmentRewriter copies the source segment
-// whole and demands one value per row of it.
+// That holds only while the range and the physical order live in the same key space. A primary-key
+// tablet ordered by a separate sort key has its rows scattered through the segment, no rowid interval
+// describes them, and Rowset::set_segment_tablet_range withholds the range outright -- at which point
+// the iterator emits every row and a consumer that assumes otherwise silently takes a sibling's.
 //
-// So ownership is one decision, made here, per row: consumers get a mask (SegmentPKChunkRef::owned)
-// and every rowid they derive still names the row's position in the source segment. #77653 stages the
-// rest of the consumers.
+// This selector is the answer for exactly that case, and the two mechanisms are complementary rather
+// than redundant: where the range narrows, the mask it produces is all ones and costs nothing; where
+// the range is withheld, the mask is the only thing that knows. No such tablet exists yet --
+// CreateTableAnalyzer requires a range-distributed primary-key table to declare ORDER BY equal to its
+// key columns, and OPTIMIZE, the only clause that rewrites a sort key, is rejected on range-distributed
+// tables -- so this is built ahead of that relaxation rather than as a fix for a live defect. #77653
+// stages the rest of the consumers.
 //
 // What the shape of the answer buys, and why it is a mask rather than a filtered chunk: the chunk
 // keeps its rows and their positions, so SegmentPKChunkRef's "chunk[i] is physical rowid

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -308,6 +308,24 @@ int64_t LakePrimaryIndex::publish_sst_flush_bytes() const {
 // - Each task allocates its own slot to avoid data races during parallel execution
 // - Shared state (deletes, status) is protected by mutex when updated
 // - Errors are accumulated and checked after all tasks complete
+Status LakePrimaryIndex::upsert_rows(uint32_t rssid, const std::vector<uint32_t>& rowids, MutableColumnPtr pks,
+                                     DeletesMap* deletes) {
+    if (rowids.empty()) {
+        return Status::OK();
+    }
+    // No token: the lookup of replaced locations runs inline, which leaves them in the slot rather
+    // than draining them, so this drains them itself -- same split of responsibility as upsert_owned.
+    std::mutex mutex;
+    Status status = Status::OK();
+    ParallelPublishContext context{.token = nullptr, .mutex = &mutex, .deletes = deletes, .status = &status};
+    context.extend_slots();
+    auto* slot = context.slots.back().get();
+    slot->pk_column = std::move(pks);
+    RETURN_IF_ERROR(upsert(rssid, rowids, *slot->pk_column, nullptr /* stat */, &context));
+    old_values_to_deletes(slot->old_values, deletes);
+    return status;
+}
+
 Status LakePrimaryIndex::upsert_owned(uint32_t rssid, const SegmentPKChunkRef& current, ParallelPublishSlot* slot,
                                       ParallelPublishContext* context) {
     DCHECK(!current.owned.empty());

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -502,9 +502,8 @@ Status LakePrimaryIndex::batch_parallel_get_rss_rowids(ThreadPoolToken* token,
         }
         // Only materialize a mask for a segment that actually has one; leaving it empty is what tells
         // the consumer "own every row", and is what every non-cross publish produces.
-        const bool has_mask = std::any_of(slots.begin(), slots.end(), [](const auto& slot) {
-            return !slot->owned.empty();
-        });
+        const bool has_mask =
+                std::any_of(slots.begin(), slots.end(), [](const auto& slot) { return !slot->owned.empty(); });
         if (!has_mask) {
             continue;
         }

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -308,24 +308,6 @@ int64_t LakePrimaryIndex::publish_sst_flush_bytes() const {
 // - Each task allocates its own slot to avoid data races during parallel execution
 // - Shared state (deletes, status) is protected by mutex when updated
 // - Errors are accumulated and checked after all tasks complete
-Status LakePrimaryIndex::upsert_rows(uint32_t rssid, const std::vector<uint32_t>& rowids, MutableColumnPtr pks,
-                                     DeletesMap* deletes) {
-    if (rowids.empty()) {
-        return Status::OK();
-    }
-    // No token: the lookup of replaced locations runs inline, which leaves them in the slot rather
-    // than draining them, so this drains them itself -- same split of responsibility as upsert_owned.
-    std::mutex mutex;
-    Status status = Status::OK();
-    ParallelPublishContext context{.token = nullptr, .mutex = &mutex, .deletes = deletes, .status = &status};
-    context.extend_slots();
-    auto* slot = context.slots.back().get();
-    slot->pk_column = std::move(pks);
-    RETURN_IF_ERROR(upsert(rssid, rowids, *slot->pk_column, nullptr /* stat */, &context));
-    old_values_to_deletes(slot->old_values, deletes);
-    return status;
-}
-
 Status LakePrimaryIndex::upsert_owned(uint32_t rssid, const SegmentPKChunkRef& current, ParallelPublishSlot* slot,
                                       ParallelPublishContext* context) {
     DCHECK(!current.owned.empty());

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -411,15 +411,22 @@ Status LakePrimaryIndex::parallel_get(ThreadPoolToken* token, SegmentPKIterator*
 // Submits chunks from all segments to a single shared thread pool token, enabling
 // cross-segment parallelism.
 Status LakePrimaryIndex::batch_parallel_get_rss_rowids(ThreadPoolToken* token,
-                                                       std::vector<SegmentPKIteratorPtr>& pk_iters,
-                                                       std::vector<std::vector<uint64_t>>* rss_rowids_per_segment) {
+                                                       std::vector<std::unique_ptr<SegmentPKIterator>>& pk_iters,
+                                                       std::vector<std::vector<uint64_t>>* rss_rowids_per_segment,
+                                                       std::vector<Filter>* owned_per_segment) {
     const uint32_t num_segments = pk_iters.size();
     rss_rowids_per_segment->resize(num_segments);
+    if (owned_per_segment != nullptr) {
+        owned_per_segment->assign(num_segments, Filter{});
+    }
 
     struct RssRowidSlot {
         size_t begin_rowid = 0;
         size_t count = 0;
         std::vector<uint64_t> values;
+        // Moved off the chunk ref before the lookup task runs, so the merge below can concatenate the
+        // segment's mask in chunk order. Empty when this chunk carried none.
+        Filter owned;
     };
 
     std::mutex mutex;
@@ -437,6 +444,7 @@ Status LakePrimaryIndex::batch_parallel_get_rss_rowids(ThreadPoolToken* token,
             auto slot = std::make_unique<RssRowidSlot>();
             slot->begin_rowid = segment_logical_offset;
             slot->count = current.chunk->num_rows();
+            slot->owned = current.owned;
             segment_logical_offset += slot->count;
             per_segment_slots[seg_idx].push_back(std::move(slot));
             auto* slot_ptr = per_segment_slots[seg_idx].back().get();
@@ -488,6 +496,25 @@ Status LakePrimaryIndex::batch_parallel_get_rss_rowids(ThreadPoolToken* token,
         output.resize(total);
         for (auto& slot : slots) {
             memcpy(output.data() + slot->begin_rowid, slot->values.data(), slot->count * sizeof(uint64_t));
+        }
+        if (owned_per_segment == nullptr) {
+            continue;
+        }
+        // Only materialize a mask for a segment that actually has one; leaving it empty is what tells
+        // the consumer "own every row", and is what every non-cross publish produces.
+        const bool has_mask = std::any_of(slots.begin(), slots.end(), [](const auto& slot) {
+            return !slot->owned.empty();
+        });
+        if (!has_mask) {
+            continue;
+        }
+        auto& owned_output = (*owned_per_segment)[seg_idx];
+        owned_output.assign(total, 1);
+        for (auto& slot : slots) {
+            if (slot->owned.empty()) {
+                continue;
+            }
+            memcpy(owned_output.data() + slot->begin_rowid, slot->owned.data(), slot->count * sizeof(uint8_t));
         }
     }
 

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -134,9 +134,16 @@ public:
     // Used by column mode partial update to build the update-row-to-source-row mapping.
     // To learn each segment's physical rowid base (range_start), call
     // SegmentPKIterator::physical_rowid_base() on the iterator after this returns.
+    // |owned_per_segment|: if non-null, receives each segment's ownership mask -- the concatenation of
+    // its chunks' SegmentPKChunkRef::owned, one byte per entry of rss_rowids_per_segment[i]. A segment
+    // whose chunks carried no mask (no CrossPublishRowSelector, i.e. every publish but a SPLIT child's
+    // cross publish) leaves its entry empty, which every consumer reads as "own every row". Callers
+    // that would ACT on a missing key -- inserting the row, allocating an id for it -- need this: the
+    // rss_rowid alone cannot tell "no old row" from "a sibling's row".
     Status batch_parallel_get_rss_rowids(ThreadPoolToken* token,
                                          std::vector<std::unique_ptr<SegmentPKIterator>>& pk_iters,
-                                         std::vector<std::vector<uint64_t>>* rss_rowids_per_segment);
+                                         std::vector<std::vector<uint64_t>>* rss_rowids_per_segment,
+                                         std::vector<Filter>* owned_per_segment = nullptr);
 
     // This function will be called when parallel upsert happens.
     // The process flow of parallel upsert is:

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -153,13 +153,6 @@ public:
     // The slot belongs to the caller: it also carries the encoded column, whose bytes the index
     // keeps referencing after this returns when the upsert runs asynchronously. Both call sites hand
     // over a freshly extended slot, so the append-only scratch inside it always starts empty.
-    // Upsert exactly the rows at `rowids` -- absolute positions in the source segment, in the order
-    // `pks` holds them -- and drain the locations they replace into `deletes`. The rowid-vector
-    // overload is the only one that can express a non-contiguous subset, but it reports replaced
-    // locations through a ParallelPublishContext rather than a DeletesMap; this wraps that difference
-    // for the publish paths that hold a DeletesMap and have already decided which rows to write.
-    Status upsert_rows(uint32_t rssid, const std::vector<uint32_t>& rowids, MutableColumnPtr pks, DeletesMap* deletes);
-
     Status upsert_owned(uint32_t rssid, const SegmentPKChunkRef& current, ParallelPublishSlot* slot,
                         ParallelPublishContext* context);
 

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -153,6 +153,13 @@ public:
     // The slot belongs to the caller: it also carries the encoded column, whose bytes the index
     // keeps referencing after this returns when the upsert runs asynchronously. Both call sites hand
     // over a freshly extended slot, so the append-only scratch inside it always starts empty.
+    // Upsert exactly the rows at `rowids` -- absolute positions in the source segment, in the order
+    // `pks` holds them -- and drain the locations they replace into `deletes`. The rowid-vector
+    // overload is the only one that can express a non-contiguous subset, but it reports replaced
+    // locations through a ParallelPublishContext rather than a DeletesMap; this wraps that difference
+    // for the publish paths that hold a DeletesMap and have already decided which rows to write.
+    Status upsert_rows(uint32_t rssid, const std::vector<uint32_t>& rowids, MutableColumnPtr pks, DeletesMap* deletes);
+
     Status upsert_owned(uint32_t rssid, const SegmentPKChunkRef& current, ParallelPublishSlot* slot,
                         ParallelPublishContext* context);
 

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -651,8 +651,7 @@ StatusOr<size_t> Rowset::get_read_iterator_num() {
 }
 
 StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator(const Schema& schema, bool file_data_cache,
-                                                                          OlapReaderStatistics* stats,
-                                                                          bool apply_tablet_range) {
+                                                                          OlapReaderStatistics* stats) {
     TRACE_COUNTER_SCOPE_LATENCY_US("get_each_segment_us");
     std::vector<LoadedSegment> segments;
     RETURN_IF_ERROR(load_segments(&segments, file_data_cache));
@@ -667,10 +666,7 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator(const 
     ASSIGN_OR_RETURN(seg_options.fs, FileSystemFactory::CreateSharedFromString(root_loc));
     seg_options.stats = stats;
 
-    std::optional<SeekRange> shared_segment_range;
-    if (apply_tablet_range) {
-        ASSIGN_OR_RETURN(shared_segment_range, get_seek_range());
-    }
+    ASSIGN_OR_RETURN(auto shared_segment_range, get_seek_range());
 
     // Contract: callers downstream (SegmentPKIterator + LakePrimaryIndex
     // publish) require each emitted chunk's physical rowids to form a single
@@ -701,9 +697,7 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator(const 
                                               tablet_id(), metadata().id(), i));
             continue;
         }
-        if (apply_tablet_range) {
-            RETURN_IF_ERROR(set_segment_tablet_range(segments[i].segment_meta_pos, shared_segment_range, &seg_options));
-        }
+        RETURN_IF_ERROR(set_segment_tablet_range(segments[i].segment_meta_pos, shared_segment_range, &seg_options));
         auto res = seg_ptr->new_iterator(schema, seg_options);
         if (res.status().is_end_of_file()) {
             // Leave seg_iterators[i] as the default null placeholder, preserving alignment.

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -425,9 +425,20 @@ Status Rowset::set_segment_tablet_range(size_t segment_idx, const std::optional<
         }
         return Status::OK();
     }
-    if (segment_idx < static_cast<size_t>(_metadata->segment_metas_size()) &&
-        _metadata->segment_metas(segment_idx).shared() && shared_segment_range.has_value()) {
-        segment_options->tablet_range = *shared_segment_range;
+    if (segment_idx < static_cast<size_t>(_metadata->segment_metas_size()) && shared_segment_range.has_value()) {
+        // A segment needs the range when it can hold rows this tablet does not own. `shared` says so
+        // directly: the split handed that segment to every child. A rowset carrying its OWN range says
+        // so too, and it is not the same set -- convert_txn_log_for_splitting stamps this tablet's range
+        // onto a cross-published op_write, and the segment a row-mode partial update rewrites out of one
+        // is private to this tablet (MetaFileBuilder clears `shared`, because the file really is not
+        // shared) while still holding every row of the source segment, the siblings' rows included.
+        // Without this a reader would serve those rows. A rowset this tablet wrote itself carries no
+        // range of its own and is in range by construction, so it stays unclipped and pays nothing.
+        const bool may_hold_rows_of_other_tablets =
+                _metadata->segment_metas(segment_idx).shared() || _metadata->has_range();
+        if (may_hold_rows_of_other_tablets) {
+            segment_options->tablet_range = *shared_segment_range;
+        }
     }
     return Status::OK();
 }
@@ -640,7 +651,8 @@ StatusOr<size_t> Rowset::get_read_iterator_num() {
 }
 
 StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator(const Schema& schema, bool file_data_cache,
-                                                                          OlapReaderStatistics* stats) {
+                                                                          OlapReaderStatistics* stats,
+                                                                          bool apply_tablet_range) {
     TRACE_COUNTER_SCOPE_LATENCY_US("get_each_segment_us");
     std::vector<LoadedSegment> segments;
     RETURN_IF_ERROR(load_segments(&segments, file_data_cache));
@@ -655,7 +667,10 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator(const 
     ASSIGN_OR_RETURN(seg_options.fs, FileSystemFactory::CreateSharedFromString(root_loc));
     seg_options.stats = stats;
 
-    ASSIGN_OR_RETURN(auto shared_segment_range, get_seek_range());
+    std::optional<SeekRange> shared_segment_range;
+    if (apply_tablet_range) {
+        ASSIGN_OR_RETURN(shared_segment_range, get_seek_range());
+    }
 
     // Contract: callers downstream (SegmentPKIterator + LakePrimaryIndex
     // publish) require each emitted chunk's physical rowids to form a single
@@ -686,7 +701,9 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator(const 
                                               tablet_id(), metadata().id(), i));
             continue;
         }
-        RETURN_IF_ERROR(set_segment_tablet_range(segments[i].segment_meta_pos, shared_segment_range, &seg_options));
+        if (apply_tablet_range) {
+            RETURN_IF_ERROR(set_segment_tablet_range(segments[i].segment_meta_pos, shared_segment_range, &seg_options));
+        }
         auto res = seg_ptr->new_iterator(schema, seg_options);
         if (res.status().is_end_of_file()) {
             // Leave seg_iterators[i] as the default null placeholder, preserving alignment.

--- a/be/src/storage/lake/rowset.h
+++ b/be/src/storage/lake/rowset.h
@@ -195,8 +195,16 @@ public:
     // if the segment is empty, it wouln't add this iterator to iterator list
     // this function does not expect segment schema will be changed, so return error if record predicate exists
     // but does not match its chunk schema
+    // |apply_tablet_range|: whether to narrow a shared (post-split) segment to this tablet's slice of
+    // it before the first row is emitted. True is the historical behaviour and what every caller that
+    // does not select rows itself needs. A cross publish consumer that decides ownership PER ROW
+    // (CrossPublishRowSelector, installed on the SegmentPKIterator) passes false: it needs every row
+    // of the segment, both because its own state has to stay one entry per source row --
+    // SegmentRewriter copies the source segment whole and demands exactly that many values -- and
+    // because clipping and masking are then two mechanisms deciding the same question.
     StatusOr<std::vector<ChunkIteratorPtr>> get_each_segment_iterator(const Schema& schema, bool file_data_cache,
-                                                                      OlapReaderStatistics* stats);
+                                                                      OlapReaderStatistics* stats,
+                                                                      bool apply_tablet_range = true);
 
     // used for primary index load, it will get segment iterator by specifice version and it's delvec,
     // without complex options like predicates

--- a/be/src/storage/lake/rowset.h
+++ b/be/src/storage/lake/rowset.h
@@ -195,16 +195,8 @@ public:
     // if the segment is empty, it wouln't add this iterator to iterator list
     // this function does not expect segment schema will be changed, so return error if record predicate exists
     // but does not match its chunk schema
-    // |apply_tablet_range|: whether to narrow a shared (post-split) segment to this tablet's slice of
-    // it before the first row is emitted. True is the historical behaviour and what every caller that
-    // does not select rows itself needs. A cross publish consumer that decides ownership PER ROW
-    // (CrossPublishRowSelector, installed on the SegmentPKIterator) passes false: it needs every row
-    // of the segment, both because its own state has to stay one entry per source row --
-    // SegmentRewriter copies the source segment whole and demands exactly that many values -- and
-    // because clipping and masking are then two mechanisms deciding the same question.
     StatusOr<std::vector<ChunkIteratorPtr>> get_each_segment_iterator(const Schema& schema, bool file_data_cache,
-                                                                      OlapReaderStatistics* stats,
-                                                                      bool apply_tablet_range = true);
+                                                                      OlapReaderStatistics* stats);
 
     // used for primary index load, it will get segment iterator by specifice version and it's delvec,
     // without complex options like predicates

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -443,7 +443,9 @@ Status RowsetUpdateState::_prepare_partial_update_states(uint32_t segment_id, co
     MutableColumns read_columns;
     read_columns.resize(read_column_ids.size());
     _partial_update_states[segment_id].write_columns.resize(read_columns.size());
-    _partial_update_states[segment_id].src_rss_rowids.resize(_upserts[segment_id]->standalone_pk_column()->size());
+    const auto& segment_pk_column = _upserts[segment_id]->standalone_pk_column();
+    auto& src_rss_rowids = _partial_update_states[segment_id].src_rss_rowids;
+    src_rss_rowids.resize(segment_pk_column->size());
     for (uint32_t j = 0; j < read_columns.size(); ++j) {
         auto column = ChunkFactory::column_from_field(*read_column_schema.field(j).get());
         read_columns[j] = column->clone_empty();
@@ -451,15 +453,43 @@ Status RowsetUpdateState::_prepare_partial_update_states(uint32_t segment_id, co
     }
 
     // use upsert to get rowids for this segment
-    RETURN_IF_ERROR(params.tablet->update_mgr()->get_rowids_from_pkindex(
-            params.tablet->id(), _base_versions[segment_id], _upserts[segment_id]->standalone_pk_column(),
-            &(_partial_update_states[segment_id].src_rss_rowids), need_lock));
+    const Filter& owned = _upserts[segment_id]->standalone_owned();
+    if (owned.empty()) {
+        RETURN_IF_ERROR(params.tablet->update_mgr()->get_rowids_from_pkindex(
+                params.tablet->id(), _base_versions[segment_id], segment_pk_column, &src_rss_rowids, need_lock));
+    } else {
+        // A cross-published child receives its siblings' rows too, and looking one up would resolve
+        // against sstables this child inherited -- the location can name a rowset the split pruned
+        // away, and get_column_values below would then fail the publish on an unknown rssid. Ask only
+        // about the rows this child owns and leave the rest at the "no old row" sentinel, which
+        // plan_read_by_rssid turns into default values. Those rows fall outside this child's key
+        // range, so nothing reads them from here anyway.
+        std::vector<uint32_t> owned_positions;
+        owned_positions.reserve(owned.size());
+        for (size_t i = 0; i < owned.size(); ++i) {
+            if (owned[i]) {
+                owned_positions.push_back(static_cast<uint32_t>(i));
+            }
+        }
+        std::fill(src_rss_rowids.begin(), src_rss_rowids.end(), static_cast<uint64_t>(-1));
+        if (!owned_positions.empty()) {
+            auto owned_pk_column = segment_pk_column->clone_empty();
+            TRY_CATCH_BAD_ALLOC(owned_pk_column->append_selective(*segment_pk_column, owned_positions.data(), 0,
+                                                                  owned_positions.size()));
+            std::vector<uint64_t> owned_rss_rowids(owned_positions.size());
+            RETURN_IF_ERROR(params.tablet->update_mgr()->get_rowids_from_pkindex(
+                    params.tablet->id(), _base_versions[segment_id], owned_pk_column, &owned_rss_rowids, need_lock));
+            for (size_t k = 0; k < owned_positions.size(); ++k) {
+                src_rss_rowids[owned_positions[k]] = owned_rss_rowids[k];
+            }
+        }
+    }
 
     size_t num_default = 0;
     std::map<uint32_t, std::vector<uint32_t>> rowids_by_rssid;
     vector<uint32_t> idxes;
-    plan_read_by_rssid(_partial_update_states[segment_id].src_rss_rowids, &num_default, &rowids_by_rssid, &idxes);
-    size_t total_rows = _partial_update_states[segment_id].src_rss_rowids.size();
+    plan_read_by_rssid(src_rss_rowids, &num_default, &rowids_by_rssid, &idxes);
+    size_t total_rows = src_rss_rowids.size();
     // get column values by rowid, also get default values if needed
     RETURN_IF_ERROR(params.tablet->update_mgr()->get_column_values(
             params, read_column_ids, num_default > 0, rowids_by_rssid, &read_columns, &_column_to_expr_value));

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -1096,11 +1096,15 @@ Status RowsetUpdateState::prepare(const RowsetUpdateStateParams& params) {
 // Drop the delete keys that fall outside this tablet's key range.
 //
 // A del file is cross-published verbatim to every SPLIT child: each child reads the SAME parent del
-// file and erases every key in it from its OWN primary index. The upsert side solves the same problem
-// per row instead: prepare() asks get_each_segment_iterator NOT to narrow the segment and installs a
-// CrossPublishRowSelector, so every consumer of _upserts is handed a mask of the rows this tablet
-// owns. A del file is a flat serialized PK column with no index and no guaranteed key order, so it
-// cannot be masked against the index lookup -- it is clipped against the range directly, here.
+// file and erases every key in it from its OWN primary index. The upsert side does not have this
+// problem because it is clipped at read time -- convert_txn_log_for_splitting stamps this tablet's
+// range onto op_write.rowset, and get_each_segment_iterator turns it into
+// SegmentReadOptions::tablet_range, which _apply_tablet_range resolves to a rowid range via the short
+// key index so out-of-range rows are never even read. Where that resolution is impossible -- a
+// primary-key tablet ordered by a separate sort key, whose range describes no rowid interval --
+// CrossPublishRowSelector answers per row instead; see cross_publish_context.h. A del file is a flat
+// serialized PK column with no index and no guaranteed key order, so it gets neither: it is clipped
+// against the range directly, here.
 //
 // Erasing a key it does not own is not merely wasted work: the child's primary index still carries
 // the ancestor entries inherited through its shared sstables (the tablet-range gate on those runs

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -589,6 +589,59 @@ static StatusOr<MutableColumnPtr> widen_rewrite_column_to_segment(
     return widened;
 }
 
+Status RowsetUpdateState::_widen_rewrite_columns_for_cross_publish(const RowsetUpdateStateParams& params,
+                                                                   uint32_t segment_id,
+                                                                   const std::vector<ColumnId>& unmodified_column_ids,
+                                                                   MutableColumns* widened_write_columns,
+                                                                   MutableColumnPtr* unwidened_auto_increment_column) {
+    // Only a resharded tablet can have a narrowed publish iterator: narrowing needs a range on the ROWSET
+    // (convert_txn_log_for_splitting stamps this tablet's onto a cross-published op_write) plus a segment
+    // the split marked shared. No range on the tablet, no narrowing, nothing to widen -- which is every
+    // tablet that was never resharded, so the ordinary publish path stops here.
+    if (!params.metadata->has_range()) {
+        return Status::OK();
+    }
+    const size_t num_segment_rows = params.op_write.rowset().segment_metas(segment_id).num_rows();
+    if (num_segment_rows == 0) {
+        // No per-segment count to widen to: metadata written by an older version, or a segment that holds
+        // no rows at all (the empty one a delete-only write leaves to reserve its del file's op_offset).
+        return Status::OK();
+    }
+    const uint32_t owned_base = _upserts[segment_id] != nullptr ? _upserts[segment_id]->physical_rowid_base() : 0;
+
+    if (has_partial_update_state(params) && !unmodified_column_ids.empty()) {
+        // An empty unmodified_column_ids means rewrite_partial_update takes its copy-only fast path and
+        // never reads these columns -- reachable when a schema change between the partial write and its
+        // publish leaves no unmodified column, in which case the cached state's columns no longer pair
+        // with the recomputed ids either.
+        auto& write_columns = _partial_update_states[segment_id].write_columns;
+        RETURN_ERROR_IF_FALSE(write_columns.size() == unmodified_column_ids.size());
+        for (size_t i = 0; i < write_columns.size(); i++) {
+            ASSIGN_OR_RETURN(auto widened,
+                             widen_rewrite_column_to_segment(*write_columns[i], owned_base, num_segment_rows,
+                                                             &params.tablet_schema->column(unmodified_column_ids[i]),
+                                                             _column_to_expr_value));
+            if (widened != nullptr) {
+                widened_write_columns->emplace_back(std::move(widened));
+            }
+        }
+        // Every column came from the same iterator, so either all of them span the segment or none do.
+        RETURN_ERROR_IF_FALSE(widened_write_columns->empty() || widened_write_columns->size() == write_columns.size());
+    }
+
+    auto& auto_increment_state = _auto_increment_partial_update_states[segment_id];
+    if (has_auto_increment_partial_update_state(params) && auto_increment_state.write_column != nullptr) {
+        ASSIGN_OR_RETURN(auto widened,
+                         widen_rewrite_column_to_segment(*auto_increment_state.write_column, owned_base,
+                                                         num_segment_rows, nullptr, _column_to_expr_value));
+        if (widened != nullptr) {
+            *unwidened_auto_increment_column = std::move(auto_increment_state.write_column);
+            auto_increment_state.write_column = std::move(widened);
+        }
+    }
+    return Status::OK();
+}
+
 Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, const RowsetUpdateStateParams& params,
                                           std::map<int, SegmentFileInfo>* replace_segments,
                                           std::vector<FileMetaPB>* orphan_files) {
@@ -663,52 +716,19 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
     ASSIGN_OR_RETURN(auto vector_index_opts, resolve_rewrite_vector_index_options(params, dest_path));
     const bool defer_vector_index_build = vector_index_opts.defer_build;
 
-    // The state covers the rows the publish iterator emitted, which on a cross publish is this tablet's
-    // slice of the segment; the rewriters need one value per row of the segment. Widen copies and leave
-    // the state alone -- see widen_rewrite_column_to_segment.
-    const size_t num_segment_rows = src_seg_meta.num_rows();
-    const uint32_t owned_base = _upserts[segment_id] != nullptr ? _upserts[segment_id]->physical_rowid_base() : 0;
     MutableColumns widened_write_columns;
-    if (num_segment_rows > 0 && has_partial_update_state(params) && !unmodified_column_ids.empty()) {
-        // unmodified_column_ids empty means the rewrite is a plain file copy and never looks at these
-        // columns -- reachable when a schema change between the partial write and its publish leaves no
-        // unmodified column, in which case the cached state's columns no longer pair with it either.
-        auto& write_columns = _partial_update_states[segment_id].write_columns;
-        RETURN_ERROR_IF_FALSE(write_columns.size() == unmodified_column_ids.size());
-        for (size_t i = 0; i < write_columns.size(); i++) {
-            ASSIGN_OR_RETURN(auto widened,
-                             widen_rewrite_column_to_segment(*write_columns[i], owned_base, num_segment_rows,
-                                                             &params.tablet_schema->column(unmodified_column_ids[i]),
-                                                             _column_to_expr_value));
-            if (widened != nullptr) {
-                widened_write_columns.emplace_back(std::move(widened));
-            }
-        }
-        // Every column came from the same iterator, so either all of them span the segment or none do.
-        RETURN_ERROR_IF_FALSE(widened_write_columns.empty() || widened_write_columns.size() == write_columns.size());
-    }
-    MutableColumns* rewrite_write_columns =
-            widened_write_columns.empty() ? &_partial_update_states[segment_id].write_columns : &widened_write_columns;
-
-    // The auto-increment rewriter reads its column out of the state (and moves it), so the widened copy
-    // has to go in. Put the original back afterwards, for the same retry reason.
-    auto& auto_increment_state = _auto_increment_partial_update_states[segment_id];
     MutableColumnPtr unwidened_auto_increment_column;
+    auto& auto_increment_state = _auto_increment_partial_update_states[segment_id];
+    // Must outlive the rewrite below: it hands the state its unwidened auto-increment column back.
     DeferOp restore_auto_increment_column([&]() {
         if (unwidened_auto_increment_column != nullptr) {
             auto_increment_state.write_column = std::move(unwidened_auto_increment_column);
         }
     });
-    if (num_segment_rows > 0 && has_auto_increment_partial_update_state(params) &&
-        auto_increment_state.write_column != nullptr) {
-        ASSIGN_OR_RETURN(auto widened,
-                         widen_rewrite_column_to_segment(*auto_increment_state.write_column, owned_base,
-                                                         num_segment_rows, nullptr, _column_to_expr_value));
-        if (widened != nullptr) {
-            unwidened_auto_increment_column = std::move(auto_increment_state.write_column);
-            auto_increment_state.write_column = std::move(widened);
-        }
-    }
+    RETURN_IF_ERROR(_widen_rewrite_columns_for_cross_publish(params, segment_id, unmodified_column_ids,
+                                                             &widened_write_columns, &unwidened_auto_increment_column));
+    MutableColumns* rewrite_write_columns =
+            widened_write_columns.empty() ? &_partial_update_states[segment_id].write_columns : &widened_write_columns;
 
     int64_t t_rewrite_start = MonotonicMillis();
     if (has_auto_increment_partial_update_state(params) &&

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -595,7 +595,7 @@ static StatusOr<MutableColumnPtr> widen_rewrite_column_to_segment(
 }
 
 Status RowsetUpdateState::_widen_rewrite_columns_for_cross_publish(const RowsetUpdateStateParams& params,
-                                                                   uint32_t segment_id,
+                                                                   uint32_t segment_id, const FileInfo& src,
                                                                    const std::vector<ColumnId>& unmodified_column_ids,
                                                                    MutableColumns* widened_write_columns,
                                                                    MutableColumnPtr* unwidened_auto_increment_column) {
@@ -606,10 +606,23 @@ Status RowsetUpdateState::_widen_rewrite_columns_for_cross_publish(const RowsetU
     if (!params.metadata->has_range()) {
         return Status::OK();
     }
-    const size_t num_segment_rows = params.op_write.rowset().segment_metas(segment_id).num_rows();
+    const auto& src_seg_meta = params.op_write.rowset().segment_metas(segment_id);
+    size_t num_segment_rows = src_seg_meta.num_rows();
+    if (!src_seg_meta.has_num_rows()) {
+        // A txn log written by an older BE carries only the deprecated per-segment arrays, and the
+        // segment_metas lake_proto_normalizer synthesizes from them have no row count. Read it off the
+        // segment rather than skip the widening: the rewrite would copy every row of this file and append
+        // only this tablet's slice, failing the publish on every retry. A count that IS present and zero
+        // means a genuinely empty segment -- the one a delete-only write leaves behind to reserve its del
+        // file's op_offset -- and there is nothing to widen there.
+        size_t footer_size_hint = 16 * 1024;
+        LakeIOOptions lake_io_opts{.fill_data_cache = false, .buffer_size = -1};
+        ASSIGN_OR_RETURN(auto segment,
+                         params.tablet->tablet_mgr()->load_segment(src, segment_id, &footer_size_hint, lake_io_opts,
+                                                                   false /*fill_meta_cache*/, params.tablet_schema));
+        num_segment_rows = segment->num_rows();
+    }
     if (num_segment_rows == 0) {
-        // No per-segment count to widen to: metadata written by an older version, or a segment that holds
-        // no rows at all (the empty one a delete-only write leaves to reserve its del file's op_offset).
         return Status::OK();
     }
     const uint32_t owned_base = _upserts[segment_id] != nullptr ? _upserts[segment_id]->physical_rowid_base() : 0;
@@ -730,7 +743,7 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
             auto_increment_state.write_column = std::move(unwidened_auto_increment_column);
         }
     });
-    RETURN_IF_ERROR(_widen_rewrite_columns_for_cross_publish(params, segment_id, unmodified_column_ids,
+    RETURN_IF_ERROR(_widen_rewrite_columns_for_cross_publish(params, segment_id, src, unmodified_column_ids,
                                                              &widened_write_columns, &unwidened_auto_increment_column));
     MutableColumns* rewrite_write_columns =
             widened_write_columns.empty() ? &_partial_update_states[segment_id].write_columns : &widened_write_columns;

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -669,7 +669,10 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
     const size_t num_segment_rows = src_seg_meta.num_rows();
     const uint32_t owned_base = _upserts[segment_id] != nullptr ? _upserts[segment_id]->physical_rowid_base() : 0;
     MutableColumns widened_write_columns;
-    if (num_segment_rows > 0 && has_partial_update_state(params)) {
+    if (num_segment_rows > 0 && has_partial_update_state(params) && !unmodified_column_ids.empty()) {
+        // unmodified_column_ids empty means the rewrite is a plain file copy and never looks at these
+        // columns -- reachable when a schema change between the partial write and its publish leaves no
+        // unmodified column, in which case the cached state's columns no longer pair with it either.
         auto& write_columns = _partial_update_states[segment_id].write_columns;
         RETURN_ERROR_IF_FALSE(write_columns.size() == unmodified_column_ids.size());
         for (size_t i = 0; i < write_columns.size(); i++) {

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -922,7 +922,13 @@ Status RowsetUpdateState::prepare(const RowsetUpdateStateParams& params) {
         // is what lets it hold its encode buffer across chunks.
         ASSIGN_OR_RETURN(_row_selector, CrossPublishRowSelector::create_if_needed(
                                                 *params.metadata, params.tablet_schema, params.op_write.rowset()));
-        ASSIGN_OR_RETURN(_segment_iters, _rowset_ptr->get_each_segment_iterator(_pkey_schema, false, &_stats));
+        // Emit every row of a shared segment and let the selector answer per row, rather than letting
+        // the tablet range narrow the iterator first. Two reasons, both about this state's own shape:
+        // it must stay one entry per row of the source segment, because rewrite_segment hands those
+        // entries to SegmentRewriter, which copies the source segment whole and demands exactly that
+        // many values; and one mechanism deciding ownership is easier to keep honest than two.
+        ASSIGN_OR_RETURN(_segment_iters, _rowset_ptr->get_each_segment_iterator(_pkey_schema, false, &_stats,
+                                                                               /*apply_tablet_range=*/false));
     }
     if (_column_to_expr_value.empty() && params.op_write.has_txn_meta()) {
         for (auto& entry : params.op_write.txn_meta().column_to_expr_value()) {
@@ -935,13 +941,11 @@ Status RowsetUpdateState::prepare(const RowsetUpdateStateParams& params) {
 // Drop the delete keys that fall outside this tablet's key range.
 //
 // A del file is cross-published verbatim to every SPLIT child: each child reads the SAME parent del
-// file and erases every key in it from its OWN primary index. The upsert side does not have this
-// problem because it is clipped at read time -- convert_txn_log_for_splitting stamps this tablet's
-// range onto op_write.rowset, and get_each_segment_iterator turns it into
-// SegmentReadOptions::tablet_range, which _apply_tablet_range resolves to a rowid range via the
-// short key index so out-of-range rows are never even read. A del file is a flat serialized PK
-// column with no index and no guaranteed key order, so it gets no such pruning and every child sees
-// every key.
+// file and erases every key in it from its OWN primary index. The upsert side solves the same problem
+// per row instead: prepare() asks get_each_segment_iterator NOT to narrow the segment and installs a
+// CrossPublishRowSelector, so every consumer of _upserts is handed a mask of the rows this tablet
+// owns. A del file is a flat serialized PK column with no index and no guaranteed key order, so it
+// cannot be masked against the index lookup -- it is clipped against the range directly, here.
 //
 // Erasing a key it does not own is not merely wasted work: the child's primary index still carries
 // the ancestor entries inherited through its shared sstables (the tablet-range gate on those runs

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -370,20 +370,19 @@ Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(uint32_t
             params.tablet->id(), _base_versions[segment_id], _upserts[segment_id]->standalone_pk_column(),
             &(_auto_increment_partial_update_states[segment_id].src_rss_rowids), need_lock));
 
-    // A cross-published child receives its siblings' rows too: not its rows to read an id for, and
-    // resolving one can name a rowset the split pruned away.
+    // A cross-published child receives its siblings' rows too, and resolving one can name a rowset the
+    // split pruned away, so blank those answers out. A sibling's row then looks like a row with no old
+    // value, and it must KEEP looking like one: every such row gets its own slot in the idxes remap
+    // below, and the values filling those slots are fetched per entry of `rowids` -- from this rowset's
+    // own segment, which is always readable. Dropping siblings from `rowids` here would leave the remap
+    // pointing past the end of the fetched column. What a sibling's row must not reach is the delete
+    // decision further down, which is derived from `rowids` and erases keys.
     const Filter& owned = _upserts[segment_id]->standalone_owned();
     mask_unowned_rowids(owned, &_auto_increment_partial_update_states[segment_id].src_rss_rowids);
 
     std::vector<uint32_t> rowids;
     uint32_t n = _auto_increment_partial_update_states[segment_id].src_rss_rowids.size();
     for (uint32_t j = 0; j < n; j++) {
-        if (!owned.empty() && owned[j] == 0) {
-            // Masking left a sibling's row looking like a new row. It is not one: allocating an id for
-            // it would claim a key outside this child's range, and a 0 id would then have this child
-            // erase that key -- the erase #77744 had to clip out of a cross-published del file.
-            continue;
-        }
         uint64_t v = _auto_increment_partial_update_states[segment_id].src_rss_rowids[j];
         uint32_t rssid = v >> 32;
         if (rssid == (uint32_t)-1) {
@@ -444,6 +443,12 @@ Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(uint32_t
     // just check the rows which are not exist in the previous version
     // because the rows exist in the previous version may contain 0 which are specified by the user
     for (unsigned int row_idx : _auto_increment_partial_update_states[segment_id].rowids) {
+        if (!owned.empty() && owned[row_idx] == 0) {
+            // A sibling's row only looks like a new row because its lookup was masked. Erasing its key
+            // is what #77744 had to clip out of a cross-published del file: the key is not this child's,
+            // and its location resolves against sstables inherited from the parent.
+            continue;
+        }
         if (data[row_idx] == 0) {
             delete_idxes.emplace_back(row_idx);
         }
@@ -834,10 +839,6 @@ Status RowsetUpdateState::_resolve_conflict(uint32_t segment_id, const RowsetUpd
     RETURN_IF_ERROR(params.tablet->update_mgr()->get_rowids_from_pkindex(
             params.tablet->id(), _base_versions[segment_id], _upserts[segment_id]->standalone_pk_column(),
             &new_rss_rowids, false));
-    // Same restriction the first lookup was given: a sibling's row is not this child's to re-read, and
-    // its location can name a rowset the split pruned away. Masking both sides of the comparison the
-    // same way also means such a row can never look like a conflict.
-    mask_unowned_rowids(_upserts[segment_id]->standalone_owned(), &new_rss_rowids);
 
     size_t total_conflicts = 0;
     std::shared_ptr<TabletSchema> tablet_schema = std::make_shared<TabletSchema>(params.metadata->schema());
@@ -872,7 +873,15 @@ Status RowsetUpdateState::_resolve_conflict_partial_update(const RowsetUpdateSta
     std::vector<uint32_t> conflict_idxes;
     std::vector<uint64_t> conflict_rowids;
     DCHECK_EQ(num_rows, _partial_update_states[segment_id].src_rss_rowids.size());
+    // A cross-published child holds its siblings' rows too. Their old values were never read (the first
+    // lookup was masked, so they sit at the "no old row" sentinel and the rewrite fills a default), so
+    // there is nothing to re-read for them here either -- and re-reading would resolve against sstables
+    // inherited from the parent, whose location can name a rowset the split pruned away.
+    const Filter& owned = _upserts[segment_id]->standalone_owned();
     for (size_t i = 0; i < new_rss_rowids.size(); ++i) {
+        if (!owned.empty() && owned[i] == 0) {
+            continue;
+        }
         uint64_t new_rss_rowid = new_rss_rowids[i];
         uint32_t new_rssid = new_rss_rowid >> 32;
         uint64_t rss_rowid = _partial_update_states[segment_id].src_rss_rowids[i];
@@ -911,10 +920,19 @@ Status RowsetUpdateState::_resolve_conflict_partial_update(const RowsetUpdateSta
     return Status::OK();
 }
 
+// NOT cross-publish aware beyond the erase guard at the end: |new_rss_rowids| arrives unmasked, so a
+// sibling's row that this child's inherited sstables still answer for is re-read from its old location,
+// which the split may have pruned from this child. Masking it here is not enough -- this function
+// rebuilds `rowids` from every sentinel entry in the whole vector while its idxes remap is derived from
+// the conflicting rows alone, so the two have different bases and widening one silently misaligns the
+// fetched column. Whatever relaxes ORDER BY on a range-distributed primary-key table owes this path a
+// rework with tests; until then the mask is all ones here, because the publish iterator is narrowed by
+// the tablet range (see CrossPublishRowSelector).
 Status RowsetUpdateState::_resolve_conflict_auto_increment(const RowsetUpdateStateParams& params,
                                                            const std::vector<uint64_t>& new_rss_rowids,
                                                            uint32_t segment_id, size_t& total_conflicts) {
     uint32_t num_rows = new_rss_rowids.size();
+    const Filter& owned = _upserts[segment_id]->standalone_owned();
     std::vector<uint32_t> conflict_idxes;
     std::vector<uint64_t> conflict_rowids;
     DCHECK_EQ(num_rows, _auto_increment_partial_update_states[segment_id].src_rss_rowids.size());
@@ -997,6 +1015,11 @@ Status RowsetUpdateState::_resolve_conflict_auto_increment(const RowsetUpdateSta
         // just check the rows which are not exist in the previous version
         // because the rows exist in the previous version may contain 0 which are specified by the user
         for (unsigned int row_idx : _auto_increment_partial_update_states[segment_id].rowids) {
+            if (!owned.empty() && owned[row_idx] == 0) {
+                // Not this child's key to erase -- see the same guard in
+                // _prepare_auto_increment_partial_update_states.
+                continue;
+            }
             if (data[row_idx] == 0) {
                 delete_idxes.emplace_back(row_idx);
             }

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -40,6 +40,7 @@
 #include "storage/lake/update_manager.h"
 #include "storage/lake/vector_index_utils.h"
 #include "storage/olap_common.h"
+#include "storage/rowset/default_value_column_iterator.h"
 #include "storage/rowset/segment_rewriter.h"
 #include "storage/rowset/segment_writer.h"
 #include "storage/tablet_schema.h"
@@ -516,6 +517,76 @@ StatusOr<bool> RowsetUpdateState::file_exist(const std::string& full_path) {
     }
 }
 
+// Append |count| copies of the value the merge produces for a row that has no old value: the column's
+// declared default, or the expression default this transaction carries for it, exactly as
+// UpdateManager::get_column_values fills its default slot -- which is what makes a narrowed publish and
+// a per-row-selected one write the same segment. |tablet_column| null means the caller has no such
+// notion (the auto-increment column, whose no-old-row values come from the FE allocation rather than a
+// default) and gets the column's plain zero value.
+static Status append_no_old_row_values(const TabletColumn* tablet_column,
+                                       const std::map<std::string, std::string>& column_to_expr_value, size_t count,
+                                       Column* column) {
+    if (count == 0) {
+        return Status::OK();
+    }
+    bool has_default_value = tablet_column != nullptr && tablet_column->has_default_value();
+    std::string default_value = has_default_value ? tablet_column->default_value() : "";
+    if (tablet_column != nullptr) {
+        auto iter = column_to_expr_value.find(std::string(tablet_column->name()));
+        if (iter != column_to_expr_value.end()) {
+            has_default_value = true;
+            default_value = iter->second;
+        }
+    }
+    if (!has_default_value) {
+        TRY_CATCH_BAD_ALLOC(column->append_default(count));
+        return Status::OK();
+    }
+    const TypeInfoPtr& type_info = get_type_info(*tablet_column);
+    auto default_value_iter = std::make_unique<DefaultValueColumnIterator>(
+            true, default_value, tablet_column->is_nullable(), type_info, tablet_column->length(), count);
+    ColumnIteratorOptions iter_opts;
+    RETURN_IF_ERROR(default_value_iter->init(iter_opts));
+    return default_value_iter->fetch_values_by_rowid(nullptr, count, column);
+}
+
+// Pad the merged values out to one per row of the SOURCE segment, defaulting the rows a sibling owns.
+//
+// On a cross publish the publish iterator is narrowed to this tablet's slice of the shared segment
+// (get_each_segment_iterator -> Rowset::set_segment_tablet_range), so the state built from it covers
+// only [base, base + k) of the segment. The rewriters are not narrowed and cannot be:
+// rewrite_partial_update copies the source segment's own columns verbatim -- every row of them -- and
+// rewrite_auto_increment_lake re-reads every row, so a short column makes the segment they emit
+// inconsistent. The first fails outright (SegmentWriter::finalize_columns, "num rows written
+// mismatch"), which fails the publish for good since publish retries; the second builds a chunk whose
+// columns disagree in length.
+//
+// The padded rows belong to a sibling, so a default is as good as anything: nothing reads them from
+// here, because the rowset carries this tablet's range and Rowset::set_segment_tablet_range clips the
+// rewrite output on it -- the output file is private (MetaFileBuilder clears `shared`) but the rows in
+// it are not all ours. Returns the bytes added, for the caller's memory accounting.
+static StatusOr<size_t> pad_rewrite_column_to_segment(MutableColumnPtr* column, uint32_t base, size_t num_segment_rows,
+                                                      const TabletColumn* tablet_column,
+                                                      const std::map<std::string, std::string>& column_to_expr_value) {
+    const size_t merged_rows = (*column)->size();
+    if (merged_rows == num_segment_rows) {
+        // Not narrowed: an ordinary publish, or a cross publish whose ownership was decided per row.
+        return 0;
+    }
+    RETURN_ERROR_IF_FALSE(base + merged_rows <= num_segment_rows,
+                          fmt::format("rewrite column does not fit the source segment, base:{} rows:{} segment:{}",
+                                      base, merged_rows, num_segment_rows));
+    const size_t before = (*column)->memory_usage();
+    auto padded = (*column)->clone_empty();
+    RETURN_IF_ERROR(append_no_old_row_values(tablet_column, column_to_expr_value, base, padded.get()));
+    TRY_CATCH_BAD_ALLOC(padded->append(**column));
+    RETURN_IF_ERROR(append_no_old_row_values(tablet_column, column_to_expr_value, num_segment_rows - base - merged_rows,
+                                             padded.get()));
+    const size_t after = padded->memory_usage();
+    *column = std::move(padded);
+    return after > before ? after - before : 0;
+}
+
 Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, const RowsetUpdateStateParams& params,
                                           std::map<int, SegmentFileInfo>* replace_segments,
                                           std::vector<FileMetaPB>* orphan_files) {
@@ -589,6 +660,33 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
     // silently dropping the index after publish.
     ASSIGN_OR_RETURN(auto vector_index_opts, resolve_rewrite_vector_index_options(params, dest_path));
     const bool defer_vector_index_build = vector_index_opts.defer_build;
+
+    // The state may cover only this tablet's slice of the segment; the rewriters need every row.
+    const size_t num_segment_rows = src_seg_meta.num_rows();
+    if (num_segment_rows > 0) {
+        const uint32_t owned_base = _upserts[segment_id] != nullptr ? _upserts[segment_id]->physical_rowid_base() : 0;
+        size_t padded_bytes = 0;
+        if (has_partial_update_state(params)) {
+            auto& write_columns = _partial_update_states[segment_id].write_columns;
+            RETURN_ERROR_IF_FALSE(write_columns.size() == unmodified_column_ids.size());
+            for (size_t i = 0; i < write_columns.size(); i++) {
+                ASSIGN_OR_RETURN(auto added,
+                                 pad_rewrite_column_to_segment(&write_columns[i], owned_base, num_segment_rows,
+                                                               &params.tablet_schema->column(unmodified_column_ids[i]),
+                                                               _column_to_expr_value));
+                padded_bytes += added;
+            }
+        }
+        if (has_auto_increment_partial_update_state(params)) {
+            ASSIGN_OR_RETURN(auto added, pad_rewrite_column_to_segment(
+                                                 &_auto_increment_partial_update_states[segment_id].write_column,
+                                                 owned_base, num_segment_rows, nullptr, _column_to_expr_value));
+            padded_bytes += added;
+        }
+        // memory_usage() of both states is computed from the columns, so the release path would
+        // subtract the padded size; keep the running total in step with it.
+        _memory_usage += padded_bytes;
+    }
 
     int64_t t_rewrite_start = MonotonicMillis();
     if (has_auto_increment_partial_update_state(params) &&
@@ -922,13 +1020,7 @@ Status RowsetUpdateState::prepare(const RowsetUpdateStateParams& params) {
         // is what lets it hold its encode buffer across chunks.
         ASSIGN_OR_RETURN(_row_selector, CrossPublishRowSelector::create_if_needed(
                                                 *params.metadata, params.tablet_schema, params.op_write.rowset()));
-        // Emit every row of a shared segment and let the selector answer per row, rather than letting
-        // the tablet range narrow the iterator first. Two reasons, both about this state's own shape:
-        // it must stay one entry per row of the source segment, because rewrite_segment hands those
-        // entries to SegmentRewriter, which copies the source segment whole and demands exactly that
-        // many values; and one mechanism deciding ownership is easier to keep honest than two.
-        ASSIGN_OR_RETURN(_segment_iters, _rowset_ptr->get_each_segment_iterator(_pkey_schema, false, &_stats,
-                                                                                /*apply_tablet_range=*/false));
+        ASSIGN_OR_RETURN(_segment_iters, _rowset_ptr->get_each_segment_iterator(_pkey_schema, false, &_stats));
     }
     if (_column_to_expr_value.empty() && params.op_write.has_txn_meta()) {
         for (auto& entry : params.op_write.txn_meta().column_to_expr_value()) {

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -928,7 +928,7 @@ Status RowsetUpdateState::prepare(const RowsetUpdateStateParams& params) {
         // entries to SegmentRewriter, which copies the source segment whole and demands exactly that
         // many values; and one mechanism deciding ownership is easier to keep honest than two.
         ASSIGN_OR_RETURN(_segment_iters, _rowset_ptr->get_each_segment_iterator(_pkey_schema, false, &_stats,
-                                                                               /*apply_tablet_range=*/false));
+                                                                                /*apply_tablet_range=*/false));
     }
     if (_column_to_expr_value.empty() && params.op_write.has_txn_meta()) {
         for (auto& entry : params.op_write.txn_meta().column_to_expr_value()) {

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -159,6 +159,19 @@ struct RowidSortEntry {
     bool operator<(const RowidSortEntry& rhs) const { return rowid < rhs.rowid; }
 };
 
+void RowsetUpdateState::mask_unowned_rowids(const Filter& owned, std::vector<uint64_t>* rss_rowids) {
+    if (owned.empty()) {
+        return;
+    }
+    DCHECK_EQ(owned.size(), rss_rowids->size());
+    const size_t n = std::min(owned.size(), rss_rowids->size());
+    for (size_t i = 0; i < n; i++) {
+        if (owned[i] == 0) {
+            (*rss_rowids)[i] = static_cast<uint64_t>(-1);
+        }
+    }
+}
+
 // group rowids by rssid, and for each group sort by rowid, return as `rowids_by_rssid`
 // num_default: return the number of rows that need to fill in default values
 // idxes: reverse indexes to restore values from (rssid,rowid) order to rowid order
@@ -356,9 +369,20 @@ Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(uint32_t
             params.tablet->id(), _base_versions[segment_id], _upserts[segment_id]->standalone_pk_column(),
             &(_auto_increment_partial_update_states[segment_id].src_rss_rowids), need_lock));
 
+    // A cross-published child receives its siblings' rows too: not its rows to read an id for, and
+    // resolving one can name a rowset the split pruned away.
+    const Filter& owned = _upserts[segment_id]->standalone_owned();
+    mask_unowned_rowids(owned, &_auto_increment_partial_update_states[segment_id].src_rss_rowids);
+
     std::vector<uint32_t> rowids;
     uint32_t n = _auto_increment_partial_update_states[segment_id].src_rss_rowids.size();
     for (uint32_t j = 0; j < n; j++) {
+        if (!owned.empty() && owned[j] == 0) {
+            // Masking left a sibling's row looking like a new row. It is not one: allocating an id for
+            // it would claim a key outside this child's range, and a 0 id would then have this child
+            // erase that key -- the erase #77744 had to clip out of a cross-published del file.
+            continue;
+        }
         uint64_t v = _auto_increment_partial_update_states[segment_id].src_rss_rowids[j];
         uint32_t rssid = v >> 32;
         if (rssid == (uint32_t)-1) {
@@ -453,37 +477,13 @@ Status RowsetUpdateState::_prepare_partial_update_states(uint32_t segment_id, co
     }
 
     // use upsert to get rowids for this segment
-    const Filter& owned = _upserts[segment_id]->standalone_owned();
-    if (owned.empty()) {
-        RETURN_IF_ERROR(params.tablet->update_mgr()->get_rowids_from_pkindex(
-                params.tablet->id(), _base_versions[segment_id], segment_pk_column, &src_rss_rowids, need_lock));
-    } else {
-        // A cross-published child receives its siblings' rows too, and looking one up would resolve
-        // against sstables this child inherited -- the location can name a rowset the split pruned
-        // away, and get_column_values below would then fail the publish on an unknown rssid. Ask only
-        // about the rows this child owns and leave the rest at the "no old row" sentinel, which
-        // plan_read_by_rssid turns into default values. Those rows fall outside this child's key
-        // range, so nothing reads them from here anyway.
-        std::vector<uint32_t> owned_positions;
-        owned_positions.reserve(owned.size());
-        for (size_t i = 0; i < owned.size(); ++i) {
-            if (owned[i]) {
-                owned_positions.push_back(static_cast<uint32_t>(i));
-            }
-        }
-        std::fill(src_rss_rowids.begin(), src_rss_rowids.end(), static_cast<uint64_t>(-1));
-        if (!owned_positions.empty()) {
-            auto owned_pk_column = segment_pk_column->clone_empty();
-            TRY_CATCH_BAD_ALLOC(owned_pk_column->append_selective(*segment_pk_column, owned_positions.data(), 0,
-                                                                  owned_positions.size()));
-            std::vector<uint64_t> owned_rss_rowids(owned_positions.size());
-            RETURN_IF_ERROR(params.tablet->update_mgr()->get_rowids_from_pkindex(
-                    params.tablet->id(), _base_versions[segment_id], owned_pk_column, &owned_rss_rowids, need_lock));
-            for (size_t k = 0; k < owned_positions.size(); ++k) {
-                src_rss_rowids[owned_positions[k]] = owned_rss_rowids[k];
-            }
-        }
-    }
+    RETURN_IF_ERROR(params.tablet->update_mgr()->get_rowids_from_pkindex(
+            params.tablet->id(), _base_versions[segment_id], segment_pk_column, &src_rss_rowids, need_lock));
+    // A cross-published child receives its siblings' rows too. Those are not its rows to merge, and
+    // resolving one can name a rowset the split pruned away, so leave them at the "no old row"
+    // sentinel -- plan_read_by_rssid turns it into default values, and rewrite_segment then writes a
+    // default in the column this write does not carry.
+    mask_unowned_rowids(_upserts[segment_id]->standalone_owned(), &src_rss_rowids);
 
     size_t num_default = 0;
     std::map<uint32_t, std::vector<uint32_t>> rowids_by_rssid;
@@ -696,6 +696,10 @@ Status RowsetUpdateState::_resolve_conflict(uint32_t segment_id, const RowsetUpd
     RETURN_IF_ERROR(params.tablet->update_mgr()->get_rowids_from_pkindex(
             params.tablet->id(), _base_versions[segment_id], _upserts[segment_id]->standalone_pk_column(),
             &new_rss_rowids, false));
+    // Same restriction the first lookup was given: a sibling's row is not this child's to re-read, and
+    // its location can name a rowset the split pruned away. Masking both sides of the comparison the
+    // same way also means such a row can never look like a conflict.
+    mask_unowned_rowids(_upserts[segment_id]->standalone_owned(), &new_rss_rowids);
 
     size_t total_conflicts = 0;
     std::shared_ptr<TabletSchema> tablet_schema = std::make_shared<TabletSchema>(params.metadata->schema());

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -550,7 +550,7 @@ static Status append_no_old_row_values(const TabletColumn* tablet_column,
     return default_value_iter->fetch_values_by_rowid(nullptr, count, column);
 }
 
-// Pad the merged values out to one per row of the SOURCE segment, defaulting the rows a sibling owns.
+// Widen the merged values to one per row of the SOURCE segment, defaulting the rows a sibling owns.
 //
 // On a cross publish the publish iterator is narrowed to this tablet's slice of the shared segment
 // (get_each_segment_iterator -> Rowset::set_segment_tablet_range), so the state built from it covers
@@ -564,27 +564,29 @@ static Status append_no_old_row_values(const TabletColumn* tablet_column,
 // The padded rows belong to a sibling, so a default is as good as anything: nothing reads them from
 // here, because the rowset carries this tablet's range and Rowset::set_segment_tablet_range clips the
 // rewrite output on it -- the output file is private (MetaFileBuilder clears `shared`) but the rows in
-// it are not all ours. Returns the bytes added, for the caller's memory accounting.
-static StatusOr<size_t> pad_rewrite_column_to_segment(MutableColumnPtr* column, uint32_t base, size_t num_segment_rows,
-                                                      const TabletColumn* tablet_column,
-                                                      const std::map<std::string, std::string>& column_to_expr_value) {
-    const size_t merged_rows = (*column)->size();
+// it are not all ours.
+//
+// Returns a COPY, and nullptr when the column already spans the segment. Widening the state in place
+// would break a publish retry: the state is cached per transaction, and on the next attempt
+// _resolve_conflict_partial_update patches write_columns at iterator-relative offsets, which line up
+// only with the unwidened column.
+static StatusOr<MutableColumnPtr> widen_rewrite_column_to_segment(
+        const Column& column, uint32_t base, size_t num_segment_rows, const TabletColumn* tablet_column,
+        const std::map<std::string, std::string>& column_to_expr_value) {
+    const size_t merged_rows = column.size();
     if (merged_rows == num_segment_rows) {
         // Not narrowed: an ordinary publish, or a cross publish whose ownership was decided per row.
-        return 0;
+        return MutableColumnPtr{};
     }
     RETURN_ERROR_IF_FALSE(base + merged_rows <= num_segment_rows,
                           fmt::format("rewrite column does not fit the source segment, base:{} rows:{} segment:{}",
                                       base, merged_rows, num_segment_rows));
-    const size_t before = (*column)->memory_usage();
-    auto padded = (*column)->clone_empty();
-    RETURN_IF_ERROR(append_no_old_row_values(tablet_column, column_to_expr_value, base, padded.get()));
-    TRY_CATCH_BAD_ALLOC(padded->append(**column));
+    auto widened = column.clone_empty();
+    RETURN_IF_ERROR(append_no_old_row_values(tablet_column, column_to_expr_value, base, widened.get()));
+    TRY_CATCH_BAD_ALLOC(widened->append(column));
     RETURN_IF_ERROR(append_no_old_row_values(tablet_column, column_to_expr_value, num_segment_rows - base - merged_rows,
-                                             padded.get()));
-    const size_t after = padded->memory_usage();
-    *column = std::move(padded);
-    return after > before ? after - before : 0;
+                                             widened.get()));
+    return widened;
 }
 
 Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, const RowsetUpdateStateParams& params,
@@ -661,31 +663,48 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
     ASSIGN_OR_RETURN(auto vector_index_opts, resolve_rewrite_vector_index_options(params, dest_path));
     const bool defer_vector_index_build = vector_index_opts.defer_build;
 
-    // The state may cover only this tablet's slice of the segment; the rewriters need every row.
+    // The state covers the rows the publish iterator emitted, which on a cross publish is this tablet's
+    // slice of the segment; the rewriters need one value per row of the segment. Widen copies and leave
+    // the state alone -- see widen_rewrite_column_to_segment.
     const size_t num_segment_rows = src_seg_meta.num_rows();
-    if (num_segment_rows > 0) {
-        const uint32_t owned_base = _upserts[segment_id] != nullptr ? _upserts[segment_id]->physical_rowid_base() : 0;
-        size_t padded_bytes = 0;
-        if (has_partial_update_state(params)) {
-            auto& write_columns = _partial_update_states[segment_id].write_columns;
-            RETURN_ERROR_IF_FALSE(write_columns.size() == unmodified_column_ids.size());
-            for (size_t i = 0; i < write_columns.size(); i++) {
-                ASSIGN_OR_RETURN(auto added,
-                                 pad_rewrite_column_to_segment(&write_columns[i], owned_base, num_segment_rows,
-                                                               &params.tablet_schema->column(unmodified_column_ids[i]),
-                                                               _column_to_expr_value));
-                padded_bytes += added;
+    const uint32_t owned_base = _upserts[segment_id] != nullptr ? _upserts[segment_id]->physical_rowid_base() : 0;
+    MutableColumns widened_write_columns;
+    if (num_segment_rows > 0 && has_partial_update_state(params)) {
+        auto& write_columns = _partial_update_states[segment_id].write_columns;
+        RETURN_ERROR_IF_FALSE(write_columns.size() == unmodified_column_ids.size());
+        for (size_t i = 0; i < write_columns.size(); i++) {
+            ASSIGN_OR_RETURN(auto widened,
+                             widen_rewrite_column_to_segment(*write_columns[i], owned_base, num_segment_rows,
+                                                             &params.tablet_schema->column(unmodified_column_ids[i]),
+                                                             _column_to_expr_value));
+            if (widened != nullptr) {
+                widened_write_columns.emplace_back(std::move(widened));
             }
         }
-        if (has_auto_increment_partial_update_state(params)) {
-            ASSIGN_OR_RETURN(auto added, pad_rewrite_column_to_segment(
-                                                 &_auto_increment_partial_update_states[segment_id].write_column,
-                                                 owned_base, num_segment_rows, nullptr, _column_to_expr_value));
-            padded_bytes += added;
+        // Every column came from the same iterator, so either all of them span the segment or none do.
+        RETURN_ERROR_IF_FALSE(widened_write_columns.empty() || widened_write_columns.size() == write_columns.size());
+    }
+    MutableColumns* rewrite_write_columns =
+            widened_write_columns.empty() ? &_partial_update_states[segment_id].write_columns : &widened_write_columns;
+
+    // The auto-increment rewriter reads its column out of the state (and moves it), so the widened copy
+    // has to go in. Put the original back afterwards, for the same retry reason.
+    auto& auto_increment_state = _auto_increment_partial_update_states[segment_id];
+    MutableColumnPtr unwidened_auto_increment_column;
+    DeferOp restore_auto_increment_column([&]() {
+        if (unwidened_auto_increment_column != nullptr) {
+            auto_increment_state.write_column = std::move(unwidened_auto_increment_column);
         }
-        // memory_usage() of both states is computed from the columns, so the release path would
-        // subtract the padded size; keep the running total in step with it.
-        _memory_usage += padded_bytes;
+    });
+    if (num_segment_rows > 0 && has_auto_increment_partial_update_state(params) &&
+        auto_increment_state.write_column != nullptr) {
+        ASSIGN_OR_RETURN(auto widened,
+                         widen_rewrite_column_to_segment(*auto_increment_state.write_column, owned_base,
+                                                         num_segment_rows, nullptr, _column_to_expr_value));
+        if (widened != nullptr) {
+            unwidened_auto_increment_column = std::move(auto_increment_state.write_column);
+            auto_increment_state.write_column = std::move(widened);
+        }
     }
 
     int64_t t_rewrite_start = MonotonicMillis();
@@ -695,8 +714,7 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
         file_info.path = params.tablet->segment_location(dest_path);
         RETURN_IF_ERROR(SegmentRewriter::rewrite_auto_increment_lake(
                 src, &file_info, params.tablet_schema, _auto_increment_partial_update_states[segment_id],
-                unmodified_column_ids,
-                has_partial_update_state(params) ? &_partial_update_states[segment_id].write_columns : nullptr,
+                unmodified_column_ids, has_partial_update_state(params) ? rewrite_write_columns : nullptr,
                 params.tablet, std::move(vector_index_opts), &file_info.vector_index_ids));
         file_info.path = dest_path;
         stamp_rewrite_vector_index_owner(params, &file_info);
@@ -707,9 +725,8 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
         file_info.path = params.tablet->segment_location(dest_path);
 
         RETURN_IF_ERROR(SegmentRewriter::rewrite_partial_update(
-                src, &file_info, params.tablet_schema, unmodified_column_ids,
-                _partial_update_states[segment_id].write_columns, segment_id, partial_rowset_footer,
-                {root_path, std::to_string(rowset_meta.id())}, std::move(vector_index_opts),
+                src, &file_info, params.tablet_schema, unmodified_column_ids, *rewrite_write_columns, segment_id,
+                partial_rowset_footer, {root_path, std::to_string(rowset_meta.id())}, std::move(vector_index_opts),
                 &file_info.vector_index_ids));
         file_info.path = dest_path;
 

--- a/be/src/storage/lake/rowset_update_state.h
+++ b/be/src/storage/lake/rowset_update_state.h
@@ -189,6 +189,20 @@ private:
     Status _prepare_auto_increment_partial_update_states(uint32_t segment_id, const RowsetUpdateStateParams& params,
                                                          bool need_lock);
 
+    // Widen the merged columns of segment |segment_id| to one value per row of the SOURCE segment, which
+    // is what the rewriters demand and what a cross publish's narrowed publish iterator does not give.
+    // A no-op on every tablet that was never resharded -- see the definition.
+    //
+    // Widens COPIES: |widened_write_columns| receives them, empty meaning nothing needed widening and the
+    // caller should hand the rewriter the state's own columns. The auto-increment column is the exception
+    // -- the rewriter reads it out of the state and moves it -- so the widened copy is swapped in here and
+    // the original handed back through |unwidened_auto_increment_column|; the caller owns putting it back,
+    // and must do so after the rewrite.
+    Status _widen_rewrite_columns_for_cross_publish(const RowsetUpdateStateParams& params, uint32_t segment_id,
+                                                    const std::vector<ColumnId>& unmodified_column_ids,
+                                                    MutableColumns* widened_write_columns,
+                                                    MutableColumnPtr* unwidened_auto_increment_column);
+
     // resolve conflict when publish transaction
     Status _resolve_conflict(uint32_t segment_id, const RowsetUpdateStateParams& params, int64_t base_version);
 

--- a/be/src/storage/lake/rowset_update_state.h
+++ b/be/src/storage/lake/rowset_update_state.h
@@ -156,6 +156,24 @@ public:
                                    std::map<uint32_t, std::vector<uint32_t>>* rowids_by_rssid,
                                    std::vector<uint32_t>* idxes);
 
+    // Blank out the index answers for the rows a sibling owns, leaving them at the "no old row"
+    // sentinel. |owned| is SegmentPKChunkRef::owned / SegmentPKIterator::standalone_owned(), one byte
+    // per entry of |rss_rowids|; empty means "own every row" and this is then a no-op, which is every
+    // publish but a SPLIT child's cross publish.
+    //
+    // Why any of this: cross publish hands each child the parent's whole op_write, siblings' rows
+    // included. A sibling's key still resolves -- against the sstables this child inherited from the
+    // parent -- and the location it returns can name a rowset the split pruned away, which
+    // plan_read_by_rssid would route to get_column_values and fail the publish for good on an unknown
+    // rssid. That is the failure #77744 fixed for del files, reached from the upsert side.
+    //
+    // A mask and not a filter on purpose: the vector keeps one entry per row of the source segment, so
+    // every caller's row i still names segment rowid i and no rowid derived from it has to be
+    // remapped -- and rewrite_segment needs one entry per row regardless. This only makes the ANSWER
+    // harmless; a caller that would act on "no old row" (insert the row, let it win a comparison,
+    // allocate an id for it) must still skip the row itself.
+    static void mask_unowned_rowids(const Filter& owned, std::vector<uint64_t>* rss_rowids);
+
     const MutableColumnPtr& auto_increment_deletes(uint32_t segment_id) const;
 
     static StatusOr<bool> file_exist(const std::string& full_path);

--- a/be/src/storage/lake/rowset_update_state.h
+++ b/be/src/storage/lake/rowset_update_state.h
@@ -199,6 +199,7 @@ private:
     // the original handed back through |unwidened_auto_increment_column|; the caller owns putting it back,
     // and must do so after the rewrite.
     Status _widen_rewrite_columns_for_cross_publish(const RowsetUpdateStateParams& params, uint32_t segment_id,
+                                                    const FileInfo& src,
                                                     const std::vector<ColumnId>& unmodified_column_ids,
                                                     MutableColumns* widened_write_columns,
                                                     MutableColumnPtr* unwidened_auto_increment_column);

--- a/be/src/storage/lake/segment_pk_iterator.h
+++ b/be/src/storage/lake/segment_pk_iterator.h
@@ -102,6 +102,12 @@ public:
 
     const MutableColumnPtr& standalone_pk_column() const { return _standalone_pk_column; }
 
+    // Ownership mask over standalone_pk_column(), position for position. Empty when there is no
+    // selector, which every consumer reads as "own every row". Only meaningful alongside
+    // standalone_pk_column(), i.e. in non-lazy mode, where the single loaded chunk IS the segment --
+    // in lazy mode _owned describes only the piece currently loaded.
+    const Filter& standalone_owned() const { return _owned; }
+
 private:
     Status _load();
 

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -1199,6 +1199,11 @@ Status UpdateManager::_process_single_chunk_update_with_condition(
     ASSIGN_OR_RETURN(auto pk_column, segment_pk_iterator->encoded_pk_column(current.chunk.get()));
     std::vector<uint64_t> old_rowids(pk_column->size());
     RETURN_IF_ERROR(index.get(*pk_column, &old_rowids));
+    // Same restriction as the non-SST path: a cross-published child must not resolve a sibling's key,
+    // whose location can name a rowset the split pruned away (get_column_values would fail the publish
+    // on it), and must not record either verdict for that row -- the loser branch below writes into
+    // this child's delvec, which the parent view ORs.
+    RowsetUpdateState::mask_unowned_rowids(current.owned, &old_rowids);
     // Fast path: If no existing rows found for any PK, all new rows win by default
     bool non_old_value = std::all_of(old_rowids.begin(), old_rowids.end(), [](int id) { return -1 == id; });
     if (!non_old_value) {
@@ -1238,7 +1243,9 @@ Status UpdateManager::_process_single_chunk_update_with_condition(
         // STEP 3: Compare condition values and generate deletion vectors
         // For each PK conflict, compare old vs new condition values to decide winner
         for (int j = 0; j < old_column->size(); ++j) {
-            if (num_default > 0 && idxes[j] == 0) {
+            if (!current.owned.empty() && current.owned[j] == 0) {
+                // A sibling's row: neither this child's new row to delete nor its old row to displace.
+            } else if (num_default > 0 && idxes[j] == 0) {
                 // EDGE CASE: Index 0 indicates default value (no old row actually exists for this PK)
                 // WHY: plan_read_by_rssid uses index 0 as sentinel for PKs with no old values
                 // ACTION: Skip comparison, new row wins by default
@@ -1373,16 +1380,6 @@ struct ChunkCondMergeResult {
     // Chunk-local indices of new rows that LOST their condition comparison
     // (old row wins); these must be deleted from the current segment.
     std::vector<uint32_t> new_loser_local_ids;
-    // Absolute source-segment rowids of the rows kept in `pk_column`, in its order. Empty on an
-    // ordinary publish, where the chunk keeps every row and rowid == chunk_physical_rowid_offset + k.
-    // A cross-published SPLIT child drops its siblings' rows from `pk_column` before anything looks
-    // at them, which renumbers what survives, so the mapping has to be carried explicitly.
-    std::vector<uint32_t> owned_rowids;
-
-    // Where chunk-local index `local` lives in the source segment.
-    uint32_t absolute_rowid(uint32_t local) const {
-        return owned_rowids.empty() ? chunk_physical_rowid_offset + local : owned_rowids[local];
-    }
 };
 
 } // namespace
@@ -1397,25 +1394,25 @@ static Status process_single_chunk_update_with_condition_no_sst(
         const std::vector<uint32_t>& read_column_ids, LakePrimaryIndex& index, ChunkCondMergeResult* result) {
     TRACE_COUNTER_INCREMENT("process_condition_update_count", 1);
     ASSIGN_OR_RETURN(result->pk_column, segment_pk_iterator->encoded_pk_column(current.chunk.get()));
-    if (!current.owned.empty()) {
-        // A cross-published child receives its siblings' rows too. Drop them here, before the index
-        // lookup below: a sibling's key resolves against sstables this child inherited, so the lookup
-        // can return a location in a rowset the split pruned away -- get_column_values would then fail
-        // the publish on an unknown rssid. And a "loser" verdict on such a row would be appended to
-        // this child's delvec, which the parent view ORs, erasing a row its owner decided to keep.
-        // Read the rowids off the mask BEFORE filtering: filtering renumbers the survivors.
-        result->owned_rowids = owned_rowids_of(current);
-        result->pk_column->filter(current.owned);
-    }
     const auto chunk_size = result->pk_column->size();
     if (chunk_size == 0) {
         return Status::OK();
     }
     std::vector<uint64_t> old_rowids(chunk_size);
     RETURN_IF_ERROR(index.get(*result->pk_column, &old_rowids));
-    // Fast path: no PKs in this chunk collide with the index → every new row wins.
+    // A cross-published child is handed its siblings' rows as well, and a sibling's key resolves --
+    // against the sstables this child inherited from the parent -- to a location that can name a
+    // rowset the split pruned away, which would fail get_column_values below on an unknown rssid.
+    // Blanking those answers keeps them out of the read; the walk below then skips the row outright,
+    // so it is neither upserted (claiming a key outside this child's range) nor appended to this
+    // child's delvec, which the parent view ORs -- a sibling's verdict would erase a row its owner
+    // had just decided to keep. Nothing is renumbered: chunk-local j stays segment rowid
+    // physical_rowid_offset + j for every row, owned or not.
+    RowsetUpdateState::mask_unowned_rowids(current.owned, &old_rowids);
+    // Fast path: no PKs in this chunk collide with the index → every new row wins. Only when this
+    // chunk is entirely ours; with a mask the walk below is what decides, one row at a time.
     bool non_old_value = std::all_of(old_rowids.begin(), old_rowids.end(), [](int64_t id) { return -1 == id; });
-    if (non_old_value) {
+    if (non_old_value && current.owned.empty()) {
         result->winner_ranges.emplace_back(0u, static_cast<uint32_t>(chunk_size));
         return Status::OK();
     }
@@ -1438,7 +1435,7 @@ static Status process_single_chunk_update_with_condition_no_sst(
     std::vector<uint32_t> rowids;
     rowids.reserve(chunk_size);
     for (size_t j = 0; j < chunk_size; ++j) {
-        rowids.push_back(result->absolute_rowid(static_cast<uint32_t>(j)));
+        rowids.push_back(current.physical_rowid_offset + static_cast<uint32_t>(j));
     }
     new_rowids_by_rssid[rowset_id + upsert_idx] = std::move(rowids);
     // only support condition update on single column
@@ -1451,7 +1448,15 @@ static Status process_single_chunk_update_with_condition_no_sst(
     uint32_t run_begin = 0;
     uint32_t run_step = 0;
     for (size_t j = 0; j < old_column->size(); ++j) {
-        if (num_default > 0 && idxes[j] == 0) {
+        if (!current.owned.empty() && current.owned[j] == 0) {
+            // A sibling's row: neither verdict is this child's to record. Close the run so the
+            // winners on either side of it stay contiguous.
+            if (run_step > 0) {
+                result->winner_ranges.emplace_back(run_begin, run_begin + run_step);
+            }
+            run_begin = static_cast<uint32_t>(j + 1);
+            run_step = 0;
+        } else if (num_default > 0 && idxes[j] == 0) {
             // plan_read_by_rssid uses idx 0 as sentinel for "no old row"; new row wins by default.
             run_step++;
         } else {
@@ -1605,10 +1610,11 @@ Status UpdateManager::_do_update_with_condition(const RowsetUpdateStateParams& p
             std::vector<uint32_t> winner_rowids;
             winner_local_indices.reserve(total_winners);
             winner_rowids.reserve(total_winners);
+            const uint32_t segment_base = result->chunk_physical_rowid_offset;
             for (const auto& range : result->winner_ranges) {
                 for (uint32_t i = range.first; i < range.second; ++i) {
                     winner_local_indices.push_back(i);
-                    winner_rowids.push_back(result->absolute_rowid(i));
+                    winner_rowids.push_back(segment_base + i);
                 }
             }
             auto winner_pk_column = result->pk_column->clone_empty();
@@ -1633,34 +1639,13 @@ Status UpdateManager::_do_update_with_condition(const RowsetUpdateStateParams& p
         // Persist the active-memtable batch built up by the parallel upserts.
         RETURN_IF_ERROR(index.flush_memtable());
     } else {
+        // Serial fallback: rowid_start = chunk_physical_rowid_offset for each winner range.
         for (const auto& result : chunk_results) {
             DCHECK(result->pk_column != nullptr);
-            if (result->owned_rowids.empty()) {
-                // Serial fallback: rowid_start = chunk_physical_rowid_offset for each winner range.
-                for (const auto& range : result->winner_ranges) {
-                    RETURN_IF_ERROR(index.upsert(rssid, result->chunk_physical_rowid_offset, *result->pk_column,
-                                                 range.first, range.second, new_deletes));
-                }
-                continue;
-            }
-            // A cross-published child's surviving rows were renumbered by the filter, so the range
-            // overload's rowid_start + index no longer names the right row. Compact the winners and
-            // upsert them by their real rowids instead.
-            std::vector<uint32_t> winner_local_indices;
-            std::vector<uint32_t> winner_rowids;
             for (const auto& range : result->winner_ranges) {
-                for (uint32_t i = range.first; i < range.second; ++i) {
-                    winner_local_indices.push_back(i);
-                    winner_rowids.push_back(result->absolute_rowid(i));
-                }
+                RETURN_IF_ERROR(index.upsert(rssid, result->chunk_physical_rowid_offset, *result->pk_column,
+                                             range.first, range.second, new_deletes));
             }
-            if (winner_rowids.empty()) {
-                continue;
-            }
-            auto winner_pk_column = result->pk_column->clone_empty();
-            winner_pk_column->append_selective(*result->pk_column, winner_local_indices.data(), 0,
-                                               winner_local_indices.size());
-            RETURN_IF_ERROR(index.upsert_rows(rssid, winner_rowids, std::move(winner_pk_column), new_deletes));
         }
     }
 
@@ -1674,7 +1659,7 @@ Status UpdateManager::_do_update_with_condition(const RowsetUpdateStateParams& p
         auto& seg_deletes = (*new_deletes)[rssid];
         seg_deletes.reserve(seg_deletes.size() + result->new_loser_local_ids.size());
         for (uint32_t local : result->new_loser_local_ids) {
-            seg_deletes.push_back(result->absolute_rowid(local));
+            seg_deletes.push_back(result->chunk_physical_rowid_offset + local);
         }
     }
     return Status::OK();

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -608,7 +608,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
                                                          current_fileset_start_idx + 1 /* new fileset*/));
             }
         } // end Phase 2 per-segment loop
-    }     // end batch loop
+    } // end batch loop
     if (async_compact_cb) {
         TRACE_COUNTER_SCOPE_LATENCY_US("early_sst_compact_wait_us");
         RETURN_IF_ERROR(async_compact_cb->wait_for());
@@ -1373,6 +1373,16 @@ struct ChunkCondMergeResult {
     // Chunk-local indices of new rows that LOST their condition comparison
     // (old row wins); these must be deleted from the current segment.
     std::vector<uint32_t> new_loser_local_ids;
+    // Absolute source-segment rowids of the rows kept in `pk_column`, in its order. Empty on an
+    // ordinary publish, where the chunk keeps every row and rowid == chunk_physical_rowid_offset + k.
+    // A cross-published SPLIT child drops its siblings' rows from `pk_column` before anything looks
+    // at them, which renumbers what survives, so the mapping has to be carried explicitly.
+    std::vector<uint32_t> owned_rowids;
+
+    // Where chunk-local index `local` lives in the source segment.
+    uint32_t absolute_rowid(uint32_t local) const {
+        return owned_rowids.empty() ? chunk_physical_rowid_offset + local : owned_rowids[local];
+    }
 };
 
 } // namespace
@@ -1387,6 +1397,16 @@ static Status process_single_chunk_update_with_condition_no_sst(
         const std::vector<uint32_t>& read_column_ids, LakePrimaryIndex& index, ChunkCondMergeResult* result) {
     TRACE_COUNTER_INCREMENT("process_condition_update_count", 1);
     ASSIGN_OR_RETURN(result->pk_column, segment_pk_iterator->encoded_pk_column(current.chunk.get()));
+    if (!current.owned.empty()) {
+        // A cross-published child receives its siblings' rows too. Drop them here, before the index
+        // lookup below: a sibling's key resolves against sstables this child inherited, so the lookup
+        // can return a location in a rowset the split pruned away -- get_column_values would then fail
+        // the publish on an unknown rssid. And a "loser" verdict on such a row would be appended to
+        // this child's delvec, which the parent view ORs, erasing a row its owner decided to keep.
+        // Read the rowids off the mask BEFORE filtering: filtering renumbers the survivors.
+        result->owned_rowids = owned_rowids_of(current);
+        result->pk_column->filter(current.owned);
+    }
     const auto chunk_size = result->pk_column->size();
     if (chunk_size == 0) {
         return Status::OK();
@@ -1418,7 +1438,7 @@ static Status process_single_chunk_update_with_condition_no_sst(
     std::vector<uint32_t> rowids;
     rowids.reserve(chunk_size);
     for (size_t j = 0; j < chunk_size; ++j) {
-        rowids.push_back(current.physical_rowid_offset + static_cast<uint32_t>(j));
+        rowids.push_back(result->absolute_rowid(static_cast<uint32_t>(j)));
     }
     new_rowids_by_rssid[rowset_id + upsert_idx] = std::move(rowids);
     // only support condition update on single column
@@ -1585,11 +1605,10 @@ Status UpdateManager::_do_update_with_condition(const RowsetUpdateStateParams& p
             std::vector<uint32_t> winner_rowids;
             winner_local_indices.reserve(total_winners);
             winner_rowids.reserve(total_winners);
-            const uint32_t segment_base = result->chunk_physical_rowid_offset;
             for (const auto& range : result->winner_ranges) {
                 for (uint32_t i = range.first; i < range.second; ++i) {
                     winner_local_indices.push_back(i);
-                    winner_rowids.push_back(segment_base + i);
+                    winner_rowids.push_back(result->absolute_rowid(i));
                 }
             }
             auto winner_pk_column = result->pk_column->clone_empty();
@@ -1614,13 +1633,34 @@ Status UpdateManager::_do_update_with_condition(const RowsetUpdateStateParams& p
         // Persist the active-memtable batch built up by the parallel upserts.
         RETURN_IF_ERROR(index.flush_memtable());
     } else {
-        // Serial fallback: rowid_start = chunk_physical_rowid_offset for each winner range.
         for (const auto& result : chunk_results) {
             DCHECK(result->pk_column != nullptr);
-            for (const auto& range : result->winner_ranges) {
-                RETURN_IF_ERROR(index.upsert(rssid, result->chunk_physical_rowid_offset, *result->pk_column,
-                                             range.first, range.second, new_deletes));
+            if (result->owned_rowids.empty()) {
+                // Serial fallback: rowid_start = chunk_physical_rowid_offset for each winner range.
+                for (const auto& range : result->winner_ranges) {
+                    RETURN_IF_ERROR(index.upsert(rssid, result->chunk_physical_rowid_offset, *result->pk_column,
+                                                 range.first, range.second, new_deletes));
+                }
+                continue;
             }
+            // A cross-published child's surviving rows were renumbered by the filter, so the range
+            // overload's rowid_start + index no longer names the right row. Compact the winners and
+            // upsert them by their real rowids instead.
+            std::vector<uint32_t> winner_local_indices;
+            std::vector<uint32_t> winner_rowids;
+            for (const auto& range : result->winner_ranges) {
+                for (uint32_t i = range.first; i < range.second; ++i) {
+                    winner_local_indices.push_back(i);
+                    winner_rowids.push_back(result->absolute_rowid(i));
+                }
+            }
+            if (winner_rowids.empty()) {
+                continue;
+            }
+            auto winner_pk_column = result->pk_column->clone_empty();
+            winner_pk_column->append_selective(*result->pk_column, winner_local_indices.data(), 0,
+                                               winner_local_indices.size());
+            RETURN_IF_ERROR(index.upsert_rows(rssid, winner_rowids, std::move(winner_pk_column), new_deletes));
         }
     }
 
@@ -1634,7 +1674,7 @@ Status UpdateManager::_do_update_with_condition(const RowsetUpdateStateParams& p
         auto& seg_deletes = (*new_deletes)[rssid];
         seg_deletes.reserve(seg_deletes.size() + result->new_loser_local_ids.size());
         for (uint32_t local : result->new_loser_local_ids) {
-            seg_deletes.push_back(result->chunk_physical_rowid_offset + local);
+            seg_deletes.push_back(result->absolute_rowid(local));
         }
     }
     return Status::OK();

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -608,7 +608,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
                                                          current_fileset_start_idx + 1 /* new fileset*/));
             }
         } // end Phase 2 per-segment loop
-    } // end batch loop
+    }     // end batch loop
     if (async_compact_cb) {
         TRACE_COUNTER_SCOPE_LATENCY_US("early_sst_compact_wait_us");
         RETURN_IF_ERROR(async_compact_cb->wait_for());

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -1731,8 +1731,8 @@ Status UpdateManager::batch_get_rss_rowids_from_pkindex(int64_t tablet_id, int64
                     ThreadPool::ExecutionMode::CONCURRENT);
         }
         TRACE_COUNTER_SCOPE_LATENCY_US("pcu_prepare_partial_update_states_us");
-        st.update(index.batch_parallel_get_rss_rowids(token.get(), pk_iters, rss_rowids_per_segment,
-                                                     owned_per_segment));
+        st.update(
+                index.batch_parallel_get_rss_rowids(token.get(), pk_iters, rss_rowids_per_segment, owned_per_segment));
     }));
     return st;
 }

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -1720,7 +1720,7 @@ Status UpdateManager::get_rowids_from_pkindex(int64_t tablet_id, int64_t base_ve
 Status UpdateManager::batch_get_rss_rowids_from_pkindex(int64_t tablet_id, int64_t base_version,
                                                         std::vector<SegmentPKIteratorPtr>& pk_iters,
                                                         std::vector<std::vector<uint64_t>>* rss_rowids_per_segment,
-                                                        bool need_lock) {
+                                                        bool need_lock, std::vector<Filter>* owned_per_segment) {
     rss_rowids_per_segment->resize(pk_iters.size());
     Status st;
     st.update(_handle_index_op(tablet_id, base_version, need_lock, [&](LakePrimaryIndex& index) {
@@ -1731,7 +1731,8 @@ Status UpdateManager::batch_get_rss_rowids_from_pkindex(int64_t tablet_id, int64
                     ThreadPool::ExecutionMode::CONCURRENT);
         }
         TRACE_COUNTER_SCOPE_LATENCY_US("pcu_prepare_partial_update_states_us");
-        st.update(index.batch_parallel_get_rss_rowids(token.get(), pk_iters, rss_rowids_per_segment));
+        st.update(index.batch_parallel_get_rss_rowids(token.get(), pk_iters, rss_rowids_per_segment,
+                                                     owned_per_segment));
     }));
     return st;
 }

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -127,8 +127,8 @@ public:
     // SegmentPKIterator::physical_rowid_base() on the iterator after this returns.
     Status batch_get_rss_rowids_from_pkindex(int64_t tablet_id, int64_t base_version,
                                              std::vector<SegmentPKIteratorPtr>& pk_iters,
-                                             std::vector<std::vector<uint64_t>>* rss_rowids_per_segment,
-                                             bool need_lock, std::vector<Filter>* owned_per_segment = nullptr);
+                                             std::vector<std::vector<uint64_t>>* rss_rowids_per_segment, bool need_lock,
+                                             std::vector<Filter>* owned_per_segment = nullptr);
 
     // get column data by rssid and rowids
     Status get_column_values(const RowsetUpdateStateParams& params, const std::vector<uint32_t>& column_ids,

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -128,7 +128,7 @@ public:
     Status batch_get_rss_rowids_from_pkindex(int64_t tablet_id, int64_t base_version,
                                              std::vector<SegmentPKIteratorPtr>& pk_iters,
                                              std::vector<std::vector<uint64_t>>* rss_rowids_per_segment,
-                                             bool need_lock);
+                                             bool need_lock, std::vector<Filter>* owned_per_segment = nullptr);
 
     // get column data by rssid and rowids
     Status get_column_values(const RowsetUpdateStateParams& params, const std::vector<uint32_t>& column_ids,

--- a/be/src/storage/rowset_column_update_state.h
+++ b/be/src/storage/rowset_column_update_state.h
@@ -17,6 +17,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "column/vectorized_fwd.h"
 #include "storage/olap_common.h"
 #include "storage/primary_index.h"
 #include "storage/rowset/column_iterator.h"
@@ -90,10 +91,20 @@ struct ColumnPartialUpdateState {
     // translated to physical positions by adding `upt_segment_physical_rowid_offset`
     // — the source segment's physical rowid base (the iterator's range_start; 0 for
     // non-shared segments and for the non-lake path, where physical == logical).
-    void build_rss_rowid_to_update_rowid(uint32_t upt_segment_physical_rowid_offset) {
+    // |owned|: one byte per row of src_rss_rowids, or empty for "own every row" (every publish but a
+    // SPLIT child's cross publish). A cross published child is handed its siblings' rows along with its
+    // own, and NEITHER branch below is its to take for such a row: the update belongs to whichever
+    // sibling owns the key, and taking the insert branch would materialize a key outside this child's
+    // range. The rss_rowid alone cannot tell the two apart -- a sibling's key that this child's
+    // inherited sstables still answer for looks like an update, and one they do not looks like an
+    // insert -- so the mask has to be passed in.
+    void build_rss_rowid_to_update_rowid(uint32_t upt_segment_physical_rowid_offset, const Filter& owned = Filter{}) {
         rss_rowid_to_update_rowid.clear();
         insert_rowids.clear();
         for (uint32_t upt_row_id = 0; upt_row_id < src_rss_rowids.size(); upt_row_id++) {
+            if (!owned.empty() && owned[upt_row_id] == 0) {
+                continue;
+            }
             uint64_t each_rss_rowid = src_rss_rowids[upt_row_id];
             // build rssid & rowid -> update file's rowid
             // each_rss_rowid == UINT64_MAX means that key not exist in pk index

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -2148,8 +2148,18 @@ TEST_P(LakePartialUpdateTest, test_partial_update_rewrite_with_apportioned_num_r
 //
 // c2 is the witness: it is not in the partial write, so a row whose old location was read carries the
 // old c2 (key * 4) and a row left at the sentinel carries c2's declared default (10). The assertion
-// opens the rewritten segment rather than reading the tablet, because MetaFileBuilder clears `shared`
-// on a rewrite output -- it is private to this tablet -- so a reader no longer clips it to the range.
+// opens the rewritten segment directly because a reader must NOT see the siblings' rows in it, which
+// is the other half of what this covers.
+//
+// It is also a regression test for the rewrite's row-count contract. SegmentRewriter::rewrite_partial_update
+// copies the source segment's own columns verbatim -- all of its rows -- and appends the merged ones,
+// so SegmentWriter::finalize_columns fails the publish outright ("num rows written mismatch") unless
+// the state holds exactly one value per SOURCE row. Narrowing the publish iterator to this child's
+// slice produced fewer, so the range is stamped on the rowset here exactly as
+// convert_txn_log_for_splitting does: that is what used to trigger the narrowing, and now the
+// ownership mask does the selecting instead. MetaFileBuilder clears `shared` on the rewrite output
+// (the file really is private), so what keeps the siblings' rows out of reads is that the ROWSET
+// carries a range -- Rowset::set_segment_tablet_range clips on either.
 TEST_P(LakePartialUpdateTest, test_cross_publish_row_mode_partial_update_reads_only_owned_rows) {
     if (GetParam().partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) {
         GTEST_SKIP() << "column mode resolves the unmodified columns through DCGs, not this lookup";
@@ -2234,6 +2244,7 @@ TEST_P(LakePartialUpdateTest, test_cross_publish_row_mode_partial_update_reads_o
         auto shared_log = std::make_shared<TxnLog>(*txn_log);
         auto* rowset = shared_log->mutable_op_write()->mutable_rowset();
         ASSERT_GT(rowset->segment_metas_size(), 0);
+        rowset->mutable_range()->CopyFrom(*range_pb);
         for (auto& segment_meta : *rowset->mutable_segment_metas()) {
             segment_meta.set_shared(true);
         }
@@ -2247,6 +2258,14 @@ TEST_P(LakePartialUpdateTest, test_cross_publish_row_mode_partial_update_reads_o
     // Guards the staging as much as the fix: only the owned keys were re-indexed, so only their old
     // rows were displaced. All n here would mean the selector never engaged.
     EXPECT_EQ(kOwnedRows, metadata->rowsets(0).num_dels());
+
+    // The rewrite output is private (no `shared` flag) but its rowset carries the range, so reads clip
+    // it: the siblings' rows are in the file and must not come back. Every key appears exactly once --
+    // the owned ones from the rewrite, the rest still from the baseline rowset.
+    ASSERT_EQ(n, check(3, [&](int c0, int c1, int c2) {
+                  const bool owned = c0 >= kOwnedLower && c0 < kOwnedUpper;
+                  return owned ? (c1 == c0 * 5 && c2 == c0 * 4) : (c1 == c0 * 3 && c2 == c0 * 4);
+              }));
 
     const auto& rewritten = metadata->rowsets(1);
     ASSERT_EQ(1, rewritten.segment_metas_size());

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -2133,6 +2133,29 @@ TEST_P(LakePartialUpdateTest, test_partial_update_rewrite_with_apportioned_num_r
     ASSERT_EQ(kChunkSize, check(version + 1, [](int c0, int c1, int c2) { return (c0 * 5 == c1) && (c0 * 4 == c2); }));
 }
 
+// Turn the fixture's tablet into a range-distributed one owning [lower, upper): the order-preserving
+// big-endian PK encoding range distribution requires (create_sst_seek_range_from rejects anything else,
+// and CrossPublishRowSelector::create_if_needed declines to build without it) plus the range itself,
+// whose bound inclusivity is not a choice -- TabletRangeHelper::validate_tablet_range accepts
+// [lower, upper) and nothing else. The schema id is refreshed so the schema file the writers load stays
+// in step with the metadata this produces.
+static void make_range_distributed(TabletMetadata* metadata, int lower_inclusive, int upper_exclusive) {
+    auto* schema_pb = metadata->mutable_schema();
+    schema_pb->set_id(next_id());
+    schema_pb->set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
+    auto append_int_bound = [](auto* bound, int value) {
+        DatumVariant variant(get_type_info(LogicalType::TYPE_INT), Datum(value));
+        VariantTuple tuple;
+        tuple.append(variant);
+        tuple.to_proto(bound);
+    };
+    auto* range_pb = metadata->mutable_range();
+    append_int_bound(range_pb->mutable_lower_bound(), lower_inclusive);
+    range_pb->set_lower_bound_included(true);
+    append_int_bound(range_pb->mutable_upper_bound(), upper_exclusive);
+    range_pb->set_upper_bound_included(false);
+}
+
 // A row-mode partial update reads the columns it does not carry from each row's old location, and a
 // cross published SPLIT child is handed its siblings' rows along with its own. Looking a sibling's key
 // up resolves against the sstables this child inherited from the parent, so the location it returns can
@@ -2169,27 +2192,10 @@ TEST_P(LakePartialUpdateTest, test_cross_publish_row_mode_partial_update_reads_o
     const int kOwnedUpper = n - n / 4;
     const int kOwnedRows = kOwnedUpper - kOwnedLower;
 
-    // Range distribution requires the order-preserving big-endian PK encoding; create_sst_seek_range_from
-    // rejects anything else and the selector declines to build without it. TabletRangeHelper::
-    // validate_tablet_range fixes the inclusivity: [lower, upper). A fresh schema id keeps the schema
-    // file the writers load in step with the metadata this edit produces.
-    auto* schema_pb = _tablet_metadata->mutable_schema();
-    schema_pb->set_id(next_id());
-    schema_pb->set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
-    auto append_int_bound = [](auto* bound, int value) {
-        DatumVariant variant(get_type_info(LogicalType::TYPE_INT), Datum(value));
-        VariantTuple tuple;
-        tuple.append(variant);
-        tuple.to_proto(bound);
-    };
-    auto* range_pb = _tablet_metadata->mutable_range();
-    append_int_bound(range_pb->mutable_lower_bound(), kOwnedLower);
-    range_pb->set_lower_bound_included(true);
-    append_int_bound(range_pb->mutable_upper_bound(), kOwnedUpper);
-    range_pb->set_upper_bound_included(false);
+    make_range_distributed(_tablet_metadata.get(), kOwnedLower, kOwnedUpper);
     ASSERT_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
-    ASSERT_OK(_tablet_mgr->create_schema_file(_tablet_metadata->id(), *schema_pb));
-    _tablet_schema = TabletSchema::create(*schema_pb);
+    ASSERT_OK(_tablet_mgr->create_schema_file(_tablet_metadata->id(), _tablet_metadata->schema()));
+    _tablet_schema = TabletSchema::create(_tablet_metadata->schema());
     _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
 
     auto chunk0 = generate_data(n, 0, false, 3); // full rows: c1 = key * 3, c2 = key * 4
@@ -2244,7 +2250,7 @@ TEST_P(LakePartialUpdateTest, test_cross_publish_row_mode_partial_update_reads_o
         auto shared_log = std::make_shared<TxnLog>(*txn_log);
         auto* rowset = shared_log->mutable_op_write()->mutable_rowset();
         ASSERT_GT(rowset->segment_metas_size(), 0);
-        rowset->mutable_range()->CopyFrom(*range_pb);
+        rowset->mutable_range()->CopyFrom(_tablet_metadata->range());
         for (auto& segment_meta : *rowset->mutable_segment_metas()) {
             segment_meta.set_shared(true);
         }
@@ -2303,6 +2309,96 @@ TEST_P(LakePartialUpdateTest, test_cross_publish_row_mode_partial_update_reads_o
         EXPECT_EQ(key * 5, it->second.first) << "key " << key;
         EXPECT_EQ(owned ? key * 4 : 10, it->second.second) << "key " << key;
     }
+}
+
+// Column-mode partial update on a cross-published rowset. This handler builds its OWN
+// SegmentPKIterators, so it needs its own selector: the mapping it derives from the index decides
+// which source row gets which update, and taking a sibling's row rewrites a value this child does not
+// own (in COLUMN_UPSERT_MODE it would materialize the key outright, which is why the ownership mask
+// has to reach build_rss_rowid_to_update_rowid -- a sibling's key that this child's inherited sstables
+// still answer for looks exactly like an update, and one they do not looks exactly like an insert).
+//
+// Staged as in the row-mode test: the baseline write is LOCAL, so every key -- siblings' included --
+// is in this child's index and resolvable. Only the owned half may end up updated.
+TEST_P(LakePartialUpdateTest, test_cross_publish_column_mode_updates_only_owned_rows) {
+    if (GetParam().partial_update_mode != PartialUpdateMode::COLUMN_UPDATE_MODE) {
+        GTEST_SKIP() << "row mode merges the unmodified columns through the rewrite, not a DCG";
+    }
+    const int n = kChunkSize;
+    const int kOwnedLower = n / 4;
+    const int kOwnedUpper = n - n / 4;
+
+    make_range_distributed(_tablet_metadata.get(), kOwnedLower, kOwnedUpper);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    ASSERT_OK(_tablet_mgr->create_schema_file(_tablet_metadata->id(), _tablet_metadata->schema()));
+    _tablet_schema = TabletSchema::create(_tablet_metadata->schema());
+    _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+
+    auto chunk0 = generate_data(n, 0, false, 3); // full rows: c1 = key * 3, c2 = key * 4
+    auto chunk1 = generate_data(n, 0, true, 5);  // partial rows: c0 and c1 = key * 5 only
+    auto indexes = std::vector<uint32_t>(n);
+    for (int i = 0; i < n; i++) {
+        indexes[i] = i;
+    }
+    auto tablet_id = _tablet_metadata->id();
+
+    // v2: local full write -> every key lands in this child's index.
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, 2, txn_id).status());
+    }
+    ASSERT_EQ(n, check(2, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
+
+    // v3: cross publish a column-mode update of every key.
+    auto txn_id = next_id();
+    {
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .set_partial_update_mode(GetParam().partial_update_mode)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+    }
+    {
+        ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_log(tablet_id, txn_id));
+        auto shared_log = std::make_shared<TxnLog>(*txn_log);
+        auto* rowset = shared_log->mutable_op_write()->mutable_rowset();
+        ASSERT_GT(rowset->segment_metas_size(), 0);
+        rowset->mutable_range()->CopyFrom(_tablet_metadata->range());
+        for (auto& segment_meta : *rowset->mutable_segment_metas()) {
+            segment_meta.set_shared(true);
+        }
+        ASSERT_OK(_tablet_mgr->put_txn_log(shared_log));
+        _tablet_mgr->prune_metacache();
+    }
+    ASSERT_OK(publish_single_version(tablet_id, 3, txn_id).status());
+
+    // The DCG lands on the baseline rowset, which this tablet wrote itself and reads whole, so a
+    // sibling's update would be plainly visible here: without the mask every key reads c1 = c0 * 5.
+    ASSERT_EQ(n, check(3, [&](int c0, int c1, int c2) {
+                  const bool owned = c0 >= kOwnedLower && c0 < kOwnedUpper;
+                  return c2 == c0 * 4 && c1 == (owned ? c0 * 5 : c0 * 3);
+              }));
 }
 
 TEST_P(LakePartialUpdateTest, test_write_multi_segment_by_diff_val_mem_limit) {

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -2169,20 +2169,19 @@ static void make_range_distributed(TabletMetadata* metadata, int lower_inclusive
 // this child's index -- without them a sibling lookup would simply miss and there would be nothing to
 // observe.
 //
-// c2 is the witness: it is not in the partial write, so a row whose old location was read carries the
-// old c2 (key * 4) and a row left at the sentinel carries c2's declared default (10). The assertion
-// opens the rewritten segment directly because a reader must NOT see the siblings' rows in it, which
-// is the other half of what this covers.
+// The range is stamped onto the ROWSET here, exactly as convert_txn_log_for_splitting does, which is
+// what narrows the publish iterator to this child's slice of the segment -- and what this covers:
 //
-// It is also a regression test for the rewrite's row-count contract. SegmentRewriter::rewrite_partial_update
-// copies the source segment's own columns verbatim -- all of its rows -- and appends the merged ones,
-// so SegmentWriter::finalize_columns fails the publish outright ("num rows written mismatch") unless
-// the state holds exactly one value per SOURCE row. Narrowing the publish iterator to this child's
-// slice produced fewer, so the range is stamped on the rowset here exactly as
-// convert_txn_log_for_splitting does: that is what used to trigger the narrowing, and now the
-// ownership mask does the selecting instead. MetaFileBuilder clears `shared` on the rewrite output
-// (the file really is private), so what keeps the siblings' rows out of reads is that the ROWSET
-// carries a range -- Rowset::set_segment_tablet_range clips on either.
+// - The rewrite's row-count contract. SegmentRewriter::rewrite_partial_update copies the source
+//   segment's own columns verbatim, every row of them, and appends the merged ones, so
+//   SegmentWriter::finalize_columns fails the publish outright ("num rows written mismatch") unless
+//   there is one merged value per SOURCE row. A narrowed iterator produces fewer, so rewrite_segment
+//   pads the rest with defaults. c2 is the witness: it is not in the partial write, so an owned row
+//   carries its old c2 (key * 4) and a padded row carries c2's declared default (10).
+// - That those padded rows stay out of reads. MetaFileBuilder clears `shared` on the rewrite output
+//   (the file really is private to this tablet), so what clips it is the range on the rowset --
+//   Rowset::set_segment_tablet_range accepts either. Hence one assertion on the file, which must hold
+//   every row, and one on the tablet, which must serve only this child's.
 TEST_P(LakePartialUpdateTest, test_cross_publish_row_mode_partial_update_reads_only_owned_rows) {
     if (GetParam().partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) {
         GTEST_SKIP() << "column mode resolves the unmodified columns through DCGs, not this lookup";
@@ -2384,7 +2383,9 @@ TEST_P(LakePartialUpdateTest, test_cross_publish_column_mode_updates_only_owned_
         auto shared_log = std::make_shared<TxnLog>(*txn_log);
         auto* rowset = shared_log->mutable_op_write()->mutable_rowset();
         ASSERT_GT(rowset->segment_metas_size(), 0);
-        rowset->mutable_range()->CopyFrom(_tablet_metadata->range());
+        // Shared segments but no rowset range, so the iterator is never narrowed and the selector's
+        // mask is what decides -- see the note in
+        // LakePrimaryKeyPublishTest.test_cross_publish_condition_update_compares_only_owned_rows.
         for (auto& segment_meta : *rowset->mutable_segment_metas()) {
             segment_meta.set_shared(true);
         }

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include <map>
 #include <random>
 
 #include "base/testutil/assert.h"
@@ -32,8 +33,10 @@
 #include "common/config_primary_key_fwd.h"
 #include "common/config_rowset_fwd.h"
 #include "common/logging.h"
+#include "fs/fs.h"
 #include "platform/key_cache.h"
 #include "storage/chunk_helper.h"
+#include "storage/datum_variant.h"
 #include "storage/lake/column_mode_partial_update_handler.h"
 #include "storage/lake/delta_writer.h"
 #include "storage/lake/meta_file.h"
@@ -45,6 +48,8 @@
 #include "storage/rowset/segment.h"
 #include "storage/rowset/segment_options.h"
 #include "storage/tablet_schema.h"
+#include "storage/types.h"
+#include "storage/variant_tuple.h"
 
 namespace starrocks::lake {
 
@@ -2126,6 +2131,159 @@ TEST_P(LakePartialUpdateTest, test_partial_update_rewrite_with_apportioned_num_r
 
     ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
     ASSERT_EQ(kChunkSize, check(version + 1, [](int c0, int c1, int c2) { return (c0 * 5 == c1) && (c0 * 4 == c2); }));
+}
+
+// A row-mode partial update reads the columns it does not carry from each row's old location, and a
+// cross published SPLIT child is handed its siblings' rows along with its own. Looking a sibling's key
+// up resolves against the sstables this child inherited from the parent, so the location it returns can
+// name a rowset the split pruned away -- get_column_values then fails the publish for good on an
+// unknown rssid, the same failure #77744 fixed for del files. Ask only about the rows this child owns
+// and leave the rest at the "no old row" sentinel, which plan_read_by_rssid turns into default values.
+//
+// A real SPLIT is out of reach here, so the two things CrossPublishRowSelector::create_if_needed keys
+// on are staged directly: a tablet range over the middle of the key space, and an op_write whose
+// segments are marked shared. The baseline write is LOCAL, which is what puts the siblings' keys in
+// this child's index -- without them a sibling lookup would simply miss and there would be nothing to
+// observe.
+//
+// c2 is the witness: it is not in the partial write, so a row whose old location was read carries the
+// old c2 (key * 4) and a row left at the sentinel carries c2's declared default (10). The assertion
+// opens the rewritten segment rather than reading the tablet, because MetaFileBuilder clears `shared`
+// on a rewrite output -- it is private to this tablet -- so a reader no longer clips it to the range.
+TEST_P(LakePartialUpdateTest, test_cross_publish_row_mode_partial_update_reads_only_owned_rows) {
+    if (GetParam().partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) {
+        GTEST_SKIP() << "column mode resolves the unmodified columns through DCGs, not this lookup";
+    }
+    const int n = kChunkSize;
+    const int kOwnedLower = n / 4;
+    const int kOwnedUpper = n - n / 4;
+    const int kOwnedRows = kOwnedUpper - kOwnedLower;
+
+    // Range distribution requires the order-preserving big-endian PK encoding; create_sst_seek_range_from
+    // rejects anything else and the selector declines to build without it. TabletRangeHelper::
+    // validate_tablet_range fixes the inclusivity: [lower, upper). A fresh schema id keeps the schema
+    // file the writers load in step with the metadata this edit produces.
+    auto* schema_pb = _tablet_metadata->mutable_schema();
+    schema_pb->set_id(next_id());
+    schema_pb->set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
+    auto append_int_bound = [](auto* bound, int value) {
+        DatumVariant variant(get_type_info(LogicalType::TYPE_INT), Datum(value));
+        VariantTuple tuple;
+        tuple.append(variant);
+        tuple.to_proto(bound);
+    };
+    auto* range_pb = _tablet_metadata->mutable_range();
+    append_int_bound(range_pb->mutable_lower_bound(), kOwnedLower);
+    range_pb->set_lower_bound_included(true);
+    append_int_bound(range_pb->mutable_upper_bound(), kOwnedUpper);
+    range_pb->set_upper_bound_included(false);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    ASSERT_OK(_tablet_mgr->create_schema_file(_tablet_metadata->id(), *schema_pb));
+    _tablet_schema = TabletSchema::create(*schema_pb);
+    _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+
+    auto chunk0 = generate_data(n, 0, false, 3); // full rows: c1 = key * 3, c2 = key * 4
+    auto chunk1 = generate_data(n, 0, true, 5);  // partial rows: c0 and c1 = key * 5 only
+    auto indexes = std::vector<uint32_t>(n);
+    for (int i = 0; i < n; i++) {
+        indexes[i] = i;
+    }
+    auto tablet_id = _tablet_metadata->id();
+
+    // v2: a local full write puts every key -- this child's and its siblings' -- in the index. Not
+    // shared, so it is neither selected at publish nor clipped at read.
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, 2, txn_id).status());
+    }
+    ASSERT_EQ(n, check(2, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
+
+    // v3: cross publish the partial update. What convert_txn_log_for_splitting leaves behind is the
+    // parent's segments on every child, so each has to select its own rows out of them.
+    auto txn_id = next_id();
+    {
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .set_partial_update_mode(GetParam().partial_update_mode)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+    }
+    {
+        ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_log(tablet_id, txn_id));
+        auto shared_log = std::make_shared<TxnLog>(*txn_log);
+        auto* rowset = shared_log->mutable_op_write()->mutable_rowset();
+        ASSERT_GT(rowset->segment_metas_size(), 0);
+        for (auto& segment_meta : *rowset->mutable_segment_metas()) {
+            segment_meta.set_shared(true);
+        }
+        ASSERT_OK(_tablet_mgr->put_txn_log(shared_log));
+        _tablet_mgr->prune_metacache();
+    }
+    ASSERT_OK(publish_single_version(tablet_id, 3, txn_id).status());
+
+    ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(tablet_id, 3));
+    ASSERT_EQ(2, metadata->rowsets_size());
+    // Guards the staging as much as the fix: only the owned keys were re-indexed, so only their old
+    // rows were displaced. All n here would mean the selector never engaged.
+    EXPECT_EQ(kOwnedRows, metadata->rowsets(0).num_dels());
+
+    const auto& rewritten = metadata->rowsets(1);
+    ASSERT_EQ(1, rewritten.segment_metas_size());
+    ASSIGN_OR_ABORT(auto fs, FileSystemFactory::CreateSharedFromString(kTestDirectory));
+    auto segment_path = _tablet_mgr->segment_location(tablet_id, rewritten.segment_metas(0).filename());
+    ASSIGN_OR_ABORT(auto segment, Segment::open(fs, FileInfo{segment_path}, /*segment_id=*/0, _tablet_schema));
+    OlapReaderStatistics stats;
+    SegmentReadOptions opts;
+    opts.fs = fs;
+    opts.tablet_id = tablet_id;
+    opts.stats = &stats;
+    opts.chunk_size = 128;
+    ASSIGN_OR_ABORT(auto seg_iter, segment->new_iterator(*_schema, opts));
+    auto read_chunk = ChunkFactory::new_chunk(*_schema, 128);
+    std::map<int, std::pair<int, int>> rows;
+    while (true) {
+        read_chunk->reset();
+        auto st = seg_iter->get_next(read_chunk.get());
+        if (st.is_end_of_file()) {
+            break;
+        }
+        ASSERT_OK(st);
+        for (size_t i = 0; i < read_chunk->num_rows(); i++) {
+            auto row = read_chunk->get(i);
+            rows[row[0].get_int32()] = {row[1].get_int32(), row[2].get_int32()};
+        }
+    }
+    seg_iter->close();
+
+    ASSERT_EQ(static_cast<size_t>(n), rows.size());
+    for (int key = 0; key < n; key++) {
+        const bool owned = key >= kOwnedLower && key < kOwnedUpper;
+        auto it = rows.find(key);
+        ASSERT_NE(rows.end(), it) << "key " << key << " missing from the rewritten segment";
+        EXPECT_EQ(key * 5, it->second.first) << "key " << key;
+        EXPECT_EQ(owned ? key * 4 : 10, it->second.second) << "key " << key;
+    }
 }
 
 TEST_P(LakePartialUpdateTest, test_write_multi_segment_by_diff_val_mem_limit) {

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -1332,10 +1332,15 @@ TEST_P(LakePrimaryKeyPublishTest, test_cross_publish_condition_update_compares_o
         delta_writer->close();
         return txn_id;
     };
-    // Both halves of what convert_txn_log_for_splitting leaves behind: the segments stay the parent's
-    // (every child publishes the same ones, so each has to select its own rows out of them) and this
-    // child's range is stamped onto the rowset, which is how the publish and the read path later learn
-    // that the rowset holds rows this child does not own.
+    // What convert_txn_log_for_splitting leaves behind: the segments stay the parent's and every child
+    // publishes the same ones, so each has to select its own rows out of them.
+    //
+    // Deliberately NOT the rowset range it also stamps. Without one the publish-time Rowset has no
+    // range at all (it is built from the txn log, so its _tablet_metadata is null and the tablet range
+    // cannot be reached), the iterator is never narrowed, and the selector's verdict is what decides --
+    // which is the code under test. A tablet whose ORDER BY differs from its PK reaches the same state
+    // for real, because Rowset::set_segment_tablet_range withholds the range there, but no path can
+    // build one yet.
     auto make_txn_log_cross_published = [&](int64_t txn_id) {
         ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_log(tablet_id, txn_id));
         auto shared_log = std::make_shared<TxnLog>(*txn_log);
@@ -1344,7 +1349,6 @@ TEST_P(LakePrimaryKeyPublishTest, test_cross_publish_condition_update_compares_o
         // The non-SST condition merge is the path under test; prebuilt ssts would route the publish
         // into _do_update_with_condition_parallel instead.
         ASSERT_EQ(0, shared_log->op_write().ssts_size());
-        rowset->mutable_range()->CopyFrom(_tablet_metadata->range());
         for (auto& segment_meta : *rowset->mutable_segment_metas()) {
             segment_meta.set_shared(true);
         }
@@ -1467,7 +1471,6 @@ TEST_P(LakePrimaryKeyPublishTest, test_cross_publish_condition_update_delvecs_lo
         auto* rowset = shared_log->mutable_op_write()->mutable_rowset();
         ASSERT_GT(rowset->segment_metas_size(), 0);
         ASSERT_EQ(0, shared_log->op_write().ssts_size());
-        rowset->mutable_range()->CopyFrom(_tablet_metadata->range());
         for (auto& segment_meta : *rowset->mutable_segment_metas()) {
             segment_meta.set_shared(true);
         }

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -1286,15 +1286,17 @@ static void set_int_tablet_range(TabletMetadata* metadata, int lower_inclusive, 
 // read), which is what puts the SIBLINGS' keys in this child's index. Without them every sibling
 // lookup would simply miss and there would be nothing left to get wrong.
 //
-// The range covers the MIDDLE of the key space on purpose. Filtering the chunk renumbers the
-// survivors, so a child owning a prefix would keep working with the pre-filter arithmetic; owning
-// [n/4, 3n/4) is what makes "row 0 of the filtered column is row n/4 of the segment" load-bearing.
+// The range covers the MIDDLE of the key space on purpose: a sibling's row sits on either side of the
+// owned block, so the verdict walk has to close a winner run at both edges, and every rowid it records
+// -- the winners' index entries, the losers' delvec -- has to stay the row's position in the SEGMENT
+// rather than its position among the rows this child kept. A child owning a prefix would pass either
+// way.
 TEST_P(LakePrimaryKeyPublishTest, test_cross_publish_condition_update_compares_only_owned_rows) {
     if (GetParam().enable_transparent_data_encryption) {
         return;
     }
     // No token below pk_index_parallel_execution_min_rows, so the winners reach the index through the
-    // serial branch -- LakePrimaryIndex::upsert_rows.
+    // serial branch: index.upsert() over each winner range of the unfiltered chunk.
     ConfigResetGuard<bool> serial(&config::enable_pk_index_parallel_execution, false);
 
     const int n = kChunkSize;
@@ -1395,8 +1397,8 @@ TEST_P(LakePrimaryKeyPublishTest, test_cross_publish_condition_update_compares_o
 
     // v4 pins the rowids the winners were indexed AT: a delete of every key is clipped to this child's
     // range, so it erases exactly the owned keys -- which the index must have placed at their real
-    // positions in v3's segment. Rowids left renumbered by the filter erase other rows and leave some
-    // of the owned ones alive.
+    // positions in v3's segment. A rowid taken from the row's position among the owned rows instead
+    // erases other rows and leaves some of the owned ones alive.
     ASSERT_OK(publish_single_version(tablet_id, 4, write_txn(make_op_chunk(n, 0, false, _slot_cid_map), "")).status());
     auto after_delete = read_key_to_value(4);
     EXPECT_EQ(static_cast<size_t>(n - kOwnedRows), after_delete.size());
@@ -1409,8 +1411,9 @@ TEST_P(LakePrimaryKeyPublishTest, test_cross_publish_condition_update_compares_o
 // The other half of the same mapping: a row that LOSES its comparison is appended to this child's
 // delvec, and the parent view ORs the children's delvecs, so a verdict reached for a sibling's row
 // erases a row its owner had just decided to keep. The verdict alternates by key here, which also
-// pins the delvec entries to the losers' real rowids -- an entry off by the filter's renumbering
-// deletes an unrelated row and leaves the loser visible next to the old row that beat it.
+// pins the delvec entries to the losers' real rowids -- an entry that names the row's position among
+// the owned rows instead deletes an unrelated row and leaves the loser visible next to the old row
+// that beat it.
 //
 // Runs the parallel compare + parallel upsert branch (the serial one is covered above).
 TEST_P(LakePrimaryKeyPublishTest, test_cross_publish_condition_update_delvecs_losers_at_real_rowids) {

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -1332,9 +1332,11 @@ TEST_P(LakePrimaryKeyPublishTest, test_cross_publish_condition_update_compares_o
         delta_writer->close();
         return txn_id;
     };
-    // What convert_txn_log_for_splitting leaves behind: the segments stay the parent's and every child
-    // publishes the same ones, so each has to select its own rows out of them.
-    auto mark_segments_shared = [&](int64_t txn_id) {
+    // Both halves of what convert_txn_log_for_splitting leaves behind: the segments stay the parent's
+    // (every child publishes the same ones, so each has to select its own rows out of them) and this
+    // child's range is stamped onto the rowset, which is how the publish and the read path later learn
+    // that the rowset holds rows this child does not own.
+    auto make_txn_log_cross_published = [&](int64_t txn_id) {
         ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_log(tablet_id, txn_id));
         auto shared_log = std::make_shared<TxnLog>(*txn_log);
         auto* rowset = shared_log->mutable_op_write()->mutable_rowset();
@@ -1342,6 +1344,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_cross_publish_condition_update_compares_o
         // The non-SST condition merge is the path under test; prebuilt ssts would route the publish
         // into _do_update_with_condition_parallel instead.
         ASSERT_EQ(0, shared_log->op_write().ssts_size());
+        rowset->mutable_range()->CopyFrom(_tablet_metadata->range());
         for (auto& segment_meta : *rowset->mutable_segment_metas()) {
             segment_meta.set_shared(true);
         }
@@ -1368,7 +1371,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_cross_publish_condition_update_compares_o
     // v3: cross publish a condition update whose every new value beats the old one (c1 = key + 100
     // against key), so every row this child compares wins and displaces its old row.
     auto condition_txn = write_txn(make_op_chunk(n, /*value_shift=*/100, true, _slot_cid_map), "c1");
-    mark_segments_shared(condition_txn);
+    make_txn_log_cross_published(condition_txn);
     ASSERT_OK(publish_single_version(tablet_id, 3, condition_txn).status());
 
     ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(tablet_id, 3));
@@ -1464,6 +1467,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_cross_publish_condition_update_delvecs_lo
         auto* rowset = shared_log->mutable_op_write()->mutable_rowset();
         ASSERT_GT(rowset->segment_metas_size(), 0);
         ASSERT_EQ(0, shared_log->op_write().ssts_size());
+        rowset->mutable_range()->CopyFrom(_tablet_metadata->range());
         for (auto& segment_meta : *rowset->mutable_segment_metas()) {
             segment_meta.set_shared(true);
         }

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -1234,6 +1234,274 @@ TEST_P(LakePrimaryKeyPublishTest, test_cross_publish_indexes_only_the_rows_this_
     EXPECT_EQ(kOwnedRows, read_rows(tablet_id, 3));
 }
 
+// Build a 3-column chunk (c0=key, c1=value_of(key), __op=UPSERT) for keys [0, n). Unlike
+// make_op_chunk's uniform shift, the value is chosen per key, so one chunk can carry rows that win
+// their condition comparison next to rows that lose it.
+static ChunkPtr make_upsert_chunk(int n, int (*value_of)(int), const Chunk::SlotHashMap& slot_cid_map) {
+    std::vector<int> keys(n), vals(n);
+    std::vector<uint8_t> ops(n);
+    for (int i = 0; i < n; i++) {
+        keys[i] = i;
+        vals[i] = value_of(i);
+        ops[i] = TOpType::UPSERT;
+    }
+    auto c0 = Int32Column::create();
+    auto c1 = Int32Column::create();
+    auto c2 = Int8Column::create();
+    c0->append_numbers(keys.data(), keys.size() * sizeof(int));
+    c1->append_numbers(vals.data(), vals.size() * sizeof(int));
+    c2->append_numbers(ops.data(), ops.size() * sizeof(uint8_t));
+    return std::make_shared<Chunk>(Columns{std::move(c0), std::move(c1), std::move(c2)}, slot_cid_map);
+}
+
+// Stage the two things CrossPublishRowSelector::create_if_needed keys on that live in tablet metadata:
+// the order-preserving big-endian PK encoding range distribution requires (create_sst_seek_range_from
+// rejects anything else, and the selector declines to build without it), and the range itself. The
+// bound inclusivity is not a choice -- TabletRangeHelper::validate_tablet_range accepts [lower, upper)
+// and nothing else.
+static void set_int_tablet_range(TabletMetadata* metadata, int lower_inclusive, int upper_exclusive) {
+    metadata->mutable_schema()->set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
+    auto append_int_bound = [](auto* bound, int value) {
+        DatumVariant variant(get_type_info(LogicalType::TYPE_INT), Datum(value));
+        VariantTuple tuple;
+        tuple.append(variant);
+        tuple.to_proto(bound);
+    };
+    auto* range_pb = metadata->mutable_range();
+    append_int_bound(range_pb->mutable_lower_bound(), lower_inclusive);
+    range_pb->set_lower_bound_included(true);
+    append_int_bound(range_pb->mutable_upper_bound(), upper_exclusive);
+    range_pb->set_upper_bound_included(false);
+}
+
+// A condition update decides each row from an index lookup, so a cross published SPLIT child has to
+// restrict that lookup the way #78045 restricted the plain upsert. A sibling's key still resolves --
+// against the sstables this child inherited from the parent -- so the comparison "succeeds" and its
+// winner displaces the old row from the ancestor rowset, while the new row that replaces it sits
+// outside this child's range and is invisible to its reads. The key is then gone from this child
+// altogether, which is what the row count below measures.
+//
+// Staged like test_cross_publish_indexes_only_the_rows_this_child_owns, with one deliberate
+// difference: the baseline write is LOCAL (not shared, so neither selected at publish nor clipped at
+// read), which is what puts the SIBLINGS' keys in this child's index. Without them every sibling
+// lookup would simply miss and there would be nothing left to get wrong.
+//
+// The range covers the MIDDLE of the key space on purpose. Filtering the chunk renumbers the
+// survivors, so a child owning a prefix would keep working with the pre-filter arithmetic; owning
+// [n/4, 3n/4) is what makes "row 0 of the filtered column is row n/4 of the segment" load-bearing.
+TEST_P(LakePrimaryKeyPublishTest, test_cross_publish_condition_update_compares_only_owned_rows) {
+    if (GetParam().enable_transparent_data_encryption) {
+        return;
+    }
+    // No token below pk_index_parallel_execution_min_rows, so the winners reach the index through the
+    // serial branch -- LakePrimaryIndex::upsert_rows.
+    ConfigResetGuard<bool> serial(&config::enable_pk_index_parallel_execution, false);
+
+    const int n = kChunkSize;
+    const int kOwnedLower = n / 4;
+    const int kOwnedUpper = n - n / 4;
+    const int kOwnedRows = kOwnedUpper - kOwnedLower;
+    set_int_tablet_range(_tablet_metadata.get(), kOwnedLower, kOwnedUpper);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    _tablet_schema = TabletSchema::create(_tablet_metadata->schema());
+    _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+
+    auto tablet_id = _tablet_metadata->id();
+    std::vector<uint32_t> indexes(n);
+    for (uint32_t i = 0; i < static_cast<uint32_t>(n); i++) {
+        indexes[i] = i;
+    }
+    auto write_txn = [&](const ChunkPtr& chunk, const std::string& merge_condition) {
+        int64_t txn_id = next_id();
+        DeltaWriterBuilder builder;
+        builder.set_tablet_manager(_tablet_mgr.get())
+                .set_tablet_id(tablet_id)
+                .set_txn_id(txn_id)
+                .set_partition_id(_partition_id)
+                .set_mem_tracker(_mem_tracker.get())
+                .set_schema_id(_tablet_schema->id())
+                .set_slot_descriptors(&_slot_pointers)
+                .set_profile(&_dummy_runtime_profile);
+        if (!merge_condition.empty()) {
+            builder.set_merge_condition(merge_condition);
+        }
+        ASSIGN_OR_ABORT(auto delta_writer, builder.build());
+        CHECK_OK(delta_writer->open());
+        CHECK_OK(delta_writer->write(*chunk, indexes.data(), indexes.size()));
+        CHECK_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        return txn_id;
+    };
+    // What convert_txn_log_for_splitting leaves behind: the segments stay the parent's and every child
+    // publishes the same ones, so each has to select its own rows out of them.
+    auto mark_segments_shared = [&](int64_t txn_id) {
+        ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_log(tablet_id, txn_id));
+        auto shared_log = std::make_shared<TxnLog>(*txn_log);
+        auto* rowset = shared_log->mutable_op_write()->mutable_rowset();
+        ASSERT_GT(rowset->segment_metas_size(), 0);
+        // The non-SST condition merge is the path under test; prebuilt ssts would route the publish
+        // into _do_update_with_condition_parallel instead.
+        ASSERT_EQ(0, shared_log->op_write().ssts_size());
+        for (auto& segment_meta : *rowset->mutable_segment_metas()) {
+            segment_meta.set_shared(true);
+        }
+        ASSERT_OK(_tablet_mgr->put_txn_log(shared_log));
+    };
+    // Rows arrive from several rowsets in no particular order, and a key appearing twice is itself a
+    // failure mode (a delvec entry landing on the wrong row leaves both copies alive), so collect
+    // rather than stream-compare.
+    auto read_key_to_value = [&](int64_t version) {
+        ASSIGN_OR_ABORT(auto chunk, read(tablet_id, version));
+        std::map<int, int> key_to_value;
+        for (size_t i = 0; i < chunk->num_rows(); i++) {
+            auto row = chunk->get(i);
+            EXPECT_TRUE(key_to_value.emplace(row[0].get_int32(), row[1].get_int32()).second)
+                    << "key " << row[0].get_int32() << " read twice";
+        }
+        return key_to_value;
+    };
+
+    // v2: a local write puts every key -- this child's and its siblings' -- in the index.
+    ASSERT_OK(publish_single_version(tablet_id, 2, write_txn(make_op_chunk(n, 0, true, _slot_cid_map), "")).status());
+    ASSERT_EQ(n, read_rows(tablet_id, 2));
+
+    // v3: cross publish a condition update whose every new value beats the old one (c1 = key + 100
+    // against key), so every row this child compares wins and displaces its old row.
+    auto condition_txn = write_txn(make_op_chunk(n, /*value_shift=*/100, true, _slot_cid_map), "c1");
+    mark_segments_shared(condition_txn);
+    ASSERT_OK(publish_single_version(tablet_id, 3, condition_txn).status());
+
+    ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(tablet_id, 3));
+    ASSERT_EQ(2, metadata->rowsets_size());
+    // Only the owned keys' old rows may be displaced. Comparing every row displaces all n instead,
+    // and the winners that replace the siblings' keys are unreadable from here -- those keys vanish.
+    EXPECT_EQ(kOwnedRows, metadata->rowsets(0).num_dels());
+    EXPECT_EQ(n, read_rows(tablet_id, 3));
+    auto after_condition = read_key_to_value(3);
+    EXPECT_EQ(static_cast<size_t>(n), after_condition.size());
+    for (int key = 0; key < n; key++) {
+        const bool owned = key >= kOwnedLower && key < kOwnedUpper;
+        auto it = after_condition.find(key);
+        ASSERT_NE(after_condition.end(), it) << "key " << key << " lost";
+        EXPECT_EQ(owned ? key + 100 : key, it->second) << "key " << key;
+    }
+
+    // v4 pins the rowids the winners were indexed AT: a delete of every key is clipped to this child's
+    // range, so it erases exactly the owned keys -- which the index must have placed at their real
+    // positions in v3's segment. Rowids left renumbered by the filter erase other rows and leave some
+    // of the owned ones alive.
+    ASSERT_OK(publish_single_version(tablet_id, 4, write_txn(make_op_chunk(n, 0, false, _slot_cid_map), "")).status());
+    auto after_delete = read_key_to_value(4);
+    EXPECT_EQ(static_cast<size_t>(n - kOwnedRows), after_delete.size());
+    for (int key = 0; key < n; key++) {
+        const bool owned = key >= kOwnedLower && key < kOwnedUpper;
+        EXPECT_EQ(owned ? 0u : 1u, after_delete.count(key)) << "key " << key;
+    }
+}
+
+// The other half of the same mapping: a row that LOSES its comparison is appended to this child's
+// delvec, and the parent view ORs the children's delvecs, so a verdict reached for a sibling's row
+// erases a row its owner had just decided to keep. The verdict alternates by key here, which also
+// pins the delvec entries to the losers' real rowids -- an entry off by the filter's renumbering
+// deletes an unrelated row and leaves the loser visible next to the old row that beat it.
+//
+// Runs the parallel compare + parallel upsert branch (the serial one is covered above).
+TEST_P(LakePrimaryKeyPublishTest, test_cross_publish_condition_update_delvecs_losers_at_real_rowids) {
+    if (GetParam().enable_transparent_data_encryption) {
+        return;
+    }
+    // The token is created only once the rowset has at least pk_index_parallel_execution_min_rows
+    // rows, so lower the bar to reach that path with a chunk this small.
+    ConfigResetGuard<bool> parallel(&config::enable_pk_index_parallel_execution, true);
+    ConfigResetGuard<int64_t> min_rows(&config::pk_index_parallel_execution_min_rows, 1);
+
+    const int n = kChunkSize;
+    const int kOwnedLower = n / 4;
+    const int kOwnedUpper = n - n / 4;
+    set_int_tablet_range(_tablet_metadata.get(), kOwnedLower, kOwnedUpper);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    _tablet_schema = TabletSchema::create(_tablet_metadata->schema());
+    _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+
+    auto tablet_id = _tablet_metadata->id();
+    std::vector<uint32_t> indexes(n);
+    for (uint32_t i = 0; i < static_cast<uint32_t>(n); i++) {
+        indexes[i] = i;
+    }
+    auto write_txn = [&](const ChunkPtr& chunk, const std::string& merge_condition) {
+        int64_t txn_id = next_id();
+        DeltaWriterBuilder builder;
+        builder.set_tablet_manager(_tablet_mgr.get())
+                .set_tablet_id(tablet_id)
+                .set_txn_id(txn_id)
+                .set_partition_id(_partition_id)
+                .set_mem_tracker(_mem_tracker.get())
+                .set_schema_id(_tablet_schema->id())
+                .set_slot_descriptors(&_slot_pointers)
+                .set_profile(&_dummy_runtime_profile);
+        if (!merge_condition.empty()) {
+            builder.set_merge_condition(merge_condition);
+        }
+        ASSIGN_OR_ABORT(auto delta_writer, builder.build());
+        CHECK_OK(delta_writer->open());
+        CHECK_OK(delta_writer->write(*chunk, indexes.data(), indexes.size()));
+        CHECK_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        return txn_id;
+    };
+
+    // v2: local write of every key at c1 = key, siblings included.
+    ASSERT_OK(publish_single_version(tablet_id, 2, write_txn(make_op_chunk(n, 0, true, _slot_cid_map), "")).status());
+    ASSERT_EQ(n, read_rows(tablet_id, 2));
+
+    // v3: cross publish a condition update where the verdict alternates -- an even key's new value
+    // beats the old one, an odd key's loses to it.
+    auto value_of = [](int key) { return key % 2 == 0 ? key + 100 : key - 100; };
+    auto condition_txn = write_txn(make_upsert_chunk(n, value_of, _slot_cid_map), "c1");
+    {
+        ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_log(tablet_id, condition_txn));
+        auto shared_log = std::make_shared<TxnLog>(*txn_log);
+        auto* rowset = shared_log->mutable_op_write()->mutable_rowset();
+        ASSERT_GT(rowset->segment_metas_size(), 0);
+        ASSERT_EQ(0, shared_log->op_write().ssts_size());
+        for (auto& segment_meta : *rowset->mutable_segment_metas()) {
+            segment_meta.set_shared(true);
+        }
+        ASSERT_OK(_tablet_mgr->put_txn_log(shared_log));
+    }
+    ASSERT_OK(publish_single_version(tablet_id, 3, condition_txn).status());
+
+    int expected_dels = 0;
+    for (int key = kOwnedLower; key < kOwnedUpper; key++) {
+        if (key % 2 == 0) {
+            expected_dels++;
+        }
+    }
+    ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(tablet_id, 3));
+    ASSERT_EQ(2, metadata->rowsets_size());
+    // Only an owned winner may displace an old row. Comparing every row makes every even key a
+    // winner, and the ones outside the range take their old row with them into invisibility.
+    EXPECT_EQ(expected_dels, metadata->rowsets(0).num_dels());
+    EXPECT_EQ(n, read_rows(tablet_id, 3));
+
+    ASSIGN_OR_ABORT(auto chunk, read(tablet_id, 3));
+    std::map<int, int> key_to_value;
+    for (size_t i = 0; i < chunk->num_rows(); i++) {
+        auto row = chunk->get(i);
+        EXPECT_TRUE(key_to_value.emplace(row[0].get_int32(), row[1].get_int32()).second)
+                << "key " << row[0].get_int32() << " read twice";
+    }
+    EXPECT_EQ(static_cast<size_t>(n), key_to_value.size());
+    for (int key = 0; key < n; key++) {
+        const bool owned = key >= kOwnedLower && key < kOwnedUpper;
+        // An owned winner shows its new value; an owned loser and every sibling keep the old row.
+        const int expected = (owned && key % 2 == 0) ? value_of(key) : key;
+        auto it = key_to_value.find(key);
+        ASSERT_NE(key_to_value.end(), it) << "key " << key << " lost";
+        EXPECT_EQ(expected, it->second) << "key " << key;
+    }
+}
+
 // Spill path regression (kevincai review on #75366): when a single op-aware merge task emits more than one
 // upsert chunk (merged upsert rows > config::vector_chunk_size), write_one_merged_chunk must not corrupt
 // the reused merge chunk's schema. The old clone_empty_with_schema + remove_column_by_index shared then


### PR DESCRIPTION
## Why I'm doing:

Part of #77653 (stage CP-5). Cross publish hands a SPLIT child the parent's whole `op_write`, its siblings' rows included. CP-3 (#77877) computes which rows a child owns and CP-4 (#78045) restricted the plain upsert and its lookup to those. This finishes the publish path, and fixes a live defect that finishing it uncovered.

**Every remaining per-row lookup.** Both condition-update paths (SST and non-SST), the row-mode partial update, `_resolve_conflict`, the auto-increment partial update and column mode all decided per row from an index lookup that ignored ownership. A sibling's key still resolves — against the sstables this child inherited from the parent — so the location returned can name a rowset the split pruned away, and `get_column_values` then fails the publish for good on an unknown rssid: the failure #77744 fixed for del files, reached from the upsert side. A *losing* condition verdict on such a row was also appended to this child's delvec.

These are dormant today: `Rowset::set_segment_tablet_range` narrows the publish iterator to this child's slice of a shared segment whenever the range resolves to a rowid interval, so the mask is all ones. They stop being dormant for a primary-key tablet ordered by a separate sort key, where the range is withheld — the shape CP-3 was built for.

**A live defect, and independent of the sort key.** That same narrowing breaks the rewrite's row-count contract. `SegmentRewriter::rewrite_partial_update` byte-copies the source segment's own columns — every row of them — and appends the merged ones, so `SegmentWriter::finalize_columns` rejects a short column outright ("num rows written mismatch") and the publish retries on it forever; `rewrite_auto_increment_lake` re-reads every row and would build a chunk whose columns disagree in length. A row-mode partial update in flight at a split cutover hits this on every child that does not happen to own all of a segment's rows — the ranges being disjoint, at least one.

**A read-side hole.** `MetaFileBuilder` clears `shared` on a rewrite output, because the file really is private to this tablet, while the file still holds every row of the source — so nothing kept the siblings' rows out of this child's reads.

## What I'm doing:

**Mask the answer instead of filtering the chunk.** The lookup is harmless; what fails the publish is feeding a sibling's answer to `get_column_values`. `RowsetUpdateState::mask_unowned_rowids` blanks those entries to the "no old row" sentinel and leaves the chunk alone, so rows keep their positions, chunk-local `j` stays segment rowid `physical_rowid_offset + j`, and nothing has to be remapped. Five sites: both condition merges, row-mode partial update, auto-increment, and — as a skip rather than a mask — row-mode conflict resolution.

Masking makes an unowned row look like a row with no old value, and "no old row" is a verdict some paths ACT on, so those paths skip the row itself: both condition merges leave it out of the winner runs and out of the delvec, and auto-increment leaves it out of the delete decision derived from `rowids` while keeping it IN `rowids` — the id fetch is one value per entry there and the remap has a slot for every sentinel row, so dropping it would misalign the fetched column.

**Widen the rewrite inputs.** `_widen_rewrite_columns_for_cross_publish` pads the merged columns out to the source segment's row count, filling the rows a sibling owns with the same value `get_column_values` puts in its no-old-row slot (declared default, or this transaction's expression default) — so a narrowed publish and a per-row-selected one write the same segment. It widens COPIES, never the cached state: that state is per transaction and a publish retry resolves conflicts against it at iterator-relative offsets.

**Clip the private rewrite output.** `Rowset::set_segment_tablet_range` clips a segment whose ROWSET carries a range, not only one flagged `shared`. A cross-published rowset always carries this tablet's range (`convert_txn_log_for_splitting`); a rowset this tablet wrote itself never does, so it stays unclipped and pays nothing.

**Column mode gets a selector.** `ColumnModePartialUpdateHandler` builds its own `SegmentPKIterator`s and had none. Its two branches — apply the update through a DCG, or materialize the row into a new segment — cannot be told apart from the rss_rowid alone, so the mask is carried to `build_rss_rowid_to_update_rowid` through `batch_parallel_get_rss_rowids`.

One gap is left deliberately, with a comment on the function saying so: `_resolve_conflict_auto_increment` rebuilds `rowids` from every sentinel entry of the whole vector while its remap is derived from the conflicting rows alone. The two have different bases, so masking it would misalign the fetched column rather than fix anything; it keeps only the erase guard. Its mask is all ones today, and the shape that could make it non-trivial cannot be built yet.

Tests, split along the two mechanisms. The condition-update and column-mode cases stage shared segments WITHOUT the rowset range, which is the only way to reach a non-trivial mask today — the publish-time Rowset is built from the txn log, so with no rowset range it has no range at all and the iterator is never narrowed, exactly as a separate-sort-key tablet would leave it. The row-mode case stamps the range the way `convert_txn_log_for_splitting` does, which narrows the iterator, and asserts both halves of the widening: the rewritten file holds every row of the source, and a reader is served only this tablet's.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

Range distribution / tablet reshard is main-only, so no backport is needed.

---

#77877 and #78045 have both landed, so this is rebased straight onto `main` and carries nothing but its own change.


