### PR TITLE
[Tool] Fix !sequential forcing sql-tester concurrency to 1

### DIFF
--- a/test/run.py
+++ b/test/run.py
@@ -188,7 +188,11 @@ if __name__ == "__main__":
     cluster_attr = "!cloud" if cluster == "native" else "!native"
     attr = f"{attr},{cluster_attr}".strip(",")
     # check sequential mode with concurrency=1
-    if "sequential" in attr and concurrency != 1:
+    # Match the attr as a token, not a substring: "!sequential" (exclude sequential cases)
+    # must not be mistaken for "sequential" (run only sequential cases), otherwise the
+    # concurrent pass silently drops to a single process.
+    attr_tokens = {each.strip() for each in attr.split(",")}
+    if "sequential" in attr_tokens and concurrency != 1:
         print("In sequential mode, set concurrency=1 in default!")
         concurrency = 1
     # check alive mode with concurrency=1


### PR DESCRIPTION
## Why I'm doing:

`test/run.py` used a substring check (`"sequential" in attr`). That is also true for `"!sequential"`, so the concurrent sql-tester CI pass (`-a '!slow,!sequential' -c 12`) was silently forced onto `--processes=1`.

## What I'm doing:

Match `sequential` as a comma-separated token instead of a substring, matching the already-merged enterprise/main fix (CelerData #61309). Community merge will sync back to enterprise.

Fixes the concurrent sql-tester pass being serialized.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

Cherry-pick/backport of the same sequential-attr token match already on enterprise main (CelerData #61309 / kevincai). Community merge will sync to enterprise.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

Made with [Cursor](https://cursor.com)
