### PR TITLE
[UT] Add SQL tests for range-distributed primary key tables with a separate ORDER BY

### DIFF
--- a/test/sql/test_range_orderby/R/test_range_orderby_add_index
+++ b/test/sql/test_range_orderby/R/test_range_orderby_add_index
@@ -1,0 +1,182 @@
+-- name: test_range_orderby_add_index @cloud
+set enable_range_distribution = true;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    k1 int not null,
+    k2 int not null,
+    v1 int not null,
+    v2 varchar(32) not null,
+    c1 int not null,
+    c2 int not null
+)
+primary key(k1, k2)
+order by(v1, v2)
+properties('replication_num' = '1');
+-- result:
+-- !result
+insert into t
+select x, x % 7, 100000 - x, concat('p', x), x % 10, x
+from table(generate_series(1, 2000)) as g(x);
+-- result:
+-- !result
+select count(*), count(distinct c1) from t;
+-- result:
+2000	10
+-- !result
+alter table t add index idx_c1 (c1) using bitmap;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+show index from t;
+-- result:
+[REGEX].*idx_c1.*BITMAP.*
+-- !result
+select count(*), count(distinct c1) from t;
+-- result:
+2000	10
+-- !result
+select count(*) from t where c1 = 3;
+-- result:
+200
+-- !result
+select k1, k2, c1 from t where c1 = 0 and k1 <= 20 order by k1;
+-- result:
+10	3	0
+20	6	0
+-- !result
+insert into t values (2001, 1, 1, 'new', 3, 2001);
+-- result:
+-- !result
+select count(*) from t where c1 = 3;
+-- result:
+201
+-- !result
+delete from t where k1 = 2001;
+-- result:
+-- !result
+select count(*) from t where c1 = 3;
+-- result:
+200
+-- !result
+drop index idx_c1 on t;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+show index from t;
+-- result:
+-- !result
+select count(*) from t where c1 = 3;
+-- result:
+200
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result
+
+-- name: test_range_orderby_add_index_after_split @cloud @sequential
+set enable_range_distribution = true;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    k1 int not null,
+    k2 int not null,
+    v1 int not null,
+    v2 varchar(256) not null,
+    c1 int not null,
+    c2 int not null
+)
+primary key(k1, k2)
+order by(v1, v2)
+properties('replication_num' = '1');
+-- result:
+-- !result
+insert into t
+select x, x % 7, 100000 - x, repeat(md5(cast(x as varchar)), 6), x % 10, x
+from table(generate_series(1, 20000)) as g(x);
+-- result:
+-- !result
+[UC]alter table t split tablet properties('tablet_reshard_target_size' = '1024');
+shell: n=1; for i in $(seq 1 55); do n=$(${mysql_cmd} -Ne "select count(1) from information_schema.tablet_reshard_jobs where db_name='db_${uuid0}' and job_state not in ('FINISHED','ABORTED')" 2>/dev/null); [ "$n" = "0" ] && break; sleep 2; done; echo "pending=$n"
+-- result:
+0
+pending=0
+-- !result
+select buckets > 1 as did_split from information_schema.partitions_meta
+    where db_name = 'db_${uuid0}' and table_name = 't';
+-- result:
+1
+-- !result
+alter table t add index idx_c1 (c1) using bitmap;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select count(*), count(distinct c1) from t;
+-- result:
+20000	10
+-- !result
+select count(*) from t where c1 = 3;
+-- result:
+2000
+-- !result
+select count(*) from t where c1 = 3 and v1 > 99000;
+-- result:
+100
+-- !result
+insert into t values (999999, 1, 1, 'tail', 3, 999999);
+-- result:
+-- !result
+select count(*) from t where c1 = 3;
+-- result:
+2001
+-- !result
+select k1, k2, v1, c1 from t where k1 = 999999;
+-- result:
+999999	1	1	3
+-- !result
+delete from t where k1 = 999999;
+-- result:
+-- !result
+select count(*) from t where c1 = 3;
+-- result:
+2000
+-- !result
+select count(*) from t;
+-- result:
+20000
+-- !result
+drop index idx_c1 on t;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select count(*) from t where c1 = 3;
+-- result:
+2000
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_range_orderby/R/test_range_orderby_alter
+++ b/test/sql/test_range_orderby/R/test_range_orderby_alter
@@ -1,0 +1,130 @@
+-- name: test_range_orderby_alter @cloud
+set enable_range_distribution = true;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    k1 int not null,
+    k2 int not null,
+    v1 int not null,
+    v2 varchar(32) not null
+)
+primary key(k1, k2)
+order by(v1, v2)
+properties('replication_num' = '1');
+-- result:
+-- !result
+insert into t values (1, 1, 300, 'c'), (2, 2, 200, 'b'), (3, 3, 100, 'a');
+-- result:
+-- !result
+select * from t order by k1;
+-- result:
+1	1	300	c
+2	2	200	b
+3	3	100	a
+-- !result
+alter table t set ('file_bundling' = 'false');
+-- result:
+E: (1064, 'file_bundling cannot be disabled on a range-distributed primary key table whose ORDER BY key differs from the primary key')
+-- !result
+alter table t order by (v2, v1);
+-- result:
+E: (1064, 'Modifying sort key (ALTER TABLE ... ORDER BY) is not supported on tables with range distribution, because the sort key defines tablet boundaries.')
+-- !result
+alter table t add column v3 int not null default '9';
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from t order by k1;
+-- result:
+1	1	300	c	9
+2	2	200	b	9
+3	3	100	a	9
+-- !result
+insert into t values (4, 4, 50, 'x', 7);
+-- result:
+-- !result
+select * from t order by k1;
+-- result:
+1	1	300	c	9
+2	2	200	b	9
+3	3	100	a	9
+4	4	50	x	7
+-- !result
+select distribute_type, primary_key, sort_key from information_schema.tables_config
+    where table_schema = 'db_${uuid0}' and table_name = 't';
+-- result:
+RANGE	`k1`, `k2`	`v1`, `v2`
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result
+-- name: test_range_orderby_alter_back_to_pk @cloud
+set enable_range_distribution = true;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    k1 int not null,
+    k2 int not null,
+    v1 int not null,
+    v2 varchar(32) not null
+)
+primary key(k1, k2)
+order by(v1, v2)
+properties('replication_num' = '1');
+-- result:
+-- !result
+insert into t values (1, 1, 300, 'c'), (2, 2, 200, 'b'), (3, 3, 100, 'a');
+-- result:
+-- !result
+alter table t order by (k1, k2);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select distribute_type, primary_key, sort_key from information_schema.tables_config
+    where table_schema = 'db_${uuid0}' and table_name = 't';
+-- result:
+RANGE	`k1`, `k2`	`k1`, `k2`
+-- !result
+select * from t order by k1;
+-- result:
+1	1	300	c
+2	2	200	b
+3	3	100	a
+-- !result
+insert into t values (2, 2, 20, 'bb');
+-- result:
+-- !result
+select * from t order by k1;
+-- result:
+1	1	300	c
+2	2	20	bb
+3	3	100	a
+-- !result
+alter table t set ('file_bundling' = 'false');
+-- result:
+-- !result
+select count(*) from t;
+-- result:
+3
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_range_orderby/R/test_range_orderby_create
+++ b/test/sql/test_range_orderby/R/test_range_orderby_create
@@ -1,0 +1,109 @@
+-- name: test_range_orderby_create @cloud
+set enable_range_distribution = true;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t1 (
+    k1 int not null,
+    k2 int not null,
+    v1 int not null,
+    v2 varchar(32) not null
+)
+primary key(k1, k2)
+order by(v1, v2)
+properties('replication_num' = '1');
+-- result:
+-- !result
+select distribute_type, primary_key, sort_key from information_schema.tables_config
+    where table_schema = 'db_${uuid0}' and table_name = 't1';
+-- result:
+RANGE	`k1`, `k2`	`v1`, `v2`
+-- !result
+insert into t1 values (1, 1, 900, 'z'), (1, 2, 100, 'a'), (2, 1, 500, 'm');
+-- result:
+-- !result
+insert into t1 values (1, 1, 1, 'b');
+-- result:
+-- !result
+select * from t1 order by k1, k2;
+-- result:
+1	1	1	b
+1	2	100	a
+2	1	500	m
+-- !result
+select count(*) from t1;
+-- result:
+3
+-- !result
+create table t_no_bundling (
+    k1 int not null,
+    v1 int not null
+)
+primary key(k1)
+order by(v1)
+properties('replication_num' = '1', 'file_bundling' = 'false');
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Range-distributed primary key tables with ORDER BY different from the primary key require file_bundling=true.')
+-- !result
+create table t_same_order (
+    k1 int not null,
+    k2 int not null,
+    v1 int not null
+)
+primary key(k1, k2)
+order by(k1, k2)
+properties('replication_num' = '1', 'file_bundling' = 'false');
+-- result:
+-- !result
+select distribute_type, primary_key, sort_key from information_schema.tables_config
+    where table_schema = 'db_${uuid0}' and table_name = 't_same_order';
+-- result:
+RANGE	`k1`, `k2`	`k1`, `k2`
+-- !result
+create table t_hash (
+    k1 int not null,
+    v1 int not null
+)
+primary key(k1)
+distributed by hash(k1) buckets 3
+order by(v1)
+properties('replication_num' = '1', 'file_bundling' = 'false');
+-- result:
+-- !result
+insert into t_hash values (1, 10), (2, 20), (1, 5);
+-- result:
+-- !result
+select * from t_hash order by k1;
+-- result:
+1	5
+2	20
+-- !result
+create table t_bad_sort_type (
+    k1 int not null,
+    v1 double not null
+)
+primary key(k1)
+order by(v1)
+properties('replication_num' = '1');
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Sort key column[v1] type not supported: double.')
+-- !result
+create table t_uniq (
+    k1 int not null,
+    k2 int not null,
+    v1 int
+)
+unique key(k1, k2)
+order by(v1, k1)
+properties('replication_num' = '1');
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: The sort columns must be same with key columns.')
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_range_orderby/R/test_range_orderby_dml
+++ b/test/sql/test_range_orderby/R/test_range_orderby_dml
@@ -1,0 +1,121 @@
+-- name: test_range_orderby_dml @cloud
+set enable_range_distribution = true;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    k1 int not null,
+    k2 int not null,
+    v1 int not null,
+    v2 varchar(32) not null,
+    v3 int not null
+)
+primary key(k1, k2)
+order by(v1, v2)
+properties('replication_num' = '1');
+-- result:
+-- !result
+insert into t values
+    (1, 1, 500, 'e', 1),
+    (1, 2, 400, 'd', 2),
+    (2, 1, 300, 'c', 3),
+    (2, 2, 200, 'b', 4),
+    (3, 1, 100, 'a', 5);
+-- result:
+-- !result
+select * from t order by k1, k2;
+-- result:
+1	1	500	e	1
+1	2	400	d	2
+2	1	300	c	3
+2	2	200	b	4
+3	1	100	a	5
+-- !result
+insert into t values (2, 1, 999, 'z', 30);
+-- result:
+-- !result
+select * from t order by k1, k2;
+-- result:
+1	1	500	e	1
+1	2	400	d	2
+2	1	999	z	30
+2	2	200	b	4
+3	1	100	a	5
+-- !result
+select count(*) from t;
+-- result:
+5
+-- !result
+select * from t where k1 = 2 and k2 = 1;
+-- result:
+2	1	999	z	30
+-- !result
+select k1, k2, v1 from t where v1 >= 400 order by k1, k2;
+-- result:
+1	1	500
+1	2	400
+2	1	999
+-- !result
+select sum(v3), count(distinct v2) from t;
+-- result:
+42	5
+-- !result
+update t set v1 = 50, v2 = 'y' where k1 = 1 and k2 = 2;
+-- result:
+-- !result
+select * from t order by k1, k2;
+-- result:
+1	1	500	e	1
+1	2	50	y	2
+2	1	999	z	30
+2	2	200	b	4
+3	1	100	a	5
+-- !result
+update t set v3 = 7 where k1 = 2 and k2 = 2;
+-- result:
+-- !result
+select * from t order by k1, k2;
+-- result:
+1	1	500	e	1
+1	2	50	y	2
+2	1	999	z	30
+2	2	200	b	7
+3	1	100	a	5
+-- !result
+insert into t properties("merge_condition" = "v1") values (3, 1, 10, 'q', 91);
+-- result:
+-- !result
+select * from t where k1 = 3 and k2 = 1;
+-- result:
+3	1	100	a	5
+-- !result
+insert into t properties("merge_condition" = "v1") values (3, 1, 1000, 'w', 92);
+-- result:
+-- !result
+select * from t where k1 = 3 and k2 = 1;
+-- result:
+3	1	1000	w	92
+-- !result
+delete from t where k1 = 1 and k2 = 1;
+-- result:
+-- !result
+delete from t where v1 < 300;
+-- result:
+-- !result
+select * from t order by k1, k2;
+-- result:
+2	1	999	z	30
+3	1	1000	w	92
+-- !result
+select count(*) from t;
+-- result:
+2
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_range_orderby/R/test_range_orderby_partial_update
+++ b/test/sql/test_range_orderby/R/test_range_orderby_partial_update
@@ -1,0 +1,410 @@
+-- name: test_range_orderby_partial_update @cloud
+set enable_range_distribution = true;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    k1 int not null,
+    k2 int not null,
+    v1 int not null,
+    v2 varchar(32) not null,
+    c1 int not null,
+    c2 int not null,
+    c3 int not null,
+    c4 int not null
+)
+primary key(k1, k2)
+order by(v1, v2)
+properties('replication_num' = '1');
+-- result:
+-- !result
+insert into t values
+    (1, 1, 100, 'a', 11, 12, 13, 14),
+    (2, 2, 200, 'b', 21, 22, 23, 24),
+    (3, 3, 300, 'c', 31, 32, 33, 34);
+-- result:
+-- !result
+select * from t order by k1;
+-- result:
+1	1	100	a	11	12	13	14
+2	2	200	b	21	22	23	24
+3	3	300	c	31	32	33	34
+-- !result
+set partial_update_mode = 'row';
+-- result:
+-- !result
+insert into t (k1, k2, v1, v2, c1) values (1, 1, 100, 'a', 111);
+-- result:
+-- !result
+select * from t order by k1;
+-- result:
+1	1	100	a	111	12	13	14
+2	2	200	b	21	22	23	24
+3	3	300	c	31	32	33	34
+-- !result
+insert into t (k1, k2, c1) values (1, 1, 112);
+-- result:
+[REGEX]E: \(5609, .*partial update on table with sort key must provide all sort key columns.*
+-- !result
+select * from t order by k1;
+-- result:
+1	1	100	a	111	12	13	14
+2	2	200	b	21	22	23	24
+3	3	300	c	31	32	33	34
+-- !result
+set partial_update_mode = 'column';
+-- result:
+-- !result
+insert into t (k1, k2, v1, v2, c1) values (1, 1, 100, 'a', 113);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Column-mode partial update is not supported on a range-distributed primary key table whose ORDER BY key differs from the primary key.')
+-- !result
+select * from t order by k1;
+-- result:
+1	1	100	a	111	12	13	14
+2	2	200	b	21	22	23	24
+3	3	300	c	31	32	33	34
+-- !result
+set partial_update_mode = 'auto';
+-- result:
+-- !result
+update t set c1 = 999 where k1 = 2 and k2 = 2;
+-- result:
+-- !result
+select * from t order by k1;
+-- result:
+1	1	100	a	111	12	13	14
+2	2	200	b	999	22	23	24
+3	3	300	c	31	32	33	34
+-- !result
+update t set c1 = 998;
+-- result:
+[REGEX]E: \(5609, .*partial update on table with sort key must provide all sort key columns.*
+-- !result
+select * from t order by k1;
+-- result:
+1	1	100	a	111	12	13	14
+2	2	200	b	999	22	23	24
+3	3	300	c	31	32	33	34
+-- !result
+update t set v1 = 250, v2 = 'bb';
+-- result:
+-- !result
+select * from t order by k1;
+-- result:
+1	1	250	bb	111	12	13	14
+2	2	250	bb	999	22	23	24
+3	3	250	bb	31	32	33	34
+-- !result
+set partial_update_mode = 'column';
+-- result:
+-- !result
+update t set c1 = 997 where k1 = 3 and k2 = 3;
+-- result:
+[REGEX]E: \(5609, .*partial update on table with sort key must provide all sort key columns.*
+-- !result
+select * from t order by k1;
+-- result:
+1	1	250	bb	111	12	13	14
+2	2	250	bb	999	22	23	24
+3	3	250	bb	31	32	33	34
+-- !result
+set partial_update_mode = 'auto';
+-- result:
+-- !result
+shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label:pu_row_${uuid0}" -H "column_separator:," -H "partial_update:true" -H "partial_update_mode:row" -H "columns:k1,k2,v1,v2,c1" -d "3,3,300,c,331" -XPUT ${url}/api/db_${uuid0}/t/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+sync;
+-- result:
+-- !result
+select * from t order by k1;
+-- result:
+1	1	250	bb	111	12	13	14
+2	2	250	bb	999	22	23	24
+3	3	300	c	331	32	33	34
+-- !result
+shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label:pu_col_${uuid0}" -H "column_separator:," -H "partial_update:true" -H "partial_update_mode:column" -H "columns:k1,k2,v1,v2,c1" -d "3,3,300,c,332" -XPUT ${url}/api/db_${uuid0}/t/_stream_load
+-- result:
+0
+{
+    "Status": "Fail",
+    "Message": "Column-mode partial update is not supported on a range-distributed primary key table whose ORDER BY key differs from the primary key"
+}
+-- !result
+sync;
+-- result:
+-- !result
+select * from t order by k1;
+-- result:
+1	1	250	bb	111	12	13	14
+2	2	250	bb	999	22	23	24
+3	3	300	c	331	32	33	34
+-- !result
+shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label:pu_auto_${uuid0}" -H "column_separator:," -H "partial_update:true" -H "columns:k1,k2,c1" -d "3,3,333" -XPUT ${url}/api/db_${uuid0}/t/_stream_load
+-- result:
+0
+{
+    "Status": "Fail"
+}
+-- !result
+sync;
+-- result:
+-- !result
+select * from t order by k1;
+-- result:
+1	1	250	bb	111	12	13	14
+2	2	250	bb	999	22	23	24
+3	3	300	c	331	32	33	34
+-- !result
+shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label:cu_old_${uuid0}" -H "column_separator:," -H "merge_condition:v1" -H "columns:k1,k2,v1,v2,c1,c2,c3,c4" -d "3,3,299,z,91,92,93,94" -XPUT ${url}/api/db_${uuid0}/t/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+sync;
+-- result:
+-- !result
+select * from t order by k1;
+-- result:
+1	1	250	bb	111	12	13	14
+2	2	250	bb	999	22	23	24
+3	3	300	c	331	32	33	34
+-- !result
+shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label:cu_new_${uuid0}" -H "column_separator:," -H "merge_condition:v1" -H "columns:k1,k2,v1,v2,c1,c2,c3,c4" -d "3,3,301,z,91,92,93,94" -XPUT ${url}/api/db_${uuid0}/t/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+sync;
+-- result:
+-- !result
+select * from t order by k1;
+-- result:
+1	1	250	bb	111	12	13	14
+2	2	250	bb	999	22	23	24
+3	3	301	z	91	92	93	94
+-- !result
+shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label:cu_pu_old_${uuid0}" -H "column_separator:," -H "merge_condition:v1" -H "partial_update:true" -H "columns:k1,k2,v1,v2,c1" -d "1,1,50,a,150" -XPUT ${url}/api/db_${uuid0}/t/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+sync;
+-- result:
+-- !result
+select * from t order by k1;
+-- result:
+1	1	250	bb	111	12	13	14
+2	2	250	bb	999	22	23	24
+3	3	301	z	91	92	93	94
+-- !result
+shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label:cu_pu_new_${uuid0}" -H "column_separator:," -H "merge_condition:v1" -H "partial_update:true" -H "columns:k1,k2,v1,v2,c1" -d "1,1,150,a,151" -XPUT ${url}/api/db_${uuid0}/t/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+sync;
+-- result:
+-- !result
+select * from t order by k1;
+-- result:
+1	1	250	bb	111	12	13	14
+2	2	250	bb	999	22	23	24
+3	3	301	z	91	92	93	94
+-- !result
+insert into t properties("merge_condition" = "v1") values (2, 2, 249, 'q', 71, 72, 73, 74);
+-- result:
+-- !result
+select * from t order by k1;
+-- result:
+1	1	250	bb	111	12	13	14
+2	2	250	bb	999	22	23	24
+3	3	301	z	91	92	93	94
+-- !result
+insert into t properties("merge_condition" = "v1") values (2, 2, 251, 'q', 71, 72, 73, 74);
+-- result:
+-- !result
+select * from t order by k1;
+-- result:
+1	1	250	bb	111	12	13	14
+2	2	251	q	71	72	73	74
+3	3	301	z	91	92	93	94
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result
+
+-- name: test_range_orderby_partial_update_after_split @cloud @sequential
+set enable_range_distribution = true;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    k1 int not null,
+    k2 int not null,
+    v1 int not null,
+    v2 varchar(256) not null,
+    c1 int not null,
+    c2 int not null,
+    c3 int not null,
+    c4 int not null
+)
+primary key(k1, k2)
+order by(v1, v2)
+properties('replication_num' = '1');
+-- result:
+-- !result
+insert into t
+select x, x % 7, 100000 - x, repeat(md5(cast(x as varchar)), 6), x, x * 2, x * 3, x * 4
+from table(generate_series(1, 20000)) as g(x);
+-- result:
+-- !result
+[UC]alter table t split tablet properties('tablet_reshard_target_size' = '1024');
+shell: n=1; for i in $(seq 1 55); do n=$(${mysql_cmd} -Ne "select count(1) from information_schema.tablet_reshard_jobs where db_name='db_${uuid0}' and job_state not in ('FINISHED','ABORTED')" 2>/dev/null); [ "$n" = "0" ] && break; sleep 2; done; echo "pending=$n"
+-- result:
+0
+pending=0
+-- !result
+select buckets > 1 as did_split from information_schema.partitions_meta
+    where db_name = 'db_${uuid0}' and table_name = 't';
+-- result:
+1
+-- !result
+select count(*) from t;
+-- result:
+20000
+-- !result
+select k1, k2, v1, c1, c2 from t where k1 in (5, 19000) order by k1;
+-- result:
+5	5	99995	5	10
+19000	2	81000	19000	38000
+-- !result
+set partial_update_mode = 'row';
+-- result:
+-- !result
+insert into t (k1, k2, v1, v2, c1) values
+    (5, 5, 99995, repeat(md5(cast(5 as varchar)), 6), 555),
+    (19000, 19000 % 7, 81000, repeat(md5(cast(19000 as varchar)), 6), 190000);
+-- result:
+-- !result
+select k1, k2, v1, c1, c2 from t where k1 in (5, 19000) order by k1;
+-- result:
+5	5	99995	555	10
+19000	2	81000	190000	38000
+-- !result
+set partial_update_mode = 'auto';
+-- result:
+-- !result
+shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label:pu_row_${uuid0}" -H "column_separator:," -H "partial_update:true" -H "partial_update_mode:row" -H "columns:k1,k2,v1,v2,c1" -d "5,5,99995,pad5,556" -XPUT ${url}/api/db_${uuid0}/t/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+sync;
+-- result:
+-- !result
+select k1, k2, v1, v2, c1, c2 from t where k1 = 5;
+-- result:
+5	5	99995	pad5	556	10
+-- !result
+shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label:pu_col_${uuid0}" -H "column_separator:," -H "partial_update:true" -H "partial_update_mode:column" -H "columns:k1,k2,v1,v2,c1" -d "5,5,99995,pad5,557" -XPUT ${url}/api/db_${uuid0}/t/_stream_load
+-- result:
+0
+{
+    "Status": "Fail",
+    "Message": "Column-mode partial update is not supported on a range-distributed primary key table whose ORDER BY key differs from the primary key"
+}
+-- !result
+sync;
+-- result:
+-- !result
+select k1, k2, v1, v2, c1, c2 from t where k1 = 5;
+-- result:
+5	5	99995	pad5	556	10
+-- !result
+insert into t properties("merge_condition" = "v1") values (5, 5, 99994, 'older', 1, 1, 1, 1);
+-- result:
+-- !result
+select k1, k2, v1, v2, c1, c2 from t where k1 = 5;
+-- result:
+5	5	99995	pad5	556	10
+-- !result
+insert into t properties("merge_condition" = "v1") values (5, 5, 99996, 'newer', 2, 2, 2, 2);
+-- result:
+-- !result
+select k1, k2, v1, v2, c1, c2 from t where k1 = 5;
+-- result:
+5	5	99996	newer	2	2
+-- !result
+shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label:cu_pu_old_${uuid0}" -H "column_separator:," -H "merge_condition:v1" -H "partial_update:true" -H "columns:k1,k2,v1,v2,c1" -d "19000,2,80999,pad19000,7" -XPUT ${url}/api/db_${uuid0}/t/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+sync;
+-- result:
+-- !result
+select k1, k2, v1, c1, c2 from t where k1 = 19000;
+-- result:
+19000	2	81000	190000	38000
+-- !result
+shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label:cu_pu_new_${uuid0}" -H "column_separator:," -H "merge_condition:v1" -H "partial_update:true" -H "columns:k1,k2,v1,v2,c1" -d "19000,2,81001,pad19000,8" -XPUT ${url}/api/db_${uuid0}/t/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+sync;
+-- result:
+-- !result
+select k1, k2, v1, c1, c2 from t where k1 = 19000;
+-- result:
+19000	2	81001	8	38000
+-- !result
+select k1, k2, v1, c1, c2, c3, c4 from t where k1 = 777;
+-- result:
+777	0	99223	777	1554	2331	3108
+-- !result
+select count(*) from t;
+-- result:
+20000
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_range_orderby/R/test_range_orderby_partitioned
+++ b/test/sql/test_range_orderby/R/test_range_orderby_partitioned
@@ -1,0 +1,105 @@
+-- name: test_range_orderby_partitioned @cloud @sequential
+set enable_range_distribution = true;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    dt date not null,
+    id int not null,
+    score int not null,
+    tag varchar(256) not null
+)
+primary key(dt, id)
+partition by range(dt) (
+    partition p1 values less than ('2026-01-02'),
+    partition p2 values less than ('2026-01-03'),
+    partition p3 values less than ('2026-01-04')
+)
+order by(score, tag)
+properties('replication_num' = '1');
+-- result:
+-- !result
+insert into t
+select '2026-01-01', x, 100000 - x, repeat(md5(cast(x as varchar)), 6)
+from table(generate_series(1, 20000)) as g(x);
+-- result:
+-- !result
+insert into t values
+    ('2026-01-02', 1, 500, 'p2a'),
+    ('2026-01-02', 2, 600, 'p2b'),
+    ('2026-01-03', 1, 700, 'p3a');
+-- result:
+-- !result
+select count(*) from t;
+-- result:
+20003
+-- !result
+select count(*) from t where dt = '2026-01-02';
+-- result:
+2
+-- !result
+select count(*) from t where dt < '2026-01-02' and score > 99000;
+-- result:
+999
+-- !result
+[UC]alter table t split tablet partition(p1) properties('tablet_reshard_target_size' = '1024');
+shell: n=1; for i in $(seq 1 55); do n=$(${mysql_cmd} -Ne "select count(1) from information_schema.tablet_reshard_jobs where db_name='db_${uuid0}' and job_state not in ('FINISHED','ABORTED')" 2>/dev/null); [ "$n" = "0" ] && break; sleep 2; done; echo "pending=$n"
+-- result:
+0
+pending=0
+-- !result
+select partition_name, buckets > 1 as did_split from information_schema.partitions_meta
+    where db_name = 'db_${uuid0}' and table_name = 't' order by partition_name;
+-- result:
+p1	1
+p2	0
+p3	0
+-- !result
+select count(*), sum(score) from t;
+-- result:
+20003	1799991800
+-- !result
+select score, length(tag) from t where dt = '2026-01-01' and id = 777;
+-- result:
+99223	192
+-- !result
+select * from t where dt = '2026-01-02' order by id;
+-- result:
+2026-01-02	1	500	p2a
+2026-01-02	2	600	p2b
+-- !result
+insert into t values ('2026-01-01', 777, 1, 'moved'), ('2026-01-03', 2, 800, 'p3b');
+-- result:
+-- !result
+select score, length(tag) from t where dt = '2026-01-01' and id = 777;
+-- result:
+1	5
+-- !result
+select * from t where dt >= '2026-01-03' order by id;
+-- result:
+2026-01-03	1	700	p3a
+2026-01-03	2	800	p3b
+-- !result
+select count(*) from t;
+-- result:
+20004
+-- !result
+truncate table t partition (p2);
+-- result:
+-- !result
+select count(*) from t;
+-- result:
+20002
+-- !result
+select count(*) from t where dt = '2026-01-02';
+-- result:
+0
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_range_orderby/R/test_range_orderby_split
+++ b/test/sql/test_range_orderby/R/test_range_orderby_split
@@ -1,0 +1,89 @@
+-- name: test_range_orderby_split @cloud @sequential
+set enable_range_distribution = true;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    k1 int not null,
+    k2 int not null,
+    v1 int not null,
+    v2 varchar(256) not null
+)
+primary key(k1, k2)
+order by(v1, v2)
+properties('replication_num' = '1');
+-- result:
+-- !result
+insert into t
+select x, x % 7, 100000 - x, repeat(md5(cast(x as varchar)), 6)
+from table(generate_series(1, 20000)) as g(x);
+-- result:
+-- !result
+select count(*), sum(v1), min(v1), max(v1) from t;
+-- result:
+20000	1799990000	80000	99999
+-- !result
+[UC]alter table t split tablet properties('tablet_reshard_target_size' = '1024');
+shell: n=1; for i in $(seq 1 55); do n=$(${mysql_cmd} -Ne "select count(1) from information_schema.tablet_reshard_jobs where db_name='db_${uuid0}' and job_state not in ('FINISHED','ABORTED')" 2>/dev/null); [ "$n" = "0" ] && break; sleep 2; done; echo "pending=$n"
+-- result:
+0
+pending=0
+-- !result
+select buckets > 1 as did_split from information_schema.partitions_meta
+    where db_name = 'db_${uuid0}' and table_name = 't';
+-- result:
+1
+-- !result
+select count(*), sum(v1), min(v1), max(v1) from t;
+-- result:
+20000	1799990000	80000	99999
+-- !result
+select k1, k2, v1 from t where k1 = 12345 and k2 = 12345 % 7;
+-- result:
+12345	4	87655
+-- !result
+select count(*) from t where v1 > 99000;
+-- result:
+999
+-- !result
+select count(*) from t where v1 between 90000 and 90009;
+-- result:
+10
+-- !result
+insert into t values (999999, 1, 1, 'tail');
+-- result:
+-- !result
+select count(*) from t;
+-- result:
+20001
+-- !result
+select k1, k2, v1, v2 from t where k1 = 999999;
+-- result:
+999999	1	1	tail
+-- !result
+insert into t values (12345, 12345 % 7, 42, 'moved');
+-- result:
+-- !result
+select k1, k2, v1, v2 from t where k1 = 12345;
+-- result:
+12345	4	42	moved
+-- !result
+delete from t where k1 = 999999;
+-- result:
+-- !result
+select count(*) from t;
+-- result:
+20000
+-- !result
+select count(*) from t where v1 = 42;
+-- result:
+1
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_range_orderby/T/test_range_orderby_add_index
+++ b/test/sql/test_range_orderby/T/test_range_orderby_add_index
@@ -1,0 +1,103 @@
+-- name: test_range_orderby_add_index @cloud
+-- SQL integration: ADD INDEX / DROP INDEX on a range-distributed PRIMARY KEY table whose
+-- ORDER BY differs from the primary key.
+--
+-- The lake index fast path writes the index as a standalone .idx sidecar keyed to the segment
+-- it annotates. A split of this shape hands the children the parent's segments and then has
+-- UNSHARE compaction rewrite them wholesale without carrying sidecars across, so the index
+-- would quietly stop covering its data -- the fast path declines this shape and the alter
+-- falls back to the regular schema-change path, which builds the index into the data itself.
+-- The fallback is invisible from SQL by design: what this case pins is that the DDL still
+-- succeeds and that reads and writes stay correct around it.
+set enable_range_distribution = true;
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    k1 int not null,
+    k2 int not null,
+    v1 int not null,
+    v2 varchar(32) not null,
+    c1 int not null,
+    c2 int not null
+)
+primary key(k1, k2)
+order by(v1, v2)
+properties('replication_num' = '1');
+
+insert into t
+select x, x % 7, 100000 - x, concat('p', x), x % 10, x
+from table(generate_series(1, 2000)) as g(x);
+select count(*), count(distinct c1) from t;
+
+alter table t add index idx_c1 (c1) using bitmap;
+function: wait_alter_table_finish()
+show index from t;
+select count(*), count(distinct c1) from t;
+select count(*) from t where c1 = 3;
+select k1, k2, c1 from t where c1 = 0 and k1 <= 20 order by k1;
+
+-- Writes after the index build have to keep it in step with the data.
+insert into t values (2001, 1, 1, 'new', 3, 2001);
+select count(*) from t where c1 = 3;
+delete from t where k1 = 2001;
+select count(*) from t where c1 = 3;
+
+drop index idx_c1 on t;
+function: wait_alter_table_finish()
+show index from t;
+select count(*) from t where c1 = 3;
+
+drop database db_${uuid0} force;
+
+-- name: test_range_orderby_add_index_after_split @cloud @sequential
+-- SQL integration: the same ADD INDEX, but on a table that has already been split -- the
+-- layout the fast path is declined for, where the children were handed the parent's segments.
+set enable_range_distribution = true;
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    k1 int not null,
+    k2 int not null,
+    v1 int not null,
+    v2 varchar(256) not null,
+    c1 int not null,
+    c2 int not null
+)
+primary key(k1, k2)
+order by(v1, v2)
+properties('replication_num' = '1');
+
+insert into t
+select x, x % 7, 100000 - x, repeat(md5(cast(x as varchar)), 6), x % 10, x
+from table(generate_series(1, 20000)) as g(x);
+
+[UC]alter table t split tablet properties('tablet_reshard_target_size' = '1024');
+
+shell: n=1; for i in $(seq 1 55); do n=$(${mysql_cmd} -Ne "select count(1) from information_schema.tablet_reshard_jobs where db_name='db_${uuid0}' and job_state not in ('FINISHED','ABORTED')" 2>/dev/null); [ "$n" = "0" ] && break; sleep 2; done; echo "pending=$n"
+
+select buckets > 1 as did_split from information_schema.partitions_meta
+    where db_name = 'db_${uuid0}' and table_name = 't';
+
+alter table t add index idx_c1 (c1) using bitmap;
+function: wait_alter_table_finish()
+select count(*), count(distinct c1) from t;
+select count(*) from t where c1 = 3;
+select count(*) from t where c1 = 3 and v1 > 99000;
+
+-- Writes still land on the children with the index in place.
+insert into t values (999999, 1, 1, 'tail', 3, 999999);
+select count(*) from t where c1 = 3;
+select k1, k2, v1, c1 from t where k1 = 999999;
+delete from t where k1 = 999999;
+select count(*) from t where c1 = 3;
+select count(*) from t;
+
+drop index idx_c1 on t;
+function: wait_alter_table_finish()
+select count(*) from t where c1 = 3;
+
+drop database db_${uuid0} force;

