### PR TITLE
[Refactor] Stop applying the PK persistent index type from an alter-meta log

### DIFF
--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -1177,27 +1177,6 @@ Status MetaFileBuilder::_finalize_delvec(int64_t version, int64_t txn_id) {
     return Status::OK();
 }
 
-// This function cleans up the SSTable metadata after an alter operation that changes the persistent index type.
-void MetaFileBuilder::_sstable_meta_clean_after_alter_type() {
-    // Check if the persistent index type is LOCAL or if the persistent index is disabled,
-    // and there are SSTables present.
-    if ((_tablet_meta->persistent_index_type() == PersistentIndexTypePB::LOCAL ||
-         !_tablet_meta->enable_persistent_index()) &&
-        _tablet_meta->sstable_meta().sstables_size() > 0) {
-        // Iterate through all SSTables and move them to orphan files.
-        for (const auto& sstable : _tablet_meta->sstable_meta().sstables()) {
-            FileMetaPB file_meta;
-            file_meta.set_name(sstable.filename());
-            file_meta.set_size(sstable.filesize());
-            file_meta.set_shared(sstable.shared());
-            file_meta.set_version(sstable.generation_version());
-            _tablet_meta->mutable_orphan_files()->Add(std::move(file_meta));
-        }
-        // Clear the SSTable metadata.
-        _tablet_meta->clear_sstable_meta();
-    }
-}
-
 Status MetaFileBuilder::finalize(int64_t txn_id, bool skip_write_tablet_metadata) {
     auto version = _tablet_meta->version();
 
@@ -1206,9 +1185,6 @@ Status MetaFileBuilder::finalize(int64_t txn_id, bool skip_write_tablet_metadata
         TRACE_COUNTER_SCOPE_LATENCY_US("finalize_delvec_write_us");
         RETURN_IF_ERROR(_finalize_delvec(version, txn_id));
     }
-
-    // Clean up SSTable metadata after an alter operation that changes the persistent index type
-    _sstable_meta_clean_after_alter_type();
 
     if (skip_write_tablet_metadata) {
         // Put metadata into cache only.

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -170,8 +170,6 @@ private:
     // collect del files which are above cloud native index's rebuild point
     void _collect_del_files_above_rebuild_point(RowsetMetadataPB* rowset,
                                                 std::vector<DelfileWithRowsetId>* collect_del_files);
-    // clean sstable meta after alter type
-    void _sstable_meta_clean_after_alter_type();
 
 private:
     struct PendingRowsetData {

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -91,33 +91,25 @@ void archive_current_schema_into_history(TabletMetadataPB* metadata) {
     }
 }
 
-Status apply_alter_meta_log(TabletMetadataPB* metadata, const TxnLogPB_OpAlterMetadata& op_alter_metas,
-                            TabletManager* tablet_mgr) {
+Status apply_alter_meta_log(TabletMetadataPB* metadata, const TxnLogPB_OpAlterMetadata& op_alter_metas) {
     for (const auto& alter_meta : op_alter_metas.metadata_update_infos()) {
-        if (alter_meta.has_enable_persistent_index()) {
-            auto update_mgr = tablet_mgr->update_mgr();
-            metadata->set_enable_persistent_index(alter_meta.enable_persistent_index());
-            // Try remove index from index cache
-            // If tablet is doing apply rowset right now, remove primary index from index cache may be failed
-            // because the primary index is available in cache
-            // But it will be remove from index cache after apply is finished
-            (void)update_mgr->index_cache().try_remove_by_key(metadata->id());
-        }
-        // Check if the alter_meta has a persistent index type change
-        if (alter_meta.has_persistent_index_type()) {
-            // Get the previous and new persistent index types
-            PersistentIndexTypePB prev_type = metadata->persistent_index_type();
-            PersistentIndexTypePB new_type = alter_meta.persistent_index_type();
-            // Apply the changes to the persistent index type
-            metadata->set_persistent_index_type(new_type);
-            LOG(INFO) << fmt::format("alter persistent index type from {} to {} for tablet id: {}",
-                                     PersistentIndexTypePB_Name(prev_type), PersistentIndexTypePB_Name(new_type),
-                                     metadata->id());
-            // Get the update manager
-            auto update_mgr = tablet_mgr->update_mgr();
-            // Try to remove the index from the index cache
-            (void)update_mgr->index_cache().try_remove_by_key(metadata->id());
-        }
+        // `enable_persistent_index` and `persistent_index_type` are deliberately NOT applied.
+        //
+        // A shared-data tablet has exactly one primary-key index implementation left, the cloud-native
+        // one: force_cloud_native_pk_persistent_index() rewrites every primary-key tablet's metadata to
+        // enabled + CLOUD_NATIVE as it is loaded, and LakePrimaryIndex::_do_lake_load unconditionally
+        // builds a LakePersistentIndex. The two fields are therefore immutable in practice, and writing
+        // them here was the only way a value contradicting that could enter a live publish's metadata --
+        // this function's output is both persisted and cached (put_tablet_metadata /
+        // cache_tablet_metadata), neither of which normalizes.
+        //
+        // FE already rejects such a request (SchemaChangeHandler refuses to disable the persistent index
+        // or to select LOCAL for a primary-key table), so ignoring it costs nothing on a matched pair;
+        // for an older FE mid-rolling-upgrade, or a replayed txn log, the alter now no-ops instead of
+        // planting a LOCAL that later deletes the tablet's index. For a non-primary-key tablet both
+        // fields are inert -- every reader of them requires enabled + CLOUD_NATIVE, i.e. asks "is this a
+        // cloud-native primary-key index".
+        //
         // A range-carrying update is a metadata-only trailing sort-key ADD: the schema arity grows by
         // one or more and every tablet bound gains one trailing NULL sentinel per added column.
         // Validate the change against the
@@ -426,7 +418,7 @@ public:
         }
         if (log.has_op_alter_metadata()) {
             DCHECK_EQ(_base_version + 1, _new_version);
-            return apply_alter_meta_log(_metadata.get(), log.op_alter_metadata(), _tablet.tablet_mgr());
+            return apply_alter_meta_log(_metadata.get(), log.op_alter_metadata());
         }
         if (log.has_op_replication()) {
             RETURN_IF_ERROR(apply_replication_log(log.op_replication(), log.txn_id()));
@@ -501,12 +493,11 @@ public:
         SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(true);
         SCOPED_THREAD_LOCAL_SINGLETON_CHECK_MEM_TRACKER_SETTER(
                 config::enable_pk_strict_memcheck ? _tablet.update_mgr()->mem_tracker() : nullptr);
-        // local persistent index will update index version, so we need to load first
-        // still need prepare primary index even when this iteration produced no
-        // rowset changes (legacy "empty compaction" or admin no-op publish)
-        if (_index_entry == nullptr &&
-            (_has_no_op_apply || (_metadata->enable_persistent_index() &&
-                                  _metadata->persistent_index_type() == PersistentIndexTypePB::LOCAL))) {
+        // Still need to prepare the primary index even when this iteration produced no rowset changes
+        // (legacy "empty compaction" or admin no-op publish). The old companion condition -- a LOCAL
+        // persistent index, which had to be loaded so that its index version could be updated -- went
+        // away with the LOCAL implementation itself.
+        if (_index_entry == nullptr && _has_no_op_apply) {
             // get lock to avoid gc
             _tablet.update_mgr()->lock_shard_pk_index_shard(_tablet.id());
             DeferOp defer([&]() { _tablet.update_mgr()->unlock_shard_pk_index_shard(_tablet.id()); });
@@ -991,7 +982,7 @@ public:
             RETURN_IF_ERROR(apply_replication_log(log.op_replication()));
         }
         if (log.has_op_alter_metadata()) {
-            return apply_alter_meta_log(_metadata.get(), log.op_alter_metadata(), _tablet.tablet_mgr());
+            return apply_alter_meta_log(_metadata.get(), log.op_alter_metadata());
         }
         return Status::OK();
     }

--- a/be/test/storage/lake/alter_tablet_meta_test.cpp
+++ b/be/test/storage/lake/alter_tablet_meta_test.cpp
@@ -38,6 +38,14 @@ class AlterTabletMetaTest : public TestBase {
 public:
     AlterTabletMetaTest() : TestBase(kTestDirectory) {
         _tablet_metadata = generate_simple_tablet_metadata(PRIMARY_KEYS);
+        // generate_simple_tablet_metadata() leaves both persistent-index fields at their proto
+        // defaults (disabled / LOCAL), which no real primary-key tablet ever has:
+        // TabletManager::create_tablet sets them and then runs
+        // force_cloud_native_pk_persistent_index() before persisting. SetUp() inserts this metadata
+        // with put_tablet_metadata(), which caches it verbatim, so nothing normalizes it here
+        // either. Every other lake primary-key suite sets them explicitly (see PrimaryKeyParam).
+        _tablet_metadata->set_enable_persistent_index(true);
+        _tablet_metadata->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
         _tablet_schema = TabletSchema::create(_tablet_metadata->schema());
         _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
     }
@@ -74,84 +82,6 @@ TEST_F(AlterTabletMetaTest, test_missing_txn_id) {
     auto status = handler.process_update_tablet_meta(update_tablet_meta_req);
     ASSERT_ERROR(status);
     ASSERT_EQ("txn_id not set in request", status.message());
-}
-
-TEST_F(AlterTabletMetaTest, test_alter_enable_persistent_index) {
-    GTEST_SKIP() << "LOCAL persistent index is deprecated for shared-data primary-key tablets";
-    lake::SchemaChangeHandler handler(_tablet_mgr.get());
-    TUpdateTabletMetaInfoReq update_tablet_meta_req;
-    int64_t txn_id = next_id();
-    update_tablet_meta_req.__set_txn_id(txn_id);
-
-    TTabletMetaInfo tablet_meta_info;
-    auto tablet_id = _tablet_metadata->id();
-    tablet_meta_info.__set_tablet_id(tablet_id);
-    tablet_meta_info.__set_meta_type(TTabletMetaType::ENABLE_PERSISTENT_INDEX);
-    tablet_meta_info.__set_enable_persistent_index(true);
-
-    update_tablet_meta_req.tabletMetaInfos.push_back(tablet_meta_info);
-    ASSERT_OK(handler.process_update_tablet_meta(update_tablet_meta_req));
-
-    auto new_tablet_meta = publish_single_version(tablet_id, 2, txn_id);
-    ASSERT_OK(new_tablet_meta.status());
-    ASSERT_EQ(true, new_tablet_meta.value()->enable_persistent_index());
-
-    txn_id = next_id();
-    std::vector<int> k0{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};
-    std::vector<int> v0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 41, 44};
-    auto c0 = Int32Column::create();
-    auto c1 = Int32Column::create();
-    c0->append_numbers(k0.data(), k0.size() * sizeof(int));
-    c1->append_numbers(v0.data(), v0.size() * sizeof(int));
-    Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
-    auto rowset_txn_meta = std::make_unique<RowsetTxnMetaPB>();
-    ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
-    std::shared_ptr<const TabletSchema> const_schema = _tablet_schema;
-    ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
-    ASSERT_OK(writer->open());
-    // write segment #1
-    ASSERT_OK(writer->write(chunk0));
-    ASSERT_OK(writer->finish());
-    // write txnlog
-    auto txn_log = std::make_shared<TxnLog>();
-    txn_log->set_tablet_id(_tablet_metadata->id());
-    txn_log->set_txn_id(txn_id);
-    auto op_write = txn_log->mutable_op_write();
-    for (const auto& f : writer->segments()) {
-        op_write->mutable_rowset()->add_segment_metas()->set_filename(f.path);
-    }
-    op_write->mutable_rowset()->set_num_rows(writer->num_rows());
-    op_write->mutable_rowset()->set_data_size(writer->data_size());
-    op_write->mutable_rowset()->set_overlapped(false);
-    ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
-    writer->close();
-    ASSERT_OK(publish_single_version(_tablet_metadata->id(), 3, txn_id).status());
-    auto data_dir = StorageEngine::instance()->get_persistent_index_store(tablet_id);
-    ASSERT_TRUE(data_dir != nullptr);
-    ASSERT_OK(FileSystem::Default()->path_exists(data_dir->get_persistent_index_path() + "/" +
-                                                 std::to_string(tablet_id)));
-
-    int64_t txn_id2 = next_id();
-    TUpdateTabletMetaInfoReq update_tablet_meta_req2;
-    update_tablet_meta_req2.__set_txn_id(txn_id2);
-
-    TTabletMetaInfo tablet_meta_info2;
-    tablet_meta_info2.__set_tablet_id(tablet_id);
-    tablet_meta_info2.__set_meta_type(TTabletMetaType::ENABLE_PERSISTENT_INDEX);
-    tablet_meta_info2.__set_enable_persistent_index(false);
-
-    update_tablet_meta_req2.tabletMetaInfos.push_back(tablet_meta_info2);
-    ASSERT_OK(handler.process_update_tablet_meta(update_tablet_meta_req2));
-
-    auto new_tablet_meta2 = publish_single_version(tablet_id, 4, txn_id2);
-    ASSERT_OK(new_tablet_meta2.status());
-    ASSERT_EQ(false, new_tablet_meta2.value()->enable_persistent_index());
-#ifdef USE_STAROS
-    data_dir = StorageEngine::instance()->get_persistent_index_store(tablet_id);
-    ASSERT_TRUE(data_dir != nullptr);
-    ASSERT_ERROR(FileSystem::Default()->path_exists(data_dir->get_persistent_index_path() + "/" +
-                                                    std::to_string(tablet_id)));
-#endif
 }
 
 TEST_F(AlterTabletMetaTest, test_alter_enable_persistent_index_not_change) {
@@ -517,10 +447,10 @@ TEST_F(AlterTabletMetaTest, test_alter_persistent_index_type) {
 
         auto new_tablet_meta = publish_single_version(tablet_id, version++, txn_id);
         ASSERT_OK(new_tablet_meta.status());
+        // A shared-data primary-key tablet keeps the cloud-native index whatever the request asked
+        // for: apply_alter_meta_log ignores both index fields.
         ASSERT_EQ(true, new_tablet_meta.value()->enable_persistent_index());
-        ASSERT_TRUE(new_tablet_meta.value()->persistent_index_type() == (type == TPersistentIndexType::LOCAL)
-                            ? PersistentIndexTypePB::LOCAL
-                            : PersistentIndexTypePB::CLOUD_NATIVE);
+        ASSERT_EQ(PersistentIndexTypePB::CLOUD_NATIVE, new_tablet_meta.value()->persistent_index_type());
     };
 
     auto write_data_fn = [&](bool rebuild_pindex) {
@@ -556,11 +486,11 @@ TEST_F(AlterTabletMetaTest, test_alter_persistent_index_type) {
         ASSERT_OK(publish_single_version(_tablet_metadata->id(), version++, txn_id, rebuild_pindex).status());
     };
 
-    // 1. change to local index
+    // 1. ask for the local index -- the request must be ignored
     change_index_fn(true, TPersistentIndexType::LOCAL);
     ASSIGN_OR_ABORT(auto tablet_meta, _tablet_mgr->get_tablet_metadata(_tablet_metadata->id(), version - 1));
     ASSERT_EQ(true, tablet_meta->enable_persistent_index());
-    ASSERT_TRUE(tablet_meta->persistent_index_type() == PersistentIndexTypePB::LOCAL);
+    ASSERT_EQ(PersistentIndexTypePB::CLOUD_NATIVE, tablet_meta->persistent_index_type());
     // 2. write data
     write_data_fn(false);
     // 3. change to cloud native index
@@ -586,13 +516,22 @@ TEST_F(AlterTabletMetaTest, test_alter_persistent_index_type) {
 
     ASSIGN_OR_ABORT(auto tablet_meta_d2, _tablet_mgr->get_tablet_metadata(_tablet_metadata->id(), version - 1));
 
-    // 5. change back to local
+    // 5. ask for the local index again, now that the tablet owns sstables.
+    //
+    // This is the case that used to lose data. Applying the request planted LOCAL in the metadata, and
+    // MetaFileBuilder::finalize() then ran _sstable_meta_clean_after_alter_type(), which orphaned and
+    // cleared the whole sstable_meta whenever the metadata said LOCAL / disabled -- deleting the
+    // cloud-native index's SSTs. The next load from object storage normalized the type back to
+    // CLOUD_NATIVE and handed back a tablet whose index files were gone. So assert the SSTs survive
+    // the alter untouched, not just that the type is right.
+    const int sstables_before = tablet_meta_d2->sstable_meta().sstables_size();
+    const int orphans_before = tablet_meta_d2->orphan_files_size();
     change_index_fn(true, TPersistentIndexType::LOCAL);
     ASSIGN_OR_ABORT(auto tablet_meta4, _tablet_mgr->get_tablet_metadata(_tablet_metadata->id(), version - 1));
     ASSERT_EQ(true, tablet_meta4->enable_persistent_index());
-    ASSERT_TRUE(tablet_meta4->persistent_index_type() == PersistentIndexTypePB::LOCAL);
-    ASSERT_TRUE(tablet_meta4->sstable_meta().sstables_size() == 0);
-    ASSERT_TRUE(tablet_meta4->orphan_files_size() > 0);
+    ASSERT_EQ(PersistentIndexTypePB::CLOUD_NATIVE, tablet_meta4->persistent_index_type());
+    ASSERT_EQ(sstables_before, tablet_meta4->sstable_meta().sstables_size());
+    ASSERT_EQ(orphans_before, tablet_meta4->orphan_files_size());
 }
 
 TEST_F(AlterTabletMetaTest, test_skip_load_pindex) {

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -283,9 +283,6 @@ TEST_P(LakePartialUpdateTest, test_write) {
         EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
     }
     EXPECT_TRUE(_update_mgr->update_state_mem_tracker()->consumption() == 0);
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
-    }
 }
 
 TEST_P(LakePartialUpdateTest, test_column_mode_partial_update_streams_source_segment) {
@@ -656,9 +653,6 @@ TEST_P(LakePartialUpdateTest, test_partial_update_with_condition) {
                       check(version, [](int c0, int c1, int c2) { return (c0 * 4 == c1) && (c0 * 4 == c2); }));
         }
     }
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
-    }
 }
 
 // Validates that column-mode partial update rejects a merge_condition when the condition column
@@ -987,9 +981,6 @@ TEST_P(LakePartialUpdateTest, test_write_multi_segment) {
         EXPECT_EQ(new_tablet_metadata->rowsets(5).segment_metas_size(), 2);
     }
     EXPECT_TRUE(_update_mgr->update_state_mem_tracker()->consumption() == 0);
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
-    }
 }
 
 TEST_P(LakePartialUpdateTest, test_write_multi_segment_by_diff_val) {
@@ -1071,9 +1062,6 @@ TEST_P(LakePartialUpdateTest, test_write_multi_segment_by_diff_val) {
         // check segment size in last metadata
         EXPECT_EQ(new_tablet_metadata->rowsets(5).segment_metas_size(), 2);
     }
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
-    }
 }
 
 TEST_P(LakePartialUpdateTest, test_resolve_conflict) {
@@ -1143,9 +1131,6 @@ TEST_P(LakePartialUpdateTest, test_resolve_conflict) {
     ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     if (GetParam().partial_update_mode != PartialUpdateMode::COLUMN_UPDATE_MODE) {
         EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
-    }
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
     }
 }
 
