### PR TITLE
[BugFix] Honor paimon.option.cache-enabled=false again

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonConnector.java
@@ -169,6 +169,11 @@ public class PaimonConnector implements Connector {
             // snapshot/schema revisions; privilege wrapper stays outside, as in createCatalog.
             Catalog unwrapped = CatalogFactory.createUnwrappedCatalog(context,
                     CatalogFactory.class.getClassLoader());
+            if (!getPaimonOptions().get(CatalogOptions.CACHE_ENABLED)) {
+                // no cache layer, hence nothing for the background refresh to track
+                this.paimonNativeCatalog = PrivilegedCatalog.tryToCreate(unwrapped, getPaimonOptions());
+                return paimonNativeCatalog;
+            }
             CachingPaimonCatalog cachingCatalog =
                     new CachingPaimonCatalog(catalogName, unwrapped, getPaimonOptions());
             this.paimonNativeCatalog = PrivilegedCatalog.tryToCreate(cachingCatalog, getPaimonOptions());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonConnectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonConnectorTest.java
@@ -23,6 +23,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.type.IntegerType;
 import mockit.Expectations;
 import mockit.Mocked;
+import org.apache.paimon.catalog.CachingCatalog;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.options.CatalogOptions;
@@ -33,6 +34,7 @@ import org.apache.paimon.types.IntType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Files;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -97,6 +99,18 @@ public class PaimonConnectorTest {
         Assertions.assertEquals(Duration.ofHours(1), options.get(CatalogOptions.CACHE_EXPIRE_AFTER_WRITE));
         Assertions.assertEquals(50L, options.get(CatalogOptions.CACHE_PARTITION_MAX_NUM));
         Assertions.assertEquals(Duration.ofHours(24), options.get(CatalogOptions.CACHE_EXPIRE_AFTER_ACCESS));
+    }
+
+    @Test
+    public void testCacheCanBeDisabled() throws Exception {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("paimon.catalog.type", "filesystem");
+        properties.put("paimon.catalog.warehouse", Files.createTempDirectory("paimon_no_cache").toString());
+        properties.put("paimon.option.cache-enabled", "false");
+        PaimonConnector connector = new PaimonConnector(new ConnectorContext("paimon_catalog", "paimon", properties));
+
+        Assertions.assertFalse(connector.getPaimonOptions().get(CatalogOptions.CACHE_ENABLED));
+        Assertions.assertFalse(connector.getPaimonNativeCatalog() instanceof CachingCatalog);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

`paimon.option.cache-enabled=false` stopped disabling the metadata cache on main.

Paimon's own factory honors the switch: `CatalogFactory.createCatalog()` routes through
`CachingCatalog.tryToCreate(catalog, options)`, whose first statement is
`if (!options.get(CatalogOptions.CACHE_ENABLED)) return catalog;`.

#78057 replaced that call with an explicit construction so the background refresh could hold the
cache layer's reference (`createUnwrappedCatalog` → `new CachingPaimonCatalog(...)` →
`PrivilegedCatalog.tryToCreate`), but it wrapped unconditionally, and `CACHE_ENABLED` is read
nowhere else in the FE. The user's value still lands in the options map through the
`paimon.option.` passthrough — it is simply never consumed. Since #78057 also raised the cache
lifetime to 24h, a catalog created with caching explicitly turned off now serves metadata from a
24-hour cache.

## What I'm doing:

Honor `CatalogOptions.CACHE_ENABLED` in `PaimonConnector.getPaimonNativeCatalog()`: when it is
false, return the unwrapped catalog behind the privilege wrapper and skip the background-refresh
registration, since there is no cache layer to refresh. This restores exactly what
`CachingCatalog.tryToCreate` used to do here. Default (unset) behavior is unchanged.

Note on backports: the regression only exists on main. #78057's backports to 4.1/4.0/3.5 were
closed, so those branches still build the catalog through `CatalogFactory.createCatalog()` and
already honor the switch — no version labels checked on purpose.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

Only catalogs that explicitly set `paimon.option.cache-enabled=false` are affected: caching stops
being forced on them. Catalogs that leave the option unset keep caching, as today.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