--- a/test/sql/test_range_orderby/T/test_range_orderby_alter
+++ b/test/sql/test_range_orderby/T/test_range_orderby_alter
@@ -1,0 +1,75 @@
+-- name: test_range_orderby_alter @cloud
+-- SQL integration: ALTER guards for a range-distributed PRIMARY KEY table whose ORDER BY
+-- differs from the primary key. The two properties this shape depends on -- bundled files
+-- and boundaries stored in primary-key space -- cannot be taken away in place.
+set enable_range_distribution = true;
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    k1 int not null,
+    k2 int not null,
+    v1 int not null,
+    v2 varchar(32) not null
+)
+primary key(k1, k2)
+order by(v1, v2)
+properties('replication_num' = '1');
+
+insert into t values (1, 1, 300, 'c'), (2, 2, 200, 'b'), (3, 3, 100, 'a');
+select * from t order by k1;
+
+-- Rejected: a split already in flight waits on an UNSHARE rewrite that is only scheduled for
+-- file-bundling tables, so turning it off would strand the table in TABLET_RESHARD.
+alter table t set ('file_bundling' = 'false');
+
+-- Rejected: the tablet boundaries on disk are in primary-key space. Re-pointing the sort key
+-- in place would reinterpret them in sort-key space.
+alter table t order by (v2, v1);
+
+-- Accepted: adding a value column leaves both the primary key and the sort key alone.
+alter table t add column v3 int not null default '9';
+function: wait_alter_table_finish()
+select * from t order by k1;
+insert into t values (4, 4, 50, 'x', 7);
+select * from t order by k1;
+select distribute_type, primary_key, sort_key from information_schema.tables_config
+    where table_schema = 'db_${uuid0}' and table_name = 't';
+
+drop database db_${uuid0} force;
+
+-- name: test_range_orderby_alter_back_to_pk @cloud
+-- SQL integration: ORDER BY can still be pointed back at the primary key. That reorder does
+-- not separate the sort key from the routing key, so it takes the range-rewrite path, which
+-- re-samples the tablet layout instead of reinterpreting the boundaries on disk. Once the
+-- two keys agree again, file_bundling is no longer load-bearing and may be turned off.
+set enable_range_distribution = true;
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    k1 int not null,
+    k2 int not null,
+    v1 int not null,
+    v2 varchar(32) not null
+)
+primary key(k1, k2)
+order by(v1, v2)
+properties('replication_num' = '1');
+
+insert into t values (1, 1, 300, 'c'), (2, 2, 200, 'b'), (3, 3, 100, 'a');
+
+alter table t order by (k1, k2);
+function: wait_alter_table_finish()
+select distribute_type, primary_key, sort_key from information_schema.tables_config
+    where table_schema = 'db_${uuid0}' and table_name = 't';
+select * from t order by k1;
+insert into t values (2, 2, 20, 'bb');
+select * from t order by k1;
+
+alter table t set ('file_bundling' = 'false');
+select count(*) from t;
+
+drop database db_${uuid0} force;

