### PR TITLE
[Enhancement] Support reading Paimon VARIANT columns through the native reader

### DIFF
--- a/docs/en/data_source/catalog/paimon_catalog.md
+++ b/docs/en/data_source/catalog/paimon_catalog.md
@@ -49,6 +49,11 @@ You can only use Paimon catalogs to query data. You cannot use Paimon catalogs t
 | `ARRAY`               | `ARRAY<element_type>`       |
 | `MAP`                 | `MAP<key_type, value_type>` |
 | `ROW/STRUCT`          | `STRUCT<field1:type1, ...>` |
+| `VARIANT`             | `VARIANT`                   |
+
+:::note
+`VARIANT` is supported from v4.2 onwards for splits read by the native reader (append-only tables and compacted primary-key data). Reading `VARIANT` from uncompacted primary-key data requires the JNI reader and is not yet supported.
+:::
 
 ## Integration preparations
 

--- a/docs/en/data_source/catalog/paimon_catalog.md
+++ b/docs/en/data_source/catalog/paimon_catalog.md
@@ -52,7 +52,7 @@ You can only use Paimon catalogs to query data. You cannot use Paimon catalogs t
 | `VARIANT`             | `VARIANT`                   |
 
 :::note
-`VARIANT` is supported from v4.2 onwards for splits read by the native reader (append-only tables and compacted primary-key data). Reading `VARIANT` from uncompacted primary-key data requires the JNI reader and is not yet supported.
+`VARIANT` is supported from v4.2 onwards for splits read by the native reader (append-only tables and compacted primary-key data). Reading `VARIANT` from uncompacted primary-key data requires the JNI reader and is not yet supported; such queries are rejected with a plan-time error.
 :::
 
 ## Integration preparations

--- a/docs/en/sql-reference/data-types/semi_structured/VARIANT.md
+++ b/docs/en/sql-reference/data-types/semi_structured/VARIANT.md
@@ -1,15 +1,17 @@
 ---
 displayed_sidebar: docs
-description: "The VARIANT type is supported only for tables in Iceberg Catalog."
+description: "The VARIANT type is supported only for tables in Iceberg Catalog and Paimon Catalog."
 ---
 
 # VARIANT
 
 :::important
-The VARIANT type is supported only for tables in Iceberg Catalog. It is not supported by StarRocks native tables.
+The VARIANT type is supported only for tables in Iceberg Catalog and Paimon Catalog. It is not supported by StarRocks native tables.
+
+For Paimon Catalog, VARIANT is supported from v4.2 onwards for splits read by the native reader (append-only tables and compacted primary-key data). Reading VARIANT from uncompacted primary-key data requires the JNI reader and is not yet supported.
 :::
 
-From v4.1 onwards, StarRocks supports the VARIANT data type for querying semi-structured data from Iceberg tables in Parquet format. This article introduces the basic concepts of VARIANT, and how StarRocks queries VARIANT-type data and processes it through VARIANT functions.
+From v4.1 onwards, StarRocks supports the VARIANT data type for querying semi-structured data from Iceberg tables in Parquet format. From v4.2 onwards, StarRocks also supports the VARIANT data type for querying semi-structured data from Paimon tables. This article introduces the basic concepts of VARIANT, and how StarRocks queries VARIANT-type data and processes it through VARIANT functions.
 
 ## What is VARIANT
 
@@ -188,6 +190,7 @@ When data is read from Parquet files with variant encoding, the following type c
 ## Limitations and Considerations
 
 - VARIANT is supported for reading data from Iceberg tables in Parquet format with variant encoding, and for writing Parquet files using StarRocks file writers (unshredded variant encoding).
+- VARIANT is also supported for reading data from Paimon tables (Paimon requires Parquet for variant columns), but only for splits read by the native reader (append-only tables and compacted primary-key data). Reading VARIANT from uncompacted primary-key data requires the JNI reader and is not yet supported.
 - The size of a VARIANT value is limited to 16 MB.
 - Currently only unshredded variant values are supported for both read and write.
 - VARIANT can be created by casting from JSON values or supported SQL types (including ARRAY, MAP, and STRUCT).

