### PR TITLE
[BugFix] Visit relations nested in PIVOT and PREPARE in AstTraverser

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authorization/SecurityPolicyRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/SecurityPolicyRewriteRule.java
@@ -19,6 +19,8 @@ import com.starrocks.catalog.TableName;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.Authorizer;
+import com.starrocks.sql.ast.AstTraverser;
+import com.starrocks.sql.ast.ParseNode;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.Relation;
 import com.starrocks.sql.ast.SelectList;
@@ -37,6 +39,83 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class SecurityPolicyRewriteRule {
+    /**
+     * Marks all relations in one executable statement for policy lookup during analysis.
+     * Deferred statements such as PREPARE deliberately stay opaque; their executable inner
+     * statement is marked explicitly at the PREPARE metadata and EXECUTE boundaries.
+     */
+    public static void markRelationsForRewrite(ParseNode statement) {
+        new AstTraverser<Void, Void>() {
+            @Override
+            public Void visitRelation(Relation relation, Void context) {
+                relation.setNeedRewrittenByPolicy(true);
+                return null;
+            }
+        }.visit(statement);
+    }
+
+    /**
+     * Checks the current authorization context without mutating the analyzed relation. This is
+     * used before reusing a cached prepared point-query plan: active policies require a fresh AST
+     * and a normal policy rewrite.
+     */
+    public static boolean hasPolicy(ConnectContext context, Relation relation) {
+        if (relation instanceof TableRelation && ((TableRelation) relation).isSyncMVQuery()) {
+            return false;
+        }
+
+        List<Column> columns;
+        TableName tableName;
+        if (relation instanceof ViewRelation) {
+            ViewRelation viewRelation = (ViewRelation) relation;
+            columns = viewRelation.getView().getBaseSchema();
+            tableName = viewRelation.getName();
+        } else if (relation instanceof TableRelation) {
+            TableRelation tableRelation = (TableRelation) relation;
+            if (tableRelation.getTable() == null) {
+                return true;
+            }
+            columns = tableRelation.getTable().getBaseSchema();
+            tableName = tableRelation.getName();
+        } else {
+            return true;
+        }
+
+        List<Column> validColumns = columns.stream().filter(c -> !c.getType().isUnknown()).collect(Collectors.toList());
+        Map<String, Expr> maskingExprMap = Authorizer.getColumnMaskingPolicy(context, tableName, validColumns);
+        Expr rowAccessExpr = Authorizer.getRowAccessPolicy(context, tableName);
+        return (maskingExprMap != null && !maskingExprMap.isEmpty()) || rowAccessExpr != null;
+    }
+
+    /**
+     * Checks every physical table or view reachable from an analyzed statement. A point query may
+     * still contain scalar subqueries in its select list, so checking only its outer relation is
+     * not sufficient before reusing a prepared plan.
+     */
+    public static boolean hasPolicy(ConnectContext context, ParseNode statement) {
+        boolean[] policyFound = {false};
+        new AstTraverser<Void, Void>() {
+            @Override
+            public Void visitTable(TableRelation node, Void ignored) {
+                if (!policyFound[0] && SecurityPolicyRewriteRule.hasPolicy(context, node)) {
+                    policyFound[0] = true;
+                }
+                return null;
+            }
+
+            @Override
+            public Void visitView(ViewRelation node, Void ignored) {
+                if (!policyFound[0] && SecurityPolicyRewriteRule.hasPolicy(context, node)) {
+                    policyFound[0] = true;
+                }
+                // A cached plan scans the expanded view definition. Policies newly added to a
+                // base table are therefore just as relevant as policies attached to the view.
+                return super.visitView(node, ignored);
+            }
+        }.visit(statement);
+        return policyFound[0];
+    }
+
     public static QueryStatement buildView(ConnectContext context, Relation relation, TableName tableName) {
         if (relation instanceof TableRelation && ((TableRelation) relation).isSyncMVQuery()) {
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -441,6 +441,10 @@ public class ConnectContext {
         this.preparedStmtCtxs.remove(stmtName);
     }
 
+    public void clearPreparedStmts() {
+        this.preparedStmtCtxs.clear();
+    }
+
     public long getStmtId() {
         return stmtId;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -40,6 +40,7 @@ import com.starrocks.authentication.AuthenticationException;
 import com.starrocks.authentication.AuthenticationProvider;
 import com.starrocks.authentication.UserIdentityUtils;
 import com.starrocks.authentication.UserProperty;
+import com.starrocks.authorization.SecurityPolicyRewriteRule;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
@@ -81,13 +82,11 @@ import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.AstToSQLBuilder;
 import com.starrocks.sql.analyzer.SemanticException;
-import com.starrocks.sql.ast.AstTraverser;
 import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.ast.ExecuteStmt;
 import com.starrocks.sql.ast.OriginStatement;
 import com.starrocks.sql.ast.PrepareStmt;
 import com.starrocks.sql.ast.QueryStatement;
-import com.starrocks.sql.ast.Relation;
 import com.starrocks.sql.ast.SetStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.expression.Expr;
@@ -201,6 +200,9 @@ public class ConnectProcessor {
         // reconstruct serializer
         ctx.getSerializer().reset();
         ctx.getSerializer().setCapability(ctx.getCapability());
+        // COM_RESET_CONNECTION and COM_CHANGE_USER start a new logical session. Prepared
+        // statements must not carry analyzed metadata, cached plans, or policy state across it.
+        ctx.clearPreparedStmts();
         // reset session variable
         ctx.resetSessionVariable();
     }
@@ -615,14 +617,8 @@ public class ConnectProcessor {
             executor = new StmtExecutor(ctx, parsedStmt);
             ctx.setExecutor(executor);
 
-            //Build View SQL without Policy Rewrite
-            new AstTraverser<Void, Void>() {
-                @Override
-                public Void visitRelation(Relation relation, Void context) {
-                    relation.setNeedRewrittenByPolicy(true);
-                    return null;
-                }
-            }.visit(parsedStmt);
+            // Build view SQL without policy rewrite.
+            SecurityPolicyRewriteRule.markRelationsForRewrite(parsedStmt);
 
             if (ctx.getQueryDetail() == null) {
                 executor.addRunningQueryDetail(parsedStmt);
@@ -887,6 +883,7 @@ public class ConnectProcessor {
         boolean enableAudit = false;
         String originStmt = null;
         ExecuteStmt executeStmt = null;
+        PrepareStmt preparedExecutionStmt = null;
         boolean needAddFinishQueryDetail = false;
         try {
             ctx.setQueryId(UUIDUtil.genUUID());
@@ -928,15 +925,19 @@ public class ConnectProcessor {
                 PrepareStmtContext prepareStmtContext = ctx.getPreparedStmt(executeStmt.getStmtName());
                 if (prepareStmtContext != null) {
                     if (prepareStmtContext.getStmt().getInnerStmt() instanceof QueryStatement) {
-                        PrepareStmt prepareStmt = prepareStmtContext.getStmt();
-                        StatementBase deparameterizedStmt = prepareStmt.assignValues(executeStmt.getParamsExpr());
-                        originStmt = AstToSQLBuilder.toSQL(deparameterizedStmt);
+                        if (prepareStmtContext.isCached()) {
+                            originStmt = prepareStmtContext.getBoundSqlForAudit(executeStmt.getParamsExpr());
+                        } else {
+                            preparedExecutionStmt = prepareStmtContext.instantiate(executeStmt.getParamsExpr());
+                            originStmt = AstToSQLBuilder.toSQL(preparedExecutionStmt.getInnerStmt());
+                        }
                         executeStmt.setOrigStmt(new OriginStatement(originStmt, 0));
                     }
                 }
             }
 
             executor = new StmtExecutor(ctx, executeStmt);
+            executor.setPreparedExecutionStmt(preparedExecutionStmt);
             ctx.setExecutor(executor);
             if (enableAudit) {
                 resetAuditEventBuilder();
@@ -1296,14 +1297,8 @@ public class ConnectProcessor {
             List<StatementBase> stmts = SqlParser.parse(request.getSql(), ctx.getSessionVariable());
             ctx.setMultiStmt(stmts.size() > 1);
             StatementBase statement = stmts.get(idx);
-            //Build View SQL without Policy Rewrite
-            new AstTraverser<Void, Void>() {
-                @Override
-                public Void visitRelation(Relation relation, Void context) {
-                    relation.setNeedRewrittenByPolicy(true);
-                    return null;
-                }
-            }.visit(statement);
+            // Build view SQL without policy rewrite.
+            SecurityPolicyRewriteRule.markRelationsForRewrite(statement);
             statement.setOrigStmt(new OriginStatement(request.getSql(), idx));
 
             executor = doProxyExecute(result, request, statement, requestFE);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/PrepareStmtContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/PrepareStmtContext.java
@@ -15,25 +15,58 @@
 package com.starrocks.qe;
 
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.sql.analyzer.AstToSQLBuilder;
 import com.starrocks.sql.analyzer.QueryAnalyzer;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.OriginStatement;
 import com.starrocks.sql.ast.PrepareStmt;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.TableRelation;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
 
+import java.util.Collections;
+import java.util.List;
+
 public class PrepareStmtContext {
+    // stmt is the analyzed working copy used only for COM_STMT_PREPARE metadata and protocol state.
     private final PrepareStmt stmt;
     private final ConnectContext connectContext;
+    // Captured before the metadata AST is marked/analyzed. Reparse the original statement rather
+    // than serializing the AST: the normal serializer intentionally redacts credentials.
+    private final OriginStatement originalStatement;
+    // Parsing semantics belong to the PREPARE boundary. A later SET sql_dialect/sql_mode (or
+    // parser-limit change) must not reinterpret the stored statement during EXECUTE.
+    private final SessionVariable parserSessionVariable;
+    private final String preparedCatalog;
+    private final String preparedDatabase;
+    private final boolean preparedRelationAliasCaseInsensitive;
+
     private ExecPlan execPlan;
+    // A separately parsed and analyzed, policy-free point-query statement. Never aliases stmt.
+    private PrepareStmt cachedExecutableStmt;
     private boolean isCached = false;
     private long lastSchemaUpdateTime = -1;
     private long tableId = -1;
 
     public PrepareStmtContext(PrepareStmt stmt, ConnectContext connectContext, ExecPlan execPlan) {
+        this(stmt, connectContext, execPlan,
+                new OriginStatement(AstToSQLBuilder.toSQLWithCredential(stmt.getInnerStmt()), 0));
+    }
+
+    public PrepareStmtContext(PrepareStmt stmt, ConnectContext connectContext, ExecPlan execPlan,
+                              OriginStatement originalStatement) {
         this.stmt = stmt;
         this.connectContext = connectContext;
         this.execPlan = execPlan;
+        this.originalStatement = originalStatement;
+        this.parserSessionVariable = connectContext.getSessionVariable().clone();
+        this.preparedCatalog = connectContext.getCurrentCatalog();
+        this.preparedDatabase = connectContext.getDatabase();
+        this.preparedRelationAliasCaseInsensitive = connectContext.isRelationAliasCaseInsensitive();
     }
 
     public PrepareStmt getStmt() {
@@ -52,6 +85,85 @@ public class PrepareStmtContext {
         return execPlan;
     }
 
+    public PrepareStmt instantiate(List<Expr> values) {
+        List<StatementBase> parsedStatements = parseOriginalStatement();
+        if (originalStatement.getIdx() >= parsedStatements.size()) {
+            throw new SemanticException("Prepared statement index changed while rebuilding execution AST");
+        }
+        StatementBase parsed = parsedStatements.get(originalStatement.getIdx());
+        PrepareStmt executableStmt;
+        if (parsed instanceof PrepareStmt) {
+            executableStmt = (PrepareStmt) parsed;
+            executableStmt.setName(stmt.getName());
+        } else {
+            executableStmt = new PrepareStmt(stmt.getName(), parsed, Collections.emptyList());
+        }
+
+        if (executableStmt.getParameters().size() != stmt.getParameters().size()) {
+            throw new SemanticException("Prepared statement parameter count changed while rebuilding execution AST");
+        }
+        executableStmt.assignValues(values);
+        return executableStmt;
+    }
+
+    private List<StatementBase> parseOriginalStatement() {
+        SessionVariable currentSessionVariable = connectContext.getSessionVariable();
+        String currentDatabase = connectContext.getDatabase();
+        boolean currentRelationAliasCaseInsensitive = connectContext.isRelationAliasCaseInsensitive();
+        ConnectContext previousThreadContext = ConnectContext.exchangeThreadLocalInfo(connectContext);
+        try {
+            // Some parser paths consult ConnectContext.get() instead of their explicit argument
+            // (for example, large IN predicates), and Trino parsing updates the alias mode on the
+            // context. Parse under the complete PREPARE-time snapshot, then restore every bit of
+            // caller-visible state.
+            SessionVariable parserVariables = parserSessionVariable.clone();
+            parserVariables.setCatalog(preparedCatalog);
+            connectContext.setSessionVariable(parserVariables);
+            connectContext.setDatabase(preparedDatabase);
+            connectContext.setRelationAliasCaseInSensitive(preparedRelationAliasCaseInsensitive);
+            return SqlParser.parse(originalStatement.getOrigStmt(), parserVariables);
+        } finally {
+            connectContext.setSessionVariable(currentSessionVariable);
+            connectContext.setDatabase(currentDatabase);
+            connectContext.setRelationAliasCaseInSensitive(currentRelationAliasCaseInsensitive);
+            if (previousThreadContext == null) {
+                ConnectContext.remove();
+            } else {
+                ConnectContext.set(previousThreadContext);
+            }
+        }
+    }
+
+    public String getPreparedCatalog() {
+        return preparedCatalog;
+    }
+
+    public String getPreparedDatabase() {
+        return preparedDatabase;
+    }
+
+    public boolean isPreparedRelationAliasCaseInsensitive() {
+        return preparedRelationAliasCaseInsensitive;
+    }
+
+    public StatementBase bindCached(List<Expr> values) {
+        if (cachedExecutableStmt == null) {
+            throw new IllegalStateException("Cached prepared statement is missing");
+        }
+        return cachedExecutableStmt.assignValues(values);
+    }
+
+    public String getBoundSqlForAudit(List<Expr> values) {
+        PrepareStmt executableStmt;
+        if (cachedExecutableStmt == null) {
+            executableStmt = instantiate(values);
+        } else {
+            cachedExecutableStmt.assignValues(values);
+            executableStmt = cachedExecutableStmt;
+        }
+        return AstToSQLBuilder.toSQL(executableStmt.getInnerStmt());
+    }
+
     public boolean isCached() {
         return isCached;
     }
@@ -65,8 +177,9 @@ public class PrepareStmtContext {
         this.tableId = table.getId();
     }
 
-    public void cachePlan(ExecPlan execPlan) {
+    public void cachePlan(ExecPlan execPlan, PrepareStmt executableStmt) {
         this.execPlan = execPlan;
+        this.cachedExecutableStmt = executableStmt;
         this.isCached = true;
     }
 
@@ -91,5 +204,7 @@ public class PrepareStmtContext {
         this.lastSchemaUpdateTime = -1;
         this.tableId = -1;
         this.execPlan = null;
+        this.cachedExecutableStmt = null;
     }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -369,6 +369,12 @@ public class StmtExecutor {
     private Optional<Boolean> isForwardToLeaderOpt = Optional.empty();
     private HttpResultSender httpResultSender;
     private PrepareStmtContext prepareStmtContext = null;
+    // A pristine executable copy may be materialized while rendering COM_STMT_EXECUTE audit SQL.
+    // Reuse it for the first planning attempt to avoid parsing the prepared SQL twice.
+    private PrepareStmt preparedExecutionStmt = null;
+    // Captured before the PREPARE metadata AST is policy-marked and analyzed. EXECUTE reparses this
+    // source instead of reusing the analyzer-mutated metadata working copy.
+    private final OriginStatement preparedStatementOrigin;
     private boolean isInternalStmt = false;
     // Stores the last generated exec plan, used to dump the plan to fe.plan.log on query failure.
     private ExecPlan lastExecPlan = null;
@@ -412,11 +418,24 @@ public class StmtExecutor {
         this.isProxy = false;
         this.isInternalStmt = isInternalStmt;
         this.deploymentFinished = deploymentFinished;
+        this.preparedStatementOrigin = parsedStmt instanceof PrepareStmt
+                ? getPreparedStatementOrigin((PrepareStmt) parsedStmt) : null;
+    }
+
+    private OriginStatement getPreparedStatementOrigin(PrepareStmt prepareStmt) {
+        if (prepareStmt.getOrigStmt() != null) {
+            return prepareStmt.getOrigStmt();
+        }
+        return new OriginStatement(AstToSQLBuilder.toSQLWithCredential(prepareStmt.getInnerStmt()), 0);
     }
 
     public void setProxy() {
         isProxy = true;
         proxyResultBuffer = new ArrayList<>();
+    }
+
+    public void setPreparedExecutionStmt(PrepareStmt preparedExecutionStmt) {
+        this.preparedExecutionStmt = preparedExecutionStmt;
     }
 
     public Coordinator getCoordinator() {
@@ -868,15 +887,23 @@ public class StmtExecutor {
                                 executeStmt.getStmtName());
                     }
                     PrepareStmt prepareStmt = prepareStmtContext.getStmt();
-                    parsedStmt = prepareStmt.assignValues(executeStmt.getParamsExpr());
-                    parsedStmt.setOrigStmt(originStmt);
-
+                    // Query-scope hints are already resolved on the metadata working copy. Apply
+                    // them before policy lookup/planning of the fresh executable copy.
+                    parsedStmt = prepareStmt.getInnerStmt();
                     if (prepareStmt.getInnerStmt().isExistQueryScopeHint()) {
                         processQueryScopeHint();
                     }
 
                     try {
-                        execPlan = PrepareStmtPlanner.plan(executeStmt, parsedStmt, context);
+                        PrepareStmt executableCopy = preparedExecutionStmt;
+                        // A retry must start from another pristine copy because normal analysis
+                        // mutates the statement passed to the first attempt.
+                        preparedExecutionStmt = null;
+                        PrepareStmtPlanner.PreparedStatementPlan preparedPlan =
+                                PrepareStmtPlanner.plan(executeStmt, context, executableCopy);
+                        parsedStmt = preparedPlan.getStatement();
+                        parsedStmt.setOrigStmt(originStmt);
+                        execPlan = preparedPlan.getExecPlan();
                     } catch (SemanticException e) {
                         if (e.getMessage().contains("Unknown partition")) {
                             throw new SemanticException(e.getMessage() +
@@ -3164,7 +3191,8 @@ public class StmtExecutor {
         boolean isBinaryRowFormat = context.getCommand() == MysqlCommand.COM_STMT_PREPARE;
         // register prepareStmt
         LOG.debug("add prepared statement {}, isBinaryProtocol {}", prepareStmt.getName(), isBinaryRowFormat);
-        context.putPreparedStmt(prepareStmt.getName(), new PrepareStmtContext(prepareStmt, context, execPlan));
+        context.putPreparedStmt(prepareStmt.getName(),
+                new PrepareStmtContext(prepareStmt, context, execPlan, preparedStatementOrigin));
         if (isBinaryRowFormat) {
             sendStmtPrepareOK(prepareStmt);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/PrepareStmtPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/PrepareStmtPlanner.java
@@ -14,11 +14,14 @@
 
 package com.starrocks.sql;
 
+import com.starrocks.authorization.SecurityPolicyRewriteRule;
 import com.starrocks.http.HttpConnectContext;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.PrepareStmtContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.sql.ast.ExecuteStmt;
+import com.starrocks.sql.ast.PrepareStmt;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.StatementBase;
@@ -40,62 +43,113 @@ import java.util.List;
 
 public class PrepareStmtPlanner {
 
-    public static ExecPlan plan(ExecuteStmt executeStmt, StatementBase stmt, ConnectContext session) {
+    public static PreparedStatementPlan plan(ExecuteStmt executeStmt, ConnectContext session,
+                                             PrepareStmt executableCopy) {
         try {
-            if (!(stmt instanceof QueryStatement)) {
-                return StatementPlanner.plan(stmt, session);
-            }
-            QueryStatement queryStmt = (QueryStatement) stmt;
-            if (!queryStmt.isPointQuery()) {
-                return StatementPlanner.plan(stmt, session);
-            }
-
             PrepareStmtContext prepareStmtContext = session.getPreparedStmt(executeStmt.getStmtName());
-            if (!prepareStmtContext.isCached()) {
-                return planAndCacheExecPlan(stmt, session, prepareStmtContext);
-            } else {
-                if (prepareStmtContext.needReAnalyze(queryStmt, session)) {
-                    return planAndCacheExecPlan(stmt, session, prepareStmtContext);
-                } else {
-                    ExecPlan execPlan = prepareStmtContext.getExecPlan();
-
-                    // use cache and rebuild physical plan
-                    rePlan(executeStmt, execPlan.getLogicalPlan(), execPlan.getPhysicalPlan());
-
-                    TResultSinkType resultSinkType = session instanceof HttpConnectContext ? TResultSinkType.HTTP_PROTOCAL :
-                            TResultSinkType.MYSQL_PROTOCAL;
-                    resultSinkType = queryStmt.hasOutFileClause() ? TResultSinkType.FILE : resultSinkType;
-
-                    OptExpression physicalPlan = execPlan.getPhysicalPlan();
-                    LogicalPlan logicalPlan = execPlan.getLogicalPlan();
-                    ColumnRefFactory columnRefFactory = execPlan.getColumnRefFactory();
-                    QueryRelation query = queryStmt.getQueryRelation();
-                    List<String> colNames = query.getColumnOutputNames();
-
-                    return PlanFragmentBuilder.createPhysicalPlan(
-                            physicalPlan, session, logicalPlan.getOutputColumn(), columnRefFactory,
-                            colNames,
-                            resultSinkType,
-                            !session.getSessionVariable().isSingleNodeExecPlan());
+            if (prepareStmtContext.isCached()) {
+                StatementBase cachedStmt = prepareStmtContext.bindCached(executeStmt.getParamsExpr());
+                QueryStatement cachedQuery = (QueryStatement) cachedStmt;
+                if (!prepareStmtContext.needReAnalyze(cachedQuery, session) && !hasPolicy(cachedQuery, session)) {
+                    // A prepared plan must not outlive the caller's current privileges (SET ROLE,
+                    // COM_CHANGE_USER, grants/revokes). Policy is checked separately above because
+                    // it changes the plan shape rather than only authorizing it.
+                    if (!session.isBypassAuthorizerCheck()) {
+                        Authorizer.check(cachedStmt, session);
+                    }
+                    return new PreparedStatementPlan(cachedStmt,
+                            rebuildCachedPlan(executeStmt, cachedQuery, prepareStmtContext.getExecPlan(), session));
                 }
+                prepareStmtContext.reset();
             }
+
+            return planFresh(executeStmt, session, prepareStmtContext, executableCopy);
         } finally {
             // Release query-level connector metadata when planning is done
             GlobalStateMgr.getCurrentState().getMetadataMgr().removeQueryMetadata();
         }
     }
 
-    private static ExecPlan planAndCacheExecPlan(StatementBase stmt, ConnectContext session,
-                                                 PrepareStmtContext prepareStmtContext) {
-        ExecPlan execPlan = StatementPlanner.plan(stmt, session);
-        if (execPlan == null) {
-            return null;
+    private static boolean hasPolicy(QueryStatement queryStmt, ConnectContext session) {
+        return SecurityPolicyRewriteRule.hasPolicy(session, queryStmt);
+    }
+
+    private static PreparedStatementPlan planFresh(ExecuteStmt executeStmt, ConnectContext session,
+                                                   PrepareStmtContext prepareStmtContext,
+                                                   PrepareStmt executableCopy) {
+        String currentCatalog = session.getCurrentCatalog();
+        String currentDatabase = session.getDatabase();
+        boolean currentRelationAliasCaseInsensitive = session.isRelationAliasCaseInsensitive();
+        try {
+            // The original prepared AST was resolved in this namespace. Re-enter it for the fresh
+            // parse/analyze so USE, sql_dialect changes, or an unqualified UDF cannot retarget the
+            // statement between PREPARE and EXECUTE.
+            session.getSessionVariable().setCatalog(prepareStmtContext.getPreparedCatalog());
+            session.setDatabase(prepareStmtContext.getPreparedDatabase());
+            session.setRelationAliasCaseInSensitive(
+                    prepareStmtContext.isPreparedRelationAliasCaseInsensitive());
+
+            PrepareStmt executableStmt = executableCopy != null
+                    ? executableCopy : prepareStmtContext.instantiate(executeStmt.getParamsExpr());
+            StatementBase stmt = executableStmt.getInnerStmt();
+            SecurityPolicyRewriteRule.markRelationsForRewrite(stmt);
+            ExecPlan execPlan = StatementPlanner.plan(stmt, session);
+
+            // isPointQuery relies on analyzer-populated table metadata and therefore must only be
+            // evaluated after normal planning. A policy rewrite changes the source to a subquery,
+            // so policy-bearing plans are intentionally never cached.
+            if (execPlan != null && stmt instanceof QueryStatement && ((QueryStatement) stmt).isPointQuery()) {
+                prepareStmtContext.updateLastSchemaUpdateTime((QueryStatement) stmt, session);
+                prepareStmtContext.cachePlan(execPlan, executableStmt);
+            }
+            return new PreparedStatementPlan(stmt, execPlan);
+        } finally {
+            // Do not use ConnectContext.setCurrentCatalog for this temporary scope: that API
+            // records a persistent modified session variable which is forwarded to other FEs.
+            session.getSessionVariable().setCatalog(currentCatalog);
+            session.setDatabase(currentDatabase);
+            session.setRelationAliasCaseInSensitive(currentRelationAliasCaseInsensitive);
+        }
+    }
+
+    private static ExecPlan rebuildCachedPlan(ExecuteStmt executeStmt, QueryStatement queryStmt,
+                                              ExecPlan execPlan, ConnectContext session) {
+        // use cache and rebuild physical plan
+        rePlan(executeStmt, execPlan.getLogicalPlan(), execPlan.getPhysicalPlan());
+
+        TResultSinkType resultSinkType = session instanceof HttpConnectContext ? TResultSinkType.HTTP_PROTOCAL :
+                TResultSinkType.MYSQL_PROTOCAL;
+        resultSinkType = queryStmt.hasOutFileClause() ? TResultSinkType.FILE : resultSinkType;
+
+        OptExpression physicalPlan = execPlan.getPhysicalPlan();
+        LogicalPlan logicalPlan = execPlan.getLogicalPlan();
+        ColumnRefFactory columnRefFactory = execPlan.getColumnRefFactory();
+        QueryRelation query = queryStmt.getQueryRelation();
+        List<String> colNames = query.getColumnOutputNames();
+
+        return PlanFragmentBuilder.createPhysicalPlan(
+                physicalPlan, session, logicalPlan.getOutputColumn(), columnRefFactory,
+                colNames,
+                resultSinkType,
+                !session.getSessionVariable().isSingleNodeExecPlan());
+    }
+
+    public static class PreparedStatementPlan {
+        private final StatementBase statement;
+        private final ExecPlan execPlan;
+
+        public PreparedStatementPlan(StatementBase statement, ExecPlan execPlan) {
+            this.statement = statement;
+            this.execPlan = execPlan;
         }
 
-        prepareStmtContext.setExecPlan(execPlan);
-        prepareStmtContext.updateLastSchemaUpdateTime((QueryStatement) stmt, session);
-        prepareStmtContext.cachePlan(execPlan);
-        return execPlan;
+        public StatementBase getStatement() {
+            return statement;
+        }
+
+        public ExecPlan getExecPlan() {
+            return execPlan;
+        }
     }
 
     private static void rePlan(ExecuteStmt executeStmt,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
@@ -32,6 +32,7 @@ import com.starrocks.sql.ast.AstTraverser;
 import com.starrocks.sql.ast.DeleteStmt;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.MergeIntoStmt;
+import com.starrocks.sql.ast.PrepareStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.TableRef;
 import com.starrocks.sql.ast.TableRelation;
@@ -285,6 +286,13 @@ public class PlannerMetaLocker implements AutoCloseable {
         }
 
         @Override
+        public Void visitPrepareStatement(PrepareStmt node, Void context) {
+            // PREPARE is opaque to the generic traverser because it is a deferred execution
+            // boundary. Metadata analysis still needs the same table locks as its inner query.
+            return visit(node.getInnerStmt(), context);
+        }
+
+        @Override
         public Void visitInsertStatement(InsertStmt node, Void context) {
             TableRef tableRef = node.getTableRef();
             TableName tableName = TableName.fromTableRef(tableRef);
@@ -317,15 +325,6 @@ public class PlannerMetaLocker implements AutoCloseable {
             TableName tableName = TableName.fromTableRef(tableRef);
             Pair<Database, Table> dbAndTable = resolveTable(session, tableName);
             put(dbAndTable);
-            // PlannerMetaLocker is constructed in StatementPlanner BEFORE
-            // Analyzer.analyze runs, so node.getQueryStatement() is null at
-            // this point. super's default traversal walks the analyzed
-            // QueryStatement and would skip the raw USING source — visit the
-            // source relation explicitly so its tables are locked alongside
-            // the target before the analyzer resolves the join.
-            if (node.getSourceRelation() != null) {
-                visit(node.getSourceRelation());
-            }
             return super.visitMergeIntoStatement(node, context);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrepareAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrepareAnalyzer.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.analyzer;
 
+import com.starrocks.authorization.SecurityPolicyRewriteRule;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.qe.ConnectContext;
@@ -49,7 +50,9 @@ public class PrepareAnalyzer {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_UNSUPPORTED_PS, ErrorType.UNSUPPORTED);
             }
             // Analyzing when preparing is only used to return the correct resultset meta, but not to generate an
-            // execution plan
+            // execution plan. This metadata working copy is intentionally separate from the pristine SQL template
+            // used by EXECUTE.
+            SecurityPolicyRewriteRule.markRelationsForRewrite(innerStmt);
             Analyzer.analyze(innerStmt, ConnectContext.get());
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstTraverser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstTraverser.java
@@ -28,17 +28,6 @@ public class AstTraverser<R, C> implements AstVisitorExtendInterface<R, C> {
         return null;
     }
 
-    @Override
-    public R visitPrepareStatement(PrepareStmt statement, C context) {
-        // The statement being prepared is the one that actually reads tables, so consumers of this
-        // traverser (security policy marking, column privilege collection, meta locking, ...) have
-        // to see the relations inside it.
-        if (statement.getInnerStmt() != null) {
-            visit(statement.getInnerStmt(), context);
-        }
-        return null;
-    }
-
     // ------------------------------------------- DML Statement -------------------------------------------------------
 
     @Override
@@ -51,27 +40,73 @@ public class AstTraverser<R, C> implements AstVisitorExtendInterface<R, C> {
 
     @Override
     public R visitUpdateStatement(UpdateStmt statement, C context) {
-        //Update Statement after analyze, all information will be used to build QueryStatement, so it is enough to traverse Query
+        // After analysis the synthesized query owns all executable expressions. Before analysis,
+        // source reads still live only in the parser-owned DML fields.
         if (statement.getQueryStatement() != null) {
             visit(statement.getQueryStatement(), context);
+            return null;
+        }
+        if (statement.getCommonTableExpressions() != null) {
+            statement.getCommonTableExpressions().forEach(x -> visit(x, context));
+        }
+        if (statement.getAssignments() != null) {
+            statement.getAssignments().forEach(x -> visit(x.getExpr(), context));
+        }
+        if (statement.getWherePredicate() != null) {
+            visit(statement.getWherePredicate(), context);
+        }
+        if (statement.getFromRelations() != null) {
+            statement.getFromRelations().forEach(x -> visit(x, context));
         }
         return null;
     }
 
     @Override
     public R visitDeleteStatement(DeleteStmt statement, C context) {
-        //Delete Statement after analyze, all information will be used to build QueryStatement, so it is enough to traverse Query
+        // See visitUpdateStatement: use exactly one representation for each analysis phase.
         if (statement.getQueryStatement() != null) {
             visit(statement.getQueryStatement(), context);
+            return null;
+        }
+        if (statement.getCommonTableExpressions() != null) {
+            statement.getCommonTableExpressions().forEach(x -> visit(x, context));
+        }
+        if (statement.getWherePredicate() != null) {
+            visit(statement.getWherePredicate(), context);
+        }
+        if (statement.getUsingRelations() != null) {
+            statement.getUsingRelations().forEach(x -> visit(x, context));
         }
         return null;
     }
 
     @Override
     public R visitMergeIntoStatement(MergeIntoStmt statement, C context) {
-        //MergeInto Statement after analyze, all information will be used to build QueryStatement, so it is enough to traverse Query
+        // See visitUpdateStatement: use exactly one representation for each analysis phase.
         if (statement.getQueryStatement() != null) {
             visit(statement.getQueryStatement(), context);
+            return null;
+        }
+        if (statement.getWhenClauses() != null) {
+            for (MergeWhenClause clause : statement.getWhenClauses()) {
+                if (clause.getOptionalCondition() != null) {
+                    visit(clause.getOptionalCondition(), context);
+                }
+                if (clause instanceof MergeWhenMatchedUpdateClause) {
+                    ((MergeWhenMatchedUpdateClause) clause).getAssignments()
+                            .forEach(x -> visit(x.getExpr(), context));
+                } else if (clause instanceof MergeWhenNotMatchedInsertClause &&
+                        ((MergeWhenNotMatchedInsertClause) clause).getValues() != null) {
+                    ((MergeWhenNotMatchedInsertClause) clause).getValues()
+                            .forEach(x -> visit(x, context));
+                }
+            }
+        }
+        if (statement.getMergeCondition() != null) {
+            visit(statement.getMergeCondition(), context);
+        }
+        if (statement.getSourceRelation() != null) {
+            visit(statement.getSourceRelation(), context);
         }
         return null;
     }
@@ -151,6 +186,12 @@ public class AstTraverser<R, C> implements AstVisitorExtendInterface<R, C> {
 
         if (node.getOutputExpression() != null) {
             node.getOutputExpression().forEach(x -> visit(x, context));
+        } else if (node.getSelectList() != null) {
+            // outputExpression is populated by the analyzer. Before analysis, expressions (including
+            // scalar subqueries) only live in the parser-owned select list.
+            node.getSelectList().getItems().stream()
+                    .filter(x -> !x.isStar())
+                    .forEach(x -> visit(x.getExpr(), context));
         }
 
         if (node.getPredicate() != null) {
@@ -159,6 +200,18 @@ public class AstTraverser<R, C> implements AstVisitorExtendInterface<R, C> {
 
         if (node.getGroupBy() != null) {
             node.getGroupBy().forEach(x -> visit(x, context));
+        } else if (node.getGroupByClause() != null) {
+            // groupBy is analyzer-owned. Traverse the non-generating parser representation before
+            // analysis so scalar subqueries are not skipped or the AST mutated by the visitor.
+            GroupByClause groupByClause = node.getGroupByClause();
+            if (groupByClause.getGroupingType() == GroupByClause.GroupingType.GROUPING_SETS) {
+                if (groupByClause.getGroupingSetList() != null) {
+                    groupByClause.getGroupingSetList().forEach(
+                            groupingSet -> groupingSet.forEach(x -> visit(x, context)));
+                }
+            } else if (groupByClause.getOriGroupingExprs() != null) {
+                groupByClause.getOriGroupingExprs().forEach(x -> visit(x, context));
+            }
         }
 
         if (node.getAggregate() != null) {
@@ -190,6 +243,7 @@ public class AstTraverser<R, C> implements AstVisitorExtendInterface<R, C> {
 
     @Override
     public R visitPivotRelation(PivotRelation node, C context) {
+        visitRelation(node, context);
         if (node.getAggregateFunctions() != null) {
             node.getAggregateFunctions().forEach(x -> visit(x.getFunctionCallExpr(), context));
         }
@@ -204,6 +258,30 @@ public class AstTraverser<R, C> implements AstVisitorExtendInterface<R, C> {
             return visit(node.getQuery(), context);
         }
         return null;
+    }
+
+    @Override
+    public R visitValues(ValuesRelation node, C context) {
+        node.getRows().forEach(row -> row.forEach(x -> visit(x, context)));
+        return visitRelation(node, context);
+    }
+
+    @Override
+    public R visitTableFunction(TableFunctionRelation node, C context) {
+        // childExpressions is analyzer-owned. Use the original function parameters before analysis,
+        // and avoid visiting both representations after analysis.
+        if (node.getChildExpressions() != null) {
+            node.getChildExpressions().forEach(x -> visit(x, context));
+        } else if (node.getFunctionParams() != null && node.getFunctionParams().exprs() != null) {
+            node.getFunctionParams().exprs().forEach(x -> visit(x, context));
+        }
+        return visitRelation(node, context);
+    }
+
+    @Override
+    public R visitNormalizedTableFunction(NormalizedTableFunctionRelation node, C context) {
+        visitRelation(node, context);
+        return visitJoin(node, context);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstTraverser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstTraverser.java
@@ -28,6 +28,17 @@ public class AstTraverser<R, C> implements AstVisitorExtendInterface<R, C> {
         return null;
     }
 
+    @Override
+    public R visitPrepareStatement(PrepareStmt statement, C context) {
+        // The statement being prepared is the one that actually reads tables, so consumers of this
+        // traverser (security policy marking, column privilege collection, meta locking, ...) have
+        // to see the relations inside it.
+        if (statement.getInnerStmt() != null) {
+            visit(statement.getInnerStmt(), context);
+        }
+        return null;
+    }
+
     // ------------------------------------------- DML Statement -------------------------------------------------------
 
     @Override
@@ -175,6 +186,24 @@ public class AstTraverser<R, C> implements AstVisitorExtendInterface<R, C> {
     @Override
     public R visitSubqueryRelation(SubqueryRelation node, C context) {
         return visit(node.getQueryStatement(), context);
+    }
+
+    @Override
+    public R visitPivotRelation(PivotRelation node, C context) {
+        if (node.getAggregateFunctions() != null) {
+            node.getAggregateFunctions().forEach(x -> visit(x.getFunctionCallExpr(), context));
+        }
+
+        if (node.getPivotColumns() != null) {
+            node.getPivotColumns().forEach(x -> visit(x, context));
+        }
+
+        // The pivoted relation is the one that actually reads the table, so it must be visited for
+        // the same reasons as any other nested relation.
+        if (node.getQuery() != null) {
+            return visit(node.getQuery(), context);
+        }
+        return null;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/QueryStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/QueryStatement.java
@@ -26,6 +26,7 @@ import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.ast.expression.Parameter;
 import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.sql.ast.expression.Subquery;
 
 import java.util.HashMap;
 import java.util.List;
@@ -94,6 +95,17 @@ public class QueryStatement extends StatementBase {
 
         if (!(selectRelation.getRelation() instanceof TableRelation)) {
             return false;
+        }
+
+        // The prepared point-query fast path only replans predicates for one direct table scan.
+        // A scalar subquery in the projection adds independent scans and policy state that cannot
+        // safely share that cached plan.
+        if (selectRelation.getOutputExpression() != null) {
+            for (Expr outputExpression : selectRelation.getOutputExpression()) {
+                if (outputExpression.contains(Subquery.class)) {
+                    return false;
+                }
+            }
         }
 
         if (((TableRelation) selectRelation.getRelation()).getTable().getType() != Table.TableType.OLAP) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/PreparedStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/PreparedStmtTest.java
@@ -15,24 +15,45 @@
 package com.starrocks.analysis;
 
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.PrepareStmtContext;
 import com.starrocks.qe.StmtExecutor;
+import com.starrocks.sql.analyzer.AstToSQLBuilder;
+import com.starrocks.sql.analyzer.Authorizer;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.ExecuteStmt;
+import com.starrocks.sql.ast.FileTableFunctionRelation;
+import com.starrocks.sql.ast.OriginStatement;
 import com.starrocks.sql.ast.PrepareStmt;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.TableRelation;
+import com.starrocks.sql.ast.expression.BoolLiteral;
 import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.IntLiteral;
+import com.starrocks.sql.ast.expression.LargeInPredicate;
+import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.common.StarRocksPlannerException;
+import com.starrocks.sql.optimizer.LogicalPlanPrinter;
 import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -66,6 +87,7 @@ public class PreparedStmtTest{
         starRocksAssert = new StarRocksAssert(ctx);
         starRocksAssert.withDatabase("demo").useDatabase("demo");
         starRocksAssert.withTable(createTable);
+        starRocksAssert.withTable(createTable.replace("`prepare_stmt`", "`prepared_policy_source`"));
     }
 
     @Test
@@ -130,6 +152,278 @@ public class PreparedStmtTest{
         Assertions.assertEquals(false, stmt.getParameters().get(0).equals(stmt.getParameters().get(1)));
         Assertions.assertEquals(false, stmt.getParameters().get(1).equals(stmt.getParameters().get(2)));
         Assertions.assertEquals(false, stmt.getParameters().get(0).equals(stmt.getParameters().get(2)));
+    }
+
+    @Test
+    public void testExecutionAstIsFreshAndMetadataAstIsImmutable() throws Exception {
+        String sql = "PREPARE fresh_stmt FROM 'select c0 from prepare_stmt where c1 = ?'";
+        PrepareStmt metadataStmt = (PrepareStmt) SqlParser.parse(sql, ctx.getSessionVariable()).get(0);
+        PrepareStmtContext prepareContext = new PrepareStmtContext(metadataStmt, ctx, null);
+
+        String preparedDatabase = ctx.getDatabase();
+        boolean originalAliasMode = ctx.isRelationAliasCaseInsensitive();
+        boolean callerAliasMode = !originalAliasMode;
+        Object catalogModification = ctx.getModifiedSessionVariablesMap().get("catalog");
+        ctx.setDatabase("a_different_database");
+        ctx.setRelationAliasCaseInSensitive(callerAliasMode);
+        try {
+            PrepareStmt first = prepareContext.instantiate(List.of(new IntLiteral(11)));
+            PrepareStmt second = prepareContext.instantiate(List.of(new IntLiteral(22)));
+
+            Assertions.assertNotSame(metadataStmt, first);
+            Assertions.assertNotSame(first, second);
+            Assertions.assertNotSame(metadataStmt.getInnerStmt(), first.getInnerStmt());
+            Assertions.assertNotSame(first.getInnerStmt(), second.getInnerStmt());
+            Assertions.assertNotSame(first.getParameters().get(0), second.getParameters().get(0));
+            Assertions.assertEquals(11, ((IntLiteral) first.getParameters().get(0).getExpr()).getValue());
+            Assertions.assertEquals(22, ((IntLiteral) second.getParameters().get(0).getExpr()).getValue());
+            Assertions.assertNull(metadataStmt.getParameters().get(0).getExpr());
+            Assertions.assertTrue(prepareContext.getBoundSqlForAudit(List.of(new IntLiteral(33))).contains("33"));
+            Assertions.assertNull(metadataStmt.getParameters().get(0).getExpr());
+
+            ctx.putPreparedStmt("fresh_stmt", prepareContext);
+            GeneratedPreparedPlan generated = generatePreparedPlan("fresh_stmt", new IntLiteral(44));
+            SelectRelation plannedSelect = (SelectRelation) ((QueryStatement) generated.executor.getParsedStmt())
+                    .getQueryRelation();
+            TableRelation plannedTable = (TableRelation) plannedSelect.getRelation();
+            Assertions.assertEquals(preparedDatabase, plannedTable.getName().getDb());
+            Assertions.assertEquals("a_different_database", ctx.getDatabase(),
+                    "EXECUTE must restore the caller's current database after planning");
+            Assertions.assertEquals(callerAliasMode, ctx.isRelationAliasCaseInsensitive());
+            Assertions.assertSame(catalogModification, ctx.getModifiedSessionVariablesMap().get("catalog"),
+                    "Temporary prepared catalog changes must not become forwarded session state");
+        } finally {
+            ctx.removePreparedStmt("fresh_stmt");
+            ctx.setDatabase(preparedDatabase);
+            ctx.setRelationAliasCaseInSensitive(originalAliasMode);
+        }
+    }
+
+    @Test
+    public void testExecutionReparseUsesPreparedParserSnapshotWithoutLeakingState() {
+        boolean originalLargeIn = ctx.getSessionVariable().enableLargeInPredicate();
+        int originalThreshold = ctx.getSessionVariable().getLargeInPredicateThreshold();
+        boolean originalAliasMode = ctx.isRelationAliasCaseInsensitive();
+        String originalDatabase = ctx.getDatabase();
+        try {
+            ctx.getSessionVariable().setEnableLargeInPredicate(true);
+            ctx.getSessionVariable().setLargeInPredicateThreshold(2);
+            String sql = "select c0 from prepare_stmt where c0 in ('a', 'b')";
+            StatementBase query = SqlParser.parse(sql, ctx.getSessionVariable()).get(0);
+            PrepareStmt metadataStmt = new PrepareStmt("parser_snapshot_stmt", query, Collections.emptyList());
+            PrepareStmtContext prepareContext = new PrepareStmtContext(
+                    metadataStmt, ctx, null, new OriginStatement(sql, 0));
+
+            ctx.getSessionVariable().setEnableLargeInPredicate(false);
+            ctx.setDatabase("a_different_database");
+            ctx.setRelationAliasCaseInSensitive(!originalAliasMode);
+            PrepareStmt executable = prepareContext.instantiate(Collections.emptyList());
+            SelectRelation select = (SelectRelation) ((QueryStatement) executable.getInnerStmt()).getQueryRelation();
+
+            Assertions.assertInstanceOf(LargeInPredicate.class, select.getPredicate());
+            Assertions.assertFalse(ctx.getSessionVariable().enableLargeInPredicate());
+            Assertions.assertEquals("a_different_database", ctx.getDatabase());
+            Assertions.assertEquals(!originalAliasMode, ctx.isRelationAliasCaseInsensitive());
+        } finally {
+            ctx.getSessionVariable().setEnableLargeInPredicate(originalLargeIn);
+            ctx.getSessionVariable().setLargeInPredicateThreshold(originalThreshold);
+            ctx.setDatabase(originalDatabase);
+            ctx.setRelationAliasCaseInSensitive(originalAliasMode);
+        }
+    }
+
+    @Test
+    public void testExecutionReparseUsesOriginalStatementWithoutRedactingCredentials() {
+        String sql = "select 0; select * from files(\"path\"=\"s3://bucket/file\", "
+                + "\"aws.s3.secret_key\"=\"secret_value\")";
+        List<StatementBase> statements = SqlParser.parse(sql, ctx.getSessionVariable());
+        PrepareStmt metadataStmt = new PrepareStmt("credential_stmt", statements.get(1), Collections.emptyList());
+        PrepareStmtContext prepareContext = new PrepareStmtContext(
+                metadataStmt, ctx, null, new OriginStatement(sql, 1));
+
+        PrepareStmt executable = prepareContext.instantiate(Collections.emptyList());
+        SelectRelation select = (SelectRelation) ((QueryStatement) executable.getInnerStmt()).getQueryRelation();
+        FileTableFunctionRelation files = (FileTableFunctionRelation) select.getRelation();
+        Assertions.assertEquals("secret_value", files.getProperties().get("aws.s3.secret_key"));
+    }
+
+    @Test
+    public void testPreparedExecutionReevaluatesChangedPolicy() throws Exception {
+        String name = "dynamic_policy_stmt";
+        AtomicReference<String> currentPolicy = new AtomicReference<>("prepare_policy");
+
+        try (MockedStatic<Authorizer> authorizer = Mockito.mockStatic(Authorizer.class)) {
+            authorizer.when(() -> Authorizer.getColumnMaskingPolicy(
+                            Mockito.any(), Mockito.any(), Mockito.any()))
+                    .thenAnswer(invocation -> Map.of("c0", new StringLiteral(currentPolicy.get())));
+            authorizer.when(() -> Authorizer.getRowAccessPolicy(Mockito.any(), Mockito.any()))
+                    .thenReturn(null);
+
+            // Exercise the real PREPARE lifecycle: metadata analysis is allowed to rewrite its
+            // working AST, while StmtExecutor must retain an untouched source for EXECUTE.
+            PrepareStmt metadataStmt = (PrepareStmt) SqlParser.parse(
+                    "PREPARE " + name + " FROM 'select c0 from prepare_stmt where c0 = ?'",
+                    ctx.getSessionVariable()).get(0);
+            new StmtExecutor(ctx, metadataStmt).execute();
+            PrepareStmtContext prepareContext = ctx.getPreparedStmt(name);
+            Assertions.assertNotNull(prepareContext);
+            Assertions.assertTrue(AstToSQLBuilder.toSQL(metadataStmt.getInnerStmt()).contains("prepare_policy"));
+
+            currentPolicy.set("execute_policy_1");
+            GeneratedPreparedPlan firstPlan = generatePreparedPlan(name, new StringLiteral("first"));
+            StatementBase first = firstPlan.executor.getParsedStmt();
+            String firstSql = AstToSQLBuilder.toSQL(first);
+
+            currentPolicy.set("execute_policy_2");
+            GeneratedPreparedPlan secondPlan = generatePreparedPlan(name, new StringLiteral("second"));
+            StatementBase second = secondPlan.executor.getParsedStmt();
+            String secondSql = AstToSQLBuilder.toSQL(second);
+
+            Assertions.assertNotSame(first, second);
+            Assertions.assertTrue(firstSql.contains("execute_policy_1"), firstSql);
+            Assertions.assertTrue(secondSql.contains("execute_policy_2"), secondSql);
+            String firstLogicalPlan = logicalPlan(firstPlan.execPlan);
+            String secondLogicalPlan = logicalPlan(secondPlan.execPlan);
+            Assertions.assertTrue(firstLogicalPlan.contains("execute_policy_1"), firstLogicalPlan);
+            Assertions.assertTrue(secondLogicalPlan.contains("execute_policy_2"), secondLogicalPlan);
+            Assertions.assertFalse(prepareContext.isCached());
+            Assertions.assertNull(metadataStmt.getParameters().get(0).getExpr());
+        } finally {
+            ctx.removePreparedStmt(name);
+        }
+    }
+
+    @Test
+    public void testPreparedPointQueryKeepsNoPolicyFastPath() throws Exception {
+        String name = "cached_policy_free_stmt";
+        PrepareStmt metadataStmt = (PrepareStmt) SqlParser.parse(
+                "PREPARE " + name + " FROM 'select c0 from prepare_stmt where c0 = ?'",
+                ctx.getSessionVariable()).get(0);
+        PrepareStmtContext prepareContext = new PrepareStmtContext(metadataStmt, ctx, null);
+        ctx.putPreparedStmt(name, prepareContext);
+        AtomicBoolean denyCachedExecution = new AtomicBoolean(false);
+
+        try (MockedStatic<Authorizer> authorizer = Mockito.mockStatic(Authorizer.class)) {
+            authorizer.when(() -> Authorizer.getColumnMaskingPolicy(
+                            Mockito.any(), Mockito.any(), Mockito.any()))
+                    .thenReturn(Collections.emptyMap());
+            authorizer.when(() -> Authorizer.getRowAccessPolicy(Mockito.any(), Mockito.any()))
+                    .thenReturn(null);
+            authorizer.when(() -> Authorizer.check(Mockito.any(), Mockito.any()))
+                    .thenAnswer(invocation -> {
+                        if (denyCachedExecution.get()) {
+                            throw new SemanticException("prepared privilege was revoked");
+                        }
+                        return null;
+                    });
+
+            GeneratedPreparedPlan firstPlan = generatePreparedPlan(name, new StringLiteral("first"));
+            Assertions.assertTrue(prepareContext.isCached());
+            ExecPlan cachedExecPlan = prepareContext.getExecPlan();
+            StatementBase first = firstPlan.executor.getParsedStmt();
+
+            GeneratedPreparedPlan secondPlan = generatePreparedPlan(name, new StringLiteral("second"));
+            Assertions.assertSame(first, secondPlan.executor.getParsedStmt());
+            Assertions.assertSame(cachedExecPlan, prepareContext.getExecPlan());
+            Assertions.assertTrue(secondPlan.execPlan.getExplainString(TExplainLevel.NORMAL).contains("second"));
+            Assertions.assertTrue(prepareContext.isCached());
+            authorizer.verify(() -> Authorizer.check(Mockito.any(), Mockito.any()), Mockito.times(2));
+
+            denyCachedExecution.set(true);
+            AnalysisException denied = Assertions.assertThrows(AnalysisException.class,
+                    () -> generatePreparedPlan(name, new StringLiteral("denied")));
+            Assertions.assertTrue(denied.getMessage().contains("prepared privilege was revoked"));
+        } finally {
+            ctx.removePreparedStmt(name);
+        }
+    }
+
+    @Test
+    public void testCachedPreparedPlanIsInvalidatedWhenPolicyAppears() throws Exception {
+        String name = "policy_added_after_cache_stmt";
+        PrepareStmt metadataStmt = (PrepareStmt) SqlParser.parse(
+                "PREPARE " + name + " FROM 'select c0 from prepare_stmt where c0 = ?'",
+                ctx.getSessionVariable()).get(0);
+        PrepareStmtContext prepareContext = new PrepareStmtContext(metadataStmt, ctx, null);
+        ctx.putPreparedStmt(name, prepareContext);
+        AtomicBoolean policyEnabled = new AtomicBoolean(false);
+
+        try (MockedStatic<Authorizer> authorizer = Mockito.mockStatic(Authorizer.class)) {
+            authorizer.when(() -> Authorizer.getColumnMaskingPolicy(
+                            Mockito.any(), Mockito.any(), Mockito.any()))
+                    .thenReturn(Collections.emptyMap());
+            authorizer.when(() -> Authorizer.getRowAccessPolicy(Mockito.any(), Mockito.any()))
+                    .thenAnswer(invocation -> policyEnabled.get() ? new BoolLiteral(false) : null);
+
+            GeneratedPreparedPlan firstPlan = generatePreparedPlan(name, new StringLiteral("first"));
+            Assertions.assertTrue(prepareContext.isCached());
+
+            policyEnabled.set(true);
+            GeneratedPreparedPlan secondPlan = generatePreparedPlan(name, new StringLiteral("second"));
+            Assertions.assertNotSame(firstPlan.executor.getParsedStmt(), secondPlan.executor.getParsedStmt());
+            Assertions.assertTrue(AstToSQLBuilder.toSQL(secondPlan.executor.getParsedStmt()).contains("WHERE FALSE"));
+            String secondLogicalPlan = logicalPlan(secondPlan.execPlan);
+            Assertions.assertTrue(secondLogicalPlan.toLowerCase().contains("false"), secondLogicalPlan);
+            Assertions.assertFalse(prepareContext.isCached());
+        } finally {
+            ctx.removePreparedStmt(name);
+        }
+    }
+
+    @Test
+    public void testPreparedPointQueryWithScalarSubqueryIsNotCached() throws Exception {
+        String name = "nested_policy_added_after_cache_stmt";
+        PrepareStmt metadataStmt = (PrepareStmt) SqlParser.parse(
+                "PREPARE " + name + " FROM 'select (select max(c0) from prepared_policy_source) "
+                        + "from prepare_stmt where c0 = ?'",
+                ctx.getSessionVariable()).get(0);
+        PrepareStmtContext prepareContext = new PrepareStmtContext(metadataStmt, ctx, null);
+        ctx.putPreparedStmt(name, prepareContext);
+        AtomicBoolean policyEnabled = new AtomicBoolean(false);
+
+        try (MockedStatic<Authorizer> authorizer = Mockito.mockStatic(Authorizer.class)) {
+            authorizer.when(() -> Authorizer.getColumnMaskingPolicy(
+                            Mockito.any(), Mockito.any(), Mockito.any()))
+                    .thenAnswer(invocation -> policyEnabled.get()
+                            && "prepared_policy_source".equals(invocation.getArgument(1, com.starrocks.catalog.TableName.class)
+                            .getTbl()) ? Map.of("c0", new StringLiteral("nested_policy")) : Collections.emptyMap());
+            authorizer.when(() -> Authorizer.getRowAccessPolicy(Mockito.any(), Mockito.any()))
+                    .thenReturn(null);
+
+            generatePreparedPlan(name, new StringLiteral("first"));
+            Assertions.assertFalse(prepareContext.isCached(),
+                    "The point-query cache cannot safely replan scans inside a scalar subquery");
+
+            policyEnabled.set(true);
+            GeneratedPreparedPlan secondPlan = generatePreparedPlan(name, new StringLiteral("second"));
+            String secondSql = AstToSQLBuilder.toSQL(secondPlan.executor.getParsedStmt());
+            Assertions.assertTrue(secondSql.contains("nested_policy"), secondSql);
+            Assertions.assertFalse(prepareContext.isCached());
+        } finally {
+            ctx.removePreparedStmt(name);
+        }
+    }
+
+    private GeneratedPreparedPlan generatePreparedPlan(String name, Expr value) throws Exception {
+        ExecuteStmt executeStmt = new ExecuteStmt(name, List.of(value));
+        executeStmt.setOrigStmt(new OriginStatement("EXECUTE " + name, 0));
+        StmtExecutor executor = new StmtExecutor(ctx, executeStmt);
+        ExecPlan execPlan = Deencapsulation.invoke(executor, "generateExecPlan");
+        return new GeneratedPreparedPlan(executor, execPlan);
+    }
+
+    private static String logicalPlan(ExecPlan execPlan) {
+        return LogicalPlanPrinter.print(execPlan.getLogicalPlan().getRoot(), true, true);
+    }
+
+    private static class GeneratedPreparedPlan {
+        private final StmtExecutor executor;
+        private final ExecPlan execPlan;
+
+        private GeneratedPreparedPlan(StmtExecutor executor, ExecPlan execPlan) {
+            this.executor = executor;
+            this.execPlan = execPlan;
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -353,12 +353,14 @@ public class ConnectProcessorTest extends DDLTestBase {
     @Test
     public void testResetConnection() throws IOException {
         ConnectContext ctx = initMockContext(mockChannel(resetConnectionPacket), GlobalStateMgr.getCurrentState());
+        ctx.putPreparedStmt("stale", new PrepareStmtContext(createMockPrepareStmt("SELECT 1"), ctx, null));
 
         ConnectProcessor processor = new ConnectProcessor(ctx);
         processor.processOnce();
         Assertions.assertEquals(MysqlCommand.COM_RESET_CONNECTION, myContext.getCommand());
         Assertions.assertTrue(myContext.getState().toResponsePacket() instanceof MysqlOkPacket);
         Assertions.assertFalse(myContext.isKilled());
+        Assertions.assertNull(ctx.getPreparedStmt("stale"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/AstTraverserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/AstTraverserTest.java
@@ -1,0 +1,85 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.starrocks.sql.analyzer.AnalyzerUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * AstTraverser must reach every nested relation, because its consumers include security-sensitive
+ * collectors: the security-policy marker (Ranger column masking / row-level filtering),
+ * ColumnPrivilege's table collector, AuthorizerStmtVisitor and PlannerMetaLocker. A relation the
+ * traverser does not reach is silently left out of those checks.
+ */
+public class AstTraverserTest {
+
+    private static StatementBase parse(String sql) {
+        return com.starrocks.sql.parser.SqlParser.parse(sql, 0L).get(0);
+    }
+
+    private static List<TableRelation> collectTableRelations(StatementBase stmt) {
+        List<TableRelation> tableRelations = new ArrayList<>();
+        new AstTraverser<Void, Void>() {
+            @Override
+            public Void visitTable(TableRelation node, Void context) {
+                tableRelations.add(node);
+                return null;
+            }
+        }.visit(stmt);
+        return tableRelations;
+    }
+
+    private static void assertTablesReached(String sql, int expected) {
+        Assertions.assertEquals(expected, collectTableRelations(parse(sql)).size(),
+                "AstTraverser did not reach every table relation in: " + sql);
+        // AnalyzerUtils uses its own AstTraverser subclass and is what ColumnPrivilege relies on.
+        Assertions.assertEquals(expected, AnalyzerUtils.collectAllTableAndViewRelations(parse(sql)).size(),
+                "collectAllTableAndViewRelations did not reach every table relation in: " + sql);
+    }
+
+    @Test
+    public void testReachesRelationsInPlainQueries() {
+        assertTablesReached("select * from db1.tbl1", 1);
+        assertTablesReached("select * from db1.tbl1 a join db1.tbl2 b on a.k1 = b.k1", 2);
+        assertTablesReached("select * from (select * from db1.tbl1) t", 1);
+    }
+
+    @Test
+    public void testReachesRelationInsidePivot() {
+        assertTablesReached("select * from db1.tbl1 PIVOT (max(k1) FOR k2 IN ('a'))", 1);
+    }
+
+    @Test
+    public void testReachesRelationInsidePivotNestedInJoinAndSubquery() {
+        assertTablesReached(
+                "select * from (select * from db1.tbl1 PIVOT (max(k1) FOR k2 IN ('a'))) p "
+                        + "join db1.tbl2 b on p.k2 = b.k2", 2);
+    }
+
+    @Test
+    public void testReachesRelationInsidePreparedStatement() {
+        assertTablesReached("PREPARE p1 FROM 'select * from db1.tbl1'", 1);
+        assertTablesReached("PREPARE p2 FROM 'select * from db1.tbl1 a join db1.tbl2 b on a.k1 = b.k1'", 2);
+    }
+
+    @Test
+    public void testReachesRelationInsidePivotWithinPreparedStatement() {
+        assertTablesReached("PREPARE p3 FROM 'select * from db1.tbl1 PIVOT (max(k1) FOR k2 IN (1))'", 1);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/AstTraverserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/AstTraverserTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.ast;
 
+import com.starrocks.authorization.SecurityPolicyRewriteRule;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -46,8 +47,13 @@ public class AstTraverserTest {
     }
 
     private static void assertTablesReached(String sql, int expected) {
-        Assertions.assertEquals(expected, collectTableRelations(parse(sql)).size(),
+        StatementBase statement = parse(sql);
+        List<TableRelation> relations = collectTableRelations(statement);
+        Assertions.assertEquals(expected, relations.size(),
                 "AstTraverser did not reach every table relation in: " + sql);
+        SecurityPolicyRewriteRule.markRelationsForRewrite(statement);
+        Assertions.assertTrue(relations.stream().allMatch(Relation::isNeedRewrittenByPolicy),
+                "Security-policy marker did not mark every table relation in: " + sql);
         // AnalyzerUtils uses its own AstTraverser subclass and is what ColumnPrivilege relies on.
         Assertions.assertEquals(expected, AnalyzerUtils.collectAllTableAndViewRelations(parse(sql)).size(),
                 "collectAllTableAndViewRelations did not reach every table relation in: " + sql);
@@ -73,13 +79,58 @@ public class AstTraverserTest {
     }
 
     @Test
-    public void testReachesRelationInsidePreparedStatement() {
-        assertTablesReached("PREPARE p1 FROM 'select * from db1.tbl1'", 1);
-        assertTablesReached("PREPARE p2 FROM 'select * from db1.tbl1 a join db1.tbl2 b on a.k1 = b.k1'", 2);
+    public void testReachesRelationsInSelectListAndTableFunctionArguments() {
+        assertTablesReached("select (select k1 from db1.tbl1) from db1.tbl2", 2);
+        assertTablesReached("select * from unnest((select array_agg(k1) from db1.tbl1))", 1);
+        assertTablesReached("select count(*) from db1.tbl1 "
+                + "group by (select max(k1) from db1.tbl2)", 2);
+        assertTablesReached("select * from (values ((select max(k1) from db1.tbl1))) v", 1);
     }
 
     @Test
-    public void testReachesRelationInsidePivotWithinPreparedStatement() {
-        assertTablesReached("PREPARE p3 FROM 'select * from db1.tbl1 PIVOT (max(k1) FOR k2 IN (1))'", 1);
+    public void testReachesRelationsInParsedDmlSources() {
+        // The write target is a TableRef, not a source Relation. Only the three source reads are
+        // expected here.
+        assertTablesReached("update db1.target set k1 = (select max(k1) from db1.tbl1) "
+                + "from db1.tbl2 where k2 in (select k2 from db1.tbl3)", 3);
+        assertTablesReached("delete from db1.target using db1.tbl1 "
+                + "where k1 in (select k1 from db1.tbl2)", 2);
+        assertTablesReached("merge into db1.target t using db1.tbl1 s on t.k1 = s.k1 "
+                + "when matched then update set v1 = (select max(v1) from db1.tbl2)", 2);
+    }
+
+    @Test
+    public void testAnalyzedDmlTraversesOnlySynthesizedQuery() {
+        QueryStatement synthesized = (QueryStatement) parse("select * from db1.synthesized_source");
+
+        UpdateStmt update = (UpdateStmt) parse("update db1.target set k1 = 1 from db1.raw_source");
+        update.setQueryStatement(synthesized);
+        Assertions.assertEquals(List.of("synthesized_source"), collectTableRelations(update).stream()
+                .map(x -> x.getName().getTbl()).toList());
+
+        DeleteStmt delete = (DeleteStmt) parse("delete from db1.target using db1.raw_source where k1 = 1");
+        delete.setQueryStatement(synthesized);
+        Assertions.assertEquals(List.of("synthesized_source"), collectTableRelations(delete).stream()
+                .map(x -> x.getName().getTbl()).toList());
+
+        MergeIntoStmt merge = (MergeIntoStmt) parse("merge into db1.target t using db1.raw_source s "
+                + "on t.k1 = s.k1 when matched then delete");
+        merge.setQueryStatement(synthesized);
+        Assertions.assertEquals(List.of("synthesized_source"), collectTableRelations(merge).stream()
+                .map(x -> x.getName().getTbl()).toList());
+    }
+
+    @Test
+    public void testPrepareIsADeferredTraversalBoundary() {
+        PrepareStmt prepareStmt = (PrepareStmt) parse("PREPARE p1 FROM 'select * from db1.tbl1'");
+        Assertions.assertTrue(collectTableRelations(prepareStmt).isEmpty());
+        SecurityPolicyRewriteRule.markRelationsForRewrite(prepareStmt);
+        Assertions.assertFalse(collectTableRelations(prepareStmt.getInnerStmt()).get(0).isNeedRewrittenByPolicy());
+
+        // PREPARE metadata and EXECUTE explicitly mark the inner executable statement.
+        SecurityPolicyRewriteRule.markRelationsForRewrite(prepareStmt.getInnerStmt());
+        List<TableRelation> innerRelations = collectTableRelations(prepareStmt.getInnerStmt());
+        Assertions.assertEquals(1, innerRelations.size());
+        Assertions.assertTrue(innerRelations.get(0).isNeedRewrittenByPolicy());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/RecursiveCTETest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/RecursiveCTETest.java
@@ -20,6 +20,7 @@ import com.starrocks.qe.recursivecte.RecursiveCTEAstCheck;
 import com.starrocks.qe.recursivecte.RecursiveCTEExecutor;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.CreateTableAsSelectStmt;
+import com.starrocks.sql.ast.PrepareStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.parser.SqlParser;
 import org.junit.jupiter.api.Assertions;
@@ -43,6 +44,17 @@ public class RecursiveCTETest extends PlanTestBase {
             return executor.explainCTE(sb);
         }
         return getCostExplain(sql);
+    }
+
+    @Test
+    public void testPrepareIsNotExecutedAsRecursiveCte() {
+        String sql = "prepare recursive_stmt from 'with recursive cte(n) as "
+                + "(select 1 union all select n + 1 from cte where n < ?) select * from cte'";
+        PrepareStmt prepareStmt = (PrepareStmt) SqlParser.parse(sql, connectContext.getSessionVariable()).get(0);
+        connectContext.getSessionVariable().setEnableRecursiveCTE(true);
+
+        Assertions.assertFalse(RecursiveCTEAstCheck.hasRecursiveCte(prepareStmt, connectContext));
+        Assertions.assertTrue(RecursiveCTEAstCheck.hasRecursiveCte(prepareStmt.getInnerStmt(), connectContext));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Ranger column masking and row-level filtering only run for relations whose `needRewrittenByPolicy` flag is set. The flag defaults to `false` on purpose — internal flows (mv refresh, create view, …) must not be policy-rewritten — so each client-facing entry point has to opt in, and `QueryAnalyzer` silently skips the rewrite for anything that was missed:

```java
// fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
if (!r.isNeedRewrittenByPolicy()) {
    return r;
}
QueryStatement policyRewriteQuery = SecurityPolicyRewriteRule.buildView(session, r, tableName);
```

Two shapes never reached that opt-in, and both return clear-text data on a Ranger-enabled cluster. Observed on `4.0.9-f647589` over the MySQL protocol, same user and same row:

```sql
SELECT phone FROM demo.customers WHERE id = 1;
--> 40FD7D77D49F4FFBDB1058B8...        (masked)

SELECT phone FROM demo.customers PIVOT (max(id) FOR grade IN ('A'));
--> 010-1111-2222                      (original value)

PREPARE p1 FROM 'SELECT phone FROM demo.customers WHERE id = ?';
SET @i = 1; EXECUTE p1 USING @i;
--> 010-1111-2222                      (original value)
```

The cause is that `AstTraverser` recurses into children only from the specific visit methods (`visitSelect`, `visitJoin`, `visitSubqueryRelation`, `visitSetOp`, `visitCTE`, `visitView`), and several nodes that own a nested relation or statement had no handling at all. Measured with `AnalyzerUtils.collectAllTableAndViewRelations` on `main`:

| statement | tables reached |
|---|---|
| `select * from db1.tbl1` | 1 |
| `select * from db1.tbl1 a join db1.tbl2 b on a.k1 = b.k1` | 2 |
| `select * from (select * from db1.tbl1) t` | 1 |
| `select * from db1.tbl1 PIVOT (max(k1) FOR k2 IN (1))` | **0** |
| `select (select k1 from db1.tbl1) from db1.tbl2` | **1** (the subquery is missed) |
| `select * from unnest((select array_agg(k1) from db1.tbl1))` | **0** |
| `PREPARE p1 FROM 'select * from db1.tbl1'` | **0** |

This is not only a masking problem. `ColumnPrivilege#check` iterates exactly that collection to run its column access checks, so a table the traverser never reaches is not checked at all. The same flag also gates `Authorizer#getRowAccessPolicy`, so row-level filters are skipped the same way.

Fixes #78174
Fixes #78176

## What I'm doing:

### 1. Complete the traversal (`AstTraverser`)

- `visitPivotRelation` — pivot aggregations, pivot columns, and the pivoted relation
- `visitValues`, `visitTableFunction`, `visitNormalizedTableFunction`
- `visitSelect` / group-by — fall back to the parser-owned `SelectList` and `GroupByClause` when the analyzer-owned `outputExpression` / `groupBy` are not populated yet, so scalar subqueries in the projection and in `GROUP BY` are reached before analysis
- `visitUpdateStatement` / `visitDeleteStatement` / `visitMergeIntoStatement` — traverse the parser-owned source reads (CTEs, `FROM`/`USING` relations, predicates, assignments, merge clauses) before analysis

Each of these uses **exactly one representation per phase** (`if (analyzed) … else …`) so a node is never visited twice after analysis.

### 2. Treat `PREPARE` as a deferred boundary, not a transparent wrapper

`PREPARE` is deliberately **not** followed by the generic traverser. An earlier revision of this PR did descend into `PrepareStmt#getInnerStmt()`, and that turned out to be unsafe: `RecursiveCTEAstCheck` also extends `AstTraverser`, so with `enable_recursive_cte=true` a `PREPARE` of a recursive CTE was detected by `StmtExecutor`, which then ran the temp-table DDL and the anchor/recursive `INSERT` at PREPARE time, permanently rewrote the stored AST to reference that temp table, and dropped the table again — leaving `EXECUTE` pointing at a deleted table.

Instead the executable inner statement is marked explicitly at the two boundaries that actually execute it:

- `PrepareAnalyzer` marks the metadata working copy, so `COM_STMT_PREPARE` returns a result-set schema that already reflects masking
- `EXECUTE` marks a freshly parsed copy (below)

`PlannerMetaLocker` gets an explicit `visitPrepareStatement` so metadata locking keeps the same coverage it had before.

### 3. Re-parse and re-authorize on every `EXECUTE`

Marking at PREPARE time alone is not enough. `PrepareStmt#assignValues` returns the *same* `innerStmt` instance, so a policy rewrite applied during PREPARE would be baked into the stored AST: prepare under policy A, change the Ranger policy (or the user's roles) to B, and `EXECUTE` would still run A. That is better than an unconditional bypass, but it does not satisfy "the policy in force at execution time applies".

So `PrepareStmtContext` now keeps the pristine statement text (captured before the metadata copy is marked/analyzed) and `EXECUTE`:

- re-parses it under the **PREPARE-time** parser snapshot — session variables, `sql_mode`/dialect, catalog, database, alias case sensitivity — so a later `USE`, `SET sql_dialect`, or an unqualified UDF cannot retarget the statement between PREPARE and EXECUTE. All of that state is restored in `finally`
- marks the fresh AST and plans it normally, so the current policies and the current privileges apply
- before reusing a cached point-query plan, re-checks `Authorizer.check(...)` (privileges can change via `SET ROLE`, `COM_CHANGE_USER`, grant/revoke) and re-checks whether any policy now applies. Policy-bearing plans are never cached, because a policy rewrite changes the plan shape rather than only authorizing it
- `QueryStatement#isPointQuery` now excludes projections containing a scalar subquery: the cached fast path only replans predicates for a single direct scan, and a subquery adds independent scans and policy state that cannot share that plan

`COM_RESET_CONNECTION` / `COM_CHANGE_USER` clear the prepared-statement cache, since they start a new logical session.

The two existing inlined copies of the marking traversal in `ConnectProcessor` are replaced by `SecurityPolicyRewriteRule.markRelationsForRewrite`, matching the helper introduced in #78049 — that duplication is how the front ends drifted out of coverage in the first place.

## Blast radius

**This is a behavior change, and deliberately a broad one.**

`AstTraverser` has nine subclasses, and the completed traversal changes what all of them see. That is the point of the fix, but it goes beyond masking:

| consumer | effect |
|---|---|
| the security-policy marker | masking / row filtering now apply to PIVOT, prepared statements, and previously missed nested expressions |
| `ColumnPrivilege.TableNameCollector` | **column privilege checks now run for tables that were previously skipped — a query that passed only because the check was skipped can now be denied** |
| `AuthorizerStmtVisitor` | same, for statement-level authorization |
| `PlannerMetaLocker` | more tables are locked during planning |
| `AnalyzerUtils.collectAllTableAndViewRelations` | audit / `queried_relations` become complete |

The prepared-statement path also changes: `EXECUTE` re-parses the pristine SQL instead of reusing the analyzer-mutated metadata AST.

### Performance cost (self-reported)

- **Prepared statements against a table with a masking or row-filter policy no longer use the cached point-query plan.** Every `EXECUTE` goes through parse → analyze → plan. For a BI tool or ORM repeatedly executing a prepared statement over a masked table, this removes the fast path entirely. This is intentional — a cached plan cannot represent "whatever policy is in force right now" — but it is a real regression for that workload and reviewers should weigh it.
- On a cache **hit**, two extra checks now run per `EXECUTE`: `SecurityPolicyRewriteRule.hasPolicy(...)` (a masking + row-filter lookup per referenced table) and `Authorizer.check(...)`. Both are in-memory policy-engine evaluations, no I/O, but they are not free.
- Projections containing a scalar subquery are no longer eligible for the point-query fast path at all.
- Each `PrepareStmtContext` retains a cloned `SessionVariable` snapshot.

If maintainers would rather trade some of this back — for example by keying the plan cache on a policy/authorization fingerprint instead of refusing to cache — I am happy to rework it.

## Test evidence

New coverage:

- `AstTraverserTest` — PIVOT, `PREPARE`, nested combinations, select-list / `GROUP BY` scalar subqueries, table-function arguments, `VALUES`, and parsed DML source reads. Asserts through both a bare `AstTraverser` and `AnalyzerUtils.collectAllTableAndViewRelations` (the path `ColumnPrivilege` relies on), and that `markRelationsForRewrite` marks every table relation. Also pins `PREPARE` as a deferred boundary, so re-adding a generic descent fails the test.
- `PreparedStmtTest` — the `EXECUTE`-time re-parse/re-authorize behavior.
- `RecursiveCTETest` — guards that `PREPARE` of a recursive CTE is not executed at prepare time.

Existing suites for every affected consumer pass unchanged — **224 tests, 0 failures**:

`PrivilegeCheckerTest` (72), `ConnectProcessorTest` (52), `RangerInterfaceTest` (20), `PreparedStmtTest` (14), `RecursiveCTETest` (14), `HiveViewTest` (11 + 1), `AnalyzerUtilsTest` (10), `PlannerMetaLockerRollbackTest` (8), `AstTraverserTest` (7), `AuthorizerStmtVisitorTest` (7), `LakePreparedPhysicalSplitScanPlanTest` (5), `PrepareCollectMetaTaskTest` (2), `PivotTest` (1).

## Not verified

- End-to-end masking of `PIVOT` / `EXECUTE` **with this patch applied** — that needs a patched FE on a Ranger-enabled cluster. What is verified here is that the traversal now reaches the inner relations and that the marker marks them, which is the condition the masking gate checks. The clear-text results quoted above are from stock `4.0.9`.
- Whether a column-privilege **denial** now triggers for these shapes, as opposed to the check merely running. That needs a cluster with a column-restricted policy.
- The `3.5` branch — reproduced on 4.0.x / 4.1.x only, so the 3.5 backport box is left unchecked.

## Relationship to #78049

#78049 fixes the same underlying flag for the native Flight SQL front end (a protocol that never marked at all). This PR is orthogonal: everything here reproduces over the plain MySQL protocol. Both changes converge on `SecurityPolicyRewriteRule.markRelationsForRewrite` as the single opt-in, and they do not conflict.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5