--- a/test/sql/test_range_orderby/T/test_range_orderby_create
+++ b/test/sql/test_range_orderby/T/test_range_orderby_create
@@ -1,0 +1,88 @@
+-- name: test_range_orderby_create @cloud
+-- SQL integration: CREATE TABLE for a range-distributed PRIMARY KEY table whose ORDER BY
+-- differs from the primary key. Tablet ranges stay in primary-key space -- ORDER BY only
+-- sets the physical sort order inside a tablet -- so the same primary key must still route
+-- to one tablet and collapse to one row.
+set enable_range_distribution = true;
+
+create database db_${uuid0};
+use db_${uuid0};
+
+-- Accepted: file_bundling defaults to true in shared-data mode.
+create table t1 (
+    k1 int not null,
+    k2 int not null,
+    v1 int not null,
+    v2 varchar(32) not null
+)
+primary key(k1, k2)
+order by(v1, v2)
+properties('replication_num' = '1');
+
+-- RANGE distribution with a sort key that is not the primary key.
+select distribute_type, primary_key, sort_key from information_schema.tables_config
+    where table_schema = 'db_${uuid0}' and table_name = 't1';
+
+-- The sort key is not the routing key: a second write of the same primary key must replace
+-- the first one, however far apart the two rows sort.
+insert into t1 values (1, 1, 900, 'z'), (1, 2, 100, 'a'), (2, 1, 500, 'm');
+insert into t1 values (1, 1, 1, 'b');
+select * from t1 order by k1, k2;
+select count(*) from t1;
+
+-- Rejected: a split of this shape rewrites the children wholesale, which needs bundled files.
+create table t_no_bundling (
+    k1 int not null,
+    v1 int not null
+)
+primary key(k1)
+order by(v1)
+properties('replication_num' = '1', 'file_bundling' = 'false');
+
+-- Accepted with file_bundling off: the ORDER BY equals the primary key, so nothing separates
+-- the sort key from the routing key and the new requirement must not fire.
+create table t_same_order (
+    k1 int not null,
+    k2 int not null,
+    v1 int not null
+)
+primary key(k1, k2)
+order by(k1, k2)
+properties('replication_num' = '1', 'file_bundling' = 'false');
+select distribute_type, primary_key, sort_key from information_schema.tables_config
+    where table_schema = 'db_${uuid0}' and table_name = 't_same_order';
+
+-- Accepted with file_bundling off: HASH distribution has always allowed a separate ORDER BY
+-- and has no split rewrite to strand, so the requirement must not leak onto it.
+create table t_hash (
+    k1 int not null,
+    v1 int not null
+)
+primary key(k1)
+distributed by hash(k1) buckets 3
+order by(v1)
+properties('replication_num' = '1', 'file_bundling' = 'false');
+insert into t_hash values (1, 10), (2, 20), (1, 5);
+select * from t_hash order by k1;
+
+-- Rejected: a sort key column of this table also has to be encodable as a range boundary.
+create table t_bad_sort_type (
+    k1 int not null,
+    v1 double not null
+)
+primary key(k1)
+order by(v1)
+properties('replication_num' = '1');
+
+-- Rejected: the relaxation is primary-key only. A UNIQUE KEY range table still needs its sort
+-- columns to be its key columns.
+create table t_uniq (
+    k1 int not null,
+    k2 int not null,
+    v1 int
+)
+unique key(k1, k2)
+order by(v1, k1)
+properties('replication_num' = '1');
+
+drop database db_${uuid0} force;

