### PR TITLE
[Enhancement] Gather segment ordinal indexes into a tail region for cold reads

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -410,6 +410,23 @@ CONF_Int32(min_file_descriptor_number, "60000");
 // data and index page size, default is 64k
 CONF_Int32(data_page_size, "65536");
 
+// Gather every column's ordinal index into one run just before the footer, instead of leaving each
+// after its own column's data pages. A cold scan loads the ordinal index of every projected column
+// before it can read a data page; scattered, those cost a cache block and a round trip each, and at
+// the tail they share blocks and often the one the footer read already fetched. Nothing else moves
+// -- the short key index and the page zone maps keep the positions they have always had.
+//
+// A shared-nothing BE ignores this and keeps the original layout: there the scattered reads hit a
+// local disk. So does a partial-update rewrite, which copies an existing segment's prefix and
+// could only build a region covering the columns it appends. Vertical compaction does produce it.
+//
+// Cost: a one-column scan of a wide table pays roughly one extra remote block per segment, since
+// a hundred columns of ordinal index do not fit in the footer's block.
+//
+// Either layout is readable by any binary in either direction and the two coexist in one tablet,
+// so this can be flipped at any time without rewriting data.
+CONF_mBool(lake_enable_segment_tail_index_region, "true");
+
 // When true, high-cardinality string columns that fall back to plain encoding are written with
 // the PLAIN_ENCODING_DELTA_OFFSET column encoding, whose page offset trailer stores per-value
 // deltas (string lengths) instead of absolute offsets. Deltas are near-constant for fixed-ish

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -833,6 +833,7 @@
         "enable_transparent_data_encryption",
         "default_num_rows_per_column_file_block",
         "data_page_size",
+        "lake_enable_segment_tail_index_region",
         "enable_bitmap_index_memory_page_cache",
         "enable_zonemap_index_memory_page_cache",
         "enable_ordinal_index_memory_page_cache",

--- a/be/src/common/config_rowset_fwd.h
+++ b/be/src/common/config_rowset_fwd.h
@@ -58,6 +58,23 @@ CONF_mInt32(default_num_rows_per_column_file_block, "1024");
 // data and index page size, default is 64k
 CONF_Int32(data_page_size, "65536");
 
+// Gather every column's ordinal index into one run just before the footer, instead of leaving each
+// after its own column's data pages. A cold scan loads the ordinal index of every projected column
+// before it can read a data page; scattered, those cost a cache block and a round trip each, and at
+// the tail they share blocks and often the one the footer read already fetched. Nothing else moves
+// -- the short key index and the page zone maps keep the positions they have always had.
+//
+// A shared-nothing BE ignores this and keeps the original layout: there the scattered reads hit a
+// local disk. So does a partial-update rewrite, which copies an existing segment's prefix and
+// could only build a region covering the columns it appends. Vertical compaction does produce it.
+//
+// Cost: a one-column scan of a wide table pays roughly one extra remote block per segment, since
+// a hundred columns of ordinal index do not fit in the footer's block.
+//
+// Either layout is readable by any binary in either direction and the two coexist in one tablet,
+// so this can be flipped at any time without rewriting data.
+CONF_mBool(lake_enable_segment_tail_index_region, "true");
+
 // When true, high-cardinality string columns that fall back to plain encoding are written with
 // the PLAIN_ENCODING_DELTA_OFFSET column encoding, whose page offset trailer stores per-value
 // deltas (string lengths) instead of absolute offsets. Deltas are near-constant for fixed-ish

--- a/be/src/storage/rowset/array_column_writer.cpp
+++ b/be/src/storage/rowset/array_column_writer.cpp
@@ -47,6 +47,15 @@ public:
     Status write_zone_map() override { return Status::OK(); }
 
     Status write_bitmap_index() override { return Status::OK(); }
+    // Same order and the same is_nullable() guard as write_ordinal_index(), so the deferred
+    // writes land exactly where the immediate ones would have.
+    void take_ordinal_index_builders(std::vector<DeferredOrdinalIndex>* out) override {
+        if (is_nullable()) {
+            _null_writer->take_ordinal_index_builders(out);
+        }
+        _array_size_writer->take_ordinal_index_builders(out);
+        _element_writer->take_ordinal_index_builders(out);
+    }
 
     Status write_bloom_filter_index() override { return Status::OK(); }
 

--- a/be/src/storage/rowset/column_writer.cpp
+++ b/be/src/storage/rowset/column_writer.cpp
@@ -255,6 +255,9 @@ public:
     Status write_ordinal_index() override { return _scalar_column_writer->write_ordinal_index(); };
     Status write_zone_map() override { return _scalar_column_writer->write_zone_map(); };
     Status write_bitmap_index() override { return _scalar_column_writer->write_bitmap_index(); };
+    void take_ordinal_index_builders(std::vector<DeferredOrdinalIndex>* out) override {
+        _scalar_column_writer->take_ordinal_index_builders(out);
+    }
     Status write_bloom_filter_index() override { return _scalar_column_writer->write_bloom_filter_index(); };
     Status write_inverted_index() override { return _scalar_column_writer->write_inverted_index(); };
 
@@ -301,6 +304,9 @@ public:
     Status write_ordinal_index() override { return _scalar_column_writer->write_ordinal_index(); };
     Status write_zone_map() override { return _scalar_column_writer->write_zone_map(); };
     Status write_bitmap_index() override { return _scalar_column_writer->write_bitmap_index(); };
+    void take_ordinal_index_builders(std::vector<DeferredOrdinalIndex>* out) override {
+        _scalar_column_writer->take_ordinal_index_builders(out);
+    }
     Status write_bloom_filter_index() override { return _scalar_column_writer->write_bloom_filter_index(); };
 
     ordinal_t get_next_rowid() const override { return _scalar_column_writer->get_next_rowid(); };
@@ -575,6 +581,13 @@ Status ScalarColumnWriter::write_zone_map() {
         return _zone_map_index_builder->finish(_wfile, _opts.meta->add_indexes());
     }
     return Status::OK();
