### PR TITLE
[BugFix] Guard legacy NGRAMBF indexes without gram_num (backport #76989)

### DIFF
--- a/be/src/exprs/function_call_expr.cpp
+++ b/be/src/exprs/function_call_expr.cpp
@@ -230,6 +230,13 @@ StatusOr<ColumnPtr> VectorizedFunctionCallExpr::evaluate_checked(starrocks::Expr
 
 bool VectorizedFunctionCallExpr::ngram_bloom_filter(ExprContext* context, const BloomFilter* bf,
                                                     const NgramBloomFilterReaderOptions& reader_options) const {
+    // Legacy NGRAMBF metadata can omit gram_num. Do not use such an index for
+    // pruning. This check must precede the cached NgramBloomFilterState because
+    // one ExprContext can scan rowsets with different index metadata.
+    if (reader_options.index_gram_num == 0) {
+        return true;
+    }
+
     FunctionContext* fn_ctx = context->fn_context(_fn_context_index);
     std::unique_ptr<NgramBloomFilterState>& ngram_state = fn_ctx->get_ngram_state();
 

--- a/be/src/storage/rowset/bloom_filter_index_writer.cpp
+++ b/be/src/storage/rowset/bloom_filter_index_writer.cpp
@@ -256,6 +256,9 @@ struct BloomFilterBuilderFunctor {
 // TODO currently we don't support bloom filter index for tinyint/hll/float/double
 Status BloomFilterIndexWriter::create(const BloomFilterOptions& bf_options, const TypeInfoPtr& typeinfo,
                                       std::unique_ptr<BloomFilterIndexWriter>* res) {
+    if (bf_options.use_ngram && bf_options.gram_num == 0) {
+        return Status::InvalidArgument("NGRAMBF index requires gram_num greater than zero");
+    }
     return field_type_dispatch_bloomfilter(typeinfo->type(), BloomFilterBuilderFunctor(), res, bf_options, typeinfo);
 }
 

--- a/be/test/exprs/function_call_expr_test.cpp
+++ b/be/test/exprs/function_call_expr_test.cpp
@@ -20,6 +20,7 @@
 #include <cmath>
 
 #include "butil/time.h"
+#include "column/binary_column.h"
 #include "column/column_helper.h"
 #include "column/fixed_length_column.h"
 #include "exprs/cast_expr.h"
@@ -27,6 +28,7 @@
 #include "runtime/mem_tracker.h"
 #include "runtime/runtime_state.h"
 #include "testutil/assert.h"
+#include "util/bloom_filter.h"
 
 namespace starrocks {
 
@@ -305,6 +307,86 @@ TEST_F(VectorizedFunctionCallExprTest, prepare_close) {
     st = expr_context.open(&_runtime_state);
     ASSERT_TRUE(st.ok());
     expr_context.close(&_runtime_state);
+}
+
+// ---------------------------------------------------------------------------
+// ngram_bloom_filter pushdown helper: builds a ngram_search_case_insensitive
+// call so the index-side reader path can be probed directly with a bloom
+// filter and the index metadata a rowset would supply.
+// ---------------------------------------------------------------------------
+
+class NgramBloomFilterPushdownTest : public ::testing::Test {
+protected:
+    static TExprNode make_typed_node(TPrimitiveType::type t) {
+        TExprNode n;
+        n.node_type = TExprNodeType::SLOT_REF;
+        n.num_children = 0;
+        n.type = gen_type_desc(t);
+        return n;
+    }
+
+    TExprNode build_ngram_call_node() {
+        TFunction function;
+        TFunctionName functionName;
+        functionName.__set_function_name("ngram_search_case_insensitive");
+        function.__set_name(functionName);
+        function.__set_binary_type(TFunctionBinaryType::BUILTIN);
+        function.__set_fid(30441);
+        function.__set_has_var_args(false);
+        std::vector<TTypeDesc> arg_types = {
+                gen_type_desc(TPrimitiveType::VARCHAR),
+                gen_type_desc(TPrimitiveType::VARCHAR),
+                gen_type_desc(TPrimitiveType::INT),
+        };
+        function.__set_arg_types(arg_types);
+        function.__set_ret_type(gen_type_desc(TPrimitiveType::DOUBLE));
+
+        TExprNode parent;
+        parent.node_type = TExprNodeType::FUNCTION_CALL;
+        parent.num_children = 3;
+        parent.type = gen_type_desc(TPrimitiveType::DOUBLE);
+        parent.__set_fn(function);
+        return parent;
+    }
+
+    RuntimeState _runtime_state;
+};
+
+TEST_F(NgramBloomFilterPushdownTest, ZeroGramNumDisablesIndex) {
+    TExprNode varchar_node = make_typed_node(TPrimitiveType::VARCHAR);
+    TExprNode int_node = make_typed_node(TPrimitiveType::INT);
+    TExprNode parent_node = build_ngram_call_node();
+
+    VectorizedFunctionCallExpr expr(parent_node);
+    MockColumnExpr haystack(varchar_node, BinaryColumn::create());
+    MockConstVectorizedExpr<TYPE_VARCHAR> needle(varchar_node, "legacy-ngram-index");
+    MockConstVectorizedExpr<TYPE_INT> gram_num(int_node, 3);
+    expr.add_child(&haystack);
+    expr.add_child(&needle);
+    expr.add_child(&gram_num);
+
+    ExprContext expr_context(&expr);
+    std::vector<ExprContext*> expr_ctxs = {&expr_context};
+    ASSERT_OK(Expr::prepare(expr_ctxs, &_runtime_state));
+    ASSERT_OK(Expr::open(expr_ctxs, &_runtime_state));
+
+    NgramBloomFilterReaderOptions opts;
+    opts.index_gram_num = 3;
+    opts.index_case_sensitive = false;
+    std::unique_ptr<BloomFilter> bf;
+    ASSERT_OK(BloomFilter::create(BLOCK_BLOOM_FILTER, &bf));
+    ASSERT_OK(bf->init(16, 0.05, HashStrategyPB::HASH_MURMUR3_X64_64));
+
+    // Populate the expression-local cache from a valid rowset first. The
+    // empty bloom filter makes the valid 3-gram probe reject the page.
+    EXPECT_FALSE(expr.ngram_bloom_filter(&expr_context, bf.get(), opts));
+
+    // A later legacy rowset must still leave the page unpruned, rather than
+    // using the ngrams cached for the earlier valid rowset.
+    opts.index_gram_num = 0;
+    EXPECT_TRUE(expr.ngram_bloom_filter(&expr_context, bf.get(), opts));
+
+    Expr::close(expr_ctxs, &_runtime_state);
 }
 
 } // namespace starrocks

--- a/be/test/storage/rowset/bloom_filter_index_reader_writer_test.cpp
+++ b/be/test/storage/rowset/bloom_filter_index_reader_writer_test.cpp
@@ -167,6 +167,19 @@ protected:
     OlapReaderStatistics _stats;
 };
 
+TEST_F(BloomFilterIndexReaderWriterTest, test_ngram_zero_gram_num_is_rejected) {
+    BloomFilterOptions bf_options;
+    bf_options.use_ngram = true;
+    bf_options.gram_num = 0;
+
+    std::unique_ptr<BloomFilterIndexWriter> writer;
+    Status status = BloomFilterIndexWriter::create(bf_options, get_type_info(TYPE_VARCHAR), &writer);
+
+    // Do not silently write an empty index for malformed legacy metadata.
+    ASSERT_TRUE(status.is_invalid_argument()) << status;
+    ASSERT_EQ(nullptr, writer);
+}
+
 TEST_F(BloomFilterIndexReaderWriterTest, test_int) {
     size_t num = 1024 * 3 - 1;
     int* val = new int[num];


### PR DESCRIPTION
## Why I'm doing:

Materialized views created by affected older FE versions can persist an NGRAMBF index without its properties. The BE then receives `gram_num = 0`, and the ngram writer reads past the UTF-8 offset vector while building a segment, crashing the CN.

### Possible crash stack when `gram_num = 0`

For a non-empty VARCHAR value containing `N` UTF-8 characters, `get_utf8_index()` produces an offset vector with entries `[0, ..., N - 1]`. The old NGRAMBF writer loop permits `j == N` when `gram_num == 0`, then reads `index[N]` out of bounds. The invalid offset becomes the data pointer/length of an ngram `Slice`, and the subsequent value copy can fault in `memcpy`.

The affected write path is:

```
SegmentWriter::append_chunk
  -> ScalarColumnWriter::append
    -> NgramBloomFilterIndexWriterImpl<TYPE_VARCHAR>::add_values
      -> ScalarTypeInfoImpl<TYPE_CHAR>::deep_copy
        -> memcpy  // SIGSEGV
```

This is the same shape as the production CN crash during MV refresh. Spill/merge can be present in the stack because it is the segment-writing path, but it is not the source of the invalid memory access. A malformed legacy index can also reach the same zero-gram split loop during `ngram_search`; the read-side guard keeps that path from producing an out-of-bounds access as well.

## What I'm doing:

- Reject creation of an NGRAMBF writer with `gram_num = 0`, so a malformed legacy schema fails the write/refresh with `InvalidArgument` instead of silently producing an empty index or crashing the CN.
- Disable NGRAMBF pruning on the read side when its metadata has no gram number. The guard runs before the cached `NgramBloomFilterState`, so a legacy rowset cannot reuse ngrams cached from an earlier valid rowset.
- Add writer and reader regression coverage for legacy zero-gram metadata.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old policy, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
<hr>Manual resubmit of the Mergify backport of pull request #76989 into `branch-3.5.21`.
The automatic backport (#78291) hit a cherry-pick conflict in `be/test/exprs/function_call_expr_test.cpp` and was auto-closed, so it is re-opened here with the conflict resolved.

Conflict resolution: the upstream commit only adds the `ZeroGramNumDisablesIndex` case, but its `NgramBloomFilterPushdownTest` fixture comes from a change that was never backported. This PR brings in only the fixture members that case needs, and adapts the 3.5 APIs (`ExprExecutor::prepare/open/close` -> `Expr::prepare/open/close`, `common/bloom_filter.h` -> `util/bloom_filter.h`). The three UTF-8 case-folding cases that surround it upstream are intentionally left out: 3.5 lowercases the needle byte-wise via `std::tolower`, not the ICU path they assert on.



