### PR TITLE
[Enhancement] Delegate TRUNCATE and ALTER TABLE in unified catalog (backport #77749)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.AlreadyExistsException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.StarRocksException;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.tvr.TvrTableDeltaTrait;
 import com.starrocks.common.tvr.TvrTableSnapshot;
@@ -34,12 +35,16 @@ import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.RemoteFileInfoSource;
 import com.starrocks.connector.SerializedMetaSpec;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.HiveMetadata;
 import com.starrocks.connector.metadata.MetadataTableType;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ShowResultSet;
+import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.DropTableStmt;
+import com.starrocks.sql.ast.TruncateTableStmt;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
@@ -117,8 +122,7 @@ public class UnifiedMetadata implements ConnectorMetadata {
     }
 
     private ConnectorMetadata metadataOfTable(String dbName, String tblName) {
-        Table.TableType type = getTableType(dbName, tblName);
-        return metadataMap.get(type);
+        return metadataOfType(getTableType(dbName, tblName));
     }
 
     private ConnectorMetadata metadataOfTable(Table table) {
@@ -126,7 +130,20 @@ public class UnifiedMetadata implements ConnectorMetadata {
         if (table.isHiveView()) {
             type = HIVE;
         }
-        return metadataMap.get(type);
+        return metadataOfType(type);
+    }
+
+    // Not every table type has an entry in metadataMap: PAIMON is only registered when the catalog was
+    // created with "paimon.catalog.warehouse", while the table type is inferred from the metastore
+    // properties alone. Every caller dereferences the result right away, so report the missing
+    // connector here instead of letting it surface as a NullPointerException.
+    private ConnectorMetadata metadataOfType(Table.TableType type) {
+        ConnectorMetadata metadata = metadataMap.get(type);
+        if (metadata == null) {
+            throw new StarRocksConnectorException("Table type %s is not available in this unified catalog, " +
+                    "the corresponding connector is not configured", type);
+        }
+        return metadata;
     }
 
     @Override
@@ -279,6 +296,18 @@ public class UnifiedMetadata implements ConnectorMetadata {
     public void dropTable(ConnectContext context, DropTableStmt stmt) throws DdlException {
         ConnectorMetadata metadata = metadataOfTable(stmt.getDbName(), stmt.getTableName());
         metadata.dropTable(context, stmt);
+    }
+
+    @Override
+    public ShowResultSet alterTable(ConnectContext context, AlterTableStmt stmt) throws StarRocksException {
+        ConnectorMetadata metadata = metadataOfTable(stmt.getDbName(), stmt.getTableName());
+        return metadata.alterTable(context, stmt);
+    }
+
+    @Override
+    public void truncateTable(TruncateTableStmt truncateTableStmt, ConnectContext context) throws DdlException {
+        ConnectorMetadata metadata = metadataOfTable(truncateTableStmt.getDbName(), truncateTableStmt.getTblName());
+        metadata.truncateTable(truncateTableStmt, context);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
@@ -26,6 +26,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.AlreadyExistsException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.StarRocksException;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.GetRemoteFilesParams;
@@ -33,6 +34,7 @@ import com.starrocks.connector.MetaPreparationItem;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.delta.DeltaLakeMetadata;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.HiveMetadata;
 import com.starrocks.connector.hudi.HudiMetadata;
 import com.starrocks.connector.iceberg.IcebergMetaSpec;
@@ -42,9 +44,12 @@ import com.starrocks.connector.paimon.PaimonMetadata;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudType;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ShowResultSet;
+import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.QualifiedName;
 import com.starrocks.sql.ast.TableRef;
+import com.starrocks.sql.ast.TruncateTableStmt;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
@@ -67,8 +72,12 @@ import static com.starrocks.catalog.Table.TableType.PAIMON;
 import static com.starrocks.connector.unified.UnifiedMetadata.DELTA_LAKE_PROVIDER;
 import static com.starrocks.connector.unified.UnifiedMetadata.ICEBERG_TABLE_TYPE_NAME;
 import static com.starrocks.connector.unified.UnifiedMetadata.ICEBERG_TABLE_TYPE_VALUE;
+import static com.starrocks.connector.unified.UnifiedMetadata.PAIMON_STORAGE_HANDLER_KEY;
+import static com.starrocks.connector.unified.UnifiedMetadata.PAIMON_STORAGE_HANDLER_VALUE;
 import static com.starrocks.connector.unified.UnifiedMetadata.SPARK_TABLE_PROVIDER_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UnifiedMetadataTest {
@@ -557,6 +566,167 @@ public class UnifiedMetadataTest {
         };
         boolean exists = unifiedMetadata.tableExists(new ConnectContext(), "test_db", "test_tbl");
         Assert.assertTrue(exists);
+    }
+
+    @Test
+    public void testTruncateTableRoutesToIcebergConnector(@Mocked HiveTable hiveTable) throws DdlException {
+        TruncateTableStmt stmt = new TruncateTableStmt(
+                new TableRef(QualifiedName.of(Lists.newArrayList("test_db", "test_tbl")), null, NodePosition.ZERO));
+
+        new Expectations() {
+            {
+                hiveTable.getProperties();
+                result = ImmutableMap.of(ICEBERG_TABLE_TYPE_NAME, ICEBERG_TABLE_TYPE_VALUE);
+                minTimes = 1;
+            }
+
+            {
+                hiveMetadata.getTable((ConnectContext) any, "test_db", "test_tbl");
+                result = hiveTable;
+                minTimes = 1;
+            }
+
+            {
+                icebergMetadata.truncateTable(stmt, connectContext);
+                times = 1;
+            }
+        };
+
+        unifiedMetadata.truncateTable(stmt, connectContext);
+    }
+
+    @Test
+    public void testTruncateTableRoutesToHiveConnector() throws DdlException {
+        HiveTable hiveTable = new HiveTable();
+        TruncateTableStmt stmt = new TruncateTableStmt(
+                new TableRef(QualifiedName.of(Lists.newArrayList("test_db", "test_tbl")), null, NodePosition.ZERO));
+
+        new Expectations() {
+            {
+                hiveMetadata.getTable((ConnectContext) any, "test_db", "test_tbl");
+                result = hiveTable;
+                minTimes = 1;
+            }
+
+            {
+                hiveMetadata.truncateTable(stmt, connectContext);
+                times = 1;
+            }
+        };
+
+        unifiedMetadata.truncateTable(stmt, connectContext);
+    }
+
+    @Test
+    public void testTruncateTableRoutesToPaimonConnector(@Mocked HiveTable hiveTable) throws DdlException {
+        TruncateTableStmt stmt = new TruncateTableStmt(
+                new TableRef(QualifiedName.of(Lists.newArrayList("test_db", "test_tbl")), null, NodePosition.ZERO));
+
+        new Expectations() {
+            {
+                hiveTable.getProperties();
+                result = ImmutableMap.of(PAIMON_STORAGE_HANDLER_KEY, PAIMON_STORAGE_HANDLER_VALUE);
+                minTimes = 1;
+            }
+
+            {
+                hiveMetadata.getTable((ConnectContext) any, "test_db", "test_tbl");
+                result = hiveTable;
+                minTimes = 1;
+            }
+
+            {
+                paimonMetadata.truncateTable(stmt, connectContext);
+                times = 1;
+            }
+        };
+
+        unifiedMetadata.truncateTable(stmt, connectContext);
+    }
+
+    @Test
+    public void testTruncateTableReportsUnconfiguredConnectorInsteadOfNpe(@Mocked HiveTable hiveTable) {
+        // A unified catalog created without "paimon.catalog.warehouse" has no PAIMON entry in the
+        // metadata map, yet a Paimon table in the shared metastore still resolves to TableType.PAIMON.
+        // The routing must report that clearly rather than dereference a null metadata.
+        UnifiedMetadata withoutPaimon = new UnifiedMetadata(ImmutableMap.of(
+                HIVE, hiveMetadata,
+                ICEBERG, icebergMetadata));
+        TruncateTableStmt stmt = new TruncateTableStmt(
+                new TableRef(QualifiedName.of(Lists.newArrayList("test_db", "test_tbl")), null, NodePosition.ZERO));
+
+        new Expectations() {
+            {
+                hiveTable.getProperties();
+                result = ImmutableMap.of(PAIMON_STORAGE_HANDLER_KEY, PAIMON_STORAGE_HANDLER_VALUE);
+                minTimes = 1;
+            }
+
+            {
+                hiveMetadata.getTable((ConnectContext) any, "test_db", "test_tbl");
+                result = hiveTable;
+                minTimes = 1;
+            }
+        };
+
+        StarRocksConnectorException e = assertThrows(StarRocksConnectorException.class,
+                () -> withoutPaimon.truncateTable(stmt, connectContext));
+        assertTrue(e.getMessage().contains("PAIMON"));
+    }
+
+    @Test
+    public void testAlterTableRoutesToIcebergConnector(@Mocked HiveTable hiveTable) throws StarRocksException {
+        AlterTableStmt stmt = new AlterTableStmt(
+                new TableRef(QualifiedName.of(Lists.newArrayList("test_db", "test_tbl")), null, NodePosition.ZERO),
+                ImmutableList.of());
+        ShowResultSet expected = new ShowResultSet(null, ImmutableList.of());
+
+        new Expectations() {
+            {
+                hiveTable.getProperties();
+                result = ImmutableMap.of(ICEBERG_TABLE_TYPE_NAME, ICEBERG_TABLE_TYPE_VALUE);
+                minTimes = 1;
+            }
+
+            {
+                hiveMetadata.getTable((ConnectContext) any, "test_db", "test_tbl");
+                result = hiveTable;
+                minTimes = 1;
+            }
+
+            {
+                icebergMetadata.alterTable(connectContext, stmt);
+                result = expected;
+                times = 1;
+            }
+        };
+
+        assertSame(expected, unifiedMetadata.alterTable(connectContext, stmt));
+    }
+
+    @Test
+    public void testAlterTableRoutesToHiveConnector() throws StarRocksException {
+        HiveTable hiveTable = new HiveTable();
+        AlterTableStmt stmt = new AlterTableStmt(
+                new TableRef(QualifiedName.of(Lists.newArrayList("test_db", "test_tbl")), null, NodePosition.ZERO),
+                ImmutableList.of());
+        ShowResultSet expected = new ShowResultSet(null, ImmutableList.of());
+
+        new Expectations() {
+            {
+                hiveMetadata.getTable((ConnectContext) any, "test_db", "test_tbl");
+                result = hiveTable;
+                minTimes = 1;
+            }
+
+            {
+                hiveMetadata.alterTable(connectContext, stmt);
+                result = expected;
+                times = 1;
+            }
+        };
+
+        assertSame(expected, unifiedMetadata.alterTable(connectContext, stmt));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Under a `unified` external catalog, `TRUNCATE TABLE` and the entire `ALTER TABLE` family are rejected with `This connector doesn't support truncate table` / `... alter table`, even though the exact same table accessed through a plain `iceberg` catalog supports all of them. INSERT / INSERT OVERWRITE / DELETE / CTAS / metadata tables / time travel / DROP TABLE are all correctly passed through, so the unified catalog's support surface is incomplete rather than absent.

`UnifiedMetadata` delegates 20+ operations to the underlying per-format metadata through `metadataOfTable(...)` (e.g. `dropTable`, `createTable`, `getRemoteFiles`, `finishSink`), but it never overrode `truncateTable` or `alterTable`. Those two calls therefore fall through to the `ConnectorMetadata` default methods, which throw unconditionally:

- `ConnectorMetadata.truncateTable(...)` → `throw new StarRocksConnectorException("This connector doesn't support truncate table")`
- `ConnectorMetadata.alterTable(...)` → `throw new StarRocksConnectorException("This connector doesn't support alter table")`

Because the whole `ALTER TABLE` surface funnels through the single `alterTable` entry point, this one gap takes out schema evolution (`ADD`/`DROP COLUMN`), partition evolution (`ADD`/`DROP`/`REPLACE PARTITION COLUMN`), every maintenance procedure (`ALTER TABLE ... EXECUTE rewrite_data_files` / `expire_snapshots` / `remove_orphan_files` / …), and branch/tag management (`CREATE`/`DROP BRANCH`/`TAG`).

The gap is not Iceberg-specific. `HiveMetadata` implements `truncateTable` (managed tables) and the `ADD PARTITION` subset of `alterTable`, and `PaimonMetadata` implements `truncateTable` — all of which are equally unreachable through a unified catalog today.

## What I'm doing:

Add the two missing delegating overrides to `UnifiedMetadata`, mirroring the existing `dropTable` pattern:

```java
@Override
public ShowResultSet alterTable(ConnectContext context, AlterTableStmt stmt) throws StarRocksException {
    ConnectorMetadata metadata = metadataOfTable(stmt.getDbName(), stmt.getTableName());
    return metadata.alterTable(context, stmt);
}

@Override
public void truncateTable(TruncateTableStmt truncateTableStmt, ConnectContext context) throws DdlException {
    ConnectorMetadata metadata = metadataOfTable(truncateTableStmt.getDbName(), truncateTableStmt.getTblName());
    metadata.truncateTable(truncateTableStmt, context);
}
```

Notes on the approach:

- The string-based `metadataOfTable(dbName, tblName)` resolver is used rather than the `Table` overload, because `AlterTableStmt` / `TruncateTableStmt` do not carry the resolved `Table`; the two resolvers agree on Hive views, and this matches what `dropTable` / `finishSink` already do.
- No table-existence handling is needed here: `MetadataMgr.alterTable` validates database and table existence before reaching the connector, and a racing DROP simply falls back to Hive metadata, which then reports the missing table instead of NPE-ing.
- Resolving a table type that has no entry in `metadataMap` used to return `null`, which the call site then dereferenced: `PAIMON` is only registered when the catalog defines `paimon.catalog.warehouse`, while `getTableType()` infers `PAIMON` from the metastore `storage_handler` property alone. So a Paimon table in a shared metastore reached through a unified catalog without that property would have turned a clear "not supported" error into a `NullPointerException`. All 19 call sites of the two `metadataOfTable` overloads dereference the result immediately — none of them treats `null` as a valid answer — so both overloads now resolve through a shared `metadataOfType(...)` that reports the unconfigured connector instead of returning `null`. That also removes the same latent NPE from the pre-existing `dropTable` / `finishSink` / `getTable` / `listPartitionNames` paths.
- No cache-invalidation is lost. The delegated `IcebergMetadata` performs its own cache eviction and cross-FE refresh, and `UnifiedConnector` passes the unified catalog's own `catalogName` down to the sub-connectors, so cross-FE refresh requests resolve back through `UnifiedMetadata.refreshTable`.

### Out of scope, but noticed while reviewing this area

`AuthorizerStmtVisitor.visitTruncateTableStatement` builds the `TableName` for its DELETE privilege check from `context.getCurrentCatalog()` instead of `statement.getCatalogName()`, while `visitAlterTableStatement` in the same file correctly uses `TableName.fromTableRef(statement.getTableRef())`. So `TRUNCATE TABLE some_catalog.db.t` issued while the session catalog is `default_catalog` checks the privilege against `default_catalog.db.t` and then truncates the external table. This is pre-existing and already reachable today through an `iceberg` catalog (TRUNCATE works there), so it is not introduced or newly exposed by this PR — flagging it here rather than folding an authorization-semantics change into a delegation fix.

Fixes https://github.com/StarRocks/StarRocksTest/issues/11609

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