@@ -1221,9 +1206,6 @@ TEST_P(LakePartialUpdateTest, test_resolve_conflict_multi_segment) {
         EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
         // check segment size in last metadata
         EXPECT_EQ(new_tablet_metadata->rowsets(5).segment_metas_size(), 2);
-    }
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
     }
 }
 
@@ -1309,9 +1291,6 @@ TEST_P(LakePartialUpdateTest, test_resolve_conflict2) {
     } else {
         EXPECT_EQ(new_tablet_metadata->rowsets_size(), 5);
     }
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
-    }
 }
 
 TEST_P(LakePartialUpdateTest, test_write_with_index_reload) {
@@ -1388,9 +1367,6 @@ TEST_P(LakePartialUpdateTest, test_write_with_index_reload) {
         EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
     } else {
         EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
-    }
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
     }
     if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::CLOUD_NATIVE) {
         auto sstable_meta = new_tablet_metadata->sstable_meta();
@@ -2483,9 +2459,6 @@ TEST_P(LakePartialUpdateTest, test_write_multi_segment_by_diff_val_mem_limit) {
         // check segment size in last metadata
         EXPECT_EQ(new_tablet_metadata->rowsets(5).segment_metas_size(), 2);
     }
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
-    }
 }
 
 TEST_P(LakePartialUpdateTest, test_partial_update_retry_check_file_exist) {
@@ -2653,9 +2626,6 @@ TEST_P(LakePartialUpdateTest, test_max_buffer_rows) {
         EXPECT_EQ(new_tablet_metadata->rowsets(5).segment_metas_size(), 2);
     }
     EXPECT_TRUE(_update_mgr->update_state_mem_tracker()->consumption() == 0);
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
-    }
 }
 
 namespace {

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -304,9 +304,6 @@ TEST_P(LakePrimaryKeyCompactionTest, test1) {
     EXPECT_TRUE(_update_mgr->TEST_check_compaction_cache_absent(tablet_id, txn_id));
     version++;
     ASSERT_EQ(kChunkSize, read(version));
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
-    }
 
     ASSIGN_OR_ABORT(auto new_tablet_metadata2, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata2->rowsets_size(), 1);
@@ -363,9 +360,6 @@ TEST_P(LakePrimaryKeyCompactionTest, test2) {
     EXPECT_TRUE(_update_mgr->TEST_check_compaction_cache_absent(tablet_id, txn_id));
     version++;
     ASSERT_EQ(kChunkSize * 3, read(version));
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
-    }
 
     ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 1);
