### PR TITLE
[Enhancement] Push runtime-filter-derived predicates into the Paimon JNI reader

### DIFF
--- a/be/src/connector/hive/scanner/jni_scanner.cpp
+++ b/be/src/connector/hive/scanner/jni_scanner.cpp
@@ -17,17 +17,23 @@
 #include <type_traits>
 #include <utility>
 
+#include "base/url_coding.h"
 #include "base/utility/defer_op.h"
 #include "column/array_column.h"
 #include "column/map_column.h"
 #include "column/runtime_type_traits.h"
 #include "column/struct_column.h"
+#include "common/config.h"
+#include "common/object_pool.h"
+#include "exec_primitive/runtime_filter/runtime_filter_probe.h"
+#include "exprs/in_const_predicate.hpp"
 #include "fmt/core.h"
 #include "fs/credential/cloud_configuration_factory.h"
 #include "runtime/descriptors_ext.h"
 #include "runtime/java/java_runtime.h"
 #include "runtime/java/jvm_helper.h"
 #include "runtime/java/native_method_helper.h"
+#include "runtime/runtime_filter.h"
 #include "runtime/runtime_state.h"
 
 namespace starrocks {
@@ -456,6 +462,210 @@ static std::string build_fs_options_properties(const FSOptions& options) {
     return data;
 }
 
+namespace {
+
+// Wire format shared with com.starrocks.paimon.reader.PaimonRuntimePredicates:
+// records separated by '\x03', fields by '\x01'; a record is
+// <column>\x01<op>\x01<base64(v1)>[\x01<base64(v2)>...] with op "minmax" (both
+// bounds inclusive) or "in". Values are canonical strings: integers in decimal,
+// strings raw, dates as YYYY-MM-DD.
+constexpr char kRuntimePredFieldSep = '\x01';
+constexpr char kRuntimePredRecordSep = '\x03';
+
+// Only the Paimon reader consumes "runtime_predicate_info"; other JNI scanners must
+// not pay the serialization cost.
+constexpr const char* kPaimonScannerFactoryClass = "com/starrocks/paimon/reader/PaimonSplitScannerFactory";
+
+std::string encode_runtime_pred_value(const std::string& raw) {
+    std::string encoded;
+    base64_encode(raw, &encoded);
+    return encoded;
+}
+
+void append_runtime_pred_record(std::string* out, const std::string& column, const char* op,
+                                const std::vector<std::string>& values) {
+    if (!out->empty()) {
+        out->push_back(kRuntimePredRecordSep);
+    }
+    out->append(column);
+    out->push_back(kRuntimePredFieldSep);
+    out->append(op);
+    for (const auto& v : values) {
+        out->push_back(kRuntimePredFieldSep);
+        out->append(encode_runtime_pred_value(v));
+    }
+}
+
+bool extract_rf_minmax_values(const RuntimeFilter* minmax, LogicalType ltype, ObjectPool* pool,
+                              std::vector<std::string>* values) {
+    switch (ltype) {
+#define EXTRACT_RF_NUMERIC(TYPE)                                                             \
+    case TYPE: {                                                                             \
+        auto* xrf = dynamic_cast<const MinMaxRuntimeFilter<TYPE>*>(minmax);                  \
+        if (xrf == nullptr || !xrf->left_close_interval() || !xrf->right_close_interval()) { \
+            return false;                                                                    \
+        }                                                                                    \
+        values->push_back(std::to_string(xrf->min_value(pool)));                             \
+        values->push_back(std::to_string(xrf->max_value(pool)));                             \
+        return true;                                                                         \
+    }
+        EXTRACT_RF_NUMERIC(TYPE_TINYINT)
+        EXTRACT_RF_NUMERIC(TYPE_SMALLINT)
+        EXTRACT_RF_NUMERIC(TYPE_INT)
+        EXTRACT_RF_NUMERIC(TYPE_BIGINT)
+#undef EXTRACT_RF_NUMERIC
+#define EXTRACT_RF_STRING(TYPE)                                                              \
+    case TYPE: {                                                                             \
+        auto* xrf = dynamic_cast<const MinMaxRuntimeFilter<TYPE>*>(minmax);                  \
+        if (xrf == nullptr || !xrf->left_close_interval() || !xrf->right_close_interval()) { \
+            return false;                                                                    \
+        }                                                                                    \
+        Slice min_slice = xrf->min_value(pool);                                              \
+        Slice max_slice = xrf->max_value(pool);                                              \
+        values->emplace_back(min_slice.data, min_slice.size);                                \
+        values->emplace_back(max_slice.data, max_slice.size);                                \
+        return true;                                                                         \
+    }
+        EXTRACT_RF_STRING(TYPE_VARCHAR)
+        EXTRACT_RF_STRING(TYPE_CHAR)
+#undef EXTRACT_RF_STRING
+    case TYPE_DATE: {
+        auto* xrf = dynamic_cast<const MinMaxRuntimeFilter<TYPE_DATE>*>(minmax);
+        if (xrf == nullptr || !xrf->left_close_interval() || !xrf->right_close_interval()) {
+            return false;
+        }
+        values->push_back(xrf->min_value(pool).to_string());
+        values->push_back(xrf->max_value(pool).to_string());
+        return true;
+    }
+    default:
+        return false;
+    }
+}
+
+template <LogicalType LT>
+bool extract_rf_in_values(const Expr* root, size_t max_in_values, std::vector<std::string>* values) {
+    const auto* pred = down_cast<const VectorizedInConstPredicate<LT>*>(root);
+    if (!pred->is_join_runtime_filter() || pred->is_not_in() || pred->null_in_set()) {
+        return false;
+    }
+    const auto& hash_set = pred->hash_set();
+    if (hash_set.empty() || hash_set.size() > max_in_values) {
+        return false;
+    }
+    for (const auto& v : hash_set) {
+        if constexpr (LT == TYPE_VARCHAR || LT == TYPE_CHAR) {
+            values->emplace_back(v.data, v.size);
+        } else if constexpr (LT == TYPE_DATE) {
+            values->push_back(v.to_string());
+        } else {
+            values->push_back(std::to_string(v));
+        }
+    }
+    return true;
+}
+
+bool extract_rf_in_values_dispatch(const Expr* root, LogicalType ltype, size_t max_in_values,
+                                   std::vector<std::string>* values) {
+    switch (ltype) {
+    case TYPE_TINYINT:
+        return extract_rf_in_values<TYPE_TINYINT>(root, max_in_values, values);
+    case TYPE_SMALLINT:
+        return extract_rf_in_values<TYPE_SMALLINT>(root, max_in_values, values);
+    case TYPE_INT:
+        return extract_rf_in_values<TYPE_INT>(root, max_in_values, values);
+    case TYPE_BIGINT:
+        return extract_rf_in_values<TYPE_BIGINT>(root, max_in_values, values);
+    case TYPE_VARCHAR:
+        return extract_rf_in_values<TYPE_VARCHAR>(root, max_in_values, values);
+    case TYPE_CHAR:
+        return extract_rf_in_values<TYPE_CHAR>(root, max_in_values, values);
+    case TYPE_DATE:
+        return extract_rf_in_values<TYPE_DATE>(root, max_in_values, values);
+    default:
+        return false;
+    }
+}
+
+} // namespace
+
+std::string JniScanner::_build_runtime_predicate_info() {
+    // Only the Paimon reader consumes this param; don't pay the serialization cost
+    // for other JNI scanners.
+    if (_jni_scanner_factory_class != kPaimonScannerFactoryClass) {
+        return {};
+    }
+    if (_scanner_ctx == nullptr) {
+        return {};
+    }
+    // Mirror the effective limit HashJoiner used when building the runtime in-filter:
+    // the query option (session variable) when set, else the BE config.
+    size_t max_in_values = config::max_pushdown_conditions_per_column;
+    if (runtime_state() != nullptr && runtime_state()->query_options().__isset.max_pushdown_conditions_per_column &&
+        runtime_state()->query_options().max_pushdown_conditions_per_column > 0) {
+        max_in_values = runtime_state()->query_options().max_pushdown_conditions_per_column;
+    }
+    std::unordered_map<SlotId, SlotDescriptor*> slot_by_id;
+    for (SlotDescriptor* slot : _scanner_ctx->materialize_slots) {
+        slot_by_id.emplace(slot->id(), slot);
+    }
+
+    std::string encoded;
+    ObjectPool pool;
+
+    // Min/max bounds of arrived join runtime filters. The same filters are re-applied
+    // row-wise after the scan, so the pushed range only has to be a superset.
+    if (_scanner_ctx->runtime_filter_collector != nullptr) {
+        for (const auto& [filter_id, rf_desc] : _scanner_ctx->runtime_filter_collector->descriptors()) {
+            if (rf_desc == nullptr || !rf_desc->can_push_down_runtime_filter()) {
+                continue;
+            }
+            const RuntimeFilter* filter = rf_desc->runtime_filter(-1);
+            SlotId slot_id;
+            if (filter == nullptr || filter->has_null() || !rf_desc->is_probe_slot_ref(&slot_id)) {
+                continue;
+            }
+            auto it = slot_by_id.find(slot_id);
+            if (it == slot_by_id.end()) {
+                continue;
+            }
+            const RuntimeFilter* minmax = filter->get_min_max_filter();
+            if (minmax == nullptr) {
+                continue;
+            }
+            std::vector<std::string> values;
+            if (extract_rf_minmax_values(minmax, it->second->type().type, &pool, &values)) {
+                append_runtime_pred_record(&encoded, std::string(it->second->col_name()), "minmax", values);
+            }
+        }
+    }
+
+    // Exact IN sets of broadcast-join runtime in-filters (bounded by
+    // max_pushdown_conditions_per_column). Static IN conjuncts are already pushed by
+    // the FE inside predicate_info, so only join runtime filters are considered.
+    for (const auto& [slot_id, expr_ctxs] : _scanner_ctx->format_scan_context.conjuncts.by_slot) {
+        auto it = slot_by_id.find(slot_id);
+        if (it == slot_by_id.end()) {
+            continue;
+        }
+        for (ExprContext* expr_ctx : expr_ctxs) {
+            const Expr* root = expr_ctx->root();
+            if (root->op() != TExprOpcode::FILTER_IN) {
+                continue;
+            }
+            const Expr* child = root->get_child(0);
+            if (!child->is_slotref() || child->type().type != it->second->type().type) {
+                continue;
+            }
+            std::vector<std::string> values;
+            if (extract_rf_in_values_dispatch(root, child->type().type, max_in_values, &values)) {
+                append_runtime_pred_record(&encoded, std::string(it->second->col_name()), "in", values);
+            }
+        }
+    }
+    return encoded;
+}
+
 Status JniScanner::update_jni_scanner_params() {
     // update materialized columns.
     {
@@ -490,6 +700,11 @@ Status JniScanner::update_jni_scanner_params() {
 
     _jni_scanner_params["required_fields"] = required_fields;
     _jni_scanner_params["nested_fields"] = nested_fields;
+
+    std::string runtime_predicates = _build_runtime_predicate_info();
+    if (!runtime_predicates.empty()) {
+        _jni_scanner_params["runtime_predicate_info"] = runtime_predicates;
+    }
     return Status::OK();
 }
 
@@ -573,8 +788,7 @@ std::unique_ptr<JniScanner> create_paimon_jni_scanner(const JniScanner::CreateOp
     jni_scanner_params["native_table"] = paimon_table->get_paimon_native_table();
     jni_scanner_params["time_zone"] = paimon_table->get_time_zone();
 
-    std::string scanner_factory_class = "com/starrocks/paimon/reader/PaimonSplitScannerFactory";
-    return std::make_unique<JniScanner>(scanner_factory_class, jni_scanner_params);
+    return std::make_unique<JniScanner>(kPaimonScannerFactoryClass, jni_scanner_params);
 }
 
 // ---------------fluss jni scanner------------------

--- a/be/src/connector/hive/scanner/jni_scanner.h
+++ b/be/src/connector/hive/scanner/jni_scanner.h
@@ -61,6 +61,11 @@ private:
 
     static Status _check_jni_exception(JNIEnv* env, const std::string& message);
 
+    // Encodes runtime-filter-derived predicates (min/max ranges and bounded IN sets)
+    // for the Java-side reader ("runtime_predicate_info" param). Returns an empty
+    // string when nothing is pushable.
+    std::string _build_runtime_predicate_info();
+
     Status _init_jni_table_scanner(JNIEnv* env, RuntimeState* runtime_state);
 
     Status _init_jni_method(JNIEnv* env);
@@ -100,7 +105,8 @@ private:
     std::string _jni_scanner_factory_class;
 
     const std::set<std::string> _skipped_log_jni_scanner_params = {
-            "native_table", "split_info", "predicate_info", "access_id", "access_key", "read_session", "runtime_conf"};
+            "native_table", "split_info",   "predicate_info", "access_id",
+            "access_key",   "read_session", "runtime_conf",   "runtime_predicate_info"};
 
 private:
     long* _chunk_meta_ptr;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonPredicateConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonPredicateConverter.java
@@ -175,7 +175,12 @@ public class PaimonPredicateConverter extends ScalarOperatorVisitor<Predicate, P
 
     @Override
     public Predicate visitLargeInPredicate(LargeInPredicateOperator operator, PaimonPredicateContext context) {
-        throw new UnsupportedOperationException("not support large in predicate in the PaimonPredicateConverter");
+        // Serializing a huge IN list into every split's predicate is too expensive.
+        // Drop the conjunct here and let the BE evaluate it row-wise instead of failing
+        // the whole query.
+        LOG.debug("Skip pushing large IN predicate ({} values) down to Paimon",
+                operator.getConstantCount());
+        return null;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonPredicateConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonPredicateConverterTest.java
@@ -100,6 +100,17 @@ public class PaimonPredicateConverterTest {
     }
 
     @Test
+    public void testLargeInPredicateIsDroppedNotThrown() {
+        List<Object> rawValues = Arrays.asList(11, 22, 333);
+        com.starrocks.sql.optimizer.operator.scalar.LargeInPredicateOperator op =
+                new com.starrocks.sql.optimizer.operator.scalar.LargeInPredicateOperator(
+                        "f0 IN (11, 22, 333)", rawValues, rawValues.size(), false, IntegerType.INT,
+                        Lists.newArrayList(F0));
+        Predicate result = CONVERTER.convert(op);
+        Assertions.assertNull(result);
+    }
+
+    @Test
     public void testEq() {
         ConstantOperator value = ConstantOperator.createInt(5);
         ScalarOperator op = new BinaryPredicateOperator(BinaryType.EQ, F0, value);

--- a/java-extensions/paimon-reader/src/main/java/com/starrocks/paimon/reader/PaimonRuntimePredicates.java
+++ b/java-extensions/paimon-reader/src/main/java/com/starrocks/paimon/reader/PaimonRuntimePredicates.java
@@ -1,0 +1,155 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.paimon.reader;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.RowType;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * Decodes runtime-filter-derived predicates sent by the BE JNI scanner
+ * ("runtime_predicate_info" param) into Paimon {@link Predicate}s.
+ *
+ * <p>Wire format (produced by {@code JniScanner::update_jni_scanner_params} in the BE):
+ * records separated by {@code \u0003}; fields within a record separated by {@code \u0001}.
+ * A record is {@code <column>\u0001<op>\u0001<v1>[\u0001<v2>...]} where {@code op} is
+ * {@code minmax} (exactly two values, both bounds inclusive) or {@code in} (one or more
+ * values). Values are Base64-encoded: strings as their raw column bytes (not
+ * necessarily valid UTF-8), integers as ASCII decimal, dates as ASCII ISO-8601
+ * ({@code YYYY-MM-DD}).
+ *
+ * <p>These predicates are best-effort hints: the BE re-applies the originating
+ * conjuncts and runtime filters row-wise after the scan, so silently skipping an
+ * unparseable or unsupported record is always safe. A record must therefore never
+ * make the scan fail.
+ */
+public final class PaimonRuntimePredicates {
+
+    private static final Logger LOG = LogManager.getLogger(PaimonRuntimePredicates.class);
+
+    private static final String FIELD_SEP = "\u0001";
+    private static final String RECORD_SEP = "\u0003";
+    private static final String OP_MINMAX = "minmax";
+    private static final String OP_IN = "in";
+
+    private PaimonRuntimePredicates() {
+    }
+
+    public static List<Predicate> parse(RowType rowType, String encoded) {
+        List<Predicate> result = new ArrayList<>();
+        if (encoded == null || encoded.isEmpty()) {
+            return result;
+        }
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        List<String> fieldNames = rowType.getFieldNames();
+        for (String record : encoded.split(RECORD_SEP)) {
+            try {
+                Predicate p = parseRecord(builder, rowType, fieldNames, record);
+                if (p != null) {
+                    result.add(p);
+                }
+            } catch (Exception e) {
+                LOG.warn("Skipping undecodable runtime predicate record: {}", e.getMessage());
+            }
+        }
+        return result;
+    }
+
+    private static Predicate parseRecord(PredicateBuilder builder, RowType rowType,
+                                         List<String> fieldNames, String record) {
+        String[] parts = record.split(FIELD_SEP, -1);
+        if (parts.length < 3) {
+            return null;
+        }
+        String column = parts[0];
+        String op = parts[1];
+        int idx = fieldNames.indexOf(column);
+        if (idx < 0) {
+            return null;
+        }
+        DataType type = rowType.getTypeAt(idx);
+        if (OP_MINMAX.equals(op)) {
+            if (parts.length != 4) {
+                return null;
+            }
+            Object min = convertLiteral(type, decode(parts[2]));
+            Object max = convertLiteral(type, decode(parts[3]));
+            if (min == null || max == null) {
+                return null;
+            }
+            return PredicateBuilder.and(
+                    builder.greaterOrEqual(idx, min),
+                    builder.lessOrEqual(idx, max));
+        } else if (OP_IN.equals(op)) {
+            List<Object> literals = new ArrayList<>(parts.length - 2);
+            for (int i = 2; i < parts.length; i++) {
+                Object literal = convertLiteral(type, decode(parts[i]));
+                if (literal == null) {
+                    return null;
+                }
+                literals.add(literal);
+            }
+            if (literals.isEmpty()) {
+                return null;
+            }
+            return builder.in(idx, literals);
+        }
+        return null;
+    }
+
+    private static byte[] decode(String base64) {
+        return Base64.getDecoder().decode(base64);
+    }
+
+    /** Returns null for types this decoder does not support; callers drop the record. */
+    private static Object convertLiteral(DataType type, byte[] raw) {
+        switch (type.getTypeRoot()) {
+            case CHAR:
+            case VARCHAR:
+                // Must stay byte-faithful: the BE serializes raw column bytes, which may
+                // not be valid UTF-8 (and full-range string filters use 0xff sentinels).
+                // Round-tripping through java.lang.String would substitute U+FFFD and
+                // could wrongly exclude valid rows.
+                return BinaryString.fromBytes(raw);
+            default:
+                break;
+        }
+        String value = new String(raw, StandardCharsets.US_ASCII);
+        switch (type.getTypeRoot()) {
+            case TINYINT:
+                return Byte.parseByte(value);
+            case SMALLINT:
+                return Short.parseShort(value);
+            case INTEGER:
+                return Integer.parseInt(value);
+            case BIGINT:
+                return Long.parseLong(value);
+            case DATE:
+                return (int) LocalDate.parse(value).toEpochDay();
+            default:
+                return null;
+        }
+    }
+}

--- a/java-extensions/paimon-reader/src/main/java/com/starrocks/paimon/reader/PaimonSplitScanner.java
+++ b/java-extensions/paimon-reader/src/main/java/com/starrocks/paimon/reader/PaimonSplitScanner.java
@@ -34,6 +34,7 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.InternalRowUtils;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +44,7 @@ public class PaimonSplitScanner extends ConnectorScanner {
     private static final Logger LOG = LogManager.getLogger(PaimonSplitScanner.class);
     private final String splitInfo;
     private final String predicateInfo;
+    private final String runtimePredicateInfo;
     private final String[] requiredFields;
     private final String encodedTable;
     private ColumnType[] requiredTypes;
@@ -61,6 +63,7 @@ public class PaimonSplitScanner extends ConnectorScanner {
         this.nestedFields = ScannerHelper.splitAndOmitEmptyStrings(params.getOrDefault("nested_fields", ""), ",");
         this.splitInfo = params.get("split_info");
         this.predicateInfo = params.get("predicate_info");
+        this.runtimePredicateInfo = params.get("runtime_predicate_info");
         this.encodedTable = params.get("native_table");
         this.classLoader = this.getClass().getClassLoader();
         this.timeZone = params.get("time_zone");
@@ -101,7 +104,12 @@ public class PaimonSplitScanner extends ConnectorScanner {
         int[] projected = Arrays.stream(requiredFields).mapToInt(fieldNames::indexOf).toArray();
         readBuilder.withProjection(projected);
         List<Predicate> predicates = PaimonScannerUtils.decodeStringToObject(predicateInfo);
-        readBuilder.withFilter(predicates);
+        List<Predicate> allPredicates = new ArrayList<>(predicates);
+        // Runtime-filter-derived predicates from the BE are best-effort pruning hints;
+        // the BE re-applies the originating filters row-wise, so they only need to be
+        // a superset of the rows the query will keep.
+        allPredicates.addAll(PaimonRuntimePredicates.parse(rowType, runtimePredicateInfo));
+        readBuilder.withFilter(allPredicates);
         Split split = PaimonScannerUtils.decodeStringToObject(splitInfo);
         RecordReader<InternalRow> reader = readBuilder.newRead().executeFilter().createReader(split);
         iterator = new RecordReaderIterator<>(reader);

--- a/java-extensions/paimon-reader/src/test/java/com/starrocks/paimon/reader/PaimonRuntimePredicatesTest.java
+++ b/java-extensions/paimon-reader/src/test/java/com/starrocks/paimon/reader/PaimonRuntimePredicatesTest.java
@@ -1,0 +1,174 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.paimon.reader;
+
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.Base64;
+import java.util.List;
+
+public class PaimonRuntimePredicatesTest {
+
+    private static final char FIELD_SEP = '\u0001';
+    private static final char RECORD_SEP = '\u0003';
+
+    private static final RowType ROW_TYPE = RowType.builder()
+            .field("project_id", DataTypes.BIGINT())
+            .field("email", DataTypes.STRING())
+            .field("country", DataTypes.STRING())
+            .field("ts", DataTypes.TIMESTAMP())
+            .field("birthday", DataTypes.DATE())
+            .build();
+
+    private static String b64(String v) {
+        return Base64.getEncoder().encodeToString(v.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String record(String col, String op, String... values) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(col).append(FIELD_SEP).append(op);
+        for (String v : values) {
+            sb.append(FIELD_SEP).append(b64(v));
+        }
+        return sb.toString();
+    }
+
+    private static GenericRow row(Long projectId, String email) {
+        return GenericRow.of(projectId, email == null ? null : BinaryString.fromString(email), null, null, null);
+    }
+
+    @Test
+    public void testMinMaxBigint() {
+        String encoded = record("project_id", "minmax", "1", "1");
+        List<Predicate> predicates = PaimonRuntimePredicates.parse(ROW_TYPE, encoded);
+        Assertions.assertEquals(1, predicates.size());
+        Predicate p = predicates.get(0);
+        Assertions.assertTrue(p.test(row(1L, "a@b.com")));
+        Assertions.assertFalse(p.test(row(2L, "a@b.com")));
+        Assertions.assertFalse(p.test(row(null, "a@b.com")));
+    }
+
+    @Test
+    public void testMinMaxString() {
+        String encoded = record("email", "minmax", "a@b.com", "c@d.com");
+        List<Predicate> predicates = PaimonRuntimePredicates.parse(ROW_TYPE, encoded);
+        Assertions.assertEquals(1, predicates.size());
+        Predicate p = predicates.get(0);
+        Assertions.assertTrue(p.test(row(1L, "a@b.com")));
+        Assertions.assertTrue(p.test(row(1L, "b@x.com")));
+        Assertions.assertTrue(p.test(row(1L, "c@d.com")));
+        Assertions.assertFalse(p.test(row(1L, "d@e.com")));
+        Assertions.assertFalse(p.test(row(1L, null)));
+    }
+
+    @Test
+    public void testInString() {
+        String encoded = record("email", "in", "a@b.com", "x@y.com");
+        List<Predicate> predicates = PaimonRuntimePredicates.parse(ROW_TYPE, encoded);
+        Assertions.assertEquals(1, predicates.size());
+        Predicate p = predicates.get(0);
+        Assertions.assertTrue(p.test(row(1L, "a@b.com")));
+        Assertions.assertTrue(p.test(row(1L, "x@y.com")));
+        Assertions.assertFalse(p.test(row(1L, "b@c.com")));
+        Assertions.assertFalse(p.test(row(1L, null)));
+    }
+
+    @Test
+    public void testInBigint() {
+        String encoded = record("project_id", "in", "1", "3");
+        List<Predicate> predicates = PaimonRuntimePredicates.parse(ROW_TYPE, encoded);
+        Assertions.assertEquals(1, predicates.size());
+        Predicate p = predicates.get(0);
+        Assertions.assertTrue(p.test(row(1L, "a")));
+        Assertions.assertTrue(p.test(row(3L, "a")));
+        Assertions.assertFalse(p.test(row(2L, "a")));
+    }
+
+    @Test
+    public void testMultipleRecordsAreAnded() {
+        String encoded = record("project_id", "minmax", "1", "1")
+                + RECORD_SEP
+                + record("email", "in", "a@b.com");
+        List<Predicate> predicates = PaimonRuntimePredicates.parse(ROW_TYPE, encoded);
+        Assertions.assertEquals(2, predicates.size());
+    }
+
+    @Test
+    public void testDateMinMax() {
+        String lo = LocalDate.of(2024, 1, 1).toString();
+        String hi = LocalDate.of(2024, 12, 31).toString();
+        String encoded = record("birthday", "minmax", lo, hi);
+        List<Predicate> predicates = PaimonRuntimePredicates.parse(ROW_TYPE, encoded);
+        Assertions.assertEquals(1, predicates.size());
+        GenericRow inside = GenericRow.of(null, null, null, null, (int) LocalDate.of(2024, 6, 1).toEpochDay());
+        GenericRow outside = GenericRow.of(null, null, null, null, (int) LocalDate.of(2023, 6, 1).toEpochDay());
+        Assertions.assertTrue(predicates.get(0).test(inside));
+        Assertions.assertFalse(predicates.get(0).test(outside));
+    }
+
+    @Test
+    public void testUnsupportedTypeSkipped() {
+        // TIMESTAMP is not supported in v1; the record must be skipped, not fail.
+        String encoded = record("ts", "minmax", "2024-01-01 00:00:00", "2024-12-31 00:00:00");
+        List<Predicate> predicates = PaimonRuntimePredicates.parse(ROW_TYPE, encoded);
+        Assertions.assertTrue(predicates.isEmpty());
+    }
+
+    @Test
+    public void testUnknownColumnSkipped() {
+        String encoded = record("no_such_col", "minmax", "1", "1");
+        List<Predicate> predicates = PaimonRuntimePredicates.parse(ROW_TYPE, encoded);
+        Assertions.assertTrue(predicates.isEmpty());
+    }
+
+    @Test
+    public void testMalformedRecordSkipped() {
+        String encoded = record("project_id", "minmax", "1", "1")
+                + RECORD_SEP + "garbage"
+                + RECORD_SEP + record("project_id", "minmax", "not_a_number", "5")
+                + RECORD_SEP + record("project_id", "in");
+        List<Predicate> predicates = PaimonRuntimePredicates.parse(ROW_TYPE, encoded);
+        Assertions.assertEquals(1, predicates.size());
+    }
+
+    @Test
+    public void testStringDecodeIsByteFaithful() {
+        // A full-range string filter's upper bound is a 0xff sentinel (invalid UTF-8).
+        // The decoded predicate must keep every string, including 4-byte UTF-8 values,
+        // instead of corrupting the bound to U+FFFD and excluding them.
+        String minB64 = Base64.getEncoder().encodeToString(new byte[0]);
+        String maxB64 = Base64.getEncoder().encodeToString(
+                new byte[] {(byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff});
+        String encoded = "email" + FIELD_SEP + "minmax" + FIELD_SEP + minB64 + FIELD_SEP + maxB64;
+        List<Predicate> predicates = PaimonRuntimePredicates.parse(ROW_TYPE, encoded);
+        Assertions.assertEquals(1, predicates.size());
+        Assertions.assertTrue(predicates.get(0).test(row(1L, "a@b.com")));
+        Assertions.assertTrue(predicates.get(0).test(row(1L, "😀emoji@x.com")));
+    }
+
+    @Test
+    public void testNullOrEmptyInput() {
+        Assertions.assertTrue(PaimonRuntimePredicates.parse(ROW_TYPE, null).isEmpty());
+        Assertions.assertTrue(PaimonRuntimePredicates.parse(ROW_TYPE, "").isEmpty());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

The JNI Paimon scanner only gets the FE's static predicates. Join runtime filters arrive at the BE. But the BE does not send them to the Java reader. So they cannot prune data before the rows are fully read and decoded through JNI. Even a 100-key broadcast join on a Paimon primary-key table reads every row in every touched split. It then rejects 95+% of those rows. Split-level runtime-filter pruning on the BE also does not work for Paimon because its scan ranges have no partition id.

In a single-node benchmark with a 5M-row Paimon PK table, a 100-key broadcast join read 5,000,000 raw rows before this change and 100 after it. Wall time fell from 2.7 s to 0.24 s. A 40,000-key join went from reading 5M raw rows to 4M because the reader removed one partition.

## What I'm doing:

When the scanner opens, the BE serializes the runtime-filter information that has already arrived into a new "runtime_predicate_info" JNI parameter. This happens once per scan range. It happens lazily during the IO task, so filters that arrive during scheduling are included.

The parameter contains:

- min/max bounds from join runtime filters as closed intervals; these are skipped when the filter tracks nulls. This includes VARCHAR/CHAR bounds, which the generic min/max-conjunct path drops;
- exact value sets from join runtime in-filters that are already used as scan conjuncts, limited to `max_pushdown_conditions_per_column` values.

On the Java side, `PaimonRuntimePredicates` decodes them into Paimon `Predicate`s. These are ANDed with the static predicates. This lets Paimon skip files and prune Parquet/ORC row groups inside the split.

Only predicates that the BE already applies row by row at this scan are pushed down. All existing post-scan filtering remains. So a pushed predicate only needs to include all rows that the query keeps. If a record cannot be decoded or is not supported, it is skipped instead of causing an error.

String bounds keep the exact column bytes. They do not use UTF-8 round-trips. This is needed because full-range string filters use 0xff sentinel bounds. `java.lang.String` would change these to U+FFFD and could wrongly exclude valid rows.

Only the Paimon reader uses the new parameter. Other JNI scanners do not pay the serialization cost.

Also, `PaimonPredicateConverter` now drops `LargeInPredicateOperator` conjuncts for IN lists above `large_in_predicate_threshold`. Before this change, it threw `UnsupportedOperationException` during split planning and failed the whole query. The BE still evaluates the conjunct row by row as before.

## Tests

- `PaimonRuntimePredicatesTest` (java-extensions): tests wire-format decoding for integers, strings, and dates; minmax and IN records; exact byte handling for 0xff string sentinels and 4-byte UTF-8 values; unparseable and unsupported records are skipped without failing; TIMESTAMP records are skipped in v1.
- `PaimonPredicateConverterTest` (fe-core): large IN lists are dropped instead of throwing; existing conversions are unchanged.
- End-to-end verification on a live cluster with a patched BE+FE build: confirmed the benchmark numbers above; static-predicate behavior is unchanged.

Fixes #N/A

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

