### PR TITLE
[Tool] Add StarRocks grammar-aware SQL generator

### DIFF
--- a/tools/starrocks_sql_generator/README.md
+++ b/tools/starrocks_sql_generator/README.md
@@ -1,0 +1,91 @@
+# StarRocks SQL Generator
+
+Generate schema-aware StarRocks SQL for grammar coverage testing, based on
+[`StarRocks.g4`](../../fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4).
+
+## Features
+
+- Enumerates major query/DML grammar paths (SELECT/JOIN/GROUP BY/CTE/compound/EXPLAIN, INSERT/UPDATE/DELETE/MERGE).
+- Uses table/column metadata to emit queryable SQL (table names, column refs, type-aware literals).
+- Supports recursion depth limits for expression/subquery/join/CTE expansion via `--max-depth`.
+- Emits optional manifest JSON mapping each SQL to its grammar path tag.
+
+## Quick Start
+
+```bash
+python3 -m tools.starrocks_sql_generator \
+  --schema tools/starrocks_sql_generator/sample_schema.json \
+  --mode paths \
+  --max-depth 3 \
+  --max-outputs 200 \
+  --with-semicolon \
+  --output /tmp/starrocks_generated.sql \
+  --manifest /tmp/starrocks_generated.manifest.json
+```
+
+## Schema Input
+
+### JSON schema
+
+```json
+{
+  "database": "demo",
+  "tables": [
+    {
+      "name": "t1",
+      "columns": [
+        {"name": "id", "type": "BIGINT", "nullable": false},
+        {"name": "name", "type": "VARCHAR(64)"}
+      ]
+    }
+  ]
+}
+```
+
+### SQL schema
+
+You can also pass a SQL DDL file:
+
+```bash
+python3 -m tools.starrocks_sql_generator --schema-sql my_tables.sql ...
+```
+
+## CLI Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `--schema` | sample schema | JSON schema path |
+| `--schema-sql` | - | SQL DDL schema path |
+| `--mode` | `paths` | `paths`, `random`, or `all` |
+| `--categories` | `query,dml` | `query`, `dml`, or `all` |
+| `--max-depth` | `3` | Max recursion for expression/subquery/CTE |
+| `--max-list-items` | `2` | Max list size in SELECT/GROUP BY/etc. |
+| `--max-outputs` | `500` | Output statement cap |
+| `--seed` | `0` | Random seed |
+| `--with-semicolon` | off | Append `;` |
+| `--output` | stdout | Output SQL file |
+| `--manifest` | - | Output path metadata JSON |
+
+## Covered Grammar Paths (Query)
+
+- `queryStatement`, `withClause`, `queryNoWith`, `queryPrimary`, `querySpecification`
+- `setQuantifier`, `selectItem` (`*`, `EXCEPT`, alias)
+- `fromClause` (`DUAL`, table, subquery, `VALUES`)
+- `joinRelation` (INNER/LEFT/RIGHT/FULL/CROSS/SEMI/ANTI/ASOF/LATERAL)
+- `where`, `groupingElement` (ROLLUP/CUBE/GROUPING SETS/ALL)
+- `having`, `qualify`, `order by`, `limitElement`
+- set operations (`UNION`, `INTERSECT`, `EXCEPT`, `MINUS`)
+- `explainDesc`
+
+## Covered Grammar Paths (DML)
+
+- `insertStatement` (`INTO`/`OVERWRITE`, `SELECT`/`VALUES`, `BY NAME`)
+- `updateStatement` (with optional `FROM`)
+- `deleteStatement` (with optional `USING`)
+- `mergeIntoStatement`
+
+## Notes
+
+- Generated SQL aims for parser/planner coverage; not every statement is guaranteed to execute successfully on all clusters.
+- Increase `--max-depth` for deeper nested subqueries/expressions.
+- Use `--mode all` to combine deterministic path coverage with random variants.

