### PR TITLE
[BugFix] Complete the first cloud-native persistent index checkpoint

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -19,6 +19,7 @@
 #include <unordered_map>
 
 #include "base/debug/trace.h"
+#include "base/testutil/sync_point.h"
 #include "base/utility/defer_op.h"
 #include "column/chunk_factory.h"
 #include "column/column_helper.h"
@@ -258,8 +259,10 @@ Status LakePersistentIndex::ingest_sst(const FileMetaPB& sst_meta, const Persist
     sstable_pb.mutable_range()->CopyFrom(sst_range);
     RETURN_IF_ERROR(
             sstable->init(std::move(rf), sstable_pb, block_cache->cache(), true /* need filter */, std::move(delvec)));
+    const uint64_t direct_max_rss_rowid = sstable_pb.max_rss_rowid();
     // try to merge to a existing fileset
     RETURN_IF_ERROR(merge_sstable_into_fileset(sstable));
+    _memtable->advance_max_rss_rowid(direct_max_rss_rowid);
     TRACE_COUNTER_INCREMENT("ingest_sst_times", 1);
     return Status::OK();
 }
@@ -613,7 +616,9 @@ Status LakePersistentIndex::bulk_erase(size_t n, const Slice* keys, IndexValue* 
     sstable_pb.mutable_range()->CopyFrom(del_sst_range);
     auto sstable = std::make_unique<PersistentIndexSstable>();
     RETURN_IF_ERROR(sstable->init(std::move(rf), sstable_pb, block_cache->cache()));
+    const uint64_t direct_max_rss_rowid = sstable_pb.max_rss_rowid();
     RETURN_IF_ERROR(merge_sstable_into_fileset(sstable));
+    _memtable->advance_max_rss_rowid(direct_max_rss_rowid);
     TRACE_COUNTER_INCREMENT("bulk_erase_keys", n);
     return Status::OK();
 }
@@ -1729,6 +1734,7 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
     const bool use_parallel = should_parallel_rebuild_prefetch(rebuild_unit_count);
 
     if (use_parallel) {
+        TEST_SYNC_POINT_CALLBACK("LakePersistentIndex::load_from_lake_tablet:parallel", nullptr);
         // Phase A: build all rebuild rowsets' iterators + flat scan units (each segment with its own
         // stats), since the parallel scan needs them all alive concurrently.
         ASSIGN_OR_RETURN(auto plan, build_rebuild_scan_units(tablet_mgr, metadata, base_version, builder, pkey_schema,
@@ -1787,6 +1793,7 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
             }
         }
     } else {
+        TEST_SYNC_POINT_CALLBACK("LakePersistentIndex::load_from_lake_tablet:serial", nullptr);
         // Serial fallback: build, scan-and-insert, and release ONE rowset at a time, so peak memory is
         // bounded to a single rowset's iterators plus one decoded chunk. Inserts each chunk straight
         // away (at most one chunk held), and applies a rowset's del files after its segments.

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -1079,6 +1079,12 @@ Status LakePersistentIndex::commit(MetaFileBuilder* builder, int64_t generation_
         // we need to do flush to reduce index rebuild cost later.
         RETURN_IF_ERROR(flush_memtable(true));
     }
+    const bool first_nonempty_checkpoint =
+            builder->tablet_meta()->sstable_meta().sstables().empty() && !_sstable_filesets.empty();
+    const bool has_pending_memtable = !_inactive_memtables.empty() || (_memtable != nullptr && !_memtable->empty());
+    if (first_nonempty_checkpoint && has_pending_memtable) {
+        RETURN_IF_ERROR(sync_flush_all_memtables(config::pk_index_memtable_max_wait_flush_timeout_ms * 1000));
+    }
     PersistentIndexSstableMetaPB sstable_meta;
     int64_t last_max_rss_rowid = 0;
     for (auto& sstable_fileset : _sstable_filesets) {

--- a/be/src/storage/lake/persistent_index_memtable.cpp
+++ b/be/src/storage/lake/persistent_index_memtable.cpp
@@ -14,10 +14,15 @@
 
 #include "storage/lake/persistent_index_memtable.h"
 
+#include <utility>
+
 #include "base/debug/trace.h"
 #include "base/string/string_util.h"
+#include "base/testutil/sync_point.h"
+#include "base/utility/defer_op.h"
 #include "common/config_primary_key_fwd.h"
 #include "common/config_rowset_fwd.h"
+#include "fs/fs_util.h"
 #include "platform/key_cache.h"
 #include "storage/lake/persistent_index_sstable.h"
 #include "storage/lake/tablet_manager.h"
@@ -214,6 +219,7 @@ Status PersistentIndexMemtable::flush() {
     }
     auto filename = gen_sst_filename();
     auto location = _tablet_mgr->sst_location(_tablet_id, filename);
+    CancelableDefer cleanup_output([&] { (void)fs::delete_file(location); });
     WritableFileOptions wopts;
     std::string encryption_meta;
     if (config::enable_transparent_data_encryption) {
@@ -222,6 +228,10 @@ Status PersistentIndexMemtable::flush() {
         encryption_meta.swap(pair.encryption_meta);
     }
     ASSIGN_OR_RETURN(auto wf, fs::new_writable_file(wopts, location));
+    Status injected_status;
+    std::pair<const std::string*, Status*> hook_arg{&location, &injected_status};
+    TEST_SYNC_POINT_CALLBACK("PersistentIndexMemtable::flush:after_create", &hook_arg);
+    RETURN_IF_ERROR(injected_status);
     uint64_t filesize = 0;
     PersistentIndexSstableRangePB range_pb;
     RETURN_IF_ERROR(flush(wf.get(), &filesize, &range_pb));
@@ -242,7 +252,15 @@ Status PersistentIndexMemtable::flush() {
     RETURN_IF_ERROR(sstable->init(std::move(rf), sstable_pb, block_cache->cache()));
     std::lock_guard<std::mutex> lg(_flush_mutex);
     _sstable = std::move(sstable);
+    cleanup_output.cancel();
     return Status::OK();
+}
+
+void PersistentIndexMemtable::advance_max_rss_rowid(uint64_t max_rss_rowid) {
+    DCHECK(empty());
+    std::lock_guard<std::mutex> lg(_flush_mutex);
+    DCHECK(_sstable == nullptr);
+    _max_rss_rowid = std::max(_max_rss_rowid, max_rss_rowid);
 }
 
 void PersistentIndexMemtable::clear() {
@@ -254,9 +272,12 @@ void PersistentIndexMemtable::run() {
     auto st = flush();
     if (!st.ok()) {
         LOG(ERROR) << "PersistentIndexMemtable flush failed for tablet " << _tablet_id << ": " << st;
+    }
+    {
         std::lock_guard<std::mutex> lg(_flush_mutex);
         _flush_status = st;
     }
+    TEST_SYNC_POINT_CALLBACK("PersistentIndexMemtable::run:after_flush", &_flush_status);
 }
 
 void PersistentIndexMemtable::cancel() {

--- a/be/src/storage/lake/persistent_index_memtable.h
+++ b/be/src/storage/lake/persistent_index_memtable.h
@@ -79,6 +79,8 @@ public:
 
     Status flush();
 
+    void advance_max_rss_rowid(uint64_t max_rss_rowid);
+
     void clear();
 
     const uint64_t max_rss_rowid() const { return _max_rss_rowid; }

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -18,12 +18,16 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <array>
 #include <atomic>
+#include <chrono>
 #include <cstdint>
+#include <future>
 #include <iterator>
 #include <limits>
 #include <memory>
 #include <mutex>
+#include <set>
 #include <utility>
 #include <vector>
 
@@ -426,6 +430,131 @@ protected:
         }
         RETURN_IF_ERROR(iterator->status());
         return entries;
+    }
+
+    void wait_for_one_async_memtable_flush(LakePersistentIndex* index) {
+        std::promise<Status> flushed;
+        auto future = flushed.get_future();
+        std::atomic<bool> notified = false;
+        SyncPoint::GetInstance()->SetCallBack("PersistentIndexMemtable::run:after_flush", [&](void* arg) {
+            if (!notified.exchange(true)) {
+                flushed.set_value(*static_cast<Status*>(arg));
+            }
+        });
+        SyncPoint::GetInstance()->EnableProcessing();
+        ASSERT_OK(index->flush_memtable(true));
+        ASSERT_EQ(std::future_status::ready, future.wait_for(std::chrono::seconds(10)));
+        ASSERT_OK(future.get());
+        EXPECT_EQ(1, notified.load());
+        SyncPoint::GetInstance()->ClearCallBack("PersistentIndexMemtable::run:after_flush");
+        SyncPoint::GetInstance()->DisableProcessing();
+    }
+
+    std::vector<IndexValue> cold_reload_values(const TabletMetadataPtr& metadata, int64_t version,
+                                               const std::vector<std::string>& keys) {
+        Tablet tablet(_tablet_mgr.get(), metadata->id());
+        auto reloaded_metadata = std::make_shared<TabletMetadata>();
+        reloaded_metadata->CopyFrom(*metadata);
+        MetaFileBuilder builder(tablet, reloaded_metadata);
+        auto reloaded = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), metadata->id());
+        CHECK_OK(reloaded->init(metadata));
+        CHECK_OK(reloaded->load_from_lake_tablet(_tablet_mgr.get(), metadata, version, &builder));
+        std::vector<Slice> slices;
+        slices.reserve(keys.size());
+        for (const auto& key : keys) {
+            slices.emplace_back(key);
+        }
+        std::vector<IndexValue> values(keys.size());
+        CHECK_OK(reloaded->get(keys.size(), slices.data(), values.data()));
+        return values;
+    }
+
+    void run_complete_checkpoint_cache_only_tail(bool parallel) {
+        constexpr uint32_t kEarlierHighRssid = 100;
+        constexpr uint32_t kLaterLowRssid = 50;
+        constexpr uint32_t kPostFrontierRssid1 = 101;
+        constexpr uint32_t kPostFrontierRssid2 = 102;
+        constexpr int64_t kFirstCommitVersion = 3;
+        constexpr int64_t kLaterCommitVersion = 5;
+
+        auto md = make_varchar_pk_metadata();
+        md->set_version(kFirstCommitVersion);
+        md->set_next_rowset_id(kPostFrontierRssid2 + 1);
+        ASSERT_OK(_tablet_mgr->put_tablet_metadata(*md));
+
+        std::vector<std::string> high_keys;
+        std::vector<std::string> low_keys;
+        std::vector<std::string> post_keys1;
+        std::vector<std::string> post_keys2;
+        append_cold_rowset(md.get(), 0, 1, kEarlierHighRssid, &high_keys);
+        append_cold_rowset(md.get(), 100, 1, kLaterLowRssid, &low_keys);
+        md->mutable_rowsets(0)->set_version(2);
+        md->mutable_rowsets(1)->set_version(3);
+
+        ConfigResetGuard<int64_t> l0_guard(&config::l0_max_mem_usage, std::numeric_limits<int64_t>::max());
+        auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), md->id());
+        ASSERT_OK(index->init(md));
+
+        const Slice high_key(high_keys[0]);
+        const Slice low_key(low_keys[0]);
+        const IndexValue high_value(uint64_t{kEarlierHighRssid} << 32);
+        const IndexValue low_value(uint64_t{kLaterLowRssid} << 32);
+        ASSERT_OK(index->insert(1, &high_key, &high_value, 2));
+        ASSERT_OK(index->sync_flush_all_memtables(10'000'000));
+        ASSERT_OK(index->insert(1, &low_key, &low_value, 3));
+
+        Tablet tablet(_tablet_mgr.get(), md->id());
+        auto checkpointed = std::make_shared<TabletMetadata>(*md);
+        MetaFileBuilder first_builder(tablet, checkpointed);
+        ASSERT_OK(index->commit(&first_builder));
+        ASSERT_GT(checkpointed->sstable_meta().sstables_size(), 0);
+
+        append_cold_rowset(checkpointed.get(), 200, 1, kPostFrontierRssid1, &post_keys1);
+        append_cold_rowset(checkpointed.get(), 300, 1, kPostFrontierRssid2, &post_keys2);
+        checkpointed->mutable_rowsets(2)->set_version(4);
+        checkpointed->mutable_rowsets(3)->set_version(5);
+        checkpointed->set_version(kLaterCommitVersion);
+        checkpointed->set_next_rowset_id(kPostFrontierRssid2 + 1);
+
+        std::array<Slice, 2> post_slices = {Slice(post_keys1[0]), Slice(post_keys2[0])};
+        std::array<IndexValue, 2> post_values = {IndexValue(uint64_t{kPostFrontierRssid1} << 32),
+                                                 IndexValue(uint64_t{kPostFrontierRssid2} << 32)};
+        ASSERT_OK(index->insert(post_slices.size(), post_slices.data(), post_values.data(), kLaterCommitVersion));
+
+        const auto first_sst_meta = checkpointed->sstable_meta().SerializeAsString();
+        const auto first_inventory = sst_inventory(md->id());
+        auto cache_only = std::make_shared<TabletMetadata>(*checkpointed);
+        MetaFileBuilder later_builder(tablet, cache_only);
+        ASSERT_OK(index->commit(&later_builder));
+        EXPECT_EQ(first_sst_meta, cache_only->sstable_meta().SerializeAsString());
+        EXPECT_EQ(first_inventory, sst_inventory(md->id()));
+        index.reset();
+
+        ConfigResetGuard<bool> parallel_guard(&config::enable_pk_index_parallel_execution, parallel);
+        ConfigResetGuard<int32_t> ratio_guard(&config::pk_index_parallel_rebuild_mem_ratio, 100);
+        ASSERT_FALSE(RuntimeEnv::GetInstance()->update_mem_tracker()->limit_exceeded_by_ratio(
+                config::pk_index_parallel_rebuild_mem_ratio));
+        std::atomic<int> parallel_callbacks = 0;
+        std::atomic<int> serial_callbacks = 0;
+        SyncPoint::GetInstance()->SetCallBack("LakePersistentIndex::load_from_lake_tablet:parallel",
+                                              [&](void*) { ++parallel_callbacks; });
+        SyncPoint::GetInstance()->SetCallBack("LakePersistentIndex::load_from_lake_tablet:serial",
+                                              [&](void*) { ++serial_callbacks; });
+        SyncPoint::GetInstance()->EnableProcessing();
+        DeferOp clear_callbacks([&]() {
+            SyncPoint::GetInstance()->ClearCallBack("LakePersistentIndex::load_from_lake_tablet:parallel");
+            SyncPoint::GetInstance()->ClearCallBack("LakePersistentIndex::load_from_lake_tablet:serial");
+            SyncPoint::GetInstance()->DisableProcessing();
+        });
+
+        const std::vector<std::string> keys = {high_keys[0], low_keys[0], post_keys1[0], post_keys2[0]};
+        auto values = cold_reload_values(cache_only, kLaterCommitVersion, keys);
+        EXPECT_EQ(parallel ? 1 : 0, parallel_callbacks.load());
+        EXPECT_EQ(parallel ? 0 : 1, serial_callbacks.load());
+        EXPECT_EQ(high_value, values[0]);
+        EXPECT_EQ(low_value, values[1]);
+        EXPECT_EQ(post_values[0], values[2]);
+        EXPECT_EQ(post_values[1], values[3]);
     }
 };
 
