### PR TITLE
[Enhancement] Prune unused output columns on primary key tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -132,7 +132,6 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AssertNumRowsElement;
 import com.starrocks.sql.ast.BrokerDesc;
 import com.starrocks.sql.ast.JoinOperator;
-import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.OrderByElement;
 import com.starrocks.sql.ast.expression.AnalyticWindow;
 import com.starrocks.sql.ast.expression.AnalyticWindowBoundary;
@@ -625,8 +624,7 @@ public class PlanFragmentBuilder {
             // ------------------------------------------------------------------------------------
             // Get mv use columns
             // ------------------------------------------------------------------------------------
-            if (materializedIndexMeta.getKeysType().isAggregationFamily() ||
-                    materializedIndexMeta.getKeysType() == KeysType.PRIMARY_KEYS) {
+            if (materializedIndexMeta.getKeysType().isAggregationFamily()) {
                 Map<String, Integer> columnNameToId = scanNode.getSlots().stream().collect(Collectors.toMap(
                         slot -> slot.getColumn().getName(),
                         slot -> slot.getId().asInt()

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -575,8 +575,7 @@ public class PlanFragmentBuilder {
          *
          * <p> The columns that can be pushed down need to meet:
          * <ul>
-         * <li> All the columns of duplicate-key model.
-         * <li> Keys of primary-key model.
+         * <li> All the columns of duplicate-key and primary-key models, keys and values alike.
          * <li> Keys of agg-key model (aggregation/unique_key model) in the skip-aggr scan stage.
          * </ul>
          *

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/FilterUnusedColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/FilterUnusedColumnTest.java
@@ -68,6 +68,19 @@ public class FilterUnusedColumnTest extends PlanTestBase {
                 "\"replication_num\" = \"1\",\n" +
                 "\"in_memory\" = \"false\"\n" +
                 ");");
+        // Same columns as primary_table, duplicate keys: the baseline this change aligns primary keys with.
+        starRocksAssert.withTable("CREATE TABLE `duplicate_table` ( \n" +
+                "`tags_id` int(11) NOT NULL COMMENT \"\", \n" +
+                "`timestamp` datetime NOT NULL COMMENT \"\", \n" +
+                "`k3` varchar(65533) NOT NULL COMMENT \"\" \n" +
+                ") ENGINE=OLAP \n" +
+                "DUPLICATE KEY(`tags_id`, `timestamp`) \n" +
+                "COMMENT \"OLAP\" \n" +
+                "DISTRIBUTED BY HASH(`tags_id`) BUCKETS 1\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\"\n" +
+                ");");
 
         FeConstants.USE_MOCK_DICT_MANAGER = true;
         connectContext.getSessionVariable().setSqlMode(2);
@@ -293,41 +306,64 @@ public class FilterUnusedColumnTest extends PlanTestBase {
 
     @Test
     public void testFilterPrimaryKeyTable() throws Exception {
+        // A primary key table never merges rows, so value columns are as prunable as on a duplicate table.
         {
             String sql = "select timestamp from primary_table where k3 = \"test\" limit 10;";
             String plan = getThriftPlan(sql);
-            assertContains(plan, "unused_output_column_name:[]");
+            assertContains(plan, "unused_output_column_name:[k3]");
         }
         {
-            // tags_id is can be pushdown, and only used by the pushdownable predicate.
+            // Both predicate columns are unused: tags_id is pushdownable and k3 is the only value column.
             String sql = "select timestamp from primary_table where k3 = \"test\" and tags_id = 1;";
             String plan = getThriftPlan(sql);
             logSysInfo(plan);
-            assertContains(plan, "unused_output_column_name:[tags_id]");
+            assertContains(plan, "unused_output_column_name:[tags_id, k3]");
         }
         {
-            // tags_id is can be pushdown and only used by the pushdownable predicate,
-            // but it also be the output column.
+            // tags_id is also the output column, so only k3 stays unused.
             String sql = "select tags_id from primary_table where k3 = \"test\" and tags_id = 1;";
             String plan = getThriftPlan(sql);
             logSysInfo(plan);
-            assertContains(plan, "unused_output_column_name:[]");
+            assertContains(plan, "unused_output_column_name:[k3]");
         }
         {
-            // tags_id is can be pushdown and used by the pushdownable predicate,
-            // but it also be used by the non-pushdownable predicate.
+            // The non-pushdownable predicate sits in a SELECT node above the scan, so the scan must output its columns.
             String sql = "select k3 from primary_table where timestamp + tags_id = \"test\" and tags_id = 1;";
             String plan = getThriftPlan(sql);
             logSysInfo(plan);
             assertContains(plan, "unused_output_column_name:[]");
         }
         {
-            // tags_id is can be pushdown and used by the pushdownable predicate,
-            // but it also be used by the non-pushdownable predicate.
             String sql = "select timestamp from primary_table where k3 + tags_id = \"test\" and tags_id = 1;";
             String plan = getThriftPlan(sql);
             logSysInfo(plan);
             assertContains(plan, "unused_output_column_name:[]");
+        }
+    }
+
+    // Locks the claim of this change: a primary key table prunes exactly what a duplicate key table prunes.
+    @Test
+    public void testFilterDuplicateKeyTableSameShapesAsPrimaryKey() throws Exception {
+        {
+            String sql = "select timestamp from duplicate_table where k3 = \"test\" limit 10;";
+            assertContains(getThriftPlan(sql), "unused_output_column_name:[k3]");
+        }
+        {
+            String sql = "select timestamp from duplicate_table where k3 = \"test\" and tags_id = 1;";
+            assertContains(getThriftPlan(sql), "unused_output_column_name:[tags_id, k3]");
+        }
+        {
+            String sql = "select tags_id from duplicate_table where k3 = \"test\" and tags_id = 1;";
+            assertContains(getThriftPlan(sql), "unused_output_column_name:[k3]");
+        }
+        {
+            // Empty here too, so the [] above is the predicate shape talking, not the key type.
+            String sql = "select k3 from duplicate_table where timestamp + tags_id = \"test\" and tags_id = 1;";
+            assertContains(getThriftPlan(sql), "unused_output_column_name:[]");
+        }
+        {
+            String sql = "select timestamp from duplicate_table where k3 + tags_id = \"test\" and tags_id = 1;";
+            assertContains(getThriftPlan(sql), "unused_output_column_name:[]");
         }
     }
 

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -368,3 +368,84 @@ select id from t_gin_or_prune_${uuid0} where v like '%red%' order by id;
 DROP TABLE t_gin_or_prune_${uuid0};
 -- result:
 -- !result
+-- name: test_gin_prune_primary_key_table @native
+ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
+-- result:
+-- !result
+set low_cardinality_optimize_v2 = false;
+-- result:
+-- !result
+set cbo_enable_low_cardinality_optimize = false;
+-- result:
+-- !result
+CREATE TABLE `t_gin_prune_pk_${uuid0}` (
+  `id` bigint NOT NULL,
+  `ts` datetime NOT NULL,
+  `v`  varchar(255) NOT NULL,
+  INDEX gin_v (`v`) USING GIN ("parser" = "none")
+) ENGINE=OLAP
+PRIMARY KEY(`id`, `ts`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1
+PROPERTIES ("replication_num" = "1", "replicated_storage" = "false");
+-- result:
+-- !result
+insert into t_gin_prune_pk_${uuid0} values
+  (1, "2024-01-01 00:00:00", "redx"),
+  (2, "2024-01-01 00:00:00", "redy"),
+  (3, "2024-01-01 00:00:00", "blue"),
+  (4, "2024-01-01 00:00:00", "redx");
+-- result:
+-- !result
+select max(id) from t_gin_prune_pk_${uuid0} where v = 'redx';
+-- result:
+4
+-- !result
+select count(1) from t_gin_prune_pk_${uuid0} where v = 'redx';
+-- result:
+2
+-- !result
+select id from t_gin_prune_pk_${uuid0} where v = 'redx' order by id;
+-- result:
+1
+4
+-- !result
+select id, v from t_gin_prune_pk_${uuid0} where v = 'redx' order by id;
+-- result:
+1	redx
+4	redx
+-- !result
+select max(id) from t_gin_prune_pk_${uuid0} where v like '%red%';
+-- result:
+4
+-- !result
+set enable_prune_column_after_index_filter = false;
+-- result:
+-- !result
+select max(id) from t_gin_prune_pk_${uuid0} where v = 'redx';
+-- result:
+4
+-- !result
+select count(1) from t_gin_prune_pk_${uuid0} where v = 'redx';
+-- result:
+2
+-- !result
+select id from t_gin_prune_pk_${uuid0} where v = 'redx' order by id;
+-- result:
+1
+4
+-- !result
+select id, v from t_gin_prune_pk_${uuid0} where v = 'redx' order by id;
+-- result:
+1	redx
+4	redx
+-- !result
+select max(id) from t_gin_prune_pk_${uuid0} where v like '%red%';
+-- result:
+4
+-- !result
+set enable_prune_column_after_index_filter = true;
+-- result:
+-- !result
+DROP TABLE t_gin_prune_pk_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_inverted_index/T/test_inverted_index
+++ b/test/sql/test_inverted_index/T/test_inverted_index
@@ -248,3 +248,40 @@ select id, v from t_gin_or_prune_${uuid0} where v like '%red%' and (v = 'redx' o
 select id from t_gin_or_prune_${uuid0} where v like '%red%' order by id;
 
 DROP TABLE t_gin_or_prune_${uuid0};
+
+-- name: test_gin_prune_primary_key_table @native
+ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
+set low_cardinality_optimize_v2 = false;
+set cbo_enable_low_cardinality_optimize = false;
+CREATE TABLE `t_gin_prune_pk_${uuid0}` (
+  `id` bigint NOT NULL,
+  `ts` datetime NOT NULL,
+  `v`  varchar(255) NOT NULL,
+  INDEX gin_v (`v`) USING GIN ("parser" = "none")
+) ENGINE=OLAP
+PRIMARY KEY(`id`, `ts`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1
+PROPERTIES ("replication_num" = "1", "replicated_storage" = "false");
+
+insert into t_gin_prune_pk_${uuid0} values
+  (1, "2024-01-01 00:00:00", "redx"),
+  (2, "2024-01-01 00:00:00", "redy"),
+  (3, "2024-01-01 00:00:00", "blue"),
+  (4, "2024-01-01 00:00:00", "redx");
+
+-- the indexed column is a value column and is not projected, so it must be prunable on a primary key table
+select max(id) from t_gin_prune_pk_${uuid0} where v = 'redx';
+select count(1) from t_gin_prune_pk_${uuid0} where v = 'redx';
+select id from t_gin_prune_pk_${uuid0} where v = 'redx' order by id;
+select id, v from t_gin_prune_pk_${uuid0} where v = 'redx' order by id;
+select max(id) from t_gin_prune_pk_${uuid0} where v like '%red%';
+
+set enable_prune_column_after_index_filter = false;
+select max(id) from t_gin_prune_pk_${uuid0} where v = 'redx';
+select count(1) from t_gin_prune_pk_${uuid0} where v = 'redx';
+select id from t_gin_prune_pk_${uuid0} where v = 'redx' order by id;
+select id, v from t_gin_prune_pk_${uuid0} where v = 'redx' order by id;
+select max(id) from t_gin_prune_pk_${uuid0} where v like '%red%';
+set enable_prune_column_after_index_filter = true;
+
+DROP TABLE t_gin_prune_pk_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

When a builtin GIN resolves a predicate completely, the indexed column is not needed any
more and the scan should stop materializing it. That already happens on a duplicate key
table. On a primary key table it does not, if the indexed column is a value column — the
whole column is read for nothing.

Three tables with byte-identical schemas, 1M rows, `v` a 104-byte string, 55% of rows
sharing one hot value, running `select max(id) from <t> where v = '<hot>'`:

| table | BytesRead | GinFilterRows | RawRowsRead | result |
|---|---|---|---|---|
| `pk_v`  — PK, indexed column is a **value** column | **60.844 MB** | 450000 | 550000 | 1000000 |
| `pk_k`  — PK, indexed column is a **key** column   | 4.196 MB | 450000 | 550000 | 1000000 |
| `dup_v` — duplicate key table                      | 4.196 MB | 450000 | 550000 | 1000000 |

`GinFilterRows`, `RawRowsRead` and the result are identical everywhere, so the index behaves
the same in all three cases; the only difference is whether the resolved column is
materialized. The 56.6 MB gap is 104 bytes x 550000 matched rows.

`setUnUsedOutputColumns` lumps `PRIMARY_KEYS` in with the aggregation family and force-adds
every non-key column to `requiredColumns`, so no value column can ever reach
`unused_output_column_name`. For the aggregation family that has a real reason, stated in the
comment just above: duplicate keys must be merged, so value columns have to be read before
aggregation. A primary key table does not aggregate — in
`TabletReader::_init_reader_params` it takes the same `new_union_iterator` branch as a
duplicate key table, while only `AGG_KEYS` / `UNIQUE_KEYS` without `skip_aggr` go through
`new_aggregate_iterator`.

The `PRIMARY_KEYS` half arrived with #5145 (2022-04), which fixed an *aggregate table* BE
SIGSEGV in `_finish_late_materialization` (#4916); neither the issue nor the PR body gives a
reason for including primary keys. Four months later #10842 added the
`isAggregationFamily() && !isPreAggregation()` early return, which is the on-point guard for
the aggregation case and does not apply to primary key tables. On the BE side the prune path
makes no key/value distinction at all — there is no `is_key` check in `segment_iterator.cpp`,
`_prune_cols` is just a set of column ids.

## What I'm doing:

Dropping only the `PRIMARY_KEYS` half of that condition, so a primary key table reports
unused output columns exactly like a duplicate key table. The `isAggregationFamily()` half is
untouched, so aggregate and unique key tables keep their current behavior. The now-unused
`KeysType` import goes with it.

Nothing about BE-side safety relies on this: the BE decides independently whether a column is
actually prunable — the predicate must have been fully erased by the index
(`prune_cols_candidate_by_inverted_index`, gated on `remaining_predicates_require_column`),
and the column must not be referenced by a delete condition (`delete_pred_columns`). FE only
says "nothing above the scan needs this column".

After the change, on the same corpus and the same BE binary:

| table | before | after |
|---|---|---|
| `pk_v`  — PK, indexed column is a **value** column | 60.844 MB | **4.196 MB** |
| `pk_k`  — PK, indexed column is a **key** column   | 4.196 MB | 4.196 MB (unchanged) |
| `dup_v` — duplicate key table                      | 4.196 MB | 4.196 MB (unchanged) |

`GinFilterRows` (450000), `RawRowsRead` (550000) and the result (1000000) are byte-identical
across all six measurements, and `PredFilterRows` is 0 throughout — only `pk_v`'s `BytesRead`
moves.

Two more things verified on a live cluster, because this also opens two paths that were
previously unreachable on primary key tables:

- The unused-column list drives `_skip_dict_decode_indexes` as well as `_prune_cols`, so
  queries with **no index at all** were checked too: a primary key table with a
  low-cardinality string predicate whose column is not projected returns exactly the same
  rows as an identically-loaded duplicate key table, and as the same table with
  `enable_filter_unused_columns_in_scan_stage = false` (bidirectional `EXCEPT` = 0 both ways).
  Re-checked after a column-mode partial update, so the read goes through a delta column
  group.
- With `requiredColumns` now able to come out empty, a primary key table can reach
  `chooseRowCarrierSlot` and synthesize a `_row_id_` carrier. `select count(*) from pk_v
  where v = '<hot>'` drops from 56.648 MB to 0 B, matching the duplicate key table exactly,
  and returns the same 550000.

Tests:

- `FilterUnusedColumnTest` — 17/17. `testFilterPrimaryKeyTable`'s first three assertions
  change (`[]` -> `[k3]`, `[tags_id]` -> `[tags_id, k3]`, `[]` -> `[k3]`). The last two stay
  `[]`: their non-pushdownable predicate sits in a `SELECT` node above the scan, so the scan
  still has to output those columns. `testFilterAggTable` and `testFilterAggMV` pass
  unchanged, as does the existing primary-key coverage in `tesOrPredicate`.
- New `testFilterDuplicateKeyTableSameShapesAsPrimaryKey` runs the same five query shapes
  against a duplicate key table with identical columns and asserts the same five values,
  pinning down the claim that a primary key table now prunes exactly what a duplicate key
  table prunes — and that the two `[]` results above come from the predicate shape, not the
  key type.
- New SQL-tester case `test_gin_prune_primary_key_table` covers `max(id)` / `count(1)` /
  `select id` / `select id, v` / `like` on a primary key table with a builtin GIN, with
  `enable_prune_column_after_index_filter` both on and off; results are identical in both
  states.
- Ran the whole `com.starrocks.sql.plan.*Test` set as a regression net: 3400 tests, no
  failures.

Not covered: the shared-data / lake scan path
(`msg.lake_scan_node.setUnused_output_column_name` -> `lake_connector.cpp`) was not exercised
on a live cluster — all the measurements above are shared-nothing. The FE code is shared
between the two paths, but that is worth a reviewer's eye.

Fixes #78136

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

Checked: this is an [Enhancement], so no release branch is selected — main only.
