### PR TITLE
[Feature] Write one lake tablet from several CNs in parallel

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -797,6 +797,17 @@ CONF_mInt32(load_fp_tablets_channel_add_chunk_block_ms, "-1");
 // The interval for performing stack trace to control the frequency.
 CONF_mInt64(diagnose_stack_trace_interval_ms, "1800000");
 
+// Shard write (TOlapTableSink.enable_shard_write): how many CONSECUTIVE rows of one tablet go to
+// the same compute node before the round-robin advances.
+//   1                  -> spread every row. Perfectly balanced, but each node then gets a strided
+//                         1/N slice of every chunk, so the sender does N small column appends where
+//                         it used to do one large one.
+//   >= the chunk size  -> effectively per-chunk routing: a chunk's rows for a tablet go to a single
+//                         node, restoring the large append at the cost of coarser balancing.
+// It does NOT change which keys a node sees: with no shuffle before the sink every instance holds
+// arbitrary rows, so at any granularity a node still receives a uniform sample of the key space.
+CONF_mInt32(shard_write_rows_per_node, "1");
+
 CONF_Bool(enable_load_segment_parallel, "false");
 CONF_Int32(load_segment_thread_pool_num_max, "128");
 CONF_Int32(load_segment_thread_pool_queue_size, "10240");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -554,6 +554,13 @@ CONF_mInt32(pk_index_early_sst_compaction_threshold, "5");
 CONF_mBool(enable_pk_index_parallel_compaction, "true");
 // Whether enable parallel get for primary key index in shared-data mode.
 CONF_mBool(enable_pk_index_parallel_execution, "true");
+// Whether to resolve a load's shadowed rows with one merge over the index and the load's own
+// sstables, instead of one index lookup per loaded key. Only applies when the load pre-built its
+// pk index sstables (no partial update, no condition merge, no delete files in the same txn).
+CONF_mBool(enable_pk_index_merge_dedup, "false");
+// Below this many bytes of incoming pk index sstable, merge dedup runs on the calling thread
+// instead of splitting the key space across the pk index thread pool.
+CONF_mInt64(pk_index_merge_dedup_min_parallel_bytes, "67108864");
 // The minimum rows threshold to enable parallel get for primary key index in shared-data mode.
 CONF_mInt64(pk_index_parallel_execution_min_rows, "16384");
 // The threadpool max thread num for pk index get in shared-data mode.

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -441,6 +441,7 @@
         "load_diagnose_rpc_timeout_stack_trace_threshold_ms",
         "load_fp_brpc_timeout_ms",
         "enable_load_segment_parallel",
+        "shard_write_rows_per_node",
         "write_buffer_size",
         "load_process_max_memory_hard_limit_ratio",
         "enable_new_load_on_memory_limit_exceeded",

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -776,6 +776,8 @@
         "pk_index_compaction_score_ratio",
         "pk_index_early_sst_compaction_threshold",
         "enable_pk_index_parallel_execution",
+        "enable_pk_index_merge_dedup",
+        "pk_index_merge_dedup_min_parallel_bytes",
         "pk_index_parallel_execution_min_rows",
         "lake_rows_mapper_read_parallelism",
         "lake_rows_mapper_sub_chunk_bytes",

--- a/be/src/common/config_ingest_fwd.h
+++ b/be/src/common/config_ingest_fwd.h
@@ -125,6 +125,17 @@ CONF_mInt32(load_fp_brpc_timeout_ms, "-1");
 // Used in load fail point. The block time to simulate TabletsChannel::add_chunk spends much time
 CONF_mInt32(load_fp_tablets_channel_add_chunk_block_ms, "-1");
 
+// Shard write (TOlapTableSink.enable_shard_write): how many CONSECUTIVE rows of one tablet go to
+// the same compute node before the round-robin advances.
+//   1                  -> spread every row. Perfectly balanced, but each node then gets a strided
+//                         1/N slice of every chunk, so the sender does N small column appends where
+//                         it used to do one large one.
+//   >= the chunk size  -> effectively per-chunk routing: a chunk's rows for a tablet go to a single
+//                         node, restoring the large append at the cost of coarser balancing.
+// It does NOT change which keys a node sees: with no shuffle before the sink every instance holds
+// arbitrary rows, so at any granularity a node still receives a uniform sample of the key space.
+CONF_mInt32(shard_write_rows_per_node, "1");
+
 CONF_Bool(enable_load_segment_parallel, "false");
 
 // write buffer size before flush

--- a/be/src/common/config_primary_key_fwd.h
+++ b/be/src/common/config_primary_key_fwd.h
@@ -68,6 +68,15 @@ CONF_mInt32(pk_index_early_sst_compaction_threshold, "5");
 // Whether enable parallel get for primary key index in shared-data mode.
 CONF_mBool(enable_pk_index_parallel_execution, "true");
 
+// Whether to resolve a load's shadowed rows with one merge over the index and the load's own
+// sstables, instead of one index lookup per loaded key. Only applies when the load pre-built its
+// pk index sstables (no partial update, no condition merge, no delete files in the same txn).
+CONF_mBool(enable_pk_index_merge_dedup, "false");
+
+// Below this many bytes of incoming pk index sstable, merge dedup runs on the calling thread
+// instead of splitting the key space across the pk index thread pool.
+CONF_mInt64(pk_index_merge_dedup_min_parallel_bytes, "67108864");
+
 // The minimum rows threshold to enable parallel get for primary key index in shared-data mode.
 CONF_mInt64(pk_index_parallel_execution_min_rows, "16384");
 

--- a/be/src/data_sink/tablet/olap_table_sink.cpp
+++ b/be/src/data_sink/tablet/olap_table_sink.cpp
@@ -110,6 +110,12 @@ Status OlapTableSink::init(const TDataSink& t_sink, RuntimeState* state) {
     _tuple_desc_id = table_sink.tuple_id;
     _is_lake_table = table_sink.is_lake_table;
     _write_txn_log = table_sink.write_txn_log;
+    _enable_shard_write = table_sink.__isset.enable_shard_write && table_sink.enable_shard_write;
+    if (_enable_shard_write) {
+        for (const auto& location : table_sink.location.tablets) {
+            _shard_write_node_num = std::max(_shard_write_node_num, location.node_ids.size());
+        }
+    }
     _enable_data_file_bundling = table_sink.enable_data_file_bundling;
     _is_multi_statements_txn = table_sink.is_multi_statements_txn;
     _enable_lake_per_partition_coordinator_txn_log = table_sink.enable_lake_per_partition_coordinator_txn_log;
@@ -212,6 +218,10 @@ void OlapTableSink::_prepare_profile(RuntimeState* state) {
     _profile->add_info_string("TxnID", fmt::format("{}", _txn_id));
     _profile->add_info_string("IndexNum", fmt::format("{}", _schema->indexes().size()));
     _profile->add_info_string("ReplicatedStorage", fmt::format("{}", _enable_replicated_storage));
+    // Shard write is decided per statement by FE and silently degrades to the single-node path when a
+    // precondition is unmet (no combined txn log, enough tablets already, one CN), so report the width
+    // it actually got: the largest number of nodes any one tablet is spread over.
+    _profile->add_info_string("ShardWriteNodes", fmt::format("{}", _shard_write_node_num));
     _profile->add_info_string("AutomaticPartition", fmt::format("{}", _enable_automatic_partition));
     _profile->add_info_string("AutomaticBucketSize", fmt::format("{}", _automatic_bucket_size));
     _profile->add_info_string("DynamicOverwrite", fmt::format("{}", _dynamic_overwrite));
@@ -346,6 +356,7 @@ Status OlapTableSink::prepare(RuntimeState* state) {
                 std::move(index_channels), std::move(node_channels), _output_expr_ctxs, _enable_replicated_storage,
                 _write_quorum_type, _num_repicas);
     }
+    _tablet_sink_sender->set_enable_shard_write(_enable_shard_write);
     return Status::OK();
 }
 

--- a/be/src/data_sink/tablet/olap_table_sink.h
+++ b/be/src/data_sink/tablet/olap_table_sink.h
@@ -190,6 +190,12 @@ private:
     int _num_senders = -1;
     bool _is_lake_table = false;
     bool _write_txn_log = false;
+    // Shared-data only: a tablet's location carries several compute nodes that each write PART of
+    // its rows (see TOlapTableSink.enable_shard_write), instead of one node per tablet.
+    bool _enable_shard_write = false;
+    // Widest tablet under shard write: how many CNs the most-spread tablet is written by. Reported in
+    // the sink profile so a load can be told apart from one where the feature silently did not apply.
+    size_t _shard_write_node_num = 1;
     bool _enable_data_file_bundling = false;
     bool _is_multi_statements_txn = false;
     bool _enable_lake_per_partition_coordinator_txn_log = false;

--- a/be/src/data_sink/tablet/tablet_sink_index_channel.cpp
+++ b/be/src/data_sink/tablet/tablet_sink_index_channel.cpp
@@ -261,6 +261,9 @@ void NodeChannel::_open(int64_t index_id, RefCountClosure<PTabletWriterOpenResul
         // false/unset, the legacy "sender_id == 0 collects all" rule is used.
         request.mutable_lake_tablet_params()->set_enable_per_partition_coordinator(
                 _parent->_enable_lake_per_partition_coordinator_txn_log);
+        // Tells the CN its delta writers only see PART of each tablet's rows, so their txn logs must
+        // not be cached under the per-tablet metacache key that publish consults first.
+        request.mutable_lake_tablet_params()->set_shard_write(_parent->_enable_shard_write);
     }
     request.set_is_replicated_storage(_parent->_enable_replicated_storage);
     request.set_node_id(_node_id);

--- a/be/src/data_sink/tablet/tablet_sink_sender.cpp
+++ b/be/src/data_sink/tablet/tablet_sink_sender.cpp
@@ -14,6 +14,7 @@
 
 #include "data_sink/tablet/tablet_sink_sender.h"
 
+#include <algorithm>
 #include <utility>
 
 #include "base/testutil/sync_point.h"
@@ -104,6 +105,11 @@ Status TabletSinkSender::_send_chunk_by_node(Chunk* chunk, IndexChannel* channel
         if (_row_target_node.size() < _tablet_ids.size()) {
             _row_target_node.resize(_tablet_ids.size());
         }
+        // Rows are handed out in runs of `shard_write_rows_per_node`. A run of 1 spreads every row
+        // and balances perfectly, but leaves each node a strided 1/N slice of the chunk, so the
+        // sender does N small per-column appends where it used to do one large one. A run at or
+        // above the chunk size routes a whole chunk's rows for a tablet to one node instead.
+        const uint64_t stride = std::max(1, config::shard_write_rows_per_node);
         int64_t last_tablet_id = -1;
         std::vector<int64_t>* last_be_ids = nullptr;
         uint64_t* last_counter = nullptr;
@@ -120,7 +126,7 @@ Status TabletSinkSender::_send_chunk_by_node(Chunk* chunk, IndexChannel* channel
                 last_counter = &_shard_write_counters[tablet_id];
             }
             DCHECK(!last_be_ids->empty());
-            _row_target_node[selection] = (*last_be_ids)[(*last_counter)++ % last_be_ids->size()];
+            _row_target_node[selection] = (*last_be_ids)[((*last_counter)++ / stride) % last_be_ids->size()];
         }
     }
     // Acquire shared lock to protect against concurrent modification of _node_channels

--- a/be/src/data_sink/tablet/tablet_sink_sender.cpp
+++ b/be/src/data_sink/tablet/tablet_sink_sender.cpp
@@ -22,8 +22,11 @@
 #include "common/statusor.h"
 #include "exprs/expr.h"
 #include "exprs/expr_executor.h"
+#include "fmt/format.h"
 #include "runtime/runtime_state.h"
 #include "storage/lake/combined_txn_log_writer.h"
