### PR TITLE
[Enhancement] Add memory index for PhysicalPartition to Partition in CatalogRecycleBin to accelerate PhysicalPartition lookup (backport #71425)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -91,6 +91,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
     // The first Long type is DdId, the second String is TableName
     private final com.google.common.collect.Table<Long, String, RecycleTableInfo> nameToTableInfo;
     private final Map<Long, RecyclePartitionInfo> idToPartition;
+    private final Map<Long, Long> physicalPartitionIdToPartitionId;
 
     private Map<RecyclePartitionInfo, CompletableFuture<Boolean>> asyncDeleteForPartitions;
     private Map<RecycleTableInfo, CompletableFuture<Boolean>> asyncDeleteForTables;
@@ -117,6 +118,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
         idToTableInfo = HashBasedTable.create();
         nameToTableInfo = HashBasedTable.create();
         idToPartition = Maps.newHashMap();
+        physicalPartitionIdToPartitionId = Maps.newHashMap();
         idToRecycleTime = Maps.newHashMap();
         enableEraseLater = new HashSet<>();
         asyncDeleteForPartitions = Maps.newHashMap();
@@ -126,6 +128,42 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
     private void removeRecycleMarkers(Long id) {
         idToRecycleTime.remove(id);
         enableEraseLater.remove(id);
+    }
+
+    private void addPhysicalPartitionIndex(RecyclePartitionInfo recyclePartitionInfo) {
+        long partitionId = recyclePartitionInfo.getPartition().getId();
+        for (PhysicalPartition physicalPartition : recyclePartitionInfo.getPartition().getSubPartitions()) {
+            physicalPartitionIdToPartitionId.put(physicalPartition.getId(), partitionId);
+        }
+    }
+
+    private void removePhysicalPartitionIndex(@Nullable RecyclePartitionInfo recyclePartitionInfo) {
+        if (recyclePartitionInfo == null) {
+            return;
+        }
+        for (PhysicalPartition physicalPartition : recyclePartitionInfo.getPartition().getSubPartitions()) {
+            physicalPartitionIdToPartitionId.remove(physicalPartition.getId());
+        }
+    }
+
+    private void putPartitionToRecycleBin(RecyclePartitionInfo recyclePartitionInfo) {
+        RecyclePartitionInfo oldPartitionInfo =
+                idToPartition.put(recyclePartitionInfo.getPartition().getId(), recyclePartitionInfo);
+        removePhysicalPartitionIndex(oldPartitionInfo);
+        addPhysicalPartitionIndex(recyclePartitionInfo);
+    }
+
+    @Nullable
+    private RecyclePartitionInfo removePartitionFromRecycleBinInternal(long partitionId) {
+        RecyclePartitionInfo partitionInfo = idToPartition.remove(partitionId);
+        removePhysicalPartitionIndex(partitionInfo);
+        return partitionInfo;
+    }
+
+    private void removePartitionFromRecycleBinInternal(Iterator<Map.Entry<Long, RecyclePartitionInfo>> iterator,
+                                                       RecyclePartitionInfo partitionInfo) {
+        removePhysicalPartitionIndex(partitionInfo);
+        iterator.remove();
     }
 
     public synchronized void recycleDatabase(Database db, Set<String> tableNames, boolean recoverable) {
@@ -222,7 +260,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
         disableRecoverPartitionWithSameName(dbId, tableId, partitionName);
 
         idToRecycleTime.put(partitionId, System.currentTimeMillis());
-        idToPartition.put(partitionId, recyclePartitionInfo);
+        putPartitionToRecycleBin(recyclePartitionInfo);
         LOG.info("Finished put partition '{}' to recycle bin. dbId: {} tableId: {} partitionId: {} recoverable: {}",
                 partitionName, dbId, tableId, partitionId, recyclePartitionInfo.isRecoverable());
     }
@@ -236,16 +274,12 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
     }
 
     public synchronized PhysicalPartition getPhysicalPartition(long physicalPartitionId) {
-        for (Partition partition : idToPartition.values().stream()
-                .map(RecyclePartitionInfo::getPartition)
-                .collect(Collectors.toList())) {
-            for (PhysicalPartition subPartition : partition.getSubPartitions()) {
-                if (subPartition.getId() == physicalPartitionId) {
-                    return subPartition;
-                }
-            }
+        Long partitionId = physicalPartitionIdToPartitionId.get(physicalPartitionId);
+        if (partitionId == null) {
+            return null;
         }
-        return null;
+        RecyclePartitionInfo partitionInfo = idToPartition.get(partitionId);
+        return partitionInfo != null ? partitionInfo.getPartition().getSubPartition(physicalPartitionId) : null;
     }
 
     public synchronized short getPartitionReplicationNum(long partitionId) {
@@ -677,7 +711,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
             }
 
             if (finished) {
-                iterator.remove();
+                removePartitionFromRecycleBinInternal(iterator, partitionInfo);
                 asyncDeleteForPartitions.remove(partitionInfo);
                 removeRecycleMarkers(partitionId);
 
@@ -730,7 +764,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
     }
 
     public synchronized void replayErasePartition(long partitionId) {
-        RecyclePartitionInfo partitionInfo = idToPartition.remove(partitionId);
+        RecyclePartitionInfo partitionInfo = removePartitionFromRecycleBinInternal(partitionId);
         idToRecycleTime.remove(partitionId);
 
         Partition partition = partitionInfo.getPartition();
@@ -890,7 +924,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
         long partitionId = recoverPartitionInfo.getPartition().getId();
 
         // remove from recycle bin
-        idToPartition.remove(partitionId);
+        removePartitionFromRecycleBinInternal(partitionId);
         removeRecycleMarkers(partitionId);
 
         // log
@@ -924,7 +958,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
                         ((RecyclePartitionInfoV2) partitionInfo).getDataCacheInfo());
             }
 