--- a/docs/en/sql-reference/data-types/semi_structured/VARIANT.md
+++ b/docs/en/sql-reference/data-types/semi_structured/VARIANT.md
@@ -7,8 +7,6 @@ description: "The VARIANT type is supported only for tables in Iceberg Catalog a
 
 :::important
 The VARIANT type is supported only for tables in Iceberg Catalog and Paimon Catalog. It is not supported by StarRocks native tables.
-
-For Paimon Catalog, VARIANT is supported from v4.2 onwards for splits read by the native reader (append-only tables and compacted primary-key data). Reading VARIANT from uncompacted primary-key data requires the JNI reader and is not yet supported.
 :::
 
 From v4.1 onwards, StarRocks supports the VARIANT data type for querying semi-structured data from Iceberg tables in Parquet format. From v4.2 onwards, StarRocks also supports the VARIANT data type for querying semi-structured data from Paimon tables. This article introduces the basic concepts of VARIANT, and how StarRocks queries VARIANT-type data and processes it through VARIANT functions.
@@ -190,7 +188,7 @@ When data is read from Parquet files with variant encoding, the following type c
 ## Limitations and Considerations
 
 - VARIANT is supported for reading data from Iceberg tables in Parquet format with variant encoding, and for writing Parquet files using StarRocks file writers (unshredded variant encoding).
-- VARIANT is also supported for reading data from Paimon tables (Paimon requires Parquet for variant columns), but only for splits read by the native reader (append-only tables and compacted primary-key data). Reading VARIANT from uncompacted primary-key data requires the JNI reader and is not yet supported.
+- VARIANT is also supported for reading data from Paimon tables (Paimon requires Parquet for variant columns), but only for splits read by the native reader (append-only tables and compacted primary-key data). Reading VARIANT from uncompacted primary-key data requires the JNI reader and is not yet supported; such queries are rejected with a plan-time error.
 - The size of a VARIANT value is limited to 16 MB.
 - Currently only unshredded variant values are supported for both read and write.
 - VARIANT can be created by casting from JSON values or supported SQL types (including ARRAY, MAP, and STRUCT).

--- a/docs/ja/data_source/catalog/paimon_catalog.md
+++ b/docs/ja/data_source/catalog/paimon_catalog.md
@@ -49,6 +49,11 @@ Paimon catalog はデータのクエリにのみ使用できます。Paimon cata
 | `ARRAY`               | `ARRAY<element_type>`       |
 | `MAP`                 | `MAP<key_type, value_type>` |
 | `ROW/STRUCT`          | `STRUCT<field1:type1, ...>` |
+| `VARIANT`             | `VARIANT`                   |
+
+:::note
+`VARIANT` はv4.2以降、ネイティブリーダーで読み取られるsplit（Append-Onlyテーブル、およびPrimary KeyテーブルのCompaction済みデータ）でのみサポートされています。Compaction前のPrimary Keyデータから`VARIANT`を読み取るにはJNIリーダーが必要であり、現時点ではまだサポートされていません。
+:::
 
 ## 統合準備
 

--- a/docs/ja/data_source/catalog/paimon_catalog.md
+++ b/docs/ja/data_source/catalog/paimon_catalog.md
@@ -52,7 +52,7 @@ Paimon catalog はデータのクエリにのみ使用できます。Paimon cata
 | `VARIANT`             | `VARIANT`                   |
 
 :::note
-`VARIANT` はv4.2以降、ネイティブリーダーで読み取られるsplit（Append-Onlyテーブル、およびPrimary KeyテーブルのCompaction済みデータ）でのみサポートされています。Compaction前のPrimary Keyデータから`VARIANT`を読み取るにはJNIリーダーが必要であり、現時点ではまだサポートされていません。
+`VARIANT` はv4.2以降、ネイティブリーダーで読み取られるsplit（Append-Onlyテーブル、およびPrimary KeyテーブルのCompaction済みデータ）でのみサポートされています。Compaction前のPrimary Keyデータから`VARIANT`を読み取るにはJNIリーダーが必要であり、現時点ではまだサポートされていません。該当するクエリはプランニング時にエラーとして拒否されます。
 :::
 
 ## 統合準備