--- a/tools/starrocks_sql_generator/__init__.py
+++ b/tools/starrocks_sql_generator/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""StarRocks SQL generator package."""
+
+from .generator import generate_paths, generate_random, load_schema_from_args
+
+__all__ = ["generate_paths", "generate_random", "load_schema_from_args"]

--- a/tools/starrocks_sql_generator/__main__.py
+++ b/tools/starrocks_sql_generator/__main__.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI for StarRocks grammar-aware SQL generation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .generator import generate_paths, generate_random, load_schema_from_args
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate StarRocks SQL from grammar paths in "
+            "fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4"
+        )
+    )
+    parser.add_argument(
+        "--schema",
+        help="JSON schema file with database/tables/columns.",
+    )
+    parser.add_argument(
+        "--schema-sql",
+        help="SQL file containing CREATE TABLE statements.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["paths", "random", "all"],
+        default="paths",
+        help="paths=enumerate grammar branches; random=random walk; all=paths then random fill.",
+    )
+    parser.add_argument(
+        "--categories",
+        default="query,dml",
+        help="Comma-separated categories: query,dml,all.",
+    )
+    parser.add_argument(
+        "--max-depth",
+        type=int,
+        default=3,
+        help="Maximum recursion depth for expression/subquery/join/cte rules.",
+    )
+    parser.add_argument(
+        "--max-list-items",
+        type=int,
+        default=2,
+        help="Maximum repeated list size (columns, tables, GROUP BY keys, etc.).",
+    )
+    parser.add_argument(
+        "--max-outputs",
+        type=int,
+        default=500,
+        help="Maximum number of SQL statements to emit.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="Random seed for reproducible generation.",
+    )
+    parser.add_argument(
+        "--with-semicolon",
+        action="store_true",
+        help="Append semicolon to each statement.",
+    )
+    parser.add_argument(
+        "--output",
+        help="Write SQL to this file (default: stdout).",
+    )
+    parser.add_argument(
+        "--manifest",
+        help="Optional JSON manifest with path tags and categories.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.schema and not args.schema_sql:
+        default_schema = Path(__file__).with_name("sample_schema.json")
+        if default_schema.exists():
+            args.schema = str(default_schema)
+        else:
+            print("error: --schema or --schema-sql is required", file=sys.stderr)
+            return 2
+
+    schema = load_schema_from_args(args.schema, args.schema_sql)
+    categories = {c.strip() for c in args.categories.split(",") if c.strip()}
+    if "all" in categories:
+        categories = {"all"}
+
+    if args.mode in ("paths", "all"):
+        items = generate_paths(
+            schema,
+            categories=categories,
+            max_depth=args.max_depth,
+            max_list_items=args.max_list_items,
+            max_outputs=args.max_outputs,
+            seed=args.seed,
+        )
+    else:
+        items = generate_random(
+            schema,
+            categories=categories,
+            max_depth=args.max_depth,
+            max_list_items=args.max_list_items,
+            max_outputs=args.max_outputs,
+            seed=args.seed,
+        )
+
+    if args.mode == "all" and len(items) < args.max_outputs:
+        extra = generate_random(
+            schema,
+            categories=categories,
+            max_depth=args.max_depth,
+            max_list_items=args.max_list_items,
+            max_outputs=args.max_outputs - len(items),
+            seed=args.seed + 9999,
+        )
+        seen = {x.sql for x in items}
+        for e in extra:
+            if e.sql not in seen:
+                items.append(e)
+                seen.add(e.sql)
+            if len(items) >= args.max_outputs:
+                break
+
+    out = sys.stdout
+    if args.output:
+        out = open(args.output, "w", encoding="utf-8")
+
+    for item in items:
+        sql = item.sql
+        if args.with_semicolon and not sql.rstrip().endswith(";"):
+            sql = f"{sql};"
+        out.write(sql + "\n")
+
+    if args.manifest:
+        manifest = [
+            {"sql": item.sql, "category": item.category, "path": item.path_tag}
+            for item in items
+        ]
+        Path(args.manifest).write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    if out is not sys.stdout:
+        out.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/starrocks_sql_generator/context.py
+++ b/tools/starrocks_sql_generator/context.py
@@ -1,0 +1,62 @@
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generation context with recursion depth tracking."""
+
+from __future__ import annotations
+
+import random
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+
+from .schema import Schema
+
+
+@dataclass
+class GenContext:
+    schema: Schema
+    max_depth: int = 3
+    max_list_items: int = 2
+    seed: int = 0
+    rng: random.Random = field(default_factory=random.Random)
+    depths: dict[str, int] = field(default_factory=dict)
+    path_tag: str = ""
+
+    def __post_init__(self):
+        if self.seed:
+            self.rng = random.Random(self.seed)
+
+    def can_recurse(self, rule: str) -> bool:
+        return self.depths.get(rule, 0) < self.max_depth
+
+    @contextmanager
+    def recurse(self, rule: str):
+        if not self.can_recurse(rule):
+            yield False
+            return
+        self.depths[rule] = self.depths.get(rule, 0) + 1
+        try:
+            yield True
+        finally:
+            self.depths[rule] = self.depths.get(rule, 0) - 1
+
+    def clone(self, *, path_tag: str | None = None, seed: int | None = None) -> GenContext:
+        return GenContext(
+            schema=self.schema,
+            max_depth=self.max_depth,
+            max_list_items=self.max_list_items,
+            seed=seed if seed is not None else self.seed,
+            depths=dict(self.depths),
+            path_tag=path_tag if path_tag is not None else self.path_tag,
+        )

--- a/tools/starrocks_sql_generator/dml.py
+++ b/tools/starrocks_sql_generator/dml.py
@@ -1,0 +1,157 @@
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DML generation aligned with StarRocks.g4 insert/update/delete/merge rules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .context import GenContext
+from .expressions import gen_boolean_expr, gen_expression, join_sql, literal_for_column
+from .query import gen_query_no_with
+
+
+@dataclass(frozen=True)
+class DmlPath:
+    tag: str
+    kind: str
+    with_cte: bool = False
+    overwrite: bool = False
+    by_name: bool = False
+    using_join: bool = False
+    use_values: bool = False
+    explain: str | None = None
+
+
+def gen_insert(ctx: GenContext, path: DmlPath) -> str:
+    tbl = ctx.schema.pick_table(ctx.rng)
+    target = tbl.qualified_name()
+    overwrite = "OVERWRITE" if path.overwrite else "INTO"
+    with_clause = ""
+    if path.with_cte:
+        with_clause = f"WITH cte AS (SELECT 1) "
+    by_name = " BY NAME" if path.by_name else ""
+
+    if path.use_values:
+        cols = tbl.columns[: min(3, len(tbl.columns))]
+        row = ", ".join(literal_for_column(c, ctx) for c in cols)
+        values = f"VALUES ({row})"
+        sql = f"INSERT {overwrite} {target}{by_name} {values}"
+    else:
+        select_sql = gen_query_no_with(ctx, minimal=False)
+        sql = f"INSERT {overwrite} {target}{by_name} {select_sql}"
+
+    if path.explain:
+        sql = join_sql([path.explain, sql])
+    return join_sql([with_clause, sql])
+
+
+def gen_update(ctx: GenContext, path: DmlPath) -> str:
+    tbl = ctx.schema.pick_table(ctx.rng)
+    assignments = []
+    for col in tbl.columns[: min(2, len(tbl.columns))]:
+        assignments.append(f"{col.name} = {literal_for_column(col, ctx)}")
+    set_clause = ", ".join(assignments)
+
+    from_clause = ""
+    if path.using_join and len(ctx.schema.tables) > 1:
+        other = ctx.rng.choice([t for t in ctx.schema.tables if t.name != tbl.name])
+        from_clause = f"FROM {other.qualified_name()} AS s"
+        where = f"WHERE {tbl.name}.{tbl.columns[0].name} = s.{other.columns[0].name}"
+    else:
+        where = f"WHERE {gen_boolean_expr(ctx, tbl, tbl.name)}"
+
+    with_clause = ""
+    if path.with_cte:
+        with_clause = "WITH cte AS (SELECT 1) "
+
+    sql = f"UPDATE {tbl.qualified_name()} SET {set_clause} {from_clause} {where}".strip()
+    if path.explain:
+        sql = join_sql([path.explain, sql])
+    return join_sql([with_clause, sql])
+
+
+def gen_delete(ctx: GenContext, path: DmlPath) -> str:
+    tbl = ctx.schema.pick_table(ctx.rng)
+    using = ""
+    if path.using_join and len(ctx.schema.tables) > 1:
+        other = ctx.rng.choice([t for t in ctx.schema.tables if t.name != tbl.name])
+        using = f"USING {other.qualified_name()} AS s"
+        where = f"WHERE {tbl.name}.{tbl.columns[0].name} = s.{other.columns[0].name}"
+    else:
+        where = f"WHERE {gen_boolean_expr(ctx, tbl, tbl.name)}"
+
+    with_clause = ""
+    if path.with_cte:
+        with_clause = "WITH cte AS (SELECT 1) "
+
+    sql = f"DELETE FROM {tbl.qualified_name()} {using} {where}".strip()
+    if path.explain:
+        sql = join_sql([path.explain, sql])
+    return join_sql([with_clause, sql])
+
+
+def gen_merge(ctx: GenContext, path: DmlPath) -> str:
+    target = ctx.schema.pick_table(ctx.rng)
+    source = ctx.rng.choice([t for t in ctx.schema.tables if t.name != target.name])
+    on = f"{target.columns[0].name} = s.{source.columns[0].name}"
+    set_parts = []
+    for col in target.columns[: min(2, len(target.columns))]:
+        set_parts.append(f"{col.name} = {literal_for_column(col, ctx)}")
+    update_set = ", ".join(set_parts)
+    insert_vals = ", ".join(literal_for_column(c, ctx) for c in target.columns[: min(3, len(target.columns))])
+    insert_cols = ", ".join(c.name for c in target.columns[: min(3, len(target.columns))])
+
+    sql = (
+        f"MERGE INTO {target.qualified_name()} AS t "
+        f"USING {source.qualified_name()} AS s "
+        f"ON {on} "
+        f"WHEN MATCHED THEN UPDATE SET {update_set} "
+        f"WHEN NOT MATCHED THEN INSERT ({insert_cols}) VALUES ({insert_vals})"
+    )
+    if path.explain:
+        sql = join_sql([path.explain, sql])
+    return sql
+
+
+def gen_dml(ctx: GenContext, path: DmlPath) -> str:
+    if path.kind == "insert":
+        return gen_insert(ctx, path)
+    if path.kind == "update":
+        return gen_update(ctx, path)
+    if path.kind == "delete":
+        return gen_delete(ctx, path)
+    if path.kind == "merge":
+        return gen_merge(ctx, path)
+    raise ValueError(f"unknown dml kind: {path.kind}")
+
+
+def enumerate_dml_paths() -> list[DmlPath]:
+    paths = [
+        DmlPath(tag="insert_select", kind="insert"),
+        DmlPath(tag="insert_values", kind="insert", use_values=True),
+        DmlPath(tag="insert_overwrite_select", kind="insert", overwrite=True),
+        DmlPath(tag="insert_by_name_values", kind="insert", by_name=True, use_values=True),
+        DmlPath(tag="insert_explain", kind="insert", explain="EXPLAIN"),
+        DmlPath(tag="update_basic", kind="update"),
+        DmlPath(tag="update_with_from", kind="update", using_join=True),
+        DmlPath(tag="update_with_cte", kind="update", with_cte=True),
+        DmlPath(tag="delete_basic", kind="delete"),
+        DmlPath(tag="delete_using", kind="delete", using_join=True),
+        DmlPath(tag="delete_with_cte", kind="delete", with_cte=True),
+        DmlPath(tag="merge_basic", kind="merge"),
+        DmlPath(tag="merge_explain", kind="merge", explain="EXPLAIN"),
+    ]
+    return paths

