### PR TITLE
[BugFix] Drop corrupted local cache when tablet merge sstable rebuild hits corruption (backport #78003)

### DIFF
--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -56,6 +56,7 @@
 #include "testutil/sync_point.h"
 #include "util/crc32c.h"
 #include "util/defer_op.h"
+#include "util/starrocks_metrics.h"
 #include "util/uid_util.h"
 
 namespace {
@@ -2150,6 +2151,22 @@ StatusOr<bool> remap_legacy_entry_or_drop(IndexValuesWithVerPB* values_pb, int32
     return true;
 }
 
+// Corrupted bytes on the sstable-rebuild read path usually come from the local
+// cache copy of the source sstable (the same failure mode as PK index
+// compaction). Drop that cache entry before propagating the error, so a retried
+// tablet merge scheduled onto this node re-reads from remote storage instead of
+// hitting the same bad blocks forever.
+Status drop_source_sstable_cache_on_corruption(TabletManager* tablet_manager, int64_t source_tablet_id,
+                                               const PersistentIndexSstablePB& src_pb, const Status& st) {
+    if (st.is_corruption()) {
+        StarRocksMetrics::instance()->pk_index_sst_read_error_total.increment(1);
+        LOG(WARNING) << "tablet merge sstable rebuild hit corruption, dropping local cache of " << src_pb.filename()
+                     << ", source tablet_id=" << source_tablet_id << ", error: " << st;
+        (void)drop_corrupted_sstable_cache(tablet_manager->sst_location(source_tablet_id, src_pb.filename()));
+    }
+    return st;
+}
+
 // Rebuilds an ancestor-inherited shared PK sstable (shared=true,
 // !has_shared_rssid) by reading every entry, remapping stored rssids to the
 // merged tablet's final rssid space via merge_contexts, applying the merged
@@ -2260,6 +2277,11 @@ Status rebuild_legacy_shared_sstable(TabletManager* tablet_manager, int64_t merg
     // a one-shot bulk merge scan doesn't pollute long-lived block / delvec
     // caches; the local cache here already deduplicates per-rssid loads.
     std::unordered_map<uint32_t, DelVectorPtr> del_vector_cache;
+    // Set when the merged delvec fails to load: a strict-CRC delvec mismatch also
+    // surfaces as Corruption, and that must not be attributed to the source sstable
+    // (its cache is innocent; dropping it would leave the actually-corrupt delvec
+    // cache in place and pollute the sst read-error metric).
+    bool delvec_load_failed = false;
     auto load_del_vector = [&](uint32_t final_rssid) -> StatusOr<DelVectorPtr> {
         auto cached_entry = del_vector_cache.find(final_rssid);
         if (cached_entry != del_vector_cache.end()) return cached_entry->second;
@@ -2271,8 +2293,12 @@ Status rebuild_legacy_shared_sstable(TabletManager* tablet_manager, int64_t merg
         }
         DelVectorPtr del_vector = std::make_shared<DelVector>();
         LakeIOOptions lake_io_options{.fill_data_cache = false, .skip_disk_cache = false};
-        RETURN_IF_ERROR(lake::get_del_vec(tablet_manager, new_metadata, delvec_page_entry->second,
-                                          /*fill_cache=*/false, lake_io_options, del_vector.get()));
+        if (auto load_status = lake::get_del_vec(tablet_manager, new_metadata, delvec_page_entry->second,
+                                                 /*fill_cache=*/false, lake_io_options, del_vector.get());
+            !load_status.ok()) {
+            delvec_load_failed = true;
+            return load_status;
+        }
         del_vector_cache.emplace(final_rssid, del_vector);
         return del_vector;
     };
@@ -2287,13 +2313,29 @@ Status rebuild_legacy_shared_sstable(TabletManager* tablet_manager, int64_t merg
         const Slice entry_raw_value = source_iterator->value();
         IndexValuesWithVerPB values_pb;
         if (!values_pb.ParseFromArray(entry_raw_value.data, static_cast<int>(entry_raw_value.size))) {
-            return Status::InternalError("Failed to parse legacy sstable value during rebuild");
+            // These bytes come straight out of the source sstable's data block, so a
+            // parse failure means the persisted content is corrupted.
+            return drop_source_sstable_cache_on_corruption(
+                    tablet_manager, src_metadata->id(), src_pb,
+                    Status::Corruption("Failed to parse legacy sstable value during rebuild"));
         }
-        // (2) + (3) per-entry remap and delvec filter, packed into one helper.
-        ASSIGN_OR_RETURN(bool keep_entry,
-                         remap_legacy_entry_or_drop(&values_pb, source_rssid_offset, rssid_lookup_maps.data_rssid_map,
-                                                    load_del_vector));
-        if (!keep_entry) {
+        // (2) + (3) per-entry remap and delvec filter, packed into one helper. A
+        // Corruption from it (stored rssid out of range after the offset shift) is
+        // decoded from the source data block's bytes, so it gets the same
+        // drop-source-cache treatment as a block-level read failure; other error
+        // kinds (e.g. delvec load failures) pass through the helper untouched.
+        auto keep_entry_or = remap_legacy_entry_or_drop(&values_pb, source_rssid_offset,
+                                                        rssid_lookup_maps.data_rssid_map, load_del_vector);
+        if (!keep_entry_or.ok()) {
+            if (delvec_load_failed) {
+                // The failure came from loading the merged delvec, not from the source
+                // sstable's bytes; propagate it untouched.
+                return keep_entry_or.status();
+            }
+            return drop_source_sstable_cache_on_corruption(tablet_manager, src_metadata->id(), src_pb,
+                                                           keep_entry_or.status());
+        }
+        if (!keep_entry_or.value()) {
             ++dropped_entry_count;
             continue;
         }
@@ -2302,7 +2344,8 @@ Status rebuild_legacy_shared_sstable(TabletManager* tablet_manager, int64_t merg
         RETURN_IF_ERROR(output_writer.table_builder->Add(entry_key, Slice(serialized_entry)));
         ++kept_entry_count;
     }
-    RETURN_IF_ERROR(source_iterator->status());
+    RETURN_IF_ERROR(drop_source_sstable_cache_on_corruption(tablet_manager, src_metadata->id(), src_pb,
+                                                            source_iterator->status()));
 
     if (dropped_entry_count > 0) {
         g_tablet_merge_legacy_sstable_rebuild_dropped_entries << static_cast<int64_t>(dropped_entry_count);
@@ -2372,7 +2415,8 @@ Status rebuild_non_shared_legacy_sstable(TabletManager* tablet_manager, int64_t 
     std::unique_ptr<sstable::Iterator> source_iterator(source_sstable->new_iterator(source_read_options));
     source_iterator->SeekToFirst();
     if (!source_iterator->Valid()) {
-        RETURN_IF_ERROR(source_iterator->status());
+        RETURN_IF_ERROR(drop_source_sstable_cache_on_corruption(tablet_manager, src_metadata->id(), src_pb,
+                                                                source_iterator->status()));
         // Zero-entry sstable: leave out_pb empty, caller drops it.
         return Status::OK();
     }
@@ -2399,7 +2443,11 @@ Status rebuild_non_shared_legacy_sstable(TabletManager* tablet_manager, int64_t 
         const Slice entry_raw_value = source_iterator->value();
         IndexValuesWithVerPB values_pb;
         if (!values_pb.ParseFromArray(entry_raw_value.data, static_cast<int>(entry_raw_value.size))) {
-            return Status::InternalError("Failed to parse non-shared sstable value during rebuild");
+            // These bytes come straight out of the source sstable's data block, so a
+            // parse failure means the persisted content is corrupted.
+            return drop_source_sstable_cache_on_corruption(
+                    tablet_manager, src_metadata->id(), src_pb,
+                    Status::Corruption("Failed to parse non-shared sstable value during rebuild"));
         }
         for (auto& index_value_ref : *values_pb.mutable_values()) {
             auto* index_value = &index_value_ref;
@@ -2407,9 +2455,15 @@ Status rebuild_non_shared_legacy_sstable(TabletManager* tablet_manager, int64_t 
             const int64_t lifted_rssid =
                     static_cast<int64_t>(index_value->rssid()) + static_cast<int64_t>(source_rssid_offset);
             if (lifted_rssid < 0 || lifted_rssid > static_cast<int64_t>(std::numeric_limits<uint32_t>::max())) {
-                return Status::Corruption(fmt::format(
-                        "non-shared rebuild: lifted rssid out of uint32 range: stored={} src_offset={} lifted={}",
-                        index_value->rssid(), source_rssid_offset, lifted_rssid));
+                // The stored rssid was decoded from the source data block's bytes, so an
+                // impossible value means corrupted content -- drop the source cache like
+                // any other read corruption.
+                return drop_source_sstable_cache_on_corruption(
+                        tablet_manager, src_metadata->id(), src_pb,
+                        Status::Corruption(fmt::format(
+                                "non-shared rebuild: lifted rssid out of uint32 range: stored={} src_offset={} "
+                                "lifted={}",
+                                index_value->rssid(), source_rssid_offset, lifted_rssid)));
             }
             ASSIGN_OR_RETURN(uint32_t final_rssid, ctx.map_rssid(static_cast<uint32_t>(lifted_rssid)));
             index_value->set_rssid(final_rssid);
@@ -2419,7 +2473,8 @@ Status rebuild_non_shared_legacy_sstable(TabletManager* tablet_manager, int64_t 
         RETURN_IF_ERROR(output_writer.table_builder->Add(entry_key, Slice(serialized_entry)));
         ++kept_entry_count;
     }
-    RETURN_IF_ERROR(source_iterator->status());
+    RETURN_IF_ERROR(drop_source_sstable_cache_on_corruption(tablet_manager, src_metadata->id(), src_pb,
+                                                            source_iterator->status()));
 
     if (kept_entry_count == 0) {
         // Defensive: SeekToFirst returned Valid() above, so this should

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -18,6 +18,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <functional>
 #include <limits>
 #include <set>
 
@@ -45,8 +47,12 @@
 #include "storage/rowset/segment_options.h"
 #include "storage/rowset/segment_writer.h"
 #include "storage/seek_range.h"
+#include "storage/sstable/block.h"
+#include "storage/sstable/comparator.h"
+#include "storage/sstable/format.h"
 #include "storage/sstable/iterator.h"
 #include "storage/sstable/options.h"
+#include "storage/sstable/table_builder.h"
 #include "storage/tablet_schema.h"
 #include "storage/variant_tuple.h"
 #include "testutil/assert.h"
@@ -8392,6 +8398,489 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_non_shared_sstable_with_delvec
     ASSERT_FALSE(status.ok()) << "non-shared sstable with embedded delvec must trigger corruption guard";
     EXPECT_TRUE(status.is_corruption()) << "expected Corruption, got: " << status.to_string();
 }
+
+#if defined(USE_STAROS) && !defined(BUILD_FORMAT_LIB)
+// Overwrite the 1-byte compression-type trailer of the first data block with an
+// invalid value, emulating a corrupted local cache copy of the sstable. The
+// block is located through the footer -> index block, so the footer and index
+// block near the file tail stay intact and opening the sstable still succeeds;
+// only reading the data block fails with Corruption ("bad block type"; once
+// block-checksum verification lands the same read fails as a checksum
+// mismatch -- still Corruption).
+static void corrupt_first_data_block_type_byte(const std::string& path) {
+    ASSIGN_OR_ABORT(auto rf, fs::new_random_access_file(path));
+    ASSIGN_OR_ABORT(auto file_size, rf->get_size());
+    ASSERT_GT(file_size, sstable::Footer::kEncodedLength);
+    std::string content(file_size, '\0');
+    ASSERT_OK(rf->read_at_fully(0, content.data(), file_size));
+
+    sstable::Footer footer;
+    Slice footer_input(content.data() + file_size - sstable::Footer::kEncodedLength, sstable::Footer::kEncodedLength);
+    ASSERT_OK(footer.DecodeFrom(&footer_input));
+    sstable::BlockContents index_contents;
+    index_contents.data = Slice(content.data() + footer.index_handle().offset(), footer.index_handle().size());
+    index_contents.cachable = false;
+    index_contents.heap_allocated = false;
+    sstable::Block index_block(index_contents);
+    std::unique_ptr<sstable::Iterator> iter(index_block.NewIterator(sstable::BytewiseComparator()));
+    iter->SeekToFirst();
+    ASSERT_TRUE(iter->Valid());
+    Slice handle_value = iter->value();
+    sstable::BlockHandle first_block;
+    ASSERT_OK(first_block.DecodeFrom(&handle_value));
+    // The compression-type byte sits right after the block payload.
+    size_t type_offset = first_block.offset() + first_block.size();
+    ASSERT_LT(type_offset, content.size());
+    content[type_offset] = 0x7f;
+
+    WritableFileOptions wf_opts;
+    wf_opts.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE;
+    ASSIGN_OR_ABORT(auto wf, FileSystem::Default()->new_writable_file(wf_opts, path));
+    ASSERT_OK(wf->append(Slice(content)));
+    ASSERT_OK(wf->close());
+}
+
+// Regression test for the legacy shared-sstable rebuild reading a corrupted
+// source sstable (usually a bad local cache copy): the merge must fail with
+// Corruption AND drop the source sstable's local cache, so a retried merge
+// scheduled onto this node re-reads from remote storage instead of hitting the
+// same bad blocks forever.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_rebuild_drops_corrupted_source_cache) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    const std::string legacy_filename = "corrupted_cache.sst";
+    const auto legacy_path = _tablet_manager->sst_location(child_a, legacy_filename);
+    const uint64_t legacy_filesize =
+            write_legacy_pk_sstable(legacy_path, {{"k1", /*rssid=*/1, /*rowid=*/0}, {"k2", /*rssid=*/2, /*rowid=*/0}});
+    corrupt_first_data_block_type_byte(legacy_path);
+
+    auto make_child = [&](int64_t tablet_id, uint32_t live_rowset_id, const std::string& seg_filename) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(live_rowset_id + 1);
+        set_primary_key_schema(meta.get(), 1001);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(live_rowset_id);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        {
+            auto* sm = rowset->add_segment_metas();
+            sm->set_filename(seg_filename);
+            sm->set_size(100);
+            sm->set_shared(true);
+        }
+        auto* sst = meta->mutable_sstable_meta()->add_sstables();
+        sst->set_filename(legacy_filename);
+        sst->set_filesize(legacy_filesize);
+        sst->set_shared(true);
+        sst->set_max_rss_rowid((static_cast<uint64_t>(2) << 32) | 0);
+        return meta;
+    };
+
+    EXPECT_OK(put_tablet_metadata(make_child(child_a, /*live_rowset_id=*/1, "seg_a.dat")));
+    EXPECT_OK(put_tablet_metadata(make_child(child_b, /*live_rowset_id=*/2, "seg_b.dat")));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(99);
+
+    bool old_cfg = config::lake_clear_corrupted_cache_data;
+    config::lake_clear_corrupted_cache_data = true;
+    int drop_cnt = 0;
+    SyncPoint::GetInstance()->SetCallBack("PersistentIndexSstable::drop_corrupted_cache", [&](void*) { ++drop_cnt; });
+    SyncPoint::GetInstance()->EnableProcessing();
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    auto status = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                                  txn_info, false, tablet_metadatas, tablet_ranges);
+
+    SyncPoint::GetInstance()->ClearCallBack("PersistentIndexSstable::drop_corrupted_cache");
+    SyncPoint::GetInstance()->DisableProcessing();
+    config::lake_clear_corrupted_cache_data = old_cfg;
+
+    ASSERT_FALSE(status.ok()) << "merge over a corrupted source sstable must fail";
+    EXPECT_TRUE(status.is_corruption()) << "expected Corruption, got: " << status.to_string();
+    // The failing source sstable's local cache must have been dropped exactly
+    // once (opening succeeds — footer and index block are intact — so only the
+    // rebuild's cleanup handler fires).
+    EXPECT_EQ(1, drop_cnt);
+}
+
+// Same corruption scenario through the non-shared legacy rebuild route
+// (rebuild_non_shared_legacy_sstable). The metadata layout mirrors
+// test_tablet_merging_non_shared_sstable_mixed_refs_routes_to_rebuild: ctx_b's
+// non-shared sstable mixes refs to the shared-ancestor rowset and a child-local
+// rowset with a non-zero offset gap, so dispatch takes the per-entry rebuild
+// (a pure-projection layout would never read the file and the corruption would
+// go unnoticed). Corruption surfaces at the initial SeekToFirst, and the early
+// status check must drop the source cache too.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_non_shared_rebuild_drops_corrupted_source_cache) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    const std::string ns_filename = "ns_corrupted_cache.sst";
+    const auto ns_path = _tablet_manager->sst_location(child_b, ns_filename);
+    const uint64_t ns_filesize = write_legacy_pk_sstable(
+            ns_path, {{"k_shared", /*rssid=*/1, /*rowid=*/0}, {"k_local", /*rssid=*/2, /*rowid=*/0}});
+    corrupt_first_data_block_type_byte(ns_path);
+
+    auto meta_a = std::make_shared<TabletMetadataPB>();
+    meta_a->set_id(child_a);
+    meta_a->set_version(base_version);
+    meta_a->set_next_rowset_id(3);
+    set_primary_key_schema(meta_a.get(), 1001);
+    auto* rs_a1 = meta_a->add_rowsets();
+    rs_a1->set_id(1);
+    rs_a1->set_version(1);
+    rs_a1->set_num_rows(10);
+    rs_a1->set_data_size(100);
+    {
+        auto* sm = rs_a1->add_segment_metas();
+        sm->set_filename("shared.dat");
+        sm->set_size(100);
+        sm->set_shared(true);
+    }
+    stamp_physical_identity_uid(rs_a1, "shared.dat");
+
+    auto meta_b = std::make_shared<TabletMetadataPB>();
+    meta_b->set_id(child_b);
+    meta_b->set_version(base_version);
+    meta_b->set_next_rowset_id(3);
+    set_primary_key_schema(meta_b.get(), 1001);
+    auto* rs_b1 = meta_b->add_rowsets();
+    rs_b1->set_id(1);
+    rs_b1->set_version(1);
+    rs_b1->set_num_rows(10);
+    rs_b1->set_data_size(100);
+    {
+        auto* sm = rs_b1->add_segment_metas();
+        sm->set_filename("shared.dat");
+        sm->set_size(100);
+        sm->set_shared(true);
+    }
+    stamp_physical_identity_uid(rs_b1, "shared.dat");
+    auto* rs_b2 = meta_b->add_rowsets();
+    rs_b2->set_id(2);
+    rs_b2->set_version(1);
+    rs_b2->set_num_rows(5);
+    rs_b2->set_data_size(50);
+    {
+        auto* sm = rs_b2->add_segment_metas();
+        sm->set_filename("ctx_b_local.dat");
+        sm->set_size(50);
+        sm->set_shared(false);
+    }
+    auto* sst_b = meta_b->mutable_sstable_meta()->add_sstables();
+    sst_b->set_filename(ns_filename);
+    sst_b->set_filesize(ns_filesize);
+    sst_b->set_shared(false);
+    sst_b->set_max_rss_rowid((static_cast<uint64_t>(2) << 32) | 0);
+
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(100);
+
+    bool old_cfg = config::lake_clear_corrupted_cache_data;
+    config::lake_clear_corrupted_cache_data = true;
+    int drop_cnt = 0;
+    SyncPoint::GetInstance()->SetCallBack("PersistentIndexSstable::drop_corrupted_cache", [&](void*) { ++drop_cnt; });
+    SyncPoint::GetInstance()->EnableProcessing();
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    auto status = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                                  txn_info, false, tablet_metadatas, tablet_ranges);
+
+    SyncPoint::GetInstance()->ClearCallBack("PersistentIndexSstable::drop_corrupted_cache");
+    SyncPoint::GetInstance()->DisableProcessing();
+    config::lake_clear_corrupted_cache_data = old_cfg;
+
+    ASSERT_FALSE(status.ok()) << "merge over a corrupted non-shared source sstable must fail";
+    EXPECT_TRUE(status.is_corruption()) << "expected Corruption, got: " << status.to_string();
+    EXPECT_EQ(1, drop_cnt);
+}
+
+// Build a real, structurally intact sstable whose single entry carries value bytes
+// that cannot be parsed as IndexValuesWithVerPB (0x00 is an invalid protobuf tag).
+// Blocks and checksums are valid, so opening and iterating succeed and the
+// corruption only surfaces when the rebuild parses the value.
+static uint64_t write_garbage_value_pk_sstable(const std::string& path) {
+    WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+    auto wf_or = fs::new_writable_file(opts, path);
+    CHECK_OK(wf_or.status());
+    auto wf = std::move(wf_or.value());
+    sstable::Options options;
+    sstable::TableBuilder builder(options, wf.get());
+    CHECK_OK(builder.Add(Slice("garbage_key"), Slice("\x00garbage", 8)));
+    CHECK_OK(builder.Finish());
+    const uint64_t filesize = builder.FileSize();
+    CHECK_OK(wf->close());
+    return filesize;
+}
+
+// The drop-source-cache handling must also cover "semantic" corruption: bytes that
+// keep the block structure (and its checksum) intact but carry impossible content.
+// Two forms, through the legacy shared rebuild route:
+//   (a) entry value bytes that fail IndexValuesWithVerPB parsing;
+//   (b) a parseable entry whose stored rssid plus the PB-level rssid_offset
+//       overflows uint32 (the per-entry remap guard reports Corruption).
+// Both must fail the merge as Corruption AND drop the source sstable's cache.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_rebuild_drops_cache_on_semantic_corruption) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+
+    auto run_scenario = [&](const std::function<uint64_t(const std::string&)>& write_sst, int32_t rssid_offset,
+                            int64_t txn_id) -> std::pair<Status, int> {
+        const int64_t child_a = next_id();
+        const int64_t child_b = next_id();
+        const int64_t merged_tablet = next_id();
+        prepare_tablet_dirs(child_a);
+        prepare_tablet_dirs(child_b);
+        prepare_tablet_dirs(merged_tablet);
+
+        const std::string filename = fmt::format("semantic_shared_{}.sst", txn_id);
+        const uint64_t filesize = write_sst(_tablet_manager->sst_location(child_a, filename));
+
+        auto make_child = [&](int64_t tablet_id, uint32_t live_rowset_id, const std::string& seg_filename) {
+            auto meta = std::make_shared<TabletMetadataPB>();
+            meta->set_id(tablet_id);
+            meta->set_version(base_version);
+            meta->set_next_rowset_id(live_rowset_id + 1);
+            set_primary_key_schema(meta.get(), 1001);
+            auto* rowset = meta->add_rowsets();
+            rowset->set_id(live_rowset_id);
+            rowset->set_version(1);
+            rowset->set_num_rows(10);
+            rowset->set_data_size(100);
+            {
+                auto* sm = rowset->add_segment_metas();
+                sm->set_filename(seg_filename);
+                sm->set_size(100);
+                sm->set_shared(true);
+            }
+            auto* sst = meta->mutable_sstable_meta()->add_sstables();
+            sst->set_filename(filename);
+            sst->set_filesize(filesize);
+            sst->set_shared(true);
+            sst->set_max_rss_rowid((static_cast<uint64_t>(1) << 32) | 0);
+            if (rssid_offset != 0) {
+                sst->set_rssid_offset(rssid_offset);
+            }
+            return meta;
+        };
+
+        EXPECT_OK(put_tablet_metadata(make_child(child_a, /*live_rowset_id=*/1, "seg_a.dat")));
+        EXPECT_OK(put_tablet_metadata(make_child(child_b, /*live_rowset_id=*/2, "seg_b.dat")));
+
+        ReshardingTabletInfoPB resharding_tablet;
+        auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+        merging_info.add_old_tablet_ids(child_a);
+        merging_info.add_old_tablet_ids(child_b);
+        merging_info.set_new_tablet_id(merged_tablet);
+
+        TxnInfoPB txn_info;
+        txn_info.set_txn_id(txn_id);
+
+        bool old_cfg = config::lake_clear_corrupted_cache_data;
+        config::lake_clear_corrupted_cache_data = true;
+        int drop_cnt = 0;
+        SyncPoint::GetInstance()->SetCallBack("PersistentIndexSstable::drop_corrupted_cache",
+                                              [&](void*) { ++drop_cnt; });
+        SyncPoint::GetInstance()->EnableProcessing();
+
+        std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+        std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+        auto status = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version,
+                                                      new_version, txn_info, false, tablet_metadatas, tablet_ranges);
+
+        SyncPoint::GetInstance()->ClearCallBack("PersistentIndexSstable::drop_corrupted_cache");
+        SyncPoint::GetInstance()->DisableProcessing();
+        config::lake_clear_corrupted_cache_data = old_cfg;
+        return {status, drop_cnt};
+    };
+
+    // (a) value bytes that fail protobuf parsing.
+    auto [parse_status, parse_drops] =
+            run_scenario([](const std::string& path) { return write_garbage_value_pk_sstable(path); },
+                         /*rssid_offset=*/0, /*txn_id=*/201);
+    ASSERT_FALSE(parse_status.ok()) << "merge over an unparseable source value must fail";
+    EXPECT_TRUE(parse_status.is_corruption()) << parse_status;
+    EXPECT_EQ(1, parse_drops);
+
+    // (b) parseable entry whose stored rssid + rssid_offset overflows uint32
+    // (rowid stays 0 so the entry is not a tombstone sentinel).
+    auto [overflow_status, overflow_drops] = run_scenario(
+            [this](const std::string& path) {
+                return write_legacy_pk_sstable(path, {{"k_overflow", std::numeric_limits<uint32_t>::max(), 0}});
+            },
+            /*rssid_offset=*/1, /*txn_id=*/202);
+    ASSERT_FALSE(overflow_status.ok()) << "merge over an out-of-range stored rssid must fail";
+    EXPECT_TRUE(overflow_status.is_corruption()) << overflow_status;
+    EXPECT_EQ(1, overflow_drops);
+}
+
+// Same two semantic-corruption forms through the non-shared rebuild route
+// (mixed-refs metadata layout, see
+// test_tablet_merging_non_shared_rebuild_drops_corrupted_source_cache).
+TEST_F(LakeTabletReshardTest, test_tablet_merging_non_shared_rebuild_drops_cache_on_semantic_corruption) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+
+    auto run_scenario = [&](const std::function<uint64_t(const std::string&)>& write_sst, int32_t rssid_offset,
+                            int64_t txn_id) -> std::pair<Status, int> {
+        const int64_t child_a = next_id();
+        const int64_t child_b = next_id();
+        const int64_t merged_tablet = next_id();
+        prepare_tablet_dirs(child_a);
+        prepare_tablet_dirs(child_b);
+        prepare_tablet_dirs(merged_tablet);
+
+        const std::string filename = fmt::format("semantic_ns_{}.sst", txn_id);
+        const uint64_t filesize = write_sst(_tablet_manager->sst_location(child_b, filename));
+
+        auto meta_a = std::make_shared<TabletMetadataPB>();
+        meta_a->set_id(child_a);
+        meta_a->set_version(base_version);
+        meta_a->set_next_rowset_id(3);
+        set_primary_key_schema(meta_a.get(), 1001);
+        auto* rs_a1 = meta_a->add_rowsets();
+        rs_a1->set_id(1);
+        rs_a1->set_version(1);
+        rs_a1->set_num_rows(10);
+        rs_a1->set_data_size(100);
+        {
+            auto* sm = rs_a1->add_segment_metas();
+            sm->set_filename("shared.dat");
+            sm->set_size(100);
+            sm->set_shared(true);
+        }
+        stamp_physical_identity_uid(rs_a1, "shared.dat");
+
+        auto meta_b = std::make_shared<TabletMetadataPB>();
+        meta_b->set_id(child_b);
+        meta_b->set_version(base_version);
+        meta_b->set_next_rowset_id(3);
+        set_primary_key_schema(meta_b.get(), 1001);
+        auto* rs_b1 = meta_b->add_rowsets();
+        rs_b1->set_id(1);
+        rs_b1->set_version(1);
+        rs_b1->set_num_rows(10);
+        rs_b1->set_data_size(100);
+        {
+            auto* sm = rs_b1->add_segment_metas();
+            sm->set_filename("shared.dat");
+            sm->set_size(100);
+            sm->set_shared(true);
+        }
+        stamp_physical_identity_uid(rs_b1, "shared.dat");
+        auto* rs_b2 = meta_b->add_rowsets();
+        rs_b2->set_id(2);
+        rs_b2->set_version(1);
+        rs_b2->set_num_rows(5);
+        rs_b2->set_data_size(50);
+        {
+            auto* sm = rs_b2->add_segment_metas();
+            sm->set_filename("ctx_b_local.dat");
+            sm->set_size(50);
+            sm->set_shared(false);
+        }
+        auto* sst_b = meta_b->mutable_sstable_meta()->add_sstables();
+        sst_b->set_filename(filename);
+        sst_b->set_filesize(filesize);
+        sst_b->set_shared(false);
+        sst_b->set_max_rss_rowid((static_cast<uint64_t>(2) << 32) | 0);
+        if (rssid_offset != 0) {
+            sst_b->set_rssid_offset(rssid_offset);
+        }
+
+        EXPECT_OK(put_tablet_metadata(meta_a));
+        EXPECT_OK(put_tablet_metadata(meta_b));
+
+        ReshardingTabletInfoPB resharding_tablet;
+        auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+        merging_info.add_old_tablet_ids(child_a);
+        merging_info.add_old_tablet_ids(child_b);
+        merging_info.set_new_tablet_id(merged_tablet);
+
+        TxnInfoPB txn_info;
+        txn_info.set_txn_id(txn_id);
+
+        bool old_cfg = config::lake_clear_corrupted_cache_data;
+        config::lake_clear_corrupted_cache_data = true;
+        int drop_cnt = 0;
+        SyncPoint::GetInstance()->SetCallBack("PersistentIndexSstable::drop_corrupted_cache",
+                                              [&](void*) { ++drop_cnt; });
+        SyncPoint::GetInstance()->EnableProcessing();
+
+        std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+        std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+        auto status = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version,
+                                                      new_version, txn_info, false, tablet_metadatas, tablet_ranges);
+
+        SyncPoint::GetInstance()->ClearCallBack("PersistentIndexSstable::drop_corrupted_cache");
+        SyncPoint::GetInstance()->DisableProcessing();
+        config::lake_clear_corrupted_cache_data = old_cfg;
+        return {status, drop_cnt};
+    };
+
+    // (a) value bytes that fail protobuf parsing. The routing predicate is
+    // metadata-only, so the mixed-refs layout still dispatches to the rebuild.
+    auto [parse_status, parse_drops] =
+            run_scenario([](const std::string& path) { return write_garbage_value_pk_sstable(path); },
+                         /*rssid_offset=*/0, /*txn_id=*/203);
+    ASSERT_FALSE(parse_status.ok()) << "merge over an unparseable source value must fail";
+    EXPECT_TRUE(parse_status.is_corruption()) << parse_status;
+    EXPECT_EQ(1, parse_drops);
+
+    // (b) parseable entry whose stored rssid + rssid_offset falls below zero.
+    // A negative offset is used because the routing range is
+    // [max(0, offset + 1), max_rss_rowid.high]: a positive offset would lift the
+    // lower bound past the disagreeing rowset id 1 and dispatch would take the
+    // metadata-only projection without ever reading the file; with offset=-1 the
+    // range [0, 2] still contains id 1, the rebuild route is kept, and the first
+    // entry (stored rssid 0, lifted to -1) trips the range guard.
+    auto [overflow_status, overflow_drops] = run_scenario(
+            [this](const std::string& path) {
+                return write_legacy_pk_sstable(path, {{"k_overflow", 0, 0}});
+            },
+            /*rssid_offset=*/-1, /*txn_id=*/204);
+    ASSERT_FALSE(overflow_status.ok()) << "merge over an out-of-range stored rssid must fail";
+    EXPECT_TRUE(overflow_status.is_corruption()) << overflow_status;
+    EXPECT_EQ(1, overflow_drops);
+}
+
+#endif // USE_STAROS && !BUILD_FORMAT_LIB
 
 // TODO(round-3 follow-up): test_tablet_merging_legacy_sstable_rebuild_filters_outside_tablet_range
 // This test would set up real INT-typed PK columns + tablet ranges with


### PR DESCRIPTION
Manual backport of #78003 to branch-4.1. The automatic Mergify backport (#78089) hit conflicts and was closed. `be/src/storage/lake/tablet_merger.cpp` cherry-picks cleanly; the only conflict is the include block of `tablet_reshard_test.cpp`, where main has split `common/config.h` into `config_*_fwd.h` headers that do not exist on this branch — resolved by keeping this branch's `common/config.h` (and adding the `<algorithm>` / `<functional>` includes the new tests use). One compile fix on top: main's `storage/storage_metrics.h` / `StorageMetrics` does not exist on this branch, so the metric bump goes through `util/starrocks_metrics.h` / `StarRocksMetrics` (the same counter and the same translation #77997 used). Everything else is line-identical to the original commit.

## Why I'm doing:

Follow-up to #77481, closing the last high-risk gap found in the PK index sstable read-path audit. The tablet-merge legacy sstable rebuild paths read every entry of the source tablets' PK index sstables with neither checksum verification nor the drop-corrupted-cache fallback:

- A corrupted local cache copy of a source sstable makes the merge fail on every retry that lands on the same node — the same wedge #77481 fixed for PK index compaction (the cache is persistent, so nothing ever invalidates the bad blocks).
- Worse, without checksum verification a corrupted-but-still-decodable block can be **silently rebuilt into the merged tablet's index** with wrong (rssid, rowid) values — a correctness hazard, not just availability.

## What I'm doing:

In `be/src/storage/lake/tablet_merger.cpp`, for both rebuild paths (`rebuild_legacy_shared_sstable` and `rebuild_non_shared_legacy_sstable`):

- Add `drop_source_sstable_cache_on_corruption(...)`: on a `Corruption` status it increments `pk_index_sst_read_error_total`, logs a WARNING, drops the source sstable's local cache via the existing `drop_corrupted_sstable_cache()` (gated by `lake_clear_corrupted_cache_data`, same as #77481), and propagates the original status. Unlike compaction's merged iterator, the rebuild knows exactly which file it is reading, so only that one file's cache is dropped.
- Wire the handler into every sst-read failure exit: the iterator status check after the scan loop (both functions), the early status check after `SeekToFirst` (non-shared), and the value protobuf parse failures — which are also reclassified from `InternalError` to `Corruption` (the bytes come straight out of the sstable's data block), matching the `KeyValueMerger::merge` change in #77481.
- Opening the source sstable already self-heals via `PersistentIndexSstable::init`'s internal drop-and-retry; behavior on success paths is unchanged.
- Checksum verification for these rebuild reads (so corrupted-but-still-decodable blocks cannot be silently rebuilt into the merged index) is added by #77479, gated by the `lake_pk_index_sst_verify_checksum` config it introduces; this PR carries only the self-healing half, so the two PRs stay independent and can merge in any order.

UT (in `tablet_reshard_test.cpp`, `USE_STAROS` guarded): four end-to-end cases, all running `publish_resharding_tablet` and asserting the merge fails with `Corruption` and the `PersistentIndexSstable::drop_corrupted_cache` sync point fired exactly once for the source file:
- block-level corruption through each rebuild route (shared-legacy and non-shared): corrupt the first data block's compression-type byte of a real source sstable (footer/index stay intact so opening succeeds);
- semantic corruption through each rebuild route: (a) entry value bytes that fail `IndexValuesWithVerPB` parsing, and (b) a parseable entry whose stored rssid plus the PB `rssid_offset` overflows uint32, covering every error exit that routes through the cleanup helper.

Backport note: only branch-4.1 carries the tablet merge/reshard rebuild paths; 4.0/3.5 do not have this code.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
