### PR TITLE
[Enhancement] Disable online optimize table by default (backport #78206)

### DIFF
--- a/docs/en/administration/configuration/FE_parameters/stats_storage.md
+++ b/docs/en/administration/configuration/FE_parameters/stats_storage.md
@@ -253,7 +253,7 @@ This topic introduces the following types of FE configurations:
 
 ### `enable_online_optimize_table`
 
-- Default: true
+- Default: false
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes

--- a/docs/ja/administration/configuration/FE_parameters/stats_storage.md
+++ b/docs/ja/administration/configuration/FE_parameters/stats_storage.md
@@ -253,7 +253,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ### `enable_online_optimize_table`
 
-- デフォルト：true
+- デフォルト：false
 - タイプ：Boolean
 - 単位：-
 - 変更可能：Yes

--- a/docs/zh/administration/configuration/FE_parameters/stats_storage.md
+++ b/docs/zh/administration/configuration/FE_parameters/stats_storage.md
@@ -253,7 +253,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ### `enable_online_optimize_table`
 
-- 默认值: true
+- 默认值: false
 - 类型: Boolean
 - 单位: -
 - 是否可变: Yes

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1461,7 +1461,7 @@ public class Config extends ConfigBase {
      * Online optimize table allows to optimize a table without blocking write operations.
      */
     @ConfField(mutable = true)
-    public static boolean enable_online_optimize_table = true;
+    public static boolean enable_online_optimize_table = false;
 
     /**
      * If set to true, FE will check backend available capacity by storage medium when create table

--- a/fe/fe-core/src/test/java/com/starrocks/alter/OptimizeJobV2BuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/OptimizeJobV2BuilderTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.alter;
 
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.sql.ast.KeysDesc;
 import com.starrocks.sql.ast.OptimizeClause;
@@ -97,15 +98,21 @@ public class OptimizeJobV2BuilderTest {
         OptimizeJobV2Builder builder = new OptimizeJobV2Builder(table);
         builder.withOptimizeClause(new OptimizeClause(null, null, null, null, null, null));
 
-        // Call the build() method
-        AlterJobV2 job = builder.build();
+        boolean savedEnableOnlineOptimizeTable = Config.enable_online_optimize_table;
+        Config.enable_online_optimize_table = true;
+        try {
+            // Call the build() method
+            AlterJobV2 job = builder.build();
 
-        // Assert that the returned job is an instance of OnlineOptimizeJobV2
-        Assertions.assertTrue(job instanceof OnlineOptimizeJobV2);
+            // Assert that the returned job is an instance of OnlineOptimizeJobV2
+            Assertions.assertTrue(job instanceof OnlineOptimizeJobV2);
 
-        // Assert that the job has the correct properties
-        OnlineOptimizeJobV2 onlineOptimizeJob = (OnlineOptimizeJobV2) job;
-        Assertions.assertEquals(123L, onlineOptimizeJob.getTableId());
-        Assertions.assertEquals("myTable", onlineOptimizeJob.getTableName());
+            // Assert that the job has the correct properties
+            OnlineOptimizeJobV2 onlineOptimizeJob = (OnlineOptimizeJobV2) job;
+            Assertions.assertEquals(123L, onlineOptimizeJob.getTableId());
+            Assertions.assertEquals("myTable", onlineOptimizeJob.getTableName());
+        } finally {
+            Config.enable_online_optimize_table = savedEnableOnlineOptimizeTable;
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/OptimizeJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/OptimizeJobV2Test.java
@@ -61,7 +61,7 @@ public class OptimizeJobV2Test extends DDLTestBase {
     @AfterEach
     public void clear() {
         GlobalStateMgr.getCurrentState().getSchemaChangeHandler().clearJobs();
-        Config.enable_online_optimize_table = true;
+        Config.enable_online_optimize_table = false;
     }
 
     @Test

--- a/test/sql/test_optimize_table/R/test_optimize_table
+++ b/test/sql/test_optimize_table/R/test_optimize_table
@@ -119,6 +119,9 @@ None
 -- !result
 
 -- name: test_online_optimize_table_pk @sequential @native
+admin set frontend config ('enable_online_optimize_table'='true');
+-- result:
+-- !result
 create table tpk(k int) primary key(k) distributed by hash(k) buckets 10;
 -- result:
 -- !result
@@ -337,8 +340,14 @@ select * from tpk;
 20
 8
 -- !result
+CLEANUP {
+    admin set frontend config ('enable_online_optimize_table'='false');
+} END CLEANUP
 
 -- name: test_online_optimize_table_stream_load @sequential @native
+admin set frontend config ('enable_online_optimize_table'='true');
+-- result:
+-- !result
 create database db_${uuid0};
 -- result:
 -- !result
@@ -649,8 +658,14 @@ select count(*) from t;
 -- result:
 63
 -- !result
+CLEANUP {
+    admin set frontend config ('enable_online_optimize_table'='false');
+} END CLEANUP
 
 -- name: test_optimize_table_with_special_characters @sequential @native
+admin set frontend config ('enable_online_optimize_table'='true');
+-- result:
+-- !result
 create table `t#t`(k int) distributed by hash(k) buckets 10;
 -- result:
 -- !result
@@ -713,11 +728,14 @@ PROPERTIES (
 "replication_num" = "3"
 );
 -- !result
+CLEANUP {
+    admin set frontend config ('enable_online_optimize_table'='false');
+} END CLEANUP
+
+-- name: test_online_optimize_table_expr_partition @sequential @native
 admin set frontend config ('enable_online_optimize_table'='true');
 -- result:
 -- !result
-
--- name: test_online_optimize_table_expr_partition @sequential @native
 create table t(k int, k1 date) PARTITION BY date_trunc('day', k1)
 distributed by hash(k) buckets 10;
 -- result:
@@ -912,6 +930,9 @@ select count(*) from t;
 -- result:
 63
 -- !result
+CLEANUP {
+    admin set frontend config ('enable_online_optimize_table'='false');
+} END CLEANUP
 
 -- name: test_cancel_optimize
 create table t(k int) distributed by hash(k) buckets 10;
@@ -929,6 +950,9 @@ None
 -- !result
 
 -- name: test_online_optimize_table_batch @sequential @native
+admin set frontend config ('enable_online_optimize_table'='true');
+-- result:
+-- !result
 create database db_${uuid0};
 -- result:
 -- !result
@@ -1588,6 +1612,9 @@ select count(*) from t;
 -- result:
 300
 -- !result
+CLEANUP {
+    admin set frontend config ('enable_online_optimize_table'='false');
+} END CLEANUP
 
 -- name: test_optimize_duplicate_partitions
 CREATE TABLE `duplicate_table_with_null_partition` (

--- a/test/sql/test_optimize_table/T/test_optimize_table
+++ b/test/sql/test_optimize_table/T/test_optimize_table
@@ -125,6 +125,7 @@ function: wait_optimize_table_finish()
 
 
 -- name: test_online_optimize_table_basic @sequential
+admin set frontend config ('enable_online_optimize_table'='true');
 create table t(k int, k1 date) PARTITION BY RANGE(`k1`)
 (
     PARTITION `p202006` VALUES LESS THAN ("2020-07-01"),
@@ -181,8 +182,12 @@ function: wait_optimize_table_finish()
 show create table t;
 -- show partitions from t;
 select * from t;
+CLEANUP {
+    admin set frontend config ('enable_online_optimize_table'='false');
+} END CLEANUP
 
 -- name: test_online_optimize_table_pk @sequential @native
+admin set frontend config ('enable_online_optimize_table'='true');
 create table tpk(k int) primary key(k) distributed by hash(k) buckets 10;
 show create table tpk;
 insert into tpk values(1);
@@ -228,8 +233,12 @@ select * from tpk;
 function: wait_optimize_table_finish()
 show create table tpk;
 select * from tpk;
+CLEANUP {
+    admin set frontend config ('enable_online_optimize_table'='false');
+} END CLEANUP
 
 -- name: test_online_optimize_table_stream_load @sequential @native
+admin set frontend config ('enable_online_optimize_table'='true');
 create database db_${uuid0};
 use db_${uuid0};
 create table t(k int, k1 date) PARTITION BY RANGE(`k1`)
@@ -288,8 +297,12 @@ function: wait_optimize_table_finish()
 show create table t;
 -- show partitions from t;
 select count(*) from t;
+CLEANUP {
+    admin set frontend config ('enable_online_optimize_table'='false');
+} END CLEANUP
 
 -- name: test_optimize_table_with_special_characters @sequential @native
+admin set frontend config ('enable_online_optimize_table'='true');
 create table `t#t`(k int) distributed by hash(k) buckets 10;
 show create table `t#t`;
 alter table `t#t` distributed by hash(k) buckets 20;
@@ -299,9 +312,12 @@ admin set frontend config ('enable_online_optimize_table'='false');
 alter table `t#t` distributed by hash(k) buckets 30;
 function: wait_optimize_table_finish()
 show create table `t#t`;
-admin set frontend config ('enable_online_optimize_table'='true');
+CLEANUP {
+    admin set frontend config ('enable_online_optimize_table'='false');
+} END CLEANUP
 
 -- name: test_online_optimize_table_expr_partition @sequential @native
+admin set frontend config ('enable_online_optimize_table'='true');
 create table t(k int, k1 date) PARTITION BY date_trunc('day', k1)
 distributed by hash(k) buckets 10;
 insert into t values(1, '2020-06-01'),(2, '2020-07-01'),(3, '2020-08-01');
@@ -352,6 +368,9 @@ select count(*) from t;
 function: wait_optimize_table_finish()
 show create table t;
 select count(*) from t;
+CLEANUP {
+    admin set frontend config ('enable_online_optimize_table'='false');
+} END CLEANUP
 
 -- name: test_cancel_optimize
 create table t(k int) distributed by hash(k) buckets 10;
@@ -359,7 +378,8 @@ alter table t distributed by hash(k);
 cancel alter table optimize from t;
 function: wait_optimize_table_finish(expect_status="CANCELLED")
 
--- name: test_online_optimize_table_batch @seqential @native
+-- name: test_online_optimize_table_batch @sequential @native
+admin set frontend config ('enable_online_optimize_table'='true');
 create database db_${uuid0};
 use db_${uuid0};
 create table t(k int, k1 date) PARTITION BY RANGE(`k1`)
@@ -376,6 +396,9 @@ function: wait_optimize_table_finish()
 show create table t;
 select * from t;
 select count(*) from t;
+CLEANUP {
+    admin set frontend config ('enable_online_optimize_table'='false');
+} END CLEANUP
 
 -- name: test_optimize_duplicate_partitions
 CREATE TABLE `duplicate_table_with_null_partition` (


### PR DESCRIPTION
Manual backport of #78206 to branch-4.1, replacing the automatic Mergify backport #78226 which hit cherry-pick conflicts in `test/sql/test_optimize_table/{T,R}/test_optimize_table`. The conflicts were resolved by re-applying the same case-level changes on top of the branch-4.1 versions of those files, which carry additional cases (`test_alter_key_buckets`, `test_cancel_optimize`, `test_optimize_duplicate_partitions`, `test_drop_all_temporary_partitions`) not present on main; those cases are left untouched.

## Why I'm doing:

Online optimize table (`enable_online_optimize_table`) allows `ALTER TABLE ... DISTRIBUTED BY ...` to run without blocking write operations. To make the default behavior more conservative, the online optimize path should be opt-in rather than enabled by default.

## What I'm doing:

Change the default value of the FE config `enable_online_optimize_table` from `true` to `false`, so `ALTER TABLE ... DISTRIBUTED BY` uses the blocking OptimizeJobV2 path unless online optimize is explicitly enabled. The config remains mutable and can be turned on with `ADMIN SET FRONTEND CONFIG ('enable_online_optimize_table'='true')`.

- Update the default value in the FE parameter docs (en/zh/ja).
- The `test_online_optimize_*` SQL cases now enable `enable_online_optimize_table` explicitly at the start of each case and restore the default in a `CLEANUP` block, so they keep exercising the online optimize path (with the non-online OptimizeJobV2, concurrent ingestion during optimize cancels the job).
- `OptimizeJobV2Test` restores the new default in its `@AfterEach` cleanup; `OptimizeJobV2BuilderTest` enables the config explicitly where it verifies online job selection.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5


---
_Generated by [Claude Code](https://claude.ai/code/session_018EPLmPwg6JUhGKaXsqD4Mh)_