### PR TITLE
[BugFix] BE graceful shutdown admission and drain semantics

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -91,6 +91,25 @@ void HeartbeatServer::heartbeat(THeartbeatResult& heartbeat_result, const TMaste
                    << " BE/CN:" << config::enable_transparent_data_encryption;
     }
 
+    // Heartbeat ack tells us whether an FE has observed this BE's shutdown. Three cases:
+    // - No ack field (legacy FE): keep the optimistic delay for mixed-version timing, but
+    //   disable BEGIN 307 — the old FE returns cached coordinators without availability
+    //   checks and would bounce the client back to this BE.
+    // - Ack advanced for the current acking FE: that FE saw the shutdown heartbeat, so this
+    //   BE is globally marked down; open the delay window and BEGIN redirect.
+    // - Ack unchanged or from a different FE (leader handover): not comparable/not advanced —
+    //   stay unaware and disable redirect; the fallback deadline rejects instead.
+    if (process_exit_in_progress()) {
+        std::string ack_source = fmt::format("{}:{}:{}", master_info.network_address.hostname,
+                                             master_info.network_address.port, master_info.epoch);
+        if (!master_info.__isset.last_heartbeat_time_ms) {
+            set_frontend_aware_of_exit();
+            disable_begin_redirect();
+        } else if (advance_heartbeat_ack(ack_source, master_info.last_heartbeat_time_ms)) {
+            set_frontend_aware_of_exit();
+        }
+    }
+
     StatusOr<CmpResult> res;
     // reject master's heartbeat when exit
     if (process_exit_in_progress() || is_process_crashing()) {
@@ -155,10 +174,6 @@ void HeartbeatServer::heartbeat(THeartbeatResult& heartbeat_result, const TMaste
             reboot_time = static_cast<int64_t>(currTime);
         }
         heartbeat_result.backend_info.__set_reboot_time(reboot_time);
-    }
-    if (process_exit_in_progress()) {
-        // Just assume this response can reach the frontend side.
-        set_frontend_aware_of_exit();
     }
 }
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1673,14 +1673,25 @@ CONF_String(dependency_librdkafka_debug, "all");
 // DEBUG: 0, INFO: 1, WARN: 2, ERROR: 3, WARN by default
 CONF_mInt16(pulsar_client_log_level, "2");
 
-// max loop count when be waiting its fragments to finish. It has no effect if the var is configured with value <= 0.
-CONF_mInt64(loop_count_wait_fragments_finish, "2");
+// Maximum drain wait in seconds is this value * 10; each drain-loop iteration sleeps 1 second.
+CONF_mInt64(loop_count_wait_fragments_finish, "6");
 
-// Determines whether to await at least one frontend heartbeat response indicating SHUTDOWN status before completing graceful exit.
-//
-// When enabled, the graceful shutdown process remains active until a SHUTDOWN confirmation is responded via heartbeat RPC,
-// ensuring the frontend has sufficient time to detect the termination state between two regular heartbeat intervals.
-CONF_mBool(graceful_exit_wait_for_frontend_heartbeat, "false");
+// Wait for FE shutdown acknowledgement before rejecting requests.
+// New FE: acknowledgement is a growing LastHeartbeat; the first value from that FE is only a
+// baseline. Legacy FE (field absent): optimistic compatibility (delay opens when the SHUTDOWN
+// heartbeat response is constructed). When false, reject new requests immediately on shutdown.
+CONF_Bool(graceful_exit_wait_for_frontend_heartbeat, "true");
+
+// Delay (ms) to keep admitting new work (new BEGINs, new loads, new fragments) after the FE
+// acknowledged the shutdown via a growing LastHeartbeat. The first value from a given FE is
+// only a baseline. The window closes early when the fallback budget expires. Not tied to
+// BEGIN retry idempotency: retries keep the normal LABEL_ALREADY_EXISTS behavior.
+// After a leader switch, BEGIN redirect is disabled for the rest of this shutdown.
+CONF_mInt64(graceful_exit_reject_delay_ms, "10000");
+
+// Fallback budget (ms) from shutdown start: after it expires new work is rejected even if no
+// FE acknowledgement was observed. Also caps the admission window opened by an acknowledgement.
+CONF_mInt64(graceful_exit_reject_fallback_ms, "15000");
 
 // the maximum number of connections in the connection pool for a single jdbc url
 CONF_Int16(jdbc_connection_pool_size, "8");

--- a/be/src/common/config_exec_env_fwd.h
+++ b/be/src/common/config_exec_env_fwd.h
@@ -197,14 +197,25 @@ CONF_String(starlet_cache_dir, "");
 #endif
 CONF_mInt64(lake_metadata_cache_limit, /*2GB=*/"2147483648");
 
-// max loop count when be waiting its fragments to finish. It has no effect if the var is configured with value <= 0.
-CONF_mInt64(loop_count_wait_fragments_finish, "2");
+// Maximum drain wait in seconds is this value * 10; each drain-loop iteration sleeps 1 second.
+CONF_mInt64(loop_count_wait_fragments_finish, "6");
 
-// Determines whether to await at least one frontend heartbeat response indicating SHUTDOWN status before completing graceful exit.
-//
-// When enabled, the graceful shutdown process remains active until a SHUTDOWN confirmation is responded via heartbeat RPC,
-// ensuring the frontend has sufficient time to detect the termination state between two regular heartbeat intervals.
-CONF_mBool(graceful_exit_wait_for_frontend_heartbeat, "false");
+// Wait for FE shutdown acknowledgement before rejecting requests.
+// New FE: acknowledgement is a growing LastHeartbeat; the first value from that FE is only a
+// baseline. Legacy FE (field absent): optimistic compatibility (delay opens when the SHUTDOWN
+// heartbeat response is constructed). When false, reject new requests immediately on shutdown.
+CONF_Bool(graceful_exit_wait_for_frontend_heartbeat, "true");
+
+// Delay (ms) to keep admitting new work (new BEGINs, new loads, new fragments) after the FE
+// acknowledged the shutdown via a growing LastHeartbeat. The first value from a given FE is
+// only a baseline. The window closes early when the fallback budget expires. Not tied to
+// BEGIN retry idempotency: retries keep the normal LABEL_ALREADY_EXISTS behavior.
+// After a leader switch, BEGIN redirect is disabled for the rest of this shutdown.
+CONF_mInt64(graceful_exit_reject_delay_ms, "10000");
+
+// Fallback budget (ms) from shutdown start: after it expires new work is rejected even if no
+// FE acknowledgement was observed. Also caps the admission window opened by an acknowledgement.
+CONF_mInt64(graceful_exit_reject_fallback_ms, "15000");
 
 // spill dirs
 CONF_String(spill_local_storage_dir, "${STARROCKS_HOME}/spill");

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -224,6 +224,8 @@
         "dictionary_cache_refresh_threadpool_size",
         "enable_resource_group_bind_cpus",
         "enable_resource_group_cpu_borrowing",
+        "graceful_exit_reject_delay_ms",
+        "graceful_exit_reject_fallback_ms",
         "graceful_exit_wait_for_frontend_heartbeat",
         "hdfs_client_enable_hedged_read",
         "hdfs_client_hedged_read_threadpool_size",