--- a/docs/ja/sql-reference/data-types/semi_structured/VARIANT.md
+++ b/docs/ja/sql-reference/data-types/semi_structured/VARIANT.md
@@ -1,15 +1,17 @@
 ---
 displayed_sidebar: docs
-description: "VARIANTタイプは、Iceberg Catalogのテーブルにのみサポートされています。"
+description: "VARIANTタイプは、Iceberg CatalogおよびPaimon Catalogのテーブルにのみサポートされています。"
 ---
 
 # VARIANT
 
 :::important
-VARIANT型はIceberg Catalogのテーブルでのみサポートされています。StarRocksネイティブテーブルではサポートされていません。
+VARIANT型はIceberg CatalogおよびPaimon Catalogのテーブルでのみサポートされています。StarRocksネイティブテーブルではサポートされていません。
+
+Paimon Catalogについては、VARIANTはv4.2以降、ネイティブリーダーで読み取られるsplit（Append-Onlyテーブル、およびPrimary KeyテーブルのCompaction済みデータ）でのみサポートされています。Compaction前のPrimary KeyデータからVARIANTを読み取るにはJNIリーダーが必要であり、現時点ではまだサポートされていません。
 :::
 
-v4.1以降、StarRocksはParquet形式のIcebergテーブルから半構造化データをクエリするためのVARIANTデータ型をサポートしています。この記事では、VARIANTの基本概念と、StarRocksがVARIANT型データをクエリしてVARIANT関数で処理する方法を紹介します。
+v4.1以降、StarRocksはParquet形式のIcebergテーブルから半構造化データをクエリするためのVARIANTデータ型をサポートしています。v4.2以降、StarRocksはPaimonテーブルの半構造化データをクエリするためのVARIANTデータ型もサポートしています。この記事では、VARIANTの基本概念と、StarRocksがVARIANT型データをクエリしてVARIANT関数で処理する方法を紹介します。
 
 ## VARIANTとは
 
@@ -188,6 +190,7 @@ $.config["key"]        -- Map-style access
 ## 制限事項と注意点
 
 - VARIANTは、バリアントエンコーディングを使用したParquet形式のIcebergテーブルからのデータ読み取り、およびStarRocksファイルライター（非シュレッドバリアントエンコーディング）を使用したParquetファイルへの書き込みに対応しています。
+- VARIANTは、Paimonテーブルからのデータ読み取りにも対応しています（Paimonではvariant列はParquet形式での格納が必須です）が、ネイティブリーダーで読み取られるsplit（Append-Onlyテーブル、およびPrimary KeyテーブルのCompaction済みデータ）でのみサポートされています。Compaction前のPrimary KeyデータからVARIANTを読み取るにはJNIリーダーが必要であり、現時点ではまだサポートされていません。
 - VARIANT値のサイズは16 MBに制限されています。
 - 現在、読み取りと書き込みの両方において、非シュレッドバリアント値のみがサポートされています。
 - VARIANTは、JSON値またはサポートされているSQLタイプ（ARRAY、MAP、STRUCTを含む）からのキャストによって作成できます。

--- a/docs/ja/sql-reference/data-types/semi_structured/VARIANT.md
+++ b/docs/ja/sql-reference/data-types/semi_structured/VARIANT.md
@@ -7,8 +7,6 @@ description: "VARIANTタイプは、Iceberg CatalogおよびPaimon Catalogのテ
 
 :::important
 VARIANT型はIceberg CatalogおよびPaimon Catalogのテーブルでのみサポートされています。StarRocksネイティブテーブルではサポートされていません。
-
-Paimon Catalogについては、VARIANTはv4.2以降、ネイティブリーダーで読み取られるsplit（Append-Onlyテーブル、およびPrimary KeyテーブルのCompaction済みデータ）でのみサポートされています。Compaction前のPrimary KeyデータからVARIANTを読み取るにはJNIリーダーが必要であり、現時点ではまだサポートされていません。
 :::
 
 v4.1以降、StarRocksはParquet形式のIcebergテーブルから半構造化データをクエリするためのVARIANTデータ型をサポートしています。v4.2以降、StarRocksはPaimonテーブルの半構造化データをクエリするためのVARIANTデータ型もサポートしています。この記事では、VARIANTの基本概念と、StarRocksがVARIANT型データをクエリしてVARIANT関数で処理する方法を紹介します。
