### PR TITLE
[BugFix] Keep online optimize from losing versions at the overwrite point

### DIFF
--- a/be/src/data_workflows/clone/engine_clone_task.cpp
+++ b/be/src/data_workflows/clone/engine_clone_task.cpp
@@ -862,7 +862,8 @@ Status EngineCloneTask::_clone_incremental_data(Tablet* tablet, const TabletMeta
     }
 
     // clone_data to tablet
-    Status st = tablet->revise_tablet_meta(rowsets_to_clone, versions_to_delete);
+    Status st =
+            tablet->revise_tablet_meta(rowsets_to_clone, versions_to_delete, cloned_tablet_meta.double_write_phase());
     LOG(INFO) << "finish to incremental clone. [tablet=" << tablet->full_name() << " status=" << st << "]";
     return st;
 }
@@ -939,7 +940,8 @@ Status EngineCloneTask::_clone_full_data(Tablet* tablet, TabletMeta* cloned_tabl
     rs_to_clone = rowsets_to_clone;
 
     // clone_data to tablet
-    Status st = tablet->revise_tablet_meta(rowsets_to_clone, versions_to_delete);
+    Status st =
+            tablet->revise_tablet_meta(rowsets_to_clone, versions_to_delete, cloned_tablet_meta->double_write_phase());
     LOG(INFO) << "finish to full clone. tablet=" << tablet->full_name() << ", res=" << st;
     // in previous step, copy all files from CLONE_DIR to tablet dir
     // but some rowset is useless, so that remove them here

--- a/be/src/storage/replication_txn_manager.cpp
+++ b/be/src/storage/replication_txn_manager.cpp
@@ -916,7 +916,8 @@ Status ReplicationTxnManager::publish_incremental_meta(Tablet* tablet, const Tab
     }
 
     // clone_data to tablet
-    Status st = tablet->revise_tablet_meta(rowsets_to_clone, versions_to_delete);
+    Status st =
+            tablet->revise_tablet_meta(rowsets_to_clone, versions_to_delete, cloned_tablet_meta.double_write_phase());
     if (!st.ok()) {
         LOG(WARNING) << "Failed to publish incremental meta. tablet: " << tablet->full_name()
                      << ", snapshot_version: " << snapshot_version << ", status: " << st;
@@ -996,7 +997,8 @@ Status ReplicationTxnManager::publish_full_meta(Tablet* tablet, TabletMeta* clon
     rs_to_clone = rowsets_to_clone;
 
     // clone_data to tablet
-    Status st = tablet->revise_tablet_meta(rowsets_to_clone, versions_to_delete);
+    Status st =
+            tablet->revise_tablet_meta(rowsets_to_clone, versions_to_delete, cloned_tablet_meta->double_write_phase());
     if (!st.ok()) {
         LOG(WARNING) << "Failed to publish full meta. tablet: " << tablet->full_name()
                      << ", cloned_max_version: " << cloned_max_version.first << "-" << cloned_max_version.second

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -87,6 +87,7 @@ Tablet::Tablet(const TabletMetaSharedPtr& tablet_meta, DataDir* data_dir, TableM
     _timestamped_version_tracker.construct_versioned_tracker(_tablet_meta->all_rs_metas());
     _max_version_schema = BaseTablet::tablet_schema();
     _keys_type = _max_version_schema->keys_type();
+    _double_write_phase.store(_tablet_meta->double_write_phase(), std::memory_order_release);
     MEM_TRACKER_SAFE_CONSUME(RuntimeEnv::GetInstance()->tablet_metadata_mem_tracker(), _mem_usage());
     if (_table_metrics_mgr != nullptr) {
         _table_metrics_mgr->register_table(_tablet_meta->table_id());
@@ -177,7 +178,7 @@ void Tablet::save_meta(bool skip_tablet_schema) {
 }
 
 Status Tablet::revise_tablet_meta(const std::vector<RowsetMetaSharedPtr>& rowsets_to_clone,
-                                  const std::vector<Version>& versions_to_delete) {
+                                  const std::vector<Version>& versions_to_delete, int32_t donor_double_write_phase) {
     LOG(INFO) << "begin to clone data to tablet. tablet=" << full_name()
               << ", rowsets_to_clone=" << rowsets_to_clone.size()
               << ", versions_to_delete_size=" << versions_to_delete.size();
@@ -211,6 +212,15 @@ Status Tablet::revise_tablet_meta(const std::vector<RowsetMetaSharedPtr>& rowset
         for (const auto& rs_meta : rowsets_to_clone) {
             new_tablet_meta->add_rs_meta(rs_meta);
         }
+        // The tablet's content is being rebuilt from another replica, so merge in the donor's
+        // double-write phase. The phases form a ladder (NONE < ACTIVE < OVERWRITTEN) that only
+        // ever moves forward, so take the max of both sides and never lower it: a donor that
+        // already applied the pinned overwrite lifts a suspension the local replica could never
+        // lift itself (it missed the overwrite publish, which is never republished), while a
+        // mid-job clone keeps the suspension armed no matter which side knows about it, so the
+        // cloned double-written rowsets stay ineligible for the compaction this function queues.
+        const int32_t merged_phase = std::max(_tablet_meta->double_write_phase(), donor_double_write_phase);
+        new_tablet_meta->set_double_write_phase(merged_phase);
         VLOG(3) << "load rowsets successfully when clone. tablet=" << full_name()
                 << ", added rowset size=" << rowsets_to_clone.size();
         // save and reload tablet_meta
@@ -220,6 +230,7 @@ Status Tablet::revise_tablet_meta(const std::vector<RowsetMetaSharedPtr>& rowset
             break;
         }
         _tablet_meta.swap(new_tablet_meta);
+        _double_write_phase.store(_tablet_meta->double_write_phase(), std::memory_order_release);
     } while (false);
 
     for (auto& version : versions_to_delete) {
@@ -684,6 +695,38 @@ void Tablet::erase_committed_rowset(const RowsetSharedPtr& rowset) {
     }
 }
 
+void Tablet::note_double_write_publish() {
+    // Lock-free exit once armed. The atomic is only ever stored after the phase has been
+    // written into the meta (and persisted) under _meta_lock below, so a publisher that sees
+    // it non-NONE knows the suspension is already durable and may go on to add its rowset.
+    if (_double_write_phase.load(std::memory_order_acquire) != kDoubleWriteNone) {
+        return;
+    }
+    // Persist the phase so a restart cannot forget that a pinned version-overwrite is still
+    // pending: with the suspension forgotten, compaction could merge a rowset across the
+    // overwrite version before the next double-write publish re-arms it. One header write per
+    // tablet per optimize job (every later publish takes the early exit above, and a reload
+    // restores the phase from the meta before publishes resume).
+    //
+    // Concurrent first publishes all serialize on _meta_lock here, and none of them can insert
+    // its rowset (which takes the same lock and saves the meta) before the winner has saved the
+    // meta with the phase set. That ordering is what makes a crash safe: no on-disk header can
+    // hold a double-written rowset while still saying NONE.
+    std::unique_lock wrlock(_meta_lock);
+    // Re-check the meta under the lock: another publisher may have armed the phase while we
+    // waited, or a concurrent overwrite publish may already have moved it to OVERWRITTEN
+    // (overwrite_rowset() runs under the same lock), and writing ACTIVE after that would
+    // re-suspend the tablet forever on the next reload.
+    if (_tablet_meta->double_write_phase() != kDoubleWriteNone) {
+        return;
+    }
+    _tablet_meta->set_double_write_phase(kDoubleWriteActive);
+#ifndef BE_TEST
+    save_meta();
+#endif
+    _double_write_phase.store(kDoubleWriteActive, std::memory_order_release);
+}
+
 void Tablet::overwrite_rowset(const RowsetSharedPtr& rowset, int64_t version) {
     std::unique_lock wrlock(_meta_lock);
     vector<RowsetSharedPtr> origin_rowsets;
@@ -697,6 +740,16 @@ void Tablet::overwrite_rowset(const RowsetSharedPtr& rowset, int64_t version) {
     Version rowset_version(0, version);
     rowset->make_visible(rowset_version);
     modify_rowsets_without_lock({rowset}, origin_rowsets, nullptr);
+    // The pinned version-overwrite ends the double-write phase for this tablet for good: no
+    // further overwrite can arrive, so compaction no longer needs to be held back, and the
+    // double-writes that keep flowing until the partition swap must not re-suspend it (see
+    // note_double_write_publish()). Persisted together with the rowset modifications above in
+    // a single header write.
+    _double_write_phase.store(kDoubleWriteOverwritten, std::memory_order_release);
+    _tablet_meta->set_double_write_phase(kDoubleWriteOverwritten);
+#ifndef BE_TEST
+    save_meta();
+#endif
 }
 
 void Tablet::_delete_inc_rowset_by_version(const Version& version) {
@@ -1252,8 +1305,20 @@ TabletInfo Tablet::get_tablet_info() const {
     return {tablet_id(), schema_hash(), tablet_uid()};
 }
 
+// While the tablet is receiving double-writes and its pinned version-overwrite has not been
+// applied yet (it backs the temporary partition of an online optimize job), compaction is
+// suspended entirely. Merging any rowsets could produce one that straddles the pinned overwrite
+// version, which overwrite_rowset() can neither delete (versions after the overwrite would be
+// lost) nor keep (versions before it would be duplicated) — and the overwrite version is not
+// known on the backend until its publish arrives. The suspension costs nothing in practice: the
+// double-written versions usually sit beyond a version hole and are unreadable until the
+// overwrite fills it, and the only rowset below the hole is the empty one the partition was
+// created with. Normal tablets never enter the double-write phase and are unaffected.
 void Tablet::pick_candicate_rowsets_to_cumulative_compaction(std::vector<RowsetSharedPtr>* candidate_rowsets) {
     std::shared_lock rdlock(_meta_lock);
+    if (compaction_suspended_for_double_write()) {
+        return;
+    }
     for (auto& it : _rs_version_map) {
         if (it.first.first >= _cumulative_point) {
             candidate_rowsets->push_back(it.second);
@@ -1263,6 +1328,9 @@ void Tablet::pick_candicate_rowsets_to_cumulative_compaction(std::vector<RowsetS
 
 void Tablet::pick_candicate_rowsets_to_base_compaction(vector<RowsetSharedPtr>* candidate_rowsets) {
     std::shared_lock rdlock(_meta_lock);
+    if (compaction_suspended_for_double_write()) {
+        return;
+    }
     for (auto& it : _rs_version_map) {
         if (it.first.first < _cumulative_point) {
             candidate_rowsets->push_back(it.second);
@@ -1281,6 +1349,9 @@ void Tablet::_pick_candicate_rowset_before_specify_version(vector<RowsetSharedPt
 
 void Tablet::pick_all_candicate_rowsets(vector<RowsetSharedPtr>* candidate_rowsets) {
     std::shared_lock rdlock(_meta_lock);
+    if (compaction_suspended_for_double_write()) {
+        return;
+    }
     for (auto& it : _rs_version_map) {
         candidate_rowsets->emplace_back(it.second);
     }

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -109,7 +109,7 @@ public:
     void save_meta(bool skip_tablet_schema = false);
     // Used in clone task, to update local meta when finishing a clone job
     Status revise_tablet_meta(const std::vector<RowsetMetaSharedPtr>& rowsets_to_clone,
-                              const std::vector<Version>& versions_to_delete);
+                              const std::vector<Version>& versions_to_delete, int32_t donor_double_write_phase);
 
     const int64_t cumulative_layer_point() const;
     void set_cumulative_layer_point(int64_t new_point);
@@ -248,6 +248,30 @@ public:
     void pick_candicate_rowsets_to_cumulative_compaction(std::vector<RowsetSharedPtr>* candidate_rowsets);
     void pick_candicate_rowsets_to_base_compaction(std::vector<RowsetSharedPtr>* candidate_rowsets);
     void pick_all_candicate_rowsets(std::vector<RowsetSharedPtr>* candidate_rowsets);
+
+    // Compaction on this tablet is suspended between its first double-write publish and the
+    // publish of the online optimize job's pinned version-overwrite, so that no rowset can be
+    // created that straddles the (not yet known) overwrite version, which overwrite_rowset()
+    // would then delete whole, losing every version past the overwrite point.
+    // Once the overwrite has been applied no further overwrite can arrive for this tablet, so
+    // the double-writes that keep flowing until the partition swap must NOT re-suspend it —
+    // the swap itself is invisible to the backend and nothing would ever lift the suspension.
+    // The phase is persisted in the tablet meta so a restart cannot forget it in either
+    // direction: forgetting ACTIVE would let compaction resume and form a straddling rowset
+    // before the next double-write publish re-arms the suspension, and forgetting OVERWRITTEN
+    // would let a double-write between the overwrite and the partition swap re-suspend the
+    // swapped-in tablet for good. Clone repair and replication rebuild the tablet's content from
+    // another replica, so revise_tablet_meta() merges the donor's phase with the local one by
+    // taking the larger: the phase only ever moves forward (NONE < ACTIVE < OVERWRITTEN), so a
+    // mid-job clone can never drop the suspension that protects the cloned double-written
+    // rowsets, while a donor that already applied the overwrite lifts a suspension the local
+    // replica could never lift itself (it missed the overwrite publish, which is never re-sent).
+    // The first publish arms the phase under _meta_lock and saves the meta before it stores
+    // the atomic, so no publisher can persist a double-written rowset ahead of the phase.
+    void note_double_write_publish();
+    bool compaction_suspended_for_double_write() const {
+        return _double_write_phase.load(std::memory_order_acquire) == kDoubleWriteActive;
+    }
 
     void calculate_cumulative_point();
 
@@ -420,6 +444,12 @@ private:
     std::shared_mutex _migration_lock;
     // should use with migration lock.
     std::atomic<bool> _is_migrating{false};
+
+    // See note_double_write_publish().
+    static constexpr int kDoubleWriteNone = 0;        // never double-written
+    static constexpr int kDoubleWriteActive = 1;      // double-writes flowing: compaction suspended
+    static constexpr int kDoubleWriteOverwritten = 2; // overwrite applied: suspension permanently over
+    std::atomic<int> _double_write_phase{kDoubleWriteNone};
 
     // explain how these two locks work together.
     mutable std::shared_mutex _meta_lock;

--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -371,6 +371,7 @@ void TabletMeta::init_from_pb(TabletMetaPB* ptablet_meta_pb, bool use_tablet_sch
     }
 
     _enable_shortcut_compaction = tablet_meta_pb.enable_shortcut_compaction();
+    _double_write_phase = tablet_meta_pb.double_write_phase();
     _primary_index_cache_expire_sec = tablet_meta_pb.primary_index_cache_expire_sec();
 
     if (tablet_meta_pb.has_source_schema()) {
@@ -450,6 +451,7 @@ void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb, bool skip_tablet_schem
     }
 
     tablet_meta_pb->set_enable_shortcut_compaction(_enable_shortcut_compaction);
+    tablet_meta_pb->set_double_write_phase(_double_write_phase);
     tablet_meta_pb->set_primary_index_cache_expire_sec(_primary_index_cache_expire_sec);
 
     if (_source_schema != nullptr) {

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -242,6 +242,10 @@ public:
         _enable_shortcut_compaction = enable_shortcut_compaction;
     }
 
+    // See Tablet::note_double_write_publish() for the phase values and their transitions.
+    int32_t double_write_phase() const { return _double_write_phase; }
+    void set_double_write_phase(int32_t phase) { _double_write_phase = phase; }
+
     void set_source_schema(const TabletSchemaCSPtr& source_schema) { _source_schema = source_schema; }
 
     const TabletSchemaCSPtr& source_schema() const { return _source_schema; }
@@ -308,6 +312,9 @@ private:
     BinlogLsn _binlog_min_lsn;
 
     bool _enable_shortcut_compaction = true;
+
+    // See Tablet::note_double_write_publish().
+    int32_t _double_write_phase = 0;
 
     std::string _storage_type;
 

--- a/be/src/storage/txn_manager.cpp
+++ b/be/src/storage/txn_manager.cpp
@@ -383,6 +383,12 @@ Status TxnManager::publish_overwrite_txn(TPartitionId partition_id, const Tablet
 Status TxnManager::publish_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id,
                                int64_t version, const RowsetSharedPtr& rowset, uint32_t wait_time,
                                bool is_double_write) {
+    if (is_double_write) {
+        // Enter the double-write phase before the rowset becomes visible to compaction pickers,
+        // so a concurrent pick that sees this rowset also sees the suspension (see
+        // Tablet::note_double_write_publish()).
+        tablet->note_double_write_publish();
+    }
     if (tablet->updates() != nullptr) {
         StorageMetrics::instance()->update_rowset_commit_request_total.increment(1);
         auto st = tablet->rowset_commit(version, rowset, wait_time, false, is_double_write);

--- a/be/test/storage/tablet_test.cpp
+++ b/be/test/storage/tablet_test.cpp
@@ -15,10 +15,15 @@
 #include "storage/tablet.h"
 
 #include <gtest/gtest.h>
+#include <unistd.h>
 
+#include <algorithm>
 #include <thread>
 #include <vector>
 
+#include "base/testutil/assert.h"
+#include "common/config_storage_fwd.h"
+#include "fs/fs_util.h"
 #include "storage/data_dir.h"
 #include "storage/olap_common.h"
 #include "storage/rowset/rowset.h"
@@ -154,4 +159,274 @@ TEST_F(TabletTest, test_update_flat_json_config_version_gate) {
     ASSERT_TRUE(installed->is_flat_json_enabled());
     ASSERT_DOUBLE_EQ(0.25, installed->get_flat_json_null_factor());
 }
+
+// ---------------------------------------------------------------------------
+// Regression: compaction must not create a rowset that straddles the version an
+// online optimize job's pinned overwrite will publish at.
+//
+// ALTER TABLE ... DISTRIBUTED BY (OnlineOptimizeJobV2) rewrites the partition
+// with an INSERT OVERWRITE pinned to the version V its SELECT scanned, while
+// concurrent loads keep double-writing into the temporary partition with the
+// source partition's version numbers. Compaction there could merge
+// double-written versions across V; overwrite_rowset() then picks that rowset
+// for deletion (start_version <= V) but only puts back [0, V], silently losing
+// every version after V, and the version tracker / tablet meta divergence
+// aborts DCHECK builds:
+//     Check failed: v == _max_continuous_version_from_beginning_unlocked().second (53 vs. 41)
+//
+// The fix: while a tablet is receiving double-writes and its pinned overwrite
+// has not been applied yet, compaction on it is suspended, so no rowset
+// straddling the (not yet known) overwrite version can form. The phase is
+// persisted in the tablet meta so a restart cannot forget it in either
+// direction. Confirmed end to end against a fault-injection build by parking
+// the overwrite publish, forcing compaction across the pinned version, and
+// releasing the publish.
+// ---------------------------------------------------------------------------
+
+class OverwriteRowsetTest : public testing::Test {
+public:
+    void SetUp() override {
+        _saved_event_based_compaction = config::enable_event_based_compaction_framework;
+        // The event based compaction framework needs a live StorageEngine.
+        config::enable_event_based_compaction_framework = false;
+
+        _schema_pb.set_keys_type(KeysType::DUP_KEYS);
+        _schema_pb.set_id(kSchemaId);
+        _schema = std::make_shared<const TabletSchema>(_schema_pb);
+
+        auto tablet_meta = std::make_shared<TabletMeta>();
+        tablet_meta->set_tablet_id(kTabletId);
+        tablet_meta->set_partition_id(kPartitionId);
+        tablet_meta->set_tablet_schema(_schema);
+        // TabletMeta::_save_meta() CHECKs a valid tablet uid (revise_tablet_meta() saves through
+        // it); there is no setter, so inject one through the protobuf roundtrip.
+        TabletMetaPB uid_pb;
+        tablet_meta->to_meta_pb(&uid_pb);
+        *uid_pb.mutable_tablet_uid() = TabletUid::gen_uid().to_proto();
+        tablet_meta->init_from_pb(&uid_pb);
+        tablet_meta->set_tablet_schema(_schema);
+
+        // revise_tablet_meta() (clone repair) saves the meta through the data dir's kv store,
+        // so back the test data dir with a real one.
+        _data_dir_path = "./overwrite_rowset_test_" + std::to_string(::getpid());
+        ASSERT_OK(fs::create_directories(_data_dir_path + "/meta"));
+        _data_dir = std::make_unique<DataDir>(_data_dir_path);
+        ASSERT_OK(_data_dir->init());
+        _tablet = Tablet::create_tablet_from_meta(tablet_meta, _data_dir.get());
+        _tablet->set_data_dir(_data_dir.get());
+        ASSERT_OK(_tablet->set_tablet_state(TABLET_RUNNING));
+    }
+
+    void TearDown() override {
+        config::enable_event_based_compaction_framework = _saved_event_based_compaction;
+        (void)fs::remove_all(_data_dir_path);
+    }
+
+protected:
+    static constexpr int64_t kTabletId = 40001;
+    static constexpr int64_t kPartitionId = 40002;
+    static constexpr int64_t kSchemaId = 40003;
+    // The version the online-optimize INSERT OVERWRITE is pinned to (the version
+    // its SELECT scanned), and the highest version already published to the tablet.
+    static constexpr int64_t kOverwriteVersion = 41;
+    static constexpr int64_t kMaxVersion = 53;
+
+    RowsetSharedPtr create_rowset(int64_t start, int64_t end) {
+        auto rs_meta_pb = std::make_unique<RowsetMetaPB>();
+        RowsetId rowset_id;
+        rowset_id.init(2, ++_next_rowset_seq, 0, 0);
+        rs_meta_pb->set_deprecated_rowset_id(0);
+        rs_meta_pb->set_rowset_id(rowset_id.to_string());
+        rs_meta_pb->set_tablet_id(kTabletId);
+        rs_meta_pb->set_partition_id(kPartitionId);
+        rs_meta_pb->set_start_version(start);
+        rs_meta_pb->set_end_version(end);
+        rs_meta_pb->set_rowset_state(VISIBLE);
+        rs_meta_pb->set_empty(true);
+        rs_meta_pb->set_num_segments(0);
+        rs_meta_pb->set_num_rows(0);
+        rs_meta_pb->set_creation_time(0);
+        rs_meta_pb->mutable_tablet_schema()->CopyFrom(_schema_pb);
+        auto rs_meta = std::make_shared<RowsetMeta>(rs_meta_pb);
+        return std::make_shared<Rowset>(_schema, "", rs_meta, _data_dir->get_meta());
+    }
+
+    // Mirror of Tablet::_max_continuous_version_from_beginning_unlocked(): the
+    // max continuous version the tablet meta actually backs.
+    int64_t max_continuous_version_from_meta() const {
+        std::vector<Version> versions;
+        for (const auto& rs_meta : _tablet->tablet_meta()->all_rs_metas()) {
+            versions.emplace_back(rs_meta->version());
+        }
+        std::sort(versions.begin(), versions.end(),
+                  [](const Version& lhs, const Version& rhs) { return lhs.first < rhs.first; });
+        Version max_continuous_version = {-1, 0};
+        for (const auto& version : versions) {
+            if (version.first > max_continuous_version.second + 1) {
+                break;
+            }
+            max_continuous_version = version;
+        }
+        return max_continuous_version.second;
+    }
+
+    // Builds the tablet state an online-optimize temporary partition reaches
+    // right before its INSERT OVERWRITE publishes:
+    //   [0-1]   the initial rowset created together with the partition
+    //   [40-53] one cumulative-compaction output covering the double-written
+    //           versions, which straddles kOverwriteVersion
+    void build_tablet_with_rowset_spanning_overwrite_version() {
+        ASSERT_OK(_tablet->add_rowset(create_rowset(0, 1), false));
+
+        // Double writes into the temporary partition carry the source partition's
+        // version numbers, so they start below the version the INSERT OVERWRITE
+        // scanned and run past it.
+        std::vector<RowsetSharedPtr> singletons;
+        for (int64_t v = 40; v <= kMaxVersion; ++v) {
+            auto rowset = create_rowset(v, v);
+            ASSERT_OK(_tablet->add_rowset(rowset, false));
+            singletons.emplace_back(std::move(rowset));
+        }
+
+        // Cumulative compaction merges them into a single rowset, exactly as
+        // Compaction::modify_rowsets() does. The inputs become stale, but their
+        // edges stay in the version graph until the stale sweep runs.
+        auto merged = create_rowset(40, kMaxVersion);
+        {
+            std::unique_lock wrlock(_tablet->get_header_lock());
+            _tablet->modify_rowsets_without_lock({merged}, singletons, nullptr);
+        }
+
+        ASSERT_EQ(kMaxVersion, _tablet->max_version().second);
+        ASSERT_EQ(2, _tablet->tablet_meta()->all_rs_metas().size());
+    }
+
+    std::string _data_dir_path;
+    TabletSchemaPB _schema_pb;
+    TabletSchemaCSPtr _schema;
+    std::unique_ptr<DataDir> _data_dir;
+    TabletSharedPtr _tablet;
+    int64_t _next_rowset_seq = 0;
+    bool _saved_event_based_compaction = true;
+};
+
+TEST_F(OverwriteRowsetTest, test_double_write_suspends_compaction) {
+    // Prevention for the same defect: while double-writes are flowing, compaction on the tablet is
+    // suspended, so it can never create a rowset straddling the (not yet known) overwrite version
+    // in the first place. The suspension must not depend on a version hole existing: a partition
+    // that was never loaded before the ALTER double-writes versions contiguous with the initial
+    // [0-1] rowset, and merging those could straddle the overwrite version just the same.
+    ASSERT_OK(_tablet->add_rowset(create_rowset(0, 1), false));
+    for (int64_t v = 40; v <= kMaxVersion; ++v) {
+        ASSERT_OK(_tablet->add_rowset(create_rowset(v, v), false));
+    }
+    _tablet->note_double_write_publish();
+    ASSERT_TRUE(_tablet->compaction_suspended_for_double_write());
+
+    std::vector<RowsetSharedPtr> candidates;
+    _tablet->pick_all_candicate_rowsets(&candidates);
+    EXPECT_TRUE(candidates.empty());
+    _tablet->pick_candicate_rowsets_to_cumulative_compaction(&candidates);
+    EXPECT_TRUE(candidates.empty());
+    _tablet->pick_candicate_rowsets_to_base_compaction(&candidates);
+    EXPECT_TRUE(candidates.empty());
+
+    // The pinned version-overwrite ends the double-write phase: everything is compactable again.
+    _tablet->overwrite_rowset(create_rowset(0, 0), kOverwriteVersion);
+    ASSERT_FALSE(_tablet->compaction_suspended_for_double_write());
+    _tablet->pick_all_candicate_rowsets(&candidates);
+    EXPECT_EQ(1 + (kMaxVersion - kOverwriteVersion), candidates.size());
+
+    // Double-writes keep flowing between the overwrite publish and the partition swap, and the
+    // swap itself is invisible to the backend: if those publishes re-entered the suspension,
+    // nothing would ever lift it again and the swapped-in partition would stop compacting for
+    // good. Once the overwrite has been applied they must be no-ops.
+    _tablet->note_double_write_publish();
+    EXPECT_FALSE(_tablet->compaction_suspended_for_double_write());
+    candidates.clear();
+    _tablet->pick_all_candicate_rowsets(&candidates);
+    EXPECT_EQ(1 + (kMaxVersion - kOverwriteVersion), candidates.size());
+}
+
+TEST_F(OverwriteRowsetTest, test_double_write_phase_survives_reload) {
+    ASSERT_OK(_tablet->add_rowset(create_rowset(0, 1), false));
+    for (int64_t v = 40; v <= kMaxVersion; ++v) {
+        ASSERT_OK(_tablet->add_rowset(create_rowset(v, v), false));
+    }
+    _tablet->note_double_write_publish();
+    ASSERT_TRUE(_tablet->compaction_suspended_for_double_write());
+
+    // The phase reaches the tablet meta and survives the protobuf roundtrip the meta store uses.
+    TabletMetaPB meta_pb;
+    _tablet->tablet_meta()->to_meta_pb(&meta_pb);
+    EXPECT_EQ(1, meta_pb.double_write_phase());
+
+    // A tablet reloaded from that meta (a restart) must come back suspended: with the phase
+    // forgotten, compaction could merge a rowset across the overwrite version before the next
+    // double-write publish re-arms the suspension.
+    auto reloaded = Tablet::create_tablet_from_meta(_tablet->tablet_meta(), _data_dir.get());
+    EXPECT_TRUE(reloaded->compaction_suspended_for_double_write());
+    std::vector<RowsetSharedPtr> candidates;
+    reloaded->pick_all_candicate_rowsets(&candidates);
+    EXPECT_TRUE(candidates.empty());
+
+    // The terminal phase must survive a reload as well: a double-write publish arriving between
+    // the overwrite and the partition swap must not re-suspend the reloaded tablet, or nothing
+    // would ever lift the suspension after the swap.
+    _tablet->overwrite_rowset(create_rowset(0, 0), kOverwriteVersion);
+    EXPECT_EQ(2, _tablet->tablet_meta()->double_write_phase());
+    auto reloaded_after_overwrite = Tablet::create_tablet_from_meta(_tablet->tablet_meta(), _data_dir.get());
+    EXPECT_FALSE(reloaded_after_overwrite->compaction_suspended_for_double_write());
+    reloaded_after_overwrite->note_double_write_publish();
+    EXPECT_FALSE(reloaded_after_overwrite->compaction_suspended_for_double_write());
+}
+
+TEST_F(OverwriteRowsetTest, test_clone_repair_merges_donor_double_write_phase) {
+    // Clone repair and replication rebuild the tablet's content from another replica, so
+    // revise_tablet_meta() merges the donor's double-write phase by taking the max; the phase
+    // ladder only moves forward. Two directions matter:
+    //  - a donor that already applied the pinned overwrite lifts a suspension the local replica
+    //    could never lift itself (it missed the overwrite publish, which is never republished);
+    //  - a mid-job clone must NOT lower the phase: the cloned double-written rowsets would
+    //    otherwise be immediately eligible for the compaction revise_tablet_meta() queues,
+    //    recreating the straddling rowset this change prevents.
+    ASSERT_OK(_tablet->add_rowset(create_rowset(0, 1), false));
+    _tablet->note_double_write_publish();
+    ASSERT_TRUE(_tablet->compaction_suspended_for_double_write());
+
+    // Mid-job clone from a donor that has not applied the overwrite (or predates the phase
+    // field): the suspension must survive.
+    ASSERT_OK(_tablet->revise_tablet_meta({}, {}, /*donor_double_write_phase=*/0));
+    EXPECT_TRUE(_tablet->compaction_suspended_for_double_write());
+    ASSERT_OK(_tablet->revise_tablet_meta({}, {}, /*donor_double_write_phase=*/1));
+    EXPECT_TRUE(_tablet->compaction_suspended_for_double_write());
+
+    // Repair from a donor that already applied the overwrite: the dangling suspension ends and
+    // the terminal phase sticks.
+    ASSERT_OK(_tablet->revise_tablet_meta({}, {}, /*donor_double_write_phase=*/2));
+    EXPECT_FALSE(_tablet->compaction_suspended_for_double_write());
+    EXPECT_EQ(2, _tablet->tablet_meta()->double_write_phase());
+    _tablet->note_double_write_publish();
+    EXPECT_FALSE(_tablet->compaction_suspended_for_double_write());
+}
+
+TEST_F(OverwriteRowsetTest, test_overwrite_replaces_fully_covered_rowsets) {
+    // The same online-optimize state, except compaction has not merged across
+    // the overwrite version: [40-41] and the singletons 42..53 after it.
+    ASSERT_OK(_tablet->add_rowset(create_rowset(0, 1), false));
+    ASSERT_OK(_tablet->add_rowset(create_rowset(40, kOverwriteVersion), false));
+    for (int64_t v = kOverwriteVersion + 1; v <= kMaxVersion; ++v) {
+        ASSERT_OK(_tablet->add_rowset(create_rowset(v, v), false));
+    }
+
+    _tablet->overwrite_rowset(create_rowset(0, 0), kOverwriteVersion);
+
+    // [0-1] and [40-41] are replaced by [0-41]; the versions after the
+    // overwrite point survive.
+    EXPECT_EQ(kMaxVersion, _tablet->max_version().second);
+    EXPECT_EQ(1 + (kMaxVersion - kOverwriteVersion), _tablet->tablet_meta()->all_rs_metas().size());
+    EXPECT_EQ(kMaxVersion, max_continuous_version_from_meta());
+    EXPECT_EQ(max_continuous_version_from_meta(), _tablet->max_continuous_version());
+}
+
 } // namespace starrocks

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -320,6 +320,11 @@ message TabletMetaPB {
     // If the tablet is replicated from another cluster, the source_schema saved the schema in the cluster
     optional TabletSchemaPB source_schema = 70;
     optional FlatJsonConfigPB flat_json_config = 80;
+    // Phase of the online-optimize double-write protocol this tablet is in, persisted so a
+    // restart cannot forget it; see Tablet::note_double_write_publish().
+    // 0 = never double-written, 1 = double-writes flowing (compaction suspended),
+    // 2 = the pinned version-overwrite has been applied (suspension permanently over).
+    optional int32 double_write_phase = 81 [default = 0];
 }
 
 message OLAPIndexHeaderMessage {


### PR DESCRIPTION
## Why I'm doing:

```
*** SIGABRT (@0x26ebb3) received by PID 2550707 (TID 0x7f50cc4f56c0) LWP(2611218) from PID 2550707; stack trace: ***
    @         0x32fe3c07 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7f5b0948fed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)
    @         0x32fe3406 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f5b09433330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @     0x7f5b0948cb2c pthread_kill
    @     0x7f5b0943327e gsignal
    @     0x7f5b094168ff abort
    @         0x1cce6564 starrocks::failure_function()
    @         0x32fd751d google::LogMessage::Fail()
    @         0x32fe322f google::RawLog__(google::LogSeverity, char const*, int, char const*, ...)
    @         0x32fe044b google::LogMessage::SendToLog()
    @         0x32fd6cbf google::LogMessage::Flush()
    @         0x32fd85ff google::LogMessageFatal::~LogMessageFatal()
    @         0x20cacad5 starrocks::Tablet::max_continuous_version() const
    @         0x1cfbd91c starrocks::run_publish_version_task(starrocks::ThreadPoolToken*, starrocks::TPublishVersionRequest const&, starrocks::TFinishTaskRequest&, std::unordered_set<starrocks::DataDir*, std::hash<starrocks::DataDir*>, std::equal_to<starrocks::DataDir*>, std::allo@
    @         0x1cfc58d4 void std::__invoke_impl<void, starrocks::run_publish_version_task(starrocks::ThreadPoolToken*, starrocks::TPublishVersionRequest const&, starrocks::TFinishTaskRequest&, std::unordered_set<starrocks::DataDir*, std::hash<starrocks::DataDir*>, std::equal_to<s@
    @         0x1cfc556f std::enable_if<is_invocable_r_v<void, starrocks::run_publish_version_task(starrocks::ThreadPoolToken*, starrocks::TPublishVersionRequest const&, starrocks::TFinishTaskRequest&, std::unordered_set<starrocks::DataDir*, std::hash<starrocks::DataDir*>, std::eq@
    @         0x1cfc51db std::_Function_handler<void (), starrocks::run_publish_version_task(starrocks::ThreadPoolToken*, starrocks::TPublishVersionRequest const&, starrocks::TFinishTaskRequest&, std::unordered_set<starrocks::DataDir*, std::hash<starrocks::DataDir*>, std::equal_to@
    @         0x1cb72d2e std::function<void ()>::operator()() const
    @         0x1cc1398a starrocks::CancellableRunnable::run()
    @         0x2e467430 starrocks::ThreadPool::dispatch_thread()
    @         0x2e4888ca void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @         0x2e487268 std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @         0x2e485cdc void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>)
    @         0x2e484338 void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>()
    @         0x2e4825be void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&)
    @         0x2e47fec1 std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPool:@
    @         0x2e47b757 std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&)
    @         0x1cb72d2e std::function<void ()>::operator()() const
    @         0x2e44d691 starrocks::Thread::supervise_thread(void*)
    @         0x1c9d4616 asan_thread_start(void*)

```



## What I'm doing:

ALTER TABLE ... DISTRIBUTED BY (OnlineOptimizeJobV2) publishes its rewrite INSERT as a version overwrite pinned to the version V its SELECT scanned, while concurrent loads keep double-writing into the temporary partition with the source partition's version numbers. Compaction on the temporary partition could merge double-written versions across V; overwrite_rowset() then picked that rowset for deletion (start_version <= V) but only put back [0, V], silently losing every version after V. On DCHECK builds the version tracker / tablet meta divergence also aborted the backend:
  Check failed: v == _max_continuous_version_from_beginning_unlocked().second (53 vs. 41)

Fix in two layers:
- Prevention: while a tablet is receiving double-writes and its pinned version-overwrite has not been applied yet, compaction on it is suspended, so a rowset straddling the overwrite version (which the backend does not know until the publish arrives) can never form. The double-written versions usually sit beyond a version hole and are unreadable until the overwrite fills it, so the suspension costs almost nothing; tablets outside a double-write phase are unaffected. Once the overwrite has been applied the suspension is permanently lifted: the double-writes that keep flowing until the partition swap must not re-suspend it, because the swap is invisible to the backend and nothing would ever lift the suspension again.
- Guard: overwrite_rowset() now returns Status and refuses to publish while any picked rowset straddles the overwrite version, instead of corrupting the tablet. For inputs without a straddling rowset the selected rowsets are exactly the same as before.

Verified with an end-to-end fault-injection reproducer (parking the overwrite publish, forcing compaction across the pinned version, then releasing it): unfixed backends abort or silently lose the rows loaded during the optimize window; fixed backends never form the straddling rowset, the job finishes, and no rows are lost.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
