### PR TITLE
[Enhancement] Remove the global metacache lock for lake segments

### DIFF
--- a/be/src/base/container/lru_cache.cpp
+++ b/be/src/base/container/lru_cache.cpp
@@ -315,14 +315,13 @@ void LRUCache::_evict_one_entry(LRUHandle* e) {
     _usage -= e->charge;
 }
 
-Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value, size_t value_size,
-                                void (*deleter)(const CacheKey& key, void* value), CachePriority priority) {
+LRUHandle* LRUCache::_alloc_handle(const CacheKey& key, uint32_t hash, void* value, size_t value_size,
+                                   void (*deleter)(const CacheKey& key, void* value), CachePriority priority) {
     size_t key_mem_size = sizeof(LRUHandle) - 1 + key.size();
-    size_t kv_mem_size = value_size + key_mem_size;
     auto* e = reinterpret_cast<LRUHandle*>(malloc(key_mem_size));
     e->value = value;
     e->deleter = deleter;
-    e->charge = kv_mem_size;
+    e->charge = value_size + key_mem_size;
     e->key_length = key.size();
     e->hash = hash;
     e->refs = 2; // one for the returned handle, one for LRUCache.
@@ -331,39 +330,48 @@ Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value,
     e->priority = priority;
     e->value_size = value_size;
     memcpy(e->key_data, key.data(), key.size());
+    return e;
+}
+
+void LRUCache::_insert_no_lock(LRUHandle* e, std::vector<LRUHandle*>* last_ref_list) {
+    // Track insert count
+    ++_insert_count;
+
+    // Free the space following strict LRU policy until enough space
+    // is freed or the lru list is empty
+    size_t evicted_count_before = last_ref_list->size();
+    _evict_from_lru(e->charge, last_ref_list);
+    size_t evicted_count_after = last_ref_list->size();
+
+    // Track evictions caused by insert
+    if (evicted_count_after > evicted_count_before) {
+        _insert_evict_count += (evicted_count_after - evicted_count_before);
+    }
+
+    // insert into the cache
+    // note that the cache might get larger than its capacity if not enough
+    // space was freed
+    auto old = _table.insert(e);
+    _usage += e->charge;
+    if (old != nullptr) {
+        old->in_cache = false;
+        if (_unref(old)) {
+            _usage -= old->charge;
+            // old is on LRU because it's in cache and its reference count
+            // was just 1 (Unref returned 0)
+            _lru_remove(old);
+            last_ref_list->push_back(old);
+        }
+    }
+}
+
+Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value, size_t value_size,
+                                void (*deleter)(const CacheKey& key, void* value), CachePriority priority) {
+    LRUHandle* e = _alloc_handle(key, hash, value, value_size, deleter, priority);
     std::vector<LRUHandle*> last_ref_list;
     {
         std::lock_guard l(_mutex);
-
-        // Track insert count
-        ++_insert_count;
-
-        // Free the space following strict LRU policy until enough space
-        // is freed or the lru list is empty
-        size_t evicted_count_before = last_ref_list.size();
-        _evict_from_lru(kv_mem_size, &last_ref_list);
-        size_t evicted_count_after = last_ref_list.size();
-
-        // Track evictions caused by insert
-        if (evicted_count_after > evicted_count_before) {
-            _insert_evict_count += (evicted_count_after - evicted_count_before);
-        }
-
-        // insert into the cache
-        // note that the cache might get larger than its capacity if not enough
-        // space was freed
-        auto old = _table.insert(e);
-        _usage += kv_mem_size;
-        if (old != nullptr) {
-            old->in_cache = false;
-            if (_unref(old)) {
-                _usage -= old->charge;
-                // old is on LRU because it's in cache and its reference count
-                // was just 1 (Unref returned 0)
-                _lru_remove(old);
-                last_ref_list.push_back(old);
-            }
-        }
+        _insert_no_lock(e, &last_ref_list);
     }
 
     // we free the entries here outside of mutex for
@@ -373,6 +381,80 @@ Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value,
     }
 
     return reinterpret_cast<Cache::Handle*>(e);