@@ -190,7 +188,7 @@ $.config["key"]        -- Map-style access
 ## 制限事項と注意点
 
 - VARIANTは、バリアントエンコーディングを使用したParquet形式のIcebergテーブルからのデータ読み取り、およびStarRocksファイルライター（非シュレッドバリアントエンコーディング）を使用したParquetファイルへの書き込みに対応しています。
-- VARIANTは、Paimonテーブルからのデータ読み取りにも対応しています（Paimonではvariant列はParquet形式での格納が必須です）が、ネイティブリーダーで読み取られるsplit（Append-Onlyテーブル、およびPrimary KeyテーブルのCompaction済みデータ）でのみサポートされています。Compaction前のPrimary KeyデータからVARIANTを読み取るにはJNIリーダーが必要であり、現時点ではまだサポートされていません。
+- VARIANTは、Paimonテーブルからのデータ読み取りにも対応しています（Paimonではvariant列はParquet形式での格納が必須です）が、ネイティブリーダーで読み取られるsplit（Append-Onlyテーブル、およびPrimary KeyテーブルのCompaction済みデータ）でのみサポートされています。Compaction前のPrimary KeyデータからVARIANTを読み取るにはJNIリーダーが必要であり、現時点ではまだサポートされていません。該当するクエリはプランニング時にエラーとして拒否されます。
 - VARIANT値のサイズは16 MBに制限されています。
 - 現在、読み取りと書き込みの両方において、非シュレッドバリアント値のみがサポートされています。
 - VARIANTは、JSON値またはサポートされているSQLタイプ（ARRAY、MAP、STRUCTを含む）からのキャストによって作成できます。

--- a/docs/zh/data_source/catalog/paimon_catalog.md
+++ b/docs/zh/data_source/catalog/paimon_catalog.md
@@ -49,6 +49,11 @@ Paimon catalog 仅支持查询数据，不支持通过 Paimon catalog 在 Paimon
 | `ARRAY`               | `ARRAY<element_type>`       |
 | `MAP`                 | `MAP<key_type, value_type>` |
 | `ROW/STRUCT`          | `STRUCT<field1:type1, ...>` |
+| `VARIANT`             | `VARIANT`                   |
+
+:::note
+`VARIANT` 从 v4.2 版本起支持，且仅支持由 Native Reader 读取的 split（Append-Only 表以及 Primary Key 表中已完成 Compaction 的数据）。从尚未 Compaction 的 Primary Key 数据中读取 `VARIANT` 需要使用 JNI Reader，目前尚不支持。
+:::
 
 ## 集成准备
 

--- a/docs/zh/data_source/catalog/paimon_catalog.md
+++ b/docs/zh/data_source/catalog/paimon_catalog.md
@@ -52,7 +52,7 @@ Paimon catalog 仅支持查询数据，不支持通过 Paimon catalog 在 Paimon
 | `VARIANT`             | `VARIANT`                   |
 
 :::note
-`VARIANT` 从 v4.2 版本起支持，且仅支持由 Native Reader 读取的 split（Append-Only 表以及 Primary Key 表中已完成 Compaction 的数据）。从尚未 Compaction 的 Primary Key 数据中读取 `VARIANT` 需要使用 JNI Reader，目前尚不支持。
+`VARIANT` 从 v4.2 版本起支持，且仅支持由 Native Reader 读取的 split（Append-Only 表以及 Primary Key 表中已完成 Compaction 的数据）。从尚未 Compaction 的 Primary Key 数据中读取 `VARIANT` 需要使用 JNI Reader，目前尚不支持，此类查询会在 Plan 阶段报错并被拒绝执行。
 :::
 
 ## 集成准备

--- a/docs/zh/sql-reference/data-types/semi_structured/VARIANT.md
+++ b/docs/zh/sql-reference/data-types/semi_structured/VARIANT.md
@@ -1,15 +1,17 @@
 ---
 displayed_sidebar: docs