--- a/tools/starrocks_sql_generator/expressions.py
+++ b/tools/starrocks_sql_generator/expressions.py
@@ -1,0 +1,182 @@
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Expression generation aligned with StarRocks.g4 expression rules."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from .context import GenContext
+from .schema import Column, Table
+
+
+def join_sql(parts: list[str]) -> str:
+    sql = " ".join(p for p in parts if p)
+    sql = sql.replace(" ,", ",")
+    sql = sql.replace("( ", "(")
+    sql = sql.replace(" )", ")")
+    return sql.strip()
+
+
+def literal_for_column(col: Column, ctx: GenContext) -> str:
+    if col.is_boolean:
+        return ctx.rng.choice(["TRUE", "FALSE"])
+    if col.is_numeric:
+        return str(ctx.rng.randint(1, 100))
+    if col.is_datetime:
+        return ctx.rng.choice(["'2024-01-01'", "'2024-01-01 10:00:00'"])
+    if col.is_json:
+        return "'{\"k\":1}'"
+    if col.is_array:
+        return "[]"
+    if col.is_map:
+        return "map{}"
+    return "'sample'"
+
+
+def column_ref(table: Table, col: Column, alias: str | None = None) -> str:
+    if alias:
+        return f"{alias}.{col.name}"
+    return col.name
+
+
+def gen_column_ref(ctx: GenContext, table: Table | None = None, alias: str | None = None) -> str:
+    tbl, col = ctx.schema.pick_column(ctx.rng, table)
+    return column_ref(tbl, col, alias)
+
+
+def gen_literal(ctx: GenContext, col: Column | None = None) -> str:
+    if col is None:
+        _, col = ctx.schema.pick_column(ctx.rng)
+    return literal_for_column(col, ctx)
+
+
+def gen_primary(ctx: GenContext, table: Table | None = None, alias: str | None = None) -> str:
+    tbl, col = ctx.schema.pick_column(ctx.rng, table)
+    choices: list[Callable[[], str]] = [
+        lambda: column_ref(tbl, col, alias),
+        lambda: gen_literal(ctx, col),
+        lambda: f"({gen_value_expr(ctx, tbl, alias)})",
+        lambda: f"CAST({gen_column_ref(ctx, tbl, alias)} AS {col.type})",
+        lambda: (
+            f"CASE WHEN {gen_column_ref(ctx, tbl, alias)} IS NULL "
+            f"THEN {gen_literal(ctx, col)} ELSE {gen_column_ref(ctx, tbl, alias)} END"
+        ),
+    ]
+    if ctx.can_recurse("subquery"):
+        choices.append(lambda: gen_scalar_subquery(ctx))
+    if col.is_string:
+        choices.append(lambda: f"TRIM(BOTH ' ' FROM {gen_column_ref(ctx, tbl, alias)})")
+    return ctx.rng.choice(choices)()
+
+
+def gen_scalar_subquery(ctx: GenContext) -> str:
+    from .query import gen_query_no_with
+
+    with ctx.recurse("subquery") as ok:
+        if not ok:
+            return "1"
+        inner = gen_query_no_with(ctx, minimal=True)
+        return f"({inner})"
+
+
+def gen_value_expr(ctx: GenContext, table: Table | None = None, alias: str | None = None) -> str:
+    left = gen_primary(ctx, table, alias)
+    if not ctx.can_recurse("expression"):
+        return left
+    with ctx.recurse("expression") as ok:
+        if not ok:
+            return left
+        _, col = ctx.schema.pick_column(ctx.rng, table)
+        if col.is_numeric:
+            op = ctx.rng.choice(["+", "-", "*", "/", "%"])
+            right = gen_literal(ctx, col)
+            return f"{left} {op} {right}"
+        return left
+
+
+def gen_predicate(ctx: GenContext, table: Table | None = None, alias: str | None = None) -> str:
+    tbl, col = ctx.schema.pick_column(ctx.rng, table)
+    ref = column_ref(tbl, col, alias)
+    lit = gen_literal(ctx, col)
+    variants = [
+        f"{ref} = {lit}",
+        f"{ref} <> {lit}",
+        f"{ref} > {lit}",
+        f"{ref} >= {lit}",
+        f"{ref} < {lit}",
+        f"{ref} <= {lit}",
+        f"{ref} IS NULL",
+        f"{ref} IS NOT NULL",
+        f"{ref} BETWEEN {lit} AND {gen_literal(ctx, col)}",
+        f"{ref} IN ({lit}, {gen_literal(ctx, col)})",
+        f"{ref} NOT IN ({lit}, {gen_literal(ctx, col)})",
+    ]
+    if col.is_string:
+        variants.extend([
+            f"{ref} LIKE '%sample%'",
+            f"{ref} RLIKE 'sample.*'",
+            f"{ref} REGEXP 'sample.*'",
+        ])
+    if ctx.can_recurse("subquery"):
+        variants.append(f"{ref} IN ({gen_scalar_subquery(ctx)})")
+        variants.append(f"EXISTS ({gen_scalar_subquery(ctx)})")
+    return ctx.rng.choice(variants)
+
+
+def gen_boolean_expr(ctx: GenContext, table: Table | None = None, alias: str | None = None) -> str:
+    pred = gen_predicate(ctx, table, alias)
+    if not ctx.can_recurse("expression"):
+        return pred
+    with ctx.recurse("expression") as ok:
+        if not ok:
+            return pred
+        if ctx.rng.random() < 0.5:
+            return f"NOT ({pred})"
+        op = ctx.rng.choice(["AND", "OR"])
+        right = gen_predicate(ctx, table, alias)
+        return f"({pred}) {op} ({right})"
+
+
+def gen_expression(ctx: GenContext, table: Table | None = None, alias: str | None = None) -> str:
+    return gen_boolean_expr(ctx, table, alias)
+
+
+def gen_sort_item(ctx: GenContext, table: Table | None = None, alias: str | None = None) -> str:
+    expr = gen_expression(ctx, table, alias)
+    order = ctx.rng.choice(["ASC", "DESC"])
+    nulls = ctx.rng.choice(["", " NULLS FIRST", " NULLS LAST"])
+    return f"{expr} {order}{nulls}"
+
+
+def gen_agg_expr(ctx: GenContext, table: Table | None = None, alias: str | None = None) -> str:
+    _, col = ctx.schema.pick_column(ctx.rng, table)
+    ref = gen_column_ref(ctx, table, alias)
+    fn = ctx.rng.choice(["COUNT", "SUM", "AVG", "MIN", "MAX"])
+    if fn == "COUNT" and ctx.rng.random() < 0.3:
+        return "COUNT(*)"
+    return f"{fn}({ref})"
+
+
+def gen_window_expr(ctx: GenContext, table: Table | None = None, alias: str | None = None) -> str:
+    fn = ctx.rng.choice(["ROW_NUMBER", "RANK", "DENSE_RANK", "SUM", "AVG"])
+    ref = gen_column_ref(ctx, table, alias)
+    partition = gen_column_ref(ctx, table, alias)
+    order = gen_sort_item(ctx, table, alias)
+    if fn in ("ROW_NUMBER", "RANK", "DENSE_RANK"):
+        body = f"{fn}() OVER (PARTITION BY {partition} ORDER BY {order})"
+    else:
+        body = f"{fn}({ref}) OVER (PARTITION BY {partition} ORDER BY {order})"
+    return body