+}
+
+Cache::Handle* LRUCache::insert_if_absent(const CacheKey& key, uint32_t hash, void* value, size_t value_size,
+                                          void (*deleter)(const CacheKey& key, void* value), bool* inserted,
+                                          CachePriority priority) {
+    // Allocated before the lock is taken because the common case is a real insert;
+    // on the losing path the handle is freed again below, the value is untouched.
+    LRUHandle* e = _alloc_handle(key, hash, value, value_size, deleter, priority);
+    LRUHandle* ret = nullptr;
+    std::vector<LRUHandle*> last_ref_list;
+    {
+        std::lock_guard l(_mutex);
+        LRUHandle* existing = _table.lookup(key, hash);
+        if (existing != nullptr) {
+            // we get it from _table, so in_cache must be true
+            DCHECK(existing->in_cache);
+            if (existing->refs == 1) {
+                // only in LRU free list, remove it from list
+                _lru_remove(existing);
+            }
+            existing->refs++;
+            ret = existing;
+        } else {
+            _insert_no_lock(e, &last_ref_list);
+            ret = e;
+        }
+    }
+
+    *inserted = (ret == e);
+    if (!*inserted) {
+        // Only the handle is ours to release; `value` still belongs to the caller.
+        ::free(e);
+    }
+    for (auto entry : last_ref_list) {
+        entry->free();
+    }
+
+    return reinterpret_cast<Cache::Handle*>(ret);
+}
+
+void LRUCache::_update_charge_no_lock(LRUHandle* e, size_t new_value_size, std::vector<LRUHandle*>* last_ref_list) {
+    const size_t new_charge = new_value_size + sizeof(LRUHandle) - 1 + e->key_length;
+    _usage = _usage - e->charge + new_charge;
+    e->charge = new_charge;
+    e->value_size = new_value_size;
+    // An entry whose size just changed is being actively populated, so refresh it to
+    // the MRU end. This matches the old "re-insert to update the charge" behaviour and
+    // keeps the eviction below from picking `e` itself unless `e` alone is over capacity.
+    if (e->refs == 1) {
+        _lru_remove(e);
+        _lru_append(&_lru, e);
+    }
+    if (_usage > _capacity) {
+        _evict_from_lru(0, last_ref_list);
+    }
+}
+
+bool LRUCache::update_charge_if(const CacheKey& key, uint32_t hash, size_t new_value_size,
+                                bool (*pred)(void* value, const void* ctx), const void* ctx) {
+    std::vector<LRUHandle*> last_ref_list;
+    bool updated = false;
+    {
+        std::lock_guard l(_mutex);
+        LRUHandle* e = _table.lookup(key, hash);
+        if (e != nullptr && (pred == nullptr || pred(e->value, ctx))) {
+            _update_charge_no_lock(e, new_value_size, &last_ref_list);
+            // `e` may have been evicted by the call above, do not touch it again.
+            updated = true;
+        }
+    }
+    for (auto entry : last_ref_list) {
+        entry->free();
+    }
+    return updated;
 }
 
 void LRUCache::erase(const CacheKey& key, uint32_t hash) {
@@ -464,6 +546,19 @@ Cache::Handle* ShardedLRUCache::insert(const CacheKey& key, void* value, size_t 
                                        void (*deleter)(const CacheKey& key, void* value), CachePriority priority) {
     const uint32_t hash = _hash_slice(key);
     return _shards[_shard(hash)].insert(key, hash, value, value_size, deleter, priority);
+}
+
+Cache::Handle* ShardedLRUCache::insert_if_absent(const CacheKey& key, void* value, size_t value_size,
+                                                 void (*deleter)(const CacheKey& key, void* value), bool* inserted,
+                                                 CachePriority priority) {
+    const uint32_t hash = _hash_slice(key);
+    return _shards[_shard(hash)].insert_if_absent(key, hash, value, value_size, deleter, inserted, priority);
+}
+
+bool ShardedLRUCache::update_charge_if(const CacheKey& key, size_t new_value_size,
+                                       bool (*pred)(void* value, const void* ctx), const void* ctx) {
+    const uint32_t hash = _hash_slice(key);
+    return _shards[_shard(hash)].update_charge_if(key, hash, new_value_size, pred, ctx);
 }
 
 Cache::Handle* ShardedLRUCache::lookup(const CacheKey& key) {

--- a/be/src/base/container/lru_cache.cpp
+++ b/be/src/base/container/lru_cache.cpp
@@ -386,8 +386,6 @@ Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value,
 Cache::Handle* LRUCache::insert_if_absent(const CacheKey& key, uint32_t hash, void* value, size_t value_size,
                                           void (*deleter)(const CacheKey& key, void* value), bool* inserted,
                                           CachePriority priority) {
-    // Allocated before the lock is taken because the common case is a real insert;
-    // on the losing path the handle is freed again below, the value is untouched.
     LRUHandle* e = _alloc_handle(key, hash, value, value_size, deleter, priority);
     LRUHandle* ret = nullptr;
     std::vector<LRUHandle*> last_ref_list;

--- a/be/src/base/container/lru_cache.h
+++ b/be/src/base/container/lru_cache.h
@@ -138,6 +138,31 @@ public:
                            void (*deleter)(const CacheKey& key, void* value),
                            CachePriority priority = CachePriority::NORMAL) = 0;
 
+    // Insert a mapping from key->value into the cache, but only if the cache does
+    // not already contain an entry for "key". The lookup and the insert happen
+    // atomically with respect to other operations on the same key, so callers do
+    // not need an external lock to get compare-and-insert semantics.
+    //
+    // If "key" is already present, returns a handle to the existing entry and sets
+    // *inserted to false; "value" is NOT adopted and the caller stays responsible
+    // for destroying it. Otherwise "value" is inserted, ownership moves to the
+    // cache and *inserted is set to true.
+    //
+    // Either way the caller must call this->release() on the returned handle.
+    virtual Handle* insert_if_absent(const CacheKey& key, void* value, size_t value_size,
+                                     void (*deleter)(const CacheKey& key, void* value), bool* inserted,
+                                     CachePriority priority = CachePriority::NORMAL) = 0;
+
+    // Change the charge of the entry for "key" in place instead of rebuilding it,
+    // and refresh it to the most recently used position. Entries are evicted if the
+    // cache ends up over capacity. Returns false, changing nothing, if "key" is
+    // absent or if "pred" is non-null and pred(value, ctx) returns false.
+    //
+    // "pred" is invoked while the shard lock is held: it must be O(1) and must not
+    // allocate, block, or re-enter the cache.
+    virtual bool update_charge_if(const CacheKey& key, size_t new_value_size,
+                                  bool (*pred)(void* value, const void* ctx), const void* ctx) = 0;
+
     // If the cache has no mapping for "key", returns NULL.
     //
     // Else return a handle that corresponds to the mapping.  The caller
@@ -277,6 +302,11 @@ public:
     Cache::Handle* insert(const CacheKey& key, uint32_t hash, void* value, size_t value_size,
                           void (*deleter)(const CacheKey& key, void* value),
                           CachePriority priority = CachePriority::NORMAL);
+    Cache::Handle* insert_if_absent(const CacheKey& key, uint32_t hash, void* value, size_t value_size,
+                                    void (*deleter)(const CacheKey& key, void* value), bool* inserted,
+                                    CachePriority priority = CachePriority::NORMAL);
+    bool update_charge_if(const CacheKey& key, uint32_t hash, size_t new_value_size,
+                          bool (*pred)(void* value, const void* ctx), const void* ctx);
     Cache::Handle* lookup(const CacheKey& key, uint32_t hash);
     void release(Cache::Handle* handle);
     void touch(const CacheKey& key, uint32_t hash);
@@ -298,6 +328,19 @@ private:
     bool _unref(LRUHandle* e);
     void _evict_from_lru(size_t charge, std::vector<LRUHandle*>* deleted);
     void _evict_one_entry(LRUHandle* e);
+
+    // Build a detached handle for `key`. Done outside _mutex so that neither insert
+    // path allocates while holding the shard lock.
+    static LRUHandle* _alloc_handle(const CacheKey& key, uint32_t hash, void* value, size_t value_size,
+                                    void (*deleter)(const CacheKey& key, void* value), CachePriority priority);
+
+    // Shared by insert() and insert_if_absent(). Entries displaced or evicted are
+    // appended to `deleted` and must be freed by the caller after _mutex is released.
+    void _insert_no_lock(LRUHandle* e, std::vector<LRUHandle*>* deleted);
+
+    // NOTE: `e` may itself end up in `deleted` (only if `e` alone exceeds the shard
+    // capacity), so callers must not dereference `e` after this returns.
+    void _update_charge_no_lock(LRUHandle* e, size_t new_value_size, std::vector<LRUHandle*>* deleted);
 
     // Initialized before use.
     size_t _capacity{0};
@@ -330,6 +373,11 @@ public:
     Handle* insert(const CacheKey& key, void* value, size_t value_size,
                    void (*deleter)(const CacheKey& key, void* value),
                    CachePriority priority = CachePriority::NORMAL) override;
+    Handle* insert_if_absent(const CacheKey& key, void* value, size_t value_size,
+                             void (*deleter)(const CacheKey& key, void* value), bool* inserted,
+                             CachePriority priority = CachePriority::NORMAL) override;
+    bool update_charge_if(const CacheKey& key, size_t new_value_size, bool (*pred)(void* value, const void* ctx),
+                          const void* ctx) override;
     Handle* lookup(const CacheKey& key) override;
     void release(Handle* handle) override;
     void touch(const CacheKey& key) override;

--- a/be/src/storage/lake/metacache.cpp
+++ b/be/src/storage/lake/metacache.cpp
@@ -16,9 +16,8 @@
 
 #include <bvar/bvar.h>
 
-#include <mutex>
-
 #include "base/container/lru_cache.h"
+#include "base/testutil/sync_point.h"
 #include "base/utility/defer_op.h"
 #include "gen_cpp/lake_types.pb.h"
 #include "storage/del_vector.h"
@@ -95,13 +94,25 @@ static size_t get_metacache_usage(void*) {
     return (cache != nullptr) ? cache->memory_usage() : 0;
 }
 
+static size_t get_metacache_evict_count(void*) {
+    auto cache = get_metacache();
+    return (cache != nullptr) ? cache->evict_count() : 0;
+}
+
 static bvar::PassiveStatus<size_t> g_metacache_capacity("lake", "metacache_capacity", get_metacache_capacity, nullptr);
 static bvar::PassiveStatus<size_t> g_metacache_usage("lake", "metacache_usage", get_metacache_usage, nullptr);
+static bvar::PassiveStatus<size_t> g_metacache_evict_count("lake", "metacache_evict_count", get_metacache_evict_count,
+                                                           nullptr);
 #endif
 
 Metacache::Metacache(int64_t cache_capacity) : _cache(new_lru_cache(cache_capacity)) {}
 
 Metacache::~Metacache() = default;
+
+void Metacache::cache_value_deleter(const CacheKey& /*key*/, void* value) {
+    TEST_SYNC_POINT_CALLBACK("lake::Metacache::cache_value_deleter", value);
+    delete static_cast<CacheValue*>(value);
+}
 
 void Metacache::insert(std::string_view key, CacheValue* ptr, size_t size) {
     Cache::Handle* handle = _cache->insert(CacheKey(key), ptr, size, cache_value_deleter);
@@ -181,11 +192,6 @@ std::shared_ptr<const TabletSchema> Metacache::lookup_tablet_schema(std::string_
 }
 
 std::shared_ptr<Segment> Metacache::lookup_segment(std::string_view key) {
-    std::shared_lock lock(_mutex);
-    return _lookup_segment_no_lock(key);
-}
-
-std::shared_ptr<Segment> Metacache::_lookup_segment_no_lock(std::string_view key) {
     auto handle = _cache->lookup(CacheKey(key));
     if (handle == nullptr) {
         g_segment_cache_miss << 1;
@@ -193,14 +199,12 @@ std::shared_ptr<Segment> Metacache::_lookup_segment_no_lock(std::string_view key
     }
     DeferOp defer([this, handle]() { _cache->release(handle); });
 
-    try {
-        auto value = static_cast<CacheValue*>(_cache->value(handle));
-        auto segment = std::get<std::shared_ptr<Segment>>(*value);
-        g_segment_cache_hit << 1;
-        return segment;
-    } catch (const std::bad_variant_access& e) {
+    auto* segment = std::get_if<std::shared_ptr<Segment>>(static_cast<CacheValue*>(_cache->value(handle)));
+    if (segment == nullptr) {
         return nullptr;
     }
+    g_segment_cache_hit << 1;
+    return *segment;
 }
 
 std::shared_ptr<const DelVector> Metacache::lookup_delvec(std::string_view key) {
@@ -241,11 +245,6 @@ bool Metacache::lookup_aggregation_partition(std::string_view key) {
 
 void Metacache::cache_segment(std::string_view key, std::shared_ptr<Segment> segment) {
     auto mem_cost = segment->mem_usage();
-    std::unique_lock lock(_mutex);
-    _cache_segment_no_lock(key, mem_cost, std::move(segment));
-}
-
-void Metacache::_cache_segment_no_lock(std::string_view key, size_t mem_cost, std::shared_ptr<Segment> segment) {
     auto value = std::make_unique<CacheValue>(std::move(segment));
     insert(key, value.release(), mem_cost);
 }
@@ -253,27 +252,34 @@ void Metacache::_cache_segment_no_lock(std::string_view key, size_t mem_cost, st
 std::shared_ptr<Segment> Metacache::cache_segment_if_absent(std::string_view key,
                                                             const std::shared_ptr<Segment>& segment) {
     auto mem_cost = segment->mem_usage();
-    std::unique_lock lock(_mutex);
-    auto seg = _lookup_segment_no_lock(key);
-    if (seg != nullptr) {
-        // already exists, return the one in cache
-        return seg;
+    // Destroyed on return unless the cache adopts it, i.e. never under a cache lock.
+    auto value = std::make_unique<CacheValue>(segment);
+    bool inserted = false;
+    auto* handle = _cache->insert_if_absent(CacheKey(key), value.get(), mem_cost, cache_value_deleter, &inserted);
+    if (handle == nullptr) {
+        return nullptr;
     }
-    _cache_segment_no_lock(key, mem_cost, segment);
-    return _lookup_segment_no_lock(key);
+    DeferOp defer([this, handle]() { _cache->release(handle); });
+
+    if (inserted) {
+        (void)value.release(); // ownership moved into the cache
+        return segment;
+    }
+    // Another thread won the race, return the segment that is actually cached.
+    auto* cached = std::get_if<std::shared_ptr<Segment>>(static_cast<CacheValue*>(_cache->value(handle)));
+    return cached != nullptr ? *cached : nullptr;
 }
 
-intptr_t Metacache::cache_segment_if_present(std::string_view key, size_t mem_cost, intptr_t segment_addr_hint) {
-    std::unique_lock lock(_mutex);
-    auto seg = _lookup_segment_no_lock(key);
-    if (seg == nullptr) {
-        return 0;
-    }
-    if (segment_addr_hint != 0 && reinterpret_cast<intptr_t>(seg.get()) != segment_addr_hint) {
-        return 0;
-    }
-    _cache_segment_no_lock(key, mem_cost, std::move(seg));
-    return segment_addr_hint;
+namespace {
+// Invoked while the cache shard lock is held, so it does nothing but compare identity.
+bool segment_ptr_matches(void* value, const void* ctx) {
+    auto* cached = std::get_if<std::shared_ptr<Segment>>(static_cast<CacheValue*>(value));
+    return cached != nullptr && cached->get() == static_cast<const Segment*>(ctx);
+}
+} // namespace
+
+bool Metacache::update_segment_cache_size(std::string_view key, size_t mem_cost, const Segment* segment) {
+    return _cache->update_charge_if(CacheKey(key), mem_cost, segment_ptr_matches, segment);
 }
 
 void Metacache::cache_delvec(std::string_view key, std::shared_ptr<const DelVector> delvec) {
@@ -330,6 +336,10 @@ size_t Metacache::memory_usage() const {
 
 size_t Metacache::capacity() const {
     return _cache->get_capacity();
+}
+
+size_t Metacache::evict_count() const {
+    return _cache->get_insert_evict_count() + _cache->get_release_evict_count();
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/metacache.cpp
+++ b/be/src/storage/lake/metacache.cpp
@@ -94,15 +94,8 @@ static size_t get_metacache_usage(void*) {
     return (cache != nullptr) ? cache->memory_usage() : 0;
 }
 
-static size_t get_metacache_evict_count(void*) {
-    auto cache = get_metacache();
-    return (cache != nullptr) ? cache->evict_count() : 0;
-}
-
 static bvar::PassiveStatus<size_t> g_metacache_capacity("lake", "metacache_capacity", get_metacache_capacity, nullptr);
 static bvar::PassiveStatus<size_t> g_metacache_usage("lake", "metacache_usage", get_metacache_usage, nullptr);
-static bvar::PassiveStatus<size_t> g_metacache_evict_count("lake", "metacache_evict_count", get_metacache_evict_count,
-                                                           nullptr);
 #endif
 
 Metacache::Metacache(int64_t cache_capacity) : _cache(new_lru_cache(cache_capacity)) {}
@@ -336,10 +329,6 @@ size_t Metacache::memory_usage() const {
 
 size_t Metacache::capacity() const {
     return _cache->get_capacity();
-}
-
-size_t Metacache::evict_count() const {
-    return _cache->get_insert_evict_count() + _cache->get_release_evict_count();
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/metacache.h
+++ b/be/src/storage/lake/metacache.h
@@ -91,9 +91,6 @@ public:
 
     size_t capacity() const;
 
-    // Total entries evicted so far, across both the insert and the release paths.
-    size_t evict_count() const;
-
 private:
     static void cache_value_deleter(const CacheKey& key, void* value);
 

--- a/be/src/storage/lake/metacache.h
+++ b/be/src/storage/lake/metacache.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <memory>
-#include <shared_mutex>
 #include <string_view>
 #include <variant>
 
@@ -70,8 +69,10 @@ public:
 
     void cache_segment(std::string_view key, std::shared_ptr<Segment> segment);
 
-    // return the same `segment_addr_hint` if the key exists in cache, 0 otherwise
-    intptr_t cache_segment_if_present(std::string_view key, size_t mem_cost, intptr_t segment_addr_hint);
+    // Update the cached memory footprint of an already cached segment in place, without
+    // rebuilding the cache entry. Does nothing and returns false when the key is absent
+    // or no longer maps to `segment`.
+    bool update_segment_cache_size(std::string_view key, size_t mem_cost, const Segment* segment);
 
     // cache the segment if the given key not exists in the cache, returns the segment shared_ptr stored in the cache.
     std::shared_ptr<Segment> cache_segment_if_absent(std::string_view key, const std::shared_ptr<Segment>& segment);
@@ -90,17 +91,20 @@ public:
 
     size_t capacity() const;
 
-private:
-    static void cache_value_deleter(const CacheKey& /*key*/, void* value) { delete static_cast<CacheValue*>(value); }
+    // Total entries evicted so far, across both the insert and the release paths.
+    size_t evict_count() const;
 
-    std::shared_ptr<Segment> _lookup_segment_no_lock(std::string_view key);
-    void _cache_segment_no_lock(std::string_view key, size_t mem_cost, std::shared_ptr<Segment> segment);
+private:
+    static void cache_value_deleter(const CacheKey& key, void* value);
 
     void insert(std::string_view key, CacheValue* ptr, size_t size);
 
+    // No metacache-level lock: the compare-and-insert needed by cache_segment_if_absent()
+    // and the in-place charge update needed by update_segment_cache_size() are provided
+    // atomically by the underlying sharded cache. Keeping the cache lock as the only lock
+    // also keeps cached value destructors (notably ~Segment) off every lock, because
+    // LRUCache always runs deleters after releasing its shard mutex.
     std::unique_ptr<Cache> _cache;
-
-    std::shared_mutex _mutex;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -220,10 +220,9 @@ Status TabletManager::drop_local_cache(const std::string& path) {
     return fs->drop_local_cache(path);
 }
 
-// current lru cache does not support updating value size, so use refill to update.
-void TabletManager::update_segment_cache_size(std::string_view key, size_t mem_cost, intptr_t segment_addr_hint) {
+void TabletManager::update_segment_cache_size(std::string_view key, size_t mem_cost, const Segment* segment) {
     TEST_SYNC_POINT_CALLBACK("lake::TabletManager::update_segment_cache_size", nullptr);
-    _metacache->cache_segment_if_present(key, mem_cost, segment_addr_hint);
+    _metacache->update_segment_cache_size(key, mem_cost, segment);
 }
 
 void TabletManager::prune_metacache() {

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -283,11 +283,10 @@ public:
     // only for TEST purpose
     void TEST_set_global_schema_cache(int64_t index_id, TabletSchemaPtr schema);
 
-    // update cache size of the segment with the given key, optionally provide the segment address hint.
-    // If segment_addr_hint is provided and it's non-zero, the cache size will be only updated when the
-    // instance address matches the address provided by the segment_addr_hint. This is used to prevent
-    // updating the cache size where the cached object is not the one as expected.
-    void update_segment_cache_size(std::string_view key, size_t mem_cost, intptr_t segment_addr_hint = 0);
+    // Update the cache size of the segment with the given key. The update is applied only when the
+    // key still maps to `segment`, so that a cache entry replaced by a different instance in the
+    // meantime is not charged with this segment's memory cost.
+    void update_segment_cache_size(std::string_view key, size_t mem_cost, const Segment* segment);
 
     StatusOr<SegmentPtr> load_segment(const FileInfo& segment_info, int segment_id, size_t* footer_size_hint,
                                       const LakeIOOptions& lake_io_opts, bool fill_meta_cache,

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -841,8 +841,7 @@ void Segment::turn_off_batch_update_cache_size() {
                 // a path-only key would miss for bundled slices (non-zero bundle_file_offset) and
                 // their cache entries would never get the post-open memory cost, defeating
                 // metacache capacity control.
-                _tablet_manager->update_segment_cache_size(_segment_file_info.cache_key(), mem_cost,
-                                                           reinterpret_cast<intptr_t>(this));
+                _tablet_manager->update_segment_cache_size(_segment_file_info.cache_key(), mem_cost, this);
             }
         }
     }
@@ -853,8 +852,7 @@ void Segment::update_cache_size() {
         // could be race condition on this `_batch_on_flags_counter` check, but it is ok to be inaccurate in such case.
         if (_batch_on_flags_counter.load(std::memory_order_relaxed) == 0) {
             auto mem_cost = mem_usage();
-            _tablet_manager->update_segment_cache_size(_segment_file_info.cache_key(), mem_cost,
-                                                       reinterpret_cast<intptr_t>(this));
+            _tablet_manager->update_segment_cache_size(_segment_file_info.cache_key(), mem_cost, this);
         } else {
             // under batch mode, only increase the _dirty_cache_counter
             _dirty_cache_counter.fetch_add(1, std::memory_order_relaxed);

--- a/be/test/base/lru_cache_test.cpp
+++ b/be/test/base/lru_cache_test.cpp
@@ -37,7 +37,9 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <atomic>
 #include <memory>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 
@@ -409,6 +411,150 @@ TEST_F(CacheTest, TouchUpdatesRecencyOnShardedCache) {
     ASSERT_EQ(1000, lookup_cache(cache.get(), keys[0]));
     ASSERT_EQ(-1, lookup_cache(cache.get(), keys[1]));
     ASSERT_EQ(3000, lookup_cache(cache.get(), keys[2]));
+}
+
+static Cache::Handle* insert_if_absent_cache(Cache* cache, int key, int value, size_t charge, bool* inserted) {
+    std::string encoded;
+    return cache->insert_if_absent(EncodeKey(&encoded, key), EncodeValue(value), charge, &CacheTest::Deleter, inserted);
+}
+
+static bool update_charge_cache(Cache* cache, int key, size_t new_value_size,
+                                bool (*pred)(void* value, const void* ctx) = nullptr, const void* ctx = nullptr) {
+    std::string encoded;
+    return cache->update_charge_if(EncodeKey(&encoded, key), new_value_size, pred, ctx);
+}
+
+static bool value_equals(void* value, const void* ctx) {
+    return DecodeValue(value) == static_cast<int>(reinterpret_cast<intptr_t>(ctx));
+}
+
+TEST_F(CacheTest, InsertIfAbsentInsertsWhenKeyMissing) {
+    std::unique_ptr<Cache> cache(new_lru_cache(entry_charge_for_int_key() * kNumShards));
+
+    bool inserted = false;
+    auto* handle = insert_if_absent_cache(cache.get(), 100, 1000, 1, &inserted);
+    ASSERT_NE(nullptr, handle);
+    ASSERT_TRUE(inserted);
+    ASSERT_EQ(1000, DecodeValue(cache->value(handle)));
+    cache->release(handle);
+
+    ASSERT_EQ(1000, lookup_cache(cache.get(), 100));
+    ASSERT_TRUE(_deleted_keys.empty());
+}
+
+TEST_F(CacheTest, InsertIfAbsentKeepsExistingEntry) {
+    std::unique_ptr<Cache> cache(new_lru_cache(entry_charge_for_int_key() * 2 * kNumShards));
+
+    insert_cache(cache.get(), 100, 1000, 1);
+
+    bool inserted = true;
+    auto* handle = insert_if_absent_cache(cache.get(), 100, 2000, 1, &inserted);
+    ASSERT_NE(nullptr, handle);
+    ASSERT_FALSE(inserted);
+    // The existing value is returned; the rejected one is never handed to the deleter,
+    // it stays the caller's responsibility.
+    ASSERT_EQ(1000, DecodeValue(cache->value(handle)));
+    cache->release(handle);
+
+    ASSERT_EQ(1000, lookup_cache(cache.get(), 100));
+    ASSERT_TRUE(_deleted_keys.empty());
+}
+
+TEST_F(CacheTest, InsertIfAbsentEvictsToStayWithinCapacity) {
+    const size_t entry_charge = entry_charge_for_int_key();
+    const auto keys = find_int_keys_in_same_shard();
+    std::unique_ptr<Cache> cache(new_lru_cache(entry_charge * 2 * kNumShards));
+
+    insert_cache(cache.get(), keys[0], 1000, 1);
+    insert_cache(cache.get(), keys[1], 2000, 1);
+
+    bool inserted = false;
+    cache->release(insert_if_absent_cache(cache.get(), keys[2], 3000, 1, &inserted));
+    ASSERT_TRUE(inserted);
+
+    ASSERT_EQ(-1, lookup_cache(cache.get(), keys[0]));
+    ASSERT_EQ(2000, lookup_cache(cache.get(), keys[1]));
+    ASSERT_EQ(3000, lookup_cache(cache.get(), keys[2]));
+    ASSERT_EQ(std::vector<int>({keys[0]}), _deleted_keys);
+}
+
+TEST_F(CacheTest, InsertIfAbsentIsAtomicUnderConcurrency) {
+    constexpr int kThreads = 16;
+    std::unique_ptr<Cache> cache(new_lru_cache(entry_charge_for_int_key() * 64 * kNumShards));
+
+    std::atomic<int> inserted_count{0};
+    std::vector<std::thread> threads;
+    threads.reserve(kThreads);
+    for (int i = 0; i < kThreads; i++) {
+        threads.emplace_back([&, i]() {
+            bool inserted = false;
+            auto* handle = insert_if_absent_cache(cache.get(), 100, 1000 + i, 1, &inserted);
+            if (inserted) {
+                inserted_count.fetch_add(1);
+            }
+            cache->release(handle);
+        });
+    }
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    ASSERT_EQ(1, inserted_count.load());
+    ASSERT_TRUE(_deleted_keys.empty());
+}
+
+TEST_F(CacheTest, UpdateChargeIfAdjustsUsage) {
+    const size_t entry_charge = entry_charge_for_int_key();
+    std::unique_ptr<Cache> cache(new_lru_cache(entry_charge * 16 * kNumShards));
+
+    insert_cache(cache.get(), 100, 1000, 1);
+    const size_t base_usage = cache->get_memory_usage();
+
+    ASSERT_TRUE(update_charge_cache(cache.get(), 100, 101));
+    ASSERT_EQ(base_usage + 100, cache->get_memory_usage());
+
+    ASSERT_TRUE(update_charge_cache(cache.get(), 100, 1));
+    ASSERT_EQ(base_usage, cache->get_memory_usage());
+
+    // The entry itself is untouched, only its accounted size changed.
+    ASSERT_EQ(1000, lookup_cache(cache.get(), 100));
+    ASSERT_TRUE(_deleted_keys.empty());
+}
+
+TEST_F(CacheTest, UpdateChargeIfIgnoresMissingKeyAndRejectedPredicate) {
+    const size_t entry_charge = entry_charge_for_int_key();
+    std::unique_ptr<Cache> cache(new_lru_cache(entry_charge * 16 * kNumShards));
+
+    insert_cache(cache.get(), 100, 1000, 1);
+    const size_t base_usage = cache->get_memory_usage();
+
+    ASSERT_FALSE(update_charge_cache(cache.get(), 200, 101));
+    ASSERT_EQ(base_usage, cache->get_memory_usage());
+
+    ASSERT_FALSE(update_charge_cache(cache.get(), 100, 101, value_equals,
+                                     reinterpret_cast<const void*>(static_cast<intptr_t>(2000))));
+    ASSERT_EQ(base_usage, cache->get_memory_usage());
+
+    ASSERT_TRUE(update_charge_cache(cache.get(), 100, 101, value_equals,
+                                    reinterpret_cast<const void*>(static_cast<intptr_t>(1000))));
+    ASSERT_EQ(base_usage + 100, cache->get_memory_usage());
+}
+
+TEST_F(CacheTest, UpdateChargeIfRefreshesRecencyBeforeEvicting) {
+    const size_t entry_charge = entry_charge_for_int_key();
+    const auto keys = find_int_keys_in_same_shard();
+    std::unique_ptr<Cache> cache(new_lru_cache(entry_charge * 2 * kNumShards));
+
+    insert_cache(cache.get(), keys[0], 1000, 1);
+    insert_cache(cache.get(), keys[1], 2000, 1);
+
+    // Grow the *older* entry past the shard capacity. Because the update refreshes it to
+    // the MRU end first, the newer entry is the one evicted, not the entry being updated.
+    ASSERT_TRUE(update_charge_cache(cache.get(), keys[0], 1 + entry_charge));
+
+    ASSERT_EQ(1000, lookup_cache(cache.get(), keys[0]));
+    ASSERT_EQ(-1, lookup_cache(cache.get(), keys[1]));
+    ASSERT_EQ(std::vector<int>({keys[1]}), _deleted_keys);
 }
 
 TEST_F(CacheTest, TouchMissingKeyDoesNotAffectRecencyOrStats) {

--- a/be/test/storage/lake/metacache_test.cpp
+++ b/be/test/storage/lake/metacache_test.cpp
@@ -14,12 +14,20 @@
 
 #include "storage/lake/metacache.h"
 
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <array>
+#include <chrono>
 #include <future>
+#include <unordered_map>
 
+#include "base/container/lru_cache.h"
 #include "base/testutil/assert.h"
 #include "base/testutil/id_generator.h"
+#include "base/testutil/sync_point.h"
+#include "base/utility/scoped_cleanup.h"
 #include "column/chunk.h"
 #include "column/chunk_factory.h"
 #include "column/datum_tuple.h"
@@ -340,6 +348,112 @@ TEST_F(LakeMetacacheTest, test_cache_segment_if_absent_concurrency) {
             EXPECT_EQ(final_result, res);
         }
     }
+}
+
+static uint32_t cache_shard(std::string_view key) {
+    CacheKey cache_key(key);
+    return cache_key.hash(cache_key.data(), cache_key.size(), 0) >> (32 - kNumShardBits);
+}
+
+static std::array<std::string, 2> find_segment_paths_in_same_cache_shard() {
+    std::unordered_map<uint32_t, std::string> first_path_by_shard;
+    for (int i = 0;; ++i) {
+        auto path = fmt::format("segment_destruction_{}.dat", i);
+        auto [it, inserted] = first_path_by_shard.emplace(cache_shard(path), path);
+        if (!inserted) {
+            return {it->second, std::move(path)};
+        }
+    }
+}
+
+// Destroying a cached Segment can be expensive (it tears down every loaded column index).
+// It must therefore never run while a cache lock is held, otherwise one slow eviction stalls
+// every other metacache user. Both paths below target the same cache shard, so if the deleter
+// ran under the shard lock the concurrent lookup would block behind it.
+TEST_F(LakeMetacacheTest, test_segment_destruction_does_not_block_cache) {
+    std::shared_ptr<FileSystem> fs;
+    TabletSchemaCSPtr schema;
+    const auto paths = find_segment_paths_in_same_cache_shard();
+    auto victim = std::make_shared<Segment>(fs, FileInfo{paths[0]}, 100, schema, _tablet_mgr.get());
+    auto replacement = std::make_shared<Segment>(fs, FileInfo{paths[1]}, 101, schema, _tablet_mgr.get());
+
+    // Size the cache so that a single shard holds exactly one of these segments.
+    const size_t victim_charge = victim->mem_usage() + LRUCache::key_handle_size(CacheKey(paths[0]));
+    const size_t replacement_charge = replacement->mem_usage() + LRUCache::key_handle_size(CacheKey(paths[1]));
+    Metacache metacache(std::max(victim_charge, replacement_charge) * kNumShards);
+    metacache.cache_segment(paths[0], victim);
+
+    auto* victim_ptr = victim.get();
+    std::weak_ptr<Segment> victim_weak = victim;
+    victim.reset();
+
+    std::promise<void> deleter_entered;
+    auto deleter_entered_future = deleter_entered.get_future();
+    std::promise<void> allow_deletion;
+    auto allow_deletion_future = allow_deletion.get_future().share();
+    auto* sync_point = SyncPoint::GetInstance();
+    sync_point->SetCallBack("lake::Metacache::cache_value_deleter", [&](void* arg) {
+        auto* segment = std::get_if<std::shared_ptr<Segment>>(static_cast<CacheValue*>(arg));
+        if (segment != nullptr && segment->get() == victim_ptr) {
+            deleter_entered.set_value();
+            allow_deletion_future.wait();
+        }
+    });
+    sync_point->EnableProcessing();
+    auto sync_point_cleanup = MakeScopedCleanup([&]() {
+        sync_point->DisableProcessing();
+        sync_point->ClearCallBack("lake::Metacache::cache_value_deleter");
+    });
+
+    // Evicts the victim, and blocks inside its deleter.
+    auto insert_future = std::async(std::launch::async, [&]() { metacache.cache_segment(paths[1], replacement); });
+    bool deletion_released = false;
+    auto unblock_deleter = MakeScopedCleanup([&]() {
+        if (!deletion_released) {
+            allow_deletion.set_value();
+        }
+    });
+
+    using namespace std::chrono_literals;
+    ASSERT_EQ(std::future_status::ready, deleter_entered_future.wait_for(5s));
+
+    auto lookup_future = std::async(std::launch::async, [&]() { return metacache.lookup_segment(paths[1]); });
+    EXPECT_EQ(std::future_status::ready, lookup_future.wait_for(1s));
+
+    allow_deletion.set_value();
+    deletion_released = true;
+    unblock_deleter.cancel();
+
+    EXPECT_EQ(replacement, lookup_future.get());
+    insert_future.get();
+    EXPECT_TRUE(victim_weak.expired());
+}
+
+TEST_F(LakeMetacacheTest, test_update_segment_cache_size) {
+    std::shared_ptr<FileSystem> fs;
+    TabletSchemaCSPtr schema;
+    auto* metacache = _tablet_mgr->metacache();
+    metacache->prune();
+
+    std::string segment_path("test_update_segment_cache_size.dat");
+    auto seg = std::make_shared<Segment>(fs, FileInfo{segment_path}, 1000, schema, _tablet_mgr.get());
+    metacache->cache_segment(segment_path, seg);
+    const size_t base_usage = metacache->memory_usage();
+
+    // Absent key is a no-op.
+    EXPECT_FALSE(metacache->update_segment_cache_size("no_such_segment.dat", 4096, seg.get()));
+    EXPECT_EQ(base_usage, metacache->memory_usage());
+
+    // Key that maps to a different Segment instance is a no-op too.
+    auto other = std::make_shared<Segment>(fs, FileInfo{segment_path}, 1000, schema, _tablet_mgr.get());
+    EXPECT_FALSE(metacache->update_segment_cache_size(segment_path, 4096, other.get()));
+    EXPECT_EQ(base_usage, metacache->memory_usage());
+
+    // Matching instance updates the charge in place, the cached segment stays the same object.
+    const size_t old_mem_cost = seg->mem_usage();
+    EXPECT_TRUE(metacache->update_segment_cache_size(segment_path, old_mem_cost + 4096, seg.get()));
+    EXPECT_EQ(base_usage + 4096, metacache->memory_usage());
+    EXPECT_EQ(seg, metacache->lookup_segment(segment_path));
 }
 
 TEST_F(LakeMetacacheTest, test_combined_txn_log_cache) {

--- a/be/test/storage/rowset/metadata_cache_test.cpp
+++ b/be/test/storage/rowset/metadata_cache_test.cpp
@@ -35,9 +35,21 @@ namespace starrocks {
 class RecordingCache final : public Cache {
 public:
     Handle* insert(const CacheKey& /*key*/, void* /*value*/, size_t /*value_size*/,
-                   void (*/*deleter*/)(const CacheKey& key, void* value),
+                   void (* /*deleter*/)(const CacheKey& key, void* value),
                    CachePriority /*priority*/ = CachePriority::NORMAL) override {
         return nullptr;
+    }
+
+    Handle* insert_if_absent(const CacheKey& /*key*/, void* /*value*/, size_t /*value_size*/,
+                             void (* /*deleter*/)(const CacheKey& key, void* value), bool* inserted,
+                             CachePriority /*priority*/ = CachePriority::NORMAL) override {
+        *inserted = false;
+        return nullptr;
+    }
+
+    bool update_charge_if(const CacheKey& /*key*/, size_t /*new_value_size*/,
+                          bool (* /*pred*/)(void* value, const void* ctx), const void* /*ctx*/) override {
+        return false;
     }
 
     Handle* lookup(const CacheKey& key) override {

--- a/be/test/storage/rowset/metadata_cache_test.cpp
+++ b/be/test/storage/rowset/metadata_cache_test.cpp
@@ -35,20 +35,20 @@ namespace starrocks {
 class RecordingCache final : public Cache {
 public:
     Handle* insert(const CacheKey& /*key*/, void* /*value*/, size_t /*value_size*/,
-                   void (* /*deleter*/)(const CacheKey& key, void* value),
+                   void (*/*deleter*/)(const CacheKey& key, void* value),
                    CachePriority /*priority*/ = CachePriority::NORMAL) override {
         return nullptr;
     }
 
     Handle* insert_if_absent(const CacheKey& /*key*/, void* /*value*/, size_t /*value_size*/,
-                             void (* /*deleter*/)(const CacheKey& key, void* value), bool* inserted,
+                             void (*/*deleter*/)(const CacheKey& key, void* value), bool* inserted,
                              CachePriority /*priority*/ = CachePriority::NORMAL) override {
         *inserted = false;
         return nullptr;
     }
 
     bool update_charge_if(const CacheKey& /*key*/, size_t /*new_value_size*/,
-                          bool (* /*pred*/)(void* value, const void* ctx), const void* /*ctx*/) override {
+                          bool (*/*pred*/)(void* value, const void* ctx), const void* /*ctx*/) override {
         return false;
     }
 


### PR DESCRIPTION
## Why I'm doing:

`lake::Metacache` guards its segment entries with a single process-wide
`std::shared_mutex`, layered on top of a `ShardedLRUCache` that is already split into
32 independently locked shards. The extra layer exists only for two reasons: to make
`lookup + insert` atomic for `cache_segment_if_absent()`, and to let
`cache_segment_if_present()` refresh a cached segment's memory footprint by rebuilding
its cache entry, because the LRU cache had no way to change an entry's charge in place.

That has three consequences:

1. Every segment cache operation serializes on one lock, collapsing the 32-way shard
   parallelism the underlying cache already provides.
2. `LRUCache` deliberately runs cached-value deleters *after* releasing its shard mutex
   (`insert()`, `release()`, `erase()`, `prune()` all do this), but the metacache lock is
   still held at that point. Evicting a segment therefore destroys it — tearing down every
   loaded column index — while holding the global lock.
3. `cache_segment_if_present()` rebuilds the whole entry (malloc, key copy, hash-table
   insert, eviction scan, free of the old handle) just to change a number.

Under metacache capacity pressure these compound into a feedback loop: every
`load_segment()` misses, every miss takes the global exclusive lock, every insert evicts,
and every eviction runs `~Segment` inside that lock. The critical section stretches into
milliseconds and every scan thread queues behind it, which presents as queries hanging
while CPU stays low.

## What I'm doing:

Push the atomicity down into the cache that already owns the data, and drop the metacache
lock entirely.

`Cache` gains two methods. `ShardedLRUCache` is the only implementation, and `Metacache`
is the only caller:

- `insert_if_absent(key, value, size, deleter, inserted, priority)` — compare and insert
  under the shard lock. If the key is already present the existing entry's handle is
  returned and the caller keeps ownership of the rejected value.
- `update_charge_if(key, new_value_size, pred, ctx)` — change an entry's charge in place,
  refresh it to the MRU position, and evict if the shard is now over capacity. `pred` runs
  under the shard lock and is documented as identity-check only.

`LRUCache::insert()` is refactored to share `_alloc_handle()` / `_insert_no_lock()` with the
new path; its observable behaviour is unchanged. Every existing `Cache` method keeps its
current signature and semantics, so `fd_cache`, `metadata_cache`, `llm_cache`, the starlet
fs cache and `update_manager` are unaffected — none of them call the new methods.

`Metacache` then drops `_mutex`, `_lookup_segment_no_lock()` and `_cache_segment_no_lock()`:

- `cache_segment_if_absent()` becomes one `insert_if_absent()` call, down from a global
  exclusive lock plus six shard-lock acquisitions.
- `cache_segment_if_present()` becomes `update_segment_cache_size(key, mem_cost, const Segment*)`
  backed by one `update_charge_if()` call, with no allocation and no entry rebuild.
- `lookup_segment()` and `cache_segment()` become plain pass-throughs.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

Segment cache hit/miss bvars change their absolute counts: `cache_segment_if_absent()`
no longer performs the internal `lookup_segment()` calls that used to be counted. No bvar
is added or removed. Query results and cache contents are unchanged.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr


## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5