@@ -2496,8 +2625,9 @@ TEST_F(LakePersistentIndexTest, test_cold_reload_preserves_non_monotonic_rssid_t
         ASSERT_OK(index->commit(&builder));
     }
 
-    ASSERT_EQ(1, checkpointed->sstable_meta().sstables_size());
-    EXPECT_EQ(static_cast<uint64_t>(kEarlierHighRssid) << 32, checkpointed->sstable_meta().sstables(0).max_rss_rowid());
+    ASSERT_GT(checkpointed->sstable_meta().sstables_size(), 0);
+    EXPECT_GE(checkpointed->sstable_meta().sstables().rbegin()->max_rss_rowid(),
+              static_cast<uint64_t>(kEarlierHighRssid) << 32);
 
     auto reloaded = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), md->id());
     ASSERT_OK(reloaded->init(checkpointed));
@@ -2511,6 +2641,262 @@ TEST_F(LakePersistentIndexTest, test_cold_reload_preserves_non_monotonic_rssid_t
     ASSERT_OK(reloaded->get(keys.size(), keys.data(), after_reload.data()));
     EXPECT_EQ(IndexValue(static_cast<uint64_t>(kEarlierHighRssid) << 32), after_reload[0]);
     EXPECT_EQ(IndexValue(static_cast<uint64_t>(kLaterLowRssid) << 32), after_reload[1]);
+}
+
+TEST_F(LakePersistentIndexTest, test_complete_checkpoint_parallel_reload_with_cache_only_post_frontier_rowsets) {
+    run_complete_checkpoint_cache_only_tail(true);
+}
+
+TEST_F(LakePersistentIndexTest, test_complete_checkpoint_serial_reload_with_cache_only_post_frontier_rowsets) {
+    run_complete_checkpoint_cache_only_tail(false);
+}
+
+TEST_F(LakePersistentIndexTest, test_complete_checkpoint_drains_inactive_and_active_lower_tails) {
+    auto md = make_varchar_pk_metadata();
+    md->set_version(4);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*md));
+    std::vector<std::string> high_keys;
+    std::vector<std::string> inactive_keys;
+    std::vector<std::string> active_keys;
+    append_cold_rowset(md.get(), 0, 1, 100, &high_keys);
+    append_cold_rowset(md.get(), 100, 1, 50, &inactive_keys);
+    append_cold_rowset(md.get(), 200, 1, 51, &active_keys);
+    for (int i = 0; i < md->rowsets_size(); ++i) {
+        md->mutable_rowsets(i)->set_version(i + 2);
+    }
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*md));
+
+    ConfigResetGuard<bool> parallel_guard(&config::enable_pk_index_parallel_execution, false);
+    ConfigResetGuard<int64_t> l0_guard(&config::l0_max_mem_usage, std::numeric_limits<int64_t>::max());
+    auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), md->id());
+    ASSERT_OK(index->init(md));
+    const Slice high_key(high_keys[0]);
+    const Slice inactive_key(inactive_keys[0]);
+    const Slice active_key(active_keys[0]);
+    const IndexValue high_value(uint64_t{100} << 32);
+    const IndexValue inactive_value(uint64_t{50} << 32);
+    const IndexValue active_value(uint64_t{51} << 32);
+    ASSERT_OK(index->insert(1, &high_key, &high_value, 2));
+    ASSERT_OK(index->sync_flush_all_memtables(10'000'000));
+    ASSERT_OK(index->insert(1, &inactive_key, &inactive_value, 3));
+    wait_for_one_async_memtable_flush(index.get());
+    ASSERT_OK(index->insert(1, &active_key, &active_value, 4));
+
+    Tablet tablet(_tablet_mgr.get(), md->id());
+    auto committed = std::make_shared<TabletMetadata>(*md);
+    MetaFileBuilder builder(tablet, committed);
+    ASSERT_OK(index->commit(&builder));
+    index.reset();
+
+    auto values = cold_reload_values(committed, 4, {high_keys[0], inactive_keys[0], active_keys[0]});
+    EXPECT_EQ(high_value, values[0]);
+    EXPECT_EQ(inactive_value, values[1]);
+    EXPECT_EQ(active_value, values[2]);
+}
+
+TEST_F(LakePersistentIndexTest, test_complete_checkpoint_drains_completed_inactive_tail_with_empty_active) {
+    auto md = make_varchar_pk_metadata();
+    md->set_version(3);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*md));
+    std::vector<std::string> high_keys;
+    std::vector<std::string> inactive_keys;
+    append_cold_rowset(md.get(), 0, 1, 100, &high_keys);
+    append_cold_rowset(md.get(), 100, 1, 50, &inactive_keys);
+    md->mutable_rowsets(0)->set_version(2);
+    md->mutable_rowsets(1)->set_version(3);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*md));
+
+    ConfigResetGuard<bool> parallel_guard(&config::enable_pk_index_parallel_execution, false);
+    ConfigResetGuard<int64_t> l0_guard(&config::l0_max_mem_usage, std::numeric_limits<int64_t>::max());
+    auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), md->id());
+    ASSERT_OK(index->init(md));
+    const Slice high_key(high_keys[0]);
+    const Slice inactive_key(inactive_keys[0]);
+    const IndexValue high_value(uint64_t{100} << 32);
+    const IndexValue inactive_value(uint64_t{50} << 32);
+    ASSERT_OK(index->insert(1, &high_key, &high_value, 2));
+    ASSERT_OK(index->sync_flush_all_memtables(10'000'000));
+    ASSERT_OK(index->insert(1, &inactive_key, &inactive_value, 3));
+    wait_for_one_async_memtable_flush(index.get());
+
+    Tablet tablet(_tablet_mgr.get(), md->id());
+    auto committed = std::make_shared<TabletMetadata>(*md);
+    MetaFileBuilder builder(tablet, committed);
+    ASSERT_OK(index->commit(&builder));
+    index.reset();
+
+    auto values = cold_reload_values(committed, 3, {high_keys[0], inactive_keys[0]});
+    EXPECT_EQ(high_value, values[0]);
+    EXPECT_EQ(inactive_value, values[1]);
+}
+
+TEST_F(LakePersistentIndexTest, test_complete_checkpoint_gate_runs_after_rebuild_threshold_flush) {
+    auto md = make_varchar_pk_metadata();
+    md->set_version(3);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*md));
+    std::vector<std::string> high_keys;
+    std::vector<std::string> low_keys;
+    append_cold_rowset(md.get(), 0, 1, 100, &high_keys);
+    append_cold_rowset(md.get(), 100, 1, 50, &low_keys);
+    md->mutable_rowsets(0)->set_version(2);
+    md->mutable_rowsets(1)->set_version(3);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*md));
+
+    ConfigResetGuard<bool> parallel_guard(&config::enable_pk_index_parallel_execution, false);
+    ConfigResetGuard<int64_t> l0_guard(&config::l0_max_mem_usage, std::numeric_limits<int64_t>::max());
+    ConfigResetGuard<int32_t> files_guard(&config::cloud_native_pk_index_rebuild_files_threshold, 0);
+    ConfigResetGuard<int64_t> rows_guard(&config::cloud_native_pk_index_rebuild_rows_threshold, 0);
+    auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), md->id());
+    ASSERT_OK(index->init(md));
+    const Slice high_key(high_keys[0]);
+    const Slice low_key(low_keys[0]);
+    const IndexValue high_value(uint64_t{100} << 32);
+    const IndexValue low_value(uint64_t{50} << 32);
+    ASSERT_OK(index->insert(1, &high_key, &high_value, 2));
+    wait_for_one_async_memtable_flush(index.get());
+
+    Tablet tablet(_tablet_mgr.get(), md->id());
+    auto preloaded = std::make_shared<TabletMetadata>(*md);
+    MetaFileBuilder preload_builder(tablet, preloaded);
+    ASSERT_OK(index->commit(&preload_builder));
+    ASSERT_EQ(0, preloaded->sstable_meta().sstables_size());
+
+    config::cloud_native_pk_index_rebuild_files_threshold = 1;
+    ASSERT_OK(index->insert(1, &low_key, &low_value, 3));
+    auto committed = std::make_shared<TabletMetadata>(*preloaded);
+    MetaFileBuilder builder(tablet, committed);
+    ASSERT_OK(index->commit(&builder));
+    ASSERT_GT(committed->sstable_meta().sstables_size(), 0);
+    // The pre-fix threshold path leaves the low tail in an asynchronous inactive memtable. Drain the
+    // test object's runtime state only after snapshotting |committed| so teardown cannot race its file.
+    ASSERT_OK(index->sync_flush_all_memtables(10'000'000));
+    index.reset();
+
+    auto values = cold_reload_values(committed, 3, {high_keys[0], low_keys[0]});
+    EXPECT_EQ(high_value, values[0]);
+    EXPECT_EQ(low_value, values[1]);
+}
+
+TEST_F(LakePersistentIndexTest, test_empty_sst_metadata_and_filesets_keep_native_cache_only_path) {
+    auto md = make_varchar_pk_metadata();
+    md->set_version(2);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*md));
+    std::vector<std::string> keys;
+    append_cold_rowset(md.get(), 0, 1, 10, &keys);
+    md->mutable_rowsets(0)->set_version(2);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*md));
+    const auto before_meta = md->sstable_meta().SerializeAsString();
+    const auto before_inventory = sst_inventory(md->id());
+
+    ConfigResetGuard<int64_t> l0_guard(&config::l0_max_mem_usage, std::numeric_limits<int64_t>::max());
+    ConfigResetGuard<int32_t> files_guard(&config::cloud_native_pk_index_rebuild_files_threshold, 0);
+    ConfigResetGuard<int64_t> rows_guard(&config::cloud_native_pk_index_rebuild_rows_threshold, 0);
+    auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), md->id());
+    ASSERT_OK(index->init(md));
+    const Slice key(keys[0]);
+    const IndexValue value(uint64_t{10} << 32);
+    ASSERT_OK(index->insert(1, &key, &value, 2));
+    Tablet tablet(_tablet_mgr.get(), md->id());
+    auto committed = std::make_shared<TabletMetadata>(*md);
+    MetaFileBuilder builder(tablet, committed);
+    ASSERT_OK(index->commit(&builder));
+
+    EXPECT_EQ(0, committed->sstable_meta().sstables_size());
+    EXPECT_EQ(before_meta, committed->sstable_meta().SerializeAsString());
+    EXPECT_EQ(before_inventory, sst_inventory(md->id()));
+}
+
+TEST_F(LakePersistentIndexTest, test_existing_sst_does_not_force_safe_later_active_entry) {
+    auto md = make_varchar_pk_metadata();
+    md->set_version(2);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*md));
+    std::vector<std::string> high_keys;
+    append_cold_rowset(md.get(), 0, 1, 100, &high_keys);
+    md->mutable_rowsets(0)->set_version(2);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*md));
+
+    ConfigResetGuard<bool> parallel_guard(&config::enable_pk_index_parallel_execution, false);
+    ConfigResetGuard<int64_t> l0_guard(&config::l0_max_mem_usage, std::numeric_limits<int64_t>::max());
+    auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), md->id());
+    ASSERT_OK(index->init(md));
+    const Slice high_key(high_keys[0]);
+    const IndexValue high_value(uint64_t{100} << 32);
+    ASSERT_OK(index->insert(1, &high_key, &high_value, 2));
+    ASSERT_OK(index->sync_flush_all_memtables(10'000'000));
+
+    Tablet tablet(_tablet_mgr.get(), md->id());
+    auto first = std::make_shared<TabletMetadata>(*md);
+    MetaFileBuilder first_builder(tablet, first);
+    ASSERT_OK(index->commit(&first_builder));
+    const auto first_meta = first->sstable_meta().SerializeAsString();
+    const auto first_inventory = sst_inventory(md->id());
+
+    std::vector<std::string> later_keys;
+    append_cold_rowset(first.get(), 100, 1, 101, &later_keys);
+    first->mutable_rowsets(1)->set_version(3);
+    first->set_version(3);
+    const Slice later_key(later_keys[0]);
+    const IndexValue later_value(uint64_t{101} << 32);
+    ASSERT_OK(index->insert(1, &later_key, &later_value, 3));
+    auto second = std::make_shared<TabletMetadata>(*first);
+    MetaFileBuilder second_builder(tablet, second);
+    ASSERT_OK(index->commit(&second_builder));
+    EXPECT_EQ(first_meta, second->sstable_meta().SerializeAsString());
+    EXPECT_EQ(first_inventory, sst_inventory(md->id()));
+    index.reset();
+
+    auto values = cold_reload_values(second, 3, {high_keys[0], later_keys[0]});
+    EXPECT_EQ(high_value, values[0]);
+    EXPECT_EQ(later_value, values[1]);
+}
+
+TEST_F(LakePersistentIndexTest, test_first_fileset_with_empty_memtables_creates_no_redundant_sst) {
+    auto md = make_varchar_pk_metadata();
+    md->set_version(2);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*md));
+    std::vector<std::string> keys;
+    append_cold_rowset(md.get(), 0, 1, 100, &keys);
+    md->mutable_rowsets(0)->set_version(2);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*md));
+    auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), md->id());
+    ASSERT_OK(index->init(md));
+    const Slice key(keys[0]);
+    const IndexValue value(uint64_t{100} << 32);
+    ASSERT_OK(index->insert(1, &key, &value, 2));
+    ASSERT_OK(index->sync_flush_all_memtables(10'000'000));
+    const auto before_inventory = sst_inventory(md->id());
+    ASSERT_EQ(1, before_inventory.size());
+
+    Tablet tablet(_tablet_mgr.get(), md->id());
+    auto committed = std::make_shared<TabletMetadata>(*md);
+    MetaFileBuilder builder(tablet, committed);
+    ASSERT_OK(index->commit(&builder));
+    EXPECT_EQ(1, committed->sstable_meta().sstables_size());
+    EXPECT_EQ(before_inventory, sst_inventory(md->id()));
+}
+
+TEST_F(LakePersistentIndexTest, test_cold_rebuild_rejects_unmasked_duplicate_primary_keys) {
+    auto md = make_varchar_pk_metadata();
+    md->set_version(3);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*md));
+    std::vector<std::string> first_keys;
+    std::vector<std::string> duplicate_keys;
+    append_cold_rowset(md.get(), 0, 1, 100, &first_keys);
+    append_cold_rowset(md.get(), 0, 1, 50, &duplicate_keys);
+    md->mutable_rowsets(0)->set_version(2);
+    md->mutable_rowsets(1)->set_version(3);
+    ASSERT_EQ(first_keys[0], duplicate_keys[0]);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*md));
+
+    ConfigResetGuard<bool> consistency_guard(&config::experimental_lake_ignore_pk_consistency_check, false);
+    ConfigResetGuard<bool> parallel_guard(&config::enable_pk_index_parallel_execution, false);
+    Tablet tablet(_tablet_mgr.get(), md->id());
+    auto reload_metadata = std::make_shared<TabletMetadata>(*md);
+    MetaFileBuilder builder(tablet, reload_metadata);
+    auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), md->id());
+    ASSERT_OK(index->init(md));
+    auto st = index->load_from_lake_tablet(_tablet_mgr.get(), md, 3, &builder);
+    EXPECT_TRUE(st.is_already_exist()) << st;
 }
 
 // A del file that did NOT originate from the rebuilt rowset must run get()+filter and drop deletes

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -2135,6 +2135,75 @@ TEST_F(LakePersistentIndexTest, test_load_from_lake_tablet_parallel_matches_seri
     }
 }
 