-description: "VARIANT 类型仅支持 Iceberg Catalog 中的表。"
+description: "VARIANT 类型仅支持 Iceberg Catalog 和 Paimon Catalog 中的表。"
 ---
 
 # VARIANT
 
 :::important
-VARIANT 类型仅支持 Iceberg Catalog 中的表，不支持 StarRocks 原生表。
+VARIANT 类型仅支持 Iceberg Catalog 和 Paimon Catalog 中的表，不支持 StarRocks 原生表。
+
+对于 Paimon Catalog，VARIANT 从 v4.2 版本起支持，且仅支持由 Native Reader 读取的 split（Append-Only 表以及 Primary Key 表中已完成 Compaction 的数据）。从尚未 Compaction 的 Primary Key 数据中读取 VARIANT 需要使用 JNI Reader，目前尚不支持。
 :::
 
-从 v4.1 版本起，StarRocks 支持 VARIANT 数据类型，用于查询 Parquet 格式的 Iceberg 表中的半结构化数据。本文介绍 VARIANT 的基本概念，以及 StarRocks 如何查询 VARIANT 类型数据并通过 VARIANT 函数对其进行处理。
+从 v4.1 版本起，StarRocks 支持 VARIANT 数据类型，用于查询 Parquet 格式的 Iceberg 表中的半结构化数据。从 v4.2 版本起，StarRocks 还支持查询 Paimon 表中的 VARIANT 半结构化数据。本文介绍 VARIANT 的基本概念，以及 StarRocks 如何查询 VARIANT 类型数据并通过 VARIANT 函数对其进行处理。
 
 ## 什么是 VARIANT
 
@@ -188,6 +190,7 @@ $.config["key"]        -- Map-style access
 ## 限制与注意事项
 
 - VARIANT 支持从 Parquet 格式的 Iceberg 表中读取具有 variant 编码的数据，以及使用 StarRocks 文件写入器写入 Parquet 文件（非分片 variant 编码）。
+- VARIANT 也支持从 Paimon 表中读取数据（Paimon 要求 variant 列必须以 Parquet 格式存储），但仅支持由 Native Reader 读取的 split（Append-Only 表以及 Primary Key 表中已完成 Compaction 的数据）。从尚未 Compaction 的 Primary Key 数据中读取 VARIANT 需要使用 JNI Reader，目前尚不支持。
 - VARIANT 值的大小限制为 16 MB。
 - 目前读写均仅支持非分片 variant 值。
 - VARIANT 可通过从 JSON 值或支持的 SQL 类型（包括 ARRAY、MAP 和 STRUCT）进行类型转换来创建。

--- a/docs/zh/sql-reference/data-types/semi_structured/VARIANT.md
+++ b/docs/zh/sql-reference/data-types/semi_structured/VARIANT.md
@@ -7,8 +7,6 @@ description: "VARIANT 类型仅支持 Iceberg Catalog 和 Paimon Catalog 中的�
 
 :::important
 VARIANT 类型仅支持 Iceberg Catalog 和 Paimon Catalog 中的表，不支持 StarRocks 原生表。
-
-对于 Paimon Catalog，VARIANT 从 v4.2 版本起支持，且仅支持由 Native Reader 读取的 split（Append-Only 表以及 Primary Key 表中已完成 Compaction 的数据）。从尚未 Compaction 的 Primary Key 数据中读取 VARIANT 需要使用 JNI Reader，目前尚不支持。
 :::
 
 从 v4.1 版本起，StarRocks 支持 VARIANT 数据类型，用于查询 Parquet 格式的 Iceberg 表中的半结构化数据。从 v4.2 版本起，StarRocks 还支持查询 Paimon 表中的 VARIANT 半结构化数据。本文介绍 VARIANT 的基本概念，以及 StarRocks 如何查询 VARIANT 类型数据并通过 VARIANT 函数对其进行处理。
@@ -190,7 +188,7 @@ $.config["key"]        -- Map-style access
 ## 限制与注意事项
 
 - VARIANT 支持从 Parquet 格式的 Iceberg 表中读取具有 variant 编码的数据，以及使用 StarRocks 文件写入器写入 Parquet 文件（非分片 variant 编码）。
