### PR TITLE
[BugFix] Fix lake compaction limiter going negative when shrinking compact_threads

### DIFF
--- a/be/src/storage/lake/compaction_scheduler.h
+++ b/be/src/storage/lake/compaction_scheduler.h
@@ -130,6 +130,7 @@ struct CompactionTaskInfo {
 };
 
 class CompactionScheduler {
+public:
     // Limiter is used to control the maximum compaction concurrency based on the memory usage limitation:
     //  - The initial maximum compaction concurrency is config::compact_threads
     //  - Once Status::MemoryLimitExceeded is encountered, reduce the maximum concurrency by one until the
@@ -157,10 +158,19 @@ class CompactionScheduler {
 
         void adapt_to_task_queue_size(int16_t new_val);
 
+        // only for TEST purpose
+        void TEST_set_state(int16_t total, int64_t free, int16_t reserved);
+        int16_t TEST_total() const;
+        int64_t TEST_free() const;
+        int16_t TEST_reserved() const;
+
     private:
         mutable std::mutex _mtx;
         int16_t _total;
         // The number of tokens can be assigned to compaction tasks.
+        // May be temporarily negative when in-flight tasks exceed the new limit after shrinking
+        // `compact_threads`. `acquire()` rejects `_free <= 0`, and each finished task increments
+        // `_free` until it becomes positive again.
         int64_t _free;
         // The number of reserved tokens. reserved tokens cannot be assigned to compaction task.
         int16_t _reserved{0};
@@ -316,26 +326,62 @@ inline int16_t CompactionScheduler::Limiter::concurrency() const {
 
 inline void CompactionScheduler::Limiter::adapt_to_task_queue_size(int16_t new_val) {
     std::lock_guard l(_mtx);
-    if (new_val > _total) {
-        auto diff = new_val - _total;
-        _free += diff;
-        _total += diff;
-    } else if (new_val < _total) {
-        if (_reserved != 0) {
-            double percentage = static_cast<double>(_total) / new_val;
-            _reserved = static_cast<int16_t>(static_cast<double>(_reserved) * percentage);
-            _total = new_val;
-            _free = _total - _reserved;
-        } else {
-            _total = new_val;
-            _free = _total;
-        }
-    } else {
-        // nothing change
+    if (new_val <= 0) {
+        LOG(ERROR) << "Ignore invalid compact_threads " << new_val << ", keep total=" << _total;
         return;
     }
+
+    // Tokens currently held by in-flight tasks. Negative means the limiter is already
+    // inconsistent; treat as no in-flight work so `_free` can be repaired.
+    int64_t running = static_cast<int64_t>(_total) - _reserved - _free;
+    if (running < 0) {
+        running = 0;
+    }
+
+    const int16_t old_total = _total;
+    if (old_total > 0 && new_val < old_total && _reserved > 0) {
+        // Keep the reserved/total ratio when shrinking. The previous formula used
+        // old_total/new_val, which *increased* `_reserved` and could make `_free` negative.
+        _reserved = static_cast<int16_t>(static_cast<int64_t>(_reserved) * new_val / old_total);
+    }
+    // When expanding, keep the absolute `_reserved` (OOM throttle should not grow).
+
+    _total = new_val;
+    if (_reserved < 0) {
+        _reserved = 0;
+    }
+    if (_reserved >= _total) {
+        _reserved = static_cast<int16_t>(_total - 1);
+    }
+    // `_free` may be negative when in-flight tasks exceed the new limit. acquire()
+    // will block new work until enough tasks finish and increment `_free`.
+    _free = static_cast<int64_t>(_total) - _reserved - running;
+
     LOG(INFO) << "Update Limiter's _total value to " << _total << ", _free value to " << _free
               << ", and _reserved value to " << _reserved;
+}
+
+inline void CompactionScheduler::Limiter::TEST_set_state(int16_t total, int64_t free, int16_t reserved) {
+    std::lock_guard l(_mtx);
+    _total = total;
+    _free = free;
+    _reserved = reserved;
+    _success = 0;
+}
+
+inline int16_t CompactionScheduler::Limiter::TEST_total() const {
+    std::lock_guard l(_mtx);
+    return _total;
+}
+
+inline int64_t CompactionScheduler::Limiter::TEST_free() const {
+    std::lock_guard l(_mtx);
+    return _free;
+}
+
+inline int16_t CompactionScheduler::Limiter::TEST_reserved() const {
+    std::lock_guard l(_mtx);
+    return _reserved;
 }
 
 inline int CompactionScheduler::WrapTaskQueues::task_queue_size() {

--- a/be/test/storage/lake/compaction_scheduler_test.cpp
+++ b/be/test/storage/lake/compaction_scheduler_test.cpp
@@ -503,4 +503,52 @@ TEST_F(LakeCompactionSchedulerTest, test_parallel_compaction_multiple_tablets) {
     latch->wait();
 }
 
+// Reproduce the inverted reserved-scale bug: after many MemoryLimitExceeded events,
+// shrinking compact_threads used old_total/new_val and produced `_reserved > _total`
+// and `_free < 0`, after which acquire() never succeeded.
+TEST(LakeCompactionLimiterTest, shrink_after_oom_does_not_go_negative) {
+    CompactionScheduler::Limiter limiter(32);
+    // total=32, reserved=15 (OOM throttled), free=17, running=0
+    limiter.TEST_set_state(32, 17, 15);
+    limiter.adapt_to_task_queue_size(8);
+
+    EXPECT_EQ(8, limiter.TEST_total());
+    EXPECT_EQ(3, limiter.TEST_reserved()); // 15 * 8 / 32
+    EXPECT_EQ(5, limiter.TEST_free());     // 8 - 3 - 0
+    EXPECT_EQ(5, limiter.concurrency());
+    EXPECT_TRUE(limiter.acquire());
+}
+
+TEST(LakeCompactionLimiterTest, expand_after_oom_keeps_reserved) {
+    CompactionScheduler::Limiter limiter(8);
+    limiter.TEST_set_state(8, 1, 7);
+    limiter.adapt_to_task_queue_size(16);
+
+    EXPECT_EQ(16, limiter.TEST_total());
+    EXPECT_EQ(7, limiter.TEST_reserved());
+    EXPECT_EQ(9, limiter.TEST_free());
+    EXPECT_EQ(9, limiter.concurrency());
+}
+
+TEST(LakeCompactionLimiterTest, shrink_with_inflight_recovers_as_tasks_finish) {
+    CompactionScheduler::Limiter limiter(16);
+    // total=16, reserved=4, free=2 => running=10
+    limiter.TEST_set_state(16, 2, 4);
+    limiter.adapt_to_task_queue_size(8);
+
+    EXPECT_EQ(2, limiter.TEST_reserved()); // 4 * 8 / 16
+    EXPECT_EQ(-4, limiter.TEST_free());    // 8 - 2 - 10
+    EXPECT_FALSE(limiter.acquire());
+
+    // Each successful finish increments `_free`. Every 2 successes also restores one reserved slot.
+    limiter.no_memory_limit_exceeded(); // free=-3
+    EXPECT_FALSE(limiter.acquire());
+    limiter.no_memory_limit_exceeded(); // restore reserved, free=-1
+    EXPECT_FALSE(limiter.acquire());
+    limiter.no_memory_limit_exceeded(); // free=0
+    EXPECT_FALSE(limiter.acquire());
+    limiter.no_memory_limit_exceeded(); // restore reserved, free=2
+    EXPECT_TRUE(limiter.acquire());
+}
+
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

OOM throttling plus shrinking `compact_threads` used an inverted reserved-scale formula (`old_total / new_val`). `_reserved` could exceed `_total` and `_free` stayed permanently negative, so `acquire()` never succeeded and lake compact RPCs sat until the 24h FE timeout.

## What I'm doing:

Recalculate reserved/free from in-flight tokens when resizing the limiter, keep `_reserved` in `[0, total-1]`, and add unit tests for shrink-after-OOM, expand-after-OOM, and in-flight recovery.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

## Test plan
- [ ] `LakeCompactionLimiterTest.shrink_after_oom_does_not_go_negative`
- [ ] `LakeCompactionLimiterTest.expand_after_oom_keeps_reserved`
- [ ] `LakeCompactionLimiterTest.shrink_with_inflight_recovers_as_tasks_finish`

Made with [Cursor](https://cursor.com)