+// A scalar max-RSSID rebuild watermark is only safe when rowset RSSIDs increase with rowset version.
+// MERGE can produce the opposite order: an earlier rowset may have a larger RSSID than a later rowset.
+// Reproduce the resulting checkpoint gap without cross-publish or concurrent resharding. The first
+// rowset is persisted in an SST while the later, lower-RSSID rowset remains in the active memtable;
+// after commit and a cold reload, both real rowsets must still be represented by the rebuilt index.
+TEST_F(LakePersistentIndexTest, test_cold_reload_preserves_non_monotonic_rssid_tail_after_partial_checkpoint) {
+    constexpr uint32_t kEarlierHighRssid = 100;
+    constexpr uint32_t kLaterLowRssid = 50;
+    constexpr int64_t kEarlierVersion = 2;
+    constexpr int64_t kLaterVersion = 3;
+
+    auto md = make_varchar_pk_metadata();
+    md->set_version(kLaterVersion);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*md));
+
+    std::vector<std::string> high_keys;
+    std::vector<std::string> low_keys;
+    append_cold_rowset(md.get(), /*start=*/0, /*n=*/1, kEarlierHighRssid, &high_keys);
+    append_cold_rowset(md.get(), /*start=*/100, /*n=*/1, kLaterLowRssid, &low_keys);
+    ASSERT_EQ(2, md->rowsets_size());
+    md->mutable_rowsets(0)->set_version(kEarlierVersion);
+    md->mutable_rowsets(1)->set_version(kLaterVersion);
+    ASSERT_GT(md->rowsets(0).id(), md->rowsets(1).id());
+
+    ConfigResetGuard<int64_t> l0_guard(&config::l0_max_mem_usage, std::numeric_limits<int64_t>::max());
+    Tablet tablet(_tablet_mgr.get(), md->id());
+    auto checkpointed = std::make_shared<TabletMetadata>();
+    checkpointed->CopyFrom(*md);
+
+    {
+        auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), md->id());
+        ASSERT_OK(index->init(md));
+
+        const Slice high_key(high_keys[0]);
+        const IndexValue high_value((static_cast<uint64_t>(kEarlierHighRssid) << 32));
+        ASSERT_OK(index->insert(1, &high_key, &high_value, kEarlierVersion));
+        ASSERT_OK(index->sync_flush_all_memtables(10'000'000));
+
+        const Slice low_key(low_keys[0]);
+        const IndexValue low_value((static_cast<uint64_t>(kLaterLowRssid) << 32));
+        ASSERT_OK(index->insert(1, &low_key, &low_value, kLaterVersion));
+
+        std::array<Slice, 2> keys = {high_key, low_key};
+        std::array<IndexValue, 2> before_reload;
+        ASSERT_OK(index->get(keys.size(), keys.data(), before_reload.data()));
+        EXPECT_EQ(high_value, before_reload[0]);
+        EXPECT_EQ(low_value, before_reload[1]);
+
+        MetaFileBuilder builder(tablet, checkpointed);
+        ASSERT_OK(index->commit(&builder));
+    }
+
+    ASSERT_EQ(1, checkpointed->sstable_meta().sstables_size());
+    EXPECT_EQ(static_cast<uint64_t>(kEarlierHighRssid) << 32, checkpointed->sstable_meta().sstables(0).max_rss_rowid());
+
+    auto reloaded = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), md->id());
+    ASSERT_OK(reloaded->init(checkpointed));
+    auto reloaded_metadata = std::make_shared<TabletMetadata>();
+    reloaded_metadata->CopyFrom(*checkpointed);
+    MetaFileBuilder reload_builder(tablet, reloaded_metadata);
+    ASSERT_OK(reloaded->load_from_lake_tablet(_tablet_mgr.get(), checkpointed, kLaterVersion, &reload_builder));
+
+    std::array<Slice, 2> keys = {Slice(high_keys[0]), Slice(low_keys[0])};
+    std::array<IndexValue, 2> after_reload;
+    ASSERT_OK(reloaded->get(keys.size(), keys.data(), after_reload.data()));
+    EXPECT_EQ(IndexValue(static_cast<uint64_t>(kEarlierHighRssid) << 32), after_reload[0]);
+    EXPECT_EQ(IndexValue(static_cast<uint64_t>(kLaterLowRssid) << 32), after_reload[1]);
+}
+
 // A del file that did NOT originate from the rebuilt rowset must run get()+filter and drop deletes
 // that are too old for the current index entry. too_old = origin_rowset_id + op_offset: keys whose
 // current rssid (value >> 32) is <= too_old get erased; keys with a newer rssid keep their value.

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -2627,8 +2627,9 @@ TEST_F(LakePersistentIndexTest, test_cold_reload_preserves_non_monotonic_rssid_t
         ASSERT_OK(index->commit(&builder));
     }
 