--- a/tools/starrocks_sql_generator/generator.py
+++ b/tools/starrocks_sql_generator/generator.py
@@ -1,0 +1,119 @@
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Top-level SQL generator orchestrating query and DML paths."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+
+from .context import GenContext
+from .dml import DmlPath, enumerate_dml_paths, gen_dml
+from .query import QueryPath, enumerate_query_paths, gen_query_statement
+from .schema import Schema, load_schema, parse_schema_from_sql
+
+
+@dataclass
+class GeneratedSql:
+    sql: str
+    category: str
+    path_tag: str
+
+
+def _dedupe(items: list[GeneratedSql]) -> list[GeneratedSql]:
+    seen = set()
+    out: list[GeneratedSql] = []
+    for item in items:
+        key = item.sql.strip()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(item)
+    return out
+
+
+def generate_paths(
+    schema: Schema,
+    *,
+    categories: set[str],
+    max_depth: int,
+    max_list_items: int,
+    max_outputs: int,
+    seed: int,
+) -> list[GeneratedSql]:
+    base_ctx = GenContext(
+        schema=schema,
+        max_depth=max_depth,
+        max_list_items=max_list_items,
+        seed=seed,
+    )
+    results: list[GeneratedSql] = []
+
+    if "query" in categories or "all" in categories:
+        for idx, path in enumerate(enumerate_query_paths()):
+            ctx = base_ctx.clone(path_tag=path.tag, seed=seed + idx)
+            sql = gen_query_statement(ctx, path)
+            results.append(GeneratedSql(sql=sql, category="query", path_tag=path.tag))
+
+    if "dml" in categories or "all" in categories:
+        for idx, path in enumerate(enumerate_dml_paths()):
+            ctx = base_ctx.clone(path_tag=path.tag, seed=seed + 1000 + idx)
+            sql = gen_dml(ctx, path)
+            results.append(GeneratedSql(sql=sql, category="dml", path_tag=path.tag))
+
+    results = _dedupe(results)
+    return results[:max_outputs]
+
+
+def generate_random(
+    schema: Schema,
+    *,
+    categories: set[str],
+    max_depth: int,
+    max_list_items: int,
+    max_outputs: int,
+    seed: int,
+) -> list[GeneratedSql]:
+    rng = random.Random(seed)
+    query_paths = enumerate_query_paths()
+    dml_paths = enumerate_dml_paths()
+    results: list[GeneratedSql] = []
+
+    for i in range(max_outputs):
+        ctx = GenContext(
+            schema=schema,
+            max_depth=max_depth,
+            max_list_items=max_list_items,
+            seed=seed + i,
+        )
+        cat = rng.choice(list(categories)) if categories != {"all"} else rng.choice(["query", "dml"])
+        if cat == "query" or (cat == "all" and rng.random() < 0.8):
+            path = rng.choice(query_paths)
+            sql = gen_query_statement(ctx, path)
+            results.append(GeneratedSql(sql=sql, category="query", path_tag=path.tag))
+        else:
+            path = rng.choice(dml_paths)
+            sql = gen_dml(ctx, path)
+            results.append(GeneratedSql(sql=sql, category="dml", path_tag=path.tag))
+
+    return _dedupe(results)[:max_outputs]
+
+
+def load_schema_from_args(schema_json: str | None, schema_sql: str | None) -> Schema:
+    if schema_json:
+        return load_schema(schema_json)
+    if schema_sql:
+        return parse_schema_from_sql(schema_sql)
+    raise ValueError("one of --schema or --schema-sql is required")

