### PR TITLE
[Enhancement] Enforce the segment/sstable positional contract in lake PK publish

### DIFF
--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -207,7 +207,12 @@ void HorizontalGeneralTabletWriter::close() {
             }
             full_paths_to_delete.emplace_back(path);
         }
+        // merge_other_writer appends an empty FileInfo placeholder for a segment with no eager PK-index
+        // SST, to keep _ssts aligned with _segments; skip those, they name no file.
         for (const auto& f : _ssts) {
+            if (f.path.empty()) {
+                continue;
+            }
             std::string path;
             if (_location_provider) {
                 path = _location_provider->sst_location(_tablet_id, f.path);
@@ -557,7 +562,12 @@ void VerticalGeneralTabletWriter::close() {
             }
             full_paths_to_delete.emplace_back(path);
         }
+        // merge_other_writer appends an empty FileInfo placeholder for a segment with no eager PK-index
+        // SST, to keep _ssts aligned with _segments; skip those, they name no file.
         for (const auto& f : _ssts) {
+            if (f.path.empty()) {
+                continue;
+            }
             std::string path;
             if (_location_provider) {
                 path = _location_provider->sst_location(_tablet_id, f.path);

--- a/be/src/storage/lake/tablet_writer.cpp
+++ b/be/src/storage/lake/tablet_writer.cpp
@@ -84,6 +84,9 @@ Status TabletWriter::merge_other_writers(const std::vector<std::unique_ptr<Table
 }
 
 Status TabletWriter::merge_other_writer(const TabletWriter* other_writer) {
+    // Number of segments this writer held before this batch, i.e. the number of _ssts entries that must
+    // already be present for the batch appended below to land at the right index (see the padding note).
+    const size_t segments_before = _segments.size();
     // merge other writer's files into current writer
     _segments.insert(_segments.end(), other_writer->_segments.begin(), other_writer->_segments.end());
     // Assign each consolidated del file an op_offset that places it right after THIS batch's segments
@@ -103,6 +106,23 @@ Status TabletWriter::merge_other_writer(const TabletWriter* other_writer) {
         _del_ssts.push_back(i < other_writer->_del_ssts.size() ? other_writer->_del_ssts[i] : FileInfo{});
         _del_sst_ranges.push_back(i < other_writer->_del_sst_ranges.size() ? other_writer->_del_sst_ranges[i]
                                                                            : PersistentIndexSstableRangePB{});
+    }
+    // _ssts, _sst_ranges and _seg_delvecs must stay positionally aligned with _segments: publish reads
+    // op_write.ssts(i) / sst_ranges(i) by SEGMENT index (UpdateManager::publish_primary_key_tablet), so a
+    // batch that contributed segments without an eager PK-index SST must not shift the following batches'
+    // entries left -- that would map a segment's rows to another segment's keys in the primary index, and
+    // the index would then miss the rows that are actually there. THIS writer can hold such segments: the
+    // spill sink's single-flush fast path (write_single_flush) writes a plain segment and clears the
+    // eager-build flag, while merge_blocks_to_segments turns it back on for the cloned merge writers,
+    // whose segments do carry SSTs. Pad up to segments_before with an empty FileInfo / range, which
+    // publish reads as "this segment has no eager SST" and upserts into the index instead of ingesting
+    // one. Same discipline as _del_ssts vs _dels above.
+    if (!_ssts.empty() || !other_writer->_ssts.empty()) {
+        while (_ssts.size() < segments_before) {
+            _ssts.emplace_back();
+            _sst_ranges.emplace_back();
+            _seg_delvecs.emplace_back();
+        }
     }
     _ssts.insert(_ssts.end(), other_writer->_ssts.begin(), other_writer->_ssts.end());
     _sst_ranges.insert(_sst_ranges.end(), other_writer->_sst_ranges.begin(), other_writer->_sst_ranges.end());

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -452,6 +452,17 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     // When too many sst files, we need to compact them early.
     int32_t current_fileset_start_idx = index.current_fileset_index();
     AsyncCompactCBPtr async_compact_cb;
+    // op_write.ssts / sst_ranges are read by SEGMENT index, and a segment need not have an eager
+    // PK-index SST: the writer appends an empty FileInfo placeholder for one that has none (see
+    // TabletWriter::merge_other_writer), and a txn log written before that padding existed can simply
+    // carry fewer ssts than segments. Decide per segment, not per transaction -- a segment whose keys
+    // are in no ingested sstable must go through the index-writing parallel_upsert instead of the
+    // read-only lookup, otherwise its rows never enter the index at all and the delete marks for the
+    // rows they supersede are never generated (issue #78224). Mirrors the del_ssts guard in _do_delete.
+    auto segment_has_eager_sst = [&op_write](uint32_t local_id) {
+        return local_id < static_cast<uint32_t>(op_write.ssts_size()) &&
+               local_id < static_cast<uint32_t>(op_write.sst_ranges_size()) && !op_write.ssts(local_id).name().empty();
+    };
     // Check if parallel row-mode partial update is applicable.
     int32_t condition_column = _get_condition_column(op_write, *tablet_schema);
     const bool has_condition_update = (condition_column >= 0);
@@ -539,8 +550,8 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
             DCHECK(state.upserts(local_id) != nullptr);
             if (!has_condition_update) {
                 RETURN_IF_ERROR(_do_update(rowset_id, global_segment_id, state.upserts(local_id), index, &new_deletes,
-                                           op_write.ssts_size() > 0, use_cloud_native_pk_index(*metadata)));
-            } else if (op_write.ssts_size() > 0) {
+                                           segment_has_eager_sst(local_id), use_cloud_native_pk_index(*metadata)));
+            } else if (segment_has_eager_sst(local_id)) {
                 RETURN_IF_ERROR(_do_update_with_condition_parallel(params, rowset_id, global_segment_id,
                                                                    condition_column, state.upserts(local_id), index,
                                                                    &new_deletes));
@@ -566,7 +577,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
             _index_cache.update_object_size(index_entry, index.memory_usage());
             state.release_segment(local_id);
             _update_state_cache.update_object_size(state_entry, state.memory_usage());
-            if (op_write.ssts_size() > 0 && use_cloud_native_pk_index(*metadata)) {
+            if (segment_has_eager_sst(local_id) && use_cloud_native_pk_index(*metadata)) {
                 DelvecPagePB delvec_page_pb = builder->delvec_page(rowset_id + global_segment_id);
                 delvec_page_pb.set_version(metadata->version());
                 RETURN_IF_ERROR(index.ingest_sst(op_write.ssts(local_id), op_write.sst_ranges(local_id),

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -319,6 +319,7 @@ SET(DW_TEST_FILES
     ./storage/lake/delete_test.cpp
     ./storage/lake/transactions_test.cpp
     ./storage/lake/pk_tablet_sst_writer_test.cpp
+    ./storage/lake/lake_pk_delvec_loss_78224_test.cpp
     ./storage/lake/txn_log_applier_test.cpp
     ./storage/lake/txn_log_applier_idg_test.cpp
     ./storage/lake/vacuum_test.cpp

--- a/be/test/storage/lake/lake_pk_delvec_loss_78224_test.cpp
+++ b/be/test/storage/lake/lake_pk_delvec_loss_78224_test.cpp
@@ -1,0 +1,352 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Issue #78224: on a shared-data primary-key tablet with a CLOUD_NATIVE persistent index, an upsert
+// of an existing key can fail to leave a durable delete-vector mark on the superseded row *as the
+// persistent-index rebuild sees it*. The next rebuild (owner CN restart / tablet re-placement) then
+// finds two live rows for one key, PersistentIndexMemtable::insert() returns AlreadyExist, and every
+// publish retry for the table fails forever.
+//
+// These tests drive the exact publish path the report is on: the load spills, so the PK tablet
+// writer builds a per-segment PK sstable eagerly and op_write carries `ssts`. Publish then takes the
+// READ-ONLY branch of UpdateManager::_do_update -- index.parallel_get() locates the superseded rows
+// without upserting, and the new keys enter the index later via LakePersistentIndex::ingest_sst().
+// The primary index is dropped from the cache between transactions, so every publish rebuilds the
+// index from segments + delete vectors, which is where a lost mark surfaces.
+//
+// The key shape is not incidental. pk_index_eager_build_supported() (tablet_writer.cpp) refuses the
+// eager SST for a V1-encoded single non-VARCHAR key column, so a one-INT-key tablet never reaches
+// this path at all. The reporter's table is PRIMARY KEY(BIGINT, DATE) -- two key columns, 12 encoded
+// bytes, matching the `PersistentIndexMemtable<12>` in their error -- so this fixture mirrors it with
+// (BIGINT, INT) keys.
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include <map>
+#include <vector>
+
+#include "base/testutil/assert.h"
+#include "base/testutil/id_generator.h"
+#include "column/chunk.h"
+#include "column/chunk_factory.h"
+#include "column/fixed_length_column.h"
+#include "column/schema.h"
+#include "common/config_ingest_fwd.h"
+#include "common/config_primary_key_fwd.h"
+#include "fs/fs_util.h"
+#include "storage/chunk_helper.h"
+#include "storage/lake/delta_writer.h"
+#include "storage/lake/tablet.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_reader.h"
+#include "storage/lake/tablet_writer.h"
+#include "storage/lake/test_util.h"
+#include "storage/lake/txn_log.h"
+#include "storage/lake/update_manager.h"
+#include "storage/storage_env.h"
+#include "storage/tablet_schema.h"
+
+namespace starrocks::lake {
+
+class LakePkDelvecLoss78224Test : public TestBase {
+public:
+    LakePkDelvecLoss78224Test() : TestBase(kTestDirectory) {
+        _tablet_metadata = generate_two_key_column_metadata();
+        _tablet_metadata->set_enable_persistent_index(true);
+        _tablet_metadata->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
+        _tablet_schema = TabletSchema::create(_tablet_metadata->schema());
+        _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+    }
+
+    // PRIMARY KEY(k0 BIGINT, k1 INT), value v INT -- the reporter's two-column, 12-byte-encoded key.
+    // A single INT key would encode with V1 and pk_index_eager_build_supported() would decline the
+    // eager SST, silently taking the load off the path under test.
+    static std::shared_ptr<TabletMetadataPB> generate_two_key_column_metadata() {
+        auto metadata = std::make_shared<TabletMetadata>();
+        metadata->set_id(next_id());
+        metadata->set_version(1);
+        metadata->set_cumulative_point(0);
+        metadata->set_next_rowset_id(1);
+        auto schema = metadata->mutable_schema();
+        schema->set_keys_type(PRIMARY_KEYS);
+        schema->set_id(next_id());
+        schema->set_num_short_key_columns(1);
+        schema->set_num_rows_per_row_block(65535);
+        auto* k0 = schema->add_column();
+        k0->set_unique_id(next_id());
+        k0->set_name("k0");
+        k0->set_type("BIGINT");
+        k0->set_is_nullable(false);
+        k0->set_is_key(true);
+        auto* k1 = schema->add_column();
+        k1->set_unique_id(next_id());
+        k1->set_name("k1");
+        k1->set_type("INT");
+        k1->set_is_nullable(false);
+        k1->set_is_key(true);
+        auto* v = schema->add_column();
+        v->set_unique_id(next_id());
+        v->set_name("v");
+        v->set_type("INT");
+        v->set_is_nullable(false);
+        v->set_is_key(false);
+        v->set_aggregation("REPLACE");
+        return metadata;
+    }
+
+protected:
+    void SetUp() override {
+        clear_and_init_test_dir();
+        StorageEnv::GetInstance()->parallel_compact_mgr()->TEST_set_tablet_mgr(_tablet_mgr.get());
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    }
+    void TearDown() override { remove_test_dir_ignore_error(); }
+
+    // One chunk of `count` consecutive primary keys starting at `start`; `val_bias` makes a re-upsert
+    // of the same keys carry a distinct value so the read-back can tell which row survived.
+    Chunk generate_data(int64_t count, int64_t start, int32_t val_bias) {
+        auto k0 = Int64Column::create();
+        auto k1 = Int32Column::create();
+        auto v = Int32Column::create();
+        for (int64_t i = 0; i < count; i++) {
+            k0->append(start + i);
+            k1->append(static_cast<int32_t>((start + i) % 7)); // second key column, derived from the first
+            v->append(static_cast<int32_t>((start + i) * 3) + val_bias);
+        }
+        return Chunk({std::move(k0), std::move(k1), std::move(v)}, _schema);
+    }
+
+    // Load `chunks` in one transaction and publish it. With write_buffer_size == 1 each write() flushes,
+    // so the load spills and the merge emits several segments plus their eager PK sstables.
+    Status load_and_publish(int64_t tablet_id, std::vector<Chunk>& chunks, int64_t new_version, int64_t* ssts_out) {
+        ASSIGN_OR_RETURN(auto txn_id, write_txn(tablet_id, chunks));
+        if (ssts_out != nullptr) {
+            ASSIGN_OR_RETURN(auto txn_log, _tablet_mgr->get_txn_log(tablet_id, txn_id));
+            *ssts_out = txn_log->op_write().ssts_size();
+        }
+        RETURN_IF_ERROR(publish_single_version(tablet_id, new_version, txn_id).status());
+        return Status::OK();
+    }
+
+    // Write `chunks` as one uncommitted transaction and return its txn id, so a test can inspect or
+    // adjust the txn log before publishing it.
+    StatusOr<int64_t> write_txn(int64_t tablet_id, std::vector<Chunk>& chunks) {
+        const int64_t txn_id = next_id();
+        ASSIGN_OR_RETURN(auto delta_writer, DeltaWriterBuilder()
+                                                    .set_tablet_manager(_tablet_mgr.get())
+                                                    .set_tablet_id(tablet_id)
+                                                    .set_txn_id(txn_id)
+                                                    .set_partition_id(_partition_id)
+                                                    .set_mem_tracker(_mem_tracker.get())
+                                                    .set_schema_id(_tablet_schema->id())
+                                                    .set_profile(&_dummy_runtime_profile)
+                                                    .build());
+        RETURN_IF_ERROR(delta_writer->open());
+        for (auto& chunk : chunks) {
+            std::vector<uint32_t> indexes(chunk.num_rows());
+            for (uint32_t i = 0, n = chunk.num_rows(); i < n; i++) {
+                indexes[i] = i;
+            }
+            RETURN_IF_ERROR(delta_writer->write(chunk, indexes.data(), indexes.size()));
+        }
+        RETURN_IF_ERROR(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        return txn_id;
+    }
+
+    // PK -> value for the whole tablet at `version`. A duplicated key would inflate the row count
+    // above the map size, so both are reported separately.
+    std::map<int64_t, int32_t> read_key_values(int64_t tablet_id, int64_t version, int64_t* rows_out) {
+        ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+        auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata, *_schema);
+        CHECK_OK(reader->prepare());
+        CHECK_OK(reader->open(TabletReaderParams()));
+        std::map<int64_t, int32_t> out;
+        int64_t rows = 0;
+        while (true) {
+            auto tmp = ChunkFactory::new_chunk(*_schema, 128);
+            auto st = reader->get_next(tmp.get());
+            if (st.is_end_of_file()) {
+                break;
+            }
+            CHECK_OK(st);
+            auto cols = tmp->columns();
+            for (size_t i = 0; i < tmp->num_rows(); i++) {
+                out[cols[0]->get(i).get_int64()] = cols[2]->get(i).get_int32();
+            }
+            rows += tmp->num_rows();
+        }
+        if (rows_out != nullptr) {
+            *rows_out = rows;
+        }
+        return out;
+    }
+
+    constexpr static const char* const kTestDirectory = "test_lake_pk_delvec_loss_78224";
+    // Three chunks per transaction, so a transaction writes several segments (and several eager SSTs).
+    constexpr static int64_t kKeysPerChunk = 100;
+    constexpr static int64_t kNumKeys = 3 * kKeysPerChunk;
+
+    std::shared_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<Schema> _schema;
+    int64_t _partition_id = next_id();
+    RuntimeProfile _dummy_runtime_profile{"dummy"};
+};
+
+// The reporter's workload: the same key set is re-upserted transaction after transaction while the
+// owner CN keeps losing its resident primary index, so every publish rebuilds the index from
+// segments + delete vectors. Every publish must succeed, and the tablet must still hold exactly one
+// row per key carrying the newest value.
+TEST_F(LakePkDelvecLoss78224Test, rebuild_after_repeated_upsert_of_same_keys) {
+    ConfigResetGuard<bool> spill_guard(&config::enable_load_spill, true);
+    ConfigResetGuard<int64_t> buffer_guard(&config::write_buffer_size, 1);
+    ConfigResetGuard<int64_t> eager_guard(&config::pk_index_eager_build_threshold_bytes, 1);
+
+    const int64_t tablet_id = _tablet_metadata->id();
+    constexpr int kRounds = 6;
+    int64_t version = 1;
+    int32_t last_bias = 0;
+
+    for (int round = 0; round < kRounds; round++) {
+        const int32_t val_bias = (round + 1) * 1000000;
+        std::vector<Chunk> chunks;
+        for (int64_t c = 0; c < 3; c++) {
+            chunks.emplace_back(generate_data(kKeysPerChunk, c * kKeysPerChunk, val_bias));
+        }
+        int64_t ssts = 0;
+        auto publish_st = load_and_publish(tablet_id, chunks, ++version, &ssts);
+        ASSERT_TRUE(publish_st.ok()) << "round " << round << ": " << publish_st;
+        // Guard the premise: the load really did take the eager-SST / read-only publish path.
+        ASSERT_GT(ssts, 0) << "round " << round
+                           << ": op_write carries no ssts, so publish did not take "
+                              "the read-only parallel_get + ingest_sst path";
+        last_bias = val_bias;
+        // The owner CN loses its resident primary index (restart or tablet re-placement). The next
+        // publish must rebuild it from segments + delete vectors.
+        _update_mgr->try_remove_primary_index_cache(static_cast<uint32_t>(tablet_id));
+    }
+
+    int64_t rows = 0;
+    auto kv = read_key_values(tablet_id, version, &rows);
+    EXPECT_EQ(kNumKeys, static_cast<int64_t>(kv.size()));
+    EXPECT_EQ(kNumKeys, rows) << "a superseded row survived: its delete-vector mark was lost";
+    for (int64_t k = 0; k < kNumKeys; k++) {
+        auto it = kv.find(k);
+        ASSERT_NE(it, kv.end()) << "key " << k << " disappeared";
+        EXPECT_EQ(static_cast<int32_t>(k * 3) + last_bias, it->second) << "key " << k << " kept a stale value";
+    }
+}
+
+// The consolidating writer of a spilled load can end up holding a segment that has no eager PK-index
+// SST: SpillMemTableSink's single-flush fast path (write_single_flush) writes a plain segment and
+// clears the eager-build flag, while merge_blocks_to_segments() turns eager build back on for the
+// cloned merge writers, whose segments do carry SSTs. Publish reads op_write.ssts(i) /
+// sst_ranges(i) by SEGMENT index, so the two must stay positionally aligned. When they are not, the
+// keys of one segment are ingested under another segment's rssid while the rows that are really in
+// that segment never enter the primary index at all -- so the next upsert of those keys finds nothing
+// to supersede, writes no delete-vector mark, and the next index rebuild sees two live rows for one
+// key (AlreadyExist). This drives the writer through exactly that sequence and pins the invariant.
+TEST_F(LakePkDelvecLoss78224Test, eager_pk_ssts_stay_aligned_with_segments) {
+    ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
+    ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, next_id()));
+    ASSERT_OK(writer->open());
+
+    // The flush that took the single-flush fast path: a plain segment, eager SST skipped.
+    auto single_flush_chunk = generate_data(kKeysPerChunk, 0, 0);
+    ASSERT_OK(writer->write_single_flush(single_flush_chunk, nullptr, false));
+    ASSERT_OK(writer->flush());
+    ASSERT_EQ(size_t{1}, writer->segments().size());
+    ASSERT_TRUE(writer->ssts().empty()) << "premise: the single-flush segment must carry no eager SST";
+
+    // merge_blocks_to_segments(): eager build back on, then the merge writers' output is consolidated.
+    writer->try_enable_pk_index_eager_build();
+    ASSERT_TRUE(writer->enable_pk_index_eager_build())
+            << "premise: (BIGINT, INT) keys must support eager PK index build";
+    ASSIGN_OR_ABORT(auto merge_writer, writer->clone());
+    auto merged_chunk = generate_data(kKeysPerChunk, kKeysPerChunk, 0);
+    ASSERT_OK(merge_writer->write(merged_chunk));
+    ASSERT_OK(merge_writer->finish());
+    ASSERT_EQ(size_t{1}, merge_writer->segments().size());
+    ASSERT_EQ(size_t{1}, merge_writer->ssts().size()) << "premise: the merge writer must build an eager SST";
+
+    ASSERT_OK(writer->merge_other_writer(merge_writer.get()));
+    ASSERT_OK(writer->finish());
+
+    ASSERT_EQ(writer->segments().size(), writer->ssts().size())
+            << "publish reads op_write.ssts by segment index, so there must be one entry per segment";
+    ASSERT_EQ(writer->segments().size(), writer->sst_ranges().size());
+    EXPECT_TRUE(writer->ssts()[0].path.empty()) << "the single-flush segment has no eager SST";
+    EXPECT_FALSE(writer->ssts()[1].path.empty()) << "the merged segment's eager SST must stay at its own segment index";
+
+    merge_writer->close();
+    writer->close();
+}
+
+// The publish side of the same contract: an ssts entry may be an empty placeholder for a segment that
+// has no eager SST. That segment's keys are in no ingested sstable, so publish must upsert it into the
+// index instead of taking the read-only lookup and ingesting nothing -- otherwise its rows never enter
+// the index and the next upsert of those keys cannot mark the rows it supersedes.
+TEST_F(LakePkDelvecLoss78224Test, publish_indexes_segment_without_eager_sst) {
+    ConfigResetGuard<bool> spill_guard(&config::enable_load_spill, true);
+    ConfigResetGuard<int64_t> buffer_guard(&config::write_buffer_size, 1);
+    ConfigResetGuard<int64_t> eager_guard(&config::pk_index_eager_build_threshold_bytes, 1);
+
+    const int64_t tablet_id = _tablet_metadata->id();
+    int64_t version = 1;
+
+    // Round 1: a normal eager-SST load, then blank the first segment's SST entry so the txn log has
+    // the shape a consolidating writer produces -- segment 0 without an eager SST, the rest with one.
+    std::vector<Chunk> chunks;
+    for (int64_t c = 0; c < 3; c++) {
+        chunks.emplace_back(generate_data(kKeysPerChunk, c * kKeysPerChunk, 1000));
+    }
+    ASSIGN_OR_ABORT(auto txn_id, write_txn(tablet_id, chunks));
+    ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_log(tablet_id, txn_id));
+    ASSERT_GE(txn_log->op_write().ssts_size(), 1) << "premise: the load must take the eager-SST path";
+    ASSERT_EQ(txn_log->op_write().rowset().segment_metas_size(), txn_log->op_write().ssts_size());
+    auto adjusted = std::make_shared<TxnLog>(*txn_log);
+    adjusted->mutable_op_write()->mutable_ssts(0)->clear_name();
+    adjusted->mutable_op_write()->mutable_sst_ranges(0)->Clear();
+    ASSERT_OK(_tablet_mgr->put_txn_log(adjusted));
+    auto publish_st = publish_single_version(tablet_id, ++version, txn_id).status();
+    ASSERT_TRUE(publish_st.ok()) << "publish must handle a segment with no eager SST: " << publish_st;
+
+    // Round 2: re-upsert every key with the resident primary index dropped, so publish rebuilds the
+    // index from segments + delete vectors. Round 1's segment 0 rows must have made it into the index,
+    // otherwise they are not superseded here and survive as duplicates.
+    _update_mgr->try_remove_primary_index_cache(static_cast<uint32_t>(tablet_id));
+    const int32_t last_bias = 2000;
+    std::vector<Chunk> chunks2;
+    for (int64_t c = 0; c < 3; c++) {
+        chunks2.emplace_back(generate_data(kKeysPerChunk, c * kKeysPerChunk, last_bias));
+    }
+    int64_t ssts = 0;
+    auto st = load_and_publish(tablet_id, chunks2, ++version, &ssts);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_GT(ssts, 0) << "op_write carries no ssts, so publish did not take the read-only path";
+
+    int64_t rows = 0;
+    auto kv = read_key_values(tablet_id, version, &rows);
+    EXPECT_EQ(kNumKeys, static_cast<int64_t>(kv.size()));
+    EXPECT_EQ(kNumKeys, rows) << "a superseded row survived: its delete-vector mark was lost";
+    for (int64_t k = 0; k < kNumKeys; k++) {
+        auto it = kv.find(k);
+        ASSERT_NE(it, kv.end()) << "key " << k << " disappeared";
+        EXPECT_EQ(static_cast<int32_t>(k * 3) + last_bias, it->second) << "key " << k << " kept a stale value";
+    }
+}
+
+} // namespace starrocks::lake


### PR DESCRIPTION
> **Draft.** The original description of this PR claimed a root cause for issue 78224 that I can no longer
> support. I have rewritten it below to say only what is actually established. Retitled from
> `[BugFix] Keep eager PK-index sstables aligned with segments at publish` for the same reason.
> See "What I got wrong" at the end.

## Why I'm doing:

`op_write.ssts` / `op_write.sst_ranges` (the eager per-segment PK-index sstables) are a **positional**
parallel array of `op_write.rowset().segment_metas`. Publish relies on that and never checks it:

* `be/src/storage/lake/update_manager.cpp` — `index.ingest_sst(op_write.ssts(local_id),
  op_write.sst_ranges(local_id), rowset_id + global_segment_id, …)` indexes both arrays by **segment**
  position with **no size guard at all**. If the arrays are ever shorter than the segment list this is
  a read past the end of a repeated field: a `DCHECK` in debug, undefined behaviour in the release
  build. Compare the guards that already exist nearby — `seg_delvecs` is bounds-checked
  (`local_id < op_write.seg_delvecs_size()`), `del_ssts` has a full equality guard
  (`del_ssts_size() == dels_meta_size() && del_sst_ranges_size() == dels_meta_size()`), and the
  compaction twin has a `DCHECK`, which is a no-op in release.
* The read-only decision was **transaction-wide** (`op_write.ssts_size() > 0`). In read-only mode
  `_do_update` calls `index.parallel_get()` and does not insert the segment's keys — they are expected
  to arrive later through `ingest_sst`. A segment covered by no sstable would therefore never enter
  the primary index at all.

On the writer side the same contract is unenforced: `TabletWriter::merge_other_writer` appends
`_ssts` / `_sst_ranges` / `_seg_delvecs` with a bare `insert`, while the sibling `_del_ssts` /
`_del_sst_ranges` loop immediately above it **explicitly pads** with an empty `FileInfo{}` to stay
aligned with `_dels`, and its comment says that padding is required. In
`HorizontalPkTabletWriter::flush_segment_writer`, `_segments.emplace_back()` and
`_ssts.emplace_back()` are gated on independent conditions, so nothing structurally prevents the two
from diverging.

`be/test/storage/lake/lake_pk_delvec_loss_78224_test.cpp:eager_pk_ssts_stay_aligned_with_segments`
demonstrates that a writer driven through `write_single_flush` → `try_enable_pk_index_eager_build` →
`clone` → `merge_other_writer` produces 2 segments and 1 sstable on stock `main`.

## What I'm doing:

Enforcing the contract on both sides, and making publish safe against any array shape.

* `TabletWriter::merge_other_writer` — pad `_ssts` / `_sst_ranges` / `_seg_delvecs` up to the
  pre-merge segment count before appending a batch, so a segment without an eager sstable cannot
  shift the following batches. Same discipline the adjacent `_del_ssts` / `_dels` loop already uses.
* `UpdateManager::publish_primary_key_tablet` — treat the arrays as positional **only** when there is
  exactly one entry per segment, and decide per segment rather than per transaction. Anything else
  falls back to the legacy path for the whole transaction: every segment goes through the
  index-writing `parallel_upsert` and nothing is ingested. This removes the out-of-bounds read, and
  it is correct for a **compacted** short array as well as a truncated one — a writer that omits the
  entry rather than padding it leaves `ssts(i)` belonging to a later segment, so a bounds check alone
  would still ingest each sstable under the wrong segment's rssid. (Thanks to the Codex review for
  catching that; the first version of this PR had exactly that hole.)
* `HorizontalGeneralTabletWriter::close` / `VerticalGeneralTabletWriter::close` — skip empty `_ssts`
  paths when deleting an unfinished writer's files, as they already do for `_del_ssts`.

Found while investigating the shared-data PK duplicate-key report (issue 78224, referenced
without a link on purpose). **Not claimed to fix it**, see below.

## What I got wrong

The first version of this description claimed a concrete producer: that `SpillMemTableSink` decides
"this is the only flush" with `_load_chunk_spiller->empty()`, that an eager intermediate merge
synchronously erases the block groups it takes, and that the final flush of a multi-flush load can
therefore slip into the `write_single_flush` fast path and emit a segment with no eager sstable.

That is wrong. The guard is `eos && _load_chunk_spiller->empty() && slot_idx == 0`, and `slot_idx` is
a per-token counter incremented on every submitted flush
(`MemtableFlushExecutor`/`FlushToken::submit`). `slot_idx == 0` therefore means *this is the first
flush of the load*, so `eos && slot_idx == 0` already implies a genuinely single-flush load — nothing
was spilled, no merge writers exist, `_ssts` stays empty, and publish takes the ordinary upsert path.
The `empty()` race I described is real but unreachable, because by then `slot_idx > 0`. Checked the
neighbouring candidates too: `init_parallel_merge()` enables eager build before it creates the token,
and the only other token creator runs after `try_enable_pk_index_eager_build()` in
`merge_blocks_to_segments`, so the eager flag cannot differ between clone batches of one load.

So: the misaligned shape is constructible through the writer API, and publish handles it unsafely,
but **I have not found a production path that produces it**, and this PR should not be read as the
root cause of issue 78224. That investigation continues. What remains unexamined: the
`VerticalPkTabletWriter` path, and whether a merge task can flush a segment while its PK sstable
writer holds no rows.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

### Mixed-version note

The txn log's `ssts` array changes shape: a segment with no eager sstable is now represented by an
empty `FileInfo` placeholder instead of being omitted.

* **Old txn log → new BE: safe.** A shorter array is not read positionally at all; the transaction
  falls back to `parallel_upsert`.
* **New txn log → old BE: publish fails, loudly.** A pre-fix BE sees `ssts_size() > 0`, goes read-only
  for every segment, and calls `ingest_sst` on the empty placeholder. It errors out rather than
  corrupting anything (`publish_indexes_segment_without_eager_sst` reproduces this on stock `main`:
  `IO error: read: Is a directory`), but during a rolling upgrade a not-yet-upgraded node that owns
  the tablet would retry that publish until it is upgraded.

If reviewers would rather have no such window, the writer-side padding can be dropped and only the
publish-side guard kept: that alone makes publish safe for every array shape, old and new, and leaves
the wire format untouched. I have no strong preference.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

Backport deferred while this is a draft: `branch-4.0` and `branch-3.5` carry neither the unpadded
`_ssts.insert` nor the `ssts_size() > 0` publish branch, so only `branch-4.1` would be a candidate.

