### PR TITLE
[BugFix] Drop iceberg table whose metadata file is missing (backport #77786)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -16,6 +16,7 @@ package com.starrocks.connector.iceberg;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.TableName;
@@ -82,6 +83,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.statistics.Statistics;
+import com.starrocks.statistic.AnalyzeMgr;
 import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.thrift.TIcebergDataFile;
 import com.starrocks.thrift.TSinkCommitInfo;
@@ -117,6 +119,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
@@ -377,7 +380,23 @@ public class IcebergMetadata implements ConnectorMetadata {
 
     @Override
     public void dropTable(ConnectContext context, DropTableStmt stmt) {
-        Table icebergTable = getTable(new ConnectContext(), stmt.getDbName(), stmt.getTableName());
+        Table icebergTable;
+        try {
+            icebergTable = getTable(new ConnectContext(), stmt.getDbName(), stmt.getTableName());
+        } catch (StarRocksConnectorException | NotFoundException e) {
+            if (!isMetadataFileMissing(e) || !isTableMetadataMissing(stmt.getDbName(), stmt.getTableName())) {
+                throw e;
+            }
+            // Iceberg tolerates this on drop: HiveCatalog#dropTable still removes the catalog entry when the
+            // metadata cannot be read. Never purge here, the table's files are unknown without its metadata.
+            LOG.warn("Metadata of iceberg table {}.{} is missing, only dropping the catalog entry",
+                    stmt.getDbName(), stmt.getTableName(), e);
+            icebergCatalog.dropTable(context, stmt.getDbName(), stmt.getTableName(), false);
+            tables.remove(TableIdentifier.of(stmt.getDbName(), stmt.getTableName()));
+            dropNameKeyedStatistics(stmt.getDbName(), stmt.getTableName());
+            asyncRefreshOthersFeMetadataCache(stmt.getDbName(), stmt.getTableName());
+            return;
+        }
 
         if (icebergTable != null && icebergTable.isIcebergView()) {
             icebergCatalog.dropView(context, stmt.getDbName(), stmt.getTableName());
@@ -392,6 +411,51 @@ public class IcebergMetadata implements ConnectorMetadata {
         tables.remove(TableIdentifier.of(stmt.getDbName(), stmt.getTableName()));
         StatisticUtils.dropStatisticsAfterDropTable(icebergTable);
         asyncRefreshOthersFeMetadataCache(stmt.getDbName(), stmt.getTableName());
+    }
+
+    /**
+     * Iceberg raises {@link NotFoundException} only for a file that is really absent, so an unreadable one
+     * (permission, connectivity) keeps propagating: that table's metadata may be intact and dropping its entry
+     * would orphan the data. The cause chain is walked because {@link CachingIcebergCatalog#getTable} wraps
+     * load failures into a {@link StarRocksConnectorException}.
+     */
+    private static boolean isMetadataFileMissing(Throwable throwable) {
+        return Throwables.getCausalChain(throwable).stream().anyMatch(t -> t instanceof NotFoundException);
+    }
+
+    /**
+     * {@link #getTable} also analyzes the table properties, which loads the tables a foreign key constraint
+     * refers to ({@link PropertyAnalyzer#analyzeForeignKeyConstraint}). Confirm the missing file is this
+     * table's own, or a healthy table would lose its catalog entry over a broken neighbour.
+     */
+    private boolean isTableMetadataMissing(String dbName, String tableName) {
+        try {
+            icebergCatalog.getTable(new ConnectContext(), dbName, tableName);
+            return false;
+        } catch (Exception e) {
+            return isMetadataFileMissing(e);
+        }
+    }
+
+    /**
+     * Drops what is reachable by name, so that a table recreated under this name does not inherit a broken
+     * table's leftovers. Data goes with the metadata describing it:
+     * {@link AnalyzeMgr#clearStatisticFromExternalDroppedTable} finds leftovers through the basic stats
+     * metadata, so dropping that alone would strand the rows for good. The rest is keyed by the table UUID,
+     * unreachable without the missing metadata and never mistaken for a recreated table's own statistics.
+     */
+    private void dropNameKeyedStatistics(String dbName, String tableName) {
+        IcebergCatalogType catalogType = icebergCatalog.getIcebergCatalogType();
+        if (catalogType == IcebergCatalogType.HIVE_CATALOG || catalogType == IcebergCatalogType.GLUE_CATALOG) {
+            // getTable() lower cases the names of these catalogs before the statistics get keyed by them
+            dbName = dbName.toLowerCase();
+            tableName = tableName.toLowerCase();
+        }
+
+        AnalyzeMgr analyzeMgr = GlobalStateMgr.getCurrentState().getAnalyzeMgr();
+        analyzeMgr.dropExternalBasicStatsMetaAndData(catalogName, dbName, tableName);
+        analyzeMgr.dropExternalHistogramStatsMetaAndData(catalogName, dbName, tableName);
+        analyzeMgr.dropAnalyzeJob(catalogName, dbName, tableName);
     }
 
     public void updateTableProperty(Database db, IcebergTable icebergTable) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
@@ -292,8 +292,10 @@ public class StatisticSQLBuilder {
     }
 
     public static String buildDropExternalStatSQL(String catalogName, String dbName, String tableName) {
-        return "DELETE FROM " + EXTERNAL_FULL_STATISTICS_TABLE_NAME + " WHERE CATALOG_NAME = '" + catalogName + "'" +
-                " AND DB_NAME = '" + dbName + "' AND TABLE_NAME = '" + tableName + "'";
+        return "DELETE FROM " + EXTERNAL_FULL_STATISTICS_TABLE_NAME +
+                " WHERE CATALOG_NAME = '" + SqlUtils.escapeSqlString(catalogName) + "'" +
+                " AND DB_NAME = '" + SqlUtils.escapeSqlString(dbName) + "'" +
+                " AND TABLE_NAME = '" + SqlUtils.escapeSqlString(tableName) + "'";
     }
 
     public static String buildDropPartitionSQL(List<Long> pids) {
@@ -369,9 +371,12 @@ public class StatisticSQLBuilder {
 
     public static String buildDropExternalHistogramSQL(String catalogName, String dbName, String tableName,
                                                        List<String> columnNames) {
-        return "delete from " + StatsConstants.EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME + " where catalog_name = '"
-                + catalogName + "' and db_name = '" + dbName + "' and table_name = '" + tableName + "' and column_name in ("
-                + Joiner.on(", ").join(columnNames.stream().map(c -> "'" + c + "'").collect(Collectors.toList())) + ")";
+        return "delete from " + StatsConstants.EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME
+                + " where catalog_name = '" + SqlUtils.escapeSqlString(catalogName) + "'"
+                + " and db_name = '" + SqlUtils.escapeSqlString(dbName) + "'"
+                + " and table_name = '" + SqlUtils.escapeSqlString(tableName) + "'"
+                + " and column_name in (" + Joiner.on(", ").join(columnNames.stream()
+                        .map(c -> "'" + SqlUtils.escapeSqlString(c) + "'").collect(Collectors.toList())) + ")";
     }
 
     private static String build(VelocityContext context, String template) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
@@ -19,6 +19,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Type;
+import com.starrocks.common.util.SqlUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.util.Strings;
 import org.apache.velocity.VelocityContext;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -100,7 +100,10 @@ import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.statistic.AnalyzeJob;
+import com.starrocks.statistic.AnalyzeMgr;
 import com.starrocks.statistic.ExternalAnalyzeJob;
+import com.starrocks.statistic.ExternalBasicStatsMeta;
+import com.starrocks.statistic.ExternalHistogramStatsMeta;
 import com.starrocks.statistic.StatsConstants;
 import com.starrocks.thrift.TIcebergColumnStats;
 import com.starrocks.thrift.TIcebergDataFile;
@@ -136,6 +139,7 @@ import org.apache.iceberg.UpdateProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.HiveTableOperations;
 import org.apache.iceberg.io.CloseableIterable;
@@ -629,6 +633,200 @@ public class IcebergMetadataTest extends TableTestBase {
         } catch (Exception e) {
             Assertions.fail();
         }
+    }
+
+    @Test
+    public void testDropTableWithMissingMetadataFile() {
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), null);
+
+        String missingMetadata = "File does not exist: oss://bucket/db/table1/metadata/00000-abc.metadata.json";
+
+        // CachingIcebergCatalog wraps the load failure, so NotFoundException only shows up as a cause.
+        new Expectations(icebergHiveCatalog) {
+            {
+                icebergHiveCatalog.getTable((ConnectContext) any, "iceberg_db", "table1");
+                result = new StarRocksConnectorException("Failed to get iceberg table",
+                        new NotFoundException(missingMetadata));
+                minTimes = 1;
+
+                // FORCE was asked for, but the fallback never purges: the table's files are unknown.
+                icebergHiveCatalog.dropTable((ConnectContext) any, "iceberg_db", "table1", false);
+                result = true;
+                times = 1;
+            }
+        };
+
+        metadata.dropTable(connectContext, new DropTableStmt(true,
+                new TableRef(QualifiedName.of(Lists.newArrayList(CATALOG_NAME,
+                        "iceberg_db", "table1")), null, NodePosition.ZERO), true));
+    }
+
+    @Test
+    public void testDropTableWithMissingMetadataFileNotWrapped() {
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), null);
+
+        // Without the caching catalog the raw NotFoundException reaches IcebergMetadata.
+        new Expectations(icebergHiveCatalog) {
+            {
+                icebergHiveCatalog.getTable((ConnectContext) any, "iceberg_db", "table1");
+                result = new NotFoundException("File does not exist: oss://bucket/db/table1/metadata/00000-abc.metadata.json");
+                minTimes = 1;
+
+                icebergHiveCatalog.dropTable((ConnectContext) any, "iceberg_db", "table1", false);
+                result = true;
+                times = 1;
+            }
+        };
+
+        metadata.dropTable(connectContext, new DropTableStmt(false,
+                new TableRef(QualifiedName.of(Lists.newArrayList(CATALOG_NAME,
+                        "iceberg_db", "table1")), null, NodePosition.ZERO), false));
+    }
+
+    @Test
+    public void testDropTableKeepsFailingWhenMetadataIsUnreadable() {
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), null);
+
+        // Unreadable, not missing: the metadata may be intact, so dropping the entry would orphan the data.
+        new Expectations(icebergHiveCatalog) {
+            {
+                icebergHiveCatalog.getTable((ConnectContext) any, "iceberg_db", "table1");
+                result = new StarRocksConnectorException("Failed to get iceberg table",
+                        new IOException("Access denied"));
+                minTimes = 1;
+
+                icebergHiveCatalog.dropTable((ConnectContext) any, anyString, anyString, anyBoolean);
+                times = 0;
+            }
+        };
+
+        Assertions.assertThrows(StarRocksConnectorException.class, () ->
+                metadata.dropTable(connectContext, new DropTableStmt(true,
+                        new TableRef(QualifiedName.of(Lists.newArrayList(CATALOG_NAME,
+                                "iceberg_db", "table1")), null, NodePosition.ZERO), true)));
+    }
+
+    @Test
+    public void testDropTableWithMissingMetadataFileDropsStatistics() throws AlreadyExistsException {
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), null);
+        String dbName = "iceberg_db";
+        String tableName = "table_missing_meta";
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public long getNextId() {
+                return 1;
+            }
+
+            @Mock
+            public EditLog getEditLog() {
+                return new EditLog(new ArrayBlockingQueue<>(100));
+            }
+        };
+
+        new MockUp<EditLog>() {
+            @Mock
+            public void logAddAnalyzeJob(AnalyzeJob job, WALApplier walApplier) {
+                walApplier.apply(job);
+            }
+
+            @Mock
+            public void logRemoveAnalyzeJob(AnalyzeJob job, WALApplier walApplier) {
+                walApplier.apply(job);
+            }
+
+            @Mock
+            public void logAddExternalBasicStatsMeta(ExternalBasicStatsMeta meta, WALApplier walApplier) {
+                walApplier.apply(meta);
+            }
+
+            @Mock
+            public void logRemoveExternalBasicStatsMeta(ExternalBasicStatsMeta meta, WALApplier walApplier) {
+                walApplier.apply(meta);
+            }
+
+            @Mock
+            public void logAddExternalHistogramStatsMeta(ExternalHistogramStatsMeta meta, WALApplier walApplier) {
+                walApplier.apply(meta);
+            }
+
+            @Mock
+            public void logRemoveExternalHistogramStatsMeta(ExternalHistogramStatsMeta meta, WALApplier walApplier) {
+                walApplier.apply(meta);
+            }
+        };
+
+        AnalyzeMgr analyzeMgr = GlobalStateMgr.getCurrentState().getAnalyzeMgr();
+        analyzeMgr.addAnalyzeJob(new ExternalAnalyzeJob(CATALOG_NAME, dbName, tableName,
+                Lists.newArrayList(), Lists.newArrayList(), StatsConstants.AnalyzeType.FULL,
+                StatsConstants.ScheduleType.ONCE, Maps.newHashMap(),
+                StatsConstants.ScheduleStatus.PENDING, LocalDateTime.MIN));
+        analyzeMgr.addExternalBasicStatsMeta(new ExternalBasicStatsMeta(CATALOG_NAME, dbName, tableName,
+                Lists.newArrayList(), StatsConstants.AnalyzeType.FULL, LocalDateTime.MIN, Maps.newHashMap()));
+        analyzeMgr.addExternalHistogramStatsMeta(new ExternalHistogramStatsMeta(CATALOG_NAME, dbName, tableName,
+                "c1", StatsConstants.AnalyzeType.HISTOGRAM, LocalDateTime.MIN, Maps.newHashMap()));
+
+        new Expectations(icebergHiveCatalog) {
+            {
+                icebergHiveCatalog.getTable((ConnectContext) any, dbName, tableName);
+                result = new StarRocksConnectorException("Failed to get iceberg table",
+                        new NotFoundException("File does not exist: oss://bucket/db/t/metadata/00000-abc.metadata.json"));
+                minTimes = 1;
+
+                icebergHiveCatalog.dropTable((ConnectContext) any, dbName, tableName, false);
+                result = true;
+                times = 1;
+            }
+        };
+
+        metadata.dropTable(connectContext, new DropTableStmt(true,
+                new TableRef(QualifiedName.of(Lists.newArrayList(CATALOG_NAME, dbName, tableName)),
+                        null, NodePosition.ZERO), true));
+
+        // A table recreated under the same name must not inherit the leftovers of the broken one.
+        Assertions.assertTrue(analyzeMgr.getAllAnalyzeJobList().stream()
+                        .noneMatch(job -> tableName.equals(((ExternalAnalyzeJob) job).getTableName())),
+                "the analyze job of the dropped table should be gone");
+        Assertions.assertTrue(analyzeMgr.getExternalBasicStatsMetaMap().keySet().stream()
+                        .noneMatch(key -> tableName.equals(key.getTableName())),
+                "the basic stats meta of the dropped table should be gone");
+        Assertions.assertTrue(analyzeMgr.getExternalHistogramStatsMetaMap().keySet().stream()
+                        .noneMatch(key -> tableName.equals(key.getTableKey().getTableName())),
+                "the histogram stats meta of the dropped table should be gone");
+    }
+
+    @Test
+    public void testDropTableKeepsFailingWhenAnotherTableMetadataIsMissing() {
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), null);
+
+        // The table being dropped is healthy; the missing file belongs to a table its foreign key
+        // constraint refers to, which getTable() loads too.
+        new Expectations(icebergHiveCatalog) {
+            {
+                icebergHiveCatalog.getTable((ConnectContext) any, "iceberg_db", "table1");
+                result = new StarRocksConnectorException("Failed to get iceberg table",
+                        new NotFoundException("File does not exist: oss://bucket/db/other/metadata/00000-abc.metadata.json"));
+                result = mockedNativeTableA;
+
+                icebergHiveCatalog.dropTable((ConnectContext) any, anyString, anyString, anyBoolean);
+                times = 0;
+            }
+        };
+
+        Assertions.assertThrows(StarRocksConnectorException.class, () ->
+                metadata.dropTable(connectContext, new DropTableStmt(true,
+                        new TableRef(QualifiedName.of(Lists.newArrayList(CATALOG_NAME,
+                                "iceberg_db", "table1")), null, NodePosition.ZERO), true)));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -639,9 +639,21 @@ public class IcebergMetadataTest extends TableTestBase {
     public void testDropTableWithMissingMetadataFile() {
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
-                Executors.newSingleThreadExecutor(), null);
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
 
         String missingMetadata = "File does not exist: oss://bucket/db/table1/metadata/00000-abc.metadata.json";
+
+        // The statistics cleanup issues real DML, which has no warehouse to run in here; it has a test
+        // of its own below.
+        new MockUp<AnalyzeMgr>() {
+            @Mock
+            public void dropExternalBasicStatsMetaAndData(String catalogName, String dbName, String tableName) {
+            }
+
+            @Mock
+            public void dropExternalHistogramStatsMetaAndData(String catalogName, String dbName, String tableName) {
+            }
+        };
 
         // CachingIcebergCatalog wraps the load failure, so NotFoundException only shows up as a cause.
         new Expectations(icebergHiveCatalog) {
@@ -659,17 +671,28 @@ public class IcebergMetadataTest extends TableTestBase {
         };
 
         metadata.dropTable(connectContext, new DropTableStmt(true,
-                new TableRef(QualifiedName.of(Lists.newArrayList(CATALOG_NAME,
-                        "iceberg_db", "table1")), null, NodePosition.ZERO), true));
+                new TableName(CATALOG_NAME, "iceberg_db", "table1"), true));
     }
 
     @Test
     public void testDropTableWithMissingMetadataFileNotWrapped() {
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
-                Executors.newSingleThreadExecutor(), null);
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
 
         // Without the caching catalog the raw NotFoundException reaches IcebergMetadata.