--- a/tools/starrocks_sql_generator/query.py
+++ b/tools/starrocks_sql_generator/query.py
@@ -1,0 +1,305 @@
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Query statement generation aligned with StarRocks.g4 query rules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .context import GenContext
+from .expressions import (
+    gen_agg_expr,
+    gen_boolean_expr,
+    gen_column_ref,
+    gen_expression,
+    gen_sort_item,
+    gen_window_expr,
+    join_sql,
+    literal_for_column,
+)
+from .schema import Table
+
+
+@dataclass(frozen=True)
+class QueryPath:
+    tag: str
+    with_cte: bool = False
+    recursive_cte: bool = False
+    set_quantifier: str | None = None
+    select_star: bool = False
+    select_exclude: bool = False
+    from_dual: bool = False
+    comma_join: bool = False
+    join_type: str | None = None
+    lateral: bool = False
+    asof_join: bool = False
+    subquery_from: bool = False
+    values_from: bool = False
+    where: bool = False
+    group_by: str | None = None
+    having: bool = False
+    qualify: bool = False
+    order_by: bool = False
+    limit_style: str | None = None
+    compound_op: str | None = None
+    explain: str | None = None
+    window_fn: bool = False
+    pivot: bool = False
+
+
+JOIN_TYPES = [
+    "JOIN",
+    "INNER JOIN",
+    "LEFT JOIN",
+    "RIGHT JOIN",
+    "FULL JOIN",
+    "LEFT OUTER JOIN",
+    "CROSS JOIN",
+    "LEFT SEMI JOIN",
+    "LEFT ANTI JOIN",
+    "NULL AWARE LEFT ANTI JOIN",
+]
+
+GROUP_BY_VARIANTS = [
+    "single",
+    "rollup",
+    "cube",
+    "grouping_sets",
+    "all",
+]
+
+
+def _table_alias(table: Table, idx: int) -> str:
+    return f"t{idx}"
+
+
+def gen_select_items(ctx: GenContext, path: QueryPath, table: Table, alias: str) -> str:
+    if path.from_dual:
+        return ", ".join([f"{ctx.rng.randint(1, 100)} AS n{i}" for i in range(1, 3)])
+    if path.select_star:
+        if path.select_exclude and len(table.columns) >= 2:
+            excluded = ", ".join(c.name for c in table.columns[:2])
+            return f"{alias}.* EXCEPT ({excluded})"
+        return "*"
+    items = []
+    count = min(ctx.max_list_items, max(1, len(table.columns)))
+    cols = ctx.rng.sample(table.columns, min(count, len(table.columns)))
+    for col in cols:
+        ref = f"{alias}.{col.name}" if alias else col.name
+        if path.window_fn and ctx.rng.random() < 0.5:
+            items.append(f"{gen_window_expr(ctx, table, alias)} AS w_{col.name}")
+        else:
+            items.append(f"{ref} AS {col.name}")
+    if path.qualify and items:
+        items[0] = f"{gen_window_expr(ctx, table, alias)} AS rn"
+    return ", ".join(items)
+
+
+def gen_from_clause(ctx: GenContext, path: QueryPath) -> tuple[str, Table, str]:
+    if path.from_dual:
+        return "FROM DUAL", ctx.schema.pick_table(ctx.rng), ""
+
+    if path.values_from:
+        tbl = ctx.schema.pick_table(ctx.rng)
+        cols = tbl.columns[: min(2, len(tbl.columns))]
+        values = []
+        for _ in range(min(2, ctx.max_list_items)):
+            row = ", ".join(literal_for_column(c, ctx) for c in cols)
+            values.append(f"({row})")
+        col_names = ", ".join(c.name for c in cols)
+        return f"FROM (VALUES {', '.join(values)}) AS v({col_names})", tbl, "v"
+
+    if path.subquery_from:
+        inner_table = ctx.schema.pick_table(ctx.rng)
+        inner_alias = "s"
+        inner_select = gen_query_no_with(ctx, minimal=True, base_table=inner_table, alias=inner_alias)
+        return f"FROM ({inner_select}) AS {inner_alias}", inner_table, inner_alias
+
+    tables = ctx.schema.pick_tables(ctx.rng, 2 if path.comma_join or path.join_type else 1)
+    primary = tables[0]
+    alias = _table_alias(primary, 0)
+    from_sql = f"FROM {primary.qualified_name()} AS {alias}"
+
+    if path.comma_join and len(tables) > 1:
+        alias2 = _table_alias(tables[1], 1)
+        from_sql = f"{from_sql}, {tables[1].qualified_name()} AS {alias2}"
+        return from_sql, primary, alias
+
+    if path.join_type and len(tables) > 1:
+        join_type = path.asof_join and f"ASOF {path.join_type}" or path.join_type
+        lateral = "LATERAL " if path.lateral else ""
+        alias2 = _table_alias(tables[1], 1)
+        join_sql_part = f"{join_type} {lateral}{tables[1].qualified_name()} AS {alias2}"
+        if "CROSS" not in join_type.upper():
+            _, join_col = ctx.schema.pick_column(ctx.rng, tables[1])
+            _, pk_col = ctx.schema.pick_column(ctx.rng, primary)
+            join_sql_part = (
+                f"{join_sql_part} ON {alias}.{pk_col.name} = {alias2}.{join_col.name}"
+            )
+        from_sql = f"{from_sql} {join_sql_part}"
+        return from_sql, primary, alias
+
+    return from_sql, primary, alias
+
+
+def gen_group_by(ctx: GenContext, path: QueryPath, table: Table, alias: str) -> str:
+    if not path.group_by:
+        return ""
+    cols = [c.name for c in table.columns[: min(ctx.max_list_items, len(table.columns))]]
+    refs = ", ".join(f"{alias}.{c}" if alias else c for c in cols)
+    if path.group_by == "rollup":
+        return f"GROUP BY ROLLUP ({refs})"
+    if path.group_by == "cube":
+        return f"GROUP BY CUBE ({refs})"
+    if path.group_by == "grouping_sets":
+        return f"GROUP BY GROUPING SETS (({refs}), ({cols[0]}))"
+    if path.group_by == "all":
+        return "GROUP BY ALL"
+    return f"GROUP BY {refs}"
+
+
+def gen_limit(path: QueryPath) -> str:
+    if path.limit_style == "offset":
+        return "LIMIT 10 OFFSET 5"
+    if path.limit_style == "comma":
+        return "LIMIT 5, 10"
+    if path.limit_style == "simple":
+        return "LIMIT 100"
+    return ""
+
+
+def gen_with_clause(ctx: GenContext, path: QueryPath) -> str:
+    if not path.with_cte:
+        return ""
+    tbl = ctx.schema.pick_table(ctx.rng)
+    alias = "c"
+    body = gen_query_no_with(ctx, minimal=True, base_table=tbl, alias=alias)
+    recursive = "RECURSIVE " if path.recursive_cte else ""
+    return f"WITH {recursive}cte AS ({body})"
+
+
+def gen_query_spec(ctx: GenContext, path: QueryPath) -> str:
+    from_sql, table, alias = gen_from_clause(ctx, path)
+    quant = f"{path.set_quantifier} " if path.set_quantifier else ""
+    select_items = gen_select_items(ctx, path, table, alias)
+    if path.group_by and not path.select_star:
+        select_items = ", ".join(
+            [
+                gen_agg_expr(ctx, table, alias),
+                gen_column_ref(ctx, table, alias),
+            ]
+        )
+
+    parts = ["SELECT", quant + select_items, from_sql]
+    if path.where:
+        parts.append(f"WHERE {gen_boolean_expr(ctx, table, alias)}")
+    group_by = gen_group_by(ctx, path, table, alias)
+    if group_by:
+        parts.append(group_by)
+    if path.having:
+        parts.append(f"HAVING {gen_agg_expr(ctx, table, alias)} > 0")
+    if path.qualify:
+        parts.append("QUALIFY rn <= 10")
+    return join_sql(parts)
+
+
+def gen_query_no_with(
+    ctx: GenContext,
+    *,
+    minimal: bool = False,
+    base_table: Table | None = None,
+    alias: str | None = None,
+    path: QueryPath | None = None,
+) -> str:
+    if minimal:
+        tbl = base_table or ctx.schema.pick_table(ctx.rng)
+        al = alias or "t0"
+        col = tbl.columns[0].name if tbl.columns else "1"
+        return f"SELECT {al}.{col} FROM {tbl.qualified_name()} AS {al}"
+
+    if path is None:
+        path = QueryPath(tag="default", where=True, order_by=True, limit_style="simple")
+
+    body = gen_query_spec(ctx, path)
+    if path.order_by:
+        _, table, alias = gen_from_clause(ctx, path)
+        body = join_sql([body, f"ORDER BY {gen_sort_item(ctx, table, alias)}"])
+    limit = gen_limit(path)
+    if limit:
+        body = join_sql([body, limit])
+    return body
+
+
+def gen_query_relation(ctx: GenContext, path: QueryPath) -> str:
+    with_clause = gen_with_clause(ctx, path)
+    body = gen_query_no_with(ctx, path=path)
+    if with_clause:
+        body = join_sql([with_clause, body])
+    if path.compound_op:
+        tbl = ctx.schema.pick_table(ctx.rng)
+        rhs = (
+            f"SELECT {tbl.columns[0].name} FROM {tbl.qualified_name()} "
+            f"WHERE {gen_boolean_expr(ctx, tbl, '')}"
+        )
+        body = join_sql([body, path.compound_op, rhs])
+    return body
+
+
+def gen_query_statement(ctx: GenContext, path: QueryPath) -> str:
+    body = gen_query_relation(ctx, path)
+    if path.explain:
+        return join_sql([path.explain, body])
+    return body
+
+
+def enumerate_query_paths() -> list[QueryPath]:
+    paths: list[QueryPath] = []
+
+    def add(tag: str, **kwargs):
+        paths.append(QueryPath(tag=tag, **kwargs))
+
+    add("basic_select", where=True, order_by=True, limit_style="simple")
+    add("select_distinct", set_quantifier="DISTINCT", where=True)
+    add("select_all_quantifier", set_quantifier="ALL", where=True)
+    add("select_star", select_star=True, where=True)
+    add("select_star_except", select_star=True, select_exclude=True, where=True)
+    add("from_dual", from_dual=True)
+    add("values_from", values_from=True, where=False)
+    add("subquery_from", subquery_from=True, where=True)
+
+    for join_type in JOIN_TYPES:
+        add(f"join_{join_type.replace(' ', '_').lower()}", join_type=join_type, where=True)
+
+    add("comma_join", comma_join=True, where=True)
+    add("lateral_join", join_type="INNER JOIN", lateral=True, where=True)
+    add("asof_join", asof_join=True, join_type="LEFT JOIN", where=True)
+
+    for group_by in GROUP_BY_VARIANTS:
+        add(f"group_by_{group_by}", group_by=group_by, having=True, order_by=True)
+
+    add("qualify", window_fn=True, qualify=True, order_by=True)
+    add("with_cte", with_cte=True, where=True, order_by=True)
+    add("with_recursive_cte", with_cte=True, recursive_cte=True, where=True)
+
+    for op in ["UNION", "UNION ALL", "INTERSECT", "EXCEPT", "MINUS"]:
+        add(f"compound_{op.replace(' ', '_').lower()}", compound_op=op, where=True)
+
+    add("limit_offset", where=True, limit_style="offset")
+    add("limit_comma", where=True, limit_style="comma")
+
+    for explain in ["EXPLAIN", "EXPLAIN VERBOSE", "EXPLAIN COSTS", "EXPLAIN LOGICAL"]:
+        add(f"{explain.replace(' ', '_').lower()}", explain=explain, where=True)
+
+    return paths