+}
+
+// Give up the ordinal-index builder so the rest of this writer can be destroyed on schedule. The
+// meta pointer travels with it because write_ordinal_index() records the page pointer through
+// _opts.meta, and by the time the region is written this writer is gone.
+void ScalarColumnWriter::take_ordinal_index_builders(std::vector<DeferredOrdinalIndex>* out) {
+    out->push_back({std::move(_ordinal_index_builder), _opts.meta});
 }
 
 Status ScalarColumnWriter::write_bitmap_index() {

--- a/be/src/storage/rowset/column_writer.h
+++ b/be/src/storage/rowset/column_writer.h
@@ -49,8 +49,9 @@
 #include "base/bit/bitmap.h"   // for BitmapChange
 #include "base/string/slice.h" // for OwnedSlice
 #include "storage/rowset/binary_dict_page.h"
-#include "storage/rowset/page_pointer.h" // for PagePointer
-#include "storage/tablet_schema.h"       // for TabletColumn
+#include "storage/rowset/ordinal_page_index.h" // DeferredOrdinalIndex, OrdinalIndexWriter
+#include "storage/rowset/page_pointer.h"       // for PagePointer
+#include "storage/tablet_schema.h"             // for TabletColumn
 #include "storage_primitive/rowid_types.h"
 
 namespace starrocks {
@@ -176,6 +177,19 @@ public:
 
     virtual Status write_inverted_index() { return Status::OK(); }
 
+    // Hand the ordinal-index builder(s) of this column to the caller, so that the writer itself can
+    // be destroyed on schedule while the index is written later, next to the footer
+    // (config::lake_enable_segment_tail_index_region). A composite writer contributes one per leaf, in
+    // the same order write_ordinal_index() would have written them.
+    //
+    // Taking only what has to survive, rather than keeping the whole writer and freeing the rest,
+    // is deliberate: every other builder is already flushed by this point and holds memory that
+    // finish() does not return -- BitmapIndexWriterImpl::finish() empties its map but keeps its
+    // MemPool -- and a vertical writer would otherwise carry one per indexed column of every
+    // column group until the footer. This way that memory goes back exactly when it always did,
+    // and a builder added here later cannot be retained by accident.
+    virtual void take_ordinal_index_builders(std::vector<DeferredOrdinalIndex>* out) {}
+
     virtual Status write_vector_index(uint64_t* index_size) { return Status::OK(); }
 
     virtual ordinal_t get_next_rowid() const = 0;
@@ -231,6 +245,10 @@ public:
     Status write_ordinal_index() override;
     Status write_zone_map() override;
     Status write_bitmap_index() override;
+
+    // Defined out of line: OrdinalIndexWriter is only forward declared in this header, and moving
+    // a unique_ptr of it needs a complete type.
+    void take_ordinal_index_builders(std::vector<DeferredOrdinalIndex>* out) override;
     Status write_bloom_filter_index() override;
     Status write_inverted_index() override;
 

--- a/be/src/storage/rowset/json_column_compactor.h
+++ b/be/src/storage/rowset/json_column_compactor.h
@@ -60,6 +60,9 @@ public:
     Status write_ordinal_index() override { return _json_writer->write_ordinal_index(); }
     Status write_zone_map() override { return _json_writer->write_zone_map(); }
     Status write_bitmap_index() override { return _json_writer->write_bitmap_index(); }
+    void take_ordinal_index_builders(std::vector<DeferredOrdinalIndex>* out) override {
+        _json_writer->take_ordinal_index_builders(out);
+    }
     Status write_bloom_filter_index() override { return _json_writer->write_bloom_filter_index(); }
     ordinal_t get_next_rowid() const override { return _json_writer->get_next_rowid(); }
     uint64_t total_mem_footprint() const override { return _json_writer->total_mem_footprint(); }

--- a/be/src/storage/rowset/json_column_writer.h
+++ b/be/src/storage/rowset/json_column_writer.h
@@ -47,6 +47,15 @@ public:
     Status write_ordinal_index() override;
     Status write_zone_map() override;
     Status write_bitmap_index() override;
+    // Same order as write_ordinal_index(): the flat children first, then the root JSON writer.
+    // Omitting the root leaves its ColumnMetaPB without an ordinal index, which ColumnReader::_init()
+    // rejects as a corrupt segment.
+    void take_ordinal_index_builders(std::vector<DeferredOrdinalIndex>* out) override {
+        for (auto& w : _flat_writers) {
+            w->take_ordinal_index_builders(out);
+        }
+        _json_writer->take_ordinal_index_builders(out);
+    }
     Status write_bloom_filter_index() override;
     ordinal_t get_next_rowid() const override;
 

--- a/be/src/storage/rowset/map_column_writer.cpp
+++ b/be/src/storage/rowset/map_column_writer.cpp
@@ -44,6 +44,15 @@ public:
     Status write_zone_map() override { return Status::OK(); }
 
     Status write_bitmap_index() override { return Status::OK(); }
+    // Same order and the same is_nullable() guard as write_ordinal_index().
+    void take_ordinal_index_builders(std::vector<DeferredOrdinalIndex>* out) override {
+        if (is_nullable()) {
+            _nulls_writer->take_ordinal_index_builders(out);
+        }
+        _offsets_writer->take_ordinal_index_builders(out);
+        _keys_writer->take_ordinal_index_builders(out);
+        _values_writer->take_ordinal_index_builders(out);
+    }
 
     Status write_bloom_filter_index() override { return Status::OK(); }
 

--- a/be/src/storage/rowset/object_column_writer.h
+++ b/be/src/storage/rowset/object_column_writer.h
@@ -35,6 +35,9 @@ public:
     Status write_ordinal_index() override { return _scalar_column_writer->write_ordinal_index(); }
     Status write_zone_map() override { return _scalar_column_writer->write_zone_map(); }
     Status write_bitmap_index() override { return _scalar_column_writer->write_bitmap_index(); }
+    void take_ordinal_index_builders(std::vector<DeferredOrdinalIndex>* out) override {
+        _scalar_column_writer->take_ordinal_index_builders(out);
+    }
     Status write_bloom_filter_index() override { return _scalar_column_writer->write_bloom_filter_index(); }
     Status write_inverted_index() override { return _scalar_column_writer->write_inverted_index(); }
     ordinal_t get_next_rowid() const override { return _scalar_column_writer->get_next_rowid(); }

--- a/be/src/storage/rowset/ordinal_page_index.h
+++ b/be/src/storage/rowset/ordinal_page_index.h
@@ -51,6 +51,7 @@
 
 namespace starrocks {
 
+class ColumnMetaPB;
 class FileSystem;
 class WritableFile;
 
@@ -73,6 +74,21 @@ public:
 private:
     std::unique_ptr<IndexPageBuilder> _page_builder;
     PagePointer _last_pp;
+};
+
+// An ordinal index whose write was deferred to the segment's tail region: the builder that owns it,
+// and the ColumnMetaPB it must record its page pointer into. The file is not carried here -- the
+// segment writer passes its own.
+//
+// `meta` points into the writer's SegmentFooterPB, handed out by add_columns() when the column
+// writer was created and used later by finish() to append this index's PagePointer. Holding it
+// across the rest of the segment is safe for the reason the column writers already rely on:
+// RepeatedPtrField grows its array of pointers, never moving the messages they point at. What
+// would break it is replacing the footer wholesale rather than appending to it -- the only path
+// that does, a partial-update rewrite, never produces a deferred index at all.
+struct DeferredOrdinalIndex {
+    std::unique_ptr<OrdinalIndexWriter> builder;
+    ColumnMetaPB* meta = nullptr;
 };
 
 class OrdinalPageIndexIterator;

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -1372,6 +1372,13 @@ Status VerticalRowsetWriter::final_flush() {
             LOG(WARNING) << "Fail to finalize segment footer, " << st;
             return st;
         }
+        // The tail index region is written by finalize_footer(), after _flush_columns() has done
+        // its accounting, so its bytes reach _total_index_size only here. Zero unless that layout
+        // is in use.
+        if (const uint64_t deferred = segment_writer->unreported_index_size(); deferred > 0) {
+            std::lock_guard<std::mutex> l(_lock);
+            _total_index_size += static_cast<int64_t>(deferred);
+        }
         if (_context.tablet_schema->keys_type() == KeysType::PRIMARY_KEYS && _context.is_partial_update) {
             auto* partial_rowset_footer = _rowset_txn_meta_pb->add_partial_rowset_footers();
             partial_rowset_footer->set_position(footer_position);

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -47,8 +47,9 @@
 #include "common/config_json_flat_fwd.h"
 #include "common/config_primary_key_fwd.h"
 #include "common/config_rowset_fwd.h"
-#include "common/logging.h" // LOG
-#include "fs/fs.h"          // FileSystem
+#include "common/logging.h"            // LOG
+#include "common/system/master_info.h" // get_master_run_mode
+#include "fs/fs.h"                     // FileSystem
 #include "gen_cpp/lake_types.pb.h"
 #include "gen_cpp/segment.pb.h"
 #include "runtime/current_thread.h"
@@ -60,6 +61,7 @@
 #include "storage/row_store_encoder.h"
 #include "storage/rowset/column_writer.h" // ColumnWriter
 #include "storage/rowset/json_column_writer.h"
+#include "storage/rowset/ordinal_page_index.h" // OrdinalIndexWriter::finish
 #include "storage/rowset/page_io.h"
 #include "storage/rowset/segment_file_info.h"
 #include "storage/seek_tuple.h"
@@ -67,6 +69,25 @@
 #include "types/logical_type.h"
 
 namespace starrocks {
+
+namespace {
+// The cluster's run mode, as the FE reports it over the heartbeat.
+//
+// Neither `#ifdef USE_STAROS` nor the presence of a lake TabletManager will do here, and both are
+// tempting: the official artifact is built with `--enable-shared-data`
+// (docker/dockerfiles/artifacts/artifact.Dockerfile), and startup then selects the starlet lake
+// provider whenever USE_STAROS is defined, regardless of run mode
+// (service_be/starrocks_be.cpp). Either check is therefore true on a shared-nothing deployment
+// too, which would hand it the tail layout that the config and the documentation promise it will
+// not get.
+//
+// Unknown -- no heartbeat yet -- is treated as shared-nothing, so an early write keeps the
+// original layout rather than guessing.
+bool is_shared_data_mode() {
+    auto run_mode = get_master_run_mode();
+    return run_mode.has_value() && run_mode.value() == TRunMode::SHARED_DATA;
+}
+} // namespace
 
 const char* const k_segment_magic = "D0R1";
 const uint32_t k_segment_magic_length = 4;
@@ -77,6 +98,10 @@ SegmentWriter::SegmentWriter(std::unique_ptr<WritableFile> wfile, uint32_t segme
           _tablet_schema(std::move(tablet_schema)),
           _opts(std::move(opts)),
           _wfile(std::move(wfile)),
+          // Declaration order: _tail_index_layout precedes _full_sort_key_index, and the
+          // initializer list has to match it or -Wreorder fires.
+          _tail_index_layout(config::lake_enable_segment_tail_index_region && is_shared_data_mode()),
+          _tail_index_layout_usable(_tail_index_layout),
           _full_sort_key_index(
                   config::enable_full_sort_key_index &&
                   is_full_sort_key_encodable(*_tablet_schema->schema(), _tablet_schema->sort_key_idxes())) {
@@ -138,6 +163,12 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
     // rewrite partial segment into full segment only need to write other value columns into full segment
     // merge partial segment footer to avoid loss of metadata
     if (footer != nullptr) {
+        // Continuing a segment someone else started: SegmentRewriter copies the partial segment's
+        // prefix byte for byte and this writer only appends the remaining value columns. The
+        // copied columns keep the ordinal index pages they were written with, so a tail region
+        // gathered from the appended columns would advertise a range covering only some of the
+        // segment's indexes. Keep the original layout for the whole rewrite instead.
+        _tail_index_layout_usable = false;
         for (uint32_t ordinal = 0; ordinal < footer->columns().size(); ++ordinal) {
             *_footer.add_columns() = footer->columns(ordinal);
         }
@@ -381,6 +412,13 @@ uint64_t SegmentWriter::current_filesz() const {
 
 Status SegmentWriter::finalize(uint64_t* segment_file_size, uint64_t* index_size, uint64_t* footer_position) {
     RETURN_IF_ERROR(finalize_columns(index_size));
+    // The deferred region is written by finalize_footer(), so its bytes are added here rather
+    // than inside finalize_columns(). (The vertical path discards its per-group index_size
+    // already, so nothing is lost there.)
+    if (_small_index_region_deferred) {
+        RETURN_IF_ERROR(_write_small_index_region(index_size));
+        _small_index_region_deferred = false;
+    }
     *footer_position = _wfile->size();
     return finalize_footer(segment_file_size);
 }
@@ -396,6 +434,33 @@ Status SegmentWriter::finalize_columns(uint64_t* index_size) {
     _num_rows_written = 0;
 
     size_t num_columns = _tablet_schema->num_columns();
+
+    // Gather the one index a cold scan cannot avoid and cannot get for free -- the ordinal index
+    // of every accessed column -- into one contiguous run at the tail, immediately before the
+    // footer (see config::lake_enable_segment_tail_index_region).
+    //
+    // The page zone map deliberately stays inline, right after its own column's data pages. In
+    // the legacy layout an index sitting next to its column's data rides in the same cache block
+    // as data the query is already reading, so it costs nothing; a zone map is only consulted for
+    // a predicate column, whose data the scan is about to read anyway, so it keeps that free ride.
+    // The ordinal index does not: it is loaded for every projected column before any data page is
+    // touched. Measured over five interleaved cold rounds on two shared-data clusters, counting
+    // remote 1 MiB blocks against the legacy layout: -121 on ClickBench (105 columns) and -146 on
+    // SSB SF100 with the zone maps left inline, against -72 and -63 with them hoisted too.
+    //
+    // This works for a vertical writer too, which calls finalize_columns() once per column
+    // group: the deferred writers accumulate across groups and finalize_footer() flushes them
+    // all at the end, so an early group's indexes still land at the tail rather than under a
+    // later group's data pages. That matters far more than it first appears -- compaction picks
+    // VERTICAL for any table wider than vertical_compaction_max_columns_per_group (5) with more
+    // than one source rowset, so leaving it on the legacy layout would mean the region vanished
+    // from essentially every wide table at its first real compaction.
+    //
+    // The larger optional indexes (bloom filter, bitmap, inverted, vector) stay inline for the
+    // same reason as the zone maps, plus their own: they are read only when a predicate needs
+    // them, and they are big enough that hoisting them would inflate the region.
+    const bool defer_small_index = _tail_index_layout_usable;
+
     for (size_t i = 0; i < _column_indexes.size(); ++i) {
         uint32_t column_index = _column_indexes[i];
         if (column_index >= num_columns) {
@@ -409,7 +474,9 @@ Status SegmentWriter::finalize_columns(uint64_t* index_size) {
         RETURN_IF_ERROR(column_writer->write_data());
         // write index
         uint64_t index_offset = _wfile->size();
-        RETURN_IF_ERROR(column_writer->write_ordinal_index());
+        if (!defer_small_index) {
+            RETURN_IF_ERROR(column_writer->write_ordinal_index());
+        }
         RETURN_IF_ERROR(column_writer->write_zone_map());
         RETURN_IF_ERROR(column_writer->write_bitmap_index());
         RETURN_IF_ERROR(column_writer->write_bloom_filter_index());
@@ -440,12 +507,20 @@ Status SegmentWriter::finalize_columns(uint64_t* index_size) {
         // check global dict valid
         _check_column_global_dict_valid(column_writer.get(), column_index);
 
+        if (defer_small_index) {
+            // Take just the ordinal-index builder; everything else this writer holds has been
+            // flushed above and is released with it, exactly as before.
+            column_writer->take_ordinal_index_builders(&_deferred_ordinal_indexes);
+        }
         // reset to release memory
         column_writer.reset();
     }
+
     _column_writers.clear();
     _column_indexes.clear();
 
+    // The short key index keeps the position it has always had, right here at the end of the
+    // column group that carried the keys. Only the ordinal indexes move.
     if (_has_key) {
         uint64_t index_offset = _wfile->size();
         RETURN_IF_ERROR(_write_short_key_index());
@@ -453,10 +528,56 @@ Status SegmentWriter::finalize_columns(uint64_t* index_size) {
         _index_builder.reset();
         _full_sort_key_index_builder.reset();
     }
+
+    if (defer_small_index) {
+        _small_index_region_deferred = true;
+    }
+    return Status::OK();
+}
+
+// Every column's ordinal index, written back to back immediately before the footer. Called from
+// finalize_footer() so that it runs after the LAST column group's data, which is what lets a
+// vertical writer produce the layout at all.
+//
+// Sitting immediately before the footer is the whole point: parsing the footer already fetches the
+// file's final cache block, so an ordinal index that lands in it arrives at no extra cost. That is
+// worth doing for these and not for the other indexes, because _init_column_iterators() loads one
+// for every projected column before any other index and before any data page.
+//
+// Nothing else moves. The short key index keeps its old position, and every index is still located
+// through its own absolute PagePointer, so no reader may assume anything about the layout.
+Status SegmentWriter::_write_small_index_region(uint64_t* index_size) {
+    const uint64_t region_offset = _wfile->size();
+
+    for (auto& deferred : _deferred_ordinal_indexes) {
+        RETURN_IF_ERROR(deferred.builder->finish(_wfile.get(), deferred.meta->add_indexes()));
+        // reset to release memory
+        deferred.builder.reset();
+    }
+    _deferred_ordinal_indexes.clear();
+
+    const uint64_t region_size = _wfile->size() - region_offset;
+    if (index_size != nullptr) {
+        *index_size += region_size;
+    } else {
+        // finalize_footer() has no index_size out-param, and the vertical rowset writer has
+        // already finished accumulating from finalize_columns() by the time it calls us. Without
+        // this the region's bytes are counted as data rather than index, understating
+        // index_disk_size and inflating data_disk_size, which feeds compaction sizing.
+        _unreported_small_index_region_size += region_size;
+    }
+    _footer.set_small_index_region_offset(region_offset);
+    _footer.set_small_index_region_size(region_size);
     return Status::OK();
 }
 
 Status SegmentWriter::finalize_footer(uint64_t* segment_file_size, uint64_t* footer_position) {
+    if (_small_index_region_deferred) {
+        // Before footer_position is taken: the region has to sit between the last data page and
+        // the footer, and the caller's footer_position must point at the footer itself.
+        RETURN_IF_ERROR(_write_small_index_region(nullptr));
+        _small_index_region_deferred = false;
+    }
     if (footer_position != nullptr) {
         *footer_position = _wfile->size();
     }

--- a/be/src/storage/rowset/segment_writer.h
+++ b/be/src/storage/rowset/segment_writer.h
@@ -47,6 +47,7 @@
 #include "gutil/macros.h"
 #include "io/input_stream.h"
 #include "storage/row_store_encoder_factory.h"
+#include "storage/rowset/ordinal_page_index.h" // DeferredOrdinalIndex
 #include "storage/tablet_schema.h"
 #include "storage/variant_tuple.h"
 #include "storage_primitive/flat_json_config.h"
@@ -154,6 +155,12 @@ public:
 
     uint32_t segment_id() const { return _segment_id; }
 
+    // Index bytes written after finalize_columns() returned, which the vertical rowset writer must
+    // fold into its own index-size total: it accumulates from finalize_columns(), and the tail
+    // region is written later, from finalize_footer(). Left at zero on the horizontal path, whose
+    // finalize() already reported them.
+    uint64_t unreported_index_size() const { return _unreported_small_index_region_size; }
+
     const DictColumnsValidMap& global_dict_columns_valid_info() { return _global_dict_columns_valid_info; }
 
     const std::string& segment_path() const;
@@ -190,6 +197,7 @@ public:
     const std::vector<VariantTuple>& get_sort_key_samples() const { return _sort_key_samples; }
 
 private:
+    Status _write_small_index_region(uint64_t* index_size);
     Status _write_short_key_index();
     Status _write_footer();
     Status _write_raw_data(const std::vector<Slice>& slices);
@@ -216,6 +224,32 @@ private:
     // test), so both indexes have one entry per block with matching num_items / rows-per-block.
     std::unique_ptr<ShortKeyIndexBuilder> _full_sort_key_index_builder;
     std::vector<std::unique_ptr<ColumnWriter>> _column_writers;
+    // Ordinal-index builders taken from column writers that have otherwise finished, accumulated
+    // across every finalize_columns() call and flushed as one contiguous region by
+    // finalize_footer(). A vertical writer calls finalize_columns() once per column group, so an
+    // early group's ordinal index can only reach the tail by outliving the last group's data.
+    //
+    // Only the builders are held: the writers themselves are destroyed on the usual schedule, so
+    // what survives here is roughly 17 bytes per page and nothing else -- no zone map, bitmap or
+    // bloom state, whose finish() flushes but does not return its memory.
+    std::vector<DeferredOrdinalIndex> _deferred_ordinal_indexes;
+    // Whether this segment uses the tail index region, decided once in the constructor and never
+    // re-read. Two reasons it is latched rather than consulted per call:
+    //   * config::lake_enable_segment_tail_index_region is mutable, and a vertical writer finalizes one
+    //     column group at a time -- a flip mid-segment would produce a hybrid, some groups'
+    //     ordinal indexes in the advertised tail and the rest still inline;
+    //   * the shared-data check below is a global lookup, and this is a per-column-group path.
+    const bool _tail_index_layout;
+    // Cleared when init() continues an existing segment (partial-update rewrite): the copied
+    // columns keep their original scattered index pages, so a tail region built from the appended
+    // columns alone would describe only part of the segment.
+    bool _tail_index_layout_usable;
+    bool _small_index_region_deferred = false;
+    // Bytes of the tail region, recorded only when _write_small_index_region() had no index_size
+    // out-param to add them to -- i.e. when it ran from finalize_footer() on the vertical path.
+    // The horizontal path reports them through finalize()'s index_size and leaves this at zero,
+    // so a caller adding both can never double count.
+    uint64_t _unreported_small_index_region_size = 0;
     std::vector<uint32_t> _column_indexes;
     bool _has_key = true;
     std::vector<uint32_t> _sort_column_indexes;

--- a/be/src/storage/rowset/struct_column_writer.cpp
+++ b/be/src/storage/rowset/struct_column_writer.cpp
@@ -44,6 +44,15 @@ public:
     Status write_zone_map() override { return Status::OK(); }
 
     Status write_bitmap_index() override { return Status::OK(); }
+    // Same order and the same is_nullable() guard as write_ordinal_index().
+    void take_ordinal_index_builders(std::vector<DeferredOrdinalIndex>* out) override {
+        if (is_nullable()) {
+            _null_writer->take_ordinal_index_builders(out);
+        }
+        for (auto& w : _field_writers) {
+            w->take_ordinal_index_builders(out);
+        }
+    }
 
     Status write_bloom_filter_index() override { return Status::OK(); }
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -375,6 +375,7 @@ SET(DW_TEST_FILES
     ./storage/rowset/segment_full_sort_key_index_test.cpp
     ./storage/rowset/segment_iterator_test.cpp
     ./storage/rowset/segment_rewriter_test.cpp
+    ./storage/rowset/segment_tail_index_region_test.cpp
     ./storage/rowset/segment_test.cpp
     ./storage/rowset/segment_writer_short_key_encode_test.cpp
     ./storage/rowset/segment_writer_sort_key_sampling_test.cpp

--- a/be/test/storage/rowset/segment_tail_index_region_test.cpp
+++ b/be/test/storage/rowset/segment_tail_index_region_test.cpp
@@ -1,0 +1,417 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Covers config::lake_enable_segment_tail_index_region: the segment writer gathers the short key index
+// and then every column's ordinal index into one contiguous run immediately before the footer,
+// instead of writing each column's ordinal index after that column's own data pages. Page zone
+// maps stay inline either way, and the ordinal indexes go last inside the region so that the cache
+// block parsing the footer already fetches covers as many of them as it can.
+//
+// The two layouts must be indistinguishable to a reader -- every index is located through an
+// absolute PagePointer either way -- so each test that asserts something about the layout also
+// reads the whole segment back and checks the values.
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "base/testutil/assert.h"
+#include "column/chunk_factory.h"
+#include "column/datum_tuple.h"
+#include "common/config_exec_fwd.h"
+#include "common/config_rowset_fwd.h"
+#include "common/system/master_info.h"
+#include "fs/fs_memory.h"
+#include "storage/chunk_helper.h"
+#include "storage/rowset/segment.h"
+#include "storage/rowset/segment_options.h"
+#include "storage/rowset/segment_writer.h"
+#include "storage/tablet_schema.h"
+#include "storage/tablet_schema_helper.h"
+#include "storage_primitive/chunk_iterator.h"
+
+namespace starrocks {
+
+namespace {
+
+// Enough rows that every column spans several 64KB data pages. With a single page per column the
+// ordinal index degenerates to `is_root_data_page` -- no index page is written at all -- and every
+// layout assertion below would pass vacuously.
+constexpr size_t kNumRows = 100000;
+
+struct WriteResult {
+    SegmentFooterPB footer;
+    uint64_t file_size = 0;
+    uint64_t index_size = 0;
+    uint64_t footer_position = 0;
+};
+
+// The one index the read path must load for EVERY projected column before it can touch a data
+// page, and the only one this layout moves. Reported as offsets in the same space as the rest of
+// the footer's PagePointers.
+std::vector<uint64_t> collect_ordinal_index_offsets(const SegmentFooterPB& footer) {
+    std::vector<uint64_t> offsets;
+    for (const auto& column : footer.columns()) {
+        for (const auto& index : column.indexes()) {
+            if (index.type() == ORDINAL_INDEX && index.ordinal_index().has_root_page()) {
+                offsets.push_back(index.ordinal_index().root_page().root_page().offset());
+            }
+        }
+    }
+    return offsets;
+}
+
+// Page zone maps, which this layout deliberately leaves inline next to their column's data.
+std::vector<uint64_t> collect_zone_map_offsets(const SegmentFooterPB& footer) {
+    std::vector<uint64_t> offsets;
+    for (const auto& column : footer.columns()) {
+        for (const auto& index : column.indexes()) {
+            if (index.type() == ZONE_MAP_INDEX && index.zone_map_index().has_page_zone_maps()) {
+                const auto& zone_maps = index.zone_map_index().page_zone_maps();
+                if (zone_maps.has_ordinal_index_meta()) {
+                    offsets.push_back(zone_maps.ordinal_index_meta().root_page().offset());
+                }
+                if (zone_maps.has_value_index_meta()) {
+                    offsets.push_back(zone_maps.value_index_meta().root_page().offset());
+                }
+            }
+        }
+    }
+    return offsets;
+}
+
+uint64_t span_of(const std::vector<uint64_t>& offsets) {
+    auto [min_it, max_it] = std::minmax_element(offsets.begin(), offsets.end());
+    return *max_it - *min_it;
+}
+
+} // namespace
+
+class SegmentTailIndexRegionTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        _fs = std::make_shared<MemoryFileSystem>();
+        ASSERT_TRUE(_fs->create_dir(kSegmentDir).ok());
+        _saved_region = config::lake_enable_segment_tail_index_region;
+        // The layout is shared-data only and reads the run mode the FE reports over the
+        // heartbeat, which nothing sets in a unit test. Report shared-data so the writer takes
+        // the path under test; restored in TearDown so no other suite inherits it.
+        _saved_master_info = get_master_info();
+        TMasterInfo shared_data = _saved_master_info;
+        shared_data.__set_run_mode(TRunMode::SHARED_DATA);
+        ASSERT_TRUE(update_master_info(shared_data));
+    }
+
+    void TearDown() override {
+        config::lake_enable_segment_tail_index_region = _saved_region;
+        (void)update_master_info(_saved_master_info);
+    }
+
+    static std::shared_ptr<TabletSchema> make_schema() {
+        return TabletSchemaHelper::create_tablet_schema(
+                {create_int_key_pb(1), create_int_key_pb(2), create_int_value_pb(3), create_int_value_pb(4)});
+    }
+
+    // Row i holds (i, i+1, i+2, i+3) so read-back can be checked without a side table.
+    void append_rows(SegmentWriter* writer, const TabletSchemaCSPtr& tablet_schema,
+                     const std::vector<uint32_t>& column_indexes) {
+        auto schema = ChunkHelper::convert_schema(tablet_schema, column_indexes);
+        const int32_t chunk_size = config::vector_chunk_size;
+        auto chunk = ChunkFactory::new_chunk(schema, chunk_size);
+        for (size_t base = 0; base < kNumRows; base += chunk_size) {
+            chunk->reset();
+            auto cols = chunk->columns();
+            for (int32_t j = 0; j < chunk_size && base + j < kNumRows; ++j) {
+                const auto row = static_cast<int32_t>(base + j);
+                for (size_t c = 0; c < column_indexes.size(); ++c) {
+                    cols[c]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(row + column_indexes[c])));
+                }
+            }
+            ASSERT_OK(writer->append_chunk(*chunk));
+        }
+    }
+
+    // Horizontal write: one column group covering every column, a single finalize_columns().
+    WriteResult write_horizontal(const std::string& file_name, const TabletSchemaCSPtr& tablet_schema) {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+        SegmentWriterOptions opts;
+        opts.num_rows_per_block = 10;
+        SegmentWriter writer(std::move(wfile), 0, tablet_schema, opts);
+        CHECK_OK(writer.init());
+        append_rows(&writer, tablet_schema, {0, 1, 2, 3});
+
+        WriteResult result;
+        CHECK_OK(writer.finalize(&result.file_size, &result.index_size, &result.footer_position));
+        result.footer = read_footer(file_name);
+        return result;
+    }
+
+    // Vertical write: one column group at a time, finalize_columns() per group, one shared footer.
+    WriteResult write_vertical(const std::string& file_name, const TabletSchemaCSPtr& tablet_schema) {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+        SegmentWriterOptions opts;
+        opts.num_rows_per_block = 10;
+        SegmentWriter writer(std::move(wfile), 0, tablet_schema, opts);
+
+        WriteResult result;
+        const std::vector<std::vector<uint32_t>> groups = {{0, 1}, {2}, {3}};
+        for (size_t g = 0; g < groups.size(); ++g) {
+            CHECK_OK(writer.init(groups[g], /*has_key=*/g == 0));
+            append_rows(&writer, tablet_schema, groups[g]);
+            CHECK_OK(writer.finalize_columns(&result.index_size));
+        }
+        CHECK_OK(writer.finalize_footer(&result.file_size, &result.footer_position));
+        result.footer = read_footer(file_name);
+        return result;
+    }
+
+    SegmentFooterPB read_footer(const std::string& file_name) {
+        ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(file_name));
+        SegmentFooterPB footer;
+        size_t footer_length_hint = 16 * 1024;
+        CHECK_OK(Segment::parse_segment_footer(rfile.get(), &footer, &footer_length_hint, nullptr).status());
+        return footer;
+    }
+
+    // Full scan of the segment, asserting the (i, i+1, i+2, i+3) pattern on every row.
+    void verify_all_rows(const std::string& file_name, const TabletSchemaCSPtr& tablet_schema) {
+        ASSIGN_OR_ABORT(auto segment, Segment::open(_fs, FileInfo{file_name}, 0, tablet_schema));
+        ASSERT_EQ(kNumRows, segment->num_rows());
+
+        SegmentReadOptions seg_options;
+        seg_options.fs = _fs;
+        OlapReaderStatistics stats;
+        seg_options.stats = &stats;
+        auto schema = ChunkHelper::convert_schema(tablet_schema);
+        ASSIGN_OR_ABORT(auto iter, segment->new_iterator(schema, seg_options));
+
+        auto chunk = ChunkFactory::new_chunk(schema, config::vector_chunk_size);
+        size_t count = 0;
+        while (true) {
+            chunk->reset();
+            auto st = iter->get_next(chunk.get());
+            if (st.is_end_of_file()) {
+                break;
+            }
+            ASSERT_OK(st);
+            for (size_t i = 0; i < chunk->num_rows(); ++i) {
+                for (int32_t c = 0; c < 4; ++c) {
+                    ASSERT_EQ(static_cast<int32_t>(count) + c, chunk->get(i)[c].get_int32());
+                }
+                ++count;
+            }
+        }
+        ASSERT_EQ(kNumRows, count);
+    }
+
+    const std::string kSegmentDir = "/segment_tail_index_region_test";
+    std::shared_ptr<MemoryFileSystem> _fs;
+    bool _saved_region = false;
+    TMasterInfo _saved_master_info;
+};
+
+// With the region on, every small index sits between the last data page and the footer, and the
+// declared range covers exactly that gap.
+TEST_F(SegmentTailIndexRegionTest, RegionCoversEverySmallIndex) {
+    auto tablet_schema = make_schema();
+    config::lake_enable_segment_tail_index_region = true;
+
+    const std::string file_name = kSegmentDir + "/region_on";
+    auto result = write_horizontal(file_name, tablet_schema);
+
+    ASSERT_TRUE(result.footer.has_small_index_region_offset());
+    ASSERT_TRUE(result.footer.has_small_index_region_size());
+    const uint64_t region_begin = result.footer.small_index_region_offset();
+    const uint64_t region_end = region_begin + result.footer.small_index_region_size();
+
+    // Adjacency to the footer is the point: parsing the footer already fetches the file's final
+    // cache block, and the ordinal indexes are what every projected column loads. So the region
+    // must end exactly where the footer begins.
+    EXPECT_EQ(result.footer_position, region_end);
+
+    auto offsets = collect_ordinal_index_offsets(result.footer);
+    ASSERT_FALSE(offsets.empty()) << "no ordinal index was written -- assertions would be vacuous";
+    for (uint64_t offset : offsets) {
+        EXPECT_GE(offset, region_begin);
+        EXPECT_LT(offset, region_end);
+    }
+
+    // The short key index does not move: it keeps the position it has always had, at the end of
+    // the column group that carried the keys, which is before the region.
+    ASSERT_TRUE(result.footer.has_short_key_index_page());
+    EXPECT_LT(result.footer.short_key_index_page().offset(), region_begin)
+            << "the short key index must keep its original position, outside the region";
+
+    // Page zone maps deliberately stay OUT of the region, inline next to their column's data,
+    // where they ride in a cache block a predicate scan is reading anyway. Hoisting them would
+    // give up that free ride and buy nothing.
+    auto zone_map_offsets = collect_zone_map_offsets(result.footer);
+    ASSERT_FALSE(zone_map_offsets.empty());
+    for (uint64_t offset : zone_map_offsets) {
+        EXPECT_LT(offset, region_begin) << "page zone maps must stay inline, not join the region";
+    }
+
+    // "Data pages stayed outside the region" is already established above: every page zone map is
+    // written immediately after its own column's data pages, and all of them are asserted to be
+    // below region_begin. A second check on the region's share of the file was tried and removed
+    // -- on a synthetic segment of 100k narrow rows the data is small enough that a legitimate
+    // region is a large fraction of it, so the assertion failed for reasons that have nothing to
+    // do with the layout being correct.
+
+    verify_all_rows(file_name, tablet_schema);
+}
+
+// A writer that continues an existing segment -- what SegmentRewriter does for a partial-update
+// rewrite -- must not advertise a region. It only appends the remaining value columns, so the
+// copied columns keep the ordinal index pages they were written with, and a region gathered from
+// the appended ones alone would describe a range covering only part of the segment's indexes.
+TEST_F(SegmentTailIndexRegionTest, ContinuedSegmentPublishesNoRegion) {
+    auto tablet_schema = make_schema();
+    config::lake_enable_segment_tail_index_region = true;
+
+    // The footer handed to init() describes what is ALREADY in the file, and init() merges those
+    // columns into the one being built. So the donor must be a genuine partial segment holding
+    // only the key columns, disjoint from the value columns the rewrite appends -- exactly the
+    // split rewrite_partial_update() produces. Overlapping the two puts a column in the footer
+    // twice, which _verify_footer() rejects.
+    const std::vector<uint32_t> already_written = {0, 1};
+    const std::vector<uint32_t> appended = {2, 3};
+
+    const std::string donor_name = kSegmentDir + "/continued_donor";
+    SegmentFooterPB donor_footer;
+    {
+        ASSIGN_OR_ABORT(auto donor_wfile, _fs->new_writable_file(donor_name));
+        SegmentWriterOptions donor_opts;
+        donor_opts.num_rows_per_block = 10;
+        SegmentWriter donor_writer(std::move(donor_wfile), 0, tablet_schema, donor_opts);
+        ASSERT_OK(donor_writer.init(already_written, /*has_key=*/true));
+        append_rows(&donor_writer, tablet_schema, already_written);
+        uint64_t donor_file_size = 0;
+        uint64_t donor_index_size = 0;
+        uint64_t donor_footer_position = 0;
+        ASSERT_OK(donor_writer.finalize(&donor_file_size, &donor_index_size, &donor_footer_position));
+        donor_footer = read_footer(donor_name);
+    }
+    // The donor is an ordinary write, so it does carry a region. That is what keeps the
+    // EXPECT_FALSE below meaningful instead of vacuous: the config is on and this path is live.
+    ASSERT_TRUE(donor_footer.has_small_index_region_offset());
+
+    const std::string file_name = kSegmentDir + "/continued";
+    ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+    SegmentWriterOptions opts;
+    opts.num_rows_per_block = 10;
+    SegmentWriter writer(std::move(wfile), 0, tablet_schema, opts);
+    // Same shape as SegmentRewriter::rewrite_partial_update: append the remaining value columns
+    // on top of a footer describing what is already there.
+    ASSERT_OK(writer.init(appended, /*has_key=*/false, &donor_footer));
+    append_rows(&writer, tablet_schema, appended);
+
+    uint64_t index_size = 0;
+    uint64_t file_size = 0;
+    uint64_t footer_position = 0;
+    ASSERT_OK(writer.finalize_columns(&index_size));
+    ASSERT_OK(writer.finalize_footer(&file_size, &footer_position));
+
+    const auto continued_footer = read_footer(file_name);
+    EXPECT_FALSE(continued_footer.has_small_index_region_offset())
+            << "a continued segment must keep the original layout, not advertise a partial region";
+    EXPECT_FALSE(continued_footer.has_small_index_region_size());
+}
+
+// With the region off nothing changes: no footer fields, and the small indexes stay spread across
+// the file instead of clustering at the tail.
+TEST_F(SegmentTailIndexRegionTest, LegacyLayoutIsUnchanged) {
+    auto tablet_schema = make_schema();
+
+    config::lake_enable_segment_tail_index_region = false;
+    const std::string legacy_file = kSegmentDir + "/region_off";
+    auto legacy = write_horizontal(legacy_file, tablet_schema);
+
+    EXPECT_FALSE(legacy.footer.has_small_index_region_offset());
+    EXPECT_FALSE(legacy.footer.has_small_index_region_size());
+
+    config::lake_enable_segment_tail_index_region = true;
+    const std::string region_file = kSegmentDir + "/region_on_for_span";
+    auto region = write_horizontal(region_file, tablet_schema);
+
+    // The whole point of the change: gathered indexes span a fraction of what scattered ones do.
+    auto legacy_offsets = collect_ordinal_index_offsets(legacy.footer);
+    auto region_offsets = collect_ordinal_index_offsets(region.footer);
+    ASSERT_EQ(legacy_offsets.size(), region_offsets.size());
+    ASSERT_FALSE(legacy_offsets.empty());
+    EXPECT_GT(span_of(legacy_offsets), 2 * span_of(region_offsets));
+
+    // Same bytes accounted for as index either way, and the same data read back.
+    EXPECT_EQ(legacy.index_size, region.index_size);
+    verify_all_rows(legacy_file, tablet_schema);
+    verify_all_rows(region_file, tablet_schema);
+}
+
+// A vertical writer finalizes one column group at a time, so an early group's indexes reach the
+// tail only by surviving until the last group's data is on disk. This matters well beyond
+// compaction ergonomics: CompactionUtils::choose_compaction_algorithm picks VERTICAL for any table
+// wider than vertical_compaction_max_columns_per_group (5) with more than one source rowset, so if
+// the vertical path fell back to the legacy layout the region would disappear from essentially
+// every wide table at its first real compaction.
+TEST_F(SegmentTailIndexRegionTest, VerticalWriteAlsoProducesRegion) {
+    auto tablet_schema = make_schema();
+    config::lake_enable_segment_tail_index_region = true;
+
+    const std::string file_name = kSegmentDir + "/vertical_region";
+    auto result = write_vertical(file_name, tablet_schema);
+
+    ASSERT_TRUE(result.footer.has_small_index_region_offset());
+    ASSERT_TRUE(result.footer.has_small_index_region_size());
+    const uint64_t region_begin = result.footer.small_index_region_offset();
+    const uint64_t region_end = region_begin + result.footer.small_index_region_size();
+    EXPECT_EQ(result.footer_position, region_end);
+
+    // Every column, including those from the FIRST group, must have landed in the tail region --
+    // that is the whole point, and the case a per-group write would get wrong.
+    auto offsets = collect_ordinal_index_offsets(result.footer);
+    ASSERT_FALSE(offsets.empty());
+    for (uint64_t offset : offsets) {
+        EXPECT_GE(offset, region_begin);
+        EXPECT_LT(offset, region_end);
+    }
+
+    // The short key index still gets written, and still from the group that carried the keys --
+    // the first one. It is not part of the region: only the ordinal indexes move, and they are
+    // deferred past every later group's data, which is what a vertical writer has to get right.
+    ASSERT_TRUE(result.footer.has_short_key_index_page());
+    EXPECT_LT(result.footer.short_key_index_page().offset(), region_begin)
+            << "the short key index must keep its original position, outside the region";
+
+    verify_all_rows(file_name, tablet_schema);
+}
+
+// The vertical and horizontal writers must agree: same rows in, same layout guarantees out.
+TEST_F(SegmentTailIndexRegionTest, VerticalAndHorizontalRegionsAgree) {
+    auto tablet_schema = make_schema();
+    config::lake_enable_segment_tail_index_region = true;
+
+    const std::string h_file = kSegmentDir + "/agree_horizontal";
+    const std::string v_file = kSegmentDir + "/agree_vertical";
+    auto h = write_horizontal(h_file, tablet_schema);
+    auto v = write_vertical(v_file, tablet_schema);
+
+    EXPECT_EQ(collect_ordinal_index_offsets(h.footer).size(), collect_ordinal_index_offsets(v.footer).size());
+    EXPECT_EQ(h.footer_position, h.footer.small_index_region_offset() + h.footer.small_index_region_size());
+    EXPECT_EQ(v.footer_position, v.footer.small_index_region_offset() + v.footer.small_index_region_size());
+
+    verify_all_rows(h_file, tablet_schema);
+    verify_all_rows(v_file, tablet_schema);
+}
+
+} // namespace starrocks

--- a/docs/en/administration/configuration/BE_parameters/stats_storage.md
+++ b/docs/en/administration/configuration/BE_parameters/stats_storage.md
@@ -1309,6 +1309,15 @@ This topic introduces the following types of BE configurations:
 - Description: Whether to use accurate row counts for lake primary-key tablets. When enabled, StarRocks reads each rowset's delete vector from object storage and subtracts deleted rows, producing more accurate stats but potentially increasing `get_tablet_stats` RPC overhead. When disabled, StarRocks uses the approximate `num_dels` value in rowset metadata to avoid remote I/O, which may slightly overcount rows that were deleted but not yet compacted.
 - Introduced in: -
 
+### lake_enable_segment_tail_index_region
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether the segment writer places the ordinal index of every column in one contiguous region immediately before the segment footer, instead of writing each column's ordinal index directly after that column's own data pages. Page zone maps and the short key index are not affected and keep their existing positions. Only the write side is gated by this config, and only in shared-data clusters: a shared-nothing BE writes the original layout whatever this is set to. Vertical compaction produces the region as well; partial-update rewrites do not, because they copy an existing segment's prefix and append only the remaining value columns, so those segments keep the original layout. Both layouts are readable by any BE or CN version in either direction and can coexist in the same table, so this can be turned on or off at any time without rewriting data.
+- Introduced in: v4.2.0
+
 ### lake_tablet_stat_slow_log_ms
 
 - Default: 300000

--- a/docs/ja/administration/configuration/BE_parameters/stats_storage.md
+++ b/docs/ja/administration/configuration/BE_parameters/stats_storage.md
@@ -1139,6 +1139,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 説明: Lake（共有データ）主キーテーブルの tablet 行数統計で正確な行数を使うかどうか。`true` の場合、各 rowset の delete vector をオブジェクトストレージから取得して削除行を差し引くため精度は上がりますが、`get_tablet_stats` RPC のオーバーヘッドが増える可能性があります。`false` の場合は rowset メタデータの近似 `num_dels` を使ってリモート I/O を回避しますが、未 compaction の削除行をわずかに過大計上する可能性があります。
 - 導入バージョン: -
 
+### lake_enable_segment_tail_index_region
+
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: Yes
+- 説明: segment の書き込み時に、各列の ordinal index を segment footer の直前の 1 つの連続領域に配置するかどうか（従来は各列の ordinal index をその列のデータページの直後に書き込みます）。ページ単位の zone map と short key index は影響を受けず、既存の位置を維持します。本設定は書き込み側のみを制御し、共有データクラスタでのみ有効です。共有ナッシングの BE は設定に関わらず従来のレイアウトで書き込みます。垂直 Compaction もこの領域を生成しますが、部分列更新の書き換えは生成しません。既存 segment の接頭部をコピーし残りの値列だけを追加するため、それらの segment は従来のレイアウトを維持します。どちらのレイアウトも任意のバージョンの BE / CN が双方向に読み取れ、同一テーブル内に混在できるため、データを書き換えずにいつでも有効化・無効化できます。
+- 導入バージョン: v4.2.0
+
 ### lake_tablet_stat_slow_log_ms
 
 - デフォルト: 300000

--- a/docs/zh/administration/configuration/BE_parameters/stats_storage.md
+++ b/docs/zh/administration/configuration/BE_parameters/stats_storage.md
@@ -1291,6 +1291,15 @@ SELECT * FROM information_schema.be_configs WHERE NAME LIKE "%<name_pattern>%"
 - 描述：是否为存算分离（Lake）主键表 tablet 使用精确行数统计。开启后会读取每个 rowset 在对象存储中的 delete vector 来扣减删除行，统计更准确，但会显著增加 `get_tablet_stats` RPC 的开销；关闭后使用 rowset 元数据中的近似 `num_dels`，可避免远端 I/O，但对“已删除但尚未 compaction”的行可能略有高估。
 - 引入版本：-
 
+### lake_enable_segment_tail_index_region
+
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：Segment 写入时，是否把所有列的 ordinal index 放在紧邻 segment footer 之前的一段连续区域内，而不是把每一列的 ordinal index 写在该列数据页之后。页级 zone map 和 short key index 不受影响，位置保持不变。该配置仅影响写入侧，且仅在存算分离集群中生效：存算一体的 BE 无论该配置为何都写入原有布局。纵向 Compaction 同样会产生该索引区；部分列更新重写不会，因为它复制已有 segment 的前缀、只追加剩余的值列，这类 segment 保持原有布局。两种布局都能被任意版本的 BE/CN 双向读取，并可在同一张表中共存，因此可以随时开启或关闭，无需重写数据。
+- 引入版本：v4.2.0
+
 ### lake_tablet_stat_slow_log_ms
 
 - 默认值：300000

--- a/gensrc/proto/segment.proto
+++ b/gensrc/proto/segment.proto
@@ -270,6 +270,34 @@ message SegmentFooterPB {
     // only when enable_full_sort_key_index is on; absent otherwise. Old binaries ignore this field
     // and read short_key_index_page as before.
     optional PagePointerPB full_sort_key_index_page = 11;
+
+    // Byte range of the "small index region": one contiguous run, written immediately before
+    // this footer, holding the ordinal index of EVERY column. In the legacy layout each column's
+    // ordinal index sits right after that column's
+    // own data pages, so opening a segment costs one scattered small read per column; with a
+    // block-granular cache in front of object storage each of those reads fetches (and mostly
+    // wastes) a whole cache block, one round trip at a time. Gathered here they share blocks,
+    // and being written last they take the block the footer read already brings in.
+    //
+    // Nothing else is in this region. Page zone maps stay beside their own column's data pages,
+    // where they ride in a cache block a predicate scan is reading anyway, and the short key index
+    // keeps the position it has always had.
+    //
+    // Written when config::lake_enable_segment_tail_index_region was on at write time AND the segment
+    // belongs to a cloud-native (shared-data) tablet. Vertical compaction produces it too. A
+    // partial-update rewrite does not: it copies an existing segment's prefix and appends the
+    // remaining value columns, so the copied columns keep their original index pages and a region
+    // gathered from the appended ones would describe only part of the segment. Absent otherwise,
+    // including on every shared-nothing segment, in which case the layout is exactly as before.
+    //
+    // Nothing on the read path requires these fields: every index is still located through its
+    // own absolute PagePointer in `columns`, so a reader that ignores them stays correct on
+    // either layout. They record where the region is, which is what makes the layout auditable
+    // from a footer dump and what a future reader-side optimization would key off. Offsets use
+    // the same origin as every other PagePointer in this footer -- the segment's own start,
+    // which is bundle-file relative when this segment is a slice of a bundle file.
+    optional uint64 small_index_region_offset = 12;
+    optional uint64 small_index_region_size = 13;
 }
 
 message BTreeMetaPB {


### PR DESCRIPTION
## Why I'm doing:

Before a cold scan in shared-data can read a single data page, it loads the ordinal index of
**every projected column** — `SegmentIterator::_init_column_iterators()` walks the columns and
each one calls `ColumnReader::load_ordinal_index()`.

Today the writer emits each column's ordinal index immediately after that column's own data
pages, so those loads land at N scattered offsets across the file. With a block-granular cache
in front of object storage (`starlet_star_cache_block_size_bytes`, 1 MB) every one of them
pulls a whole cache block, and the loop issues them one at a time. K projected columns cost K
serial round trips before any data is read — a cost that depends on the width of the projection,
not on how much data the query actually wants.

The footer is already read from the tail, and that read populates the file's last cache block.
Indexes that live in that block cost nothing extra.

## What I'm doing:

**Write side only.** Gathers every column's ordinal index into one contiguous run immediately
before the footer, instead of leaving each one after its own column's data pages.

```
before   [c1 data][c1 ord][c2 data][c2 ord] ... [cN data][cN ord][short key][footer]
after    [c1 data][c2 data] ...      [cN data]  [short key][all ordinal indexes][footer]
                                                                              ^ shares the block
                                                                                the footer read
                                                                                already fetched
```

**Only the ordinal indexes move.** The short key index and the page zone maps keep the positions
they have always had. Two optional `SegmentFooterPB` fields record the new run's range.

### Gate

`lake_enable_segment_tail_index_region`, **default `true`**.

The `lake_` prefix is this tree's convention for a BE config that applies only to shared-data
(`lake_enable_accurate_pk_row_count`, `lake_enable_protobuf_file_checksum`, and seven more).

A shared-nothing BE reads its segments off local disk, where the scattered offsets cost nothing,
so its segment format is left byte-for-byte as it was. The writer latches the decision once per
segment from `get_master_run_mode()`, which reads the cached master info and issues no RPC.

Two placement decisions worth a reviewer's eye:

- **The ordinal indexes go last, not the short key index.** The file grows towards the footer,
  so whatever is written last shares the block the footer read already brings in. The short key
  index is read only by a scan carrying a key range, and loads through its own file handle in
  `Segment::_load_index()`, so proximity to the footer buys it nothing. Putting it there instead
  measured **+39** remote 1 MiB blocks on the 105-column ClickBench table where this order
  measured **-121**.
- **Page zone maps stay inline, beside their own column's data.** An index next to its column's
  data rides in a cache block the query is already reading, and a zone map is only consulted for
  a predicate column — whose data the scan is about to read anyway. So it keeps that free ride;
  the ordinal index has none to keep. Hoisting the zone maps too measured **-72** blocks against
  **-121** for leaving them inline. It also keeps a vertical writer's retained state down to the
  ordinal-index builders alone.

### Vertical writes

Vertical writes produce the region too. A vertical writer calls `finalize_columns()` once per
column group, so an early group's ordinal index reaches the tail only by outliving the last
group's data: each group hands its ordinal-index builders to the segment writer, which holds
them until `finalize_footer()` flushes them all. That is not a corner case — compaction picks
VERTICAL for any table wider than `vertical_compaction_max_columns_per_group` with more than one
source rowset, so gating it out would drop the layout from essentially every wide table at its
first real compaction.

**A partial-update rewrite is the one exception** and keeps the original layout: it copies an
existing segment's prefix byte for byte and only appends the remaining value columns, so a run
gathered from the appended columns would advertise a range covering only some of the segment's
indexes.

### Compatibility

Every index is still located through its own absolute `PagePointer`, and **nothing on the read
path consults the two new footer fields** — this PR does not touch a single read-side file. A
segment written either way is readable by any binary in either direction, both layouts coexist
in one tablet, and the config can be flipped at any time without rewriting data.

### Cost

A one-column scan of a wide table pays roughly one extra remote block per segment, since a
hundred columns' worth of ordinal index does not fit in the footer's block.

## Measured: `ColumnIteratorInit`

Two AWS shared-data clusters, 1 FE + 3 CN. Both layouts written back to back from the same
source by one binary. Five interleaved cold rounds: metacache disabled, storage page cache off
and asserted at zero hits, DataCache drained before every query, client on the FE. Medians.

**SSB SF100** — 17 columns, 48 segments x 326 MiB

| Query | Columns | Before | After | |
| --- | ---: | ---: | ---: | ---: |
| single-column full scan | 1 | 4.12 s | 0.01 s | **280x** |
| q2.1 | 11 | 17.12 s | 0.49 s | **35x** |
| q3.4 | 11 | 17.44 s | 0.63 s | **28x** |
| all-column LIMIT 10 | 17 | 2.98 s | 0.35 s | **9x** |
| all-column point lookup | 17 | 0.62 s | 0.10 s | **7x** |
| **total** | | **42.27 s** | **1.57 s** | **27x** |

**ClickBench** — 105 columns, 27 segments x 622 MiB

| Query | Columns | Before | After | |
| --- | ---: | ---: | ---: | ---: |
| Q02 | 1 | 2.17 s | 0.25 s | **9x** |
| Q30 | 1 | 2.17 s | 0.24 s | **9x** |
| Q29 | 1 | 2.53 s | 0.38 s | **7x** |
| Q03 | 2 | 4.15 s | 0.25 s | **17x** |
| Q33 | 4 | 8.73 s | 0.68 s | **13x** |
| Q24 | 105 | 4.84 s | 0.69 s | **7x** |
| **total** | | **24.59 s** | **2.49 s** | **10x** |

Two things this number is not, stated so it is not over-read:

- `ColumnIteratorInit` is a **cumulative timer summed across parallel scan instances**, so it
  describes the segment-open path, not wall clock. On several queries it exceeds the query's own
  wall clock for exactly that reason.
- **End-to-end improvement is bounded by how much of a query `ColumnIteratorInit` actually
  accounts for.** This change removes the serial index round trips and little else, so a query
  that spends most of its time reading data pages sees a fraction of the ratios above. The wins
  concentrate where the index work is a real share of the query — wide projections, selective
  scans over many columns, point lookups — and thin out on scans dominated by data volume.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

`lake_enable_segment_tail_index_region` defaults to `true`, so a shared-data cluster starts writing
the new physical segment layout without any operator action. Query results, the read path and
the shared-nothing format are all unchanged; what changes is where a newly written shared-data
segment places its ordinal indexes. Existing segments are not rewritten, and setting the config
to `false` returns the writer to the old layout.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkwxcQXEf4bkCfUZYouhF3