### PR TITLE
[BugFix] Fix empty Sql Statement in profile by supporting CTAS deparse (backport #77978)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -61,6 +61,7 @@ import com.starrocks.authorization.ObjectType;
 import com.starrocks.authorization.PEntryObject;
 import com.starrocks.authorization.PrivilegeType;
 import com.starrocks.catalog.BrokerTable;
+import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ConnectorView;
 import com.starrocks.catalog.DistributionInfo;
@@ -103,6 +104,9 @@ import com.starrocks.sql.ast.CreateCatalogStmt;
 import com.starrocks.sql.ast.CreateResourceStmt;
 import com.starrocks.sql.ast.CreateRoutineLoadStmt;
 import com.starrocks.sql.ast.CreateStorageVolumeStmt;
+import com.starrocks.sql.ast.CreateTableAsSelectStmt;
+import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.sql.ast.CreateTemporaryTableAsSelectStmt;
 import com.starrocks.sql.ast.CreateUserStmt;
 import com.starrocks.sql.ast.DataDescription;
 import com.starrocks.sql.ast.DefaultValueExpr;
@@ -111,6 +115,7 @@ import com.starrocks.sql.ast.DescribeStmt;
 import com.starrocks.sql.ast.DictionaryGetExpr;
 import com.starrocks.sql.ast.DropMaterializedViewStmt;
 import com.starrocks.sql.ast.ExceptRelation;
+import com.starrocks.sql.ast.ExpressionPartitionDesc;
 import com.starrocks.sql.ast.ExportStmt;
 import com.starrocks.sql.ast.FieldReference;
 import com.starrocks.sql.ast.FileTableFunctionRelation;
@@ -119,15 +124,19 @@ import com.starrocks.sql.ast.GrantRoleStmt;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.IntersectRelation;
 import com.starrocks.sql.ast.JoinRelation;
+import com.starrocks.sql.ast.KeysDesc;
 import com.starrocks.sql.ast.LambdaFunctionExpr;
+import com.starrocks.sql.ast.ListPartitionDesc;
 import com.starrocks.sql.ast.LoadStmt;
 import com.starrocks.sql.ast.MapExpr;
 import com.starrocks.sql.ast.NormalizedTableFunctionRelation;
+import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.sql.ast.PivotAggregation;
 import com.starrocks.sql.ast.PivotRelation;
 import com.starrocks.sql.ast.PivotValue;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.RangePartitionDesc;
 import com.starrocks.sql.ast.Relation;
 import com.starrocks.sql.ast.SelectList;
 import com.starrocks.sql.ast.SelectListItem;
@@ -1030,6 +1039,121 @@ public class AstToStringBuilder {
             if (StringUtils.isNotEmpty(label)) {
                 sb.append("WITH LABEL `").append(label).append("` ");
             }
+        }
+
+        @Override
+        public String visitCreateTableAsSelectStatement(CreateTableAsSelectStmt stmt, Void context) {
+            StringBuilder sb = new StringBuilder();
+            CreateTableStmt createStmt = stmt.getCreateTableStmt();
+            sb.append("CREATE ");
+            if (stmt instanceof CreateTemporaryTableAsSelectStmt) {
+                sb.append("TEMPORARY ");
+            }
+            sb.append("TABLE ");
+            if (createStmt.isSetIfNotExists()) {
+                sb.append("IF NOT EXISTS ");
+            }
+            sb.append(createStmt.getDbTbl().toSql());
+
+            // The parenthesized clause carries column names, index definitions, or both.
+            List<String> parenthesizedItems = new ArrayList<>();
+            if (CollectionUtils.isNotEmpty(stmt.getColumnNames())) {
+                stmt.getColumnNames().forEach(c -> parenthesizedItems.add(ParseUtil.backquote(c)));
+            }
+            if (CollectionUtils.isNotEmpty(createStmt.getIndexDefs())) {
+                createStmt.getIndexDefs().forEach(d -> parenthesizedItems.add(d.toSql()));
+            }
+            if (!parenthesizedItems.isEmpty()) {
+                sb.append(" (").append(String.join(",", parenthesizedItems)).append(")");
+            }
+
+            String engineName = createStmt.getEngineName();
+            if (StringUtils.isNotEmpty(engineName) && !createStmt.isOlapEngine()) {
+                sb.append(" ENGINE = ").append(engineName);
+            }
+
+            KeysDesc keysDesc = createStmt.getKeysDesc();
+            if (keysDesc != null && CollectionUtils.isNotEmpty(keysDesc.getKeysColumnNames())) {
+                sb.append(" ").append(keysDesc.getKeysType().toSql())
+                        .append("(").append(joinBackQuoted(keysDesc.getKeysColumnNames())).append(")");
+            }
+
+            if (StringUtils.isNotEmpty(createStmt.getComment())) {
+                sb.append(" COMMENT \"")
+                        .append(CatalogUtils.addEscapeCharacter(createStmt.getComment()))
+                        .append("\"");
+            }
+
+            if (createStmt.getPartitionDesc() != null) {
+                String partitionSql = partitionDescToSql(createStmt.getPartitionDesc());
+                if (StringUtils.isNotEmpty(partitionSql)) {
+                    sb.append(" ").append(partitionSql);
+                }
+            }
+
+            if (createStmt.getDistributionDesc() != null) {
+                sb.append(" ").append(createStmt.getDistributionDesc());
+            }
+
+            if (CollectionUtils.isNotEmpty(createStmt.getOrderByElements())) {
+                String orderByColumns = createStmt.getOrderByElements().stream()
+                        .map(e -> visit(e.getExpr()))
+                        .collect(Collectors.joining(","));
+                sb.append(" ORDER BY (").append(orderByColumns).append(")");
+            }
+
+            Map<String, String> properties = createStmt.getProperties();
+            if (properties != null && !properties.isEmpty()) {
+                sb.append(" PROPERTIES (")
+                        .append(new PrintableMap<>(properties, "=", true, false, hideCredential))
+                        .append(")");
+            }
+
+            sb.append(" AS ").append(visit(stmt.getQueryStatement(), context));
+            return sb.toString();
+        }
+
+        /**
+         * PartitionDesc#toSql() is unimplemented across its subclasses, so render the
+         * PARTITION BY clause here. Partition definitions are omitted because this output
+         * is for display in profiles and audit logs, rather than for re-execution.
+         */
+        private String partitionDescToSql(PartitionDesc partitionDesc) {
+            if (partitionDesc instanceof ExpressionPartitionDesc) {
+                return "PARTITION BY " + visit(((ExpressionPartitionDesc) partitionDesc).getExpr());
+            }
+            if (partitionDesc instanceof ListPartitionDesc) {
+                ListPartitionDesc listPartitionDesc = (ListPartitionDesc) partitionDesc;
+                if (CollectionUtils.isNotEmpty(listPartitionDesc.getMultiDescList())) {
+                    String partitionItems = listPartitionDesc.getMultiDescList().stream()
+                            .map(this::visit)
+                            .collect(Collectors.joining(","));
+                    return "PARTITION BY (" + partitionItems + ")";
+                }
+                if (CollectionUtils.isNotEmpty(listPartitionDesc.getPartitionColNames())) {
+                    // On these branches the parser represents an explicit LIST clause as a
+                    // RangePartitionDesc. A ListPartitionDesc with column names therefore comes
+                    // from PARTITION BY (cols), even before analysis sets the automatic flag.
+                    if (listPartitionDesc.isAutoPartitionTable()
+                            || CollectionUtils.isEmpty(listPartitionDesc.getPartitionDescs())) {
+                        return "PARTITION BY (" + joinBackQuoted(listPartitionDesc.getPartitionColNames()) + ")";
+                    }
+                    return "PARTITION BY LIST(" + joinBackQuoted(listPartitionDesc.getPartitionColNames()) + ")";
+                }
+            }
+            if (partitionDesc instanceof RangePartitionDesc) {
+                RangePartitionDesc rangePartitionDesc = (RangePartitionDesc) partitionDesc;
+                if (CollectionUtils.isNotEmpty(rangePartitionDesc.getPartitionColNames())) {
+                    return "PARTITION BY RANGE(" + joinBackQuoted(rangePartitionDesc.getPartitionColNames()) + ") ()";
+                }
+            }
+            return null;
+        }
+
+        private static String joinBackQuoted(List<String> names) {
+            return names.stream()
+                    .map(ParseUtil::backquote)
+                    .collect(Collectors.joining(","));
         }
 
         @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AstToSQLBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AstToSQLBuilderTest.java
@@ -67,4 +67,73 @@ public class AstToSQLBuilderTest {
                         "\"aws.s3.secret_key\" = \"***\", \"format\" = \"parquet\", \"path\" = \"s3://xxx/zzz\")",
                 AstToSQLBuilder.toSQL(stmt));
     }
