### PR TITLE
[Refactor] Dispatch checkDependOnExpr on the expression

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -465,25 +465,32 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         context.structManager = structManager;
     }
 
-    // For SubfieldOperators, we just need to get the field column refs, not the whole columns in the struct.
-    private List<ColumnRefOperator> getColumnRefs(ScalarOperator op) {
-        if (op.isColumnRef()) {
-            return List.of((ColumnRefOperator) op);
+    private boolean checkDependOnExpr(ScalarOperator expr, Collection<Integer> checkList) {
+        if (expr instanceof ColumnRefOperator ref) {
+            return checkDependOnExpr(ref.getId(), checkList);
         }
-        if (op instanceof SubfieldOperator) {
-            SubfieldOperator subfieldOp = op.cast();
-            Map<String, ColumnRefOperator> fields = structManager.getFieldStringRefMap(subfieldOp.getChild((0)));
-            if (fields != null
-                    && subfieldOp.getFieldNames().size() == 1
-                    && fields.containsKey(subfieldOp.getFieldNames().get(0))) {
-                return List.of(fields.get(subfieldOp.getFieldNames().get(0)));
+        if (expr instanceof CallOperator call && FunctionSet.ARRAY_AGG.equals(call.getFnName())) {
+            return call.getChild(0).isColumnRef() && checkDependOnExpr(call.getChild(0), checkList);
+        }
+        if (expr.getType().isStructType()) {
+            Map<String, ColumnRefOperator> fieldsMap = structManager.getFieldStringRefMap(expr);
+            if (fieldsMap == null) {
+                return false;
             }
+            // Any structs with encoded fields should pass. We filter the fields list later.
+            return fieldsMap.values().stream().anyMatch(c -> checkDependOnExpr(c.getId(), checkList));
         }
-        List<ColumnRefOperator> result = Lists.newArrayList();
-        for (ScalarOperator child : op.getChildren()) {
-            result.addAll(getColumnRefs(child));
+        if (expr instanceof SubfieldOperator subfieldOperator) {
+            Map<String, ColumnRefOperator> fieldsMap = structManager.getFieldStringRefMap(subfieldOperator.getChild(0));
+            if (fieldsMap == null || subfieldOperator.getFieldNames().size() != 1) {
+                return false;
+            }
+            ColumnRefOperator fieldRef = fieldsMap.get(subfieldOperator.getFieldNames().get(0));
+            return fieldRef != null && checkDependOnExpr(fieldRef.getId(), checkList);
         }
-        return result;
+        // Expressions containing multiple columns must be handled by the explicit cases above; what
+        // reaches here holds a single dictionary column and constants, so any matching child is enough.
+        return expr.getChildren().stream().anyMatch(child -> checkDependOnExpr(child, checkList));
     }
 
     private boolean checkDependOnExpr(int cid, Collection<Integer> checkList) {
@@ -494,36 +501,10 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
             return false;
         }
         ScalarOperator define = stringRefToDefineExprMap.get(cid);
-        if (define instanceof CallOperator && FunctionSet.ARRAY_AGG.equals(((CallOperator) define).getFnName())) {
-            return define.getChild(0).isColumnRef() &&
-                    checkDependOnExpr(((ColumnRefOperator) define.getChild(0)).getId(), checkList);
+        if (define instanceof ColumnRefOperator defineRef && defineRef.getId() == cid) {
+            return false;
         }
-        if (define.getType().isStructType()) {
-            Map<String, ColumnRefOperator> fieldsMap = structManager.getFieldStringRefMap(define);
-            if (fieldsMap == null) {
-                return false;
-            }
-            // Any structs with encoded fields should pass. We filter the fields list later.
-            return fieldsMap.values().stream().anyMatch(c -> checkDependOnExpr(c.getId(), checkList));
-        }
-        if (define instanceof SubfieldOperator) {
-            SubfieldOperator subfieldOperator = define.cast();
-            Map<String, ColumnRefOperator> fieldsMap = structManager.getFieldStringRefMap(subfieldOperator.getChild(0));
-            if (fieldsMap == null || subfieldOperator.getFieldNames().size() != 1) {
-                return false;
-            }
-            ColumnRefOperator fieldRef = fieldsMap.get(subfieldOperator.getFieldNames().get(0));
-            return fieldRef != null && checkDependOnExpr(fieldRef.getId(), checkList);
-        }
-        for (ColumnRefOperator ref : getColumnRefs(define)) {
-            if (ref.getId() == cid) {
-                return false;
-            }
-            if (!checkDependOnExpr(ref.getId(), checkList)) {
-                return false;
-            }
-        }
-        return true;
+        return checkDependOnExpr(define, checkList);
     }
 
     void setDefineExpr(ColumnRefOperator col, ScalarOperator define, int counter) {


### PR DESCRIPTION
## Why I'm doing:

`checkDependOnExpr` decided whether a column's define expression can be dictified by flattening it to a column-ref list with `getColumnRefs` and requiring every ref in it to pass. That check stands in the way of multi-input array functions — `array_filter`, `array_sortby`, and `array_map` with a lambda — where an expression legitimately depends on more than one column, and on columns that are not encoded. Removing it is a prerequisite for supporting them.

## What I'm doing:

Dispatch on the expression itself instead, so the `array_agg`, struct and subfield shapes are recognised at any depth and the `getColumnRefs` helper goes away.

The generic fallback becomes `anyMatch` over the children rather than "every flattened ref must pass". Nothing multi-column reaches it today: `DictExpressionCollector.mergeWithArray` only propagates an expression upward when it holds exactly one distinct dict column and zero non-dict columns, and `setDefineExpr` is only called when the whole expression survived that filter — so a define always holds one dictionary column plus constants.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