-- VARIANT 也支持从 Paimon 表中读取数据（Paimon 要求 variant 列必须以 Parquet 格式存储），但仅支持由 Native Reader 读取的 split（Append-Only 表以及 Primary Key 表中已完成 Compaction 的数据）。从尚未 Compaction 的 Primary Key 数据中读取 VARIANT 需要使用 JNI Reader，目前尚不支持。
+- VARIANT 也支持从 Paimon 表中读取数据（Paimon 要求 variant 列必须以 Parquet 格式存储），但仅支持由 Native Reader 读取的 split（Append-Only 表以及 Primary Key 表中已完成 Compaction 的数据）。从尚未 Compaction 的 Primary Key 数据中读取 VARIANT 需要使用 JNI Reader，目前尚不支持，此类查询会在 Plan 阶段报错并被拒绝执行。
 - VARIANT 值的大小限制为 16 MB。
 - 目前读写均仅支持非分片 variant 值。
 - VARIANT 可通过从 JSON 值或支持的 SQL 类型（包括 ARRAY、MAP 和 STRUCT）进行类型转换来创建。

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
@@ -597,6 +597,10 @@ public class ColumnTypeConverter {
             return new StructType(structFields);
         }
 
+        public Type visit(org.apache.paimon.types.VariantType variantType) {
+            return VariantType.VARIANT;
+        }
+
         @Override
         protected Type defaultMethod(org.apache.paimon.types.DataType dataType) {
             return UNKNOWN_TYPE;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
@@ -597,10 +597,6 @@ public class ColumnTypeConverter {
             return new StructType(structFields);
         }
 
-        public Type visit(org.apache.paimon.types.VariantType variantType) {
-            return VariantType.VARIANT;
-        }
-
         @Override
         protected Type defaultMethod(org.apache.paimon.types.DataType dataType) {
             return UNKNOWN_TYPE;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
@@ -170,11 +170,11 @@ public class PaimonScanNode extends ScanNode {
                         }
                     } else {
                         long totalFileLength = getTotalFileLength(dataSplit);
-                        addSplitScanRangeLocations(dataSplit, predicateInfo, totalFileLength);
+                        addJNISplitScanRangeLocations(dataSplit, predicateInfo, totalFileLength);
                     }
                 } else {
                     long totalFileLength = getTotalFileLength(dataSplit);
-                    addSplitScanRangeLocations(dataSplit, predicateInfo, totalFileLength);
+                    addJNISplitScanRangeLocations(dataSplit, predicateInfo, totalFileLength);
                 }
                 BinaryRow partitionValue = dataSplit.partition();
                 if (!selectedPartitions.containsKey(partitionValue)) {
@@ -183,7 +183,7 @@ public class PaimonScanNode extends ScanNode {
             } else {
                 // paimon system table
                 long length = getEstimatedLength(split.rowCount(), tupleDescriptor);
-                addSplitScanRangeLocations(split, predicateInfo, length);
+                addJNISplitScanRangeLocations(split, predicateInfo, length);
             }
 
         }
@@ -325,7 +325,7 @@ public class PaimonScanNode extends ScanNode {
         }
     }
 
