### PR TITLE
[Feature] Support spill for the analytic operator (whole-partition frames)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1223,6 +1223,12 @@ CONF_Int32(pipeline_analytic_max_buffer_size, "128");
 CONF_Int32(pipeline_analytic_removable_chunk_num, "128");
 CONF_Bool(pipeline_analytic_enable_streaming_process, "true");
 CONF_mBool(pipeline_analytic_enable_removable_cumulative_process, "true");
+// Cluster-wide kill switch for spilling in the analytic (window) operator. Only
+// materializing whole-partition frames are eligible (e.g. SUM(x) OVER (PARTITION
+// BY k) without a window clause); spilling additionally requires the session to
+// enable spilling via enable_spill and to keep the ANALYTIC bit of
+// spillable_operator_mask set (the per-operator opt-out, on by default).
+CONF_mBool(pipeline_analytic_enable_spill, "false");
 CONF_Int32(pipline_limit_max_delivery, "4096");
 
 // only used in DCHECK

--- a/be/src/common/config_exec_flow_fwd.h
+++ b/be/src/common/config_exec_flow_fwd.h
@@ -113,6 +113,13 @@ CONF_Bool(pipeline_analytic_enable_streaming_process, "true");
 
 CONF_mBool(pipeline_analytic_enable_removable_cumulative_process, "true");
 
+// Cluster-wide kill switch for spilling in the analytic (window) operator. Only
+// materializing whole-partition frames are eligible (e.g. SUM(x) OVER (PARTITION
+// BY k) without a window clause); spilling additionally requires the session to
+// enable spilling via enable_spill and to keep the ANALYTIC bit of
+// spillable_operator_mask set (the per-operator opt-out, on by default).
+CONF_mBool(pipeline_analytic_enable_spill, "false");
+
 CONF_Int32(pipline_limit_max_delivery, "4096");
 
 // the maximum number of connections in the connection pool for a single jdbc url

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -160,6 +160,7 @@
         "pipeline_analytic_removable_chunk_num",
         "pipeline_analytic_enable_streaming_process",
         "pipeline_analytic_enable_removable_cumulative_process",
