### PR TITLE
[BugFix] Invert runtime filter bounds onto the column instead of pushing the probe expression

### DIFF
--- a/be/src/compute_env/query/scan_conjuncts_manager.cpp
+++ b/be/src/compute_env/query/scan_conjuncts_manager.cpp
@@ -924,8 +924,9 @@ Status ChunkPredicateBuilder<E, Type>::normalize_join_runtime_filter(const SlotD
             if (rf->has_null()) {
                 normalized_rf_with_null<SlotType, MappingType, Decoder>(rf, &slot, std::forward<Args>(args)...);
             } else {
+                // No offset: this path normalizes a slot-ref probe, whose key IS the column value.
                 detail::RuntimeColumnPredicateBuilder::build_minmax_range<RangeType, SlotType, MappingType, Decoder>(
-                        *range, rf, _opts.obj_pool, std::forward<Args>(args)...);
+                        *range, rf, _opts.obj_pool, {}, std::forward<Args>(args)...);
             }
         }
 

--- a/be/src/compute_env/runtime_range_pruner.hpp
+++ b/be/src/compute_env/runtime_range_pruner.hpp
@@ -16,12 +16,15 @@
 
 #include <cstddef>
 #include <memory>
+#include <optional>
+#include <type_traits>
 #include <utility>
 
 #include "column/global_dict/config.h"
 #include "compute_env/runtime_range_pruner.h"
 #include "exec_primitive/runtime_filter/runtime_filter_probe.h"
 #include "exprs/binary_predicate.h"
+#include "exprs/column_ref.h"
 #include "exprs/expr_context.h"
 #include "exprs/literal.h"
 #include "runtime/descriptors.h"
@@ -32,9 +35,52 @@
 #include "storage_primitive/column_value_range.h"
 #include "storage_primitive/filter_condition.h"
 #include "storage_primitive/predicate_parser.h"
