### PR TITLE
[BugFix] Refuse incomplete combined txn log and stop replication_num weakening the shared-data write quorum

### DIFF
--- a/be/src/data_sink/tablet/tablet_sink_sender.cpp
+++ b/be/src/data_sink/tablet/tablet_sink_sender.cpp
@@ -396,14 +396,51 @@ bool TabletSinkSender::get_immutable_partition_ids(std::set<int64_t>* partition_
     return has_immutable_partition;
 }
 
+ExpectedTabletsByPartition TabletSinkSender::_expected_tablets_by_partition() const {
+    ExpectedTabletsByPartition expected;
+    if (_partition_params == nullptr) {
+        return expected;
+    }
+    std::unordered_set<int64_t> participating_indexes;
+    participating_indexes.reserve(_channels.size());
+    for (const auto* index_channel : _channels) {
+        participating_indexes.insert(index_channel->index_id());
+    }
+    const auto& partitions = _partition_params->get_partitions();
+    for (const auto& [partition_id, logs] : _txn_log_map) {
+        (void)logs;
+        auto it = partitions.find(partition_id);
+        if (it == partitions.end() || it->second == nullptr) {
+            continue;
+        }
+        std::set<int64_t> tablets;
+        for (const auto& index : it->second->indexes) {
+            if (participating_indexes.count(index.index_id) == 0) {
+                continue;
+            }
+            tablets.insert(index.tablet_ids.begin(), index.tablet_ids.end());
+        }
+        if (!tablets.empty()) {
+            expected.emplace(partition_id, std::move(tablets));
+        }
+    }
+    return expected;
+}
+
 Status TabletSinkSender::_write_combined_txn_log() {
+    // A combined txn log is the only record of a partition's rowset metadata -- publish resolves
+    // each tablet inside it and has no per-tablet fallback -- so an object written short of an
+    // entry leaves the transaction permanently unpublishable once it commits. Check coverage
+    // against what the FE dispatched before anything reaches object storage.
+    const ExpectedTabletsByPartition expected = _expected_tablets_by_partition();
     if (config::enable_put_combinded_txn_log_parallel) {
-        return write_combined_txn_log_parallel(_txn_log_map);
+        return write_combined_txn_log_parallel(_txn_log_map, expected);
     }
 
+    static const std::set<int64_t> kNoExpectation;
     for (const auto& [partition_id, logs] : _txn_log_map) {
-        (void)partition_id;
-        RETURN_IF_ERROR(write_combined_txn_log(logs));
+        auto it = expected.find(partition_id);
+        RETURN_IF_ERROR(write_combined_txn_log(logs, it != expected.end() ? it->second : kNoExpectation));
     }
     return Status::OK();
 }

--- a/be/src/data_sink/tablet/tablet_sink_sender.h
+++ b/be/src/data_sink/tablet/tablet_sink_sender.h
@@ -78,8 +78,9 @@ protected:
     // For every partition this sink is about to write a combined txn log for, the set of tablets
     // that log must cover, taken from the partition metadata the FE dispatched -- a source
     // independent of the collected logs themselves. Partitions with no dispatched metadata here
-    // (e.g. brought in by an incremental open) are left out, so they stay unchecked rather than
-    // being judged against a guess.
+    // (e.g. dropped from _partition_params by remove_partitions() on the immutable-partition
+    // path) are left out, so they stay unchecked rather than being judged against a guess.
+    // Partitions brought in by an incremental open do have metadata here and are checked.
     ExpectedTabletsByPartition _expected_tablets_by_partition() const;
     void _mark_as_failed(const NodeChannel* ch) { _failed_channels.insert(ch->node_id()); }
     bool _is_failed_channel(const NodeChannel* ch) { return _failed_channels.count(ch->node_id()) != 0; }

--- a/be/src/data_sink/tablet/tablet_sink_sender.h
+++ b/be/src/data_sink/tablet/tablet_sink_sender.h
@@ -16,6 +16,7 @@
 
 #include "data_sink/tablet/range_router.h"
 #include "data_sink/tablet/tablet_sink_index_channel.h"