+
+        // The statistics cleanup issues real DML, which has no warehouse to run in here; it has a test
+        // of its own below.
+        new MockUp<AnalyzeMgr>() {
+            @Mock
+            public void dropExternalBasicStatsMetaAndData(String catalogName, String dbName, String tableName) {
+            }
+
+            @Mock
+            public void dropExternalHistogramStatsMetaAndData(String catalogName, String dbName, String tableName) {
+            }
+        };
         new Expectations(icebergHiveCatalog) {
             {
                 icebergHiveCatalog.getTable((ConnectContext) any, "iceberg_db", "table1");
@@ -683,15 +706,14 @@ public class IcebergMetadataTest extends TableTestBase {
         };
 
         metadata.dropTable(connectContext, new DropTableStmt(false,
-                new TableRef(QualifiedName.of(Lists.newArrayList(CATALOG_NAME,
-                        "iceberg_db", "table1")), null, NodePosition.ZERO), false));
+                new TableName(CATALOG_NAME, "iceberg_db", "table1"), false));
     }
 
     @Test
     public void testDropTableKeepsFailingWhenMetadataIsUnreadable() {
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
-                Executors.newSingleThreadExecutor(), null);
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
 
         // Unreadable, not missing: the metadata may be intact, so dropping the entry would orphan the data.
         new Expectations(icebergHiveCatalog) {
@@ -708,15 +730,14 @@ public class IcebergMetadataTest extends TableTestBase {
 
         Assertions.assertThrows(StarRocksConnectorException.class, () ->
                 metadata.dropTable(connectContext, new DropTableStmt(true,
-                        new TableRef(QualifiedName.of(Lists.newArrayList(CATALOG_NAME,
-                                "iceberg_db", "table1")), null, NodePosition.ZERO), true)));
+                        new TableName(CATALOG_NAME, "iceberg_db", "table1"), true)));
     }
 
     @Test
     public void testDropTableWithMissingMetadataFileDropsStatistics() throws AlreadyExistsException {
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
-                Executors.newSingleThreadExecutor(), null);
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
         String dbName = "iceberg_db";
         String tableName = "table_missing_meta";
 