-            iterator.remove();
+            removePartitionFromRecycleBinInternal(iterator, partitionInfo);
             idToRecycleTime.remove(partitionId);
 
             LOG.info("replay recover partition[{}-{}] finished", partitionId, partitionInfo.getPartition().getName());
@@ -1287,6 +1321,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
     }
 
     public void load(SRMetaBlockReader reader) throws IOException, SRMetaBlockException, SRMetaBlockEOFException {
+        physicalPartitionIdToPartitionId.clear();
         reader.readCollection(RecycleDatabaseInfo.class, recycleDatabaseInfo -> {
             idToDatabase.put(recycleDatabaseInfo.db.getId(), recycleDatabaseInfo);
         });
@@ -1297,7 +1332,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
         });
 
         reader.readCollection(RecyclePartitionInfoV2.class, recyclePartitionInfo -> {
-            idToPartition.put(recyclePartitionInfo.partition.getId(), recyclePartitionInfo);
+            putPartitionToRecycleBin(recyclePartitionInfo);
         });
 
         idToRecycleTime = (Map<Long, Long>) reader.readJson(new TypeToken<Map<Long, Long>>() {
@@ -1332,6 +1367,12 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
     }
 
     // for test
+    protected void setPartitionInfo(long partitionId, RecyclePartitionInfo partitionInfo) {
+        Preconditions.checkState(partitionId == partitionInfo.getPartition().getId());
+        putPartitionToRecycleBin(partitionInfo);
+    }
+
+    // for test
     protected void setDeleteFutureForPartition(RecyclePartitionInfo partitionInfo, CompletableFuture<Boolean> future) {
         asyncDeleteForPartitions.put(partitionInfo, future);
     }
@@ -1339,5 +1380,12 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
     // for test
     protected void setDeleteFutureForTable(RecycleTableInfo tableInfo, CompletableFuture<Boolean> future) {
         asyncDeleteForTables.put(tableInfo, future);
+    }
+
+    // for test
+    public void removePartitionFromRecycleBin(long partitionId) {
+        removePartitionFromRecycleBinInternal(partitionId);
+        idToRecycleTime.remove(partitionId);
+        enableEraseLater.remove(partitionId);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
@@ -187,6 +187,54 @@ public class CatalogRecycleBinTest {
         Assertions.assertNotNull(recycledPart);
         recycledPart = bin.getPhysicalPartition(4L);
         Assertions.assertEquals(4L, recycledPart.getId());
+
+        Partition replacementPartition = new Partition(1L, 5L, "pt", new MaterializedIndex(), null);
+        bin.setPartitionInfo(1L,
+                new RecycleRangePartitionInfo(11L, 22L, replacementPartition, range, dataProperty,
+                        (short) 1, false, null));
+
+        Assertions.assertNull(bin.getPhysicalPartition(3L));
+        recycledPart = bin.getPhysicalPartition(5L);
+        Assertions.assertNotNull(recycledPart);
+        Assertions.assertEquals(5L, recycledPart.getId());
+
+        bin.removePartitionFromRecycleBin(1L);
+        Assertions.assertNull(bin.getPhysicalPartition(5L));
+        Assertions.assertNotNull(bin.getPhysicalPartition(4L));
+    }
+
+    @Test
+    public void testLoadRebuildsPhysicalPartitionIndex() throws Exception {
+        CatalogRecycleBin originalBin = new CatalogRecycleBin();
+        List<Column> columns = Lists.newArrayList(new Column("k1", ScalarType.createVarcharType(10)));
+        Range<PartitionKey> range =
+                Range.range(PartitionKey.createPartitionKey(Lists.newArrayList(new PartitionValue("1")), columns),
+                        BoundType.CLOSED,
+                        PartitionKey.createPartitionKey(Lists.newArrayList(new PartitionValue("3")), columns),
+                        BoundType.CLOSED);
+        DataProperty dataProperty = new DataProperty(TStorageMedium.HDD);
+        Partition partition = new Partition(1L, 3L, "pt", new MaterializedIndex(), null);
+        originalBin.recyclePartition(
+                new RecycleRangePartitionInfo(11L, 22L, partition, range, dataProperty,
+                        (short) 1, false, null));
+        Partition partition2 = new Partition(2L, 4L, "pt2", new MaterializedIndex(), null);
+        originalBin.recyclePartition(
+                new RecycleRangePartitionInfo(11L, 22L, partition2, range, dataProperty,
+                        (short) 1, false, null));
+
+        UtFrameUtils.PseudoImage image = new UtFrameUtils.PseudoImage();
+        originalBin.save(image.getImageWriter());
+
+        CatalogRecycleBin loadedBin = new CatalogRecycleBin();
+        loadedBin.load(image.getMetaBlockReader());
+
+        PhysicalPartition recycledPart = loadedBin.getPhysicalPartition(3L);
+        Assertions.assertNotNull(recycledPart);
+        Assertions.assertEquals(3L, recycledPart.getId());
+        recycledPart = loadedBin.getPhysicalPartition(4L);
+        Assertions.assertNotNull(recycledPart);
+        Assertions.assertEquals(4L, recycledPart.getId());
+        Assertions.assertNull(loadedBin.getPhysicalPartition(5L));
     }
 
     @Test
@@ -684,6 +732,8 @@ public class CatalogRecycleBinTest {
 
         Assertions.assertEquals(recycleBin.getPartition(p1.getId()), p1);
         Assertions.assertEquals(recycleBin.getPartition(p2.getId()), p2);
+        Assertions.assertSame(p1.getDefaultPhysicalPartition(), recycleBin.getPhysicalPartition(112));
+        Assertions.assertSame(p2.getDefaultPhysicalPartition(), recycleBin.getPhysicalPartition(223));
         Assertions.assertTrue(recycleBin.idToRecycleTime.containsKey(p1.getId()));
         Assertions.assertTrue(recycleBin.idToRecycleTime.containsKey(p2.getId()));
 
@@ -696,7 +746,9 @@ public class CatalogRecycleBinTest {
         waitPartitionClearFinished(recycleBin, p1.getId(), now);
 
         Assertions.assertNull(recycleBin.getPartition(p1.getId()));
+        Assertions.assertNull(recycleBin.getPhysicalPartition(112));
         Assertions.assertEquals(recycleBin.getPartition(p2.getId()), p2);
+        Assertions.assertSame(p2.getDefaultPhysicalPartition(), recycleBin.getPhysicalPartition(223));
 
         // 3. set recyle later, check if recycle now
         CatalogRecycleBin.LATE_RECYCLE_INTERVAL_SECONDS = 10;
@@ -721,6 +773,7 @@ public class CatalogRecycleBinTest {
         recycleBin.erasePartition(now);
         waitPartitionClearFinished(recycleBin, p2.getId(), now);
         Assertions.assertEquals(recycleBin.getPartition(p2.getId()), null);
+        Assertions.assertNull(recycleBin.getPhysicalPartition(223));
         Assertions.assertEquals(0, recycleBin.idToRecycleTime.size());
         Assertions.assertEquals(0, recycleBin.enableEraseLater.size());
     }


### PR DESCRIPTION
## Why I'm doing:

CPU profiling indicates that TabletScheduler spends significant time scanning CatalogRecycleBin for physical partitions. With tens of thousands of recycled partitions, these repeated linear scans cause scheduler contention and catalog-wide slow locks.
This can delay tablet scheduling, report handling, publish-version tasks, load commits, and colocate-table balancing.
This backport adds the lookup optimization from #71425

## What I'm doing:

Backport #71425 to `branch-3.5`.
Add memory index for searching PhysicalPartition in CatalogRecycleBin.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