+
+    @Test
+    public void testCreateTableAsSelect() {
+        // CTAS used to have no deparse visitor and fell through to visitNode() which returns an empty
+        // string, so the profile and audit log of a CTAS in a multi-statement request showed no SQL.
+        String[][] cases = {
+                {"CREATE TABLE t1 AS SELECT v1, v2 FROM t0",
+                        "CREATE TABLE `t1` AS SELECT `v1`, `v2`\nFROM `t0`"},
+                {"CREATE TABLE IF NOT EXISTS db1.t1 (c1, c2) COMMENT \"test ctas\" " +
+                        "DISTRIBUTED BY HASH(c1) BUCKETS 8 " +
+                        "PROPERTIES('replication_num'='1') AS SELECT v1, v2 FROM t0 WHERE v1 > 1",
+                        "CREATE TABLE IF NOT EXISTS `db1`.`t1` (`c1`,`c2`) COMMENT \"test ctas\" " +
+                                "DISTRIBUTED BY HASH(c1) BUCKETS 8 " +
+                                "PROPERTIES (\"replication_num\" = \"1\") AS SELECT `v1`, `v2`\nFROM `t0`\nWHERE `v1` > 1"},
+                {"CREATE TEMPORARY TABLE t2 AS SELECT v1 FROM t0",
+                        "CREATE TEMPORARY TABLE `t2` AS SELECT `v1`\nFROM `t0`"},
+                {"CREATE TABLE t3 PRIMARY KEY (c1) DISTRIBUTED BY HASH(c1) AS SELECT v1 AS c1 FROM t0",
+                        "CREATE TABLE `t3` PRIMARY KEY(`c1`) DISTRIBUTED BY HASH(c1) AS SELECT `v1` AS `c1`\nFROM `t0`"},
+                // Automatic partitioning: the LIST keyword must not appear, or the output re-parses
+                // as explicit list partitioning (a different table).
+                {"CREATE TABLE t4 PARTITION BY (dt) AS SELECT dt, v1 FROM t0",
+                        "CREATE TABLE `t4` PARTITION BY (`dt`) AS SELECT `dt`, `v1`\nFROM `t0`"},
+                // An explicit LIST clause is folded into a RangePartitionDesc by AstBuilder#visitPartitionDesc
+                // (the LIST/RANGE branch), dropping the list definitions, so the deparse reflects that AST.
+                {"CREATE TABLE t4 PARTITION BY LIST(dt) (PARTITION p1 VALUES IN ('2021-01-01')) " +
+                        "DISTRIBUTED BY HASH(dt) AS SELECT dt FROM t0",
+                        "CREATE TABLE `t4` PARTITION BY RANGE(`dt`) () DISTRIBUTED BY HASH(dt) AS SELECT `dt`\nFROM `t0`"},
+                {"CREATE TABLE t4 PARTITION BY date_trunc('day', dt) AS SELECT dt, v1 FROM t0",
+                        "CREATE TABLE `t4` PARTITION BY date_trunc('day', `dt`) AS SELECT `dt`, `v1`\nFROM `t0`"},
+                // The grammar requires parentheses after RANGE(cols), so an empty pair is kept.
+                {"CREATE TABLE t4 PARTITION BY RANGE(dt) " +
+                        "(START ('2021-01-01') END ('2021-01-10') EVERY (INTERVAL 1 DAY)) " +
+                        "DISTRIBUTED BY HASH(dt) AS SELECT dt FROM t0",
+                        "CREATE TABLE `t4` PARTITION BY RANGE(`dt`) () DISTRIBUTED BY HASH(dt) AS SELECT `dt`\nFROM `t0`"},
+                {"CREATE TABLE t5 ORDER BY (v1) AS SELECT v1, v2 FROM t0",
+                        "CREATE TABLE `t5` ORDER BY (`v1`) AS SELECT `v1`, `v2`\nFROM `t0`"},
+                {"CREATE TABLE t7 (c1, c2, INDEX idx1 (c1) USING BITMAP) AS SELECT v1, v2 FROM t0",
+                        "CREATE TABLE `t7` (`c1`,`c2`,INDEX idx1 (`c1`) USING BITMAP COMMENT '') " +
+                                "AS SELECT `v1`, `v2`\nFROM `t0`"},
+                // Index definitions alone must not drop the parenthesized clause.
+                {"CREATE TABLE t8 (INDEX idx1 (c1) USING BITMAP) AS SELECT v1 AS c1 FROM t0",
+                        "CREATE TABLE `t8` (INDEX idx1 (`c1`) USING BITMAP COMMENT '') AS SELECT `v1` AS `c1`\nFROM `t0`"},
+                // A double quote inside the comment must be escaped to keep the output legal SQL.
+                {"CREATE TABLE t9 COMMENT 'say \"hello\"' AS SELECT v1 FROM t0",
+                        "CREATE TABLE `t9` COMMENT \"say \\\"hello\\\"\" AS SELECT `v1`\nFROM `t0`"},
+        };
+        for (String[] c : cases) {
+            StatementBase stmt = SqlParser.parseSingleStatement(c[0], SqlModeHelper.MODE_DEFAULT);
+            String serializedSql = AstToSQLBuilder.toSQL(stmt);
+            Assertions.assertEquals(c[1], serializedSql, c[0]);
+            Assertions.assertFalse(AstToStringBuilder.toString(stmt).isEmpty(), c[0]);
+            // Regression: the fallback path used to hand out the visitor's empty string as-is.
+            Assertions.assertEquals(c[1], AstToSQLBuilder.toSQLOrDefault(stmt, c[0]), c[0]);
+            // The deparsed form must stay legal SQL even where partition definitions are omitted.
+            Assertions.assertDoesNotThrow(() -> SqlParser.parseSingleStatement(serializedSql, SqlModeHelper.MODE_DEFAULT),
+                    c[0]);
+        }
+    }
+
+    @Test
+    public void testCreateTableAsSelectHidesCredentials() {
+        String sql = "CREATE TABLE t6 PROPERTIES ('aws.s3.access_key'='abc', 'aws.s3.secret_key'='def') " +
+                "AS SELECT v1 FROM t0";
+        StatementBase stmt = SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
+        Assertions.assertEquals(
+                "CREATE TABLE `t6` PROPERTIES (\"aws.s3.access_key\" = \"***\", \"aws.s3.secret_key\" = \"***\") " +
+                        "AS SELECT `v1`\nFROM `t0`",
+                AstToSQLBuilder.toSQL(stmt));
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

Backport #77978 to branch-3.5. When SQL in a query profile or audit log is rebuilt from the AST, a CTAS statement can serialize to an empty string because this branch has no CTAS deparse visitor.

## What I'm doing:

Manually port the CTAS deparse implementation to `AstToStringBuilder.AST2StringBuilderVisitor`, the branch-local counterpart of the main-branch `AST2StringVisitor`. `AstToSQLBuilder.AST2SQLBuilderVisitor` inherits the implementation from this shared base visitor. The original target file does not exist on branch-3.5, so the automatic cherry-pick conflicted.

The implementation covers temporary tables, IF NOT EXISTS, column and index lists, engine, key description, escaped comments, partition/distribution/order clauses, masked properties, and the SELECT query. It also adds CTAS serialization and credential-masking regression cases.

Backport of #77978.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [x] 3.5
  - [ ] 3.4

## Testing:

Not run locally, as requested. CI will compile the code and run the tests.