--- a/be/src/common/process_exit.cpp
+++ b/be/src/common/process_exit.cpp
@@ -65,13 +65,17 @@ RequestAdmissionGuard::RequestAdmissionGuard() {
     std::lock_guard<std::mutex> lock(k_starrocks_admission_mutex);
     _accepted = !k_starrocks_force_reject.load(std::memory_order_seq_cst) && !is_process_crashing() &&
                 !process_quick_exit_in_progress();
-    if (_accepted) {
+    // Cutoff rejects are not admitted work. Count only while should_accept is true so
+    // HTTP BEGIN/stream-load retries after delay/fallback cannot pin drain.
+    // accepted() stays true after cutoff so BEGIN can still 307.
+    if (_accepted && should_accept_new_request()) {
         k_starrocks_shutdown_work.fetch_add(1, std::memory_order_seq_cst);
+        _counted = true;
     }
 }
 
 RequestAdmissionGuard::~RequestAdmissionGuard() {
-    if (_accepted) {
+    if (_counted) {
         k_starrocks_shutdown_work.fetch_sub(1, std::memory_order_seq_cst);
     }
 }

--- a/be/src/common/process_exit.cpp
+++ b/be/src/common/process_exit.cpp
@@ -14,13 +14,17 @@
 
 #include "common/process_exit.h"
 
+#include <mutex>
+
+#include "base/testutil/sync_point.h"
+#include "base/time/time.h"
+#include "config_exec_env_fwd.h"
+
 namespace starrocks {
 
 // TODO: use bitmask to merge all the atomic variables into one atomic variable.
 
-// NOTE: when BE receiving SIGTERM, this flag will be set to true. Then BE will reject
-// all ExecPlanFragments call by returning a fail status(brpc::EINTERNAL).
-// After all existing fragments executed, BE will exit.
+// SIGTERM flag; admission follows should_accept_new_request().
 std::atomic<bool> k_starrocks_exit;
 
 // NOTE: when call `/api/_stop_be` http interface, this flag will be set to true. Then BE will reject
@@ -31,19 +35,68 @@ std::atomic<bool> k_starrocks_exit;
 // but also waiting for all threads to exit gracefully.
 std::atomic<bool> k_starrocks_quick_exit;
 
-// NOTE: when backend is going to shutdown, if FE's heartbeat request received, the status code
-// in the response will be set to SHUTDOWN, then FE leader will know the node is in shutdown immediately.
-// This flag records whether there is a such response with status SHUTDOWN sent back to FE.
-std::atomic<bool> k_starrocks_fe_heartbeat_aware_shutdown = false;
+// Latest heartbeat ack (acking FE address, time) seen during shutdown. Advances are compared
+// only within one source: a leader handover may come with an unsynchronized wall clock, so a
+// source switch re-anchors the baseline instead of dead-locking on cross-clock comparison.
+std::mutex k_starrocks_ack_mutex;
+std::string k_starrocks_last_ack_source;
+int64_t k_starrocks_last_ack_ms = 0;
 
+// Monotonic timestamp of the first heartbeat ack observed after shutdown began; 0 means the
+// FE has not yet confirmed the shutdown, so the delay window (reject_delay_ms) is not open.
+std::atomic<int64_t> k_starrocks_fe_aware_shutdown_ms = 0;
+
+// First shutdown timestamp; anchors the fallback deadline.
+std::atomic<int64_t> k_starrocks_exit_start_ms = 0;
 // NOTE: when BE is crashing (e.g., due to fatal signal), this flag will be set to true.
 // In this case, BE will return not alive status to FE's heartbeat request.
 // This flag prevents infinite loops when errors occur in jemalloc data structures.
 std::atomic<bool> k_starrocks_be_crashing = false;
 
+// Set to reject new fragments and bypass the delay/fallback windows.
+std::atomic<bool> k_starrocks_force_reject = false;
+// Set when BEGIN 307 is disabled for the rest of this shutdown (legacy FE missing ack
+// field, or a different FE leader starts acking).
+std::atomic<bool> k_starrocks_redirect_disabled = false;
+std::mutex k_starrocks_admission_mutex;
+std::atomic<size_t> k_starrocks_shutdown_work = 0;
+
+RequestAdmissionGuard::RequestAdmissionGuard() {
+    std::lock_guard<std::mutex> lock(k_starrocks_admission_mutex);
+    _accepted = !k_starrocks_force_reject.load(std::memory_order_seq_cst) && !is_process_crashing() &&
+                !process_quick_exit_in_progress();
+    if (_accepted) {
+        k_starrocks_shutdown_work.fetch_add(1, std::memory_order_seq_cst);
+    }
+}
+
+RequestAdmissionGuard::~RequestAdmissionGuard() {
+    if (_accepted) {
+        k_starrocks_shutdown_work.fetch_sub(1, std::memory_order_seq_cst);
+    }
+}
+
+void inc_shutdown_work() {
+    k_starrocks_shutdown_work.fetch_add(1, std::memory_order_seq_cst);
+}
+
+void dec_shutdown_work() {
+    k_starrocks_shutdown_work.fetch_sub(1, std::memory_order_seq_cst);
+}
+
+size_t shutdown_work_inflight() {
+    return k_starrocks_shutdown_work.load(std::memory_order_seq_cst);
+}
+
 bool set_process_exit() {
+    int64_t now = MonotonicMillis();
+    int64_t zero = 0;
+    k_starrocks_exit_start_ms.compare_exchange_strong(zero, now, std::memory_order_release, std::memory_order_relaxed);
+    TEST_SYNC_POINT("ProcessExit::set_process_exit:after_start_ms");
+    TEST_SYNC_POINT("ProcessExit::set_process_exit:before_exit");
     bool expected = false;
-    return k_starrocks_exit.compare_exchange_strong(expected, true);
+    return k_starrocks_exit.compare_exchange_strong(expected, true, std::memory_order_release,
+                                                    std::memory_order_relaxed);
 }
 
 bool set_process_quick_exit() {
@@ -60,15 +113,102 @@ bool process_quick_exit_in_progress() {
 }
 
 void set_frontend_aware_of_exit() {
-    k_starrocks_fe_heartbeat_aware_shutdown.store(true);
+    // Called when the heartbeat ack advances: the FE processed a heartbeat response this BE sent
+    // after shutdown began (it reports SHUTDOWN), so the node is marked SHUTDOWN/not-alive
+    // globally.
+    int64_t now = MonotonicMillis();
+    int64_t expected = 0;
+    k_starrocks_fe_aware_shutdown_ms.compare_exchange_strong(expected, now);
 }
 
 void clear_frontend_aware_of_exit() {
-    k_starrocks_fe_heartbeat_aware_shutdown.store(false);
+    k_starrocks_fe_aware_shutdown_ms.store(0);
+    k_starrocks_redirect_disabled.store(false, std::memory_order_relaxed);
+    std::lock_guard<std::mutex> l(k_starrocks_ack_mutex);
+    k_starrocks_last_ack_source.clear();
+    k_starrocks_last_ack_ms = 0;
 }
 
 bool is_frontend_aware_of_exit() {
-    return k_starrocks_fe_heartbeat_aware_shutdown.load(std::memory_order_relaxed);
+    return k_starrocks_fe_aware_shutdown_ms.load(std::memory_order_relaxed) != 0;
+}
+
+// Tracks the FE's last-seen heartbeat time (the shutdown ack, echoed in every heartbeat
+// request). `ack_source` identifies the FE that sent the ack (its heartbeat network address).
+// Returns true when the ack advances relative to the current source's baseline, meaning that
+// FE processed a heartbeat response this BE sent after shutdown began. The first value of a
+// source is only the baseline (it may correspond to a pre-shutdown response, and its wall
+// clock is not comparable with the previous leader's) and returns false.
+bool advance_heartbeat_ack(const std::string& ack_source, int64_t ack) {
+    std::lock_guard<std::mutex> l(k_starrocks_ack_mutex);
+    if (ack_source != k_starrocks_last_ack_source) {
+        if (!k_starrocks_last_ack_source.empty()) {
+            // Leader handover while shutting down: the new leader's wall clock is not
+            // comparable and the old redirect target may be gone, so disable redirect for the
+            // rest of this shutdown. A later advance of the new source still opens the delay
+            // window (new BEGINs keep being admitted) but never re-enables redirect.
+            disable_begin_redirect();
+        }
+        k_starrocks_last_ack_source = ack_source;
+        k_starrocks_last_ack_ms = ack;
+        return false;
+    }
+    if (ack > k_starrocks_last_ack_ms) {
+        k_starrocks_last_ack_ms = ack;
+        return true;
+    }
+    return false;
+}
+
+bool may_redirect_to_fe_leader() {
+    if (k_starrocks_redirect_disabled.load(std::memory_order_relaxed)) {
+        return false;
+    }
+    return is_frontend_aware_of_exit();
+}
+
+void disable_begin_redirect() {
+    k_starrocks_redirect_disabled.store(true, std::memory_order_relaxed);
+}
+
+bool should_accept_new_request() {
+    if (is_process_crashing()) {
+        return false;
+    }
+    if (!k_starrocks_exit.load(std::memory_order_acquire) && !process_quick_exit_in_progress()) {
+        return true;
+    }
+    if (k_starrocks_force_reject.load(std::memory_order_seq_cst) || process_quick_exit_in_progress()) {
+        return false;
+    }
+    if (!config::graceful_exit_wait_for_frontend_heartbeat) {
+        return false;
+    }
+
+    int64_t now = MonotonicMillis();
+    int64_t aware_ms = k_starrocks_fe_aware_shutdown_ms.load(std::memory_order_relaxed);
+    if (aware_ms != 0 && now - aware_ms >= config::graceful_exit_reject_delay_ms) {
+        return false;
+    }
+
+    int64_t exit_start_ms = k_starrocks_exit_start_ms.load(std::memory_order_acquire);
+    if (exit_start_ms == 0) {
+        return false;
+    }
+    return now - exit_start_ms < config::graceful_exit_reject_fallback_ms;
+}
+
+bool should_accept_load_channel_open() {
+    if (k_starrocks_be_crashing.load(std::memory_order_seq_cst) ||
+        k_starrocks_quick_exit.load(std::memory_order_seq_cst)) {
+        return false;
+    }
+    return !k_starrocks_force_reject.load(std::memory_order_seq_cst);
+}
+
+void force_reject_exec_plan_fragment() {
+    std::lock_guard<std::mutex> lock(k_starrocks_admission_mutex);
+    k_starrocks_force_reject.store(true, std::memory_order_seq_cst);
 }
 
 void set_process_is_crashing() {

--- a/be/src/common/process_exit.h
+++ b/be/src/common/process_exit.h
@@ -95,6 +95,7 @@ public:
 
 private:
     bool _accepted = false;
+    bool _counted = false;
 };
 
 // Drain-visible work in the admission window, or async work not fully represented

--- a/be/src/common/process_exit.h
+++ b/be/src/common/process_exit.h
@@ -15,6 +15,8 @@
 #pragma once
 
 #include <atomic>
+#include <cstddef>
+#include <string>
 
 namespace starrocks {
 
@@ -42,17 +44,78 @@ bool process_exit_in_progress();
 //  - false: process is not in quick exit
 bool process_quick_exit_in_progress();
 
-// set the flag of FE leader awareness of the shutdown
+// Mark that the heartbeat ack advanced: the FE processed a heartbeat response this BE sent
+// after shutdown began (it reports SHUTDOWN), so the node is marked SHUTDOWN/not-alive globally.
 void set_frontend_aware_of_exit();
 
 // whether the FE leader is aware of the shutdown
 // returns:
-//  - true: at least one response is marked as shutdown to FE's heartbeat request
-//  - false: no response is marked as shutdown to FE's heartbeat request
+//  - true: the heartbeat ack advanced at least once during shutdown
+//  - false: the ack has not advanced yet
 bool is_frontend_aware_of_exit();
+
+// Tracks the FE's last-seen heartbeat time (the shutdown ack). `ack_source` identifies the FE
+// that sent it (its heartbeat network address + leader epoch): a change of source (leader
+// handover) re-anchors the baseline instead of comparing unsynchronized wall clocks, disables
+// BEGIN redirect for the rest of this shutdown (conservative failover downgrade), and only
+// advances within the current source return true. The first value of a source is the baseline
+// and returns false.
+bool advance_heartbeat_ack(const std::string& ack_source, int64_t ack);
+
+// Whether a cutoff BEGIN may still be redirected to the FE leader: the FE has acknowledged the
+// shutdown (a delay window was opened), no leader/term handover was observed, and this is not a
+// legacy FE that omitted last_heartbeat_time_ms. Callers reply with ServiceUnavailable JSON when
+// it returns false.
+bool may_redirect_to_fe_leader();
+
+// Disable BEGIN 307 for the rest of this shutdown (legacy FE missing ack field, or leader
+// handover). Delay/admission is unchanged. Reset by clear_frontend_aware_of_exit().
+void disable_begin_redirect();
 
 // clear the flag of frontend awareness of the shutdown.
 void clear_frontend_aware_of_exit();
+
+// Whether a new request may be accepted during graceful shutdown.
+bool should_accept_new_request();
+
+// Load-channel open is treated as a potential successor: cutoff does not apply.
+// Without propagated admission provenance this receiver cannot distinguish a
+// first remote successor open from a new load, so all opens are allowed until
+// force_reject / quick_exit / crash. Does not guarantee a BEGUN txn can still open after force_reject.
+bool should_accept_load_channel_open();
+
+class RequestAdmissionGuard {
+public:
+    RequestAdmissionGuard();
+    ~RequestAdmissionGuard();
+    RequestAdmissionGuard(const RequestAdmissionGuard&) = delete;
+    RequestAdmissionGuard& operator=(const RequestAdmissionGuard&) = delete;
+
+    bool accepted() const { return _accepted; }
+
+private:
+    bool _accepted = false;
+};
+
+// Drain-visible work in the admission window, or async work not fully represented
+// by successor gauges/maps/registries (e.g. routine-load until finish callback;
+// short-circuit / forwarded load covering the whole sync RPC). HTTP
+// RequestAdmissionGuard, RPC prep/short-circuit, stream-load execute, routine-load
+// submit, and LoadChannel open RPCs share this counter.
+void inc_shutdown_work();
+void dec_shutdown_work();
+size_t shutdown_work_inflight();
+
+class ShutdownWorkGuard {
+public:
+    ShutdownWorkGuard() { inc_shutdown_work(); }
+    ~ShutdownWorkGuard() { dec_shutdown_work(); }
+    ShutdownWorkGuard(const ShutdownWorkGuard&) = delete;
+    ShutdownWorkGuard& operator=(const ShutdownWorkGuard&) = delete;
+};
+
+// Force the BE to reject new fragments immediately before teardown.
+void force_reject_exec_plan_fragment();
 
 void set_process_is_crashing();
 

--- a/be/src/data_workflows/load/tablet_writer/load_channel.h
+++ b/be/src/data_workflows/load/tablet_writer/load_channel.h
@@ -61,6 +61,9 @@ struct LoadChannelOpenContext {
     PTabletWriterOpenResult* response;
     google::protobuf::Closure* done;
     int64_t receive_rpc_time_ns;
+    // Captured in open() before queueing. New-channel creation uses this snapshot so an
+    // open admitted before cutoff still succeeds after async delay. Existing channels ignore it.
+    bool admitted_at_open = false;
 };
 
 // A LoadChannel manages tablets channels for all indexes

--- a/be/src/data_workflows/load/tablet_writer/load_channel_mgr.cpp
+++ b/be/src/data_workflows/load/tablet_writer/load_channel_mgr.cpp
@@ -20,7 +20,9 @@
 #include <memory>
 
 #include "base/concurrency/stopwatch.hpp"
+#include "base/testutil/sync_point.h"
 #include "common/config_ingest_fwd.h"
+#include "common/process_exit.h"
 #include "common/system/cpu_info.h"
 #include "common/thread/thread.h"
 #include "data_workflows/load/tablet_writer/load_channel.h"
@@ -41,12 +43,15 @@ public:
             : _load_channel_mgr(load_channel_mgr), _open_context(open_context) {}
 
     ~ChannelOpenTask() override {
+        // Covers both the completed run() path and a cancelled task whose run() never ran.
+        _load_channel_mgr->dec_open_rpc_inflight();
         if (!_is_done) {
             cancel_task(Status::ServiceUnavailable("Thread pool was shut down"));
         }
     }
 
     void run() override {
+        TEST_SYNC_POINT("ChannelOpenTask::run:before_open");
         if (_try_mark_done()) {
             _load_channel_mgr->_open(_open_context);
         }
@@ -122,6 +127,11 @@ void LoadChannelMgr::close() {
     }
 }
 
+size_t LoadChannelMgr::pending_work_count() const {
+    std::lock_guard l(_lock);
+    return _load_channels.size();
+}
+
 Status LoadChannelMgr::init(MemTracker* mem_tracker) {
     _mem_tracker = mem_tracker;
     RETURN_IF_ERROR(_start_bg_worker());
@@ -149,8 +159,14 @@ void LoadChannelMgr::open(brpc::Controller* cntl, const PTabletWriterOpenRequest
     open_context.response = response;
     open_context.done = done;
     open_context.receive_rpc_time_ns = MonotonicNanos();
+    // Drain-visible before the admission check (same order as fragment RPCs): wait_for_finish
+    // force-rejects then re-samples pending_work_count. If the check ran first, a deschedule
+    // gap could let drain see 0, finish, and still create a channel from a stale true snapshot.
+    inc_open_rpc_inflight();
+    open_context.admitted_at_open = should_accept_load_channel_open();
     if (!config::enable_load_channel_rpc_async) {
         _open(open_context);
+        dec_open_rpc_inflight();
         return;
     }
     auto task = std::make_shared<ChannelOpenTask>(this, open_context);
@@ -191,6 +207,15 @@ void LoadChannelMgr::_open(LoadChannelOpenContext open_context) {
             const auto& reason = aborted_iter->second.second;
             response->mutable_status()->set_status_code(TStatusCode::ABORTED);
             response->mutable_status()->add_error_msgs(reason);
+            return;
+        } else if (!open_context.admitted_at_open) {
+            // Teardown. Snapshot at open() so a queued worker is not aborted solely
+            // because it ran later. No local provenance: first remote successor and
+            // brand-new load_id are indistinguishable, so cutoff still admits all
+            // new channels; incremental opens of existing channels stay served.
+            response->mutable_status()->set_status_code(TStatusCode::ABORTED);
+            response->mutable_status()->add_error_msgs(
+                    "load channel rejected: BE is shutting down, please choose another BE");
             return;
         } else if (!is_tracker_hit_hard_limit(_mem_tracker, config::load_process_max_memory_hard_limit_ratio) ||
                    config::enable_new_load_on_memory_limit_exceeded) {

--- a/be/src/data_workflows/load/tablet_writer/load_channel_mgr.h
+++ b/be/src/data_workflows/load/tablet_writer/load_channel_mgr.h
@@ -26,6 +26,7 @@
 #include "base/concurrency/blocking_queue.hpp"
 #include "base/uid_util.h"
 #include "common/compiler_util.h"
+#include "common/process_exit.h"
 #include "common/statusor.h"
 #include "common/thread/threadpool.h"
 #include "data_workflows/load/tablet_writer/load_channel.h"
@@ -121,6 +122,13 @@ public:
 
     void close();
 
+    // Drain-visible work: channels still in the map. Open RPCs share process_exit
+    // shutdown_work. Callbacks/flush after map erase are remote replica work.
+    size_t pending_work_count() const;
+
+    void inc_open_rpc_inflight() { inc_shutdown_work(); }
+    void dec_open_rpc_inflight() { dec_shutdown_work(); }
+
     ThreadPool* async_rpc_pool() { return _async_rpc_pool.get(); }
 
     std::shared_ptr<LoadChannel> TEST_get_load_channel(UniqueId load_id) {
@@ -150,7 +158,7 @@ private:
     std::shared_ptr<LoadChannel> _find_load_channel(int64_t txn_id);
     void _start_load_channels_clean();
 
-    // lock protect the load channel map and aborted load channels map.
+    // lock protects the load channel map and aborted load channels map.
     // performance is not critical here, so rw lock is not used.
     mutable bthread::Mutex _lock;
     // load id -> load channel

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -233,7 +233,8 @@ int StreamLoadAction::on_header(HttpRequest* req) {
     StreamLoadContext* ctx;
     {
         RequestAdmissionGuard request_admission;
-        if (!request_admission.accepted()) {
+        if (!request_admission.accepted() || !should_accept_new_request()) {
+            LOG(INFO) << "[reject] stream load received after graceful shutdown admission window, uri=" << req->uri();
             StreamLoadContext reply_ctx(_exec_env->load_stream_mgr(), nullptr);
             reply_ctx.status = Status::ServiceUnavailable("Service is shutting down, please retry later!");
             _send_reply(req, reply_ctx.to_json());
@@ -284,17 +285,6 @@ int StreamLoadAction::on_header(HttpRequest* req) {
     if (config::enable_stream_load_verbose_log) {
         LOG(INFO) << "streaming load request: " << req->debug_string();
     }
-
-    // The context gauge covers this request through execution.
-    if (!should_accept_new_request()) {
-        LOG(INFO) << "[reject] stream load received after graceful shutdown admission window, uri=" << req->uri()
-                  << ", label=" << ctx->label;
-        ctx->status = Status::ServiceUnavailable("Service is shutting down, please retry later!");
-        auto str = ctx->to_json();
-        _send_reply(req, str);
-        return -1;
-    }
-
     auto st = _on_header(req, ctx);
     if (!st.ok()) {
         ctx->status = st;

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -197,7 +197,9 @@ Status StreamLoadAction::_handle(StreamLoadContext* ctx) {
         // then execute_plan_fragment here
         // this will close file
         ctx->body_sink.reset();
-        RETURN_IF_ERROR(_stream_load_orchestrator->execute_plan_fragment(ctx));
+        // on_header admitted this load; do not recheck after body upload.
+        // The context gauge keeps it visible during drain.
+        RETURN_IF_ERROR(_stream_load_orchestrator->execute_plan_fragment(ctx, true));
     } else {
         if (ctx->buffer != nullptr && ctx->buffer->pos > 0) {
             ctx->buffer->flip_to_read();
@@ -228,10 +230,20 @@ Status StreamLoadAction::_handle_batch_write(starrocks::HttpRequest* http_req, S
 }
 
 int StreamLoadAction::on_header(HttpRequest* req) {
-    auto* ctx = new StreamLoadContext(_exec_env->load_stream_mgr(),
-                                      &StreamLoadMetrics::instance()->streaming_load_current_processing);
-    ctx->ref();
-    req->set_handler_ctx(ctx);
+    StreamLoadContext* ctx;
+    {
+        RequestAdmissionGuard request_admission;
+        if (!request_admission.accepted()) {
+            StreamLoadContext reply_ctx(_exec_env->load_stream_mgr(), nullptr);
+            reply_ctx.status = Status::ServiceUnavailable("Service is shutting down, please retry later!");
+            _send_reply(req, reply_ctx.to_json());
+            return -1;
+        }
+        ctx = new StreamLoadContext(_exec_env->load_stream_mgr(),
+                                    &StreamLoadMetrics::instance()->streaming_load_current_processing);
+        ctx->ref();
+        req->set_handler_ctx(ctx);
+    }
 
     ctx->load_type = TLoadType::MANUAL_LOAD;
     ctx->load_src_type = TLoadSourceType::RAW;
@@ -271,6 +283,16 @@ int StreamLoadAction::on_header(HttpRequest* req) {
 
     if (config::enable_stream_load_verbose_log) {
         LOG(INFO) << "streaming load request: " << req->debug_string();
+    }
+
+    // The context gauge covers this request through execution.
+    if (!should_accept_new_request()) {
+        LOG(INFO) << "[reject] stream load received after graceful shutdown admission window, uri=" << req->uri()
+                  << ", label=" << ctx->label;
+        ctx->status = Status::ServiceUnavailable("Service is shutting down, please retry later!");
+        auto str = ctx->to_json();
+        _send_reply(req, str);
+        return -1;
     }
 
     auto st = _on_header(req, ctx);
@@ -372,12 +394,6 @@ Status StreamLoadAction::_on_header(HttpRequest* http_req, StreamLoadContext* ct
 
     if (ctx->enable_batch_write) {
         return Status::OK();
-    }
-
-    // Check if the process is going to quit before beginning the transaction, to avoid
-    // creating a dangling transaction on FE side.
-    if (process_exit_in_progress()) {
-        return Status::ServiceUnavailable("Service is shutting down, please retry later!");
     }
 
     // begin transaction
@@ -695,7 +711,7 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req, StreamLoadContext* 
         }
         ctx->put_result.params.query_options.mem_limit = exec_mem_limit;
     }
-    return _stream_load_orchestrator->execute_plan_fragment(ctx);
+    return _stream_load_orchestrator->execute_plan_fragment(ctx, true);
 }
 
 Status stream_load_put_internal(const TStreamLoadPutRequest& request, int32_t rpc_timeout_ms,

--- a/be/src/http/action/transaction_stream_load.cpp
+++ b/be/src/http/action/transaction_stream_load.cpp
@@ -33,9 +33,10 @@
 #include "base/time/time.h"
 #include "base/uid_util.h"
 #include "base/utility/defer_op.h"
+#include "common/config_exec_env_fwd.h"
 #include "common/config_ingest_fwd.h"
-#include "common/config_rpc_client_fwd.h"
 #include "common/logging.h"
+#include "common/process_exit.h"
 #include "common/system/master_info.h"
 #include "common/util/debug_util.h"
 #include "common/util/thrift_client_cache.h"
@@ -51,6 +52,7 @@
 #include "gen_cpp/FrontendService.h"
 #include "gen_cpp/FrontendService_types.h"
 #include "gen_cpp/HeartbeatService_types.h"
+#include "http/action/utils.h"
 #include "orchestration/stream_load_orchestrator.h"
 #include "platform/http/http_channel.h"
 #include "platform/http/http_headers.h"
@@ -129,6 +131,24 @@ void TransactionManagerAction::handle(HttpRequest* req) {
     }
 
     if (boost::iequals(txn_op, TXN_BEGIN)) {
+        RequestAdmissionGuard request_admission;
+        if (!request_admission.accepted()) {
+            return _send_error_reply(req, Status::ServiceUnavailable("Service is shutting down, please retry later!"));
+        }
+        if (!should_accept_new_request()) {
+            LOG(INFO) << "[reject] BEGIN received after graceful shutdown admission window, txn_op=" << txn_op
+                      << ", uri=" << req->uri() << ", label=" << req->header(HTTP_LABEL_KEY);
+            // Redirect only when the delay window may still be used: heartbeat waiting is
+            // enabled, the FE has acknowledged the shutdown, and no leader/term handover was
+            // observed during this shutdown. Otherwise (heartbeat=false, fallback cutoff, no
+            // ack yet, or a failover downgrade) a redirect could bounce back to this BE or
+            // target a stale leader, so reply ServiceUnavailable instead.
+            if (config::graceful_exit_wait_for_frontend_heartbeat && may_redirect_to_fe_leader() &&
+                redirect_to_fe_leader(req, req->header(HTTP_LABEL_KEY), "txn BEGIN")) {
+                return;
+            }
+            return _send_error_reply(req, Status::ServiceUnavailable("Service is shutting down, please retry later!"));
+        }
         st = _transaction_mgr->begin_transaction(req, &resp);
     } else if (boost::iequals(txn_op, TXN_COMMIT) || boost::iequals(txn_op, TXN_PREPARE)) {
         st = _transaction_mgr->commit_transaction(req, &resp);
@@ -579,8 +599,8 @@ Status TransactionStreamLoadAction::_exec_plan_fragment(HttpRequest* http_req, S
     }
     request.__set_warehouse(ctx->warehouse);
 
-    // check reuse
-    return _stream_load_orchestrator->execute_plan_fragment(ctx);
+    // Existing BEGIN transactions may cross the drain cutoff.
+    return _stream_load_orchestrator->execute_plan_fragment(ctx, true);
 }
 
 void TransactionStreamLoadAction::on_chunk_data(HttpRequest* req) {

--- a/be/src/http/action/utils.h
+++ b/be/src/http/action/utils.h
@@ -1,0 +1,56 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <event2/http.h>
+#include <fmt/format.h>
+
+#include <string>
+
+#include "base/network/network_util.h"
+#include "common/logging.h"
+#include "common/system/master_info.h"
+#include "platform/http/http_channel.h"
+#include "platform/http/http_request.h"
+
+namespace starrocks {
+
+// Redirect a request to the FE leader while this BE is shutting down, so that the FE can pick
+// another coordinator BE. The caller must only redirect when the FE has observed the shutdown
+// heartbeat (`is_frontend_aware_of_exit()`), i.e. the delay-path cutoff: otherwise (fallback
+// deadline or heartbeat=false cutoff) the FE may not know this BE is exiting and could pick it
+// again. No `exclude_bes` query param is attached for the same reason. Returns true if the 307
+// redirect was sent; false if the FE master info could not be obtained (the caller is
+// responsible for replying with an error). `source` names the redirect origin in logs.
+inline bool redirect_to_fe_leader(HttpRequest* req, const std::string& label, const std::string& source) {
+    MasterInfoPtr master_info;
+    // get_master_info() may succeed with an unset FE address (no heartbeat received yet); a
+    // redirect to an empty host or port 0 would be a malformed Location, so fall back instead.
+    if (!get_master_info(&master_info) || master_info->network_address.hostname.empty() ||
+        master_info->http_port <= 0) {
+        LOG(WARNING) << "[redirect] " << source
+                     << " get_master_info failed or FE address unset, reply SERVICE_UNAVAILABLE, label=" << label;
+        return false;
+    }
+    std::string redirect_url = fmt::format(
+            "http://{}{}", get_host_port(master_info->network_address.hostname, master_info->http_port), req->uri());
+    LOG(INFO) << "[redirect] " << source << " sending 307 to FE leader, redirect_url=" << redirect_url
+              << ", label=" << label;
+    evhttp_add_header(evhttp_request_get_output_headers(req->get_evhttp_request()), "Location", redirect_url.c_str());
+    HttpChannel::send_reply(req, HttpStatus::TEMPORARY_REDIRECT, "");
+    return true;
+}
+
+} // namespace starrocks

--- a/be/src/orchestration/orchestration_env.cpp
+++ b/be/src/orchestration/orchestration_env.cpp
@@ -19,12 +19,16 @@
 #include <memory>
 #include <vector>
 
+#include "base/testutil/sync_point.h"
 #include "common/config_exec_env_fwd.h"
 #include "common/logging.h"
 #include "common/process_exit.h"
+#include "common/status.h"
 #include "common/system/master_info.h"
 #include "compute_env/compute_env.h"
+#include "compute_env/load/stream_load_metrics.h"
 #include "compute_env/profile_report_worker.h"
+#include "data_workflows/load/tablet_writer/load_channel_mgr.h"
 #include "exec/exec_env.h"
 #include "exec/pipeline/pipeline_fragment_reporter.h"
 #include "exec/runtime/query_context_manager.h"
@@ -44,11 +48,12 @@ OrchestrationEnv::~OrchestrationEnv() {
     destroy();
 }
 
-Status OrchestrationEnv::init(ExecEnv* exec_env, MetricRegistry* metrics, StreamLoadExecutor* stream_load_executor) {
+Status OrchestrationEnv::init(ExecEnv* exec_env, MetricRegistry* metrics, StreamLoadExecutor* stream_load_executor,
+                              LoadChannelMgr* load_channel_mgr) {
     DCHECK(exec_env != nullptr);
     DCHECK(stream_load_executor != nullptr);
     _exec_env = exec_env;
-
+    _load_channel_mgr = load_channel_mgr;
     _fragment_mgr = std::make_unique<FragmentMgr>(exec_env, metrics);
 
     ProfileReportWorkerOptions profile_report_worker_options;
@@ -91,30 +96,62 @@ Status OrchestrationEnv::init(ExecEnv* exec_env, MetricRegistry* metrics, Stream
 }
 
 void OrchestrationEnv::wait_for_finish() {
-    if (config::loop_count_wait_fragments_finish < 0) {
-        LOG(WARNING) << "'config::loop_count_wait_fragments_finish' is set to a negative integer, ignore it.";
+    // New-request admission is handled by should_accept_new_request().
+    if (config::loop_count_wait_fragments_finish <= 0) {
+        if (config::loop_count_wait_fragments_finish < 0) {
+            LOG(WARNING) << "'config::loop_count_wait_fragments_finish' is set to a negative integer, ignore it.";
+        }
+        force_reject_exec_plan_fragment();
         return;
     }
 
     size_t max_loop_secs = config::loop_count_wait_fragments_finish * 10;
-    if (max_loop_secs == 0) {
-        return;
+    const int64_t drain_budget_ms = static_cast<int64_t>(max_loop_secs) * 1000;
+    if (config::graceful_exit_reject_delay_ms >= drain_budget_ms ||
+        config::graceful_exit_reject_fallback_ms >= drain_budget_ms) {
+        LOG(WARNING) << "Graceful exit admission cutoff is not before the drain budget: delay_ms="
+                     << config::graceful_exit_reject_delay_ms
+                     << ", fallback_ms=" << config::graceful_exit_reject_fallback_ms
+                     << ", drain_budget_ms=" << drain_budget_ms;
     }
 
-    size_t running_fragments = _get_running_fragments_count();
     size_t loop_secs = 0;
-
-    // TODO: decouple the heartbeat with the graceful exit
-    // only wait for frontend's heartbeat when the node is ever received heartbeats from the frontend
-    bool need_wait_frontend_hb = config::graceful_exit_wait_for_frontend_heartbeat && get_backend_id().has_value();
-
-    while ((running_fragments > 0 || (need_wait_frontend_hb && !is_frontend_aware_of_exit())) &&
-           loop_secs < max_loop_secs) {
-        LOG(INFO) << "Frontend is aware of exit: " << is_frontend_aware_of_exit() << ", " << running_fragments
+    size_t running_fragments = 0;
+    // Separate reads may miss an RPC admitted while count is zero.
+    // Force-reject then re-sample (seq_cst with admission guards). Zero-count
+    // break means every admitted request has already decremented. Hard budget
+    // expiry below is the only path that may exit with work still in flight.
+    while (loop_secs < max_loop_secs) {
+        running_fragments = _get_running_fragments_count();
+        if (running_fragments == 0 && (!process_exit_in_progress() || !should_accept_new_request())) {
+            if (process_exit_in_progress()) {
+                force_reject_exec_plan_fragment();
+                running_fragments = _get_running_fragments_count();
+                if (running_fragments != 0) {
+                    LOG(INFO) << "Fragment admitted while closing admissions; " << running_fragments
+                              << " fragment(s) still running, keep draining...";
+                    sleep(1);
+                    loop_secs++;
+                    continue;
+                }
+            }
+            break;
+        }
+        LOG(INFO) << "Frontend is aware of exit: " << is_frontend_aware_of_exit()
+                  << ", reject new fragment: " << !should_accept_new_request() << ", " << running_fragments
                   << " fragment(s) are still running...";
         sleep(1);
-        running_fragments = _get_running_fragments_count();
         loop_secs++;
+    }
+
+    // Force rejection at budget expiry; report remaining admitted work.
+    if (process_exit_in_progress()) {
+        force_reject_exec_plan_fragment();
+        running_fragments = _get_running_fragments_count();
+        if (running_fragments != 0) {
+            LOG(WARNING) << "Drain wait budget exhausted; " << running_fragments
+                         << " admitted fragment(s) still running, proceed with shutdown.";
+        }
     }
 }
 
@@ -152,11 +189,30 @@ void OrchestrationEnv::destroy() {
 }
 
 size_t OrchestrationEnv::_get_running_fragments_count() const {
+    if (process_quick_exit_in_progress()) {
+        // /api/_stop_be: wait for admitted work and fragments/queries, not idle load gauges/maps.
+        const auto shutdown_work = shutdown_work_inflight();
+        const auto non_pipeline_fragments = _fragment_mgr == nullptr ? 0 : _fragment_mgr->running_fragment_count();
+        TEST_SYNC_POINT("OrchestrationEnv::_get_running_fragments_count:before_query_read");
+        const auto pipeline_fragments = (_exec_env == nullptr || _exec_env->query_context_mgr() == nullptr)
+                                                ? 0
+                                                : _exec_env->query_context_mgr()->size();
+        return shutdown_work + non_pipeline_fragments + pipeline_fragments;
+    }
+    // Sample predecessor (shared admission-window counter) then successor registries.
+    // Independent statements: C++ `+` operand order is unspecified. Plan §8.1.
+    const auto shutdown_work = shutdown_work_inflight();
+    const auto stream_loads = StreamLoadMetrics::instance()->streaming_load_current_processing.value();
+    const auto transaction_stream_loads =
+            StreamLoadMetrics::instance()->transaction_streaming_load_current_processing.value();
+    const auto load_channels = (_load_channel_mgr == nullptr ? 0 : _load_channel_mgr->pending_work_count());
     const auto non_pipeline_fragments = _fragment_mgr == nullptr ? 0 : _fragment_mgr->running_fragment_count();
+    TEST_SYNC_POINT("OrchestrationEnv::_get_running_fragments_count:before_query_read");
     const auto pipeline_fragments = (_exec_env == nullptr || _exec_env->query_context_mgr() == nullptr)
                                             ? 0
                                             : _exec_env->query_context_mgr()->size();
-    return non_pipeline_fragments + pipeline_fragments;
+    return shutdown_work + stream_loads + transaction_stream_loads + load_channels + non_pipeline_fragments +
+           pipeline_fragments;
 }
 
 } // namespace starrocks::orchestration

--- a/be/src/orchestration/orchestration_env.h
+++ b/be/src/orchestration/orchestration_env.h
@@ -21,6 +21,7 @@
 namespace starrocks {
 
 class ExecEnv;
+class LoadChannelMgr;
 class MetricRegistry;
 class StreamLoadExecutor;
 
@@ -39,7 +40,8 @@ public:
     OrchestrationEnv();
     ~OrchestrationEnv();
 
-    Status init(ExecEnv* exec_env, MetricRegistry* metrics, StreamLoadExecutor* stream_load_executor);
+    Status init(ExecEnv* exec_env, MetricRegistry* metrics, StreamLoadExecutor* stream_load_executor,
+                LoadChannelMgr* load_channel_mgr = nullptr);
     void wait_for_finish();
     void stop();
     void destroy();
@@ -55,10 +57,18 @@ public:
     RuntimeFilterWorker* runtime_filter_worker() { return _runtime_filter_worker.get(); }
     const RuntimeFilterWorker* runtime_filter_worker() const { return _runtime_filter_worker.get(); }
 
+    // Test hook: exposes the drain re-sample so a regression test can verify the
+    // predecessor->successor handoff is not collapsed to a false zero.
+    size_t get_running_fragments_count_for_test() const { return _get_running_fragments_count(); }
+    // Test hook: bind a pre-initialized ExecEnv (query_context_mgr etc.) without running
+    // the full init() dependency chain.
+    void set_exec_env_for_test(ExecEnv* exec_env) { _exec_env = exec_env; }
+
 private:
     size_t _get_running_fragments_count() const;
 
     ExecEnv* _exec_env = nullptr;
+    LoadChannelMgr* _load_channel_mgr = nullptr;
     std::unique_ptr<FragmentMgr> _fragment_mgr;
     std::unique_ptr<OrchestrationMetrics> _metrics;
     std::unique_ptr<RuntimeFilterWorker> _runtime_filter_worker;

--- a/be/src/orchestration/routine_load_task_executor.cpp
+++ b/be/src/orchestration/routine_load_task_executor.cpp
@@ -39,9 +39,11 @@
 #include <thread>
 
 #include "base/concurrency/stopwatch.hpp"
+#include "base/testutil/sync_point.h"
 #include "base/uid_util.h"
 #include "base/utility/defer_op.h"
 #include "common/logging.h"
+#include "common/process_exit.h"
 #include "common/status.h"
 #include "compute_env/load/load_stream_mgr.h"
 #include "compute_env/load/stream_load_context.h"
@@ -315,12 +317,18 @@ Status RoutineLoadTaskExecutor::get_pulsar_partition_backlog(const PPulsarBacklo
 Status RoutineLoadTaskExecutor::submit_task(const TRoutineLoadTask& task) {
     std::unique_lock<std::mutex> l(_lock);
     if (_task_map.find(task.id) != _task_map.end()) {
-        // already submitted
         LOG(INFO) << "routine load task " << UniqueId(task.id) << " has already been submitted";
         return Status::OK();
     }
 
-    // create the context
+    // Drain-visible before the admission check so wait_for_finish cannot sample 0 while
+    // this RPC is still in submit_task / queued.
+    inc_shutdown_work();
+    if (!should_accept_new_request()) {
+        dec_shutdown_work();
+        return Status::ServiceUnavailable("Service is shutting down, please retry later!");
+    }
+
     auto* ctx = new StreamLoadContext(_exec_env->load_stream_mgr());
     ctx->load_type = TLoadType::ROUTINE_LOAD;
     ctx->load_src_type = task.type;
@@ -342,7 +350,6 @@ Status RoutineLoadTaskExecutor::submit_task(const TRoutineLoadTask& task) {
         ctx->max_batch_size = task.max_batch_size;
     }
 
-    // set execute plan params
     TStreamLoadPutResult put_result;
     TStatus tstatus;
     tstatus.status_code = TStatusCode::OK;
@@ -353,8 +360,6 @@ Status RoutineLoadTaskExecutor::submit_task(const TRoutineLoadTask& task) {
     if (task.__isset.format) {
         ctx->format = task.format;
     }
-    // the routine load task'txn has alreay began in FE.
-    // so it need to rollback if encounter error.
     set_need_rollback(ctx, _stream_load_executor);
     if (task.__isset.max_filter_ratio) {
         ctx->max_filter_ratio = task.max_filter_ratio;
@@ -362,13 +367,9 @@ Status RoutineLoadTaskExecutor::submit_task(const TRoutineLoadTask& task) {
         ctx->max_filter_ratio = 1.0;
     }
 
-    // set source related params
     switch (task.type) {
     case TLoadSourceType::KAFKA:
         ctx->kafka_info = std::make_unique<KafkaLoadInfo>(task.kafka_load_info);
-        // Make the kafka topic/partitions/offsets visible to the fragment's
-        // RuntimeState so rejected_records.source_info points back at the
-        // real source instead of the SequentialFile placeholder name.
         ctx->put_result.params.query_options.__set_routine_load_source_info(
                 build_kafka_source_info(task.kafka_load_info));
         break;
@@ -380,15 +381,14 @@ Status RoutineLoadTaskExecutor::submit_task(const TRoutineLoadTask& task) {
     default:
         LOG(WARNING) << "unknown load source type: " << task.type;
         delete ctx;
+        dec_shutdown_work();
         return Status::InternalError("unknown load source type");
     }
 
     VLOG(2) << "receive a new routine load task: " << ctx->brief();
-    // register the task
     ctx->ref();
     _task_map[ctx->id] = ctx;
 
-    // offer the task to thread pool
     if (!_thread_pool
                  ->submit_func([this, ctx, capture0 = &_data_consumer_pool,
                                 capture1 =
@@ -401,23 +401,31 @@ Status RoutineLoadTaskExecutor::submit_task(const TRoutineLoadTask& task) {
                                             if (ctx->unref()) {
                                                 delete ctx;
                                             }
-                                        }] { exec_task(ctx, capture0, capture1); })
+                                            dec_shutdown_work();
+                                        }] {
+                     bool skip_exec = false;
+                     TEST_SYNC_POINT_CALLBACK("RoutineLoadTaskExecutor::submit_task:before_exec", &skip_exec);
+                     if (skip_exec) {
+                         capture1(ctx);
+                     } else {
+                         exec_task(ctx, capture0, capture1, true);
+                     }
+                 })
                  .ok()) {
-        // failed to submit task, clear and return
         LOG(WARNING) << "failed to submit routine load task: " << ctx->brief();
         _task_map.erase(ctx->id);
         if (ctx->unref()) {
             delete ctx;
         }
+        dec_shutdown_work();
         return Status::InternalError("failed to submit routine load task");
-    } else {
-        LOG(INFO) << "submit a new routine load task: " << ctx->brief() << ", current tasks num: " << _task_map.size();
-        return Status::OK();
     }
+    LOG(INFO) << "submit a new routine load task: " << ctx->brief() << ", current tasks num: " << _task_map.size();
+    return Status::OK();
 }
 
 void RoutineLoadTaskExecutor::exec_task(StreamLoadContext* ctx, DataConsumerPool* consumer_pool,
-                                        const ExecFinishCallback& cb) {
+                                        const ExecFinishCallback& cb, bool admission_already_granted) {
 #define HANDLE_ERROR(stmt, err_msg)                                       \
     do {                                                                  \
         Status _status_ = (stmt);                                         \
@@ -473,7 +481,8 @@ void RoutineLoadTaskExecutor::exec_task(StreamLoadContext* ctx, DataConsumerPool
     HANDLE_ERROR(_exec_env->load_stream_mgr()->put(ctx->id, pipe), "failed to add pipe")
 
     // execute plan fragment, async
-    HANDLE_ERROR(_stream_load_orchestrator->execute_plan_fragment(ctx), "failed to execute plan fragment")
+    HANDLE_ERROR(_stream_load_orchestrator->execute_plan_fragment(ctx, admission_already_granted),
+                 "failed to execute plan fragment")
 
     // start to consume, this may block a while
     HANDLE_ERROR(consumer_grp->start_all(ctx), "consuming failed")

--- a/be/src/orchestration/routine_load_task_executor.h
+++ b/be/src/orchestration/routine_load_task_executor.h
@@ -34,6 +34,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <climits>
 #include <functional>
 #include <map>
@@ -96,7 +97,8 @@ public:
 
 private:
     // execute the task
-    void exec_task(StreamLoadContext* ctx, DataConsumerPool* pool, const ExecFinishCallback& cb);
+    void exec_task(StreamLoadContext* ctx, DataConsumerPool* pool, const ExecFinishCallback& cb,
+                   bool admission_already_granted);
 
     void err_handler(StreamLoadContext* ctx, const Status& st, std::string_view err_msg);
 

--- a/be/src/orchestration/stream_load_orchestrator.cpp
+++ b/be/src/orchestration/stream_load_orchestrator.cpp
@@ -117,8 +117,11 @@ StreamLoadOrchestrator::StreamLoadOrchestrator(ExecEnv* exec_env, FragmentMgr* f
     DCHECK(_exec_env != nullptr);
 }
 
-Status StreamLoadOrchestrator::execute_plan_fragment(StreamLoadContext* ctx) {
-    if (process_exit_in_progress()) {
+Status StreamLoadOrchestrator::execute_plan_fragment(StreamLoadContext* ctx, bool admission_already_granted) {
+    // Count before rejection so drain covers the check-to-register gap.
+    ShutdownWorkGuard load_guard;
+    // New fragments reject after cutoff; already admitted loads may continue.
+    if (!admission_already_granted && !should_accept_new_request()) {
         return Status::ServiceUnavailable("Service is shutting down, please retry later!");
     }
 

--- a/be/src/orchestration/stream_load_orchestrator.h
+++ b/be/src/orchestration/stream_load_orchestrator.h
@@ -29,7 +29,7 @@ class StreamLoadOrchestrator {
 public:
     StreamLoadOrchestrator(ExecEnv* exec_env, FragmentMgr* fragment_mgr);
 
-    Status execute_plan_fragment(StreamLoadContext* ctx, bool admission_already_granted = false);
+    Status execute_plan_fragment(StreamLoadContext* ctx, bool admission_already_granted);
 
 private:
     // Legacy (non-pipeline) BE-local execution via FragmentMgr + PlanFragmentExecutor.

--- a/be/src/orchestration/stream_load_orchestrator.h
+++ b/be/src/orchestration/stream_load_orchestrator.h
@@ -29,7 +29,7 @@ class StreamLoadOrchestrator {
 public:
     StreamLoadOrchestrator(ExecEnv* exec_env, FragmentMgr* fragment_mgr);
 
-    Status execute_plan_fragment(StreamLoadContext* ctx);
+    Status execute_plan_fragment(StreamLoadContext* ctx, bool admission_already_granted = false);
 
 private:
     // Legacy (non-pipeline) BE-local execution via FragmentMgr + PlanFragmentExecutor.
@@ -38,7 +38,7 @@ private:
     Status _execute_plan_fragment_by_pipeline(StreamLoadContext* ctx);
 
     ExecEnv* _exec_env;
-    [[maybe_unused]] FragmentMgr* _fragment_mgr;
+    FragmentMgr* _fragment_mgr;
 };
 
 } // namespace orchestration

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -303,8 +303,25 @@ void PInternalServiceImplBase<T>::exec_plan_fragment(google::protobuf::RpcContro
                                                      const PExecPlanFragmentRequest* request,
                                                      PExecPlanFragmentResult* response,
                                                      google::protobuf::Closure* done) {
-    auto task = [=]() { this->_exec_plan_fragment(cntl_base, request, response, done); };
+    // Admit before queueing with a paired inc/dec: drain sees the queued work immediately, a
+    // task queued before the cutoff keeps executing after it (no re-check in the worker), and
+    // an offer failure restores the count. Linearization vs force_reject is by the seq_cst
+    // total order shared with wait_for_finish's re-sample (see that comment); try_offer
+    // returns true only when enqueued on a non-shutdown pool, so the task's dec always runs.
+    inc_shutdown_work();
+    if (!should_accept_new_request()) {
+        dec_shutdown_work();
+        ClosureGuard closure_guard(done);
+        static_cast<brpc::Controller*>(cntl_base)->SetFailed(brpc::EINTERNAL, "BE is shutting down");
+        LOG(WARNING) << "reject exec plan fragment because of exit";
+        return;
+    }
+    auto task = [=]() {
+        this->_exec_plan_fragment(cntl_base, request, response, done);
+        dec_shutdown_work();
+    };
     if (!_exec_env->execution_services().query_rpc_pool->try_offer(std::move(task))) {
+        dec_shutdown_work();
         ClosureGuard closure_guard(done);
         Status::ServiceUnavailable("submit exec_plan_fragment task failed").to_protobuf(response->mutable_status());
     }
@@ -317,12 +334,6 @@ void PInternalServiceImplBase<T>::_exec_plan_fragment(google::protobuf::RpcContr
                                                       google::protobuf::Closure* done) {
     ClosureGuard closure_guard(done);
     auto* cntl = static_cast<brpc::Controller*>(cntl_base);
-    if (process_exit_in_progress()) {
-        cntl->SetFailed(brpc::EINTERNAL, "BE is shutting down");
-        LOG(WARNING) << "reject exec plan fragment because of exit";
-        return;
-    }
-
     auto st = _exec_plan_fragment(cntl, request, response);
     if (!st.ok()) {
         LOG(WARNING) << "exec plan fragment failed, errmsg=" << st.message();
@@ -335,8 +346,22 @@ void PInternalServiceImplBase<T>::exec_batch_plan_fragments(google::protobuf::Rp
                                                             const PExecBatchPlanFragmentsRequest* request,
                                                             PExecBatchPlanFragmentsResult* response,
                                                             google::protobuf::Closure* done) {
-    auto task = [=]() { this->_exec_batch_plan_fragments(cntl_base, request, response, done); };
+    // Same paired admission as exec_plan_fragment: visible to drain while queued, no re-check
+    // in the worker, count restored on an offer failure.
+    inc_shutdown_work();
+    if (!should_accept_new_request()) {
+        dec_shutdown_work();
+        ClosureGuard closure_guard(done);
+        static_cast<brpc::Controller*>(cntl_base)->SetFailed(brpc::EINTERNAL, "BE is shutting down");
+        LOG(WARNING) << "reject exec batch plan fragments because of exit";
+        return;
+    }
+    auto task = [=]() {
+        this->_exec_batch_plan_fragments(cntl_base, request, response, done);
+        dec_shutdown_work();
+    };
     if (!_exec_env->execution_services().pipeline_prepare_pool->try_offer(std::move(task))) {
+        dec_shutdown_work();
         ClosureGuard closure_guard(done);
         Status::ServiceUnavailable("submit exec_batch_plan_fragments failed").to_protobuf(response->mutable_status());
     }
@@ -349,11 +374,6 @@ void PInternalServiceImplBase<T>::_exec_batch_plan_fragments(google::protobuf::R
                                                              google::protobuf::Closure* done) {
     ClosureGuard closure_guard(done);
     auto* cntl = static_cast<brpc::Controller*>(cntl_base);
-    if (process_exit_in_progress()) {
-        cntl->SetFailed(brpc::EINTERNAL, "BE is shutting down");
-        LOG(WARNING) << "reject exec plan fragment because of exit";
-        return;
-    }
 
     auto ser_request = cntl->request_attachment().to_string();
     std::shared_ptr<TExecBatchPlanFragmentsParams> t_batch_requests = std::make_shared<TExecBatchPlanFragmentsParams>();
@@ -1355,7 +1375,10 @@ void PInternalServiceImplBase<T>::exec_short_circuit(google::protobuf::RpcContro
     watch.start();
 
     auto* cntl = static_cast<brpc::Controller*>(cntl_base);
-    if (process_exit_in_progress()) {
+    // Track short-circuit RPCs before rejection; drain otherwise misses them.
+    ShutdownWorkGuard inflight_guard;
+
+    if (!should_accept_new_request()) {
         cntl->SetFailed(brpc::EINTERNAL, "BE is shutting down");
         return;
     }
@@ -1372,6 +1395,15 @@ void PInternalServiceImplBase<T>::stream_load(google::protobuf::RpcController* c
                                               google::protobuf::Closure* done) {
     ClosureGuard closure_guard(done);
     auto* cntl = static_cast<brpc::Controller*>(cntl_base);
+    // A forwarded merge-commit load is new work for this node: count it before the rejection
+    // check (drain must see accepted RPCs) and refuse it once admission closes, the same
+    // policy fragment and short-circuit RPCs follow. The sending coordinator turns this
+    // failure into a load error the client can retry elsewhere.
+    ShutdownWorkGuard rpc_prep_guard;
+    if (!should_accept_new_request()) {
+        response->set_json_result(R"({"Status":"Fail","Message":"Service is shutting down, please retry later"})");
+        return;
+    }
     if (_batch_write_mgr == nullptr) {
         response->set_json_result(R"({"Status":"Fail","Message":"Batch write manager is unavailable"})");
         return;

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -249,7 +249,8 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
 
     auto orchestration_env = std::make_unique<orchestration::OrchestrationEnv>();
     EXIT_IF_ERROR(orchestration_env->init(exec_env, process_metrics_registry->root_registry(),
-                                          data_workflows_env->stream_load_executor()));
+                                          data_workflows_env->stream_load_executor(),
+                                          data_workflows_env->load_channel_mgr()));
     LOG(INFO) << process_name << " start step " << start_step++ << ": orchestration env init successfully";
 
     auto agent_server = std::make_unique<AgentServer>(exec_env, false);

--- a/be/test/agent/heartbeat_server_test.cpp
+++ b/be/test/agent/heartbeat_server_test.cpp
@@ -23,8 +23,10 @@ namespace starrocks {
 
 // defined in common/process_exit.cpp
 extern std::atomic<bool> k_starrocks_exit;
+extern std::atomic<int64_t> k_starrocks_exit_start_ms;
 
 TEST(HeartbeatServerTest, test_shutdown_heartbeat) {
+    clear_frontend_aware_of_exit();
     HeartbeatServer server;
     THeartbeatResult result;
     TMasterInfo info;
@@ -35,6 +37,7 @@ TEST(HeartbeatServerTest, test_shutdown_heartbeat) {
     Status status(result.status);
     EXPECT_TRUE(status.is_shutdown());
     k_starrocks_exit = false;
+    clear_frontend_aware_of_exit();
 }
 
 TEST(HeartbeatServerTest, test_print_master_info_with_token_null) {
@@ -52,7 +55,8 @@ TEST(HeartbeatServerTest, test_print_master_info_with_token_null) {
             "cluster_id=12345, epoch=100, token=<null>, backend_ip=192.168.1.1, "
             "http_port=<null>, heartbeat_flags=<null>, backend_id=<null>, "
             "min_active_txn_id=0, run_mode=<null>, disabled_disks=<null>, "
-            "decommissioned_disks=<null>, encrypted=<null>, stop_regular_tablet_report=<null>, node_type=<null>)";
+            "decommissioned_disks=<null>, encrypted=<null>, stop_regular_tablet_report=<null>, node_type=<null>, "
+            "last_heartbeat_time_ms=<null>)";
 
     EXPECT_EQ(server.print_master_info(master_info), expected_output);
 }
@@ -73,7 +77,8 @@ TEST(HeartbeatServerTest, test_print_master_info_with_token_hidden) {
             "cluster_id=12345, epoch=100, token=<hidden>, backend_ip=192.168.1.1, "
             "http_port=<null>, heartbeat_flags=<null>, backend_id=<null>, "
             "min_active_txn_id=0, run_mode=<null>, disabled_disks=<null>, "
-            "decommissioned_disks=<null>, encrypted=<null>, stop_regular_tablet_report=<null>, node_type=<null>)";
+            "decommissioned_disks=<null>, encrypted=<null>, stop_regular_tablet_report=<null>, node_type=<null>, "
+            "last_heartbeat_time_ms=<null>)";
 
     EXPECT_EQ(server.print_master_info(master_info), expected_output);
 }
@@ -125,7 +130,7 @@ TEST(HeartbeatServerTest, test_frontend_aware_of_exit) {
         ASSERT_FALSE(is_frontend_aware_of_exit());
     }
 
-    k_starrocks_exit = true;
+    ASSERT_TRUE(set_process_exit());
     {
         THeartbeatResult result;
         TMasterInfo info;
@@ -133,10 +138,42 @@ TEST(HeartbeatServerTest, test_frontend_aware_of_exit) {
         EXPECT_EQ(TStatusCode::SHUTDOWN, result.status.status_code);
         Status status(result.status);
         EXPECT_TRUE(status.is_shutdown());
-        // service is in shutdown, the shutdown response is replied to the frontend
+        // Legacy FE (no ack field): delay opens, BEGIN 307 stays off.
         ASSERT_TRUE(is_frontend_aware_of_exit());
+        ASSERT_FALSE(may_redirect_to_fe_leader());
+        ASSERT_TRUE(should_accept_new_request());
     }
     k_starrocks_exit = false;
+    k_starrocks_exit_start_ms.store(0);
+    clear_frontend_aware_of_exit();
+}
+
+TEST(HeartbeatServerTest, test_acked_heartbeat_allows_redirect) {
+    // New FE: last_heartbeat_time_ms is set. First value is baseline; growth opens delay
+    // and BEGIN 307. This is not the missing-field legacy path.
+    clear_frontend_aware_of_exit();
+    ASSERT_TRUE(set_process_exit());
+    HeartbeatServer server;
+    THeartbeatResult result;
+    TMasterInfo info;
+    info.network_address.__set_hostname("127.0.0.1");
+    info.network_address.__set_port(9010);
+    info.__set_epoch(1);
+    info.__set_last_heartbeat_time_ms(100);
+    server.heartbeat(result, info);
+    EXPECT_EQ(TStatusCode::SHUTDOWN, result.status.status_code);
+    ASSERT_FALSE(is_frontend_aware_of_exit());
+    ASSERT_FALSE(may_redirect_to_fe_leader());
+
+    info.__set_last_heartbeat_time_ms(101);
+    server.heartbeat(result, info);
+    ASSERT_TRUE(is_frontend_aware_of_exit());
+    ASSERT_TRUE(may_redirect_to_fe_leader());
+    ASSERT_TRUE(should_accept_new_request());
+
+    k_starrocks_exit = false;
+    k_starrocks_exit_start_ms.store(0);
+    clear_frontend_aware_of_exit();
 }
 
 } // namespace starrocks

--- a/be/test/common/process_exit_test.cpp
+++ b/be/test/common/process_exit_test.cpp
@@ -221,6 +221,31 @@ TEST_F(ProcessExitTest, testRequestAdmissionGuardClosesWithForceReject) {
     EXPECT_FALSE(guard.accepted());
 }
 
+TEST_F(ProcessExitTest, testRequestAdmissionGuardDoesNotCountAfterCutoff) {
+    ASSERT_TRUE(set_process_exit());
+    k_starrocks_fe_aware_shutdown_ms.store(MonotonicMillis() - config::graceful_exit_reject_delay_ms - 1);
+    EXPECT_FALSE(should_accept_new_request());
+    const size_t before = shutdown_work_inflight();
+    {
+        RequestAdmissionGuard guard;
+        EXPECT_TRUE(guard.accepted());
+        EXPECT_EQ(before, shutdown_work_inflight());
+    }
+    EXPECT_EQ(before, shutdown_work_inflight());
+}
+
+TEST_F(ProcessExitTest, testRequestAdmissionGuardCountsDuringAdmissionWindow) {
+    ASSERT_TRUE(set_process_exit());
+    EXPECT_TRUE(should_accept_new_request());
+    const size_t before = shutdown_work_inflight();
+    {
+        RequestAdmissionGuard guard;
+        EXPECT_TRUE(guard.accepted());
+        EXPECT_EQ(before + 1, shutdown_work_inflight());
+    }
+    EXPECT_EQ(before, shutdown_work_inflight());
+}
+
 TEST_F(ProcessExitTest, testSetProcessExitPublishesStartMsBeforeExit) {
     DeferOp defer([]() { SyncPoint::GetInstance()->DisableProcessing(); });
 

--- a/be/test/common/process_exit_test.cpp
+++ b/be/test/common/process_exit_test.cpp
@@ -17,22 +17,49 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <thread>
 
+#include "base/testutil/sync_point.h"
+#include "base/time/time.h"
+#include "base/utility/defer_op.h"
+#include "common/config_exec_env_fwd.h"
 #include "common/status.h"
 
 namespace starrocks {
 
 extern std::atomic<bool> k_starrocks_exit;
 extern std::atomic<bool> k_starrocks_quick_exit;
-
+extern std::atomic<bool> k_starrocks_force_reject;
+extern std::atomic<bool> k_starrocks_be_crashing;
+extern std::atomic<int64_t> k_starrocks_exit_start_ms;
+extern std::atomic<int64_t> k_starrocks_fe_aware_shutdown_ms;
 using namespace ::testing;
 
 class ProcessExitTest : public testing::Test {
+    void SetUp() override {
+        _old_reject_delay_ms = config::graceful_exit_reject_delay_ms;
+        _old_reject_fallback_ms = config::graceful_exit_reject_fallback_ms;
+        _old_wait_for_frontend_heartbeat = config::graceful_exit_wait_for_frontend_heartbeat;
+        config::graceful_exit_wait_for_frontend_heartbeat = true;
+        config::graceful_exit_reject_delay_ms = 5000;
+        config::graceful_exit_reject_fallback_ms = 15000;
+    }
     void TearDown() override {
-        // restore the flags
+        config::graceful_exit_wait_for_frontend_heartbeat = _old_wait_for_frontend_heartbeat;
+        config::graceful_exit_reject_delay_ms = _old_reject_delay_ms;
+        config::graceful_exit_reject_fallback_ms = _old_reject_fallback_ms;
         k_starrocks_exit.store(false);
         k_starrocks_quick_exit.store(false);
+        k_starrocks_force_reject.store(false);
+        k_starrocks_be_crashing.store(false);
+        k_starrocks_exit_start_ms.store(0);
+        clear_frontend_aware_of_exit();
     }
+
+private:
+    int64_t _old_reject_fallback_ms;
+    int64_t _old_reject_delay_ms;
+    bool _old_wait_for_frontend_heartbeat;
 };
 
 TEST_F(ProcessExitTest, testExitFlag) {
@@ -72,4 +99,156 @@ TEST_F(ProcessExitTest, testQuickExitFlag) {
     EXPECT_TRUE(process_exit_in_progress());
     EXPECT_TRUE(process_quick_exit_in_progress());
 }
+
+TEST_F(ProcessExitTest, testShouldAcceptNotExiting) {
+    EXPECT_TRUE(should_accept_new_request());
+}
+
+TEST_F(ProcessExitTest, testShouldNotAcceptForceReject) {
+    ASSERT_TRUE(set_process_exit());
+    k_starrocks_force_reject.store(true);
+    EXPECT_FALSE(should_accept_new_request());
+}
+
+TEST_F(ProcessExitTest, testForceRejectExecPlanFragment) {
+    ASSERT_TRUE(set_process_exit());
+    force_reject_exec_plan_fragment();
+    EXPECT_TRUE(k_starrocks_force_reject.load());
+}
+
+TEST_F(ProcessExitTest, testShouldNotAcceptQuickExit) {
+    ASSERT_TRUE(set_process_quick_exit());
+    EXPECT_FALSE(should_accept_new_request());
+}
+
+TEST_F(ProcessExitTest, testLoadChannelOpenAfterCutoff) {
+    ASSERT_TRUE(set_process_exit());
+    k_starrocks_fe_aware_shutdown_ms.store(MonotonicMillis() - config::graceful_exit_reject_delay_ms - 1);
+    EXPECT_FALSE(should_accept_new_request());
+    EXPECT_TRUE(should_accept_load_channel_open());
+}
+
+TEST_F(ProcessExitTest, testLoadChannelOpenRejectedOnForceReject) {
+    force_reject_exec_plan_fragment();
+    EXPECT_FALSE(should_accept_load_channel_open());
+}
+
+TEST_F(ProcessExitTest, testLoadChannelOpenRejectedOnQuickExit) {
+    ASSERT_TRUE(set_process_quick_exit());
+    EXPECT_FALSE(should_accept_load_channel_open());
+}
+
+TEST_F(ProcessExitTest, testLoadChannelOpenRejectedOnCrash) {
+    set_process_is_crashing();
+    EXPECT_FALSE(should_accept_load_channel_open());
+}
+
+TEST_F(ProcessExitTest, testShouldAcceptUntilFrontendAware) {
+    ASSERT_TRUE(set_process_exit());
+    EXPECT_TRUE(should_accept_new_request());
+    set_frontend_aware_of_exit();
+    EXPECT_TRUE(should_accept_new_request());
+}
+
+TEST_F(ProcessExitTest, testShouldNotAcceptAfterFrontendAwareDelay) {
+    ASSERT_TRUE(set_process_exit());
+    k_starrocks_fe_aware_shutdown_ms.store(MonotonicMillis() - config::graceful_exit_reject_delay_ms - 1);
+    EXPECT_FALSE(should_accept_new_request());
+}
+TEST_F(ProcessExitTest, testShouldNotAcceptAfterFallbackWithoutFrontendAware) {
+    ASSERT_TRUE(set_process_exit());
+    k_starrocks_exit_start_ms.store(MonotonicMillis() - config::graceful_exit_reject_fallback_ms - 1);
+    EXPECT_FALSE(should_accept_new_request());
+}
+
+TEST_F(ProcessExitTest, testShouldNotAcceptImmediatelyWhenHeartbeatWaitDisabled) {
+    config::graceful_exit_wait_for_frontend_heartbeat = false;
+    ASSERT_TRUE(set_process_exit());
+    // New requests reject immediately when heartbeat waiting is disabled.
+    EXPECT_FALSE(should_accept_new_request());
+}
+
+TEST_F(ProcessExitTest, testShouldAcceptDuringHeartbeatDelay) {
+    ASSERT_TRUE(set_process_exit());
+    set_frontend_aware_of_exit();
+    EXPECT_TRUE(should_accept_new_request());
+
+    k_starrocks_fe_aware_shutdown_ms.store(MonotonicMillis() - config::graceful_exit_reject_delay_ms - 1);
+    EXPECT_FALSE(should_accept_new_request());
+}
+
+TEST_F(ProcessExitTest, testHeartbeatAckReanchorsPerSource) {
+    // First value of a source is the baseline; later growth advances within the source.
+    EXPECT_FALSE(advance_heartbeat_ack("fe1:9010:1", 100));
+    EXPECT_FALSE(is_frontend_aware_of_exit());
+    EXPECT_TRUE(advance_heartbeat_ack("fe1:9010:1", 101));
+    // A different source (leader handover) re-anchors and never compares clocks.
+    EXPECT_FALSE(advance_heartbeat_ack("fe2:9010:2", 900));
+    EXPECT_FALSE(advance_heartbeat_ack("fe2:9010:2", 900));
+    EXPECT_TRUE(advance_heartbeat_ack("fe2:9010:2", 901));
+}
+
+TEST_F(ProcessExitTest, testRedirectDisabledAfterLeaderHandover) {
+    EXPECT_FALSE(advance_heartbeat_ack("fe1:9010:1", 100));
+    EXPECT_TRUE(advance_heartbeat_ack("fe1:9010:1", 101));
+    set_frontend_aware_of_exit();
+    // Aware of FE1 before the handover: redirect allowed.
+    EXPECT_TRUE(may_redirect_to_fe_leader());
+
+    // Leader handover: redirect is disabled for the rest of this shutdown, even though the
+    // delay window stays open (the ack of the new source still advances).
+    EXPECT_FALSE(advance_heartbeat_ack("fe2:9010:2", 900));
+    EXPECT_TRUE(advance_heartbeat_ack("fe2:9010:2", 901));
+    set_frontend_aware_of_exit();
+    EXPECT_FALSE(may_redirect_to_fe_leader());
+
+    // A fresh shutdown cycle resets the downgrade.
+    clear_frontend_aware_of_exit();
+    EXPECT_FALSE(advance_heartbeat_ack("fe1:9010:1", 100));
+    EXPECT_TRUE(advance_heartbeat_ack("fe1:9010:1", 101));
+    set_frontend_aware_of_exit();
+    EXPECT_TRUE(may_redirect_to_fe_leader());
+}
+TEST_F(ProcessExitTest, testRequestAdmissionGuardClosesWithForceReject) {
+    {
+        RequestAdmissionGuard guard;
+        EXPECT_TRUE(guard.accepted());
+    }
+
+    force_reject_exec_plan_fragment();
+
+    RequestAdmissionGuard guard;
+    EXPECT_FALSE(guard.accepted());
+}
+
+TEST_F(ProcessExitTest, testSetProcessExitPublishesStartMsBeforeExit) {
+    DeferOp defer([]() { SyncPoint::GetInstance()->DisableProcessing(); });
+
+    SyncPoint::GetInstance()->LoadDependency({
+            {"ProcessExit::set_process_exit:after_start_ms", "ProcessExitTest::observer"},
+            {"ProcessExitTest::observer_done", "ProcessExit::set_process_exit:before_exit"},
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+
+    std::thread observer([]() {
+        TEST_SYNC_POINT("ProcessExitTest::observer");
+        EXPECT_NE(0, k_starrocks_exit_start_ms.load());
+        EXPECT_FALSE(k_starrocks_exit.load());
+        EXPECT_TRUE(should_accept_new_request());
+        TEST_SYNC_POINT("ProcessExitTest::observer_done");
+    });
+
+    EXPECT_TRUE(set_process_exit());
+    observer.join();
+
+    EXPECT_TRUE(process_exit_in_progress());
+    EXPECT_NE(0, k_starrocks_exit_start_ms.load());
+    EXPECT_TRUE(should_accept_new_request());
+
+    const int64_t start_ms = k_starrocks_exit_start_ms.load();
+    EXPECT_FALSE(set_process_exit());
+    EXPECT_EQ(start_ms, k_starrocks_exit_start_ms.load());
+    EXPECT_TRUE(should_accept_new_request());
+}
+
 } // namespace starrocks

--- a/be/test/data_workflows/load/tablet_writer/load_channel_mgr_test.cpp
+++ b/be/test/data_workflows/load/tablet_writer/load_channel_mgr_test.cpp
@@ -17,10 +17,17 @@
 #include <brpc/controller.h>
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <thread>
+
 #include "base/concurrency/await.h"
 #include "base/testutil/assert.h"
+#include "base/testutil/sync_point.h"
+#include "base/time/time.h"
 #include "base/utility/defer_op.h"
+#include "common/config_exec_env_fwd.h"
 #include "common/config_ingest_fwd.h"
+#include "common/process_exit.h"
 #include "platform/platform_env.h"
 #include "runtime/runtime_env.h"
 #include "service/brpc_service_test_util.h"
@@ -30,6 +37,11 @@
 #include "storage/tablet_schema.h"
 
 namespace starrocks {
+
+extern std::atomic<bool> k_starrocks_exit;
+extern std::atomic<bool> k_starrocks_quick_exit;
+extern std::atomic<bool> k_starrocks_force_reject;
+extern std::atomic<int64_t> k_starrocks_exit_start_ms;
 
 class LoadChannelMgrTest : public testing::Test {
 public:
@@ -51,6 +63,10 @@ protected:
         _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet->tablet_schema()));
     }
     void TearDown() override {
+        k_starrocks_exit.store(false);
+        k_starrocks_quick_exit.store(false);
+        k_starrocks_force_reject.store(false);
+        k_starrocks_exit_start_ms.store(0);
         if (_tablet) {
             _tablet.reset();
             ASSERT_OK(StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet_id));
@@ -195,6 +211,9 @@ TEST_F(LoadChannelMgrTest, async_open_submit_task_fail) {
     ASSERT_TRUE(result.status().status_code() == TStatusCode::SERVICE_UNAVAILABLE);
     auto load_channel = _load_channel_mgr->TEST_get_load_channel(UniqueId(load_id));
     ASSERT_TRUE(load_channel == nullptr);
+    ASSERT_EQ(0, _load_channel_mgr->pending_work_count());
+    ASSERT_EQ(0, _load_channel_mgr->async_rpc_pool()->total_executed_tasks());
+    ASSERT_EQ(0, shutdown_work_inflight());
 }
 
 TEST_F(LoadChannelMgrTest, sync_open_success) {
@@ -220,6 +239,179 @@ TEST_F(LoadChannelMgrTest, sync_open_success) {
     ASSERT_TRUE(result.status().status_code() == TStatusCode::OK);
     auto load_channel = _load_channel_mgr->TEST_get_load_channel(UniqueId(load_id));
     ASSERT_TRUE(load_channel != nullptr);
+}
+
+TEST_F(LoadChannelMgrTest, sync_open_success_after_shutdown_cutoff) {
+    // tablet_writer_open is successor work: cutoff does not reject a new channel.
+    // pending_work_count is the channel map; open RPCs share shutdown_work_inflight.
+    ASSERT_OK(_load_channel_mgr->init(_mem_tracker.get()));
+    PUniqueId load_id;
+    load_id.set_hi(456789);
+    load_id.set_lo(987654);
+    brpc::Controller cntl;
+    MockClosure closure;
+    PTabletWriterOpenRequest request = create_open_request(load_id, rand());
+    PTabletWriterOpenResult result;
+
+    ASSERT_TRUE(set_process_exit());
+    k_starrocks_exit_start_ms.store(MonotonicMillis() - config::graceful_exit_reject_fallback_ms - 1);
+    ASSERT_FALSE(should_accept_new_request());
+    ASSERT_TRUE(should_accept_load_channel_open());
+
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("ThreadPool::do_submit:1");
+        SyncPoint::GetInstance()->DisableProcessing();
+        config::enable_load_channel_rpc_async = true;
+        k_starrocks_exit.store(false);
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("ThreadPool::do_submit:1", [](void* arg) { *(int64_t*)arg = 0; });
+    config::enable_load_channel_rpc_async = false;
+    _load_channel_mgr->open(&cntl, request, &result, &closure);
+    ASSERT_TRUE(closure.has_run());
+    ASSERT_EQ(TStatusCode::OK, result.status().status_code());
+    ASSERT_TRUE(_load_channel_mgr->TEST_get_load_channel(UniqueId(load_id)) != nullptr);
+    ASSERT_EQ(1, _load_channel_mgr->pending_work_count());
+    ASSERT_EQ(0, shutdown_work_inflight());
+}
+
+TEST_F(LoadChannelMgrTest, async_open_keeps_admission_across_cutoff) {
+    ASSERT_OK(_load_channel_mgr->init(_mem_tracker.get()));
+    PUniqueId load_id;
+    load_id.set_hi(456789);
+    load_id.set_lo(987654);
+    brpc::Controller cntl;
+    MockClosure closure;
+    PTabletWriterOpenRequest request = create_open_request(load_id, rand());
+    PTabletWriterOpenResult result;
+    std::atomic<int> phase{0};
+
+    DeferOp defer([&]() {
+        phase.store(2);
+        SyncPoint::GetInstance()->ClearCallBack("ChannelOpenTask::run:before_open");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("ChannelOpenTask::run:before_open", [&](void*) {
+        phase.store(1);
+        while (phase.load() < 2) {
+            std::this_thread::yield();
+        }
+    });
+
+    _load_channel_mgr->open(&cntl, request, &result, &closure);
+    ASSERT_TRUE(Awaitility().timeout(60000).until([&] { return phase.load() == 1; }));
+    ASSERT_EQ(1, shutdown_work_inflight());
+    ASSERT_TRUE(set_process_exit());
+    phase.store(2);
+    ASSERT_TRUE(Awaitility().timeout(60000).until([&] { return closure.has_run(); }));
+    ASSERT_EQ(TStatusCode::OK, result.status().status_code());
+    ASSERT_TRUE(_load_channel_mgr->TEST_get_load_channel(UniqueId(load_id)) != nullptr);
+    ASSERT_EQ(0, shutdown_work_inflight());
+}
+
+TEST_F(LoadChannelMgrTest, async_open_success_after_shutdown_cutoff) {
+    ASSERT_OK(_load_channel_mgr->init(_mem_tracker.get()));
+    PUniqueId load_id;
+    load_id.set_hi(456789);
+    load_id.set_lo(987654);
+    brpc::Controller cntl;
+    MockClosure closure;
+    PTabletWriterOpenRequest request = create_open_request(load_id, rand());
+    PTabletWriterOpenResult result;
+
+    ASSERT_TRUE(set_process_exit());
+    k_starrocks_exit_start_ms.store(MonotonicMillis() - config::graceful_exit_reject_fallback_ms - 1);
+    ASSERT_FALSE(should_accept_new_request());
+    ASSERT_TRUE(should_accept_load_channel_open());
+
+    _load_channel_mgr->open(&cntl, request, &result, &closure);
+    ASSERT_TRUE(Awaitility().timeout(60000).until(
+            [&] { return _load_channel_mgr->async_rpc_pool()->total_executed_tasks() == 1; }));
+    ASSERT_TRUE(closure.has_run());
+    ASSERT_EQ(TStatusCode::OK, result.status().status_code());
+    ASSERT_TRUE(_load_channel_mgr->TEST_get_load_channel(UniqueId(load_id)) != nullptr);
+    ASSERT_EQ(1, _load_channel_mgr->pending_work_count());
+    ASSERT_EQ(0, shutdown_work_inflight());
+}
+
+TEST_F(LoadChannelMgrTest, sync_open_rejected_when_force_reject) {
+    ASSERT_OK(_load_channel_mgr->init(_mem_tracker.get()));
+    PUniqueId load_id;
+    load_id.set_hi(456789);
+    load_id.set_lo(987654);
+    brpc::Controller cntl;
+    MockClosure closure;
+    PTabletWriterOpenRequest request = create_open_request(load_id, rand());
+    PTabletWriterOpenResult result;
+
+    force_reject_exec_plan_fragment();
+    ASSERT_FALSE(should_accept_load_channel_open());
+
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("ThreadPool::do_submit:1");
+        SyncPoint::GetInstance()->DisableProcessing();
+        config::enable_load_channel_rpc_async = true;
+        k_starrocks_force_reject.store(false);
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("ThreadPool::do_submit:1", [](void* arg) { *(int64_t*)arg = 0; });
+    config::enable_load_channel_rpc_async = false;
+    _load_channel_mgr->open(&cntl, request, &result, &closure);
+    ASSERT_TRUE(closure.has_run());
+    ASSERT_EQ(TStatusCode::ABORTED, result.status().status_code());
+    ASSERT_TRUE(_load_channel_mgr->TEST_get_load_channel(UniqueId(load_id)) == nullptr);
+    ASSERT_EQ(0, _load_channel_mgr->pending_work_count());
+    ASSERT_EQ(0, shutdown_work_inflight());
+}
+
+TEST_F(LoadChannelMgrTest, async_open_rejected_when_force_reject) {
+    ASSERT_OK(_load_channel_mgr->init(_mem_tracker.get()));
+    PUniqueId load_id;
+    load_id.set_hi(456789);
+    load_id.set_lo(987654);
+    brpc::Controller cntl;
+    MockClosure closure;
+    PTabletWriterOpenRequest request = create_open_request(load_id, rand());
+    PTabletWriterOpenResult result;
+
+    force_reject_exec_plan_fragment();
+    ASSERT_FALSE(should_accept_load_channel_open());
+
+    _load_channel_mgr->open(&cntl, request, &result, &closure);
+    ASSERT_TRUE(Awaitility().timeout(60000).until(
+            [&] { return _load_channel_mgr->async_rpc_pool()->total_executed_tasks() == 1; }));
+    ASSERT_TRUE(closure.has_run());
+    ASSERT_EQ(TStatusCode::ABORTED, result.status().status_code());
+    ASSERT_TRUE(_load_channel_mgr->TEST_get_load_channel(UniqueId(load_id)) == nullptr);
+    ASSERT_EQ(0, _load_channel_mgr->pending_work_count());
+    ASSERT_EQ(0, shutdown_work_inflight());
+}
+
+TEST_F(LoadChannelMgrTest, incremental_open_after_cutoff_keeps_existing_channel) {
+    ASSERT_OK(_load_channel_mgr->init(_mem_tracker.get()));
+    PUniqueId load_id;
+    load_id.set_hi(456789);
+    load_id.set_lo(987654);
+    brpc::Controller cntl;
+    MockCountDownClosure first_done;
+    PTabletWriterOpenRequest request = create_open_request(load_id, rand());
+    PTabletWriterOpenResult result;
+    _load_channel_mgr->open(&cntl, request, &result, &first_done);
+    first_done.wait();
+    ASSERT_EQ(TStatusCode::OK, result.status().status_code());
+
+    ASSERT_TRUE(set_process_exit());
+    k_starrocks_exit_start_ms.store(MonotonicMillis() - config::graceful_exit_reject_fallback_ms - 1);
+    ASSERT_FALSE(should_accept_new_request());
+
+    MockCountDownClosure second_done;
+    PTabletWriterOpenResult incremental_result;
+    request.set_is_incremental(true);
+    _load_channel_mgr->open(&cntl, request, &incremental_result, &second_done);
+    second_done.wait();
+    ASSERT_EQ(TStatusCode::OK, incremental_result.status().status_code());
+    ASSERT_TRUE(_load_channel_mgr->TEST_get_load_channel(UniqueId(load_id)) != nullptr);
 }
 
 TEST_F(LoadChannelMgrTest, test_aborted_load_channel) {

--- a/be/test/http/stream_load_test.cpp
+++ b/be/test/http/stream_load_test.cpp
@@ -298,6 +298,8 @@ TEST_F(StreamLoadActionTest, process_exit_abort_stream_load) {
     ASSERT_STREQ("application/json", content_type);
     auto* location = evhttp_find_header(evhttp_request_get_output_headers(_evhttp_req), HttpHeaders::LOCATION);
     ASSERT_EQ(location, nullptr);
+    ASSERT_EQ(nullptr, request.handler_ctx());
+    ASSERT_EQ(0, shutdown_work_inflight());
 
     // restore the flags
     k_starrocks_exit.store(false);

--- a/be/test/http/stream_load_test.cpp
+++ b/be/test/http/stream_load_test.cpp
@@ -40,15 +40,17 @@
 #include <gtest/gtest.h>
 #include <rapidjson/document.h>
 
+#include <atomic>
 #include <cstring>
-#include <utility>
 
 #include "base/concurrency/concurrent_limiter.h"
 #include "base/metrics.h"
 #include "base/testutil/assert.h"
 #include "base/testutil/sync_point.h"
 #include "base/time/monotime.h"
+#include "base/time/time.h"
 #include "base/utility/defer_op.h"
+#include "common/config_exec_env_fwd.h"
 #include "common/config_ingest_fwd.h"
 #include "common/config_storage_fwd.h"
 #include "common/process_exit.h"
@@ -76,13 +78,17 @@
 class mg_connection;
 
 namespace starrocks {
-
 extern void (*s_injected_send_reply)(HttpRequest*, HttpStatus, std::string_view);
+
 extern std::atomic<bool> k_starrocks_exit;
+extern std::atomic<bool> k_starrocks_force_reject;
+extern std::atomic<int64_t> k_starrocks_fe_aware_shutdown_ms;
 
 namespace {
 static std::string k_response_str;
+static HttpStatus k_response_status = HttpStatus::INTERNAL_SERVER_ERROR;
 static void inject_send_reply(HttpRequest* request, HttpStatus status, std::string_view content) {
+    k_response_status = status;
     k_response_str = content;
 }
 
@@ -131,11 +137,15 @@ public:
     static void TearDownTestSuite() { s_injected_send_reply = nullptr; }
 
     void SetUp() override {
+        k_starrocks_exit.store(false);
+        k_starrocks_force_reject.store(false);
+        k_starrocks_fe_aware_shutdown_ms.store(0);
         k_stream_load_begin_result = TLoadTxnBeginResult();
         k_stream_load_commit_result = TLoadTxnCommitResult();
         k_stream_load_rollback_result = TLoadTxnRollbackResult();
         k_stream_load_put_result = TStreamLoadPutResult();
         k_response_str = "";
+        k_response_status = HttpStatus::INTERNAL_SERVER_ERROR;
         config::streaming_load_max_mb = 1;
 
         ASSERT_OK(init_platform_env_for_stream_load_test(&_metrics, &_owns_platform_env));
@@ -176,6 +186,9 @@ public:
         if (_evhttp_req != nullptr) {
             evhttp_request_free(_evhttp_req);
         }
+        k_starrocks_exit.store(false);
+        k_starrocks_force_reject.store(false);
+        k_starrocks_fe_aware_shutdown_ms.store(0);
     }
 
 private:
@@ -263,27 +276,32 @@ TEST_F(StreamLoadActionTest, process_exit_abort_stream_load) {
     request._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
     request.set_handler(&action);
 
-    // set process exit in progress flag
     k_starrocks_exit.store(true);
+    k_starrocks_fe_aware_shutdown_ms.store(MonotonicMillis() - config::graceful_exit_reject_delay_ms - 1);
 
-    action.on_header(&request);
-    action.handle(&request);
+    int rc = action.on_header(&request);
 
-    rapidjson::Document doc;
-    doc.Parse(k_response_str.c_str());
-
+    ASSERT_EQ(-1, rc);
     // {
     //   "TxnId": -1,
     //   "Status": "Fail",
-    //   "Message", "Service is shutting down, please retry later!",
+    //   "Message": "Service is shutting down, please retry later!",
     //   ...
     // }
+    rapidjson::Document doc;
+    doc.Parse(k_response_str.c_str());
     ASSERT_STREQ("Fail", doc["Status"].GetString()) << k_response_str;
     ASSERT_EQ(-1, doc["TxnId"].GetInt());
     ASSERT_STREQ("Service is shutting down, please retry later!", doc["Message"].GetString());
+    auto* content_type = evhttp_find_header(evhttp_request_get_output_headers(_evhttp_req), "Content-Type");
+    ASSERT_NE(content_type, nullptr);
+    ASSERT_STREQ("application/json", content_type);
+    auto* location = evhttp_find_header(evhttp_request_get_output_headers(_evhttp_req), HttpHeaders::LOCATION);
+    ASSERT_EQ(location, nullptr);
 
     // restore the flags
     k_starrocks_exit.store(false);
+    k_starrocks_fe_aware_shutdown_ms.store(0);
 }
 
 TEST_F(StreamLoadActionTest, put_fail) {
@@ -791,6 +809,26 @@ TEST_F(StreamLoadActionTest, format_arrow) {
     StreamLoadContext* ctx = static_cast<StreamLoadContext*>(request._handler_ctx);
     ASSERT_NE(nullptr, ctx);
     ASSERT_EQ(TFileFormatType::FORMAT_ARROW, ctx->format);
+}
+
+TEST_F(StreamLoadActionTest, on_header_rejects_when_force_reject) {
+    force_reject_exec_plan_fragment();
+    StreamLoadAction action(&_env, &_stream_load_orchestrator, _stream_load_executor.get(), _limiter.get(),
+                            _batch_write_mgr.get());
+    HttpRequest request(_evhttp_req);
+    request.set_handler(&action);
+    ASSERT_EQ(-1, action.on_header(&request));
+    ASSERT_EQ(HttpStatus::OK, k_response_status);
+    rapidjson::Document doc;
+    doc.Parse(k_response_str.c_str());
+    ASSERT_STREQ("Fail", doc["Status"].GetString()) << k_response_str;
+    ASSERT_EQ(-1, doc["TxnId"].GetInt());
+    ASSERT_STREQ("Service is shutting down, please retry later!", doc["Message"].GetString());
+    auto* content_type = evhttp_find_header(evhttp_request_get_output_headers(_evhttp_req), "Content-Type");
+    ASSERT_NE(content_type, nullptr);
+    ASSERT_STREQ("application/json", content_type);
+    ASSERT_EQ(nullptr, request.handler_ctx());
+    ASSERT_EQ(0, shutdown_work_inflight());
 }
 
 } // namespace starrocks

--- a/be/test/http/transaction_stream_load_test.cpp
+++ b/be/test/http/transaction_stream_load_test.cpp
@@ -20,18 +20,24 @@
 #include <gtest/gtest.h>
 #include <rapidjson/document.h>
 
+#include <atomic>
 #include <cstring>
 #include <string>
 #include <utility>
 
 #include "base/metrics.h"
+#include "base/network/network_util.h"
 #include "base/testutil/assert.h"
 #include "base/testutil/sync_point.h"
+#include "base/time/time.h"
 #include "base/utility/defer_op.h"
+#include "common/config_exec_env_fwd.h"
 #include "common/config_ingest_fwd.h"
 #include "common/config_storage_fwd.h"
+#include "common/process_exit.h"
 #include "common/status.h"
 #include "common/system/cpu_info.h"
+#include "common/system/master_info.h"
 #include "compute_env/compute_env.h"
 #include "compute_env/load/http_load_params.h"
 #include "compute_env/load/stream_context_mgr.h"
@@ -47,6 +53,7 @@
 #include "http/download_action.h"
 #include "orchestration/stream_load_orchestrator.h"
 #include "platform/http/http_channel.h"
+#include "platform/http/http_headers.h"
 #include "platform/http/http_request.h"
 #include "platform/platform_env.h"
 #include "runtime/runtime_env.h"
@@ -54,12 +61,17 @@
 class mg_connection;
 
 namespace starrocks {
-
 extern void (*s_injected_send_reply)(HttpRequest*, HttpStatus, std::string_view);
-
+extern std::atomic<bool> k_starrocks_exit;
+extern std::atomic<bool> k_starrocks_force_reject;
+extern std::atomic<int64_t> k_starrocks_exit_start_ms;
+extern std::atomic<int64_t> k_starrocks_fe_aware_shutdown_ms;
 namespace {
+
 static std::string k_response_str;
+static HttpStatus k_response_status = HttpStatus::OK;
 static void inject_send_reply(HttpRequest* request, HttpStatus status, std::string_view content) {
+    k_response_status = status;
     k_response_str = content;
 }
 
@@ -107,6 +119,10 @@ public:
     static void SetUpTestSuite() { s_injected_send_reply = inject_send_reply; }
     static void TearDownTestSuite() { s_injected_send_reply = nullptr; }
     void SetUp() override {
+        k_starrocks_exit.store(false);
+        k_starrocks_force_reject.store(false);
+        k_starrocks_exit_start_ms.store(0);
+        clear_frontend_aware_of_exit();
         k_stream_load_begin_result = TLoadTxnBeginResult();
         k_stream_load_commit_result = TLoadTxnCommitResult();
         k_stream_load_rollback_result = TLoadTxnRollbackResult();
@@ -140,6 +156,14 @@ public:
         if (_evhttp_req != nullptr) {
             evhttp_request_free(_evhttp_req);
         }
+        k_starrocks_exit.store(false);
+        k_starrocks_force_reject.store(false);
+        k_starrocks_exit_start_ms.store(0);
+        clear_frontend_aware_of_exit();
+        TMasterInfo restored;
+        restored.__set_network_address(make_network_address("127.0.0.1", 8030));
+        restored.__set_http_port(8030);
+        (void)update_master_info(restored);
     }
 
 protected:
@@ -227,6 +251,296 @@ TEST_F(TransactionStreamLoadActionTest, txn_begin_normal) {
     auto* val = evhttp_find_header(evhttp_request_get_output_headers(_evhttp_req), "Content-Type");
     ASSERT_NE(val, nullptr);
     ASSERT_STREQ("application/json", val);
+}
+TEST_F(TransactionStreamLoadActionTest, txn_begin_accepts_until_shutdown_delay) {
+    ASSERT_TRUE(set_process_exit());
+
+    TransactionManagerAction txn_action(&_env, _transaction_mgr.get());
+    HttpRequest b(_evhttp_req);
+    b._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    b._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+    b._headers.emplace(HTTP_LABEL_KEY, "123");
+    b._params.emplace(HTTP_TXN_OP_KEY, TXN_BEGIN);
+    txn_action.handle(&b);
+
+    rapidjson::Document doc;
+    doc.Parse(k_response_str.c_str());
+    ASSERT_STREQ("OK", doc["Status"].GetString());
+}
+
+TEST_F(TransactionStreamLoadActionTest, txn_begin_duplicate_label_within_delay) {
+    ASSERT_TRUE(set_process_exit());
+
+    TransactionManagerAction txn_action(&_env, _transaction_mgr.get());
+    HttpRequest begin(_evhttp_req);
+    begin._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    begin._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+    begin._headers.emplace(HTTP_LABEL_KEY, "123");
+    begin._params.emplace(HTTP_TXN_OP_KEY, TXN_BEGIN);
+    txn_action.handle(&begin);
+
+    rapidjson::Document doc;
+    doc.Parse(k_response_str.c_str());
+    ASSERT_STREQ("OK", doc["Status"].GetString());
+
+    // A duplicate BEGIN while admission is still open takes the standard label conflict:
+    // the delay window does not make a retry idempotent.
+    k_response_str.clear();
+    HttpRequest retry(_evhttp_req);
+    retry._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    retry._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+    retry._headers.emplace(HTTP_LABEL_KEY, "123");
+    retry._params.emplace(HTTP_TXN_OP_KEY, TXN_BEGIN);
+    txn_action.handle(&retry);
+
+    rapidjson::Document retry_doc;
+    retry_doc.Parse(k_response_str.c_str());
+    ASSERT_STREQ("LABEL_ALREADY_EXISTS", retry_doc["Status"].GetString());
+}
+
+TEST_F(TransactionStreamLoadActionTest, txn_begin_redirects_after_shutdown_delay) {
+    TMasterInfo master_info;
+    master_info.__set_network_address(make_network_address("127.0.0.1", 8030));
+    master_info.__set_http_port(8030);
+    ASSERT_TRUE(update_master_info(master_info));
+
+    k_response_str.clear();
+    k_starrocks_exit.store(true);
+    k_starrocks_fe_aware_shutdown_ms.store(MonotonicMillis() - config::graceful_exit_reject_delay_ms - 1);
+
+    TransactionManagerAction txn_action(&_env, _transaction_mgr.get());
+    HttpRequest b(_evhttp_req);
+    b._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    b._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+    b._headers.emplace(HTTP_LABEL_KEY, "123");
+    b._params.emplace(HTTP_TXN_OP_KEY, TXN_BEGIN);
+    txn_action.handle(&b);
+
+    // Redirected (307) to the FE leader: no JSON body, a Location header instead.
+    ASSERT_EQ(k_response_status, HttpStatus::TEMPORARY_REDIRECT);
+    ASSERT_TRUE(k_response_str.empty());
+    auto* location = evhttp_find_header(evhttp_request_get_output_headers(_evhttp_req), HttpHeaders::LOCATION);
+    ASSERT_NE(location, nullptr);
+    ASSERT_NE(std::strstr(location, "http://127.0.0.1:8030"), nullptr);
+}
+
+TEST_F(TransactionStreamLoadActionTest, txn_begin_retry_redirected_after_shutdown_delay) {
+    TMasterInfo master_info;
+    master_info.__set_network_address(make_network_address("127.0.0.1", 8030));
+    master_info.__set_http_port(8030);
+    ASSERT_TRUE(update_master_info(master_info));
+
+    TransactionManagerAction txn_action(&_env, _transaction_mgr.get());
+    HttpRequest begin(_evhttp_req);
+    begin._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    begin._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+    begin._headers.emplace(HTTP_LABEL_KEY, "123");
+    begin._params.emplace(HTTP_TXN_OP_KEY, TXN_BEGIN);
+    txn_action.handle(&begin);
+
+    k_response_str.clear();
+    k_starrocks_exit.store(true);
+    k_starrocks_fe_aware_shutdown_ms.store(MonotonicMillis() - config::graceful_exit_reject_delay_ms - 1);
+
+    // The admission gate does not inspect the label: even a retry whose transaction already
+    // began here is redirected like any other BEGIN (no idempotent pass-through).
+    HttpRequest retry(_evhttp_req);
+    retry._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    retry._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+    retry._headers.emplace(HTTP_LABEL_KEY, "123");
+    retry._params.emplace(HTTP_TXN_OP_KEY, TXN_BEGIN);
+    txn_action.handle(&retry);
+
+    ASSERT_EQ(k_response_status, HttpStatus::TEMPORARY_REDIRECT);
+    ASSERT_TRUE(k_response_str.empty());
+    auto* location = evhttp_find_header(evhttp_request_get_output_headers(_evhttp_req), HttpHeaders::LOCATION);
+    ASSERT_NE(location, nullptr);
+    ASSERT_NE(std::strstr(location, "http://127.0.0.1:8030"), nullptr);
+}
+
+TEST_F(TransactionStreamLoadActionTest, txn_begin_rejects_after_shutdown_fallback) {
+    TMasterInfo master_info;
+    master_info.__set_network_address(make_network_address("127.0.0.1", 8030));
+    master_info.__set_http_port(8030);
+    ASSERT_TRUE(update_master_info(master_info));
+
+    TransactionManagerAction txn_action(&_env, _transaction_mgr.get());
+    HttpRequest begin(_evhttp_req);
+    begin._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    begin._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+    begin._headers.emplace(HTTP_LABEL_KEY, "123");
+    begin._params.emplace(HTTP_TXN_OP_KEY, TXN_BEGIN);
+    txn_action.handle(&begin);
+
+    rapidjson::Document doc;
+    doc.Parse(k_response_str.c_str());
+    ASSERT_STREQ("OK", doc["Status"].GetString());
+
+    // Fallback cutoff without an FE ack: ServiceUnavailable, and no redirect (an unaware FE
+    // could route the retry straight back to this BE).
+    k_response_str.clear();
+    k_starrocks_exit.store(true);
+    k_starrocks_exit_start_ms.store(MonotonicMillis() - config::graceful_exit_reject_fallback_ms - 1);
+
+    HttpRequest retry(_evhttp_req);
+    retry._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    retry._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+    retry._headers.emplace(HTTP_LABEL_KEY, "123");
+    retry._params.emplace(HTTP_TXN_OP_KEY, TXN_BEGIN);
+    txn_action.handle(&retry);
+
+    rapidjson::Document retry_doc;
+    retry_doc.Parse(k_response_str.c_str());
+    ASSERT_STREQ("SERVICE_UNAVAILABLE", retry_doc["Status"].GetString());
+    ASSERT_EQ(nullptr, evhttp_find_header(evhttp_request_get_output_headers(_evhttp_req), HttpHeaders::LOCATION));
+}
+
+TEST_F(TransactionStreamLoadActionTest, txn_begin_rejects_when_force_reject) {
+    force_reject_exec_plan_fragment();
+    TransactionManagerAction txn_action(&_env, _transaction_mgr.get());
+    HttpRequest begin(_evhttp_req);
+    begin._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    begin._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+    begin._headers.emplace(HTTP_LABEL_KEY, "123");
+    begin._params.emplace(HTTP_TXN_OP_KEY, TXN_BEGIN);
+    txn_action.handle(&begin);
+
+    rapidjson::Document doc;
+    doc.Parse(k_response_str.c_str());
+    ASSERT_STREQ("SERVICE_UNAVAILABLE", doc["Status"].GetString());
+    ASSERT_EQ(nullptr, evhttp_find_header(evhttp_request_get_output_headers(_evhttp_req), HttpHeaders::LOCATION));
+    ASSERT_EQ(nullptr, _env.stream_context_mgr()->get("123"));
+}
+
+TEST_F(TransactionStreamLoadActionTest, txn_begin_no_redirect_when_fe_address_unset) {
+    TMasterInfo master_info;
+    master_info.__set_http_port(0);
+    ASSERT_TRUE(update_master_info(master_info));
+
+    k_response_str.clear();
+    k_starrocks_exit.store(true);
+    k_starrocks_fe_aware_shutdown_ms.store(MonotonicMillis() - config::graceful_exit_reject_delay_ms - 1);
+
+    TransactionManagerAction txn_action(&_env, _transaction_mgr.get());
+    HttpRequest b(_evhttp_req);
+    b._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    b._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+    b._headers.emplace(HTTP_LABEL_KEY, "123");
+    b._params.emplace(HTTP_TXN_OP_KEY, TXN_BEGIN);
+    txn_action.handle(&b);
+
+    rapidjson::Document doc;
+    doc.Parse(k_response_str.c_str());
+    ASSERT_STREQ("SERVICE_UNAVAILABLE", doc["Status"].GetString());
+    ASSERT_EQ(nullptr, evhttp_find_header(evhttp_request_get_output_headers(_evhttp_req), HttpHeaders::LOCATION));
+}
+
+TEST_F(TransactionStreamLoadActionTest, txn_begin_no_redirect_after_leader_handover) {
+    TMasterInfo master_info;
+    master_info.__set_network_address(make_network_address("127.0.0.1", 8030));
+    master_info.__set_http_port(8030);
+    ASSERT_TRUE(update_master_info(master_info));
+
+    // Redirect is only possible once the FE has observed the shutdown heartbeat; the
+    // leader-handover scenario below starts from that state.
+    k_starrocks_exit.store(true);
+    k_starrocks_fe_aware_shutdown_ms.store(MonotonicMillis() - config::graceful_exit_reject_delay_ms - 1);
+
+    // The first FE acknowledges and opens the delay window.
+    ASSERT_FALSE(advance_heartbeat_ack("127.0.0.1:8030:1", 100));
+    ASSERT_TRUE(advance_heartbeat_ack("127.0.0.1:8030:1", 101));
+    ASSERT_TRUE(may_redirect_to_fe_leader());
+
+    // A different leader starts acking (epoch changed): redirect is disabled for the rest of
+    // this shutdown, so the cutoff reply is ServiceUnavailable without a Location header.
+    ASSERT_FALSE(advance_heartbeat_ack("127.0.0.1:8030:2", 900));
+    ASSERT_TRUE(advance_heartbeat_ack("127.0.0.1:8030:2", 901));
+    ASSERT_FALSE(may_redirect_to_fe_leader());
+
+    TransactionManagerAction txn_action(&_env, _transaction_mgr.get());
+    HttpRequest b(_evhttp_req);
+    b._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    b._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+    b._headers.emplace(HTTP_LABEL_KEY, "123");
+    b._params.emplace(HTTP_TXN_OP_KEY, TXN_BEGIN);
+    txn_action.handle(&b);
+
+    rapidjson::Document doc;
+    doc.Parse(k_response_str.c_str());
+    ASSERT_STREQ("SERVICE_UNAVAILABLE", doc["Status"].GetString());
+    ASSERT_EQ(nullptr, evhttp_find_header(evhttp_request_get_output_headers(_evhttp_req), HttpHeaders::LOCATION));
+}
+
+TEST_F(TransactionStreamLoadActionTest, txn_begin_no_redirect_on_legacy_fe) {
+    // Legacy FE omits last_heartbeat_time_ms: delay still opens, but BEGIN 307 is off so the
+    // old FE cannot bounce the client back to this BE.
+    TMasterInfo master_info;
+    master_info.__set_network_address(make_network_address("127.0.0.1", 8030));
+    master_info.__set_http_port(8030);
+    ASSERT_TRUE(update_master_info(master_info));
+
+    ASSERT_TRUE(set_process_exit());
+    set_frontend_aware_of_exit();
+    disable_begin_redirect();
+    ASSERT_TRUE(should_accept_new_request());
+    ASSERT_FALSE(may_redirect_to_fe_leader());
+
+    TransactionManagerAction txn_action(&_env, _transaction_mgr.get());
+    HttpRequest begin(_evhttp_req);
+    begin._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    begin._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+    begin._headers.emplace(HTTP_LABEL_KEY, "legacy");
+    begin._params.emplace(HTTP_TXN_OP_KEY, TXN_BEGIN);
+    txn_action.handle(&begin);
+
+    rapidjson::Document doc;
+    doc.Parse(k_response_str.c_str());
+    ASSERT_EQ(k_response_status, HttpStatus::OK);
+    ASSERT_STREQ("OK", doc["Status"].GetString());
+    ASSERT_EQ(nullptr, evhttp_find_header(evhttp_request_get_output_headers(_evhttp_req), HttpHeaders::LOCATION));
+
+    k_response_str.clear();
+    k_starrocks_fe_aware_shutdown_ms.store(MonotonicMillis() - config::graceful_exit_reject_delay_ms - 1);
+    ASSERT_FALSE(should_accept_new_request());
+
+    HttpRequest retry(_evhttp_req);
+    retry._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    retry._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+    retry._headers.emplace(HTTP_LABEL_KEY, "legacy");
+    retry._params.emplace(HTTP_TXN_OP_KEY, TXN_BEGIN);
+    txn_action.handle(&retry);
+
+    rapidjson::Document retry_doc;
+    retry_doc.Parse(k_response_str.c_str());
+    ASSERT_STREQ("SERVICE_UNAVAILABLE", retry_doc["Status"].GetString());
+    ASSERT_EQ(nullptr, evhttp_find_header(evhttp_request_get_output_headers(_evhttp_req), HttpHeaders::LOCATION));
+}
+TEST_F(TransactionStreamLoadActionTest, txn_begin_rejects_after_fallback_without_heartbeat) {
+    // The fallback deadline can close admission before the FE has observed the shutdown heartbeat.
+    // A redirect would let the unaware FE pick this BE again, so reply ServiceUnavailable instead.
+    TMasterInfo master_info;
+    master_info.__set_network_address(make_network_address("127.0.0.1", 8030));
+    master_info.__set_http_port(8030);
+    ASSERT_TRUE(update_master_info(master_info));
+
+    k_response_str.clear();
+    k_starrocks_exit.store(true);
+    k_starrocks_exit_start_ms.store(MonotonicMillis() - config::graceful_exit_reject_fallback_ms - 1);
+    ASSERT_FALSE(should_accept_new_request());
+    ASSERT_FALSE(is_frontend_aware_of_exit());
+
+    TransactionManagerAction txn_action(&_env, _transaction_mgr.get());
+    HttpRequest b(_evhttp_req);
+    b._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    b._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+    b._headers.emplace(HTTP_LABEL_KEY, "123");
+    b._params.emplace(HTTP_TXN_OP_KEY, TXN_BEGIN);
+    txn_action.handle(&b);
+
+    rapidjson::Document doc;
+    doc.Parse(k_response_str.c_str());
+    ASSERT_STREQ("SERVICE_UNAVAILABLE", doc["Status"].GetString());
+    ASSERT_EQ(nullptr, evhttp_find_header(evhttp_request_get_output_headers(_evhttp_req), HttpHeaders::LOCATION));
 }
 
 TEST_F(TransactionStreamLoadActionTest, txn_commit_fail) {
@@ -358,7 +672,7 @@ TEST_F(TransactionStreamLoadActionTest, txn_rollback) {
     }
 }
 
-TEST_F(TransactionStreamLoadActionTest, txn_commit_success) {
+TEST_F(TransactionStreamLoadActionTest, txn_commit_success_after_shutdown_cutoff) {
     TransactionManagerAction txn_action(&_env, _transaction_mgr.get());
 
     {
@@ -373,6 +687,9 @@ TEST_F(TransactionStreamLoadActionTest, txn_commit_success) {
         doc.Parse(k_response_str.c_str());
         ASSERT_STREQ("OK", doc["Status"].GetString());
     }
+    ASSERT_TRUE(set_process_exit());
+    k_starrocks_fe_aware_shutdown_ms.store(MonotonicMillis() - config::graceful_exit_reject_delay_ms - 1);
+    ASSERT_FALSE(should_accept_new_request());
 
     {
         TransactionStreamLoadAction action(&_env, &_stream_load_orchestrator, _transaction_mgr.get());
@@ -784,6 +1101,19 @@ TEST_F(TransactionStreamLoadActionTest, txn_list) {
         ASSERT_STREQ("OK", doc["Status"].GetString());
         ASSERT_STREQ("123", doc["Label"].GetString());
     }
+}
+
+TEST_F(TransactionStreamLoadActionTest, txn_list_allowed_after_shutdown_cutoff) {
+    ASSERT_TRUE(set_process_exit());
+    k_starrocks_fe_aware_shutdown_ms.store(MonotonicMillis() - config::graceful_exit_reject_delay_ms - 1);
+
+    TransactionManagerAction txn_action(&_env, _transaction_mgr.get());
+    HttpRequest request(_evhttp_req);
+    request._params.emplace(HTTP_TXN_OP_KEY, TXN_LIST);
+    txn_action.handle(&request);
+
+    // LIST is read-only and remains available while new writes are rejected.
+    ASSERT_TRUE(k_response_str.empty());
 }
 
 TEST_F(TransactionStreamLoadActionTest, txn_idle_timeout) {

--- a/be/test/orchestration/CMakeLists.txt
+++ b/be/test/orchestration/CMakeLists.txt
@@ -24,7 +24,9 @@ add_executable(orchestration_test
     fragment_executor_test.cpp
     fragment_mgr_test.cpp
     orchestration_metrics_test.cpp
+    orchestration_env_test.cpp
     query_orchestrator_test.cpp
+    routine_load_task_executor_admission_test.cpp
     stream_load_orchestrator_test.cpp
 )
 target_link_libraries(orchestration_test Orchestration ${TEST_LINK_LIBS} gtest_main)

--- a/be/test/orchestration/orchestration_env_test.cpp
+++ b/be/test/orchestration/orchestration_env_test.cpp
@@ -1,0 +1,80 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "orchestration/orchestration_env.h"
+
+#include <gtest/gtest.h>
+
+#include "base/utility/defer_op.h"
+#include "common/process_exit.h"
+#include "common/system/cpu_info.h"
+#include "compute_env/load/stream_load_metrics.h"
+
+namespace starrocks {
+
+extern std::atomic<bool> k_starrocks_quick_exit;
+
+namespace orchestration {
+
+class OrchestrationEnvTest : public testing::Test {
+protected:
+    static void SetUpTestSuite() { CpuInfo::init(); }
+
+    void TearDown() override { k_starrocks_quick_exit.store(false); }
+};
+
+TEST_F(OrchestrationEnvTest, quick_exit_ignores_idle_load_state) {
+    OrchestrationEnv env;
+    auto* metrics = StreamLoadMetrics::instance();
+    const auto stream_before = metrics->streaming_load_current_processing.value();
+    const auto txn_before = metrics->transaction_streaming_load_current_processing.value();
+    const size_t work_before = shutdown_work_inflight();
+
+    metrics->streaming_load_current_processing.increment(1);
+    metrics->transaction_streaming_load_current_processing.increment(1);
+    DeferOp restore([&] {
+        metrics->streaming_load_current_processing.set_value(stream_before);
+        metrics->transaction_streaming_load_current_processing.set_value(txn_before);
+        k_starrocks_quick_exit.store(false);
+    });
+
+    ASSERT_TRUE(set_process_quick_exit());
+    EXPECT_EQ(work_before, env.get_running_fragments_count_for_test());
+
+    k_starrocks_quick_exit.store(false);
+    EXPECT_GE(env.get_running_fragments_count_for_test(), work_before + 2);
+}
+
+TEST_F(OrchestrationEnvTest, quick_exit_counts_shutdown_work) {
+    OrchestrationEnv env;
+    const size_t work_before = shutdown_work_inflight();
+    inc_shutdown_work();
+    bool owns = true;
+    DeferOp restore([&] {
+        if (owns) {
+            dec_shutdown_work();
+        }
+        k_starrocks_quick_exit.store(false);
+    });
+
+    ASSERT_TRUE(set_process_quick_exit());
+    EXPECT_GE(env.get_running_fragments_count_for_test(), work_before + 1);
+
+    owns = false;
+    dec_shutdown_work();
+    EXPECT_EQ(work_before, env.get_running_fragments_count_for_test());
+}
+
+} // namespace orchestration
+} // namespace starrocks

--- a/be/test/orchestration/routine_load_task_executor_admission_test.cpp
+++ b/be/test/orchestration/routine_load_task_executor_admission_test.cpp
@@ -1,0 +1,145 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <thread>
+
+#include "base/concurrency/await.h"
+#include "base/testutil/assert.h"
+#include "base/testutil/sync_point.h"
+#include "base/time/time.h"
+#include "base/utility/defer_op.h"
+#include "common/config_exec_env_fwd.h"
+#include "common/config_ingest_fwd.h"
+#include "common/process_exit.h"
+#include "common/system/cpu_info.h"
+#include "data_workflows/load/stream_load/stream_load_executor.h"
+#include "exec/exec_env.h"
+#include "gen_cpp/BackendService_types.h"
+#include "gen_cpp/FrontendService_types.h"
+#include "orchestration/routine_load_task_executor.h"
+#include "orchestration/stream_load_orchestrator.h"
+
+namespace starrocks {
+
+extern std::atomic<bool> k_starrocks_exit;
+extern std::atomic<int64_t> k_starrocks_exit_start_ms;
+
+namespace orchestration {
+
+class RoutineLoadTaskExecutorAdmissionTest : public testing::Test {
+protected:
+    static void SetUpTestSuite() { CpuInfo::init(); }
+
+    void SetUp() override {
+        _stream_load_executor = std::make_unique<StreamLoadExecutor>();
+        _executor = std::make_unique<RoutineLoadTaskExecutor>(&_env, &_orchestrator, _stream_load_executor.get());
+        ASSERT_OK(_executor->init());
+    }
+
+    void TearDown() override {
+        k_starrocks_exit.store(false);
+        k_starrocks_exit_start_ms.store(0);
+        if (_executor) {
+            _executor->stop();
+        }
+        _executor.reset();
+        _stream_load_executor.reset();
+    }
+
+    TRoutineLoadTask make_task() {
+        TRoutineLoadTask task;
+        task.type = TLoadSourceType::KAFKA;
+        task.job_id = 1;
+        task.id = TUniqueId();
+        task.txn_id = 4;
+        task.auth_code = 5;
+        task.__set_db("db1");
+        task.__set_tbl("tbl1");
+        task.__set_label("l1");
+        TKafkaLoadInfo k_info;
+        k_info.brokers = "127.0.0.1:9092";
+        k_info.topic = "test";
+        std::map<int32_t, int64_t> part_off;
+        part_off[0] = 13;
+        k_info.__set_partition_begin_offset(part_off);
+        task.__set_kafka_load_info(k_info);
+        return task;
+    }
+
+    ExecEnv _env;
+    StreamLoadOrchestrator _orchestrator{&_env, nullptr};
+    std::unique_ptr<StreamLoadExecutor> _stream_load_executor;
+    std::unique_ptr<RoutineLoadTaskExecutor> _executor;
+};
+
+TEST_F(RoutineLoadTaskExecutorAdmissionTest, submit_rejects_after_cutoff) {
+    ASSERT_TRUE(set_process_exit());
+    k_starrocks_exit_start_ms.store(MonotonicMillis() - config::graceful_exit_reject_fallback_ms - 1);
+    ASSERT_FALSE(should_accept_new_request());
+
+    Status st = _executor->submit_task(make_task());
+    ASSERT_TRUE(st.is_service_unavailable());
+    ASSERT_EQ(0, shutdown_work_inflight());
+}
+
+TEST_F(RoutineLoadTaskExecutorAdmissionTest, submit_fail_zeros_inflight) {
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("ThreadPool::do_submit:1");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("ThreadPool::do_submit:1", [](void* arg) { *(int64_t*)arg = 0; });
+
+    Status st = _executor->submit_task(make_task());
+    ASSERT_TRUE(st.is_internal_error());
+    ASSERT_EQ(0, shutdown_work_inflight());
+}
+
+TEST_F(RoutineLoadTaskExecutorAdmissionTest, submit_unknown_source_zeros_inflight) {
+    TRoutineLoadTask task = make_task();
+    task.type = static_cast<TLoadSourceType::type>(99);
+    Status st = _executor->submit_task(task);
+    ASSERT_TRUE(st.is_internal_error());
+    ASSERT_NE(st.message().find("unknown load source type"), std::string::npos);
+    ASSERT_EQ(0, shutdown_work_inflight());
+}
+
+TEST_F(RoutineLoadTaskExecutorAdmissionTest, submit_holds_inflight_until_finish) {
+    std::atomic<int> phase{0};
+    DeferOp defer([&]() {
+        phase.store(2);
+        SyncPoint::GetInstance()->ClearCallBack("RoutineLoadTaskExecutor::submit_task:before_exec");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("RoutineLoadTaskExecutor::submit_task:before_exec", [&](void* arg) {
+        *static_cast<bool*>(arg) = true;
+        phase.store(1);
+        while (phase.load() < 2) {
+            std::this_thread::yield();
+        }
+    });
+
+    ASSERT_OK(_executor->submit_task(make_task()));
+    ASSERT_TRUE(Awaitility().timeout(60000).until([&] { return phase.load() == 1; }));
+    ASSERT_EQ(1, shutdown_work_inflight());
+    phase.store(2);
+    ASSERT_TRUE(Awaitility().timeout(60000).until([&] { return shutdown_work_inflight() == 0; }));
+}
+
+} // namespace orchestration
+} // namespace starrocks

--- a/be/test/orchestration/stream_load_orchestrator_test.cpp
+++ b/be/test/orchestration/stream_load_orchestrator_test.cpp
@@ -16,15 +16,28 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+
 #include "base/testutil/assert.h"
 #include "base/testutil/sync_point.h"
 #include "base/utility/defer_op.h"
+#include "common/process_exit.h"
+#include "common/system/cpu_info.h"
 #include "compute_env/load/stream_load_context.h"
 #include "exec/exec_env.h"
 
-namespace starrocks::orchestration {
+namespace starrocks {
 
-TEST(StreamLoadOrchestratorTest, execute_plan_fragment_preserves_be_test_sync_point) {
+extern std::atomic<bool> k_starrocks_exit;
+extern std::atomic<bool> k_starrocks_force_reject;
+
+namespace orchestration {
+class StreamLoadOrchestratorTest : public testing::Test {
+protected:
+    static void SetUpTestSuite() { CpuInfo::init(); }
+};
+
+TEST_F(StreamLoadOrchestratorTest, execute_plan_fragment_preserves_be_test_sync_point) {
     ExecEnv exec_env;
     StreamLoadOrchestrator stream_load_orchestrator(&exec_env, nullptr);
     StreamLoadContext ctx(nullptr);
@@ -43,4 +56,39 @@ TEST(StreamLoadOrchestratorTest, execute_plan_fragment_preserves_be_test_sync_po
     ASSERT_EQ("TestFail", status.message());
 }
 
-} // namespace starrocks::orchestration
+// Verify the guard releases its count when rejection occurs.
+TEST_F(StreamLoadOrchestratorTest, execute_plan_fragment_rejects_when_force_reject) {
+    ASSERT_TRUE(set_process_exit());
+    force_reject_exec_plan_fragment();
+    DeferOp reset_exit([] {
+        k_starrocks_exit.store(false);
+        k_starrocks_force_reject.store(false);
+    });
+
+    ExecEnv exec_env;
+    StreamLoadOrchestrator stream_load_orchestrator(&exec_env, nullptr);
+    StreamLoadContext ctx(nullptr);
+
+    Status status = stream_load_orchestrator.execute_plan_fragment(&ctx);
+    ASSERT_TRUE(status.is_service_unavailable());
+    EXPECT_EQ(0, shutdown_work_inflight());
+}
+
+TEST_F(StreamLoadOrchestratorTest, execute_plan_fragment_skips_gate_when_already_granted) {
+    ASSERT_TRUE(set_process_exit());
+    force_reject_exec_plan_fragment();
+    DeferOp reset_exit([] {
+        k_starrocks_exit.store(false);
+        k_starrocks_force_reject.store(false);
+    });
+
+    ExecEnv exec_env;
+    StreamLoadOrchestrator stream_load_orchestrator(&exec_env, nullptr);
+    StreamLoadContext ctx(nullptr);
+
+    ASSERT_OK(stream_load_orchestrator.execute_plan_fragment(&ctx, true));
+    EXPECT_EQ(0, shutdown_work_inflight());
+}
+
+} // namespace orchestration
+} // namespace starrocks

--- a/be/test/orchestration/stream_load_orchestrator_test.cpp
+++ b/be/test/orchestration/stream_load_orchestrator_test.cpp
@@ -50,7 +50,7 @@ TEST_F(StreamLoadOrchestratorTest, execute_plan_fragment_preserves_be_test_sync_
         SyncPoint::GetInstance()->DisableProcessing();
     });
 
-    ASSERT_OK(stream_load_orchestrator.execute_plan_fragment(&ctx));
+    ASSERT_OK(stream_load_orchestrator.execute_plan_fragment(&ctx, false));
     auto status = ctx.future.get();
     ASSERT_TRUE(status.is_internal_error());
     ASSERT_EQ("TestFail", status.message());
@@ -69,7 +69,7 @@ TEST_F(StreamLoadOrchestratorTest, execute_plan_fragment_rejects_when_force_reje
     StreamLoadOrchestrator stream_load_orchestrator(&exec_env, nullptr);
     StreamLoadContext ctx(nullptr);
 
-    Status status = stream_load_orchestrator.execute_plan_fragment(&ctx);
+    Status status = stream_load_orchestrator.execute_plan_fragment(&ctx, false);
     ASSERT_TRUE(status.is_service_unavailable());
     EXPECT_EQ(0, shutdown_work_inflight());
 }

--- a/be/test/service/service_be/internal_service_test.cpp
+++ b/be/test/service/service_be/internal_service_test.cpp
@@ -17,14 +17,22 @@
 #include <brpc/controller.h>
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <memory>
 
 #include "base/testutil/assert.h"
+#include "base/testutil/sync_point.h"
+#include "base/uid_util.h"
+#include "base/utility/defer_op.h"
 #include "cache/datacache.h"
 #include "cache/disk_cache/test_cache_utils.h"
+#include "common/process_exit.h"
+#include "compute_env/load/stream_load_metrics.h"
 #include "data_sink/tablet/tablet_sink_index_channel.h"
 #include "data_workflows/load/tablet_writer/load_channel_mgr.h"
 #include "exec/exec_env.h"
+#include "exec/runtime/query_context_manager.h"
+#include "orchestration/orchestration_env.h"
 #include "platform/platform_env.h"
 #include "runtime/runtime_env.h"
 #include "service/brpc_service_test_util.h"
@@ -267,6 +275,156 @@ TEST_F(InternalServiceTest, test_get_load_replica_status) {
     MockClosure closure;
     service.get_load_replica_status(&cntl, &request, &response, &closure);
     ASSERT_EQ(1, response.replica_statuses_size());
+}
+
+extern std::atomic<bool> k_starrocks_exit;
+extern std::atomic<bool> k_starrocks_quick_exit;
+extern std::atomic<bool> k_starrocks_force_reject;
+
+TEST_F(InternalServiceTest, test_short_circuit_rejected_while_shutting_down) {
+    // Verify rejection and guard cleanup for a short-circuit RPC.
+    k_starrocks_exit.store(true);
+    k_starrocks_force_reject.store(true);
+    orchestration::OrchestrationEnv orchestration_env;
+
+    BackendInternalServiceImpl<PInternalService> service(ExecEnv::GetInstance(), &orchestration_env,
+                                                         _load_channel_mgr.get());
+
+    PExecShortCircuitRequest request;
+    PExecShortCircuitResult response;
+    brpc::Controller cntl;
+    MockClosure closure;
+
+    service.exec_short_circuit(&cntl, &request, &response, &closure);
+
+    ASSERT_TRUE(cntl.Failed());
+    ASSERT_EQ(brpc::EINTERNAL, cntl.ErrorCode());
+    // ErrorText includes brpc's error-code prefix.
+    ASSERT_EQ("[E2001]BE is shutting down", cntl.ErrorText());
+
+    k_starrocks_exit.store(false);
+    k_starrocks_force_reject.store(false);
+}
+
+TEST_F(InternalServiceTest, test_exec_plan_fragment_rejected_while_shutting_down) {
+    // Verify rejection and guard cleanup for a fragment-prep RPC.
+    k_starrocks_exit.store(true);
+    k_starrocks_force_reject.store(true);
+
+    orchestration::OrchestrationEnv orchestration_env;
+    BackendInternalServiceImpl<PInternalService> service(ExecEnv::GetInstance(), &orchestration_env,
+                                                         _load_channel_mgr.get());
+
+    PExecPlanFragmentRequest request;
+    PExecPlanFragmentResult response;
+    brpc::Controller cntl;
+    MockClosure closure;
+
+    // Rejection moved to the public entry (admission gate): force_reject makes it SetFailed
+    // and restore the inflight count, instead of the private worker which no longer rejects.
+    service.exec_plan_fragment(&cntl, &request, &response, &closure);
+
+    ASSERT_TRUE(cntl.Failed());
+    ASSERT_EQ(brpc::EINTERNAL, cntl.ErrorCode());
+    ASSERT_EQ("[E2001]BE is shutting down", cntl.ErrorText());
+
+    k_starrocks_exit.store(false);
+    k_starrocks_force_reject.store(false);
+}
+
+TEST_F(InternalServiceTest, test_exec_batch_plan_fragments_rejected_while_shutting_down) {
+    k_starrocks_exit.store(true);
+    k_starrocks_force_reject.store(true);
+
+    orchestration::OrchestrationEnv orchestration_env;
+    BackendInternalServiceImpl<PInternalService> service(ExecEnv::GetInstance(), &orchestration_env,
+                                                         _load_channel_mgr.get());
+
+    PExecBatchPlanFragmentsRequest request;
+    PExecBatchPlanFragmentsResult response;
+    brpc::Controller cntl;
+    MockClosure closure;
+
+    // Rejection moved to the public entry (admission gate), same as exec_plan_fragment.
+    service.exec_batch_plan_fragments(&cntl, &request, &response, &closure);
+
+    ASSERT_TRUE(cntl.Failed());
+    ASSERT_EQ(brpc::EINTERNAL, cntl.ErrorCode());
+    ASSERT_EQ("[E2001]BE is shutting down", cntl.ErrorText());
+
+    k_starrocks_exit.store(false);
+    k_starrocks_force_reject.store(false);
+}
+
+TEST_F(InternalServiceTest, test_drain_resample_observes_successor_after_predecessor_release) {
+    // Drain reads shutdown_work first, then registries. Hold one predecessor, then at
+    // before_query_read publish this test's query and drop the predecessor so the
+    // re-sample must still see the successor (never a false zero).
+    // before+1 / before assumes this fixture is serial: no sibling test mutates
+    // shutdown_work during the sample. Not a process-wide invariant.
+    orchestration::OrchestrationEnv orchestration_env;
+    orchestration_env.set_exec_env_for_test(ExecEnv::GetInstance());
+
+    TUniqueId query_id = UniqueId::gen_uid().to_thrift();
+    std::atomic<bool> registered_query{false};
+
+    const size_t before = shutdown_work_inflight();
+    std::atomic<bool> owns_shutdown_work{true};
+    inc_shutdown_work();
+    ASSERT_EQ(before + 1, shutdown_work_inflight());
+
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("OrchestrationEnv::_get_running_fragments_count:before_query_read",
+                                          [&](void* arg) {
+                                              auto st = ExecEnv::GetInstance()->query_context_mgr()->get_or_register(
+                                                      query_id,
+                                                      /*return_error_if_not_exist=*/false);
+                                              ASSERT_OK(st);
+                                              registered_query.store(true);
+                                              if (owns_shutdown_work.exchange(false)) {
+                                                  dec_shutdown_work();
+                                              }
+                                          });
+    DeferOp clear_sync_point([&] {
+        SyncPoint::GetInstance()->ClearCallBack("OrchestrationEnv::_get_running_fragments_count:before_query_read");
+        SyncPoint::GetInstance()->DisableProcessing();
+        if (registered_query.load()) {
+            ExecEnv::GetInstance()->query_context_mgr()->remove(query_id);
+        }
+        if (owns_shutdown_work.exchange(false)) {
+            dec_shutdown_work();
+        }
+    });
+
+    size_t count = orchestration_env.get_running_fragments_count_for_test();
+    ASSERT_GT(count, 0);
+    ASSERT_FALSE(owns_shutdown_work.load());
+    ASSERT_EQ(before, shutdown_work_inflight());
+}
+
+TEST_F(InternalServiceTest, test_quick_exit_still_counts_pipeline_query) {
+    ASSERT_NE(nullptr, ExecEnv::GetInstance()->query_context_mgr());
+    orchestration::OrchestrationEnv orchestration_env;
+    orchestration_env.set_exec_env_for_test(ExecEnv::GetInstance());
+
+    TUniqueId query_id = UniqueId::gen_uid().to_thrift();
+    ASSERT_OK(ExecEnv::GetInstance()->query_context_mgr()->get_or_register(query_id, false));
+    auto* metrics = StreamLoadMetrics::instance();
+    const auto stream_before = metrics->streaming_load_current_processing.value();
+    metrics->streaming_load_current_processing.increment(1);
+    inc_shutdown_work();
+    DeferOp restore([&] {
+        ExecEnv::GetInstance()->query_context_mgr()->remove(query_id);
+        metrics->streaming_load_current_processing.set_value(stream_before);
+        dec_shutdown_work();
+        k_starrocks_quick_exit.store(false);
+    });
+
+    ASSERT_TRUE(set_process_quick_exit());
+    EXPECT_GE(orchestration_env.get_running_fragments_count_for_test(), 1);
+
+    k_starrocks_quick_exit.store(false);
+    EXPECT_GE(orchestration_env.get_running_fragments_count_for_test(), 2);
 }
 
 } // namespace starrocks

--- a/docs/en/administration/configuration/BE_parameters/log_server_meta.md
+++ b/docs/en/administration/configuration/BE_parameters/log_server_meta.md
@@ -384,6 +384,24 @@ This topic introduces the following types of BE configurations:
 - Description: Sets the number of worker threads for the "get_pindex" thread pool in UpdateManager, which is used to load / fetch persistent index data (used when applying rowsets for primary-key tables). At runtime, a config update will adjust the pool's maximum threads: if `>0` that value is applied; if 0 the runtime callback uses the number of CPU cores (CpuInfo::num_cores()). On initialization the pool's max threads is computed as max(get_pindex_worker_count, max_apply_thread_cnt * 2) where max_apply_thread_cnt is the apply-thread pool maximum. Increase to raise parallelism for pindex loading; lowering reduces concurrency and memory/CPU usage.
 - Introduced in: v3.2.0
 
+### graceful_exit_reject_delay_ms
+
+- Default: 10000
+- Type: Int64
+- Unit: ms
+- Is mutable: Yes
+- Description: Delay (in milliseconds) during which the BE keeps accepting new work (new BEGINs, new loads, new fragments, routine load tasks, and short-circuit queries) after a new FE has acknowledged the shutdown, before the BE starts rejecting new requests. A new FE acknowledges shutdown when the `LastHeartbeat` value echoed in the next heartbeat request grows; the first value from that FE is only a baseline and does not open this window. The window also closes when `graceful_exit_reject_fallback_ms` expires. During this window the BE keeps accepting and running new requests as a healthy node, including new transaction BEGINs.
+- Introduced in: -
+
+### graceful_exit_reject_fallback_ms
+
+- Default: 15000
+- Type: Int64
+- Unit: ms
+- Is mutable: Yes
+- Description: The absolute upper bound (in milliseconds) from the start of a graceful exit before the BE rejects new requests (query fragments, stream loads, transaction BEGINs, routine load tasks, and short-circuit queries), even if no FE acknowledgement (growing `LastHeartbeat`) was observed. It also caps the acknowledgement-based admission window. This avoids unbounded acceptance and must fire before the drain wait budget (`loop_count_wait_fragments_finish` x 10s).
+- Introduced in: -
+
 ### heartbeat_service_port
 
 - Default: 9050

--- a/docs/en/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/en/administration/configuration/BE_parameters/shared_lake_other.md
@@ -70,11 +70,11 @@ This topic introduces the following types of BE configurations:
 
 ### graceful_exit_wait_for_frontend_heartbeat
 
-- Default: false
+- Default: true
 - Type: Boolean
 - Unit: -
-- Is mutable: Yes
-- Description: Determines whether to await at least one frontend heartbeat response indicating SHUTDOWN status before completing graceful exit. When enabled, the graceful shutdown process remains active until a SHUTDOWN confirmation is responded via heartbeat RPC, ensuring the frontend has sufficient time to detect the termination state between two regular heartbeat intervals.
+- Is mutable: No
+- Description: If true, the BE waits for a new FE to acknowledge the shutdown via a growing `LastHeartbeat` value echoed in the heartbeat request (the first value from that FE is only a baseline) and then keeps accepting new requests for a `graceful_exit_reject_delay_ms` window before rejecting them. A legacy FE that does not carry the field falls back to the optimistic behavior (the delay opens when the shutdown heartbeat response is constructed). If false, the BE starts rejecting new requests as soon as graceful shutdown begins, without waiting for FE acknowledgement. Already-begun transactions continue to be accepted during the drain window regardless of this setting. New BEGINs are still accepted during the delay.
 - Introduced in: v3.4.5
 
 ### lake_compaction_stream_buffer_size_bytes
@@ -255,11 +255,11 @@ This topic introduces the following types of BE configurations:
 
 ### loop_count_wait_fragments_finish
 
-- Default: 2
-- Type: Int
+- Default: 6
+- Type: Int64
 - Unit: -
 - Is mutable: Yes
-- Description: The number of loops to be waited when the BE/CN process exits. Each loop is a fixed interval of 10 seconds. You can set it to `0` to disable the loop wait. From v3.4 onwards, this item is changed to mutable and its default value is changed from `0` to `2`.
+- Description: The number of loops to be waited when the BE/CN process exits. Each loop is a fixed interval of 10 seconds. You can set it to `0` to disable the loop wait.
 - Introduced in: v2.5
 
 ### max_client_cache_size_per_host

--- a/docs/en/administration/management/graceful_exit.md
+++ b/docs/en/administration/management/graceful_exit.md
@@ -14,7 +14,7 @@ Graceful Exit is a mechanism designed to support **non-disruptive upgrades and r
 
 Graceful Exit ensures that:
 
-- The node **stops accepting new tasks** once exit begins;
+- FE **stops accepting new work** when graceful exit begins; BE/CN stop accepting new work after their configured admission window.
 - Existing queries and load jobs are **allowed to complete** within a controlled time window;
 - System components (FE/BE/CN) **coordinate status changes** so that the cluster correctly reroutes traffic.
 
@@ -83,12 +83,14 @@ This sends a `SIGTERM` signal, while the default exit (without the `-g` option) 
 After receiving the signal:
 
 - The BE/CN node marks itself as **exiting**.
-- It rejects **new query fragments** by returning `INTERNAL_ERROR`.
-- It continues processing existing fragments.
+- When `graceful_exit_wait_for_frontend_heartbeat` is `true`, it keeps accepting new requests until whichever comes first: the admission delay after the FE has acknowledged the shutdown (observed as a growing `LastHeartbeat` value echoed back in the heartbeat request; the first value from that FE is only a baseline), or the fallback deadline measured from the start of the graceful shutdown. Within this admission window, new transaction BEGINs are still accepted; a new BEGIN that arrives after the cutoff is redirected (HTTP 307) to the FE leader only if the FE has already acknowledged the shutdown; if the cutoff is the fallback deadline with no acknowledgement, or redirect is disabled, the BEGIN returns SERVICE_UNAVAILABLE JSON instead of HTTP 307. If a different FE leader starts acknowledging during the shutdown (leader handover), the redirect path is disabled for the rest of this shutdown and requests receive an explicit error instead.
+- When `graceful_exit_wait_for_frontend_heartbeat` is `false`, it starts rejecting new requests as soon as graceful shutdown begins.
+- It then rejects **new requests** (query fragments, stream loads, transaction BEGINs, routine load tasks, and short-circuit queries) and continues processing admitted ones.
+- Operations (LOAD, PREPARE, COMMIT, ROLLBACK) of a transaction whose BEGIN already succeeded continue to be served on its original coordinator while the drain is active.
 
 #### Wait Loop for In-Flight Queries
 
-The behavior that BE/CN waits for existing fragments to finish is controlled by the BE/CN configuration `loop_count_wait_fragments_finish` (Default: 2). The actual wait duration equals `loop_count_wait_fragments_finish × 10 seconds` (that is, 20 seconds by default). If fragments remain after timeout, BE/CN proceeds with normal shutdown (closing threads, network, and other processes).
+The BE/CN waits for admitted work (query fragments, loads, and short-circuit queries) for at most `loop_count_wait_fragments_finish × 10 seconds` (60 seconds by default). When this hard budget expires, BE/CN closes admission and proceeds with teardown; any remaining admitted work is not guaranteed to finish. Load channels on a receiving BE (which may hold no local query or transaction context) are also counted as admitted work, so a write-only replica is not torn down while its channels are still draining.
 
 #### Improved FE Awareness
 
@@ -115,20 +117,34 @@ From v3.4 onwards, FE no longer marks BE/CN as `DEAD` based on heartbeat failure
 #### `loop_count_wait_fragments_finish`
 
 - Description: BE/CN wait duration for existing fragments. Multiply the value with 10 seconds.
-- Default: 2
+- Default: 6
 - How to apply: Modify it in the BE/CN configuration file or update it dynamically.
 
 #### `graceful_exit_wait_for_frontend_heartbeat`
 
-- Description: Whether BE/CN waits for FE to confirm **SHUTDOWN** via heartbeat. From v3.4.5 onwards.
-- Default: false
+- Description: If true, the BE waits until a new FE has acknowledged the shutdown (a growing `LastHeartbeat` value echoed back in the heartbeat request; the first value from that FE is only a baseline) and then keeps accepting new requests for a `graceful_exit_reject_delay_ms` window before rejecting them. A legacy FE that does not carry the field falls back to the optimistic behavior (the delay opens when the shutdown heartbeat response is constructed). If false, the BE starts rejecting new requests as soon as graceful shutdown begins. Already-begun transactions continue to be accepted during the drain window regardless of this setting. New BEGINs are still accepted during the delay.
+- Default: true
+- How to apply: Modify it in the BE/CN configuration file. Requires a BE/CN restart to take effect.
+
+#### `graceful_exit_reject_delay_ms`
+
+- Description: Delay (in ms) during which the BE/CN keeps accepting new work (new BEGINs, new loads, new fragments) after a new FE acknowledged the shutdown via a growing `LastHeartbeat`, before it starts rejecting new requests. The first value from that FE is only a baseline and does not open this window. During this window the node keeps accepting and running new requests as a healthy node, giving the FE time to stop scheduling new fragments to it.
+- Default: 10000
 - How to apply: Modify it in the BE/CN configuration file or update it dynamically.
+- Timing relationship: Must be shorter than the drain budget `loop_count_wait_fragments_finish` x 10s so rejection starts before the wait expires.
+
+#### `graceful_exit_reject_fallback_ms`
+
+- Description: Absolute upper bound (in ms) from the start of a graceful exit before the BE/CN rejects new requests, even if no FE acknowledgement (growing `LastHeartbeat`) was observed. It also caps the acknowledgement-based admission window, and it guards against unbounded acceptance when the FE never or very late observes the shutdown.
+- Default: 15000
+- How to apply: Modify it in the BE/CN configuration file or update it dynamically.
+- Timing relationship: Must be smaller than the drain budget `loop_count_wait_fragments_finish` x 10s (60000 by default) so new requests stop being accepted before the drain wait expires.
 
 #### `stop_be.sh -g --timeout`, `stop_cn.sh -g --timeout`
 
-- Description: Maximum waiting time before BE/CN is force-killed. Set it to a value larger than `loop_count_wait_fragments_finish` * 10 to prevent termination before the BE/CN wait duration is reached.
+- Description: Maximum waiting time before BE/CN is force-killed. Size it for the whole graceful-exit sequence: draining admitted work (`loop_count_wait_fragments_finish` × 10s), later storage cleanup, and other stop/join steps. Leave headroom for configured budgets and actual duration. `--timeout 300` is an example, not a guarantee that the process finishes within 300 seconds.
 - Default: false
-- How to apply: Specify it in the script command, for example, `--timeout 30`.
+- How to apply: Specify it in the script command, for example, `--timeout 300`.
 
 ### Global Switches
 
@@ -182,7 +198,6 @@ Graceful Exit ensures:
 **Configuration**:
 
 - Make sure `loop_count_wait_fragments_finish` is set to a positive integer.
-- Set `graceful_exit_wait_for_frontend_heartbeat` to `true` allow FE to detect BE's "EXITING" state.
 
 ### Perform FE Graceful Exit
 
@@ -275,4 +290,4 @@ If tasks fail to complete within the Graceful Exit period, BE/CN will trigger fo
 
 ### Node status is not SHUTDOWN
 
-If the node status is not `SHUTDOWN`, verify whether `loop_count_wait_fragments_finish` is set to a positive integer, or if BE/CN reported a heartbeat before exiting (if not, set `graceful_exit_wait_for_frontend_heartbeat` to `true`).
+If the node status is not `SHUTDOWN`, verify that `loop_count_wait_fragments_finish` is positive and that the BE reported its shutdown state through heartbeat.

--- a/docs/en/administration/management/graceful_exit.md
+++ b/docs/en/administration/management/graceful_exit.md
@@ -254,7 +254,7 @@ LB removes the node after receiving consecutive non-200 responses.
   ./bin/stop_cn.sh -g --timeout 600
   ```
 
-BE/CN exits immediately if no fragments remain.
+With the default heartbeat admission window, an idle BE/CN still waits until the delay or fallback cutoff. After cutoff it exits when no drain-visible work remains (query fragments, admitted loads, and load channels). The drain budget remains a hard limit.
 
 #### Validate BE/CN Status
 

--- a/docs/ja/administration/configuration/BE_parameters/log_server_meta.md
+++ b/docs/ja/administration/configuration/BE_parameters/log_server_meta.md
@@ -309,6 +309,24 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 説明: UpdateManager の "get_pindex" スレッドプールのワーカースレッド数を設定します。このプールは永続インデックスデータをロード／取得するために使用され（主キー表の rowset 適用時に使用）、実行時の設定更新はプールの最大スレッド数を調整します：`>0` の場合はその値が適用され、0 の場合はランタイムコールバックが CPU コア数（`CpuInfo::num_cores()`）を使用します。初期化時にはプールの最大スレッド数は max(get_pindex_worker_count, max_apply_thread_cnt * 2) として計算され、ここで max_apply_thread_cnt は apply-thread プールの最大値です。pindex ロードの並列度を上げるには増やし、同時実行性とメモリ／CPU 使用量を減らすには減らしてください。
 - 導入バージョン: v3.2.0
 
+### graceful_exit_reject_delay_ms
+
+- デフォルト: 10000
+- タイプ: Int64
+- 単位: ms
+- 変更可能: はい
+- 説明: 新しい FE がハートビートリクエストで返される `LastHeartbeat` 値の増加によってシャットダウンを確認した後、BE が新しいリクエスト（クエリフラグメント、Stream Load、トランザクション BEGIN、Routine Load タスク、short-circuit クエリ）の拒否を開始するまでの、新しい処理を受け入れ続ける遅延（ミリ秒）。ある FE からの最初の値は baseline に過ぎず、このウィンドウは開きません。ウィンドウは `graceful_exit_reject_fallback_ms` の期限でも閉じます。この期間中、BE は正常なノードとして新しいリクエスト（新しい BEGIN を含む）を受け入れて実行し続けます。
+- 導入バージョン: -
+
+### graceful_exit_reject_fallback_ms
+
+- デフォルト: 15000
+- タイプ: Int64
+- 単位: ms
+- 変更可能: はい
+- 説明: グレースフルシャットダウン開始から、FE の確認（`LastHeartbeat` の増加）がない場合でも BE が新しいリクエスト（クエリフラグメント、Stream Load、トランザクション BEGIN、Routine Load タスク、short-circuit クエリ）を拒否するまでの絶対上限（ミリ秒）。確認に基づく admission ウィンドウも制限し、無制限な受け入れを避けます。排空待機予算（`loop_count_wait_fragments_finish` × 10 秒）より前に発動する必要があります。
+- 導入バージョン: -
+
 ### heartbeat_service_port
 
 - デフォルト: 9050

--- a/docs/ja/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/configuration/BE_parameters/shared_lake_other.md
@@ -70,11 +70,11 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 
 ### graceful_exit_wait_for_frontend_heartbeat
 
-- デフォルト: false
+- デフォルト: true
 - タイプ: Boolean
 - 単位: -
-- 変更可能: Yes
-- 説明: グレースフルシャットダウンを完了する前に、少なくとも1件のフロントエンドからの heartbeat 応答で SHUTDOWN 状態が返されるのを待つかどうかを決定します。有効にすると、heartbeat RPC を介して SHUTDOWN の確認が返されるまでグレースフルシャットダウン処理は継続され、フロントエンドが通常の2回のハートビート間隔内で終了状態を検出するための十分な時間を確保します。
+- 変更可能: いいえ
+- 説明: true の場合、BE は新しい FE がハートビートリクエストで返される `LastHeartbeat` 値の増加によってシャットダウンを確認するまで待機し（ある FE からの最初の値は baseline に過ぎません）、その後 `graceful_exit_reject_delay_ms` の間新しいリクエストを受け入れ続けてから拒否を開始します。フィールドを持たない旧バージョンの FE は楽観的な互換動作にフォールバックします（シャットダウン heartbeat 応答の構築時に遅延が開始されます）。false の場合、BE は Graceful Shutdown 開始と同時に新しいリクエストの拒否を開始し、FE の確認を待ちません。既に BEGIN されたトランザクションは、この設定にかかわらず排空ウィンドウ中は引き続き受け入れられます。delay 中の新しい BEGIN も引き続き受け入れられます。
 - 導入バージョン: v3.4.5
 
 ### lake_compaction_stream_buffer_size_bytes
@@ -255,11 +255,11 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 
 ### loop_count_wait_fragments_finish
 
-- デフォルト: 2
-- タイプ: Int
+- デフォルト: 6
+- タイプ: Int64
 - 単位: -
 - 変更可能: Yes
-- 説明: BE/CN プロセスが終了する際に待機するループ回数。各ループは固定間隔の 10 秒です。ループ待機を無効にするには `0` に設定できます。v3.4 以降、この項目は変更可能になり、デフォルト値は `0` から `2` に変更されました。
+- 説明: BE/CN プロセスが終了する際に待機するループ回数。各ループは固定間隔の 10 秒です。ループ待機を無効にするには `0` に設定できます。
 - 導入バージョン: v2.5
 
 ### starlet_filesystem_instance_cache_capacity

--- a/docs/ja/administration/management/graceful_exit.md
+++ b/docs/ja/administration/management/graceful_exit.md
@@ -254,7 +254,7 @@ LB は連続して非 200 応答を受信した後にノードを削除します
   ./bin/stop_cn.sh -g --timeout 600
   ```
 
-BE/CN はフラグメントが残っていない場合、即座に終了します。
+デフォルトのハートビート admission ウィンドウでは、フラグメントがなくても BE/CN は delay または fallback の cutoff まで待ちます。cutoff 後は、drain 対象の処理（クエリフラグメント、admission 済みロード、Load Channel）がなくなったときに終了します。drain のハード上限は変わりません。
 
 #### BE/CN 状態の検証
 

--- a/docs/ja/administration/management/graceful_exit.md
+++ b/docs/ja/administration/management/graceful_exit.md
@@ -14,7 +14,7 @@ Graceful Exit は、StarRocks FE、BE、CN ノードの**非破壊的なアッ�
 
 Graceful Exit は以下を保証します：
 
-- ノードは、終了が始まると**新しいタスクの受け入れを停止**します。
+- FE はグレースフル終了の開始時に新しい作業の受け入れを停止します。BE/CN は設定された受付ウィンドウの終了後に新しい作業の受け入れを停止します。
 - 既存のクエリとロードジョブは、制御された時間枠内で**完了することが許可**されます。
 - システムコンポーネント（FE/BE/CN）は、クラスターが正しくトラフィックを再ルーティングするように**状態変更を調整**します。
 
@@ -82,13 +82,15 @@ stop_cn.sh -g
 
 シグナルを受信すると：
 
-- BE/CN ノードは自分自身を**EXITING**とマークします。
-- **新しいクエリフラグメント**を拒否し、`INTERNAL_ERROR` を返します。
-- 既存のフラグメントの処理を続行します。
+- BE/CN ノードは自身を**EXITING**とマークします。
+- `graceful_exit_wait_for_frontend_heartbeat` が `true` の場合、新しいリクエストを受け入れ続け、次のいずれか早い方で受け入れを停止します：FE がシャットダウンを確認した後（ハートビートリクエストで返される `LastHeartbeat` 値の増加により確認。ある FE からの最初の値は baseline に過ぎません）の admission 遅延、または Graceful Shutdown 開始から計測される fallback の期限。この admission ウィンドウ中は、新しいトランザクション BEGIN も引き続き受け入れられます。cutoff 後に到着した新しい BEGIN は、FE がすでにシャットダウンを確認している場合のみ HTTP 307 で FE リーダーにリダイレクトされます。cutoff が確認なしの fallback 期限である場合、またはリダイレクトが無効な場合は、HTTP 307 ではなく SERVICE_UNAVAILABLE JSON を返します。シャットダウン中に別の FE リーダーが確認を開始した場合（リーダー切り替え）、今回のシャットダウンの残りの間リダイレクトは無効化され、リクエストは明示的なエラーを受け取ります。
+- `graceful_exit_wait_for_frontend_heartbeat` が `false` の場合、Graceful Shutdown の開始と同時に新しいリクエストの拒否を開始します。
+- その後、**新しいリクエスト**（クエリフラグメント、Stream Load、トランザクション BEGIN、Routine Load タスク、short-circuit クエリ）を拒否し、すでに admission 済みの処理を続行します。
+- BEGIN が成功したトランザクションの LOAD、PREPARE、COMMIT、ROLLBACK は、drain が有効な間は元の coordinator で引き続き処理されます。
 
 #### フライト中のクエリの待機ループ
 
-BE/CN が既存のフラグメントの終了を待つ動作は、BE/CN の設定 `loop_count_wait_fragments_finish` によって制御されます（デフォルト：2）。実際の待機時間は `loop_count_wait_fragments_finish × 10 秒`（デフォルトでは 20 秒）です。タイムアウト後もフラグメントが残っている場合、BE/CN は通常のSHUTDOWNを続行します（スレッド、ネットワーク、その他のプロセスを閉じる）。
+BE/CN が admission 済みの処理（クエリフラグメント、ロード、short-circuit クエリ）を待機する時間は、`loop_count_wait_fragments_finish × 10 秒`（デフォルト 60 秒）を上限とします。このハード上限に達すると、BE/CN は新しいリクエストの admission を停止して teardown に進み、残っている admission 済みの処理が完了することは保証されません。書き込みを受信する BE 上の Load Channel（そのノードはローカルのクエリやトランザクションコンテキストを持たない場合がある）も admission 済みの処理としてカウントされるため、書き込み専用のレプリカノードは channel が drain 中でも早期に破棄されません。
 
 #### 改善された FE 認識
 
@@ -115,20 +117,34 @@ v3.4 以降、FE はハートビートの失敗に基づいて BE/CN を `DEAD` 
 #### `loop_count_wait_fragments_finish`
 
 - 説明：BE/CN が既存のフラグメントを待機する期間。値に 10 秒を掛けます。
-- デフォルト：2
+- デフォルト：6
 - 適用方法：BE/CN 設定ファイルで変更するか、動的に更新します。
 
 #### `graceful_exit_wait_for_frontend_heartbeat`
 
-- 説明：BE/CN がハートビートを介して FE が**SHUTDOWN**を確認するのを待つかどうか。v3.4.5 以降。
-- デフォルト：false
+- 説明：true の場合、BE は新しい FE がシャットダウンを確認するまで待機し（ハートビートリクエストで返される `LastHeartbeat` 値の増加により確認。ある FE からの最初の値は baseline に過ぎません）、その後 `graceful_exit_reject_delay_ms` の間新しいリクエストを受け入れ続けてから拒否を開始します。フィールドを持たない旧バージョンの FE は、楽観的な互換動作にフォールバックします（シャットダウン heartbeat 応答の構築時に遅延が開始されます）。false の場合、BE は Graceful Shutdown 開始と同時に新しいリクエストの拒否を開始します。既に BEGIN されたトランザクションは、この設定にかかわらず排空ウィンドウ中は引き続き受け入れられます。delay 中の新しい BEGIN も引き続き受け入れられます。
+- デフォルト：true
+- 適用方法：BE/CN 設定ファイルで変更します。BE/CN の再起動が必要です。
+
+#### `graceful_exit_reject_delay_ms`
+
+- 説明：新しい FE が `LastHeartbeat` の増加によってシャットダウンを確認した後、ノードが新しいリクエストの拒否を開始するまでの、新しい処理（新しい BEGIN、新しいロード、新しいフラグメント）を受け入れ続ける遅延（ミリ秒）。ある FE からの最初の値は baseline に過ぎず、このウィンドウは開きません。この期間中、ノードは正常なノードとして新しいリクエストを受け入れて実行し続け、FE がこのノードへの新しいフラグメントのスケジュールを停止する時間を確保します。
+- デフォルト：10000
 - 適用方法：BE/CN 設定ファイルで変更するか、動的に更新します。
+- タイミング関係：排空予算 `loop_count_wait_fragments_finish` × 10 秒より短く、待機が期限切れになる前に拒否が開始されるようにします。
+
+#### `graceful_exit_reject_fallback_ms`
+
+- 説明：FE の確認（`LastHeartbeat` の増加）がない場合でも、Graceful Exit の開始から BE/CN が新しいリクエストを拒否するまでの絶対上限（ミリ秒）。確認に基づく admission ウィンドウも制限し、FE が確認しない、または大幅に遅れて確認する場合の無制限な受け入れを防ぎます。
+- デフォルト：15000
+- 適用方法：BE/CN 設定ファイルで変更するか、動的に更新します。
+- タイミング関係：排空予算 `loop_count_wait_fragments_finish` × 10 秒（デフォルト 60000）より小さく、排空待機が期限切れになる前に新しいリクエストの受け入れが停止されるようにします。
 
 #### `stop_be.sh -g --timeout`, `stop_cn.sh -g --timeout`
 
-- 説明：BE/CN が強制終了されるまでの最大待機時間。BE/CN の待機期間に達する前に終了しないように、`loop_count_wait_fragments_finish` * 10 より大きい値に設定します。
+- 説明：BE/CN が強制終了されるまでの最大待機時間。Graceful Exit 全体の所要時間を見込んで設定します。受け入れ済み作業の排空（`loop_count_wait_fragments_finish` × 10 秒）、その後のストレージクリーンアップ、その他の stop/join を含みます。設定上の予算と実際の所要時間に余裕を持たせてください。`--timeout 300` は例であり、プロセスが 300 秒以内に安全に終了することを保証しません。
 - デフォルト：false
-- 適用方法：スクリプトコマンドで指定します。例：`--timeout 30`。
+- 適用方法：スクリプトコマンドで指定します。例：`--timeout 300`。
 
 ### グローバルスイッチ
 
@@ -182,7 +198,6 @@ Graceful Exit は以下を保証します：
 **設定**：
 
 - `loop_count_wait_fragments_finish` を正の整数に設定してください。
-- `graceful_exit_wait_for_frontend_heartbeat` を `true` に設定し、FE が BE の「EXITING」状態を検出できるようにします。
 
 ### FE Graceful Exit の実行
 
@@ -275,4 +290,4 @@ FE ログ `fe.log`、BE ログ `be.log`、または CN ログ `cn.log` を確認
 
 ### ノードの状態が SHUTDOWN でない
 
-ノードの状態が `SHUTDOWN` でない場合、`loop_count_wait_fragments_finish` が正の整数に設定されているか、BE/CN が終了前にハートビートを報告したかどうかを確認してください（そうでない場合、`graceful_exit_wait_for_frontend_heartbeat` を `true` に設定します）。
+ノードの状態が `SHUTDOWN` でない場合、`loop_count_wait_fragments_finish` が正の整数であり、BE が heartbeat を介してシャットダウン状態を報告したかどうかを確認してください。

--- a/docs/zh/administration/configuration/BE_parameters/log_server_meta.md
+++ b/docs/zh/administration/configuration/BE_parameters/log_server_meta.md
@@ -405,6 +405,24 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 描述：为 UpdateManager 中的 "get_pindex" 线程池设置工作线程数，该线程池用于加载/获取持久化索引数据（在为主键表应用 rowset 时使用）。如果设置为大于 0 则系统应用该值；如果设置为 0 则运行时回调使用 CPU 核心数。在初始化时，改线程池的最大线程数计算为 `max(get_pindex_worker_count, max_apply_thread_cnt * 2)`，其中 `max_apply_thread_cnt` 是 apply-thread 池的最大值。增大此值可提高 pindex 加载的并行度；降低则减少并发和内存/CPU 使用。
 - 引入版本：v3.2.0
 
+### graceful_exit_reject_delay_ms
+
+- 默认值：10000
+- 类型：Int64
+- 单位：ms
+- 是否动态：是
+- 描述：新 FE 通过心跳请求中回传的 `LastHeartbeat` 增长确认 shutdown 后，BE 在开始拒绝新请求（查询 Fragment、Stream Load、事务 BEGIN、Routine Load 任务和 short-circuit 查询）之前继续接受新工作的延迟（毫秒）。某个 FE 的首次 `LastHeartbeat` 值仅作为 baseline，不会打开该窗口。窗口也会在 `graceful_exit_reject_fallback_ms` 到期时关闭。该窗口内 BE 继续作为健康节点接受并运行新请求，包括新的事务 BEGIN。
+- 引入版本：-
+
+### graceful_exit_reject_fallback_ms
+
+- 默认值：15000
+- 类型：Int64
+- 单位：ms
+- 是否动态：是
+- 描述：从优雅退出开始起的绝对上限（毫秒），即使从未观察到 FE 确认（`LastHeartbeat` 增长），BE 也会在该时间点后拒绝新请求（查询 Fragment、Stream Load、事务 BEGIN、Routine Load 任务和 short-circuit 查询）。该上限同时截断基于确认的准入窗口，避免无限期接受新请求，且必须早于排空等待预算（`loop_count_wait_fragments_finish` x 10s）触发。
+- 引入版本：-
+
 ### heartbeat_service_port
 
 - 默认值：9050

--- a/docs/zh/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/configuration/BE_parameters/shared_lake_other.md
@@ -67,11 +67,11 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 
 ### graceful_exit_wait_for_frontend_heartbeat
 
-- 默认值：false
-- 类型： Boolean
+- 默认值：true
+- 类型：Boolean
 - 单位：-
-- 是否动态：是
-- 描述： 确定是否在完成优雅退出前等待至少一个指示SHUTDOWN状态的FE心跳响应。启用后，优雅关闭进程将持续运行直至通过心跳RPC返回给FE SHUTDOWN状态变化，确保FE在两次常规心跳探测间隔期间有足够时间感知终止状态。
+- 是否动态：否
+- 描述：如果为 true，BE 等待新 FE 通过心跳请求中回传的 `LastHeartbeat` 增长确认 shutdown（某个 FE 的首次值仅作为 baseline），然后在 `graceful_exit_reject_delay_ms` 窗口内继续接受新请求，之后开始拒绝。不带该字段的旧版本 FE 沿用乐观兼容行为（shutdown 心跳响应构造时即打开 delay）。如果为 false，BE 在 graceful shutdown 开始时立即拒绝新请求，不等待 FE 确认。已成功 BEGIN 的事务在排空窗口内继续被接受，不受此设置影响。delay 内新 BEGIN 仍被接受。
 - 引入版本：v3.4.5
 
 ### lake_compaction_stream_buffer_size_bytes
@@ -252,11 +252,11 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 
 ### loop_count_wait_fragments_finish
 
-- 默认值：2
-- 类型：Int
+- 默认值：6
+- 类型：Int64
 - 单位：-
 - 是否动态：是
-- 描述：BE/CN 退出时需要等待正在执行的查询完成的轮次，一轮次固定 10 秒。设置为 `0` 表示禁用轮询等待，立即退出。自 v3.4 起，该参数变为动态参数，且默认值由 `0` 变为 `2`。
+- 描述：BE/CN 退出时需要等待正在执行的查询完成的轮次，一轮次固定 10 秒。设置为 `0` 表示禁用轮询等待。
 - 引入版本：v2.5
 
 ### max_client_cache_size_per_host

--- a/docs/zh/administration/management/graceful_exit.md
+++ b/docs/zh/administration/management/graceful_exit.md
@@ -254,7 +254,7 @@ LB 在收到连续的非 200 响应后移除节点。
   ./bin/stop_cn.sh -g --timeout 600
   ```
 
-如果没有 Fragment 剩余，BE/CN 会立即退出。
+默认开启心跳准入窗口时，即使没有 Fragment，BE/CN 仍会等到 delay 或 fallback cutoff。cutoff 之后，仅当没有 drain 可见工作（查询 Fragment、已准入 Load、Load Channel）时才退出。drain 预算仍是硬上限。
 
 #### 验证 BE/CN 状态
 

--- a/docs/zh/administration/management/graceful_exit.md
+++ b/docs/zh/administration/management/graceful_exit.md
@@ -14,7 +14,7 @@ description: "StarRocks FE、BE 和 CN 节点支持优雅退出，实现无中�
 
 优雅退出确保：
 
-- 节点在退出开始后**停止接受新任务**；
+- FE 在优雅退出开始时停止接受新工作；BE/CN 在其配置的准入窗口结束后停止接受新工作。
 - 现有查询和导入作业在控制的时间窗口内**允许完成**；
 - 系统组件（FE/BE/CN）**协调状态变化**，以便集群正确地重新路由流量。
 
@@ -83,12 +83,14 @@ stop_cn.sh -g
 收到信号后：
 
 - BE/CN 节点将自身标记为**Exiting**。
-- 它通过返回 `INTERNAL_ERROR` 拒绝**新的查询 Fragment**。
-- 它继续处理现有Fragment。
+- 当 `graceful_exit_wait_for_frontend_heartbeat` 为 `true` 时，继续接受新请求，直到以下两者中的先到者：FE 确认 shutdown（心跳请求中回传的 `LastHeartbeat` 值出现增长；某个 FE 的首次值仅作为 baseline）后的 admission 延迟，或从 graceful shutdown 开始计算的 fallback 截止时间。在该准入窗口内，新的事务 BEGIN 仍被接受；cutoff 后到达的新 BEGIN：仅当 FE 已确认 shutdown 时才 HTTP 307 到 FE leader 以重选 coordinator；若 cutoff 来自 fallback 且从未确认，或 redirect 已禁用，则返回 SERVICE_UNAVAILABLE JSON 而不是 307。如果 shutdown 期间另一个 FE leader 开始确认（leader 切换），本次退出后续将禁用重定向，请求会收到明确的错误。
+- 当 `graceful_exit_wait_for_frontend_heartbeat` 为 `false` 时，从 graceful shutdown 开始时立即拒绝新请求。
+- 随后拒绝**新请求**（查询 Fragment、Stream Load、事务 BEGIN、Routine Load 任务和 short-circuit 查询），并继续处理已经准入的请求。
+- 已成功 BEGIN 的事务，其 LOAD、PREPARE、COMMIT 和 ROLLBACK 在 drain 活动期间仍由原 coordinator 继续服务。
 
 #### 等待进行中的查询循环
 
-BE/CN 等待现有 Fragment 完成的行为由 BE/CN 配置 `loop_count_wait_fragments_finish` 控制（默认值：2）。实际等待时间等于 `loop_count_wait_fragments_finish × 10 秒`（即默认 20 秒）。如果 Fragment 在超时后仍然存在，BE/CN 将继续正常关闭（关闭线程、网络和其他进程）。
+BE/CN 等待已准入工作（查询 Fragment、Load 和 short-circuit 查询）的时间最多为 `loop_count_wait_fragments_finish × 10 秒`（默认 60 秒）。达到该硬性预算后，BE/CN 关闭新请求准入并继续 teardown；剩余已准入工作不保证完成。接收写入的 BE 上的 Load Channel（该节点可能没有任何本地查询或事务上下文）同样计入已准入工作，因此只负责写入的副本节点不会在 channel 仍在排空时被提前销毁。
 
 #### 改进的 FE 感知
 
@@ -115,20 +117,34 @@ BE/CN 等待现有 Fragment 完成的行为由 BE/CN 配置 `loop_count_wait_fra
 #### `loop_count_wait_fragments_finish`
 
 - 描述：BE/CN 等待现有 Fragment 的持续时间。将该值乘以 10 秒。
-- 默认值：2
+- 默认值：6
 - 如何应用：在 BE/CN 配置文件中修改或动态更新。
 
 #### `graceful_exit_wait_for_frontend_heartbeat`
 
-- 描述：BE/CN 是否等待 FE 通过心跳确认 **SHUTDOWN**。从 v3.4.5 开始支持。
-- 默认值：false
+- 描述：如果为 true，BE 等待新 FE 确认 shutdown（心跳请求中回传的 `LastHeartbeat` 值出现增长；某个 FE 的首次值仅作为 baseline）后，在 `graceful_exit_reject_delay_ms` 窗口内继续接受新请求，之后开始拒绝。不带该字段的旧版本 FE 沿用乐观兼容行为（shutdown 心跳响应构造时即认为 FE 可观察到）。如果为 false，BE 在 graceful shutdown 开始时立即拒绝新请求。已成功 BEGIN 的事务在排空窗口内继续被接受，不受此设置影响。delay 内新 BEGIN 仍被接受。
+- 默认值：true
+- 如何应用：在 BE/CN 配置文件中修改。需要重启 BE/CN 生效。
+
+#### `graceful_exit_reject_delay_ms`
+
+- 描述：新 FE 通过 `LastHeartbeat` 增长确认 shutdown 后，BE/CN 在开始拒绝新请求之前继续接受新工作（新 BEGIN、新 Load、新 Fragment）的延迟（毫秒）。某个 FE 的首次值仅作为 baseline，不会打开该窗口。在此期间节点作为健康节点继续接受并运行新请求，给 FE 足够时间停止向该节点调度新的 Fragment。
+- 默认值：10000
 - 如何应用：在 BE/CN 配置文件中修改或动态更新。
+- 时序关系：必须小于排空预算 `loop_count_wait_fragments_finish` × 10 秒，以便在等待超时前开始拒绝。
+
+#### `graceful_exit_reject_fallback_ms`
+
+- 描述：优雅退出开始后，即使从未观察到 FE 确认（`LastHeartbeat` 增长），BE/CN 拒绝新请求的绝对上限（毫秒）。它同时限制基于确认的准入窗口，防止 FE 从不确认或过晚确认时无限接受新请求。
+- 默认值：15000
+- 如何应用：在 BE/CN 配置文件中修改或动态更新。
+- 时序关系：必须小于排空预算 `loop_count_wait_fragments_finish` × 10 秒（默认 60000），以便新请求在排空等待超时前停止被接受。
 
 #### `stop_be.sh -g --timeout`, `stop_cn.sh -g --timeout`
 
-- 描述：BE/CN 被强制终止前的最大等待时间。将其设置为大于 `loop_count_wait_fragments_finish` * 10 的值，以防止在 BE/CN 等待时间到达之前终止。
+- 描述：BE/CN 被强制终止前的最大等待时间。应按整个优雅退出流程预留：已准入工作排空（`loop_count_wait_fragments_finish` × 10 秒）、后续存储清理，以及其他 stop/join。按配置预算与实际耗时留余量。`--timeout 300` 只是示例，不保证进程能在 300 秒内安全退出。
 - 默认值：false
-- 如何应用：在脚本命令中指定，例如 `--timeout 30`。
+- 如何应用：在脚本命令中指定，例如 `--timeout 300`。
 
 ### 全局开关
 
@@ -182,7 +198,6 @@ BE/CN 等待现有 Fragment 完成的行为由 BE/CN 配置 `loop_count_wait_fra
 **配置**：
 
 - 确保 `loop_count_wait_fragments_finish` 设置为正整数。
-- 将 `graceful_exit_wait_for_frontend_heartbeat` 设置为 `true` 以允许 FE 检测 BE 的“Exiting”状态。
 
 ### 执行 FE 优雅退出
 
@@ -275,4 +290,4 @@ SHOW BACKENDS;
 
 ### 节点状态不是 SHUTDOWN
 
-如果节点状态不是 `SHUTDOWN`，请验证 `loop_count_wait_fragments_finish` 是否设置为正整数，或者 BE/CN 在退出前是否报告了心跳（如果没有，请将 `graceful_exit_wait_for_frontend_heartbeat` 设置为 `true`）。
+如果节点状态不是 `SHUTDOWN`，请验证 `loop_count_wait_fragments_finish` 是否为正整数，以及 BE 是否通过心跳报告了关闭状态。

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
@@ -264,7 +264,8 @@ public class TransactionLoadAction extends RestBaseAction {
         if (null == redirectAddress) {
             // TODO This must be a transaction stream load. Should refactor the code to make it clearer.
             ComputeNode node = TXN_BEGIN.equals(txnOperation) ?
-                    coordinatorMgr.allocate(label, txnOperationParams.getWarehouseName()) :
+                    coordinatorMgr.allocate(label, txnOperationParams.getWarehouseName(),
+                            txnOperationParams.getDbName()) :
                     coordinatorMgr.get(label, txnOperationParams.getDbName());
 
             redirectAddress = new TNetworkAddress(node.getHost(), node.getHttpPort());

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadCoordinatorMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadCoordinatorMgr.java
@@ -19,11 +19,13 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.VisibleForTesting;
 import com.starrocks.catalog.Database;
 import com.starrocks.common.Config;
+import com.starrocks.common.LabelAlreadyUsedException;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.transaction.TransactionState;
+import com.starrocks.transaction.TransactionStatus;
 import com.starrocks.warehouse.cngroup.CRAcquireContext;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
@@ -123,17 +125,35 @@ public class TransactionLoadCoordinatorMgr {
      *
      * @param label         the transaction label
      * @param warehouseName the name of the warehouse
+     * @param dbName        the database name, used to look up the transaction state
      * @return the allocated {@link ComputeNode}
      * @throws StarRocksException if allocation fails or no suitable node is found
      */
-    public @NonNull ComputeNode allocate(String label, String warehouseName) throws StarRocksException {
-        // Check if the label already exists in cache to avoid overwriting
-        // This ensures that repeated BEGIN requests for the same label
-        // are routed to the same BE where the transaction context exists
+    public @NonNull ComputeNode allocate(String label, String warehouseName, String dbName)
+            throws StarRocksException {
+        // Return the cached coordinator while it is available: repeated BEGINs for the same
+        // label keep reaching the BE that owns the stream context and fail with the normal
+        // LABEL_ALREADY_EXISTS error there.
         Long existingNodeId = cache.getIfPresent(label);
         if (existingNodeId != null) {
-            return getNodeFromId(existingNodeId);
+            // A node missing from the cluster (dropped) propagates the error; only a node
+            // that is still registered but unavailable falls through to the guard below.
+            ComputeNode node = getNodeFromId(existingNodeId);
+            if (node.isAvailable()) {
+                return node;
+            }
         }
+
+        // Before picking a new coordinator, stop retries of a label that already owns a live
+        // transaction: selecting another node would orphan the original transaction's
+        // LOAD/COMMIT routing, and redirecting the retry back to its (unavailable)
+        // coordinator would bounce 307s between FE and that BE. The cache is left untouched
+        // so the live transaction's later LOAD/COMMIT still resolve to its original owner.
+        TransactionState txnState = getLabelTransactionState(label, dbName);
+        if (txnState != null && txnState.getTransactionStatus() != TransactionStatus.ABORTED) {
+            throw new LabelAlreadyUsedException(label, txnState.getTransactionStatus());
+        }
+        cache.invalidate(label);
 
         final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
         final CRAcquireContext acquireContext = CRAcquireContext.of(warehouseName);
@@ -143,6 +163,18 @@ public class TransactionLoadCoordinatorMgr {
         ComputeNode node = getNodeFromId(chosenNodeId);
         cache.put(label, chosenNodeId);
         return node;
+    }
+
+    /**
+     * Returns the FE transaction state for the label, or null when there is none.
+     */
+    private TransactionState getLabelTransactionState(String label, String dbName) throws StarRocksException {
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        Database db = globalStateMgr.getLocalMetastore().getDb(dbName);
+        if (db == null) {
+            return null;
+        }
+        return globalStateMgr.getGlobalTransactionMgr().getLabelTransactionState(db.getId(), label);
     }
 
     /**
@@ -160,7 +192,7 @@ public class TransactionLoadCoordinatorMgr {
     }
 
     /**
-     * Remove key form cache. It is only used in test cases
+     * Remove key form cache.
      *
      * @param label  the transaction label
      */
@@ -170,7 +202,7 @@ public class TransactionLoadCoordinatorMgr {
     }
 
     /**
-     * Calculate the length of the cache. It is only used in test cases
+     * Calculate the length of the cache.
      */
     @VisibleForTesting
     public long size() {
@@ -178,7 +210,7 @@ public class TransactionLoadCoordinatorMgr {
     }
 
     /**
-     * It is only used in test cases
+     * Put a label with its coordinator node id into the cache.
      */
     @VisibleForTesting
     public void put(String key, Long value) {
@@ -186,10 +218,15 @@ public class TransactionLoadCoordinatorMgr {
     }
 
     /**
-     * Checks if a transaction label exists in the cache.
-     *
-     * @param label the transaction label
-     * @return true if the label exists in the cache, false otherwise
+     * Peek the cached txn id without mutating state.
+     */
+    @VisibleForTesting
+    public Long getTxnId(String label) {
+        return cache.getIfPresent(label);
+    }
+
+    /**
+     * Checks if a label exists in the cache.
      */
     public boolean existInCache(String label) {
         return cache.getIfPresent(label) != null;

--- a/fe/fe-core/src/main/java/com/starrocks/system/BackendHbResponse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/BackendHbResponse.java
@@ -64,6 +64,9 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
     private long memLimitBytes;
     @SerializedName(value = "rebootTime")
     private long rebootTime = -1L;
+    @SerializedName(value = "stiw")
+    private long shutdownTxnIdWatermark = 0L;
+
 
     @SerializedName(value = "statusCode")
     private TStatusCode statusCode = TStatusCode.OK;
@@ -161,6 +164,14 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
 
     public void setStatusCode(TStatusCode statusCode) {
         this.statusCode = statusCode;
+    }
+
+    public long getShutdownTxnIdWatermark() {
+        return shutdownTxnIdWatermark;
+    }
+
+    public void setShutdownTxnIdWatermark(long shutdownTxnIdWatermark) {
+        this.shutdownTxnIdWatermark = shutdownTxnIdWatermark;
     }
 
 

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -81,6 +81,11 @@ public class ComputeNode implements IComputable, Writable, GsonPostProcessable {
     private volatile long lastUpdateMs;
     @SerializedName("lastStartTime")
     private volatile long lastStartTime;
+    // Exclusive txn-id watermark while SHUTDOWN: last observed SHUTDOWN peekNext.
+    // Abort uses txnId < watermark and matching backendId. Ids at/after watermark
+    // are not aborted. 0 means unset. Persisted for leader failover.
+    @SerializedName("stiw")
+    private volatile long shutdownTxnIdWatermark;
     @SerializedName("isAlive")
     private AtomicBoolean isAlive;
 
@@ -395,6 +400,14 @@ public class ComputeNode implements IComputable, Writable, GsonPostProcessable {
 
     public void setLastStartTime(long currentTime) {
         this.lastStartTime = currentTime;
+    }
+
+    public long getShutdownTxnIdWatermark() {
+        return shutdownTxnIdWatermark;
+    }
+
+    public void setShutdownTxnIdWatermark(long watermark) {
+        this.shutdownTxnIdWatermark = watermark;
     }
 
     public long getLastMissingHeartbeatTime() {

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -41,6 +41,8 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.FsBroker;
 import com.starrocks.common.Config;
+import com.starrocks.common.Pair;
+import com.starrocks.common.StarRocksException;
 import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.Version;
 import com.starrocks.common.util.LeaderDaemon;
@@ -68,6 +70,7 @@ import com.starrocks.thrift.TMasterInfo;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TNodeType;
 import com.starrocks.thrift.TStatusCode;
+import com.starrocks.transaction.GlobalTransactionMgr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -257,16 +260,45 @@ public class HeartbeatMgr extends LeaderDaemon {
                             GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getComputeNode(hbResponse.getBeId());
                 }
                 if (computeNode != null) {
+                    ComputeNode.Status prevStatus = computeNode.getStatus();
                     boolean isChanged = computeNode.handleHbResponse(hbResponse, isReplay);
                     if (hbResponse.getStatus() != HbStatus.OK) {
                         // invalid all connections cached in ClientPool
                         ThriftConnectionPool.backendPool.clearPool(
                                 new TNetworkAddress(computeNode.getHost(), computeNode.getBePort()));
-                        if (!isReplay && !computeNode.isAlive()) {
-                            GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
-                                    .abortTxnWhenCoordinateBeDown(computeNode.getHost(), 100);
+                        // A graceful shutdown BE keeps draining in-flight loads, so its
+                        // coordinator transactions must not be aborted here; only a
+                        // DISCONNECTED BE (failed heartbeat_retry_times) is aborted, so a
+                        // single transient heartbeat loss does not kill a draining load.
+                        if (computeNode.getStatus() == ComputeNode.Status.SHUTDOWN) {
+                            if (!isReplay) {
+                                long peek = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                                        .peekNextTransactionId();
+                                if (peek > computeNode.getShutdownTxnIdWatermark()) {
+                                    computeNode.setShutdownTxnIdWatermark(peek);
+                                    isChanged = true;
+                                }
+                                hbResponse.setShutdownTxnIdWatermark(computeNode.getShutdownTxnIdWatermark());
+                            } else if (hbResponse.getShutdownTxnIdWatermark()
+                                    > computeNode.getShutdownTxnIdWatermark()) {
+                                computeNode.setShutdownTxnIdWatermark(hbResponse.getShutdownTxnIdWatermark());
+                            }
+                        }
+                        if (!isReplay && !computeNode.isAlive()
+                                && computeNode.getStatus() == ComputeNode.Status.DISCONNECTED) {
+                            abortCoordinatorTxnsOnBe(computeNode);
                         }
                     } else {
+                        if (prevStatus == ComputeNode.Status.SHUTDOWN) {
+                            if (!isReplay) {
+                                LOG.info("BE {} {}:{} skipped DISCONNECTED after graceful shutdown "
+                                                + "(fast restart: SHUTDOWN -> OK); abort txnId < watermark",
+                                        computeNode.getId(), computeNode.getHost(), computeNode.getHeartbeatPort());
+                                abortShutdownSnapshotTxns(computeNode);
+                            } else {
+                                computeNode.setShutdownTxnIdWatermark(0);
+                            }
+                        }
                         if (RunMode.isSharedDataMode() && !isReplay) {
                             // addWorker
                             int starletPort = computeNode.getStarletPort();
@@ -303,6 +335,31 @@ public class HeartbeatMgr extends LeaderDaemon {
         return false;
     }
 
+    private static void abortCoordinatorTxnsOnBe(ComputeNode computeNode) {
+        GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                .abortTxnWhenCoordinateBeDown(computeNode.getHost(), 100);
+    }
+
+    // Abort this BE's coordinator txns with txnId < last observed SHUTDOWN watermark.
+    // Txn ids at/after the watermark are not aborted.
+    private static void abortShutdownSnapshotTxns(ComputeNode computeNode) {
+        long watermark = computeNode.getShutdownTxnIdWatermark();
+        if (watermark <= 0) {
+            return;
+        }
+        GlobalTransactionMgr gtm = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        List<Pair<Long, Long>> txns = gtm.getTransactionIdByCoordinateBe(
+                computeNode.getHost(), computeNode.getId(), watermark, Integer.MAX_VALUE);
+        for (Pair<Long, Long> txn : txns) {
+            try {
+                gtm.abortTransaction(txn.first, txn.second, "coordinate BE is down after graceful shutdown restart");
+            } catch (StarRocksException e) {
+                LOG.warn("Abort txn on coordinate BE {} failed, msg={}", computeNode.getHost(), e.getMessage());
+            }
+        }
+        computeNode.setShutdownTxnIdWatermark(0);
+    }
+
     // backend heartbeat
     public static class BackendHeartbeatHandler implements Callable<HeartbeatResponse> {
         private final ComputeNode computeNode;
@@ -322,6 +379,7 @@ public class HeartbeatMgr extends LeaderDaemon {
                 copiedMasterInfo.setBackend_ip(computeNode.getHost());
                 long flags = HeartbeatFlags.getHeartbeatFlags();
                 copiedMasterInfo.setHeartbeat_flags(flags);
+                copiedMasterInfo.setLast_heartbeat_time_ms(computeNode.getLastUpdateMs());
                 copiedMasterInfo.setBackend_id(computeNodeId);
                 copiedMasterInfo.setMin_active_txn_id(
                         GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getMinActiveTxnId());

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -340,9 +340,9 @@ public class HeartbeatMgr extends LeaderDaemon {
                 .abortTxnWhenCoordinateBeDown(computeNode.getHost(), 100);
     }
 
-    // Abort this BE's coordinator txns with txnId < last observed SHUTDOWN watermark.
-    // Same batch size as DISCONNECTED. Leftover PREPARE times out. PREPARED is kept
-    // (abortPrepared=false) so FE can still COMMIT. Watermark is cleared after this
+    // Abort this BE's coordinator PREPARE txns with txnId < last observed SHUTDOWN watermark.
+    // Same batch size as DISCONNECTED. PREPARED is not queried (does not consume the 100).
+    // Leftover PREPARE times out. abortPrepared=false. Watermark is cleared after this
     // one-shot; later OK heartbeats do not abort again.
     private static void abortShutdownSnapshotTxns(ComputeNode computeNode) {
         long watermark = computeNode.getShutdownTxnIdWatermark();

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -341,8 +341,9 @@ public class HeartbeatMgr extends LeaderDaemon {
     }
 
     // Abort this BE's coordinator txns with txnId < last observed SHUTDOWN watermark.
-    // Txn ids at/after the watermark are not aborted. PREPARED is kept (abortPrepared=false),
-    // same as DISCONNECTED: LOAD already finished and FE can still COMMIT.
+    // Same batch size as DISCONNECTED. Leftover PREPARE times out. PREPARED is kept
+    // (abortPrepared=false) so FE can still COMMIT. Watermark is cleared after this
+    // one-shot; later OK heartbeats do not abort again.
     private static void abortShutdownSnapshotTxns(ComputeNode computeNode) {
         long watermark = computeNode.getShutdownTxnIdWatermark();
         if (watermark <= 0) {
@@ -350,7 +351,7 @@ public class HeartbeatMgr extends LeaderDaemon {
         }
         GlobalTransactionMgr gtm = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
         List<Pair<Long, Long>> txns = gtm.getTransactionIdByCoordinateBe(
-                computeNode.getHost(), computeNode.getId(), watermark, Integer.MAX_VALUE);
+                computeNode.getHost(), computeNode.getId(), watermark, 100);
         for (Pair<Long, Long> txn : txns) {
             try {
                 gtm.abortTransaction(txn.first, txn.second,

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -341,7 +341,8 @@ public class HeartbeatMgr extends LeaderDaemon {
     }
 
     // Abort this BE's coordinator txns with txnId < last observed SHUTDOWN watermark.
-    // Txn ids at/after the watermark are not aborted.
+    // Txn ids at/after the watermark are not aborted. PREPARED is kept (abortPrepared=false),
+    // same as DISCONNECTED: LOAD already finished and FE can still COMMIT.
     private static void abortShutdownSnapshotTxns(ComputeNode computeNode) {
         long watermark = computeNode.getShutdownTxnIdWatermark();
         if (watermark <= 0) {
@@ -352,7 +353,8 @@ public class HeartbeatMgr extends LeaderDaemon {
                 computeNode.getHost(), computeNode.getId(), watermark, Integer.MAX_VALUE);
         for (Pair<Long, Long> txn : txns) {
             try {
-                gtm.abortTransaction(txn.first, txn.second, "coordinate BE is down after graceful shutdown restart");
+                gtm.abortTransaction(txn.first, txn.second,
+                        "coordinate BE is down after graceful shutdown restart", false);
             } catch (StarRocksException e) {
                 LOG.warn("Abort txn on coordinate BE {} failed, msg={}", computeNode.getHost(), e.getMessage());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -2099,7 +2099,8 @@ public class DatabaseTransactionMgr {
     }
 
     /**
-     * Running BE-coordinated txns on {@code coordinateHost} with txnId &lt; {@code maxTxnIdExclusive}.
+     * Running BE-coordinated PREPARE txns on {@code coordinateHost} with txnId &lt; {@code maxTxnIdExclusive}.
+     * Only PREPARE is eligible; PREPARED is preserved and COMMITTED is not abortable.
      * If the coordinator's backendId is set ({@code >= 0}), it must equal {@code backendId};
      * otherwise (legacy, backendId == -1) host match is enough.
      */
@@ -2120,6 +2121,9 @@ public class DatabaseTransactionMgr {
 
     private static boolean isRestartAbortCandidate(TransactionState t, String coordinateHost, long backendId,
                                                    long maxTxnIdExclusive) {
+        if (t.getTransactionStatus() != TransactionStatus.PREPARE) {
+            return false;
+        }
         TransactionState.TxnCoordinator coordinator = t.getCoordinator();
         if (coordinator.sourceType != TransactionState.TxnSourceType.BE
                 || !coordinator.ip.equals(coordinateHost)

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -2098,6 +2098,38 @@ public class DatabaseTransactionMgr {
         return txnInfos;
     }
 
+    /**
+     * Running BE-coordinated txns on {@code coordinateHost} with txnId &lt; {@code maxTxnIdExclusive}.
+     * If the coordinator's backendId is set ({@code >= 0}), it must equal {@code backendId};
+     * otherwise (legacy, backendId == -1) host match is enough.
+     */
+    public List<Pair<Long, Long>> getTransactionIdByCoordinateBe(String coordinateHost, long backendId,
+                                                                 long maxTxnIdExclusive, int limit) {
+        ArrayList<Pair<Long, Long>> txnInfos = new ArrayList<>();
+        readLock();
+        try {
+            idToRunningTransactionState.values().stream()
+                    .filter(t -> isRestartAbortCandidate(t, coordinateHost, backendId, maxTxnIdExclusive))
+                    .limit(limit)
+                    .forEach(t -> txnInfos.add(new Pair<>(t.getDbId(), t.getTransactionId())));
+        } finally {
+            readUnlock();
+        }
+        return txnInfos;
+    }
+
+    private static boolean isRestartAbortCandidate(TransactionState t, String coordinateHost, long backendId,
+                                                   long maxTxnIdExclusive) {
+        TransactionState.TxnCoordinator coordinator = t.getCoordinator();
+        if (coordinator.sourceType != TransactionState.TxnSourceType.BE
+                || !coordinator.ip.equals(coordinateHost)
+                || t.getTransactionId() >= maxTxnIdExclusive) {
+            return false;
+        }
+        long coordBeId = coordinator.getBackendId();
+        return coordBeId < 0 || coordBeId == backendId;
+    }
+
     public Long getTransactionNumByCoordinateBe(String coordinateHost) {
         readLock();
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -622,6 +622,14 @@ public class GlobalTransactionMgr implements MemoryTrackable {
         abortTransaction(dbId, transactionId, reason, Collections.emptyList());
     }
 
+    // abortPrepared=false leaves PREPARED txns for a later COMMIT (coordinator BE is gone).
+    public void abortTransaction(long dbId, long transactionId, String reason, boolean abortPrepared)
+            throws StarRocksException {
+        DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(dbId);
+        dbTransactionMgr.abortTransaction(transactionId, abortPrepared, reason, null,
+                Collections.emptyList(), Collections.emptyList());
+    }
+
     public void abortTransaction(long dbId, long transactionId, String reason, List<TabletFailInfo> failedTablets)
             throws StarRocksException {
         abortTransaction(dbId, transactionId, reason, Collections.emptyList(), failedTablets, null);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -1029,6 +1029,10 @@ public class GlobalTransactionMgr implements MemoryTrackable {
         return this.idGenerator;
     }
 
+    public long peekNextTransactionId() {
+        return idGenerator.peekNextTransactionId();
+    }
+
     public void loadTransactionStateV2(SRMetaBlockReader reader)
             throws IOException, SRMetaBlockException, SRMetaBlockEOFException {
         long now = System.currentTimeMillis();
@@ -1067,6 +1071,19 @@ public class GlobalTransactionMgr implements MemoryTrackable {
         ArrayList<Pair<Long, Long>> txnInfos = new ArrayList<>();
         for (DatabaseTransactionMgr databaseTransactionMgr : dbIdToDatabaseTransactionMgrs.values()) {
             txnInfos.addAll(databaseTransactionMgr.getTransactionIdByCoordinateBe(coordinateHost, limit));
+            if (txnInfos.size() > limit) {
+                break;
+            }
+        }
+        return txnInfos.size() > limit ? new ArrayList<>(txnInfos.subList(0, limit)) : txnInfos;
+    }
+
+    public List<Pair<Long, Long>> getTransactionIdByCoordinateBe(String coordinateHost, long backendId,
+                                                                 long maxTxnIdExclusive, int limit) {
+        ArrayList<Pair<Long, Long>> txnInfos = new ArrayList<>();
+        for (DatabaseTransactionMgr databaseTransactionMgr : dbIdToDatabaseTransactionMgrs.values()) {
+            txnInfos.addAll(databaseTransactionMgr.getTransactionIdByCoordinateBe(
+                    coordinateHost, backendId, maxTxnIdExclusive, limit));
             if (txnInfos.size() > limit) {
                 break;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
@@ -330,6 +330,13 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
 
     @Test
     public void transactionLoadCoordinatorMgrWithoutChannelTest() throws Exception {
+        new Expectations() {
+            {
+                globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                minTimes = 0;
+                result = null;
+            }
+        };
 
         String label = RandomStringUtils.randomAlphanumeric(32);
         Request request = newRequest(TransactionOperation.TXN_BEGIN, (uriBuilder, reqBuilder) -> {
@@ -360,6 +367,13 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
 
     @Test
     public void transactionLoadCoordinatorMgrMultiBeOnSameNodeWithoutChannelTest() throws Exception {
+        new Expectations() {
+            {
+                globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                minTimes = 0;
+                result = null;
+            }
+        };
 
         String label = RandomStringUtils.randomAlphanumeric(32);
         Request request = newRequest(TransactionOperation.TXN_BEGIN, (uriBuilder, reqBuilder) -> {
@@ -424,6 +438,13 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
 
     @Test
     public void transactionLoadCoordinatorMgrOneBeOnNodeWithoutChannelTest() throws Exception {
+        new Expectations() {
+            {
+                globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                minTimes = 0;
+                result = null;
+            }
+        };
 
         String label = RandomStringUtils.randomAlphanumeric(32);
         Request request = newRequest(TransactionOperation.TXN_BEGIN, (uriBuilder, reqBuilder) -> {
@@ -472,6 +493,14 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
 
     @Test
     public void beginTransactionWithoutChannelInfoTest() throws Exception {
+        new Expectations() {
+            {
+                globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                minTimes = 0;
+                result = null;
+            }
+        };
+
         String label = RandomStringUtils.randomAlphanumeric(32);
         Request request = newRequest(TransactionOperation.TXN_BEGIN, (uriBuilder, reqBuilder) -> {
             reqBuilder.addHeader(DB_KEY, DB_NAME);

--- a/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadCoordinatorMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadCoordinatorMgrTest.java
@@ -17,6 +17,7 @@ package com.starrocks.http;
 import com.google.common.collect.ImmutableMap;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DiskInfo;
+import com.starrocks.common.LabelAlreadyUsedException;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.http.rest.TransactionLoadCoordinatorMgr;
@@ -48,6 +49,8 @@ import java.util.concurrent.Future;
 
 import static com.starrocks.http.TransactionLoadActionTest.newTxnStateWithCoordinator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestMethodOrder(MethodName.class)
 public class TransactionLoadCoordinatorMgrTest {
@@ -101,6 +104,9 @@ public class TransactionLoadCoordinatorMgrTest {
         backend1.setHttpPort(9301);
         backend1.setDisks(new ImmutableMap.Builder<String, DiskInfo>().put("1", new DiskInfo("")).build());
         GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().addBackend(backend1);
+        // newInstance skips the constructor, so wire the mocked transaction mgr in explicitly:
+        // getNodeFromTransactionState and transactionOwnedBy reach it via getGlobalTransactionMgr().
+        Deencapsulation.setField(globalStateMgr, "globalTransactionMgr", globalTransactionMgr);
     }
 
     @Test
@@ -144,6 +150,150 @@ public class TransactionLoadCoordinatorMgrTest {
         }
     }
 
+
+    @Test
+    public void testAllocateRejectsRetryWhenTransactionLive() throws Exception {
+        // A label whose FE transaction is still live (PREPARE/PREPARED/COMMITTED/VISIBLE/UNKNOWN)
+        // must fail the retried BEGIN with the normal LABEL_ALREADY_EXISTS error instead of
+        // being sent to a new coordinator (which would orphan the original transaction's
+        // LOAD/COMMIT routing) or bounced back to its unavailable one (a 307 loop). The cache
+        // is left untouched, so later LOAD/COMMIT still resolve to the original owner.
+        Backend backend2 = new Backend(5678, "otherhost", 8040);
+        backend2.setBePort(9300);
+        backend2.setAlive(false);
+        backend2.setHttpPort(9301);
+        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().addBackend(backend2);
+        // MockUp intercepts the real LocalMetastore instance returned by setUp's
+        // getLocalMetastore expectation; a chained getDb record in an Expectations block would
+        // be shadowed by that expectation and never match.
+        new MockUp<LocalMetastore>() {
+            @Mock
+            public Database getDb(String dbName) {
+                return DB_NAME.equals(dbName) ? db : null;
+            }
+        };
+        // Build the states outside the Expectations block: the helper reaches
+        // GlobalStateMgr.getCurrentState(), which is itself mocked, and recording it inside
+        // would swallow the getLabelTransactionState result.
+        TransactionState prepareTxn = newTxnStateWithCoordinator(1, "label_prepare",
+                TransactionState.LoadJobSourceType.BACKEND_STREAMING, TransactionStatus.PREPARE,
+                "otherhost", 5678);
+        TransactionState preparedTxn = newTxnStateWithCoordinator(2, "label_prepared",
+                TransactionState.LoadJobSourceType.BACKEND_STREAMING, TransactionStatus.PREPARED,
+                "otherhost", 5678);
+        TransactionState committedTxn = newTxnStateWithCoordinator(3, "label_committed",
+                TransactionState.LoadJobSourceType.BACKEND_STREAMING, TransactionStatus.COMMITTED,
+                "otherhost", 5678);
+        TransactionState visibleTxn = newTxnStateWithCoordinator(4, "label_visible",
+                TransactionState.LoadJobSourceType.BACKEND_STREAMING, TransactionStatus.VISIBLE,
+                "otherhost", 5678);
+        TransactionState unknownTxn = newTxnStateWithCoordinator(5, "label_unknown",
+                TransactionState.LoadJobSourceType.BACKEND_STREAMING, TransactionStatus.UNKNOWN,
+                "otherhost", 5678);
+        new Expectations() {
+            {
+                globalTransactionMgr.getLabelTransactionState(testDbId, "label_prepare");
+                minTimes = 0;
+                result = prepareTxn;
+
+                globalTransactionMgr.getLabelTransactionState(testDbId, "label_prepared");
+                minTimes = 0;
+                result = preparedTxn;
+
+                globalTransactionMgr.getLabelTransactionState(testDbId, "label_committed");
+                minTimes = 0;
+                result = committedTxn;
+
+                globalTransactionMgr.getLabelTransactionState(testDbId, "label_visible");
+                minTimes = 0;
+                result = visibleTxn;
+
+                globalTransactionMgr.getLabelTransactionState(testDbId, "label_unknown");
+                minTimes = 0;
+                result = unknownTxn;
+            }
+        };
+
+        TransactionLoadCoordinatorMgr cache = new TransactionLoadCoordinatorMgr();
+
+        // Cached unavailable coordinator + live transaction: terminal error, cache kept.
+        for (String label : new String[] {"label_prepare", "label_prepared", "label_committed",
+                "label_visible", "label_unknown"}) {
+            cache.put(label, 5678L);
+            Assertions.assertThrows(LabelAlreadyUsedException.class,
+                    () -> cache.allocate(label, "default_warehouse", DB_NAME));
+            Assertions.assertEquals(5678L, cache.getTxnId(label));
+            // Still rejected on the next retry: no new coordinator was written.
+            Assertions.assertThrows(LabelAlreadyUsedException.class,
+                    () -> cache.allocate(label, "default_warehouse", DB_NAME));
+        }
+
+        // Cache miss + live transaction: rejected, nothing written.
+        cache.remove("label_prepare");
+        Assertions.assertNull(cache.getTxnId("label_prepare"));
+        Assertions.assertThrows(LabelAlreadyUsedException.class,
+                () -> cache.allocate("label_prepare", "default_warehouse", DB_NAME));
+        Assertions.assertNull(cache.getTxnId("label_prepare"));
+
+        // Cached node missing from the cluster (dropped): the error propagates and the
+        // cache entry is kept, matching upstream behavior for a vanished coordinator.
+        cache.put("label_prepare", 99999L);
+        Assertions.assertThrows(StarRocksException.class,
+                () -> cache.allocate("label_prepare", "default_warehouse", DB_NAME));
+        Assertions.assertEquals(99999L, cache.getTxnId("label_prepare"));
+    }
+
+    @Test
+    public void testAllocateReassignsWhenTransactionTerminalOrAbsent() throws Exception {
+        // Only ABORTED or absent transactions free the label: allocate drops the stale cache
+        // entry and selects a live node. A cached alive node short-circuits without any
+        // transaction lookup.
+        Backend backend2 = new Backend(5678, "otherhost", 8040);
+        backend2.setBePort(9300);
+        backend2.setAlive(false);
+        backend2.setHttpPort(9301);
+        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().addBackend(backend2);
+        new MockUp<LocalMetastore>() {
+            @Mock
+            public Database getDb(String dbName) {
+                return DB_NAME.equals(dbName) ? db : null;
+            }
+        };
+        TransactionState abortedTxn = newTxnStateWithCoordinator(1, "label_aborted",
+                TransactionState.LoadJobSourceType.BACKEND_STREAMING, TransactionStatus.ABORTED,
+                "otherhost", 5678);
+        new Expectations() {
+            {
+                globalTransactionMgr.getLabelTransactionState(testDbId, "label_aborted");
+                minTimes = 0;
+                result = abortedTxn;
+
+                globalTransactionMgr.getLabelTransactionState(testDbId, "label_gone");
+                minTimes = 0;
+                result = null; // no transaction for the label
+            }
+        };
+
+        TransactionLoadCoordinatorMgr cache = new TransactionLoadCoordinatorMgr();
+
+        // Cached alive node is returned as-is (no transaction lookup happens for it).
+        cache.put("label_alive", 1234L);
+        assertEquals(1234L, cache.allocate("label_alive", "default_warehouse", DB_NAME).getId());
+
+        // ABORTED transaction on an unavailable coordinator: reassign and replace the entry.
+        cache.put("label_aborted", 5678L);
+        assertEquals(1234L, cache.allocate("label_aborted", "default_warehouse", DB_NAME).getId());
+        assertEquals(1234L, cache.allocate("label_aborted", "default_warehouse", DB_NAME).getId());
+
+        // Missing cached node: the error propagates; the label is not reassigned to a new
+        // coordinator just because the old node disappeared from the cluster.
+        cache.put("label_gone", 99999L);
+        StarRocksException e = assertThrows(StarRocksException.class,
+                () -> cache.allocate("label_gone", "default_warehouse", DB_NAME));
+        assertTrue(e.getMessage().contains("Can't find node id 99999"));
+        assertEquals(99999L, cache.getTxnId("label_gone"));
+    }
+
     @Test
     public void multiThreadWriteTransactionLoadCoordinatorMgrTest() throws Exception {
         TransactionLoadCoordinatorMgr cache = new TransactionLoadCoordinatorMgr();
@@ -174,7 +324,7 @@ public class TransactionLoadCoordinatorMgrTest {
         for (int i = 0; i < 5; i++) {
             String label = "label_" + i;
             long expectedValue = (long) i;
-            assertEquals(expectedValue, cache.get(label, "").getId());
+            assertEquals(expectedValue, cache.get(label, DB_NAME).getId());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/system/HeartbeatMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/HeartbeatMgrTest.java
@@ -35,9 +35,12 @@
 package com.starrocks.system;
 
 import com.starrocks.catalog.FsBroker;
+import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
+import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.Util;
 import com.starrocks.ha.FrontendNodeType;
+import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.rpc.ThriftConnectionPool;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
@@ -56,6 +59,7 @@ import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TRunMode;
 import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
+import com.starrocks.transaction.GlobalTransactionMgr;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -247,6 +251,438 @@ public class HeartbeatMgrTest {
                 Assertions.assertEquals(TRunMode.SHARED_DATA, masterInfo.getRun_mode());
             }
         };
+    }
+
+    @Test
+    public void testBackendHandlerCarriesLastHeartbeatTime(@Mocked HeartbeatService.Client client) throws Exception {
+        TStatus shutdownStatus = new TStatus(TStatusCode.SHUTDOWN);
+        shutdownStatus.setError_msgs(Collections.singletonList("BE is shutting down"));
+        THeartbeatResult res = new THeartbeatResult();
+        res.setStatus(shutdownStatus);
+
+        new MockUp<ThriftConnectionPool<HeartbeatService.Client>>() {
+            @Mock
+            public HeartbeatService.Client borrowObject(TNetworkAddress address, int timeoutMs) throws Exception {
+                return client;
+            }
+
+            @Mock
+            public void returnObject(TNetworkAddress address, HeartbeatService.Client object) {
+            }
+
+            @Mock
+            public void invalidateObject(TNetworkAddress address, HeartbeatService.Client object) {
+            }
+        };
+
+        new MockUp<HeartbeatMgr>() {
+            @Mock
+            public long computeMinActiveTxnId() {
+                return 100L;
+            }
+        };
+
+        new Expectations() {
+            {
+                client.heartbeat((TMasterInfo) any);
+                minTimes = 1;
+                result = res;
+            }
+        };
+
+        // call setLeader() to init the MASTER_INFO
+        new HeartbeatMgr(false).setLeader(1, "123", 1);
+
+        ComputeNode cn = new ComputeNode(1, "192.168.1.1", 8111);
+        cn.setLastUpdateMs(777777L);
+        HeartbeatMgr.BackendHeartbeatHandler handler = new HeartbeatMgr.BackendHeartbeatHandler(cn, true);
+
+        handler.call();
+        new Verifications() {
+            {
+                TMasterInfo masterInfo;
+                client.heartbeat(masterInfo = withCapture());
+                Assertions.assertNotNull(masterInfo);
+                // The request always carries the FE's LastHeartbeat time for this BE; the BE uses
+                // its advance as the shutdown ack.
+                Assertions.assertTrue(masterInfo.isSetLast_heartbeat_time_ms());
+                Assertions.assertEquals(777777L, masterInfo.getLast_heartbeat_time_ms());
+            }
+        };
+    }
+
+    @Test
+    public void testShutdownHeartbeatDoesNotAbortCoordinatorTxns(@Mocked SystemInfoService clusterInfo,
+                                                                 @Mocked GlobalTransactionMgr txnMgr) {
+        Backend cn = new Backend(1, "192.168.1.1", 8111);
+        new Expectations() {
+            {
+                nodeMgr.getClusterInfo();
+                minTimes = 0;
+                result = clusterInfo;
+
+                clusterInfo.getBackend(1);
+                minTimes = 0;
+                result = cn;
+
+                globalStateMgr.getGlobalTransactionMgr();
+                minTimes = 0;
+                result = txnMgr;
+            }
+        };
+
+        HeartbeatMgr mgr = new HeartbeatMgr(false);
+        BackendHbResponse hbResponse = new BackendHbResponse(1, TStatusCode.SHUTDOWN, "BE is shutting down");
+        Deencapsulation.invoke(mgr, "handleHbResponse", hbResponse, false);
+
+        // The shutdown BE keeps draining its coordinator loads; they must commit or abort normally.
+        new Verifications() {
+            {
+                txnMgr.abortTxnWhenCoordinateBeDown(anyString, anyInt);
+                times = 0;
+            }
+        };
+        Assertions.assertFalse(cn.isAlive(), "SHUTDOWN must still mark the node not alive");
+    }
+
+    @Test
+    public void testNonShutdownHeartbeatFailureAbortsCoordinatorTxns(@Mocked SystemInfoService clusterInfo,
+                                                                     @Mocked GlobalTransactionMgr txnMgr) {
+        Backend cn = new Backend(1, "192.168.1.1", 8111);
+        cn.setAlive(false); // already marked not alive, e.g. by a previous SHUTDOWN heartbeat
+        new Expectations() {
+            {
+                nodeMgr.getClusterInfo();
+                minTimes = 0;
+                result = clusterInfo;
+
+                clusterInfo.getBackend(1);
+                minTimes = 0;
+                result = cn;
+
+                globalStateMgr.getGlobalTransactionMgr();
+                minTimes = 0;
+                result = txnMgr;
+            }
+        };
+
+        HeartbeatMgr mgr = new HeartbeatMgr(false);
+        BackendHbResponse hbResponse = new BackendHbResponse(1, TStatusCode.INTERNAL_ERROR, "connection refused");
+        // Transient losses while the status is still SHUTDOWN/CONNECTING must not abort; the
+        // node only turns DISCONNECTED (and aborts) after heartbeat_retry_times failures.
+        for (int i = 0; i <= Config.heartbeat_retry_times; i++) {
+            Deencapsulation.invoke(mgr, "handleHbResponse", hbResponse, false);
+        }
+
+        Assertions.assertEquals(ComputeNode.Status.DISCONNECTED, cn.getStatus());
+        new Verifications() {
+            {
+                txnMgr.abortTxnWhenCoordinateBeDown(cn.getHost(), 100);
+                times = 1;
+            }
+        };
+    }
+
+    @Test
+    public void testOkAfterShutdownAbortsCoordinatorTxns(@Mocked SystemInfoService clusterInfo,
+                                                        @Mocked GlobalTransactionMgr txnMgr) throws Exception {
+        Backend cn = new Backend(1, "192.168.1.1", 8111);
+        cn.setLastStartTime(100_000L);
+        mockBackendTxn(clusterInfo, txnMgr, cn);
+
+        new Expectations() {
+            {
+                txnMgr.peekNextTransactionId();
+                minTimes = 1;
+                result = 100L;
+                txnMgr.getTransactionIdByCoordinateBe(cn.getHost(), 1L, 100L, Integer.MAX_VALUE);
+                minTimes = 1;
+                result = java.util.List.of(new Pair<>(5L, 10L), new Pair<>(6L, 20L));
+            }
+        };
+
+        HeartbeatMgr mgr = new HeartbeatMgr(false);
+        Deencapsulation.invoke(mgr, "handleHbResponse",
+                new BackendHbResponse(1, TStatusCode.SHUTDOWN, "BE is shutting down"), false);
+        Deencapsulation.invoke(mgr, "handleHbResponse", okHb(1, 100), false);
+        Deencapsulation.invoke(mgr, "handleHbResponse", okHb(1, 100), false);
+
+        new Verifications() {
+            {
+                txnMgr.abortTransaction(5L, 10L, anyString);
+                times = 1;
+                txnMgr.abortTransaction(6L, 20L, anyString);
+                times = 1;
+                txnMgr.abortTransaction(anyLong, anyLong, anyString);
+                times = 2;
+            }
+        };
+        Assertions.assertTrue(cn.isAlive());
+        Assertions.assertEquals(ComputeNode.Status.OK, cn.getStatus());
+        Assertions.assertEquals(0L, cn.getShutdownTxnIdWatermark());
+    }
+
+    @Test
+    public void testOkAfterShutdownSkipsPostRestartTxn(@Mocked SystemInfoService clusterInfo,
+                                                       @Mocked GlobalTransactionMgr txnMgr) throws Exception {
+        Backend cn = new Backend(1, "192.168.1.1", 8111);
+        cn.setLastStartTime(100_000L);
+        mockBackendTxn(clusterInfo, txnMgr, cn);
+
+        // Query layer returns only txns below the watermark.
+        new Expectations() {
+            {
+                txnMgr.peekNextTransactionId();
+                minTimes = 1;
+                result = 100L;
+                txnMgr.getTransactionIdByCoordinateBe(cn.getHost(), 1L, 100L, Integer.MAX_VALUE);
+                result = java.util.List.of(new Pair<>(5L, 10L));
+            }
+        };
+
+        HeartbeatMgr mgr = new HeartbeatMgr(false);
+        Deencapsulation.invoke(mgr, "handleHbResponse",
+                new BackendHbResponse(1, TStatusCode.SHUTDOWN, "BE is shutting down"), false);
+        Deencapsulation.invoke(mgr, "handleHbResponse", okHb(1, 100), false);
+
+        new Verifications() {
+            {
+                txnMgr.abortTransaction(5L, 10L, anyString);
+                times = 1;
+            }
+        };
+    }
+
+    @Test
+    public void testRepeatedShutdownRaisesWatermark(@Mocked SystemInfoService clusterInfo,
+                                                   @Mocked GlobalTransactionMgr txnMgr) throws Exception {
+        Backend cn = new Backend(1, "192.168.1.1", 8111);
+        mockBackendTxn(clusterInfo, txnMgr, cn);
+
+        new Expectations() {
+            {
+                txnMgr.peekNextTransactionId();
+                returns(100L, 150L);
+                txnMgr.getTransactionIdByCoordinateBe(cn.getHost(), 1L, 150L, Integer.MAX_VALUE);
+                result = java.util.List.of(new Pair<>(1L, 120L));
+            }
+        };
+
+        HeartbeatMgr mgr = new HeartbeatMgr(false);
+        Deencapsulation.invoke(mgr, "handleHbResponse",
+                new BackendHbResponse(1, TStatusCode.SHUTDOWN, "BE is shutting down"), false);
+        Assertions.assertEquals(100L, cn.getShutdownTxnIdWatermark());
+        Deencapsulation.invoke(mgr, "handleHbResponse",
+                new BackendHbResponse(1, TStatusCode.SHUTDOWN, "BE is shutting down"), false);
+        Assertions.assertEquals(150L, cn.getShutdownTxnIdWatermark());
+        Deencapsulation.invoke(mgr, "handleHbResponse", okHb(1, 100), false);
+
+        new Verifications() {
+            {
+                txnMgr.abortTransaction(1L, 120L, anyString);
+                times = 1;
+            }
+        };
+        Assertions.assertEquals(0L, cn.getShutdownTxnIdWatermark());
+    }
+
+    @Test
+    public void testRepeatedShutdownDoesNotLowerWatermark(@Mocked SystemInfoService clusterInfo,
+                                                         @Mocked GlobalTransactionMgr txnMgr) throws Exception {
+        Backend cn = new Backend(1, "192.168.1.1", 8111);
+        mockBackendTxn(clusterInfo, txnMgr, cn);
+
+        new Expectations() {
+            {
+                txnMgr.peekNextTransactionId();
+                returns(100L, 90L);
+                txnMgr.getTransactionIdByCoordinateBe(cn.getHost(), 1L, 100L, Integer.MAX_VALUE);
+                result = java.util.List.of(new Pair<>(1L, 50L));
+            }
+        };
+
+        HeartbeatMgr mgr = new HeartbeatMgr(false);
+        Deencapsulation.invoke(mgr, "handleHbResponse",
+                new BackendHbResponse(1, TStatusCode.SHUTDOWN, "BE is shutting down"), false);
+        Assertions.assertEquals(100L, cn.getShutdownTxnIdWatermark());
+        Deencapsulation.invoke(mgr, "handleHbResponse",
+                new BackendHbResponse(1, TStatusCode.SHUTDOWN, "BE is shutting down"), false);
+        Assertions.assertEquals(100L, cn.getShutdownTxnIdWatermark());
+        Deencapsulation.invoke(mgr, "handleHbResponse", okHb(1, 100), false);
+
+        new Verifications() {
+            {
+                txnMgr.abortTransaction(1L, 50L, anyString);
+                times = 1;
+            }
+        };
+    }
+
+    @Test
+    public void testReplayShutdownRestoresWatermarkThenOkAborts(@Mocked SystemInfoService clusterInfo,
+                                                               @Mocked GlobalTransactionMgr txnMgr) throws Exception {
+        Backend cn = new Backend(1, "192.168.1.1", 8111);
+        mockBackendTxn(clusterInfo, txnMgr, cn);
+
+        new Expectations() {
+            {
+                txnMgr.peekNextTransactionId();
+                minTimes = 0;
+                txnMgr.getTransactionIdByCoordinateBe(cn.getHost(), 1L, 100L, Integer.MAX_VALUE);
+                result = java.util.List.of(new Pair<>(5L, 10L));
+            }
+        };
+
+        BackendHbResponse shutdown = new BackendHbResponse(1, TStatusCode.SHUTDOWN, "BE is shutting down");
+        shutdown.setShutdownTxnIdWatermark(100L);
+        HeartbeatMgr mgr = new HeartbeatMgr(false);
+        Deencapsulation.invoke(mgr, "handleHbResponse", shutdown, true);
+        Assertions.assertEquals(100L, cn.getShutdownTxnIdWatermark());
+        Deencapsulation.invoke(mgr, "handleHbResponse", okHb(1, 100), false);
+
+        new Verifications() {
+            {
+                txnMgr.abortTransaction(5L, 10L, anyString);
+                times = 1;
+            }
+        };
+        Assertions.assertEquals(0L, cn.getShutdownTxnIdWatermark());
+    }
+
+    @Test
+    public void testWatermarkSurvivesGsonRoundTrip() {
+        Backend cn = new Backend(1, "192.168.1.1", 8111);
+        cn.setShutdownTxnIdWatermark(99L);
+        Backend copy = GsonUtils.GSON.fromJson(GsonUtils.GSON.toJson(cn), Backend.class);
+        Assertions.assertEquals(99L, copy.getShutdownTxnIdWatermark());
+    }
+
+    @Test
+    public void testSameHostPassesRestartedBackendIdToQuery(@Mocked SystemInfoService clusterInfo,
+                                                           @Mocked GlobalTransactionMgr txnMgr) throws Exception {
+        Backend cn = new Backend(7, "10.0.0.1", 8111);
+        mockBackendTxn(clusterInfo, txnMgr, cn);
+        new Expectations() {
+            {
+                clusterInfo.getBackend(1);
+                minTimes = 0;
+                result = cn;
+                txnMgr.peekNextTransactionId();
+                result = 50L;
+                txnMgr.getTransactionIdByCoordinateBe("10.0.0.1", 7L, 50L, Integer.MAX_VALUE);
+                result = java.util.List.of(new Pair<>(1L, 9L));
+            }
+        };
+
+        HeartbeatMgr mgr = new HeartbeatMgr(false);
+        Deencapsulation.invoke(mgr, "handleHbResponse",
+                new BackendHbResponse(1, TStatusCode.SHUTDOWN, "BE is shutting down"), false);
+        Deencapsulation.invoke(mgr, "handleHbResponse", okHb(1, 100), false);
+
+        new Verifications() {
+            {
+                txnMgr.getTransactionIdByCoordinateBe("10.0.0.1", 7L, 50L, Integer.MAX_VALUE);
+                times = 1;
+                txnMgr.abortTransaction(1L, 9L, anyString);
+                times = 1;
+            }
+        };
+    }
+
+    @Test
+    public void testOkRebootWhileAliveDoesNotAbortCoordinatorTxns(@Mocked SystemInfoService clusterInfo,
+                                                                 @Mocked GlobalTransactionMgr txnMgr) throws Exception {
+        Backend cn = new Backend(1, "192.168.1.1", 8111);
+        cn.setAlive(true);
+        cn.setLastStartTime(100_000L);
+        mockBackendTxn(clusterInfo, txnMgr, cn);
+
+        HeartbeatMgr mgr = new HeartbeatMgr(false);
+        Deencapsulation.invoke(mgr, "handleHbResponse", okHb(1, 200), false);
+
+        new Verifications() {
+            {
+                txnMgr.abortTxnWhenCoordinateBeDown(anyString, anyInt);
+                times = 0;
+                txnMgr.abortTransaction(anyLong, anyLong, anyString);
+                times = 0;
+            }
+        };
+    }
+
+    @Test
+    public void testReplayOkAfterShutdownDoesNotAbort(@Mocked SystemInfoService clusterInfo,
+                                                     @Mocked GlobalTransactionMgr txnMgr) throws Exception {
+        Backend cn = new Backend(1, "192.168.1.1", 8111);
+        cn.setLastStartTime(100_000L);
+        mockBackendTxn(clusterInfo, txnMgr, cn);
+
+        new Expectations() {
+            {
+                txnMgr.peekNextTransactionId();
+                minTimes = 0;
+                result = 100L;
+            }
+        };
+
+        HeartbeatMgr mgr = new HeartbeatMgr(false);
+        Deencapsulation.invoke(mgr, "handleHbResponse",
+                new BackendHbResponse(1, TStatusCode.SHUTDOWN, "BE is shutting down"), false);
+        Deencapsulation.invoke(mgr, "handleHbResponse", okHb(1, 100), true);
+
+        new Verifications() {
+            {
+                txnMgr.abortTxnWhenCoordinateBeDown(anyString, anyInt);
+                times = 0;
+                // Replay OK after a shutdown must not abort the snapshot.
+                txnMgr.abortTransaction(anyLong, anyLong, anyString);
+                times = 0;
+            }
+        };
+    }
+
+    @Test
+    public void testFirstJoinOkDoesNotAbortCoordinatorTxns(@Mocked SystemInfoService clusterInfo,
+                                                          @Mocked GlobalTransactionMgr txnMgr) throws Exception {
+        Backend cn = new Backend(1, "192.168.1.1", 8111);
+        mockBackendTxn(clusterInfo, txnMgr, cn);
+
+        HeartbeatMgr mgr = new HeartbeatMgr(false);
+        Deencapsulation.invoke(mgr, "handleHbResponse", okHb(1, 100), false);
+
+        new Verifications() {
+            {
+                txnMgr.abortTxnWhenCoordinateBeDown(anyString, anyInt);
+                times = 0;
+                txnMgr.abortTransaction(anyLong, anyLong, anyString);
+                times = 0;
+            }
+        };
+    }
+
+    private void mockBackendTxn(SystemInfoService clusterInfo, GlobalTransactionMgr txnMgr, Backend cn) {
+        new Expectations() {
+            {
+                nodeMgr.getClusterInfo();
+                minTimes = 0;
+                result = clusterInfo;
+
+                clusterInfo.getBackend(1);
+                minTimes = 0;
+                result = cn;
+
+                globalStateMgr.getGlobalTransactionMgr();
+                minTimes = 0;
+                result = txnMgr;
+            }
+        };
+    }
+
+    private static BackendHbResponse okHb(long beId, long rebootSec) {
+        BackendHbResponse hb = new BackendHbResponse(beId, 9050, 8040, 8060, 0,
+                System.currentTimeMillis(), "v", 8, 0L);
+        hb.setRebootTime(rebootSec);
+        return hb;
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/system/HeartbeatMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/HeartbeatMgrTest.java
@@ -409,11 +409,11 @@ public class HeartbeatMgrTest {
 
         new Verifications() {
             {
-                txnMgr.abortTransaction(5L, 10L, anyString);
+                txnMgr.abortTransaction(5L, 10L, anyString, false);
                 times = 1;
-                txnMgr.abortTransaction(6L, 20L, anyString);
+                txnMgr.abortTransaction(6L, 20L, anyString, false);
                 times = 1;
-                txnMgr.abortTransaction(anyLong, anyLong, anyString);
+                txnMgr.abortTransaction(anyLong, anyLong, anyString, false);
                 times = 2;
             }
         };
@@ -447,7 +447,7 @@ public class HeartbeatMgrTest {
 
         new Verifications() {
             {
-                txnMgr.abortTransaction(5L, 10L, anyString);
+                txnMgr.abortTransaction(5L, 10L, anyString, false);
                 times = 1;
             }
         };
@@ -479,7 +479,7 @@ public class HeartbeatMgrTest {
 
         new Verifications() {
             {
-                txnMgr.abortTransaction(1L, 120L, anyString);
+                txnMgr.abortTransaction(1L, 120L, anyString, false);
                 times = 1;
             }
         };
@@ -512,7 +512,7 @@ public class HeartbeatMgrTest {
 
         new Verifications() {
             {
-                txnMgr.abortTransaction(1L, 50L, anyString);
+                txnMgr.abortTransaction(1L, 50L, anyString, false);
                 times = 1;
             }
         };
@@ -542,7 +542,7 @@ public class HeartbeatMgrTest {
 
         new Verifications() {
             {
-                txnMgr.abortTransaction(5L, 10L, anyString);
+                txnMgr.abortTransaction(5L, 10L, anyString, false);
                 times = 1;
             }
         };
@@ -583,7 +583,7 @@ public class HeartbeatMgrTest {
             {
                 txnMgr.getTransactionIdByCoordinateBe("10.0.0.1", 7L, 50L, Integer.MAX_VALUE);
                 times = 1;
-                txnMgr.abortTransaction(1L, 9L, anyString);
+                txnMgr.abortTransaction(1L, 9L, anyString, false);
                 times = 1;
             }
         };
@@ -604,7 +604,7 @@ public class HeartbeatMgrTest {
             {
                 txnMgr.abortTxnWhenCoordinateBeDown(anyString, anyInt);
                 times = 0;
-                txnMgr.abortTransaction(anyLong, anyLong, anyString);
+                txnMgr.abortTransaction(anyLong, anyLong, anyString, false);
                 times = 0;
             }
         };
@@ -635,7 +635,7 @@ public class HeartbeatMgrTest {
                 txnMgr.abortTxnWhenCoordinateBeDown(anyString, anyInt);
                 times = 0;
                 // Replay OK after a shutdown must not abort the snapshot.
-                txnMgr.abortTransaction(anyLong, anyLong, anyString);
+                txnMgr.abortTransaction(anyLong, anyLong, anyString, false);
                 times = 0;
             }
         };
@@ -654,7 +654,7 @@ public class HeartbeatMgrTest {
             {
                 txnMgr.abortTxnWhenCoordinateBeDown(anyString, anyInt);
                 times = 0;
-                txnMgr.abortTransaction(anyLong, anyLong, anyString);
+                txnMgr.abortTransaction(anyLong, anyLong, anyString, false);
                 times = 0;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/system/HeartbeatMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/HeartbeatMgrTest.java
@@ -395,7 +395,7 @@ public class HeartbeatMgrTest {
                 txnMgr.peekNextTransactionId();
                 minTimes = 1;
                 result = 100L;
-                txnMgr.getTransactionIdByCoordinateBe(cn.getHost(), 1L, 100L, Integer.MAX_VALUE);
+                txnMgr.getTransactionIdByCoordinateBe(cn.getHost(), 1L, 100L, 100);
                 minTimes = 1;
                 result = java.util.List.of(new Pair<>(5L, 10L), new Pair<>(6L, 20L));
             }
@@ -435,7 +435,7 @@ public class HeartbeatMgrTest {
                 txnMgr.peekNextTransactionId();
                 minTimes = 1;
                 result = 100L;
-                txnMgr.getTransactionIdByCoordinateBe(cn.getHost(), 1L, 100L, Integer.MAX_VALUE);
+                txnMgr.getTransactionIdByCoordinateBe(cn.getHost(), 1L, 100L, 100);
                 result = java.util.List.of(new Pair<>(5L, 10L));
             }
         };
@@ -463,7 +463,7 @@ public class HeartbeatMgrTest {
             {
                 txnMgr.peekNextTransactionId();
                 returns(100L, 150L);
-                txnMgr.getTransactionIdByCoordinateBe(cn.getHost(), 1L, 150L, Integer.MAX_VALUE);
+                txnMgr.getTransactionIdByCoordinateBe(cn.getHost(), 1L, 150L, 100);
                 result = java.util.List.of(new Pair<>(1L, 120L));
             }
         };
@@ -496,7 +496,7 @@ public class HeartbeatMgrTest {
             {
                 txnMgr.peekNextTransactionId();
                 returns(100L, 90L);
-                txnMgr.getTransactionIdByCoordinateBe(cn.getHost(), 1L, 100L, Integer.MAX_VALUE);
+                txnMgr.getTransactionIdByCoordinateBe(cn.getHost(), 1L, 100L, 100);
                 result = java.util.List.of(new Pair<>(1L, 50L));
             }
         };
@@ -528,7 +528,7 @@ public class HeartbeatMgrTest {
             {
                 txnMgr.peekNextTransactionId();
                 minTimes = 0;
-                txnMgr.getTransactionIdByCoordinateBe(cn.getHost(), 1L, 100L, Integer.MAX_VALUE);
+                txnMgr.getTransactionIdByCoordinateBe(cn.getHost(), 1L, 100L, 100);
                 result = java.util.List.of(new Pair<>(5L, 10L));
             }
         };
@@ -569,7 +569,7 @@ public class HeartbeatMgrTest {
                 result = cn;
                 txnMgr.peekNextTransactionId();
                 result = 50L;
-                txnMgr.getTransactionIdByCoordinateBe("10.0.0.1", 7L, 50L, Integer.MAX_VALUE);
+                txnMgr.getTransactionIdByCoordinateBe("10.0.0.1", 7L, 50L, 100);
                 result = java.util.List.of(new Pair<>(1L, 9L));
             }
         };
@@ -581,7 +581,7 @@ public class HeartbeatMgrTest {
 
         new Verifications() {
             {
-                txnMgr.getTransactionIdByCoordinateBe("10.0.0.1", 7L, 50L, Integer.MAX_VALUE);
+                txnMgr.getTransactionIdByCoordinateBe("10.0.0.1", 7L, 50L, 100);
                 times = 1;
                 txnMgr.abortTransaction(1L, 9L, anyString, false);
                 times = 1;

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
@@ -356,6 +356,28 @@ public class DatabaseTransactionMgrTest {
     }
 
     @Test
+    public void testAbortPreparedFalseKeepsPrepared() throws StarRocksException {
+        FakeGlobalStateMgr.setGlobalStateMgr(masterGlobalStateMgr);
+        long transactionId = masterTransMgr.beginTransaction(
+                GlobalStateMgrTestUtil.testDbId1,
+                Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
+                "test_abort_prepared_false",
+                transactionSource,
+                TransactionState.LoadJobSourceType.FRONTEND,
+                Config.stream_load_default_timeout_second);
+        masterTransMgr.prepareTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId, -1,
+                buildTabletCommitInfoList(), Lists.newArrayList(), null);
+        DatabaseTransactionMgr masterDbTransMgr =
+                masterTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1);
+        assertEquals(TransactionStatus.PREPARED,
+                masterDbTransMgr.getTransactionState(transactionId).getTransactionStatus());
+        masterTransMgr.abortTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId,
+                "coordinate BE is down after graceful shutdown restart", false);
+        assertEquals(TransactionStatus.PREPARED,
+                masterDbTransMgr.getTransactionState(transactionId).getTransactionStatus());
+    }
+
+    @Test
     public void getLakeCompactionActiveTxnListTest() throws StarRocksException {
         TransactionState.TxnCoordinator feTransactionSource =
                 new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE, "fe1");

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
@@ -627,6 +627,35 @@ public class DatabaseTransactionMgrTest {
     }
 
     @Test
+    public void testGetTransactionIdByCoordinateBeFiltersBackendId() throws StarRocksException {
+        DatabaseTransactionMgr masterDbTransMgr =
+                masterTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1);
+        String host = "samehost";
+        long txnBe1 = masterTransMgr.beginTransaction(GlobalStateMgrTestUtil.testDbId1,
+                Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1), "coord_be1_" + System.nanoTime(),
+                TransactionState.TxnCoordinator.fromBackend(host, 11L),
+                TransactionState.LoadJobSourceType.BACKEND_STREAMING,
+                Config.stream_load_default_timeout_second);
+        long txnBe2 = masterTransMgr.beginTransaction(GlobalStateMgrTestUtil.testDbId1,
+                Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1), "coord_be2_" + System.nanoTime(),
+                TransactionState.TxnCoordinator.fromBackend(host, 22L),
+                TransactionState.LoadJobSourceType.BACKEND_STREAMING,
+                Config.stream_load_default_timeout_second);
+        long txnLegacy = masterTransMgr.beginTransaction(GlobalStateMgrTestUtil.testDbId1,
+                Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1), "coord_legacy_" + System.nanoTime(),
+                new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.BE, host),
+                TransactionState.LoadJobSourceType.BACKEND_STREAMING,
+                Config.stream_load_default_timeout_second);
+
+        List<Pair<Long, Long>> forBe1 = masterDbTransMgr.getTransactionIdByCoordinateBe(
+                host, 11L, Long.MAX_VALUE, 100);
+        java.util.Set<Long> ids = forBe1.stream().map(p -> p.second).collect(java.util.stream.Collectors.toSet());
+        Assertions.assertTrue(ids.contains(txnBe1));
+        Assertions.assertTrue(ids.contains(txnLegacy));
+        Assertions.assertFalse(ids.contains(txnBe2));
+    }
+
+    @Test
     public void testGetSingleTranInfo() throws AnalysisException {
         DatabaseTransactionMgr masterDbTransMgr =
                 masterTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1);

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
@@ -678,6 +678,64 @@ public class DatabaseTransactionMgrTest {
     }
 
     @Test
+    public void testRestartAbortQuerySkipsPreparedAndDoesNotConsumeLimit() throws StarRocksException {
+        FakeGlobalStateMgr.setGlobalStateMgr(masterGlobalStateMgr);
+        DatabaseTransactionMgr masterDbTransMgr =
+                masterTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1);
+        String host = "prepquota";
+        long backendId = 33L;
+        java.util.Set<Long> preparedIds = new java.util.HashSet<>();
+        for (int i = 0; i < 20; i++) {
+            long txnId = masterTransMgr.beginTransaction(GlobalStateMgrTestUtil.testDbId1,
+                    Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
+                    "prep_skip_" + i + "_" + System.nanoTime(),
+                    TransactionState.TxnCoordinator.fromBackend(host, backendId),
+                    TransactionState.LoadJobSourceType.BACKEND_STREAMING,
+                    Config.stream_load_default_timeout_second);
+            masterTransMgr.prepareTransaction(GlobalStateMgrTestUtil.testDbId1, txnId, -1,
+                    buildTabletCommitInfoList(), Lists.newArrayList(), null);
+            preparedIds.add(txnId);
+        }
+        long prepareA = masterTransMgr.beginTransaction(GlobalStateMgrTestUtil.testDbId1,
+                Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
+                "prep_keep_a_" + System.nanoTime(),
+                TransactionState.TxnCoordinator.fromBackend(host, backendId),
+                TransactionState.LoadJobSourceType.BACKEND_STREAMING,
+                Config.stream_load_default_timeout_second);
+        long prepareB = masterTransMgr.beginTransaction(GlobalStateMgrTestUtil.testDbId1,
+                Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
+                "prep_keep_b_" + System.nanoTime(),
+                TransactionState.TxnCoordinator.fromBackend(host, backendId),
+                TransactionState.LoadJobSourceType.BACKEND_STREAMING,
+                Config.stream_load_default_timeout_second);
+        long committedId = masterTransMgr.beginTransaction(GlobalStateMgrTestUtil.testDbId1,
+                Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1),
+                "prep_committed_" + System.nanoTime(),
+                TransactionState.TxnCoordinator.fromBackend(host, backendId),
+                TransactionState.LoadJobSourceType.BACKEND_STREAMING,
+                Config.stream_load_default_timeout_second);
+        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, committedId,
+                buildTabletCommitInfoList(), Lists.newArrayList(), null);
+        Assertions.assertEquals(TransactionStatus.COMMITTED,
+                masterDbTransMgr.getTransactionState(committedId).getTransactionStatus());
+
+        List<Pair<Long, Long>> limited = masterDbTransMgr.getTransactionIdByCoordinateBe(
+                host, backendId, Long.MAX_VALUE, 2);
+        java.util.Set<Long> ids = limited.stream().map(p -> p.second).collect(java.util.stream.Collectors.toSet());
+        Assertions.assertEquals(2, ids.size());
+        Assertions.assertTrue(ids.contains(prepareA));
+        Assertions.assertTrue(ids.contains(prepareB));
+        for (Long preparedId : preparedIds) {
+            Assertions.assertFalse(ids.contains(preparedId));
+        }
+        Assertions.assertFalse(ids.contains(committedId));
+        Assertions.assertEquals(TransactionStatus.PREPARE,
+                masterDbTransMgr.getTransactionState(prepareA).getTransactionStatus());
+        Assertions.assertEquals(TransactionStatus.PREPARE,
+                masterDbTransMgr.getTransactionState(prepareB).getTransactionStatus());
+    }
+
+    @Test
     public void testGetSingleTranInfo() throws AnalysisException {
         DatabaseTransactionMgr masterDbTransMgr =
                 masterTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1);

--- a/gensrc/thrift/HeartbeatService.thrift
+++ b/gensrc/thrift/HeartbeatService.thrift
@@ -36,6 +36,7 @@ struct TMasterInfo {
     13: optional bool encrypted;
     14: optional bool stop_regular_tablet_report; // used for upgrade/downgrade compatibility, can be removed after 3.5
     15: optional Types.TNodeType node_type
+    16: optional i64 last_heartbeat_time_ms  // the LastHeartbeat time recorded by the FE, echoed back as the shutdown ack
 }
 
 struct TBackendInfo {
@@ -55,7 +56,7 @@ struct TBackendInfo {
 }
 
 struct THeartbeatResult {
-    1: required Status.TStatus status 
+    1: required Status.TStatus status
     2: required TBackendInfo backend_info
 }
 


### PR DESCRIPTION
## Why I'm doing:

During graceful shutdown, BE drains in a delay window, but HTTP loads (e.g. stream load) that arrive inside that window are still rejected because BE reports itself as shutting down. This tears down in-flight loads that should be allowed to complete.

the case
1. be A starts graceful shutdown (kill -g)
2. an http load request arrives inside the delay window
3. `load` is rejected due to be A is shutting down
4. the load / txn fails even though it began within the drain window

## What I'm doing:

Admit HTTP loads that begin inside the delay window, so an in-flight load started before shutdown completes successfully.

1. be A starts graceful shutdown (kill -g)
2. an http load request arrives inside the delay window
3. `load` is accepted because it begins within the draining window
4. the load / txn succeeds

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5