### PR TITLE
[BugFix] Do not keep NestLoopJoin ON columns dict-encoded

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -50,6 +50,7 @@ import com.starrocks.sql.optimizer.operator.ScanOperatorPredicates;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEConsumeOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEProduceOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalHashJoinOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHiveScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalIcebergScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalJoinOperator;
@@ -777,8 +778,13 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
 
         DistributionProperty leftDistribution = optExpression.getRequiredProperties().get(0).getDistributionProperty();
         DistributionProperty rightDistribution = optExpression.getRequiredProperties().get(1).getDistributionProperty();
-        // Currently only supports broadcast join.
+        // Only broadcast hash join keeps its ON columns dict-encoded: DecodeRewriter rewrites the ON
+        // predicate to dict refs only in visitPhysicalHashJoin. For any non-hash join (NestLoop, Merge)
+        // the generic rewriter never touches onPredicate, so keeping those ON columns encoded would
+        // leave the onPredicate referencing string refs the dict-encoded scan no longer emits, which
+        // fails planning with "Invalid plan: Input dependency cols check failed".
         if (!sessionVariable.isEnableLowCardinalityOptimizeForJoin() ||
+                !(join instanceof PhysicalHashJoinOperator) ||
                 (leftDistribution.isShuffle() && rightDistribution.isShuffle())) {
             onColumns.getStream().forEach(disableRewriteStringColumns::union);
         } else {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityJoinTest.java
@@ -1,0 +1,90 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.common.FeConstants;
+import com.starrocks.utframe.StarRocksAssert;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+// Isolated from LowCardinalityTest2 on purpose: adding a test that plans dict queries mutates the
+// mock-dict/session state shared across methods within a class, which perturbs that class's
+// absolute-id plan assertions. Surefire runs each class in its own fork (reuseForks=false), so a
+// separate class keeps this regression self-contained.
+public class LowCardinalityJoinTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withTable("CREATE TABLE `low_card_t1` (\n" +
+                "  `d_date` date ,\n" +
+                "  `c_user` varchar(50) ,\n" +
+                "  `c_dept` varchar(50) ,\n" +
+                "  `c_par` varchar(50) ,\n" +
+                "  `cpc` int(11) \n" +
+                ") ENGINE=OLAP \n" +
+                "DUPLICATE KEY(`d_date`, `c_user`, `c_dept`, `c_par`)\n" +
+                "DISTRIBUTED BY HASH(`d_date`, `c_user`, `c_dept`, `c_par`) BUCKETS 16 \n" +
+                "PROPERTIES (\"replication_num\" = \"1\");");
+        FeConstants.USE_MOCK_DICT_MANAGER = true;
+        connectContext.getSessionVariable().setEnableLowCardinalityOptimize(true);
+        connectContext.getSessionVariable().setUseLowCardinalityOptimizeV2(true);
+        connectContext.getSessionVariable().setCboCteReuse(false);
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        connectContext.getSessionVariable().setEnableLowCardinalityOptimize(false);
+        FeConstants.USE_MOCK_DICT_MANAGER = false;
+    }
+
+    @Test
+    public void testNestLoopJoinOnPredicateNotEncoded() throws Exception {
+        FeConstants.runningUnitTest = true;
+        // A same-table equality in an outer-join ON clause is not a hash-join key, so it plans as a
+        // NestLoopJoin with the equality kept in onPredicate. The LC collector must NOT keep the ON
+        // columns dict-encoded for a NestLoopJoin, because DecodeRewriter only rewrites the ON
+        // predicate of a PhysicalHashJoinOperator; otherwise the join would reference string refs the
+        // dict-encoded scan no longer emits, yielding "Invalid plan: Input dependency cols check failed".
+        String sql = "SELECT COUNT(distinct t1.c_user), COUNT(distinct t1.c_dept) FROM low_card_t1 t1 "
+                + "LEFT JOIN low_card_t1 t2 ON t1.c_user = t1.c_dept";
+        String plan = getVerboseExplain(sql);
+        // Must plan without throwing, and the NestLoopJoin ON keeps the columns as VARCHAR (decoded),
+        // not INT dict codes.
+        assertContains(plan, "NESTLOOP JOIN");
+        assertContains(plan, "other join predicates: [2: c_user, VARCHAR, true] = [3: c_dept, VARCHAR, true]");
+
+        // The RIGHT-join / group-by variants must plan as well.
+        getVerboseExplain("SELECT COUNT(distinct t2.c_user), COUNT(distinct t2.c_dept) FROM low_card_t1 t1 "
+                + "RIGHT JOIN low_card_t1 t2 ON t2.c_user = t2.c_dept");
+        getVerboseExplain("SELECT t1.c_user, t1.c_dept, count(1) FROM low_card_t1 t1 "
+                + "LEFT JOIN low_card_t1 t2 ON t1.c_user = t1.c_dept GROUP BY t1.c_user, t1.c_dept");
+
+        // A sort-merge join has the same exposure: DecodeRewriter only rewrites hash joins, so its ON
+        // columns must stay decoded too.
+        String saved = connectContext.getSessionVariable().getJoinImplementationMode();
+        connectContext.getSessionVariable().setJoinImplementationMode("merge");
+        try {
+            String mergePlan = getVerboseExplain("SELECT COUNT(distinct t1.c_user) FROM low_card_t1 t1 "
+                    + "JOIN low_card_t1 t2 ON t1.c_user = t2.c_user");
+            assertContains(mergePlan, "MERGE JOIN");
+            assertContains(mergePlan, "equal join conjunct: [2: c_user, VARCHAR, true] = [7: c_user, VARCHAR, true]");
+        } finally {
+            connectContext.getSessionVariable().setJoinImplementationMode(saved);
+        }
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

The low-cardinality collector (DecodeCollector.visitPhysicalJoin) forms a join-eq group and keeps both ON columns dict-encoded for any join type, but DecodeRewriter only rewrites the ON predicate of a PhysicalHashJoinOperator (visitPhysicalHashJoin). A NestLoopJoin falls through to the generic visit(), which rewrites only predicate/projection and never touches onPredicate. So a NestLoopJoin whose ON references a dict-encoded column keeps string refs the encoded scan no longer emits, and planning fails with "Invalid plan: Input dependency cols check failed".

A NestLoopJoin arises, for example, from a same-table equality in an outer-join ON clause (no cross-child hash key), e.g.
  SELECT COUNT(distinct t1.a), COUNT(distinct t1.b)
  FROM t t1 LEFT JOIN t t2 ON t1.a = t1.b;
where a and b are low-cardinality columns made profitable to encode.

Fix on the collector side: exclude NestLoopJoin from the join-eq encoding path, so its ON columns are decoded and compared as strings (the same treatment already applied to shuffle joins and when the join LC optimization is disabled). This is the safe choice because the NestLoopJoin broadcast exchange ships no global dict, so rewriting the ON to dict refs would fail at the BE instead.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
