### PR TITLE
[BugFix] Fix Clang 20 shared-data build errors

### DIFF
--- a/be/src/exec_primitive/runtime_filter/runtime_filter_probe.cpp
+++ b/be/src/exec_primitive/runtime_filter/runtime_filter_probe.cpp
@@ -14,14 +14,11 @@
 
 #include "exec_primitive/runtime_filter/runtime_filter_probe.h"
 
-#include <algorithm>
-#include <cstdlib>
 #include <sstream>
 
 #include "base/simd/simd.h"
 #include "base/time/time.h"
 #include "base/utility/defer_op.h"
-#include "exprs/column_ref.h"
 #include "exprs/expr_factory.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/runtime_state.h"
@@ -494,23 +491,6 @@ void RuntimeFilterProbeCollector::update_selectivity(Chunk* chunk, RuntimeMember
     if (!seletivity_map.empty()) {
         chunk->filter(merged_selection);
     }
-}
-
-static bool contains_dict_mapping_expr(Expr* expr) {
-    if (expr->is_dictmapping_expr()) {
-        return true;
-    }
-
-    return std::any_of(expr->children().begin(), expr->children().end(),
-                       [](Expr* child) { return contains_dict_mapping_expr(child); });
-}
-
-static bool contains_dict_mapping_expr(RuntimeFilterProbeDescriptor* probe_desc) {
-    auto* probe_expr_ctx = probe_desc->probe_expr_ctx();
-    if (probe_expr_ctx == nullptr) {
-        return false;
-    }
-    return contains_dict_mapping_expr(probe_expr_ctx->root());
 }
 
 std::string RuntimeFilterProbeCollector::debug_string() const {

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -2015,7 +2015,7 @@ std::vector<SubtaskGroup> TabletParallelCompactionManager::_create_unshare_subta
 Status TabletParallelCompactionManager::_validate_unshare_group_coverage(const std::vector<RowsetPtr>& rowsets,
                                                                          const std::vector<SubtaskGroup>& groups) {
     struct Coverage {
-        int32_t segment_count = 0;
+        int64_t segment_count = 0;
         bool whole_rowset = false;
         std::vector<std::pair<int32_t, int32_t>> segment_ranges;
     };


### PR DESCRIPTION
## Why I'm doing:

A shared-data BE build with Clang 20 fails while compiling `tablet_parallel_compaction_manager.cpp`: `Rowset::num_segments()` returns `int64_t`, but list-initialization narrows it into an `int32_t` coverage field. The same build also reports an unused static runtime-filter helper that has no callers.

## What I'm doing:

- Store the UNSHARE coverage segment count as `int64_t`, matching `Rowset::num_segments()` and avoiding narrowing or truncation.
- Remove the unreachable runtime-filter helper overloads and their unused includes instead of suppressing the compiler diagnostic.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

Validation:

- Clang 20.1.8 shared-data ASAN object builds pass; the runtime-filter object also passes with `-Werror=unused-function`.
- `exec_primitive_test`: 28/28 passed.
- `TabletParallelCompactionManagerTest.*`: 97/97 passed.
- clang-format-10, `git diff --check`, full BE module boundaries, and generated AGENTS checks pass.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