--- a/test/sql/test_range_orderby/T/test_range_orderby_dml
+++ b/test/sql/test_range_orderby/T/test_range_orderby_dml
@@ -1,0 +1,59 @@
+-- name: test_range_orderby_dml @cloud
+-- SQL integration: write paths on a range-distributed PRIMARY KEY table whose ORDER BY
+-- differs from the primary key. Routing and dedup live in primary-key space, so upsert,
+-- UPDATE, condition update and DELETE must behave exactly as on any other primary key table.
+-- Partial update has rules of its own on this shape; those live in
+-- test_range_orderby_partial_update.
+set enable_range_distribution = true;
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    k1 int not null,
+    k2 int not null,
+    v1 int not null,
+    v2 varchar(32) not null,
+    v3 int not null
+)
+primary key(k1, k2)
+order by(v1, v2)
+properties('replication_num' = '1');
+
+insert into t values
+    (1, 1, 500, 'e', 1),
+    (1, 2, 400, 'd', 2),
+    (2, 1, 300, 'c', 3),
+    (2, 2, 200, 'b', 4),
+    (3, 1, 100, 'a', 5);
+select * from t order by k1, k2;
+
+-- Upsert with sort key values that move the row to the other end of the sort order.
+insert into t values (2, 1, 999, 'z', 30);
+select * from t order by k1, k2;
+select count(*) from t;
+
+-- Read paths: a primary key point lookup, a sort key range, and an aggregate.
+select * from t where k1 = 2 and k2 = 1;
+select k1, k2, v1 from t where v1 >= 400 order by k1, k2;
+select sum(v3), count(distinct v2) from t;
+
+-- UPDATE with a WHERE clause rewrites whole rows, sort key columns included.
+update t set v1 = 50, v2 = 'y' where k1 = 1 and k2 = 2;
+select * from t order by k1, k2;
+update t set v3 = 7 where k1 = 2 and k2 = 2;
+select * from t order by k1, k2;
+
+-- Condition update: the row is replaced only when the condition column advances.
+insert into t properties("merge_condition" = "v1") values (3, 1, 10, 'q', 91);
+select * from t where k1 = 3 and k2 = 1;
+insert into t properties("merge_condition" = "v1") values (3, 1, 1000, 'w', 92);
+select * from t where k1 = 3 and k2 = 1;
+
+-- DELETE by primary key and by a sort key predicate.
+delete from t where k1 = 1 and k2 = 1;
+delete from t where v1 < 300;
+select * from t order by k1, k2;
+select count(*) from t;
+
+drop database db_${uuid0} force;

