### PR TITLE
[Enhancement] Support constant folding for double mod

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -1431,6 +1431,14 @@ public class ScalarOperatorFunctions {
         return ConstantOperator.createLargeInt(first.getLargeInt().remainder(second.getLargeInt()));
     }
 
+    @ConstantFunction(name = "mod", argTypes = {DOUBLE, DOUBLE}, returnType = DOUBLE)
+    public static ConstantOperator modDouble(ConstantOperator first, ConstantOperator second) {
+        if (second.getDouble() == 0.0) {
+            return handleDivisionByZero(FloatType.DOUBLE);
+        }
+        return ConstantOperator.createDouble(first.getDouble() % second.getDouble());
+    }
+
     @ConstantFunction.List(list = {
             @ConstantFunction(name = "mod", argTypes = {DECIMALV2, DECIMALV2}, returnType = DECIMALV2),
             @ConstantFunction(name = "mod", argTypes = {DECIMAL32, DECIMAL32}, returnType = DECIMAL32),

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -1201,6 +1201,12 @@ public class ScalarOperatorFunctionsTest {
     }
 
     @Test
+    public void modDouble() {
+        assertEquals(1.5, ScalarOperatorFunctions.modDouble(
+                ConstantOperator.createDouble(10.5), ConstantOperator.createDouble(3.0)).getDouble());
+    }
+
+    @Test
     public void modDecimal() {
         assertEquals("0", ScalarOperatorFunctions.modDecimal(O_DECIMAL_100, O_DECIMAL_100).getDecimal().toString());
         assertEquals("0",

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
@@ -671,6 +671,14 @@ public class ConstantExpressionTest extends PlanTestBase {
     }
 
     @Test
+    public void testFoldDoubleModInPredicate() throws Exception {
+        String plan = getFragmentPlan(
+                "SELECT v1 FROM t0 WHERE v1 = (3493131456125200 / 100) % 256");
+        assertContains(plan, "PREDICATES: 1: v1 = 228");
+        assertNotContains(plan, "mod(");
+    }
+
+    @Test
     public void testStrToDateWithAllowThrowException() throws Exception {
         long savedSqlMode = connectContext.getSessionVariable().getSqlMode();
         try {


### PR DESCRIPTION

## Why I'm doing:

StarRocks supports `MOD(DOUBLE, DOUBLE)` during query execution, but the FE constant evaluator does not implement the corresponding function.

As a result, constant expressions such as:

```sql
(3493131456125200 / 100) % 256
```

cannot be folded during query optimization. The expression remains in the predicate instead of being evaluated to `228`.

For external tables such as Paimon, this may prevent the connector predicate converter from recognizing the right-hand side as a literal, which can further prevent partition predicate pushdown and partition pruning.

## What I'm doing:

- Add FE constant evaluation for `MOD(DOUBLE, DOUBLE)`.
- Reuse the existing division-by-zero handling to keep the behavior consistent with other arithmetic functions.
- Add a function-level unit test for DOUBLE modulo.
- Add a planner regression test to verify that the original expression is folded into the following predicate:

```text
v1 = 228
```

Tests:

```text
ScalarOperatorFunctionsTest: 126 passed
ConstantExpressionTest:       23 passed
Total:                       149 passed
BUILD SUCCESS
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
```