### PR TITLE
[Doc] Fix typo DISTRUBTE_BUCKET to DISTRIBUTE_BUCKET in tables_config

### DIFF
--- a/COMMITMSG
+++ b/COMMITMSG
@@ -1,0 +1,7 @@
+fix: [Docs]: Fix typo DISTRUBTE_BUCKET to DISTRIBUTE_BUCKET in tables_confi
+
+- docs\ja\sql-reference\information_schema\tables_config.md: 'DISTRUBTE_BUCKET'->'DISTRIBUTE_BUCKET'
+
+Fixes #75664
+
+Signed-off-by: Vedant Madane <6527493+VedantMadane@users.noreply.github.com>

--- a/COMMITMSG
+++ b/COMMITMSG
@@ -1,7 +1,0 @@
-fix: [Docs]: Fix typo DISTRUBTE_BUCKET to DISTRIBUTE_BUCKET in tables_confi
-
-- docs\ja\sql-reference\information_schema\tables_config.md: 'DISTRUBTE_BUCKET'->'DISTRIBUTE_BUCKET'
-
-Fixes #75664
-
-Signed-off-by: Vedant Madane <6527493+VedantMadane@users.noreply.github.com>

--- a/docs/ja/sql-reference/information_schema/tables_config.md
+++ b/docs/ja/sql-reference/information_schema/tables_config.md
@@ -19,7 +19,7 @@ description: "tables_configはテーブルの設定に関する情報を提供�
 | PARTITION_KEY    | テーブルのパーティション列。                                |
 | DISTRIBUTE_KEY   | テーブルのバケット列。                                       |
 | DISTRIBUTE_TYPE  | テーブルのデータ分散方法。                                   |
-| DISTRUBTE_BUCKET | テーブルのバケット数。                                       |
+| DISTRIBUTE_BUCKET | テーブルのバケット数。                                       |
 | SORT_KEY         | テーブルのソートキー。                                       |
 | PROPERTIES       | テーブルのプロパティ。                                       |
 | TABLE_ID         | テーブルのID。                                               |


### PR DESCRIPTION
## Summary

[Docs]: Fix typo DISTRUBTE_BUCKET to DISTRIBUTE_BUCKET in tables_config docs

## Changes

- docs\ja\sql-reference\information_schema\tables_config.md: 'DISTRUBTE_BUCKET'->'DISTRIBUTE_BUCKET'

Fixes #75664