--- a/tools/starrocks_sql_generator/sample_schema.json
+++ b/tools/starrocks_sql_generator/sample_schema.json
@@ -1,0 +1,109 @@
+{
+  "database": "prod_models_demo",
+  "tables": [
+    {
+      "name": "dim_user",
+      "columns": [
+        {"name": "user_id", "type": "BIGINT", "nullable": false},
+        {"name": "user_name", "type": "VARCHAR(128)"},
+        {"name": "phone", "type": "VARCHAR(32)"},
+        {"name": "email", "type": "VARCHAR(128)"},
+        {"name": "city_id", "type": "INT"},
+        {"name": "register_time", "type": "DATETIME"},
+        {"name": "status", "type": "TINYINT"},
+        {"name": "update_time", "type": "DATETIME"}
+      ]
+    },
+    {
+      "name": "dim_product",
+      "columns": [
+        {"name": "product_id", "type": "BIGINT", "nullable": false},
+        {"name": "sku_id", "type": "BIGINT"},
+        {"name": "product_name", "type": "VARCHAR(256)"},
+        {"name": "category_id", "type": "INT"},
+        {"name": "brand_id", "type": "INT"},
+        {"name": "list_price", "type": "DECIMAL(18,2)"},
+        {"name": "is_active", "type": "BOOLEAN"},
+        {"name": "update_time", "type": "DATETIME"}
+      ]
+    },
+    {
+      "name": "dim_store",
+      "columns": [
+        {"name": "store_id", "type": "BIGINT", "nullable": false},
+        {"name": "store_name", "type": "VARCHAR(128)"},
+        {"name": "region", "type": "VARCHAR(64)"},
+        {"name": "city_id", "type": "INT"},
+        {"name": "open_date", "type": "DATE"},
+        {"name": "status", "type": "TINYINT"},
+        {"name": "update_time", "type": "DATETIME"}
+      ]
+    },
+    {
+      "name": "fact_order",
+      "columns": [
+        {"name": "order_id", "type": "BIGINT", "nullable": false},
+        {"name": "order_date", "type": "DATE", "nullable": false},
+        {"name": "order_time", "type": "DATETIME"},
+        {"name": "user_id", "type": "BIGINT"},
+        {"name": "store_id", "type": "BIGINT"},
+        {"name": "pay_method", "type": "TINYINT"},
+        {"name": "order_status", "type": "TINYINT"},
+        {"name": "total_amount", "type": "DECIMAL(18,2)"},
+        {"name": "total_discount", "type": "DECIMAL(18,2)"},
+        {"name": "update_time", "type": "DATETIME"}
+      ]
+    },
+    {
+      "name": "fact_order_item",
+      "columns": [
+        {"name": "order_id", "type": "BIGINT", "nullable": false},
+        {"name": "order_date", "type": "DATE", "nullable": false},
+        {"name": "item_id", "type": "BIGINT", "nullable": false},
+        {"name": "product_id", "type": "BIGINT"},
+        {"name": "quantity", "type": "INT"},
+        {"name": "item_price", "type": "DECIMAL(18,2)"},
+        {"name": "item_discount", "type": "DECIMAL(18,2)"},
+        {"name": "update_time", "type": "DATETIME"}
+      ]
+    },
+    {
+      "name": "agg_daily_sales",
+      "columns": [
+        {"name": "sales_date", "type": "DATE", "nullable": false},
+        {"name": "store_id", "type": "BIGINT", "nullable": false},
+        {"name": "product_id", "type": "BIGINT", "nullable": false},
+        {"name": "order_cnt", "type": "BIGINT"},
+        {"name": "item_cnt", "type": "BIGINT"},
+        {"name": "gross_amount", "type": "DECIMAL(18,2)"},
+        {"name": "discount_amount", "type": "DECIMAL(18,2)"},
+        {"name": "pay_amount", "type": "DECIMAL(18,2)"}
+      ]
+    },
+    {
+      "name": "user_activity_log",
+      "columns": [
+        {"name": "event_time", "type": "DATETIME", "nullable": false},
+        {"name": "user_id", "type": "BIGINT"},
+        {"name": "session_id", "type": "VARCHAR(64)"},
+        {"name": "page_id", "type": "VARCHAR(128)"},
+        {"name": "event_type", "type": "VARCHAR(32)"},
+        {"name": "event_properties", "type": "JSON"},
+        {"name": "device_type", "type": "VARCHAR(32)"},
+        {"name": "ip_address", "type": "VARCHAR(64)"}
+      ]
+    },
+    {
+      "name": "inventory_snapshot",
+      "columns": [
+        {"name": "store_id", "type": "BIGINT", "nullable": false},
+        {"name": "product_id", "type": "BIGINT", "nullable": false},
+        {"name": "snapshot_date", "type": "DATE", "nullable": false},
+        {"name": "on_hand_qty", "type": "INT"},
+        {"name": "reserved_qty", "type": "INT"},
+        {"name": "available_qty", "type": "INT"},
+        {"name": "update_time", "type": "DATETIME"}
+      ]
+    }
+  ]
+}

