### PR TITLE
[BugFix] Fix FE schema corruption from concurrent flat-JSON subfield pushdown (issue #78187)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
@@ -208,22 +208,24 @@ public class JsonPathRewriteRule extends TransformationRule {
         }
 
         private Column createExtendedColumn(Table table, String path, ColumnAccessPath jsonPath) {
-            if (!table.containColumn(path)) {
-                Preconditions.checkState(table instanceof OlapTable, "Only support OlapTable");
-                // NOTE: The safety of adding a column dynamically is ensured by the fact that
-                // this rule is only applied during query planning, thus the Table here is already copied for the
-                // query. So this change would not affect the original table schema.
-                Column extendedColumn = new Column(path, jsonPath.getValueType(), true);
+            synchronized (table) {
+                if (!table.containColumn(path)) {
+                    Preconditions.checkState(table instanceof OlapTable, "Only support OlapTable");
+                    // NOTE: The safety of adding a column dynamically is ensured by the fact that
+                    // this rule is only applied during query planning, thus the Table here is already copied for the
+                    // query. So this change would not affect the original table schema.
+                    Column extendedColumn = new Column(path, jsonPath.getValueType(), true);
 
-                // Allocate the unique id for extended column
-                OlapTable olapTable = (OlapTable) table;
-                int nextUniqueId = olapTable.incAndGetMaxColUniqueId();
-                extendedColumn.setUniqueId(nextUniqueId);
+                    // Allocate the unique id for extended column
+                    OlapTable olapTable = (OlapTable) table;
+                    int nextUniqueId = olapTable.incAndGetMaxColUniqueId();
+                    extendedColumn.setUniqueId(nextUniqueId);
 
-                table.addColumn(extendedColumn);
-                return extendedColumn;
-            } else {
-                return table.getColumn(path);
+                    table.addColumn(extendedColumn);
+                    return extendedColumn;
+                } else {
+                    return table.getColumn(path);
+                }
             }
         }
 


### PR DESCRIPTION
## Why I am doing

Concurrent queries with flat-JSON subfield pushdown against the same table can corrupt the FE in-memory schema via a TOCTOU race condition in `JsonPathRewriteRule.createExtendedColumn()`. This causes all subsequent queries to fail until the FE is restarted.

## What I am doing

Add `synchronized (table)` block around the check-and-add sequence in `createExtendedColumn()` to make the operation atomic.

Fixes #78187

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:
- [ ] Interface/UI changes
- [ ] Delete a deprecated feature
- [ ] Change a non-deterministic behavior
- [ ] Other

## Checklist
- [x] I have read the [Contributing Guide](https://github.com/StarRocks/starrocks/blob/main/CONTRIBUTING.md)
- [x] I have signed the [CLA](https://cla-assistant.io/StarRocks/starrocks)
- [x] I have added unit tests and/or manually tested the changes
- [x] I have checked the version labels