### PR TITLE
[BugFix] Skip table metrics for non-table StarOS shards

### DIFF
--- a/be/src/compute_env/staros/staros_worker.cpp
+++ b/be/src/compute_env/staros/staros_worker.cpp
@@ -29,6 +29,7 @@
 #include "compute_env/staros/staros_worker_runtime.h"
 #include "file_store.pb.h"
 #include "fmt/format.h"
+#include "gutil/strings/numbers.h"
 
 namespace starrocks {
 
@@ -43,26 +44,22 @@ StarOSWorker::StarOSWorker(TableMetricsManager* table_metrics_mgr)
 
 StarOSWorker::~StarOSWorker() = default;
 
-static const uint64_t kUnknownTableId = UINT64_MAX;
-
 void StarOSWorker::set_fs_cache_capacity(int32_t capacity) {
     _fs_cache->set_capacity(capacity);
 }
 
-uint64_t StarOSWorker::get_table_id(const ShardInfo& shard) {
-    const auto& properties = shard.properties;
-    auto iter = properties.find("tableId");
-    if (iter == properties.end()) {
-        DCHECK(false) << "tableId doesn't exist in shard properties";
-        return kUnknownTableId;
+std::optional<uint64_t> StarOSWorker::get_table_id(const ShardInfo& shard) {
+    const auto iter = shard.properties.find("tableId");
+    if (iter == shard.properties.end()) {
+        return std::nullopt;
     }
-    const auto& tableId = properties.at("tableId");
-    try {
-        return std::stoull(tableId);
-    } catch (const std::exception& e) {
-        DCHECK(false) << "failed to parse tableId: " << tableId << ", " << e.what();
-        return kUnknownTableId;
+
+    uint64_t table_id = 0;
+    if (!safe_strtou64(iter->second, &table_id)) {
+        LOG(WARNING) << "failed to parse tableId: " << iter->second;
+        return std::nullopt;
     }
+    return table_id;
 }
 
 absl::Status StarOSWorker::add_shard(const ShardInfo& shard) {
@@ -80,7 +77,9 @@ absl::Status StarOSWorker::add_shard(const ShardInfo& shard) {
     l.unlock();
     if (ret.second) {
         if (_table_metrics_mgr != nullptr) {
-            _table_metrics_mgr->register_table(get_table_id(shard));
+            if (auto table_id = get_table_id(shard); table_id.has_value()) {
+                _table_metrics_mgr->register_table(*table_id);
+            }
         }
         // it is an insert op to the map
         // NOTE:
@@ -111,9 +110,10 @@ absl::Status StarOSWorker::remove_shard(const ShardId id) {
     std::unique_lock l(_mtx);
     auto iter = _shards.find(id);
     if (iter != _shards.end()) {
-        uint64_t table_id = get_table_id(iter->second.shard_info);
         if (_table_metrics_mgr != nullptr) {
-            _table_metrics_mgr->unregister_table(table_id);
+            if (auto table_id = get_table_id(iter->second.shard_info); table_id.has_value()) {
+                _table_metrics_mgr->unregister_table(*table_id);
+            }
         }
         _shards.erase(iter);
         StarOSWorkerMetrics::instance()->staros_shard_count.set_value(_shards.size());

--- a/be/src/compute_env/staros/staros_worker.cpp
+++ b/be/src/compute_env/staros/staros_worker.cpp
@@ -55,7 +55,7 @@ std::optional<uint64_t> StarOSWorker::get_table_id(const ShardInfo& shard) {
     }
 
     uint64_t table_id = 0;
-    if (!safe_strtou64(iter->second, &table_id)) {
+    if (iter->second.find('\0') != std::string::npos || !safe_strtou64(iter->second, &table_id)) {
         LOG(WARNING) << "failed to parse tableId: " << iter->second;
         return std::nullopt;
     }

--- a/be/src/compute_env/staros/staros_worker.h
+++ b/be/src/compute_env/staros/staros_worker.h
@@ -21,6 +21,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <shared_mutex>
 #include <string>
 #include <string_view>
@@ -121,7 +122,7 @@ private:
             _add_shard_listener(shardId);
         }
     }
-    uint64_t get_table_id(const ShardInfo& shared_info);
+    std::optional<uint64_t> get_table_id(const ShardInfo& shard_info);
 
     absl::StatusOr<std::shared_ptr<FileSystem>> build_filesystem_on_demand(ShardId id, const Configuration& conf);
     absl::StatusOr<std::pair<std::shared_ptr<std::string>, std::shared_ptr<FileSystem>>>

--- a/be/test/compute_env/staros/staros_worker_test.cpp
+++ b/be/test/compute_env/staros/staros_worker_test.cpp
@@ -189,6 +189,13 @@ TEST_F(StarOSWorkerTest, TableMetricsRejectOverflowingTableId) {
     expect_malformed_table_id("18446744073709551616", 105);
 }
 
+TEST_F(StarOSWorkerTest, TableMetricsRejectEmbeddedNullTableId) {
+    const bool old_enable_table_metrics = config::enable_table_metrics;
+    DeferOp restore_config([&] { config::enable_table_metrics = old_enable_table_metrics; });
+    config::enable_table_metrics = true;
+    expect_malformed_table_id(std::string("42\0junk", 7), 108);
+}
+
 TEST_F(StarOSWorkerTest, TableMetricsPreserveTableShardReferenceCounts) {
     const bool old_enable_table_metrics = config::enable_table_metrics;
     DeferOp restore_config([&] { config::enable_table_metrics = old_enable_table_metrics; });

--- a/be/test/compute_env/staros/staros_worker_test.cpp
+++ b/be/test/compute_env/staros/staros_worker_test.cpp
@@ -23,11 +23,19 @@
 #include <manager.grpc.pb.h>
 #include <shard.pb.h>
 
+#include <algorithm>
 #include <condition_variable>
 #include <functional>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "base/utility/defer_op.h"
+#include "common/config_metrics_fwd.h"
+#include "common/logging.h"
 #include "common/shutdown_hook.h"
+#include "common/util/table_metrics.h"
 #include "compute_env/staros/staros_worker_metrics.h"
 #include "compute_env/staros/staros_worker_runtime.h"
 
@@ -40,6 +48,26 @@ static void add_shard_listener(std::vector<StarOSWorker::ShardId>* shardIds, int
 
 static Aws::SDKOptions _s_options;
 
+class RecordingLogSink final : public google::LogSink {
+public:
+    void send(google::LogSeverity severity, const char* full_filename, const char* base_filename, int line,
+              const google::LogMessageTime& time, const char* message, size_t message_len) override {
+        std::lock_guard lock(_mutex);
+        _messages.emplace_back(severity, std::string(message, message_len));
+    }
+
+    size_t count(google::LogSeverity severity, const std::string& needle) const {
+        std::lock_guard lock(_mutex);
+        return std::count_if(_messages.begin(), _messages.end(), [&](const auto& entry) {
+            return entry.first == severity && entry.second.find(needle) != std::string::npos;
+        });
+    }
+
+private:
+    mutable std::mutex _mutex;
+    std::vector<std::pair<google::LogSeverity, std::string>> _messages;
+};
+
 class StarOSWorkerTest : public ::testing::Test {
 public:
     static void SetUpTestCase() { Aws::InitAPI(_s_options); }
@@ -47,6 +75,23 @@ public:
     static void TearDownTestCase() {
         staros::starlet::common::ShutdownHook::shutdown();
         Aws::ShutdownAPI(_s_options);
+    }
+
+    static void expect_malformed_table_id(std::string table_id, StarOSWorker::ShardId shard_id) {
+        TableMetricsManager table_metrics_mgr;
+        StarOSWorker worker(&table_metrics_mgr);
+        RecordingLogSink sink;
+        google::AddLogSink(&sink);
+        DeferOp remove_sink([&] { google::RemoveLogSink(&sink); });
+
+        StarOSWorker::ShardInfo shard;
+        shard.id = shard_id;
+        shard.properties.emplace("tableId", table_id);
+        EXPECT_TRUE(worker.add_shard(shard).ok());
+        EXPECT_EQ(0, table_metrics_mgr.size());
+        EXPECT_TRUE(worker.remove_shard(shard.id).ok());
+        EXPECT_EQ(0, table_metrics_mgr.size());
+        EXPECT_EQ(2, sink.count(google::GLOG_WARNING, "failed to parse tableId: " + table_id));
     }
 };
 
@@ -100,6 +145,77 @@ TEST_F(StarOSWorkerTest, test_add_listener) {
 
     EXPECT_TRUE(worker->remove_shard(2).ok());
     EXPECT_EQ(0, shard_count_metric.value());
+}
+
+TEST_F(StarOSWorkerTest, TableMetricsIgnoreVirtualShard) {
+    const bool old_enable_table_metrics = config::enable_table_metrics;
+    DeferOp restore_config([&] { config::enable_table_metrics = old_enable_table_metrics; });
+    config::enable_table_metrics = true;
+
+    TableMetricsManager table_metrics_mgr;
+    StarOSWorker worker(&table_metrics_mgr);
+    RecordingLogSink sink;
+    google::AddLogSink(&sink);
+    DeferOp remove_sink([&] { google::RemoveLogSink(&sink); });
+
+    StarOSWorker::ShardInfo shard;
+    shard.id = 101;
+    EXPECT_TRUE(worker.add_shard(shard).ok());
+    EXPECT_EQ(0, table_metrics_mgr.size());
+    EXPECT_TRUE(worker.remove_shard(shard.id).ok());
+    EXPECT_EQ(0, table_metrics_mgr.size());
+    EXPECT_EQ(0, sink.count(google::GLOG_WARNING, "tableId"));
+}
+
+TEST_F(StarOSWorkerTest, TableMetricsRejectPartiallyParsedTableIds) {
+    const bool old_enable_table_metrics = config::enable_table_metrics;
+    DeferOp restore_config([&] { config::enable_table_metrics = old_enable_table_metrics; });
+    config::enable_table_metrics = true;
+    expect_malformed_table_id("-1", 102);
+    expect_malformed_table_id("42junk", 103);
+}
+
+TEST_F(StarOSWorkerTest, TableMetricsRejectEmptyTableId) {
+    const bool old_enable_table_metrics = config::enable_table_metrics;
+    DeferOp restore_config([&] { config::enable_table_metrics = old_enable_table_metrics; });
+    config::enable_table_metrics = true;
+    expect_malformed_table_id("", 104);
+}
+
+TEST_F(StarOSWorkerTest, TableMetricsRejectOverflowingTableId) {
+    const bool old_enable_table_metrics = config::enable_table_metrics;
+    DeferOp restore_config([&] { config::enable_table_metrics = old_enable_table_metrics; });
+    config::enable_table_metrics = true;
+    expect_malformed_table_id("18446744073709551616", 105);
+}
+
+TEST_F(StarOSWorkerTest, TableMetricsPreserveTableShardReferenceCounts) {
+    const bool old_enable_table_metrics = config::enable_table_metrics;
+    DeferOp restore_config([&] { config::enable_table_metrics = old_enable_table_metrics; });
+    config::enable_table_metrics = true;
+
+    TableMetricsManager table_metrics_mgr;
+    StarOSWorker worker(&table_metrics_mgr);
+    RecordingLogSink sink;
+    google::AddLogSink(&sink);
+    DeferOp remove_sink([&] { google::RemoveLogSink(&sink); });
+
+    StarOSWorker::ShardInfo first;
+    first.id = 106;
+    first.properties.emplace("tableId", "42");
+    StarOSWorker::ShardInfo second;
+    second.id = 107;
+    second.properties.emplace("tableId", " 42 ");
+
+    EXPECT_TRUE(worker.add_shard(first).ok());
+    EXPECT_TRUE(worker.add_shard(second).ok());
+    ASSERT_EQ(1, table_metrics_mgr.size());
+    EXPECT_EQ(2, table_metrics_mgr.get_table_metrics(42)->ref_count);
+    EXPECT_TRUE(worker.remove_shard(first.id).ok());
+    EXPECT_EQ(1, table_metrics_mgr.get_table_metrics(42)->ref_count);
+    EXPECT_TRUE(worker.remove_shard(second.id).ok());
+    EXPECT_EQ(0, table_metrics_mgr.get_table_metrics(42)->ref_count);
+    EXPECT_EQ(0, sink.count(google::GLOG_WARNING, "tableId"));
 }
 
 TEST_F(StarOSWorkerTest, test_fs_cache) {


### PR DESCRIPTION
## Why I'm doing:

Shared-data cross-cluster replication creates a virtual StarOS shard for a storage volume. This shard intentionally has no `tableId`, but `StarOSWorker` treated every shard as table-owned. In Debug builds this reached a `DCHECK(false)`; with table metrics enabled, Release builds registered a bogus `UINT64_MAX` table metric and consumed the bounded table-metrics quota.

Malformed `tableId` properties had the same problem and could also be partially parsed as valid IDs.

## What I'm doing:

- Represent a missing or invalid private `tableId` extraction result with `std::optional`.
- Strictly validate supplied IDs, including negative, trailing, overflow, empty, and embedded-NUL inputs.
- Register and unregister table metrics only for valid table-owned shards.
- Add focused tests for virtual shards, malformed IDs, warning behavior, whitespace parsing, and table-metric reference counts.

Validation:

- `StarOSWorkerTest.*`: 12/12 passed.
- `compute_env_test`: 304 passed; 16 environment-gated Starlet filesystem cases skipped.
- BE metrics-header, full module-boundary, generated-AGENTS, clang-format, and diff checks passed.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
