### PR TITLE
[BugFix] Defer metacache eviction cleanup outside lock

### DIFF
--- a/be/src/base/container/lru_cache.cpp
+++ b/be/src/base/container/lru_cache.cpp
@@ -17,10 +17,22 @@ CacheCleanup::~CacheCleanup() {
 }
 
 void CacheCleanup::cleanup() {
-    for (auto* handle : _handles) {
+    while (_head != nullptr) {
+        auto* handle = _head;
+        _head = handle->next_hash;
         handle->free();
     }
-    _handles.clear();
+    _tail = nullptr;
+}
+
+void CacheCleanup::add(LRUHandle* handle) {
+    handle->next_hash = nullptr;
+    if (_tail == nullptr) {
+        _head = handle;
+    } else {
+        _tail->next_hash = handle;
+    }
+    _tail = handle;
 }
 
 uint32_t CacheKey::hash(const char* data, size_t n, uint32_t seed) const {
@@ -282,7 +294,7 @@ void LRUCache::release(Cache::Handle* handle, CacheCleanup* cleanup) {
     // free handle out of mutex
     if (last_ref) {
         if (cleanup != nullptr) {
-            cleanup->_handles.push_back(e);
+            cleanup->add(e);
         } else {
             e->free();
         }
@@ -385,7 +397,9 @@ Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value,
     // we free the entries here outside of mutex for
     // performance reasons
     if (cleanup != nullptr) {
-        cleanup->_handles.insert(cleanup->_handles.end(), last_ref_list.begin(), last_ref_list.end());
+        for (auto* entry : last_ref_list) {
+            cleanup->add(entry);
+        }
     } else {
         for (auto* entry : last_ref_list) {
             entry->free();

--- a/be/src/base/container/lru_cache.cpp
+++ b/be/src/base/container/lru_cache.cpp
@@ -495,6 +495,11 @@ bool ShardedLRUCache::adjust_capacity(int64_t delta, size_t min_capacity) {
 }
 
 Cache::Handle* ShardedLRUCache::insert(const CacheKey& key, void* value, size_t value_size,
+                                       void (*deleter)(const CacheKey& key, void* value), CachePriority priority) {
+    return insert(key, value, value_size, deleter, priority, nullptr);
+}
+
+Cache::Handle* ShardedLRUCache::insert(const CacheKey& key, void* value, size_t value_size,
                                        void (*deleter)(const CacheKey& key, void* value), CachePriority priority,
                                        CacheCleanup* cleanup) {
     const uint32_t hash = _hash_slice(key);
@@ -504,6 +509,10 @@ Cache::Handle* ShardedLRUCache::insert(const CacheKey& key, void* value, size_t 
 Cache::Handle* ShardedLRUCache::lookup(const CacheKey& key) {
     const uint32_t hash = _hash_slice(key);
     return _shards[_shard(hash)].lookup(key, hash);
+}
+
+void ShardedLRUCache::release(Handle* handle) {
+    release(handle, nullptr);
 }
 
 void ShardedLRUCache::release(Handle* handle, CacheCleanup* cleanup) {

--- a/be/src/base/container/lru_cache.cpp
+++ b/be/src/base/container/lru_cache.cpp
@@ -12,6 +12,17 @@
 
 namespace starrocks {
 
+CacheCleanup::~CacheCleanup() {
+    cleanup();
+}
+
+void CacheCleanup::cleanup() {
+    for (auto* handle : _handles) {
+        handle->free();
+    }
+    _handles.clear();
+}
+
 uint32_t CacheKey::hash(const char* data, size_t n, uint32_t seed) const {
     // Similar to murmur hash
     const uint32_t m = 0xc6a4a793;
@@ -239,7 +250,7 @@ Cache::Handle* LRUCache::lookup(const CacheKey& key, uint32_t hash) {
     return reinterpret_cast<Cache::Handle*>(e);
 }
 
-void LRUCache::release(Cache::Handle* handle) {
+void LRUCache::release(Cache::Handle* handle, CacheCleanup* cleanup) {
     if (handle == nullptr) {
         return;
     }
@@ -270,7 +281,11 @@ void LRUCache::release(Cache::Handle* handle) {
 
     // free handle out of mutex
     if (last_ref) {
-        e->free();
+        if (cleanup != nullptr) {
+            cleanup->_handles.push_back(e);
+        } else {
+            e->free();
+        }
     }
 }
 
@@ -316,7 +331,8 @@ void LRUCache::_evict_one_entry(LRUHandle* e) {
 }
 
 Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value, size_t value_size,
-                                void (*deleter)(const CacheKey& key, void* value), CachePriority priority) {
+                                void (*deleter)(const CacheKey& key, void* value), CachePriority priority,
+                                CacheCleanup* cleanup) {
     size_t key_mem_size = sizeof(LRUHandle) - 1 + key.size();
     size_t kv_mem_size = value_size + key_mem_size;
     auto* e = reinterpret_cast<LRUHandle*>(malloc(key_mem_size));
@@ -368,8 +384,12 @@ Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value,
 
     // we free the entries here outside of mutex for
     // performance reasons
-    for (auto entry : last_ref_list) {
-        entry->free();
+    if (cleanup != nullptr) {
+        cleanup->_handles.insert(cleanup->_handles.end(), last_ref_list.begin(), last_ref_list.end());
+    } else {
+        for (auto* entry : last_ref_list) {
+            entry->free();
+        }
     }
 
     return reinterpret_cast<Cache::Handle*>(e);
@@ -461,9 +481,10 @@ bool ShardedLRUCache::adjust_capacity(int64_t delta, size_t min_capacity) {
 }
 
 Cache::Handle* ShardedLRUCache::insert(const CacheKey& key, void* value, size_t value_size,
-                                       void (*deleter)(const CacheKey& key, void* value), CachePriority priority) {
+                                       void (*deleter)(const CacheKey& key, void* value), CachePriority priority,
+                                       CacheCleanup* cleanup) {
     const uint32_t hash = _hash_slice(key);
-    return _shards[_shard(hash)].insert(key, hash, value, value_size, deleter, priority);
+    return _shards[_shard(hash)].insert(key, hash, value, value_size, deleter, priority, cleanup);
 }
 
 Cache::Handle* ShardedLRUCache::lookup(const CacheKey& key) {
@@ -471,9 +492,9 @@ Cache::Handle* ShardedLRUCache::lookup(const CacheKey& key) {
     return _shards[_shard(hash)].lookup(key, hash);
 }
 
-void ShardedLRUCache::release(Handle* handle) {
+void ShardedLRUCache::release(Handle* handle, CacheCleanup* cleanup) {
     auto* h = reinterpret_cast<LRUHandle*>(handle);
-    _shards[_shard(h->hash)].release(handle);
+    _shards[_shard(h->hash)].release(handle, cleanup);
 }
 
 void ShardedLRUCache::touch(const CacheKey& key) {

--- a/be/src/base/container/lru_cache.cpp
+++ b/be/src/base/container/lru_cache.cpp
@@ -262,6 +262,10 @@ Cache::Handle* LRUCache::lookup(const CacheKey& key, uint32_t hash) {
     return reinterpret_cast<Cache::Handle*>(e);
 }
 
+void LRUCache::release(Cache::Handle* handle) {
+    release(handle, nullptr);
+}
+
 void LRUCache::release(Cache::Handle* handle, CacheCleanup* cleanup) {
     if (handle == nullptr) {
         return;
@@ -340,6 +344,11 @@ void LRUCache::_evict_one_entry(LRUHandle* e) {
     e->in_cache = false;
     _unref(e);
     _usage -= e->charge;
+}
+
+Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value, size_t value_size,
+                                void (*deleter)(const CacheKey& key, void* value), CachePriority priority) {
+    return insert(key, hash, value, value_size, deleter, priority, nullptr);
 }
 
 Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value, size_t value_size,

--- a/be/src/base/container/lru_cache.h
+++ b/be/src/base/container/lru_cache.h
@@ -35,12 +35,16 @@ public:
     CacheCleanup& operator=(CacheCleanup&&) = delete;
 
     void cleanup();
-    bool empty() const { return _handles.empty(); }
+    bool empty() const { return _head == nullptr; }
 
 private:
     friend class LRUCache;
 
-    std::vector<LRUHandle*> _handles;
+    void add(LRUHandle* handle);
+
+    // Reuse detached handles as an intrusive queue to avoid allocations.
+    LRUHandle* _head = nullptr;
+    LRUHandle* _tail = nullptr;
 };
 
 // Create a new cache with a fixed size capacity.  This implementation

--- a/be/src/base/container/lru_cache.h
+++ b/be/src/base/container/lru_cache.h
@@ -19,6 +19,29 @@ namespace starrocks {
 
 class Cache;
 class CacheKey;
+struct LRUHandle;
+
+// Collects cache entries whose deleters must run after an outer caller-owned
+// lock has been released. Entries have already been detached from the cache
+// and no longer contribute to its usage before they are added here.
+class CacheCleanup {
+public:
+    CacheCleanup() = default;
+    ~CacheCleanup();
+
+    CacheCleanup(const CacheCleanup&) = delete;
+    CacheCleanup& operator=(const CacheCleanup&) = delete;
+    CacheCleanup(CacheCleanup&&) = delete;
+    CacheCleanup& operator=(CacheCleanup&&) = delete;
+
+    void cleanup();
+    bool empty() const { return _handles.empty(); }
+
+private:
+    friend class LRUCache;
+
+    std::vector<LRUHandle*> _handles;
+};
 
 // Create a new cache with a fixed size capacity.  This implementation
 // of Cache uses a least-recently-used eviction policy.
@@ -133,10 +156,11 @@ public:
     // longer needed.
     //
     // When the inserted entry is no longer needed, the key and
-    // value will be passed to "deleter".
+    // value will be passed to "deleter". If cleanup is non-null,
+    // detached entries are added to it instead of invoking their deleters inline.
     virtual Handle* insert(const CacheKey& key, void* value, size_t value_size,
                            void (*deleter)(const CacheKey& key, void* value),
-                           CachePriority priority = CachePriority::NORMAL) = 0;
+                           CachePriority priority = CachePriority::NORMAL, CacheCleanup* cleanup = nullptr) = 0;
 
     // If the cache has no mapping for "key", returns NULL.
     //
@@ -148,7 +172,8 @@ public:
     // Release a mapping returned by a previous Lookup().
     // REQUIRES: handle must not have been released yet.
     // REQUIRES: handle must have been returned by a method on *this.
-    virtual void release(Handle* handle) = 0;
+    // If cleanup is non-null, a deleter triggered by this release is deferred to it.
+    virtual void release(Handle* handle, CacheCleanup* cleanup = nullptr) = 0;
 
     // Refresh the recency of an existing cache entry without taking or
     // releasing a handle, so callers can update LRU order without triggering
@@ -200,7 +225,7 @@ public:
 
 // An entry is a variable length heap-allocated structure.  Entries
 // are kept in a circular doubly linked list ordered by access time.
-typedef struct LRUHandle {
+struct LRUHandle {
     void* value;
     void (*deleter)(const CacheKey&, void* value);
     LRUHandle* next_hash;
@@ -229,8 +254,7 @@ typedef struct LRUHandle {
         (*deleter)(key(), value);
         ::free(this);
     }
-
-} LRUHandle;
+};
 
 // We provide our own simple hash tablet since it removes a whole bunch
 // of porting hacks and is also faster than some of the built-in hash
@@ -276,9 +300,9 @@ public:
     // Like Cache methods, but with an extra "hash" parameter.
     Cache::Handle* insert(const CacheKey& key, uint32_t hash, void* value, size_t value_size,
                           void (*deleter)(const CacheKey& key, void* value),
-                          CachePriority priority = CachePriority::NORMAL);
+                          CachePriority priority = CachePriority::NORMAL, CacheCleanup* cleanup = nullptr);
     Cache::Handle* lookup(const CacheKey& key, uint32_t hash);
-    void release(Cache::Handle* handle);
+    void release(Cache::Handle* handle, CacheCleanup* cleanup = nullptr);
     void touch(const CacheKey& key, uint32_t hash);
     void erase(const CacheKey& key, uint32_t hash);
     int prune();
@@ -328,10 +352,10 @@ public:
     explicit ShardedLRUCache(size_t capacity);
     ~ShardedLRUCache() override = default;
     Handle* insert(const CacheKey& key, void* value, size_t value_size,
-                   void (*deleter)(const CacheKey& key, void* value),
-                   CachePriority priority = CachePriority::NORMAL) override;
+                   void (*deleter)(const CacheKey& key, void* value), CachePriority priority = CachePriority::NORMAL,
+                   CacheCleanup* cleanup = nullptr) override;
     Handle* lookup(const CacheKey& key) override;
-    void release(Handle* handle) override;
+    void release(Handle* handle, CacheCleanup* cleanup = nullptr) override;
     void touch(const CacheKey& key) override;
     void erase(const CacheKey& key) override;
     void* value(Handle* handle) override;

--- a/be/src/base/container/lru_cache.h
+++ b/be/src/base/container/lru_cache.h
@@ -227,7 +227,7 @@ public:
 
 // An entry is a variable length heap-allocated structure.  Entries
 // are kept in a circular doubly linked list ordered by access time.
-struct LRUHandle {
+typedef struct LRUHandle {
     void* value;
     void (*deleter)(const CacheKey&, void* value);
     LRUHandle* next_hash;
@@ -256,7 +256,8 @@ struct LRUHandle {
         (*deleter)(key(), value);
         ::free(this);
     }
-};
+
+} LRUHandle;
 
 // We provide our own simple hash tablet since it removes a whole bunch
 // of porting hacks and is also faster than some of the built-in hash
@@ -302,9 +303,13 @@ public:
     // Like Cache methods, but with an extra "hash" parameter.
     Cache::Handle* insert(const CacheKey& key, uint32_t hash, void* value, size_t value_size,
                           void (*deleter)(const CacheKey& key, void* value),
-                          CachePriority priority = CachePriority::NORMAL, CacheCleanup* cleanup = nullptr);
+                          CachePriority priority = CachePriority::NORMAL);
+    Cache::Handle* insert(const CacheKey& key, uint32_t hash, void* value, size_t value_size,
+                          void (*deleter)(const CacheKey& key, void* value), CachePriority priority,
+                          CacheCleanup* cleanup);
     Cache::Handle* lookup(const CacheKey& key, uint32_t hash);
-    void release(Cache::Handle* handle, CacheCleanup* cleanup = nullptr);
+    void release(Cache::Handle* handle);
+    void release(Cache::Handle* handle, CacheCleanup* cleanup);
     void touch(const CacheKey& key, uint32_t hash);
     void erase(const CacheKey& key, uint32_t hash);
     int prune();

--- a/be/src/base/container/lru_cache.h
+++ b/be/src/base/container/lru_cache.h
@@ -160,11 +160,10 @@ public:
     // longer needed.
     //
     // When the inserted entry is no longer needed, the key and
-    // value will be passed to "deleter". If cleanup is non-null,
-    // detached entries are added to it instead of invoking their deleters inline.
+    // value will be passed to "deleter".
     virtual Handle* insert(const CacheKey& key, void* value, size_t value_size,
                            void (*deleter)(const CacheKey& key, void* value),
-                           CachePriority priority = CachePriority::NORMAL, CacheCleanup* cleanup = nullptr) = 0;
+                           CachePriority priority = CachePriority::NORMAL) = 0;
 
     // If the cache has no mapping for "key", returns NULL.
     //
@@ -176,8 +175,7 @@ public:
     // Release a mapping returned by a previous Lookup().
     // REQUIRES: handle must not have been released yet.
     // REQUIRES: handle must have been returned by a method on *this.
-    // If cleanup is non-null, a deleter triggered by this release is deferred to it.
-    virtual void release(Handle* handle, CacheCleanup* cleanup = nullptr) = 0;
+    virtual void release(Handle* handle) = 0;
 
     // Refresh the recency of an existing cache entry without taking or
     // releasing a handle, so callers can update LRU order without triggering
@@ -356,10 +354,13 @@ public:
     explicit ShardedLRUCache(size_t capacity);
     ~ShardedLRUCache() override = default;
     Handle* insert(const CacheKey& key, void* value, size_t value_size,
-                   void (*deleter)(const CacheKey& key, void* value), CachePriority priority = CachePriority::NORMAL,
-                   CacheCleanup* cleanup = nullptr) override;
+                   void (*deleter)(const CacheKey& key, void* value),
+                   CachePriority priority = CachePriority::NORMAL) override;
+    Handle* insert(const CacheKey& key, void* value, size_t value_size,
+                   void (*deleter)(const CacheKey& key, void* value), CachePriority priority, CacheCleanup* cleanup);
     Handle* lookup(const CacheKey& key) override;
-    void release(Handle* handle, CacheCleanup* cleanup = nullptr) override;
+    void release(Handle* handle) override;
+    void release(Handle* handle, CacheCleanup* cleanup);
     void touch(const CacheKey& key) override;
     void erase(const CacheKey& key) override;
     void* value(Handle* handle) override;

--- a/be/src/storage/lake/metacache.cpp
+++ b/be/src/storage/lake/metacache.cpp
@@ -19,6 +19,7 @@
 #include <mutex>
 
 #include "base/container/lru_cache.h"
+#include "base/testutil/sync_point.h"
 #include "base/utility/defer_op.h"
 #include "gen_cpp/lake_types.pb.h"
 #include "storage/del_vector.h"
@@ -103,9 +104,15 @@ Metacache::Metacache(int64_t cache_capacity) : _cache(new_lru_cache(cache_capaci
 
 Metacache::~Metacache() = default;
 
-void Metacache::insert(std::string_view key, CacheValue* ptr, size_t size) {
-    Cache::Handle* handle = _cache->insert(CacheKey(key), ptr, size, cache_value_deleter);
-    _cache->release(handle);
+void Metacache::cache_value_deleter(const CacheKey& /*key*/, void* value) {
+    TEST_SYNC_POINT_CALLBACK("lake::Metacache::cache_value_deleter", value);
+    delete static_cast<CacheValue*>(value);
+}
+
+void Metacache::insert(std::string_view key, CacheValue* ptr, size_t size, CacheCleanup* cleanup) {
+    Cache::Handle* handle =
+            _cache->insert(CacheKey(key), ptr, size, cache_value_deleter, CachePriority::NORMAL, cleanup);
+    _cache->release(handle, cleanup);
 }
 
 std::shared_ptr<const TabletMetadataPB> Metacache::lookup_tablet_metadata(std::string_view key) {
@@ -181,17 +188,22 @@ std::shared_ptr<const TabletSchema> Metacache::lookup_tablet_schema(std::string_
 }
 
 std::shared_ptr<Segment> Metacache::lookup_segment(std::string_view key) {
-    std::shared_lock lock(_mutex);
-    return _lookup_segment_no_lock(key);
+    CacheCleanup cleanup;
+    std::shared_ptr<Segment> segment;
+    {
+        std::shared_lock lock(_mutex);
+        segment = _lookup_segment_no_lock(key, &cleanup);
+    }
+    return segment;
 }
 
-std::shared_ptr<Segment> Metacache::_lookup_segment_no_lock(std::string_view key) {
+std::shared_ptr<Segment> Metacache::_lookup_segment_no_lock(std::string_view key, CacheCleanup* cleanup) {
     auto handle = _cache->lookup(CacheKey(key));
     if (handle == nullptr) {
         g_segment_cache_miss << 1;
         return nullptr;
     }
-    DeferOp defer([this, handle]() { _cache->release(handle); });
+    DeferOp defer([this, handle, cleanup]() { _cache->release(handle, cleanup); });
 
     try {
         auto value = static_cast<CacheValue*>(_cache->value(handle));
@@ -241,39 +253,48 @@ bool Metacache::lookup_aggregation_partition(std::string_view key) {
 
 void Metacache::cache_segment(std::string_view key, std::shared_ptr<Segment> segment) {
     auto mem_cost = segment->mem_usage();
-    std::unique_lock lock(_mutex);
-    _cache_segment_no_lock(key, mem_cost, std::move(segment));
+    CacheCleanup cleanup;
+    {
+        std::unique_lock lock(_mutex);
+        _cache_segment_no_lock(key, mem_cost, std::move(segment), &cleanup);
+    }
 }
 
-void Metacache::_cache_segment_no_lock(std::string_view key, size_t mem_cost, std::shared_ptr<Segment> segment) {
+void Metacache::_cache_segment_no_lock(std::string_view key, size_t mem_cost, std::shared_ptr<Segment> segment,
+                                       CacheCleanup* cleanup) {
     auto value = std::make_unique<CacheValue>(std::move(segment));
-    insert(key, value.release(), mem_cost);
+    insert(key, value.release(), mem_cost, cleanup);
 }
 
 std::shared_ptr<Segment> Metacache::cache_segment_if_absent(std::string_view key,
                                                             const std::shared_ptr<Segment>& segment) {
     auto mem_cost = segment->mem_usage();
-    std::unique_lock lock(_mutex);
-    auto seg = _lookup_segment_no_lock(key);
-    if (seg != nullptr) {
-        // already exists, return the one in cache
-        return seg;
+    CacheCleanup cleanup;
+    std::shared_ptr<Segment> result;
+    {
+        std::unique_lock lock(_mutex);
+        result = _lookup_segment_no_lock(key, &cleanup);
+        if (result == nullptr) {
+            _cache_segment_no_lock(key, mem_cost, segment, &cleanup);
+            result = _lookup_segment_no_lock(key, &cleanup);
+        }
     }
-    _cache_segment_no_lock(key, mem_cost, segment);
-    return _lookup_segment_no_lock(key);
+    return result;
 }
 
 intptr_t Metacache::cache_segment_if_present(std::string_view key, size_t mem_cost, intptr_t segment_addr_hint) {
-    std::unique_lock lock(_mutex);
-    auto seg = _lookup_segment_no_lock(key);
-    if (seg == nullptr) {
-        return 0;
+    CacheCleanup cleanup;
+    intptr_t result = 0;
+    {
+        std::unique_lock lock(_mutex);
+        auto segment = _lookup_segment_no_lock(key, &cleanup);
+        if (segment != nullptr &&
+            (segment_addr_hint == 0 || reinterpret_cast<intptr_t>(segment.get()) == segment_addr_hint)) {
+            _cache_segment_no_lock(key, mem_cost, std::move(segment), &cleanup);
+            result = segment_addr_hint;
+        }
     }
-    if (segment_addr_hint != 0 && reinterpret_cast<intptr_t>(seg.get()) != segment_addr_hint) {
-        return 0;
-    }
-    _cache_segment_no_lock(key, mem_cost, std::move(seg));
-    return segment_addr_hint;
+    return result;
 }
 
 void Metacache::cache_delvec(std::string_view key, std::shared_ptr<const DelVector> delvec) {

--- a/be/src/storage/lake/metacache.cpp
+++ b/be/src/storage/lake/metacache.cpp
@@ -100,7 +100,7 @@ static bvar::PassiveStatus<size_t> g_metacache_capacity("lake", "metacache_capac
 static bvar::PassiveStatus<size_t> g_metacache_usage("lake", "metacache_usage", get_metacache_usage, nullptr);
 #endif
 
-Metacache::Metacache(int64_t cache_capacity) : _cache(new_lru_cache(cache_capacity)) {}
+Metacache::Metacache(int64_t cache_capacity) : _cache(std::make_unique<ShardedLRUCache>(cache_capacity)) {}
 
 Metacache::~Metacache() = default;
 

--- a/be/src/storage/lake/metacache.cpp
+++ b/be/src/storage/lake/metacache.cpp
@@ -109,6 +109,10 @@ void Metacache::cache_value_deleter(const CacheKey& /*key*/, void* value) {
     delete static_cast<CacheValue*>(value);
 }
 
+void Metacache::insert(std::string_view key, CacheValue* ptr, size_t size) {
+    insert(key, ptr, size, nullptr);
+}
+
 void Metacache::insert(std::string_view key, CacheValue* ptr, size_t size, CacheCleanup* cleanup) {
     Cache::Handle* handle =
             _cache->insert(CacheKey(key), ptr, size, cache_value_deleter, CachePriority::NORMAL, cleanup);
@@ -189,12 +193,8 @@ std::shared_ptr<const TabletSchema> Metacache::lookup_tablet_schema(std::string_
 
 std::shared_ptr<Segment> Metacache::lookup_segment(std::string_view key) {
     CacheCleanup cleanup;
-    std::shared_ptr<Segment> segment;
-    {
-        std::shared_lock lock(_mutex);
-        segment = _lookup_segment_no_lock(key, &cleanup);
-    }
-    return segment;
+    std::shared_lock lock(_mutex);
+    return _lookup_segment_no_lock(key, &cleanup);
 }
 
 std::shared_ptr<Segment> Metacache::_lookup_segment_no_lock(std::string_view key, CacheCleanup* cleanup) {
@@ -254,10 +254,8 @@ bool Metacache::lookup_aggregation_partition(std::string_view key) {
 void Metacache::cache_segment(std::string_view key, std::shared_ptr<Segment> segment) {
     auto mem_cost = segment->mem_usage();
     CacheCleanup cleanup;
-    {
-        std::unique_lock lock(_mutex);
-        _cache_segment_no_lock(key, mem_cost, std::move(segment), &cleanup);
-    }
+    std::unique_lock lock(_mutex);
+    _cache_segment_no_lock(key, mem_cost, std::move(segment), &cleanup);
 }
 
 void Metacache::_cache_segment_no_lock(std::string_view key, size_t mem_cost, std::shared_ptr<Segment> segment,
@@ -270,31 +268,28 @@ std::shared_ptr<Segment> Metacache::cache_segment_if_absent(std::string_view key
                                                             const std::shared_ptr<Segment>& segment) {
     auto mem_cost = segment->mem_usage();
     CacheCleanup cleanup;
-    std::shared_ptr<Segment> result;
-    {
-        std::unique_lock lock(_mutex);
-        result = _lookup_segment_no_lock(key, &cleanup);
-        if (result == nullptr) {
-            _cache_segment_no_lock(key, mem_cost, segment, &cleanup);
-            result = _lookup_segment_no_lock(key, &cleanup);
-        }
+    std::unique_lock lock(_mutex);
+    auto seg = _lookup_segment_no_lock(key, &cleanup);
+    if (seg != nullptr) {
+        // already exists, return the one in cache
+        return seg;
     }
-    return result;
+    _cache_segment_no_lock(key, mem_cost, segment, &cleanup);
+    return _lookup_segment_no_lock(key, &cleanup);
 }
 
 intptr_t Metacache::cache_segment_if_present(std::string_view key, size_t mem_cost, intptr_t segment_addr_hint) {
     CacheCleanup cleanup;
-    intptr_t result = 0;
-    {
-        std::unique_lock lock(_mutex);
-        auto segment = _lookup_segment_no_lock(key, &cleanup);
-        if (segment != nullptr &&
-            (segment_addr_hint == 0 || reinterpret_cast<intptr_t>(segment.get()) == segment_addr_hint)) {
-            _cache_segment_no_lock(key, mem_cost, std::move(segment), &cleanup);
-            result = segment_addr_hint;
-        }
+    std::unique_lock lock(_mutex);
+    auto seg = _lookup_segment_no_lock(key, &cleanup);
+    if (seg == nullptr) {
+        return 0;
     }
-    return result;
+    if (segment_addr_hint != 0 && reinterpret_cast<intptr_t>(seg.get()) != segment_addr_hint) {
+        return 0;
+    }
+    _cache_segment_no_lock(key, mem_cost, std::move(seg), &cleanup);
+    return segment_addr_hint;
 }
 
 void Metacache::cache_delvec(std::string_view key, std::shared_ptr<const DelVector> delvec) {

--- a/be/src/storage/lake/metacache.h
+++ b/be/src/storage/lake/metacache.h
@@ -23,6 +23,7 @@
 
 namespace starrocks {
 class Cache;
+class CacheCleanup;
 class CacheKey;
 class DelVector;
 class Segment;
@@ -91,12 +92,13 @@ public:
     size_t capacity() const;
 
 private:
-    static void cache_value_deleter(const CacheKey& /*key*/, void* value) { delete static_cast<CacheValue*>(value); }
+    static void cache_value_deleter(const CacheKey& key, void* value);
 
-    std::shared_ptr<Segment> _lookup_segment_no_lock(std::string_view key);
-    void _cache_segment_no_lock(std::string_view key, size_t mem_cost, std::shared_ptr<Segment> segment);
+    std::shared_ptr<Segment> _lookup_segment_no_lock(std::string_view key, CacheCleanup* cleanup);
+    void _cache_segment_no_lock(std::string_view key, size_t mem_cost, std::shared_ptr<Segment> segment,
+                                CacheCleanup* cleanup);
 
-    void insert(std::string_view key, CacheValue* ptr, size_t size);
+    void insert(std::string_view key, CacheValue* ptr, size_t size, CacheCleanup* cleanup = nullptr);
 
     std::unique_ptr<Cache> _cache;
 

--- a/be/src/storage/lake/metacache.h
+++ b/be/src/storage/lake/metacache.h
@@ -98,7 +98,8 @@ private:
     void _cache_segment_no_lock(std::string_view key, size_t mem_cost, std::shared_ptr<Segment> segment,
                                 CacheCleanup* cleanup);
 
-    void insert(std::string_view key, CacheValue* ptr, size_t size, CacheCleanup* cleanup = nullptr);
+    void insert(std::string_view key, CacheValue* ptr, size_t size);
+    void insert(std::string_view key, CacheValue* ptr, size_t size, CacheCleanup* cleanup);
 
     std::unique_ptr<ShardedLRUCache> _cache;
 

--- a/be/src/storage/lake/metacache.h
+++ b/be/src/storage/lake/metacache.h
@@ -22,11 +22,11 @@
 #include "gutil/macros.h"
 
 namespace starrocks {
-class Cache;
 class CacheCleanup;
 class CacheKey;
 class DelVector;
 class Segment;
+class ShardedLRUCache;
 class TabletSchema;
 class TabletMetadataPB;
 class TxnLogPB;
@@ -100,7 +100,7 @@ private:
 
     void insert(std::string_view key, CacheValue* ptr, size_t size, CacheCleanup* cleanup = nullptr);
 
-    std::unique_ptr<Cache> _cache;
+    std::unique_ptr<ShardedLRUCache> _cache;
 
     std::shared_mutex _mutex;
 };

--- a/be/test/base/lru_cache_test.cpp
+++ b/be/test/base/lru_cache_test.cpp
@@ -411,6 +411,48 @@ TEST_F(CacheTest, TouchUpdatesRecencyOnShardedCache) {
     ASSERT_EQ(3000, lookup_cache(cache.get(), keys[2]));
 }
 
+TEST_F(CacheTest, InsertDefersDeleterUntilCleanup) {
+    const size_t entry_charge = entry_charge_for_int_key();
+    const auto keys = find_int_keys_in_same_shard();
+    std::unique_ptr<Cache> cache(new_lru_cache(entry_charge * kNumShards));
+
+    insert_cache(cache.get(), keys[0], 1000, 1);
+
+    CacheCleanup cleanup;
+    std::string encoded;
+    auto* handle = cache->insert(EncodeKey(&encoded, keys[1]), EncodeValue(2000), 1, &CacheTest::Deleter,
+                                 CachePriority::NORMAL, &cleanup);
+    cache->release(handle, &cleanup);
+
+    ASSERT_TRUE(_deleted_keys.empty());
+    ASSERT_EQ(-1, lookup_cache(cache.get(), keys[0]));
+    ASSERT_EQ(2000, lookup_cache(cache.get(), keys[1]));
+
+    cleanup.cleanup();
+    ASSERT_EQ(std::vector<int>({keys[0]}), _deleted_keys);
+    ASSERT_EQ(std::vector<int>({1000}), _deleted_values);
+}
+
+TEST_F(CacheTest, ReleaseDefersDeleterUntilCleanup) {
+    const size_t entry_charge = entry_charge_for_int_key();
+    std::unique_ptr<Cache> cache(new_lru_cache(entry_charge * kNumShards));
+
+    std::string encoded;
+    auto* handle = cache->insert(EncodeKey(&encoded, 100), EncodeValue(1000), 1, &CacheTest::Deleter);
+    cache->set_capacity(0);
+
+    CacheCleanup cleanup;
+    cache->release(handle, &cleanup);
+
+    ASSERT_TRUE(_deleted_keys.empty());
+    ASSERT_FALSE(cleanup.empty());
+    ASSERT_EQ(0, cache->get_memory_usage());
+
+    cleanup.cleanup();
+    ASSERT_EQ(std::vector<int>({100}), _deleted_keys);
+    ASSERT_EQ(std::vector<int>({1000}), _deleted_values);
+}
+
 TEST_F(CacheTest, TouchMissingKeyDoesNotAffectRecencyOrStats) {
     const size_t entry_charge = entry_charge_for_int_key();
     LRUCache cache;

--- a/be/test/base/lru_cache_test.cpp
+++ b/be/test/base/lru_cache_test.cpp
@@ -414,7 +414,7 @@ TEST_F(CacheTest, TouchUpdatesRecencyOnShardedCache) {
 TEST_F(CacheTest, InsertDefersDeleterUntilCleanup) {
     const size_t entry_charge = entry_charge_for_int_key();
     const auto keys = find_int_keys_in_same_shard();
-    std::unique_ptr<Cache> cache(new_lru_cache(entry_charge * kNumShards));
+    auto cache = std::make_unique<ShardedLRUCache>(entry_charge * kNumShards);
 
     insert_cache(cache.get(), keys[0], 1000, 1);
 
@@ -440,7 +440,7 @@ TEST_F(CacheTest, InsertDefersDeleterUntilCleanup) {
 
 TEST_F(CacheTest, ReleaseDefersDeleterUntilCleanup) {
     const size_t entry_charge = entry_charge_for_int_key();
-    std::unique_ptr<Cache> cache(new_lru_cache(entry_charge * kNumShards));
+    auto cache = std::make_unique<ShardedLRUCache>(entry_charge * kNumShards);
 
     std::string encoded;
     auto* handle = cache->insert(EncodeKey(&encoded, 100), EncodeValue(1000), 1, &CacheTest::Deleter);

--- a/be/test/base/lru_cache_test.cpp
+++ b/be/test/base/lru_cache_test.cpp
@@ -423,14 +423,19 @@ TEST_F(CacheTest, InsertDefersDeleterUntilCleanup) {
     auto* handle = cache->insert(EncodeKey(&encoded, keys[1]), EncodeValue(2000), 1, &CacheTest::Deleter,
                                  CachePriority::NORMAL, &cleanup);
     cache->release(handle, &cleanup);
+    encoded.clear();
+    handle = cache->insert(EncodeKey(&encoded, keys[2]), EncodeValue(3000), 1, &CacheTest::Deleter,
+                           CachePriority::NORMAL, &cleanup);
+    cache->release(handle, &cleanup);
 
     ASSERT_TRUE(_deleted_keys.empty());
     ASSERT_EQ(-1, lookup_cache(cache.get(), keys[0]));
-    ASSERT_EQ(2000, lookup_cache(cache.get(), keys[1]));
+    ASSERT_EQ(-1, lookup_cache(cache.get(), keys[1]));
+    ASSERT_EQ(3000, lookup_cache(cache.get(), keys[2]));
 
     cleanup.cleanup();
-    ASSERT_EQ(std::vector<int>({keys[0]}), _deleted_keys);
-    ASSERT_EQ(std::vector<int>({1000}), _deleted_values);
+    ASSERT_EQ(std::vector<int>({keys[0], keys[1]}), _deleted_keys);
+    ASSERT_EQ(std::vector<int>({1000, 2000}), _deleted_values);
 }
 
 TEST_F(CacheTest, ReleaseDefersDeleterUntilCleanup) {

--- a/be/test/storage/lake/metacache_test.cpp
+++ b/be/test/storage/lake/metacache_test.cpp
@@ -14,12 +14,20 @@
 
 #include "storage/lake/metacache.h"
 
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <array>
+#include <chrono>
 #include <future>
+#include <unordered_map>
 
+#include "base/container/lru_cache.h"
 #include "base/testutil/assert.h"
 #include "base/testutil/id_generator.h"
+#include "base/testutil/sync_point.h"
+#include "base/utility/scoped_cleanup.h"
 #include "column/chunk.h"
 #include "column/chunk_factory.h"
 #include "column/datum_tuple.h"
@@ -340,6 +348,80 @@ TEST_F(LakeMetacacheTest, test_cache_segment_if_absent_concurrency) {
             EXPECT_EQ(final_result, res);
         }
     }
+}
+
+static uint32_t cache_shard(std::string_view key) {
+    CacheKey cache_key(key);
+    return cache_key.hash(cache_key.data(), cache_key.size(), 0) >> (32 - kNumShardBits);
+}
+
+static std::array<std::string, 2> find_segment_paths_in_same_cache_shard() {
+    std::unordered_map<uint32_t, std::string> first_path_by_shard;
+    for (int i = 0;; ++i) {
+        auto path = fmt::format("deferred_cleanup_segment_{}.dat", i);
+        auto [it, inserted] = first_path_by_shard.emplace(cache_shard(path), path);
+        if (!inserted) {
+            return {it->second, std::move(path)};
+        }
+    }
+}
+
+TEST_F(LakeMetacacheTest, test_segment_eviction_runs_outside_metacache_lock) {
+    std::shared_ptr<FileSystem> fs;
+    TabletSchemaCSPtr schema;
+    const auto paths = find_segment_paths_in_same_cache_shard();
+    auto victim = std::make_shared<Segment>(fs, FileInfo{paths[0]}, 100, schema, _tablet_mgr.get());
+    auto replacement = std::make_shared<Segment>(fs, FileInfo{paths[1]}, 101, schema, _tablet_mgr.get());
+
+    const size_t victim_charge = victim->mem_usage() + LRUCache::key_handle_size(CacheKey(paths[0]));
+    const size_t replacement_charge = replacement->mem_usage() + LRUCache::key_handle_size(CacheKey(paths[1]));
+    Metacache metacache(std::max(victim_charge, replacement_charge) * kNumShards);
+    metacache.cache_segment(paths[0], victim);
+
+    auto* victim_ptr = victim.get();
+    std::weak_ptr<Segment> victim_weak = victim;
+    victim.reset();
+
+    std::promise<void> deleter_entered;
+    auto deleter_entered_future = deleter_entered.get_future();
+    std::promise<void> allow_deletion;
+    auto allow_deletion_future = allow_deletion.get_future().share();
+    auto* sync_point = SyncPoint::GetInstance();
+    sync_point->SetCallBack("lake::Metacache::cache_value_deleter", [&](void* arg) {
+        auto* value = static_cast<CacheValue*>(arg);
+        auto* segment = std::get_if<std::shared_ptr<Segment>>(value);
+        if (segment != nullptr && segment->get() == victim_ptr) {
+            deleter_entered.set_value();
+            allow_deletion_future.wait();
+        }
+    });
+    sync_point->EnableProcessing();
+    auto sync_point_cleanup = MakeScopedCleanup([&]() {
+        sync_point->DisableProcessing();
+        sync_point->ClearCallBack("lake::Metacache::cache_value_deleter");
+    });
+
+    auto insert_future = std::async(std::launch::async, [&]() { metacache.cache_segment(paths[1], replacement); });
+    bool deletion_released = false;
+    auto unblock_deleter = MakeScopedCleanup([&]() {
+        if (!deletion_released) {
+            allow_deletion.set_value();
+        }
+    });
+
+    using namespace std::chrono_literals;
+    ASSERT_EQ(std::future_status::ready, deleter_entered_future.wait_for(5s));
+
+    auto lookup_future = std::async(std::launch::async, [&]() { return metacache.lookup_segment(paths[1]); });
+    EXPECT_EQ(std::future_status::ready, lookup_future.wait_for(1s));
+
+    allow_deletion.set_value();
+    deletion_released = true;
+    unblock_deleter.cancel();
+
+    EXPECT_EQ(replacement, lookup_future.get());
+    insert_future.get();
+    EXPECT_TRUE(victim_weak.expired());
 }
 
 TEST_F(LakeMetacacheTest, test_combined_txn_log_cache) {

--- a/be/test/storage/rowset/metadata_cache_test.cpp
+++ b/be/test/storage/rowset/metadata_cache_test.cpp
@@ -35,8 +35,8 @@ namespace starrocks {
 class RecordingCache final : public Cache {
 public:
     Handle* insert(const CacheKey& /*key*/, void* /*value*/, size_t /*value_size*/,
-                   void (*/*deleter*/)(const CacheKey& key, void* value),
-                   CachePriority /*priority*/ = CachePriority::NORMAL) override {
+                   void (* /*deleter*/)(const CacheKey& key, void* value),
+                   CachePriority /*priority*/ = CachePriority::NORMAL, CacheCleanup* /*cleanup*/ = nullptr) override {
         return nullptr;
     }
 
@@ -46,7 +46,7 @@ public:
         return &_handle;
     }
 
-    void release(Handle* /*handle*/) override { ++release_calls; }
+    void release(Handle* /*handle*/, CacheCleanup* /*cleanup*/ = nullptr) override { ++release_calls; }
 
     void touch(const CacheKey& key) override {
         ++touch_calls;

--- a/be/test/storage/rowset/metadata_cache_test.cpp
+++ b/be/test/storage/rowset/metadata_cache_test.cpp
@@ -35,7 +35,7 @@ namespace starrocks {
 class RecordingCache final : public Cache {
 public:
     Handle* insert(const CacheKey& /*key*/, void* /*value*/, size_t /*value_size*/,
-                   void (* /*deleter*/)(const CacheKey& key, void* value),
+                   void (*/*deleter*/)(const CacheKey& key, void* value),
                    CachePriority /*priority*/ = CachePriority::NORMAL, CacheCleanup* /*cleanup*/ = nullptr) override {
         return nullptr;
     }

--- a/be/test/storage/rowset/metadata_cache_test.cpp
+++ b/be/test/storage/rowset/metadata_cache_test.cpp
@@ -36,7 +36,7 @@ class RecordingCache final : public Cache {
 public:
     Handle* insert(const CacheKey& /*key*/, void* /*value*/, size_t /*value_size*/,
                    void (*/*deleter*/)(const CacheKey& key, void* value),
-                   CachePriority /*priority*/ = CachePriority::NORMAL, CacheCleanup* /*cleanup*/ = nullptr) override {
+                   CachePriority /*priority*/ = CachePriority::NORMAL) override {
         return nullptr;
     }
 
@@ -46,7 +46,7 @@ public:
         return &_handle;
     }
 
-    void release(Handle* /*handle*/, CacheCleanup* /*cleanup*/ = nullptr) override { ++release_calls; }
+    void release(Handle* /*handle*/) override { ++release_calls; }
 
     void touch(const CacheKey& key) override {
         ++touch_calls;


### PR DESCRIPTION
## Why I'm doing:

Lake Metacache segment operations hold a process-wide read-write lock while the underlying LRU cache may invoke an evicted entry's deleter. Destroying a segment can be expensive, so a slow deleter can block unrelated segment lookups and inserts behind the Metacache lock and cause query stalls.

## What I'm doing:

- Add a `CacheCleanup` collector that lets LRU cache callers defer detached-entry deleters.
- Run segment cache eviction cleanup after releasing the Metacache read-write lock while preserving same-key insertion semantics.
- Add deterministic tests for deferred insert/release cleanup and concurrent Metacache lookup during segment destruction.

Verification:

- ASAN `CacheTest.*`: 15 tests passed.
- ASAN `LakeMetacacheTest.*`: 11 tests passed.
- BE module boundary check passed.
- Generated BE `AGENTS.md` consistency check passed.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
