### PR TITLE
[Enhancement] Make the FE meta dir free disk threshold configurable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -867,6 +867,18 @@ public class Config extends ConfigBase {
     public static long bdbje_reserved_disk_size = 512L * 1024 * 1024;
 
     /**
+     * The amount of free space (in bytes) bdb-je tries to keep on the volume holding `meta_dir`.
+     * The same value gates FE startup: the FE refuses to start when the free space is below it.
+     * <p>
+     * The default equals the bdb-je default. Lowering it is the recovery path for an FE that cannot
+     * start on a nearly full metadata volume: it lets bdb-je open and reclaim its own reserved files.
+     * Note that bdb-je needs this headroom for its housekeeping, so a value far below the default
+     * leaves an FE that starts but may reject metadata writes. Takes effect after a restart.
+     */
+    @ConfField
+    public static long bdbje_free_disk_size = 5L * 1024 * 1024 * 1024;
+
+    /**
      * Timeout seconds for doing checkpoint
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
@@ -231,6 +231,10 @@ public class BDBEnvironment {
                 String.valueOf(Config.bdbje_cleaner_threads));
         environmentConfig.setConfigParam(EnvironmentConfig.RESERVED_DISK,
                 String.valueOf(Config.bdbje_reserved_disk_size));
+        // Keep bdb-je's own threshold aligned with the startup gate in MetaHelper#checkMetaDir, otherwise
+        // lowering the gate only yields an FE that starts and then has bdb-je reject every write.
+        environmentConfig.setConfigParam(EnvironmentConfig.FREE_DISK,
+                String.valueOf(Config.bdbje_free_disk_size));
 
         if (isElectable) {
             Durability durability = new Durability(getSyncPolicy(Config.master_sync_policy),

--- a/fe/fe-core/src/main/java/com/starrocks/leader/MetaHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/MetaHelper.java
@@ -35,7 +35,6 @@
 package com.starrocks.leader;
 
 import com.google.common.base.Strings;
-import com.sleepycat.je.config.EnvironmentParams;
 import com.starrocks.common.Config;
 import com.starrocks.common.InvalidMetaDirException;
 import com.starrocks.common.io.IOUtils;
@@ -245,10 +244,11 @@ public class MetaHelper {
             throw new InvalidMetaDirException();
         }
 
-        long lowerFreeDiskSize = Long.parseLong(EnvironmentParams.FREE_DISK.getDefault());
+        long lowerFreeDiskSize = Config.bdbje_free_disk_size;
         FileStore store = Files.getFileStore(Paths.get(Config.meta_dir));
         if (store.getUsableSpace() < lowerFreeDiskSize) {
-            LOG.error("Free capacity left for meta dir: {} is less than {}",
+            LOG.error("Free capacity left for meta dir: {} is less than {}. Free up space, or lower " +
+                            "bdbje_free_disk_size to start with less headroom and let bdb-je reclaim its own files",
                     Config.meta_dir, new ByteSizeValue(lowerFreeDiskSize));
             throw new InvalidMetaDirException();
         }

--- a/fe/fe-core/src/test/java/com/starrocks/leader/MetaHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/leader/MetaHelperTest.java
@@ -105,6 +105,29 @@ public class MetaHelperTest {
         }
     }
 
+    @Test
+    public void testFreeDiskSizeIsConfigurable() throws IOException, InvalidMetaDirException {
+        Config.start_with_incomplete_meta = false;
+        Config.meta_dir = testDir + "/meta";
+        mkdir(Config.meta_dir + "/bdb");
+        File file = new File(Config.meta_dir + "/bdb/EF889.jdb");
+        Assertions.assertTrue(file.createNewFile());
+
+        long originalFreeDiskSize = Config.bdbje_free_disk_size;
+        try {
+            // No volume can satisfy this, so the startup gate must reject the meta dir.
+            Config.bdbje_free_disk_size = Long.MAX_VALUE;
+            assertThrows(InvalidMetaDirException.class, MetaHelper::checkMetaDir);
+
+            // Lowering the config is the recovery path: the same meta dir now passes.
+            Config.bdbje_free_disk_size = 0;
+            MetaHelper.checkMetaDir();
+        } finally {
+            Config.bdbje_free_disk_size = originalFreeDiskSize;
+            deleteDir(new File(testDir + "/"));
+        }
+    }
+
     private void mkdir(String targetDir) {
         File dir = new File(targetDir);
         if (dir.exists()) {


### PR DESCRIPTION
## Why I'm doing:

When an FE starts, `MetaHelper#checkMetaDir` checks the free space of the filesystem holding `meta_dir` and refuses to start if it is below 5GB. That number was read straight from the bdb-je `je.freeDisk` default and was fixed at build time — there was no config for it and no flag to skip the check.

Two things make this a recovery blocker rather than a guardrail:

- The check runs **before** bdb-je is opened. Once open, bdb-je reclaims its own space by deleting reserved files it keeps only until space is needed. The startup gate prevents it from ever reaching that point.
- Because the value is fixed, an FE whose metadata volume drops below 5GB cannot start and cannot recover on its own. The only ways out are adding disk capacity or deleting files by hand on every FE host.

This was hit in production: all three FEs of a cluster were below the limit at the same time and none of them would start, so restoring service required manual disk work on each host with the cluster down. Under that kind of time pressure operators delete journal files to free space, and when the last image is old those journal files are the only copy of recent metadata — so the workaround risks permanent metadata loss.

Worth noting: the same 5GB value is a *dynamic* limit inside bdb-je that triggers space reclamation, while StarRocks was using it as a *hard* startup gate that prevents reclamation. The same number was serving the opposite purpose.

## What I'm doing:

Add a new FE config `bdbje_free_disk_size`, defaulting to `5 * 1024 * 1024 * 1024` — exactly the bdb-je `je.freeDisk` default — so **behavior is unchanged unless an operator lowers it**.

- `MetaHelper#checkMetaDir` now reads the threshold from the config instead of `EnvironmentParams.FREE_DISK.getDefault()`.
- The same value is passed to bdb-je as `EnvironmentConfig.FREE_DISK`, keeping the startup gate and bdb-je's own reclamation threshold on one number. This part matters: if only the gate were lowered, the FE would start and then have bdb-je reject every metadata write — a cluster that looks healthy but cannot commit any metadata change, which is a worse failure mode than not starting at all.
- The startup error message now names the config, so the recovery path is visible to whoever is reading the log at the time.

The config is read at startup only and takes effect after a restart; it is deliberately **not** mutable, since the case it exists for is an FE that will not start.

Lowering it is a trade-off, not a free win — bdb-je needs the headroom for its own housekeeping — and the doc text says so. But it turns "manual disk surgery on every FE host, with the cluster down" into "change a setting and restart".

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

A new parameter is introduced, but its default reproduces the current hard-coded 5GB exactly, so existing deployments are unaffected.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

Documentation for `bdbje_free_disk_size` (`docs/en` + `docs/zh`, next to `bdbje_reserved_disk_size`) will be submitted in a separate doc PR.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