-    ASSERT_EQ(1, checkpointed->sstable_meta().sstables_size());
+    ASSERT_EQ(2, checkpointed->sstable_meta().sstables_size());
     EXPECT_EQ(static_cast<uint64_t>(kEarlierHighRssid) << 32, checkpointed->sstable_meta().sstables(0).max_rss_rowid());
+    EXPECT_EQ(static_cast<uint64_t>(kEarlierHighRssid) << 32, checkpointed->sstable_meta().sstables(1).max_rss_rowid());
 
     auto reloaded = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), md->id());
     ASSERT_OK(reloaded->init(checkpointed));

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -14,16 +14,20 @@
 
 #include "storage/lake/lake_persistent_index.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <algorithm>
 #include <atomic>
 #include <cstdint>
+#include <limits>
 #include <memory>
+#include <mutex>
 #include <utility>
 #include <vector>
 
 #include "base/container/lru_cache.h"
+#include "base/phmap/btree.h"
 #include "base/testutil/assert.h"
 #include "base/testutil/sync_point.h"
 #include "base/utility/defer_op.h"
@@ -130,6 +134,19 @@ public:
             c1->set_is_key(false);
             c1->set_is_nullable(false);
         }
+
+        EncryptionKeyPB pb;
+        pb.set_id(EncryptionKey::DEFAULT_MASTER_KYE_ID);
+        pb.set_type(EncryptionKeyTypePB::NORMAL_KEY);
+        pb.set_algorithm(EncryptionAlgorithmPB::AES_128);
+        pb.set_plain_key("0000000000000000");
+        std::unique_ptr<EncryptionKey> root_encryption_key = EncryptionKey::create_from_pb(pb).value();
+        auto key_or = root_encryption_key->generate_key();
+        EXPECT_TRUE(key_or.ok());
+        std::unique_ptr<EncryptionKey> encryption_key = std::move(key_or.value());
+        encryption_key->set_id(2);
+        KeyCache::instance().add_key(root_encryption_key);
+        KeyCache::instance().add_key(encryption_key);
     }
 
 protected:
@@ -143,6 +160,18 @@ protected:
     constexpr static const char* const kTestDirectory = "test_lake_persistent_index";
 
     std::shared_ptr<TabletMetadata> _tablet_metadata;
+
+    std::vector<std::string> sst_inventory(int64_t tablet_id) {
+        std::vector<std::string> ssts;
+        CHECK_OK(FileSystem::Default()->iterate_dir(_lp->segment_root_location(tablet_id), [&](std::string_view name) {
+            if (name.ends_with(".sst")) {
+                ssts.emplace_back(name);
+            }
+            return true;
+        }));
+        std::sort(ssts.begin(), ssts.end());
+        return ssts;
+    }
 
     TabletSchemaPB create_tablet_schema_pb(const std::vector<std::pair<std::string, std::string>>& columns,
                                            int num_key_columns) {
@@ -704,6 +733,249 @@ TEST_F(LakePersistentIndexTest, test_bulk_erase_matches_memtable) {
     for (int i = 0; i < R; ++i) {
         ASSERT_EQ(keep_a[i].get_value(), (uint64_t)(M + i + 1)) << "memtable path: kept key wrong at " << i;
         ASSERT_EQ(keep_b[i].get_value(), (uint64_t)(M + i + 1)) << "sst path: kept key wrong at " << i;
+    }
+}
+
+// Direct SST ingest bypasses the active memtable. A following lower-RSSID write must inherit the direct
+// SST's watermark; otherwise commit rejects the resulting file order and a cold reload loses the tail.
+TEST_F(LakePersistentIndexTest, test_ingest_sst_preserves_lower_tail_watermark) {
+    constexpr uint32_t kDirectRssid = 100;
+    constexpr uint32_t kTailRssid = 50;
+    constexpr uint64_t kDirectValue = (static_cast<uint64_t>(kDirectRssid) << 32) | (UINT32_MAX - 1);
+    constexpr uint64_t kTailValue = static_cast<uint64_t>(kTailRssid) << 32;
+    const int64_t tablet_id = _tablet_metadata->id();
+    const std::string direct_key = "direct-ingest-key";
+    const std::string tail_key = "lower-rssid-tail";
+    const std::string filename = "direct-ingest-watermark.sst";
+
+    phmap::btree_map<std::string, IndexValueWithVer, std::less<>> entries;
+    entries.emplace(direct_key, std::make_pair(int64_t{1}, IndexValue(kDirectValue)));
+    ASSIGN_OR_ABORT(auto wf, fs::new_writable_file(_tablet_mgr->sst_location(tablet_id, filename)));
+    uint64_t filesize = 0;
+    PersistentIndexSstableRangePB range;
+    ASSERT_OK(PersistentIndexSstable::build_sstable(entries, wf.get(), &filesize, &range));
+    ASSERT_OK(wf->close());
+
+    FileMetaPB direct_sst;
+    direct_sst.set_name(filename);
+    direct_sst.set_size(filesize);
+    DelvecPagePB delvec_page;
+    auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
+    ASSERT_OK(index->init(_tablet_metadata));
+    ASSERT_OK(index->ingest_sst(direct_sst, range, kDirectRssid, /*version=*/1, delvec_page, nullptr));
+
+    const Slice tail_slice(tail_key);
+    const IndexValue tail_value(kTailValue);
+    ASSERT_OK(index->insert(1, &tail_slice, &tail_value, /*version=*/2));
+    ASSERT_OK(index->sync_flush_all_memtables(10'000'000));
+
+    auto committed = std::make_shared<TabletMetadata>();
+    committed->CopyFrom(*_tablet_metadata);
+    Tablet tablet(_tablet_mgr.get(), tablet_id);
+    MetaFileBuilder builder(tablet, committed);
+    ASSERT_OK(index->commit(&builder));
+    ASSERT_GE(committed->sstable_meta().sstables_size(), 2);
+    for (int i = 1; i < committed->sstable_meta().sstables_size(); ++i) {
+        EXPECT_LE(committed->sstable_meta().sstables(i - 1).max_rss_rowid(),
+                  committed->sstable_meta().sstables(i).max_rss_rowid());
+    }
+
+    auto reloaded = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
+    ASSERT_OK(reloaded->init(committed));
+    std::array<Slice, 2> keys = {Slice(direct_key), Slice(tail_key)};
+    std::array<IndexValue, 2> values;
+    ASSERT_OK(reloaded->get(keys.size(), keys.data(), values.data()));
+    EXPECT_EQ(IndexValue(kDirectValue), values[0]);
+    EXPECT_EQ(IndexValue(kTailValue), values[1]);
+}
+
+// bulk_erase also directly appends an SST. Its tombstone watermark must advance the empty tail memtable
+// so a later lower-RSSID live key can commit and cold-reload behind the tombstone.
+TEST_F(LakePersistentIndexTest, test_bulk_erase_preserves_lower_tail_watermark) {
+    constexpr uint32_t kLiveRssid = 10;
+    constexpr uint32_t kDeleteRssid = 100;
+    constexpr uint32_t kTailRssid = 50;
+    constexpr uint64_t kLiveValue = (static_cast<uint64_t>(kLiveRssid) << 32) | 7;
+    constexpr uint64_t kTailValue = static_cast<uint64_t>(kTailRssid) << 32;
+    const int64_t tablet_id = _tablet_metadata->id();
+    const std::string deleted_key = "bulk-erase-key";
+    const std::string tail_key = "bulk-erase-lower-tail";
+
+    auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
+    ASSERT_OK(index->init(_tablet_metadata));
+    const Slice deleted_slice(deleted_key);
+    const IndexValue live_value(kLiveValue);
+    ASSERT_OK(index->insert(1, &deleted_slice, &live_value, /*version=*/1));
+    ASSERT_OK(index->sync_flush_all_memtables(10'000'000));
+
+    const std::string filename = "bulk-erase-watermark.sst";
+    ASSIGN_OR_ABORT(auto wf, fs::new_writable_file(_tablet_mgr->sst_location(tablet_id, filename)));
+    uint64_t filesize = 0;
+    PersistentIndexSstableRangePB range;
+    ASSERT_OK(PersistentIndexSstable::build_tombstone_sstable(&deleted_slice, 1, /*version=*/0, wf.get(), &filesize,
+                                                              &range));
+    ASSERT_OK(wf->close());
+    FileMetaPB tombstone_sst;
+    tombstone_sst.set_name(filename);
+    tombstone_sst.set_size(filesize);
+
+    std::array<IndexValue, 1> old_values;
+    ASSERT_OK(index->bulk_erase(1, &deleted_slice, old_values.data(), kDeleteRssid, tombstone_sst, range,
+                                /*version=*/2));
+    EXPECT_EQ(IndexValue(kLiveValue), old_values[0]);
+
+    const Slice tail_slice(tail_key);
+    const IndexValue tail_value(kTailValue);
+    ASSERT_OK(index->insert(1, &tail_slice, &tail_value, /*version=*/3));
+    ASSERT_OK(index->sync_flush_all_memtables(10'000'000));
+
+    auto committed = std::make_shared<TabletMetadata>();
+    committed->CopyFrom(*_tablet_metadata);
+    Tablet tablet(_tablet_mgr.get(), tablet_id);
+    MetaFileBuilder builder(tablet, committed);
+    ASSERT_OK(index->commit(&builder));
+    for (int i = 1; i < committed->sstable_meta().sstables_size(); ++i) {
+        EXPECT_LE(committed->sstable_meta().sstables(i - 1).max_rss_rowid(),
+                  committed->sstable_meta().sstables(i).max_rss_rowid());
+    }
+
+    auto reloaded = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
+    ASSERT_OK(reloaded->init(committed));
+    std::array<Slice, 2> keys = {Slice(deleted_key), Slice(tail_key)};
+    std::array<IndexValue, 2> values;
+    ASSERT_OK(reloaded->get(keys.size(), keys.data(), values.data()));
+    EXPECT_EQ(IndexValue(NullIndexValue), values[0]);
+    EXPECT_EQ(IndexValue(kTailValue), values[1]);
+}
+
+// A failed memtable flush must not publish metadata or leave its current output behind. The first hook is
+// intentionally absent before the implementation; build/footer and table-open cover the later ownership
+// points. Every retry starts with a new index because a partially drained index has no reuse contract.
+TEST_F(LakePersistentIndexTest, test_memtable_flush_failure_removes_current_output) {
+    constexpr uint64_t kValue = (static_cast<uint64_t>(7) << 32) | 3;
+    const std::array<const char*, 3> failure_points = {
+            "PersistentIndexMemtable::flush:after_create",
+            "table_builder_footer_error",
+            "PersistentIndexSstable::init:table_open_error",
+    };
+
+    auto retry_from_fresh_index = [&](const TabletMetadataPtr& metadata, bool tde, const std::string& key) {
+        auto retry = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), metadata->id());
+        ASSERT_OK(retry->init(metadata));
+        const Slice key_slice(key);
+        const IndexValue value(kValue);
+        ASSERT_OK(retry->insert(1, &key_slice, &value, /*version=*/2));
+        ASSERT_OK(retry->sync_flush_all_memtables(10'000'000));
+
+        auto committed = std::make_shared<TabletMetadata>();
+        committed->CopyFrom(*metadata);
+        Tablet tablet(_tablet_mgr.get(), metadata->id());
+        MetaFileBuilder builder(tablet, committed);
+        ASSERT_OK(retry->commit(&builder));
+        ASSERT_EQ(1, committed->sstable_meta().sstables_size());
+        if (tde) {
+            EXPECT_FALSE(committed->sstable_meta().sstables(0).encryption_meta().empty());
+        }
+
+        retry.reset();
+        auto reloaded = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), metadata->id());
+        ASSERT_OK(reloaded->init(committed));
+        IndexValue actual;
+        ASSERT_OK(reloaded->get(1, &key_slice, &actual));
+        EXPECT_EQ(value, actual);
+    };
+
+    for (bool tde : {false, true}) {
+        ConfigResetGuard<bool> tde_guard(&config::enable_transparent_data_encryption, tde);
+        for (const char* failure_point : failure_points) {
+            auto metadata = make_varchar_pk_metadata();
+            ASSERT_OK(_tablet_mgr->put_tablet_metadata(*metadata));
+            const std::string key = fmt::format("flush-failure-{}-{}", tde, failure_point);
+            const Slice key_slice(key);
+            const IndexValue value(kValue);
+            const auto before = sst_inventory(metadata->id());
+            const std::string metadata_before = metadata->SerializeAsString();
+            std::string created_path;
+
+            auto failed = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), metadata->id());
+            ASSERT_OK(failed->init(metadata));
+            ASSERT_OK(failed->insert(1, &key_slice, &value, /*version=*/1));
+            if (std::string_view(failure_point) == "PersistentIndexMemtable::flush:after_create") {
+                SyncPoint::GetInstance()->SetCallBack(failure_point, [&](void* arg) {
+                    auto* result = static_cast<std::pair<const std::string*, Status*>*>(arg);
+                    created_path = *result->first;
+                    *result->second = Status::InternalError("injected memtable flush failure");
+                });
+            } else {
+                SyncPoint::GetInstance()->SetCallBack(failure_point, [](void* arg) {
+                    *(Status*)arg = Status::InternalError("injected memtable flush failure");
+                });
+            }
+            SyncPoint::GetInstance()->EnableProcessing();
+            DeferOp disable_injection([&]() {
+                SyncPoint::GetInstance()->ClearCallBack(failure_point);
+                SyncPoint::GetInstance()->DisableProcessing();
+            });
+
+            const Status st = failed->sync_flush_all_memtables(10'000'000);
+            EXPECT_TRUE(st.is_internal_error()) << failure_point << ": " << st;
+            EXPECT_EQ(metadata_before, metadata->SerializeAsString()) << failure_point;
+            EXPECT_THAT(sst_inventory(metadata->id()), testing::ElementsAreArray(before)) << failure_point;
+            if (std::string_view(failure_point) == "PersistentIndexMemtable::flush:after_create") {
+                EXPECT_TRUE(FileSystem::Default()->path_exists(created_path).is_not_found());
+            }
+
+            failed.reset();
+            SyncPoint::GetInstance()->ClearCallBack(failure_point);
+            SyncPoint::GetInstance()->DisableProcessing();
+            retry_from_fresh_index(metadata, tde, key);
+        }
+
+        // The first completed inactive output can remain after a later inactive output fails: that outer
+        // orphan window is intentionally outside the nearest-output cleanup contract. The failed second
+        // output, metadata mutation, and fresh retry remain covered here.
+        auto metadata = make_varchar_pk_metadata();
+        ASSERT_OK(_tablet_mgr->put_tablet_metadata(*metadata));
+        const std::string first_key = fmt::format("first-inactive-{}", tde);
+        const std::string second_key = fmt::format("second-inactive-{}", tde);
+        const std::string metadata_before = metadata->SerializeAsString();
+        std::vector<std::string> created_paths;
+        int create_count = 0;
+        std::mutex created_paths_mutex;
+        ConfigResetGuard<int32_t> max_memtables_guard(&config::pk_index_memtable_max_count, 3);
+        auto failed = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), metadata->id());
+        ASSERT_OK(failed->init(metadata));
+        SyncPoint::GetInstance()->SetCallBack("PersistentIndexMemtable::flush:after_create", [&](void* arg) {
+            std::lock_guard<std::mutex> lock(created_paths_mutex);
+            auto* result = static_cast<std::pair<const std::string*, Status*>*>(arg);
+            created_paths.emplace_back(*result->first);
+            if (++create_count == 2) {
+                *result->second = Status::InternalError("injected memtable flush failure");
+            }
+        });
+        SyncPoint::GetInstance()->EnableProcessing();
+        DeferOp disable_multi_injection([&]() {
+            SyncPoint::GetInstance()->ClearCallBack("PersistentIndexMemtable::flush:after_create");
+            SyncPoint::GetInstance()->DisableProcessing();
+        });
+        const Slice first_slice(first_key);
+        const Slice second_slice(second_key);
+        const IndexValue value(kValue);
+        ASSERT_OK(failed->insert(1, &first_slice, &value, /*version=*/1));
+        ASSERT_OK(failed->flush_memtable(/*force=*/true));
+        ASSERT_OK(failed->insert(1, &second_slice, &value, /*version=*/1));
+        ASSERT_OK(failed->flush_memtable(/*force=*/true));
+        const Status multi_status = failed->sync_flush_all_memtables(10'000'000);
+        EXPECT_TRUE(multi_status.is_internal_error()) << multi_status;
+        EXPECT_EQ(metadata_before, metadata->SerializeAsString());
+        ASSERT_GE(created_paths.size(), 2);
+        EXPECT_TRUE(FileSystem::Default()->path_exists(created_paths.front()).ok());
+        EXPECT_TRUE(FileSystem::Default()->path_exists(created_paths.back()).is_not_found());
+
+        failed.reset();
+        SyncPoint::GetInstance()->ClearCallBack("PersistentIndexMemtable::flush:after_create");
+        SyncPoint::GetInstance()->DisableProcessing();
+        retry_from_fresh_index(metadata, tde, second_key);
     }
 }
 

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cstdint>
+#include <iterator>
 #include <limits>
 #include <memory>
 #include <mutex>