--- a/test/sql/test_range_orderby/T/test_range_orderby_partial_update
+++ b/test/sql/test_range_orderby/T/test_range_orderby_partial_update
@@ -1,0 +1,194 @@
+-- name: test_range_orderby_partial_update @cloud
+-- SQL integration: partial update and condition update on a range-distributed PRIMARY KEY
+-- table whose ORDER BY differs from the primary key.
+--
+-- Two rules meet on this shape. A primary key table with a sort key already requires a
+-- row-mode partial update to carry every sort key column, because the row moves when they
+-- change. And column mode -- the mode that is allowed to leave them out, because it patches
+-- columns in place -- is refused here: its patch lives beside the segment it annotates, and
+-- the UNSHARE compaction a split of this shape drags behind it rewrites every segment
+-- wholesale without carrying patches across. So every partial update here must restate the
+-- whole sort key.
+set enable_range_distribution = true;
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    k1 int not null,
+    k2 int not null,
+    v1 int not null,
+    v2 varchar(32) not null,
+    c1 int not null,
+    c2 int not null,
+    c3 int not null,
+    c4 int not null
+)
+primary key(k1, k2)
+order by(v1, v2)
+properties('replication_num' = '1');
+
+insert into t values
+    (1, 1, 100, 'a', 11, 12, 13, 14),
+    (2, 2, 200, 'b', 21, 22, 23, 24),
+    (3, 3, 300, 'c', 31, 32, 33, 34);
+select * from t order by k1;
+
+-- Row-mode partial update through INSERT: the sort key is restated, c2..c4 keep their values.
+set partial_update_mode = 'row';
+insert into t (k1, k2, v1, v2, c1) values (1, 1, 100, 'a', 111);
+select * from t order by k1;
+
+-- Leaving a sort key column out is refused: row mode cannot place the row without it.
+insert into t (k1, k2, c1) values (1, 1, 112);
+select * from t order by k1;
+
+-- Column mode is the mode that could leave it out, and it is refused on this table shape.
+set partial_update_mode = 'column';
+insert into t (k1, k2, v1, v2, c1) values (1, 1, 100, 'a', 113);
+select * from t order by k1;
+set partial_update_mode = 'auto';
+
+-- UPDATE with a WHERE clause is not a partial update at all -- it rewrites whole rows.
+update t set c1 = 999 where k1 = 2 and k2 = 2;
+select * from t order by k1;
+
+-- Without a WHERE clause UPDATE becomes a partial update, so the same rule applies: a set
+-- of columns that misses the sort key is refused ...
+update t set c1 = 998;
+select * from t order by k1;
+
+-- ... while a set that covers the whole sort key goes through as a row-mode partial update,
+-- leaving c1..c4 alone.
+update t set v1 = 250, v2 = 'bb';
+select * from t order by k1;
+
+-- An explicit column-mode UPDATE lands on the same refusal as the column-mode INSERT above,
+-- since this table shape has no column mode to fall back to.
+set partial_update_mode = 'column';
+update t set c1 = 997 where k1 = 3 and k2 = 3;
+select * from t order by k1;
+set partial_update_mode = 'auto';
+
+-- Row-mode partial update through stream load.
+shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label:pu_row_${uuid0}" -H "column_separator:," -H "partial_update:true" -H "partial_update_mode:row" -H "columns:k1,k2,v1,v2,c1" -d "3,3,300,c,331" -XPUT ${url}/api/db_${uuid0}/t/_stream_load
+sync;
+select * from t order by k1;
+
+-- Column mode through stream load is refused by the same guard.
+shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label:pu_col_${uuid0}" -H "column_separator:," -H "partial_update:true" -H "partial_update_mode:column" -H "columns:k1,k2,v1,v2,c1" -d "3,3,300,c,332" -XPUT ${url}/api/db_${uuid0}/t/_stream_load
+sync;
+select * from t order by k1;
+
+-- Auto mode without the sort key columns is refused by the storage engine.
+shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label:pu_auto_${uuid0}" -H "column_separator:," -H "partial_update:true" -H "columns:k1,k2,c1" -d "3,3,333" -XPUT ${url}/api/db_${uuid0}/t/_stream_load
+sync;
+select * from t order by k1;
+
+-- Condition update on a sort key column: a smaller v1 must not win ...
+shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label:cu_old_${uuid0}" -H "column_separator:," -H "merge_condition:v1" -H "columns:k1,k2,v1,v2,c1,c2,c3,c4" -d "3,3,299,z,91,92,93,94" -XPUT ${url}/api/db_${uuid0}/t/_stream_load
+sync;
+select * from t order by k1;
+
+-- ... and a larger one must.
+shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label:cu_new_${uuid0}" -H "column_separator:," -H "merge_condition:v1" -H "columns:k1,k2,v1,v2,c1,c2,c3,c4" -d "3,3,301,z,91,92,93,94" -XPUT ${url}/api/db_${uuid0}/t/_stream_load
+sync;
+select * from t order by k1;
+
+-- Condition update combined with a partial update: the condition column is among the updated
+-- columns, the sort key is complete, and the columns left out keep their values.
+shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label:cu_pu_old_${uuid0}" -H "column_separator:," -H "merge_condition:v1" -H "partial_update:true" -H "columns:k1,k2,v1,v2,c1" -d "1,1,50,a,150" -XPUT ${url}/api/db_${uuid0}/t/_stream_load
+sync;
+select * from t order by k1;
+shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label:cu_pu_new_${uuid0}" -H "column_separator:," -H "merge_condition:v1" -H "partial_update:true" -H "columns:k1,k2,v1,v2,c1" -d "1,1,150,a,151" -XPUT ${url}/api/db_${uuid0}/t/_stream_load
+sync;
+select * from t order by k1;
+
+-- Condition update through INSERT takes the same path.
+insert into t properties("merge_condition" = "v1") values (2, 2, 249, 'q', 71, 72, 73, 74);
+select * from t order by k1;
+insert into t properties("merge_condition" = "v1") values (2, 2, 251, 'q', 71, 72, 73, 74);
+select * from t order by k1;
+
+drop database db_${uuid0} force;
+
+-- name: test_range_orderby_partial_update_after_split @cloud @sequential
+-- SQL integration: the same partial-update and condition-update paths, but after the table has
+-- been split. A split of this shape hands the children the parent's segments, so the owner of a
+-- row has to be decided per child before an update can read the row it patches -- the case an
+-- unsplit table, with only one owner, cannot reach.
+set enable_range_distribution = true;
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    k1 int not null,
+    k2 int not null,
+    v1 int not null,
+    v2 varchar(256) not null,
+    c1 int not null,
+    c2 int not null,
+    c3 int not null,
+    c4 int not null
+)
+primary key(k1, k2)
+order by(v1, v2)
+properties('replication_num' = '1');
+
+-- v1 descends as the primary key ascends, so the sort order is the reverse of the routing
+-- order. The md5 padding resists compression, so the tablet really does reach the threshold.
+insert into t
+select x, x % 7, 100000 - x, repeat(md5(cast(x as varchar)), 6), x, x * 2, x * 3, x * 4
+from table(generate_series(1, 20000)) as g(x);
+
+[UC]alter table t split tablet properties('tablet_reshard_target_size' = '1024');
+
+shell: n=1; for i in $(seq 1 55); do n=$(${mysql_cmd} -Ne "select count(1) from information_schema.tablet_reshard_jobs where db_name='db_${uuid0}' and job_state not in ('FINISHED','ABORTED')" 2>/dev/null); [ "$n" = "0" ] && break; sleep 2; done; echo "pending=$n"
+
+select buckets > 1 as did_split from information_schema.partitions_meta
+    where db_name = 'db_${uuid0}' and table_name = 't';
+select count(*) from t;
+
+-- One row from the low end of the primary key range and one from the high end, so the updates
+-- below land on different children.
+select k1, k2, v1, c1, c2 from t where k1 in (5, 19000) order by k1;
+
+-- Row-mode partial update through INSERT, one row in each child. c2..c4 must survive.
+set partial_update_mode = 'row';
+insert into t (k1, k2, v1, v2, c1) values
+    (5, 5, 99995, repeat(md5(cast(5 as varchar)), 6), 555),
+    (19000, 19000 % 7, 81000, repeat(md5(cast(19000 as varchar)), 6), 190000);
+select k1, k2, v1, c1, c2 from t where k1 in (5, 19000) order by k1;
+set partial_update_mode = 'auto';
+
+-- Row-mode partial update through stream load, on the row in the low child.
+shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label:pu_row_${uuid0}" -H "column_separator:," -H "partial_update:true" -H "partial_update_mode:row" -H "columns:k1,k2,v1,v2,c1" -d "5,5,99995,pad5,556" -XPUT ${url}/api/db_${uuid0}/t/_stream_load
+sync;
+select k1, k2, v1, v2, c1, c2 from t where k1 = 5;
+
+-- Column mode stays refused after the split.
+shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label:pu_col_${uuid0}" -H "column_separator:," -H "partial_update:true" -H "partial_update_mode:column" -H "columns:k1,k2,v1,v2,c1" -d "5,5,99995,pad5,557" -XPUT ${url}/api/db_${uuid0}/t/_stream_load
+sync;
+select k1, k2, v1, v2, c1, c2 from t where k1 = 5;
+
+-- Condition update against the row's own v1 (100000 - 5): the older value loses, the newer wins.
+insert into t properties("merge_condition" = "v1") values (5, 5, 99994, 'older', 1, 1, 1, 1);
+select k1, k2, v1, v2, c1, c2 from t where k1 = 5;
+insert into t properties("merge_condition" = "v1") values (5, 5, 99996, 'newer', 2, 2, 2, 2);
+select k1, k2, v1, v2, c1, c2 from t where k1 = 5;
+
+-- Condition update combined with a partial update, on the row in the high child
+-- (v1 there is 100000 - 19000).
+shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label:cu_pu_old_${uuid0}" -H "column_separator:," -H "merge_condition:v1" -H "partial_update:true" -H "columns:k1,k2,v1,v2,c1" -d "19000,2,80999,pad19000,7" -XPUT ${url}/api/db_${uuid0}/t/_stream_load
+sync;
+select k1, k2, v1, c1, c2 from t where k1 = 19000;
+shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label:cu_pu_new_${uuid0}" -H "column_separator:," -H "merge_condition:v1" -H "partial_update:true" -H "columns:k1,k2,v1,v2,c1" -d "19000,2,81001,pad19000,8" -XPUT ${url}/api/db_${uuid0}/t/_stream_load
+sync;
+select k1, k2, v1, c1, c2 from t where k1 = 19000;
+
+-- Rows nobody touched, and the row count, are intact.
+select k1, k2, v1, c1, c2, c3, c4 from t where k1 = 777;
+select count(*) from t;
+
+drop database db_${uuid0} force;

