### PR TITLE
[Enhancement] Implement statistics propagation for CONVERT_TZ operator(backport #77850)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ConvertTzStatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ConvertTzStatisticUtils.java
@@ -1,0 +1,173 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.statistics;
+
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorFunctions;
+import com.starrocks.type.Type;
+import com.starrocks.type.VarcharType;
+
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.zone.ZoneOffsetTransition;
+import java.time.zone.ZoneRules;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalDouble;
+
+/**
+ * Convert_tz-specific helpers used by {@link ExpressionStatisticCalculator}.
+ * Orchestration (NDV, nulls, assembling {@link ColumnStatistic}) stays in the calculator.
+ */
+public final class ConvertTzStatisticUtils {
+    // Timezone offsets differ by at most 26 hours
+    // (see ExtractRangePredicateFromScalarApplyRule).
+    public static final double MAX_TIMEZONE_OFFSET_SECONDS = 26.0 * 3600.0;
+
+    private ConvertTzStatisticUtils() {
+    }
+
+    public static OptionalDouble convertTzDateTime(double dateTimeStat, ConstantOperator fromTz,
+                                                   ConstantOperator toTz) {
+        try {
+            ConstantOperator input = ConstantOperator.createDatetime(Utils.getDatetimeFromLong((long) dateTimeStat));
+            ConstantOperator converted = ScalarOperatorFunctions.convert_tz(input, fromTz, toTz);
+            return OptionalDouble.of(Utils.getLongFromDateTime(converted.getDatetime()));
+        } catch (DateTimeException | SemanticException e) {
+            return OptionalDouble.empty();
+        }
+    }
+
+    /**
+     * convert_tz is only a constant wall-clock shift while both zones keep the same UTC offset over
+     * the whole input range. Around a DST transition the mapping is not monotonic in wall-clock space,
+     * e.g. UTC 00:30 and 01:30 both map to Europe/Berlin 02:30 on 2024-10-27 while 00:59 maps to 02:59,
+     * so converting only the endpoints would under-range the result.
+     *
+     * {@code LocalDateTime.atZone} also skips spring-forward gaps and picks one offset in fall-back
+     * overlaps, so an instant interval built from the endpoints can miss the transition entirely.
+     * If either endpoint is skipped or ambiguous in {@code fromTz}, keep the widened range.
+     */
+    public static boolean hasTimezoneOffsetDrift(double minValue, double maxValue,
+                                                 ConstantOperator fromTz, ConstantOperator toTz) {
+        try {
+            ZoneId from = ZoneId.of(fromTz.getVarchar());
+            ZoneId to = ZoneId.of(toTz.getVarchar());
+            LocalDateTime minLocal = Utils.getDatetimeFromLong((long) minValue);
+            LocalDateTime maxLocal = Utils.getDatetimeFromLong((long) maxValue);
+            if (isSkippedOrAmbiguous(from, minLocal) || isSkippedOrAmbiguous(from, maxLocal)) {
+                return true;
+            }
+            Instant minInstant = minLocal.atZone(from).toInstant();
+            Instant maxInstant = maxLocal.atZone(from).toInstant();
+            Instant start = minInstant.isAfter(maxInstant) ? maxInstant : minInstant;
+            Instant end = minInstant.isAfter(maxInstant) ? minInstant : maxInstant;
+            return hasOffsetTransition(from, start, end) || hasOffsetTransition(to, start, end);
+        } catch (DateTimeException e) {
+            // Invalid zone id or out-of-range temporal value: keep the widened range.
+            return true;
+        }
+    }
+
+    public static boolean isValidTimeZone(ConstantOperator tz) {
+        try {
+            ZoneId.of(tz.getVarchar());
+            return true;
+        } catch (DateTimeException e) {
+            return false;
+        }
+    }
+
+    private static boolean isSkippedOrAmbiguous(ZoneId zone, LocalDateTime localDateTime) {
+        return zone.getRules().getValidOffsets(localDateTime).size() != 1;
+    }
+
+    private static boolean hasOffsetTransition(ZoneId zone, Instant start, Instant end) {
+        ZoneRules rules = zone.getRules();
+        if (!rules.getOffset(start).equals(rules.getOffset(end))) {
+            return true;
+        }
+        ZoneOffsetTransition next = rules.nextTransition(start);
+        return next != null && !next.getInstant().isAfter(end);
+    }
+
+    public static Optional<Histogram> transformHistogram(CallOperator callOperator,
+                                                         ColumnStatistic childStats,
+                                                         double minValue, double maxValue,
+                                                         double rowCount,
+                                                         Optional<ConstantOperator> fromTz,
+                                                         Optional<ConstantOperator> toTz) {
+        Histogram hist = childStats == null ? null : childStats.getHistogram();
+        if (hist == null || hist.getMCV().isEmpty()) {
+            return Optional.empty();
+        }
+
+        if (fromTz.isEmpty() || toTz.isEmpty()) {
+            return Optional.empty();
+        }
+
+        final Type resultType = callOperator.getType();
+        Map<String, Long> newMcv = new HashMap<>();
+        for (Map.Entry<String, Long> entry : hist.getMCV().entrySet()) {
+            Optional<ConstantOperator> parsedKey =
+                    ConstantOperator.createVarchar(entry.getKey()).castTo(resultType);
+            if (parsedKey.isEmpty() || parsedKey.get().isNull()) {
+                return Optional.empty();
+            }
+
+            ConstantOperator converted;
+            try {
+                converted = ScalarOperatorFunctions.convert_tz(parsedKey.get(), fromTz.get(), toTz.get());
+            } catch (DateTimeException | SemanticException e) {
+                return Optional.empty();
+            }
+
+            Optional<ConstantOperator> keyString = converted.castTo(VarcharType.VARCHAR);
+            if (keyString.isEmpty()) {
+                return Optional.empty();
+            }
+            newMcv.merge(keyString.get().getVarchar(), entry.getValue(), Long::sum);
+        }
+
+        // Exact per-key MCV transform; keep one covering bucket for the non-MCV mass
+        // (same idea as HistogramStatisticsCollectJob.buildCollectSingleBucket in stats collection).
+        return Optional.of(buildSingleBucketHistogram(minValue, maxValue, rowCount, newMcv));
+    }
+
+    /**
+     * Build an MCV histogram with a single covering bucket for the remaining non-MCV rows.
+     * Mirrors the stats-collection fallback that stores one bucket over [min, max] with
+     * count = totalRows - sum(MCV) when a full multi-bucket histogram is unavailable.
+     */
+    public static Histogram buildSingleBucketHistogram(double minValue, double maxValue,
+                                                       double totalRows, Map<String, Long> mcv) {
+        if (Double.isInfinite(minValue) || Double.isInfinite(maxValue)
+                || Double.isNaN(minValue) || Double.isNaN(maxValue)) {
+            return new Histogram(Collections.emptyList(), mcv);
+        }
+        long mcvRows = mcv.values().stream().mapToLong(Long::longValue).sum();
+        long nonMcvRows = Math.max(0L, Math.round(totalRows) - mcvRows);
+        List<Bucket> buckets = List.of(new Bucket(minValue, maxValue, nonMcvRows, 0L));
+        return new Histogram(buckets, mcv);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ConvertTzStatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ConvertTzStatisticUtils.java
@@ -14,13 +14,12 @@
 
 package com.starrocks.sql.optimizer.statistics;
 
+import com.starrocks.catalog.Type;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorFunctions;
-import com.starrocks.type.Type;
-import com.starrocks.type.VarcharType;
 
 import java.time.DateTimeException;
 import java.time.Instant;
@@ -142,7 +141,7 @@ public final class ConvertTzStatisticUtils {
                 return Optional.empty();
             }
 
-            Optional<ConstantOperator> keyString = converted.castTo(VarcharType.VARCHAR);
+            Optional<ConstantOperator> keyString = converted.castTo(Type.VARCHAR);
             if (keyString.isEmpty()) {
                 return Optional.empty();
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -1041,6 +1041,64 @@ public class ExpressionStatisticCalculator {
             return Optional.empty();
         }
 
+        private ColumnStatistic calcConvertTzStats(List<ColumnStatistic> inputs, CallOperator callOperator) {
+            ColumnStatistic childStat = inputs.get(0);
+            ColumnStatistic fromTzStat = inputs.get(1);
+            ColumnStatistic toTzStat = inputs.get(2);
+
+            Optional<ConstantOperator> fromTz = toConstantOperator(callOperator.getChild(1));
+            Optional<ConstantOperator> toTz = toConstantOperator(callOperator.getChild(2));
+            // Invalid constant zones are not folded when the datetime is a column, but the BE
+            // returns NULL for every row (convert_tz_prepare sets is_valid=false).
+            if ((fromTz.isPresent() && !ConvertTzStatisticUtils.isValidTimeZone(fromTz.get()))
+                    || (toTz.isPresent() && !ConvertTzStatisticUtils.isValidTimeZone(toTz.get()))) {
+                return ColumnStatistic.builder()
+                        .setNullsFraction(1.0)
+                        .setAverageRowSize(callOperator.getType().getTypeSize())
+                        .setDistinctValuesCount(0)
+                        .build();
+            }
+
+            final double nullsFraction = 1.0
+                    - (1.0 - childStat.getNullsFraction())
+                    * (1.0 - fromTzStat.getNullsFraction())
+                    * (1.0 - toTzStat.getNullsFraction());
+            final double nonNullRowCount = rowCount * (1.0 - nullsFraction);
+
+            final double distinctValues = Math.min(nonNullRowCount,
+                    childStat.getDistinctValuesCount()
+                            * fromTzStat.getDistinctValuesCount()
+                            * toTzStat.getDistinctValuesCount());
+
+            double minValue = childStat.getMinValue() - ConvertTzStatisticUtils.MAX_TIMEZONE_OFFSET_SECONDS;
+            double maxValue = childStat.getMaxValue() + ConvertTzStatisticUtils.MAX_TIMEZONE_OFFSET_SECONDS;
+
+            if (fromTz.isPresent() && toTz.isPresent()
+                    && !childStat.hasNaNValue() && !childStat.isInfiniteRange()
+                    && !ConvertTzStatisticUtils.hasTimezoneOffsetDrift(childStat.getMinValue(), childStat.getMaxValue(),
+                            fromTz.get(), toTz.get())) {
+                OptionalDouble convertedMin =
+                        ConvertTzStatisticUtils.convertTzDateTime(childStat.getMinValue(), fromTz.get(), toTz.get());
+                OptionalDouble convertedMax =
+                        ConvertTzStatisticUtils.convertTzDateTime(childStat.getMaxValue(), fromTz.get(), toTz.get());
+                if (convertedMin.isPresent() && convertedMax.isPresent()) {
+                    minValue = Math.min(convertedMin.getAsDouble(), convertedMax.getAsDouble());
+                    maxValue = Math.max(convertedMin.getAsDouble(), convertedMax.getAsDouble());
+                }
+            }
+
+            return ColumnStatistic.builder()
+                    .setMinValue(minValue)
+                    .setMaxValue(maxValue)
+                    .setNullsFraction(nullsFraction)
+                    .setAverageRowSize(callOperator.getType().getTypeSize())
+                    .setDistinctValuesCount(distinctValues)
+                    .setHistogram(ConvertTzStatisticUtils.transformHistogram(
+                            callOperator, childStat, minValue, maxValue, nonNullRowCount, fromTz, toTz)
+                            .orElse(null))
+                    .build();
+        }
+
         private ColumnStatistic calcCoalesceStats(List<ColumnStatistic> inputs, CallOperator callOperator) {
             double nullsFraction = inputs.stream()
                     .mapToDouble(ColumnStatistic::getNullsFraction)
@@ -1287,6 +1345,8 @@ public class ExpressionStatisticCalculator {
             double averageRowSize;
             double nullsFraction;
             switch (callOperator.getFnName().toLowerCase()) {
+                case FunctionSet.CONVERT_TZ:
+                    return calcConvertTzStats(childColumnStatisticList, callOperator);
                 case FunctionSet.COALESCE:
                     return calcCoalesceStats(childColumnStatisticList, callOperator);
                 case FunctionSet.IF:

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ConvertTzStatisticUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ConvertTzStatisticUtilsTest.java
@@ -1,0 +1,261 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.statistics;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorFunctions;
+import com.starrocks.type.DateType;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalDouble;
+
+import static com.starrocks.sql.optimizer.Utils.getLongFromDateTime;
+
+/**
+ * Unit tests that directly exercise the individual helpers of {@link ConvertTzStatisticUtils}.
+ * End-to-end statistics assertions (through the expression calculator) live in
+ * {@code ExpressionStatisticsCalculatorTest}.
+ */
+public class ConvertTzStatisticUtilsTest {
+
+    // ---------- convertTzDateTime ----------
+
+    @Test
+    public void testConvertTzDateTimeShiftsByZoneOffset() {
+        final double input = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 0, 0));
+        final OptionalDouble converted = ConvertTzStatisticUtils.convertTzDateTime(
+                input, ConstantOperator.createVarchar("UTC"), ConstantOperator.createVarchar("Asia/Shanghai"));
+
+        Assertions.assertTrue(converted.isPresent());
+        // Asia/Shanghai is UTC+8 year-round, so the wall clock shifts forward 8 hours.
+        Assertions.assertEquals(8 * 3600.0, converted.getAsDouble() - input, 0.001);
+    }
+
+    @Test
+    public void testConvertTzDateTimeReturnsEmptyForInvalidZone() {
+        final double input = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 0, 0));
+        final OptionalDouble converted = ConvertTzStatisticUtils.convertTzDateTime(
+                input, ConstantOperator.createVarchar("Not/AZone"), ConstantOperator.createVarchar("UTC"));
+
+        Assertions.assertTrue(converted.isEmpty());
+    }
+
+    @Test
+    public void testIsValidTimeZone() {
+        Assertions.assertTrue(ConvertTzStatisticUtils.isValidTimeZone(ConstantOperator.createVarchar("UTC")));
+        Assertions.assertTrue(ConvertTzStatisticUtils.isValidTimeZone(ConstantOperator.createVarchar("America/New_York")));
+        Assertions.assertFalse(ConvertTzStatisticUtils.isValidTimeZone(ConstantOperator.createVarchar("Not/AZone")));
+    }
+
+    // ---------- hasTimezoneOffsetDrift ----------
+
+    @Test
+    public void testHasTimezoneOffsetDriftFalseForConstantOffsetZones() {
+        final double min = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30));
+        final double max = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 14, 45, 0));
+
+        Assertions.assertFalse(ConvertTzStatisticUtils.hasTimezoneOffsetDrift(
+                min, max, ConstantOperator.createVarchar("UTC"), ConstantOperator.createVarchar("Asia/Shanghai")));
+    }
+
+    @Test
+    public void testHasTimezoneOffsetDriftTrueAcrossDstTransition() {
+        // Europe/Berlin falls back on 2024-10-27 at 01:00 UTC; the interval straddles that transition.
+        final double min = getLongFromDateTime(LocalDateTime.of(2024, 10, 27, 0, 30, 0));
+        final double max = getLongFromDateTime(LocalDateTime.of(2024, 10, 27, 1, 30, 0));
+
+        Assertions.assertTrue(ConvertTzStatisticUtils.hasTimezoneOffsetDrift(
+                min, max, ConstantOperator.createVarchar("UTC"), ConstantOperator.createVarchar("Europe/Berlin")));
+    }
+
+    @Test
+    public void testHasTimezoneOffsetDriftTrueWhenEndpointInSpringForwardGap() {
+        // America/New_York springs forward 2024-03-10 02:00 -> 03:00. 02:30 is skipped; atZone
+        // normalizes it to after the transition, so an instant-only check would miss the gap.
+        final double min = getLongFromDateTime(LocalDateTime.of(2024, 3, 10, 2, 30, 0));
+        final double max = getLongFromDateTime(LocalDateTime.of(2024, 3, 10, 3, 15, 0));
+
+        Assertions.assertTrue(ConvertTzStatisticUtils.hasTimezoneOffsetDrift(
+                min, max, ConstantOperator.createVarchar("America/New_York"),
+                ConstantOperator.createVarchar("UTC")));
+    }
+
+    @Test
+    public void testHasTimezoneOffsetDriftTrueWhenEndpointInFallBackOverlap() {
+        // America/New_York falls back 2024-11-03 02:00 -> 01:00. 01:30 is ambiguous.
+        final double min = getLongFromDateTime(LocalDateTime.of(2024, 11, 3, 1, 15, 0));
+        final double max = getLongFromDateTime(LocalDateTime.of(2024, 11, 3, 1, 45, 0));
+
+        Assertions.assertTrue(ConvertTzStatisticUtils.hasTimezoneOffsetDrift(
+                min, max, ConstantOperator.createVarchar("America/New_York"),
+                ConstantOperator.createVarchar("UTC")));
+    }
+
+    @Test
+    public void testHasTimezoneOffsetDriftTrueForInvalidZone() {
+        final double min = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 0, 0));
+        final double max = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 12, 0, 0));
+
+        Assertions.assertTrue(ConvertTzStatisticUtils.hasTimezoneOffsetDrift(
+                min, max, ConstantOperator.createVarchar("Not/AZone"), ConstantOperator.createVarchar("UTC")));
+    }
+
+    // ---------- buildSingleBucketHistogram ----------
+
+    @Test
+    public void testBuildSingleBucketHistogramComputesNonMcvRows() {
+        final Map<String, Long> mcv = Map.of("a", 100L, "b", 200L);
+        final Histogram hist = ConvertTzStatisticUtils.buildSingleBucketHistogram(100.0, 200.0, 1000, mcv);
+
+        Assertions.assertEquals(1, hist.getBuckets().size());
+        final Bucket bucket = hist.getBuckets().get(0);
+        Assertions.assertEquals(100.0, bucket.getLower(), 0.001);
+        Assertions.assertEquals(200.0, bucket.getUpper(), 0.001);
+        Assertions.assertEquals(700L, bucket.getCount()); // 1000 - (100 + 200)
+        Assertions.assertEquals(0L, bucket.getUpperRepeats());
+        Assertions.assertEquals(2, hist.getMCV().size());
+    }
+
+    @Test
+    public void testBuildSingleBucketHistogramWithInfiniteBoundsHasNoBucket() {
+        final Map<String, Long> mcv = Map.of("a", 100L);
+        final Histogram hist = ConvertTzStatisticUtils.buildSingleBucketHistogram(
+                Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, 1000, mcv);
+
+        Assertions.assertTrue(hist.getBuckets().isEmpty());
+        Assertions.assertEquals(1, hist.getMCV().size());
+    }
+
+    @Test
+    public void testBuildSingleBucketHistogramClampsNonMcvRowsAtZero() {
+        final Map<String, Long> mcv = Map.of("a", 800L, "b", 400L); // sum 1200 > total 1000
+        final Histogram hist = ConvertTzStatisticUtils.buildSingleBucketHistogram(1.0, 2.0, 1000, mcv);
+
+        Assertions.assertEquals(0L, hist.getBuckets().get(0).getCount());
+    }
+
+    // ---------- transformHistogram ----------
+
+    @Test
+    public void testTransformHistogramConvertsMcvForConstantZones() {
+        final String fromTz = "UTC";
+        final String toTz = "Asia/Shanghai";
+        final String dt1 = "2024-01-15 10:20:30";
+        final String dt2 = "2024-01-15 14:45:00";
+        final ColumnStatistic childStats = ColumnStatistic.builder()
+                .setDistinctValuesCount(2)
+                .setHistogram(new Histogram(Collections.emptyList(), Map.of(dt1, 100L, dt2, 200L)))
+                .build();
+        final CallOperator call = convertTzCall(
+                ConstantOperator.createVarchar(fromTz), ConstantOperator.createVarchar(toTz));
+
+        final Optional<Histogram> result = ConvertTzStatisticUtils.transformHistogram(
+                call, childStats, 1.0, 2.0, 1000,
+                Optional.of(ConstantOperator.createVarchar(fromTz)),
+                Optional.of(ConstantOperator.createVarchar(toTz)));
+
+        Assertions.assertTrue(result.isPresent());
+        final Map<String, Long> mcv = result.get().getMCV();
+        Assertions.assertEquals(2, mcv.size());
+        Assertions.assertEquals(100L, mcv.get(convertTzMcvKey(dt1, fromTz, toTz)));
+        Assertions.assertEquals(200L, mcv.get(convertTzMcvKey(dt2, fromTz, toTz)));
+        Assertions.assertEquals(1, result.get().getBuckets().size());
+        final Bucket bucket = result.get().getBuckets().get(0);
+        Assertions.assertEquals(1.0, bucket.getLower(), 0.001);
+        Assertions.assertEquals(2.0, bucket.getUpper(), 0.001);
+        Assertions.assertEquals(700L, bucket.getCount()); // 1000 - (100 + 200)
+    }
+
+    @Test
+    public void testTransformHistogramEmptyWhenNoMcv() {
+        final ColumnStatistic childStats = ColumnStatistic.builder().setDistinctValuesCount(2).build();
+        final CallOperator call = convertTzCall(
+                ConstantOperator.createVarchar("UTC"), ConstantOperator.createVarchar("Asia/Shanghai"));
+
+        Assertions.assertTrue(ConvertTzStatisticUtils.transformHistogram(
+                call, childStats, 1.0, 2.0, 1000,
+                Optional.of(ConstantOperator.createVarchar("UTC")),
+                Optional.of(ConstantOperator.createVarchar("Asia/Shanghai"))).isEmpty());
+    }
+
+    @Test
+    public void testTransformHistogramEmptyWhenTimezonesNotConstant() {
+        final ColumnRefOperator fromTzCol = new ColumnRefOperator(1, VarcharType.VARCHAR, "from_tz", true);
+        final ColumnRefOperator toTzCol = new ColumnRefOperator(2, VarcharType.VARCHAR, "to_tz", true);
+        final ColumnStatistic childStats = ColumnStatistic.builder()
+                .setDistinctValuesCount(1)
+                .setHistogram(new Histogram(Collections.emptyList(), Map.of("2024-01-15 10:20:30", 100L)))
+                .build();
+        final CallOperator call = convertTzCall(fromTzCol, toTzCol);
+
+        Assertions.assertTrue(ConvertTzStatisticUtils.transformHistogram(
+                call, childStats, 1.0, 2.0, 1000, Optional.empty(), Optional.empty()).isEmpty());
+    }
+
+    @Test
+    public void testTransformHistogramEmptyWhenMcvKeyInvalid() {
+        final ColumnStatistic childStats = ColumnStatistic.builder()
+                .setDistinctValuesCount(1)
+                .setHistogram(new Histogram(Collections.emptyList(), Map.of("not-a-datetime", 100L)))
+                .build();
+        final CallOperator call = convertTzCall(
+                ConstantOperator.createVarchar("UTC"), ConstantOperator.createVarchar("Asia/Shanghai"));
+
+        Assertions.assertTrue(ConvertTzStatisticUtils.transformHistogram(
+                call, childStats, 1.0, 2.0, 1000,
+                Optional.of(ConstantOperator.createVarchar("UTC")),
+                Optional.of(ConstantOperator.createVarchar("Asia/Shanghai"))).isEmpty());
+    }
+
+    @Test
+    public void testTransformHistogramEmptyWhenTimezoneInvalid() {
+        final ColumnStatistic childStats = ColumnStatistic.builder()
+                .setDistinctValuesCount(1)
+                .setHistogram(new Histogram(Collections.emptyList(), Map.of("2024-01-15 10:20:30", 100L)))
+                .build();
+        final CallOperator call = convertTzCall(
+                ConstantOperator.createVarchar("Not/AZone"), ConstantOperator.createVarchar("UTC"));
+
+        Assertions.assertTrue(ConvertTzStatisticUtils.transformHistogram(
+                call, childStats, 1.0, 2.0, 1000,
+                Optional.of(ConstantOperator.createVarchar("Not/AZone")),
+                Optional.of(ConstantOperator.createVarchar("UTC"))).isEmpty());
+    }
+
+    private static CallOperator convertTzCall(ScalarOperator fromTz, ScalarOperator toTz) {
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        return new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(dtCol, fromTz, toTz));
+    }
+
+    private static String convertTzMcvKey(String datetime, String fromTz, String toTz) {
+        final ConstantOperator converted = ScalarOperatorFunctions.convert_tz(
+                ConstantOperator.createVarchar(datetime).castTo(DateType.DATETIME).get(),
+                ConstantOperator.createVarchar(fromTz),
+                ConstantOperator.createVarchar(toTz));
+        return converted.castTo(VarcharType.VARCHAR).get().getVarchar();
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ConvertTzStatisticUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ConvertTzStatisticUtilsTest.java
@@ -16,13 +16,12 @@ package com.starrocks.sql.optimizer.statistics;
 
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.Type;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorFunctions;
-import com.starrocks.type.DateType;
-import com.starrocks.type.VarcharType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -203,8 +202,8 @@ public class ConvertTzStatisticUtilsTest {
 
     @Test
     public void testTransformHistogramEmptyWhenTimezonesNotConstant() {
-        final ColumnRefOperator fromTzCol = new ColumnRefOperator(1, VarcharType.VARCHAR, "from_tz", true);
-        final ColumnRefOperator toTzCol = new ColumnRefOperator(2, VarcharType.VARCHAR, "to_tz", true);
+        final ColumnRefOperator fromTzCol = new ColumnRefOperator(1, Type.VARCHAR, "from_tz", true);
+        final ColumnRefOperator toTzCol = new ColumnRefOperator(2, Type.VARCHAR, "to_tz", true);
         final ColumnStatistic childStats = ColumnStatistic.builder()
                 .setDistinctValuesCount(1)
                 .setHistogram(new Histogram(Collections.emptyList(), Map.of("2024-01-15 10:20:30", 100L)))
@@ -246,16 +245,16 @@ public class ConvertTzStatisticUtilsTest {
     }
 
     private static CallOperator convertTzCall(ScalarOperator fromTz, ScalarOperator toTz) {
-        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
-        return new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, Type.DATETIME, "dt", true);
+        return new CallOperator(FunctionSet.CONVERT_TZ, Type.DATETIME,
                 Lists.newArrayList(dtCol, fromTz, toTz));
     }
 
     private static String convertTzMcvKey(String datetime, String fromTz, String toTz) {
         final ConstantOperator converted = ScalarOperatorFunctions.convert_tz(
-                ConstantOperator.createVarchar(datetime).castTo(DateType.DATETIME).get(),
+                ConstantOperator.createVarchar(datetime).castTo(Type.DATETIME).get(),
                 ConstantOperator.createVarchar(fromTz),
                 ConstantOperator.createVarchar(toTz));
-        return converted.castTo(VarcharType.VARCHAR).get().getVarchar();
+        return converted.castTo(Type.VARCHAR).get().getVarchar();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -2048,9 +2048,9 @@ public class ExpressionStatisticsCalculatorTest {
         final double minEpoch = getLongFromDateTime(minDt);
         final double maxEpoch = getLongFromDateTime(maxDt);
 
-        final ColumnRefOperator dtCol = new ColumnRefOperator(1, DateType.DATETIME, "dt", true);
-        final ColumnRefOperator fromTzCol = new ColumnRefOperator(2, VarcharType.VARCHAR, "from_tz", true);
-        final ColumnRefOperator toTzCol = new ColumnRefOperator(3, VarcharType.VARCHAR, "to_tz", true);
+        final ColumnRefOperator dtCol = new ColumnRefOperator(1, Type.DATETIME, "dt", true);
+        final ColumnRefOperator fromTzCol = new ColumnRefOperator(2, Type.VARCHAR, "from_tz", true);
+        final ColumnRefOperator toTzCol = new ColumnRefOperator(3, Type.VARCHAR, "to_tz", true);
         final Statistics statistics = Statistics.builder()
                 .setOutputRowCount(rowCount)
                 .addColumnStatistic(dtCol, ColumnStatistic.builder()
@@ -2075,7 +2075,7 @@ public class ExpressionStatisticsCalculatorTest {
                         .setDistinctValuesCount(toTzNdv)
                         .build())
                 .build();
-        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, Type.DATETIME,
                 Lists.newArrayList(dtCol, fromTzCol, toTzCol));
 
         final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
@@ -2086,16 +2086,16 @@ public class ExpressionStatisticsCalculatorTest {
         assertConvertTzStatRangeCovers(actual, "Pacific/Kiritimati", "Etc/GMT+12", minDt, maxDt);
         Assertions.assertEquals(nullsFraction, actual.getNullsFraction(), 0.001);
         Assertions.assertEquals(4, actual.getDistinctValuesCount(), 0.001); // min(100*(1-0.1), 2*1*2)
-        Assertions.assertEquals(DateType.DATETIME.getTypeSize(), actual.getAverageRowSize(), 0.001);
+        Assertions.assertEquals(Type.DATETIME.getTypeSize(), actual.getAverageRowSize(), 0.001);
         Assertions.assertNull(actual.getHistogram());
     }
 
     @Test
     public void testConvertTzCapsDistinctValuesAtRowCount() {
         final int rowCount = 5;
-        final ColumnRefOperator dtCol = new ColumnRefOperator(1, DateType.DATETIME, "dt", true);
-        final ColumnRefOperator fromTzCol = new ColumnRefOperator(2, VarcharType.VARCHAR, "from_tz", true);
-        final ColumnRefOperator toTzCol = new ColumnRefOperator(3, VarcharType.VARCHAR, "to_tz", true);
+        final ColumnRefOperator dtCol = new ColumnRefOperator(1, Type.DATETIME, "dt", true);
+        final ColumnRefOperator fromTzCol = new ColumnRefOperator(2, Type.VARCHAR, "from_tz", true);
+        final ColumnRefOperator toTzCol = new ColumnRefOperator(3, Type.VARCHAR, "to_tz", true);
         final Statistics statistics = Statistics.builder()
                 .setOutputRowCount(rowCount)
                 .addColumnStatistic(dtCol, ColumnStatistic.builder()
@@ -2120,7 +2120,7 @@ public class ExpressionStatisticsCalculatorTest {
                         .setDistinctValuesCount(2)
                         .build())
                 .build();
-        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, Type.DATETIME,
                 Lists.newArrayList(dtCol, fromTzCol, toTzCol));
 
         final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
@@ -2132,9 +2132,9 @@ public class ExpressionStatisticsCalculatorTest {
     public void testConvertTzCapsDistinctValuesAtNonNullRowCount() {
         final int rowCount = 10;
         final double dtNulls = 0.4;
-        final ColumnRefOperator dtCol = new ColumnRefOperator(1, DateType.DATETIME, "dt", true);
-        final ColumnRefOperator fromTzCol = new ColumnRefOperator(2, VarcharType.VARCHAR, "from_tz", true);
-        final ColumnRefOperator toTzCol = new ColumnRefOperator(3, VarcharType.VARCHAR, "to_tz", true);
+        final ColumnRefOperator dtCol = new ColumnRefOperator(1, Type.DATETIME, "dt", true);
+        final ColumnRefOperator fromTzCol = new ColumnRefOperator(2, Type.VARCHAR, "from_tz", true);
+        final ColumnRefOperator toTzCol = new ColumnRefOperator(3, Type.VARCHAR, "to_tz", true);
         final Statistics statistics = Statistics.builder()
                 .setOutputRowCount(rowCount)
                 .addColumnStatistic(dtCol, ColumnStatistic.builder()
@@ -2159,7 +2159,7 @@ public class ExpressionStatisticsCalculatorTest {
                         .setDistinctValuesCount(2)
                         .build())
                 .build();
-        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, Type.DATETIME,
                 Lists.newArrayList(dtCol, fromTzCol, toTzCol));
 
         final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
@@ -2177,9 +2177,9 @@ public class ExpressionStatisticsCalculatorTest {
         final double toTzNulls = 0.4;
         final double expectedNulls = 1.0 - (1.0 - dtNulls) * (1.0 - fromTzNulls) * (1.0 - toTzNulls);
 
-        final ColumnRefOperator dtCol = new ColumnRefOperator(1, DateType.DATETIME, "dt", true);
-        final ColumnRefOperator fromTzCol = new ColumnRefOperator(2, VarcharType.VARCHAR, "from_tz", true);
-        final ColumnRefOperator toTzCol = new ColumnRefOperator(3, VarcharType.VARCHAR, "to_tz", true);
+        final ColumnRefOperator dtCol = new ColumnRefOperator(1, Type.DATETIME, "dt", true);
+        final ColumnRefOperator fromTzCol = new ColumnRefOperator(2, Type.VARCHAR, "from_tz", true);
+        final ColumnRefOperator toTzCol = new ColumnRefOperator(3, Type.VARCHAR, "to_tz", true);
         final Statistics statistics = Statistics.builder()
                 .setOutputRowCount(100)
                 .addColumnStatistic(dtCol, ColumnStatistic.builder()
@@ -2204,7 +2204,7 @@ public class ExpressionStatisticsCalculatorTest {
                         .setDistinctValuesCount(2)
                         .build())
                 .build();
-        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, Type.DATETIME,
                 Lists.newArrayList(dtCol, fromTzCol, toTzCol));
 
         final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
@@ -2217,7 +2217,7 @@ public class ExpressionStatisticsCalculatorTest {
     public void testConvertTzNullsFractionWithConstantTimezonesUsesOnlyDatetimeNulls() {
         // Constant timezones have nullsFraction 0, so result nulls = dt nulls.
         final double dtNulls = 0.3;
-        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, Type.DATETIME, "dt", true);
         final Statistics statistics = Statistics.builder()
                 .setOutputRowCount(1000)
                 .addColumnStatistic(dtCol, ColumnStatistic.builder()
@@ -2228,7 +2228,7 @@ public class ExpressionStatisticsCalculatorTest {
                         .setDistinctValuesCount(2)
                         .build())
                 .build();
-        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, Type.DATETIME,
                 Lists.newArrayList(
                         dtCol,
                         ConstantOperator.createVarchar("UTC"),
@@ -2247,7 +2247,7 @@ public class ExpressionStatisticsCalculatorTest {
         final String dt2 = "2024-01-15 14:45:00";
         final Map<String, Long> inputMcv = Map.of(dt1, 100L, dt2, 200L);
 
-        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, Type.DATETIME, "dt", true);
         final ColumnStatistic dtStat = ColumnStatistic.builder()
                 .setMinValue(getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30)))
                 .setMaxValue(getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 14, 45, 0)))
@@ -2260,7 +2260,7 @@ public class ExpressionStatisticsCalculatorTest {
                 .setOutputRowCount(1000)
                 .addColumnStatistic(dtCol, dtStat)
                 .build();
-        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, Type.DATETIME,
                 Lists.newArrayList(
                         dtCol,
                         ConstantOperator.createVarchar(fromTz),
@@ -2291,7 +2291,7 @@ public class ExpressionStatisticsCalculatorTest {
         final LocalDateTime minDt = LocalDateTime.of(2024, 1, 15, 10, 20, 30);
         final LocalDateTime maxDt = LocalDateTime.of(2024, 1, 15, 14, 45, 0);
 
-        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, Type.DATETIME, "dt", true);
         final Statistics statistics = Statistics.builder()
                 .setOutputRowCount(1000)
                 .addColumnStatistic(dtCol, ColumnStatistic.builder()
@@ -2302,7 +2302,7 @@ public class ExpressionStatisticsCalculatorTest {
                         .setDistinctValuesCount(2)
                         .build())
                 .build();
-        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, Type.DATETIME,
                 Lists.newArrayList(
                         dtCol,
                         ConstantOperator.createVarchar(fromTz),
@@ -2323,7 +2323,7 @@ public class ExpressionStatisticsCalculatorTest {
         final LocalDateTime minDt = LocalDateTime.of(2024, 10, 27, 0, 30, 0);
         final LocalDateTime maxDt = LocalDateTime.of(2024, 10, 27, 1, 30, 0);
 
-        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, Type.DATETIME, "dt", true);
         final Statistics statistics = Statistics.builder()
                 .setOutputRowCount(1000)
                 .addColumnStatistic(dtCol, ColumnStatistic.builder()
@@ -2334,7 +2334,7 @@ public class ExpressionStatisticsCalculatorTest {
                         .setDistinctValuesCount(3)
                         .build())
                 .build();
-        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, Type.DATETIME,
                 Lists.newArrayList(
                         dtCol,
                         ConstantOperator.createVarchar(fromTz),
@@ -2352,7 +2352,7 @@ public class ExpressionStatisticsCalculatorTest {
         final LocalDateTime minDt = LocalDateTime.of(2024, 1, 15, 10, 20, 30);
         final LocalDateTime maxDt = LocalDateTime.of(2024, 1, 15, 14, 45, 0);
 
-        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, Type.DATETIME, "dt", true);
         final Statistics statistics = Statistics.builder()
                 .setOutputRowCount(1000)
                 .addColumnStatistic(dtCol, ColumnStatistic.builder()
@@ -2363,7 +2363,7 @@ public class ExpressionStatisticsCalculatorTest {
                         .setDistinctValuesCount(2)
                         .build())
                 .build();
-        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, Type.DATETIME,
                 Lists.newArrayList(
                         dtCol,
                         ConstantOperator.createVarchar(fromTz),
@@ -2380,7 +2380,7 @@ public class ExpressionStatisticsCalculatorTest {
         final double minValue = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30));
         final double maxValue = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 14, 45, 0));
 
-        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, Type.DATETIME, "dt", true);
         final Statistics statistics = Statistics.builder()
                 .setOutputRowCount(1000)
                 .addColumnStatistic(dtCol, ColumnStatistic.builder()
@@ -2391,7 +2391,7 @@ public class ExpressionStatisticsCalculatorTest {
                         .setDistinctValuesCount(2)
                         .build())
                 .build();
-        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, Type.DATETIME,
                 Lists.newArrayList(
                         dtCol,
                         ConstantOperator.createVarchar("Not/AZone"),
@@ -2406,7 +2406,7 @@ public class ExpressionStatisticsCalculatorTest {
 
     @Test
     public void testConvertTzKeepsWidenedRangeWhenChildRangeIsInfinite() {
-        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, Type.DATETIME, "dt", true);
         final Statistics statistics = Statistics.builder()
                 .setOutputRowCount(1000)
                 .addColumnStatistic(dtCol, ColumnStatistic.builder()
@@ -2417,7 +2417,7 @@ public class ExpressionStatisticsCalculatorTest {
                         .setDistinctValuesCount(2)
                         .build())
                 .build();
-        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, Type.DATETIME,
                 Lists.newArrayList(
                         dtCol,
                         ConstantOperator.createVarchar("UTC"),
@@ -2449,10 +2449,10 @@ public class ExpressionStatisticsCalculatorTest {
 
     private static String convertTzMcvKey(String datetime, String fromTz, String toTz) {
         final ConstantOperator converted = ScalarOperatorFunctions.convert_tz(
-                ConstantOperator.createVarchar(datetime).castTo(DateType.DATETIME).get(),
+                ConstantOperator.createVarchar(datetime).castTo(Type.DATETIME).get(),
                 ConstantOperator.createVarchar(fromTz),
                 ConstantOperator.createVarchar(toTz));
-        return converted.castTo(VarcharType.VARCHAR).get().getVarchar();
+        return converted.castTo(Type.VARCHAR).get().getVarchar();
     }
 
     private static double convertTzDateTimeValue(double dateTimeValue, String fromTz, String toTz) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -32,6 +32,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.LambdaFunctionOperator;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorFunctions;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -2033,6 +2034,433 @@ public class ExpressionStatisticsCalculatorTest {
 
         // THEN
         Assertions.assertNull(result.getHistogram());
+    }
+
+    @Test
+    public void testConvertTzWidensRangeAndUsesProductOfNdvsWhenBelowRowCount() {
+        final int rowCount = 100;
+        final double dtNdv = 2;
+        final double fromTzNdv = 1;
+        final double toTzNdv = 2;
+        final double nullsFraction = 0.1;
+        final LocalDateTime minDt = LocalDateTime.of(2021, 1, 10, 8, 30, 0);
+        final LocalDateTime maxDt = LocalDateTime.of(2021, 12, 25, 23, 59, 59);
+        final double minEpoch = getLongFromDateTime(minDt);
+        final double maxEpoch = getLongFromDateTime(maxDt);
+
+        final ColumnRefOperator dtCol = new ColumnRefOperator(1, DateType.DATETIME, "dt", true);
+        final ColumnRefOperator fromTzCol = new ColumnRefOperator(2, VarcharType.VARCHAR, "from_tz", true);
+        final ColumnRefOperator toTzCol = new ColumnRefOperator(3, VarcharType.VARCHAR, "to_tz", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(rowCount)
+                .addColumnStatistic(dtCol, ColumnStatistic.builder()
+                        .setMinValue(minEpoch)
+                        .setMaxValue(maxEpoch)
+                        .setNullsFraction(nullsFraction)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(dtNdv)
+                        .build())
+                .addColumnStatistic(fromTzCol, ColumnStatistic.builder()
+                        .setMinValue(Double.NEGATIVE_INFINITY)
+                        .setMaxValue(Double.POSITIVE_INFINITY)
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(fromTzNdv)
+                        .build())
+                .addColumnStatistic(toTzCol, ColumnStatistic.builder()
+                        .setMinValue(Double.NEGATIVE_INFINITY)
+                        .setMaxValue(Double.POSITIVE_INFINITY)
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(toTzNdv)
+                        .build())
+                .build();
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(dtCol, fromTzCol, toTzCol));
+
+        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
+
+        Assertions.assertFalse(actual.isUnknown());
+        // Variable zones: estimated range must cover conversions under near-extreme offsets.
+        assertConvertTzStatRangeCovers(actual, "UTC", "Asia/Shanghai", minDt, maxDt);
+        assertConvertTzStatRangeCovers(actual, "Pacific/Kiritimati", "Etc/GMT+12", minDt, maxDt);
+        Assertions.assertEquals(nullsFraction, actual.getNullsFraction(), 0.001);
+        Assertions.assertEquals(4, actual.getDistinctValuesCount(), 0.001); // min(100*(1-0.1), 2*1*2)
+        Assertions.assertEquals(DateType.DATETIME.getTypeSize(), actual.getAverageRowSize(), 0.001);
+        Assertions.assertNull(actual.getHistogram());
+    }
+
+    @Test
+    public void testConvertTzCapsDistinctValuesAtRowCount() {
+        final int rowCount = 5;
+        final ColumnRefOperator dtCol = new ColumnRefOperator(1, DateType.DATETIME, "dt", true);
+        final ColumnRefOperator fromTzCol = new ColumnRefOperator(2, VarcharType.VARCHAR, "from_tz", true);
+        final ColumnRefOperator toTzCol = new ColumnRefOperator(3, VarcharType.VARCHAR, "to_tz", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(rowCount)
+                .addColumnStatistic(dtCol, ColumnStatistic.builder()
+                        .setMinValue(getLongFromDateTime(LocalDateTime.of(2021, 1, 1, 0, 0, 0)))
+                        .setMaxValue(getLongFromDateTime(LocalDateTime.of(2021, 1, 3, 0, 0, 0)))
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(3)
+                        .build())
+                .addColumnStatistic(fromTzCol, ColumnStatistic.builder()
+                        .setMinValue(Double.NEGATIVE_INFINITY)
+                        .setMaxValue(Double.POSITIVE_INFINITY)
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(2)
+                        .build())
+                .addColumnStatistic(toTzCol, ColumnStatistic.builder()
+                        .setMinValue(Double.NEGATIVE_INFINITY)
+                        .setMaxValue(Double.POSITIVE_INFINITY)
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(2)
+                        .build())
+                .build();
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(dtCol, fromTzCol, toTzCol));
+
+        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
+
+        Assertions.assertEquals(5, actual.getDistinctValuesCount(), 0.001); // min(5*(1-0), 3*2*2)
+    }
+
+    @Test
+    public void testConvertTzCapsDistinctValuesAtNonNullRowCount() {
+        final int rowCount = 10;
+        final double dtNulls = 0.4;
+        final ColumnRefOperator dtCol = new ColumnRefOperator(1, DateType.DATETIME, "dt", true);
+        final ColumnRefOperator fromTzCol = new ColumnRefOperator(2, VarcharType.VARCHAR, "from_tz", true);
+        final ColumnRefOperator toTzCol = new ColumnRefOperator(3, VarcharType.VARCHAR, "to_tz", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(rowCount)
+                .addColumnStatistic(dtCol, ColumnStatistic.builder()
+                        .setMinValue(getLongFromDateTime(LocalDateTime.of(2021, 1, 1, 0, 0, 0)))
+                        .setMaxValue(getLongFromDateTime(LocalDateTime.of(2021, 1, 3, 0, 0, 0)))
+                        .setNullsFraction(dtNulls)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(3)
+                        .build())
+                .addColumnStatistic(fromTzCol, ColumnStatistic.builder()
+                        .setMinValue(Double.NEGATIVE_INFINITY)
+                        .setMaxValue(Double.POSITIVE_INFINITY)
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(2)
+                        .build())
+                .addColumnStatistic(toTzCol, ColumnStatistic.builder()
+                        .setMinValue(Double.NEGATIVE_INFINITY)
+                        .setMaxValue(Double.POSITIVE_INFINITY)
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(2)
+                        .build())
+                .build();
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(dtCol, fromTzCol, toTzCol));
+
+        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
+
+        // min(10*(1-0.4), 3*2*2) = min(6, 12) = 6
+        Assertions.assertEquals(6, actual.getDistinctValuesCount(), 0.001);
+    }
+
+    @Test
+    public void testConvertTzCombinesNullsFractionFromAllArguments() {
+        // convert_tz is null if any argument is null:
+        // 1 - (1-0.2)*(1-0.5)*(1-0.4) = 1 - 0.8*0.5*0.6 = 0.76
+        final double dtNulls = 0.2;
+        final double fromTzNulls = 0.5;
+        final double toTzNulls = 0.4;
+        final double expectedNulls = 1.0 - (1.0 - dtNulls) * (1.0 - fromTzNulls) * (1.0 - toTzNulls);
+
+        final ColumnRefOperator dtCol = new ColumnRefOperator(1, DateType.DATETIME, "dt", true);
+        final ColumnRefOperator fromTzCol = new ColumnRefOperator(2, VarcharType.VARCHAR, "from_tz", true);
+        final ColumnRefOperator toTzCol = new ColumnRefOperator(3, VarcharType.VARCHAR, "to_tz", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(100)
+                .addColumnStatistic(dtCol, ColumnStatistic.builder()
+                        .setMinValue(getLongFromDateTime(LocalDateTime.of(2021, 1, 1, 0, 0, 0)))
+                        .setMaxValue(getLongFromDateTime(LocalDateTime.of(2021, 1, 3, 0, 0, 0)))
+                        .setNullsFraction(dtNulls)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(3)
+                        .build())
+                .addColumnStatistic(fromTzCol, ColumnStatistic.builder()
+                        .setMinValue(Double.NEGATIVE_INFINITY)
+                        .setMaxValue(Double.POSITIVE_INFINITY)
+                        .setNullsFraction(fromTzNulls)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(2)
+                        .build())
+                .addColumnStatistic(toTzCol, ColumnStatistic.builder()
+                        .setMinValue(Double.NEGATIVE_INFINITY)
+                        .setMaxValue(Double.POSITIVE_INFINITY)
+                        .setNullsFraction(toTzNulls)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(2)
+                        .build())
+                .build();
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(dtCol, fromTzCol, toTzCol));
+
+        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
+
+        Assertions.assertEquals(expectedNulls, actual.getNullsFraction(), 0.001);
+        Assertions.assertEquals(0.76, actual.getNullsFraction(), 0.001);
+    }
+
+    @Test
+    public void testConvertTzNullsFractionWithConstantTimezonesUsesOnlyDatetimeNulls() {
+        // Constant timezones have nullsFraction 0, so result nulls = dt nulls.
+        final double dtNulls = 0.3;
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(dtCol, ColumnStatistic.builder()
+                        .setMinValue(getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30)))
+                        .setMaxValue(getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 14, 45, 0)))
+                        .setNullsFraction(dtNulls)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(2)
+                        .build())
+                .build();
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(
+                        dtCol,
+                        ConstantOperator.createVarchar("UTC"),
+                        ConstantOperator.createVarchar("Asia/Shanghai")));
+
+        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
+
+        Assertions.assertEquals(dtNulls, actual.getNullsFraction(), 0.001);
+    }
+
+    @Test
+    public void testConvertTzMcvPropagationWithConstantTimezones() {
+        final String fromTz = "UTC";
+        final String toTz = "Asia/Shanghai";
+        final String dt1 = "2024-01-15 10:20:30";
+        final String dt2 = "2024-01-15 14:45:00";
+        final Map<String, Long> inputMcv = Map.of(dt1, 100L, dt2, 200L);
+
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        final ColumnStatistic dtStat = ColumnStatistic.builder()
+                .setMinValue(getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30)))
+                .setMaxValue(getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 14, 45, 0)))
+                .setNullsFraction(0)
+                .setAverageRowSize(8)
+                .setDistinctValuesCount(2)
+                .setHistogram(new Histogram(Collections.emptyList(), inputMcv))
+                .build();
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(dtCol, dtStat)
+                .build();
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(
+                        dtCol,
+                        ConstantOperator.createVarchar(fromTz),
+                        ConstantOperator.createVarchar(toTz)));
+
+        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
+
+        Assertions.assertNotNull(actual.getHistogram());
+        Assertions.assertEquals(1, actual.getHistogram().getBuckets().size());
+        final Bucket bucket = actual.getHistogram().getBuckets().get(0);
+        Assertions.assertEquals(actual.getMinValue(), bucket.getLower(), 0.001);
+        Assertions.assertEquals(actual.getMaxValue(), bucket.getUpper(), 0.001);
+        Assertions.assertEquals(700L, bucket.getCount()); // 1000 - (100 + 200)
+        Assertions.assertEquals(0L, bucket.getUpperRepeats());
+        final Map<String, Long> mcv = actual.getHistogram().getMCV();
+        Assertions.assertEquals(2, mcv.size());
+        Assertions.assertEquals(100L, mcv.get(convertTzMcvKey(dt1, fromTz, toTz)));
+        Assertions.assertEquals(200L, mcv.get(convertTzMcvKey(dt2, fromTz, toTz)));
+        assertConvertTzStatRangeCovers(actual, fromTz, toTz,
+                LocalDateTime.of(2024, 1, 15, 10, 20, 30),
+                LocalDateTime.of(2024, 1, 15, 14, 45, 0));
+    }
+
+    @Test
+    public void testConvertTzRangeCoversSamplesForConstantTimezones() {
+        final String fromTz = "UTC";
+        final String toTz = "Asia/Shanghai";
+        final LocalDateTime minDt = LocalDateTime.of(2024, 1, 15, 10, 20, 30);
+        final LocalDateTime maxDt = LocalDateTime.of(2024, 1, 15, 14, 45, 0);
+
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(dtCol, ColumnStatistic.builder()
+                        .setMinValue(getLongFromDateTime(minDt))
+                        .setMaxValue(getLongFromDateTime(maxDt))
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(2)
+                        .build())
+                .build();
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(
+                        dtCol,
+                        ConstantOperator.createVarchar(fromTz),
+                        ConstantOperator.createVarchar(toTz)));
+
+        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
+
+        assertConvertTzStatRangeCoversEveryMinute(actual, fromTz, toTz, minDt, maxDt);
+        Assertions.assertEquals(2, actual.getDistinctValuesCount(), 0.001);
+    }
+
+    @Test
+    public void testConvertTzRangeCoversSamplesAcrossDstTransition() {
+        // Europe/Berlin falls back on 2024-10-27. Endpoint-only conversion under-ranges because
+        // UTC 00:59 -> Berlin 02:59 lies outside convert(00:30)/convert(01:30).
+        final String fromTz = "UTC";
+        final String toTz = "Europe/Berlin";
+        final LocalDateTime minDt = LocalDateTime.of(2024, 10, 27, 0, 30, 0);
+        final LocalDateTime maxDt = LocalDateTime.of(2024, 10, 27, 1, 30, 0);
+
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(dtCol, ColumnStatistic.builder()
+                        .setMinValue(getLongFromDateTime(minDt))
+                        .setMaxValue(getLongFromDateTime(maxDt))
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(3)
+                        .build())
+                .build();
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(
+                        dtCol,
+                        ConstantOperator.createVarchar(fromTz),
+                        ConstantOperator.createVarchar(toTz)));
+
+        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
+
+        assertConvertTzStatRangeCoversEveryMinute(actual, fromTz, toTz, minDt, maxDt);
+    }
+
+    @Test
+    public void testConvertTzRangeCoversSamplesWhenOffsetShiftsEarlier() {
+        final String fromTz = "Asia/Shanghai";
+        final String toTz = "UTC";
+        final LocalDateTime minDt = LocalDateTime.of(2024, 1, 15, 10, 20, 30);
+        final LocalDateTime maxDt = LocalDateTime.of(2024, 1, 15, 14, 45, 0);
+
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(dtCol, ColumnStatistic.builder()
+                        .setMinValue(getLongFromDateTime(minDt))
+                        .setMaxValue(getLongFromDateTime(maxDt))
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(2)
+                        .build())
+                .build();
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(
+                        dtCol,
+                        ConstantOperator.createVarchar(fromTz),
+                        ConstantOperator.createVarchar(toTz)));
+
+        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
+
+        Assertions.assertTrue(actual.getMinValue() <= actual.getMaxValue());
+        assertConvertTzStatRangeCoversEveryMinute(actual, fromTz, toTz, minDt, maxDt);
+    }
+
+    @Test
+    public void testConvertTzIsAllNullWhenConstantTimezoneInvalid() {
+        final double minValue = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 10, 20, 30));
+        final double maxValue = getLongFromDateTime(LocalDateTime.of(2024, 1, 15, 14, 45, 0));
+
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(dtCol, ColumnStatistic.builder()
+                        .setMinValue(minValue)
+                        .setMaxValue(maxValue)
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(2)
+                        .build())
+                .build();
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(
+                        dtCol,
+                        ConstantOperator.createVarchar("Not/AZone"),
+                        ConstantOperator.createVarchar("UTC")));
+
+        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
+
+        Assertions.assertEquals(1.0, actual.getNullsFraction(), 0.001);
+        Assertions.assertEquals(0, actual.getDistinctValuesCount(), 0.001);
+        Assertions.assertNull(actual.getHistogram());
+    }
+
+    @Test
+    public void testConvertTzKeepsWidenedRangeWhenChildRangeIsInfinite() {
+        final ColumnRefOperator dtCol = new ColumnRefOperator(0, DateType.DATETIME, "dt", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(dtCol, ColumnStatistic.builder()
+                        .setMinValue(Double.NEGATIVE_INFINITY)
+                        .setMaxValue(Double.POSITIVE_INFINITY)
+                        .setNullsFraction(0)
+                        .setAverageRowSize(8)
+                        .setDistinctValuesCount(2)
+                        .build())
+                .build();
+        final CallOperator convertTz = new CallOperator(FunctionSet.CONVERT_TZ, DateType.DATETIME,
+                Lists.newArrayList(
+                        dtCol,
+                        ConstantOperator.createVarchar("UTC"),
+                        ConstantOperator.createVarchar("Asia/Shanghai")));
+
+        final ColumnStatistic actual = ExpressionStatisticCalculator.calculate(convertTz, statistics);
+
+        Assertions.assertTrue(actual.isInfiniteRange());
+        Assertions.assertEquals(2, actual.getDistinctValuesCount(), 0.001);
+    }
+
+    private static void assertConvertTzStatRangeCovers(ColumnStatistic actual, String fromTz, String toTz,
+                                                       LocalDateTime... samples) {
+        for (LocalDateTime sample : samples) {
+            final double converted = convertTzDateTimeValue(getLongFromDateTime(sample), fromTz, toTz);
+            Assertions.assertTrue(
+                    converted >= actual.getMinValue() - 0.001 && converted <= actual.getMaxValue() + 0.001,
+                    () -> "convert_tz(" + sample + ", " + fromTz + ", " + toTz + ") = " + converted
+                            + " outside estimated range [" + actual.getMinValue() + ", " + actual.getMaxValue() + "]");
+        }
+    }
+
+    private static void assertConvertTzStatRangeCoversEveryMinute(ColumnStatistic actual, String fromTz, String toTz,
+                                                                  LocalDateTime start, LocalDateTime end) {
+        for (LocalDateTime sample = start; !sample.isAfter(end); sample = sample.plusMinutes(1)) {
+            assertConvertTzStatRangeCovers(actual, fromTz, toTz, sample);
+        }
+    }
+
+    private static String convertTzMcvKey(String datetime, String fromTz, String toTz) {
+        final ConstantOperator converted = ScalarOperatorFunctions.convert_tz(
+                ConstantOperator.createVarchar(datetime).castTo(DateType.DATETIME).get(),
+                ConstantOperator.createVarchar(fromTz),
+                ConstantOperator.createVarchar(toTz));
+        return converted.castTo(VarcharType.VARCHAR).get().getVarchar();
+    }
+
+    private static double convertTzDateTimeValue(double dateTimeValue, String fromTz, String toTz) {
+        final ConstantOperator converted = ScalarOperatorFunctions.convert_tz(
+                ConstantOperator.createDatetime(Utils.getDatetimeFromLong((long) dateTimeValue)),
+                ConstantOperator.createVarchar(fromTz),
+                ConstantOperator.createVarchar(toTz));
+        return Utils.getLongFromDateTime(converted.getDatetime());
     }
 
     @Test


### PR DESCRIPTION
Backport of #77850 to `branch-3.5-cc` .

Original commit: https://github.com/StarRocks/starrocks/commit/b37c6a0fc18491d8ca24d69e146cb2e3d00433d8
Original PR: #77850 

## Why I'm doing:

Statistics for `CONVERT_TZ` were not implemented. This can lead to suboptimal query plans.
 
## What I'm doing:

Add statistics propagation for `CONVERT_TZ` in `ExpressionStatisticCalculator`. I am using the already existing FE implementation used for constant folding for min/max values. In cases, where it is not constant, we use the 26 hour window frame as min/max values. 

We also add MCVs calculation for `CONVERT_TZ` operator using `convert_tz` function from `ScalarOperatorFunctions` in FE. 

Add unit coverage in `ExpressionStatisticsCalculatorTest`.

Fixes #

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