+#include "storage/lake/lake_proto_normalizer.h"
+#include "storage/lake/shard_write_txn_log.h"
 
 namespace starrocks {
 
@@ -93,6 +96,33 @@ Status TabletSinkSender::_send_chunk_by_node(Chunk* chunk, IndexChannel* channel
 
     DCHECK(_index_id_to_tablet_be_map.find(channel->index_id()) != _index_id_to_tablet_be_map.end());
     auto& tablet_to_be = _index_id_to_tablet_be_map.find(channel->index_id())->second;
+    // Shard write picks ONE node per row up front. It cannot be decided inside the per-node loop
+    // below: that loop visits the same row once per node, and a counter advanced there would step
+    // a different number of times on each pass, so a row could be claimed by several nodes (data
+    // duplication) or by none (data loss).
+    if (_enable_shard_write) {
+        if (_row_target_node.size() < _tablet_ids.size()) {
+            _row_target_node.resize(_tablet_ids.size());
+        }
+        int64_t last_tablet_id = -1;
+        std::vector<int64_t>* last_be_ids = nullptr;
+        uint64_t* last_counter = nullptr;
+        for (unsigned short selection : selection_idx) {
+            const int64_t tablet_id = _tablet_ids[selection];
+            if (tablet_id != last_tablet_id) {
+                auto iter = tablet_to_be.find(tablet_id);
+                DCHECK(iter != tablet_to_be.end());
+                if (iter == tablet_to_be.end()) {
+                    return Status::InternalError(fmt::format("Unknown tablet_id {} in tablet be map", tablet_id));
+                }
+                last_tablet_id = tablet_id;
+                last_be_ids = &iter->second;
+                last_counter = &_shard_write_counters[tablet_id];
+            }
+            DCHECK(!last_be_ids->empty());
+            _row_target_node[selection] = (*last_be_ids)[(*last_counter)++ % last_be_ids->size()];
+        }
+    }
     // Acquire shared lock to protect against concurrent modification of _node_channels
     // during incremental partition opens (see IndexChannel::init with is_incremental=true).
     std::shared_lock<std::shared_mutex> lock(channel->_node_channels_mutex);
@@ -107,7 +137,15 @@ Status TabletSinkSender::_send_chunk_by_node(Chunk* chunk, IndexChannel* channel
         _node_select_idx.clear();
         _node_select_idx.reserve(selection_idx.size());
 
-        if (_enable_replicated_storage) {
+        if (_enable_shard_write) {
+            // The node list of a tablet is a SHARD set, not a replica set: every row goes to exactly
+            // one of them, so each node receives a disjoint part of the tablet.
+            for (unsigned short selection : selection_idx) {
+                if (_row_target_node[selection] == be_id) {
+                    _node_select_idx.emplace_back(selection);
+                }
+            }
+        } else if (_enable_replicated_storage) {
             for (unsigned short selection : selection_idx) {
                 DCHECK(tablet_to_be.find(_tablet_ids[selection]) != tablet_to_be.end());
                 std::vector<int64_t>& be_ids = tablet_to_be.find(_tablet_ids[selection])->second;
@@ -326,17 +364,10 @@ Status TabletSinkSender::close_wait(RuntimeState* state, Status close_status, Ta
             }
         }
         if (status.ok() && write_txn_log) {
-            auto merge_txn_log = [this](NodeChannel* channel) {
-                for (auto& log : channel->txn_logs()) {
-                    _txn_log_map[log.partition_id()].add_txn_logs()->Swap(&log);
-                }
-            };
-
-            for (auto& index_channel : _channels) {
-                index_channel->for_each_node_channel(merge_txn_log);
+            status.update(_collect_txn_logs());
+            if (status.ok()) {
+                status.update(_write_combined_txn_log());
             }
-
-            status.update(_write_combined_txn_log());
         }
     } else {
         for_each_index_channel(
@@ -425,6 +456,56 @@ ExpectedTabletsByPartition TabletSinkSender::_expected_tablets_by_partition() co
         }
     }
     return expected;
+}
+
+Status TabletSinkSender::_collect_txn_logs() {
+    if (!_enable_shard_write) {
+        for (auto& index_channel : _channels) {
+            index_channel->for_each_node_channel([this](NodeChannel* channel) {
+                for (auto& log : channel->txn_logs()) {
+                    _txn_log_map[log.partition_id()].add_txn_logs()->Swap(&log);
+                }
+            });
+        }
+        return Status::OK();
+    }
+
+    // Shard write: several nodes wrote the same tablet, so each of them handed back a PARTIAL txn log
+    // for it. Fold them into a single log per tablet here, before the combined log is written out, so
+    // the {txn_id}.logs file publish reads still holds exactly one log per tablet.
+    //
+    // Walk the node channels in node-id order: the fold is a concatenation, and a stable input order
+    // keeps the resulting segment layout reproducible across retries of the same load.
+    std::map<int64_t, std::map<int64_t, TxnLogPB*>> tablet_log_by_partition;
+    size_t merged_logs = 0;
+    for (auto& index_channel : _channels) {
+        std::map<int64_t, NodeChannel*> ordered_nodes;
+        index_channel->for_each_node_channel(
+                [&ordered_nodes](NodeChannel* channel) { ordered_nodes.emplace(channel->node_id(), channel); });
+        for (auto& [node_id, channel] : ordered_nodes) {
+            for (auto& log : channel->txn_logs()) {
+                auto& tablet_logs = tablet_log_by_partition[log.partition_id()];
+                auto it = tablet_logs.find(log.tablet_id());
+                if (it == tablet_logs.end()) {
+                    auto* slot = _txn_log_map[log.partition_id()].add_txn_logs();
+                    slot->Swap(&log);
+                    // The structured arrays are the only ones merge_shard_write_txn_log maintains;
+                    // after-load makes them canonical and drops the deprecated parallel arrays that
+                    // the producing CN dual-wrote. put_combined_txn_log rebuilds those on save.
+                    lake::normalize_txn_log_after_load(slot);
+                    tablet_logs.emplace(slot->tablet_id(), slot);
+                    continue;
+                }
+                lake::normalize_txn_log_after_load(&log);
+                RETURN_IF_ERROR(lake::merge_shard_write_txn_log(it->second, &log));
+                ++merged_logs;
+            }
+        }
+    }
+    if (merged_logs > 0) {
+        VLOG(2) << "shard write: folded " << merged_logs << " extra txn logs, txn_id=" << _txn_id;
+    }
+    return Status::OK();
 }
 
 Status TabletSinkSender::_write_combined_txn_log() {

--- a/be/src/data_sink/tablet/tablet_sink_sender.h
+++ b/be/src/data_sink/tablet/tablet_sink_sender.h
@@ -57,6 +57,10 @@ public:
     // mutable
     IndexIdToTabletBEMap* index_id_to_tablet_be_map() { return &_index_id_to_tablet_be_map; }
 
+    // See TOlapTableSink.enable_shard_write: a tablet's node list is a SHARD set (round-robin one
+    // node per row) instead of a replica set (same rows to every node).
+    void set_enable_shard_write(bool enable) { _enable_shard_write = enable; }
+
     void for_each_node_channel(const std::function<void(NodeChannel*)>& func) {
         for (auto& it : _node_channels) {
             func(it.second);
@@ -73,6 +77,9 @@ protected:
     // Virtual to allow tests or derived senders (e.g. colocate sender) to intercept
     // how chunks are dispatched to BE nodes.
     virtual Status _send_chunk_by_node(Chunk* chunk, IndexChannel* channel, const std::vector<uint16_t>& selection_idx);
+    // Move every node channel's txn logs into _txn_log_map, folding the several partial logs a
+    // shard-write tablet produces into one. See merge_shard_write_txn_log.
+    Status _collect_txn_logs();
     Status _write_combined_txn_log();
 
     // For every partition this sink is about to write a combined txn log for, the set of tablets
@@ -115,6 +122,13 @@ protected:
     // one chunk selection for BE node
     std::vector<uint32_t> _node_select_idx;
     std::vector<int64_t> _tablet_ids;
+    bool _enable_shard_write = false;
+    // Shard write only. Indexed like _tablet_ids: the single node each row was assigned to, decided
+    // once per chunk before the per-node dispatch loop.
+    std::vector<int64_t> _row_target_node;
+    // Shard write only. Per-tablet round-robin cursor; lives across chunks so the spread stays even
+    // when a chunk carries only a few rows of a tablet.
+    std::unordered_map<int64_t, uint64_t> _shard_write_counters;
     std::set<int64_t> _failed_channels;
     // mapping from partition id to CombinedTxnLogPB
     std::map<int64_t, CombinedTxnLogPB> _txn_log_map;

--- a/be/src/data_workflows/load/tablet_writer/lake_tablets_channel.cpp
+++ b/be/src/data_workflows/load/tablet_writer/lake_tablets_channel.cpp
@@ -242,6 +242,8 @@ private:
     static bool _is_data_file_bundle_enabled(const PTabletWriterOpenRequest& params);
 
     static bool _is_multi_statements_txn(const PTabletWriterOpenRequest& params);
+    // See TOlapTableSink.enable_shard_write: this CN receives only part of each tablet's rows.
+    static bool _is_shard_write(const PTabletWriterOpenRequest& params);
 
     Status log_and_error_tablet_not_found(int64_t tablet_id, const PUniqueId& id, std::string_view signature) const;
 
@@ -910,6 +912,10 @@ bool LakeTabletsChannel::_is_multi_statements_txn(const PTabletWriterOpenRequest
            params.lake_tablet_params().is_multi_statements_txn();
 }
 
+bool LakeTabletsChannel::_is_shard_write(const PTabletWriterOpenRequest& params) {
+    return params.has_lake_tablet_params() && params.lake_tablet_params().shard_write();
+}
+
 Status LakeTabletsChannel::_create_delta_writers(const PTabletWriterOpenRequest& params, bool is_incremental) {
     int64_t schema_id = 0;
     std::vector<SlotDescriptor*>* slots = nullptr;
@@ -947,6 +953,7 @@ Status LakeTabletsChannel::_create_delta_writers(const PTabletWriterOpenRequest&
     std::vector<int64_t> tablet_ids;
     tablet_ids.reserve(params.tablets_size());
     bool multi_stmt = _is_multi_statements_txn(params);
+    bool shard_write = _is_shard_write(params);
     for (const PTabletWithPartition& tablet : params.tablets()) {
         BundleWritableFileContext* bundle_writable_file_context = nullptr;
         // Enable bundle write for both single-statement and multi-statement transactions.
@@ -984,6 +991,7 @@ Status LakeTabletsChannel::_create_delta_writers(const PTabletWriterOpenRequest&
                                               .set_bundle_writable_file_context(bundle_writable_file_context)
                                               .set_global_dicts(&_global_dicts)
                                               .set_is_multi_statements_txn(multi_stmt)
+                                              .set_shard_write(shard_write)
                                               .build());
         mutable_delta_writers()->emplace(tablet.tablet_id(), std::move(writer));
         tablet_ids.emplace_back(tablet.tablet_id());

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -221,6 +221,7 @@ set(STORAGE_FILES
     lake/tablet_manager.cpp
     lake/tablet_reader.cpp
     lake/tablet_range_helper.cpp
+    lake/shard_write_txn_log.cpp
     lake/sst_seek_range.cpp
     lake/transactions.cpp
     lake/metadata_iterator.cpp

--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -473,6 +473,7 @@ StatusOr<AsyncDeltaWriterBuilder::AsyncDeltaWriterPtr> AsyncDeltaWriterBuilder::
                                           .set_bundle_writable_file_context(_bundle_writable_file_context)
                                           .set_global_dicts(_global_dicts)
                                           .set_is_multi_statements_txn(_is_multi_statements_txn)
+                                          .set_shard_write(_shard_write)
                                           .build());
     auto impl = new AsyncDeltaWriterImpl(std::move(writer));
     return std::make_unique<AsyncDeltaWriter>(impl);

--- a/be/src/storage/lake/async_delta_writer.h
+++ b/be/src/storage/lake/async_delta_writer.h
@@ -236,6 +236,12 @@ public:
         return *this;
     }
 
+    // See DeltaWriterBuilder::set_shard_write.
+    AsyncDeltaWriterBuilder& set_shard_write(bool shard_write) {
+        _shard_write = shard_write;
+        return *this;
+    }
+
     StatusOr<AsyncDeltaWriterPtr> build();
 
 private:
@@ -258,6 +264,7 @@ private:
     BundleWritableFileContext* _bundle_writable_file_context{nullptr};
     GlobalDictByNameMaps* _global_dicts = nullptr;
     bool _is_multi_statements_txn = false;
+    bool _shard_write = false;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -125,7 +125,7 @@ public:
                              int64_t schema_id, const PartialUpdateMode& partial_update_mode,
                              const std::map<string, string>* column_to_expr_value, PUniqueId load_id,
                              RuntimeProfile* profile, BundleWritableFileContext* bundle_writable_file_context,
-                             GlobalDictByNameMaps* global_dicts, bool is_multi_statements_txn,
+                             GlobalDictByNameMaps* global_dicts, bool is_multi_statements_txn, bool shard_write,
                              std::shared_ptr<const TabletSchema> tablet_schema, bool force_build_vector_index_inline)
             : _tablet_manager(tablet_manager),
               _tablet_id(tablet_id),
@@ -148,6 +148,7 @@ public:
               _bundle_writable_file_context(bundle_writable_file_context),
               _global_dicts(global_dicts),
               _is_multi_statements_txn(is_multi_statements_txn),
+              _shard_write(shard_write),
               _force_build_vector_index_inline(force_build_vector_index_inline) {}
 
     ~DeltaWriterImpl() = default;
@@ -333,6 +334,9 @@ private:
 
     GlobalDictByNameMaps* _global_dicts = nullptr;
     bool _is_multi_statements_txn = false;
+    // See TOlapTableSink.enable_shard_write: this writer holds only PART of the tablet's rows for
+    // this transaction, so the txn log it produces must not be cached as if it were the whole thing.
+    bool _shard_write = false;
     // When true, the internal TabletWriter builds the vector index inline (overriding async
     // index_build_mode). Set by lake schema-change conversions (SortedSchemaChange) so the
     // shadow tablet's existing data is fully indexed during the ALTER, matching DirectSchemaChange.
@@ -1014,7 +1018,13 @@ StatusOr<TxnLogPtr> DeltaWriterImpl::finish_with_txnlog(DeltaWriterFinishMode mo
         VLOG(2) << "Wrote txn log for tablet=" << _tablet_id << " txn=" << _txn_id
                 << " load_id=" << UniqueId(_load_id).to_string();
     } else {
-        if (_is_multi_statements_txn) {
+        if (_shard_write) {
+            // Under shard write this log covers only the rows THIS node received, while the cache key
+            // below claims to hold the tablet's whole transaction. publish consults that key before
+            // reading the aggregated {txn_id}.logs and would stop at this partial log, dropping every
+            // other node's data. Skipping the fill makes publish miss and read the aggregated file.
+            VLOG(2) << "Skipped caching partial shard-write txn log for tablet=" << _tablet_id << " txn=" << _txn_id;
+        } else if (_is_multi_statements_txn) {
             auto cache_key = _tablet_manager->txn_log_location(_tablet_id, _txn_id, _load_id);
             _tablet_manager->metacache()->cache_txn_log(cache_key, txn_log);
         } else {
@@ -1380,7 +1390,7 @@ StatusOr<DeltaWriterBuilder::DeltaWriterPtr> DeltaWriterBuilder::build() {
             _tablet_mgr, _tablet_id, _txn_id, _partition_id, _slots, _merge_condition, _miss_auto_increment_column,
             _db_id, _table_id, _immutable_tablet_size, _mem_tracker, _max_buffer_size, _schema_id, _partial_update_mode,
             _column_to_expr_value, _load_id, _profile, _bundle_writable_file_context, _global_dicts,
-            _is_multi_statements_txn, _tablet_schema, _force_build_vector_index_inline);
+            _is_multi_statements_txn, _shard_write, _tablet_schema, _force_build_vector_index_inline);
     return std::make_unique<DeltaWriter>(impl);
 }
 

--- a/be/src/storage/lake/delta_writer.h
+++ b/be/src/storage/lake/delta_writer.h
@@ -304,6 +304,13 @@ public:
         return *this;
     }
 
+    // See TOlapTableSink.enable_shard_write. Marks this writer as holding only part of the tablet's
+    // rows for the transaction, which keeps its (partial) txn log out of the metacache.
+    DeltaWriterBuilder& set_shard_write(bool shard_write) {
+        _shard_write = shard_write;
+        return *this;
+    }
+
     // Force the internal TabletWriter to build the vector index inline, overriding async
     // index_build_mode. Used by lake schema-change conversions (SortedSchemaChange) so the
     // shadow tablet's existing data is fully indexed within the ALTER, matching DirectSchemaChange.
@@ -335,6 +342,7 @@ private:
     BundleWritableFileContext* _bundle_writable_file_context{nullptr};
     GlobalDictByNameMaps* _global_dicts = nullptr;
     bool _is_multi_statements_txn = false;
+    bool _shard_write = false;
     std::shared_ptr<const TabletSchema> _tablet_schema;
     bool _force_build_vector_index_inline = false;
 };

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -794,10 +794,13 @@ struct MergeResolvedEntry {
 };
 
 // One input to the merge: an open sstable plus the read options that project its entries into the
-// index's current id space. Iterators are stateful, so each range task builds its own set.
+// index's current id space. Each range task builds its own iterators from these, and its own file
+// handle per source -- see merge_dedup_range for why the handle cannot be shared.
 struct MergeSource {
     PersistentIndexSstable* sstable = nullptr;
     sstable::ReadOptions options;
+    std::string file_path;
+    std::string encryption_meta;
 };
 
 // The order compaction uses to pick the surviving entry for a key: newer version wins; on a tie the
@@ -821,15 +824,32 @@ bool merge_entry_wins(const MergeResolvedEntry& candidate, const MergeResolvedEn
 Status merge_dedup_range(const std::vector<MergeSource>& sources, const std::unordered_set<uint32_t>& new_rssids,
                          const std::string& begin_key, const std::string& end_key, DeletesMap* deletes,
                          int64_t* out_entries, int64_t* out_dup_groups) {
+    // A file handle per source, per task. RandomAccessFile::read_at_fully is a seek followed by a
+    // read, so two threads sharing one handle interleave into each other's stream position; on a
+    // starlet-backed file that corrupts the cache's own state, not just the bytes read. This is why
+    // PersistentIndexSstable::multi_get opens a fresh handle per call under parallel execution, and
+    // ReadOptions::file exists to route the block reads through it. Declared before the iterators so
+    // it outlives them.
+    std::vector<std::unique_ptr<RandomAccessFile>> files;
     std::vector<sstable::Iterator*> iters;
     DeferOp free_iters([&] {
         for (sstable::Iterator* iter : iters) {
             delete iter;
         }
     });
+    files.reserve(sources.size());
     iters.reserve(sources.size());
     for (const auto& source : sources) {
-        iters.emplace_back(source.sstable->new_iterator(source.options));
+        RandomAccessFileOptions opts;
+        if (!source.encryption_meta.empty()) {
+            ASSIGN_OR_RETURN(opts.encryption_info, KeyCache::instance().unwrap_encryption_meta(source.encryption_meta));
+        }
+        ASSIGN_OR_RETURN(auto rf, fs::new_random_access_file(opts, source.file_path));
+        auto options = source.options;
+        options.file = rf.get();
+        // TwoLevelIterator holds its ReadOptions by value, so only the handle has to outlive it.
+        iters.emplace_back(source.sstable->new_iterator(options));
+        files.emplace_back(std::move(rf));
     }
     if (iters.empty()) {
         return Status::OK();
@@ -999,6 +1019,10 @@ Status LakePersistentIndex::merge_dedup(const TabletMetadataPtr& metadata,
             source.options.shared_version = sstable_pb.shared_version();
             source.options.rssid_offset = sstable_pb.rssid_offset();
             source.options.delvec = sst->delvec();
+            // Taken from the open sstable rather than rebuilt from the tablet id: an sstable shared
+            // with a split sibling lives under the tablet that wrote it, not under this one.
+            source.file_path = sst->filename();
+            source.encryption_meta = sstable_pb.encryption_meta();
             sources.push_back(std::move(source));
         }
     }
@@ -1027,6 +1051,8 @@ Status LakePersistentIndex::merge_dedup(const TabletMetadataPtr& metadata,
         source.options.max_rss_rowid = sstable_pb.max_rss_rowid();
         source.options.shared_rssid = sstable_pb.shared_rssid();
         source.options.shared_version = sstable_pb.shared_version();
+        source.file_path = sstable->filename();
+        source.encryption_meta = sstable_pb.encryption_meta();
         sources.push_back(std::move(source));
         if (new_ssts[i]->size() > new_ssts[probe_idx]->size()) {
             probe_idx = i;

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <numeric>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "base/debug/trace.h"
 #include "base/testutil/sync_point.h"
@@ -764,6 +765,353 @@ Status LakePersistentIndex::prepare_merging_iterator(
     (*merging_iter_ptr)->SeekToFirst();
     iters.clear(); // Clear the vector without deleting iterators since they are now managed by merge_iter_ptr.
     VLOG(2) << "prepare sst for merge : " << ss_debug.str();
+    return Status::OK();
+}
+
+namespace {
+// One entry of the key group currently being resolved. The merging iterator's key and value slices
+// are only valid until the next Next(), but a group can only be judged once its last entry has been
+// seen, so each entry is copied out first. The buffers are reused across groups -- on a bulk load
+// this runs once per loaded row.
+struct MergeGroupEntry {
+    std::string value;
+    uint64_t max_rss_rowid = 0;
+    uint32_t shared_rssid = 0;
+    int64_t shared_version = 0;
+    int32_t rssid_offset = 0;
+    // Borrowed from the sstable the entry came from, which outlives the walk.
+    DelVector* delvec = nullptr;
+};
+
+// An entry after the same rssid/version projection the compaction merger applies.
+struct MergeResolvedEntry {
+    int64_t version = 0;
+    uint64_t max_rss_rowid = 0;
+    uint32_t rssid = 0;
+    uint32_t rowid = 0;
+    bool tombstone = false;
+    bool is_new = false;
+};
+
+// One input to the merge: an open sstable plus the read options that project its entries into the
+// index's current id space. Iterators are stateful, so each range task builds its own set.
+struct MergeSource {
+    PersistentIndexSstable* sstable = nullptr;
+    sstable::ReadOptions options;
+};
+
+// The order compaction uses to pick the surviving entry for a key: newer version wins; on a tie the
+// higher rss rowid wins, which is what orders the sstables of a single publish, since they all carry
+// that publish's version. See KeyValueMerger::merge for the full reasoning behind needing the pair.
+//
+// This has to agree with LakePersistentIndex::get(), which resolves a key by scanning the filesets
+// newest-first and taking the first hit. It does: a fileset only ever grows at the back, so fileset
+// order is ingest order, versions are non-decreasing along it, and within one publish max_rss_rowid
+// increases with the rssid each sstable is ingested under.
+bool merge_entry_wins(const MergeResolvedEntry& candidate, const MergeResolvedEntry& incumbent) {
+    if (candidate.version != incumbent.version) {
+        return candidate.version > incumbent.version;
+    }
+    return candidate.max_rss_rowid > incumbent.max_rss_rowid;
+}
+
+// Walks the merged stream over [begin_key, end_key) -- both empty meaning unbounded -- and records
+// the rows this transaction shadows. A key's entries all share the same bytes, so a key group never
+// straddles a boundary and the ranges can be walked independently.
+Status merge_dedup_range(const std::vector<MergeSource>& sources, const std::unordered_set<uint32_t>& new_rssids,
+                         const std::string& begin_key, const std::string& end_key, DeletesMap* deletes,
+                         int64_t* out_entries, int64_t* out_dup_groups) {
+    std::vector<sstable::Iterator*> iters;
+    DeferOp free_iters([&] {
+        for (sstable::Iterator* iter : iters) {
+            delete iter;
+        }
+    });
+    iters.reserve(sources.size());
+    for (const auto& source : sources) {
+        iters.emplace_back(source.sstable->new_iterator(source.options));
+    }
+    if (iters.empty()) {
+        return Status::OK();
+    }
+    sstable::Options options;
+    std::unique_ptr<sstable::Iterator> merging_iter(
+            sstable::NewMergingIterator(options.comparator, iters.data(), iters.size()));
+    // Ownership moved into merging_iter; the DeferOp above must not double free.
+    iters.clear();
+
+    std::vector<MergeGroupEntry> group;
+    std::vector<MergeResolvedEntry> resolved;
+    size_t group_size = 0;
+    std::string current_key;
+    bool has_current_key = false;
+    IndexValuesWithVerPB parse_scratch;
+    int64_t entries = 0;
+    int64_t dup_groups = 0;
+
+    // Only a group with more than one entry can shadow anything, and on a bulk load nearly every
+    // group has exactly one. Keeping the value protobuf unparsed until a duplicate actually shows up
+    // is what makes this pass cheaper than the per-key lookups it replaces.
+    auto resolve_group = [&]() -> Status {
+        if (group_size < 2) {
+            return Status::OK();
+        }
+        resolved.clear();
+        for (size_t i = 0; i < group_size; ++i) {
+            const auto& entry = group[i];
+            parse_scratch.Clear();
+            if (!parse_scratch.ParseFromArray(entry.value.data(), static_cast<int>(entry.value.size()))) {
+                // Written as a serialized IndexValuesWithVerPB, so a parse failure means the
+                // persisted bytes are corrupt -- usually a bad local cache copy.
+                return Status::Corruption("merge_dedup: failed to parse index value");
+            }
+            if (parse_scratch.values_size() == 0) {
+                continue;
+            }
+            const auto& value = parse_scratch.values(0);
+            MergeResolvedEntry out;
+            out.version = value.version();
+            out.rssid = value.rssid();
+            out.rowid = value.rowid();
+            out.tombstone = is_index_tombstone(value);
+            out.max_rss_rowid = entry.max_rss_rowid;
+            // Rows this sstable's own delete vector already masks are gone; naming one again would
+            // record a delete against a location the index no longer points at.
+            if (entry.delvec != nullptr && !entry.delvec->empty() && entry.delvec->roaring()->contains(out.rowid)) {
+                continue;
+            }
+            // Same projection as KeyValueMerger::merge: an ingested sstable stores locations in its
+            // source's id space and carries the destination's in shared_rssid/shared_version.
+            if (entry.shared_version > 0) {
+                out.version = entry.shared_version;
+                if (!out.tombstone) {
+                    out.rssid = entry.shared_rssid;
+                }
+            } else if (entry.rssid_offset != 0 && !out.tombstone) {
+                out.rssid = static_cast<uint32_t>(static_cast<int64_t>(out.rssid) + entry.rssid_offset);
+            }
+            out.is_new = new_rssids.count(out.rssid) > 0;
+            resolved.push_back(out);
+        }
+
+        // The per-segment lookup path emits exactly two kinds of delete, and this reproduces both:
+        // the first segment carrying the key finds the index's current value for it, and every later
+        // segment finds the previous segment's entry, because each segment's sstable is ingested
+        // before the next segment is looked up. So the survivor is the newest entry this transaction
+        // adds, and everything it shadows -- the older segments of this same transaction, plus the
+        // one entry that was current in the index -- is deleted. Older entries buried behind that
+        // current value are deliberately left alone: the lookup path never saw them either, and they
+        // can name rowsets already compacted away.
+        int best_new = -1;
+        int best_old = -1;
+        for (size_t i = 0; i < resolved.size(); ++i) {
+            if (resolved[i].is_new) {
+                if (best_new < 0 || merge_entry_wins(resolved[i], resolved[best_new])) {
+                    best_new = static_cast<int>(i);
+                }
+            } else if (best_old < 0 || merge_entry_wins(resolved[i], resolved[best_old])) {
+                best_old = static_cast<int>(i);
+            }
+        }
+        if (best_new < 0) {
+            // The key is not part of this load, so the lookup path would not have touched it either.
+            return Status::OK();
+        }
+        ++dup_groups;
+        for (size_t i = 0; i < resolved.size(); ++i) {
+            if (resolved[i].is_new && static_cast<int>(i) != best_new && !resolved[i].tombstone) {
+                (*deletes)[resolved[i].rssid].push_back(resolved[i].rowid);
+            }
+        }
+        if (best_old >= 0 && !resolved[best_old].tombstone) {
+            (*deletes)[resolved[best_old].rssid].push_back(resolved[best_old].rowid);
+        }
+        return Status::OK();
+    };
+
+    if (begin_key.empty()) {
+        merging_iter->SeekToFirst();
+    } else {
+        merging_iter->Seek(Slice(begin_key));
+    }
+    for (; merging_iter->Valid(); merging_iter->Next()) {
+        const Slice key = merging_iter->key();
+        if (!end_key.empty() && key.compare(Slice(end_key)) >= 0) {
+            break;
+        }
+        if (!has_current_key || Slice(current_key) != key) {
+            RETURN_IF_ERROR(resolve_group());
+            current_key.assign(key.data, key.size);
+            has_current_key = true;
+            group_size = 0;
+        }
+        if (group_size == group.size()) {
+            group.emplace_back();
+        }
+        auto& entry = group[group_size++];
+        const Slice value = merging_iter->value();
+        // assign() reuses the string's existing buffer, so this stops allocating after a few rows.
+        entry.value.assign(value.data, value.size);
+        entry.max_rss_rowid = merging_iter->max_rss_rowid();
+        entry.shared_rssid = merging_iter->shared_rssid();
+        entry.shared_version = merging_iter->shared_version();
+        entry.rssid_offset = merging_iter->rssid_offset();
+        entry.delvec = merging_iter->delvec().get();
+        ++entries;
+    }
+    RETURN_IF_ERROR(merging_iter->status());
+    RETURN_IF_ERROR(resolve_group());
+    *out_entries = entries;
+    *out_dup_groups = dup_groups;
+    return Status::OK();
+}
+} // namespace
+
+Status LakePersistentIndex::merge_dedup(const TabletMetadataPtr& metadata,
+                                        const std::vector<const FileMetaPB*>& new_ssts,
+                                        const std::vector<uint32_t>& new_rssids, int64_t version,
+                                        DeletesMap* new_deletes) {
+    TRACE_COUNTER_SCOPE_LATENCY_US("merge_dedup_latency_us");
+    if (new_ssts.size() != new_rssids.size()) {
+        return Status::InternalError("merge_dedup: sstable and rssid counts differ");
+    }
+    // Everything the merge reads has to be in a file. The memtables hold entries no sstable carries
+    // yet, and a key living only there would look absent to the merge, leaving the row it shadows
+    // alive. ingest_sst() flushes at this same point for the same reason.
+    RETURN_IF_ERROR(sync_flush_all_memtables(config::pk_index_memtable_max_wait_flush_timeout_ms * 1000));
+
+    std::vector<MergeSource> sources;
+    // Keeps the sstables opened for the new side alive as long as any task's iterators are.
+    std::vector<PersistentIndexSstableUniquePtr> opened_new_ssts;
+
+    // The side already in the index, read exactly as compaction reads it -- delvec included, so a
+    // row an older sstable still lists but a newer delvec has masked is not resurrected here.
+    for (const auto& fileset : _sstable_filesets) {
+        std::vector<PersistentIndexSstable*> fileset_ssts;
+        fileset->collect_sstables(&fileset_ssts);
+        for (auto* sst : fileset_ssts) {
+            const auto& sstable_pb = sst->sstable_pb();
+            MergeSource source;
+            source.sstable = sst;
+            source.options.fill_cache = false;
+            source.options.max_rss_rowid = sstable_pb.max_rss_rowid();
+            source.options.shared_rssid = sstable_pb.shared_rssid();
+            source.options.shared_version = sstable_pb.shared_version();
+            source.options.rssid_offset = sstable_pb.rssid_offset();
+            source.options.delvec = sst->delvec();
+            sources.push_back(std::move(source));
+        }
+    }
+    const size_t num_old_sources = sources.size();
+
+    // The side this transaction adds. These are the files ingest_sst() registers right after, opened
+    // with the same rssid/version projection it stamps on them, so an entry read here already
+    // carries the location it will have in the index.
+    std::unordered_set<uint32_t> new_rssid_set(new_rssids.begin(), new_rssids.end());
+    int64_t new_sst_bytes = 0;
+    size_t probe_idx = 0;
+    for (size_t i = 0; i < new_ssts.size(); ++i) {
+        PersistentIndexSstablePB sstable_pb;
+        sstable_pb.set_filename(new_ssts[i]->name());
+        sstable_pb.set_filesize(new_ssts[i]->size());
+        sstable_pb.set_encryption_meta(new_ssts[i]->encryption_meta());
+        sstable_pb.set_shared_rssid(new_rssids[i]);
+        sstable_pb.set_shared_version(version);
+        sstable_pb.set_max_rss_rowid((static_cast<uint64_t>(new_rssids[i]) << 32) | (UINT32_MAX - 1));
+        ASSIGN_OR_RETURN(auto sstable, PersistentIndexSstable::new_sstable(
+                                               sstable_pb, _tablet_mgr->sst_location(_tablet_id, sstable_pb.filename()),
+                                               nullptr, false /* need filter */, nullptr, metadata, _tablet_mgr));
+        MergeSource source;
+        source.sstable = sstable.get();
+        source.options.fill_cache = false;
+        source.options.max_rss_rowid = sstable_pb.max_rss_rowid();
+        source.options.shared_rssid = sstable_pb.shared_rssid();
+        source.options.shared_version = sstable_pb.shared_version();
+        sources.push_back(std::move(source));
+        if (new_ssts[i]->size() > new_ssts[probe_idx]->size()) {
+            probe_idx = i;
+        }
+        new_sst_bytes += new_ssts[i]->size();
+        opened_new_ssts.emplace_back(std::move(sstable));
+    }
+    if (sources.empty()) {
+        return Status::OK();
+    }
+
+    // Split the key space so the merge can use the same pool the lookups it replaces used. Without
+    // this the comparison is a single thread against a saturated pool, which is close to a wash even
+    // when the merge does an order of magnitude less work. Boundaries come from the index-block
+    // separators of the largest incoming sstable -- no data is read to find them -- and every
+    // sstable of one load spans roughly the same key domain, so its quantiles split them all.
+    std::vector<std::pair<std::string, std::string>> ranges;
+    size_t num_tasks = 1;
+    auto* pool = RuntimeEnv::GetInstance()->pk_index_execution_thread_pool();
+    if (config::enable_pk_index_parallel_execution && pool != nullptr && !opened_new_ssts.empty() &&
+        new_sst_bytes >= config::pk_index_merge_dedup_min_parallel_bytes) {
+        num_tasks = std::max<size_t>(1, pool->max_threads());
+    }
+    if (num_tasks > 1) {
+        auto& probe = *opened_new_ssts[probe_idx];
+        std::vector<std::string> samples;
+        const size_t interval =
+                std::max<size_t>(4096, static_cast<size_t>(new_ssts[probe_idx]->size()) / (num_tasks * 8));
+        RETURN_IF_ERROR(probe.sample_keys(&samples, interval));
+        std::sort(samples.begin(), samples.end());
+        samples.erase(std::unique(samples.begin(), samples.end()), samples.end());
+        std::vector<std::string> bounds;
+        for (size_t t = 1; t < num_tasks && samples.size() >= num_tasks; ++t) {
+            const auto& candidate = samples[t * samples.size() / num_tasks];
+            if (bounds.empty() || bounds.back() != candidate) {
+                bounds.push_back(candidate);
+            }
+        }
+        std::string prev;
+        for (const auto& bound : bounds) {
+            ranges.emplace_back(prev, bound);
+            prev = bound;
+        }
+        ranges.emplace_back(prev, std::string());
+    } else {
+        ranges.emplace_back(std::string(), std::string());
+    }
+    num_tasks = ranges.size();
+
+    // Each task fills its own map so the walk needs no locking; the maps are disjoint only by
+    // accident (two ranges can shadow rows of the same segment), so they are concatenated after.
+    std::vector<DeletesMap> task_deletes(num_tasks);
+    std::vector<int64_t> task_entries(num_tasks, 0);
+    std::vector<int64_t> task_dups(num_tasks, 0);
+    std::unique_ptr<ThreadPoolToken> token;
+    if (num_tasks > 1) {
+        token = pool->new_token(ThreadPool::ExecutionMode::CONCURRENT);
+    }
+    {
+        ParallelTaskRunner runner(token.get());
+        for (size_t t = 0; t < num_tasks; ++t) {
+            runner.run([&, t]() -> Status {
+                return merge_dedup_range(sources, new_rssid_set, ranges[t].first, ranges[t].second, &task_deletes[t],
+                                         &task_entries[t], &task_dups[t]);
+            });
+        }
+        RETURN_IF_ERROR(runner.join());
+    }
+
+    int64_t merged_entries = 0;
+    int64_t dup_groups = 0;
+    for (size_t t = 0; t < num_tasks; ++t) {
+        merged_entries += task_entries[t];
+        dup_groups += task_dups[t];
+        for (auto& [rssid, rowids] : task_deletes[t]) {
+            auto& dst = (*new_deletes)[rssid];
+            dst.insert(dst.end(), rowids.begin(), rowids.end());
+        }
+    }
+
+    TRACE_COUNTER_INCREMENT("merge_dedup_entries", merged_entries);
+    TRACE_COUNTER_INCREMENT("merge_dedup_dup_groups", dup_groups);
+    TRACE_COUNTER_INCREMENT("merge_dedup_input_ssts", sources.size());
+    TRACE_COUNTER_INCREMENT("merge_dedup_old_ssts", num_old_sources);
+    TRACE_COUNTER_INCREMENT("merge_dedup_tasks", num_tasks);
     return Status::OK();
 }
 

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -134,6 +134,14 @@ public:
     Status ingest_sst(const FileMetaPB& sst_meta, const PersistentIndexSstableRangePB& sst_range, uint32_t rssid,
                       int64_t version, const DelvecPagePB& delvec_page, DelVectorPtr delvec);
 
+    // Resolve this transaction's shadowed rows with one N-way merge over the index's sstables and
+    // the load's own pre-built sstables, instead of one index lookup per loaded key. |new_ssts| and
+    // |new_rssids| are this rowset's per-segment sstables and the global rssids ingest_sst() will
+    // stamp them with, in segment order; |version| is the publish version. Fills |new_deletes| with
+    // exactly what the per-segment lookup path would have produced -- see the .cpp for why.
+    Status merge_dedup(const TabletMetadataPtr& metadata, const std::vector<const FileMetaPB*>& new_ssts,
+                       const std::vector<uint32_t>& new_rssids, int64_t version, DeletesMap* new_deletes);
+
     static Status major_compact(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata, TxnLogPB* txn_log);
 
     static Status parallel_major_compact(LakePersistentIndexParallelCompactMgr* compact_mgr, TabletManager* tablet_mgr,

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -157,6 +157,16 @@ Status LakePrimaryIndex::ingest_sst(const FileMetaPB& sst_meta, const Persistent
     return index->ingest_sst(sst_meta, sst_range, rssid, version, delvec_page, std::move(delvec));
 }
 
+Status LakePrimaryIndex::merge_dedup(const TabletMetadataPtr& metadata, const std::vector<const FileMetaPB*>& new_ssts,
+                                     const std::vector<uint32_t>& new_rssids, int64_t version,
+                                     DeletesMap* new_deletes) {
+    auto* index = _index.get();
+    if (index == nullptr) {
+        return Status::InternalError("merge_dedup on an unloaded lake primary index");
+    }
+    return index->merge_dedup(metadata, new_ssts, new_rssids, version, new_deletes);
+}
+
 Status LakePrimaryIndex::commit(const TabletMetadataPtr& metadata, MetaFileBuilder* builder,
                                 int64_t generation_version) {
     TRACE_COUNTER_SCOPE_LATENCY_US("primary_index_commit_latency_us");

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -14,9 +14,11 @@
 
 #include "storage/lake/lake_primary_index.h"
 
+#include <atomic>
 #include <utility>
 #include <vector>
 
+#include "base/concurrency/stopwatch.hpp"
 #include "base/debug/trace.h"
 #include "base/testutil/sync_point.h"
 #include "base/utility/defer_op.h"
@@ -281,14 +283,29 @@ Status LakePrimaryIndex::parallel_get(ThreadPoolToken* token, SegmentPKIterator*
     std::mutex deletes_mutex;
     // One slot per chunk, owned here so the encoded key bytes outlive the task that reads them.
     std::vector<std::unique_ptr<ParallelPublishSlot>> slots;
+    // Time actually spent inside the tasks, split by phase and summed across worker threads (so the
+    // totals can exceed wall clock). `parallel_get_wait_us` below only measures the tail wait on the
+    // token, which says how far behind the workers were but not what they were doing -- it cannot
+    // tell an expensive index lookup from an undersized pool or from key encoding dominating. These
+    // separate the three. Relaxed is enough: only the emit after join() reads them, and join()
+    // provides the ordering. They live in this scope because Trace is thread-local and does not
+    // survive the hop into the pool, so a TRACE_COUNTER inside a task would be silently dropped.
+    std::atomic<int64_t> pk_encode_ns{0};
+    std::atomic<int64_t> index_get_ns{0};
+    std::atomic<int64_t> drain_ns{0};
+    std::atomic<int64_t> looked_up_keys{0};
 
     for (; !segment_pk_iterator->done(); segment_pk_iterator->next()) {
         auto current = segment_pk_iterator->current();
         slots.push_back(std::make_unique<ParallelPublishSlot>());
         auto* slot = slots.back().get();
 
-        runner.run([this, current, slot, segment_pk_iterator, new_deletes, &deletes_mutex]() -> Status {
+        runner.run([this, current, slot, segment_pk_iterator, new_deletes, &deletes_mutex, &pk_encode_ns, &index_get_ns,
+                    &drain_ns, &looked_up_keys]() -> Status {
+            MonotonicStopWatch phase;
+            phase.start();
             ASSIGN_OR_RETURN(slot->pk_column, segment_pk_iterator->encoded_pk_column(current.chunk.get()));
+            pk_encode_ns.fetch_add(phase.elapsed_time(), std::memory_order_relaxed);
             // Drop the siblings' keys first. Their old locations would otherwise reach
             // old_values_to_deletes below and be marked deleted in THIS child's delvec, and the
             // parent view ORs the children's delvecs -- so a sibling's lookup would erase a row
@@ -301,9 +318,16 @@ Status LakePrimaryIndex::parallel_get(ThreadPoolToken* token, SegmentPKIterator*
                 return Status::OK();
             }
             slot->old_values.resize(slot->pk_column->size(), NullIndexValue);
+            looked_up_keys.fetch_add(static_cast<int64_t>(slot->pk_column->size()), std::memory_order_relaxed);
+            phase.reset();
+            phase.start();
             RETURN_IF_ERROR(get(*slot->pk_column, &slot->old_values));
+            index_get_ns.fetch_add(phase.elapsed_time(), std::memory_order_relaxed);
+            phase.reset();
+            phase.start();
             std::lock_guard<std::mutex> l(deletes_mutex);
             old_values_to_deletes(slot->old_values, new_deletes);
+            drain_ns.fetch_add(phase.elapsed_time(), std::memory_order_relaxed);
             return Status::OK();
         });
         if (token != nullptr) {
@@ -315,6 +339,11 @@ Status LakePrimaryIndex::parallel_get(ThreadPoolToken* token, SegmentPKIterator*
         TRACE_COUNTER_SCOPE_LATENCY_US("parallel_get_wait_us");
         RETURN_IF_ERROR(runner.join());
     }
+    // Emitted here rather than from the tasks: see the atomics' comment above.
+    TRACE_COUNTER_INCREMENT("parallel_get_pk_encode_us", pk_encode_ns.load() / 1000);
+    TRACE_COUNTER_INCREMENT("parallel_get_index_get_us", index_get_ns.load() / 1000);
+    TRACE_COUNTER_INCREMENT("parallel_get_drain_us", drain_ns.load() / 1000);
+    TRACE_COUNTER_INCREMENT("parallel_get_keys", looked_up_keys.load());
     return segment_pk_iterator->status();
 }
 

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -110,6 +110,11 @@ public:
     Status ingest_sst(const FileMetaPB& sst_meta, const PersistentIndexSstableRangePB& sst_range, uint32_t rssid,
                       int64_t version, const DelvecPagePB& delvec_page, DelVectorPtr delvec);
 
+    // See LakePersistentIndex::merge_dedup. Callers gate on use_cloud_native_pk_index(), the same
+    // condition under which the underlying index exists.
+    Status merge_dedup(const TabletMetadataPtr& metadata, const std::vector<const FileMetaPB*>& new_ssts,
+                       const std::vector<uint32_t>& new_rssids, int64_t version, DeletesMap* new_deletes);
+
     // This function is used for handling delete operation in cloud native PK table.
     // Unlike the base PrimaryIndex::erase, it needs `del_rssid` to set up the rebuild point.
     //

--- a/be/src/storage/lake/persistent_index_sstable_fileset.cpp
+++ b/be/src/storage/lake/persistent_index_sstable_fileset.cpp
@@ -176,6 +176,16 @@ bool PersistentIndexSstableFileset::contains_sst(const std::string& filename) co
     return false;
 }
 
+void PersistentIndexSstableFileset::collect_sstables(std::vector<PersistentIndexSstable*>* out) const {
+    if (_standalone_sstable != nullptr) {
+        out->push_back(_standalone_sstable.get());
+        return;
+    }
+    for (const auto& [range, sstable] : _sstable_map) {
+        out->push_back(sstable.get());
+    }
+}
+
 size_t PersistentIndexSstableFileset::memory_usage() const {
     size_t total_memory = 0;
     for (const auto& [key_pair, sstable] : _sstable_map) {

--- a/be/src/storage/lake/persistent_index_sstable_fileset.h
+++ b/be/src/storage/lake/persistent_index_sstable_fileset.h
@@ -61,6 +61,10 @@ public:
     // Cheaper than get_all_sstable_pbs: no protobuf copy, just string comparison.
     bool contains_sst(const std::string& filename) const;
 
+    // Append every sstable this fileset holds to |out|, in key order. Used by the merge-based
+    // publish path, which needs an iterator per sstable rather than a per-key lookup.
+    void collect_sstables(std::vector<PersistentIndexSstable*>* out) const;
+
     size_t memory_usage() const;
 
     void print_debug_info(std::stringstream& ss);

--- a/be/src/storage/lake/shard_write_txn_log.cpp
+++ b/be/src/storage/lake/shard_write_txn_log.cpp
@@ -1,0 +1,188 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/shard_write_txn_log.h"
+
+#include <limits>
+
+#include "fmt/format.h"
+
+namespace starrocks::lake {
+
+namespace {
+
+constexpr uint32_t kUnknownDelOpOffset = std::numeric_limits<uint32_t>::max();
+
+// A shard-write node contributes plain appended data and nothing else. Anything that ties the log to
+// a per-node view of the tablet (partial-update rewrite plans, a compaction/schema-change body) means
+// this transaction should never have been routed to several writers, so fail loudly instead of
+// silently dropping the field during the fold.
+Status check_mergeable(const TxnLogPB& log) {
+    if (!log.has_op_write()) {
+        return Status::NotSupported(fmt::format("shard write: txn log of tablet {} has no op_write", log.tablet_id()));
+    }
+    if (log.has_op_compaction() || log.has_op_schema_change() || log.has_op_replication() ||
+        log.has_op_parallel_compaction()) {
+        return Status::NotSupported(
+                fmt::format("shard write: txn log of tablet {} carries a non-write operation", log.tablet_id()));
+    }
+    const auto& op_write = log.op_write();
+    if (op_write.has_txn_meta() || op_write.rewrite_segments_meta_size() > 0) {
+        return Status::NotSupported(
+                fmt::format("shard write: partial update is not supported, tablet {}", log.tablet_id()));
+    }
+    return Status::OK();
+}
+
+// ssts are indexed BY SEGMENT at publish time (update_manager reads op_write.ssts(segment_id) and
+// stamps the ingested sstable's rssid from that index), so a log either carries one sst per segment
+// or none at all. A mix across nodes would shift every sst onto the wrong segment, corrupting the
+// primary key index without any visible error, so reject it here.
+Status check_sst_alignment(const TxnLogPB& log) {
+    const auto& op_write = log.op_write();
+    const int segments = op_write.rowset().segment_metas_size();
+    if (op_write.ssts_size() != 0 && op_write.ssts_size() != segments) {
+        return Status::Corruption(fmt::format("shard write: tablet {} has {} ssts for {} segments", log.tablet_id(),
+                                              op_write.ssts_size(), segments));
+    }
+    if (op_write.sst_ranges_size() != 0 && op_write.sst_ranges_size() != op_write.ssts_size()) {
+        return Status::Corruption(fmt::format("shard write: tablet {} has {} sst_ranges for {} ssts", log.tablet_id(),
+                                              op_write.sst_ranges_size(), op_write.ssts_size()));
+    }
+    // del_ssts is indexed by del_id and is all-or-nothing (see the field's proto comment).
+    if (op_write.del_ssts_size() != 0 && op_write.del_ssts_size() != op_write.dels_meta_size()) {
+        return Status::Corruption(fmt::format("shard write: tablet {} has {} del_ssts for {} del files",
+                                              log.tablet_id(), op_write.del_ssts_size(), op_write.dels_meta_size()));
+    }
+    return Status::OK();
+}
+
+} // namespace
+
+Status merge_shard_write_txn_log(TxnLogPB* dst, TxnLogPB* src) {
+    if (dst->tablet_id() != src->tablet_id() || dst->txn_id() != src->txn_id() ||
+        dst->partition_id() != src->partition_id()) {
+        return Status::InternalError(fmt::format(
+                "shard write: refusing to merge txn logs of different targets, ({}, {}, {}) vs ({}, {}, {})",
+                dst->tablet_id(), dst->txn_id(), dst->partition_id(), src->tablet_id(), src->txn_id(),
+                src->partition_id()));
+    }
+    RETURN_IF_ERROR(check_mergeable(*dst));
+    RETURN_IF_ERROR(check_mergeable(*src));
+    RETURN_IF_ERROR(check_sst_alignment(*dst));
+    RETURN_IF_ERROR(check_sst_alignment(*src));
+
+    auto* dst_op = dst->mutable_op_write();
+    auto* src_op = src->mutable_op_write();
+    auto* dst_rowset = dst_op->mutable_rowset();
+    auto* src_rowset = src_op->mutable_rowset();
+
+    const int base_segments = dst_rowset->segment_metas_size();
+    const int base_ssts = dst_op->ssts_size();
+    // With both sides carrying segments, either both build the PK index eagerly (one sst per segment)
+    // or neither does. Mixing them leaves fewer ssts than segments, and publish would then read every
+    // sst under the wrong segment id. An empty side is fine: it contributes neither.
+    if (base_segments > 0 && src_rowset->segment_metas_size() > 0 && (base_ssts > 0) != (src_op->ssts_size() > 0)) {
+        return Status::Corruption(fmt::format(
+                "shard write: tablet {} mixes eager-sst and no-sst txn logs, {} ssts for {} segments vs {} for {}",
+                dst->tablet_id(), base_ssts, base_segments, src_op->ssts_size(), src_rowset->segment_metas_size()));
+    }
+
+    // Segments: a plain append. The position of a segment in this array is its rowset-local index and
+    // therefore its rssid offset, so renumbering segment_idx is all that keeps the ids contiguous.
+    for (auto& segment_meta : *src_rowset->mutable_segment_metas()) {
+        auto* appended = dst_rowset->add_segment_metas();
+        appended->Swap(&segment_meta);
+        appended->set_segment_idx(dst_rowset->segment_metas_size() - 1);
+    }
+
+    // Del files: shift each del's op_offset past the segments |dst| already holds, so the delete still
+    // follows exactly the upserts it followed on its own node and does not swallow rows another node
+    // wrote earlier. del_op_offsets / del_num_rows / del_ssts / del_sst_ranges all stay positionally
+    // aligned with dels_meta.
+    const int base_dels = dst_op->dels_meta_size();
+    const int src_dels = src_op->dels_meta_size();
+    const bool dst_has_offsets = dst_op->del_op_offsets_size() == base_dels;
+    const bool src_has_offsets = src_op->del_op_offsets_size() == src_dels;
+    // A pre-built tombstone sstable is optional PER DEL FILE (an empty entry means "below the eager
+    // threshold, fall back to the memtable erase path"), but the array itself is all-or-nothing. So a
+    // contributor that built none is padded with empty entries rather than collapsing the whole array.
+    const bool any_del_sst = dst_op->del_ssts_size() > 0 || src_op->del_ssts_size() > 0;
+    while (dst_op->del_num_rows_size() < base_dels) {
+        dst_op->add_del_num_rows(0);
+    }
+    if (any_del_sst) {
+        while (dst_op->del_ssts_size() < base_dels) {
+            dst_op->add_del_ssts();
+        }
+        while (dst_op->del_sst_ranges_size() < base_dels) {
+            dst_op->add_del_sst_ranges();
+        }
+    }
+    for (int i = 0; i < src_dels; ++i) {
+        dst_op->add_dels_meta()->Swap(src_op->mutable_dels_meta(i));
+        dst_op->add_del_num_rows(i < src_op->del_num_rows_size() ? src_op->del_num_rows(i) : 0);
+        if (any_del_sst) {
+            auto* del_sst = dst_op->add_del_ssts();
+            if (i < src_op->del_ssts_size()) {
+                del_sst->Swap(src_op->mutable_del_ssts(i));
+            }
+            auto* del_sst_range = dst_op->add_del_sst_ranges();
+            if (i < src_op->del_sst_ranges_size()) {
+                del_sst_range->Swap(src_op->mutable_del_sst_ranges(i));
+            }
+        }
+    }
+    if (dst_has_offsets && src_has_offsets) {
+        for (int i = 0; i < src_op->del_op_offsets_size(); ++i) {
+            const uint32_t offset = src_op->del_op_offsets(i);
+            dst_op->add_del_op_offsets(offset == kUnknownDelOpOffset ? kUnknownDelOpOffset : offset + base_segments);
+        }
+    } else if (base_dels + src_dels > 0) {
+        // Not every contributor recorded per-del offsets. Keeping a partial array would misalign it
+        // with dels_meta; clearing it falls back to the legacy "all deletes after all upserts" reading,
+        // which is exactly what a producer without the offsets already meant.
+        dst_op->clear_del_op_offsets();
+    }
+
+    // ssts / sst_ranges / seg_delvecs are all indexed by segment, so they follow the segments verbatim.
+    for (auto& sst : *src_op->mutable_ssts()) {
+        dst_op->add_ssts()->Swap(&sst);
+    }
+    for (auto& sst_range : *src_op->mutable_sst_ranges()) {
+        dst_op->add_sst_ranges()->Swap(&sst_range);
+    }
+    if (src_op->seg_delvecs_size() > 0) {
+        // seg_delvecs is optional and indexed like ssts; pad the slots of contributors that emitted
+        // none so the incoming entries land on their own segments.
+        while (dst_op->seg_delvecs_size() < base_ssts) {
+            dst_op->add_seg_delvecs();
+        }
+        for (auto& seg_delvec : *src_op->mutable_seg_delvecs()) {
+            dst_op->add_seg_delvecs()->Swap(&seg_delvec);
+        }
+    }
+
+    dst_rowset->set_num_rows(dst_rowset->num_rows() + src_rowset->num_rows());
+    dst_rowset->set_data_size(dst_rowset->data_size() + src_rowset->data_size());
+    // The merged rowset holds segments from several nodes whose key ranges freely overlap.
+    dst_rowset->set_overlapped(dst_rowset->segment_metas_size() > 1);
+
+    if (!dst_op->has_schema_key() && src_op->has_schema_key()) {
+        dst_op->mutable_schema_key()->Swap(src_op->mutable_schema_key());
+    }
+    return Status::OK();
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/shard_write_txn_log.h
+++ b/be/src/storage/lake/shard_write_txn_log.h
@@ -1,0 +1,50 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "common/status.h"
+#include "gen_cpp/lake_types.pb.h"
+
+namespace starrocks::lake {
+
+// Fold |src| -- the txn log one shard-write node produced for a tablet -- into |dst|, the log being
+// assembled for the same tablet from every node that wrote it in this transaction.
+//
+// Shard write (TOlapTableSink.enable_shard_write) has N compute nodes each write a disjoint part of
+// one tablet's rows, so the transaction ends with N partial op_write logs for that tablet. They are
+// folded together here, on the sender, BEFORE the combined {txn_id}.logs file is written, which is
+// what keeps publish unchanged: the file it reads still holds exactly one log per tablet, and the
+// tablet still gains exactly one rowset.
+//
+// The fold is a flat concatenation, mirroring TabletWriter::merge_other_writer (which does the same
+// thing for the multi-threaded spill merge inside one node):
+//   - segment_metas are appended and renumbered, so a segment's position IS its rowset-local index;
+//   - ssts / sst_ranges / seg_delvecs are appended alongside them and stay positionally aligned,
+//     which is what publish relies on (update_manager indexes op_write.ssts() by segment id and
+//     stamps the resulting sstable's rssid from that position, so no rssid rewriting is needed);
+//   - dels_meta are appended with their op_offset shifted by the segments already in |dst|, so a
+//     delete keeps beating the upserts it followed on its own node;
+//   - row and byte counters are summed.
+//
+// Both logs must describe the same tablet, txn and partition. Callers must run
+// normalize_txn_log_after_load() on each input first: it makes the structured arrays canonical and
+// drops the deprecated parallel arrays, which this function does not maintain.
+//
+// Ordering between two nodes' rows is NOT defined -- rows were spread round-robin, so a key upserted
+// on one node and deleted on another has no arrival order left to honour. This is the documented
+// contract of the feature, not an artifact of the merge.
+Status merge_shard_write_txn_log(TxnLogPB* dst, TxnLogPB* src);
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -171,8 +171,17 @@ StatusOr<std::vector<TxnLogVector>> load_txn_log(TabletManager* tablet_mgr, std:
             ASSIGN_OR_RETURN(auto combined_log, tablet_mgr->get_combined_txn_log(log_path, true));
             for (const auto& log : combined_log->txn_logs()) {
                 if (log.tablet_id() == tablet_id) {
+                    if (!txn_logs.empty()) {
+                        // A combined log holds at most one entry per tablet. Under shard write several
+                        // nodes each produce a partial log for the same tablet and the sender folds them
+                        // into one before writing this file (see merge_shard_write_txn_log); a second
+                        // entry means the fold missed a node, so applying just the first would silently
+                        // drop that node's rows. Fail the publish instead.
+                        return Status::Corruption(
+                                fmt::format("combined txn log of txn {} contains more than one txn log for tablet {}",
+                                            txn_info.txn_id(), tablet_id));
+                    }
                     txn_logs.push_back(std::make_shared<TxnLogPB>(log));
-                    break;
                 }
             }
             if (txn_logs.empty()) {
@@ -494,7 +503,7 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const Pub
                     return new_version_metadata_or_error(txn_log_st.status());
                 }
             } // close: if (txn_log_st.status().is_not_found())
-        }     // close: else (admin force-skip vs normal path)
+        } // close: else (admin force-skip vs normal path)
 
         if (!txn_log_st.ok() && !ignore_txn_log) {
             LOG(WARNING) << "Fail to get txn log: " << txn_log_st.status() << " tablet_info=" << tablet_info

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -503,7 +503,7 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const Pub
                     return new_version_metadata_or_error(txn_log_st.status());
                 }
             } // close: if (txn_log_st.status().is_not_found())
-        } // close: else (admin force-skip vs normal path)
+        }     // close: else (admin force-skip vs normal path)
 
         if (!txn_log_st.ok() && !ignore_txn_log) {
             LOG(WARNING) << "Fail to get txn log: " << txn_log_st.status() << " tablet_info=" << tablet_info

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -464,6 +464,29 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     const bool has_condition_update = (condition_column >= 0);
     // Skip early sst compact when condition update with pregenerate sst files.
     bool skip_early_sst_compact = false;
+    // Merge-based dedup. When the load already built this rowset's pk index sstables, the rows it
+    // shadows can be found by merging those sstables against the ones already in the index -- one
+    // ordered pass over both sides, instead of one index lookup per loaded key. Ruled out whenever a
+    // segment has to be read for its columns anyway (partial update, condition merge), and whenever
+    // the per-segment interleaving below carries meaning (delete files in the same transaction),
+    // because the merge collapses the whole rowset into a single step.
+    const bool use_merge_dedup = config::enable_pk_index_merge_dedup && use_cloud_native_pk_index(*metadata) &&
+                                 local_segments > 0 && op_write.ssts_size() == static_cast<int>(local_segments) &&
+                                 !has_condition_update && !op_write.has_txn_meta() && op_write.dels_meta_size() == 0 &&
+                                 op_write.rewrite_segments_meta_size() == 0;
+    if (use_merge_dedup) {
+        TRACE_COUNTER_SCOPE_LATENCY_US("update_index_latency_us");
+        std::vector<const FileMetaPB*> merge_ssts;
+        std::vector<uint32_t> merge_rssids;
+        merge_ssts.reserve(local_segments);
+        merge_rssids.reserve(local_segments);
+        for (uint32_t local_id = 0; local_id < local_segments; ++local_id) {
+            merge_ssts.push_back(&op_write.ssts(local_id));
+            merge_rssids.push_back(rowset_id + rowset_segment_ids[local_id]);
+        }
+        RETURN_IF_ERROR(index.merge_dedup(metadata, merge_ssts, merge_rssids, metadata->version(), &new_deletes));
+        _index_cache.update_object_size(index_entry, index.memory_usage());
+    }
     const bool is_row_mode_partial_update =
             op_write.has_txn_meta() && op_write.rewrite_segments_meta_size() > 0 && op_write.rowset().num_rows() > 0;
     const bool use_parallel_partial_update = config::enable_pk_index_parallel_execution && is_row_mode_partial_update &&
@@ -525,7 +548,12 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
             std::shared_ptr<DelVector> dv_generated_during_merge_update;
             uint32_t global_segment_id = rowset_segment_ids[local_id];
 
-            if (!use_parallel_partial_update || batch_end - batch_start <= 1) {
+            if (use_merge_dedup) {
+                // The merge above already produced every delete this rowset causes, so no segment is
+                // read here at all -- only the rssid to file mapping the rest of publish expects.
+                rssid_fileinfo_container.add_rssid_to_file(op_write.rowset(), metadata->next_rowset_id(), local_id,
+                                                           replace_segments);
+            } else if (!use_parallel_partial_update || batch_end - batch_start <= 1) {
                 // Serial path: load + rewrite inline.
                 RETURN_IF_ERROR(state.load_segment(local_id, params, base_version, true /*resolve conflict*/,
                                                    false /*no need lock*/));
@@ -535,38 +563,44 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
                                                            replace_segments);
             }
 
-            // PK index update + condition merge.
-            TRACE_COUNTER_SCOPE_LATENCY_US("update_index_latency_us");
-            DCHECK(state.upserts(local_id) != nullptr);
-            if (!has_condition_update) {
-                RETURN_IF_ERROR(_do_update(rowset_id, global_segment_id, state.upserts(local_id), index, &new_deletes,
-                                           op_write.ssts_size() > 0, use_cloud_native_pk_index(*metadata)));
-            } else if (op_write.ssts_size() > 0) {
-                RETURN_IF_ERROR(_do_update_with_condition_parallel(params, rowset_id, global_segment_id,
-                                                                   condition_column, state.upserts(local_id), index,
-                                                                   &new_deletes));
-                auto itr = new_deletes.find(rowset_id + global_segment_id);
-                if (itr != new_deletes.end() && itr->second.size() > 0) {
-                    dv_generated_during_merge_update = std::make_shared<DelVector>();
-                    dv_generated_during_merge_update->init(metadata->version(), itr->second.data(), itr->second.size());
-                    builder->append_delvec(dv_generated_during_merge_update, rowset_id + global_segment_id);
+            // Already done in one pass by the merge above; the state never loaded this segment, so
+            // nothing here has anything to read or release.
+            if (!use_merge_dedup) {
+                // PK index update + condition merge.
+                TRACE_COUNTER_SCOPE_LATENCY_US("update_index_latency_us");
+                DCHECK(state.upserts(local_id) != nullptr);
+                if (!has_condition_update) {
+                    RETURN_IF_ERROR(_do_update(rowset_id, global_segment_id, state.upserts(local_id), index,
+                                               &new_deletes, op_write.ssts_size() > 0,
+                                               use_cloud_native_pk_index(*metadata)));
+                } else if (op_write.ssts_size() > 0) {
+                    RETURN_IF_ERROR(_do_update_with_condition_parallel(params, rowset_id, global_segment_id,
+                                                                       condition_column, state.upserts(local_id), index,
+                                                                       &new_deletes));
+                    auto itr = new_deletes.find(rowset_id + global_segment_id);
+                    if (itr != new_deletes.end() && itr->second.size() > 0) {
+                        dv_generated_during_merge_update = std::make_shared<DelVector>();
+                        dv_generated_during_merge_update->init(metadata->version(), itr->second.data(),
+                                                               itr->second.size());
+                        builder->append_delvec(dv_generated_during_merge_update, rowset_id + global_segment_id);
+                    }
+                    skip_early_sst_compact = true;
+                } else {
+                    // NON-SST CONDITION MERGE PATH:
+                    // When SST files are absent, new-row condition values are read from the freshly
+                    // ingested segment file on demand. Compare work is parallelized per chunk; the
+                    // final index.upsert is applied serially after the barrier.
+                    RETURN_IF_ERROR(_do_update_with_condition(params, rowset_id, global_segment_id, condition_column,
+                                                              state.upserts(local_id), index, &new_deletes));
                 }
-                skip_early_sst_compact = true;
-            } else {
-                // NON-SST CONDITION MERGE PATH:
-                // When SST files are absent, new-row condition values are read from the freshly
-                // ingested segment file on demand. Compare work is parallelized per chunk; the
-                // final index.upsert is applied serially after the barrier.
-                RETURN_IF_ERROR(_do_update_with_condition(params, rowset_id, global_segment_id, condition_column,
-                                                          state.upserts(local_id), index, &new_deletes));
+                if (state.auto_increment_deletes(local_id) != nullptr) {
+                    RETURN_IF_ERROR(index.erase(metadata, *state.auto_increment_deletes(local_id), &new_deletes,
+                                                del_rebuild_rssid));
+                }
+                _index_cache.update_object_size(index_entry, index.memory_usage());
+                state.release_segment(local_id);
+                _update_state_cache.update_object_size(state_entry, state.memory_usage());
             }
-            if (state.auto_increment_deletes(local_id) != nullptr) {
-                RETURN_IF_ERROR(index.erase(metadata, *state.auto_increment_deletes(local_id), &new_deletes,
-                                            del_rebuild_rssid));
-            }
-            _index_cache.update_object_size(index_entry, index.memory_usage());
-            state.release_segment(local_id);
-            _update_state_cache.update_object_size(state_entry, state.memory_usage());
             if (op_write.ssts_size() > 0 && use_cloud_native_pk_index(*metadata)) {
                 DelvecPagePB delvec_page_pb = builder->delvec_page(rowset_id + global_segment_id);
                 delvec_page_pb.set_version(metadata->version());

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -317,6 +317,7 @@ SET(DW_TEST_FILES
     ./storage/lake/tablet_test.cpp
     ./storage/lake/tablet_writer_test.cpp
     ./storage/lake/delete_test.cpp
+    ./storage/lake/shard_write_txn_log_test.cpp
     ./storage/lake/transactions_test.cpp
     ./storage/lake/pk_tablet_sst_writer_test.cpp
     ./storage/lake/txn_log_applier_test.cpp

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -3971,6 +3971,117 @@ TEST_P(LakePrimaryKeyPublishTest, test_same_cache_second_upsert_preserves_old_ro
     EXPECT_EQ(expected_new_value, cached_point_get(tablet_id, kLowKey));
 }
 
+// Merge-based dedup has to produce the same delete set as the per-segment lookup path it replaces,
+// and therefore the same visible rows. This loads a shape carrying both kinds of duplicate the merge
+// must resolve -- a key repeated across two segments of a single transaction, and a key carried over
+// from an earlier transaction -- into two identical tablets, one down each path, and compares the
+// results row for row. Values are biased per write so the assertion pins down *which* duplicate won,
+// not merely how many survived.
+TEST_P(LakePrimaryKeyPublishTest, test_merge_dedup_matches_lookup_path) {
+    // Multi-segment rowsets, each segment carrying its own index sst: the precondition merge dedup
+    // gates on. Same recipe as test_light_compaction_publish_row_count_from_metadata.
+    ConfigResetGuard<int64_t> g_write_buffer(&config::write_buffer_size, 512);
+    ConfigResetGuard<int64_t> g_eager_threshold(&config::pk_index_eager_build_threshold_bytes, 1);
+    // Eager index-sst build is unsupported for the fixture's default PK encoding V1.
+    _tablet_metadata->mutable_schema()->set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    _tablet_schema = TabletSchema::create(_tablet_metadata->schema());
+    _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+
+    // The fixture's gen_data derives the value from the key, so a re-write of the same key is
+    // indistinguishable from the original and could not tell a right winner from a wrong one.
+    auto gen = [&](int first_key, int n, int value_bias) {
+        std::vector<int> v0(n);
+        std::vector<int> v1(n);
+        std::vector<uint8_t> v2(n, static_cast<uint8_t>(TOpType::UPSERT));
+        for (int i = 0; i < n; i++) {
+            v0[i] = first_key + i;
+            v1[i] = v0[i] * 3 + value_bias;
+        }
+        auto c0 = Int32Column::create();
+        auto c1 = Int32Column::create();
+        auto c2 = Int8Column::create();
+        c0->append_numbers(v0.data(), v0.size() * sizeof(int));
+        c1->append_numbers(v1.data(), v1.size() * sizeof(int));
+        c2->append_numbers(v2.data(), v2.size() * sizeof(uint8_t));
+        return std::make_shared<Chunk>(Columns{std::move(c0), std::move(c1), std::move(c2)}, _slot_cid_map);
+    };
+
+    // Writes chunks into one transaction, publishes it, and asserts the load built an index sst per
+    // segment -- without that the gate never fires and the test would compare two identical runs of
+    // the lookup path.
+    auto load = [&](int64_t tablet_id, int64_t version, const std::vector<ChunkPtr>& chunks) {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto dw, DeltaWriterBuilder()
+                                         .set_tablet_manager(_tablet_mgr.get())
+                                         .set_tablet_id(tablet_id)
+                                         .set_txn_id(txn_id)
+                                         .set_partition_id(_partition_id)
+                                         .set_mem_tracker(_mem_tracker.get())
+                                         .set_schema_id(_tablet_schema->id())
+                                         .set_slot_descriptors(&_slot_pointers)
+                                         .set_profile(&_dummy_runtime_profile)
+                                         .build());
+        CHECK_OK(dw->open());
+        for (const auto& chunk : chunks) {
+            std::vector<uint32_t> indexes(chunk->num_rows());
+            for (uint32_t i = 0; i < chunk->num_rows(); i++) {
+                indexes[i] = i;
+            }
+            CHECK_OK(dw->write(*chunk, indexes.data(), indexes.size()));
+        }
+        CHECK_OK(dw->finish_with_txnlog());
+        dw->close();
+        ASSIGN_OR_ABORT(auto wlog, _tablet_mgr->get_txn_log(tablet_id, txn_id));
+        ASSERT_GT(wlog->op_write().ssts_size(), 0);
+        ASSERT_EQ(wlog->op_write().rowset().segment_metas_size(), wlog->op_write().ssts_size());
+        ASSERT_OK(publish_single_version(tablet_id, version, txn_id).status());
+    };
+
+    // txn 1 seeds keys 0..239. txn 2 rewrites 100..239 and extends to 299, so its segments shadow
+    // rows already in the index. txn 3 writes two overlapping chunks in one transaction, so keys
+    // 50..149 are duplicated *within* it and the later chunk has to win.
+    auto run = [&](int64_t tablet_id) {
+        load(tablet_id, 2, {gen(0, 240, 0)});
+        load(tablet_id, 3, {gen(100, 200, 1)});
+        load(tablet_id, 4, {gen(0, 150, 2), gen(50, 150, 3)});
+        ASSIGN_OR_ABORT(auto chunk, read(tablet_id, 4));
+        std::map<int32_t, int32_t> rows;
+        for (size_t i = 0; i < chunk->num_rows(); i++) {
+            rows.emplace(chunk->get(i)[0].get_int32(), chunk->get(i)[1].get_int32());
+        }
+        // A duplicate left unresolved would show up as a smaller map than the row count.
+        EXPECT_EQ(chunk->num_rows(), rows.size());
+        return rows;
+    };
+
+    std::map<int32_t, int32_t> expected;
+    for (int k = 0; k < 300; k++) {
+        int bias = 1; // txn 2 covers 100..299
+        if (k < 50) {
+            bias = 2; // txn 3's first chunk only
+        } else if (k < 200) {
+            bias = 3; // txn 3's second chunk wins over its first
+        }
+        expected[k] = k * 3 + bias;
+    }
+
+    std::map<int32_t, int32_t> lookup_rows;
+    {
+        ConfigResetGuard<bool> g_merge(&config::enable_pk_index_merge_dedup, false);
+        lookup_rows = run(_tablet_metadata->id());
+    }
+    ASSERT_EQ(expected, lookup_rows);
+
+    std::map<int32_t, int32_t> merge_rows;
+    {
+        ConfigResetGuard<bool> g_merge(&config::enable_pk_index_merge_dedup, true);
+        auto metadata = new_cloud_native_pk_tablet();
+        merge_rows = run(metadata->id());
+    }
+    ASSERT_EQ(lookup_rows, merge_rows);
+}
+
 INSTANTIATE_TEST_SUITE_P(LakePrimaryKeyPublishTest, LakePrimaryKeyPublishTest,
                          ::testing::Values(PrimaryKeyParam{true, PersistentIndexTypePB::CLOUD_NATIVE},
                                            PrimaryKeyParam{true, PersistentIndexTypePB::CLOUD_NATIVE,

--- a/be/test/storage/lake/shard_write_txn_log_test.cpp
+++ b/be/test/storage/lake/shard_write_txn_log_test.cpp
@@ -1,0 +1,201 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/shard_write_txn_log.h"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+#include "base/testutil/assert.h"
+#include "fmt/format.h"
+
+namespace starrocks::lake {
+
+namespace {
+
+constexpr int64_t kTabletId = 1001;
+constexpr int64_t kTxnId = 77;
+constexpr int64_t kPartitionId = 55;
+constexpr uint32_t kUnknownDelOpOffset = std::numeric_limits<uint32_t>::max();
+
+// One shard-write node's contribution: |segments| segments, each with its own sst when |with_sst|.
+TxnLogPB make_log(const std::string& node, int segments, bool with_sst, int64_t rows_per_segment) {
+    TxnLogPB log;
+    log.set_tablet_id(kTabletId);
+    log.set_txn_id(kTxnId);
+    log.set_partition_id(kPartitionId);
+    auto* op_write = log.mutable_op_write();
+    auto* rowset = op_write->mutable_rowset();
+    for (int i = 0; i < segments; i++) {
+        auto* seg = rowset->add_segment_metas();
+        seg->set_filename(fmt::format("{}_seg{}.dat", node, i));
+        seg->set_size(1024 * (i + 1));
+        seg->set_num_rows(rows_per_segment);
+        seg->set_segment_idx(i);
+        if (with_sst) {
+            op_write->add_ssts()->set_name(fmt::format("{}_sst{}.sst", node, i));
+            op_write->add_sst_ranges()->set_start_key(fmt::format("{}{}", node, i));
+        }
+    }
+    rowset->set_num_rows(static_cast<int64_t>(segments) * rows_per_segment);
+    rowset->set_data_size(1024 * segments);
+    rowset->set_overlapped(segments > 1);
+    return log;
+}
+
+} // namespace
+
+TEST(ShardWriteTxnLogTest, merge_appends_segments_and_renumbers) {
+    auto dst = make_log("a", 2, true, 10);
+    auto src = make_log("b", 3, true, 7);
+
+    ASSERT_OK(merge_shard_write_txn_log(&dst, &src));
+
+    const auto& rowset = dst.op_write().rowset();
+    ASSERT_EQ(5, rowset.segment_metas_size());
+    EXPECT_EQ("a_seg0.dat", rowset.segment_metas(0).filename());
+    EXPECT_EQ("a_seg1.dat", rowset.segment_metas(1).filename());
+    EXPECT_EQ("b_seg0.dat", rowset.segment_metas(2).filename());
+    EXPECT_EQ("b_seg2.dat", rowset.segment_metas(4).filename());
+    // The position of a segment IS its rowset-local id, so the appended ones are renumbered.
+    for (int i = 0; i < rowset.segment_metas_size(); i++) {
+        EXPECT_EQ(i, rowset.segment_metas(i).segment_idx()) << "segment " << i;
+    }
+    EXPECT_EQ(2 * 10 + 3 * 7, rowset.num_rows());
+    EXPECT_EQ(1024 * 2 + 1024 * 3, rowset.data_size());
+    EXPECT_TRUE(rowset.overlapped());
+
+    // ssts stay positionally aligned with the segments: publish indexes them by segment id.
+    ASSERT_EQ(5, dst.op_write().ssts_size());
+    EXPECT_EQ("a_sst0.sst", dst.op_write().ssts(0).name());
+    EXPECT_EQ("b_sst0.sst", dst.op_write().ssts(2).name());
+    ASSERT_EQ(5, dst.op_write().sst_ranges_size());
+    EXPECT_EQ("b0", dst.op_write().sst_ranges(2).start_key());
+}
+
+TEST(ShardWriteTxnLogTest, merge_shifts_del_op_offsets_past_earlier_segments) {
+    auto dst = make_log("a", 2, false, 10);
+    dst.mutable_op_write()->add_dels_meta()->set_name("a.del");
+    dst.mutable_op_write()->add_del_op_offsets(1);
+    dst.mutable_op_write()->add_del_num_rows(3);
+
+    auto src = make_log("b", 3, false, 10);
+    src.mutable_op_write()->add_dels_meta()->set_name("b0.del");
+    src.mutable_op_write()->add_del_op_offsets(0);
+    src.mutable_op_write()->add_del_num_rows(5);
+    src.mutable_op_write()->add_dels_meta()->set_name("b1.del");
+    src.mutable_op_write()->add_del_op_offsets(2);
+    src.mutable_op_write()->add_del_num_rows(6);
+
+    ASSERT_OK(merge_shard_write_txn_log(&dst, &src));
+
+    const auto& op_write = dst.op_write();
+    ASSERT_EQ(3, op_write.dels_meta_size());
+    ASSERT_EQ(3, op_write.del_op_offsets_size());
+    ASSERT_EQ(3, op_write.del_num_rows_size());
+    EXPECT_EQ(1, op_write.del_op_offsets(0));
+    // b's dels followed b's own segments, which now start at index 2.
+    EXPECT_EQ(0 + 2, op_write.del_op_offsets(1));
+    EXPECT_EQ(2 + 2, op_write.del_op_offsets(2));
+    EXPECT_EQ(5, op_write.del_num_rows(1));
+}
+
+TEST(ShardWriteTxnLogTest, merge_keeps_unknown_del_op_offset_sentinel) {
+    auto dst = make_log("a", 1, false, 10);
+    dst.mutable_op_write()->add_dels_meta()->set_name("a.del");
+    dst.mutable_op_write()->add_del_op_offsets(0);
+    dst.mutable_op_write()->add_del_num_rows(1);
+
+    auto src = make_log("b", 1, false, 10);
+    src.mutable_op_write()->add_dels_meta()->set_name("b.del");
+    src.mutable_op_write()->add_del_op_offsets(kUnknownDelOpOffset);
+    src.mutable_op_write()->add_del_num_rows(1);
+
+    ASSERT_OK(merge_shard_write_txn_log(&dst, &src));
+    ASSERT_EQ(2, dst.op_write().del_op_offsets_size());
+    EXPECT_EQ(kUnknownDelOpOffset, dst.op_write().del_op_offsets(1));
+}
+
+TEST(ShardWriteTxnLogTest, merge_drops_partial_del_op_offsets) {
+    auto dst = make_log("a", 1, false, 10);
+    dst.mutable_op_write()->add_dels_meta()->set_name("a.del");
+    dst.mutable_op_write()->add_del_op_offsets(0);
+
+    // A contributor that did not record offsets at all: keeping dst's array would leave it
+    // misaligned with dels_meta, so it must be dropped entirely.
+    auto src = make_log("b", 1, false, 10);
+    src.mutable_op_write()->add_dels_meta()->set_name("b.del");
+
+    ASSERT_OK(merge_shard_write_txn_log(&dst, &src));
+    EXPECT_EQ(2, dst.op_write().dels_meta_size());
+    EXPECT_EQ(0, dst.op_write().del_op_offsets_size());
+}
+
+TEST(ShardWriteTxnLogTest, merge_rejects_mixed_sst_presence) {
+    auto dst = make_log("a", 2, true, 10);
+    auto src = make_log("b", 2, false, 10);
+    // Silently accepting this would leave 2 ssts for 4 segments and publish would stamp each sst
+    // with the wrong segment id.
+    EXPECT_FALSE(merge_shard_write_txn_log(&dst, &src).ok());
+}
+
+TEST(ShardWriteTxnLogTest, merge_accepts_empty_contributor) {
+    auto dst = make_log("a", 2, true, 10);
+    auto src = make_log("b", 0, false, 0);
+    ASSERT_OK(merge_shard_write_txn_log(&dst, &src));
+    EXPECT_EQ(2, dst.op_write().rowset().segment_metas_size());
+    EXPECT_EQ(2, dst.op_write().ssts_size());
+    EXPECT_EQ(20, dst.op_write().rowset().num_rows());
+}
+
+TEST(ShardWriteTxnLogTest, merge_into_empty_contributor) {
+    auto dst = make_log("a", 0, false, 0);
+    auto src = make_log("b", 2, true, 10);
+    ASSERT_OK(merge_shard_write_txn_log(&dst, &src));
+    ASSERT_EQ(2, dst.op_write().rowset().segment_metas_size());
+    ASSERT_EQ(2, dst.op_write().ssts_size());
+    EXPECT_EQ("b_seg0.dat", dst.op_write().rowset().segment_metas(0).filename());
+    EXPECT_EQ(20, dst.op_write().rowset().num_rows());
+}
+
+TEST(ShardWriteTxnLogTest, merge_rejects_different_targets) {
+    auto dst = make_log("a", 1, false, 10);
+    auto src = make_log("b", 1, false, 10);
+    src.set_tablet_id(kTabletId + 1);
+    EXPECT_FALSE(merge_shard_write_txn_log(&dst, &src).ok());
+}
+
+TEST(ShardWriteTxnLogTest, merge_rejects_partial_update) {
+    auto dst = make_log("a", 1, false, 10);
+    auto src = make_log("b", 1, false, 10);
+    src.mutable_op_write()->mutable_txn_meta();
+    EXPECT_FALSE(merge_shard_write_txn_log(&dst, &src).ok());
+}
+
+TEST(ShardWriteTxnLogTest, merge_pads_seg_delvecs_of_a_contributor_without_any) {
+    auto dst = make_log("a", 2, true, 10);
+    auto src = make_log("b", 1, true, 10);
+    src.mutable_op_write()->add_seg_delvecs()->set_data("dv");
+
+    ASSERT_OK(merge_shard_write_txn_log(&dst, &src));
+    // seg_delvecs is indexed like ssts, so the 2 slots of the contributor that emitted none are
+    // padded before b's entry, which must land on segment 2.
+    ASSERT_EQ(3, dst.op_write().seg_delvecs_size());
+    EXPECT_TRUE(dst.op_write().seg_delvecs(0).data().empty());
+    EXPECT_TRUE(dst.op_write().seg_delvecs(1).data().empty());
+    EXPECT_EQ("dv", dst.op_write().seg_delvecs(2).data());
+}
+
+} // namespace starrocks::lake

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -275,7 +275,7 @@ public class OlapTableSink extends DataSink {
 
     // Resolve the effective single-tablet write parallelism for this sink. Returns NO_SHARD_WRITE
     // whenever any precondition of the feature is not met.
-    private int shardWriteParallelism(TransactionState txnState) {
+    private int shardWriteParallelism(TOlapTableSink tSink, TransactionState txnState) {
         if (!dstTable.isCloudNativeTableOrMaterializedView()) {
             return NO_SHARD_WRITE;
         }
@@ -285,9 +285,22 @@ public class OlapTableSink extends DataSink {
         if (txnState == null || !txnState.isUseCombinedTxnLog()) {
             return NO_SHARD_WRITE;
         }
-        // Partial update rewrites segments at publish using per-node rowset txn metadata; splitting one
-        // tablet's rows across nodes is not supported there.
+        // A load that makes BE attach RowsetTxnMetaPB to its op_write cannot have its txn logs folded
+        // across nodes: that publish rewrites segments from per-node rowset metadata. BE attaches it in
+        // exactly three cases (see DeltaWriterImpl::finish_with_txnlog), all of which are decided here:
+        // a partial update, a condition update, and a load missing the auto-increment column. BE's fold
+        // refuses such a log rather than corrupt the rowset, so a load FE spread but BE cannot fold FAILS
+        // -- these checks are what keep it on the single-node path in the first place.
+        if (!sinkWritesEveryColumn() || tSink.isSetMerge_condition() || missAutoIncrementColumn) {
+            return NO_SHARD_WRITE;
+        }
         if (partialUpdateMode != null && partialUpdateMode != TPartialUpdateMode.UNKNOWN_MODE) {
+            return NO_SHARD_WRITE;
+        }
+        // While a schema change is in flight the load also writes a shadow index whose column count
+        // differs from the base schema, so sinkWritesEveryColumn() below cannot be trusted to predict
+        // what BE will see.
+        if (dstTable.getState() != OlapTable.OlapTableState.NORMAL) {
             return NO_SHARD_WRITE;
         }
         ConnectContext context = ConnectContext.get();
@@ -295,6 +308,24 @@ public class OlapTableSink extends DataSink {
             return NO_SHARD_WRITE;
         }
         return Math.max(NO_SHARD_WRITE, context.getSessionVariable().getTabletWriteParallelism());
+    }
+
+    // Mirror of DeltaWriterImpl::init_write_schema: BE counts the sink's slots, drops a trailing `__op`,
+    // and calls the load a partial update when what is left is narrower than the table. DELETE on a
+    // primary-key table lands here too -- it is written as the key columns plus `__op`.
+    private boolean sinkWritesEveryColumn() {
+        if (tupleDescriptor == null) {
+            return false;
+        }
+        List<SlotDescriptor> slots = tupleDescriptor.getSlots();
+        int writeColumns = slots.size();
+        if (!slots.isEmpty()) {
+            Column lastColumn = slots.get(slots.size() - 1).getColumn();
+            if (lastColumn != null && Load.LOAD_OP_COLUMN.equalsIgnoreCase(lastColumn.getName())) {
+                writeColumns--;
+            }
+        }
+        return writeColumns >= dstTable.getBaseSchema().size();
     }
 
     private static boolean hasMultiNodeTablet(TOlapTableLocationParam location) {
@@ -496,7 +527,7 @@ public class OlapTableSink extends DataSink {
                     enableAutomaticPartition, automaticBucketSize, getOpenPartitions(), txnState, targetWriteIndexId);
             tSink.setPartition(partitionParam);
             TOlapTableLocationParam location = createLocation(dstTable, partitionParam, enableReplicatedStorage,
-                    computeResource, txnState, shardWriteParallelism(txnState));
+                    computeResource, txnState, shardWriteParallelism(tSink, txnState));
             tSink.setLocation(location);
             // In shared-data mode a tablet normally carries exactly one node, so more than one can only
             // come from the shard-write path above. Deriving the flag from the location keeps it true to

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -98,6 +98,7 @@ import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.common.MetaUtils;
+import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TColumn;
 import com.starrocks.thrift.TDataSink;
@@ -267,6 +268,40 @@ public class OlapTableSink extends DataSink {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_UNKNOWN_PARTITION, partitionId, dstTable.getName());
             }
         }
+    }
+
+    // `shardWriteParallelism` value that keeps the historical behaviour: one node per tablet.
+    public static final int NO_SHARD_WRITE = 1;
+
+    // Resolve the effective single-tablet write parallelism for this sink. Returns NO_SHARD_WRITE
+    // whenever any precondition of the feature is not met.
+    private int shardWriteParallelism(TransactionState txnState) {
+        if (!dstTable.isCloudNativeTableOrMaterializedView()) {
+            return NO_SHARD_WRITE;
+        }
+        // Every writing node produces a PARTIAL txn log for the tablet, and only the combined-txn-log
+        // path funnels them back to one sender that can aggregate them. Without it each node would write
+        // its own {txn_id}.log to the SAME object-storage path and silently clobber the others.
+        if (txnState == null || !txnState.isUseCombinedTxnLog()) {
+            return NO_SHARD_WRITE;
+        }
+        // Partial update rewrites segments at publish using per-node rowset txn metadata; splitting one
+        // tablet's rows across nodes is not supported there.
+        if (partialUpdateMode != null && partialUpdateMode != TPartialUpdateMode.UNKNOWN_MODE) {
+            return NO_SHARD_WRITE;
+        }
+        ConnectContext context = ConnectContext.get();
+        if (context == null) {
+            return NO_SHARD_WRITE;
+        }
+        return Math.max(NO_SHARD_WRITE, context.getSessionVariable().getTabletWriteParallelism());
+    }
+
+    private static boolean hasMultiNodeTablet(TOlapTableLocationParam location) {
+        if (location.getTablets() == null) {
+            return false;
+        }
+        return location.getTablets().stream().anyMatch(t -> t.getNode_ids() != null && t.getNode_ids().size() > 1);
     }
 
     public void setMissAutoIncrementColumn() {
@@ -460,7 +495,15 @@ public class OlapTableSink extends DataSink {
             TOlapTablePartitionParam partitionParam = createPartition(tSink.getDb_id(), dstTable, tupleDescriptor,
                     enableAutomaticPartition, automaticBucketSize, getOpenPartitions(), txnState, targetWriteIndexId);
             tSink.setPartition(partitionParam);
-            tSink.setLocation(createLocation(dstTable, partitionParam, enableReplicatedStorage, computeResource, txnState));
+            TOlapTableLocationParam location = createLocation(dstTable, partitionParam, enableReplicatedStorage,
+                    computeResource, txnState, shardWriteParallelism(txnState));
+            tSink.setLocation(location);
+            // In shared-data mode a tablet normally carries exactly one node, so more than one can only
+            // come from the shard-write path above. Deriving the flag from the location keeps it true to
+            // what BE actually received: if no partition turned out eligible, BE stays on the old path.
+            if (dstTable.isCloudNativeTableOrMaterializedView() && hasMultiNodeTablet(location)) {
+                tSink.setEnable_shard_write(true);
+            }
             tSink.setNodes_info(GlobalStateMgr.getCurrentState().createNodesInfo(computeResource, getSystemInfoService(dstTable)));
             // A column-mode partial update writes the new values into a DCG beside the segment it
             // patches. A split's UNSHARE compaction rewrites every segment wholesale and does not carry
@@ -1067,6 +1110,30 @@ public class OlapTableSink extends DataSink {
         }
     }
 
+    // Build the shard-write node list of one tablet: its owner node first, then other alive compute
+    // nodes until |parallelism| entries are collected. The owner comes first so that the node which
+    // will later publish this tablet also holds part of its data (and thus its caches). The extra
+    // nodes are picked starting at an offset derived from the tablet id so that different tablets of
+    // the same partition do not all pile onto the same followers.
+    @VisibleForTesting
+    static List<Long> buildShardWriteNodeIds(long ownerNodeId, List<Long> aliveNodeIds, int parallelism,
+                                             long tabletId) {
+        int target = Math.min(parallelism, aliveNodeIds.size());
+        List<Long> nodeIds = Lists.newArrayList(ownerNodeId);
+        if (target <= 1) {
+            return nodeIds;
+        }
+        int size = aliveNodeIds.size();
+        int start = (int) Math.floorMod(tabletId, size);
+        for (int i = 0; i < size && nodeIds.size() < target; i++) {
+            long nodeId = aliveNodeIds.get((start + i) % size);
+            if (nodeId != ownerNodeId) {
+                nodeIds.add(nodeId);
+            }
+        }
+        return nodeIds;
+    }
+
     // Pick the first alive node id from a pre-fetched candidate list.
     // Returns -1 when the list is null/empty or no candidate is alive; callers fall back to a per-tablet lookup.
     private static long pickAliveComputeNodeId(List<Long> candidates, SystemInfoService infoService) {
@@ -1091,6 +1158,18 @@ public class OlapTableSink extends DataSink {
                                                          boolean enableReplicatedStorage,
                                                          ComputeResource computeResource,
                                                          TransactionState txnState) throws StarRocksException {
+        return createLocation(table, partitionParam, enableReplicatedStorage, computeResource, txnState,
+                NO_SHARD_WRITE);
+    }
+
+    // |shardWriteParallelism| > 1 asks for shard write (shared-data only): each eligible tablet's
+    // location carries several compute nodes so the sink can spread one tablet's rows over them.
+    // See TOlapTableSink.enable_shard_write. NO_SHARD_WRITE keeps the historical one-node behaviour.
+    public static TOlapTableLocationParam createLocation(OlapTable table, TOlapTablePartitionParam partitionParam,
+                                                         boolean enableReplicatedStorage,
+                                                         ComputeResource computeResource,
+                                                         TransactionState txnState,
+                                                         int shardWriteParallelism) throws StarRocksException {
         TOlapTableLocationParam locationParam = new TOlapTableLocationParam();
         // replica -> path hash
         Multimap<Long, Long> allBePathsMap = HashMultimap.create();
@@ -1126,6 +1205,17 @@ public class OlapTableSink extends DataSink {
                 }
             }
         }
+        // Shard write: the candidate compute nodes one tablet's rows may be spread over. Resolved once
+        // per statement (not per tablet) and left empty when the feature is off or the warehouse has a
+        // single node, in which case every tablet keeps exactly one node in its location.
+        List<Long> shardWriteCandidates = Collections.emptyList();
+        if (shardWriteParallelism > 1 && table.isCloudNativeTableOrMaterializedView()) {
+            shardWriteCandidates = warehouseManager.getAliveComputeNodes(computeResource).stream()
+                    .map(ComputeNode::getId).sorted().collect(Collectors.toList());
+            if (shardWriteCandidates.size() < 2) {
+                shardWriteCandidates = Collections.emptyList();
+            }
+        }
         for (TOlapTablePartition tPhysicalPartition : partitionParam.getPartitions()) {
             PhysicalPartition physicalPartition = table.getPhysicalPartition(tPhysicalPartition.getId());
             int quorum = table.getPartitionInfo().getQuorumNum(physicalPartition.getParentId(), table.writeQuorum());
@@ -1137,6 +1227,11 @@ public class OlapTableSink extends DataSink {
                     ? txnState.getPartitionLoadedIndexes(table.getId(), physicalPartition)
                     : physicalPartition.getLatestMaterializedIndices(IndexExtState.ALL);
             for (MaterializedIndex index : indexes) {
+                // Shard write only helps while bucket-level parallelism cannot fill the cluster: once a
+                // partition holds at least as many tablets as there are alive CNs, every node already has
+                // work and spreading a single tablet further only multiplies segments and txn logs.
+                boolean shardWriteIndex = !shardWriteCandidates.isEmpty()
+                        && index.getTablets().size() < shardWriteCandidates.size();
                 for (int idx = 0; idx < index.getTablets().size(); ++idx) {
                     Tablet tablet = index.getTablets().get(idx);
                     if (table.isCloudNativeTableOrMaterializedView()) {
@@ -1148,7 +1243,11 @@ public class OlapTableSink extends DataSink {
                             computeNodeId = warehouseManager
                                     .getComputeNodeAssignedToTablet(computeResource, tablet.getId()).getId();
                         }
-                        locationParam.addToTablets(new TTabletLocation(tablet.getId(), Lists.newArrayList(computeNodeId)));
+                        List<Long> nodeIds = shardWriteIndex
+                                ? buildShardWriteNodeIds(computeNodeId, shardWriteCandidates, shardWriteParallelism,
+                                        tablet.getId())
+                                : Lists.newArrayList(computeNodeId);
+                        locationParam.addToTablets(new TTabletLocation(tablet.getId(), nodeIds));
                     } else {
                         // we should ensure the replica backend is alive
                         // otherwise, there will be a 'unknown node id, id=xxx' error for stream load

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -252,6 +252,15 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String BINARY_ENCODING_FORMAT = "binary_encoding_format";
     public static final String BINARY_ENCODING_LEVEL = "binary_encoding_level";
 
+    /**
+     * Shared-data only. Number of compute nodes that may write a SINGLE tablet in parallel within one
+     * load transaction. 1 (default) keeps today's behaviour: a tablet is written only by the compute
+     * node it is assigned to. A value > 1 lets FE hand the sink several nodes per tablet and the sink
+     * round-robins rows across them, decoupling write parallelism from the bucket count.
+     * Only takes effect while a partition has fewer tablets than the warehouse has alive CNs.
+     */
+    public static final String TABLET_WRITE_PARALLELISM = "tablet_write_parallelism";
+
     public static final String ENABLE_LOAD_PROFILE = "enable_load_profile";
     public static final String PROFILING = "profiling";
     public static final String SQL_MODE = "sql_mode";
@@ -1390,6 +1399,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = LOAD_MEM_LIMIT)
     private long loadMemLimit = 0L;
+
+    @VariableMgr.VarAttr(name = TABLET_WRITE_PARALLELISM)
+    private int tabletWriteParallelism = 1;
 
     @VariableMgr.VarAttr(name = QUERY_MEM_LIMIT)
     private long queryMemLimit = 0L;
@@ -4124,6 +4136,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public long getLoadMemLimit() {
         return loadMemLimit;
+    }
+
+    public int getTabletWriteParallelism() {
+        return tabletWriteParallelism;
+    }
+
+    public void setTabletWriteParallelism(int tabletWriteParallelism) {
+        this.tabletWriteParallelism = tabletWriteParallelism;
     }
 
     public int getQueryTimeoutS() {

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -189,6 +189,13 @@ message PTabletWriterOpenRequest {
         // sender 0 is not present (the driver with _sender_id==0 never routed a
         // row that triggered `_incremental_open_node_channel` onto this CN).
         optional bool enable_per_partition_coordinator = 4;
+
+        // See TOlapTableSink.enable_shard_write. When true this CN receives only PART of the
+        // tablet's rows for this transaction, so the txn log its delta writer produces is a
+        // PARTIAL log. It must not be cached under the per-tablet metacache key
+        // `txn_log_location(tablet_id, txn_id)`: publish looks that key up first and would
+        // short-circuit on the partial log, silently dropping the other nodes' data.
+        optional bool shard_write = 5;
     };
 
     required PUniqueId id = 1;

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -256,6 +256,13 @@ struct TOlapTableSink {
     // legacy "sender_id == 0 collects all" rule. FE only sets this to true once
     // it knows every target CN supports the mode (rolling-upgrade interlock).
     35: optional bool enable_lake_per_partition_coordinator_txn_log
+    // Shared-data only: when true, a tablet's `TTabletLocation.node_ids` is a SHARD set rather than
+    // a replica set -- the sender round-robins rows across those nodes so one tablet is written by
+    // several CNs in parallel, instead of sending the same rows to every node in the list. FE sets
+    // it only when the session variable `tablet_write_parallelism` > 1 AND the transaction uses
+    // combined txn logs (each writing CN produces a PARTIAL txn log for the tablet; the sender
+    // aggregates them into one before writing the combined log).
+    36: optional bool enable_shard_write
 }
 
 struct TSchemaTableSink {

--- a/test/sql/test_tablet_write_parallelism/T/test_tablet_write_parallelism
+++ b/test/sql/test_tablet_write_parallelism/T/test_tablet_write_parallelism
@@ -1,0 +1,45 @@
+-- name: test_tablet_write_parallelism @cloud
+create database db_${uuid0};
+use db_${uuid0};
+
+-- One bucket on purpose: this is the shape tablet_write_parallelism exists for -- without it
+-- the whole load lands on the single compute node that owns the tablet. `file_bundling` puts
+-- the transaction on combined txn logs, which shard write requires: each writing node emits a
+-- PARTIAL txn log and the sender folds them into one before writing the combined file.
+create table t_shard (k1 bigint, k2 int, v1 string, v2 bigint)
+    primary key(k1, k2)
+    distributed by hash(k1, k2) buckets 1
+    properties('replication_num' = '1', 'file_bundling' = 'true', 'enable_persistent_index' = 'true');
+
+set tablet_write_parallelism = 3;
+
+-- Enough rows for many chunks, so the per-row round-robin actually lands data on every node
+-- the tablet was spread over rather than on whichever one happened to get the first chunk.
+insert into t_shard select generate_series, cast(generate_series % 7 as int), concat('v', generate_series), generate_series * 3 from table(generate_series(1, 20000));
+select count(*), count(distinct k1), sum(k1), sum(v2) from t_shard;
+
+-- Rows inside one transaction have no order once they are spread over several nodes, but
+-- TRANSACTIONS are still ordered: a later load must overwrite the same keys.
+insert into t_shard select generate_series, cast(generate_series % 7 as int), concat('w', generate_series), generate_series * 5 from table(generate_series(1, 20000));
+select count(*), sum(v2) from t_shard;
+select k1, k2, v1, v2 from t_shard where k1 = 12345;
+
+-- Deletes must still erase rows written by earlier transactions.
+delete from t_shard where k1 <= 10000;
+select count(*), sum(k1), sum(v2) from t_shard;
+
+-- The same routing change without a primary key index behind it.
+create table t_shard_dup (k1 bigint, k2 int, v1 string)
+    duplicate key(k1, k2)
+    distributed by hash(k1) buckets 1
+    properties('replication_num' = '1', 'file_bundling' = 'true');
+insert into t_shard_dup select generate_series, cast(generate_series % 7 as int), concat('v', generate_series) from table(generate_series(1, 20000));
+select count(*), sum(k1) from t_shard_dup;
+
+-- Back to the default: the same load must give exactly the same answer.
+set tablet_write_parallelism = 1;
+truncate table t_shard_dup;
+insert into t_shard_dup select generate_series, cast(generate_series % 7 as int), concat('v', generate_series) from table(generate_series(1, 20000));
+select count(*), sum(k1) from t_shard_dup;
+
+drop database db_${uuid0} force;


### PR DESCRIPTION
## Why I'm doing:

A range-bucket table starts life with a single bucket. In shared-data one tablet belongs to one
compute node, so every row of the first loads funnels into that one CN's memtable, segments and PK
SSTs — write throughput is pinned to a single machine no matter how many CNs the cluster has.

`presplit` does not close this gap: it sizes the split from estimated bytes divided by the target
bucket size, so a small first batch still yields one or two tablets (and none at all when presplit
itself did not kick in). The performance expectation, however, does not shrink with the data volume.

## What I'm doing:

Let FE hand the sink **several** nodes for such a tablet and have the sink round-robin rows across
them, so write parallelism is decoupled from the bucket count. The mechanism retires itself: once
auto-split raises the bucket count to at least the CN count, the precondition no longer holds.

```
today                                   with tablet_write_parallelism = 3
 sink ──all rows──▶ CN-2 (owner)         sink ──rr──▶ CN-1 ─┐
                     └ 1 DeltaWriter          └──▶ CN-2 ─┼─▶ 3 DeltaWriters, one tablet
                                               └──▶ CN-3 ─┘
```

**FE**
- New session variable `tablet_write_parallelism` (default `1` = off).
- `OlapTableSink.createLocation` fills N nodes into an eligible tablet's location, with
  `N = min(tablet_write_parallelism, alive CNs in the warehouse)`; the owner node comes first so the
  node that later publishes also holds part of the data. A partition is eligible only while it has
  **fewer tablets than the warehouse has CNs**.
- Gated off unless the transaction uses **combined txn logs** (each writing node produces a partial
  log; without the combined path they would clobber each other at the same object-storage key) and
  the load is not a partial update.
- `TOlapTableSink.enable_shard_write` tells BE the node list is a *shard* set, not a replica set.

**BE — routing**
- `TabletSinkSender::_send_chunk_by_node` picks **one** node per row instead of sending the rows to
  every node in the list. The choice is made once per chunk, before the per-node dispatch loop,
  because that loop revisits each row once per node — a counter advanced inside it would step a
  different number of times per pass and could duplicate or drop rows. Range distribution reuses the
  same hook via `RangeTabletSinkSender`.

**BE — txn log aggregation (the part that keeps publish unchanged)**
- The N nodes each hand back a partial `op_write` for the tablet. The sender folds them into one
  **before** writing `{txn_id}.logs`, so that file still holds exactly one log per tablet and the
  tablet still gains exactly one rowset.
- New `merge_shard_write_txn_log()` is a flat concatenation mirroring
  `TabletWriter::merge_other_writer` (which already does this for the multi-threaded spill merge
  inside one node): segments are appended and renumbered; `ssts` / `sst_ranges` / `seg_delvecs`
  follow them positionally — which is what publish relies on, since `update_manager` indexes
  `op_write.ssts()` by segment id and stamps the ingested sstable's rssid from that position, so no
  rssid rewriting is needed; del files keep their `op_offset`, shifted past the segments contributed
  by earlier nodes; `del_ssts` / `del_num_rows` stay aligned; counters are summed.
- Mixed shapes that would corrupt silently (an eager-SST log folded with a no-SST one, a partial
  update, a non-write op) are rejected rather than merged.

**BE — the two safety valves**
- The delta writer no longer caches a partial log under the per-tablet metacache key
  `txn_log_location(tablet, txn)`. Publish consults that key **before** reading the combined file and
  would otherwise stop at one node's share and silently drop the rest.
- `load_txn_log` now fails the publish when a combined log carries more than one entry for a tablet,
  turning "the fold missed a node" from silent data loss into a visible error.

**Observability**: the sink profile reports `ShardWriteNodes` — the widest tablet's node count — so a
load where the feature silently did not apply is distinguishable from one where it did.

**Contract**: rows are spread round-robin, so ordering between two nodes' rows is undefined by
construction. A load that depends on the arrival order of a repeated primary key within one
transaction must not enable this. The system cannot tell whether the input has duplicate keys, so
this is the user's call when turning the variable on.

Status: **draft / PoC — measured; the design holds and the win grows with load size.** See
"PoC result" at the end of this description. User-facing documentation for the new session variable is not written yet.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

New session variable `tablet_write_parallelism` defaults to `1`, which is exactly today's behaviour;
nothing changes unless it is raised.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

---

## PoC result: measured, and the design holds — speedup grows with load size

Measured on a 3-CN shared-data cluster (16c64g each, 1 FE), build `main-31c3d9b`, BE binary
fingerprinted for `merge_shard_write_txn_log` before measuring.

**An earlier revision of this description reported the opposite conclusion. That was wrong** — it
came from a harness with three confounds, all since identified and controlled. What they were and
how they inverted the result is documented at the end, because each one will silently corrupt any
lake import benchmark, not just this one.

### Setup

Target is a real range-bucket table (`SET enable_range_distribution = true`, no `DISTRIBUTED BY`),
so the partition starts with exactly one tablet. Every run drops and recreates the target, so each
load goes into an empty single-tablet table, and the tablet count is re-checked afterwards. Source
is 336M rows / 50 GB of hash-derived incompressible payload (149 B/row on disk), sliced by a `k1`
upper bound into disjoint bands so one table yields every size with distinct keys throughout.

Controls, all verified live before the run:

- `enable_statistic_collect_on_first_load = false`
- all four `enable_tablet_pre_split_for_*` switches false
- `tablet_reshard_min_split_size = tablet_reshard_target_size` (raising the target ALONE does not
  disable the adaptive split — see below)
- `datacache_disk_size = 10 GiB`, leaving room for the single-node arm's ~52 GB spill

### Result: DUPLICATE KEY, empty single-tablet range table

| load | baseline (`=1`) | shard write (`=3`) | speedup |
|---|---|---|---|
| 5 GB | 40.5 / 40.2 s | 29.6 / 30.2 s | **1.35x** |
| 10 GB | 64.3 / 75.1 s | 36.4 / 36.5 s | **1.91x** |
| 20 GB | 198.9 / 175.7 s | 74.8 / 48.3 s | **3.04x** |
| 50 GB | 579.0 / 601.0 s | 208.1 / 216.9 s | **2.78x** |

All 16 runs landed the exact expected row count with the tablet still unsplit.

As throughput, which shows the shape more clearly — the single-node arm **degrades
superlinearly** while the three-node arm stays close to linear:

| load | baseline | shard write |
|---|---|---|
| 5 GB | 127 MB/s | 172 MB/s |
| 10 GB | 147 MB/s | 281 MB/s |
| 20 GB | 109 MB/s | 333 MB/s |
| 50 GB | **87 MB/s** | **241 MB/s** |

Doubling 10 GB to 20 GB costs the baseline 2.7x the time; going from 20 GB to 50 GB (2.5x the data)
costs it 3.15x.

### Result: PRIMARY KEY, empty single-tablet range table

Same ladder, same controls, target changed to a primary-key table. `publish` is the per-run publish
cost pulled from the CN log by tablet id; `write` is the remainder of the wall clock.

| load | A total | A write | A publish | B total | B write | B publish | **write speedup** | total |
|---|---|---|---|---|---|---|---|---|
| 5 GB | 53.1 s | 46.3 | 6.8 | 49.7 s | 34.3 | 15.4 | **1.35x** | 1.07x |
| 10 GB | 103.1 s | 77.1 | 26.0 | 72.7 s | 41.8 | 30.9 | **1.85x** | 1.42x |
| 20 GB | 255.4 s | 197.0 | 58.4 | 124.7 s | 52.4 | 72.3 | **3.76x** | 2.05x |
| 50 GB | 901.4 s | 688.2 | 213.2 | 448.4 s | 226.1 | 222.3 | **3.04x** | 2.01x |

The write phase scales *better* than on DUPLICATE KEY (3.76x at 20 GB). But **publish is single-node
and does not scale at all** — 213 s versus 222 s at 50 GB. Once the write phase is compressed,
publish becomes half the wall clock: its share of total is 13/25/23/24% in the A arm and
31/43/**58**/50% in the B arm. If publish were parallelised too, the 50 GB B arm would drop from
448 s to roughly 226 s — 4x against the baseline.

### Where publish time goes

50 GB run, both arms, from the publish trace:

| counter | A (1 node) | B (3 nodes) | ratio | share of publish |
|---|---|---|---|---|
| `publish_tablet_total_us` | 213.1 s | 222.2 s | 1.04x | 100% |
| **`update_index_latency_us`** | **187.0 s** | **211.5 s** | 1.13x | **88-95%** |
| â†³ `parallel_get_wait_us` | 103.6 s | 128.1 s | 1.24x | 49-58% |
| `early_sst_compact_wait_us` | 53.1 s | 37.6 s | **0.71x** | 25 / 17% |
| `segment_get_next_us` | 41.1 s | 40.6 s | 0.99x | 19 / 18% |
| `ingest_sst_latency_us` | 12.3 s | 12.7 s | 1.03x | 6% |
| `do_load_upserts_us` | 6.1 s | 5.8 s | 0.94x | 3% |
| `upserts` / `ingest_sst_times` | 51 / 51 | 51 / 51 | 1.00x | — |
| `parallel_get_cnt` | 20 527 | 20 526 | 1.00x | — |

**The segment count is identical between the arms.** `upserts`, `ingest_sst_times` and
`parallel_get_cnt` all match exactly, so the txn-log fold does **not** multiply segments and the B
arm's publish is not applying more work. Its entire penalty sits in `parallel_get_wait` (+24.5 s —
index lookups wait longer, consistent with each node's segments spanning the whole key range and
hurting lookup locality), and that is mostly cancelled by `early_sst_compact_wait` being 15.5 s
better, leaving a net +9 s. This is a much smaller cost than the earlier, confounded measurement
suggested.

The optimisation target is therefore narrow: `update_index_latency_us` is 88-95% of publish and
everything else together is under 12%. Half of it is `parallel_get_wait_us` — 20 527 batched
lookups at ~6.2 ms each, a latency that says the lookups reach storage rather than memory. Worth
noting this is a load into an **empty** table: all 336M keys are new, and the lookups only serve
dedup across the 51 segments.

### Why the 50 GB point dips

Speedup peaks at 20 GB (3.04x on DUP, 2.05x on PK) and falls back at 50 GB. Measured per resource,
the cause is **the test cluster's local disk write bandwidth**, not the design:

| resource | 20 GB, 3 nodes | 50 GB, 3 nodes | saturated |
|---|---|---|---|
| CPU | user 19-26% | user 20-22% | no — idle throughout |
| memory | 17-20 GB / 64 GB | 17-21 GB / 64 GB | no |
| iowait | 4% | 14-30% | rising |
| local disk write | 134-136 MB/s | 159-167 MB/s | **yes — plateaued** |
| disk queue depth | 18-20 | 42-48 | **yes — doubled** |
| disk util | 73-75% | 90-96% | **yes** |

The signature is *throughput flat while the queue doubles*: writes rise only 22% (135 → 165 MB/s)
while queue depth rises 140%. An `O_DIRECT` sequential write to the same volume measures a raw
ceiling of **187 MB/s** (100 GB ESSD PL1), so the load sustains 87-89% of the hardware limit.

Write amplification is the lever: each node holds 16.7 GB of data but writes ~29 GB to local disk
(spill blocks ~17 GB plus datacache fill ~12 GB), sharing one 187 MB/s channel. datacache cannot be
traded away for it — disabling it took the same run from 181 s to **588 s**, because the source
reads then all fall back to object storage.

So the 50 GB dip is a property of this hardware, not the ceiling of three-node scaling. ESSD
throughput scales with volume size, so a larger or higher-tier local disk, or putting the spill
directory on its own volume, should hold 3x to larger batches.

### The three confounds, for anyone benchmarking lake imports

1. **Post-load statistics wait.** `INSERT INTO ... SELECT` blocks after publish for up to
   `semi_sync_collect_statistic_await_seconds`. It penalised **only the faster arm** (the spread
   segments make its analyze slower), so the client wall clock showed a tie where the transaction
   timeline showed 1.62x. Measure `beginTransaction -> finishTransaction`, or disable
   `enable_statistic_collect_on_first_load`. The timeout also does **not** cancel the job, so it
   keeps running into the next run's window.
2. **The under-provisioned adaptive split.** An index holding fewer tablets than the warehouse has
   CNs is split to one tablet per node regardless of size, gated by `tablet_reshard_min_split_size`
   — raising `tablet_reshard_target_size` alone does not stop it. A "single-tablet" table silently
   becomes three, and `SHOW TABLET` still lists the superseded parent, so a `TABLET()` hint aimed at
   it fails instantly and reads as a very fast query.
3. **Swallowed errors.** With `2>/dev/null`, a query that failed in 20 ms is indistinguishable from
   one that succeeded in 20 ms. Two rounds of measurements were lost to this.

### Status

The mechanism is correct (three CNs write one tablet, N partial logs fold into one, one rowset,
checksums identical on every run) and the performance case holds for both table types: the write
phase scales up to 3.76x, and on DUPLICATE KEY, where publish is trivial, that carries through to
3.04x end to end. On PRIMARY KEY the single-node publish caps the end-to-end gain at ~2x.

Before this is mergeable it still needs: the SQL-Tester case's `R` file recorded (the PR is a draft,
so `RUN CHECKER` blocks the pipeline on "no integration testing" and BUILD / BE UT / FE UT never
run — the new BE unit test has therefore never been compiled), and user-facing documentation for
`tablet_write_parallelism`.