-    public void addSplitScanRangeLocations(Split split, String predicateInfo, long totalFileLength) {
+    public void addJNISplitScanRangeLocations(Split split, String predicateInfo, long totalFileLength) {
         checkJniReaderVariantSupport(desc);
         TScanRangeLocations scanRangeLocations = new TScanRangeLocations();
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
@@ -25,6 +25,7 @@ import com.starrocks.connector.CatalogConnector;
 import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.RemoteFileInfo;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.paimon.PaimonRemoteFileDesc;
 import com.starrocks.connector.paimon.PaimonSplitsInfo;
 import com.starrocks.credential.CloudConfiguration;
@@ -311,7 +312,21 @@ public class PaimonScanNode extends ScanNode {
         scanRangeLocationsList.add(scanRangeLocations);
     }
 
+    static void checkJniReaderVariantSupport(TupleDescriptor tupleDescriptor) {
+        for (SlotDescriptor slot : tupleDescriptor.getSlots()) {
+            if (slot.getType().containsVariant()) {
+                throw new StarRocksConnectorException(
+                        "Paimon VARIANT column '%s' requires the native reader, but this split must use the JNI " +
+                        "reader (merge-on-read data, system table, or paimon_force_jni_reader=true). Reading " +
+                        "VARIANT through the Paimon JNI reader is not yet supported. Compact the table or " +
+                        "exclude the VARIANT column from the query.",
+                        slot.getColumn() != null ? slot.getColumn().getName() : slot.getLabel());
+            }
+        }
+    }
+
     public void addSplitScanRangeLocations(Split split, String predicateInfo, long totalFileLength) {
+        checkJniReaderVariantSupport(desc);
         TScanRangeLocations scanRangeLocations = new TScanRangeLocations();
 
         THdfsScanRange hdfsScanRange = new THdfsScanRange();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonColumnConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonColumnConverterTest.java
@@ -361,13 +361,6 @@ public class PaimonColumnConverterTest {
     }
 
     @Test
-    public void testConvertVariant() {
-        org.apache.paimon.types.VariantType paimonType = new org.apache.paimon.types.VariantType();
-        Type result = ColumnTypeConverter.fromPaimonType(paimonType);
-        Assertions.assertEquals(com.starrocks.type.VariantType.VARIANT, result);
-    }
-
-    @Test
     public void testConvertArrayOfVariant() {
         org.apache.paimon.types.ArrayType paimonType =
                 new org.apache.paimon.types.ArrayType(new org.apache.paimon.types.VariantType());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonColumnConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonColumnConverterTest.java
@@ -359,4 +359,28 @@ public class PaimonColumnConverterTest {
         Assertions.assertFalse(((ScalarType) result).isDatetimeNtz());
         Assertions.assertEquals(DateType.DATETIME, result);
     }
+
+    @Test
+    public void testConvertVariant() {
+        org.apache.paimon.types.VariantType paimonType = new org.apache.paimon.types.VariantType();
+        Type result = ColumnTypeConverter.fromPaimonType(paimonType);
+        Assertions.assertEquals(com.starrocks.type.VariantType.VARIANT, result);
+    }
+
+    @Test
+    public void testConvertArrayOfVariant() {
+        org.apache.paimon.types.ArrayType paimonType =
+                new org.apache.paimon.types.ArrayType(new org.apache.paimon.types.VariantType());
+        Type result = ColumnTypeConverter.fromPaimonType(paimonType);
+        Assertions.assertTrue(result.isArrayType());
+        Assertions.assertTrue(result.containsVariant());
+    }
+
+    @Test
+    public void testConvertMultisetStaysUnknown() {
+        org.apache.paimon.types.MultisetType paimonType =
+                new org.apache.paimon.types.MultisetType(new org.apache.paimon.types.IntType());
+        Type result = ColumnTypeConverter.fromPaimonType(paimonType);
+        Assertions.assertEquals(com.starrocks.type.UnknownType.UNKNOWN_TYPE, result);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/PaimonScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/PaimonScanNodeTest.java
@@ -155,7 +155,7 @@ public class PaimonScanNodeTest {
         DeletionFile deletionFile = new DeletionFile("dummy", 1, 22, 0L);
         scanNode.splitRawFileScanRangeLocations(rawFile, deletionFile);
         scanNode.splitScanRangeLocations(rawFile, 0, 256 * 1024 * 1024, 64 * 1024 * 1024, null);
-        scanNode.addSplitScanRangeLocations(split, null, 256 * 1024 * 1024);
+        scanNode.addJNISplitScanRangeLocations(split, null, 256 * 1024 * 1024);
         Assertions.assertEquals(6, scanNode.getScanRangeLocations(10).size());
     }
 
@@ -182,7 +182,7 @@ public class PaimonScanNodeTest {
         TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
         desc.setTable(table);
         PaimonScanNode scanNode = new PaimonScanNode(new PlanNodeId(0), desc, "XXX");
-        scanNode.addSplitScanRangeLocations(split, null, 256 * 1024 * 1024);
+        scanNode.addJNISplitScanRangeLocations(split, null, 256 * 1024 * 1024);
         Assertions.assertEquals(1, scanNode.getScanRangeLocations(10).size());
         TScanRangeLocations tScanRangeLocations = scanNode.getScanRangeLocations(10).get(0);
         Assertions.assertEquals(THdfsFileFormat.UNKNOWN, tScanRangeLocations.getScan_range().getHdfs_scan_range().getFile_format());

--- a/fe/fe-core/src/test/java/com/starrocks/planner/PaimonScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/PaimonScanNodeTest.java
@@ -17,6 +17,7 @@ package com.starrocks.planner;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.PaimonTable;
 import com.starrocks.connector.CatalogConnector;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationFactory;
 import com.starrocks.qe.ConnectContext;
@@ -210,5 +211,27 @@ public class PaimonScanNodeTest {
         PaimonScanNode scanNode = new PaimonScanNode(new PlanNodeId(0), desc, "XXX");
         scanNode.splitRawFileScanRangeLocations(rawFile, null);
         Assertions.assertEquals(2, scanNode.getScanRangeLocations(10).size());
+    }
+
+    @Test
+    public void testJniReaderRejectsVariantSlot() {
+        TupleDescriptor tuple = new TupleDescriptor(new TupleId(0));
+        SlotDescriptor slot = new SlotDescriptor(new SlotId(0), tuple);
+        slot.setType(com.starrocks.type.VariantType.VARIANT);
+        slot.setColumn(new Column("v", com.starrocks.type.VariantType.VARIANT));
+        tuple.addSlot(slot);
+        StarRocksConnectorException e = Assertions.assertThrows(StarRocksConnectorException.class,
+                () -> PaimonScanNode.checkJniReaderVariantSupport(tuple));
+        Assertions.assertTrue(e.getMessage().contains("VARIANT"));
+    }
+
+    @Test
+    public void testJniReaderAllowsNonVariantSlots() {
+        TupleDescriptor tuple = new TupleDescriptor(new TupleId(0));
+        SlotDescriptor slot = new SlotDescriptor(new SlotId(0), tuple);
+        slot.setType(IntegerType.INT); // same constant PaimonColumnConverterTest asserts against
+        slot.setColumn(new Column("i", IntegerType.INT));
+        tuple.addSlot(slot);
+        Assertions.assertDoesNotThrow(() -> PaimonScanNode.checkJniReaderVariantSupport(tuple));
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Paimon supports the Parquet-backed VARIANT type. However, StarRocks' Paimon type converter does not map `org.apache.paimon.types.VariantType`. Because of this, variant columns appear as unknown types and cannot be queried.

StarRocks can already read VARIANT from Parquet directly through Iceberg VARIANT support in v4.1. Paimon splits that use the native reader use the same Parquet reading code. This means most of the read path already works after the type is mapped correctly.

There is one exception. Some splits must use the JNI reader. These include uncompacted primary-key data read with merge-on-read, system tables, and queries with `paimon_force_jni_reader=true`. The JNI bridge does not support a variant representation yet. Without a guard, these queries would fail deep inside the scanner with an unclear error.

## What I'm doing:

- Map Paimon `VariantType` to StarRocks `VARIANT` in `ColumnTypeConverter`. This also supports nested uses, such as arrays of variant.
- Make reads through the native reader work from start to finish with the existing Parquet variant code. This includes append-only tables and compacted primary-key data.
- Make `PaimonScanNode` reject VARIANT slots at plan time when splits use the JNI reader. The clear error names the column and tells the user to compact the table or remove the column from the query. This avoids a runtime failure inside the scanner.
- Update the Paimon catalog page and the VARIANT type page in en/zh/ja.

JNI-reader support will remove the plan-time restriction. It will be added in a follow-up PR built on this one.

## Tests

- `PaimonColumnConverterTest`: variant maps to VARIANT, array-of-variant maps to an array containing variant, and multiset stays unknown.
- `PaimonScanNodeTest`: the plan-time guard runs for VARIANT slots on JNI-routed splits and does nothing otherwise.

Fixes #N/A

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)