### PR TITLE
[BugFix] Keep a grouping set from carrying the same key twice

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteGroupingSetsByCTERule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteGroupingSetsByCTERule.java
@@ -127,9 +127,11 @@ public class RewriteGroupingSetsByCTERule extends TransformationRule {
                 newAggregations.put(aggColumnRef, (CallOperator) rewriter.rewrite(kv.getValue()));
             }
 
-            // new group by keys
+            // new group by keys. A grouping set must never yield a duplicated group-by key: the aggregation
+            // tuple holds one slot per distinct key, while the BE builds its output from one column per
+            // group-by expression.
             List<ColumnRefOperator> rewriteGroupingKeys = groupingSetKeys.stream().
-                    map(column -> (ColumnRefOperator) rewriter.rewrite(column)).collect(
+                    map(column -> (ColumnRefOperator) rewriter.rewrite(column)).distinct().collect(
                             Collectors.toList());
             // add grouping id and grouping
             Map<ColumnRefOperator, ConstantOperator> groupingIdMap = new HashMap<>();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
@@ -665,7 +665,14 @@ public class QueryTransformer {
                 for (Expr groupingField : grouping) {
                     ColumnRefOperator groupingKey = (ColumnRefOperator) SqlToScalarOperatorTranslator.translate(
                             groupingField, subOpt.getExpressionMapping(), columnRefFactory);
-                    repeatColumnRef.add(groupingKey);
+                    // A grouping set may name the same column more than once, e.g. ROLLUP(a, b, a) expands
+                    // to the set (a, b, a), which groups exactly like (a, b). Record each key once: the
+                    // grouping-sets-to-union-all rewrite turns this list into an aggregation's group-by keys,
+                    // and a duplicated key there makes the FE emit one output slot fewer than group-by
+                    // expressions, which the BE then dereferences out of bounds.
+                    if (!repeatColumnRef.contains(groupingKey)) {
+                        repeatColumnRef.add(groupingKey);
+                    }
                     if (groupByColumnRefs.contains(groupingKey)) {
                         groupingIdBitSet.set(groupByColumnRefs.indexOf(groupingKey), false);
                     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetsTest.java
@@ -46,9 +46,12 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class GroupingSetsTest extends PlanTestBase {
@@ -67,6 +70,42 @@ public class GroupingSetsTest extends PlanTestBase {
     @BeforeEach
     public void before() {
         connectContext.getSessionVariable().setNewPlanerAggStage(0);
+    }
+
+    @Test
+    public void testRepeatNodeWithUnionAllRewriteDuplicateGroupingKey() throws Exception {
+        connectContext.getSessionVariable().setEnableRewriteGroupingSetsToUnionAll(true);
+        try {
+            // ROLLUP(v1, v2, v1) expands to the grouping sets (), (v1), (v1, v2), (v1, v2, v1). The rewrite
+            // turns each set into an aggregation's group-by keys; the last set must not carry v1 twice, or the
+            // FE emits one output slot fewer than group-by expressions and the BE crashes building the chunk.
+            String[] sqls = {
+                    "select v1, v2, sum(v3) from t0 group by rollup(v1, v2, v1)",
+                    "select v1, v2, sum(v3) from t0 group by cube(v1, v2, v1)",
+                    "select v1, v2, sum(v3) from t0 group by grouping sets((v1, v2), (v1, v2, v1), (v1, v1))",
+            };
+            for (String sql : sqls) {
+                String plan = getFragmentPlan(sql);
+                assertContains(plan, "1:UNION");
+                for (String line : plan.split("\n")) {
+                    int pos = line.indexOf("group by:");
+                    if (pos < 0) {
+                        continue;
+                    }
+                    List<String> keys = Arrays.stream(line.substring(pos + "group by:".length()).split(","))
+                            .map(String::trim).filter(k -> !k.isEmpty()).collect(Collectors.toList());
+                    Assertions.assertEquals(keys.size(), new HashSet<>(keys).size(),
+                            "duplicated group-by key in " + sql + ":\n" + plan);
+                }
+            }
+
+            // Every grouping set still becomes its own union branch: 4 sets for ROLLUP(v1, v2, v1).
+            String plan = getFragmentPlan(sqls[0]).replaceAll(" ", "");
+            Assertions.assertTrue(Pattern.compile("1:UNION\n\\|\n(\\|----\\d+:EXCHANGE\n\\|\n){3}\\d+:EXCHANGE\n")
+                    .matcher(plan).find(), plan);
+        } finally {
+            connectContext.getSessionVariable().setEnableRewriteGroupingSetsToUnionAll(false);
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/grouping-sets.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/grouping-sets.sql
@@ -276,7 +276,7 @@ select v7 from t2 group by rollup(v7,v7)
 AGGREGATE ([GLOBAL] aggregate [{}] group by [[1: v7, 4: GROUPING_ID]] having [null]
     EXCHANGE SHUFFLE[1, 4]
         AGGREGATE ([LOCAL] aggregate [{}] group by [[1: v7, 4: GROUPING_ID]] having [null]
-            REPEAT [[], [1: v7], [1: v7, 1: v7]]
+            REPEAT [[], [1: v7], [1: v7]]
                 SCAN (columns[1: v7] predicate[null])
 [end]
 
@@ -286,6 +286,6 @@ select v7,v8 from t2 group by cube(v7,v7,v8)
 AGGREGATE ([GLOBAL] aggregate [{}] group by [[1: v7, 2: v8, 4: GROUPING_ID]] having [null]
     EXCHANGE SHUFFLE[1, 2, 4]
         AGGREGATE ([LOCAL] aggregate [{}] group by [[1: v7, 2: v8, 4: GROUPING_ID]] having [null]
-            REPEAT [[], [1: v7], [1: v7], [1: v7, 1: v7], [2: v8], [1: v7, 2: v8], [1: v7, 2: v8], [1: v7, 1: v7, 2: v8]]
+            REPEAT [[], [1: v7], [1: v7], [1: v7], [2: v8], [1: v7, 2: v8], [1: v7, 2: v8], [1: v7, 2: v8]]
                 SCAN (columns[1: v7, 2: v8] predicate[null])
 [end]


### PR DESCRIPTION
## Why I'm doing:

`GROUP BY ROLLUP(a, b, a)` (likewise CUBE and GROUPING SETS naming a column twice inside one set) expands to the grouping set (a, b, a). The analyzer deduplicates the aggregation's group-by list, but the repeat operator kept the set as written. With `enable_rewrite_groupingsets_to_union_all` the rewrite turns every set into its own aggregation whose group-by keys are exactly that list, so the child aggregation grouped by `a, b, a`. `DescriptorTable` registers one slot per distinct slot id, so the aggregation tuple had one slot fewer than group-by expressions; the BE indexed past the end of the tuple's slot vector while building the output chunk and dereferenced a null `SlotDescriptor` (ASan build), or shipped a chunk whose column layout no longer matched the exchange receiver's, which then crashed in `serde::read_raw` (release build).

Record each key of a grouping set once when the repeat operator is built -- (a, b, a) groups exactly like (a, b), and the grouping id, GROUPING() and per-set NULL projection are all keyed by distinct columns already -- and make the union-all rewrite distinct its keys as well so it can never emit an aggregation with a duplicated group-by key.

```
query_id:01a025e1-bd06-7525-ac0f-5710783be028, fragment_instance:01a025e1-bd06-7525-ac0f-5710783be02c, plan_node_id:24
*** Aborted at 1787341946 (unix time) try "date -d @1787341946" if you are using GNU date ***
PC: @         0x1d569a32 starrocks::SlotDescriptor::id() const
*** SIGSEGV (@0x0) received by PID 4103019 (TID 0x7f3fdf02f6c0) LWP(4103852) from PID 0; stack trace: ***
    @         0x32fe3c07 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7f42c0b44ed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)
    @         0x32fe3406 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f42c0ae8330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @         0x1d569a32 starrocks::SlotDescriptor::id() const
    @         0x1d845e2e starrocks::Aggregator::_build_output_chunk(std::vector<starrocks::Cow<starrocks::Column>::MutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::MutPtr<starrocks::Column> > >&&, std::
vector<starrocks::Cow<starrocks::Column>::MutPtr<st@
    @         0x1d8ec464 auto starrocks::Aggregator::convert_hash_map_to_chunk(int, std::shared_ptr<starrocks::Chunk>*, bool)::{lambda(auto:1&)#1}::operator()<std::unique_ptr<starrocks::AggHashMapWithSerializedKey<phmap::parallel_
flat_hash_map<starrocks::Slice, unsigned char*, sta@
    @         0x1da1e270 starrocks::Status std::__invoke_impl<starrocks::Status, starrocks::Aggregator::convert_hash_map_to_chunk(int, std::shared_ptr<starrocks::Chunk>*, bool)::{lambda(auto:1&)#1}, std::unique_ptr<starrocks::AggH
ashMapWithSerializedKey<phmap::parallel_flat_hash_m@
    @         0x1da09c0e std::__invoke_result<starrocks::Aggregator::convert_hash_map_to_chunk(int, std::shared_ptr<starrocks::Chunk>*, bool)::{lambda(auto:1&)#1}, std::unique_ptr<starrocks::AggHashMapWithSerializedKey<phmap::para
llel_flat_hash_map<starrocks::Slice, unsigned char*@
    @         0x1d98762b (unknown)
    @         0x1d988db8 (unknown)
    @         0x1d988e21 (unknown)
    @         0x1d84c460 auto starrocks::AggHashMapVariant::visit<starrocks::Aggregator::convert_hash_map_to_chunk(int, std::shared_ptr<starrocks::Chunk>*, bool)::{lambda(auto:1&)#1}>(starrocks::Aggregator::convert_hash_map_to_chu
nk(int, std::shared_ptr<starrocks::Chunk>*, bool)::@
    @         0x1d84c6c1 starrocks::Aggregator::convert_hash_map_to_chunk(int, std::shared_ptr<starrocks::Chunk>*, bool)
    @         0x1ec258e0 starrocks::pipeline::AggregateStreamingSourceOperator::_output_chunk_from_hash_map(std::shared_ptr<starrocks::Chunk>*, starrocks::RuntimeState*)
    @         0x1ec253da starrocks::pipeline::AggregateStreamingSourceOperator::pull_chunk(starrocks::RuntimeState*)
    @         0x237ceda4 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @         0x1e6808d3 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @         0x1e67ec6a starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}::operator()() const
    @         0x1e686974 void std::__invoke_impl<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(std::__invoke_other, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&)
    @         0x1e6860ba std::enable_if<is_invocable_r_v<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>, void>::type std::__invoke_r<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int
)::{lambda()#1}&>(starrocks::pipeline::GlobalDriver@
    @         0x1e685b8a std::_Function_handler<void (), starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}>::_M_invoke(std::_Any_data const&)
    @         0x1cb72d2e std::function<void ()>::operator()() const
    @         0x2e46d62a starrocks::FunctionRunnable::run()
    @         0x2e467430 starrocks::ThreadPool::dispatch_thread()
    @         0x2e4888ca void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @         0x2e487268 std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starro
cks::ThreadPool*&)
    @         0x2e485cdc void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>)
    @         0x2e484338 void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>()
    @         0x2e4825be void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&)
    @         0x2e47fec1 std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadP
ool*))()>&>(std::_Bind<void (starrocks::ThreadPool:@

```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