@@ -430,9 +424,6 @@ TEST_P(LakePrimaryKeyCompactionTest, test3) {
     ASSERT_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
     EXPECT_TRUE(_update_mgr->TEST_check_compaction_cache_absent(tablet_id, txn_id));
     version++;
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
-    }
     ASSERT_EQ(kChunkSize * 2, read(version));
 
     ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
@@ -795,9 +786,6 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy_min_input) {
         EXPECT_TRUE(_update_mgr->TEST_check_compaction_cache_absent(tablet_id, txn_id));
         version++;
         ASSERT_EQ(kChunkSize * 4, read(version));
-        if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-            check_local_persistent_index_meta(tablet_id, version);
-        }
 
         ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
         EXPECT_EQ(new_tablet_metadata->rowsets_size(), 4);
@@ -1249,9 +1237,6 @@ TEST_P(LakePrimaryKeyCompactionTest, test_multi_output_seg) {
     config::vector_chunk_size = 4096;
     version++;
     ASSERT_EQ(kChunkSize * 3, read(version));
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
-    }
 
     ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 1);
@@ -1315,9 +1300,6 @@ TEST_P(LakePrimaryKeyCompactionTest, test_pk_recover_rowset_order_after_compact)
     EXPECT_TRUE(_update_mgr->TEST_check_compaction_cache_absent(tablet_id, txn_id));
     version++;
     ASSERT_EQ(3 * kChunkSize, read(version));
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
-    }
 
     ASSIGN_OR_ABORT(auto new_tablet_metadata2, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata2->rowsets_size(), 2);
@@ -2061,9 +2043,6 @@ TEST_P(LakePrimaryKeyCompactionTest, test_rows_mapper) {
     EXPECT_TRUE(_update_mgr->TEST_check_compaction_cache_absent(tablet_id, txn_id));
     version++;
     ASSERT_EQ(kChunkSize * 3, read(version));
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
-    }
 }
 
 TEST_P(LakePrimaryKeyCompactionTest, test_compaction_data_load_conc) {
@@ -2151,9 +2130,6 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_data_load_conc) {
 }
 
 TEST_P(LakePrimaryKeyCompactionTest, test_major_compaction) {
-    if (!GetParam().enable_persistent_index || GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        return;
-    }
     // Prepare data for writing
     std::vector<Chunk> chunks;
     int N = 10;
@@ -2212,9 +2188,6 @@ TEST_P(LakePrimaryKeyCompactionTest, test_major_compaction) {
 }
 
 TEST_P(LakePrimaryKeyCompactionTest, test_major_compaction_thread_safe) {
-    if (!GetParam().enable_persistent_index || GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        return;
-    }
     // Prepare data for writing
     std::vector<Chunk> chunks;
     int N = 10;
@@ -2328,17 +2301,10 @@ TEST_P(LakePrimaryKeyCompactionTest, test_should_enable_pk_index_eager_build) {
     auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
     ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
     // check should_enable_pk_index_eager_build
-    if (!GetParam().enable_persistent_index || GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        EXPECT_FALSE(task->should_enable_pk_index_eager_build(0));
-        EXPECT_FALSE(task->should_enable_pk_index_eager_build(config::pk_index_eager_build_threshold_bytes - 1));
-        EXPECT_FALSE(task->should_enable_pk_index_eager_build(config::pk_index_eager_build_threshold_bytes));
-        EXPECT_FALSE(task->should_enable_pk_index_eager_build(config::pk_index_eager_build_threshold_bytes + 1));
-    } else {
-        EXPECT_FALSE(task->should_enable_pk_index_eager_build(0));
-        EXPECT_FALSE(task->should_enable_pk_index_eager_build(config::pk_index_eager_build_threshold_bytes - 1));
-        EXPECT_TRUE(task->should_enable_pk_index_eager_build(config::pk_index_eager_build_threshold_bytes));
-        EXPECT_TRUE(task->should_enable_pk_index_eager_build(config::pk_index_eager_build_threshold_bytes + 1));
-    }
+    EXPECT_FALSE(task->should_enable_pk_index_eager_build(0));
+    EXPECT_FALSE(task->should_enable_pk_index_eager_build(config::pk_index_eager_build_threshold_bytes - 1));
+    EXPECT_TRUE(task->should_enable_pk_index_eager_build(config::pk_index_eager_build_threshold_bytes));
+    EXPECT_TRUE(task->should_enable_pk_index_eager_build(config::pk_index_eager_build_threshold_bytes + 1));
 }
 
 TEST_P(LakePrimaryKeyCompactionTest, test_concurrent_compaction_and_publish) {

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -397,9 +397,6 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_multitime_check_result) {
     EXPECT_EQ(new_tablet_metadata->rowsets(1).num_dels(), kChunkSize);
     EXPECT_EQ(new_tablet_metadata->rowsets(2).num_dels(), 0);
     EXPECT_TRUE(_update_mgr->update_state_mem_tracker()->consumption() == 0);
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
-    }
 }
 
 TEST_P(LakePrimaryKeyPublishTest, test_write_fail_retry) {
@@ -493,9 +490,6 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_fail_retry) {
     EXPECT_EQ(new_tablet_metadata->rowsets(2).num_dels(), 0);
     EXPECT_EQ(new_tablet_metadata->rowsets(3).num_dels(), 0);
     EXPECT_EQ(new_tablet_metadata->rowsets(4).num_dels(), 0);
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
-    }
 }
 
 TEST_P(LakePrimaryKeyPublishTest, test_publish_multi_segments) {
@@ -1607,9 +1601,6 @@ TEST_P(LakePrimaryKeyPublishTest, test_publish_multi_times) {
     EXPECT_EQ(new_tablet_metadata->rowsets(1).num_dels(), kChunkSize);
     EXPECT_EQ(new_tablet_metadata->rowsets(2).num_dels(), 0);
     EXPECT_TRUE(_update_mgr->update_state_mem_tracker()->consumption() == 0);
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
-    }
 }
 
 TEST_P(LakePrimaryKeyPublishTest, test_publish_with_oom) {
@@ -1677,9 +1668,6 @@ TEST_P(LakePrimaryKeyPublishTest, test_publish_concurrent) {
     EXPECT_EQ(new_tablet_metadata->rowsets(0).num_dels(), kChunkSize);
     EXPECT_EQ(new_tablet_metadata->rowsets(1).num_dels(), kChunkSize);
     EXPECT_EQ(new_tablet_metadata->rowsets(2).num_dels(), 0);
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
-    }
 }
 
 TEST_P(LakePrimaryKeyPublishTest, test_resolve_conflict) {
@@ -1746,9 +1734,6 @@ TEST_P(LakePrimaryKeyPublishTest, test_resolve_conflict) {
     EXPECT_EQ(new_tablet_metadata->rowsets(4).num_dels(), kChunkSize);
     EXPECT_EQ(new_tablet_metadata->rowsets(5).num_dels(), 0);
     EXPECT_TRUE(_update_mgr->update_state_mem_tracker()->consumption() == 0);
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
-    }
 }
 
 TEST_P(LakePrimaryKeyPublishTest, test_write_read_success_multiple_tablet) {
@@ -1794,10 +1779,6 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_read_success_multiple_tablet) {
     chunk1->remove_column_by_index(2);
     assert_chunk_equals(*chunk0, **chunk2);
     assert_chunk_equals(*chunk1, **chunk3);
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id_1, version);
-        check_local_persistent_index_meta(tablet_id_2, version);
-    }
 }
 
 TEST_P(LakePrimaryKeyPublishTest, test_write_largedata) {
@@ -1832,9 +1813,6 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_largedata) {
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), N);
     for (int i = 0; i < N; i++) {
         EXPECT_EQ(new_tablet_metadata->rowsets(i).num_dels(), 0);
-    }
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
     }
     config::l0_max_mem_usage = old_config;
 }
@@ -1883,9 +1861,6 @@ TEST_P(LakePrimaryKeyPublishTest, test_recover) {
     ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
     ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
-    }
     config::enable_primary_key_recover = false;
 }
 
@@ -1937,9 +1912,6 @@ TEST_P(LakePrimaryKeyPublishTest, test_recover_with_multi_reason) {
     ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 30);
     ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
-    }
     config::enable_primary_key_recover = false;
 }
 
@@ -1998,9 +1970,6 @@ TEST_P(LakePrimaryKeyPublishTest, test_recover_with_dels) {
         EXPECT_EQ(new_tablet_metadata->rowsets(i).del_files_size(), i % 2);
     }
     ASSERT_EQ(0, read_rows(tablet_id, version));
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
-    }
     config::enable_primary_key_recover = false;
 }
 
@@ -2069,9 +2038,6 @@ TEST_P(LakePrimaryKeyPublishTest, test_recover_with_dels2) {
         EXPECT_EQ(new_tablet_metadata->rowsets(i).del_files_size(), i);
     }
     ASSERT_EQ(0, read_rows(tablet_id, version));
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
-    }
     config::enable_primary_key_recover = false;
 }
 
@@ -2120,9 +2086,6 @@ TEST_P(LakePrimaryKeyPublishTest, test_index_load_failure) {
     ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
     ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
-    }
 }
 
 TEST_P(LakePrimaryKeyPublishTest, test_write_rebuild_persistent_index) {
@@ -2169,9 +2132,6 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_rebuild_persistent_index) {
     EXPECT_EQ(new_tablet_metadata->rowsets(0).num_dels(), kChunkSize);
     EXPECT_EQ(new_tablet_metadata->rowsets(1).num_dels(), kChunkSize);
     EXPECT_EQ(new_tablet_metadata->rowsets(2).num_dels(), 0);
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
-    }
     config::l0_max_mem_usage = l0_max_mem_usage;
 }
 