+#include "types/datum.h"
 
 namespace starrocks {
 namespace detail {
+// The offset of a probe expression shaped `slot + c` / `slot - c` / `c + slot`, or nullopt.
+// Only these invert: multiplication is not injective under wrapping (wrap(2a) collides a with
+// a + 2^63) and `c - slot` reverses the order. Non-integral value types are excluded too -- the
+// checked builtins do not apply to them.
+template <typename CppType>
+std::optional<CppType> probe_expr_offset(const Expr* expr, SlotId slot_id, ExprContext* ctx) {
+    if constexpr (std::is_integral_v<CppType>) {
+        if (expr->node_type() != TExprNodeType::ARITHMETIC_EXPR) return std::nullopt;
+        if (expr->op() != TExprOpcode::ADD && expr->op() != TExprOpcode::SUBTRACT) return std::nullopt;
+        if (expr->get_num_children() != 2) return std::nullopt;
+
+        auto is_the_slot = [&](const Expr* e) {
+            return e->node_type() == TExprNodeType::SLOT_REF && e->is_slotref() &&
+                   down_cast<const ColumnRef*>(e)->slot_id() == slot_id;
+        };
+        // evaluate_const() dereferences the context it is given, so it gets the one owning this tree.
+        auto literal_value = [&](const Expr* e, CppType* out) {
+            if (e->node_type() != TExprNodeType::INT_LITERAL) return false;
+            auto res = const_cast<Expr*>(e)->evaluate_const(ctx);
+            if (!res.ok()) return false;
+            ColumnPtr column = std::move(res).value();
+            if (column == nullptr || column->size() < 1 || column->is_null(0)) return false;
+            *out = column->get(0).get<CppType>();
+            return true;
+        };
+
+        CppType c{};
+        if (is_the_slot(expr->get_child(0)) && literal_value(expr->get_child(1), &c)) {
+            if (expr->op() == TExprOpcode::ADD) return c;
+            CppType negated{};
+            // `slot - CppType_MIN` has no representable offset.
+            if (__builtin_sub_overflow(CppType{0}, c, &negated)) return std::nullopt;
+            return negated;
+        }
+        if (expr->op() == TExprOpcode::ADD && is_the_slot(expr->get_child(1)) &&
+            literal_value(expr->get_child(0), &c)) {
+            return c;
+        }
+    }
+    return std::nullopt;
+}
+
 struct RuntimeColumnPredicateBuilder {
     template <LogicalType ltype>
     StatusOr<std::vector<const ColumnPredicate*>> operator()(const ColumnIdToGlobalDictMap* global_dictmaps,
@@ -53,8 +99,32 @@ struct RuntimeColumnPredicateBuilder {
             ExprContext* probe_expr_ctx = desc->probe_expr_ctx();
             Expr* probe_expr = probe_expr_ctx->root();
 
+            // Offset of an additive probe expression, in the column's own value space; zero for a
+            // plain slot ref. Carrying it into the range built below is all the inversion takes.
+            typename RunTimeTypeLimits<ltype>::value_type key_offset{};
+            bool has_key_offset = false;
+
             if (!probe_expr->is_slotref()) {
                 if (!probe_expr->is_monotonic()) return preds;
+
+                // The FE marks arithmetic monotonic from the expression's shape alone, but machine
+                // integers wrap, and zone_map_filter skips a segment from the expression's value at
+                // the zone's two ends -- one row at BIGINT_MIN makes `a - 4000` positive there and
+                // takes the whole segment with it (#76720, d3002abafa9). Invert the bounds onto the
+                // column instead, and only for shapes computed in the column's own width: ltype is
+                // the expression's type (see _get_predicates()), so a promotion means the join
+                // wraps in a width the column does not have.
+                if (auto offset = probe_expr_offset<typename RunTimeTypeLimits<ltype>::value_type>(
+                            probe_expr, slot->id(), probe_expr_ctx);
+                    offset.has_value() && slot->type().type == ltype) {
+                    key_offset = *offset;
+                    has_key_offset = true;
+                }
+            }
+
+            if (!probe_expr->is_slotref() && !has_key_offset) {
+                // year() keeps the pushdown: total, and its 0..9999 result cannot overflow.
+                if (probe_expr->node_type() != TExprNodeType::FUNCTION_CALL) return preds;
 
                 // Skip index filtering if the column referenced by the expr is dict encoded.
                 if (global_dictmaps != nullptr &&
@@ -122,7 +192,7 @@ struct RuntimeColumnPredicateBuilder {
 
             // process agg in runtime-filter
             auto* in_filter = rf->get_in_filter();
-            if (in_filter) {
+            if (in_filter && !has_key_offset) { // the IN values would need shifting as well
                 if constexpr (ltype == TYPE_VARCHAR) {
                     auto cid = parser->column_id(*slot);
                     if (global_dictmaps == nullptr || global_dictmaps->find(cid) == global_dictmaps->end()) {
@@ -140,13 +210,15 @@ struct RuntimeColumnPredicateBuilder {
                     auto cid = parser->column_id(*slot);
                     if (auto iter = global_dictmaps->find(cid); iter != global_dictmaps->end()) {
                         build_minmax_range<RangeType, limit_type, LowCardDictType, GlobalDictCodeDecoder>(
-                                range, minmax, pool, iter->second);
+                                range, minmax, pool, {}, iter->second);
                     } else {
                         build_minmax_range<RangeType, limit_type, mapping_type, DummyDecoder>(range, minmax, pool,
-                                                                                              nullptr);
+                                                                                              {}, nullptr);
                     }
                 } else {
-                    build_minmax_range<RangeType, limit_type, mapping_type, DummyDecoder>(range, minmax, pool, nullptr);
+                    build_minmax_range<RangeType, limit_type, mapping_type, DummyDecoder>(
+                            range, minmax, pool, static_cast<typename RunTimeTypeTraits<limit_type>::CppType>(key_offset),
+                            nullptr);
                 }
             }
 
@@ -272,9 +344,15 @@ struct RuntimeColumnPredicateBuilder {
         (void)range.add_fixed_values(FILTER_IN, values);
     }
 
+    // `offset` moves the filter's bounds out of the probe key's space and back onto the column, for
+    // a probe expression of `slot + offset`; it is zero for a plain slot ref. The shift is checked:
+    // when it overflows the preimage wraps around the type and is no longer an interval, so neither
+    // bound is added and the range stays open. Pruning on a wrapped preimage would drop rows the
+    // join really does match -- the join compares wrapped values too.
     template <class Range, LogicalType SlotType, LogicalType mapping_type, template <class> class Decoder,
               class... Args>
-    static void build_minmax_range(Range& range, const RuntimeFilter* rf, ObjectPool* pool, Args&&... args) {
+    static void build_minmax_range(Range& range, const RuntimeFilter* rf, ObjectPool* pool,
+                                   typename RunTimeTypeTraits<SlotType>::CppType offset, Args&&... args) {
         using ValueType = typename RunTimeTypeTraits<SlotType>::CppType;
 
         auto* filter = down_cast<const MinMaxRuntimeFilter<mapping_type>*>(rf->get_min_max_filter());
@@ -293,8 +371,7 @@ struct RuntimeColumnPredicateBuilder {
         } else {
             min_op = to_olap_filter_type(TExprOpcode::GT, false);
         }
-        auto min_value = parser.min_value(pool);
-        (void)range.add_range(min_op, static_cast<ValueType>(min_value));
+        auto min_value = static_cast<ValueType>(parser.min_value(pool));
 
         SQLFilterOp max_op;
         if (filter->right_close_interval()) {
@@ -303,8 +380,21 @@ struct RuntimeColumnPredicateBuilder {
             max_op = to_olap_filter_type(TExprOpcode::LT, false);
         }
 
-        auto max_value = parser.max_value(pool);
-        (void)range.add_range(max_op, static_cast<ValueType>(max_value));
+        auto max_value = static_cast<ValueType>(parser.max_value(pool));
+
+        if constexpr (std::is_integral_v<ValueType>) {
+            // Both or neither: with one bound shifted the range would describe the wrong half of a
+            // preimage that has wrapped into two pieces.
+            ValueType shifted_min{};
+            ValueType shifted_max{};
+            if (__builtin_sub_overflow(min_value, offset, &shifted_min)) return;
+            if (__builtin_sub_overflow(max_value, offset, &shifted_max)) return;
+            min_value = shifted_min;
+            max_value = shifted_max;
+        }
+
+        (void)range.add_range(min_op, min_value);
+        (void)range.add_range(max_op, max_value);
     }
 };
 } // namespace detail

--- a/be/src/compute_env/runtime_range_pruner.hpp
+++ b/be/src/compute_env/runtime_range_pruner.hpp
@@ -212,13 +212,13 @@ struct RuntimeColumnPredicateBuilder {
                         build_minmax_range<RangeType, limit_type, LowCardDictType, GlobalDictCodeDecoder>(
                                 range, minmax, pool, {}, iter->second);
                     } else {
-                        build_minmax_range<RangeType, limit_type, mapping_type, DummyDecoder>(range, minmax, pool,
-                                                                                              {}, nullptr);
+                        build_minmax_range<RangeType, limit_type, mapping_type, DummyDecoder>(range, minmax, pool, {},
+                                                                                              nullptr);
                     }
                 } else {
                     build_minmax_range<RangeType, limit_type, mapping_type, DummyDecoder>(
-                            range, minmax, pool, static_cast<typename RunTimeTypeTraits<limit_type>::CppType>(key_offset),
-                            nullptr);
+                            range, minmax, pool,
+                            static_cast<typename RunTimeTypeTraits<limit_type>::CppType>(key_offset), nullptr);
                 }
             }
 

--- a/be/test/compute_env/runtime_range_pruner_test.cpp
+++ b/be/test/compute_env/runtime_range_pruner_test.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <vector>
 
 #include "exec_primitive/runtime_filter/runtime_filter_probe.h"
@@ -35,6 +36,7 @@ class RuntimeRangePrunerTest : public ::testing::Test {
 protected:
     StatusOr<std::shared_ptr<RuntimeFilterProbeDescriptor>> _gen_runtime_filter_desc();
     StatusOr<std::shared_ptr<RuntimeFilterProbeDescriptor>> _gen_runtime_filter_desc(const TExpr& probe_expr);
+    static TExpr _arithmetic_probe_expr(TExprOpcode::type opcode, int32_t literal_value);
 
     using Int32Decoder = detail::RuntimeColumnPredicateBuilder::DummyDecoder<int32_t>;
     using Int32RuntimeFilter = ComposedRuntimeBloomFilter<TYPE_INT>;
@@ -69,6 +71,34 @@ StatusOr<std::shared_ptr<RuntimeFilterProbeDescriptor>> RuntimeRangePrunerTest::
     return runtime_filter_desc;
 }
 
+// `c0 <opcode> <literal_value>`, flagged monotonic the way the FE flags arithmetic: from the shape
+// of the expression alone, ignoring that the BE evaluates it in wrapping arithmetic.
+TExpr RuntimeRangePrunerTest::_arithmetic_probe_expr(TExprOpcode::type opcode, int32_t literal_value) {
+    TExprNode arithmetic_node;
+    arithmetic_node.node_type = TExprNodeType::ARITHMETIC_EXPR;
+    arithmetic_node.num_children = 2;
+    arithmetic_node.type = TYPE_INT_DESC.to_thrift();
+    arithmetic_node.__set_opcode(opcode);
+    arithmetic_node.__set_child_type(TPrimitiveType::INT);
+    arithmetic_node.__set_is_nullable(true);
+    arithmetic_node.__set_is_monotonic(true);
+
+    TExprNode literal_node;
+    literal_node.node_type = TExprNodeType::INT_LITERAL;
+    literal_node.num_children = 0;
+    literal_node.type = TYPE_INT_DESC.to_thrift();
+    literal_node.__set_is_nullable(false);
+    TIntLiteral literal;
+    literal.value = literal_value;
+    literal_node.__set_int_literal(literal);
+
+    TExpr probe_expr;
+    probe_expr.nodes.emplace_back(arithmetic_node);
+    probe_expr.nodes.emplace_back(ExprsTestHelper::create_column_ref_t_expr<TYPE_INT>(0, true).nodes[0]);
+    probe_expr.nodes.emplace_back(literal_node);
+    return probe_expr;
+}
+
 TEST_F(RuntimeRangePrunerTest, min_max_parser) {
     Int32Decoder decoder(nullptr);
 
@@ -99,35 +129,14 @@ TEST_F(RuntimeRangePrunerTest, min_max_parser_for_decimal) {
     ASSERT_EQ(max_column->debug_string(), "CONST: 0.0020 Size : 1");
 }
 
-TEST_F(RuntimeRangePrunerTest, monotonic_expr_builds_two_column_expr_predicates) {
+// The bounds go onto the column, not onto the expression: `c0 + 1` in [10, 20] means `c0` in [9, 19].
+TEST_F(RuntimeRangePrunerTest, additive_probe_expr_inverts_bounds_onto_the_column) {
     SlotDescriptor slot(0, "c0", TYPE_INT_DESC);
     std::vector<SlotDescriptor*> slot_descs{&slot};
     ConnectorPredicateParser predicate_parser(&slot_descs);
 
-    TExprNode add_node;
-    add_node.node_type = TExprNodeType::ARITHMETIC_EXPR;
-    add_node.num_children = 2;
-    add_node.type = TYPE_INT_DESC.to_thrift();
-    add_node.__set_opcode(TExprOpcode::ADD);
-    add_node.__set_child_type(TPrimitiveType::INT);
-    add_node.__set_is_nullable(true);
-    add_node.__set_is_monotonic(true);
-
-    TExpr slot_expr = ExprsTestHelper::create_column_ref_t_expr<TYPE_INT>(0, true);
-    TExprNode literal_node;
-    literal_node.node_type = TExprNodeType::INT_LITERAL;
-    literal_node.num_children = 0;
-    literal_node.type = TYPE_INT_DESC.to_thrift();
-    literal_node.__set_is_nullable(false);
-    TIntLiteral literal;
-    literal.value = 1;
-    literal_node.__set_int_literal(literal);
-
-    TExpr probe_expr;
-    probe_expr.nodes.emplace_back(add_node);
-    probe_expr.nodes.emplace_back(slot_expr.nodes[0]);
-    probe_expr.nodes.emplace_back(literal_node);
-    ASSIGN_OR_ASSERT_FAIL(auto runtime_filter_desc, _gen_runtime_filter_desc(probe_expr));
+    ASSIGN_OR_ASSERT_FAIL(auto runtime_filter_desc,
+                          _gen_runtime_filter_desc(_arithmetic_probe_expr(TExprOpcode::ADD, 1)));
     ASSERT_OK(runtime_filter_desc->probe_expr_ctx()->prepare(&_runtime_state));
     ASSERT_OK(runtime_filter_desc->probe_expr_ctx()->open(&_runtime_state));
 
@@ -141,29 +150,90 @@ TEST_F(RuntimeRangePrunerTest, monotonic_expr_builds_two_column_expr_predicates)
     RuntimeScanRangePruner pruner(&predicate_parser, unarrived_runtime_filters);
 
     std::vector<PredicateType> predicate_types;
-    std::vector<TExprOpcode::type> predicate_opcodes;
-    std::vector<std::string> predicate_bounds;
+    std::vector<std::string> predicate_strings;
     ASSERT_OK(pruner.update_range_if_arrived(
             nullptr,
             [&](auto, const PredicateList& predicates) {
                 for (const auto* predicate : predicates) {
                     predicate_types.emplace_back(predicate->type());
-                    const auto* expr_predicate = down_cast<const ColumnExprPredicate*>(predicate);
-                    Expr* root = expr_predicate->get_expr_ctxs()[0]->root();
-                    predicate_opcodes.emplace_back(root->op());
-                    const auto* literal = down_cast<const VectorizedLiteral*>(root->get_child(1));
-                    predicate_bounds.emplace_back(literal->value()->debug_string());
+                    predicate_strings.emplace_back(predicate->debug_string());
                 }
                 return Status::OK();
             },
             false, 200000));
     ASSERT_EQ(2, predicate_types.size());
-    EXPECT_EQ(PredicateType::kExpr, predicate_types[0]);
-    EXPECT_EQ(PredicateType::kExpr, predicate_types[1]);
-    EXPECT_EQ(TExprOpcode::GE, predicate_opcodes[0]);
-    EXPECT_EQ(TExprOpcode::LE, predicate_opcodes[1]);
-    EXPECT_EQ("CONST: 10 Size : 1", predicate_bounds[0]);
-    EXPECT_EQ("CONST: 20 Size : 1", predicate_bounds[1]);
+    EXPECT_EQ(PredicateType::kGE, predicate_types[0]);
+    EXPECT_EQ(PredicateType::kLE, predicate_types[1]);
+    EXPECT_EQ("(columnId(0)>=9)", predicate_strings[0]);
+    EXPECT_EQ("(columnId(0)<=19)", predicate_strings[1]);
+
+    runtime_filter_desc->close(&_runtime_state);
+}
+
+// An overflowing inversion emits nothing, never an empty range: the preimage wraps around the type
+// and is no longer an interval, and pruning on it would drop rows the join wanted.
+TEST_F(RuntimeRangePrunerTest, inversion_that_overflows_emits_no_predicate) {
+    SlotDescriptor slot(0, "c0", TYPE_INT_DESC);
+    std::vector<SlotDescriptor*> slot_descs{&slot};
+    ConnectorPredicateParser predicate_parser(&slot_descs);
+
+    ASSIGN_OR_ASSERT_FAIL(auto runtime_filter_desc,
+                          _gen_runtime_filter_desc(_arithmetic_probe_expr(TExprOpcode::ADD, 1)));
+    ASSERT_OK(runtime_filter_desc->probe_expr_ctx()->prepare(&_runtime_state));
+    ASSERT_OK(runtime_filter_desc->probe_expr_ctx()->open(&_runtime_state));
+
+    MinMaxRuntimeFilter<TYPE_INT> rf;
+    rf.insert(std::numeric_limits<int32_t>::min());
+    rf.insert(20);
+    runtime_filter_desc->set_runtime_filter(&rf);
+
+    UnarrivedRuntimeFilterList unarrived_runtime_filters;
+    unarrived_runtime_filters.add_unarrived_rf(runtime_filter_desc.get(), &slot, 1);
+    RuntimeScanRangePruner pruner(&predicate_parser, unarrived_runtime_filters);
+
+    size_t predicates_built = 0;
+    ASSERT_OK(pruner.update_range_if_arrived(
+            nullptr,
+            [&](auto, const PredicateList& predicates) {
+                predicates_built += predicates.size();
+                return Status::OK();
+            },
+            false, 200000));
+    EXPECT_EQ(0, predicates_built);
+
+    runtime_filter_desc->close(&_runtime_state);
+}
+
+// Multiplication is not invertible under wrapping -- wrap(2 * c0) puts two column values on every
+// key -- so the pruner declines it even though the FE marked it monotonic.
+TEST_F(RuntimeRangePrunerTest, multiplicative_probe_expr_emits_no_predicate) {
+    SlotDescriptor slot(0, "c0", TYPE_INT_DESC);
+    std::vector<SlotDescriptor*> slot_descs{&slot};
+    ConnectorPredicateParser predicate_parser(&slot_descs);
+
+    ASSIGN_OR_ASSERT_FAIL(auto runtime_filter_desc,
+                          _gen_runtime_filter_desc(_arithmetic_probe_expr(TExprOpcode::MULTIPLY, 2)));
+    ASSERT_OK(runtime_filter_desc->probe_expr_ctx()->prepare(&_runtime_state));
+    ASSERT_OK(runtime_filter_desc->probe_expr_ctx()->open(&_runtime_state));
+
+    MinMaxRuntimeFilter<TYPE_INT> rf;
+    rf.insert(10);
+    rf.insert(20);
+    runtime_filter_desc->set_runtime_filter(&rf);
+
+    UnarrivedRuntimeFilterList unarrived_runtime_filters;
+    unarrived_runtime_filters.add_unarrived_rf(runtime_filter_desc.get(), &slot, 1);
+    RuntimeScanRangePruner pruner(&predicate_parser, unarrived_runtime_filters);
+
+    size_t predicates_built = 0;
+    ASSERT_OK(pruner.update_range_if_arrived(
+            nullptr,
+            [&](auto, const PredicateList& predicates) {
+                predicates_built += predicates.size();
+                return Status::OK();
+            },
+            false, 200000));
+    EXPECT_EQ(0, predicates_built);
 
     runtime_filter_desc->close(&_runtime_state);
 }

--- a/test/sql/test_runtime_filter/R/test_runtime_filter_range_prune_wraparound
+++ b/test/sql/test_runtime_filter/R/test_runtime_filter_range_prune_wraparound
@@ -1,0 +1,60 @@
+-- name: test_runtime_filter_range_prune_wraparound
+CREATE TABLE p (a bigint NULL)
+DUPLICATE KEY(a)
+DISTRIBUTED BY HASH(a) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO p
+SELECT generate_series FROM TABLE(generate_series(1, 100))
+UNION ALL SELECT -9223372036854775800
+UNION ALL SELECT 9223372036854775800;
+-- result:
+-- !result
+CREATE TABLE b_minus (k bigint NULL)
+DUPLICATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO b_minus SELECT generate_series - 4000 FROM TABLE(generate_series(1, 100));
+-- result:
+-- !result
+CREATE TABLE b_plus (k bigint NULL)
+DUPLICATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO b_plus SELECT generate_series + 4000 FROM TABLE(generate_series(1, 100));
+-- result:
+-- !result
+CREATE TABLE b_mul (k bigint NULL)
+DUPLICATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO b_mul SELECT generate_series * 2 FROM TABLE(generate_series(1, 100));
+-- result:
+-- !result
+SELECT count(*) FROM (SELECT a - 4000 AS a FROM p) x JOIN [broadcast] b_minus b ON x.a = b.k;
+-- result:
+100
+-- !result
+SELECT count(*) FROM (SELECT a + 4000 AS a FROM p) x JOIN [broadcast] b_plus b ON x.a = b.k;
+-- result:
+100
+-- !result
+SELECT count(*) FROM (SELECT a * 2 AS a FROM p) x JOIN [broadcast] b_mul b ON x.a = b.k;
+-- result:
+101
+-- !result
+SELECT count(*) FROM p JOIN [broadcast] b_minus b ON p.a = b.k + 4000;
+-- result:
+100
+-- !result
+SELECT count(*) FROM p JOIN [broadcast] (SELECT generate_series AS k FROM TABLE(generate_series(1, 100))) b ON p.a = b.k;
+-- result:
+100
+-- !result

--- a/test/sql/test_runtime_filter/T/test_runtime_filter_range_prune_wraparound
+++ b/test/sql/test_runtime_filter/T/test_runtime_filter_range_prune_wraparound
@@ -1,0 +1,49 @@
+-- name: test_runtime_filter_range_prune_wraparound
+-- A join whose probe key is `column +/- constant` must not lose rows when the column reaches the
+-- limits of its type: the runtime filter's bounds are pushed to the probe scan's index, and the
+-- zone map spans the whole column, so one row near BIGINT_MIN makes `a - 4000` wrap there and both
+-- ends of the range compare false, skipping the segment and every matching row in it.
+CREATE TABLE p (a bigint NULL)
+DUPLICATE KEY(a)
+DISTRIBUTED BY HASH(a) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- ONE insert, so the matching rows and the two extremes share a segment and a zone map. Split
+-- across several inserts the matching rows get a zone map that no longer reaches the type limits,
+-- and this passes even unfixed.
+INSERT INTO p
+SELECT generate_series FROM TABLE(generate_series(1, 100))
+UNION ALL SELECT -9223372036854775800
+UNION ALL SELECT 9223372036854775800;
+
+CREATE TABLE b_minus (k bigint NULL)
+DUPLICATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+INSERT INTO b_minus SELECT generate_series - 4000 FROM TABLE(generate_series(1, 100));
+
+CREATE TABLE b_plus (k bigint NULL)
+DUPLICATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+INSERT INTO b_plus SELECT generate_series + 4000 FROM TABLE(generate_series(1, 100));
+
+CREATE TABLE b_mul (k bigint NULL)
+DUPLICATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+INSERT INTO b_mul SELECT generate_series * 2 FROM TABLE(generate_series(1, 100));
+
+-- Wraps at the low end: both ends of `a - 4000 <= max_key` come out false.
+SELECT count(*) FROM (SELECT a - 4000 AS a FROM p) x JOIN [broadcast] b_minus b ON x.a = b.k;
+
+-- Same defect from the other side: `a + 4000` wraps at the high end.
+SELECT count(*) FROM (SELECT a + 4000 AS a FROM p) x JOIN [broadcast] b_plus b ON x.a = b.k;
+
+-- 101, not 100: -9223372036854775800 * 2 wraps to 16, a real key on the build side. Dividing the
+-- bounds to recover a column range would give [1, 100] and drop that row.
+SELECT count(*) FROM (SELECT a * 2 AS a FROM p) x JOIN [broadcast] b_mul b ON x.a = b.k;
+
+-- Controls: arithmetic on the build side, and a bare probe key. Neither takes the expression path.
+SELECT count(*) FROM p JOIN [broadcast] b_minus b ON p.a = b.k + 4000;
+SELECT count(*) FROM p JOIN [broadcast] (SELECT generate_series AS k FROM TABLE(generate_series(1, 100))) b ON p.a = b.k;


### PR DESCRIPTION
## Why I'm doing:

A join whose probe key is `column - 4000` silently returns no rows when the column holds values near the type's limit:

    select count(*) from (select a - 4000 a from cte1 where a > 700) x
    join zm on x.a = zm.a;     -- 0 rows, should be 100

The runtime filter's bounds were pushed down as an index_filter_only ColumnExprPredicate wrapping the probe expression itself. That predicate settles a whole segment in zone_map_filter by evaluating the expression at the zone's two endpoints -- and the zone map spans the entire column, since no predicate of the query narrows it. One row at BIGINT_MIN is therefore enough: `a - 4000` evaluates there to 9223372036854771808, an ordinary-looking value that is neither null nor an error, both endpoint comparisons come out false, and the segment is skipped along with every matching row in it.

Expr::is_monotonic() does not rule this out. The FE sets it for arithmetic from the shape of the expression alone: ADD/SUBTRACT/MULTIPLY/DIVIDE are monotonic over the mathematical integers, not over the wrapping ones the BE computes with. Nor can the BE sample its way out of it -- a wrapped endpoint and a legitimately decreasing expression both give f(min) > f(max).

So stop pushing the expression down and invert the filter's bounds back onto the column, which is what the FE's ArithmeticCommutativeRule already does for ordinary predicates: `wrap(a + offset)` lands in [min, max] exactly when `a` lands in [min - offset, max - offset]. Both subtractions are checked, and an overflow emits no predicate at all rather than an empty range -- the join compares wrapped values, so a key of wrap(BIGINT_MIN - 4000) really is produced by the row a = BIGINT_MIN, and pruning there would drop live rows from the other side.

Only `slot + c`, `slot - c` and `c + slot` over machine integers are inverted. Multiplication is not injective under wrapping, `c - slot` reverses the order, and decimals and dates carry more than the bounds. Those shapes now emit no index predicate: the runtime filter still applies row by row, and only the pruning is given up. year() keeps its expression pushdown, being total with a result that cannot overflow.

Also guards against the probe expression being wider than the column: for a non-slot-ref probe the dispatch type is the expression's type, and a width promotion means the join wraps in a width the column does not have.

Covered by three unit tests -- the inverted bounds, an overflowing inversion emitting nothing, and multiplication being declined -- and by a SQL test where `a - 4000` and `a + 4000` each lose all 100 matching rows against the unfixed backend. That test also pins the multiplication result at 101 rather than 100: -9223372036854775800 * 2 wraps to 16, a real key on the build side, so dividing the bounds to recover a column range would have dropped a row that genuinely joins. Its three rows have to be inserted in a single statement; split across several inserts the matching rows get a segment whose zone map no longer reaches the type limits, and the test passes even unfixed.

Introduced by #76720 (d3002abafa9, 2026-08-13), which added the index filtering for monotonic runtime filter expressions. It is on main only -- branch-4.1, branch-4.0 and branch-3.5 do not carry it -- so nothing needs backporting.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
