### PR TITLE
[BugFix] Fix Query Queue dual bugs: worker error termination (#77488) and busy-spin CPU 100% (#77483)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotManager.java
@@ -115,9 +115,9 @@ public class SlotManager extends BaseSlotManager {
                     long minExpiredTimeMs = slotTracker.getMinExpiredTimeMs();
                     long nowMs = System.currentTimeMillis();
                     try {
-                        if (minExpiredTimeMs == 0) {
-                            newTask = requests.take();
-                        } else if (nowMs < minExpiredTimeMs) {
+                        if (minExpiredTimeMs == 0 || nowMs >= minExpiredTimeMs) {
+                            newTask = requests.poll(1000, TimeUnit.MILLISECONDS);
+                        } else {
                             newTask = requests.poll(minExpiredTimeMs - nowMs, TimeUnit.MILLISECONDS);
                         }
                     } catch (InterruptedException e) {
@@ -141,8 +141,8 @@ public class SlotManager extends BaseSlotManager {
                     while (isAllocatedSlots) {
                         isAllocatedSlots = schedule();
                     }
-                } catch (Exception e) {
-                    LOG.warn("[Slot] RequestWorker throws unexpected error", e);
+                } catch (Throwable t) {
+                    LOG.warn("[Slot] RequestWorker throws unexpected error", t);
                 }
             }
         }


### PR DESCRIPTION
## Why I'm doing:
Fix two bugs in the Query Queue's `SlotManager.RequestWorker`:

1. **#77488**: Any `Error` (not `Exception`) permanently terminates the `slot-mgr-req` worker thread, halting all slot admission/reclamation/cleanup.
2. **#77483**: When `expiredPendingTimeMs=0`, the request worker busy-spins at 100% CPU, and expired slot reclamation stops.

## What I'm doing:
### Bug #77488 — Worker termination
Changed `catch (Exception e)` → `catch (Throwable t)` in `RequestWorker.run()` so that `Error` (e.g., `OutOfMemoryError`, `StackOverflowError`) is caught and the worker survives.

### Bug #77483 — Busy-spin + slot reclamation
Restructured the poll logic in `RequestWorker.run()`:
- When `minExpiredTimeMs == 0` or `nowMs >= minExpiredTimeMs`: use `poll(1000ms)` instead of `take()` (permanent block) or direct pass-through (busy-spin)
- This allows `schedule()` to reclaim expired slots every 1 second
- Normal path (`nowMs < minExpiredTimeMs`): unchanged

## Changes:
- 1 file changed: `SlotManager.java`
- 5 insertions, 5 deletions

Fixes #77488, Fixes #77483