### PR TITLE
[BugFix] Make dropped FE exit by itself on DROP FOLLOWER/OBSERVER

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -57,6 +57,7 @@ import com.starrocks.common.io.DataOutputBuffer;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.SmallFileMgr.SmallFile;
+import com.starrocks.common.util.Util;
 import com.starrocks.ha.LeaderInfo;
 import com.starrocks.journal.JournalEntity;
 import com.starrocks.journal.JournalInconsistentException;
@@ -516,8 +517,14 @@ public class EditLog {
                     DropFrontendInfo dropFrontendInfo = (DropFrontendInfo) journal.data();
                     globalStateMgr.getNodeMgr().replayDropFrontend(dropFrontendInfo);
                     if (dropFrontendInfo.getNodeName().equals(GlobalStateMgr.getCurrentState().getNodeMgr().getNodeName())) {
-                        throw new JournalInconsistentException("current fe "
-                                + dropFrontendInfo.getNodeName() + " is removed. will exit");
+                        // The removed frontend must exit by itself, and it must NOT be raised as a
+                        // JournalInconsistentException: OP_REMOVE_FRONTEND_V2 is an ignorable operation,
+                        // so the exception would be swallowed by canSkipBadReplayedJournal() when
+                        // metadata_journal_ignore_replay_failure is true (the default).
+                        String errMsg = "current fe " + dropFrontendInfo.getNodeName() + " is removed. will exit";
+                        LOG.error(errMsg);
+                        Util.stdoutWithTime(errMsg);
+                        System.exit(-1);
                     }
                     break;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
@@ -879,21 +879,26 @@ public class NodeMgr {
                         NetUtils.getHostPortInAccessibleFormat(host, port) + "]");
             }
 
-            if (fe.getRole() == FrontendNodeType.FOLLOWER) {
-                // Adjust the electable group size override BEFORE writing the edit log, otherwise
-                // the log commit may wait for the ack of the dropped (possibly gone) follower.
-                GlobalStateMgr.getCurrentState().getHaProtocol().removeUnstableNode(fe.getNodeName(), getFollowerCnt() - 1);
-            }
             Frontend finalFE = fe;
             // Write the edit log BEFORE removing the frontend from the bdbje replication group.
             // removeElectableNode() shuts down the feeder to the dropped follower immediately,
             // so if the log were written after it, the dropped follower could never receive
             // OP_REMOVE_FRONTEND_V2 and would hang in UNKNOWN state forever, instead of exiting
             // by itself through the self-check in EditLog.loadJournal().