--- a/test/sql/test_range_orderby/T/test_range_orderby_partitioned
+++ b/test/sql/test_range_orderby/T/test_range_orderby_partitioned
@@ -1,0 +1,61 @@
+-- name: test_range_orderby_partitioned @cloud @sequential
+-- SQL integration: a partitioned range-distributed PRIMARY KEY table whose ORDER BY differs
+-- from the primary key. Tablet ranges are per physical partition, so a split of one partition
+-- must leave the others untouched, and partition pruning must keep working alongside a
+-- predicate on the sort key.
+set enable_range_distribution = true;
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    dt date not null,
+    id int not null,
+    score int not null,
+    tag varchar(256) not null
+)
+primary key(dt, id)
+partition by range(dt) (
+    partition p1 values less than ('2026-01-02'),
+    partition p2 values less than ('2026-01-03'),
+    partition p3 values less than ('2026-01-04')
+)
+order by(score, tag)
+properties('replication_num' = '1');
+
+-- Fill p1 heavily and leave p2/p3 tiny, so only p1 is worth splitting.
+insert into t
+select '2026-01-01', x, 100000 - x, repeat(md5(cast(x as varchar)), 6)
+from table(generate_series(1, 20000)) as g(x);
+insert into t values
+    ('2026-01-02', 1, 500, 'p2a'),
+    ('2026-01-02', 2, 600, 'p2b'),
+    ('2026-01-03', 1, 700, 'p3a');
+
+select count(*) from t;
+select count(*) from t where dt = '2026-01-02';
+select count(*) from t where dt < '2026-01-02' and score > 99000;
+
+[UC]alter table t split tablet partition(p1) properties('tablet_reshard_target_size' = '1024');
+
+shell: n=1; for i in $(seq 1 55); do n=$(${mysql_cmd} -Ne "select count(1) from information_schema.tablet_reshard_jobs where db_name='db_${uuid0}' and job_state not in ('FINISHED','ABORTED')" 2>/dev/null); [ "$n" = "0" ] && break; sleep 2; done; echo "pending=$n"
+
+-- Only p1 was over the target, so only p1 fanned out.
+select partition_name, buckets > 1 as did_split from information_schema.partitions_meta
+    where db_name = 'db_${uuid0}' and table_name = 't' order by partition_name;
+
+select count(*), sum(score) from t;
+select score, length(tag) from t where dt = '2026-01-01' and id = 777;
+select * from t where dt = '2026-01-02' order by id;
+
+-- Writes land correctly in the split partition and in an untouched one.
+insert into t values ('2026-01-01', 777, 1, 'moved'), ('2026-01-03', 2, 800, 'p3b');
+select score, length(tag) from t where dt = '2026-01-01' and id = 777;
+select * from t where dt >= '2026-01-03' order by id;
+select count(*) from t;
+
+truncate table t partition (p2);
+select count(*) from t;
+select count(*) from t where dt = '2026-01-02';
+
+drop database db_${uuid0} force;

