### PR TITLE
[Enhancement] Bound and coalesce small remote reads on the cloud-native scan path

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1325,6 +1325,9 @@ CONF_Strings(s3_compatible_fs_list, "s3n://, s3a://, s3://, oss://, cos://, cosn
 CONF_mBool(s3_use_list_objects_v1, "false");
 
 // Lake
+// Force page-range coalescing on for every cloud-native scan read. Off, coalescing is still
+// used wherever the size of the read is ours to choose rather than dictated by the datacache's
+// block layout -- see should_enable_io_coalesce_lake_read().
 CONF_mBool(io_coalesce_lake_read_enable, "false");
 
 // orc reader
@@ -1497,6 +1500,23 @@ CONF_mBool(starlet_write_file_with_tag, "false");
 CONF_mInt64(lake_metadata_cache_limit, /*2GB=*/"2147483648");
 CONF_mBool(lake_print_delete_log, "false");
 CONF_mInt64(lake_compaction_stream_buffer_size_bytes, "1048576"); // 1MB
+
+// Lower bound on the size of a remote read issued by the cloud-native scan path: the segment
+// footer, the short-key index, and each column's index and data pages. A read already this
+// large is issued unchanged, so this never splits a read; it only keeps a small one from being
+// served by an oversized fetch. The scan asks for exact page ranges, so a large read-ahead
+// only rounds every request up and fetches bytes the scan never looks at. Lowering the bound
+// trades more requests for less read bandwidth.
+//
+// Supplies the value when LakeIOOptions::buffer_size is left at -1, which the query scan path
+// always does, overriding starlet_fs_stream_buffer_size_bytes for those reads. Callers that
+// pick their own size, compaction among them, are unaffected; callers that leave it unset,
+// such as segment rewrite, follow this value too. Applies only where the datacache is not
+// already rounding reads out to whole blocks -- see lake_scan_buffer_size().
+//     > 0   use this many bytes
+//    == 0   do not buffer: issue every read at exactly its requested size
+//     < 0   inherit starlet_fs_stream_buffer_size_bytes
+CONF_mInt64(lake_scan_min_remote_read_bytes, "131072"); // 128KB
 // The interval to check whether lake compaction is valid. Set to <= 0 to disable the check.
 CONF_mInt32(lake_compaction_check_valid_interval_minutes, "10"); // 10 minutes
 // Minimum elapsed time in milliseconds for logging a completed lake compaction attempt or parallel subtask profile.

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -514,6 +514,7 @@
         "tablet_internal_parallel_min_scan_dop",
         "max_hdfs_file_handle",
         "io_coalesce_lake_read_enable",
+        "lake_scan_min_remote_read_bytes",
         "enable_orc_late_materialization",
         "orc_tiny_stripe_threshold_size",
         "orc_loading_buffer_size",

--- a/be/src/common/config_scan_io_fwd.h
+++ b/be/src/common/config_scan_io_fwd.h
@@ -87,6 +87,9 @@ CONF_mInt64(lake_prepared_split_max_splitted_scan_rows, "262144");
 CONF_mInt32(max_hdfs_file_handle, "1000");
 
 // Lake
+// Force page-range coalescing on for every cloud-native scan read. Off, coalescing is still
+// used wherever the size of the read is ours to choose rather than dictated by the datacache's
+// block layout -- see should_enable_io_coalesce_lake_read().
 CONF_mBool(io_coalesce_lake_read_enable, "false");
 
 // orc reader
@@ -159,6 +162,23 @@ CONF_Int32(connector_io_tasks_adjust_smooth, "4");
 CONF_mDouble(scan_use_query_mem_ratio, "0.25");
 
 CONF_Double(connector_scan_use_query_mem_ratio, "0.3");
+
+// Lower bound on the size of a remote read issued by the cloud-native scan path: the segment
+// footer, the short-key index, and each column's index and data pages. A read already this
+// large is issued unchanged, so this never splits a read; it only keeps a small one from being
+// served by an oversized fetch. The scan asks for exact page ranges, so a large read-ahead
+// only rounds every request up and fetches bytes the scan never looks at. Lowering the bound
+// trades more requests for less read bandwidth.
+//
+// Supplies the value when LakeIOOptions::buffer_size is left at -1, which the query scan path
+// always does, overriding starlet_fs_stream_buffer_size_bytes for those reads. Callers that
+// pick their own size, compaction among them, are unaffected; callers that leave it unset,
+// such as segment rewrite, follow this value too. Applies only where the datacache is not
+// already rounding reads out to whole blocks -- see lake_scan_buffer_size().
+//     > 0   use this many bytes
+//    == 0   do not buffer: issue every read at exactly its requested size
+//     < 0   inherit starlet_fs_stream_buffer_size_bytes
+CONF_mInt64(lake_scan_min_remote_read_bytes, "131072"); // 128KB
 
 // If your sort key cardinality is very high,
 // You could enable this config to speed up the point lookup query,

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -50,6 +50,7 @@ set(STORAGE_FILES
     kv_store.cpp
     local_tablet_reader.cpp
     olap_server.cpp
+    options.cpp
     persistent_index.cpp
     primary_index.cpp
     query/bucket_sequence_morsel_queue.cpp

--- a/be/src/storage/options.cpp
+++ b/be/src/storage/options.cpp
@@ -1,0 +1,59 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/options.h"
+
+#include "common/config_scan_io_fwd.h"
+
+namespace starrocks {
+
+namespace {
+
+// True when cachefs will fetch a whole starlet_star_cache_block_size_bytes block to serve this
+// read, which makes the size of the request that reaches the object store not ours to choose.
+// Two cases escape that: the read bypasses cachefs outright, or it goes through cachefs with
+// nothing to cache and so reads just the bytes asked for.
+bool reads_whole_cache_blocks(const LakeIOOptions& lake_io_opts) {
+    return !lake_io_opts.skip_disk_cache && lake_io_opts.fill_data_cache;
+}
+
+} // namespace
+
+int64_t lake_scan_buffer_size(const LakeIOOptions& lake_io_opts) {
+    if (lake_io_opts.buffer_size >= 0) {
+        return lake_io_opts.buffer_size;
+    }
+    // Where the request size is block-aligned for us, a smaller bound buys nothing: leave the
+    // size to starlet, as before. Where it is ours to choose, choosing it smaller cuts read
+    // bandwidth, because the scan asks for exact page ranges and a large read-ahead only rounds
+    // every request up and fetches bytes the scan never looks at.
+    if (reads_whole_cache_blocks(lake_io_opts)) {
+        return -1;
+    }
+    return config::lake_scan_min_remote_read_bytes;
+}
+
+bool should_enable_io_coalesce_lake_read(const LakeIOOptions& lake_io_opts) {
+    if (config::io_coalesce_lake_read_enable) {
+        return true;
+    }
+    // Coalescing merges a column's page ranges into fewer, larger reads, which is only
+    // something we can do where the request size is ours to choose in the first place. Those
+    // are exactly the reads lake_scan_min_remote_read_bytes bounds, and it is the same reads
+    // that pay for that smaller bound in request count -- merging them back up is what keeps
+    // the bound from being a trade.
+    return !reads_whole_cache_blocks(lake_io_opts);
+}
+
+} // namespace starrocks

--- a/be/src/storage/options.h
+++ b/be/src/storage/options.h
@@ -82,4 +82,16 @@ struct LakeIOOptions {
     std::shared_ptr<starrocks::lake::LocationProvider> location_provider;
 };
 
+// The read size to open a cloud-native scan file with: the caller's own choice when it made
+// one, otherwise config::lake_scan_min_remote_read_bytes for reads the datacache will not
+// round out to whole blocks, and starlet's own default for the ones it will.  Feeds
+// RandomAccessFileOptions::buffer_size, whose contract this preserves: a negative value
+// leaves the size to starlet.
+int64_t lake_scan_buffer_size(const LakeIOOptions& lake_io_opts);
+
+// Whether to wrap a cloud-native scan read in SharedBufferedInputStream and merge its page
+// ranges. On besides io_coalesce_lake_read_enable, coalescing is on wherever the read size is
+// ours to choose, which is where lake_scan_min_remote_read_bytes applies.
+bool should_enable_io_coalesce_lake_read(const LakeIOOptions& lake_io_opts);
+
 } // namespace starrocks

--- a/be/src/storage/rowset/column_iterator.h
+++ b/be/src/storage/rowset/column_iterator.h
@@ -139,8 +139,8 @@ public:
     }
 
     Status convert_sparse_range_to_io_range(const SparseRange<>& range) {
-        if (auto sharedBufferStream = dynamic_cast<SharedBufferedInputStream*>(_opts.read_file);
-            sharedBufferStream == nullptr) {
+        auto* shared_buffer_stream = dynamic_cast<SharedBufferedInputStream*>(_opts.read_file);
+        if (shared_buffer_stream == nullptr) {
             return Status::OK();
         }
 
@@ -151,7 +151,14 @@ public:
             result.emplace_back(io_range);
         }
 
-        return dynamic_cast<SharedBufferedInputStream*>(_opts.read_file)->set_io_ranges(result);
+        // These ranges describe the upcoming scan in full, so whatever is still in the stream's map
+        // belongs to the previous one. set_io_ranges() inserts without clearing and reset_for_reuse()
+        // keeps the streams, so without this a prepared-split fan-out stacks one round of buffers per
+        // child. The end-of-stream release in ScalarColumnIterator does not cover it: every column
+        // read goes through the sparse-range overload, whose loop exits on has_more() rather than on
+        // eos, so that release only ever fires on the ordinal and metadata-only paths.
+        shared_buffer_stream->release();
+        return shared_buffer_stream->set_io_ranges(result);
     }
 
     virtual ordinal_t get_current_ordinal() const = 0;

