### PR TITLE
[BugFix] Fix tablet split fallback cross-publish

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -286,6 +286,19 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
         return;
     }
 
+    for (const auto& resharding_tablet_info : request->resharding_tablet_infos()) {
+        if (!resharding_tablet_info.has_splitting_tablet_info()) {
+            continue;
+        }
+        const auto& splitting_tablet_info = resharding_tablet_info.splitting_tablet_info();
+        const int split_count = splitting_tablet_info.new_tablet_ids_size();
+        if (split_count <= 1) {
+            cntl->SetFailed(fmt::format("splitting tablet {} requires at least 2 new tablet ids, got {}",
+                                        splitting_tablet_info.old_tablet_id(), split_count));
+            return;
+        }
+    }
+
     int task_num = request->tablet_ids_size();
 
     // Prepare publish tablet infos

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -300,6 +300,44 @@ protected:
         return request;
     }
 
+    void expect_invalid_split_count(bool is_reshard_txn, int split_count) {
+        std::atomic<int> submit_count = 0;
+        SyncPoint::GetInstance()->SetCallBack("ThreadPool::do_submit:1",
+                                              [&submit_count](void*) { submit_count.fetch_add(1); });
+        SyncPoint::GetInstance()->EnableProcessing();
+        DeferOp defer([]() {
+            SyncPoint::GetInstance()->ClearCallBack("ThreadPool::do_submit:1");
+            SyncPoint::GetInstance()->DisableProcessing();
+        });
+
+        brpc::Controller cntl;
+        PublishVersionRequest request;
+        PublishVersionResponse response;
+        request.set_base_version(1);
+        request.set_new_version(2);
+        if (is_reshard_txn) {
+            auto* txn_info = request.add_txn_infos();
+            txn_info->set_txn_id(next_id());
+            txn_info->set_txn_type(TXN_TABLET_RESHARD);
+        } else {
+            request.add_txn_ids(next_id());
+            request.add_tablet_ids(_tablet_id);
+        }
+        auto* splitting = request.add_resharding_tablet_infos()->mutable_splitting_tablet_info();
+        splitting->set_old_tablet_id(_tablet_id);
+        for (int i = 0; i < split_count; ++i) {
+            splitting->add_new_tablet_ids(next_id());
+        }
+
+        _lake_service.publish_version(&cntl, &request, &response, nullptr);
+
+        EXPECT_TRUE(cntl.Failed());
+        EXPECT_EQ(
+                fmt::format("splitting tablet {} requires at least 2 new tablet ids, got {}", _tablet_id, split_count),
+                cntl.ErrorText());
+        EXPECT_EQ(0, submit_count.load());
+    }
+
     void build_schemas_and_metadata(TabletSchemaPB* schema_pb1, TabletSchemaPB* schema_pb2, TabletSchemaPB* schema_pb3,
                                     starrocks::TabletMetadataPB* metadata1, starrocks::TabletMetadataPB* metadata2) {
         // schema 1
@@ -373,6 +411,22 @@ protected:
     std::unique_ptr<LoadChannelMgr> _load_channel_mgr;
     LakeServiceImpl _lake_service;
 };
