### PR TITLE
[BugFix] Wait for async persistent-index flush before commit

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -19,6 +19,7 @@
 #include <unordered_map>
 
 #include "base/debug/trace.h"
+#include "base/time/time.h"
 #include "base/utility/defer_op.h"
 #include "column/chunk_factory.h"
 #include "column/column_helper.h"
@@ -278,30 +279,23 @@ Status LakePersistentIndex::ingest_sst(const FileMetaPB& sst_meta, const Persist
     return Status::OK();
 }
 
-Status LakePersistentIndex::sync_flush_all_memtables(int64_t wait_timeout_us) {
-    TRACE_COUNTER_SCOPE_LATENCY_US("sync_flush_all_memtables_us");
-    // 1. flush inactive memtables
+Status LakePersistentIndex::sync_flush_inactive_memtables(int64_t wait_timeout_us) {
+    const int64_t deadline_us = MonotonicMicros() + wait_timeout_us;
     for (auto& memtable : _inactive_memtables) {
-        int64_t start_us = butil::gettimeofday_us();
-        bool wait_success = false;
-        while (butil::gettimeofday_us() - start_us < wait_timeout_us) {
-            RETURN_IF_ERROR(memtable->flush_status());
-            auto sstable = memtable->release_sstable();
-            if (sstable != nullptr) {
-                // try to merge to a existing fileset
-                RETURN_IF_ERROR(merge_sstable_into_fileset(sstable));
-                wait_success = true;
-                break;
-            } else {
-                usleep(1000000); // wait for flush finish, 1s
-            }
-        }
-        if (!wait_success) {
-            return Status::TimedOut(fmt::format("wait memtable flush timeout for tablet {}", _tablet_id));
-        }
+        RETURN_IF_ERROR(memtable->wait_for_flush(std::max<int64_t>(0, deadline_us - MonotonicMicros())));
+        auto sstable = memtable->release_sstable();
+        DCHECK(sstable != nullptr);
+        // try to merge to a existing fileset
+        RETURN_IF_ERROR(merge_sstable_into_fileset(sstable));
     }
     _inactive_memtables.clear();
-    // 2. flush current memtable
+    return Status::OK();
+}
+
+Status LakePersistentIndex::sync_flush_all_memtables(int64_t wait_timeout_us) {
+    TRACE_COUNTER_SCOPE_LATENCY_US("sync_flush_all_memtables_us");
+    RETURN_IF_ERROR(sync_flush_inactive_memtables(wait_timeout_us));
+    // flush current memtable
     if (_memtable && !_memtable->empty()) {
         RETURN_IF_ERROR(_memtable->flush());
         auto sstable = _memtable->release_sstable();
@@ -1107,6 +1101,7 @@ Status LakePersistentIndex::commit(MetaFileBuilder* builder, int64_t generation_
         // we need to do flush to reduce index rebuild cost later.
         RETURN_IF_ERROR(flush_memtable(true));
     }
+    RETURN_IF_ERROR(sync_flush_inactive_memtables(config::pk_index_memtable_max_wait_flush_timeout_ms * 1000));
     PersistentIndexSstableMetaPB sstable_meta;
     int64_t last_max_rss_rowid = 0;
     for (auto& sstable_fileset : _sstable_filesets) {

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -183,6 +183,8 @@ public:
     int64_t publish_sst_flush_bytes() const { return _publish_sst_flush_bytes; }
 
 private:
+    Status sync_flush_inactive_memtables(int64_t wait_timeout_us);
+
     // Open all SSTables in parallel using thread pool.
     // Returns opened SSTables in the same order as sstable_meta.sstables().
     static StatusOr<std::vector<PersistentIndexSstableUniquePtr>> _open_sstables_parallel(

--- a/be/src/storage/lake/persistent_index_memtable.cpp
+++ b/be/src/storage/lake/persistent_index_memtable.cpp
@@ -14,6 +14,10 @@
 
 #include "storage/lake/persistent_index_memtable.h"
 
+#include <fmt/format.h>
+
+#include <chrono>
+
 #include "base/debug/trace.h"
 #include "base/string/string_util.h"
 #include "common/config_primary_key_fwd.h"
@@ -240,8 +244,11 @@ Status PersistentIndexMemtable::flush() {
     sstable_pb.set_encryption_meta(encryption_meta);
     sstable_pb.mutable_range()->CopyFrom(range_pb);
     RETURN_IF_ERROR(sstable->init(std::move(rf), sstable_pb, block_cache->cache()));
-    std::lock_guard<std::mutex> lg(_flush_mutex);
-    _sstable = std::move(sstable);
+    {
+        std::lock_guard<std::mutex> lg(_flush_mutex);
+        _sstable = std::move(sstable);
+    }
+    _flush_cv.notify_all();
     return Status::OK();
 }
 
@@ -254,14 +261,20 @@ void PersistentIndexMemtable::run() {
     auto st = flush();
     if (!st.ok()) {
         LOG(ERROR) << "PersistentIndexMemtable flush failed for tablet " << _tablet_id << ": " << st;
-        std::lock_guard<std::mutex> lg(_flush_mutex);
-        _flush_status = st;
+        {
+            std::lock_guard<std::mutex> lg(_flush_mutex);
+            _flush_status = st;
+        }
+        _flush_cv.notify_all();
     }
 }
 
 void PersistentIndexMemtable::cancel() {
-    std::lock_guard<std::mutex> lg(_flush_mutex);
-    _flush_status = Status::Cancelled("PersistentIndexMemtable flush cancelled");
+    {
+        std::lock_guard<std::mutex> lg(_flush_mutex);
+        _flush_status = Status::Cancelled("PersistentIndexMemtable flush cancelled");
+    }
+    _flush_cv.notify_all();
 }
 
 std::unique_ptr<PersistentIndexSstable> PersistentIndexMemtable::release_sstable() {
@@ -271,6 +284,15 @@ std::unique_ptr<PersistentIndexSstable> PersistentIndexMemtable::release_sstable
 
 Status PersistentIndexMemtable::flush_status() const {
     std::lock_guard<std::mutex> lg(_flush_mutex);
+    return _flush_status;
+}
+
+Status PersistentIndexMemtable::wait_for_flush(int64_t wait_timeout_us) {
+    std::unique_lock<std::mutex> lock(_flush_mutex);
+    if (!_flush_cv.wait_for(lock, std::chrono::microseconds(wait_timeout_us),
+                            [this] { return _sstable != nullptr || !_flush_status.ok(); })) {
+        return Status::TimedOut(fmt::format("wait memtable flush timeout for tablet {}", _tablet_id));
+    }
     return _flush_status;
 }
 

--- a/be/src/storage/lake/persistent_index_memtable.h
+++ b/be/src/storage/lake/persistent_index_memtable.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <condition_variable>
+
 #include "base/phmap/btree.h"
 #include "common/thread/threadpool.h"
 #include "storage/lake/types_fwd.h"
@@ -93,6 +95,8 @@ public:
 
     Status flush_status() const;
 
+    Status wait_for_flush(int64_t wait_timeout_us);
+
 private:
     Status flush(WritableFile* wf, uint64_t* filesize, PersistentIndexSstableRangePB* range_pb);
     static void update_index_value(IndexValueWithVer* index_value_info, int64_t version, const IndexValue& value);
@@ -110,6 +114,7 @@ private:
     Status _flush_status = Status::OK();
     // flush state mutex
     mutable std::mutex _flush_mutex;
+    std::condition_variable _flush_cv;
 };
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -2595,7 +2595,8 @@ TEST_P(LakePrimaryKeyPublishTest, test_cloud_native_index_minor_compact_because_
         GetParam().persistent_index_type != PersistentIndexTypePB::CLOUD_NATIVE) {
         GTEST_SKIP() << "this case only for cloud native index";
     }
-    ConfigResetGuard guard(&config::pk_index_memtable_max_count, 1);
+    // Exercise the asynchronous flush branch. commit() must wait for it before finalising metadata.
+    ConfigResetGuard guard(&config::pk_index_memtable_max_count, 2);
     auto version = 1;
     auto tablet_id = _tablet_metadata->id();
     for (int i = 0; i <= config::cloud_native_pk_index_rebuild_files_threshold; i++) {


### PR DESCRIPTION
## Why I'm doing:

In a shared-data Primary Key table, `commit()` can trigger a persistent-index memtable flush when the index rebuild threshold is reached. With asynchronous flushing enabled, commit can serialise the SST metadata before that flush finishes. The SST is written to object storage, but it is absent from both the committed `sstable_meta` and `orphan_files`, so vacuum cannot reclaim it.

This failure is silent because reads and loads continue to succeed. In one affected deployment, around 60 TiB of unreferenced persistent-index SSTs accumulated alongside roughly 5 TiB of live data. The garbage was about 12 times the live dataset and was growing by around 1 TiB per day.

Addresses the asynchronous flush path reported in #78236. Early SST compaction can also leave inputs out of `orphan_files`; that separate path is not changed by this PR.

## What I'm doing:

- Extract the existing inactive-memtable wait into a reusable helper.
- Wait for inactive memtable flushes before commit builds and finalises persistent-index SST metadata.
- Signal flush completion with a condition variable so commit waits without polling.
- Run the existing cloud-native index rebuild test with `pk_index_memtable_max_count = 2` so it exercises the asynchronous flush branch.

The wait is bounded by the existing `pk_index_memtable_max_wait_flush_timeout_ms` setting. Other flush paths remain asynchronous; commit waits only when inactive memtables exist, so the resulting SST is included in tablet metadata before commit returns.

Test evidence:

- Focused ASAN parameterised regression: 2/2 cases pass with the wait.
- The focused run fell from 3.716 seconds with one-second polling to 1.515 seconds with completion signalling.
- Negative control after removing only the commit wait: 0/2 cases pass.
- Restoring the wait returns the result to 2/2 passing cases.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
