### PR TITLE
[Feature] Support submitting UPDATE as an async task

### DIFF
--- a/docs/en/sql-reference/information_schema/task_runs.md
+++ b/docs/en/sql-reference/information_schema/task_runs.md
@@ -27,7 +27,7 @@ The following fields are provided in `task_runs`:
 | PROPERTIES    | Properties of the task.                                      |
 | JOB_ID        | Job ID of the task.                                          |
 | PROCESS_TIME  | Process time of the task.                                    |
-| TASK_SOURCE   | Source that submitted the task. Valid values: `CTAS`, `MV`, `INSERT`, `PIPE`, and `DATACACHE_SELECT`. `UNKNOWN` is returned for legacy records whose source was not recorded. |
+| TASK_SOURCE   | Source that submitted the task. Valid values: `CTAS`, `MV`, `INSERT`, `UPDATE`, `PIPE`, and `DATACACHE_SELECT`. `UNKNOWN` is returned for legacy records whose source was not recorded. |
 
 A task run record is produced by either [SUBMIT TASK](../sql-statements/loading_unloading/ETL/SUBMIT_TASK.md) or [CREATE MATRIALIZED VIEW](../sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md).
 

--- a/docs/en/sql-reference/sql-statements/loading_unloading/ETL/SUBMIT_TASK.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/ETL/SUBMIT_TASK.md
@@ -19,6 +19,7 @@ Supported statements include:
 - [CREATE TABLE AS SELECT](../../table_bucket_part_index/CREATE_TABLE_AS_SELECT.md) (from v3.0 onwards)
 - [INSERT](../INSERT.md) (from v3.0 onwards)
 - [CACHE SELECT](../../../../data_source/data_cache/block_cache_warmup.md) (from v3.3 onwards)
