### PR TITLE
[BugFix] Resolve tablet backend ids outside the TabletInvertedIndex write lock

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -224,15 +224,25 @@ public class TabletInvertedIndex implements MemoryTrackable {
         if (tablets.iterator().next() instanceof LakeTablet) {
             return;
         }
+        // Resolve the backend ids BEFORE taking the write lock, like markTabletForceDelete(Tablet) does:
+        // LocalTablet.getBackendIds() acquires the per-tablet read lock, while the replica deletion paths
+        // take the tablet write lock first and this write lock second (LocalTablet.deleteReplicaByBackendId
+        // -> TabletInvertedIndex.deleteReplica). Reading the backend ids while holding this lock inverts
+        // that order and deadlocks the FE.
+        Map<Long, Set<Long>> tabletToBackendIds = Maps.newHashMapWithExpectedSize(tablets.size());
+        for (Tablet tablet : tablets) {
+            Set<Long> backendIds = tablet.getBackendIds();
+            if (backendIds.isEmpty()) {
+                continue;
+            }
+            tabletToBackendIds.put(tablet.getId(), backendIds);
+        }
+        if (tabletToBackendIds.isEmpty()) {
+            return;
+        }
         writeLock();
         try {
-            for (Tablet tablet : tablets) {
-                Set<Long> backendIds = tablet.getBackendIds();
-                if (backendIds.isEmpty()) {
-                    continue;
-                }
-                forceDeleteTablets.put(tablet.getId(), backendIds);
-            }
+            forceDeleteTablets.putAll(tabletToBackendIds);
         } finally {
             writeUnlock();
         }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TabletInvertedIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TabletInvertedIndexTest.java
@@ -29,7 +29,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Unit tests for TabletInvertedIndex class
@@ -277,6 +280,47 @@ public class TabletInvertedIndexTest {
     public void testMarkTabletsForceDeleteEmptyCollection() {
         tabletInvertedIndex.markTabletsForceDelete(Collections.emptyList());
         Assertions.assertTrue(tabletInvertedIndex.getForceDeleteTablets().isEmpty());
+    }
+
+    @Test
+    public void testMarkTabletsForceDeleteDoesNotHoldIndexLockAcrossTabletLock() {
+        // Regression guard: markTabletsForceDelete() must resolve Tablet.getBackendIds() outside the
+        // inverted index write lock. getBackendIds() takes the per-tablet read lock, while the replica
+        // deletion path takes the same two locks in the opposite order
+        // (LocalTablet.deleteReplicaByBackendId -> TabletInvertedIndex.deleteReplica), so reading the
+        // backend ids under the index lock lets the two paths deadlock the FE.
+        Replica replica = new Replica(500L, 5000L, 1L, 123, 0L, 0L,
+                Replica.ReplicaState.NORMAL, -1L, 1L);
+        AtomicBoolean indexWritableFromOtherThread = new AtomicBoolean(false);
+
+        // While the batch mark reads this tablet's backend ids, another thread must still be able to
+        // acquire the index write lock. It cannot if the caller already holds it, which is the bug.
+        LocalTablet probeTablet = new LocalTablet(8001L, Arrays.asList(replica)) {
+            @Override
+            public Set<Long> getBackendIds() {
+                Set<Long> backendIds = super.getBackendIds();
+                CountDownLatch indexWriteDone = new CountDownLatch(1);
+                Thread writer = new Thread(() -> {
+                    tabletInvertedIndex.markTabletForceDelete(9001L, 9000L);
+                    indexWriteDone.countDown();
+                });
+                writer.setDaemon(true);
+                writer.start();
+                try {
+                    indexWritableFromOtherThread.set(indexWriteDone.await(5, TimeUnit.SECONDS));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                return backendIds;
+            }
+        };
+
+        tabletInvertedIndex.markTabletsForceDelete(Collections.singletonList(probeTablet));
+
+        Assertions.assertTrue(indexWritableFromOtherThread.get(),
+                "markTabletsForceDelete must not hold the inverted index write lock while reading backend ids");
+        // the mark itself still lands
+        Assertions.assertTrue(tabletInvertedIndex.tabletForceDelete(8001L, 5000L));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

`TabletInvertedIndex.markTabletsForceDelete()` reads `Tablet.getBackendIds()` while holding the inverted index write lock. `LocalTablet.getBackendIds()` acquires the per-tablet read lock, while every replica deletion path acquires the tablet write lock first and the index write lock second (`LocalTablet.deleteReplicaByBackendId` -> `TabletInvertedIndex.deleteReplica`). The two orders deadlock the FE:

```
"starrocks-taskrun-pool-N"  (MV refresh -> insert overwrite commit)
    holds  TabletInvertedIndex write lock
    waits  LocalTablet read lock
      TabletInvertedIndex.markTabletsForceDelete -> LocalTablet.getBackendIds

"tablet scheduler"          (redundant replica deletion)
    holds  that LocalTablet write lock
    waits  TabletInvertedIndex write lock
      LocalTablet.deleteReplicaByBackendId -> TabletInvertedIndex.deleteReplica
```

The JVM reports it as `Found one Java-level deadlock`. Once the cycle forms the whole FE follows it down: every thread that touches the inverted index blocks (BE report RPCs, `loadTxnPrepare`, `truncate table`, `create partition`, `tablet stat mgr`, `consistency checker`, ...), and because some of them are blocked while holding a `TransactionState` write lock, BEs retry `loadTxnRollback` forever until the thrift worker pool is exhausted (`thrift_server_max_worker_threads`, 4096 by default). At that point the accept thread parks in the pool's blocking rejection policy instead of `accept()`, and the FE rpc port stops answering entirely.

This regressed in #75616: the batch method moved the `getBackendIds()` loop inside `writeLock()`. The single-tablet `markTabletForceDelete(Tablet)` next to it has always resolved the backend ids *before* locking, which is why only the batch path deadlocks.

`main` and `branch-4.1` are not affected: #66288 removed the `TabletInvertedIndex` read/write lock there and `markTabletsForceDelete()` is a plain loop over the lock-free path, so there is nothing to fix on main. That is why this PR targets `branch-4.0` directly. `branch-3.5` carries the same defect through #75659 and will be covered by a backport of this PR once it merges.

## What I'm doing:

Resolve the backend ids into a local map before taking the write lock, then write the whole batch with a single `putAll` while holding it. This keeps the one-acquisition behavior #75616 was after, without nesting the tablet lock inside the index lock. Semantics are unchanged: per-tablet overwrite, empty backend sets skipped, lake batches short-circuited.

Regression test: a probe tablet asserts that another thread can still acquire the index write lock while `markTabletsForceDelete()` is reading that tablet's backend ids. It passes with this change and fails (times out) against the previous code.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0 (this PR targets branch-4.0 directly)
  - [x] 3.5 (affected as well, through #75659; the label-driven auto-backport only runs for `base=main`, so this needs an explicit `@Mergifyio backport branch-3.5` after merge)
  - [ ] 3.4 (not affected: `markTabletsForceDelete` does not exist there)