--- a/test/sql/test_range_orderby/T/test_range_orderby_split
+++ b/test/sql/test_range_orderby/T/test_range_orderby_split
@@ -1,0 +1,63 @@
+-- name: test_range_orderby_split @cloud @sequential
+-- SQL integration: splitting a range-distributed PRIMARY KEY table whose ORDER BY differs
+-- from the primary key. Such a split cannot range-filter the parent's shared segments, so
+-- every child is rewritten wholesale by an UNSHARE compaction while reads keep being served
+-- from the parent. Data must be intact throughout, and writes must land on the children
+-- afterwards.
+--
+-- [UC] on the split statement only avoids asserting on its uuid-bearing message; that the
+-- fan-out really happened is asserted separately, on the partition's bucket count.
+set enable_range_distribution = true;
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    k1 int not null,
+    k2 int not null,
+    v1 int not null,
+    v2 varchar(256) not null
+)
+primary key(k1, k2)
+order by(v1, v2)
+properties('replication_num' = '1');
+
+-- v1 descends as the primary key ascends, so the sort order is the reverse of the routing
+-- order -- exactly the layout a split has to keep straight. The md5 padding resists
+-- compression, so the tablet really does reach the split threshold.
+insert into t
+select x, x % 7, 100000 - x, repeat(md5(cast(x as varchar)), 6)
+from table(generate_series(1, 20000)) as g(x);
+
+select count(*), sum(v1), min(v1), max(v1) from t;
+
+[UC]alter table t split tablet properties('tablet_reshard_target_size' = '1024');
+
+-- Wait out the split job -- including the UNSHARE rewrite it schedules -- so the reads below
+-- land on the children rather than the parent.
+shell: n=1; for i in $(seq 1 55); do n=$(${mysql_cmd} -Ne "select count(1) from information_schema.tablet_reshard_jobs where db_name='db_${uuid0}' and job_state not in ('FINISHED','ABORTED')" 2>/dev/null); [ "$n" = "0" ] && break; sleep 2; done; echo "pending=$n"
+
+-- The parent tablet was over the 1KB target, so the split really did fan out (the fan-out
+-- itself is clamped by tablet_reshard_orderby_max_split_count, so only "more than one" is
+-- asserted here).
+select buckets > 1 as did_split from information_schema.partitions_meta
+    where db_name = 'db_${uuid0}' and table_name = 't';
+
+select count(*), sum(v1), min(v1), max(v1) from t;
+
+-- Primary key point lookup, and a predicate on the sort key.
+select k1, k2, v1 from t where k1 = 12345 and k2 = 12345 % 7;
+select count(*) from t where v1 > 99000;
+select count(*) from t where v1 between 90000 and 90009;
+
+-- Writes after the split: a new row, an upsert of an existing primary key, and a delete.
+insert into t values (999999, 1, 1, 'tail');
+select count(*) from t;
+select k1, k2, v1, v2 from t where k1 = 999999;
+insert into t values (12345, 12345 % 7, 42, 'moved');
+select k1, k2, v1, v2 from t where k1 = 12345;
+delete from t where k1 = 999999;
+select count(*) from t;
+select count(*) from t where v1 = 42;
+
+drop database db_${uuid0} force;