@@ -734,33 +755,27 @@ public class IcebergMetadataTest extends TableTestBase {
 
         new MockUp<EditLog>() {
             @Mock
-            public void logAddAnalyzeJob(AnalyzeJob job, WALApplier walApplier) {
-                walApplier.apply(job);
+            public void logAddAnalyzeJob(AnalyzeJob job) {
             }
 
             @Mock
-            public void logRemoveAnalyzeJob(AnalyzeJob job, WALApplier walApplier) {
-                walApplier.apply(job);
+            public void logRemoveAnalyzeJob(AnalyzeJob job) {
             }
 
             @Mock
-            public void logAddExternalBasicStatsMeta(ExternalBasicStatsMeta meta, WALApplier walApplier) {
-                walApplier.apply(meta);
+            public void logAddExternalBasicStatsMeta(ExternalBasicStatsMeta meta) {
             }
 
             @Mock
-            public void logRemoveExternalBasicStatsMeta(ExternalBasicStatsMeta meta, WALApplier walApplier) {
-                walApplier.apply(meta);
+            public void logRemoveExternalBasicStatsMeta(ExternalBasicStatsMeta meta) {
             }
 
             @Mock
-            public void logAddExternalHistogramStatsMeta(ExternalHistogramStatsMeta meta, WALApplier walApplier) {
-                walApplier.apply(meta);
+            public void logAddExternalHistogramStatsMeta(ExternalHistogramStatsMeta meta) {
             }
 
             @Mock
-            public void logRemoveExternalHistogramStatsMeta(ExternalHistogramStatsMeta meta, WALApplier walApplier) {
-                walApplier.apply(meta);
+            public void logRemoveExternalHistogramStatsMeta(ExternalHistogramStatsMeta meta) {
             }
         };
 
@@ -788,8 +803,7 @@ public class IcebergMetadataTest extends TableTestBase {
         };
 
         metadata.dropTable(connectContext, new DropTableStmt(true,
-                new TableRef(QualifiedName.of(Lists.newArrayList(CATALOG_NAME, dbName, tableName)),
-                        null, NodePosition.ZERO), true));
+                new TableName(CATALOG_NAME, dbName, tableName), true));
 
         // A table recreated under the same name must not inherit the leftovers of the broken one.
         Assertions.assertTrue(analyzeMgr.getAllAnalyzeJobList().stream()
@@ -807,7 +821,7 @@ public class IcebergMetadataTest extends TableTestBase {
     public void testDropTableKeepsFailingWhenAnotherTableMetadataIsMissing() {
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
-                Executors.newSingleThreadExecutor(), null);
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
 
         // The table being dropped is healthy; the missing file belongs to a table its foreign key
         // constraint refers to, which getTable() loads too.
@@ -825,8 +839,7 @@ public class IcebergMetadataTest extends TableTestBase {
 
         Assertions.assertThrows(StarRocksConnectorException.class, () ->
                 metadata.dropTable(connectContext, new DropTableStmt(true,
-                        new TableRef(QualifiedName.of(Lists.newArrayList(CATALOG_NAME,
-                                "iceberg_db", "table1")), null, NodePosition.ZERO), true)));
+                        new TableName(CATALOG_NAME, "iceberg_db", "table1"), true)));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticSQLBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticSQLBuilderTest.java
@@ -1,0 +1,37 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.statistic;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class StatisticSQLBuilderTest {
+
+    @Test
+    void nameBasedDeletesEscapeNames() {
+        String sql = StatisticSQLBuilder.buildDropExternalStatSQL("ice'berg", "d'b", "o'brien\\table");
+        Assertions.assertTrue(sql.contains("CATALOG_NAME = 'ice''berg'"), sql);
+        Assertions.assertTrue(sql.contains("DB_NAME = 'd''b'"), sql);
+        Assertions.assertTrue(sql.contains("TABLE_NAME = 'o''brien\\\\table'"), sql);
+
+        String histogramSql = StatisticSQLBuilder.buildDropExternalHistogramSQL("ice'berg", "d'b", "o'brien",
+                ImmutableList.of("c'1"));
+        Assertions.assertTrue(histogramSql.contains("catalog_name = 'ice''berg'"), histogramSql);
+        Assertions.assertTrue(histogramSql.contains("db_name = 'd''b'"), histogramSql);
+        Assertions.assertTrue(histogramSql.contains("table_name = 'o''brien'"), histogramSql);
+        Assertions.assertTrue(histogramSql.contains("column_name in ('c''1')"), histogramSql);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Once the metadata file a catalog entry points at is gone from the storage, the iceberg table it describes can no longer be dropped through StarRocks — not even with `DROP TABLE IF EXISTS ... FORCE`, which is exactly the statement meant to get rid of a broken table:

```
mysql> DROP TABLE IF EXISTS iceberg_catalog.db.t FORCE;
ERROR 1064 (HY000): File does not exist: oss://.../db/t/metadata/00000-....metadata.json
```

The metastore entry then has no SQL way out and has to be removed by hand. `DROP DATABASE` is blocked too, since the database never becomes empty.

`IcebergMetadata#dropTable` loads the table before doing anything else, so the load failure keeps the code from ever reaching `icebergCatalog#dropTable`. The loaded table is only used to tell a view apart from a table and to clean up statistics — removing the catalog entry itself needs nothing but the database and table name. Iceberg is already tolerant here: `HiveCatalog#dropTable` skips the purge when the metadata cannot be read and still removes the entry, so the drop works as soon as it is reached.

The failure only shows up when the table is in neither of the two FE caches (a restarted FE, another FE, a rebuilt catalog), which is why it is usually leftovers from an earlier run that cannot be cleaned up.

## What I'm doing:

Fall back to dropping the catalog entry alone when the table cannot be loaded because its metadata file is missing. The fallback never purges: without the metadata there is no way to tell which data files belong to the table, so they are left behind for orphan-file cleanup rather than deleted from a state that could not be validated.

Two guards keep the fallback narrow, so that a table only ever loses its catalog entry when that entry is really the broken one:

- Only an iceberg `NotFoundException` in the cause chain counts as missing. An unreadable file — a permission or connectivity failure — still propagates, because the metadata may well be intact and dropping the entry would orphan the data. The chain has to be walked because `CachingIcebergCatalog#getTable` wraps load failures into a `StarRocksConnectorException`.
- The table is loaded once more on its own before the fallback runs. `getTable()` does more than load the table: it also analyzes the table properties, and a foreign key constraint makes it load the referenced tables. A file missing over there must not be read as this table being broken.

Two things go along with the fallback. The statistics that are reachable by name are dropped with the entry — the analyze job and the basic and histogram statistics together with their collected rows — so a table recreated under the same name does not inherit them. And the two name-keyed deletes they go through, in `StatisticSQLBuilder`, interpolated catalog, database, table and column names into their predicates unescaped; they are escaped now. That builder is the only file this PR touches outside the iceberg connector.

Fixes StarRocks/StarRocksTest#11511

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5

