### PR TITLE
[Enhancement] Allow unused-column pruning on tables with delete predicates

### DIFF
--- a/be/src/connector/lake/lake_connector.cpp
+++ b/be/src/connector/lake/lake_connector.cpp
@@ -540,10 +540,13 @@ Status LakeDataSource::init_reader_params(const std::vector<OlapScanRange*>& key
     }
 
     // The delete filter evaluates these on the outgoing chunk, so they must survive into the output schema.
-    std::set<ColumnId> delete_pred_cids;
-    RETURN_IF_ERROR(lake::delete_predicate_column_ids(*_tablet.metadata(), *_tablet_schema, &delete_pred_cids));
-    for (ColumnId cid : delete_pred_cids) {
-        _unused_output_column_ids.erase(cid);
+    // An empty unused set makes every erase a no-op, so skip walking the rowset metadata entirely.
+    if (!_unused_output_column_ids.empty()) {
+        std::set<ColumnId> delete_pred_cids;
+        RETURN_IF_ERROR(lake::delete_predicate_column_ids(*_tablet.metadata(), *_tablet_schema, &delete_pred_cids));
+        for (ColumnId cid : delete_pred_cids) {
+            _unused_output_column_ids.erase(cid);
+        }
     }
 
     std::vector<ExprContext*> not_pushdown_conjuncts;

--- a/be/src/connector/lake/lake_connector.cpp
+++ b/be/src/connector/lake/lake_connector.cpp
@@ -15,6 +15,7 @@
 #include "connector/lake/lake_connector.h"
 
 #include <atomic>
+#include <set>
 #include <vector>
 
 #include "base/string/string_parser.hpp"
@@ -53,6 +54,7 @@
 #include "storage/lake/rowset.h"
 #include "storage/lake/table_schema_service.h"
 #include "storage/lake/tablet.h"
+#include "storage/lake/tablet_reader.h"
 #include "storage/predicate_parser.h"
 #include "storage/query/olap_dynamic_morsel_queue_builder.h"
 #include "storage/query/split_morsel_queue_builder.h"
@@ -534,6 +536,13 @@ Status LakeDataSource::init_reader_params(const std::vector<OlapScanRange*>& key
     _non_pushdown_pred_tree = PredicateTree::create(std::move(non_pushdown_pred_root));
 
     for (const auto& cid : _non_pushdown_pred_tree.column_ids()) {
+        _unused_output_column_ids.erase(cid);
+    }
+
+    // The delete filter evaluates these on the outgoing chunk, so they must survive into the output schema.
+    std::set<ColumnId> delete_pred_cids;
+    RETURN_IF_ERROR(lake::delete_predicate_column_ids(*_tablet.metadata(), *_tablet_schema, &delete_pred_cids));
+    for (ColumnId cid : delete_pred_cids) {
         _unused_output_column_ids.erase(cid);
     }
 

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -17,6 +17,8 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <set>
+#include <shared_mutex>
 #include <string_view>
 #include <unordered_map>
 
@@ -56,6 +58,7 @@
 #include "runtime/runtime_state.h"
 #include "storage/chunk_helper.h"
 #include "storage/column_predicate_rewriter.h"
+#include "storage/delete_handler.h"
 #include "storage/extends_column_utils.h"
 #include "storage/flat_json_metrics.h"
 #include "storage/metadata_util.h"
@@ -353,6 +356,17 @@ Status OlapChunkSource::_init_reader_params(const std::vector<std::unique_ptr<Ol
 
     for (auto& id : _non_pushdown_pred_tree.column_ids()) {
         _unused_output_column_ids.erase(id);
+    }
+
+    // The delete filter evaluates these on the outgoing chunk, so they must survive into the output schema.
+    std::set<ColumnId> delete_pred_cids;
+    {
+        std::shared_lock header_lock(_tablet->get_header_lock());
+        RETURN_IF_ERROR(DeleteHandler::delete_predicate_column_ids(_tablet->delete_predicates(), *_tablet_schema,
+                                                                   _version, &delete_pred_cids));
+    }
+    for (ColumnId cid : delete_pred_cids) {
+        _unused_output_column_ids.erase(cid);
     }
 
     std::vector<ExprContext*> not_pushdown_conjuncts;

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -359,14 +359,17 @@ Status OlapChunkSource::_init_reader_params(const std::vector<std::unique_ptr<Ol
     }
 
     // The delete filter evaluates these on the outgoing chunk, so they must survive into the output schema.
-    std::set<ColumnId> delete_pred_cids;
-    {
-        std::shared_lock header_lock(_tablet->get_header_lock());
-        RETURN_IF_ERROR(DeleteHandler::delete_predicate_column_ids(_tablet->delete_predicates(), *_tablet_schema,
-                                                                   _version, &delete_pred_cids));
-    }
-    for (ColumnId cid : delete_pred_cids) {
-        _unused_output_column_ids.erase(cid);
+    // An empty unused set makes every erase a no-op, so skip the header lock and the condition parsing entirely.
+    if (!_unused_output_column_ids.empty()) {
+        std::set<ColumnId> delete_pred_cids;
+        {
+            std::shared_lock header_lock(_tablet->get_header_lock());
+            RETURN_IF_ERROR(DeleteHandler::delete_predicate_column_ids(_tablet->delete_predicates(), *_tablet_schema,
+                                                                       _version, &delete_pred_cids));
+        }
+        for (ColumnId cid : delete_pred_cids) {
+            _unused_output_column_ids.erase(cid);
+        }
     }
 
     std::vector<ExprContext*> not_pushdown_conjuncts;

--- a/be/src/storage/delete_handler.cpp
+++ b/be/src/storage/delete_handler.cpp
@@ -260,6 +260,13 @@ bool DeleteHandler::is_delete_condition_evaluated(const TabletSchema& schema, co
 Status DeleteHandler::delete_predicate_column_ids(const DelPredicateArray& delete_predicates,
                                                   const TabletSchema& schema, int64_t max_version,
                                                   std::set<ColumnId>* column_ids) {
+    // An unknown column is not evaluated either: the reader's parse_thrift_cond rejects it outright.
+    auto keep = [&](const std::string& column_name) {
+        const size_t index = schema.field_index(column_name);
+        if (index < schema.num_columns()) {
+            column_ids->insert(index);
+        }
+    };
     for (const DeletePredicatePB& pred_pb : delete_predicates) {
         if (pred_pb.version() > max_version) {
             continue;
@@ -273,14 +280,11 @@ Status DeleteHandler::delete_predicate_column_ids(const DelPredicateArray& delet
             if (!is_delete_condition_evaluated(schema, cond.column_name)) {
                 continue;
             }
-            column_ids->insert(schema.field_index(cond.column_name));
+            keep(cond.column_name);
         }
         // The reader applies no non-key filter to IN predicates, so neither does this.
         for (int i = 0; i != pred_pb.in_predicates_size(); ++i) {
-            const size_t index = schema.field_index(pred_pb.in_predicates(i).column_name());
-            if (index < schema.num_columns()) {
-                column_ids->insert(index);
-            }
+            keep(pred_pb.in_predicates(i).column_name());
         }
     }
     return Status::OK();

--- a/be/src/storage/delete_handler.cpp
+++ b/be/src/storage/delete_handler.cpp
@@ -253,4 +253,37 @@ bool DeleteHandler::parse_condition(const std::string& condition_str, TCondition
     return true;
 }
 
+bool DeleteHandler::is_delete_condition_evaluated(const TabletSchema& schema, const std::string& column_name) {
+    return schema.field_index(column_name) < schema.num_key_columns() || schema.keys_type() == DUP_KEYS;
+}
+
+Status DeleteHandler::delete_predicate_column_ids(const DelPredicateArray& delete_predicates,
+                                                  const TabletSchema& schema, int64_t max_version,
+                                                  std::set<ColumnId>* column_ids) {
+    for (const DeletePredicatePB& pred_pb : delete_predicates) {
+        if (pred_pb.version() > max_version) {
+            continue;
+        }
+        for (int i = 0; i != pred_pb.sub_predicates_size(); ++i) {
+            TCondition cond;
+            if (!parse_condition(pred_pb.sub_predicates(i), &cond)) {
+                LOG(WARNING) << "invalid delete condition: " << pred_pb.sub_predicates(i) << "]";
+                return Status::InternalError("invalid delete condition string");
+            }
+            if (!is_delete_condition_evaluated(schema, cond.column_name)) {
+                continue;
+            }
+            column_ids->insert(schema.field_index(cond.column_name));
+        }
+        // The reader applies no non-key filter to IN predicates, so neither does this.
+        for (int i = 0; i != pred_pb.in_predicates_size(); ++i) {
+            const size_t index = schema.field_index(pred_pb.in_predicates(i).column_name());
+            if (index < schema.num_columns()) {
+                column_ids->insert(index);
+            }
+        }
+    }
+    return Status::OK();
+}
+
 } // namespace starrocks

--- a/be/src/storage/delete_handler.h
+++ b/be/src/storage/delete_handler.h
@@ -34,9 +34,11 @@
 
 #pragma once
 
+#include <set>
 #include <string>
 #include <vector>
 
+#include "common/column_id.h"
 #include "common/storage_define.h"
 #include "gen_cpp/AgentService_types.h"
 #include "gen_cpp/olap_file.pb.h"
@@ -93,6 +95,15 @@ class DeleteHandler {
 public:
     // Use regular expression to extract 'column_name', 'op' and 'operands'
     static bool parse_condition(const std::string& condition_str, TCondition* condition);
+
+    // A non-key column's delete condition is dropped on non-DUP tables, so the reader never evaluates it.
+    static bool is_delete_condition_evaluated(const TabletSchema& schema, const std::string& column_name);
+
+    // Column ids the delete predicates up to |max_version| really evaluate; shares its filtering with
+    // TabletReader::_init_delete_predicates so a caller keeping them out of the unused-output set cannot
+    // disagree with what the reader reads.
+    static Status delete_predicate_column_ids(const DelPredicateArray& delete_predicates, const TabletSchema& schema,
+                                              int64_t max_version, std::set<ColumnId>* column_ids);
 };
 
 } // namespace starrocks

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -1011,6 +1011,33 @@ Status TabletReader::init_predicates(const TabletReaderParams& params) {
     return Status::OK();
 }
 
+Status delete_predicate_column_ids(const TabletMetadataPB& metadata, const TabletSchema& schema,
+                                   std::set<ColumnId>* column_ids) {
+    auto keep = [&](const std::string& column_name) {
+        const size_t index = schema.field_index(column_name);
+        if (index < schema.num_columns()) {
+            column_ids->insert(index);
+        }
+    };
+    for (int index = 0, size = metadata.rowsets_size(); index < size; ++index) {
+        const auto& rowset_metadata = metadata.rowsets(index);
+        if (!rowset_metadata.has_delete_predicate()) {
+            continue;
+        }
+        const auto& pred_pb = rowset_metadata.delete_predicate();
+        for (int i = 0; i < pred_pb.binary_predicates_size(); ++i) {
+            keep(pred_pb.binary_predicates(i).column_name());
+        }
+        for (int i = 0; i < pred_pb.is_null_predicates_size(); ++i) {
+            keep(pred_pb.is_null_predicates(i).column_name());
+        }
+        for (int i = 0; i < pred_pb.in_predicates_size(); ++i) {
+            keep(pred_pb.in_predicates(i).column_name());
+        }
+    }
+    return Status::OK();
+}
+
 Status TabletReader::init_delete_predicates(const TabletReaderParams& params, DeletePredicates* dels) {
     if (UNLIKELY(_tablet_metadata == nullptr)) {
         return Status::InternalError("tablet metadata is null. forget or fail to call prepare()");

--- a/be/src/storage/lake/tablet_reader.h
+++ b/be/src/storage/lake/tablet_reader.h
@@ -15,8 +15,10 @@
 #pragma once
 
 #include <optional>
+#include <set>
 #include <vector>
 
+#include "common/column_id.h"
 #include "exec_primitive/pipeline/scan/scan_morsel.h"
 #include "runtime/mem_pool.h"
 #include "storage/delete_predicates.h"
@@ -51,6 +53,12 @@ class TabletManager;
 // prepared-split refine path to compute the REFINED coverage (pruned - already-allocated-coarse).
 // Declared here so it can be unit-tested directly (the definition lives in tablet_reader.cpp).
 SparseRange<> subtract_sparse_ranges(const SparseRange<>& lhs, const SparseRange<>& rhs);
+
+// Column ids the tablet's delete predicates evaluate; mirrors TabletReader::init_delete_predicates, which
+// filters neither by version nor by key column, so a caller keeping them out of the unused-output set cannot
+// disagree with what the reader reads.
+Status delete_predicate_column_ids(const TabletMetadataPB& metadata, const TabletSchema& schema,
+                                   std::set<ColumnId>* column_ids);
 
 class TabletReader final : public ChunkIterator {
     using Chunk = starrocks::Chunk;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -511,8 +511,6 @@ private:
 
     Status _encode_to_global_id(ScanContext* ctx);
 
-    StatusOr<const Chunk*> _delete_predicate_eval_chunk(const Chunk* chunk, Chunk* view) const;
-
     FieldPtr _make_field(size_t i);
 
     Status _switch_context(ScanContext* to);
@@ -659,9 +657,6 @@ private:
 
     // initial number of columns of |_opts.pred_tree|.
     int _predicate_columns = 0;
-
-    // Delete-predicate columns that FE pruned from |output_schema|; borrowed from |_dict_chunk| to filter on.
-    std::vector<ColumnId> _pruned_delete_pred_columns;
 
     // the next rowid to read
     rowid_t _cur_rowid = 0;
@@ -3105,11 +3100,7 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
         size_t old_sz = chunk->num_rows();
         // NOTE: risk of using _selection.data() without initialization
         // if the delete_predicates do nothing to the selection.
-        {
-            Chunk eval_view;
-            ASSIGN_OR_RETURN(const Chunk* eval_chunk, _delete_predicate_eval_chunk(chunk, &eval_view));
-            RETURN_IF_ERROR(_opts.delete_predicates.evaluate(eval_chunk, _selection.data()));
-        }
+        RETURN_IF_ERROR(_opts.delete_predicates.evaluate(chunk, _selection.data()));
         size_t deletes = SIMD::count_nonzero(_selection.data(), old_sz);
         // When brute-force vector fallback is active and FE pruned the vector
         // column from output_schema, the vector data column lives in
@@ -4033,20 +4024,11 @@ Status SegmentIterator::_build_context(ScanContext* ctx) {
         ctx->_has_force_dict_encode |= _column_decoders[cid].need_force_encode_to_global_id();
     }
 
-    // A pruned delete column must be a predicate column, so early-materialized and decoded; verify, don't assume.
-    _pruned_delete_pred_columns.clear();
+    // The chunk source keeps delete-predicate columns out of the unused set, so they must reach the output.
     for (ColumnId cid : delete_pred_columns) {
-        if (output_columns.count(cid) != 0) {
-            continue;
-        }
-        auto index_it = ctx->_column_ids_to_index.find(cid);
-        RETURN_IF(index_it == ctx->_column_ids_to_index.end(),
-                  Status::InternalError(strings::Substitute(
-                          "delete predicate column $0 is pruned from the output but not early-materialized", cid)));
-        RETURN_IF(ctx->_skip_dict_decode_indexes[index_it->second],
-                  Status::InternalError(strings::Substitute(
-                          "delete predicate column $0 is pruned from the output but left dict-encoded", cid)));
-        _pruned_delete_pred_columns.emplace_back(cid);
+        RETURN_IF(output_columns.count(cid) == 0,
+                  Status::InternalError(
+                          strings::Substitute("delete predicate column $0 is missing from the output schema", cid)));
     }
 
     // build index map
@@ -4061,7 +4043,7 @@ Status SegmentIterator::_build_context(ScanContext* ctx) {
         }
     }
 
-    // |read_indexes| also carries delete-predicate columns absent from the output, so walk the output schema.
+    // |_read_index_map| is indexed by output schema position, so size and walk it by the output schema.
     const size_t num_output_fields = output_schema().num_fields();
     ctx->_read_index_map.reserve(num_output_fields);
     for (size_t i = 0; i < num_output_fields; i++) {
@@ -4315,34 +4297,6 @@ Status SegmentIterator::_rewrite_predicates() {
     }
 
     return Status::OK();
-}
-
-// Borrowing from |_dict_chunk| keeps the pruned delete column out of the outgoing chunk's contractual schema.
-StatusOr<const Chunk*> SegmentIterator::_delete_predicate_eval_chunk(const Chunk* chunk, Chunk* view) const {
-    if (_pruned_delete_pred_columns.empty()) {
-        return chunk;
-    }
-    const size_t num_rows = chunk->num_rows();
-    for (const auto& [cid, index] : chunk->get_column_id_to_index_map()) {
-        view->append_column(chunk->columns()[index], cid, true);
-    }
-    const Chunk* read_chunk = _context->_dict_chunk.get();
-    for (ColumnId cid : _pruned_delete_pred_columns) {
-        if (view->is_cid_exist(cid)) {
-            continue;
-        }
-        // Never fall through to evaluating without the column: that would silently keep deleted rows.
-        RETURN_IF(read_chunk == nullptr || !read_chunk->is_cid_exist(cid),
-                  Status::InternalError(strings::Substitute(
-                          "delete predicate column $0 missing from both output and read chunk", cid)));
-        const ColumnPtr& col = read_chunk->get_column_by_id(cid);
-        RETURN_IF(col == nullptr || col->size() != num_rows,
-                  Status::InternalError(strings::Substitute(
-                          "delete predicate column $0 borrowed from the read chunk holds $1 rows, chunk holds $2", cid,
-                          col == nullptr ? 0 : col->size(), num_rows)));
-        view->append_column(col, cid, true);
-    }
-    return view;
 }
 
 Status SegmentIterator::_decode_dict_codes(ScanContext* ctx) {

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -511,6 +511,8 @@ private:
 
     Status _encode_to_global_id(ScanContext* ctx);
 
+    StatusOr<const Chunk*> _delete_predicate_eval_chunk(const Chunk* chunk, Chunk* view) const;
+
     FieldPtr _make_field(size_t i);
 
     Status _switch_context(ScanContext* to);
@@ -657,6 +659,9 @@ private:
 
     // initial number of columns of |_opts.pred_tree|.
     int _predicate_columns = 0;
+
+    // Delete-predicate columns that FE pruned from |output_schema|; borrowed from |_dict_chunk| to filter on.
+    std::vector<ColumnId> _pruned_delete_pred_columns;
 
     // the next rowid to read
     rowid_t _cur_rowid = 0;
@@ -3100,7 +3105,11 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
         size_t old_sz = chunk->num_rows();
         // NOTE: risk of using _selection.data() without initialization
         // if the delete_predicates do nothing to the selection.
-        RETURN_IF_ERROR(_opts.delete_predicates.evaluate(chunk, _selection.data()));
+        {
+            Chunk eval_view;
+            ASSIGN_OR_RETURN(const Chunk* eval_chunk, _delete_predicate_eval_chunk(chunk, &eval_view));
+            RETURN_IF_ERROR(_opts.delete_predicates.evaluate(eval_chunk, _selection.data()));
+        }
         size_t deletes = SIMD::count_nonzero(_selection.data(), old_sz);
         // When brute-force vector fallback is active and FE pruned the vector
         // column from output_schema, the vector data column lives in
@@ -4024,10 +4033,24 @@ Status SegmentIterator::_build_context(ScanContext* ctx) {
         ctx->_has_force_dict_encode |= _column_decoders[cid].need_force_encode_to_global_id();
     }
 
+    // A pruned delete column must be a predicate column, so early-materialized and decoded; verify, don't assume.
+    _pruned_delete_pred_columns.clear();
+    for (ColumnId cid : delete_pred_columns) {
+        if (output_columns.count(cid) != 0) {
+            continue;
+        }
+        auto index_it = ctx->_column_ids_to_index.find(cid);
+        RETURN_IF(index_it == ctx->_column_ids_to_index.end(),
+                  Status::InternalError(strings::Substitute(
+                          "delete predicate column $0 is pruned from the output but not early-materialized", cid)));
+        RETURN_IF(ctx->_skip_dict_decode_indexes[index_it->second],
+                  Status::InternalError(strings::Substitute(
+                          "delete predicate column $0 is pruned from the output but left dict-encoded", cid)));
+        _pruned_delete_pred_columns.emplace_back(cid);
+    }
+
     // build index map
     DCHECK_LE(output_schema().num_fields(), _schema.num_fields());
-    DCHECK(!(output_schema().num_fields() < _schema.num_fields()) || _opts.delete_predicates.empty())
-            << "delete condition couldn't work with filter_unused_columns";
 
     // skip dict_decode column in _read_schema would not be mapping
     std::unordered_map<ColumnId, size_t> read_indexes;   // fid -> read schema index
@@ -4038,12 +4061,25 @@ Status SegmentIterator::_build_context(ScanContext* ctx) {
         }
     }
 
-    // map output_schema[cid, index] to read_schema[cid index]
-    ctx->_read_index_map.resize(read_indexes.size());
-    for (size_t i = 0; i < read_indexes.size(); i++) {
-        ctx->_read_index_map[i] = read_indexes[output_schema().field(i)->id()];
-        output_indexes[output_schema().field(i)->id()] = i;
+    // |read_indexes| also carries delete-predicate columns absent from the output, so walk the output schema.
+    const size_t num_output_fields = output_schema().num_fields();
+    ctx->_read_index_map.reserve(num_output_fields);
+    for (size_t i = 0; i < num_output_fields; i++) {
+        const ColumnId ocid = output_schema().field(i)->id();
+        auto read_it = read_indexes.find(ocid);
+        if (read_it == read_indexes.end()) {
+            // Late-materialized output columns start here; _finish_late_materialization fills them.
+            break;
+        }
+        ctx->_read_index_map.emplace_back(read_it->second);
+        output_indexes[ocid] = i;
     }
+    // _finish_late_materialization resumes at |_read_index_map.size()|, so the walk must stop at the late tail.
+    RETURN_IF(ctx->_read_index_map.size() + num_fields - early_materialize_fields != num_output_fields,
+              Status::InternalError(strings::Substitute(
+                      "output schema is not an early-materialized prefix plus the late tail: mapped=$0 late=$1 "
+                      "output=$2",
+                      ctx->_read_index_map.size(), num_fields - early_materialize_fields, num_output_fields)));
 
     // convert the read schema index to output scheam index for subfield
     for (size_t i = 0; i < ctx->_subfield_columns.size(); i++) {
@@ -4279,6 +4315,34 @@ Status SegmentIterator::_rewrite_predicates() {
     }
 
     return Status::OK();
+}
+
+// Borrowing from |_dict_chunk| keeps the pruned delete column out of the outgoing chunk's contractual schema.
+StatusOr<const Chunk*> SegmentIterator::_delete_predicate_eval_chunk(const Chunk* chunk, Chunk* view) const {
+    if (_pruned_delete_pred_columns.empty()) {
+        return chunk;
+    }
+    const size_t num_rows = chunk->num_rows();
+    for (const auto& [cid, index] : chunk->get_column_id_to_index_map()) {
+        view->append_column(chunk->columns()[index], cid, true);
+    }
+    const Chunk* read_chunk = _context->_dict_chunk.get();
+    for (ColumnId cid : _pruned_delete_pred_columns) {
+        if (view->is_cid_exist(cid)) {
+            continue;
+        }
+        // Never fall through to evaluating without the column: that would silently keep deleted rows.
+        RETURN_IF(read_chunk == nullptr || !read_chunk->is_cid_exist(cid),
+                  Status::InternalError(strings::Substitute(
+                          "delete predicate column $0 missing from both output and read chunk", cid)));
+        const ColumnPtr& col = read_chunk->get_column_by_id(cid);
+        RETURN_IF(col == nullptr || col->size() != num_rows,
+                  Status::InternalError(strings::Substitute(
+                          "delete predicate column $0 borrowed from the read chunk holds $1 rows, chunk holds $2", cid,
+                          col == nullptr ? 0 : col->size(), num_rows)));
+        view->append_column(col, cid, true);
+    }
+    return view;
 }
 
 Status SegmentIterator::_decode_dict_codes(ScanContext* ctx) {

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -32,6 +32,7 @@
 #include "runtime/type_info_allocator_adapter.h"
 #include "storage/chunk_helper.h"
 #include "storage/column_predicate_rewriter.h"
+#include "storage/delete_handler.h"
 #include "storage/delete_predicates.h"
 #include "storage/json_path_deriver.h"
 #include "storage/olap_common.h"
@@ -601,8 +602,7 @@ Status TabletReader::_init_delete_predicates(const TabletReaderParams& params, D
                 LOG(WARNING) << "invalid delete condition: " << pred_pb.sub_predicates(i) << "]";
                 return Status::InternalError("invalid delete condition string");
             }
-            if (_tablet_schema->field_index(cond.column_name) >= _tablet_schema->num_key_columns() &&
-                _tablet_schema->keys_type() != DUP_KEYS) {
+            if (!DeleteHandler::is_delete_condition_evaluated(*_tablet_schema, cond.column_name)) {
                 LOG(WARNING) << "ignore delete condition of non-key column: " << pred_pb.sub_predicates(i);
                 continue;
             }

--- a/be/test/storage/delete_handler_test.cpp
+++ b/be/test/storage/delete_handler_test.cpp
@@ -41,6 +41,7 @@
 #include <vector>
 
 #include "base/logging.h"
+#include "base/testutil/assert.h"
 #include "common/config_memory_allocator_fwd.h"
 #include "common/config_storage_fwd.h"
 #include "common/storage_define.h"
@@ -844,6 +845,88 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     res = _delete_condition_handler.generate_delete_predicate(tablet->unsafe_tablet_schema_ref(), conditions,
                                                               &del_pred_24);
     ASSERT_TRUE(res.is_invalid_argument());
+}
+
+// Builds a schema with two key columns (k1, k2) and two value columns (v1, v2).
+static TabletSchemaSPtr make_schema(KeysType keys_type) {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(keys_type);
+    schema_pb.set_num_short_key_columns(1);
+    schema_pb.set_num_rows_per_row_block(65535);
+    const char* names[] = {"k1", "k2", "v1", "v2"};
+    for (int i = 0; i < 4; ++i) {
+        auto* col = schema_pb.add_column();
+        col->set_unique_id(i);
+        col->set_name(names[i]);
+        col->set_type("INT");
+        col->set_is_nullable(false);
+        col->set_is_key(i < 2);
+        if (i >= 2) {
+            col->set_aggregation(keys_type == DUP_KEYS ? "NONE" : "REPLACE");
+        }
+    }
+    return TabletSchema::create(schema_pb);
+}
+
+static DeletePredicatePB* add_pred(DelPredicateArray* preds, int32_t version) {
+    auto* pred = preds->Add();
+    pred->set_version(version);
+    return pred;
+}
+
+TEST(DeletePredicateColumnIdsTest, CollectsKeyAndValueColumnsOnDupKeys) {
+    auto schema = make_schema(DUP_KEYS);
+    DelPredicateArray preds;
+    auto* pred = add_pred(&preds, 2);
+    pred->add_sub_predicates("k1=1");
+    pred->add_sub_predicates("v1=2");
+
+    std::set<ColumnId> cids;
+    ASSERT_OK(DeleteHandler::delete_predicate_column_ids(preds, *schema, 10, &cids));
+    // A DUP table evaluates delete conditions on value columns too, so both are read.
+    ASSERT_EQ((std::set<ColumnId>{0, 2}), cids);
+}
+
+TEST(DeletePredicateColumnIdsTest, SkipsPredicatesNewerThanTheReadVersion) {
+    auto schema = make_schema(DUP_KEYS);
+    DelPredicateArray preds;
+    add_pred(&preds, 3)->add_sub_predicates("k1=1");
+    add_pred(&preds, 11)->add_sub_predicates("k2=2");
+
+    std::set<ColumnId> cids;
+    ASSERT_OK(DeleteHandler::delete_predicate_column_ids(preds, *schema, 10, &cids));
+    ASSERT_EQ((std::set<ColumnId>{0}), cids);
+}
+
+TEST(DeletePredicateColumnIdsTest, NonKeySubPredicateIsDroppedButInPredicateIsKept) {
+    auto schema = make_schema(AGG_KEYS);
+    DelPredicateArray preds;
+    auto* pred = add_pred(&preds, 2);
+    // The reader drops a non-key column's sub predicate on a non-DUP table, but applies no such filter to
+    // IN predicates; this asymmetry is pre-existing behaviour that the helper must mirror exactly.
+    pred->add_sub_predicates("v1=1");
+    auto* in_pred = pred->add_in_predicates();
+    in_pred->set_column_name("v2");
+    in_pred->set_is_not_in(false);
+    in_pred->add_values("7");
+
+    std::set<ColumnId> cids;
+    ASSERT_OK(DeleteHandler::delete_predicate_column_ids(preds, *schema, 10, &cids));
+    ASSERT_EQ((std::set<ColumnId>{3}), cids);
+}
+
+TEST(DeletePredicateColumnIdsTest, IgnoresUnknownColumns) {
+    auto schema = make_schema(DUP_KEYS);
+    DelPredicateArray preds;
+    auto* pred = add_pred(&preds, 2);
+    pred->add_sub_predicates("nosuchcol=1");
+    auto* in_pred = pred->add_in_predicates();
+    in_pred->set_column_name("alsomissing");
+    in_pred->add_values("7");
+
+    std::set<ColumnId> cids;
+    ASSERT_OK(DeleteHandler::delete_predicate_column_ids(preds, *schema, 10, &cids));
+    ASSERT_TRUE(cids.empty());
 }
 
 } // namespace starrocks

--- a/be/test/storage/lake/tablet_reader_test.cpp
+++ b/be/test/storage/lake/tablet_reader_test.cpp
@@ -1769,4 +1769,51 @@ TEST_F(LakeTabletReaderSpit, test_seek_range_cached_across_reopen) {
     reader->close();
 }
 
+TEST(LakeDeletePredicateColumnIdsTest, CollectsAllThreePredicateKinds) {
+    auto metadata = generate_simple_tablet_metadata(DUP_KEYS, 4);
+    auto schema = TabletSchema::create(metadata->schema());
+
+    // c1 via a binary predicate, c2 via IS NULL, c3 via IN: the reader evaluates all three kinds.
+    auto* binary_pred = metadata->add_rowsets()->mutable_delete_predicate()->add_binary_predicates();
+    binary_pred->set_column_name("c1");
+    binary_pred->set_op("=");
+    binary_pred->set_value("1");
+
+    auto* is_null_pred = metadata->add_rowsets()->mutable_delete_predicate()->add_is_null_predicates();
+    is_null_pred->set_column_name("c2");
+    is_null_pred->set_is_not_null(false);
+
+    auto* in_pred = metadata->add_rowsets()->mutable_delete_predicate()->add_in_predicates();
+    in_pred->set_column_name("c3");
+    in_pred->set_is_not_in(false);
+    in_pred->add_values("7");
+
+    // A rowset without a delete predicate contributes nothing.
+    metadata->add_rowsets();
+
+    std::set<ColumnId> cids;
+    ASSERT_OK(delete_predicate_column_ids(*metadata, *schema, &cids));
+    ASSERT_EQ((std::set<ColumnId>{1, 2, 3}), cids);
+}
+
+TEST(LakeDeletePredicateColumnIdsTest, KeepsNonKeyColumnsAndIgnoresUnknownOnes) {
+    // Unlike the shared-nothing reader, the lake reader filters neither by key column nor by version.
+    auto metadata = generate_simple_tablet_metadata(AGG_KEYS, 2);
+    auto schema = TabletSchema::create(metadata->schema());
+
+    auto* pred = metadata->add_rowsets()->mutable_delete_predicate();
+    auto* binary_pred = pred->add_binary_predicates();
+    binary_pred->set_column_name("c1");
+    binary_pred->set_op("=");
+    binary_pred->set_value("1");
+    auto* missing = pred->add_binary_predicates();
+    missing->set_column_name("nosuchcol");
+    missing->set_op("=");
+    missing->set_value("1");
+
+    std::set<ColumnId> cids;
+    ASSERT_OK(delete_predicate_column_ids(*metadata, *schema, &cids));
+    ASSERT_EQ((std::set<ColumnId>{1}), cids);
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/rowset/segment_iterator_test.cpp
+++ b/be/test/storage/rowset/segment_iterator_test.cpp
@@ -537,9 +537,9 @@ TEST_F(SegmentIteratorTest, TestForceGlobalDictEncodeWithTrailingUnusedColumn) {
     res_chunk->reset();
 }
 
-// A DELETE turns `c2` into a delete-predicate column while the query still prunes it from the output,
-// which is what `hasDelete` used to keep the BE from ever seeing.
-TEST_F(SegmentIteratorTest, TestDeletePredicateOnPrunedOutputColumn) {
+// The chunk source keeps delete-predicate columns out of the unused set; bypassing it must fail the scan
+// loudly rather than evaluate the delete filter against a column that is not in the outgoing chunk.
+TEST_F(SegmentIteratorTest, TestDeletePredicateColumnPrunedFromOutputFails) {
     using namespace starrocks::test;
 
     std::string file_name = kSegmentDir + "/delete_predicate_on_pruned_output_column";
@@ -600,35 +600,16 @@ TEST_F(SegmentIteratorTest, TestDeletePredicateOnPrunedOutputColumn) {
 
     auto chunk_iter = new_segment_iterator(segment, vec_schema, seg_opts);
     ASSERT_OK(chunk_iter->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS));
-    // c2 is a predicate-only column, so it is both pruned from the output and needed by the delete filter.
+    // c2 is a predicate-only column, so filter_unused_columns would prune it from the output on its own.
     std::unordered_set<uint32_t> unused_output_column_ids{2};
     ASSERT_OK(chunk_iter->init_output_schema(unused_output_column_ids));
     ASSERT_EQ(2, chunk_iter->output_schema().num_fields());
 
-    std::vector<int32_t> got_c0;
-    std::vector<int32_t> got_c1;
     auto res_chunk = ChunkFactory::new_chunk(chunk_iter->output_schema(), chunk_size);
-    while (true) {
-        res_chunk->reset();
-        auto st = chunk_iter->get_next(res_chunk.get());
-        if (st.is_end_of_file()) {
-            break;
-        }
-        ASSERT_OK(st);
-        ASSERT_EQ(2, res_chunk->num_columns());
-        const auto& c0 = res_chunk->get_column_by_index(0);
-        const auto& c1 = res_chunk->get_column_by_index(1);
-        for (size_t i = 0; i < res_chunk->num_rows(); ++i) {
-            got_c0.emplace_back(c0->get(i).get_int32());
-            got_c1.emplace_back(c1->get(i).get_int32());
-        }
-    }
-
-    ASSERT_EQ(num_rows / 2, got_c0.size());
-    for (size_t i = 0; i < got_c0.size(); ++i) {
-        EXPECT_EQ(static_cast<int32_t>(i * 2), got_c0[i]);
-        EXPECT_EQ(static_cast<int32_t>(i * 20), got_c1[i]);
-    }
+    auto st = chunk_iter->get_next(res_chunk.get());
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.is_internal_error()) << st.to_string();
+    ASSERT_NE(std::string::npos, st.to_string().find("missing from the output schema")) << st.to_string();
 }
 
 // Verify predicate late materialization keeps non-predicate columns correct.

--- a/be/test/storage/rowset/segment_iterator_test.cpp
+++ b/be/test/storage/rowset/segment_iterator_test.cpp
@@ -537,6 +537,100 @@ TEST_F(SegmentIteratorTest, TestForceGlobalDictEncodeWithTrailingUnusedColumn) {
     res_chunk->reset();
 }
 
+// A DELETE turns `c2` into a delete-predicate column while the query still prunes it from the output,
+// which is what `hasDelete` used to keep the BE from ever seeing.
+TEST_F(SegmentIteratorTest, TestDeletePredicateOnPrunedOutputColumn) {
+    using namespace starrocks::test;
+
+    std::string file_name = kSegmentDir + "/delete_predicate_on_pruned_output_column";
+    ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+    TabletSchemaBuilder builder;
+    std::shared_ptr<TabletSchema> tablet_schema =
+            builder.create(1, false, TYPE_INT, true).create(2, false, TYPE_INT).create(3, false, TYPE_VARCHAR).build();
+
+    SegmentWriterOptions opts;
+    opts.num_rows_per_block = 32;
+    SegmentWriter writer(std::move(wfile), 0, tablet_schema, opts);
+
+    const int32_t chunk_size = 64;
+    const size_t num_rows = 40;
+    const std::string kKeep = "keep";
+    const std::string kDeleted = "zdel";
+
+    auto c0_provider = [](int32_t i) { return i; };
+    auto c1_provider = [](int32_t i) { return i * 10; };
+    // Odd rows carry the value the delete predicate matches, so exactly half the rows must disappear.
+    auto c2_provider = [&](int32_t i) { return Slice(i % 2 == 0 ? kKeep : kDeleted); };
+
+    TabletDataBuilder data_builder(writer, tablet_schema, chunk_size, num_rows);
+    ASSERT_OK(data_builder.append(0, c0_provider));
+    ASSERT_OK(data_builder.append(1, c1_provider));
+    ASSERT_OK(data_builder.append(2, c2_provider));
+    ASSERT_OK(data_builder.finalize_footer());
+
+    auto segment = *Segment::open(_fs, FileInfo{file_name}, 0, tablet_schema);
+    ASSERT_EQ(segment->num_rows(), num_rows);
+
+    VecSchemaBuilder schema_builder;
+    schema_builder.add(0, "c0", TYPE_INT).add(1, "c1", TYPE_INT).add(2, "c2", TYPE_VARCHAR);
+    auto vec_schema = schema_builder.build();
+
+    ObjectPool pool;
+    SegmentReadOptions seg_opts;
+    OlapReaderStatistics stats;
+    seg_opts.fs = _fs;
+    seg_opts.stats = &stats;
+    seg_opts.tablet_schema = tablet_schema;
+
+    // Every scanned column carries a predicate, so the schema reaches the iterator as is: with fewer
+    // predicate columns `new_segment_iterator()` reorders it and wraps a projection that hides the pruning.
+    std::unique_ptr<ColumnPredicate> pred_c0(new_column_ge_predicate(get_type_info(TYPE_INT), 0, "0"));
+    std::unique_ptr<ColumnPredicate> pred_c1(new_column_ge_predicate(get_type_info(TYPE_INT), 1, "0"));
+    std::unique_ptr<ColumnPredicate> pred_c2(new_column_ge_predicate(get_type_info(TYPE_VARCHAR), 2, kKeep.c_str()));
+    PredicateAndNode pred_root;
+    pred_root.add_child(PredicateColumnNode{pred_c0.get()});
+    pred_root.add_child(PredicateColumnNode{pred_c1.get()});
+    pred_root.add_child(PredicateColumnNode{pred_c2.get()});
+    seg_opts.pred_tree = PredicateTree::create(std::move(pred_root));
+
+    // DELETE FROM t WHERE c2 = 'zdel'
+    auto* del_pred = pool.add(new ConjunctivePredicates());
+    del_pred->add(pool.add(new_column_eq_predicate(get_type_info(TYPE_VARCHAR), 2, kDeleted.c_str())));
+    seg_opts.delete_predicates.add(*del_pred);
+
+    auto chunk_iter = new_segment_iterator(segment, vec_schema, seg_opts);
+    ASSERT_OK(chunk_iter->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS));
+    // c2 is a predicate-only column, so it is both pruned from the output and needed by the delete filter.
+    std::unordered_set<uint32_t> unused_output_column_ids{2};
+    ASSERT_OK(chunk_iter->init_output_schema(unused_output_column_ids));
+    ASSERT_EQ(2, chunk_iter->output_schema().num_fields());
+
+    std::vector<int32_t> got_c0;
+    std::vector<int32_t> got_c1;
+    auto res_chunk = ChunkFactory::new_chunk(chunk_iter->output_schema(), chunk_size);
+    while (true) {
+        res_chunk->reset();
+        auto st = chunk_iter->get_next(res_chunk.get());
+        if (st.is_end_of_file()) {
+            break;
+        }
+        ASSERT_OK(st);
+        ASSERT_EQ(2, res_chunk->num_columns());
+        const auto& c0 = res_chunk->get_column_by_index(0);
+        const auto& c1 = res_chunk->get_column_by_index(1);
+        for (size_t i = 0; i < res_chunk->num_rows(); ++i) {
+            got_c0.emplace_back(c0->get(i).get_int32());
+            got_c1.emplace_back(c1->get(i).get_int32());
+        }
+    }
+
+    ASSERT_EQ(num_rows / 2, got_c0.size());
+    for (size_t i = 0; i < got_c0.size(); ++i) {
+        EXPECT_EQ(static_cast<int32_t>(i * 2), got_c0[i]);
+        EXPECT_EQ(static_cast<int32_t>(i * 20), got_c1[i]);
+    }
+}
+
 // Verify predicate late materialization keeps non-predicate columns correct.
 TEST_F(SegmentIteratorTest, TestPredicateLateMaterializationMaterializesRestColumns) {
     using namespace starrocks::test;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -1224,9 +1224,8 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
             }
             msg.lake_scan_node.setDict_string_id_to_int_ids(dictStringIdToIntIds);
 
-            if (!olapTable.hasDelete()) {
-                msg.lake_scan_node.setUnused_output_column_name(unUsedOutputStringColumns);
-            }
+            // The BE reads delete-predicate columns even when pruned from output, so deleted tables stay prunable.
+            msg.lake_scan_node.setUnused_output_column_name(unUsedOutputStringColumns);
 
             if (!bucketExprs.isEmpty()) {
                 msg.lake_scan_node.setBucket_exprs(ExprToThrift.treesToThrift(bucketExprs));
@@ -1296,9 +1295,8 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
             }
             msg.olap_scan_node.setDict_string_id_to_int_ids(dictStringIdToIntIds);
 
-            if (!olapTable.hasDelete()) {
-                msg.olap_scan_node.setUnused_output_column_name(unUsedOutputStringColumns);
-            }
+            // The BE reads delete-predicate columns even when pruned from output, so deleted tables stay prunable.
+            msg.olap_scan_node.setUnused_output_column_name(unUsedOutputStringColumns);
 
             if (!scanTabletIds.isEmpty()) {
                 msg.olap_scan_node.setSorted_by_keys_per_tablet(isSortedByKeyPerTablet);

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -449,3 +449,75 @@ set enable_prune_column_after_index_filter = true;
 DROP TABLE t_gin_prune_pk_${uuid0};
 -- result:
 -- !result
+-- name: test_gin_prune_on_table_with_delete @native
+ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
+-- result:
+-- !result
+CREATE TABLE `t_gin_del_prune_${uuid0}` (
+  `id` bigint NOT NULL,
+  `k`  bigint NOT NULL,
+  `v`  varchar(255) NOT NULL,
+  INDEX gin_v (`v`) USING GIN ("parser" = "none")
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1
+PROPERTIES ("replication_num" = "1", "replicated_storage" = "false");
+-- result:
+-- !result
+insert into t_gin_del_prune_${uuid0} values (1, 7, "redx"), (2, 8, "redy"), (3, 7, "blue"), (4, 9, "redz"), (5, 7, "redx");
+-- result:
+-- !result
+delete from t_gin_del_prune_${uuid0} where k = 7;
+-- result:
+-- !result
+set enable_filter_unused_columns_in_scan_stage = true;
+-- result:
+-- !result
+select id from t_gin_del_prune_${uuid0} where k = 7 order by id;
+-- result:
+-- !result
+select id from t_gin_del_prune_${uuid0} where k = 8 order by id;
+-- result:
+2
+-- !result
+select id from t_gin_del_prune_${uuid0} where v like '%red%' order by id;
+-- result:
+2
+4
+-- !result
+select id, k from t_gin_del_prune_${uuid0} where v like '%red%' order by id;
+-- result:
+2	8
+4	9
+-- !result
+select count(*) from t_gin_del_prune_${uuid0};
+-- result:
+2
+-- !result
+set enable_filter_unused_columns_in_scan_stage = false;
+-- result:
+-- !result
+select id from t_gin_del_prune_${uuid0} where k = 7 order by id;
+-- result:
+-- !result
+select id from t_gin_del_prune_${uuid0} where k = 8 order by id;
+-- result:
+2
+-- !result
+select id from t_gin_del_prune_${uuid0} where v like '%red%' order by id;
+-- result:
+2
+4
+-- !result
+select id, k from t_gin_del_prune_${uuid0} where v like '%red%' order by id;
+-- result:
+2	8
+4	9
+-- !result
+select count(*) from t_gin_del_prune_${uuid0};
+-- result:
+2
+-- !result
+DROP TABLE t_gin_del_prune_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_inverted_index/T/test_inverted_index
+++ b/test/sql/test_inverted_index/T/test_inverted_index
@@ -285,3 +285,37 @@ select max(id) from t_gin_prune_pk_${uuid0} where v like '%red%';
 set enable_prune_column_after_index_filter = true;
 
 DROP TABLE t_gin_prune_pk_${uuid0};
+
+-- name: test_gin_prune_on_table_with_delete @native
+ADMIN SET FRONTEND CONFIG("enable_experimental_gin" = "true");
+CREATE TABLE `t_gin_del_prune_${uuid0}` (
+  `id` bigint NOT NULL,
+  `k`  bigint NOT NULL,
+  `v`  varchar(255) NOT NULL,
+  INDEX gin_v (`v`) USING GIN ("parser" = "none")
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1
+PROPERTIES ("replication_num" = "1", "replicated_storage" = "false");
+
+insert into t_gin_del_prune_${uuid0} values (1, 7, "redx"), (2, 8, "redy"), (3, 7, "blue"), (4, 9, "redz"), (5, 7, "redx");
+
+-- one DELETE used to disable unused-column pruning for the whole table
+delete from t_gin_del_prune_${uuid0} where k = 7;
+
+set enable_filter_unused_columns_in_scan_stage = true;
+-- k is both the delete-predicate column and a pruned query predicate column
+select id from t_gin_del_prune_${uuid0} where k = 7 order by id;
+select id from t_gin_del_prune_${uuid0} where k = 8 order by id;
+select id from t_gin_del_prune_${uuid0} where v like '%red%' order by id;
+select id, k from t_gin_del_prune_${uuid0} where v like '%red%' order by id;
+select count(*) from t_gin_del_prune_${uuid0};
+
+set enable_filter_unused_columns_in_scan_stage = false;
+select id from t_gin_del_prune_${uuid0} where k = 7 order by id;
+select id from t_gin_del_prune_${uuid0} where k = 8 order by id;
+select id from t_gin_del_prune_${uuid0} where v like '%red%' order by id;
+select id, k from t_gin_del_prune_${uuid0} where v like '%red%' order by id;
+select count(*) from t_gin_del_prune_${uuid0};
+
+DROP TABLE t_gin_del_prune_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

`OlapScanNode` only sent the unused-output-column list to the BE when `!olapTable.hasDelete()`.
`hasDelete` is a table-level, one-way, persisted flag with no reset path, so **a single `DELETE`
permanently disabled unused-output-column pruning for the whole table**. With a builtin GIN index that
turns the index into a net regression: the index filters the rows, and the predicate column the query
never reads is materialized in full anyway.

Measured on a 1M-row duplicate table, GIN index on a 104-byte varchar column `v`, query
`select max(id) from t where v = '<hot>'`:

| table | before | after |
|---|---|---|
| never deleted from | 4.196 MB | 4.196 MB |
| one `DELETE` on another column | 60.844 MB | **4.196 MB** |
| one `DELETE` on the indexed column | 60.844 MB | 60.844 MB (see limitations) |

`GinFilterRows` (450000) and `RowsRead` (550000) are identical in every case, so the same rows are
matched; only the wasted column read goes away.

The gate could not simply be removed: the column FE lists as unused may be exactly a
delete-predicate column, and the BE evaluates delete predicates against the outgoing chunk. That
combination also tripped a hard invariant in `SegmentIterator::_build_context()` asserting the
opposite:

```cpp
DCHECK(!(output_schema().num_fields() < _schema.num_fields()) || _opts.delete_predicates.empty())
        << "delete condition couldn't work with filter_unused_columns";
```

## What I'm doing:

- **FE**: send the unused-output-column list unconditionally.
- **BE**: erase delete-predicate columns from `_unused_output_column_ids` in the chunk source, next to
  the two erases already there for non-pushdown predicate columns and not-pushed-down conjunct slots
  (`OlapChunkSource::_init_reader_params()` and `LakeDataSource::init_reader_params()`). A
  delete-predicate column therefore always survives into `output_schema`, and **the delete filter and
  the whole read path are untouched**. Each side gets one helper that mirrors its own reader's
  filtering so the two cannot disagree about which columns are evaluated; on the shared-nothing side
  the non-key rule is now literally shared with `TabletReader::_init_delete_predicates()` via
  `DeleteHandler::is_delete_condition_evaluated()`. Both helpers are skipped when the unused set is
  empty.
- The reversed `DCHECK` above is replaced by the invariant that actually holds — **every
  delete-predicate column must be in `output_schema`** — enforced with `Status::InternalError` so it
  is effective in release builds too. If a future caller forgets the erase, the scan fails loudly
  instead of evaluating a delete predicate against a column that is not in the chunk.
- `_read_index_map` is now built by walking the output schema with `find()` instead of sizing the loop
  by `read_indexes.size()` and indexing it with the default-inserting `operator[]`. With the erase in
  place the bad edge is unreachable, so this closes a latent trap rather than a separately verified
  fix, and no test exercises it.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

Unused-output-column pruning, already on by default via
`enable_filter_unused_columns_in_scan_stage`, now also applies to tables that have been deleted from.
Query results are unchanged; only the set of columns the BE materializes changes.

Filed as an Enhancement rather than a BugFix: nothing is broken for users today. The BE defects this
PR fixes are **unreachable on main and on every released branch**, because the FE gate removed here is
exactly what keeps the BE from ever seeing a narrowed output schema together with delete predicates.
The net user-visible effect is the restored optimization.

## Known limitations

1. **A delete-predicate column is itself never pruned** — that is the cost of this design. If the
   `DELETE` condition happens to be on the column the query filters by, that column keeps being read
   (third row of the table above).
2. **`be/src/exec/tablet_scanner.cpp`** (the old non-pipeline scan path) has no erase at all, not even
   the two that already exist on the pipeline paths. That path is rejected at the RPC entry
   ("non-pipeline engine is no longer supported since 3.2", `internal_service.cpp`), so it is left
   alone rather than widened into this PR.
3. The chunk source and `TabletReader` read the delete predicates separately, so a full clone landing
   between the two reads could in theory make the scan return `InternalError`. The window is narrow,
   the failure is transient and self-heals on retry, and it never produces wrong results; the
   underlying "live meta vs captured snapshot" asymmetry is pre-existing.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

Deliberately left unchecked. The BE defects are unreachable on the released branches, so a backport
would not fix a live problem; it would newly enable the pruning policy on stable branches. Happy to
tick them if maintainers prefer.

## Testing

- **Unit tests**: `DeletePredicateColumnIdsTest` and `LakeDeletePredicateColumnIdsTest` cover both
  helpers (version filter, the sub/IN non-key asymmetry, DUP vs non-DUP key rules, all three lake
  predicate kinds, unknown columns). `SegmentIteratorTest.TestDeletePredicateColumnPrunedFromOutputFails`
  pins the new invariant. `FilterUnusedColumnTest` and `LowCardinalityTest` stay green.
- **Delete semantics**, both toggle states, byte-identical at 5 rows and at 1M rows: rows removed by
  `DELETE` stay removed when the delete column is also the pruned predicate column. The original
  repro (a `group_concat` over a subquery on a deleted-from table), which crashed the BE once the FE
  gate was removed without the BE-side fix, now returns the same rows as with pruning disabled.
- **SQL regression** `test_gin_prune_on_table_with_delete` in `test/sql/test_inverted_index`, covering
  both shapes: the delete column coinciding with the pruned predicate column, and a GIN predicate on
  a different column than the one deleted on. The pruning win itself is shown by the `BytesRead`
  table above — the SQL tester only compares result text and cannot show that a column was not read.