--- a/be/src/storage/rowset/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/scalar_column_iterator.cpp
@@ -268,7 +268,7 @@ Status ScalarColumnIterator::next_batch(size_t* n, Column* dst) {
             RETURN_IF_ERROR(_load_next_page(&eos));
             if (eos) {
                 // release shareBufferStream
-                if (config::io_coalesce_lake_read_enable && _opts.is_io_coalesce) {
+                if (_opts.is_io_coalesce) {
                     auto shared_buffer_stream = dynamic_cast<SharedBufferedInputStream*>(_opts.read_file);
                     if (shared_buffer_stream != nullptr) {
                         shared_buffer_stream->release();
@@ -302,7 +302,7 @@ Status ScalarColumnIterator::null_count(size_t* count) {
         RETURN_IF_ERROR(_load_next_page(&eos));
         if (eos) {
             // release shareBufferStream
-            if (config::io_coalesce_lake_read_enable && _opts.is_io_coalesce) {
+            if (_opts.is_io_coalesce) {
                 auto shared_buffer_stream = dynamic_cast<SharedBufferedInputStream*>(_opts.read_file);
                 if (shared_buffer_stream != nullptr) {
                     shared_buffer_stream->release();
@@ -344,7 +344,7 @@ Status ScalarColumnIterator::_next_batch_template(const SparseRange<>& range, Co
             RETURN_IF_ERROR(_load_next_page(&eos));
             if (eos) {
                 // release shareBufferStream
-                if (config::io_coalesce_lake_read_enable && _opts.is_io_coalesce) {
+                if (_opts.is_io_coalesce) {
                     auto shared_buffer_stream = dynamic_cast<SharedBufferedInputStream*>(_opts.read_file);
                     if (shared_buffer_stream != nullptr) {
                         shared_buffer_stream->release();

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -271,7 +271,7 @@ Status Segment::_open(size_t* footer_length_hint, const FooterPointerPB* partial
                       const LakeIOOptions& lake_io_opts) {
     SegmentFooterPB footer;
     RandomAccessFileOptions opts{.skip_fill_local_cache = !lake_io_opts.fill_data_cache,
-                                 .buffer_size = lake_io_opts.buffer_size};
+                                 .buffer_size = lake_scan_buffer_size(lake_io_opts)};
 
     if (!_segment_file_info.encryption_meta.empty()) {
         ASSIGN_OR_RETURN(auto info, KeyCache::instance().unwrap_encryption_meta(_segment_file_info.encryption_meta));
@@ -414,7 +414,7 @@ Status Segment::load_index(const LakeIOOptions& lake_io_opts) {
 Status Segment::_load_index(const LakeIOOptions& lake_io_opts) {
     // read and parse short key index page
     RandomAccessFileOptions file_opts{.skip_fill_local_cache = !lake_io_opts.fill_data_cache,
-                                      .buffer_size = lake_io_opts.buffer_size};
+                                      .buffer_size = lake_scan_buffer_size(lake_io_opts)};
     if (_encryption_info) {
         file_opts.encryption_info = *_encryption_info;
     } else if (!_segment_file_info.encryption_meta.empty()) {

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2036,7 +2036,7 @@ Status SegmentIterator::_init_column_iterator_by_cid(const ColumnId cid, const C
     iter_opts.col_unique_id = ucid;
 
     RandomAccessFileOptions opts{.skip_fill_local_cache = !_opts.lake_io_opts.fill_data_cache,
-                                 .buffer_size = _opts.lake_io_opts.buffer_size,
+                                 .buffer_size = lake_scan_buffer_size(_opts.lake_io_opts),
                                  .skip_disk_cache = _opts.lake_io_opts.skip_disk_cache};
 
     std::string dcg_filename;
@@ -2058,7 +2058,7 @@ Status SegmentIterator::_init_column_iterator_by_cid(const ColumnId cid, const C
             opts.encryption_info = *encryption_info;
         }
         ASSIGN_OR_RETURN(auto rfile, _opts.fs->new_random_access_file_with_bundling(opts, _segment->file_info()));
-        if (config::io_coalesce_lake_read_enable && !_segment->is_default_column(col) &&
+        if (should_enable_io_coalesce_lake_read(_opts.lake_io_opts) && !_segment->is_default_column(col) &&
             _segment->lake_tablet_manager() != nullptr) {
             ASSIGN_OR_RETURN(auto file_size, rfile->get_size());
             auto shared_buffered_input_stream =

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -334,6 +334,7 @@ SET(DW_TEST_FILES
     ./storage/meta_reader_test.cpp
     ./storage/non_retryable_load_errors_test.cpp
     ./storage/olap_meta_reader_test.cpp
+    ./storage/options_test.cpp
     ./storage/persistent_index_consistency_test.cpp
     ./storage/persistent_index_load_executor_test.cpp
     ./storage/persistent_index_snapshot_load_test.cpp

--- a/be/test/storage/options_test.cpp
+++ b/be/test/storage/options_test.cpp
@@ -1,0 +1,132 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/options.h"
+
+#include <gtest/gtest.h>
+
+#include "common/config_scan_io_fwd.h"
+
+namespace starrocks {
+
+class LakeScanBufferSizeTest : public testing::Test {
+public:
+    void SetUp() override {
+        _saved = config::lake_scan_min_remote_read_bytes;
+        config::lake_scan_min_remote_read_bytes = 131072;
+    }
+    void TearDown() override { config::lake_scan_min_remote_read_bytes = _saved; }
+
+private:
+    int64_t _saved = 0;
+};
+
+// A caller that picked its own size keeps it. Compaction and segment rewrite do this, and
+// they must not be pulled down to the scan path's much smaller bound.
+TEST_F(LakeScanBufferSizeTest, caller_choice_wins) {
+    LakeIOOptions opts;
+    opts.buffer_size = 8 * 1024 * 1024;
+    EXPECT_EQ(8 * 1024 * 1024, lake_scan_buffer_size(opts));
+    // Even where the bound would otherwise apply.
+    opts.skip_disk_cache = true;
+    EXPECT_EQ(8 * 1024 * 1024, lake_scan_buffer_size(opts));
+}
+
+// Zero is a choice, not "unset": it asks for unbuffered, exactly-sized reads.
+TEST_F(LakeScanBufferSizeTest, zero_is_a_caller_choice) {
+    LakeIOOptions opts;
+    opts.buffer_size = 0;
+    EXPECT_EQ(0, lake_scan_buffer_size(opts));
+}
+
+// Bypassing the disk cache means the request size is ours to choose, so the bound applies.
+TEST_F(LakeScanBufferSizeTest, skipping_the_disk_cache_takes_the_bound) {
+    LakeIOOptions opts;
+    opts.skip_disk_cache = true;
+    opts.fill_data_cache = true;
+    EXPECT_EQ(131072, lake_scan_buffer_size(opts));
+}
+
+// Not filling the cache also escapes block alignment: cachefs reads just the bytes asked
+// for rather than rounding out to a whole block, so the bound applies here too.
+TEST_F(LakeScanBufferSizeTest, not_filling_the_cache_takes_the_bound) {
+    LakeIOOptions opts;
+    ASSERT_EQ(-1, opts.buffer_size);
+    ASSERT_FALSE(opts.fill_data_cache);
+    ASSERT_FALSE(opts.skip_disk_cache);
+    EXPECT_EQ(131072, lake_scan_buffer_size(opts));
+}
+
+// Filling the cache without skipping it: cachefs fetches a whole block whatever we ask for,
+// so shrinking the bound would buy nothing. Defer to starlet, as before this config existed.
+TEST_F(LakeScanBufferSizeTest, block_aligned_reads_defer_to_starlet) {
+    LakeIOOptions opts;
+    opts.fill_data_cache = true;
+    opts.skip_disk_cache = false;
+    EXPECT_LT(lake_scan_buffer_size(opts), 0);
+}
+
+// A negative config is the escape hatch back to starlet's own default, so it has to survive
+// as a negative value rather than being clamped to zero, which would disable buffering.
+TEST_F(LakeScanBufferSizeTest, negative_config_defers_to_starlet) {
+    config::lake_scan_min_remote_read_bytes = -1;
+    LakeIOOptions opts;
+    EXPECT_LT(lake_scan_buffer_size(opts), 0);
+}
+
+class ShouldEnableIoCoalesceLakeReadTest : public testing::Test {
+public:
+    void SetUp() override {
+        _saved = config::io_coalesce_lake_read_enable;
+        config::io_coalesce_lake_read_enable = false;
+    }
+    void TearDown() override { config::io_coalesce_lake_read_enable = _saved; }
+
+private:
+    bool _saved = false;
+};
+
+// The reads whose size is ours to choose are the ones worth merging, and they are the same
+// reads lake_scan_min_remote_read_bytes shrinks -- so coalescing is on for them by default.
+TEST_F(ShouldEnableIoCoalesceLakeReadTest, on_where_the_read_size_is_ours) {
+    LakeIOOptions skip_cache;
+    skip_cache.skip_disk_cache = true;
+    skip_cache.fill_data_cache = true;
+    EXPECT_TRUE(should_enable_io_coalesce_lake_read(skip_cache));
+
+    LakeIOOptions no_fill;
+    ASSERT_FALSE(no_fill.fill_data_cache);
+    ASSERT_FALSE(no_fill.skip_disk_cache);
+    EXPECT_TRUE(should_enable_io_coalesce_lake_read(no_fill));
+}
+
+// A read cachefs serves from whole blocks has its size dictated by the block layout, so
+// merging page ranges cannot change what reaches the object store. Leave it off.
+TEST_F(ShouldEnableIoCoalesceLakeReadTest, off_for_block_aligned_reads) {
+    LakeIOOptions opts;
+    opts.fill_data_cache = true;
+    opts.skip_disk_cache = false;
+    EXPECT_FALSE(should_enable_io_coalesce_lake_read(opts));
+}
+
+// The config still forces it on everywhere, including the block-aligned case.
+TEST_F(ShouldEnableIoCoalesceLakeReadTest, config_forces_it_on_everywhere) {
+    config::io_coalesce_lake_read_enable = true;
+    LakeIOOptions opts;
+    opts.fill_data_cache = true;
+    opts.skip_disk_cache = false;
+    EXPECT_TRUE(should_enable_io_coalesce_lake_read(opts));
+}
+
+} // namespace starrocks

--- a/be/test/storage/rowset/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/column_reader_writer_test.cpp
@@ -42,6 +42,7 @@
 #include "base/types/decimal12.h"
 #include "base/uid_util.h"
 #include "base/utility/defer_op.h"
+#include "cache/scan/shared_buffered_input_stream.h"
 #include "column/array_column.h"
 #include "column/binary_column.h"
 #include "column/chunk_factory.h"
@@ -53,6 +54,7 @@
 #include "column/nullable_column.h"
 #include "column/vectorized_fwd.h"
 #include "common/config_rowset_fwd.h"
+#include "common/config_scan_io_fwd.h"
 #include "fs/fs_memory.h"
 #include "gen_cpp/segment.pb.h"
 #include "runtime/mem_pool.h"
@@ -973,6 +975,79 @@ TEST_F(ColumnReaderWriterTest, test_next_batch_after_eos_is_idempotent) {
         ASSERT_EQ(0U, n);
         ASSERT_EQ(0U, dst->size());
     }
+}
+
+// release() is the only thing that clears a SharedBufferedInputStream's range map, and
+// set_io_ranges() inserts into it without clearing, so a coalescing scan has to hand the buffers
+// back or an iterator that outlives one scan stacks a fresh round of up-to-
+// io_coalesce_read_max_buffer_size buffers on top of the last. Two places do it, and both are
+// keyed on the scan itself rather than on io_coalesce_lake_read_enable, which stays at its default
+// false here because the cloud-native scan path now turns coalescing on by itself wherever the
+// read size is its own to choose: registering a new scan's ranges drops the previous scan's, and
+// ScalarColumnIterator drops them at end of stream on the paths that reach one.
+TEST_F(ColumnReaderWriterTest, coalesced_buffers_do_not_accumulate) {
+    // Pinned off rather than merely asserted off: another fixture in this binary flips it, and
+    // the point of the test is that the release does not depend on it.
+    const bool saved_coalesce_config = config::io_coalesce_lake_read_enable;
+    config::io_coalesce_lake_read_enable = false;
+    DeferOp restore_coalesce_config([&] { config::io_coalesce_lake_read_enable = saved_coalesce_config; });
+
+    constexpr size_t kNumRows = 2 * 1024;
+    constexpr size_t kNullEvery = 4;
+    auto src = ChunkFactory::column_from_field_type(TYPE_INT, true);
+    src->reserve(kNumRows);
+    for (size_t i = 0; i < kNumRows; ++i) {
+        auto v = static_cast<int32_t>(i);
+        (void)src->append_numbers(&v, sizeof(v));
+    }
+    for (size_t i = 0; i < kNumRows; i += kNullEvery) {
+        (void)src->set_null(i);
+    }
+
+    const std::string fname = TEST_DIR + "/" + generate_uuid_string() + ".data";
+    auto segment = create_dummy_segment(fname);
+    ColumnMetaPB meta;
+    {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(fname));
+        ColumnWriterOptions writer_opts = make_writer_opts<TYPE_INT, DEFAULT_ENCODING, 2>(&meta);
+        TabletColumn column = make_tablet_column<TYPE_INT>();
+        ASSIGN_OR_ABORT(auto writer, ColumnWriter::create(writer_opts, &column, wfile.get()));
+        ASSERT_OK(writer->init());
+        ASSERT_OK(writer->append(*src));
+        flush_column_writer(writer.get());
+        ASSERT_OK(wfile->close());
+    }
+
+    ASSIGN_OR_ABORT(_reader, ColumnReader::create(&meta, segment.get(), nullptr));
+    ASSIGN_OR_ABORT(_read_file, _fs->new_random_access_file(fname));
+    ASSIGN_OR_ABORT(auto file_size, _read_file->get_size());
+    // Wired the way SegmentIterator does it when coalescing is on: reads go through the shared
+    // stream, and the page ranges the scan will touch are registered on it up front.
+    auto shared = std::make_unique<SharedBufferedInputStream>(_read_file->stream(), fname, file_size);
+
+    ASSIGN_OR_ABORT(auto iter, _reader->new_iterator());
+    ColumnIteratorOptions iter_opts;
+    iter_opts.stats = &_stats;
+    iter_opts.read_file = shared.get();
+    iter_opts.use_page_cache = false;
+    iter_opts.is_io_coalesce = true;
+    ASSERT_OK(iter->init(iter_opts));
+
+    ASSERT_OK(iter->convert_sparse_range_to_io_range(SparseRange<>(0, kNumRows)));
+    const int64_t registered = shared->current_range_ref_sum();
+    ASSERT_GT(registered, 0);
+
+    // What a reused segment iterator does: reset_for_reuse() keeps the stream, so the next scan
+    // registers its ranges on the same map. It must be rebuilt, not appended to, or a prepared-split
+    // fan-out grows by one round of buffers per child.
+    ASSERT_OK(iter->convert_sparse_range_to_io_range(SparseRange<>(0, kNumRows)));
+    ASSERT_EQ(registered, shared->current_range_ref_sum());
+
+    ASSERT_OK(iter->seek_to_first());
+    size_t nulls = 0;
+    ASSERT_OK(iter->null_count(&nulls));
+    ASSERT_EQ(kNumRows / kNullEvery, nulls);
+    ASSERT_EQ(0, shared->current_range_ref_sum());
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/en/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/en/administration/configuration/BE_parameters/shared_lake_other.md
@@ -237,6 +237,15 @@ This topic introduces the following types of BE configurations:
 - Is mutable: Yes
 - Description: Sub-chunk granularity for `RowsMapperIterator` pipelined reads of `.lcrm` files during light Primary Key compaction publish in a shared-data cluster. Each output segment is split into `ceil(segment_bytes / lake_rows_mapper_sub_chunk_bytes)` sub-chunks pipelined independently. Smaller values raise the achievable parallelism for few-but-large output segments at the cost of more range reads and an extra memcpy on consume. Defaults to 4 MiB to align with the starcache disk-tier block size.
 
+### lake_scan_min_remote_read_bytes
+
+- Default: 131072
+- Type: Long
+- Unit: Bytes
+- Is mutable: Yes
+- Description: The lower bound on the size of a remote read issued by the query scan path for a cloud-native table in a shared-data cluster: the segment footer, the short-key index, and each column's index and data pages. A read that is already at least this large is issued unchanged, so this never splits a read; it only keeps a small read from being served by an oversized fetch. The scan asks for exact page ranges, so a large read-ahead only rounds every request up and fetches bytes the scan never reads, which is why the default is well below `starlet_fs_stream_buffer_size_bytes`. Lowering it further trades more requests for less read bandwidth. Set it to `0` to issue every read at exactly its requested size, or to a negative value to fall back to `starlet_fs_stream_buffer_size_bytes`. It applies only where the data cache is not already rounding reads out to whole `starlet_star_cache_block_size_bytes` blocks, that is, when the read skips the disk cache or is not populating it.
+- Introduced in: v4.2
+
 ### lake_vacuum_enable_task_timeout
 
 - Default: true

--- a/docs/ja/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/configuration/BE_parameters/shared_lake_other.md
@@ -237,6 +237,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 変更可能: はい
 - 説明: 共有データクラスタでの主キーテーブル軽量コンパクション publish 時、`RowsMapperIterator` のパイプライン化された `.lcrm` 読み取りにおける sub-chunk の粒度。各出力 segment は `ceil(segment_bytes / lake_rows_mapper_sub_chunk_bytes)` 個の sub-chunk に分割され、独立してパイプライン化されます。値を小さくするほど、少数の大きな出力 segment で達成可能な並列度が上がりますが、その代わりに範囲読み取りが増え、consume 時に追加の memcpy が発生します。デフォルトは 4 MiB で、starcache のディスク層 block サイズと一致させています。
 
+### lake_scan_min_remote_read_bytes
+
+- デフォルト: 131072
+- タイプ: Long
+- 単位: Bytes
+- 変更可能: はい
+- 説明: 共有データクラスタでクラウドネイティブテーブルをクエリスキャンする際に発行されるリモート読み取りサイズの下限です。対象は Segment フッター、ショートキーインデックス、および各列のインデックスページとデータページです。すでにこの値以上の読み取りはそのまま発行されるため、このパラメータが読み取りを分割することはなく、小さな読み取りが過大なフェッチで処理されるのを防ぐだけです。スキャンは正確なページ範囲を要求するため、大きな先読みは各リクエストを切り上げ、スキャンが読まないバイトを取得するだけです。そのためデフォルト値は `starlet_fs_stream_buffer_size_bytes` よりかなり小さく設定されています。さらに小さくすると、リクエスト数の増加と引き換えに読み取り帯域幅が減ります。`0` を指定すると各読み取りは要求されたサイズのまま発行され、負の値を指定すると `starlet_fs_stream_buffer_size_bytes` にフォールバックします。このパラメータは、Data Cache が読み取りを `starlet_star_cache_block_size_bytes` のブロック単位に丸めていない場合、つまり読み取りがディスクキャッシュをスキップするか、キャッシュを充填しない場合にのみ有効です。
+- Introduced in: v4.2
+
 ### lake_vacuum_enable_task_timeout
 
 - デフォルト: true

--- a/docs/zh/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/configuration/BE_parameters/shared_lake_other.md
@@ -234,6 +234,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 是否动态：是
 - 描述：存算分离集群下，主键表轻量 Compaction 发布阶段，`RowsMapperIterator` 流水化读取 `.lcrm` 文件时使用的 sub-chunk 粒度。每个输出 segment 被切分为 `ceil(segment_bytes / lake_rows_mapper_sub_chunk_bytes)` 个 sub-chunk，独立流水化。值越小，少而大的输出 segment 能获得越高的并发度，但代价是更多的范围读取和消费时一次额外的 memcpy。默认 4 MiB，与 starcache 磁盘层 block 大小对齐。
 
+### lake_scan_min_remote_read_bytes
+
+- 默认值：131072
+- 类型：Long
+- 单位：Bytes
+- 是否动态：是
+- 描述：存算分离集群中，查询扫描云原生表时单次远程读取的大小下限，作用于 Segment footer、短键索引以及各列的索引页和数据页。如果一次读取本身已经不小于该值，则按原样下发，因此该参数不会拆分读取，只会避免用过大的一次取回去服务一次很小的读取。扫描请求的是精确的页范围，过大的预读只会把每次请求向上取整、多取回扫描根本不会读的字节，因此默认值远小于 `starlet_fs_stream_buffer_size_bytes`。继续调小会以更多的请求数换取更少的读带宽。设为 `0` 表示每次读取都按其请求的大小精确下发；设为负值表示回退到 `starlet_fs_stream_buffer_size_bytes`。该参数仅在 Data Cache 没有把读取按 `starlet_star_cache_block_size_bytes` 对齐成整块时生效，即读取跳过磁盘缓存或不回填缓存的情况。
+- 引入版本：v4.2
+
 ### lake_vacuum_enable_task_timeout
 
 - 默认值：true


### PR DESCRIPTION
## Why I'm doing:

The query scan path leaves `LakeIOOptions::buffer_size` at `-1`, so every file it opens falls through to starlet's global `fs_stream_buffer_size_bytes` (1 MiB). That is a sequential read-ahead size, but the scan asks for exact page ranges, and much of what it reads is nowhere near 1 MiB — most of all the per-column index pages, loaded once per column per segment per scan range.

Measured on a cold SSB 100 GB `lineorder` segment (12.5M rows, 17 columns, 342 MiB):

| part of the segment | size |
|---|---|
| column data pages | 342 MiB |
| footer + short-key index | 450.6 KiB, read in one request |
| one column's index pages | **10.9 KiB** (INT) / **21.9 KiB** (BIGINT) / **12.0 KiB** (VARCHAR) |

Against a 1 MiB lower bound, each of those ~11 KiB index reads costs a full 1 MiB fetch.

## What I'm doing:

**1. `lake_scan_min_remote_read_bytes` (128 KiB).** A lower bound on each remote read, supplied wherever the scan path leaves the size unset — mirroring the existing `lake_compaction_stream_buffer_size_bytes` for the compaction path. The `RandomAccessFileOptions::buffer_size` contract is preserved: `> 0` is a size, `0` disables buffering so reads are issued exactly as requested, `< 0` defers to starlet. A read already at least this large is issued unchanged, so this never splits a read — it only stops a small read from being served by an oversized fetch.

**2. Coalescing for the same reads,** via a new `should_enable_io_coalesce_lake_read()`. Page-range coalescing is only possible where the request size is ours to choose, and those reads are also the ones that pay for the smaller bound in request count — so the two belong in one change. On its own, the bound trades requests for bytes.

**Both apply only where the datacache is not already rounding reads out to whole blocks.** On a miss it intends to cache, cachefs fetches a whole `starlet_star_cache_block_size_bytes` block, so the request reaching the object store is a whole 1 MiB block whatever we ask for, and a merged range is re-split by the block layout anyway. Two cases escape that alignment, factored into one predicate read by both resolvers:

| case | why the size is ours to choose |
|---|---|
| `skip_disk_cache` | the read bypasses cachefs entirely and goes straight to the object store |
| `!fill_data_cache` | the read still goes through cachefs, but with nothing to cache it reads just the requested bytes rather than rounding out to the block |

Everything else keeps deferring to starlet and keeps coalescing off, exactly as before. `io_coalesce_lake_read_enable` stays as the switch that forces coalescing on **everywhere**, including the block-aligned case; it no longer gates the unaligned reads.

### Measurements

Cold SSB 100 GB, page cache and metadata cache off, datacache bypassed, 52 samples per arm, arms interleaved with the order rotated per query.

**Aliyun** — one 1 FE + 3 CN (32c64g) cluster, 1.2B-row `lineorder`, arms alternated by redeploy:

| | base | pr | |
|---|---|---|---|
| remote bytes | 245.55 GiB | **159.58 GiB** | **−35.0%** |
| requests | 251,554 | **132,404** | **−47.4%** |
| amplification | 1.54 – 1.90 | **1.03 – 1.14** | |
| wall p50 | 9.26 s | 7.75 s | 1.20× |
| wall max | 58.39 s | 20.07 s | |

**AWS** — two 1 FE + 3 CN (`m6i.4xlarge`) clusters, one per arm, SSB SF100, driver in-region. A control round with both clusters on the base build gave identical bytes/requests and wall clock within 1–5%, so the pair is a fair comparison:

| | base | pr | |
|---|---|---|---|
| remote bytes | 77.96 GiB | 74.52 GiB | −4.4% |
| requests | 79,966 | **5,249** | **15.2× fewer** |
| amplification | 1.05 – 1.13 | **1.00 – 1.09** | |
| wall p50 | 7.06 s | **3.68 s** | **1.92×** |
| wall max | 11.76 s | 7.04 s | |

All 13 queries are faster on AWS (1.51× – 2.29×), no regressions. On Aliyun the wall clock is noisy enough that 4 of 13 come out slower on the median while every one reads strictly less; the defensible latency claims there are the median and the tail.

The two datasets stress opposite halves: the Aliyun baseline wastes a third of every read, so the bound dominates; the AWS page ranges are already dense, so the win is almost all from collapsing ~6,000 requests into ~400. Neither half alone would look convincing on both.

Per-query tables are in the comments below.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

Parameter change: the new `lake_scan_min_remote_read_bytes` defaults to 128 KiB rather than inheriting starlet's 1 MiB for the scan path. Policy change: coalescing becomes automatic for reads whose size is not dictated by the datacache block layout, and `io_coalesce_lake_read_enable` no longer gates those reads.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5