### PR TITLE
[Enhancement] Support MAP arguments in UNNEST for the Trino dialect

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -1985,6 +1985,26 @@ public class QueryAnalyzer {
             if (names != null && !names.isEmpty()) {
                 namesArray = names.toArray(String[]::new);
             }
+
+            if (session.getSessionVariable().getSqlDialect().equalsIgnoreCase("trino") && namesArray == null &&
+                    node.getFunctionName().getFunction().equalsIgnoreCase(FunctionSet.UNNEST)) {
+                List<Expr> expandedArgs = new ArrayList<>();
+                for (Expr arg : args) {
+                    if (arg.getType().isMapType()) {
+                        FunctionCallExpr mapKeys = new FunctionCallExpr(FunctionSet.MAP_KEYS, Lists.newArrayList(arg));
+                        FunctionCallExpr mapValues = new FunctionCallExpr(FunctionSet.MAP_VALUES, Lists.newArrayList(arg));
+                        analyzeExpression(mapKeys, analyzeState, scope);
+                        analyzeExpression(mapValues, analyzeState, scope);
+                        expandedArgs.add(mapKeys);
+                        expandedArgs.add(mapValues);
+                    } else {
+                        expandedArgs.add(arg);
+                    }
+                }
+                args = expandedArgs;
+                argTypes = args.stream().map(Expr::getType).toArray(Type[]::new);
+            }
+
             Function fn = ExprUtils.getBuiltinFunction(node.getFunctionName().getFunction(), argTypes, namesArray,
                     Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
 
@@ -2008,10 +2028,10 @@ public class QueryAnalyzer {
             if (namesArray != null) {
                 Preconditions.checkState(fn.hasNamedArg());
                 childExpressions = reorderNamedArgAndAppendDefaults(node.getFunctionParams(), fn);
-            } else if (node.getFunctionParams().exprs().size() < fn.getNumArgs()) {
+            } else if (args.size() < fn.getNumArgs()) {
                 childExpressions = appendPositionalDefaultArgExprs(node.getFunctionParams(), fn);
             } else {
-                childExpressions = node.getFunctionParams().exprs();
+                childExpressions = args;
             }
             Preconditions.checkState(childExpressions.size() == fn.getNumArgs());
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -1204,6 +1204,34 @@ public class TrinoQueryTest extends TrinoTestBase {
                 "cross join unnest(plat.pid) as t(plat_id);";
         assertPlanContains(sql, "[1,2]", "[10: expr,11: expr]", "returnTypes: [TINYINT, ARRAY<TINYINT>]",
                 "returnTypes: [TINYINT]");
+
+        sql = "select language, first_appeared_year from (values 1) as x(dummy) " +
+                "cross join unnest(map(array['SQL', 'Java'], array[1974, 1995])) " +
+                "as t(language, first_appeared_year)";
+        assertPlanContains(sql, "tableFunctionName: unnest", "map_keys(map_from_arrays",
+                "map_values(map_from_arrays", "returnTypes: [VARCHAR, SMALLINT]");
+
+        sql = "select map_key, map_value from test_map " +
+                "cross join unnest(c1) as t(map_key, map_value)";
+        assertPlanContains(sql, "map_keys(2: c1)", "map_values(2: c1)", "returnTypes: [INT, INT]");
+
+        sql = "select map_key, map_value, array_value from (values 1) as x(dummy) " +
+                "cross join unnest(map(array[1, 2], array['a', 'b']), " +
+                "array[10000000000, 20000000000, 30000000000]) " +
+                "as t(map_key, map_value, array_value)";
+        assertPlanContains(sql, "tableFunctionName: unnest", "map_keys(map_from_arrays",
+                "map_values(map_from_arrays", "[10000000000,20000000000,30000000000]",
+                "returnTypes: [TINYINT, VARCHAR, BIGINT]");
+
+        assertPlanContains("select map_key, map_value from (values 1) as x(dummy) " +
+                        "cross join unnest(map()) as t(map_key, map_value)",
+                "tableFunctionName: unnest", "map_keys", "map_values");
+        assertPlanContains("select map_key, map_value from test_map " +
+                        "cross join unnest(if(c0 > 0, c1, null)) as t(map_key, map_value)",
+                "tableFunctionName: unnest", "map_keys(", "map_values(", "returnTypes: [INT, INT]");
+        analyzeFail("select * from (values 1) as x(dummy) " +
+                        "cross join unnest(map(array[1], array['a'])) as t(map_key)",
+                "table t has 2 columns available but 1 columns specified");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeLateralTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeLateralTest.java
@@ -48,6 +48,7 @@ public class AnalyzeLateralTest {
         analyzeFail("select * from tarray, unknow_table_function(v2)",
                 "Unknown table function 'unknow_table_function(BIGINT)'");
         analyzeFail("select * from tarray,unnest(v2)", "Unknown table function 'unnest(BIGINT)'");
+        analyzeFail("select * from t0,unnest(map{1:2})", "Unknown table function 'unnest(MAP<TINYINT,TINYINT>)'");
         analyzeFail("select * from tarray,unnest(foo)", "Column 'foo' cannot be resolved");
         analyzeFail("select * from t0 cross join lateral t1", "Only support lateral join with UDTF");
         analyzeFail("select  unnest(split('1,2,3',','))", "Table function cannot be used in expression");


### PR DESCRIPTION

## Why I'm doing:

Trino supports passing a MAP expression to `UNNEST` and expands it into two columns containing the map keys and values.

For example:

```sql
SET sql_dialect = 'trino';

SELECT map_key, map_value
FROM (VALUES 1) AS x(dummy)
CROSS JOIN UNNEST(
    MAP(ARRAY[1, 2], ARRAY['a', 'b'])
) AS t(map_key, map_value);
```

StarRocks currently fails to resolve this query:

```text
Unknown table function 'unnest(MAP<TINYINT,VARCHAR>)'
```

This prevents Trino queries using `UNNEST(map_expr)` from running in StarRocks even when `sql_dialect` is set to `trino`.

## What I'm doing:

Support MAP arguments in `UNNEST` when `sql_dialect = 'trino'`.

During table-function analysis, each MAP argument is lowered to two ARRAY expressions. For example:

```sql
UNNEST(map_expr)
```

is analyzed as:

```sql
UNNEST(map_keys(map_expr), map_values(map_expr))
```

The rewritten arguments are then resolved and executed by the existing multi-array `UNNEST` implementation.

This also supports MAP and ARRAY arguments in the same call:

```sql
SET sql_dialect = 'trino';

SELECT map_key, map_value, array_value
FROM (VALUES 1) AS x(dummy)
CROSS JOIN UNNEST(
    MAP(ARRAY[1, 2], ARRAY['a', 'b']),
    ARRAY[10, 20, 30]
) AS t(map_key, map_value, array_value);
```

The existing multi-array null-padding behavior is preserved. In this example, the third row contains `NULL` for `map_key` and `map_value`, and `30` for `array_value`.

### Why this is implemented in `QueryAnalyzer`

`QueryAnalyzer.visitTableFunction` is the appropriate place for this Trino compatibility conversion because it has all the information required by the rewrite:

- The function arguments have already been analyzed, so MAP-typed columns and expressions can be identified reliably.
- The current session SQL dialect is available, so the behavior can be restricted to `sql_dialect = 'trino'`.
- The rewrite happens before table-function overload resolution, allowing the existing ARRAY-based `UNNEST` function to be reused.
- The expanded columns continue through the existing output alias validation and multi-argument null-padding logic.

This is not implemented in the Trino parser because the parser only handles syntax and does not know the resolved type of a column or expression. A parser-level rewrite could handle a MAP literal, but it could not reliably recognize a MAP-typed column.

This is also not implemented by adding a generic MAP overload to the table-function registry because function signatures are shared across SQL dialects. Registering `UNNEST(MAP)` there would also enable the syntax in the default StarRocks dialect.

No Backend implementation is required because StarRocks already provides the necessary execution capabilities through `map_keys`, `map_values`, and multi-array `UNNEST`.

Therefore, this change is implemented as a Trino-specific analyzer lowering. It does not add parser grammar, a new table-function signature, or a new Backend execution path.

The change covers:

- MAP literals.
- MAP-typed columns and expressions.
- MAP and ARRAY arguments in the same `UNNEST` call.
- Empty MAP values.
- NULL MAP values.
- Explicit output column alias validation.
- Existing multi-argument null-padding behavior.

The default StarRocks dialect remains unchanged and still rejects direct MAP arguments to `UNNEST`.

The following FE tests are added:

- A single MAP literal producing key and value columns.
- A MAP-typed table column.
- MAP and ARRAY arguments in the same call.
- Empty and NULL MAP values.
- Correct and incorrect explicit output column aliases.
- Rejection of `UNNEST(map_expr)` in the default StarRocks dialect.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
````