@@ -171,6 +172,25 @@ protected:
         }));
         std::sort(ssts.begin(), ssts.end());
         return ssts;
+    }
+
+    std::vector<std::string> sst_inventory_delta(const std::vector<std::string>& before,
+                                                 const std::vector<std::string>& after) {
+        std::vector<std::string> delta;
+        std::set_difference(after.begin(), after.end(), before.begin(), before.end(), std::back_inserter(delta));
+        return delta;
+    }
+
+    void remove_exact_ssts(int64_t tablet_id, const std::vector<std::string>& filenames) {
+        for (const auto& filename : filenames) {
+            const auto path = _lp->sst_location(tablet_id, filename);
+            const auto exists = FileSystem::Default()->path_exists(path);
+            if (exists.ok()) {
+                CHECK_OK(FileSystem::Default()->delete_file(path));
+            } else {
+                CHECK(exists.is_not_found()) << path << ": " << exists;
+            }
+        }
     }
 
     TabletSchemaPB create_tablet_schema_pb(const std::vector<std::pair<std::string, std::string>>& columns,
@@ -859,7 +879,8 @@ TEST_F(LakePersistentIndexTest, test_memtable_flush_failure_removes_current_outp
             "PersistentIndexSstable::init:table_open_error",
     };
 
-    auto retry_from_fresh_index = [&](const TabletMetadataPtr& metadata, bool tde, const std::string& key) {
+    auto retry_from_fresh_index = [&](const TabletMetadataPtr& metadata, bool tde, const std::string& key,
+                                      std::vector<std::string>* committed_filenames) {
         auto retry = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), metadata->id());
         ASSERT_OK(retry->init(metadata));
         const Slice key_slice(key);
@@ -883,6 +904,10 @@ TEST_F(LakePersistentIndexTest, test_memtable_flush_failure_removes_current_outp
         IndexValue actual;
         ASSERT_OK(reloaded->get(1, &key_slice, &actual));
         EXPECT_EQ(value, actual);
+
+        for (const auto& sstable : committed->sstable_meta().sstables()) {
+            committed_filenames->emplace_back(sstable.filename());
+        }
     };
 
     for (bool tde : {false, true}) {
@@ -890,6 +915,7 @@ TEST_F(LakePersistentIndexTest, test_memtable_flush_failure_removes_current_outp
         for (const char* failure_point : failure_points) {
             auto metadata = make_varchar_pk_metadata();
             ASSERT_OK(_tablet_mgr->put_tablet_metadata(*metadata));
+            ASSERT_TRUE(sst_inventory(metadata->id()).empty());
             const std::string key = fmt::format("flush-failure-{}-{}", tde, failure_point);
             const Slice key_slice(key);
             const IndexValue value(kValue);
@@ -928,54 +954,65 @@ TEST_F(LakePersistentIndexTest, test_memtable_flush_failure_removes_current_outp
             failed.reset();
             SyncPoint::GetInstance()->ClearCallBack(failure_point);
             SyncPoint::GetInstance()->DisableProcessing();
-            retry_from_fresh_index(metadata, tde, key);
+            const auto failed_outputs = sst_inventory_delta(before, sst_inventory(metadata->id()));
+            std::vector<std::string> retry_outputs;
+            retry_from_fresh_index(metadata, tde, key, &retry_outputs);
+            remove_exact_ssts(metadata->id(), failed_outputs);
+            remove_exact_ssts(metadata->id(), retry_outputs);
+            EXPECT_THAT(sst_inventory(metadata->id()), testing::ElementsAreArray(before));
         }
 
-        // The first completed inactive output can remain after a later inactive output fails: that outer
-        // orphan window is intentionally outside the nearest-output cleanup contract. The failed second
-        // output, metadata mutation, and fresh retry remain covered here.
+        // Make the first output an inactive flush, then synchronously hand it off before arming the second
+        // flush's callback. This gives the callback one deterministic current output to fail: callback order
+        // cannot decide which logical memtable receives the error.
         auto metadata = make_varchar_pk_metadata();
         ASSERT_OK(_tablet_mgr->put_tablet_metadata(*metadata));
+        ASSERT_TRUE(sst_inventory(metadata->id()).empty());
         const std::string first_key = fmt::format("first-inactive-{}", tde);
         const std::string second_key = fmt::format("second-inactive-{}", tde);
+        const auto before = sst_inventory(metadata->id());
         const std::string metadata_before = metadata->SerializeAsString();
-        std::vector<std::string> created_paths;
-        int create_count = 0;
-        std::mutex created_paths_mutex;
-        ConfigResetGuard<int32_t> max_memtables_guard(&config::pk_index_memtable_max_count, 3);
         auto failed = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), metadata->id());
         ASSERT_OK(failed->init(metadata));
+        const Slice first_slice(first_key);
+        const Slice second_slice(second_key);
+        const IndexValue value(kValue);
+        ASSERT_OK(failed->insert(1, &first_slice, &value, /*version=*/1));
+        ASSERT_OK(failed->flush_memtable(/*force=*/true));
+        ASSERT_OK(failed->sync_flush_all_memtables(10'000'000));
+        const auto after_first_handoff = sst_inventory(metadata->id());
+        const auto first_outputs = sst_inventory_delta(before, after_first_handoff);
+        ASSERT_EQ(1, first_outputs.size());
+
+        std::string second_created_path;
         SyncPoint::GetInstance()->SetCallBack("PersistentIndexMemtable::flush:after_create", [&](void* arg) {
-            std::lock_guard<std::mutex> lock(created_paths_mutex);
             auto* result = static_cast<std::pair<const std::string*, Status*>*>(arg);
-            created_paths.emplace_back(*result->first);
-            if (++create_count == 2) {
-                *result->second = Status::InternalError("injected memtable flush failure");
-            }
+            second_created_path = *result->first;
+            *result->second = Status::InternalError("injected memtable flush failure");
         });
         SyncPoint::GetInstance()->EnableProcessing();
         DeferOp disable_multi_injection([&]() {
             SyncPoint::GetInstance()->ClearCallBack("PersistentIndexMemtable::flush:after_create");
             SyncPoint::GetInstance()->DisableProcessing();
         });
-        const Slice first_slice(first_key);
-        const Slice second_slice(second_key);
-        const IndexValue value(kValue);
-        ASSERT_OK(failed->insert(1, &first_slice, &value, /*version=*/1));
-        ASSERT_OK(failed->flush_memtable(/*force=*/true));
         ASSERT_OK(failed->insert(1, &second_slice, &value, /*version=*/1));
         ASSERT_OK(failed->flush_memtable(/*force=*/true));
         const Status multi_status = failed->sync_flush_all_memtables(10'000'000);
         EXPECT_TRUE(multi_status.is_internal_error()) << multi_status;
         EXPECT_EQ(metadata_before, metadata->SerializeAsString());
-        ASSERT_GE(created_paths.size(), 2);
-        EXPECT_TRUE(FileSystem::Default()->path_exists(created_paths.front()).ok());
-        EXPECT_TRUE(FileSystem::Default()->path_exists(created_paths.back()).is_not_found());
+        EXPECT_TRUE(FileSystem::Default()->path_exists(_lp->sst_location(metadata->id(), first_outputs[0])).ok());
+        EXPECT_TRUE(FileSystem::Default()->path_exists(second_created_path).is_not_found());
+        EXPECT_THAT(sst_inventory(metadata->id()), testing::ElementsAreArray(after_first_handoff));
 
         failed.reset();
         SyncPoint::GetInstance()->ClearCallBack("PersistentIndexMemtable::flush:after_create");
         SyncPoint::GetInstance()->DisableProcessing();
-        retry_from_fresh_index(metadata, tde, second_key);
+        const auto failed_outputs = sst_inventory_delta(before, sst_inventory(metadata->id()));
+        std::vector<std::string> retry_outputs;
+        retry_from_fresh_index(metadata, tde, second_key, &retry_outputs);
+        remove_exact_ssts(metadata->id(), failed_outputs);
+        remove_exact_ssts(metadata->id(), retry_outputs);
+        EXPECT_THAT(sst_inventory(metadata->id()), testing::ElementsAreArray(before));
     }
 }
 

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -435,19 +435,21 @@ protected:
     void wait_for_one_async_memtable_flush(LakePersistentIndex* index) {
         std::promise<Status> flushed;
         auto future = flushed.get_future();
-        std::atomic<bool> notified = false;
+        std::atomic<int> callback_count = 0;
         SyncPoint::GetInstance()->SetCallBack("PersistentIndexMemtable::run:after_flush", [&](void* arg) {
-            if (!notified.exchange(true)) {
+            if (callback_count.fetch_add(1) == 0) {
                 flushed.set_value(*static_cast<Status*>(arg));
             }
         });
         SyncPoint::GetInstance()->EnableProcessing();
+        DeferOp clear_callback([]() {
+            SyncPoint::GetInstance()->ClearCallBack("PersistentIndexMemtable::run:after_flush");
+            SyncPoint::GetInstance()->DisableProcessing();
+        });
         ASSERT_OK(index->flush_memtable(true));
         ASSERT_EQ(std::future_status::ready, future.wait_for(std::chrono::seconds(10)));
         ASSERT_OK(future.get());
-        EXPECT_EQ(1, notified.load());
-        SyncPoint::GetInstance()->ClearCallBack("PersistentIndexMemtable::run:after_flush");
-        SyncPoint::GetInstance()->DisableProcessing();
+        EXPECT_EQ(1, callback_count.load());
     }
 
     std::vector<IndexValue> cold_reload_values(const TabletMetadataPtr& metadata, int64_t version,
@@ -2625,9 +2627,8 @@ TEST_F(LakePersistentIndexTest, test_cold_reload_preserves_non_monotonic_rssid_t
         ASSERT_OK(index->commit(&builder));
     }
 
-    ASSERT_GT(checkpointed->sstable_meta().sstables_size(), 0);
-    EXPECT_GE(checkpointed->sstable_meta().sstables().rbegin()->max_rss_rowid(),
-              static_cast<uint64_t>(kEarlierHighRssid) << 32);
+    ASSERT_EQ(1, checkpointed->sstable_meta().sstables_size());
+    EXPECT_EQ(static_cast<uint64_t>(kEarlierHighRssid) << 32, checkpointed->sstable_meta().sstables(0).max_rss_rowid());
 
     auto reloaded = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), md->id());
     ASSERT_OK(reloaded->init(checkpointed));

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -26,8 +26,6 @@
 #include <iterator>
 #include <limits>
 #include <memory>
