### PR TITLE
[BugFix] Fix compaction read chunk size estimation

### DIFF
--- a/be/src/storage/horizontal_compaction_task.cpp
+++ b/be/src/storage/horizontal_compaction_task.cpp
@@ -82,9 +82,9 @@ Status HorizontalCompactionTask::_horizontal_compact_data(Statistics* statistics
     for (const auto& rowset : _input_rowsets) {
         total_mem_footprint += rowset->total_row_size();
     }
-    int32_t chunk_size = CompactionUtils::get_read_chunk_size(
-            config::compaction_memory_limit_per_worker, config::vector_chunk_size, _task_info.input_rows_num,
-            total_mem_footprint, _task_info.segment_iterator_num);
+    int32_t chunk_size = CompactionUtils::get_read_chunk_size(config::compaction_memory_limit_per_worker,
+                                                              config::vector_chunk_size, _task_info.input_rows_num,
+                                                              total_mem_footprint, _task_info.segment_iterator_num);
     TEST_SYNC_POINT_CALLBACK("HorizontalCompactionTask::_horizontal_compact_data:chunk_size", &chunk_size);
     VLOG(2) << "compaction task_id:" << _task_info.task_id << ", tablet=" << _tablet->tablet_id()
             << ", reader chunk size=" << chunk_size;

--- a/be/src/storage/horizontal_compaction_task.cpp
+++ b/be/src/storage/horizontal_compaction_task.cpp
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "base/debug/trace.h"
+#include "base/testutil/sync_point.h"
 #include "base/time/time.h"
 #include "column/chunk_factory.h"
 #include "column/chunk_schema_helper.h"
@@ -77,9 +78,14 @@ Status HorizontalCompactionTask::_horizontal_compact_data(Statistics* statistics
     reader_params.profile = _runtime_profile.create_child("merge_rowsets");
     reader_params.column_access_paths = &_column_access_paths;
 
+    int64_t total_mem_footprint = 0;
+    for (const auto& rowset : _input_rowsets) {
+        total_mem_footprint += rowset->total_row_size();
+    }
     int32_t chunk_size = CompactionUtils::get_read_chunk_size(
             config::compaction_memory_limit_per_worker, config::vector_chunk_size, _task_info.input_rows_num,
-            _task_info.input_rowsets_size, _task_info.segment_iterator_num);
+            total_mem_footprint, _task_info.segment_iterator_num);
+    TEST_SYNC_POINT_CALLBACK("HorizontalCompactionTask::_horizontal_compact_data:chunk_size", &chunk_size);
     VLOG(2) << "compaction task_id:" << _task_info.task_id << ", tablet=" << _tablet->tablet_id()
             << ", reader chunk size=" << chunk_size;
     reader_params.chunk_size = chunk_size;

--- a/be/src/storage/rowset_merger.cpp
+++ b/be/src/storage/rowset_merger.cpp
@@ -25,6 +25,7 @@
 #include "column/raw_data_visitor.h"
 #include "common/config_compaction_fwd.h"
 #include "common/config_exec_fwd.h"
+#include "common/statusor.h"
 #include "gutil/stl_util.h"
 #include "runtime/current_thread.h"
 #include "storage/chunk_helper.h"
@@ -187,13 +188,16 @@ struct MergeEntryCmp {
     }
 };
 