+#include "storage/lake/combined_txn_log_writer.h"
 
 namespace starrocks {
 
@@ -73,6 +74,13 @@ protected:
     // how chunks are dispatched to BE nodes.
     virtual Status _send_chunk_by_node(Chunk* chunk, IndexChannel* channel, const std::vector<uint16_t>& selection_idx);
     Status _write_combined_txn_log();
+
+    // For every partition this sink is about to write a combined txn log for, the set of tablets
+    // that log must cover, taken from the partition metadata the FE dispatched -- a source
+    // independent of the collected logs themselves. Partitions with no dispatched metadata here
+    // (e.g. brought in by an incremental open) are left out, so they stay unchecked rather than
+    // being judged against a guess.
+    ExpectedTabletsByPartition _expected_tablets_by_partition() const;
     void _mark_as_failed(const NodeChannel* ch) { _failed_channels.insert(ch->node_id()); }
     bool _is_failed_channel(const NodeChannel* ch) { return _failed_channels.count(ch->node_id()) != 0; }
     bool _has_intolerable_failure() {

--- a/be/src/storage/lake/combined_txn_log_writer.cpp
+++ b/be/src/storage/lake/combined_txn_log_writer.cpp
@@ -56,9 +56,11 @@ std::function<void()> create_txn_log_task(const CombinedTxnLogPB* logs, const st
             Status status = tablet_mgr->put_combined_txn_log(
                     *logs, expected_tablet_ids != nullptr ? *expected_tablet_ids : kNoExpectation);
             if (!status.ok()) {
-                // Surface the real reason: an incomplete-coverage rejection is not an IO error and
-                // must not be flattened into one, or the load fails with a misleading message.
-                throw std::runtime_error(status.to_string());
+                // Report the status as it came back. Throwing here instead would route it through
+                // the handler below and re-wrap it as an IOError, so an incomplete-coverage
+                // rejection -- an invariant violation, not a transient object-store failure --
+                // would reach the caller indistinguishable from one, both in code and in message.
+                mark_failure(status, has_error, final_status);
             }
         } catch (const std::exception& e) {
             mark_failure(Status::IOError(e.what()), has_error, final_status);

--- a/be/src/storage/lake/combined_txn_log_writer.cpp
+++ b/be/src/storage/lake/combined_txn_log_writer.cpp
@@ -30,9 +30,9 @@
 
 namespace starrocks {
 
-Status write_combined_txn_log(const CombinedTxnLogPB& logs) {
+Status write_combined_txn_log(const CombinedTxnLogPB& logs, const std::set<int64_t>& expected_tablet_ids) {
     auto tablet_mgr = StorageEnv::GetInstance()->lake_tablet_manager();
-    return tablet_mgr->put_combined_txn_log(logs);
+    return tablet_mgr->put_combined_txn_log(logs, expected_tablet_ids);
 }
 
 namespace {
@@ -47,13 +47,18 @@ void mark_failure(const Status& status, std::atomic<bool>* has_error, Status* fi
     }
 }
 
-std::function<void()> create_txn_log_task(const CombinedTxnLogPB* logs, lake::TabletManager* tablet_mgr,
-                                          std::atomic<bool>* has_error, Status* final_status, CountDownLatch* latch) {
-    return [logs, tablet_mgr, has_error, final_status, latch]() {
+std::function<void()> create_txn_log_task(const CombinedTxnLogPB* logs, const std::set<int64_t>* expected_tablet_ids,
+                                          lake::TabletManager* tablet_mgr, std::atomic<bool>* has_error,
+                                          Status* final_status, CountDownLatch* latch) {
+    return [logs, expected_tablet_ids, tablet_mgr, has_error, final_status, latch]() {
         try {
-            Status status = tablet_mgr->put_combined_txn_log(*logs);
+            static const std::set<int64_t> kNoExpectation;
+            Status status = tablet_mgr->put_combined_txn_log(
+                    *logs, expected_tablet_ids != nullptr ? *expected_tablet_ids : kNoExpectation);
             if (!status.ok()) {
-                throw std::runtime_error("Txn log write failed");
+                // Surface the real reason: an incomplete-coverage rejection is not an IO error and
+                // must not be flattened into one, or the load fails with a misleading message.
+                throw std::runtime_error(status.to_string());
             }
         } catch (const std::exception& e) {
             mark_failure(Status::IOError(e.what()), has_error, final_status);
@@ -66,15 +71,19 @@ std::function<void()> create_txn_log_task(const CombinedTxnLogPB* logs, lake::Ta
 
 } // namespace
 
-Status write_combined_txn_log_parallel(const std::map<int64_t, CombinedTxnLogPB>& txn_log_map) {
+Status write_combined_txn_log_parallel(const std::map<int64_t, CombinedTxnLogPB>& txn_log_map,
+                                       const ExpectedTabletsByPartition& expected_by_partition) {
     CountDownLatch latch(txn_log_map.size());
     std::atomic<bool> has_error(false);
     Status final_status;
     {
         std::vector<std::shared_ptr<CancellableRunnable>> tasks;
         for (const auto& [partition_id, logs] : txn_log_map) {
-            auto task_logic = create_txn_log_task(&logs, StorageEnv::GetInstance()->lake_tablet_manager(), &has_error,
-                                                  &final_status, &latch);
+            auto expected_it = expected_by_partition.find(partition_id);
+            const std::set<int64_t>* expected =
+                    expected_it != expected_by_partition.end() ? &expected_it->second : nullptr;
+            auto task_logic = create_txn_log_task(&logs, expected, StorageEnv::GetInstance()->lake_tablet_manager(),
+                                                  &has_error, &final_status, &latch);
             auto task =
                     std::make_shared<CancellableRunnable>(std::move(task_logic), [&latch, &has_error, &final_status]() {
                         Status st = Status::Cancelled("Task cancelled before execution");

--- a/be/src/storage/lake/combined_txn_log_writer.h
+++ b/be/src/storage/lake/combined_txn_log_writer.h
@@ -16,13 +16,20 @@
 
 #include <cstdint>
 #include <map>
+#include <set>
 
 #include "common/status.h"
 
 namespace starrocks {
 class CombinedTxnLogPB;
 
-Status write_combined_txn_log(const CombinedTxnLogPB& logs);
-Status write_combined_txn_log_parallel(const std::map<int64_t, CombinedTxnLogPB>& txn_log_map);
+// partition id -> the tablets that partition's combined txn log must cover. Supplying it makes
+// put_combined_txn_log() refuse to write an object that is short of an entry; see the comment on
+// TabletManager::put_combined_txn_log. Pass empty to keep the previous unchecked behaviour.
+using ExpectedTabletsByPartition = std::map<int64_t, std::set<int64_t>>;
+
+Status write_combined_txn_log(const CombinedTxnLogPB& logs, const std::set<int64_t>& expected_tablet_ids = {});
+Status write_combined_txn_log_parallel(const std::map<int64_t, CombinedTxnLogPB>& txn_log_map,
+                                       const ExpectedTabletsByPartition& expected_by_partition = {});
 
 } // namespace starrocks

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -1317,12 +1317,16 @@ DEFINE_FAIL_POINT(put_combined_txn_log_success);
 DEFINE_FAIL_POINT(put_combined_txn_log_fail);
 Status TabletManager::put_combined_txn_log(const starrocks::CombinedTxnLogPB& logs,
                                            const std::set<int64_t>& expected_tablet_ids) {
+    // Ahead of the fail points on purpose: this is an invariant on the object we are about to
+    // write, not part of the write itself, so a fail point that stubs out the object-store call
+    // must not be able to skip it -- otherwise put_combined_txn_log_success silently disables the
+    // check and no test using that fail point can observe it.
+    RETURN_IF_ERROR(check_combined_txn_log_coverage(logs, expected_tablet_ids));
     FAIL_POINT_TRIGGER_RETURN(put_combined_txn_log_success, Status::OK());
     FAIL_POINT_TRIGGER_RETURN(put_combined_txn_log_fail, Status::InternalError("write combined_txn_log_fail"));
     if (UNLIKELY(logs.txn_logs_size() == 0)) {
         return Status::InvalidArgument("empty CombinedTxnLogPB");
     }
-    RETURN_IF_ERROR(check_combined_txn_log_coverage(logs, expected_tablet_ids));
     DUMP_TRACE_IF_TIMEOUT(config::lake_put_txn_log_timeout_guard_ms);
     std::vector<int64_t> candidate_tablet_ids;
     candidate_tablet_ids.reserve(logs.txn_logs_size());

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -1283,14 +1283,46 @@ Status TabletManager::put_txn_vlog(const TxnLogPtr& log, int64_t version) {
     return put_txn_log(log, txn_vlog_location(log->tablet_id(), version));
 }
 
+static Status check_combined_txn_log_coverage(const CombinedTxnLogPB& logs,
+                                              const std::set<int64_t>& expected_tablet_ids) {
+    if (expected_tablet_ids.empty()) {
+        return Status::OK();
+    }
+    std::set<int64_t> present;
+    for (const auto& log : logs.txn_logs()) {
+        present.insert(log.tablet_id());
+    }
+    std::string missing;
+    size_t missing_count = 0;
+    for (int64_t expected_id : expected_tablet_ids) {
+        if (present.count(expected_id) > 0) {
+            continue;
+        }
+        // Cap the id list: a whole node's contribution can go missing at once, and this string
+        // ends up in a load error that gets logged and returned to the client.
+        if (missing_count < 16) {
+            missing.append(missing.empty() ? "" : ",").append(std::to_string(expected_id));
+        }
+        ++missing_count;
+    }
+    if (missing_count > 0) {
+        return Status::InternalError(
+                fmt::format("refuse to write incomplete combined txn log: missing {} of {} tablets [{}{}]",
+                            missing_count, expected_tablet_ids.size(), missing, missing_count > 16 ? ",..." : ""));
+    }
+    return Status::OK();
+}
+
 DEFINE_FAIL_POINT(put_combined_txn_log_success);
 DEFINE_FAIL_POINT(put_combined_txn_log_fail);
-Status TabletManager::put_combined_txn_log(const starrocks::CombinedTxnLogPB& logs) {
+Status TabletManager::put_combined_txn_log(const starrocks::CombinedTxnLogPB& logs,
+                                           const std::set<int64_t>& expected_tablet_ids) {
     FAIL_POINT_TRIGGER_RETURN(put_combined_txn_log_success, Status::OK());
     FAIL_POINT_TRIGGER_RETURN(put_combined_txn_log_fail, Status::InternalError("write combined_txn_log_fail"));
     if (UNLIKELY(logs.txn_logs_size() == 0)) {
         return Status::InvalidArgument("empty CombinedTxnLogPB");
     }
+    RETURN_IF_ERROR(check_combined_txn_log_coverage(logs, expected_tablet_ids));
     DUMP_TRACE_IF_TIMEOUT(config::lake_put_txn_log_timeout_guard_ms);
     std::vector<int64_t> candidate_tablet_ids;
     candidate_tablet_ids.reserve(logs.txn_logs_size());

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -174,7 +174,18 @@ public:
 
     Status put_txn_vlog(const TxnLogPtr& log, int64_t version);
 
-    Status put_combined_txn_log(const CombinedTxnLogPB& logs);
+    // |expected_tablet_ids| is the set of tablets this combined txn log must cover. A combined txn
+    // log is the only record of those tablets' rowset metadata: publish looks each tablet up inside
+    // it and has no per-tablet fallback, so an object written short of an entry leaves the
+    // transaction permanently unpublishable once it commits.
+    //
+    // Mirrors put_bundle_tablet_metadata(): the set is only worth passing when it comes from a
+    // source independent of whatever produced |logs| -- deriving it from the collected logs would
+    // just compare that source against itself. Callers with no such source pass empty, which is
+    // what the single-argument overload does, leaving them exactly as they were.
+    Status put_combined_txn_log(const CombinedTxnLogPB& logs, const std::set<int64_t>& expected_tablet_ids);
+
+    Status put_combined_txn_log(const CombinedTxnLogPB& logs) { return put_combined_txn_log(logs, {}); }
 
     StatusOr<TxnLogPtr> get_txn_log(int64_t tablet_id, int64_t txn_id);
 

--- a/be/test/storage/lake/combined_txn_log_writer_test.cpp
+++ b/be/test/storage/lake/combined_txn_log_writer_test.cpp
@@ -17,9 +17,11 @@
 #include <gtest/gtest.h>
 
 #include <map>
+#include <set>
 
 #include "base/failpoint/fail_point.h"
 #include "base/testutil/assert.h"
+#include "gen_cpp/lake_types.pb.h"
 
 namespace starrocks::lake {
 
@@ -47,6 +49,64 @@ TEST_F(WriteCombinedTxnLogTest, test_write_combined_txn_log_parallel) {
     fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get("put_combined_txn_log_fail");
     fp->setMode(trigger_mode);
     ASSERT_FALSE(write_combined_txn_log_parallel(txn_log_map).ok());
+    trigger_mode.set_mode(FailPointTriggerModeType::DISABLE);
+    fp->setMode(trigger_mode);
+}
+
+namespace {
+CombinedTxnLogPB make_logs(int64_t partition_id, const std::vector<int64_t>& tablet_ids) {
+    CombinedTxnLogPB logs;
+    for (int64_t tablet_id : tablet_ids) {
+        auto* log = logs.add_txn_logs();
+        log->set_tablet_id(tablet_id);
+        log->set_txn_id(1000);
+        log->set_partition_id(partition_id);
+    }
+    return logs;
+}
+} // namespace
+
+// A combined txn log missing an entry makes the transaction permanently unpublishable once it
+// commits: publish resolves every tablet inside that object and has no per-tablet fallback. The
+// write must be refused instead of leaving a partial object behind.
+TEST_F(WriteCombinedTxnLogTest, test_refuse_incomplete_combined_txn_log) {
+    // The partition owns tablets {1, 2, 3}; only two of them made it into the collected log.
+    std::map<int64_t, CombinedTxnLogPB> txn_log_map;
+    txn_log_map.emplace(100, make_logs(100, {1, 2}));
+    ExpectedTabletsByPartition expected;
+    expected.emplace(100, std::set<int64_t>{1, 2, 3});
+
+    auto st = write_combined_txn_log_parallel(txn_log_map, expected);
+    ASSERT_FALSE(st.ok());
+    const auto msg = st.to_string();
+    ASSERT_NE(msg.find("refuse to write incomplete combined txn log"), std::string::npos) << msg;
+    ASSERT_NE(msg.find("missing 1 of 3"), std::string::npos) << msg;
+    ASSERT_NE(msg.find('3'), std::string::npos) << msg;
+
+    // The single-partition entry point must reject it too.
+    auto single = write_combined_txn_log(make_logs(100, {1, 2}), std::set<int64_t>{1, 2, 3});
+    ASSERT_FALSE(single.ok());
+    ASSERT_NE(single.to_string().find("refuse to write incomplete combined txn log"), std::string::npos)
+            << single.to_string();
+}
+
+// A complete log, and the legacy no-expectation call, must both get past the coverage check.
+// The failpoint stands in for the object-store write that follows it.
+TEST_F(WriteCombinedTxnLogTest, test_complete_combined_txn_log_passes_coverage) {
+    std::map<int64_t, CombinedTxnLogPB> txn_log_map;
+    txn_log_map.emplace(100, make_logs(100, {1, 2, 3}));
+    ExpectedTabletsByPartition expected;
+    expected.emplace(100, std::set<int64_t>{1, 2, 3});
+
+    PFailPointTriggerMode trigger_mode;
+    trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
+    auto fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get("put_combined_txn_log_success");
+    fp->setMode(trigger_mode);
+
+    ASSERT_TRUE(write_combined_txn_log_parallel(txn_log_map, expected).ok());
+    // No expectation supplied -> unchanged behaviour for callers that have no independent source.
+    ASSERT_TRUE(write_combined_txn_log_parallel(txn_log_map).ok());
+
     trigger_mode.set_mode(FailPointTriggerModeType::DISABLE);
     fp->setMode(trigger_mode);
 }

--- a/be/test/storage/lake/combined_txn_log_writer_test.cpp
+++ b/be/test/storage/lake/combined_txn_log_writer_test.cpp
@@ -78,6 +78,9 @@ TEST_F(WriteCombinedTxnLogTest, test_refuse_incomplete_combined_txn_log) {
 
     auto st = write_combined_txn_log_parallel(txn_log_map, expected);
     ASSERT_FALSE(st.ok());
+    // The parallel path must hand back the rejection itself, not a re-wrapped IOError: a caller
+    // that retries on IO errors would otherwise keep retrying an invariant violation.
+    ASSERT_TRUE(st.is_internal_error()) << st.to_string();
     const auto msg = st.to_string();
     ASSERT_NE(msg.find("refuse to write incomplete combined txn log"), std::string::npos) << msg;
     ASSERT_NE(msg.find("missing 1 of 3"), std::string::npos) << msg;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -424,11 +424,20 @@ public class OlapTableSink extends DataSink {
         Locker locker = new Locker();
         locker.lockTableWithIntensiveDbLock(dbId, tableId, LockType.READ);
         try {
+            // In shared-data mode a tablet has exactly one writer and exactly one copy in object
+            // storage, so `replication_num` carries no write redundancy there -- RunMode.SharedData
+            // already defaults it to 1. A cloud-native table created with an explicit
+            // replication_num > 1 (typically carried over from a shared-nothing DDL) would
+            // otherwise raise the sink's write-quorum threshold, letting a failed node channel be
+            // tolerated even though the tablets it owned have no data anywhere. Report a single
+            // replica for cloud-native tables so any node channel failure aborts the load.
             int numReplicas = 1;
-            Optional<Partition> optionalPartition = dstTable.getPartitions().stream().findFirst();
-            if (optionalPartition.isPresent()) {
-                long partitionId = optionalPartition.get().getId();
-                numReplicas = dstTable.getPartitionInfo().getReplicationNum(partitionId);
+            if (!dstTable.isCloudNativeTableOrMaterializedView()) {
+                Optional<Partition> optionalPartition = dstTable.getPartitions().stream().findFirst();
+                if (optionalPartition.isPresent()) {
+                    long partitionId = optionalPartition.get().getId();
+                    numReplicas = dstTable.getPartitionInfo().getReplicationNum(partitionId);
+                }
             }
             if (enableAutomaticPartition && enableDynamicOverwrite) {
                 tSink.setDynamic_overwrite(true);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -241,8 +241,7 @@ public class OlapTableSink extends DataSink {
         }
         tSink.setDb_id(dbId);
         tSink.setLoad_channel_timeout_s(loadChannelTimeoutS);
-        tSink.setIs_lake_table(dstTable.isCloudNativeTableOrMaterializedView() ||
-                dstTable.isOlapExternalTable() && ((ExternalOlapTable) dstTable).isSourceTableCloudNativeTableOrMaterializedView());
+        tSink.setIs_lake_table(writesToCloudNativeTable());
         tSink.setKeys_type(ExprToThrift.keysTypeToThrift(dstTable.getKeysType()));
         tSink.setWrite_quorum_type(writeQuorum);
         // If table has Gin index, do not allow replicated storage
@@ -406,6 +405,16 @@ public class OlapTableSink extends DataSink {
         return txnState;
     }
 
+    // True when the load lands in object storage -- either the destination is itself a
+    // cloud-native table, or it is an ExternalOlapTable whose source table is one. This is the
+    // condition `is_lake_table` is derived from; anything that depends on "the BE will treat this
+    // as a lake write" must use the same predicate, or the two views drift apart.
+    private boolean writesToCloudNativeTable() {
+        return dstTable.isCloudNativeTableOrMaterializedView() ||
+                (dstTable.isOlapExternalTable() &&
+                        ((ExternalOlapTable) dstTable).isSourceTableCloudNativeTableOrMaterializedView());
+    }
+
     // must called after tupleDescriptor is computed
     public void complete() throws StarRocksException {
         TOlapTableSink tSink = tDataSink.getOlap_table_sink();
@@ -432,7 +441,7 @@ public class OlapTableSink extends DataSink {
             // tolerated even though the tablets it owned have no data anywhere. Report a single
             // replica for cloud-native tables so any node channel failure aborts the load.
             int numReplicas = 1;
-            if (!dstTable.isCloudNativeTableOrMaterializedView()) {
+            if (!writesToCloudNativeTable()) {
                 Optional<Partition> optionalPartition = dstTable.getPartitions().stream().findFirst();
                 if (optionalPartition.isPresent()) {
                     long partitionId = optionalPartition.get().getId();

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -617,6 +617,119 @@ public class OlapTableSinkTest {
         Assertions.assertTrue(sink.toThrift() instanceof TDataSink);
     }
 
+    private OlapTableSink buildSinkForReplicaCountTest(TupleDescriptor tuple, short replicationNum) {
+        ListPartitionInfo listPartitionInfo = new ListPartitionInfo(PartitionType.LIST,
+                Lists.newArrayList(new Column("province", StringType.STRING)));
+        listPartitionInfo.setValues(1, Lists.newArrayList("beijing", "shanghai"));
+        listPartitionInfo.setReplicationNum(1, replicationNum);
+        MaterializedIndex index = new MaterializedIndex(1, MaterializedIndex.IndexState.NORMAL);
+        HashDistributionInfo distInfo = new HashDistributionInfo(
+                3, Lists.newArrayList(new Column("id", IntegerType.BIGINT)));
+        Partition partition = new Partition(1, 11, "p1", index, distInfo);
+
+        Map<ColumnId, Column> idToColumn = Maps.newTreeMap(ColumnId.CASE_INSENSITIVE_ORDER);
+        idToColumn.put(ColumnId.create("province"), new Column("province", StringType.STRING));
+
+        new Expectations() {
+            {
+                dstTable.getId();
+                result = 1;
+                minTimes = 0;
+                dstTable.getPartitions();
+                result = Lists.newArrayList(partition);
+                minTimes = 0;
+                dstTable.getPartition(1L);
+                result = partition;
+                minTimes = 0;
+                dstTable.getPartitionInfo();
+                result = listPartitionInfo;
+                minTimes = 0;
+                dstTable.getIdToColumn();
+                result = idToColumn;
+                minTimes = 0;
+                dstTable.getDefaultDistributionInfo();
+                result = distInfo;
+                minTimes = 0;
+            }
+        };
+
+        return new OlapTableSink(dstTable, tuple, Lists.newArrayList(1L),
+                TWriteQuorumType.MAJORITY, false, false, false);
+    }
+
+    /**
+     * A shared-data table can still carry replication_num > 1 in its persisted PartitionInfo,
+     * typically inherited from a shared-nothing DDL. Shipping that value to the sink raises the
+     * write-quorum threshold to (n + 1) / 2, so a single failed node channel is tolerated even
+     * though, in shared-data, the tablets that node owned have no data anywhere. The sink must
+     * report exactly one replica for cloud-native tables regardless of the stored property.
+     */
+    @Test
+    public void testCloudNativeTableReportsSingleReplica(@Mocked GlobalStateMgr globalStateMgr,
+                                                         @Mocked GlobalTransactionMgr globalTransactionMgr)
+            throws StarRocksException {
+        TupleDescriptor tuple = getTuple();
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                minTimes = 0;
+                globalStateMgr.getGlobalTransactionMgr();
+                result = globalTransactionMgr;
+                minTimes = 0;
+                globalTransactionMgr.getTransactionState(anyLong, anyLong);
+                result = new TransactionState();
+                minTimes = 0;
+                globalStateMgr.getNodeMgr().getClusterInfo();
+                result = new SystemInfoService();
+                minTimes = 0;
+                dstTable.isCloudNativeTableOrMaterializedView();
+                result = true;
+                minTimes = 0;
+            }
+        };
+
+        OlapTableSink sink = buildSinkForReplicaCountTest(tuple, (short) 3);
+        sink.init(new TUniqueId(1, 2), 3, 4, 1000);
+        sink.complete();
+
+        Assertions.assertEquals(1, sink.toThrift().getOlap_table_sink().getNum_replicas(),
+                "shared-data sink must report a single replica so any node channel failure aborts the load");
+    }
+
+    /** The shared-nothing path must keep using the table's real replication_num. */
+    @Test
+    public void testSharedNothingTableKeepsReplicationNum(@Mocked GlobalStateMgr globalStateMgr,
+                                                          @Mocked GlobalTransactionMgr globalTransactionMgr)
+            throws StarRocksException {
+        TupleDescriptor tuple = getTuple();
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                minTimes = 0;
+                globalStateMgr.getGlobalTransactionMgr();
+                result = globalTransactionMgr;
+                minTimes = 0;
+                globalTransactionMgr.getTransactionState(anyLong, anyLong);
+                result = new TransactionState();
+                minTimes = 0;
+                globalStateMgr.getNodeMgr().getClusterInfo();
+                result = new SystemInfoService();
+                minTimes = 0;
+                dstTable.isCloudNativeTableOrMaterializedView();
+                result = false;
+                minTimes = 0;
+            }
+        };
+
+        OlapTableSink sink = buildSinkForReplicaCountTest(tuple, (short) 3);
+        sink.init(new TUniqueId(1, 2), 3, 4, 1000);
+        sink.complete();
+
+        Assertions.assertEquals(3, sink.toThrift().getOlap_table_sink().getNum_replicas());
+    }
+
     @Test
     public void testImmutablePartition(@Mocked GlobalStateMgr globalStateMgr,
                                        @Mocked GlobalTransactionMgr globalTransactionMgr) throws StarRocksException {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.ExternalOlapTable;
 import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.LocalTablet;
@@ -618,6 +619,10 @@ public class OlapTableSinkTest {
     }
 
     private OlapTableSink buildSinkForReplicaCountTest(TupleDescriptor tuple, short replicationNum) {
+        return buildSinkForReplicaCountTest(tuple, dstTable, replicationNum);
+    }
+
+    private OlapTableSink buildSinkForReplicaCountTest(TupleDescriptor tuple, OlapTable table, short replicationNum) {
         ListPartitionInfo listPartitionInfo = new ListPartitionInfo(PartitionType.LIST,
                 Lists.newArrayList(new Column("province", StringType.STRING)));
         listPartitionInfo.setValues(1, Lists.newArrayList("beijing", "shanghai"));
@@ -632,28 +637,28 @@ public class OlapTableSinkTest {
 
         new Expectations() {
             {
-                dstTable.getId();
+                table.getId();
                 result = 1;
                 minTimes = 0;
-                dstTable.getPartitions();
+                table.getPartitions();
                 result = Lists.newArrayList(partition);
                 minTimes = 0;
-                dstTable.getPartition(1L);
+                table.getPartition(1L);
                 result = partition;
                 minTimes = 0;
-                dstTable.getPartitionInfo();
+                table.getPartitionInfo();
                 result = listPartitionInfo;
                 minTimes = 0;
-                dstTable.getIdToColumn();
+                table.getIdToColumn();
                 result = idToColumn;
                 minTimes = 0;
-                dstTable.getDefaultDistributionInfo();
+                table.getDefaultDistributionInfo();
                 result = distInfo;
                 minTimes = 0;
             }
         };
 
-        return new OlapTableSink(dstTable, tuple, Lists.newArrayList(1L),
+        return new OlapTableSink(table, tuple, Lists.newArrayList(1L),
                 TWriteQuorumType.MAJORITY, false, false, false);
     }
 
@@ -695,6 +700,53 @@ public class OlapTableSinkTest {
 
         Assertions.assertEquals(1, sink.toThrift().getOlap_table_sink().getNum_replicas(),
                 "shared-data sink must report a single replica so any node channel failure aborts the load");
+    }
+
+    /**
+     * A cross-cluster INSERT whose destination is an ExternalOlapTable backed by a cloud-native
+     * source table is a lake write too -- init() derives is_lake_table from exactly that composite
+     * condition. The replica count has to follow the same predicate: judged only by
+     * isCloudNativeTableOrMaterializedView(), such a destination keeps shipping the source table's
+     * stored replication_num and the quorum threshold stays raised on a single-copy write.
+     */
+    @Test
+    public void testExternalCloudNativeTableReportsSingleReplica(@Injectable ExternalOlapTable extTable,
+                                                                 @Mocked GlobalStateMgr globalStateMgr,
+                                                                 @Mocked GlobalTransactionMgr globalTransactionMgr)
+            throws StarRocksException {
+        TupleDescriptor tuple = getTuple();
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                minTimes = 0;
+                globalStateMgr.getGlobalTransactionMgr();
+                result = globalTransactionMgr;
+                minTimes = 0;
+                globalStateMgr.getNodeMgr().getClusterInfo();
+                result = new SystemInfoService();
+                minTimes = 0;
+                extTable.isCloudNativeTableOrMaterializedView();
+                result = false;
+                minTimes = 0;
+                extTable.isOlapExternalTable();
+                result = true;
+                minTimes = 0;
+                extTable.isSourceTableCloudNativeTableOrMaterializedView();
+                result = true;
+                minTimes = 0;
+            }
+        };
+
+        OlapTableSink sink = buildSinkForReplicaCountTest(tuple, extTable, (short) 3);
+        sink.init(new TUniqueId(1, 2), 3, 4, 1000);
+        sink.complete();
+
+        TOlapTableSink thriftSink = sink.toThrift().getOlap_table_sink();
+        // Guard the invariant itself: the two must never disagree.
+        Assertions.assertTrue(thriftSink.isIs_lake_table());
+        Assertions.assertEquals(1, thriftSink.getNum_replicas(),
+                "an external destination backed by a cloud-native table is still a single-copy write");
     }
 
     /** The shared-nothing path must keep using the table's real replication_num. */


### PR DESCRIPTION
## Why I'm doing:

In shared-data mode a load can commit a transaction whose combined txn log was never fully
written. Publish then fails **deterministically and forever** with

```
Fail to publish version for tablets:[[...]], error msg:
  txn log list does not contain txn log of tablet <id>
```

The object is immutable and there is no per-tablet fallback under `file_bundling`, so the
transaction can never become visible; because lake publish advances a partition's versions in
order, every later transaction on the table queues behind it. The only exits are
`ADMIN SKIP COMMITTED TRANSACTION` (accepting the data loss) or a destructive rollback.

This is the second time this failure mode has been reported. #71992 fixed one route into it
(a static `sender_id == 0` coordinator that could be absent on an incremental-only channel).
This PR fixes a second route and, more importantly, adds the invariant check that makes the
whole class of routes non-silent.

**Route fixed here — `replication_num` weakening the write quorum.**
`OlapTableSink` ships the table's `replication_num` to the BE as `num_replicas`, and
`IndexChannel::has_intolerable_failure()` turns it into a majority threshold
`failed_channels >= (num_replicas + 1) / 2`. A cloud-native table created with an explicit
`replication_num = 3` — typically inherited from a shared-nothing DDL — therefore tolerates
**one** failed node channel. In shared-data that is wrong: each tablet has exactly one writer
and one copy in object storage, so a failed node channel means the tablets that node owned
have no data anywhere. The load reports success, the combined txn log is written without that
node's entries, and the transaction commits into the unpublishable state above.
`RunMode.SharedData.getDefaultReplicationNum()` is already 1 — the property simply carries no
write redundancy in this mode.

**Missing invariant — no coverage check before the write.**
`put_bundle_tablet_metadata()` already takes an `expected_tablet_ids` set and refuses to write
tablet metadata that is short of an entry, with the reasoning spelled out in its comment: the
expectation is derived from the request rather than from the responses, "so that a response
silently short of a tablet cannot pass the check". Its twin `put_combined_txn_log()` had no such
parameter and no such check, even though a combined txn log is exactly as load-bearing.

## What I'm doing:

1. **`OlapTableSink`**: report `num_replicas = 1` for cloud-native destinations regardless of the
   stored `replication_num`. This restores the correct semantics for all three copies of the
   quorum rule (`IndexChannel`, `TabletSinkSender`, `OlapTableSink`) without touching them, and
   applies to existing tables immediately — the persisted `idToReplicationNum` is not rewritten,
   so a fix confined to table creation would leave every already-created table exposed. With
   `num_replicas = 1`, `ALL` / `ONE` / `MAJORITY` all reduce to "one failed channel fails the
   load", which is the only correct rule when there is a single writer per tablet.

   "Cloud-native destination" is the same composite condition `is_lake_table` is derived from,
   now extracted into one `writesToCloudNativeTable()` helper used by both: it also covers an
   `ExternalOlapTable` whose source table is cloud-native, so a cross-cluster insert into one
   does not keep shipping the source table's `replication_num`.

2. **`put_combined_txn_log(logs, expected_tablet_ids)`**: new overload mirroring
   `put_bundle_tablet_metadata()`, rejecting an incomplete object with
   `refuse to write incomplete combined txn log: missing N of M tablets [...]`. The
   single-argument overload keeps the previous behaviour for callers with no independent
   expectation.

3. **`TabletSinkSender`**: derive the expected tablet set per partition from the partition
   metadata the FE dispatched — a source independent of the collected logs — and pass it down.
   Partitions with no dispatched metadata on this sink are left unchecked rather than judged
   against a guess.

4. Also fixes a masking bug in `create_txn_log_task()`: it reported failures by throwing, and the
   handler re-wrapped whatever it caught as `Status::IOError`, so a coverage rejection would have
   reached the caller indistinguishable from a transient object-store failure — and retryable in
   the eyes of anything that keys off the status code. The status is now handed to
   `mark_failure()` as-is; the exception handlers stay for genuine exceptions.

### Known limitation

The sink only computes an expectation for partitions that already appear in `_txn_log_map`. If a
partition's logs are missing *entirely*, it never becomes a key and this check cannot see it —
that case needs the FE's global view of all fragment instances and is left for a follow-up.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [x] Feature removed/UI changes: N/A — the change is that a shared-data load which previously
      "succeeded" while silently dropping a node's txn logs now fails and can be retried. Loads
      that were genuinely healthy are unaffected.
- [ ] Others:

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