+
+TEST_F(LakeServiceTest, test_publish_version_rejects_normal_split_count_zero) {
+    expect_invalid_split_count(false, 0);
+}
+
+TEST_F(LakeServiceTest, test_publish_version_rejects_reshard_split_count_zero) {
+    expect_invalid_split_count(true, 0);
+}
+
+TEST_F(LakeServiceTest, test_publish_version_rejects_reshard_split_count_one) {
+    expect_invalid_split_count(true, 1);
+}
+
+TEST_F(LakeServiceTest, test_publish_version_rejects_normal_split_count_one) {
+    expect_invalid_split_count(false, 1);
+}
 
 TEST_F(LakeServiceTest, test_publish_version_missing_tablet_ids) {
     brpc::Controller cntl;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplittingTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplittingTablet.java
@@ -148,7 +148,8 @@ public class SplittingTablet implements ReshardingTablet {
         List<Long> tabletIdsSnapshot = newTabletIds;
         Preconditions.checkState(!tabletIdsSnapshot.isEmpty());
         // Publish IDs first and ranges second. Readers snapshot ranges before IDs,
-        // so this order prevents a reader from pairing one ID with stale ranges.
+        // so observing cleared ranges guarantees singleton IDs; singleton IDs with stale ranges
+        // are safe because toProto() chooses identical and ignores ranges.
         newTabletIds = List.of(tabletIdsSnapshot.get(0));
         // Drop stale FE-supplied ranges. After BE's identical fallback there is
         // a single inherited new tablet, not the K originally requested, so

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplittingTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplittingTablet.java
@@ -21,7 +21,6 @@ import com.starrocks.proto.ReshardingTabletInfoPB;
 import com.starrocks.proto.SplittingTabletInfoPB;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -42,7 +41,7 @@ public class SplittingTablet implements ReshardingTablet {
     protected final long oldTabletId;
 
     @SerializedName(value = "newTabletIds")
-    protected final List<Long> newTabletIds;
+    protected volatile List<Long> newTabletIds;
 
     // Defaulted to empty list in the no-arg Gson constructor below so legacy
     // SplittingTablet records persisted before this field existed deserialize
@@ -51,30 +50,27 @@ public class SplittingTablet implements ReshardingTablet {
     // present in the JSON, so toProto / fallbackToIdenticalTablet never see
     // null even on an in-flight reshard job replayed from a pre-PR snapshot.
     @SerializedName(value = "newTabletRanges")
-    protected final List<TabletRange> newTabletRanges;
+    protected volatile List<TabletRange> newTabletRanges;
 
     // Used only by Gson deserialization; delegates to the validated 3-arg
     // constructor so the same wrapping / preconditions apply. Gson then
     // reflection-sets each field present in the JSON, leaving newTabletRanges
     // at the empty default for legacy records that predate the field.
     private SplittingTablet() {
-        this(0, Collections.emptyList(), Collections.emptyList());
+        this(0, List.of(), List.of());
     }
 
     public SplittingTablet(long oldTabletId, List<Long> newTabletIds) {
-        this(oldTabletId, newTabletIds, Collections.emptyList());
+        this(oldTabletId, newTabletIds, List.of());
     }
 
     public SplittingTablet(long oldTabletId, List<Long> newTabletIds, List<TabletRange> newTabletRanges) {
         this.oldTabletId = oldTabletId;
-        this.newTabletIds = newTabletIds;
         Preconditions.checkNotNull(newTabletRanges, "newTabletRanges must not be null");
         Preconditions.checkArgument(newTabletRanges.stream().allMatch(Objects::nonNull),
                 "newTabletRanges must not contain null elements");
-        // Always wrap in a mutable ArrayList: fallbackToIdenticalTablet() clears
-        // this list after a BE-side fallback, mirroring how newTabletIds is
-        // mutated via subList(...).clear().
-        this.newTabletRanges = new ArrayList<>(newTabletRanges);
+        this.newTabletIds = List.copyOf(newTabletIds);
+        this.newTabletRanges = List.copyOf(newTabletRanges);
         Preconditions.checkState(this.newTabletRanges.isEmpty()
                         || this.newTabletRanges.size() == newTabletIds.size(),
                 "newTabletRanges.size=%s must equal newTabletIds.size=%s when set",
@@ -131,24 +127,33 @@ public class SplittingTablet implements ReshardingTablet {
 
     @Override
     public ReshardingTabletInfoPB toProto() {
+        List<TabletRange> tabletRangesSnapshot = newTabletRanges;
+        List<Long> tabletIdsSnapshot = newTabletIds;
+        if (tabletIdsSnapshot.size() == 1) {
+            return new IdenticalTablet(oldTabletId, tabletIdsSnapshot.get(0)).toProto();
+        }
+
         ReshardingTabletInfoPB reshardingTabletInfoPB = new ReshardingTabletInfoPB();
         reshardingTabletInfoPB.splittingTabletInfo = new SplittingTabletInfoPB();
         reshardingTabletInfoPB.splittingTabletInfo.oldTabletId = oldTabletId;
-        reshardingTabletInfoPB.splittingTabletInfo.newTabletIds = newTabletIds;
-        if (!newTabletRanges.isEmpty()) {
+        reshardingTabletInfoPB.splittingTabletInfo.newTabletIds = new ArrayList<>(tabletIdsSnapshot);
+        if (!tabletRangesSnapshot.isEmpty()) {
             reshardingTabletInfoPB.splittingTabletInfo.newTabletRanges =
-                    newTabletRanges.stream().map(TabletRange::toProto).collect(Collectors.toList());
+                    tabletRangesSnapshot.stream().map(TabletRange::toProto).collect(Collectors.toList());
         }
         return reshardingTabletInfoPB;
     }
 
     public void fallbackToIdenticalTablet() {
-        Preconditions.checkState(!newTabletIds.isEmpty());
-        newTabletIds.subList(1, newTabletIds.size()).clear();
+        List<Long> tabletIdsSnapshot = newTabletIds;
+        Preconditions.checkState(!tabletIdsSnapshot.isEmpty());
+        // Publish IDs first and ranges second. Readers snapshot ranges before IDs,
+        // so this order prevents a reader from pairing one ID with stale ranges.
+        newTabletIds = List.of(tabletIdsSnapshot.get(0));
         // Drop stale FE-supplied ranges. After BE's identical fallback there is
         // a single inherited new tablet, not the K originally requested, so
         // the external-boundaries-style range list would be both mis-sized and meaningless.
-        newTabletRanges.clear();
+        newTabletRanges = List.of();
     }
 
     public boolean isIdenticalTablet() {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplittingTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplittingTabletTest.java
@@ -19,6 +19,7 @@ import com.starrocks.catalog.TabletRange;
 import com.starrocks.catalog.Tuple;
 import com.starrocks.catalog.Variant;
 import com.starrocks.common.Range;
+import com.starrocks.proto.ReshardingTabletInfoPB;
 import com.starrocks.proto.SplittingTabletInfoPB;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
@@ -87,12 +88,37 @@ public class SplittingTabletTest {
         Assertions.assertFalse(t.isIdenticalTablet());
         Assertions.assertEquals(3, t.getNewTabletRanges().size());
 
+        ReshardingTabletInfoPB beforeFallback = t.toProto();
+
         t.fallbackToIdenticalTablet();
+
+        Assertions.assertEquals(List.of(21L, 22L, 23L),
+                beforeFallback.splittingTabletInfo.newTabletIds);
+        Assertions.assertEquals(3, beforeFallback.splittingTabletInfo.newTabletRanges.size());
+        ReshardingTabletInfoPB afterFallback = t.toProto();
+        Assertions.assertNull(afterFallback.splittingTabletInfo);
+        Assertions.assertNotNull(afterFallback.identicalTabletInfo);
+        Assertions.assertEquals(Long.valueOf(2L), afterFallback.identicalTabletInfo.oldTabletId);
+        Assertions.assertEquals(Long.valueOf(21L), afterFallback.identicalTabletInfo.newTabletId);
 
         Assertions.assertTrue(t.isIdenticalTablet());
         Assertions.assertEquals(1, t.getNewTabletIds().size());
         Assertions.assertTrue(t.getNewTabletRanges().isEmpty(),
                 "fallback must clear stale FE-supplied ranges along with the trailing new tablet ids");
+    }
+
+    @Test
+    public void testDataDrivenFallbackReplaysAsIdenticalTablet() {
+        SplittingTablet tablet = new SplittingTablet(2, new ArrayList<>(List.of(21L, 22L)));
+        tablet.fallbackToIdenticalTablet();
+
+        SplittingTablet replayed = GSON.fromJson(GSON.toJson(tablet), SplittingTablet.class);
+        ReshardingTabletInfoPB proto = replayed.toProto();
+
+        Assertions.assertNull(proto.splittingTabletInfo);
+        Assertions.assertNotNull(proto.identicalTabletInfo);
+        Assertions.assertEquals(Long.valueOf(2L), proto.identicalTabletInfo.oldTabletId);
+        Assertions.assertEquals(Long.valueOf(21L), proto.identicalTabletInfo.newTabletId);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

When a shared-data range tablet split cannot produce enough boundaries, BE falls back to one identical child. FE kept the registered object as a one-child `SplittingTablet` and still serialized `splitting_tablet_info`. A following cross-publish therefore constructed `SPLITTING_TABLET` with `split_count=1` and aborted assertion-enabled BE builds.

## What I'm doing:

- Publish split fallback as `identical_tablet_info` from a stable FE snapshot while preserving pre-fallback protobuf payloads.
- Reject zero/one-child `splitting_tablet_info` at the common BE publish RPC boundary before any task is submitted.
- Add FE fallback/replay coverage and BE normal/reshard invalid-cardinality coverage, with the existing K=2 split test as a positive control.

Fixes StarRocks/StarRocksTest#12017

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