-static int32_t calculate_chunk_size_for_column_group(const Schema& column_group_schema,
-                                                     const vector<RowsetSharedPtr>& rowsets) {
+static StatusOr<int32_t> calculate_chunk_size_for_column_group(const Schema& column_group_schema,
+                                                               const vector<RowsetSharedPtr>& rowsets) {
     int64_t total_num_rows = 0;
     int64_t total_mem_footprint = 0;
     // TODO: using actual merge element count after fixing merge bug for non-overlapping rowset
     int64_t total_input_segs = 0;
     for (const auto& rowset : rowsets) {
+        RowsetReleaseGuard guard(rowset);
+        RETURN_IF_ERROR(rowset->load());
+
         total_num_rows += rowset->num_rows();
         total_input_segs += rowset->num_segments();
         const auto& segments = rowset->segments();
@@ -385,7 +389,7 @@ private:
         } else if (schema.sort_key_idxes().size() == 1 && schema.field(schema.sort_key_idxes()[0])->is_nullable()) {
             sort_column = BinaryColumn::create();
         }
-        _chunk_size = calculate_chunk_size_for_column_group(schema, rowsets);
+        ASSIGN_OR_RETURN(_chunk_size, calculate_chunk_size_for_column_group(schema, rowsets));
         if (tablet.is_column_with_row_store() && config::update_compaction_chunk_size_for_row_store > 0) {
             _chunk_size = config::update_compaction_chunk_size_for_row_store;
         }
@@ -570,7 +574,7 @@ private:
             iterators.reserve(rowsets.size());
             OlapReaderStatistics non_key_stats;
             Schema schema = ChunkHelper::convert_schema(tablet_schema, column_groups[i]);
-            _chunk_size = calculate_chunk_size_for_column_group(schema, rowsets);
+            ASSIGN_OR_RETURN(_chunk_size, calculate_chunk_size_for_column_group(schema, rowsets));
             if (tablet.is_column_with_row_store() && config::update_compaction_chunk_size_for_row_store > 0) {
                 _chunk_size = config::update_compaction_chunk_size_for_row_store;
             }

--- a/be/test/storage/compaction_parallelization_test.cpp
+++ b/be/test/storage/compaction_parallelization_test.cpp
@@ -253,7 +253,7 @@ TEST_F(CompactionParallelizationTest, horizontal_chunk_size_uses_total_row_size)
 
     int32_t actual_chunk_size = 0;
     SyncPoint::GetInstance()->SetCallBack("HorizontalCompactionTask::_horizontal_compact_data:chunk_size",
-                                         [&](void* arg) { actual_chunk_size = *static_cast<int32_t*>(arg); });
+                                          [&](void* arg) { actual_chunk_size = *static_cast<int32_t*>(arg); });
     SyncPoint::GetInstance()->EnableProcessing();
     DeferOp clear_sync_point([&]() {
         SyncPoint::GetInstance()->ClearCallBack("HorizontalCompactionTask::_horizontal_compact_data:chunk_size");

--- a/be/test/storage/compaction_parallelization_test.cpp
+++ b/be/test/storage/compaction_parallelization_test.cpp
@@ -18,9 +18,12 @@
 #include <memory>
 
 #include "base/testutil/assert.h"
+#include "base/testutil/sync_point.h"
+#include "base/utility/defer_op.h"
 #include "column/chunk_factory.h"
 #include "column/schema.h"
 #include "common/config_compaction_fwd.h"
+#include "common/config_exec_fwd.h"
 #include "common/config_storage_fwd.h"
 #include "exec/exec_env.h"
 #include "fs/fs_util.h"
@@ -209,6 +212,56 @@ protected:
     int64_t _rowset_id;
     int64_t _version;
 };
+
+TEST_F(CompactionParallelizationTest, horizontal_chunk_size_uses_total_row_size) {
+    const auto old_compaction_memory_limit_per_worker = config::compaction_memory_limit_per_worker;
+    const auto old_vector_chunk_size = config::vector_chunk_size;
+    DeferOp restore_config([&]() {
+        config::compaction_memory_limit_per_worker = old_compaction_memory_limit_per_worker;
+        config::vector_chunk_size = old_vector_chunk_size;
+    });
+    config::compaction_memory_limit_per_worker = 640 * 1024 * 1024;
+    config::vector_chunk_size = 4096;
+
+    create_tablet_schema(UNIQUE_KEYS);
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, _engine->get_stores()[0]);
+    ASSERT_OK(tablet->init());
+    for (int i = 0; i < 5; ++i) {
+        write_new_version(tablet);
+    }
+
+    _engine->compaction_manager()->update_tablet(tablet);
+    CompactionCandidate compaction_candidate;
+    ASSERT_TRUE(_engine->compaction_manager()->pick_candidate(&compaction_candidate));
+    auto compaction_task = compaction_candidate.tablet->create_compaction_task();
+    ASSERT_NE(nullptr, dynamic_cast<HorizontalCompactionTask*>(compaction_task.get()));
+
+    int64_t total_row_size = 0;
+    for (const auto& rowset : compaction_task->input_rowsets()) {
+        rowset->rowset_meta()->set_total_row_size(1L * 1024 * 1024 * 1024);
+        total_row_size += rowset->total_row_size();
+    }
+    const auto expected_chunk_size = CompactionUtils::get_read_chunk_size(
+            config::compaction_memory_limit_per_worker, config::vector_chunk_size, compaction_task->input_rows_num(),
+            total_row_size, compaction_task->segment_iterator_num());
+    const auto disk_size_based_chunk_size = CompactionUtils::get_read_chunk_size(
+            config::compaction_memory_limit_per_worker, config::vector_chunk_size, compaction_task->input_rows_num(),
+            compaction_task->input_rowsets_size(), compaction_task->segment_iterator_num());
+    ASSERT_NE(expected_chunk_size, disk_size_based_chunk_size);
+
+    int32_t actual_chunk_size = 0;
+    SyncPoint::GetInstance()->SetCallBack("HorizontalCompactionTask::_horizontal_compact_data:chunk_size",
+                                         [&](void* arg) { actual_chunk_size = *static_cast<int32_t*>(arg); });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp clear_sync_point([&]() {
+        SyncPoint::GetInstance()->ClearCallBack("HorizontalCompactionTask::_horizontal_compact_data:chunk_size");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+    ASSERT_OK(dynamic_cast<HorizontalCompactionTask*>(compaction_task.get())->run_impl());
+    EXPECT_EQ(expected_chunk_size, actual_chunk_size);
+}
 
 /*
  select and execute new compaction task while the other one is in the execution progress：

--- a/be/test/storage/rowset_merger_test.cpp
+++ b/be/test/storage/rowset_merger_test.cpp
@@ -330,8 +330,7 @@ TEST_F(RowsetMergerTest, chunk_size_estimation_loads_unloaded_rowset) {
 
     TestRowsetWriter writer;
     Schema schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
-    ASSERT_OK(PrimaryKeyEncoder::create_column(schema, &writer.all_pks,
-                                               PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
+    ASSERT_OK(PrimaryKeyEncoder::create_column(schema, &writer.all_pks, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
     MergeConfig cfg;
     ASSERT_OK(compaction_merge_rowsets(*_tablet, 2, {unloaded_rowset}, &writer, cfg));
     ASSERT_EQ(pks.size(), writer.all_pks->size());

--- a/be/test/storage/rowset_merger_test.cpp
+++ b/be/test/storage/rowset_merger_test.cpp
@@ -59,6 +59,7 @@ public:
 
     Status add_chunk(const Chunk& chunk, const std::vector<uint64_t>& rssid_rowids) override {
         added_chunks.emplace_back(&chunk);
+        added_chunk_num_rows.emplace_back(chunk.num_rows());
         all_pks->append(*(chunk.get_column_raw_ptr_by_index(0)), 0, chunk.num_rows());
         return Status::OK();
     }
@@ -112,6 +113,7 @@ public:
     MutableColumnPtr all_pks;
     vector<uint32_t> all_rssids;
     std::vector<const Chunk*> added_chunks;
+    std::vector<size_t> added_chunk_num_rows;
 
     MutableColumns non_key_columns;
 };
@@ -302,6 +304,41 @@ TEST_F(RowsetMergerTest, compaction_chunk_reset_memory_tracker_threshold_percent
     ASSERT_EQ(pks.size(), writer.all_pks->size());
     ASSERT_GE(writer.added_chunks.size(), 2);
     EXPECT_NE(writer.added_chunks[0], writer.added_chunks[1]);
+}
+
+TEST_F(RowsetMergerTest, chunk_size_estimation_loads_unloaded_rowset) {
+    const auto old_compaction_memory_limit_per_worker = config::compaction_memory_limit_per_worker;
+    const auto old_vector_chunk_size = config::vector_chunk_size;
+    DeferOp restore_config([&]() {
+        config::compaction_memory_limit_per_worker = old_compaction_memory_limit_per_worker;
+        config::vector_chunk_size = old_vector_chunk_size;
+    });
+    config::compaction_memory_limit_per_worker = 1;
+    config::vector_chunk_size = 4096;
+
+    create_tablet(GetCurrentTimeMicros(), GetCurrentTimeMicros() & 0x7fffffff);
+    std::vector<int64_t> pks = {1, 2, 3, 4, 5, 6, 7, 8};
+    auto rowset = create_rowset(_tablet, pks);
+    ASSERT_OK(_tablet->rowset_commit(2, rowset));
+    std::vector<RowsetSharedPtr> applied_rowsets;
+    ASSERT_OK(_tablet->updates()->get_applied_rowsets(2, &applied_rowsets));
+
+    RowsetSharedPtr unloaded_rowset;
+    ASSERT_OK(RowsetFactory::create_rowset(_tablet->tablet_schema(), rowset->rowset_path(), rowset->rowset_meta(),
+                                           &unloaded_rowset, _tablet->data_dir()->get_meta()));
+    ASSERT_TRUE(unloaded_rowset->segments().empty());
+
+    TestRowsetWriter writer;
+    Schema schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
+    ASSERT_OK(PrimaryKeyEncoder::create_column(schema, &writer.all_pks,
+                                               PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
+    MergeConfig cfg;
+    ASSERT_OK(compaction_merge_rowsets(*_tablet, 2, {unloaded_rowset}, &writer, cfg));
+    ASSERT_EQ(pks.size(), writer.all_pks->size());
+    ASSERT_FALSE(writer.added_chunk_num_rows.empty());
+    for (size_t num_rows : writer.added_chunk_num_rows) {
+        EXPECT_EQ(1, num_rows);
+    }
 }
 
 TEST_F(RowsetMergerTest, horizontal_merge) {


### PR DESCRIPTION
## What I'm doing:
Load rowset segment metadata before estimating per-column-group chunk sizes in PK compaction. Use uncompressed rowset size instead of compressed disk size when sizing horizontal compaction reads. Add regressions for unloaded rowsets and divergent disk and memory sizes.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