+            // While this record is being committed the dropped follower is still a group member,
+            // but that does not raise the quorum: either it is a normal follower (then it is either
+            // alive and can ack, or the group has already lost its quorum and every edit log write
+            // fails anyway), or it is an unstable joiner still masked by the electable group size
+            // override, which is cleared only at the end of this block.
             GlobalStateMgr.getCurrentState().getEditLog().logRemoveFrontend(
                     new DropFrontendInfo(fe.getNodeName()), wal -> applyDropFrontend(finalFE));
             if (fe.getRole() == FrontendNodeType.FOLLOWER) {
                 GlobalStateMgr.getCurrentState().getHaProtocol().removeElectableNode(fe.getNodeName());
+                // Clear the unstable-node bookkeeping AFTER the member is removed from the
+                // replication group. Doing it before the edit log write would clear the electable
+                // group size override while the (possibly non-acking) dropped joiner still counts
+                // toward the ack group size, making the commit above unachievable.
+                GlobalStateMgr.getCurrentState().getHaProtocol().removeUnstableNode(fe.getNodeName(), getFollowerCnt());
             }
         } finally {
             unlock();

--- a/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
@@ -880,12 +880,21 @@ public class NodeMgr {
             }
 
             if (fe.getRole() == FrontendNodeType.FOLLOWER) {
-                GlobalStateMgr.getCurrentState().getHaProtocol().removeElectableNode(fe.getNodeName());
+                // Adjust the electable group size override BEFORE writing the edit log, otherwise
+                // the log commit may wait for the ack of the dropped (possibly gone) follower.
                 GlobalStateMgr.getCurrentState().getHaProtocol().removeUnstableNode(fe.getNodeName(), getFollowerCnt() - 1);
             }
             Frontend finalFE = fe;
+            // Write the edit log BEFORE removing the frontend from the bdbje replication group.
+            // removeElectableNode() shuts down the feeder to the dropped follower immediately,
+            // so if the log were written after it, the dropped follower could never receive
+            // OP_REMOVE_FRONTEND_V2 and would hang in UNKNOWN state forever, instead of exiting
+            // by itself through the self-check in EditLog.loadJournal().
             GlobalStateMgr.getCurrentState().getEditLog().logRemoveFrontend(
                     new DropFrontendInfo(fe.getNodeName()), wal -> applyDropFrontend(finalFE));
+            if (fe.getRole() == FrontendNodeType.FOLLOWER) {
+                GlobalStateMgr.getCurrentState().getHaProtocol().removeElectableNode(fe.getNodeName());
+            }
         } finally {
             unlock();
 

--- a/fe/fe-core/src/test/java/com/starrocks/server/NodeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/NodeMgrTest.java
@@ -17,6 +17,8 @@ package com.starrocks.server;
 import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.ha.FrontendNodeType;
+import com.starrocks.ha.HAProtocol;
+import com.starrocks.leader.CheckpointController;
 import com.starrocks.system.Frontend;
 import com.starrocks.system.FrontendHbResponse;
 import com.starrocks.utframe.UtFrameUtils;
@@ -25,7 +27,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -107,5 +111,98 @@ public class NodeMgrTest {
         Assertions.assertEquals(nodeName, frontends.get(0).getNodeName());
         Assertions.assertEquals(selfNode.first, frontends.get(0).getHost());
         Assertions.assertEquals((int) selfNode.second, frontends.get(0).getEditLogPort());
+    }
+
+    /**
+     * A dropped follower only learns that it was removed by replaying OP_REMOVE_FRONTEND_V2, and
+     * removeElectableNode() shuts down its feeder immediately, so the journal write (and its
+     * in-memory apply) has to happen first. removeUnstableNode() has to come last: it clears the
+     * electable group size override, and while a still-catching-up joiner is a group member it
+     * counts toward the ack quorum without ever acking.
+     */
+    @Test
+    public void testDropFollowerJournalsBeforeLeavingReplicationGroup() throws Exception {
+        NodeMgr nodeMgr = new NodeMgr(FrontendNodeType.LEADER, "leader", Pair.create("192.168.4.1", 9010));
+        nodeMgr.replayAddFrontend(new Frontend(FrontendNodeType.FOLLOWER, "follower1", "192.168.4.2", 9010));
+
+        List<String> calls = new ArrayList<>();
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        HAProtocol previousHaProtocol = globalStateMgr.getHaProtocol();
+        CheckpointController previousController = globalStateMgr.getCheckpointController();
+        globalStateMgr.setHaProtocol(new RecordingHAProtocol(calls, nodeMgr));
+        // dropFrontendHook() cancels the checkpoint of the dropped node, and this test does not
+        // run a checkpoint controller of its own
+        globalStateMgr.setCheckpointController(
+                new CheckpointController("test_checkpoint_controller", globalStateMgr.getJournal(), ""));
+        try {
+            nodeMgr.dropFrontend(FrontendNodeType.FOLLOWER, "192.168.4.2", 9010);
+        } finally {
+            globalStateMgr.setHaProtocol(previousHaProtocol);
+            globalStateMgr.setCheckpointController(previousController);
+        }
+
+        // "journaled=true" means the record was already written and applied when the call was made
+        Assertions.assertEquals(
+                List.of("removeElectableNode(journaled=true)", "removeUnstableNode(journaled=true)"), calls);
+    }
+
+    private static class RecordingHAProtocol implements HAProtocol {
+        private final List<String> calls;
+        private final NodeMgr nodeMgr;
+
+        RecordingHAProtocol(List<String> calls, NodeMgr nodeMgr) {
+            this.calls = calls;
+            this.nodeMgr = nodeMgr;
+        }
+
+        private void record(String call) {
+            calls.add(call + "(journaled=" + (nodeMgr.checkFeExist("192.168.4.2", 9010) == null) + ")");
+        }
+
+        @Override
+        public boolean removeElectableNode(String nodeName) {
+            record("removeElectableNode");
+            return true;
+        }
+
+        @Override
+        public void removeUnstableNode(String nodeName, int currentFollowerCnt) {
+            record("removeUnstableNode");
+        }
+
+        @Override
+        public boolean fencing() {
+            return true;
+        }
+
+        @Override
+        public InetSocketAddress getLeader() {
+            return null;
+        }
+
+        @Override
+        public String getLeaderNodeName() {
+            return null;
+        }
+
+        @Override
+        public List<InetSocketAddress> getObserverNodes() {
+            return new ArrayList<>();
+        }
+
+        @Override
+        public List<InetSocketAddress> getElectableNodes(boolean leaderIncluded) {
+            return new ArrayList<>();
+        }
+
+        @Override
+        public long getLatestEpoch() {
+            return 0;
+        }
+
+        @Override
+        public String transferToLeader(String nodeName, int timeoutMs, boolean force) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

A live FE follower dropped via `ALTER SYSTEM DROP FOLLOWER` never exits and becomes a zombie:

- `NodeMgr.dropFrontend()` removes the follower from the bdbje replication group (`removeElectableNode()`, which immediately shuts down the feeder to it) **before** writing the `OP_REMOVE_FRONTEND_V2` edit log, so the dropped follower can never receive the record.
- The dropped node goes to UNKNOWN and holds elections forever (`Proposer phase 1 protocol error: ... was not a member of the group`); it never learns it was removed, keeps listening on the query port, logs `meta out of date` after 300s, and fails every forwarded statement with `Internal error processing forward`.

In addition, the self-removal check in `EditLog.loadJournal()` for `OP_REMOVE_FRONTEND_V2` (`"current fe ... is removed. will exit"`) is dead code: the op is annotated `@IgnorableOnReplayFailed` and `metadata_journal_ignore_replay_failure` defaults to `true`, so the `JournalInconsistentException` it throws is swallowed by `canSkipBadReplayedJournal()` (`!!! DANGER: SKIP JOURNAL`). Because of this a dropped **OBSERVER** (whose feeder is not cut, so it does replay the record) does not exit either.

## What I'm doing:

1. `NodeMgr.dropFrontend()`: write the edit log **before** `removeElectableNode()`, so the record reaches the dropped follower through the still-alive feeder. The unstable-node bookkeeping (`removeUnstableNode`, electable group size override) stays **before** the log write — otherwise the log commit may wait for the ack of the dropped (possibly gone) follower (this exact scenario is covered by `BDBHATest.testAddAndDropFollower`).
2. `EditLog.loadJournal()` `OP_REMOVE_FRONTEND_V2`: when the removed frontend is the current node, exit directly instead of throwing a `JournalInconsistentException` that gets swallowed as an ignorable-op replay failure.

Verified on a real 3-FE cluster (1 LEADER + 1 FOLLOWER + 1 OBSERVER, built from this branch):

- `DROP FOLLOWER <live follower>`: the dropped FE logs `current fe ... is removed. will exit` and the process exits ~1s after the DDL (before the fix: alive >6 min in UNKNOWN with an election storm until manually killed).
- `DROP OBSERVER <live observer>`: same, exits within ~1s (before the fix: the record is replayed but the exception is swallowed — `!!! DANGER: SKIP JOURNAL` — and the process stays alive).
- The surviving leader stays healthy and writable; `BDBHATest`, `NodeMgrTest`, `OperationTypeTest` stay green.

Fixes #78195

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr
