### PR TITLE
[BugFix] es external table and es catalog compatible with elasticsearch v8 v9, and v10 in future

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsMajorVersion.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsMajorVersion.java
@@ -52,7 +52,7 @@ public class EsMajorVersion {
     public static final EsMajorVersion V_8_X  = new EsMajorVersion((byte) 8,  "8.x");
     public static final EsMajorVersion V_9_X  = new EsMajorVersion((byte) 9,  "9.x");
     public static final EsMajorVersion V_10_X = new EsMajorVersion((byte) 10, "10.x");
-    public static final EsMajorVersion LATEST = V_7_X;
+    public static final EsMajorVersion LATEST = V_9_X;
 
     public final byte major;
     private final String version;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsMajorVersion.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsMajorVersion.java
@@ -43,13 +43,15 @@ import com.starrocks.connector.exception.StarRocksConnectorException;
  */
 public class EsMajorVersion {
 
-    public static final EsMajorVersion V_0_X = new EsMajorVersion((byte) 0, "0.x");
-    public static final EsMajorVersion V_1_X = new EsMajorVersion((byte) 1, "1.x");
-    public static final EsMajorVersion V_2_X = new EsMajorVersion((byte) 2, "2.x");
-    public static final EsMajorVersion V_5_X = new EsMajorVersion((byte) 5, "5.x");
-    public static final EsMajorVersion V_6_X = new EsMajorVersion((byte) 6, "6.x");
-    public static final EsMajorVersion V_7_X = new EsMajorVersion((byte) 7, "7.x");
-    public static final EsMajorVersion V_8_X = new EsMajorVersion((byte) 8, "8.x");
+    public static final EsMajorVersion V_0_X  = new EsMajorVersion((byte) 0,  "0.x");
+    public static final EsMajorVersion V_1_X  = new EsMajorVersion((byte) 1,  "1.x");
+    public static final EsMajorVersion V_2_X  = new EsMajorVersion((byte) 2,  "2.x");
+    public static final EsMajorVersion V_5_X  = new EsMajorVersion((byte) 5,  "5.x");
+    public static final EsMajorVersion V_6_X  = new EsMajorVersion((byte) 6,  "6.x");
+    public static final EsMajorVersion V_7_X  = new EsMajorVersion((byte) 7,  "7.x");
+    public static final EsMajorVersion V_8_X  = new EsMajorVersion((byte) 8,  "8.x");
+    public static final EsMajorVersion V_9_X  = new EsMajorVersion((byte) 9,  "9.x");
+    public static final EsMajorVersion V_10_X = new EsMajorVersion((byte) 10, "10.x");
     public static final EsMajorVersion LATEST = V_7_X;
 
     public final byte major;
@@ -103,9 +105,15 @@ public class EsMajorVersion {
         if (version.startsWith("7.")) {
             return new EsMajorVersion((byte) 7, version);
         }
-        // used for the next released ES version
         if (version.startsWith("8.")) {
             return new EsMajorVersion((byte) 8, version);
+        }
+        if (version.startsWith("9.")) {
+            return new EsMajorVersion((byte) 9, version);
+        }
+        // used for the next released ES version
+        if (version.startsWith("10.")) {
+            return new EsMajorVersion((byte) 10, version);
         }
         throw new StarRocksConnectorException("Unsupported/Unknown ES Cluster version [" + version + "]." +
                 "Highest supported version is [" + LATEST.version + "].");

--- a/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsRestClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsRestClient.java
@@ -90,10 +90,8 @@ public class EsRestClient {
 
     private static OkHttpClient sslNetworkClient;
 
-    private final Request.Builder builder;
+    private final String authHeader;
     private final String[] nodes;
-    private String currentNode;
-    private int currentNodeIndex = 0;
 
     private boolean sslEnabled;
 
@@ -104,21 +102,11 @@ public class EsRestClient {
 
     public EsRestClient(String[] nodes, String authUser, String authPassword) {
         this.nodes = nodes;
-        this.builder = new Request.Builder();
         if (!Strings.isEmpty(authUser) && !Strings.isEmpty(authPassword)) {
-            this.builder.addHeader(HttpHeaders.AUTHORIZATION,
-                    Credentials.basic(authUser, authPassword));
+            this.authHeader = Credentials.basic(authUser, authPassword);
+        } else {
+            this.authHeader = null;
         }
-        this.currentNode = nodes[currentNodeIndex];
-    }
-
-    private void selectNextNode() {
-        currentNodeIndex++;
-        // reroute, because the previously failed node may have already been restored
-        if (currentNodeIndex >= nodes.length) {
-            currentNodeIndex = 0;
-        }
-        currentNode = nodes[currentNodeIndex];
     }
 
     public Map<String, EsNodeInfo> getHttpNodes() throws StarRocksConnectorException {
@@ -225,7 +213,6 @@ public class EsRestClient {
      * @return response
      */
     String execute(String path) throws StarRocksConnectorException {
-        int retrySize = nodes.length;
         StarRocksConnectorException scratchExceptionForThrow = null;
         OkHttpClient client;
         if (sslEnabled) {
@@ -233,24 +220,28 @@ public class EsRestClient {
         } else {
             client = NETWORK_CLIENT;
         }
-        for (int i = 0; i < retrySize; i++) {
+        for (int i = 0; i < nodes.length; i++) {
             // maybe should add HTTP schema to the address
             // actually, at this time we can only process http protocol
-            // NOTE. currentNode may have some spaces.
+            // NOTE. nodes[i] may have some spaces.
             // User may set a config like described below:
             // hosts: "http://192.168.0.1:8200, http://192.168.0.2:8200"
-            // then currentNode will be "http://192.168.0.1:8200", " http://192.168.0.2:8200"
+            // then nodes[i] will be "http://192.168.0.1:8200", " http://192.168.0.2:8200"
             // If use ipv6, remember to use format like [2001:0db8:85a3:0000:0000:8a2e:0370:7334]:8080
-            currentNode = currentNode.trim();
-            if (!(currentNode.startsWith("http://") || currentNode.startsWith("https://"))) {
-                currentNode = "http://" + currentNode;
+            String node = nodes[i].trim();
+            if (!(node.startsWith("http://") || node.startsWith("https://"))) {
+                node = "http://" + node;
             }
-            Request request = builder.get()
-                    .url(currentNode + "/" + path)
+            Request.Builder localBuilder = new Request.Builder();
+            if (authHeader != null) {
+                localBuilder.addHeader(HttpHeaders.AUTHORIZATION, authHeader);
+            }
+            Request request = localBuilder.get()
+                    .url(node + "/" + path)
                     .build();
             Response response = null;
             if (LOG.isTraceEnabled()) {
-                LOG.trace("es rest client request URL: {}", currentNode + "/" + path);
+                LOG.trace("es rest client request URL: {}", node + "/" + path);
             }
             try {
                 response = client.newCall(request).execute();
@@ -258,14 +249,13 @@ public class EsRestClient {
                     return response.body().string();
                 }
             } catch (IOException e) {
-                LOG.warn("request node [{}] [{}] failures {}, try next nodes", currentNode, path, e);
+                LOG.warn("request node [{}] [{}] failures {}, try next nodes", node, path, e);
                 scratchExceptionForThrow = new StarRocksConnectorException(e.getMessage());
             } finally {
                 if (response != null) {
                     response.close();
                 }
             }
-            selectNextNode();
         }
         LOG.warn("try all nodes [{}],no other nodes left", (Object) nodes);
         if (scratchExceptionForThrow != null) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/EsTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/EsTestCase.java
@@ -86,11 +86,15 @@ public class EsTestCase {
     }
 
     public EsTable fakeEsTable(String table, String index, String type, List<Column> columns) throws DdlException {
+        return fakeEsTable(table, index, type, columns, "6.5.3");
+    }
+
+    public EsTable fakeEsTable(String table, String index, String type, List<Column> columns, String version) throws DdlException {
         Map<String, String> props = new HashMap<>();
         props.put(EsTable.KEY_HOSTS, "http://127.0.0.1:8200");
         props.put(EsTable.KEY_INDEX, index);
         props.put(EsTable.KEY_TYPE, type);
-        props.put(EsTable.KEY_VERSION, "6.5.3");
+        props.put(EsTable.KEY_VERSION, version);
         return new EsTable(new Random().nextLong(), table, columns, props, null);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/VersionPhaseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/VersionPhaseTest.java
@@ -75,8 +75,8 @@ public class VersionPhaseTest extends EsTestCase {
         List<Column> columns = new ArrayList<>();
         Column k1 = new Column("k1", IntegerType.BIGINT);
         columns.add(k1);
-        EsTable esTableBefore7X = fakeEsTable("fake", "test", "doc", columns,"8.19.20");
-        SearchContext context = new SearchContext(esTableBefore7X);
+        EsTable esTableV8X = fakeEsTable("fake", "test", "doc", columns,"8.19.20");
+        SearchContext context = new SearchContext(esTableV8X);
 
         new Expectations(client) {
             {
@@ -96,8 +96,8 @@ public class VersionPhaseTest extends EsTestCase {
         List<Column> columns = new ArrayList<>();
         Column k1 = new Column("k1", IntegerType.BIGINT);
         columns.add(k1);
-        EsTable esTableBefore7X = fakeEsTable("fake", "test", "doc", columns,"9.5.3");
-        SearchContext context = new SearchContext(esTableBefore7X);
+        EsTable esTableV9X = fakeEsTable("fake", "test", "doc", columns,"9.5.3");
+        SearchContext context = new SearchContext(esTableV9X);
 
         new Expectations(client) {
             {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/VersionPhaseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/VersionPhaseTest.java
@@ -70,4 +70,46 @@ public class VersionPhaseTest extends EsTestCase {
         assertTrue(context.version().on(EsMajorVersion.V_6_X));
     }
 
+    @Test
+    public void testVersion8X(@Injectable EsRestClient client) throws Exception {
+        List<Column> columns = new ArrayList<>();
+        Column k1 = new Column("k1", IntegerType.BIGINT);
+        columns.add(k1);
+        EsTable esTableBefore7X = fakeEsTable("fake", "test", "doc", columns,"8.19.20");
+        SearchContext context = new SearchContext(esTableBefore7X);
+
+        new Expectations(client) {
+            {
+                client.version();
+                minTimes = 0;
+                result = EsMajorVersion.V_8_X;
+            }
+        };
+        VersionPhase versionPhase = new VersionPhase(client);
+        ExceptionChecker.expectThrowsNoException(() -> versionPhase.preProcess(context));
+        ExceptionChecker.expectThrowsNoException(() -> versionPhase.execute(context));
+        assertTrue(context.version().on(EsMajorVersion.V_8_X));
+    }
+
+    @Test
+    public void testVersion9X(@Injectable EsRestClient client) throws Exception {
+        List<Column> columns = new ArrayList<>();
+        Column k1 = new Column("k1", IntegerType.BIGINT);
+        columns.add(k1);
+        EsTable esTableBefore7X = fakeEsTable("fake", "test", "doc", columns,"9.5.3");
+        SearchContext context = new SearchContext(esTableBefore7X);
+
+        new Expectations(client) {
+            {
+                client.version();
+                minTimes = 0;
+                result = EsMajorVersion.V_9_X;
+            }
+        };
+        VersionPhase versionPhase = new VersionPhase(client);
+        ExceptionChecker.expectThrowsNoException(() -> versionPhase.preProcess(context));
+        ExceptionChecker.expectThrowsNoException(() -> versionPhase.execute(context));
+        assertTrue(context.version().on(EsMajorVersion.V_9_X));
+    }
+
 }


### PR DESCRIPTION
## Why I'm doing:

https://github.com/StarRocks/starrocks/issues/78266

We had ElasticSearch external tables working normally, after we upgraded ElasticSearch cluster to version 9.5.2, queries on es tables encounter error:

`Unsupported/Unknown ES Cluster version [9.5.2].Highest supported version is [7.x].`

## What I'm doing:

Add Elasticsearch V8 and V9 versions to EsMajorVersion.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