@@ -3134,9 +3094,6 @@ TEST_P(LakePrimaryKeyPublishTest, test_publish_with_lazy_load) {
     }
     config::pk_column_lazy_load_threshold_bytes = old_val;
     ASSERT_EQ(N, read_rows(tablet_id, version));
-    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
-        check_local_persistent_index_meta(tablet_id, version);
-    }
 }
 
 TEST_P(LakePrimaryKeyPublishTest, test_aggregate_publish_version) {

--- a/be/test/storage/lake/test_util.h
+++ b/be/test/storage/lake/test_util.h
@@ -45,7 +45,6 @@
 #include "storage/lake/update_manager.h"
 #include "storage/storage_engine.h"
 #include "storage/storage_env.h"
-#include "storage/tablet_meta_manager.h"
 
 namespace starrocks::lake {
 
@@ -120,13 +119,6 @@ protected:
         CHECK_OK(fs::create_directories(lake::join_path(_test_dir, lake::kSegmentDirectoryName)));
         CHECK_OK(fs::create_directories(lake::join_path(_test_dir, lake::kMetadataDirectoryName)));
         CHECK_OK(fs::create_directories(lake::join_path(_test_dir, lake::kTxnLogDirectoryName)));
-    }
-
-    void check_local_persistent_index_meta(int64_t tablet_id, int64_t expected_version) {
-        PersistentIndexMetaPB index_meta;
-        DataDir* data_dir = StorageEngine::instance()->get_persistent_index_store(tablet_id);
-        CHECK_OK(TabletMetaManager::get_persistent_index_meta(data_dir, tablet_id, &index_meta));
-        ASSERT_TRUE(index_meta.version().major_number() == expected_version);
     }
 
     StatusOr<TabletMetadataPtr> publish_single_version(int64_t tablet_id, int64_t new_version, int64_t txn_id,


### PR DESCRIPTION
## Why I'm doing:

A shared-data tablet has exactly one primary-key index implementation left. `force_cloud_native_pk_persistent_index()` rewrites every primary-key tablet's metadata to `enable_persistent_index = true` + `persistent_index_type = CLOUD_NATIVE` as it is loaded (`normalize_tablet_metadata_after_load`), and `LakePrimaryIndex::_do_lake_load()` unconditionally builds a `LakePersistentIndex`. The `LOCAL` implementation, `LakeLocalPersistentIndex`, has no construction site left at all.

So those two metadata fields are immutable in practice — except that `apply_alter_meta_log()` still wrote them straight through from the request. That is the one way a value contradicting the invariant can enter a live publish's metadata, and normalization does not clean up after it: this function's output is both persisted and cached (`TabletManager::put_tablet_metadata`, `tablet_manager.cpp:520/526`, and `TabletManager::cache_tablet_metadata`, `tablet_manager.cpp:538`), neither of which normalizes.

The consequence is data loss, not just an inconsistent field:

1. Every in-process reader sees `LOCAL` until the metacache entry is evicted, so `use_cloud_native_pk_index()` in `UpdateManager` returns false and the publish path for that tablet silently changes.
2. **The cloud-native index's SST files get deleted.** `MetaFileBuilder::_sstable_meta_clean_after_alter_type()` read those same two fields on **every** `finalize()` and moved the entire `sstable_meta` into `orphan_files` when they said `LOCAL` / disabled. The orphans are then vacuumed. The next load from object storage normalizes the type back to `CLOUD_NATIVE` and hands back a primary-key tablet whose index files are gone.

**Reachability.** Not reachable through a current FE: `SchemaChangeHandler` (`fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java:3024-3061`) already throws `DdlException` for both `enable_persistent_index = false` and a non-`CLOUD_NATIVE` `persistent_index_type` on a primary-key table. It stays reachable from an FE that predates that check — a rolling upgrade in which the BE moves first — and from a replayed txn log.

## What I'm doing:

**1. Stop applying the two fields, instead of coercing them**

`apply_alter_meta_log()` no longer writes `enable_persistent_index` or `persistent_index_type`. Deleting the write makes the bad state structurally unreachable rather than guarded; `force_cloud_native_pk_persistent_index()` is a read-side upgrade shim for metadata written by an older version, and it stays that.

Nothing is lost by ignoring the request:

* **Primary-key tablets:** the value would have been normalized away on the next load anyway. FE rejects the request, and even the pre-check path returns early on a no-change alter.
* **Non-primary-key tablets:** both fields are inert. Every BE reader of them requires `enable_persistent_index() && type == CLOUD_NATIVE`, i.e. asks "is this a cloud-native primary-key index" — `compaction_task.cpp:49/168`, `tablet_parallel_compaction_manager.cpp:1625`, `update_manager.cpp:66/249`, `meta_file.cpp:710`, `lake_connector.cpp:1208`. FE's own code notes that `enable_persistent_index` is a no-op for non-primary-key types.
* **The `index_cache().try_remove_by_key()` eviction** that both blocks performed existed to discard a cached index when the implementation switched. With no switch possible it buys nothing.

**2. Remove the two consumers this orphans**

* `MetaFileBuilder::_sstable_meta_clean_after_alter_type()` (`meta_file.cpp`) and its `finalize()` call site. Its only legitimate trigger was a real cloud-native → `LOCAL` switch. In a cloud-native-only world every trigger is a metadata inconsistency, and its response to one is to delete the primary index's SSTs — so keeping it as a "safety net" is backwards. Verified unreachable-with-`LOCAL`: both `MetaFileBuilder` construction sites (`update_manager.cpp:265`, `txn_log_applier.cpp:359`) receive metadata from a normalized `get_tablet_metadata`, and the replication finalize (`finalize_lake_replication`) bypasses the builder entirely.
* The `type == LOCAL` half of the publish-time condition at `txn_log_applier.cpp:529`: `_has_no_op_apply || (enable && type == LOCAL)` collapses to `_has_no_op_apply`. Its comment ("local persistent index will update index version, so we need to load first") went with it.
* `apply_alter_meta_log()`'s `TabletManager*` parameter, now unused.

**3. Fix the tests that had encoded the old behavior**

`be/test/storage/lake/alter_tablet_meta_test.cpp`:

* `test_alter_persistent_index_type` now asserts that the request is ignored, and that the alter leaves `sstable_meta` and `orphan_files` **unchanged** — the SST deletion above is what this fixes, so that is the property worth pinning. It previously asserted the opposite (`sstables_size() == 0`, `orphan_files_size() > 0`).
* The assertion inside its `change_index_fn` helper was **vacuous**. `==` binds tighter than `?:`, so

  ```cpp
  ASSERT_TRUE(meta->persistent_index_type() == (type == TPersistentIndexType::LOCAL)
                      ? PersistentIndexTypePB::LOCAL
                      : PersistentIndexTypePB::CLOUD_NATIVE);
  ```

  parsed as `ASSERT_TRUE((pit == (int)(type == LOCAL)) ? LOCAL : CLOUD_NATIVE)`, i.e. `ASSERT_TRUE` on an `int`. With `LOCAL = 0` / `CLOUD_NATIVE = 1` it passed for every input. Replaced with a real `ASSERT_EQ`.
* Dropped `test_alter_enable_persistent_index`: already `GTEST_SKIP`ped with *"LOCAL persistent index is deprecated for shared-data primary-key tablets"*, and its assertions (`enable_persistent_index == false` after the alter) contradict the invariant.

**4. Remove the dead LOCAL branches in the lake primary-key test suites**

Left over from when those suites were still parameterized on the index type. `PrimaryKeyParam` (`be/test/storage/lake/test_util.h`) now defaults to `enable_persistent_index = true` + `CLOUD_NATIVE`, and every instantiation passes `CLOUD_NATIVE` explicitly, so none of these can run:

| Shape | Count | Files |
|---|---|---|
| `if (enable && type == LOCAL) { check_local_persistent_index_meta(...); }` | 31 (32 calls) | `primary_key_publish_test.cpp` 14, `partial_update_test.cpp` 10, `primary_key_compaction_task_test.cpp` 7 |
| `if (!enable \|\| type == LOCAL) { return; }` | 2 | `primary_key_compaction_task_test.cpp` |
| dead `LOCAL` arm of an `if/else` in `test_should_enable_pk_index_eager_build` | 1 | `primary_key_compaction_task_test.cpp` |

That made `TestBase::check_local_persistent_index_meta()` unreachable, so it goes too, along with the `storage/tablet_meta_manager.h` include it was the only user of (verified: no other includer of `test_util.h` references `TabletMetaManager`, `PersistentIndexMetaPB`, `DataDir`, `WriteBatch`, `KVStore`, `DeltaColumnGroup`, `TabletMetaSharedPtr` or `EditVersion`).

**5. Make `AlterTabletMetaTest`'s fixture describe a tablet that can exist**

`generate_simple_tablet_metadata()` leaves both persistent-index fields at their proto defaults —
disabled / `LOCAL` — which no real primary-key tablet ever has: `TabletManager::create_tablet` sets them
and then runs `force_cloud_native_pk_persistent_index()` before persisting (`tablet_manager.cpp:253-260`
and `:299`). `SetUp()` inserts that metadata with `put_tablet_metadata()`, which caches it verbatim, so
nothing normalizes it in the test either. The suite's `ASSERT_EQ(true, enable_persistent_index())`
assertions only passed because the alter itself wrote the value — removing the write exposed that, and
the first CI round failed on exactly those two tests. Every other lake primary-key suite sets both
fields explicitly (see `PrimaryKeyParam`); this fixture now does the same.

Deliberately left alone: `CompactionParam` (`compaction_test_utils.h:27-28`) still defaults to `enable_persistent_index = false` + `LOCAL`. The duplicate/unique-key compaction suites use those defaults, where the fields are meaningless, and `to_string_param_name` bakes them into the gtest case names — changing them would only churn test names.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

An alter-meta log carrying `enable_persistent_index` or `persistent_index_type` is now ignored rather than applied. A current FE cannot produce a request that would have changed anything, so no user-visible behavior changes on a matched FE/BE pair; on a mismatched pair the alter becomes a no-op for those two fields instead of destroying the tablet's index SSTs. No config, metric, or on-disk format changes.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

Verified locally: `python3 build-support/check_be_module_boundaries.py --mode full` clean, `python3 build-support/render_be_agents.py --check` clean, `clang-format` clean on every changed file, and both changed sources (`txn_log_applier.cpp`, `meta_file.cpp`) pass `g++ -fsyntax-only`. BE UT execution is left to CI.

One thing a reviewer may want to confirm, since it cannot be checked without running the suite: `test_alter_persistent_index_type` step 5 now asserts `sstable_meta` / `orphan_files` invariance across the alter. That is safe either way, but the coverage is only non-trivial if the tablet actually holds SSTs at that point — step 4 generates them with `l0_max_mem_usage = 1`, and the pre-existing `tablet_meta3` assertion confirms it does before the index rebuild.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

**No backport — main only, deliberately.** `force_cloud_native_pk_persistent_index()` does not exist on `branch-4.1`, `branch-4.0` or `branch-3.5`, so the invariant this PR relies on does not hold there: on those branches the LOCAL persistent index is still a supported configuration for a shared-data primary-key tablet, and FE's `SchemaChangeHandler` does not reject it. Cherry-picking this would turn a user's `persistent_index_type = LOCAL` into a silent no-op and break a live feature. The same reasoning applies to the test cleanup, which depends on `PrimaryKeyParam` already defaulting to `CLOUD_NATIVE` — also main-only.
