### PR TITLE
[BugFix] Normalize Azure Blob endpoints for Hadoop credential keys

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureStorageCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureStorageCloudCredential.java
@@ -106,7 +106,7 @@ class AzureBlobCloudCredential extends AzureStorageCloudCredential {
         if (!endpoint.isEmpty()) {
             // If user specific endpoint, they don't need to specific storage account anymore
             // Like if user is using Azurite, they need to specific endpoint
-            String hadoopEndpoint = stripEndpointScheme(endpoint);
+            String hadoopEndpoint = getHadoopEndpoint(endpoint);
             if (!sharedKey.isEmpty()) {
                 String key = String.format("fs.azure.account.key.%s", hadoopEndpoint);
                 generatedConfigurationMap.put(key, sharedKey);
@@ -145,14 +145,18 @@ class AzureBlobCloudCredential extends AzureStorageCloudCredential {
         }
     }
 
-    private static String stripEndpointScheme(String endpoint) {
+    private static String getHadoopEndpoint(String endpoint) {
+        String endpointWithoutScheme = endpoint;
         if (endpoint.regionMatches(true, 0, "https://", 0, "https://".length())) {
-            return endpoint.substring("https://".length());
+            endpointWithoutScheme = endpoint.substring("https://".length());
+        } else if (endpoint.regionMatches(true, 0, "http://", 0, "http://".length())) {
+            endpointWithoutScheme = endpoint.substring("http://".length());
         }
-        if (endpoint.regionMatches(true, 0, "http://", 0, "http://".length())) {
-            return endpoint.substring("http://".length());
-        }
-        return endpoint;
+
+        // Hadoop WASB uses the account portion of the filesystem URI's raw authority for credential lookup.
+        // Exclude a trailing slash or path, but retain an explicit port because it is part of that authority.
+        int pathSeparator = endpointWithoutScheme.indexOf('/');
+        return pathSeparator >= 0 ? endpointWithoutScheme.substring(0, pathSeparator) : endpointWithoutScheme;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureStorageCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureStorageCloudCredential.java
@@ -106,11 +106,12 @@ class AzureBlobCloudCredential extends AzureStorageCloudCredential {
         if (!endpoint.isEmpty()) {
             // If user specific endpoint, they don't need to specific storage account anymore
             // Like if user is using Azurite, they need to specific endpoint
+            String hadoopEndpoint = stripEndpointScheme(endpoint);
             if (!sharedKey.isEmpty()) {
-                String key = String.format("fs.azure.account.key.%s", endpoint);
+                String key = String.format("fs.azure.account.key.%s", hadoopEndpoint);
                 generatedConfigurationMap.put(key, sharedKey);
             } else if (!container.isEmpty() && !sasToken.isEmpty()) {
-                String key = String.format("fs.azure.sas.%s.%s", container, endpoint);
+                String key = String.format("fs.azure.sas.%s.%s", container, hadoopEndpoint);
                 generatedConfigurationMap.put(key, sasToken);
             }
         } else {
@@ -142,6 +143,16 @@ class AzureBlobCloudCredential extends AzureStorageCloudCredential {
                 generatedConfigurationMap.put(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_TENANT_ID, tenantId);
             }
         }
+    }
+
+    private static String stripEndpointScheme(String endpoint) {
+        if (endpoint.regionMatches(true, 0, "https://", 0, "https://".length())) {
+            return endpoint.substring("https://".length());
+        }
+        if (endpoint.regionMatches(true, 0, "http://", 0, "http://".length())) {
+            return endpoint.substring("http://".length());
+        }
+        return endpoint;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureStorageCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureStorageCloudCredential.java
@@ -65,6 +65,20 @@ abstract class AzureStorageCloudCredential implements CloudCredential {
         properties.putAll(generatedConfigurationMap);
     }
 
+    protected static String getHadoopEndpoint(String endpoint) {
+        String endpointWithoutScheme = endpoint;
+        if (endpoint.regionMatches(true, 0, "https://", 0, "https://".length())) {
+            endpointWithoutScheme = endpoint.substring("https://".length());
+        } else if (endpoint.regionMatches(true, 0, "http://", 0, "http://".length())) {
+            endpointWithoutScheme = endpoint.substring("http://".length());
+        }
+
+        // Hadoop Azure filesystems use the account portion of the filesystem URI's raw authority for credential lookup.
+        // Exclude a trailing slash or path, but retain an explicit port because it is part of that authority.
+        int pathSeparator = endpointWithoutScheme.indexOf('/');
+        return pathSeparator >= 0 ? endpointWithoutScheme.substring(0, pathSeparator) : endpointWithoutScheme;
+    }
+
     abstract void tryGenerateConfigurationMap();
 }
 
@@ -143,20 +157,6 @@ class AzureBlobCloudCredential extends AzureStorageCloudCredential {
                 generatedConfigurationMap.put(CloudConfigurationConstants.AZURE_BLOB_OAUTH2_TENANT_ID, tenantId);
             }
         }
-    }
-
-    private static String getHadoopEndpoint(String endpoint) {
-        String endpointWithoutScheme = endpoint;
-        if (endpoint.regionMatches(true, 0, "https://", 0, "https://".length())) {
-            endpointWithoutScheme = endpoint.substring("https://".length());
-        } else if (endpoint.regionMatches(true, 0, "http://", 0, "http://".length())) {
-            endpointWithoutScheme = endpoint.substring("http://".length());
-        }
-
-        // Hadoop WASB uses the account portion of the filesystem URI's raw authority for credential lookup.
-        // Exclude a trailing slash or path, but retain an explicit port because it is part of that authority.
-        int pathSeparator = endpointWithoutScheme.indexOf('/');
-        return pathSeparator >= 0 ? endpointWithoutScheme.substring(0, pathSeparator) : endpointWithoutScheme;
     }
 
     @Override
@@ -298,11 +298,12 @@ class AzureADLS2CloudCredential extends AzureStorageCloudCredential {
                         String.format("fs.azure.account.key.%s.dfs.core.windows.net", storageAccount),
                         sharedKey);
             } else if (!endpoint.isEmpty()) {
+                String hadoopEndpoint = getHadoopEndpoint(endpoint);
                 generatedConfigurationMap.put(
-                        String.format("fs.azure.account.auth.type.%s", endpoint),
+                        String.format("fs.azure.account.auth.type.%s", hadoopEndpoint),
                         "SharedKey");
                 generatedConfigurationMap.put(
-                        String.format("fs.azure.account.key.%s", endpoint),
+                        String.format("fs.azure.account.key.%s", hadoopEndpoint),
                         sharedKey);
             }
         } else if (!sasToken.isEmpty()) {
@@ -314,11 +315,12 @@ class AzureADLS2CloudCredential extends AzureStorageCloudCredential {
                         String.format("fs.azure.sas.fixed.token.%s.dfs.core.windows.net", storageAccount),
                         sasToken);
             } else if (!endpoint.isEmpty()) {
+                String hadoopEndpoint = getHadoopEndpoint(endpoint);
                 generatedConfigurationMap.put(
-                        String.format("fs.azure.account.auth.type.%s", endpoint),
+                        String.format("fs.azure.account.auth.type.%s", hadoopEndpoint),
                         "SAS");
                 generatedConfigurationMap.put(
-                        String.format("fs.azure.sas.fixed.token.%s", endpoint),
+                        String.format("fs.azure.sas.fixed.token.%s", hadoopEndpoint),
                         sasToken);
             }
         } else if (!oauth2ClientId.isEmpty() && !oauth2ClientSecret.isEmpty() &&

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
@@ -287,6 +287,38 @@ public class CloudConfigurationFactoryTest {
     }
 
     @Test
+    public void testAzureBlobEndpointAuthorityIsUsedInHadoopCredentialKeys() {
+        Map<String, String> sharedKeyProperties = new HashMap<>();
+        sharedKeyProperties.put(CloudConfigurationConstants.AZURE_BLOB_ENDPOINT,
+                "https://account.blob.core.windows.net:8443/");
+        sharedKeyProperties.put(CloudConfigurationConstants.AZURE_BLOB_SHARED_KEY, "shared-key");
+
+        CloudConfiguration sharedKeyConfiguration =
+                CloudConfigurationFactory.buildCloudConfigurationForStorage(sharedKeyProperties);
+        Configuration sharedKeyHadoopConfiguration = new Configuration();
+        sharedKeyConfiguration.applyToConfiguration(sharedKeyHadoopConfiguration);
+        Assertions.assertEquals("shared-key", sharedKeyHadoopConfiguration.get(
+                "fs.azure.account.key.account.blob.core.windows.net:8443"));
+        Assertions.assertNull(sharedKeyHadoopConfiguration.get(
+                "fs.azure.account.key.account.blob.core.windows.net:8443/"));
+
+        Map<String, String> sasProperties = new HashMap<>();
+        sasProperties.put(CloudConfigurationConstants.AZURE_BLOB_ENDPOINT,
+                "http://account.blob.core.windows.net:10000/");
+        sasProperties.put(CloudConfigurationConstants.AZURE_BLOB_CONTAINER, "container");
+        sasProperties.put(CloudConfigurationConstants.AZURE_BLOB_SAS_TOKEN, "sas-token");
+
+        CloudConfiguration sasConfiguration =
+                CloudConfigurationFactory.buildCloudConfigurationForStorage(sasProperties);
+        Configuration sasHadoopConfiguration = new Configuration();
+        sasConfiguration.applyToConfiguration(sasHadoopConfiguration);
+        Assertions.assertEquals("sas-token", sasHadoopConfiguration.get(
+                "fs.azure.sas.container.account.blob.core.windows.net:10000"));
+        Assertions.assertNull(sasHadoopConfiguration.get(
+                "fs.azure.sas.container.account.blob.core.windows.net:10000/"));
+    }
+
+    @Test
     public void testAzureASLS1eCloudConfiguration() {
         Map<String, String> map = new HashMap<String, String>() {
             {

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
@@ -255,6 +255,38 @@ public class CloudConfigurationFactoryTest {
     }
 
     @Test
+    public void testAzureBlobEndpointSchemeIsExcludedFromHadoopCredentialKeys() {
+        Map<String, String> sharedKeyProperties = new HashMap<>();
+        sharedKeyProperties.put(CloudConfigurationConstants.AZURE_BLOB_ENDPOINT,
+                "https://account.blob.core.windows.net");
+        sharedKeyProperties.put(CloudConfigurationConstants.AZURE_BLOB_SHARED_KEY, "shared-key");
+
+        CloudConfiguration sharedKeyConfiguration =
+                CloudConfigurationFactory.buildCloudConfigurationForStorage(sharedKeyProperties);
+        Configuration sharedKeyHadoopConfiguration = new Configuration();
+        sharedKeyConfiguration.applyToConfiguration(sharedKeyHadoopConfiguration);
+        Assertions.assertEquals("shared-key", sharedKeyHadoopConfiguration.get(
+                "fs.azure.account.key.account.blob.core.windows.net"));
+        Assertions.assertNull(sharedKeyHadoopConfiguration.get(
+                "fs.azure.account.key.https://account.blob.core.windows.net"));
+
+        Map<String, String> sasProperties = new HashMap<>();
+        sasProperties.put(CloudConfigurationConstants.AZURE_BLOB_ENDPOINT,
+                "http://account.blob.core.windows.net");
+        sasProperties.put(CloudConfigurationConstants.AZURE_BLOB_CONTAINER, "container");
+        sasProperties.put(CloudConfigurationConstants.AZURE_BLOB_SAS_TOKEN, "sas-token");
+
+        CloudConfiguration sasConfiguration =
+                CloudConfigurationFactory.buildCloudConfigurationForStorage(sasProperties);
+        Configuration sasHadoopConfiguration = new Configuration();
+        sasConfiguration.applyToConfiguration(sasHadoopConfiguration);
+        Assertions.assertEquals("sas-token", sasHadoopConfiguration.get(
+                "fs.azure.sas.container.account.blob.core.windows.net"));
+        Assertions.assertNull(sasHadoopConfiguration.get(
+                "fs.azure.sas.container.http://account.blob.core.windows.net"));
+    }
+
+    @Test
     public void testAzureASLS1eCloudConfiguration() {
         Map<String, String> map = new HashMap<String, String>() {
             {

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
@@ -370,6 +370,41 @@ public class CloudConfigurationFactoryTest {
     }
 
     @Test
+    public void testAzureADLS2EndpointSchemeIsExcludedFromHadoopCredentialKeys() {
+        Map<String, String> sharedKeyProperties = new HashMap<>();
+        sharedKeyProperties.put(CloudConfigurationConstants.AZURE_ADLS2_ENDPOINT,
+                "https://account.dfs.core.windows.net");
+        sharedKeyProperties.put(CloudConfigurationConstants.AZURE_ADLS2_SHARED_KEY, "shared-key");
+
+        CloudConfiguration sharedKeyConfiguration =
+                CloudConfigurationFactory.buildCloudConfigurationForStorage(sharedKeyProperties);
+        Configuration sharedKeyHadoopConfiguration = new Configuration();
+        sharedKeyConfiguration.applyToConfiguration(sharedKeyHadoopConfiguration);
+        Assertions.assertEquals("SharedKey", sharedKeyHadoopConfiguration.get(
+                "fs.azure.account.auth.type.account.dfs.core.windows.net"));
+        Assertions.assertEquals("shared-key", sharedKeyHadoopConfiguration.get(
+                "fs.azure.account.key.account.dfs.core.windows.net"));
+        Assertions.assertNull(sharedKeyHadoopConfiguration.get(
+                "fs.azure.account.key.https://account.dfs.core.windows.net"));
+
+        Map<String, String> sasProperties = new HashMap<>();
+        sasProperties.put(CloudConfigurationConstants.AZURE_ADLS2_ENDPOINT,
+                "http://account.dfs.core.windows.net");
+        sasProperties.put(CloudConfigurationConstants.AZURE_ADLS2_SAS_TOKEN, "sas-token");
+
+        CloudConfiguration sasConfiguration =
+                CloudConfigurationFactory.buildCloudConfigurationForStorage(sasProperties);
+        Configuration sasHadoopConfiguration = new Configuration();
+        sasConfiguration.applyToConfiguration(sasHadoopConfiguration);
+        Assertions.assertEquals("SAS", sasHadoopConfiguration.get(
+                "fs.azure.account.auth.type.account.dfs.core.windows.net"));
+        Assertions.assertEquals("sas-token", sasHadoopConfiguration.get(
+                "fs.azure.sas.fixed.token.account.dfs.core.windows.net"));
+        Assertions.assertNull(sasHadoopConfiguration.get(
+                "fs.azure.sas.fixed.token.http://account.dfs.core.windows.net"));
+    }
+
+    @Test
     public void testAzureADLS2ManagedIdentity() {
         Map<String, String> map = new HashMap<>() {
             {


### PR DESCRIPTION
## Why this change is needed

Azure Blob endpoints can be configured as full URLs, for example:

```text
https://account.blob.core.windows.net
```

The Hadoop Azure filesystem scopes shared-key and SAS-token configuration keys by filesystem authority. The current implementation embeds the full URL in those keys:

```text
fs.azure.account.key.https://account.blob.core.windows.net
```

The filesystem instead looks up:

```text
fs.azure.account.key.account.blob.core.windows.net
```

As a result, credential lookup fails when the configured endpoint includes `http://` or `https://`.

## What this PR does

- Removes the HTTP or HTTPS scheme only when constructing Hadoop Azure Blob credential property keys.
- Preserves the original endpoint for the Azure native SDK and file-store metadata.
- Applies the normalization to both shared-key and SAS-token authentication.
- Adds regression tests for HTTP and HTTPS endpoint forms.

## What type of PR is this

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: correctly resolve Azure Blob credentials for URL-form endpoints

## Checklist

- [x] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation
- [ ] This is a backport PR

## Testing

```bash
mvn -pl fe-core -am -Dpython=python3 -Dtest=CloudConfigurationFactoryTest -Dsurefire.failIfNoSpecifiedTests=false test
```

Result: reactor build succeeded for all 9 modules. `CloudConfigurationFactoryTest` ran 21 tests with 0 failures, 0 errors, and 0 skipped. Checkstyle completed with 0 violations.


## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5