+- [UPDATE](../../table_bucket_part_index/UPDATE.md) (from v4.2 onwards)
 
 You can view the list of tasks by querying `INFORMATION_SCHEMA.tasks`, or view the execution history of tasks by querying `INFORMATION_SCHEMA.task_runs`. For more information, see [Usage Notes](#usage-notes).
 
@@ -64,7 +65,7 @@ AS insert into t2 select * from t1;
 | task_name          | Yes     | The name of the task.                                                                               |
 | schedule_start     | No      | The start time for the scheduled task.                                                                 |
 | schedule_interval  | No      | The interval at which the scheduled task is executed, with a minimum interval of 10 seconds.          |
-| etl_statement      | Yes     | The ETL statement that you want to submit as an asynchronous task. StarRocks currently supports submitting asynchronous tasks for [CREATE TABLE AS SELECT](../../table_bucket_part_index/CREATE_TABLE_AS_SELECT.md) and [INSERT](../INSERT.md). |
+| etl_statement      | Yes     | The ETL statement that you want to submit as an asynchronous task. StarRocks currently supports submitting asynchronous tasks for [CREATE TABLE AS SELECT](../../table_bucket_part_index/CREATE_TABLE_AS_SELECT.md), [INSERT](../INSERT.md), and [UPDATE](../../table_bucket_part_index/UPDATE.md). |
 
 ## Return value
 
@@ -160,4 +161,15 @@ PROPERTIES (
     "session.insert_timeout" = "10000"
 )
 AS insert into t2 select * from t1;
+```
+
+Example 7: Submit an asynchronous task for an UPDATE statement that refreshes a Primary Key table from a staging table. The task will be regularly executed at an interval of 5 minutes:
+
+```SQL
+SUBMIT TASK etl_update
+SCHEDULE EVERY(INTERVAL 5 MINUTE)
+AS
+UPDATE target_tbl SET v1 = src.v1
+FROM staging_tbl src
+WHERE target_tbl.pk = src.pk;
 ```

--- a/docs/ja/sql-reference/information_schema/task_runs.md
+++ b/docs/ja/sql-reference/information_schema/task_runs.md
@@ -27,7 +27,7 @@ description: "task_runsは非同期タスクの実行に関する情報を提供
 | PROPERTIES    | タスクのプロパティ。                                         |
 | JOB_ID        | タスクのジョブ ID。                                          |
 | PROCESS_TIME  | タスクの処理時間。                                           |
-| TASK_SOURCE   | タスクを送信したソース。 有効な値は `CTAS`、`MV`、`INSERT`、`PIPE`、`DATACACHE_SELECT` です。ソースが記録されていないレガシーレコードの場合は `UNKNOWN` が返されます。 |
+| TASK_SOURCE   | タスクを送信したソース。 有効な値は `CTAS`、`MV`、`INSERT`、`UPDATE`、`PIPE`、`DATACACHE_SELECT` です。ソースが記録されていないレガシーレコードの場合は `UNKNOWN` が返されます。 |
 
 タスク実行記録は、[SUBMIT TASK](../sql-statements/loading_unloading/ETL/SUBMIT_TASK.md) または [CREATE MATERIALIZED VIEW](../sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md) によって生成されます。
 

--- a/docs/ja/sql-reference/sql-statements/loading_unloading/ETL/SUBMIT_TASK.md
+++ b/docs/ja/sql-reference/sql-statements/loading_unloading/ETL/SUBMIT_TASK.md
@@ -21,6 +21,7 @@ ETL ステートメントを非同期タスクとして送信します。
 - [CREATE TABLE AS SELECT](../../table_bucket_part_index/CREATE_TABLE_AS_SELECT.md) (v3.0 以降)
 - [INSERT](../INSERT.md) (v3.0 以降)
 - [CACHE SELECT](../../../../data_source/data_cache/block_cache_warmup.md) (v3.3 以降)
+- [UPDATE](../../table_bucket_part_index/UPDATE.md) (v4.2 以降)
 
 タスクの一覧は `INFORMATION_SCHEMA.tasks` をクエリすることで確認でき、タスクの実行履歴は `INFORMATION_SCHEMA.task_runs` をクエリすることで確認できます。詳細については、[使用上の注意](#使用上の注意)を参照してください。
 
@@ -66,7 +67,7 @@ AS insert into t2 select * from t1;
 | task_name          | はい     | タスクの名前です。                                                                               |
 | schedule_start     | いいえ      | スケジュールされたタスクの開始時間です。                                                                 |
 | schedule_interval  | いいえ      | スケジュールされたタスクが実行される間隔で、最小間隔は10秒です。          |
-| etl_statement      | はい     | 非同期タスクとして送信したい ETL ステートメントです。StarRocks は現在、[CREATE TABLE AS SELECT](../../table_bucket_part_index/CREATE_TABLE_AS_SELECT.md) と [INSERT](../INSERT.md) の非同期タスクの送信をサポートしています。 |
+| etl_statement      | はい     | 非同期タスクとして送信したい ETL ステートメントです。StarRocks は現在、[CREATE TABLE AS SELECT](../../table_bucket_part_index/CREATE_TABLE_AS_SELECT.md)、[INSERT](../INSERT.md)、および [UPDATE](../../table_bucket_part_index/UPDATE.md) の非同期タスクの送信をサポートしています。 |
 
 ## 戻り値
 
@@ -162,4 +163,15 @@ PROPERTIES (
     "session.insert_timeout" = "10000"
 )
 AS insert into t2 select * from t1;
+```
+
+例 7: ステージングテーブルから主キーテーブルを更新する UPDATE ステートメントの非同期タスクを送信します。このタスクは 5 分間隔で定期的に実行されます:
+
+```SQL
+SUBMIT TASK etl_update
+SCHEDULE EVERY(INTERVAL 5 MINUTE)
+AS
+UPDATE target_tbl SET v1 = src.v1
+FROM staging_tbl src
+WHERE target_tbl.pk = src.pk;
 ```

--- a/docs/zh/sql-reference/information_schema/task_runs.md
+++ b/docs/zh/sql-reference/information_schema/task_runs.md
@@ -27,7 +27,7 @@ description: "task_runs 提供异步任务执行的信息。"
 | PROPERTIES    | 任务的属性。                                                 |
 | JOB_ID        | 任务的作业 ID。                                              |
 | PROCESS_TIME  | 任务的处理时间。                                             |
-| TASK_SOURCE   | 提交任务的来源。有效值：`CTAS`、`MV`、`INSERT`、`PIPE` 和 `DATACACHE_SELECT`。对于未记录来源的历史记录，返回 `UNKNOWN`。 |
+| TASK_SOURCE   | 提交任务的来源。有效值：`CTAS`、`MV`、`INSERT`、`UPDATE`、`PIPE` 和 `DATACACHE_SELECT`。对于未记录来源的历史记录，返回 `UNKNOWN`。 |
 
 Task Run 记录由 [SUBMIT TASK](../sql-statements/loading_unloading/ETL/SUBMIT_TASK.md) 或 [CREATE MATRIALIZED VIEW](../sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md) 生成。
 

--- a/docs/zh/sql-reference/sql-statements/loading_unloading/ETL/SUBMIT_TASK.md
+++ b/docs/zh/sql-reference/sql-statements/loading_unloading/ETL/SUBMIT_TASK.md
@@ -21,6 +21,7 @@ import PropertyWarehouse from '../../../../_assets/commonMarkdown/property_wareh
 - [CREATE TABLE AS SELECT](../../table_bucket_part_index/CREATE_TABLE_AS_SELECT.md)（从 v3.0 开始支持）
 - [INSERT](../INSERT.md)（从 v3.0 开始支持）
 - [CACHE SELECT](../../../../data_source/data_cache/block_cache_warmup.md)（从 v3.3 开始支持）
+- [UPDATE](../../table_bucket_part_index/UPDATE.md)（从 v4.2 开始支持）
 
 您可以通过查询 `INFORMATION_SCHEMA.tasks` 查看任务列表，或通过查询 `INFORMATION_SCHEMA.task_runs` 查看任务的执行历史。有关更多信息，请参阅[使用说明](#使用说明)。
 
@@ -65,7 +66,7 @@ AS insert into t2 select * from t1;
 | task_name          | 是      | 任务名称。                                                                                   |
 | schedule_start     | 否      | 定时任务的开始时间。                                                                           |
 | schedule_interval  | 否      | 定时任务的执行间隔，最小间隔为 10 秒。                                                           |
-| etl_statement      | 是      | 需要创建异步任务的 ETL 语句。StarRocks 当前支持为 [CREATE TABLE AS SELECT](../../table_bucket_part_index/CREATE_TABLE_AS_SELECT.md) 和 [INSERT](../INSERT.md) |
+| etl_statement      | 是      | 需要创建异步任务的 ETL 语句。StarRocks 当前支持为 [CREATE TABLE AS SELECT](../../table_bucket_part_index/CREATE_TABLE_AS_SELECT.md)、[INSERT](../INSERT.md) 和 [UPDATE](../../table_bucket_part_index/UPDATE.md) 创建异步任务。 |
 
 ## 返回值
 
@@ -160,4 +161,15 @@ PROPERTIES (
     "session.insert_timeout" = "10000"
 )
 AS insert into t2 select * from t1;
+```
+
+示例七：为 UPDATE 语句创建异步任务，该语句根据 Staging 表更新主键表。任务将以五分钟为间隔定期执行：
+
+```SQL
+SUBMIT TASK etl_update
+SCHEDULE EVERY(INTERVAL 5 MINUTE)
+AS
+UPDATE target_tbl SET v1 = src.v1
+FROM staging_tbl src
+WHERE target_tbl.pk = src.pk;
 ```

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/Constants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/Constants.java
@@ -47,7 +47,8 @@ public class Constants {
         MV,
         INSERT,
         PIPE,
-        DATACACHE_SELECT;
+        DATACACHE_SELECT,
+        UPDATE;
 
         // Whether the task source is mergeable, only MV is mergeable by default.
         public boolean isMergeable() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
@@ -71,6 +71,9 @@ public class TaskBuilder {
         if (submitTaskStmt.getInsertStmt() != null) {
             taskNamePrefix = "insert-";
             taskSource = Constants.TaskSource.INSERT;
+        } else if (submitTaskStmt.getUpdateStmt() != null) {
+            taskNamePrefix = "update-";
+            taskSource = Constants.TaskSource.UPDATE;
         } else if (submitTaskStmt.getCreateTableAsSelectStmt() != null) {
             taskNamePrefix = "ctas-";
             taskSource = Constants.TaskSource.CTAS;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
@@ -394,6 +394,10 @@ public class Analyzer {
                 InsertStmt insertStmt = statement.getInsertStmt();
                 Analyzer.analyze(insertStmt, context);
                 taskStmt = insertStmt;
+            } else if (statement.getUpdateStmt() != null) {
+                UpdateStmt updateStmt = statement.getUpdateStmt();
+                Analyzer.analyze(updateStmt, context);
+                taskStmt = updateStmt;
             } else if (statement.getDataCacheSelectStmt() != null) {
                 DataCacheStmtAnalyzer.analyze(statement.getDataCacheSelectStmt(), context);
                 taskStmt = statement.getDataCacheSelectStmt();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -2257,6 +2257,8 @@ public class AuthorizerStmtVisitor implements AstVisitorExtendInterface<Void, Co
             visitCreateTableAsSelectStatement(statement.getCreateTableAsSelectStmt(), context);
         } else if (statement.getDataCacheSelectStmt() != null) {
             visitDataCacheSelectStatement(statement.getDataCacheSelectStmt(), context);
+        } else if (statement.getUpdateStmt() != null) {
+            visitUpdateStatement(statement.getUpdateStmt(), context);
         } else {
             visitInsertStatement(statement.getInsertStmt(), context);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstTraverser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstTraverser.java
@@ -70,6 +70,9 @@ public class AstTraverser<R, C> implements AstVisitorExtendInterface<R, C> {
         if (statement.getInsertStmt() != null) {
             visit(statement.getInsertStmt(), context);
         }
+        if (statement.getUpdateStmt() != null) {
+            visit(statement.getUpdateStmt(), context);
+        }
         if (statement.getCreateTableAsSelectStmt() != null) {
             visit(statement.getCreateTableAsSelectStmt(), context);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SubmitTaskStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SubmitTaskStmt.java
@@ -38,6 +38,7 @@ public class SubmitTaskStmt extends DdlStmt {
     private CreateTableAsSelectStmt createTableAsSelectStmt;
     private DataCacheSelectStatement dataCacheSelectStmt;
     private InsertStmt insertStmt;
+    private UpdateStmt updateStmt;
 
     public SubmitTaskStmt(TaskName taskName, int sqlBeginIndex, CreateTableAsSelectStmt createTableAsSelectStmt,
                           NodePosition pos) {
@@ -66,6 +67,14 @@ public class SubmitTaskStmt extends DdlStmt {
         this.taskName = taskName.getName();
         this.sqlBeginIndex = sqlBeginIndex;
         this.insertStmt = insertStmt;
+    }
+
+    public SubmitTaskStmt(TaskName taskName, int sqlBeginIndex, UpdateStmt updateStmt, NodePosition pos) {
+        super(pos);
+        this.dbName = taskName.getDbName();
+        this.taskName = taskName.getName();
+        this.sqlBeginIndex = sqlBeginIndex;
+        this.updateStmt = updateStmt;
     }
 
     public String getCatalogName() {
@@ -142,6 +151,10 @@ public class SubmitTaskStmt extends DdlStmt {
 
     public void setInsertStmt(InsertStmt insertStmt) {
         this.insertStmt = insertStmt;
+    }
+
+    public UpdateStmt getUpdateStmt() {
+        return updateStmt;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2180,11 +2180,14 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
 
         CreateTableAsSelectStmt createTableAsSelectStmt = null;
         InsertStmt insertStmt = null;
+        UpdateStmt updateStmt = null;
         DataCacheSelectStatement dataCacheSelectStmt = null;
         if (context.createTableAsSelectStatement() != null) {
             createTableAsSelectStmt = (CreateTableAsSelectStmt) visit(context.createTableAsSelectStatement());
         } else if (context.insertStatement() != null) {
             insertStmt = (InsertStmt) visit(context.insertStatement());
+        } else if (context.updateStatement() != null) {
+            updateStmt = (UpdateStmt) visit(context.updateStatement());
         } else if (context.dataCacheSelectStatement() != null) {
             dataCacheSelectStmt = (DataCacheSelectStatement) visit(context.dataCacheSelectStatement());
         }
@@ -2194,6 +2197,8 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             startIndex = context.createTableAsSelectStatement().start.getStartIndex();
         } else if (dataCacheSelectStmt != null) {
             startIndex = context.dataCacheSelectStatement().start.getStartIndex();
+        } else if (updateStmt != null) {
+            startIndex = context.updateStatement().start.getStartIndex();
         } else {
             startIndex = context.insertStatement().start.getStartIndex();
         }
@@ -2210,6 +2215,8 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             res = new SubmitTaskStmt(taskName, startIndex, createTableAsSelectStmt, pos);
         } else if (dataCacheSelectStmt != null) {
             res = new SubmitTaskStmt(taskName, startIndex, dataCacheSelectStmt, pos);
+        } else if (updateStmt != null) {
+            res = new SubmitTaskStmt(taskName, startIndex, updateStmt, pos);
         } else {
             res = new SubmitTaskStmt(taskName, startIndex, insertStmt, pos);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/HintCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/HintCollector.java
@@ -85,6 +85,8 @@ public class HintCollector extends StarRocksBaseVisitor<Void> {
             visit(context.createTableAsSelectStatement());
         } else if (context.insertStatement() != null) {
             visit(context.insertStatement());
+        } else if (context.updateStatement() != null) {
+            visit(context.updateStatement());
         }
         return null;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SubmitTaskStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SubmitTaskStmtTest.java
@@ -31,12 +31,16 @@ import com.starrocks.scheduler.TaskRun;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.analyzer.TaskAnalyzer;
+import com.starrocks.sql.ast.AstTraverser;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.SubmitTaskStmt;
+import com.starrocks.sql.ast.TaskName;
+import com.starrocks.sql.ast.UpdateStmt;
 import com.starrocks.sql.common.AuditEncryptionChecker;
 import com.starrocks.sql.common.UnsupportedException;
 import com.starrocks.sql.formatter.AST2StringVisitor;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
+import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.sql.parser.ParsingException;
 import com.starrocks.utframe.UtFrameUtils;
 import com.starrocks.warehouse.DefaultWarehouse;
@@ -161,6 +165,19 @@ public class SubmitTaskStmtTest extends MVTestBase {
         SubmitTaskStmt submitStmt = (SubmitTaskStmt) UtFrameUtils.parseStmtWithNewParser(sql1, ctx);
         Assertions.assertNotNull(submitStmt.getDbName());
         Assertions.assertNotNull(submitStmt.getSqlText());
+    }
+
+    @Test
+    public void testSubmitTaskStmtUpdateConstructor() {
+        UpdateStmt updateStmt = new UpdateStmt(null, Collections.emptyList(), Collections.emptyList(),
+                null, Collections.emptyList());
+        SubmitTaskStmt stmt = new SubmitTaskStmt(new TaskName("test", "task_update"), 10, updateStmt, NodePosition.ZERO);
+        Assertions.assertEquals("test", stmt.getDbName());
+        Assertions.assertEquals("task_update", stmt.getTaskName());
+        Assertions.assertEquals(10, stmt.getSqlBeginIndex());
+        Assertions.assertSame(updateStmt, stmt.getUpdateStmt());
+        Assertions.assertNull(stmt.getInsertStmt());
+        new AstTraverser<>().visit(stmt, null);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SubmitTaskStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SubmitTaskStmtTest.java
@@ -34,6 +34,7 @@ import com.starrocks.sql.analyzer.TaskAnalyzer;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.SubmitTaskStmt;
 import com.starrocks.sql.common.AuditEncryptionChecker;
+import com.starrocks.sql.common.UnsupportedException;
 import com.starrocks.sql.formatter.AST2StringVisitor;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
 import com.starrocks.sql.parser.ParsingException;
@@ -160,6 +161,85 @@ public class SubmitTaskStmtTest extends MVTestBase {
         SubmitTaskStmt submitStmt = (SubmitTaskStmt) UtFrameUtils.parseStmtWithNewParser(sql1, ctx);
         Assertions.assertNotNull(submitStmt.getDbName());
         Assertions.assertNotNull(submitStmt.getSqlText());
+    }
+
+    @Test
+    public void testSubmitUpdate() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        starRocksAssert.withDatabase("test").useDatabase("test")
+                .withTable("CREATE TABLE test.test_update\n" +
+                        "(\n" +
+                        "    pk bigint NOT NULL,\n" +
+                        "    v1 int NOT NULL\n" +
+                        ")\n" +
+                        "PRIMARY KEY(pk)\n" +
+                        "DISTRIBUTED BY HASH(pk) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');");
+
+        String sql = "submit task task_update as update test.test_update set v1 = 1 where pk = 2";
+        SubmitTaskStmt submitStmt = (SubmitTaskStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        Assertions.assertNotNull(submitStmt.getUpdateStmt());
+        Assertions.assertNull(submitStmt.getInsertStmt());
+        Assertions.assertEquals("test", submitStmt.getDbName());
+        Assertions.assertEquals("update test.test_update set v1 = 1 where pk = 2", submitStmt.getSqlText());
+        Assertions.assertNotNull(submitStmt.getUpdateStmt().getQueryStatement());
+
+        TaskManager tm = GlobalStateMgr.getCurrentState().getTaskManager();
+        DDLStmtExecutor.execute(submitStmt, ctx);
+        Task task = tm.getTask("task_update");
+        Assertions.assertNotNull(task);
+        Assertions.assertEquals(Constants.TaskSource.UPDATE, task.getSource());
+        Assertions.assertEquals("update test.test_update set v1 = 1 where pk = 2", task.getDefinition());
+        connectContext.executeSql("drop task task_update");
+
+        ctx.setThreadLocalInfo();
+        ctx.setExecutionId(UUIDUtil.toTUniqueId(UUIDUtil.genUUID()));
+        SubmitTaskStmt unnamedStmt = (SubmitTaskStmt) UtFrameUtils.parseStmtWithNewParser(
+                "submit task as update test.test_update set v1 = 1 where pk = 2", ctx);
+        Assertions.assertTrue(TaskBuilder.buildTask(unnamedStmt, ctx).getName().startsWith("update-"));
+    }
+
+    @Test
+    public void testSubmitUpdateFromSource() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        starRocksAssert.withDatabase("test").useDatabase("test")
+                .withTable("CREATE TABLE test.update_target\n" +
+                        "(\n" +
+                        "    k1 int NOT NULL,\n" +
+                        "    v1 int NOT NULL\n" +
+                        ")\n" +
+                        "PRIMARY KEY(k1)\n" +
+                        "DISTRIBUTED BY HASH(k1) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
+                .withTable("CREATE TABLE test.update_source\n" +
+                        "(\n" +
+                        "    k1 int,\n" +
+                        "    v1 int\n" +
+                        ")\n" +
+                        "DUPLICATE KEY(k1)\n" +
+                        "DISTRIBUTED BY HASH(k1) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');");
+
+        String sql = "submit task task_update_join as update test.update_target set v1 = s.v1 " +
+                "from test.update_source s where test.update_target.k1 = s.k1";
+        SubmitTaskStmt submitStmt = (SubmitTaskStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        Assertions.assertNotNull(submitStmt.getUpdateStmt().getQueryStatement());
+
+        TaskManager tm = GlobalStateMgr.getCurrentState().getTaskManager();
+        DDLStmtExecutor.execute(submitStmt, ctx);
+        Task task = tm.getTask("task_update_join");
+        Assertions.assertNotNull(task);
+        Assertions.assertEquals(Constants.TaskSource.UPDATE, task.getSource());
+        connectContext.executeSql("drop task task_update_join");
+    }
+
+    @Test
+    public void testSubmitUpdateNonPrimaryKey() {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        Exception e = assertThrows(UnsupportedException.class, () ->
+                UtFrameUtils.parseStmtWithNewParser(
+                        "submit task as update test.tbl1 set v1 = 1 where k2 = 1", ctx));
+        Assertions.assertTrue(e.getMessage().contains("does not support update"), e.getMessage());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SubmitTaskStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SubmitTaskStmtTest.java
@@ -183,7 +183,7 @@ public class SubmitTaskStmtTest extends MVTestBase {
     @Test
     public void testSubmitUpdate() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
-        starRocksAssert.withDatabase("test").useDatabase("test")
+        starRocksAssert.useDatabase("test")
                 .withTable("CREATE TABLE test.test_update\n" +
                         "(\n" +
                         "    pk bigint NOT NULL,\n" +
@@ -219,7 +219,7 @@ public class SubmitTaskStmtTest extends MVTestBase {
     @Test
     public void testSubmitUpdateFromSource() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
-        starRocksAssert.withDatabase("test").useDatabase("test")
+        starRocksAssert.useDatabase("test")
                 .withTable("CREATE TABLE test.update_target\n" +
                         "(\n" +
                         "    k1 int NOT NULL,\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/qe/RedirectStatusTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/RedirectStatusTest.java
@@ -985,6 +985,13 @@ public class RedirectStatusTest {
                         null, NodePosition.ZERO), queryStatement);
         SubmitTaskStmt stmt = new SubmitTaskStmt(new TaskName("", ""), 0, insertStmt, NodePosition.ZERO);
         Assertions.assertEquals(RedirectStatus.FORWARD_WITH_SYNC, RedirectStatus.getRedirectStatus(stmt));
+
+        UpdateStmt updateStmt = new UpdateStmt(null, java.util.Collections.emptyList(), java.util.Collections.emptyList(),
+                null, java.util.Collections.emptyList());
+        SubmitTaskStmt updateTaskStmt = new SubmitTaskStmt(new TaskName("test", "task_update"), 0, updateStmt,
+                NodePosition.ZERO);
+        Assertions.assertSame(updateStmt, updateTaskStmt.getUpdateStmt());
+        Assertions.assertEquals(RedirectStatus.FORWARD_WITH_SYNC, RedirectStatus.getRedirectStatus(updateTaskStmt));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -1254,6 +1254,19 @@ public class PrivilegeCheckerTest extends StarRocksTestBase {
                     "Access denied;");
         }
 
+        // check SUBMIT TASK AS UPDATE: UPDATE on the target table
+        verifyGrantRevoke(
+                "submit task as update db1.tbl1 set k4 = 2 where k3 = 1",
+                "grant update on db1.tbl1 to test",
+                "revoke update on db1.tbl1 from test",
+                "Access denied; you need (at least one of) the UPDATE privilege(s) on TABLE tbl1 for this operation");
+        verifyGrantRevokeFail(
+                "submit task as update db1.tbl1 set k4 = s.k4 from db1.tbl2 s where db1.tbl1.k1 = s.k1",
+                "grant update on db1.tbl1 to test",
+                "revoke update on db1.tbl1 from test",
+                "Access denied; you need (at least one of) the UPDATE privilege(s) on TABLE tbl1 for this operation",
+                "Access denied; you need (at least one of) the SELECT privilege(s) on TABLE tbl2 for this operation");
+
         // check drop non-existed table
         statement = UtFrameUtils.parseStmtWithNewParser(
                 "drop table if exists db1.tbl_not_exist1", ctx);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/HintCollectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/HintCollectorTest.java
@@ -63,6 +63,9 @@ class HintCollectorTest {
                 "where tbl.col = t1.col", 3));
         arguments.add(Arguments.of("submit /*+ set_var(abc = abc) */ task " +
                 "as create table temp as select count(*) as cnt from tbl1", 1));
+        arguments.add(Arguments.of("submit /*+ set_var(abc = abc) */ task as update /*+ set_var(abc = abc) */ tbl set col = 1 " +
+                "from (select /*+ set_var(abc = abc) */ * from (select /*+ set_var(abc = abc) */ * from t1) t) t1 " +
+                "where t1.col = tbl.col", 4));
         arguments.add(Arguments.of("LOAD /*+ set_var(abc = abc) */ LABEL test.testLabel " +
                 "(DATA INFILE(\"hdfs://hdfs_host:hdfs_port/file\") " +
                 "INTO TABLE `t0`) WITH BROKER hdfs_broker (\"username\"=\"sr\", \"password\"=\"PASSWORDDDD\") " +

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -699,7 +699,7 @@ columnNameWithComment
 submitTaskStatement
     : SUBMIT TASK qualifiedName?
         taskClause*
-        AS (createTableAsSelectStatement | insertStatement | dataCacheSelectStatement)
+        AS (createTableAsSelectStatement | insertStatement | updateStatement | dataCacheSelectStatement)
     ;
 
 alterTaskStatement

--- a/test/sql/test_information_schema/R/test_task_run_status
+++ b/test/sql/test_information_schema/R/test_task_run_status
@@ -80,6 +80,25 @@ select distinct TASK_SOURCE from information_schema.task_runs where task_name='t
 -- result:
 CTAS
 -- !result
+CREATE TABLE ss_pk( pk INT NOT NULL, pv BIGINT NOT NULL) PRIMARY KEY(pk) DISTRIBUTED BY HASH(pk) BUCKETS 8 PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+insert into ss_pk values(1, 1), (2, 2);
+-- result:
+-- !result
+submit task task_src_update_${uuid0} as update ss_pk set pv = 100 where pk = 1;
+-- result:
+task_src_update_${uuid0}	SUBMITTED
+-- !result
+LOOP {
+  PROPERTY: {"timeout": 30, "interval": 2, "desc": "wait for UPDATE task run to appear"}
+  result=select count(*) from information_schema.task_runs where task_name='task_src_update_${uuid0}';
+  CHECK: int(${result}[-1][0]) > 0
+} END LOOP
+select distinct TASK_SOURCE from information_schema.task_runs where task_name='task_src_update_${uuid0}';
+-- result:
+UPDATE
+-- !result
 admin set frontend config('enable_task_run_fe_evaluation'='false');
 -- result:
 -- !result

--- a/test/sql/test_information_schema/R/test_task_run_status
+++ b/test/sql/test_information_schema/R/test_task_run_status
@@ -54,10 +54,7 @@ SELECT TASK_SOURCE FROM information_schema.task_runs WHERE task_name = '${task_n
 -- result:
 MV
 -- !result
-submit task task_src_insert_${uuid0} as insert into ss select * from ss;
--- result:
-task_src_insert_${uuid0}	SUBMITTED
--- !result
+[UC]submit task task_src_insert_${uuid0} as insert into ss select * from ss;
 LOOP {
   PROPERTY: {"timeout": 30, "interval": 2, "desc": "wait for INSERT task run to appear"}
   result=select count(*) from information_schema.task_runs where task_name='task_src_insert_${uuid0}';
@@ -67,10 +64,7 @@ select distinct TASK_SOURCE from information_schema.task_runs where task_name='t
 -- result:
 INSERT
 -- !result
-submit task task_src_ctas_${uuid0} as create table ss_ctas as select event_day, pv from ss;
--- result:
-task_src_ctas_${uuid0}	SUBMITTED
--- !result
+[UC]submit task task_src_ctas_${uuid0} as create table ss_ctas as select event_day, pv from ss;
 LOOP {
   PROPERTY: {"timeout": 30, "interval": 2, "desc": "wait for CTAS task run to appear"}
   result=select count(*) from information_schema.task_runs where task_name='task_src_ctas_${uuid0}';
@@ -86,10 +80,7 @@ CREATE TABLE ss_pk( pk INT NOT NULL, pv BIGINT NOT NULL) PRIMARY KEY(pk) DISTRIB
 insert into ss_pk values(1, 1), (2, 2);
 -- result:
 -- !result
-submit task task_src_update_${uuid0} as update ss_pk set pv = 100 where pk = 1;
--- result:
-task_src_update_${uuid0}	SUBMITTED
--- !result
+[UC]submit task task_src_update_${uuid0} as update ss_pk set pv = 100 where pk = 1;
 LOOP {
   PROPERTY: {"timeout": 30, "interval": 2, "desc": "wait for UPDATE task run to appear"}
   result=select count(*) from information_schema.task_runs where task_name='task_src_update_${uuid0}';

--- a/test/sql/test_information_schema/T/test_task_run_status
+++ b/test/sql/test_information_schema/T/test_task_run_status
@@ -36,6 +36,15 @@ LOOP {
   CHECK: int(${result}[-1][0]) > 0
 } END LOOP
 select distinct TASK_SOURCE from information_schema.task_runs where task_name='task_src_ctas_${uuid0}';
+CREATE TABLE ss_pk( pk INT NOT NULL, pv BIGINT NOT NULL) PRIMARY KEY(pk) DISTRIBUTED BY HASH(pk) BUCKETS 8 PROPERTIES("replication_num" = "1");
+insert into ss_pk values(1, 1), (2, 2);
+submit task task_src_update_${uuid0} as update ss_pk set pv = 100 where pk = 1;
+LOOP {
+  PROPERTY: {"timeout": 30, "interval": 2, "desc": "wait for UPDATE task run to appear"}
+  result=select count(*) from information_schema.task_runs where task_name='task_src_update_${uuid0}';
+  CHECK: int(${result}[-1][0]) > 0
+} END LOOP
+select distinct TASK_SOURCE from information_schema.task_runs where task_name='task_src_update_${uuid0}';
 
 admin set frontend config('enable_task_run_fe_evaluation'='false');
 [UC]query_id=SELECT `QUERY_ID` FROM information_schema.task_runs WHERE task_name = '${task_name}' limit 1;

--- a/test/sql/test_information_schema/T/test_task_run_status
+++ b/test/sql/test_information_schema/T/test_task_run_status
@@ -22,14 +22,14 @@ SELECT count(1) FROM information_schema.task_runs WHERE TASK_NAME = '${task_name
 SELECT count(1) FROM information_schema.task_runs WHERE task_name = '${task_name}';
 SELECT TASK_SOURCE FROM information_schema.task_runs WHERE task_name = '${task_name}';
 
-submit task task_src_insert_${uuid0} as insert into ss select * from ss;
+[UC]submit task task_src_insert_${uuid0} as insert into ss select * from ss;
 LOOP {
   PROPERTY: {"timeout": 30, "interval": 2, "desc": "wait for INSERT task run to appear"}
   result=select count(*) from information_schema.task_runs where task_name='task_src_insert_${uuid0}';
   CHECK: int(${result}[-1][0]) > 0
 } END LOOP
 select distinct TASK_SOURCE from information_schema.task_runs where task_name='task_src_insert_${uuid0}';
-submit task task_src_ctas_${uuid0} as create table ss_ctas as select event_day, pv from ss;
+[UC]submit task task_src_ctas_${uuid0} as create table ss_ctas as select event_day, pv from ss;
 LOOP {
   PROPERTY: {"timeout": 30, "interval": 2, "desc": "wait for CTAS task run to appear"}
   result=select count(*) from information_schema.task_runs where task_name='task_src_ctas_${uuid0}';
@@ -38,7 +38,7 @@ LOOP {
 select distinct TASK_SOURCE from information_schema.task_runs where task_name='task_src_ctas_${uuid0}';
 CREATE TABLE ss_pk( pk INT NOT NULL, pv BIGINT NOT NULL) PRIMARY KEY(pk) DISTRIBUTED BY HASH(pk) BUCKETS 8 PROPERTIES("replication_num" = "1");
 insert into ss_pk values(1, 1), (2, 2);
-submit task task_src_update_${uuid0} as update ss_pk set pv = 100 where pk = 1;
+[UC]submit task task_src_update_${uuid0} as update ss_pk set pv = 100 where pk = 1;
 LOOP {
   PROPERTY: {"timeout": 30, "interval": 2, "desc": "wait for UPDATE task run to appear"}
   result=select count(*) from information_schema.task_runs where task_name='task_src_update_${uuid0}';

--- a/test/sql/test_task/R/test_submit_update_task
+++ b/test/sql/test_task/R/test_submit_update_task
@@ -1,0 +1,49 @@
+-- name: test_submit_update_task
+create database test_task_${uuid0};
+-- result:
+-- !result
+use test_task_${uuid0};
+-- result:
+-- !result
+create table target(pk int not null, v int not null) primary key(pk) distributed by hash(pk) buckets 1 properties("replication_num" = "1");
+-- result:
+-- !result
+create table staging(pk int, v int) duplicate key(pk) distributed by hash(pk) buckets 1 properties("replication_num" = "1");
+-- result:
+-- !result
+insert into target values(1, 10), (2, 20);
+-- result:
+-- !result
+insert into staging values(1, 100), (3, 300);
+-- result:
+-- !result
+submit task t_update as update target set v = staging.v from staging where target.pk = staging.pk;
+-- result:
+t_update	SUBMITTED
+-- !result
+select TASK_NAME, DEFINITION from information_schema.tasks where `DATABASE`='test_task_${uuid0}' and task_name='t_update';
+-- result:
+t_update	update target set v = staging.v from staging where target.pk = staging.pk;
+-- !result
+LOOP {
+  PROPERTY: {"timeout": 30, "interval": 2, "desc": "wait for the UPDATE task run to succeed"}
+  result=select count(*) from information_schema.task_runs where `DATABASE`='test_task_${uuid0}' and task_name='t_update' and `STATE`='SUCCESS';
+  CHECK: int(${result}[-1][0]) > 0
+} END LOOP
+select * from target order by pk;
+-- result:
+1	100
+2	20
+-- !result
+drop task t_update;
+-- result:
+-- !result
+drop table staging;
+-- result:
+-- !result
+drop table target;
+-- result:
+-- !result
+drop database test_task_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_task/R/test_submit_update_task
+++ b/test/sql/test_task/R/test_submit_update_task
@@ -17,17 +17,17 @@ insert into target values(1, 10), (2, 20);
 insert into staging values(1, 100), (3, 300);
 -- result:
 -- !result
-submit task t_update as update target set v = staging.v from staging where target.pk = staging.pk;
+submit task t_update_${uuid0} as update target set v = staging.v from staging where target.pk = staging.pk;
 -- result:
-t_update	SUBMITTED
+t_update_${uuid0}	SUBMITTED
 -- !result
-select TASK_NAME, DEFINITION from information_schema.tasks where `DATABASE`='test_task_${uuid0}' and task_name='t_update';
+select TASK_NAME, DEFINITION from information_schema.tasks where `DATABASE`='test_task_${uuid0}' and task_name='t_update_${uuid0}';
 -- result:
-t_update	update target set v = staging.v from staging where target.pk = staging.pk;
+t_update_${uuid0}	update target set v = staging.v from staging where target.pk = staging.pk;
 -- !result
 LOOP {
   PROPERTY: {"timeout": 30, "interval": 2, "desc": "wait for the UPDATE task run to succeed"}
-  result=select count(*) from information_schema.task_runs where `DATABASE`='test_task_${uuid0}' and task_name='t_update' and `STATE`='SUCCESS';
+  result=select count(*) from information_schema.task_runs where `DATABASE`='test_task_${uuid0}' and task_name='t_update_${uuid0}' and `STATE`='SUCCESS';
   CHECK: int(${result}[-1][0]) > 0
 } END LOOP
 select * from target order by pk;
@@ -35,7 +35,7 @@ select * from target order by pk;
 1	100
 2	20
 -- !result
-drop task t_update;
+drop task t_update_${uuid0};
 -- result:
 -- !result
 drop table staging;

--- a/test/sql/test_task/R/test_submit_update_task
+++ b/test/sql/test_task/R/test_submit_update_task
@@ -17,19 +17,17 @@ insert into target values(1, 10), (2, 20);
 insert into staging values(1, 100), (3, 300);
 -- result:
 -- !result
-submit task t_update_${uuid0} as update target set v = staging.v from staging where target.pk = staging.pk;
+[UC]submit task t_update_${uuid0} as update target set v = staging.v from staging where target.pk = staging.pk;
+select DEFINITION from information_schema.tasks where `DATABASE`='test_task_${uuid0}' and task_name='t_update_${uuid0}';
 -- result:
-t_update_${uuid0}	SUBMITTED
--- !result
-select TASK_NAME, DEFINITION from information_schema.tasks where `DATABASE`='test_task_${uuid0}' and task_name='t_update_${uuid0}';
--- result:
-t_update_${uuid0}	update target set v = staging.v from staging where target.pk = staging.pk;
+update target set v = staging.v from staging where target.pk = staging.pk;
 -- !result
 LOOP {
   PROPERTY: {"timeout": 30, "interval": 2, "desc": "wait for the UPDATE task run to succeed"}
   result=select count(*) from information_schema.task_runs where `DATABASE`='test_task_${uuid0}' and task_name='t_update_${uuid0}' and `STATE`='SUCCESS';
   CHECK: int(${result}[-1][0]) > 0
 } END LOOP
+
 select * from target order by pk;
 -- result:
 1	100

--- a/test/sql/test_task/T/test_submit_update_task
+++ b/test/sql/test_task/T/test_submit_update_task
@@ -1,0 +1,24 @@
+-- name: test_submit_update_task
+create database test_task_${uuid0};
+use test_task_${uuid0};
+
+create table target(pk int not null, v int not null) primary key(pk) distributed by hash(pk) buckets 1 properties("replication_num" = "1");
+create table staging(pk int, v int) duplicate key(pk) distributed by hash(pk) buckets 1 properties("replication_num" = "1");
+insert into target values(1, 10), (2, 20);
+insert into staging values(1, 100), (3, 300);
+
+submit task t_update as update target set v = staging.v from staging where target.pk = staging.pk;
+select TASK_NAME, DEFINITION from information_schema.tasks where `DATABASE`='test_task_${uuid0}' and task_name='t_update';
+
+LOOP {
+  PROPERTY: {"timeout": 30, "interval": 2, "desc": "wait for the UPDATE task run to succeed"}
+  result=select count(*) from information_schema.task_runs where `DATABASE`='test_task_${uuid0}' and task_name='t_update' and `STATE`='SUCCESS';
+  CHECK: int(${result}[-1][0]) > 0
+} END LOOP
+
+select * from target order by pk;
+
+drop task t_update;
+drop table staging;
+drop table target;
+drop database test_task_${uuid0};

--- a/test/sql/test_task/T/test_submit_update_task
+++ b/test/sql/test_task/T/test_submit_update_task
@@ -7,8 +7,8 @@ create table staging(pk int, v int) duplicate key(pk) distributed by hash(pk) bu
 insert into target values(1, 10), (2, 20);
 insert into staging values(1, 100), (3, 300);
 
-submit task t_update_${uuid0} as update target set v = staging.v from staging where target.pk = staging.pk;
-select TASK_NAME, DEFINITION from information_schema.tasks where `DATABASE`='test_task_${uuid0}' and task_name='t_update_${uuid0}';
+[UC]submit task t_update_${uuid0} as update target set v = staging.v from staging where target.pk = staging.pk;
+select DEFINITION from information_schema.tasks where `DATABASE`='test_task_${uuid0}' and task_name='t_update_${uuid0}';
 
 LOOP {
   PROPERTY: {"timeout": 30, "interval": 2, "desc": "wait for the UPDATE task run to succeed"}

--- a/test/sql/test_task/T/test_submit_update_task
+++ b/test/sql/test_task/T/test_submit_update_task
@@ -7,18 +7,18 @@ create table staging(pk int, v int) duplicate key(pk) distributed by hash(pk) bu
 insert into target values(1, 10), (2, 20);
 insert into staging values(1, 100), (3, 300);
 
-submit task t_update as update target set v = staging.v from staging where target.pk = staging.pk;
-select TASK_NAME, DEFINITION from information_schema.tasks where `DATABASE`='test_task_${uuid0}' and task_name='t_update';
+submit task t_update_${uuid0} as update target set v = staging.v from staging where target.pk = staging.pk;
+select TASK_NAME, DEFINITION from information_schema.tasks where `DATABASE`='test_task_${uuid0}' and task_name='t_update_${uuid0}';
 
 LOOP {
   PROPERTY: {"timeout": 30, "interval": 2, "desc": "wait for the UPDATE task run to succeed"}
-  result=select count(*) from information_schema.task_runs where `DATABASE`='test_task_${uuid0}' and task_name='t_update' and `STATE`='SUCCESS';
+  result=select count(*) from information_schema.task_runs where `DATABASE`='test_task_${uuid0}' and task_name='t_update_${uuid0}' and `STATE`='SUCCESS';
   CHECK: int(${result}[-1][0]) > 0
 } END LOOP
 
 select * from target order by pk;
 
-drop task t_update;
+drop task t_update_${uuid0};
 drop table staging;
 drop table target;
 drop database test_task_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
SUBMIT TASK already async-runs CTAS/INSERT. UPDATE is the same long-running ETL, but it still had to run in-session.

## What I'm doing:
Allow SUBMIT TASK ... AS UPDATE: grammar, AST, analyzer/auth, TaskSource.UPDATE, docs, tests.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
Fixes https://github.com/StarRocks/starrocks/issues/78132

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5