--- a/tools/starrocks_sql_generator/schema.py
+++ b/tools/starrocks_sql_generator/schema.py
@@ -1,0 +1,202 @@
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Load table/column metadata used to generate schema-aware SQL."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Column:
+    name: str
+    type: str
+    nullable: bool = True
+
+    @property
+    def is_numeric(self) -> bool:
+        t = self.type.upper()
+        return any(k in t for k in ("INT", "BIGINT", "DOUBLE", "FLOAT", "DECIMAL", "NUMERIC"))
+
+    @property
+    def is_string(self) -> bool:
+        t = self.type.upper()
+        return any(k in t for k in ("CHAR", "STRING", "TEXT"))
+
+    @property
+    def is_datetime(self) -> bool:
+        t = self.type.upper()
+        return any(k in t for k in ("DATE", "TIME", "DATETIME"))
+
+    @property
+    def is_boolean(self) -> bool:
+        return "BOOL" in self.type.upper()
+
+    @property
+    def is_json(self) -> bool:
+        return "JSON" in self.type.upper()
+
+    @property
+    def is_array(self) -> bool:
+        return self.type.upper().startswith("ARRAY")
+
+    @property
+    def is_map(self) -> bool:
+        return self.type.upper().startswith("MAP")
+
+
+@dataclass
+class Table:
+    name: str
+    columns: list[Column]
+    database: str | None = None
+
+    def qualified_name(self) -> str:
+        if self.database:
+            return f"{self.database}.{self.name}"
+        return self.name
+
+    def column(self, name: str) -> Column | None:
+        for col in self.columns:
+            if col.name.lower() == name.lower():
+                return col
+        return None
+
+
+@dataclass
+class Schema:
+    database: str | None = None
+    tables: list[Table] = field(default_factory=list)
+
+    def table(self, name: str) -> Table | None:
+        for tbl in self.tables:
+            if tbl.name.lower() == name.lower():
+                return tbl
+        return None
+
+    def pick_table(self, rng) -> Table:
+        if not self.tables:
+            raise ValueError("schema has no tables")
+        return rng.choice(self.tables)
+
+    def pick_tables(self, rng, count: int) -> list[Table]:
+        if not self.tables:
+            raise ValueError("schema has no tables")
+        count = min(count, len(self.tables))
+        return rng.sample(self.tables, count)
+
+    def pick_column(self, rng, table: Table | None = None) -> tuple[Table, Column]:
+        tbl = table or self.pick_table(rng)
+        if not tbl.columns:
+            raise ValueError(f"table {tbl.name} has no columns")
+        return tbl, rng.choice(tbl.columns)
+
+    def numeric_columns(self) -> list[tuple[Table, Column]]:
+        out = []
+        for tbl in self.tables:
+            for col in tbl.columns:
+                if col.is_numeric:
+                    out.append((tbl, col))
+        return out
+
+    def string_columns(self) -> list[tuple[Table, Column]]:
+        out = []
+        for tbl in self.tables:
+            for col in tbl.columns:
+                if col.is_string:
+                    out.append((tbl, col))
+        return out
+
+    def datetime_columns(self) -> list[tuple[Table, Column]]:
+        out = []
+        for tbl in self.tables:
+            for col in tbl.columns:
+                if col.is_datetime:
+                    out.append((tbl, col))
+        return out
+
+
+def _parse_column(raw: dict[str, Any]) -> Column:
+    return Column(
+        name=raw["name"],
+        type=raw.get("type", "VARCHAR"),
+        nullable=raw.get("nullable", True),
+    )
+
+
+def _parse_table(raw: dict[str, Any], default_db: str | None) -> Table:
+    db = raw.get("database", default_db)
+    return Table(
+        name=raw["name"],
+        database=db,
+        columns=[_parse_column(c) for c in raw.get("columns", [])],
+    )
+
+
+def load_schema(path: str | Path) -> Schema:
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    default_db = data.get("database")
+    tables = [_parse_table(t, default_db) for t in data.get("tables", [])]
+    return Schema(database=default_db, tables=tables)
+
+
+def parse_schema_from_sql(path: str | Path) -> Schema:
+    """Best-effort parser for CREATE TABLE blocks in a SQL file."""
+    text = Path(path).read_text(encoding="utf-8")
+    database = None
+    db_match = re.search(
+        r"CREATE\s+DATABASE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\w+)",
+        text,
+        re.IGNORECASE,
+    )
+    if db_match:
+        database = db_match.group(1)
+
+    tables: list[Table] = []
+    create_pattern = re.compile(
+        r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"
+        r"(?:(\w+)\.)?(\w+)\s*\((.*?)\)\s*ENGINE\s*=",
+        re.IGNORECASE | re.DOTALL,
+    )
+    col_pattern = re.compile(
+        r"^\s*(\w+)\s+([A-Z<>,\(\)\d\s]+?)(?:\s+NOT\s+NULL|\s+NULL|\s+DEFAULT|\s*,|\s*$)",
+        re.IGNORECASE | re.MULTILINE,
+    )
+    for match in create_pattern.finditer(text):
+        db_name = match.group(1) or database
+        table_name = match.group(2)
+        body = match.group(3)
+        columns: list[Column] = []
+        for line in body.splitlines():
+            line = line.strip().rstrip(",")
+            if not line or line.upper().startswith(
+                ("PRIMARY", "UNIQUE", "AGGREGATE", "DUPLICATE", "KEY", "PARTITION", "DISTRIBUTED")
+            ):
+                continue
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+            col_name = parts[0]
+            col_type = parts[1]
+            nullable = "NOT NULL" not in line.upper()
+            columns.append(Column(name=col_name, type=col_type, nullable=nullable))
+        if columns:
+            tables.append(Table(name=table_name, database=db_name, columns=columns))
+
+    return Schema(database=database, tables=tables)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `tools/starrocks_sql_generator/`, a schema-aware SQL generator for StarRocks grammar coverage testing based on `fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4`.