-#include <mutex>
-#include <set>
 #include <utility>
 #include <vector>
 

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -275,7 +275,7 @@ public:
         return std::string(reinterpret_cast<const char*>(visitor.result()), encoded->type_size());
     }
 
-    TabletMetadataPtr build_non_monotonic_cache_only_history(bool append_post_frontier) {
+    TabletMetadataPtr build_non_monotonic_cache_only_history() {
         constexpr int32_t kHighKey = 1000;
         constexpr int32_t kHighValue = 10'000;
         constexpr int32_t kLowKey = 50;
@@ -306,22 +306,7 @@ public:
                          .status());
         ASSIGN_OR_ABORT(auto version3, _tablet_mgr->get_tablet_metadata(metadata->id(), 3));
         CHECK_EQ(50, version3->rowsets(version3->rowsets_size() - 1).id());
-        if (!append_post_frontier) {
-            return version3;
-        }
-
-        auto mutable_version3 = std::make_shared<TabletMetadata>(*version3);
-        mutable_version3->set_next_rowset_id(101);
-        CHECK_OK(_tablet_mgr->put_tablet_metadata(*mutable_version3));
-        CHECK_OK(publish_single_version(metadata->id(), 4, write_single_upsert_txn(metadata->id(), 1010, 10'100))
-                         .status());
-        CHECK_OK(publish_single_version(metadata->id(), 5, write_single_upsert_txn(metadata->id(), 1020, 10'200))
-                         .status());
-        ASSIGN_OR_ABORT(auto version5, _tablet_mgr->get_tablet_metadata(metadata->id(), 5));
-        CHECK_GT(version5->next_rowset_id(), 102);
-        CHECK_EQ(101, version5->rowsets(version5->rowsets_size() - 2).id());
-        CHECK_EQ(102, version5->rowsets(version5->rowsets_size() - 1).id());
-        return version5;
+        return version3;
     }
 
     TabletMetadataPtr build_non_monotonic_complete_checkpoint_history() {
@@ -3963,7 +3948,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_same_cache_second_upsert_preserves_old_ro
     const IndexValue expected_new_value(uint64_t{kNewRssid} << 32);
 
     ConfigResetGuard<int64_t> l0_guard(&config::l0_max_mem_usage, std::numeric_limits<int64_t>::max());
-    auto metadata = build_non_monotonic_cache_only_history(false);
+    auto metadata = build_non_monotonic_cache_only_history();
     const auto tablet_id = metadata->id();
     DeferOp cleanup([&]() { _update_mgr->unload_and_remove_primary_index(tablet_id); });
     ASSERT_EQ(expected_old_value, prepare_and_point_get(metadata, kBaseVersion, kLowKey));

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -29,6 +29,7 @@
 #include "column/chunk_factory.h"
 #include "column/datum_tuple.h"
 #include "column/fixed_length_column.h"
+#include "column/raw_data_visitor.h"
 #include "column/schema.h"
 #include "column/vectorized_fwd.h"
 #include "common/config_compaction_fwd.h"
@@ -253,7 +254,28 @@ public:
         return txn_id;
     }
 
-    TabletMetadataPtr build_non_monotonic_partial_checkpoint_history(bool append_post_frontier) {
+    std::string encoded_primary_key(int32_t key) {
+        auto chunk = std::make_unique<Chunk>();
+        auto column = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false);
+        column->append_datum(Datum(key));
+        chunk->append_column(std::move(column), 0);
+
+        std::vector<ColumnId> pk_columns = {0};
+        auto pkey_schema = ChunkHelper::convert_schema(_tablet_schema, pk_columns);
+        MutableColumnPtr encoded;
+        const auto encoding_type = _tablet_metadata->has_range() ? PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2
+                                                                 : PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1;
+        CHECK_OK(PrimaryKeyEncoder::create_column(pkey_schema, &encoded, encoding_type));
+        PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, 1, encoded.get(), encoding_type);
+        if (encoded->is_binary()) {
+            return ColumnHelper::get_binary_column(encoded.get())->get_slice(0).to_string();
+        }
+        RawDataVisitor visitor;
+        CHECK_OK(encoded->accept(&visitor));
+        return std::string(reinterpret_cast<const char*>(visitor.result()), encoded->type_size());
+    }
+
+    TabletMetadataPtr build_non_monotonic_cache_only_history(bool append_post_frontier) {
         constexpr int32_t kHighKey = 1000;
         constexpr int32_t kHighValue = 10'000;
         constexpr int32_t kLowKey = 50;
@@ -300,6 +322,58 @@ public:
         CHECK_EQ(101, version5->rowsets(version5->rowsets_size() - 2).id());
         CHECK_EQ(102, version5->rowsets(version5->rowsets_size() - 1).id());
         return version5;
+    }
+
+    TabletMetadataPtr build_non_monotonic_complete_checkpoint_history() {
+        constexpr int32_t kHighKey = 1000;
+        constexpr int32_t kHighValue = 10'000;
+        constexpr int32_t kLowKey = 50;
+        constexpr int32_t kOldLowValue = 500;
+        auto metadata = new_cloud_native_pk_tablet();
+        metadata->set_version(3);
+        metadata->set_next_rowset_id(101);
+        append_physical_rowset(metadata.get(), kHighKey, kHighValue, 100, 2);
+        append_physical_rowset(metadata.get(), kLowKey, kOldLowValue, 50, 3);
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*metadata));
+
+        auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), metadata->id());
+        CHECK_OK(index->init(metadata));
+        const auto high_key = encoded_primary_key(kHighKey);
+        const auto low_key = encoded_primary_key(kLowKey);
+        const Slice high_slice(high_key);
+        const Slice low_slice(low_key);
+        const IndexValue high_value(uint64_t{100} << 32);
+        const IndexValue low_value(uint64_t{50} << 32);
+        CHECK_OK(index->insert(1, &high_slice, &high_value, 2));
+        CHECK_OK(index->sync_flush_all_memtables(10'000'000));
+        CHECK_OK(index->insert(1, &low_slice, &low_value, 3));
+
+        Tablet tablet(_tablet_mgr.get(), metadata->id());
+        MetaFileBuilder first_builder(tablet, metadata);
+        CHECK_OK(index->commit(&first_builder));
+        CHECK_EQ(2, metadata->sstable_meta().sstables_size());
+        CHECK_EQ(uint64_t{100} << 32, metadata->sstable_meta().sstables(0).max_rss_rowid());
+        CHECK_EQ(uint64_t{100} << 32, metadata->sstable_meta().sstables(1).max_rss_rowid());
+
+        metadata->set_version(4);
+        append_physical_rowset(metadata.get(), 1010, 10'100, 101, 4);
+        const auto key_101 = encoded_primary_key(1010);
+        const Slice slice_101(key_101);
+        const IndexValue value_101(uint64_t{101} << 32);
+        CHECK_OK(index->insert(1, &slice_101, &value_101, 4));
+        metadata->set_version(5);
+        append_physical_rowset(metadata.get(), 1020, 10'200, 102, 5);
+        const auto key_102 = encoded_primary_key(1020);
+        const Slice slice_102(key_102);
+        const IndexValue value_102(uint64_t{102} << 32);
+        CHECK_OK(index->insert(1, &slice_102, &value_102, 5));
+        metadata->set_next_rowset_id(103);
+        const auto first_sstable_meta = metadata->sstable_meta().SerializeAsString();
+        MetaFileBuilder cache_only_builder(tablet, metadata);
+        CHECK_OK(index->commit(&cache_only_builder));
+        CHECK_EQ(first_sstable_meta, metadata->sstable_meta().SerializeAsString());
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*metadata));
+        return metadata;
     }
 
     IndexValue prepare_and_point_get(const TabletMetadataPtr& metadata, int64_t version, int32_t key) {
@@ -3819,7 +3893,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_non_monotonic_partial_checkpoint_publish_
     for (bool parallel : {false, true}) {
         SCOPED_TRACE(parallel ? "parallel" : "serial");
         ConfigResetGuard<bool> parallel_guard(&config::enable_pk_index_parallel_execution, parallel);
-        auto metadata = build_non_monotonic_partial_checkpoint_history(true);
+        auto metadata = build_non_monotonic_complete_checkpoint_history();
         const auto tablet_id = metadata->id();
         ASSERT_EQ(kBaseVersion, metadata->version());
         ASSERT_GT(metadata->next_rowset_id(), 102);
@@ -3889,7 +3963,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_same_cache_second_upsert_preserves_old_ro
     const IndexValue expected_new_value(uint64_t{kNewRssid} << 32);
 
     ConfigResetGuard<int64_t> l0_guard(&config::l0_max_mem_usage, std::numeric_limits<int64_t>::max());
-    auto metadata = build_non_monotonic_partial_checkpoint_history(false);
+    auto metadata = build_non_monotonic_cache_only_history(false);
     const auto tablet_id = metadata->id();
     DeferOp cleanup([&]() { _update_mgr->unload_and_remove_primary_index(tablet_id); });
     ASSERT_EQ(expected_old_value, prepare_and_point_get(metadata, kBaseVersion, kLowKey));

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -39,6 +39,7 @@
 #include "common/logging.h"
 #include "fs/bundle_file.h"
 #include "fs/fs.h"
+#include "fs/fs_factory.h"
 #include "fs/fs_util.h"
 #include "platform/key_cache.h"
 #include "storage/chunk_helper.h"
@@ -59,6 +60,7 @@
 #include "storage/lake/tablet_reader.h"
 #include "storage/lake/tablet_writer.h"
 #include "storage/lake/test_util.h"
+#include "storage/rowset/segment.h"
 #include "storage/rowset/segment_iterator.h"
 #include "storage/rowset/segment_options.h"
 #include "storage/rowset/segment_writer.h"
@@ -184,6 +186,222 @@ public:
     int64_t read_rows(int64_t tablet_id, int64_t version) {
         auto chunk = read(tablet_id, version);
         return chunk.value()->num_rows();
+    }
+
+    MutableTabletMetadataPtr new_cloud_native_pk_tablet() {
+        auto metadata = std::make_shared<TabletMetadata>(*_tablet_metadata);
+        metadata->set_id(next_id());
+        metadata->set_version(1);
+        metadata->set_next_rowset_id(1);
+        metadata->clear_rowsets();
+        metadata->clear_delvec_meta();
+        metadata->clear_sstable_meta();
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*metadata));
+        return metadata;
+    }
+
+    void append_physical_rowset(TabletMetadata* metadata, int32_t key, int32_t value, uint32_t rowset_id,
+                                int64_t version) {
+        ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(metadata->id()));
+        ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, next_id()));
+        ASSERT_OK(writer->open());
+        auto keys = Int32Column::create();
+        auto values = Int32Column::create();
+        keys->append(key);
+        values->append(value);
+        Chunk chunk({std::move(keys), std::move(values)}, _schema);
+        ASSERT_OK(writer->write(chunk));
+        ASSERT_OK(writer->finish());
+
+        auto* rowset = metadata->add_rowsets();
+        rowset->set_id(rowset_id);
+        rowset->set_version(version);
+        rowset->set_overlapped(false);
+        rowset->set_num_rows(writer->num_rows());
+        rowset->set_data_size(writer->data_size());
+        for (uint32_t i = 0; i < writer->segments().size(); ++i) {
+            writer->segments()[i].to_proto(i, rowset->add_segment_metas());
+        }
+        writer->close();
+    }
+
+    int64_t write_single_upsert_txn(int64_t tablet_id, int32_t key, int32_t value) {
+        auto keys = Int32Column::create();
+        auto values = Int32Column::create();
+        auto ops = Int8Column::create();
+        keys->append(key);
+        values->append(value);
+        ops->append(TOpType::UPSERT);
+        auto chunk =
+                std::make_shared<Chunk>(Columns{std::move(keys), std::move(values), std::move(ops)}, _slot_cid_map);
+        std::vector<uint32_t> indexes = {0};
+        const int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto writer, DeltaWriterBuilder()
+                                             .set_tablet_manager(_tablet_mgr.get())
+                                             .set_tablet_id(tablet_id)
+                                             .set_txn_id(txn_id)
+                                             .set_partition_id(_partition_id)
+                                             .set_mem_tracker(_mem_tracker.get())
+                                             .set_schema_id(_tablet_schema->id())
+                                             .set_slot_descriptors(&_slot_pointers)
+                                             .set_profile(&_dummy_runtime_profile)
+                                             .build());
+        CHECK_OK(writer->open());
+        CHECK_OK(writer->write(*chunk, indexes.data(), indexes.size()));
+        CHECK_OK(writer->finish_with_txnlog());
+        writer->close();
+        return txn_id;
+    }
+
+    TabletMetadataPtr build_non_monotonic_partial_checkpoint_history(bool append_post_frontier) {
+        constexpr int32_t kHighKey = 1000;
+        constexpr int32_t kHighValue = 10'000;
+        constexpr int32_t kLowKey = 50;
+        constexpr int32_t kOldLowValue = 500;
+        auto metadata = new_cloud_native_pk_tablet();
+        metadata->set_version(2);
+        append_physical_rowset(metadata.get(), kHighKey, kHighValue, 100, 2);
+        metadata->set_next_rowset_id(50);
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*metadata));
+
+        Tablet tablet(_tablet_mgr.get(), metadata->id());
+        MetaFileBuilder builder(tablet, metadata);
+        _update_mgr->lock_shard_pk_index_shard(metadata->id());
+        std::unique_ptr<std::lock_guard<std::shared_timed_mutex>> write_guard;
+        ASSIGN_OR_ABORT(auto* entry, _update_mgr->prepare_primary_index(metadata, &builder, 2, 2, write_guard));
+        CHECK_EQ(2, entry->get_ref());
+        CHECK_OK(entry->value().sync_flush_persistent_index(10'000'000));
+        CHECK_OK(entry->value().commit(metadata, &builder));
+        write_guard.reset();
+        _update_mgr->release_primary_index_cache(entry);
+        _update_mgr->unlock_shard_pk_index_shard(metadata->id());
+        CHECK(_update_mgr->TEST_check_primary_index_cache_ref(metadata->id(), 1));
+        CHECK_GT(metadata->sstable_meta().sstables_size(), 0);
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*metadata));
+
+        CHECK_OK(publish_single_version(metadata->id(), 3,
+                                        write_single_upsert_txn(metadata->id(), kLowKey, kOldLowValue))
+                         .status());
+        ASSIGN_OR_ABORT(auto version3, _tablet_mgr->get_tablet_metadata(metadata->id(), 3));
+        CHECK_EQ(50, version3->rowsets(version3->rowsets_size() - 1).id());
+        if (!append_post_frontier) {
+            return version3;
+        }
+
+        auto mutable_version3 = std::make_shared<TabletMetadata>(*version3);
+        mutable_version3->set_next_rowset_id(101);
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*mutable_version3));
+        CHECK_OK(publish_single_version(metadata->id(), 4, write_single_upsert_txn(metadata->id(), 1010, 10'100))
+                         .status());
+        CHECK_OK(publish_single_version(metadata->id(), 5, write_single_upsert_txn(metadata->id(), 1020, 10'200))
+                         .status());
+        ASSIGN_OR_ABORT(auto version5, _tablet_mgr->get_tablet_metadata(metadata->id(), 5));
+        CHECK_GT(version5->next_rowset_id(), 102);
+        CHECK_EQ(101, version5->rowsets(version5->rowsets_size() - 2).id());
+        CHECK_EQ(102, version5->rowsets(version5->rowsets_size() - 1).id());
+        return version5;
+    }
+
+    IndexValue prepare_and_point_get(const TabletMetadataPtr& metadata, int64_t version, int32_t key) {
+        Tablet tablet(_tablet_mgr.get(), metadata->id());
+        auto mutable_metadata = std::make_shared<TabletMetadata>(*metadata);
+        MetaFileBuilder builder(tablet, mutable_metadata);
+        _update_mgr->lock_shard_pk_index_shard(metadata->id());
+        std::unique_ptr<std::lock_guard<std::shared_timed_mutex>> write_guard;
+        ASSIGN_OR_ABORT(auto* entry,
+                        _update_mgr->prepare_primary_index(metadata, &builder, version, version, write_guard));
+        EXPECT_EQ(2, entry->get_ref());
+        auto keys = Int32Column::create();
+        keys->append(key);
+        std::vector<uint64_t> values(keys->size(), NullIndexValue);
+        EXPECT_OK(entry->value().get(*keys, &values));
+        EXPECT_EQ(1, values.size());
+        const IndexValue result(values.empty() ? NullIndexValue : values[0]);
+        write_guard.reset();
+        _update_mgr->release_primary_index_cache(entry);
+        _update_mgr->unlock_shard_pk_index_shard(metadata->id());
+        EXPECT_TRUE(_update_mgr->TEST_check_primary_index_cache_ref(metadata->id(), 1));
+        return result;
+    }
+
+    IndexValue cached_point_get(int64_t tablet_id, int32_t key) {
+        auto* entry = _update_mgr->index_cache().get(tablet_id);
+        CHECK(entry != nullptr);
+        CHECK_EQ(2, entry->get_ref());
+        auto guard = entry->value().fetch_guard();
+        auto keys = Int32Column::create();
+        keys->append(key);
+        std::vector<uint64_t> values(keys->size(), NullIndexValue);
+        CHECK_OK(entry->value().get(*keys, &values));
+        CHECK_EQ(1, values.size());
+        const IndexValue result(values[0]);
+        guard.reset();
+        _update_mgr->release_primary_index_cache(entry);
+        CHECK(_update_mgr->TEST_check_primary_index_cache_ref(tablet_id, 1));
+        return result;
+    }
+
+    int64_t raw_pk_occurrences(const TabletMetadataPtr& metadata, int32_t key) {
+        int64_t occurrences = 0;
+        ASSIGN_OR_ABORT(auto fs, FileSystemFactory::CreateSharedFromString(_test_dir));
+        for (const auto& rowset : metadata->rowsets()) {
+            for (int i = 0; i < rowset.segment_metas_size(); ++i) {
+                const auto& segment_meta = rowset.segment_metas(i);
+                FileInfo file_info{.path = _tablet_mgr->segment_location(metadata->id(), segment_meta.filename())};
+                if (segment_meta.has_size()) {
+                    file_info.size = segment_meta.size();
+                }
+                if (segment_meta.has_encryption_meta()) {
+                    file_info.encryption_meta = segment_meta.encryption_meta();
+                }
+                ASSIGN_OR_ABORT(auto segment, Segment::open(fs, std::move(file_info), rowset.id() + i, _tablet_schema));
+                OlapReaderStatistics stats;
+                SegmentReadOptions options;
+                options.fs = fs;
+                options.stats = &stats;
+                options.tablet_id = metadata->id();
+                options.rowset_id = rowset.id();
+                options.version = metadata->version();
+                options.chunk_size = 64;
+                options.tablet_schema = _tablet_schema;
+                ASSIGN_OR_ABORT(auto iterator, segment->new_iterator(*_schema, options));
+                while (true) {
+                    auto chunk = ChunkFactory::new_chunk(*_schema, 64);
+                    auto st = iterator->get_next(chunk.get());
+                    if (st.is_end_of_file()) {
+                        break;
+                    }
+                    CHECK_OK(st);
+                    for (size_t row = 0; row < chunk->num_rows(); ++row) {
+                        occurrences += chunk->get(row)[0].get_int32() == key;
+                    }
+                }
+                iterator->close();
+            }
+        }
+        return occurrences;
+    }
+
+    struct VisibleOracle {
+        int64_t row_count = 0;
+        int64_t pk_occurrences = 0;
+        std::set<int32_t> distinct_keys;
+        std::optional<int32_t> target_value;
+    };
+
+    VisibleOracle visible_oracle(int64_t tablet_id, int64_t version, int32_t key) {
+        ASSIGN_OR_ABORT(auto chunk, read(tablet_id, version));
+        VisibleOracle oracle;
+        oracle.row_count = chunk->num_rows();
+        for (size_t row = 0; row < chunk->num_rows(); ++row) {
+            const auto pk = chunk->get(row)[0].get_int32();
+            oracle.distinct_keys.insert(pk);
+            if (pk == key) {
+                ++oracle.pk_occurrences;
+                oracle.target_value = chunk->get(row)[1].get_int32();
+            }
+        }
+        return oracle;
     }
 
 protected:
@@ -3579,6 +3797,119 @@ TEST_P(LakePrimaryKeyPublishTest, test_light_compaction_publish_loads_segments_u
 
     // Segments were loaded (flag on) and none was lost, so every row survives the compaction.
     EXPECT_EQ(240, read_rows(tablet_id, version));
+}
+
+TEST_P(LakePrimaryKeyPublishTest, test_non_monotonic_partial_checkpoint_publish_delvec_and_visibility) {
+    constexpr int32_t kLowKey = 50;
+    constexpr int32_t kNewLowValue = 501;
+    constexpr uint32_t kOldRssid = 50;
+    constexpr uint32_t kNewRssid = 103;
+    constexpr uint32_t kOldRowid = 0;
+    constexpr uint32_t kNewRowid = 0;
+    constexpr int64_t kBaseVersion = 5;
+    constexpr int64_t kPublishVersion = 6;
+    const IndexValue expected_old_value((uint64_t{kOldRssid} << 32) | kOldRowid);
+    const IndexValue expected_new_rss_rowid((uint64_t{kNewRssid} << 32) | kNewRowid);
+
+    ConfigResetGuard<int64_t> l0_guard(&config::l0_max_mem_usage, std::numeric_limits<int64_t>::max());
+    ConfigResetGuard<int32_t> ratio_guard(&config::pk_index_parallel_rebuild_mem_ratio, 100);
+    ASSERT_FALSE(RuntimeEnv::GetInstance()->update_mem_tracker()->limit_exceeded_by_ratio(
+            config::pk_index_parallel_rebuild_mem_ratio));
+
+    for (bool parallel : {false, true}) {
+        SCOPED_TRACE(parallel ? "parallel" : "serial");
+        ConfigResetGuard<bool> parallel_guard(&config::enable_pk_index_parallel_execution, parallel);
+        auto metadata = build_non_monotonic_partial_checkpoint_history(true);
+        const auto tablet_id = metadata->id();
+        ASSERT_EQ(kBaseVersion, metadata->version());
+        ASSERT_GT(metadata->next_rowset_id(), 102);
+        _update_mgr->unload_and_remove_primary_index(tablet_id);
+
+        std::atomic<int> parallel_callbacks = 0;
+        std::atomic<int> serial_callbacks = 0;
+        SyncPoint::GetInstance()->SetCallBack("LakePersistentIndex::load_from_lake_tablet:parallel",
+                                              [&](void*) { ++parallel_callbacks; });
+        SyncPoint::GetInstance()->SetCallBack("LakePersistentIndex::load_from_lake_tablet:serial",
+                                              [&](void*) { ++serial_callbacks; });
+        SyncPoint::GetInstance()->EnableProcessing();
+        DeferOp clear_callbacks([&]() {
+            SyncPoint::GetInstance()->ClearCallBack("LakePersistentIndex::load_from_lake_tablet:parallel");
+            SyncPoint::GetInstance()->ClearCallBack("LakePersistentIndex::load_from_lake_tablet:serial");
+            SyncPoint::GetInstance()->DisableProcessing();
+            _update_mgr->unload_and_remove_primary_index(tablet_id);
+        });
+
+        const auto old_value = prepare_and_point_get(metadata, kBaseVersion, kLowKey);
+        EXPECT_EQ(expected_old_value, old_value);
+        EXPECT_EQ(parallel ? 1 : 0, parallel_callbacks.load());
+        EXPECT_EQ(parallel ? 0 : 1, serial_callbacks.load());
+
+        ASSERT_OK(publish_single_version(tablet_id, kPublishVersion,
+                                         write_single_upsert_txn(tablet_id, kLowKey, kNewLowValue))
+                          .status());
+        ASSIGN_OR_ABORT(auto published, _tablet_mgr->get_tablet_metadata(tablet_id, kPublishVersion));
+        ASSERT_EQ(kNewRssid, published->rowsets(published->rowsets_size() - 1).id());
+
+        DelVector dv;
+        ASSERT_OK(_update_mgr->get_del_vec_in_meta(TabletSegmentId{tablet_id, kOldRssid}, kPublishVersion, true, &dv));
+        EXPECT_EQ(1, dv.cardinality());
+        EXPECT_NE(nullptr, dv.roaring());
+        EXPECT_TRUE(dv.roaring() != nullptr && dv.roaring()->contains(kOldRowid));
+
+        const auto raw_occurrences = raw_pk_occurrences(published, kLowKey);
+        EXPECT_EQ(2, raw_occurrences);
+        auto visible = visible_oracle(tablet_id, kPublishVersion, kLowKey);
+        EXPECT_EQ(1, visible.pk_occurrences);
+        EXPECT_EQ(visible.row_count, visible.distinct_keys.size());
+        EXPECT_EQ(std::optional<int32_t>(kNewLowValue), visible.target_value);
+        EXPECT_EQ(expected_new_rss_rowid, cached_point_get(tablet_id, kLowKey));
+
+        _update_mgr->unload_and_remove_primary_index(tablet_id);
+        ASSIGN_OR_ABORT(auto latest, _tablet_mgr->get_tablet_metadata(tablet_id, kPublishVersion));
+        const auto cold_point_value = prepare_and_point_get(latest, kPublishVersion, kLowKey);
+        EXPECT_EQ(expected_new_rss_rowid, cold_point_value);
+        EXPECT_EQ(parallel ? 2 : 0, parallel_callbacks.load());
+        EXPECT_EQ(parallel ? 0 : 2, serial_callbacks.load());
+        auto restarted_visible = visible_oracle(tablet_id, kPublishVersion, kLowKey);
+        EXPECT_EQ(1, restarted_visible.pk_occurrences);
+        EXPECT_EQ(restarted_visible.row_count, restarted_visible.distinct_keys.size());
+        EXPECT_EQ(std::optional<int32_t>(kNewLowValue), restarted_visible.target_value);
+    }
+}
+
+TEST_P(LakePrimaryKeyPublishTest, test_same_cache_second_upsert_preserves_old_row_delvec_and_visibility) {
+    constexpr int32_t kLowKey = 50;
+    constexpr int32_t kNewLowValue = 501;
+    constexpr uint32_t kOldRssid = 50;
+    constexpr uint32_t kNewRssid = 51;
+    constexpr uint32_t kOldRowid = 0;
+    constexpr int64_t kBaseVersion = 3;
+    constexpr int64_t kPublishVersion = 4;
+    const IndexValue expected_old_value((uint64_t{kOldRssid} << 32) | kOldRowid);
+    const IndexValue expected_new_value(uint64_t{kNewRssid} << 32);
+
+    ConfigResetGuard<int64_t> l0_guard(&config::l0_max_mem_usage, std::numeric_limits<int64_t>::max());
+    auto metadata = build_non_monotonic_partial_checkpoint_history(false);
+    const auto tablet_id = metadata->id();
+    DeferOp cleanup([&]() { _update_mgr->unload_and_remove_primary_index(tablet_id); });
+    ASSERT_EQ(expected_old_value, prepare_and_point_get(metadata, kBaseVersion, kLowKey));
+
+    ASSERT_OK(publish_single_version(tablet_id, kPublishVersion,
+                                     write_single_upsert_txn(tablet_id, kLowKey, kNewLowValue))
+                      .status());
+    ASSIGN_OR_ABORT(auto published, _tablet_mgr->get_tablet_metadata(tablet_id, kPublishVersion));
+    ASSERT_EQ(kNewRssid, published->rowsets(published->rowsets_size() - 1).id());
+    DelVector dv;
+    ASSERT_OK(_update_mgr->get_del_vec_in_meta(TabletSegmentId{tablet_id, kOldRssid}, kPublishVersion, true, &dv));
+    EXPECT_EQ(1, dv.cardinality());
+    ASSERT_NE(nullptr, dv.roaring());
+    EXPECT_TRUE(dv.roaring()->contains(kOldRowid));
+    EXPECT_EQ(2, raw_pk_occurrences(published, kLowKey));
+    auto visible = visible_oracle(tablet_id, kPublishVersion, kLowKey);
+    EXPECT_EQ(1, visible.pk_occurrences);
+    EXPECT_EQ(visible.row_count, visible.distinct_keys.size());
+    EXPECT_EQ(std::optional<int32_t>(kNewLowValue), visible.target_value);
+    EXPECT_EQ(expected_new_value, cached_point_get(tablet_id, kLowKey));
 }
 
 INSTANTIATE_TEST_SUITE_P(LakePrimaryKeyPublishTest, LakePrimaryKeyPublishTest,


### PR DESCRIPTION
## Why I'm doing:

A writable tablet MERGE can produce version-ordered rowsets whose RSSIDs are not numerically monotonic. If the cloud-native persistent index publishes only a partial first SST checkpoint, `max_rss_rowid` records the earlier high RSSID while a later lower-RSSID rowset remains only in memory. After cache eviction or restart, cold reload treats that lower RSSID as already covered and skips it. A subsequent UPSERT then misses the old row, does not create its delvec entry, and can expose duplicate primary keys.

The failure is reproducible without cross-publish: a real RSSID-100 rowset checkpoint followed by a later RSSID-50 in-memory tail loses the tail after cold reload.

## What I'm doing:

- Complete pending active/inactive memtables before publishing the first empty-to-nonempty persistent-index checkpoint.
- Advance the empty active memtable watermark after successful direct `ingest_sst` and `bulk_erase` ownership transfer, preserving SST ordering for a later lower-RSSID tail.
- Delete the exact current memtable SST when build/close/open/init fails before ownership handoff.
- Add real-file regressions for serial/parallel cold reload, active/inactive and threshold ordering, plaintext/TDE, failure/retry cleanup, direct SST/tombstone ingestion, publish delvec ownership, physical-vs-visible PK uniqueness, cache-only fast paths, restart, and duplicate-PK fail-fast behavior.

The first-checkpoint boundary is sufficient because all nonmonotonic rowsets produced by MERGE are already part of the new target metadata before that checkpoint is completed. Every later normal or MERGE-cross-published `op_write` is assigned from the target tablet's current `next_rowset_id`, rather than retaining a source-tablet RSSID, and #78032 finalizes that target allocator above every projected rowset, delete reference, and SST high watermark. A later cache-only tail is therefore above the completed frontier and cold reload will replay it. The serial/parallel regressions exercise this existing-SST case with post-frontier RSSIDs 101 and 102 and verify that the later commit remains cache-only while both rows survive cold reload.

This PR adds no protobuf or storage-format field and does not change tablet MERGE/split logic. #78032 has now merged, but tablet MERGE remains disabled by default. Keep `tablet_reshard_enable_tablet_merge=false` until this fix is deployed; clusters that never enabled the experimental MERGE path cannot have created this checkpoint shape. If a cluster deployed #78032 and explicitly enabled MERGE before this fix, disable it and restore or recreate affected merged tablets from a known-good snapshot before further DML; this PR intentionally does not repair historical ambiguous checkpoints or duplicate physical rows. Wider cleanup of an earlier successfully handed-off SST after a later flush failure remains follow-up work.

Local verification on the final head:

- ASAN affected suites: 402/402 passed.
- Dedicated TDE/error/cache/compaction/delvec matrix: 32/32 passed.
- Release shared-data backend build passed.
- Formatter, diff, BE module-boundary, generated AGENTS, DCO, CORE, preflight, and simplifier checks passed.

Fixes #78263

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