+        "pipeline_analytic_enable_spill",
         "pipline_limit_max_delivery",
         "jdbc_connection_pool_size",
         "jdbc_minimum_idle_connections",

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -172,6 +172,8 @@ set(PIPELINE_OPERATORS_BATCH_SRCS
     pipeline/aggregate/repeat/repeat_operator.cpp
     pipeline/analysis/analytic_sink_operator.cpp
     pipeline/analysis/analytic_source_operator.cpp
+    pipeline/analysis/spillable_analytic_sink_operator.cpp
+    pipeline/analysis/spillable_analytic_source_operator.cpp
     pipeline/bucket_process_operator.cpp
     pipeline/table_function_operator.cpp
     pipeline/assert_num_rows_operator.cpp

--- a/be/src/exec/analytic_node.cpp
+++ b/be/src/exec/analytic_node.cpp
@@ -19,9 +19,12 @@
 #include <memory>
 
 #include "column/chunk.h"
+#include "common/config_exec_flow_fwd.h"
 #include "common/runtime_profile.h"
 #include "exec/pipeline/analysis/analytic_sink_operator.h"
 #include "exec/pipeline/analysis/analytic_source_operator.h"
+#include "exec/pipeline/analysis/spillable_analytic_sink_operator.h"
+#include "exec/pipeline/analysis/spillable_analytic_source_operator.h"
 #include "exec/pipeline/exec_node_pipeline_adapter.h"
 #include "exec/pipeline/hash_partition_context.h"
 #include "exec/pipeline/hash_partition_sink_operator.h"
@@ -128,15 +131,29 @@ StatusOr<pipeline::OpFactories> AnalyticNode::decompose_to_pipeline(pipeline::Pi
             degree_of_parallelism, _tnode, _result_tuple_desc, _use_hash_based_partition);
     auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(2, std::move(this->runtime_filter_collector()));
 
-    ops_with_sink.emplace_back(
-            std::make_shared<AnalyticSinkOperatorFactory>(context->next_operator_id(), id(), _tnode, analytor_factory));
+    // Analytic spill v1 covers materializing whole-partition frames only.
+    const bool may_spill = runtime_state()->enable_spill() && runtime_state()->enable_analytic_spill() &&
+                           config::pipeline_analytic_enable_spill && Analytor::tnode_supports_spill(_tnode);
+
+    std::shared_ptr<AnalyticSinkOperatorFactory> sink_op;
+    OpFactories ops_with_source;
+    std::shared_ptr<AnalyticSourceOperatorFactory> source_op;
+    if (may_spill) {
+        sink_op = std::make_shared<SpillableAnalyticSinkOperatorFactory>(context->next_operator_id(), id(), _tnode,
+                                                                         analytor_factory);
+        source_op = std::make_shared<SpillableAnalyticSourceOperatorFactory>(context->next_operator_id(), id(),
+                                                                             analytor_factory);
+    } else {
+        sink_op = std::make_shared<AnalyticSinkOperatorFactory>(context->next_operator_id(), id(), _tnode,
+                                                                analytor_factory);
+        source_op =
+                std::make_shared<AnalyticSourceOperatorFactory>(context->next_operator_id(), id(), analytor_factory);
+    }
+    source_op->set_skewed(is_skewed);
+
+    ops_with_sink.emplace_back(std::move(sink_op));
     pipeline::init_runtime_filter_for_operator(*this, ops_with_sink.back().get(), context, rc_rf_probe_collector);
     context->add_pipeline(ops_with_sink);
-
-    OpFactories ops_with_source;
-    auto source_op =
-            std::make_shared<AnalyticSourceOperatorFactory>(context->next_operator_id(), id(), analytor_factory);
-    source_op->set_skewed(is_skewed);
     pipeline::init_runtime_filter_for_operator(*this, source_op.get(), context, rc_rf_probe_collector);
     context->inherit_upstream_source_properties(source_op.get(), upstream_source_op);
     ops_with_source.push_back(std::move(source_op));

--- a/be/src/exec/analytor.cpp
+++ b/be/src/exec/analytor.cpp
@@ -2013,11 +2013,10 @@ StatusOr<ChunkPtr> Analytor::store_pull_chunk(RuntimeState* state, bool allow_sh
         }
         if (ctx.out_rows_total != pushed || ctx.out_rows_total != published ||
             partitions_consumed != partitions_published) {
-            return Status::InternalError(
-                    strings::Substitute("analytic spill replay accounting mismatch: pushed=$0 published=$1 "
-                                        "replayed=$2 partitions published=$3 consumed=$4",
-                                        pushed, published, ctx.out_rows_total, partitions_published,
-                                        partitions_consumed));
+            return Status::InternalError(strings::Substitute(
+                    "analytic spill replay accounting mismatch: pushed=$0 published=$1 "
+                    "replayed=$2 partitions published=$3 consumed=$4",
+                    pushed, published, ctx.out_rows_total, partitions_published, partitions_consumed));
         }
         _store_eos = true;
         return nullptr;
@@ -2070,8 +2069,8 @@ StatusOr<ChunkPtr> Analytor::store_pull_chunk(RuntimeState* state, bool allow_sh
             if (ctx.descriptor_idx >= ctx.descriptor_batch->num_rows()) {
                 // Batch fully consumed: release it eagerly (the spans hold
                 // their own references) and return its bytes to the backlog.
-                _store_descriptor_bytes_consumed.fetch_add(
-                        static_cast<int64_t>(ctx.descriptor_batch->memory_usage()), std::memory_order_relaxed);
+                _store_descriptor_bytes_consumed.fetch_add(static_cast<int64_t>(ctx.descriptor_batch->memory_usage()),
+                                                           std::memory_order_relaxed);
                 ctx.descriptor_batch.reset();
                 ctx.descriptor_idx = 0;
             }

--- a/be/src/exec/analytor.cpp
+++ b/be/src/exec/analytor.cpp
@@ -21,9 +21,11 @@
 #include "base/utility/defer_op.h"
 #include "column/chunk.h"
 #include "column/column_helper.h"
+#include "column/fixed_length_column.h"
 #include "common/config_exec_flow_fwd.h"
 #include "common/runtime_profile.h"
 #include "common/status.h"
+#include "exec/pipeline/exchange/mem_limited_chunk_queue.h"
 #include "exprs/agg/aggregate_state_allocator.h"
 #include "exprs/agg/count.h"
 #include "exprs/agg/window.h"
@@ -55,6 +57,16 @@
     }
 
 namespace starrocks {
+
+namespace {
+// Result columns of these types cannot be resized in place, so window results
+// are appended to them instead of being written at absolute positions. Shared
+// by the in-memory result columns and the spill per-partition result columns.
+bool window_result_column_is_append_only(LogicalType type) {
+    return type == LogicalType::TYPE_CHAR || type == LogicalType::TYPE_VARCHAR || type == LogicalType::TYPE_JSON ||
+           type == LogicalType::TYPE_ARRAY || type == LogicalType::TYPE_MAP || type == LogicalType::TYPE_STRUCT;
+}
+} // namespace
 Status window_init_jvm_context(int64_t fid, const std::string& url, const std::string& checksum,
                                const std::string& symbol, FunctionContext* context,
                                const TCloudConfiguration& cloud_configuration, bool use_cache,
@@ -80,6 +92,7 @@ Analytor::Analytor(const TPlanNode& tnode, const TupleDescriptor* result_tuple_d
     TAnalyticWindow window = analytic_node.window;
     if (!analytic_node.__isset.window) {
         _need_partition_materializing = true;
+        _is_whole_partition_frame = true;
     } else if (analytic_node.window.type == TAnalyticWindowType::RANGE) {
         _is_range_window = true;
 
@@ -110,6 +123,7 @@ Analytor::Analytor(const TPlanNode& tnode, const TupleDescriptor* result_tuple_d
         if (_range_start_boundary.type == RangeBoundaryType::UNBOUNDED_PRECEDING &&
             _range_end_boundary.type == RangeBoundaryType::UNBOUNDED_FOLLOWING) {
             _need_partition_materializing = true;
+            _is_whole_partition_frame = true;
         } else if (!(_range_start_boundary.type == RangeBoundaryType::UNBOUNDED_PRECEDING &&
                      _range_end_boundary.type == RangeBoundaryType::CURRENT_ROW)) {
             // Non-cumulative RANGE windows are handled by definition in materializing mode.
@@ -121,6 +135,7 @@ Analytor::Analytor(const TPlanNode& tnode, const TupleDescriptor* result_tuple_d
     } else {
         if (!window.__isset.window_start && !window.__isset.window_end) {
             _need_partition_materializing = true;
+            _is_whole_partition_frame = true;
         } else {
             if (window.__isset.window_start) {
                 TAnalyticWindowBoundary b = window.window_start;
@@ -429,6 +444,20 @@ Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* 
         _fns.emplace_back(_tnode.analytic_node.analytic_functions[i].nodes[0].fn);
     }
 
+    // ==== Analytic spill eligibility. tnode_supports_spill is the single
+    // source of truth (also used at pipeline-decompose time); the DCHECK guards
+    // against its rules drifting from the parsed state.
+    _spill_supported = tnode_supports_spill(_tnode);
+    DCHECK(!_spill_supported ||
+           (_need_partition_materializing && _is_whole_partition_frame && !_should_set_partition_size &&
+            std::none_of(_is_lead_lag_functions.begin(), _is_lead_lag_functions.end(), [](bool v) { return v; })));
+    if (!_spill_supported) {
+        _input_run.reset();
+    }
+    if (partition_streams_enabled()) {
+        _runtime_profile->add_info_string("AnalyticSpill", "true");
+    }
+
     return _prepare_processing_mode(state, runtime_profile);
 }
 
@@ -524,6 +553,8 @@ void Analytor::close(RuntimeState* state) {
         return;
     }
 
+    _input_run.reset();
+
     while (!_buffer.empty()) {
         _buffer.pop();
     }
@@ -574,6 +605,13 @@ void Analytor::close(RuntimeState* state) {
 }
 
 Status Analytor::process(RuntimeState* state, const ChunkPtr& chunk) {
+    if (_input_run != nullptr) {
+        TRY_CATCH_ALLOC_SCOPE_START()
+        RETURN_IF_ERROR(store_process_chunk(state, chunk));
+        TRY_CATCH_ALLOC_SCOPE_END()
+        return _check_has_error();
+    }
+
     _remove_unused_rows(state);
 
     // Wrap the whole processing path in a bad-alloc scope so that all allocations inside _add_chunk and the window
@@ -1467,12 +1505,7 @@ void Analytor::_init_window_result_columns() {
         // so we only reserve it.
         if (_agg_functions[i]->get_name().ends_with("fused_multi_distinct")) {
             _result_window_columns[i]->resize(chunk_size);
-        } else if (_agg_fn_types[i].result_type.type == LogicalType::TYPE_CHAR ||
-                   _agg_fn_types[i].result_type.type == LogicalType::TYPE_VARCHAR ||
-                   _agg_fn_types[i].result_type.type == LogicalType::TYPE_JSON ||
-                   _agg_fn_types[i].result_type.type == LogicalType::TYPE_ARRAY ||
-                   _agg_fn_types[i].result_type.type == LogicalType::TYPE_MAP ||
-                   _agg_fn_types[i].result_type.type == LogicalType::TYPE_STRUCT) {
+        } else if (window_result_column_is_append_only(_agg_fn_types[i].result_type.type)) {
             _result_window_columns[i]->reserve(chunk_size);
         } else {
             _result_window_columns[i]->resize(chunk_size);
@@ -1658,6 +1691,438 @@ void Analytor::_set_partition_size_for_function() {
         auto& state = *reinterpret_cast<CumeDistState*>(_managed_fn_states[0]->mutable_data() + _agg_states_offsets[i]);
         state.count = _partition.end - _partition.start;
     }
+}
+
+// ==== Analytic spill (v1) ====================================================
+// Only materializing whole-partition frames are supported (see analytor.h).
+// FIFO replay is intrinsic to the run store: chunks live in an ordered block
+// with a single mem table: flushes are strictly serialized, so blocks join the
+// block group set in append order and the unordered input stream reads them
+// back in exactly that order.
+
+bool Analytor::tnode_supports_spill(const TPlanNode& tnode) {
+    const TAnalyticNode& analytic_node = tnode.analytic_node;
+    if (analytic_node.__isset.window) {
+        const TAnalyticWindow& window = analytic_node.window;
+        if (window.__isset.window_start || window.__isset.window_end) {
+            return false;
+        }
+    }
+    for (const TExpr& desc : analytic_node.analytic_functions) {
+        const TFunction& fn = desc.nodes[0].fn;
+        if (fn.binary_type != TFunctionBinaryType::BUILTIN) {
+            return false;
+        }
+        const std::string& name = fn.name.function_name;
+        if (!(name == "sum" || name == "avg" || name == "count" || name == "max" || name == "min" ||
+              name == "first_value" || name == "last_value")) {
+            return false;
+        }
+    }
+    return true;
+}
+
+Status Analytor::store_process_chunk(RuntimeState* state, const ChunkPtr& chunk) {
+    DCHECK(partition_streams_enabled());
+    DCHECK(chunk != nullptr && !chunk->is_empty());
+    const size_t chunk_size = chunk->num_rows();
+
+    // Payload first: a descriptor must never refer to rows that are not in
+    // the input run yet. The chunk is immutable from here on — the source may
+    // pop it while this driver is still scanning it.
+    RETURN_IF_ERROR(_input_run->push(chunk));
+    _store_rows_pushed.fetch_add(chunk_size, std::memory_order_release);
+
+    // Evaluate each expression at most once per chunk; the span loop below
+    // only references the results.
+    Columns part_cols(_partition_ctxs.size());
+    for (size_t i = 0; i < _partition_ctxs.size(); i++) {
+        ASSIGN_OR_RETURN(ColumnPtr column, _partition_ctxs[i]->evaluate(chunk.get()));
+        auto normalized = _partition_columns[i]->clone_empty();
+        _append_column(chunk_size, normalized.get(), column);
+        part_cols[i] = std::move(normalized);
+    }
+
+    std::vector<Columns> fn_cols(_agg_fn_ctxs.size());
+    for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
+        // count(*) has no input expressions and gets zero argument columns;
+        // every update path branches on the argument count instead of
+        // dereferencing a placeholder.
+        fn_cols[i].resize(_agg_expr_ctxs[i].size());
+        for (size_t j = 0; j < _agg_expr_ctxs[i].size(); j++) {
+            auto normalized = _agg_intput_columns[i][j]->clone_empty();
+            ASSIGN_OR_RETURN(ColumnPtr column, _agg_expr_ctxs[i][j]->evaluate(chunk.get()));
+            _append_column(chunk_size, normalized.get(), column);
+            fn_cols[i][j] = std::move(normalized);
+        }
+    }
+
+    if (!_spill_ctx.has_open_partition) {
+        _store_open_partition(part_cols, 0);
+    } else if (!_store_row_equals_last_key(part_cols, 0)) {
+        RETURN_IF_ERROR(_store_seal_open_partition());
+        _store_open_partition(part_cols, 0);
+    }
+
+    size_t seg_start = 0;
+    for (size_t row = 1; row <= chunk_size; row++) {
+        bool is_boundary = false;
+        if (row < chunk_size) {
+            for (auto& column : part_cols) {
+                if (column->compare_at(row, row - 1, *column, 1) != 0) {
+                    is_boundary = true;
+                    break;
+                }
+            }
+        }
+
+        //TODO simplify logic
+        if (row == chunk_size || is_boundary) {
+            RETURN_IF_ERROR(_store_update_states(fn_cols, seg_start, row));
+            _spill_ctx.open_partition_rows += row - seg_start;
+            if (row < chunk_size) {
+                RETURN_IF_ERROR(_store_seal_open_partition());
+                _store_open_partition(part_cols, row);
+                seg_start = row;
+            }
+        }
+    }
+
+    // Publish every partition sealed by this chunk before returning.
+    return _store_flush_descriptors();
+}
+
+Status Analytor::_store_update_states(const std::vector<Columns>& fn_cols, int64_t frame_start, int64_t frame_end) {
+    SCOPED_THREAD_LOCAL_AGG_STATE_ALLOCATOR_SETTER(_allocator.get());
+    for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
+        const size_t column_size = fn_cols[i].size();
+        const Column* data_columns[std::max<size_t>(column_size, 1)];
+        for (size_t j = 0; j < column_size; j++) {
+            data_columns[j] = fn_cols[i][j].get();
+        }
+        if (_is_merge_funcs) {
+            DCHECK_GT(column_size, 0);
+            for (int64_t j = frame_start; j < frame_end; j++) {
+                _agg_functions[i]->merge(_agg_fn_ctxs[i], data_columns[0],
+                                         _managed_fn_states[0]->mutable_data() + _agg_states_offsets[i], j);
+            }
+        } else {
+            _agg_functions[i]->update_batch_single_state_with_frame(
+                    _agg_fn_ctxs[i], _managed_fn_states[0]->mutable_data() + _agg_states_offsets[i], data_columns,
+                    frame_start, frame_end, frame_start, frame_end);
+        }
+    }
+    return Status::OK();
+}
+
+void Analytor::_store_open_partition(const Columns& part_cols, size_t row) {
+    if (_spill_ctx.last_partition_key.size() != _partition_columns.size()) {
+        _spill_ctx.last_partition_key.clear();
+        for (auto& column : _partition_columns) {
+            _spill_ctx.last_partition_key.emplace_back(column->clone_empty());
+        }
+    }
+    for (size_t i = 0; i < _spill_ctx.last_partition_key.size(); i++) {
+        _spill_ctx.last_partition_key[i]->resize(0);
+        _spill_ctx.last_partition_key[i]->append(*part_cols[i], row, 1);
+    }
+    _spill_ctx.has_open_partition = true;
+}
+
+bool Analytor::_store_row_equals_last_key(const Columns& part_cols, size_t row) const {
+    for (size_t i = 0; i < part_cols.size(); i++) {
+        if (part_cols[i]->compare_at(row, 0, *_spill_ctx.last_partition_key[i], 1) != 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+Status Analytor::_store_seal_open_partition() {
+    auto& ctx = _spill_ctx;
+    DCHECK(ctx.has_open_partition);
+    DCHECK_GT(ctx.open_partition_rows, 0);
+    if (ctx.descriptor_builder.empty()) {
+        ctx.descriptor_builder.reserve(1 + _agg_fn_types.size());
+        ctx.descriptor_builder.emplace_back(Int64Column::create());
+        for (auto& agg_fn_type : _agg_fn_types) {
+            ctx.descriptor_builder.emplace_back(
+                    ColumnHelper::create_column(agg_fn_type.result_type, agg_fn_type.has_nullable_child));
+        }
+    }
+    SCOPED_THREAD_LOCAL_AGG_STATE_ALLOCATOR_SETTER(_allocator.get());
+    down_cast<Int64Column*>(ctx.descriptor_builder[0].get())->append(ctx.open_partition_rows);
+    for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
+        Column* dst = ctx.descriptor_builder[i + 1].get();
+        // Fixed-size result columns are resized and written in place by
+        // get_values, var-size ones append.
+        if (!window_result_column_is_append_only(_agg_fn_types[i].result_type.type)) {
+            dst->resize(ctx.builder_records + 1);
+        }
+        _agg_functions[i]->get_values(_agg_fn_ctxs[i], _managed_fn_states[0]->data() + _agg_states_offsets[i], dst,
+                                      ctx.builder_records, ctx.builder_records + 1);
+    }
+    ctx.builder_records++;
+    ctx.builder_rows += ctx.open_partition_rows;
+    ctx.open_partition_rows = 0;
+    ctx.has_open_partition = false;
+    _reset_window_state();
+    // Cap descriptor batches at the vector chunk size like any chunk stream.
+    if (ctx.builder_records >= static_cast<size_t>(_state->chunk_size())) {
+        return _store_flush_descriptors();
+    }
+    return Status::OK();
+}
+
+Status Analytor::_store_flush_descriptors() {
+    auto& ctx = _spill_ctx;
+    if (ctx.builder_records == 0) {
+        return Status::OK();
+    }
+    auto batch = std::make_shared<Chunk>();
+    for (size_t i = 0; i < ctx.descriptor_builder.size(); i++) {
+        batch->append_column(std::move(ctx.descriptor_builder[i]), static_cast<SlotId>(i));
+    }
+    ctx.descriptor_builder.clear();
+    const int64_t records = static_cast<int64_t>(ctx.builder_records);
+    const int64_t rows = ctx.builder_rows;
+    const int64_t bytes = static_cast<int64_t>(batch->memory_usage());
+    ctx.builder_records = 0;
+    ctx.builder_rows = 0;
+    _descriptor_queue.push(std::move(batch));
+    // Publication: the queue push is the synchronization point for the data;
+    // these counters feed the sink backpressure (relaxed reads) and the
+    // source EOF validation (which runs after both streams reported EOF).
+    _store_rows_published.fetch_add(rows, std::memory_order_release);
+    _store_partitions_published.fetch_add(records, std::memory_order_release);
+    _store_descriptor_bytes_published.fetch_add(bytes, std::memory_order_release);
+    return Status::OK();
+}
+
+bool Analytor::store_can_push() {
+    DCHECK(partition_streams_enabled());
+    // Early consumer close (LIMIT): stop accepting input, the framework
+    // finishes this pipeline.
+    if (_input_run->is_all_source_finished()) {
+        return false;
+    }
+    // Sealed-but-unconsumed backlog: when the source lags, stop accepting
+    // more input so retained memory/disk stay bounded by the open partition
+    // plus this backlog. Relaxed reads: approximate is fine for flow control.
+    const int64_t ready_rows = _store_rows_published.load(std::memory_order_relaxed) -
+                               _store_rows_consumed.load(std::memory_order_relaxed);
+    const int64_t ready_partitions = _store_partitions_published.load(std::memory_order_relaxed) -
+                                     _store_partitions_consumed.load(std::memory_order_relaxed);
+    const int64_t ready_descriptor_bytes = _store_descriptor_bytes_published.load(std::memory_order_relaxed) -
+                                           _store_descriptor_bytes_consumed.load(std::memory_order_relaxed);
+    if (ready_rows >= kStoreReadyRowsLimit || ready_partitions >= kStoreReadyPartitionsLimit ||
+        ready_descriptor_bytes >= kStoreReadyDescriptorBytesLimit) {
+        return false;
+    }
+    // The descriptor stream is a pure in-memory bounded queue -- the backlog
+    // limits above ARE its capacity -- so only the input run (which may have
+    // a flush in flight) gates the push.
+    return _input_run->can_push();
+}
+
+Status Analytor::store_finish_input(RuntimeState* state) {
+    DCHECK(partition_streams_enabled());
+    _input_eos = true;
+    TRY_CATCH_ALLOC_SCOPE_START()
+    if (_spill_ctx.has_open_partition) {
+        RETURN_IF_ERROR(_store_seal_open_partition());
+    }
+    RETURN_IF_ERROR(_store_flush_descriptors());
+    TRY_CATCH_ALLOC_SCOPE_END()
+    // No IO barrier: resident blocks serve directly and flushed blocks are
+    // prefetched by the source side's can_pop.
+    _descriptor_queue.close_producer();
+    _input_run->close_producer();
+    _is_sink_complete.store(true, std::memory_order_release);
+    return _check_has_error();
+}
+
+bool Analytor::store_has_output() {
+    DCHECK(partition_streams_enabled());
+    const auto& ctx = _spill_ctx;
+    if (_store_eos) {
+        return false;
+    }
+    // A permit in hand, one poppable from the stream, or the stream at EOF
+    // (store_pull_chunk still has to run the final validation then).
+    const bool permit = ctx.out_rows_remaining > 0 ||
+                        (ctx.descriptor_batch != nullptr && ctx.descriptor_idx < ctx.descriptor_batch->num_rows()) ||
+                        ctx.descriptor_eos || _descriptor_queue.can_pop();
+    if (!permit) {
+        return false;
+    }
+    return ctx.pending_input != nullptr || ctx.input_eos || _input_run->can_pop(kOutputConsumerIndex);
+}
+
+StatusOr<ChunkPtr> Analytor::store_pull_chunk(RuntimeState* state, bool allow_share_columns) {
+    DCHECK(partition_streams_enabled());
+    auto& ctx = _spill_ctx;
+    if (_store_eos) {
+        return nullptr;
+    }
+
+    // Ensure input rows at hand.
+    if (ctx.pending_input == nullptr && !ctx.input_eos) {
+        auto res = _input_run->pop(kOutputConsumerIndex);
+        if (res.status().is_end_of_file()) {
+            ctx.input_eos = true;
+        } else {
+            RETURN_IF_ERROR(res.status());
+            ChunkPtr chunk = std::move(res.value());
+            if (chunk == nullptr || chunk->is_empty()) {
+                // Transient: the block was flushed between can_pop and pop;
+                // the next can_pop schedules its load.
+                return nullptr;
+            }
+            ctx.pending_input = std::move(chunk);
+            ctx.pending_offset = 0;
+        }
+    }
+
+    if (ctx.pending_input == nullptr) {
+        DCHECK(ctx.input_eos);
+        // Drain the descriptor stream to its EOF and verify the accounting.
+        if (ctx.out_rows_remaining > 0 ||
+            (ctx.descriptor_batch != nullptr && ctx.descriptor_idx < ctx.descriptor_batch->num_rows())) {
+            return Status::InternalError("analytic spill replay: input EOF with descriptors remaining");
+        }
+        if (!ctx.descriptor_eos) {
+            auto res = _descriptor_queue.pop();
+            if (res.status().is_end_of_file()) {
+                ctx.descriptor_eos = true;
+            } else {
+                RETURN_IF_ERROR(res.status());
+                return Status::InternalError("analytic spill replay: descriptors after input EOF");
+            }
+        }
+        const int64_t pushed = _store_rows_pushed.load(std::memory_order_acquire);
+        const int64_t published = _store_rows_published.load(std::memory_order_acquire);
+        const int64_t partitions_published = _store_partitions_published.load(std::memory_order_acquire);
+        const int64_t partitions_consumed = _store_partitions_consumed.load(std::memory_order_relaxed);
+        const int64_t descriptor_bytes_published = _store_descriptor_bytes_published.load(std::memory_order_acquire);
+        const int64_t descriptor_bytes_consumed = _store_descriptor_bytes_consumed.load(std::memory_order_relaxed);
+        if (descriptor_bytes_published != descriptor_bytes_consumed) {
+            return Status::InternalError(strings::Substitute(
+                    "analytic spill replay accounting mismatch: descriptor bytes published=$0 consumed=$1",
+                    descriptor_bytes_published, descriptor_bytes_consumed));
+        }
+        if (ctx.out_rows_total != pushed || ctx.out_rows_total != published ||
+            partitions_consumed != partitions_published) {
+            return Status::InternalError(
+                    strings::Substitute("analytic spill replay accounting mismatch: pushed=$0 published=$1 "
+                                        "replayed=$2 partitions published=$3 consumed=$4",
+                                        pushed, published, ctx.out_rows_total, partitions_published,
+                                        partitions_consumed));
+        }
+        _store_eos = true;
+        return nullptr;
+    }
+
+    // Authorize as many pending rows as the published descriptors cover.
+    ChunkPtr in = ctx.pending_input;
+    const size_t in_rows = in->num_rows();
+    size_t avail = in_rows - ctx.pending_offset;
+    // Never authorize more rows than the limit still needs. Stopping at the
+    // source keeps the replay accounting exact and avoids trimming an already
+    // built output chunk, which would resize columns the input run may share.
+    if (_limit != -1) {
+        const int64_t remaining = _limit - _num_rows_returned;
+        if (remaining <= 0) {
+            _store_eos = true;
+            return nullptr;
+        }
+        avail = std::min<size_t>(avail, static_cast<size_t>(remaining));
+    }
+    std::vector<std::tuple<ChunkPtr, size_t, size_t>> spans; // (batch, record, length)
+    size_t take = 0;
+    while (take < avail) {
+        if (ctx.out_rows_remaining == 0) {
+            if (ctx.descriptor_batch == nullptr || ctx.descriptor_idx >= ctx.descriptor_batch->num_rows()) {
+                if (ctx.descriptor_eos || !_descriptor_queue.can_pop()) {
+                    break; // permit not yet published
+                }
+                auto res = _descriptor_queue.pop();
+                if (res.status().is_end_of_file()) {
+                    ctx.descriptor_eos = true;
+                    break;
+                }
+                RETURN_IF_ERROR(res.status());
+                DCHECK(res.value() != nullptr && !res.value()->is_empty());
+                ctx.descriptor_batch = std::move(res.value());
+                ctx.descriptor_idx = 0;
+            }
+            const auto& row_counts = down_cast<const Int64Column&>(*ctx.descriptor_batch->columns()[0]);
+            ctx.out_rows_remaining = row_counts.get_data()[ctx.descriptor_idx];
+            DCHECK_GT(ctx.out_rows_remaining, 0);
+        }
+        const size_t span = std::min<size_t>(static_cast<size_t>(ctx.out_rows_remaining), avail - take);
+        spans.emplace_back(ctx.descriptor_batch, ctx.descriptor_idx, span);
+        take += span;
+        ctx.out_rows_remaining -= span;
+        if (ctx.out_rows_remaining == 0) {
+            ctx.descriptor_idx++;
+            _store_partitions_consumed.fetch_add(1, std::memory_order_relaxed);
+            if (ctx.descriptor_idx >= ctx.descriptor_batch->num_rows()) {
+                // Batch fully consumed: release it eagerly (the spans hold
+                // their own references) and return its bytes to the backlog.
+                _store_descriptor_bytes_consumed.fetch_add(
+                        static_cast<int64_t>(ctx.descriptor_batch->memory_usage()), std::memory_order_relaxed);
+                ctx.descriptor_batch.reset();
+                ctx.descriptor_idx = 0;
+            }
+        }
+    }
+
+    if (take == 0) {
+        if (ctx.descriptor_eos) {
+            return Status::InternalError("analytic spill replay: descriptor EOF with unauthorized input rows");
+        }
+        return nullptr; // wait for the next descriptor publication
+    }
+
+    // Build the output. Sharing the data columns is only allowed when the whole
+    // chunk goes out in one piece AND nothing downstream will rewrite them:
+    // pop() hands out the ChunkPtr the queue stored, and a flush task selected
+    // under the queue lock keeps its own reference while serializing those
+    // columns outside that lock. Column::filter compacts survivors forward in
+    // the same buffer and Chunk::set_num_rows resizes it, so an in-place edit
+    // races that serializer and desynchronizes the block's framing -- the whole
+    // block is one flat byte stream replayed by a single sequential cursor, so
+    // a torn chunk corrupts every chunk behind it. Copy in every other case;
+    // the source must never trim columns still shared with the queue.
+    ChunkPtr output;
+    TRY_CATCH_ALLOC_SCOPE_START()
+    if (allow_share_columns && ctx.pending_offset == 0 && take == in_rows) {
+        output = std::make_shared<Chunk>(Columns(in->columns()), in->get_slot_id_to_index_map());
+    } else {
+        output = in->clone_empty(take);
+        output->append(*in, ctx.pending_offset, take);
+    }
+    for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
+        auto column = ColumnHelper::create_column(_agg_fn_types[i].result_type, _agg_fn_types[i].has_nullable_child);
+        column->reserve(take);
+        for (const auto& [batch, record, span] : spans) {
+            column->append_value_multiple_times(*batch->columns()[i + 1], record, span);
+        }
+        output->append_column(std::move(column), _result_tuple_desc->slots()[i]->id());
+    }
+    TRY_CATCH_ALLOC_SCOPE_END()
+
+    ctx.pending_offset += take;
+    if (ctx.pending_offset == in_rows) {
+        ctx.pending_input.reset();
+        ctx.pending_offset = 0;
+    }
+    ctx.out_rows_total += take;
+    _store_rows_consumed.fetch_add(take, std::memory_order_relaxed);
+
+    _num_rows_returned += static_cast<int64_t>(take);
+    return output;
 }
 
 AnalytorPtr AnalytorFactory::create(int i) {

--- a/be/src/exec/analytor.h
+++ b/be/src/exec/analytor.h
@@ -259,9 +259,7 @@ public:
     static bool tnode_supports_spill(const TPlanNode& tnode);
     bool spill_supported() const { return _spill_supported; }
     bool partition_streams_enabled() const { return _input_run != nullptr; }
-    void set_input_run(std::shared_ptr<pipeline::MemLimitedChunkQueue> input_run) {
-        _input_run = std::move(input_run);
-    }
+    void set_input_run(std::shared_ptr<pipeline::MemLimitedChunkQueue> input_run) { _input_run = std::move(input_run); }
     const std::shared_ptr<pipeline::MemLimitedChunkQueue>& input_run() const { return _input_run; }
     AnalyticDescriptorQueue& descriptor_queue() { return _descriptor_queue; }
     // Sink side. False while a stream flush is in flight, while the

--- a/be/src/exec/analytor.h
+++ b/be/src/exec/analytor.h
@@ -15,6 +15,9 @@
 #pragma once
 
 #include <algorithm>
+#include <atomic>
+#include <deque>
+#include <mutex>
 #include <queue>
 #include <string>
 
@@ -23,6 +26,7 @@
 #include "common/global_types.h"
 #include "common/memory/mem_hook_allocator.h"
 #include "common/runtime_profile.h"
+#include "common/statusor.h"
 #include "exec/pipeline/context_with_dependency.h"
 #include "exec_primitive/pipeline/primitives/pipeline_observer.h"
 #include "exprs/agg/aggregate_factory.h"
@@ -31,6 +35,10 @@
 #include "gen_cpp/Types_types.h"
 #include "runtime/descriptors.h"
 #include "types/type_descriptor.h"
+
+namespace starrocks::pipeline {
+class MemLimitedChunkQueue;
+} // namespace starrocks::pipeline
 
 namespace starrocks {
 
@@ -43,6 +51,56 @@ struct FunctionTypes {
 class Analytor;
 using AnalytorPtr = std::shared_ptr<Analytor>;
 using Analytors = std::vector<AnalytorPtr>;
+
+// In-memory FIFO carrying sealed-partition descriptor batches from the sink
+// driver to the source driver. Purely resident by design: it only ever holds
+// records the source can drain, so a full queue is a backpressure condition,
+// never a deadlock risk — capacity enforcement therefore lives in the
+// analytor's ready-backlog limits and this queue only provides ordering,
+// cross-thread hand-off and end-of-stream semantics. (The input run, which
+// buffers not-yet-consumable open-partition data, is the spillable one.)
+class AnalyticDescriptorQueue {
+public:
+    void push(ChunkPtr batch) {
+        std::lock_guard<std::mutex> l(_mutex);
+        if (_consumer_closed) {
+            return; // early LIMIT: the consumer will never read it
+        }
+        _batches.emplace_back(std::move(batch));
+    }
+    // Data available, or drained with the producer closed (pop -> EndOfFile).
+    bool can_pop() {
+        std::lock_guard<std::mutex> l(_mutex);
+        return !_batches.empty() || _producer_closed;
+    }
+    StatusOr<ChunkPtr> pop() {
+        std::lock_guard<std::mutex> l(_mutex);
+        if (!_batches.empty()) {
+            ChunkPtr batch = std::move(_batches.front());
+            _batches.pop_front();
+            return batch;
+        }
+        if (_producer_closed) {
+            return Status::EndOfFile("no more descriptors");
+        }
+        return Status::InternalError("descriptor queue pop without can_pop");
+    }
+    void close_producer() {
+        std::lock_guard<std::mutex> l(_mutex);
+        _producer_closed = true;
+    }
+    void close_consumer() {
+        std::lock_guard<std::mutex> l(_mutex);
+        _consumer_closed = true;
+        _batches.clear();
+    }
+
+private:
+    std::mutex _mutex;
+    std::deque<ChunkPtr> _batches;
+    bool _producer_closed = false;
+    bool _consumer_closed = false;
+};
 
 template <typename T>
 class ManagedFunctionStates;
@@ -164,6 +222,72 @@ public:
 
     std::string debug_string() const;
 
+    // ==== Analytic spill (incremental partition-stream edition) ====
+    // Spill support covers materializing whole-partition frames, i.e.
+    // `... OVER (PARTITION BY k)` without a window clause, or with
+    // `ROWS|RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING`.
+    // Every window value within a partition is one scalar per function, so
+    // processing becomes two cooperating sequential streams (both
+    // MemLimitedChunkQueue) shared by the sink and source drivers:
+    // - InputRun holds the raw input chunks in arrival order, resident below
+    //   its memory limit, flushing cold blocks beyond it;
+    // - the descriptor queue publishes one record per sealed partition: its
+    //   row count plus one result row per window function. It is a dedicated
+    //   in-memory queue, never spilled: it only holds sealed records, which
+    //   the source can always drain, so a full queue is a backpressure
+    //   condition rather than a deadlock risk and the ready-backlog limits
+    //   below are its capacity (see AnalyticDescriptorQueue).
+    // A descriptor is the read permit for its rows. The source consumes the
+    // sealed prefix of InputRun as soon as the covering descriptors arrive,
+    // attaches the per-partition constants as result columns, and lets the
+    // queues release consumed blocks immediately — it does not wait for the
+    // sink to finish. A sealed-but-unconsumed backlog limit feeds back into
+    // the sink's need_input(), so retained memory and disk stay bounded by
+    // the open partition plus that backlog instead of the whole query.
+    //
+    // There is no activation event and no processing-mode conversion: the
+    // memory limit IS the policy (spill_mode=force -> 0, auto -> threshold),
+    // and eligible queries always execute on this single path.
+    //
+    // Known limitations, by design:
+    // - A partition emits nothing before it seals: the first-row latency of
+    //   one giant partition is SQL semantics, not a protocol artifact. The
+    //   per-session escape hatch is the ANALYTIC bit of
+    //   spillable_operator_mask.
+    // - The resident threshold derives from spill_mem_table_size instead of
+    //   the operator memory-reservation mechanism (follow-up).
+    static bool tnode_supports_spill(const TPlanNode& tnode);
+    bool spill_supported() const { return _spill_supported; }
+    bool partition_streams_enabled() const { return _input_run != nullptr; }
+    void set_input_run(std::shared_ptr<pipeline::MemLimitedChunkQueue> input_run) {
+        _input_run = std::move(input_run);
+    }
+    const std::shared_ptr<pipeline::MemLimitedChunkQueue>& input_run() const { return _input_run; }
+    AnalyticDescriptorQueue& descriptor_queue() { return _descriptor_queue; }
+    // Sink side. False while a stream flush is in flight, while the
+    // sealed-but-unconsumed backlog exceeds its limit, or once the consumer
+    // side closed early (LIMIT).
+    bool store_can_push();
+    Status store_process_chunk(RuntimeState* state, const ChunkPtr& chunk);
+    // Seals the open partition, publishes the last descriptors and closes
+    // both producers. Bounded work with no IO barrier.
+    Status store_finish_input(RuntimeState* state);
+    // Source side. True when a descriptor permit and the covering input rows
+    // can both make progress (a block on disk triggers an async load and
+    // reads as false until loaded). store_pull_chunk() returns nullptr
+    // transiently (flush race, or permit not yet published) and sets
+    // store_eos() at end of stream after verifying the replay accounting.
+    //
+    // allow_share_columns lets a fully authorized chunk go out sharing the
+    // input run's data columns instead of copying them. The caller must only
+    // pass true when nothing will rewrite the returned chunk in place: the
+    // queue hands out the ChunkPtr it stored and an in-flight flush task
+    // serializes those columns outside the queue lock, so any filter or resize
+    // races that serializer (see the comment at the output-building site).
+    bool store_has_output();
+    bool store_eos() const { return _store_eos; }
+    StatusOr<ChunkPtr> store_pull_chunk(RuntimeState* state, bool allow_share_columns);
+
 private:
     Status _prepare_processing_mode(RuntimeState* state, RuntimeProfile* runtime_profile);
     Status _evaluate_const_columns(int i);
@@ -276,6 +400,71 @@ private:
     bool _require_partition_size(const std::string& function_name) {
         return function_name == "cume_dist" || function_name == "percent_rank";
     }
+
+    // ==== Analytic spill — see the comment on tnode_supports_spill ====
+    // Sink-side fields below are owned by the sink driver, source-side fields
+    // by the source driver; neither touches the other's. Everything crossing
+    // the two pipelines flows through the queues (internally synchronized) or
+    // through the atomic counters.
+    struct AnalyticSpillContext {
+        // -- Sink side: open-partition tracking. The open partition's key is
+        // kept as one-row column copies so it survives chunk boundaries.
+        bool has_open_partition = false;
+        int64_t open_partition_rows = 0;
+        MutableColumns last_partition_key;
+        // Sealed-but-unpublished partitions: column 0 holds the row counts,
+        // column 1 + i the one-row results of function i. Flushed into the
+        // descriptor stream before store_process_chunk returns, so a sealed
+        // record is never privately held across scheduling periods (the
+        // source could otherwise starve with no way to trigger a flush).
+        MutableColumns descriptor_builder;
+        size_t builder_records = 0;
+        int64_t builder_rows = 0;
+
+        // -- Source side: replay cursor over the two streams.
+        ChunkPtr descriptor_batch; // current descriptor chunk
+        size_t descriptor_idx = 0; // next record within the batch
+        int64_t out_rows_remaining = 0;
+        bool descriptor_eos = false;
+        bool input_eos = false;
+        ChunkPtr pending_input; // popped but not fully covered by permits
+        size_t pending_offset = 0;
+        int64_t out_rows_total = 0;
+    };
+
+    static constexpr int32_t kOutputConsumerIndex = 0;
+    // Sealed-but-unconsumed backlog limits: bound retained memory/disk when
+    // the source lags; the open partition itself is never throttled. The
+    // rows/partitions limits bound the sealed input payload and the record
+    // count; the bytes limit bounds the descriptor stream's resident memory
+    // (variable-size results make a pure count limit insufficient).
+    static constexpr int64_t kStoreReadyRowsLimit = 1LL << 20;
+    static constexpr int64_t kStoreReadyPartitionsLimit = 1LL << 16;
+    static constexpr int64_t kStoreReadyDescriptorBytesLimit = 16LL << 20;
+
+    Status _store_update_states(const std::vector<Columns>& fn_cols, int64_t frame_start, int64_t frame_end);
+    Status _store_seal_open_partition();
+    Status _store_flush_descriptors();
+    void _store_open_partition(const Columns& part_cols, size_t row);
+    bool _store_row_equals_last_key(const Columns& part_cols, size_t row) const;
+
+    bool _spill_supported = false;
+    bool _is_whole_partition_frame = false;
+    std::shared_ptr<pipeline::MemLimitedChunkQueue> _input_run;
+    AnalyticDescriptorQueue _descriptor_queue;
+    bool _store_eos = false;
+    AnalyticSpillContext _spill_ctx;
+    // Cross-pipeline accounting. The sink publishes, the source consumes;
+    // backpressure reads are relaxed (approximate is fine), the source's EOF
+    // validation reads happen after both queues reported end-of-stream, which
+    // orders them behind the sink's final updates.
+    std::atomic<int64_t> _store_rows_pushed{0};
+    std::atomic<int64_t> _store_rows_published{0};
+    std::atomic<int64_t> _store_partitions_published{0};
+    std::atomic<int64_t> _store_rows_consumed{0};
+    std::atomic<int64_t> _store_partitions_consumed{0};
+    std::atomic<int64_t> _store_descriptor_bytes_published{0};
+    std::atomic<int64_t> _store_descriptor_bytes_consumed{0};
 
     RuntimeState* _state = nullptr;
     bool _is_closed = false;

--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.h
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.h
@@ -23,8 +23,8 @@ namespace starrocks::pipeline {
 class AnalyticSinkOperator : public Operator {
 public:
     AnalyticSinkOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
-                         const TPlanNode& tnode, AnalytorPtr&& analytor)
-            : Operator(factory, id, "analytic_sink", plan_node_id, false, driver_sequence),
+                         const TPlanNode& tnode, AnalytorPtr&& analytor, const char* name = "analytic_sink")
+            : Operator(factory, id, name, plan_node_id, false, driver_sequence),
               _tnode(tnode),
               _analytor(std::move(analytor)) {
         _analytor->ref();
@@ -42,7 +42,7 @@ public:
     StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
     Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
 
-private:
+protected:
     TPlanNode _tnode;
     // It is used to perform analytic algorithms
     // shared by AnalyticSourceOperator
@@ -51,13 +51,11 @@ private:
     bool _is_finished = false;
 };
 
-class AnalyticSinkOperatorFactory final : public OperatorFactory {
+class AnalyticSinkOperatorFactory : public OperatorFactory {
 public:
     AnalyticSinkOperatorFactory(int32_t id, int32_t plan_node_id, const TPlanNode& tnode,
-                                AnalytorFactoryPtr analytor_factory)
-            : OperatorFactory(id, "analytic_sink", plan_node_id),
-              _tnode(tnode),
-              _analytor_factory(std::move(analytor_factory)) {}
+                                AnalytorFactoryPtr analytor_factory, const char* name = "analytic_sink")
+            : OperatorFactory(id, name, plan_node_id), _tnode(tnode), _analytor_factory(std::move(analytor_factory)) {}
 
     ~AnalyticSinkOperatorFactory() override = default;
     bool support_event_scheduler() const override { return true; }
@@ -68,7 +66,7 @@ public:
                                                       std::move(analytor));
     }
 
-private:
+protected:
     TPlanNode _tnode;
     AnalytorFactoryPtr _analytor_factory;
 };

--- a/be/src/exec/pipeline/analysis/analytic_source_operator.h
+++ b/be/src/exec/pipeline/analysis/analytic_source_operator.h
@@ -24,9 +24,8 @@ namespace starrocks::pipeline {
 class AnalyticSourceOperator : public SourceOperator {
 public:
     AnalyticSourceOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
-                           AnalytorPtr&& analytor)
-            : SourceOperator(factory, id, "analytic_source", plan_node_id, false, driver_sequence),
-              _analytor(std::move(analytor)) {
+                           AnalytorPtr&& analytor, const char* name = "analytic_source")
+            : SourceOperator(factory, id, name, plan_node_id, false, driver_sequence), _analytor(std::move(analytor)) {
         _analytor->ref();
     }
     ~AnalyticSourceOperator() override = default;
@@ -42,17 +41,17 @@ public:
 
     StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
 
-private:
+protected:
     // It is used to perform analytic algorithms
     // shared by AnalyticSinkOperator
     AnalytorPtr _analytor = nullptr;
 };
 
-class AnalyticSourceOperatorFactory final : public SourceOperatorFactory {
+class AnalyticSourceOperatorFactory : public SourceOperatorFactory {
 public:
-    AnalyticSourceOperatorFactory(int32_t id, int32_t plan_node_id, AnalytorFactoryPtr analytor_factory)
-            : SourceOperatorFactory(id, "analytic_source", plan_node_id),
-              _analytor_factory(std::move(analytor_factory)) {}
+    AnalyticSourceOperatorFactory(int32_t id, int32_t plan_node_id, AnalytorFactoryPtr analytor_factory,
+                                  const char* name = "analytic_source")
+            : SourceOperatorFactory(id, name, plan_node_id), _analytor_factory(std::move(analytor_factory)) {}
 
     ~AnalyticSourceOperatorFactory() override = default;
     bool support_event_scheduler() const override { return true; }
@@ -62,7 +61,7 @@ public:
         return std::make_shared<AnalyticSourceOperator>(this, _id, _plan_node_id, driver_sequence, std::move(analytor));
     }
 
-private:
+protected:
     AnalytorFactoryPtr _analytor_factory = nullptr;
 };
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/analysis/spillable_analytic_sink_operator.cpp
+++ b/be/src/exec/pipeline/analysis/spillable_analytic_sink_operator.cpp
@@ -1,0 +1,98 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "spillable_analytic_sink_operator.h"
+
+#include "compute_env/query/fragment_runtime_state.h"
+#include "compute_env/query/query_runtime_state.h"
+#include "exec/pipeline/query_context.h"
+#include "gen_cpp/InternalService_types.h"
+#include "runtime/runtime_state.h"
+
+namespace starrocks::pipeline {
+
+Status SpillableAnalyticSinkOperator::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(AnalyticSinkOperator::prepare(state));
+    // Analytor::prepare drops the streams when the plan shape is not eligible.
+    if (_analytor->partition_streams_enabled()) {
+        RETURN_IF_ERROR(_analytor->input_run()->init_metrics(_unique_metrics.get()));
+        _unique_metrics->add_info_string("AnalyticSpill", "true");
+    }
+    return Status::OK();
+}
+
+Status SpillableAnalyticSinkOperator::set_finishing(RuntimeState* state) {
+    if (!_analytor->partition_streams_enabled()) {
+        return AnalyticSinkOperator::set_finishing(state);
+    }
+
+    auto notify = _analytor->defer_notify_source();
+    _is_finished = true;
+
+    if (state->is_cancelled()) {
+        _analytor->descriptor_queue().close_producer();
+        _analytor->input_run()->close_producer();
+        return Status::OK();
+    }
+    // Bounded work, no IO barrier: seal the open partition, publish the last
+    // descriptors and close both producers.
+    return _analytor->store_finish_input(state);
+}
+
+Status SpillableAnalyticSinkOperatorFactory::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(AnalyticSinkOperatorFactory::prepare(state));
+    _state = state;
+    // The memory limit IS the spill policy: force flushes everything, auto
+    // keeps blocks resident up to the threshold. max_unconsumed_bytes must be
+    // unbounded on both streams: the source can only consume rows whose
+    // partition sealed, so an open partition must keep writing (and spilling)
+    // without waiting for consumption — a bounded unconsumed gate would
+    // deadlock on the first partition larger than it. The sealed backlog is
+    // bounded by the analytor's ready-backlog limits instead.
+    _input_run_options.plan_node_id = _plan_node_id;
+    _input_run_options.encode_level = state->spill_encode_level();
+    _input_run_options.block_manager = state->query_runtime_state()->query_spill_manager()->block_manager();
+    _input_run_options.wg = state->fragment_runtime_state()->workgroup();
+    _input_run_options.max_unconsumed_bytes = std::numeric_limits<size_t>::max();
+    if (state->spill_mode() == TSpillMode::FORCE) {
+        _input_run_options.memory_limit = 0;
+    } else {
+        _input_run_options.memory_limit =
+                static_cast<size_t>(state->spill_mem_table_size()) * std::max(1, state->spill_mem_table_num());
+    }
+    // The descriptor side needs no options: it is a dedicated in-memory queue
+    // owned by the analytor (see AnalyticDescriptorQueue) — it only holds
+    // sealed-partition records, which the source can always drain, so its
+    // capacity is the analytor's ready-backlog limits, not a spill policy.
+    return Status::OK();
+}
+
+OperatorPtr SpillableAnalyticSinkOperatorFactory::create(int32_t degree_of_parallelism, int32_t driver_sequence) {
+    auto analytor = _analytor_factory->create(driver_sequence);
+    if (!analytor->partition_streams_enabled()) {
+        auto input_run = std::make_shared<MemLimitedChunkQueue>(_state, 1, _input_run_options);
+        // Register both ends at construction time (single-threaded pipeline
+        // build phase): the source pipeline may poll before the sink
+        // pipeline's prepare runs, and an unopened producer would read as a
+        // premature end-of-stream. The descriptor queue needs no
+        // registration — it is a plain member of the analytor.
+        input_run->open_producer();
+        input_run->open_consumer(0);
+        analytor->set_input_run(std::move(input_run));
+    }
+    return std::make_shared<SpillableAnalyticSinkOperator>(this, _id, _plan_node_id, driver_sequence, _tnode,
+                                                           std::move(analytor));
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/analysis/spillable_analytic_sink_operator.h
+++ b/be/src/exec/pipeline/analysis/spillable_analytic_sink_operator.h
@@ -1,0 +1,75 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "exec/pipeline/analysis/analytic_sink_operator.h"
+#include "exec/pipeline/exchange/mem_limited_chunk_queue.h"
+
+namespace starrocks::pipeline {
+
+// Sink side of the spillable analytic operator (see the analytic-spill comment
+// block in analytor.h). Window states update chunk by chunk, the raw chunks go
+// into the shared input run and every sealed partition publishes a descriptor
+// record; the stream memory limit is the spill policy (force -> 0, auto ->
+// threshold). Backpressure and cold-block flushing are the streams' business;
+// this operator never waits on IO.
+class SpillableAnalyticSinkOperator final : public AnalyticSinkOperator {
+public:
+    SpillableAnalyticSinkOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
+                                  const TPlanNode& tnode, AnalytorPtr&& analytor)
+            : AnalyticSinkOperator(factory, id, plan_node_id, driver_sequence, tnode, std::move(analytor),
+                                   "spillable_analytic_sink") {}
+    ~SpillableAnalyticSinkOperator() override = default;
+
+    Status prepare(RuntimeState* state) override;
+
+    bool need_input() const override {
+        if (!AnalyticSinkOperator::need_input()) {
+            return false;
+        }
+        // False while a stream flush is in flight (completion is observed by
+        // the next poll), while the sealed-but-unconsumed backlog exceeds its
+        // limit, or once the consumer side closed early (LIMIT).
+        if (_analytor->partition_streams_enabled() && !_analytor->store_can_push()) {
+            return false;
+        }
+        return true;
+    }
+
+    Status set_finishing(RuntimeState* state) override;
+};
+
+class SpillableAnalyticSinkOperatorFactory final : public AnalyticSinkOperatorFactory {
+public:
+    SpillableAnalyticSinkOperatorFactory(int32_t id, int32_t plan_node_id, const TPlanNode& tnode,
+                                         AnalytorFactoryPtr analytor_factory)
+            : AnalyticSinkOperatorFactory(id, plan_node_id, tnode, std::move(analytor_factory),
+                                          "spillable_analytic_sink") {}
+    ~SpillableAnalyticSinkOperatorFactory() override = default;
+
+    // The run store has no event-scheduler wakeups for can_push/can_pop; the
+    // polling scheduler drives these pipelines.
+    bool support_event_scheduler() const override { return false; }
+
+    Status prepare(RuntimeState* state) override;
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override;
+
+private:
+    RuntimeState* _state = nullptr;
+    MemLimitedChunkQueue::Options _input_run_options;
+};
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/analysis/spillable_analytic_source_operator.cpp
+++ b/be/src/exec/pipeline/analysis/spillable_analytic_source_operator.cpp
@@ -58,12 +58,10 @@ StatusOr<ChunkPtr> SpillableAnalyticSourceOperator::pull_chunk(RuntimeState* sta
     // never drops it, whereas runtime_in_filters() is rebound (and cleared) by
     // set_precondition_ready -- once a filter has appeared, keep copying.
     const auto* bloom_filters = _runtime_access->get_runtime_bloom_filters();
-    _output_may_be_filtered |= !runtime_in_filters().empty() ||
-                               (bloom_filters != nullptr && !bloom_filters->empty()) ||
+    _output_may_be_filtered |= !runtime_in_filters().empty() || (bloom_filters != nullptr && !bloom_filters->empty()) ||
                                !_runtime_access->get_filter_null_value_columns().empty();
 
-    ASSIGN_OR_RETURN(auto chunk,
-                     _analytor->store_pull_chunk(state, /*allow_share_columns=*/!_output_may_be_filtered));
+    ASSIGN_OR_RETURN(auto chunk, _analytor->store_pull_chunk(state, /*allow_share_columns=*/!_output_may_be_filtered));
     if (chunk != nullptr && !chunk->is_empty()) {
         [[maybe_unused]] const size_t rows_before = chunk->num_rows();
         eval_runtime_bloom_filters(chunk.get());

--- a/be/src/exec/pipeline/analysis/spillable_analytic_source_operator.cpp
+++ b/be/src/exec/pipeline/analysis/spillable_analytic_source_operator.cpp
@@ -1,0 +1,77 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "spillable_analytic_source_operator.h"
+
+#include "exec/pipeline/exchange/mem_limited_chunk_queue.h"
+
+namespace starrocks::pipeline {
+
+void SpillableAnalyticSourceOperator::close(RuntimeState* state) {
+    if (_analytor->partition_streams_enabled()) {
+        _analytor->descriptor_queue().close_consumer();
+        _analytor->input_run()->close_consumer(0);
+    }
+    AnalyticSourceOperator::close(state);
+}
+
+bool SpillableAnalyticSourceOperator::has_output() const {
+    if (!_analytor->partition_streams_enabled()) {
+        return AnalyticSourceOperator::has_output();
+    }
+    // No sink-complete barrier: a descriptor is the read permit for its rows,
+    // so this operator streams the sealed prefix while the sink keeps
+    // producing. A permit and the covering input rows must both make
+    // progress: resident -> true; on disk -> async load submitted, false
+    // until loaded; drained -> true (pop returns EndOfFile); IO error ->
+    // true (surfaces through pull).
+    return _analytor->store_has_output();
+}
+
+bool SpillableAnalyticSourceOperator::is_finished() const {
+    if (!_analytor->partition_streams_enabled()) {
+        return AnalyticSourceOperator::is_finished();
+    }
+    return _analytor->store_eos() || _analytor->reached_limit() || _analytor->is_finished();
+}
+
+StatusOr<ChunkPtr> SpillableAnalyticSourceOperator::pull_chunk(RuntimeState* state) {
+    if (!_analytor->partition_streams_enabled()) {
+        return AnalyticSourceOperator::pull_chunk(state);
+    }
+    // A fully authorized chunk is replayed by sharing the input run's data
+    // columns, which the queue and an in-flight flush task still reference. The
+    // eval_* calls below filter in place, so sharing is only safe while this
+    // operator has nothing to filter with. The flag is sticky because
+    // eval_conjuncts_and_in_filters caches its predicate list on first use and
+    // never drops it, whereas runtime_in_filters() is rebound (and cleared) by
+    // set_precondition_ready -- once a filter has appeared, keep copying.
+    const auto* bloom_filters = _runtime_access->get_runtime_bloom_filters();
+    _output_may_be_filtered |= !runtime_in_filters().empty() ||
+                               (bloom_filters != nullptr && !bloom_filters->empty()) ||
+                               !_runtime_access->get_filter_null_value_columns().empty();
+
+    ASSIGN_OR_RETURN(auto chunk,
+                     _analytor->store_pull_chunk(state, /*allow_share_columns=*/!_output_may_be_filtered));
+    if (chunk != nullptr && !chunk->is_empty()) {
+        [[maybe_unused]] const size_t rows_before = chunk->num_rows();
+        eval_runtime_bloom_filters(chunk.get());
+        RETURN_IF_ERROR(eval_conjuncts_and_in_filters({}, chunk.get()));
+        DCHECK(_output_may_be_filtered || chunk->num_rows() == rows_before)
+                << "a replay chunk sharing the input run's columns must not be filtered in place";
+    }
+    return chunk;
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/analysis/spillable_analytic_source_operator.h
+++ b/be/src/exec/pipeline/analysis/spillable_analytic_source_operator.h
@@ -1,0 +1,65 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "exec/pipeline/analysis/analytic_source_operator.h"
+
+namespace starrocks::pipeline {
+
+// Source side of the spillable analytic operator: pops the raw chunks back
+// from the shared input run in arrival order, authorizes them against the
+// sealed-partition descriptors and attaches the per-partition window results.
+// The streams' can_pop gates has_output, so blocks flushed to disk are
+// prefetched asynchronously and this operator never waits on IO.
+class SpillableAnalyticSourceOperator final : public AnalyticSourceOperator {
+public:
+    SpillableAnalyticSourceOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
+                                    AnalytorPtr&& analytor)
+            : AnalyticSourceOperator(factory, id, plan_node_id, driver_sequence, std::move(analytor),
+                                     "spillable_analytic_source") {}
+    ~SpillableAnalyticSourceOperator() override = default;
+
+    void close(RuntimeState* state) override;
+
+    bool has_output() const override;
+    bool is_finished() const override;
+
+    StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
+
+private:
+    // Sticky: set once this operator has a conjunct / runtime filter that would
+    // rewrite the output chunk in place, which forbids the zero-copy replay.
+    bool _output_may_be_filtered = false;
+};
+
+class SpillableAnalyticSourceOperatorFactory final : public AnalyticSourceOperatorFactory {
+public:
+    SpillableAnalyticSourceOperatorFactory(int32_t id, int32_t plan_node_id, AnalytorFactoryPtr analytor_factory)
+            : AnalyticSourceOperatorFactory(id, plan_node_id, std::move(analytor_factory),
+                                            "spillable_analytic_source") {}
+    ~SpillableAnalyticSourceOperatorFactory() override = default;
+
+    // See SpillableAnalyticSinkOperatorFactory: the run store has no
+    // event-scheduler wakeups, the polling scheduler drives these pipelines.
+    bool support_event_scheduler() const override { return false; }
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
+        auto analytor = _analytor_factory->create(driver_sequence);
+        return std::make_shared<SpillableAnalyticSourceOperator>(this, _id, _plan_node_id, driver_sequence,
+                                                                 std::move(analytor));
+    }
+};
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.cpp
+++ b/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.cpp
@@ -131,6 +131,11 @@ Status MemLimitedChunkQueue::push(const ChunkPtr& chunk) {
 }
 
 bool MemLimitedChunkQueue::can_push() {
+    // An asynchronous flush failure must surface instead of reading as "not
+    // ready" forever: report ready so the next push returns the error.
+    if (UNLIKELY(!_get_io_task_status().ok())) {
+        return true;
+    }
     std::shared_lock l(_mutex);
     size_t unconsumed_bytes = _total_accumulated_bytes - _fastest_accumulated_bytes;
     // if the fastest consumer still has a lot of data to consume, it will no longer accept new input.
@@ -219,6 +224,12 @@ void MemLimitedChunkQueue::_evict_loaded_block() {
 
 bool MemLimitedChunkQueue::can_pop(int32_t consumer_index) {
     DCHECK(consumer_index < _consumer_number);
+    // See can_push: a failed load task would otherwise leave has_load_task
+    // set and this consumer not-ready forever; report ready so the next pop
+    // returns the error.
+    if (UNLIKELY(!_get_io_task_status().ok())) {
+        return true;
+    }
     std::shared_lock l(_mutex);
     DCHECK(_consumer_progress[consumer_index] != nullptr);
 

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -401,6 +401,7 @@ public:
         return spillable_operator_mask() & (1LL << TSpillableOperatorType::AGG_DISTINCT);
     }
     bool enable_sort_spill() const { return spillable_operator_mask() & (1LL << TSpillableOperatorType::SORT); }
+    bool enable_analytic_spill() const { return spillable_operator_mask() & (1LL << TSpillableOperatorType::ANALYTIC); }
     bool enable_nl_join_spill() const { return spillable_operator_mask() & (1LL << TSpillableOperatorType::NL_JOIN); }
     bool enable_multi_cast_local_exchange_spill() const {
         return spillable_operator_mask() & (1LL << TSpillableOperatorType::MULTI_CAST_LOCAL_EXCHANGE);

--- a/be/test/exec/analytor_test.cpp
+++ b/be/test/exec/analytor_test.cpp
@@ -125,4 +125,113 @@ TEST_F(AnalytorTest, find_partition_end) {
     ASSERT_EQ(analytor3._partition.end, 0);
 }
 
+namespace {
+TExpr make_window_function(const std::string& name,
+                           TFunctionBinaryType::type binary_type = TFunctionBinaryType::BUILTIN,
+                           TPrimitiveType::type ret_type = TPrimitiveType::BIGINT) {
+    TFunctionName fn_name;
+    fn_name.__set_function_name(name);
+    TFunction fn;
+    fn.__set_name(fn_name);
+    fn.__set_binary_type(binary_type);
+    TScalarType scalar_type;
+    scalar_type.__set_type(ret_type);
+    if (ret_type == TPrimitiveType::VARCHAR) {
+        scalar_type.__set_len(10);
+    }
+    TTypeNode type_node;
+    type_node.__set_type(TTypeNodeType::SCALAR);
+    type_node.__set_scalar_type(scalar_type);
+    TTypeDesc ret;
+    ret.types.push_back(type_node);
+    fn.__set_ret_type(ret);
+    TExprNode node;
+    node.__set_fn(fn);
+    TExpr expr;
+    expr.nodes.push_back(node);
+    return expr;
+}
+
+TPlanNode make_analytic_plan_node(const std::vector<TExpr>& functions) {
+    TAnalyticNode analytic_node;
+    analytic_node.__set_analytic_functions(functions);
+    TPlanNode plan_node;
+    plan_node.__set_analytic_node(analytic_node);
+    return plan_node;
+}
+} // namespace
+
+// NOLINTNEXTLINE
+TEST_F(AnalytorTest, tnode_supports_spill_frames) {
+    // No window clause: frame is the whole partition, eligible.
+    TPlanNode plan_node = make_analytic_plan_node({make_window_function("sum")});
+    ASSERT_TRUE(Analytor::tnode_supports_spill(plan_node));
+
+    // Window clause with neither bound set (UNBOUNDED ~ UNBOUNDED): eligible.
+    TAnalyticWindow window;
+    window.__set_type(TAnalyticWindowType::ROWS);
+    plan_node.analytic_node.__set_window(window);
+    ASSERT_TRUE(Analytor::tnode_supports_spill(plan_node));
+
+    // Any explicit bound makes the frame non-whole-partition: not eligible.
+    TAnalyticWindowBoundary window_start;
+    window_start.__set_type(TAnalyticWindowBoundaryType::PRECEDING);
+    plan_node.analytic_node.window.__set_window_start(window_start);
+    ASSERT_FALSE(Analytor::tnode_supports_spill(plan_node));
+}
+
+// NOLINTNEXTLINE
+TEST_F(AnalytorTest, tnode_supports_spill_functions) {
+    // Whitelisted aggregates over the whole-partition frame are eligible.
+    for (const auto& name : {"sum", "avg", "count", "max", "min", "first_value", "last_value"}) {
+        TPlanNode plan_node = make_analytic_plan_node({make_window_function(name)});
+        ASSERT_TRUE(Analytor::tnode_supports_spill(plan_node)) << name;
+    }
+
+    // Rank-family / partition-size / offset functions are not.
+    for (const auto& name : {"ntile", "cume_dist", "percent_rank", "rank", "row_number", "lead", "lag"}) {
+        TPlanNode plan_node = make_analytic_plan_node({make_window_function(name)});
+        ASSERT_FALSE(Analytor::tnode_supports_spill(plan_node)) << name;
+    }
+
+    // One ineligible function disqualifies the whole node.
+    TPlanNode plan_node = make_analytic_plan_node({make_window_function("sum"), make_window_function("ntile")});
+    ASSERT_FALSE(Analytor::tnode_supports_spill(plan_node));
+
+    // Non-builtin (UDAF) functions are not eligible.
+    plan_node = make_analytic_plan_node({make_window_function("sum", TFunctionBinaryType::SRJAR)});
+    ASSERT_FALSE(Analytor::tnode_supports_spill(plan_node));
+
+    // Variable-size result types are eligible too (append-only result
+    // columns); their per-partition results stay resident until pass 2
+    // completes — the per-session opt-out is the ANALYTIC mask bit.
+    plan_node = make_analytic_plan_node(
+            {make_window_function("max", TFunctionBinaryType::BUILTIN, TPrimitiveType::VARCHAR)});
+    ASSERT_TRUE(Analytor::tnode_supports_spill(plan_node));
+}
+
+// NOLINTNEXTLINE
+TEST_F(AnalytorTest, whole_partition_frame_flag) {
+    // Mirrors the constructor sites that mark _is_whole_partition_frame.
+    TPlanNode plan_node = make_analytic_plan_node({make_window_function("sum")});
+    Analytor no_window(plan_node, nullptr, false);
+    ASSERT_TRUE(no_window._is_whole_partition_frame);
+    ASSERT_TRUE(no_window._need_partition_materializing);
+
+    TAnalyticWindow window;
+    window.__set_type(TAnalyticWindowType::ROWS);
+    plan_node.analytic_node.__set_window(window);
+    Analytor unbounded_rows(plan_node, nullptr, false);
+    ASSERT_TRUE(unbounded_rows._is_whole_partition_frame);
+
+    TAnalyticWindowBoundary window_start;
+    window_start.__set_type(TAnalyticWindowBoundaryType::CURRENT_ROW);
+    plan_node.analytic_node.window.__set_window_start(window_start);
+    TAnalyticWindowBoundary window_end;
+    window_end.__set_type(TAnalyticWindowBoundaryType::CURRENT_ROW);
+    plan_node.analytic_node.window.__set_window_end(window_end);
+    Analytor bounded(plan_node, nullptr, false);
+    ASSERT_FALSE(bounded._is_whole_partition_frame);
+}
+
 } // namespace starrocks

--- a/docs/en/administration/management/BE_parameters/query_loading.md
+++ b/docs/en/administration/management/BE_parameters/query_loading.md
@@ -467,6 +467,15 @@ This topic introduces the following types of BE configurations:
 - Description: The time interval at which GC cleans expired data.
 - Introduced in: -
 
+### pipeline_analytic_enable_spill
+
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether the analytic (window) operator is allowed to spill. Only takes effect for materializing whole-partition frames (for example `SUM(x) OVER (PARTITION BY k)` without a window clause) over the built-in aggregate functions `sum`, `avg`, `count`, `min`, `max`, `first_value`, and `last_value`, and requires the session to enable spilling via `enable_spill`. Only the buffered input rows are spilled; per-partition results stay in memory, bounded by a fixed backlog limit.
+- Introduced in: -
+
 ### pipeline_connector_scan_thread_num_per_cpu
 
 - Default: 8

--- a/docs/ja/administration/management/BE_parameters/query_loading.md
+++ b/docs/ja/administration/management/BE_parameters/query_loading.md
@@ -459,6 +459,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 説明: GCが期限切れのデータをクリーンアップする時間間隔。
 - 導入バージョン: -
 
+### pipeline_analytic_enable_spill
+
+- デフォルト: false
+- タイプ: ブール
+- 単位: -
+- 変更可能: はい
+- 説明: 分析（ウィンドウ）オペレーターにスピルを許可するかどうか。ウィンドウ句のないパーティション全体のフレーム（例: `SUM(x) OVER (PARTITION BY k)`）にのみ適用され、セッションが `enable_spill` でスピルを有効にしている場合に有効になります。
+- 導入バージョン: -
+
 ### pipeline_connector_scan_thread_num_per_cpu
 
 - デフォルト: 8

--- a/docs/zh/administration/management/BE_parameters/query_loading.md
+++ b/docs/zh/administration/management/BE_parameters/query_loading.md
@@ -455,6 +455,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 描述：GC 线程清理过期数据的间隔时间。
 - 引入版本：-
 
+### pipeline_analytic_enable_spill
+
+- 默认值：false
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：是否允许窗口（analytic）算子落盘。仅对整分区帧的物化窗口（例如不带 window 子句的 `SUM(x) OVER (PARTITION BY k)`，函数限内置的 sum/avg/count/min/max/first_value/last_value）生效，需要会话开启 `enable_spill`。仅原始输入行参与落盘；各分区结果常驻内存，总量受固定积压上限约束。
+- 引入版本：-
+
 ### pipeline_connector_scan_thread_num_per_cpu
 
 - 默认值：8

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1761,6 +1761,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // if spillable_operator_mask & 4 != 0, agg distinct operator can spill
     // if spillable_operator_mask & 8 != 0, sort operator can spill
     // if spillable_operator_mask & 16 != 0, nest loop join operator can spill
+    // if spillable_operator_mask & 64 != 0, analytic (window) operator can spill
     // ...
     // default value is -1, means all operators can spill
     @VariableMgr.VarAttr(name = SPILLABLE_OPERATOR_MASK, flag = VariableMgr.INVISIBLE)

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -120,6 +120,7 @@ enum TSpillableOperatorType {
   SORT = 3;
   NL_JOIN = 4;
   MULTI_CAST_LOCAL_EXCHANGE = 5;
+  ANALYTIC = 6;
 }
 
 enum TTabletInternalParallelMode {

--- a/test/sql/test_spill/R/test_spill_analytic
+++ b/test/sql/test_spill/R/test_spill_analytic
@@ -1,0 +1,192 @@
+-- name: test_spill_analytic
+update information_schema.be_configs set value = "true" where name = "pipeline_analytic_enable_spill";
+-- result:
+-- !result
+drop table if exists t_wpa;
+-- result:
+-- !result
+create table t_wpa (dt int, x bigint) duplicate key(dt) distributed by hash(dt) buckets 4 properties('replication_num' = '1');
+-- result:
+-- !result
+insert into t_wpa select generate_series % 7, generate_series from TABLE(generate_series(1, 2000000));
+-- result:
+-- !result
+insert into t_wpa values (0, null), (7, null), (7, 1);
+-- result:
+-- !result
+select count(*) from t_wpa;
+-- result:
+2000003
+-- !result
+set enable_spill=true;
+-- result:
+-- !result
+set spill_mode="force";
+-- result:
+-- !result
+set pipeline_dop=2;
+-- result:
+-- !result
+set spill_mem_table_size=1048576;
+-- result:
+-- !result
+select dt, count(*) cnt, min(s) mn, max(s) mx from (select dt, sum(x) over (partition by dt) s from t_wpa) w group by dt order by dt;
+-- result:
+0	285715	285714714285	285714714285
+1	285715	285715000000	285715000000
+2	285715	285715285715	285715285715
+3	285714	285713571429	285713571429
+4	285714	285713857143	285713857143
+5	285714	285714142857	285714142857
+6	285714	285714428571	285714428571
+7	2	1	1
+-- !result
+select count(c), min(c), max(c) from (select count(*) over (partition by dt) c from t_wpa) w;
+-- result:
+2000003	2	285715
+-- !result
+select dt, min(c) mnc, max(c) mxc, min(a) mna, max(a) mxa from (select dt, count(x) over (partition by dt) c, avg(x) over (partition by dt) a from t_wpa) w group by dt order by dt;
+-- result:
+0	285714	285714	1000002.5	1000002.5
+1	285715	285715	1000000.0	1000000.0
+2	285715	285715	1000001.0	1000001.0
+3	285714	285714	999998.5	999998.5
+4	285714	285714	999999.5	999999.5
+5	285714	285714	1000000.5	1000000.5
+6	285714	285714	1000001.5	1000001.5
+7	1	1	1.0	1.0
+-- !result
+select dt, min(s) mn, max(s) mx from (select dt, sum(x) over (partition by dt order by x rows between unbounded preceding and unbounded following) s from t_wpa) w group by dt order by dt;
+-- result:
+0	285714714285	285714714285
+1	285715000000	285715000000
+2	285715285715	285715285715
+3	285713571429	285713571429
+4	285713857143	285713857143
+5	285714142857	285714142857
+6	285714428571	285714428571
+7	1	1
+-- !result
+select dt, min(f) mnf, max(l) mxl from (select dt, first_value(x) over (partition by dt order by x rows between unbounded preceding and unbounded following) f, last_value(x) over (partition by dt order by x rows between unbounded preceding and unbounded following) l from t_wpa) w group by dt order by dt;
+-- result:
+0	None	1999998
+1	1	1999999
+2	2	2000000
+3	3	1999994
+4	4	1999995
+5	5	1999996
+6	6	1999997
+7	None	1
+-- !result
+select count(s), min(s), max(s) from (select sum(x) over () s from t_wpa) w;
+-- result:
+2000003	2000001000001	2000001000001
+-- !result
+select count(*) from (select dt, max(s) mx from (select dt, sum(x) over (partition by dt) s from t_wpa) w group by dt) a join (select dt, sum(x) ss from t_wpa group by dt) b on a.dt = b.dt and a.mx <=> b.ss;
+-- result:
+8
+-- !result
+select count(*) from (select s from (select sum(x) over (partition by dt) s from t_wpa) w limit 10) t;
+-- result:
+10
+-- !result
+select k, min(c) mnc, max(m) mxm from (select cast(dt as string) k, count(*) over (partition by cast(dt as string)) c, max(cast(x as string)) over (partition by cast(dt as string)) m from t_wpa) w group by k order by k;
+-- result:
+0	285715	999999
+1	285715	999993
+2	285715	999994
+3	285714	999995
+4	285714	999996
+5	285714	999997
+6	285714	999998
+7	2	1
+-- !result
+set spill_mode="auto";
+-- result:
+-- !result
+select dt, count(*) cnt, min(s) mn from (select dt, sum(x) over (partition by dt) s from t_wpa) w group by dt order by dt;
+-- result:
+0	285715	285714714285
+1	285715	285715000000
+2	285715	285715285715
+3	285714	285713571429
+4	285714	285713857143
+5	285714	285714142857
+6	285714	285714428571
+7	2	1
+-- !result
+drop table if exists t_wpa_skew;
+-- result:
+-- !result
+create table t_wpa_skew (dt int, x bigint) duplicate key(dt) distributed by hash(dt) buckets 1 properties('replication_num' = '1');
+-- result:
+-- !result
+insert into t_wpa_skew select 1, generate_series from TABLE(generate_series(1, 10));
+-- result:
+-- !result
+insert into t_wpa_skew select 2, generate_series from TABLE(generate_series(1, 10));
+-- result:
+-- !result
+insert into t_wpa_skew select 3, generate_series from TABLE(generate_series(1, 10));
+-- result:
+-- !result
+insert into t_wpa_skew select 9, generate_series from TABLE(generate_series(1, 2000000));
+-- result:
+-- !result
+set pipeline_dop=1;
+-- result:
+-- !result
+select dt, count(*) cnt, min(s) mn, max(s) mx from (select dt, sum(x) over (partition by dt) s from t_wpa_skew) w group by dt order by dt;
+-- result:
+1	10	55	55
+2	10	55	55
+3	10	55	55
+9	2000000	2000001000000	2000001000000
+-- !result
+select dt, count(*) cnt, sum(x) ss from t_wpa_skew group by dt order by dt;
+-- result:
+1	10	55
+2	10	55
+3	10	55
+9	2000000	2000001000000
+-- !result
+set spillable_operator_mask = -65;
+-- result:
+-- !result
+select dt, count(*) cnt, min(s) mn, max(s) mx from (select dt, sum(x) over (partition by dt) s from t_wpa_skew) w group by dt order by dt;
+-- result:
+1	10	55	55
+2	10	55	55
+3	10	55	55
+9	2000000	2000001000000	2000001000000
+-- !result
+set spillable_operator_mask = -1;
+-- result:
+-- !result
+update information_schema.be_configs set value = "false" where name = "pipeline_analytic_enable_spill";
+-- result:
+-- !result
+select dt, count(*) cnt, min(s) mn from (select dt, sum(x) over (partition by dt) s from t_wpa) w group by dt order by dt;
+-- result:
+0	285715	285714714285
+1	285715	285715000000
+2	285715	285715285715
+3	285714	285713571429
+4	285714	285713857143
+5	285714	285714142857
+6	285714	285714428571
+7	2	1
+-- !result
+select dt, count(*) cnt, min(s) mn, max(s) mx from (select dt, sum(x) over (partition by dt) s from t_wpa_skew) w group by dt order by dt;
+-- result:
+1	10	55	55
+2	10	55	55
+3	10	55	55
+9	2000000	2000001000000	2000001000000
+-- !result
+drop table t_wpa;
+-- result:
+-- !result
+drop table t_wpa_skew;
+-- result:
+-- !result

--- a/test/sql/test_spill/T/test_spill_analytic
+++ b/test/sql/test_spill/T/test_spill_analytic
@@ -1,0 +1,65 @@
+-- name: test_spill_analytic
+-- NOTE: pipeline_analytic_enable_spill is the cluster-wide kill switch (a BE
+-- config); the per-session opt-out is the ANALYTIC bit of spillable_operator_mask.
+-- The config is flipped on here and restored at the end. If the case aborts
+-- midway the config may be left enabled, which only widens the feature's
+-- eligibility and never changes query results.
+update information_schema.be_configs set value = "true" where name = "pipeline_analytic_enable_spill";
+drop table if exists t_wpa;
+create table t_wpa (dt int, x bigint) duplicate key(dt) distributed by hash(dt) buckets 4 properties('replication_num' = '1');
+insert into t_wpa select generate_series % 7, generate_series from TABLE(generate_series(1, 2000000));
+insert into t_wpa values (0, null), (7, null), (7, 1);
+select count(*) from t_wpa;
+set enable_spill=true;
+set spill_mode="force";
+set pipeline_dop=2;
+-- Shrink the mem table BEFORE the forced-spill queries: at the default 100MB a
+-- single mem table swallows this data set whole, so every query below would flush
+-- exactly once and the multi-block replay, the writer-full backpressure and the
+-- staging rollover would all stay dead code.
+set spill_mem_table_size=1048576;
+-- whole-partition sum under force spill
+select dt, count(*) cnt, min(s) mn, max(s) mx from (select dt, sum(x) over (partition by dt) s from t_wpa) w group by dt order by dt;
+-- count(*): input slot without an input expression
+select count(c), min(c), max(c) from (select count(*) over (partition by dt) c from t_wpa) w;
+-- multiple functions incl. nullable avg
+select dt, min(c) mnc, max(c) mxc, min(a) mna, max(a) mxa from (select dt, count(x) over (partition by dt) c, avg(x) over (partition by dt) a from t_wpa) w group by dt order by dt;
+-- explicit UNBOUNDED..UNBOUNDED frame with order by
+select dt, min(s) mn, max(s) mx from (select dt, sum(x) over (partition by dt order by x rows between unbounded preceding and unbounded following) s from t_wpa) w group by dt order by dt;
+-- first_value/last_value over a deterministic frame
+select dt, min(f) mnf, max(l) mxl from (select dt, first_value(x) over (partition by dt order by x rows between unbounded preceding and unbounded following) f, last_value(x) over (partition by dt order by x rows between unbounded preceding and unbounded following) l from t_wpa) w group by dt order by dt;
+-- global window without partition by
+select count(s), min(s), max(s) from (select sum(x) over () s from t_wpa) w;
+-- spilled window results must agree with group by aggregation (8 partitions)
+select count(*) from (select dt, max(s) mx from (select dt, sum(x) over (partition by dt) s from t_wpa) w group by dt) a join (select dt, sum(x) ss from t_wpa group by dt) b on a.dt = b.dt and a.mx <=> b.ss;
+-- limit triggers downstream early finish of the spilling sink
+select count(*) from (select s from (select sum(x) over (partition by dt) s from t_wpa) w limit 10) t;
+-- varchar partition key and string result column (append-only result columns)
+select k, min(c) mnc, max(m) mxm from (select cast(dt as string) k, count(*) over (partition by cast(dt as string)) c, max(cast(x as string)) over (partition by cast(dt as string)) m from t_wpa) w group by k order by k;
+-- auto mode on a balanced data set: conversion happens inside the first partition
+set spill_mode="auto";
+select dt, count(*) cnt, min(s) mn from (select dt, sum(x) over (partition by dt) s from t_wpa) w group by dt order by dt;
+-- Skewed shape the feature exists for: several tiny partitions are emitted (and
+-- evicted) first, then one huge partition crosses the activation threshold. This
+-- only spills if auto activation can convert mid-stream.
+drop table if exists t_wpa_skew;
+create table t_wpa_skew (dt int, x bigint) duplicate key(dt) distributed by hash(dt) buckets 1 properties('replication_num' = '1');
+insert into t_wpa_skew select 1, generate_series from TABLE(generate_series(1, 10));
+insert into t_wpa_skew select 2, generate_series from TABLE(generate_series(1, 10));
+insert into t_wpa_skew select 3, generate_series from TABLE(generate_series(1, 10));
+insert into t_wpa_skew select 9, generate_series from TABLE(generate_series(1, 2000000));
+set pipeline_dop=1;
+select dt, count(*) cnt, min(s) mn, max(s) mx from (select dt, sum(x) over (partition by dt) s from t_wpa_skew) w group by dt order by dt;
+-- the same numbers computed without any window function
+select dt, count(*) cnt, sum(x) ss from t_wpa_skew group by dt order by dt;
+-- per-session opt-out: clearing the ANALYTIC bit (64) of the mask (-1 & ~64)
+-- keeps agg/join/sort spill enabled and forces this query onto the in-memory path
+set spillable_operator_mask = -65;
+select dt, count(*) cnt, min(s) mn, max(s) mx from (select dt, sum(x) over (partition by dt) s from t_wpa_skew) w group by dt order by dt;
+set spillable_operator_mask = -1;
+-- the in-memory path with the feature disabled must agree
+update information_schema.be_configs set value = "false" where name = "pipeline_analytic_enable_spill";
+select dt, count(*) cnt, min(s) mn from (select dt, sum(x) over (partition by dt) s from t_wpa) w group by dt order by dt;
+select dt, count(*) cnt, min(s) mn, max(s) mx from (select dt, sum(x) over (partition by dt) s from t_wpa_skew) w group by dt order by dt;
+drop table t_wpa;
+drop table t_wpa_skew;


### PR DESCRIPTION
## Why I am doing:

The analytic (window) operator is the last blocking operator in StarRocks without spill support. Materializing whole-partition frames (e.g. `SUM(x) OVER (PARTITION BY k)`) must keep every row of the current window partition resident until the partition closes, so a single huge partition (skewed key) fails the query with `Memory limit exceeded` regardless of configuration — `enable_spill` rescues agg/sort/join, but not analytic.

## What I am doing:

Add a spillable execution path for eligible analytic nodes, selected at plan-decompose time (single path, no runtime mode conversion):

**Eligibility** (all required): BE config `pipeline_analytic_enable_spill` (new, default `false`) + session `enable_spill` + the `ANALYTIC` bit of `spillable_operator_mask` (new thrift enum value) + whole-partition frames only + built-in `sum` / `avg` / `count` / `min` / `max` / `first_value` / `last_value`. Non-eligible nodes keep the original operators, unchanged behavior.

**Execution** — two cooperating sequential passes over a shared store:
- **pass-1 (sink)**: evaluates expressions once per chunk into transient columns and folds them incrementally into one reused agg state row — the O(partition) evaluated columns of the in-memory path are *eliminated*, not spilled. Raw input chunks go into a spillable FIFO (reusing `MemLimitedChunkQueue`; `memory_limit` **is** the spill policy: `force` → 0, `auto` → `spill_mem_table_size × spill_mem_table_num`). Each sealed partition publishes a descriptor (row count + one finalized value per function) through a small in-memory queue.
- **pass-2 (source)**: a descriptor is the read permit for its rows. The source replays the sealed prefix concurrently with the sink (no sink-complete barrier — first-row latency matches the in-memory path), attaches per-partition constants as result columns (zero-copy for fully authorized chunks when no in-place filtering can occur), and releases consumed blocks / descriptor batches eagerly.

**Bounded resources**: the sealed-but-unconsumed backlog is capped by three limits (2^20 rows / 2^16 partitions / 16MB descriptor bytes) feeding the sink `need_input()`; the open partition is never throttled by consumption (it spills through the queue memory limit instead), avoiding the producer/consumer/seal deadlock triangle. Agg state is O(1) per driver by construction and never spills.

**Correctness guards**: five `InternalError` reconciliation checks over the two-stream accounting (rows pushed/published/replayed, partitions, descriptor bytes) turn any protocol violation into an explicit error instead of silently wrong results.

**Common component fix**: `MemLimitedChunkQueue::can_push()/can_pop()` now report ready after an async flush/load failure, so the next push/pop surfaces the IO error instead of the operator polling not-ready forever (also benefits spillable multicast local exchange).

## Validation

- `be/test/exec/analytor_test.cpp`: eligibility whitelist (frames and functions), whole-partition-frame flag.
- SQL `test/sql/test_spill/test_spill_analytic` (force + auto, dop 2, 1MB mem table so multi-block replay and writer backpressure are exercised): whole-partition `sum` / `count(*)` / `count(x)` / `avg` / `first_value` / `last_value` / `max` with varchar result, explicit `UNBOUNDED..UNBOUNDED` frames, global window without PARTITION BY, varchar partition keys, LIMIT early-stop, per-session mask opt-out; results cross-checked against the non-spill path and group-by aggregation. Skewed shape (3 tiny partitions then one 2M-row partition, auto mode) exercises mid-stream spilling.
- All changed BE translation units pass `-fsyntax-only` revalidation.

## Remaining test TODO (why this is a draft)

- SQL: `min` as a window function; auto-mode coverage beyond `sum`; NULL partition keys; a high-cardinality shape (1e5+ partitions) to exercise descriptor batching and the backlog limits.
- UT: pass-1 boundary scan; pass-2 replay cursor (partition spanning chunks / alignment / overrun); `AnalyticDescriptorQueue` semantics; `MemLimitedChunkQueue` error-aware readiness.
- Fault injection via existing `TEST_SYNC_POINT`s (flush/load failure, can_pop→pop flush race).

Known follow-ups (tracked, not blocking): pass-1 partition boundary detection is a per-row linear scan (should reuse the binary search of the in-memory path); descriptor batch splitting is record-count-only (a single batch of var-size results can overshoot the byte limit once); the operator does not yet implement `spillable()` / `set_execute_mode()` for the query-level memory arbitration.

Fixes #N/A

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: new optional execution path, disabled by default; query results are identical when enabled

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qtf8iL4ttJ3LnieEddDRRH