Key capabilities:
- Enumerates major query/DML grammar paths (SELECT/JOIN/GROUP BY/CTE/compound/EXPLAIN, INSERT/UPDATE/DELETE/MERGE)
- Uses table/column metadata to generate queryable SQL with type-aware literals
- Supports recursion depth limits via `--max-depth` for expression/subquery/CTE expansion
- Optional manifest output mapping SQL to grammar path tags

## Usage

```bash
python3 -m tools.starrocks_sql_generator \
  --schema tools/starrocks_sql_generator/sample_schema.json \
  --mode paths \
  --max-depth 3 \
  --max-outputs 200 \
  --with-semicolon \
  --output /tmp/starrocks_generated.sql \
  --manifest /tmp/starrocks_generated.manifest.json
```

## Behavior Classification

- [ ] User-visible behavior change
- [x] No user-visible behavior change (tooling only)

## Tests

- [x] Manual smoke test: `python3 -m tools.starrocks_sql_generator --mode paths --max-outputs 53`
- [ ] Unit tests (not added; standalone generator tool)

## Docs

- [x] Added `tools/starrocks_sql_generator/README.md`
- [ ] User/admin docs update (not required for internal tool)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dbc90004-459e-4003-b98b-6f12240c7bc8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbc90004-459e-4003-b98b-6f12240c7bc8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