### PR DESCRIPTION
## Why I'm doing:

#77872 made a new table shape creatable in shared-data mode: a range-distributed PRIMARY KEY
table whose `ORDER BY` differs from its primary key. Routing and tablet boundaries stay in
primary-key space while the segments are physically sorted by the `ORDER BY`, and a split of
this shape cannot range-filter the parent's shared segments, so its children are rewritten
wholesale by an UNSHARE compaction. That combination has FE unit tests but no end-to-end
coverage.

## What I'm doing:

Adding a `test/sql/test_range_orderby` suite -- 10 cases over 7 files, all `@cloud`:

- `test_range_orderby_create`: the DDL is accepted and `information_schema.tables_config`
  reports RANGE routing with a sort key that is not the primary key; a repeated primary key
  still collapses to one row however far apart the two rows sort. `file_bundling=false` is
  refused for this shape, while the `ORDER BY == PK` and HASH-distributed shapes still accept
  it, and the pre-existing sort-key-type and UNIQUE KEY rejections are unchanged.
- `test_range_orderby_dml`: upsert, primary key point lookup, sort key predicate,
  `UPDATE ... WHERE`, condition update, and DELETE by primary key and by sort key.
- `test_range_orderby_partial_update`: every partial update on this shape has to restate the
  whole sort key, because column mode -- the mode that may leave it out -- is refused here;
  covered through INSERT, stream load and UPDATE, together with condition update and
  condition update combined with a partial update. A second case runs the same set after a
  split, where the owning child decides the update, with one row taken from each child.
- `test_range_orderby_alter`: `file_bundling` cannot be disabled and the sort key cannot be
  re-pointed in place; adding a value column still works; pointing `ORDER BY` back at the
  primary key takes the range-rewrite path, after which `file_bundling` may be turned off
  again.
- `test_range_orderby_split`: a manual split really does fan the tablet out, data and reads
  are unchanged across it, and writes and deletes land correctly on the children.
- `test_range_orderby_partitioned`: only the partition over the target size is split, and
  partition pruning, cross-partition writes and `TRUNCATE PARTITION` still behave.
- `test_range_orderby_add_index`: the lake index fast path declines this shape, since its
  standalone `.idx` sidecar would not survive the wholesale segment rewrite a split drags
  behind it, so `ADD INDEX ... USING BITMAP` falls back to the regular schema-change path.
  The fallback is invisible from SQL, so what is pinned is that the DDL still succeeds,
  `SHOW INDEX` reports the index, reads and writes around it stay correct, and `DROP INDEX`
  takes it back off -- once on a plain table and once on a table already split.

Three expectations are matched by regex rather than literally, because the storage engine
prefixes the message with the node address.

Recorded and validated on a shared-data cluster (1 FE + 3 CN) built from
`bb65dbfed5d2ad335033b5d700f3388488cac4a0`; every case passes 3/3, sequential cases included
(`-a sequential`).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
