### PR TITLE
[BugFix] Reset the context start time for each statistics statement

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -819,6 +819,7 @@ public class StatisticExecutor {
 
     private List<TResultBatch> executeDQL(ConnectContext context, String sql) {
         context.setQueryId(UUIDUtil.genUUID());
+        context.setStartTime();
         if (Config.enable_print_sql) {
             LOG.info("Begin to execute sql, type: Statistics collect，query id:{}, sql:{}", context.getQueryId(), sql);
         }
@@ -854,6 +855,7 @@ public class StatisticExecutor {
             StmtExecutor executor = StmtExecutor.newInternalExecutor(context, parsedStmt);
             context.setExecutor(executor);
             context.setQueryId(UUIDUtil.genUUID());
+            context.setStartTime();
             executor.execute();
             AuditInternalLog.handleInternalLog(AuditInternalLog.InternalType.DML, DebugUtil.printId(context.getQueryId()),
                     sql, watch);

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
@@ -25,8 +25,10 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.GlobalVariable;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
@@ -49,6 +51,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -174,6 +177,39 @@ public class StatisticsExecutorTest extends PlanTestBase {
                 "t1");
         StatisticExecutor statisticExecutor = new StatisticExecutor();
         statisticExecutor.queryStatisticSync(context, tableUUID, table, ImmutableList.of("c1", "c2"));
+    }
+
+    @Test
+    public void testStatisticsStatementResetsContextStartTime() throws Exception {
+        boolean savedEnableUnitStatistics = FeConstants.enableUnitStatistics;
+        FeConstants.enableUnitStatistics = true;
+        try {
+            ConnectContext context = StatisticUtils.buildConnectContext();
+            // The query queue derives each slot's pending deadline from the context start time, so an
+            // anchor older than the pending timeout expires the slot before it is ever requested.
+            Instant staleAnchor = Instant.now()
+                    .minusSeconds(GlobalVariable.getQueryQueuePendingTimeoutSecond() + 1L);
+
+            // DQL, through the frame reported in #59706.
+            ExternalAnalyzeStatus analyzeStatus = new ExternalAnalyzeStatus(1, "test_catalog", "test_db",
+                    "test_table", "test123", Lists.newArrayList("col1"), StatsConstants.AnalyzeType.FULL,
+                    StatsConstants.ScheduleType.ONCE, Maps.newHashMap(), LocalDateTime.now());
+            ExternalFullStatisticsCollectJob collectJob = new ExternalFullStatisticsCollectJob("test_catalog",
+                    new Database(1, "test_db"), HiveTable.builder().setTableName("test_table").build(),
+                    List.of(), Lists.newArrayList("col1"), Lists.newArrayList(IntegerType.INT),
+                    StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.ONCE, Maps.newHashMap());
+
+            context.setStartTime(staleAnchor);
+            collectJob.collectStatisticSync("select 1", context, analyzeStatus);
+            Assertions.assertTrue(context.getStartTimeInstant().isAfter(staleAnchor));
+
+            // DML, which StatisticsCollectionTrigger#executeOverWrite runs once per partition.
+            context.setStartTime(staleAnchor);
+            new StatisticExecutor().dropPartitionStatistics(context, Lists.newArrayList(1L));
+            Assertions.assertTrue(context.getStartTimeInstant().isAfter(staleAnchor));
+        } finally {
+            FeConstants.enableUnitStatistics = savedEnableUnitStatistics;
+        }
     }
 
     public static StatementBase parseSql(String originStmt) {


### PR DESCRIPTION

## Why I'm doing:

`QueryQueueManager#createSlot` derives a slot's pending deadline from the *connection* start time:

```java
// QueryQueueManager.java:155-160
long nowMs = context.getStartTime();
long expiredPendingTimeMs = nowMs + queryQueuePendingTimeoutSecond * 1000L;
```

A collect job runs all of its statements on one stats `ConnectContext`, so unless every statement
re-anchors that value the deadline stays pinned to the start of the job. Once the job outlives
`query_queue_pending_timeout_second` each new slot is born expired
(`LogicalSlot#isPendingTimeout:189`), and `maybeWait` throws at `QueryQueueManager.java:98` before
the query waits at all - so the failure reports a pending time of 0s:

```
Failed to allocate resource to query: pending timeout [300s], you could modify the session variable
[query_queue_pending_timeout_second] to pending more time
```

#56196 fixed this for the hyper collector by resetting the start time around each of its statements
(`HyperQueryJob.java:182`). That reset lives in the caller, and the shared runner underneath it does
not do it: `StatisticExecutor#executeDQL` (`:820-832`) and `#executeDML` (`:849-859`) refresh
`context.setQueryId(...)` and `context.setExecutor(...)` per statement but never the start time. Every
path that does not go through `HyperQueryJob` is therefore still affected:

| path | affected collection |
|---|---|
| `ExternalFullStatisticsCollectJob#collectStatisticSync:589-599` | external-catalog FULL, and SAMPLE via its subclass |
| `FullStatisticsCollectJob#collectStatisticSync:190-200` | native FULL when `statistic_use_meta_statistics=false` |
| `StatisticsCollectJob#queryStatisticSync:295-300` | HISTOGRAM, native and external |
| `StatisticsCollectionTrigger#executeOverWrite:183-193` | one DML per overwritten partition, all on one context |

Native FULL/SAMPLE looks healthy only because `Config.statistic_use_meta_statistics` defaults to
`true`, which routes it through the #56196 reset; there is no hyper variant for external tables, so
external-catalog collection always takes the unfixed path. Over three days on a 4.1 cluster with
`enable_query_queue_statistic=true`, native jobs succeeded 1758/1767 (99.5%) against 89/521 (17.1%)
for external catalogs.

Reproduction - lowering the pending timeout makes any multi-statement job fail, so table size stops
mattering:

```sql
set global enable_query_queue_statistic = true;
set global query_queue_pending_timeout_second = 1;
-- any external-catalog table whose FULL analyze needs more than one collect statement
analyze full table <catalog>.<db>.<table>;
```

This fails from the second statement onwards with the error above, and completes after the fix.
#59706 is the same recipe with `= 10`; the failed reproduction attempt recorded there is consistent
with the mechanism, since at the default 300s the job has to outlive that on its own.

The job budget is separate and unaffected: `StatisticsCollectJob#calculateAndSetRemainingTimeout:215-240`
anchors on `analyzeStatus.getStartTime()` and still throws `Analyze job timeout exceeded` past
`statistic_collect_query_timeout`. The connection start time is a per-statement quantity, which is how
all five existing reset sites treat it - `StatisticsCollectJob:272`, `FullStatisticsCollectJob:267`,
`ExternalFullStatisticsCollectJob:662`, `HyperStatisticsCollectJob:181`, `HyperQueryJob:182`.

Fixes #59706

## What I'm doing:

Resetting the start time in `StatisticExecutor#executeDQL` and `#executeDML`, next to the query id
they already refresh - the narrowest site covering every path above.

Every caller of those two methods passes a dedicated statistics connection from
`StatisticUtils.buildConnectContext()` - `StatisticAutoCollector:96,112`, `StmtExecutor:2380` for
manual `ANALYZE`, `StatisticsCollectionTrigger:181`, `AnalyzeMgr`, `StatisticsMetaManager`, and both
statistics cache loaders - so no user query's start time, returned-row count or pending time changes.
`HyperQueryJob:182` becomes redundant; I left it alone.

This is the narrow fix. The wider issue is that the per-statement reset is an implicit contract
across six call sites with nothing enforcing it: either `createSlot` should stop reading the
connection start time as "now", or the reset should be structural rather than per-caller. Both change
behavior for user queries, so I left them out - happy to follow up there instead if you prefer.

Test: `StatisticsExecutorTest#testStatisticsStatementResetsContextStartTime` pins the connection start
time older than `query_queue_pending_timeout_second` - the exact condition that expires a slot on
creation - then drives one statement through `ExternalFullStatisticsCollectJob#collectStatisticSync`,
the frame in the #59706 stack trace, and one through the DML path, asserting each moves the anchor
forward. Without the production change:

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0 -- in com.starrocks.statistic.StatisticsExecutorTest
[ERROR] StatisticsExecutorTest.testStatisticsStatementResetsContextStartTime
org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
        at ...StatisticsExecutorTest.testStatisticsStatementResetsContextStartTime(StatisticsExecutorTest.java:204)
```

Affected versions: the two production lines apply unchanged to branch-4.1 through branch-3.3 -
`executeDQL` and `executeDML` have the same shape on all of them. The test does not:
`StatisticsExecutorTest` is still JUnit 4 on branch-3.4 and branch-3.3 (`org.junit.Assert`), and
those branches' `executeDQL` has no `FeConstants.enableUnitStatistics` short circuit for it to rely
on. I checked only 4.1/4.0/3.5 below, and can open manual `(backport #NNNNN)` PRs for 3.4 and 3.3
with the test adapted.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
