### PR TITLE
[BugFix] Read large AD groups completely and never publish a partial group cache

### DIFF
--- a/docs/en/administration/configuration/FE_parameters/user_query_loading.md
+++ b/docs/en/administration/configuration/FE_parameters/user_query_loading.md
@@ -63,6 +63,15 @@ This topic introduces the following types of FE configurations:
 - Description: When true, StarRocks redacts credentials from task SQL definitions before returning them in `information_schema.tasks` and `information_schema.task_runs` by applying SqlCredentialRedactor.redact to the DEFINITION column. In `information_schema.task_runs` the same redaction is applied whether the definition comes from the task run status or, when empty, from the task definition lookup. When false, raw task definitions are returned (may expose credentials). Masking is CPU/string-processing work and can be time-consuming when the number of tasks or `task_runs` is large; disable only if you need unredacted definitions and accept the security risk.
 - Introduced in: v3.5.6
 
+### `ldap_group_provider_search_page_size`
+
+- Default: 1000
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: Page size of the RFC 2696 simple paged results control that an LDAP group provider uses when it enumerates group entries. Without paging, a directory whose server-side result limit (`MaxPageSize`, 1000 on Active Directory) is smaller than the number of groups matching `ldap_group_filter` answers with `sizeLimitExceeded`, and the refresh collects no group at all. The control is sent as non-critical, so a directory that does not implement RFC 2696 ignores it and returns the full result set. Set this to `0` to stop sending the control altogether and fall back to a single unpaged search.
+- Introduced in: v4.1.5, v4.2.0
+
 ### `privilege_max_role_depth`
 
 - Default: 16

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/LDAPGroupProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/LDAPGroupProvider.java
@@ -19,6 +19,7 @@ import com.google.common.base.Strings;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.sql.analyzer.SemanticException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -27,10 +28,13 @@ import org.apache.logging.log4j.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -39,21 +43,28 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.naming.Context;
+import javax.naming.InvalidNameException;
+import javax.naming.NameNotFoundException;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.PartialResultException;
 import javax.naming.directory.Attribute;
 import javax.naming.directory.Attributes;
 import javax.naming.directory.DirContext;
-import javax.naming.directory.InitialDirContext;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
+import javax.naming.ldap.Control;
+import javax.naming.ldap.InitialLdapContext;
+import javax.naming.ldap.LdapContext;
+import javax.naming.ldap.PagedResultsControl;
+import javax.naming.ldap.PagedResultsResponseControl;
 import javax.net.ssl.SSLContext;
 
-public class LDAPGroupProvider extends GroupProvider {
+public class LDAPGroupProvider extends GroupProvider implements GsonPostProcessable {
     private static final Logger LOG = LogManager.getLogger(LDAPGroupProvider.class);
 
     public static final String TYPE = "ldap";
@@ -96,6 +107,28 @@ public class LDAPGroupProvider extends GroupProvider {
      */
     public static final String LDAP_CACHE_REFRESH_INTERVAL = "ldap_cache_refresh_interval";
 
+    /**
+     * Matches the range suffix Active Directory encodes into the attribute id itself, e.g.
+     * {@code member;range=0-1499} or {@code member;range=1500-*}. Tolerates other attribute options
+     * around it, such as {@code member;lang-en;range=0-1499}.
+     */
+    private static final Pattern RANGE_PATTERN = Pattern.compile("(?i)(?:^|;)range=(\\d+)-(\\d+|\\*)(?:;|$)");
+
+    /**
+     * Hard cap on follow-up range pages fetched per group, so a server that keeps advertising a
+     * non-terminal range cannot spin us forever. At AD's typical MaxValRange of 1500 this covers
+     * ~150k members, far above any realistic group.
+     */
+    @VisibleForTesting
+    static int MAX_RANGE_PAGES = 100;
+
+    /**
+     * Hard cap on paged search rounds per refresh, so a server that keeps handing back a non-empty cookie
+     * cannot spin us forever. At the default page size of 1000 this covers ten million group entries.
+     */
+    @VisibleForTesting
+    static int MAX_SEARCH_PAGES = 10_000;
+
     public static final Set<String> REQUIRED_PROPERTIES = new HashSet<>(Arrays.asList(
             LDAP_LDAP_CONN_URL,
             LDAP_PROP_ROOT_DN_KEY,
@@ -109,9 +142,27 @@ public class LDAPGroupProvider extends GroupProvider {
             Executors.newScheduledThreadPool(Config.group_provider_refresh_thread_num);
 
     /**
-     * Cache user-to-group mapping
+     * Cache user-to-group mapping. Volatile because the refreshing thread swaps the whole reference while
+     * authentication threads read it; ConcurrentHashMap alone would not make that assignment visible.
+     *
+     * <p>NOTE: none of the runtime state below survives a metadata image round trip. GSON instantiates a
+     * provider loaded from the image through UnsafeAllocator, which skips both the constructor and these
+     * inline initializers - and {@code HiddenAnnotationExclusionStrategy} skips every field without
+     * {@code @SerializedName}, so nothing in the JSON fills them back in either. They arrive as null / 0.
+     * {@link #gsonPostProcess()} is what restores them; see the comment there before adding a field here.
      */
-    private Map<String, Set<String>> userToGroupCache = new ConcurrentHashMap<>();
+    private volatile Map<String, Set<String>> userToGroupCache = Map.of();
+
+    /** Health of the cache above, surfaced through SHOW GROUP PROVIDERS and the refresh log. */
+    private volatile long lastSuccessfulRefreshTimeMs = 0L;
+    private volatile int lastPublishedGroupEntryCount = 0;
+    private volatile String lastRefreshError = null;
+    /**
+     * A plain volatile int rather than an AtomicInteger on purpose: a primitive cannot be null, so it
+     * needs nothing from {@link #gsonPostProcess()} to survive an image load. Only the single refresh
+     * thread writes it, so read-modify-write here needs no atomicity.
+     */
+    private volatile int consecutiveFailureCount = 0;
 
     /**
      * The current ldap group provider is registered to the scheduling task in the thread pool.
@@ -123,14 +174,60 @@ public class LDAPGroupProvider extends GroupProvider {
         super(name, properties);
     }
 
+    /**
+     * Restore the runtime state that GSON could not.
+     *
+     * <p>A provider loaded from the metadata image is instantiated through GSON's UnsafeAllocator, which
+     * runs neither the constructor nor the inline field initializers, and every field here is skipped by
+     * {@code HiddenAnnotationExclusionStrategy} (no {@code @SerializedName}) so the JSON does not carry
+     * them either. Without this hook {@code userToGroupCache} is null on such a provider, and the first
+     * {@code SHOW GROUP PROVIDERS} or scheduled refresh dies with an NPE.
+     *
+     * <p>Prefer primitives for new runtime state - they cannot be null and need nothing here. If a new
+     * field must be a reference type, initialize it below.
+     */
+    @Override
+    public void gsonPostProcess() throws IOException {
+        if (userToGroupCache == null) {
+            userToGroupCache = Map.of();
+        }
+    }
+
     @Override
     public void init() throws DdlException {
-        scheduleTask = SCHEDULER.scheduleAtFixedRate(this::refreshGroups, 0, getLdapCacheRefreshInterval(), TimeUnit.SECONDS);
+        // scheduleWithFixedDelay, not scheduleAtFixedRate: a refresh that outlives the interval must not
+        // queue up an immediate re-run and hammer the directory. Large directories can easily exceed the
+        // default 300s once range retrieval and paged search are in play.
+        scheduleTask =
+                SCHEDULER.scheduleWithFixedDelay(this::refreshGroups, 0, getLdapCacheRefreshInterval(), TimeUnit.SECONDS);
     }
 
     @Override
     public void destroy() {
-        scheduleTask.cancel(true);
+        // init() may have failed before the task was registered.
+        if (scheduleTask != null) {
+            scheduleTask.cancel(true);
+        }
+    }
+
+    /**
+     * Surfaces cache health in the COMMENT column of SHOW GROUP PROVIDERS. A stale cache is deliberately
+     * not an error at query time, so this is the cheapest way for an operator to notice that refreshes
+     * have been failing without adding a new schema or metric.
+     */
+    @Override
+    public String getComment() {
+        StringBuilder sb = new StringBuilder()
+                .append("cachedUsers=").append(userToGroupCache.size())
+                .append(", groupEntries=").append(lastPublishedGroupEntryCount)
+                .append(", lastSuccessAgoSec=")
+                .append(lastSuccessfulRefreshTimeMs == 0L ? "never" : cacheStaleForMs() / 1000)
+                .append(", consecutiveFailures=").append(consecutiveFailureCount);
+        String error = lastRefreshError;
+        if (error != null) {
+            sb.append(", lastError=").append(error);
+        }
+        return sb.toString();
     }
 
     @Override
@@ -147,84 +244,668 @@ public class LDAPGroupProvider extends GroupProvider {
         return userToGroupCache.getOrDefault(lookupKey, Set.of());
     }
 
+    /**
+     * Refresh the cache, but only replace it when the directory was read completely.
+     * <p>An incomplete read is the failure mode this whole class has to avoid: publishing a partial
+     * user-to-group map looks exactly like "these users are in no groups", which denies access fleet-wide.
+     * A stale-but-complete cache is strictly better, so a failed refresh keeps the last known good one and
+     * says so loudly.
+     * <p>This method must never throw. {@link java.util.concurrent.ScheduledExecutorService} cancels all
+     * future runs of a task that lets an exception escape, so an unchecked exception here would silently
+     * freeze group refresh until the FE restarts.
+     */
     public void refreshGroups() {
-        LOG.info("refresh ldap group cache for group provider: {}", name);
-        Map<String, Set<String>> groups = new ConcurrentHashMap<>();
+        // The whole body is guarded, not just collectGroups(): ScheduledExecutorService cancels every
+        // future run of a task that lets anything escape, so a single throw here would silently stop
+        // group refresh until the FE restarts. An earlier revision guarded only the collect call, and an
+        // NPE in the publish/logging code below did exactly that.
         try {
-            DirContext ctx = createDirContextOnConnection(getLdapBindRootDn(), getLdapBindRootPwd());
+            refreshGroupsUnsafe();
+        } catch (Throwable t) {
+            LOG.error("LDAP group refresh threw unexpectedly for group provider: {}, "
+                    + "keeping the last known good cache", name, t);
+        }
+    }
+
+    private void refreshGroupsUnsafe() {
+        LOG.info("refresh ldap group cache for group provider: {}", name);
+        long startMs = System.currentTimeMillis();
+
+        RefreshResult result;
+        try {
+            result = collectGroups();
+        } catch (Throwable t) {
+            LOG.error("LDAP group collect threw unexpectedly for group provider: {}", name, t);
+            result = RefreshResult.failed(String.valueOf(t));
+        }
+
+        // Blanking guard: a filter that suddenly matches no group at all is far more likely to be an
+        // outage or a broken filter than a real directory in which every group vanished. Note this counts
+        // group entries, not users, so a user legitimately removed from every group still propagates.
+        boolean blanked = result.groupEntryCount == 0 && lastPublishedGroupEntryCount > 0;
+
+        if (result.fatal || blanked) {
+            int failures = ++consecutiveFailureCount;
+            lastRefreshError = result.fatal ? result.failureReason : "group search matched 0 group entries";
+            LOG.error("LDAP group refresh FAILED for group provider: {}, keeping the last known good cache. "
+                            + "reason={}, consecutiveFailures={}, cacheStaleForMs={}, cachedUsers={}",
+                    name, lastRefreshError, failures, cacheStaleForMs(), userToGroupCache.size());
+            return;
+        }
+
+        this.userToGroupCache = freeze(result.userToGroups);
+        lastPublishedGroupEntryCount = result.groupEntryCount;
+        lastSuccessfulRefreshTimeMs = System.currentTimeMillis();
+        consecutiveFailureCount = 0;
+        lastRefreshError = null;
+
+        if (result.groupEntryCount == 0) {
+            LOG.warn("LDAP group refresh for group provider: {} matched no group entry. Check ldap_group_filter "
+                    + "or ldap_group_dn - no user will resolve to any group.", name);
+        }
+        LOG.info("LDAP group refresh finished for group provider: {}, groupEntries={}, memberDnsRead={}, "
+                        + "cachedUsers={}, softErrors={}, elapsedMs={}",
+                name, result.groupEntryCount, result.memberDnsRead, this.userToGroupCache.size(),
+                result.softErrorCount, System.currentTimeMillis() - startMs);
+    }
+
+    /**
+     * Read every configured group out of the directory. Never throws: a failure is reported through
+     * {@link RefreshResult#fatal} so the caller can decide whether the result is safe to publish.
+     */
+    @VisibleForTesting
+    RefreshResult collectGroups() {
+        Map<String, Set<String>> groups = new ConcurrentHashMap<>();
+        // Phase A collects whatever the server returned inline and records the groups whose member list
+        // was truncated by range retrieval. Phase B resolves those, and only those, afterwards.
+        List<PendingMemberRange> pending = new ArrayList<>();
+        Stats stats = new Stats();
+        LdapContext ctx = null;
+        try {
+            ctx = createDirContextOnConnection(getLdapBindRootDn(), getLdapBindRootPwd());
             UserNameExtractInterface userNameExtractInterface = getUserNameExtractInterface();
 
             if (getLdapGroupFilter() != null) {
-                SearchControls searchControls = new SearchControls();
-                searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE);
-                NamingEnumeration<SearchResult> results = ctx.search(getLdapBaseDn(), getLdapGroupFilter(), searchControls);
-                try {
-                    while (results.hasMore()) {
-                        SearchResult result = results.next();
-                        Attributes attributes = result.getAttributes();
-                        matchUserAndUpdateGroups(groups, attributes, userNameExtractInterface);
-                    }
-                } catch (PartialResultException e) {
-                    LOG.warn("LDAP group search partial result exception", e);
+                // Ask for the identifier and member attributes explicitly. Relying on the server's default
+                // attribute set is not deterministic on Active Directory, and being explicit is what makes AD
+                // emit the member attribute in range-encoded form when the group exceeds MaxValRange.
+                String[] returningAttrs = new String[] {getLdapGroupIdentifierAttr(), getLDAPGroupMemberAttr()};
+                boolean searchComplete = searchGroupEntriesPaged(ctx, getLdapBaseDn(), getLdapGroupFilter(),
+                        returningAttrs, Config.ldap_group_provider_search_page_size, result -> {
+                            String groupDN = extractGroupDN(result, getLdapBaseDn());
+                            try {
+                                matchUserAndUpdateGroups(groups, groupDN, result.getAttributes(),
+                                        userNameExtractInterface, pending, stats);
+                            } catch (NamingException ne) {
+                                // Isolate the failure to this group so the rest of the directory still refreshes,
+                                // but only when the server gave a determinate answer about this entry.
+                                if (!isDeterministicAbsence(ne)) {
+                                    throw ne;
+                                }
+                                stats.softErrors++;
+                                LOG.warn("Failed to process LDAP group with DN '{}', skipping", groupDN, ne);
+                            }
+                            stats.groupEntries++;
+                        });
+                if (!searchComplete) {
+                    return RefreshResult.failed(
+                            "group entry search stopped early with pages still pending, entries were lost");
                 }
             } else if (getLdapGroupDn() != null) {
                 for (String ldapGroupDN : getLdapGroupDn()) {
-                    Attributes attributes =
-                            ctx.getAttributes(ldapGroupDN, new String[] {getLdapGroupIdentifierAttr(), getLDAPGroupMemberAttr()});
-                    matchUserAndUpdateGroups(groups, attributes, userNameExtractInterface);
+                    try {
+                        Attributes attributes = ctx.getAttributes(ldapGroupDN,
+                                new String[] {getLdapGroupIdentifierAttr(), getLDAPGroupMemberAttr()});
+                        matchUserAndUpdateGroups(groups, ldapGroupDN, attributes, userNameExtractInterface, pending,
+                                stats);
+                        stats.groupEntries++;
+                    } catch (NamingException ne) {
+                        // Isolate the failure to this group so the other configured groups still refresh.
+                        if (!isDeterministicAbsence(ne)) {
+                            throw ne;
+                        }
+                        stats.softErrors++;
+                        LOG.warn("Failed to fetch attributes for LDAP group '{}', skipping", ldapGroupDN, ne);
+                    }
                 }
             } else {
                 LOG.warn("Neither ldap_group_filter nor ldap_group_dn exists");
             }
+
+            if (!resolvePendingRanges(ctx, pending, groups, userNameExtractInterface, stats)) {
+                return RefreshResult.failed("range retrieval did not reach the terminal page for every group");
+            }
         } catch (Exception e) {
-            //Do not affect the normal login process at this time. If an error occurs, an empty group will be returned.
-            LOG.error("LDAP group search failed", e);
+            LOG.error("LDAP group search failed for group provider: {}", name, e);
+            return RefreshResult.failed(e.toString());
+        } finally {
+            closeDirContext(ctx);
         }
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("LDAP group refresh completed, userToGroupCache: {}", groups);
+            LOG.debug("LDAP group collect completed, userToGroupCache: {}", groups);
+        }
+        return RefreshResult.collected(groups, stats);
+    }
+
+    /**
+     * Whether the server answered authoritatively that the entry is not there, as opposed to failing to
+     * answer. Only a determinate absence is safe to skip past; anything else means the read may have been
+     * truncated, and a truncated read must not be published. The list is a whitelist on purpose - an
+     * exception nobody has classified yet counts as a failure.
+     */
+    @VisibleForTesting
+    static boolean isDeterministicAbsence(NamingException e) {
+        return e instanceof NameNotFoundException || e instanceof InvalidNameException;
+    }
+
+    private long cacheStaleForMs() {
+        return lastSuccessfulRefreshTimeMs == 0L ? -1L : System.currentTimeMillis() - lastSuccessfulRefreshTimeMs;
+    }
+
+    /**
+     * Publish as an immutable snapshot. Combined with the volatile field this gives safe publication:
+     * {@code ConcurrentHashMap} protects its own contents but not the reference assignment, and callers
+     * of {@link #getGroup} only ever read.
+     */
+    private static Map<String, Set<String>> freeze(Map<String, Set<String>> groups) {
+        Map<String, Set<String>> frozen = new HashMap<>();
+        groups.forEach((user, memberOf) -> frozen.put(user, Set.copyOf(memberOf)));
+        return Map.copyOf(frozen);
+    }
+
+    /** Mutable counters for one refresh. Confined to the refreshing thread. */
+    @VisibleForTesting
+    static final class Stats {
+        int groupEntries;
+        int softErrors;
+        long memberDnsRead;
+    }
+
+    /** Outcome of one directory read, so the publish decision is a value rather than a side effect. */
+    @VisibleForTesting
+    static final class RefreshResult {
+        final Map<String, Set<String>> userToGroups;
+        final int groupEntryCount;
+        final long memberDnsRead;
+        final int softErrorCount;
+        final boolean fatal;
+        final String failureReason;
+
+        private RefreshResult(Map<String, Set<String>> userToGroups, int groupEntryCount, long memberDnsRead,
+                              int softErrorCount, boolean fatal, String failureReason) {
+            this.userToGroups = userToGroups;
+            this.groupEntryCount = groupEntryCount;
+            this.memberDnsRead = memberDnsRead;
+            this.softErrorCount = softErrorCount;
+            this.fatal = fatal;
+            this.failureReason = failureReason;
         }
 
-        this.userToGroupCache = groups;
+        static RefreshResult collected(Map<String, Set<String>> userToGroups, Stats stats) {
+            return new RefreshResult(userToGroups, stats.groupEntries, stats.memberDnsRead, stats.softErrors,
+                    false, null);
+        }
+
+        static RefreshResult failed(String failureReason) {
+            return new RefreshResult(Map.of(), 0, 0L, 0, true, failureReason);
+        }
     }
 
     private void matchUserAndUpdateGroups(Map<String, Set<String>> groups,
+                                          String groupDN,
                                           Attributes attributes,
-                                          UserNameExtractInterface userNameExtractInterface)
+                                          UserNameExtractInterface userNameExtractInterface,
+                                          List<PendingMemberRange> pending,
+                                          Stats stats)
             throws NamingException {
         Attribute ldapGroupIdentifierAttr = attributes.get(getLdapGroupIdentifierAttr());
         if (ldapGroupIdentifierAttr == null) {
-            LOG.warn("LDAP group identifier attribute '{}' not found in attributes: {}",
-                    getLdapGroupIdentifierAttr(), attributes);
+            LOG.warn("LDAP group identifier attribute '{}' not found for group '{}', attributes: {}",
+                    getLdapGroupIdentifierAttr(), groupDN, attributes);
             return;
         }
         String groupName = (String) ldapGroupIdentifierAttr.get();
 
-        Attribute memberAttribute = attributes.get(getLDAPGroupMemberAttr());
-        if (memberAttribute == null) {
-            LOG.warn("LDAP group member attribute '{}' not found in attributes: {}", getLDAPGroupMemberAttr(), attributes);
+        long nextStart = consumeMemberPage(attributes, getLDAPGroupMemberAttr(), memberDN -> {
+            stats.memberDnsRead++;
+            collectMember(groups, groupName, memberDN, userNameExtractInterface);
+        });
+
+        if (nextStart >= 0) {
+            if (Strings.isNullOrEmpty(groupDN)) {
+                // Without an absolute DN we cannot ask for the next page. Record it as a truncation
+                // rather than pretending the group was read completely.
+                LOG.warn("LDAP group '{}' is range-truncated at {} but its DN is unavailable, members will be incomplete",
+                        groupName, nextStart);
+                pending.add(new PendingMemberRange(null, groupName, nextStart));
+            } else {
+                pending.add(new PendingMemberRange(groupDN, groupName, nextStart));
+            }
+        }
+    }
+
+    /**
+     * Resolve the groups whose member list Active Directory truncated via range retrieval.
+     * <p>Runs strictly after the group entries have all been walked, so the context carries no
+     * search-scoped request controls when these base-object reads go out.
+     *
+     * @return true when every pending group was read through to its terminal page.
+     */
+    private boolean resolvePendingRanges(DirContext ctx,
+                                         List<PendingMemberRange> pending,
+                                         Map<String, Set<String>> groups,
+                                         UserNameExtractInterface userNameExtractInterface,
+                                         Stats stats) {
+        boolean complete = true;
+        for (PendingMemberRange range : pending) {
+            if (range.groupDN == null) {
+                complete = false;
+                continue;
+            }
+            LOG.debug("Fetching range retrieval pages for LDAP group '{}' starting at {}", range.groupDN, range.nextStart);
+            boolean done = fetchRemainingMemberPages(ctx, range.groupDN, getLDAPGroupMemberAttr(), range.nextStart,
+                    memberDN -> {
+                        stats.memberDnsRead++;
+                        collectMember(groups, range.groupName, memberDN, userNameExtractInterface);
+                    });
+            complete &= done;
+        }
+        return complete;
+    }
+
+    @FunctionalInterface
+    interface SearchResultHandler {
+        void handle(SearchResult result) throws NamingException;
+    }
+
+    /**
+     * Walk the group entries matching {@code filter}, using the RFC 2696 simple paged results control so a
+     * directory whose server-side size limit (MaxPageSize, 1000 on Active Directory) is smaller than the
+     * result set still returns everything instead of failing with sizeLimitExceeded.
+     * <p>The control is sent as {@link Control#NONCRITICAL}: a server that does not implement RFC 2696
+     * ignores it and answers with the full result set and no response control, which collapses this into
+     * the single unpaged search it replaces. {@code pageSize <= 0} skips the control entirely.
+     * <p>The request controls are always cleared on the way out. They are scoped to the context, and a
+     * cookie belonging to this search must not ride along on the base-object reads that range retrieval
+     * issues afterwards.
+     *
+     * @return true when every page was walked to the end. false means the walk stopped early and the
+     *         caller must not publish the result as a complete view of the directory.
+     */
+    @VisibleForTesting
+    static boolean searchGroupEntriesPaged(LdapContext ctx, String baseDN, String filter, String[] returningAttrs,
+                                           int pageSize, SearchResultHandler handler)
+            throws NamingException, IOException {
+        SearchControls searchControls = new SearchControls();
+        searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+        searchControls.setReturningAttributes(returningAttrs);
+
+        boolean paged = pageSize > 0;
+        try {
+            byte[] cookie = null;
+            int page = 0;
+            do {
+                if (paged) {
+                    ctx.setRequestControls(
+                            new Control[] {new PagedResultsControl(pageSize, cookie, Control.NONCRITICAL)});
+                }
+
+                NamingEnumeration<SearchResult> results = null;
+                try {
+                    results = ctx.search(baseDN, filter, searchControls);
+                    while (results.hasMore()) {
+                        handler.handle(results.next());
+                    }
+                    // Read the response controls before closing: the cookie is only available once the
+                    // enumeration for this page has been drained.
+                    cookie = paged ? extractPagedResultsCookie(ctx.getResponseControls()) : null;
+                } catch (PartialResultException e) {
+                    // A referral the provider will not chase. With the domain root as base DN this is routine
+                    // on Active Directory (CN=Configuration and the other subordinate naming contexts) and it
+                    // surfaces after the real entries, so it must not fail an otherwise healthy refresh.
+                    //
+                    // But it also aborts this page's enumeration. If further pages were still pending we have
+                    // genuinely lost group entries, and reporting that as a complete read would publish a
+                    // partial map - which is indistinguishable from "these users are in no groups".
+                    LOG.warn("LDAP group search hit an unfollowable referral on page {} for filter '{}'",
+                            page + 1, filter, e);
+                    return !hasFurtherPage(ctx, paged, filter);
+                } finally {
+                    closeNamingEnumeration(results);
+                }
+
+                if (++page >= MAX_SEARCH_PAGES && cookie != null) {
+                    throw new NamingException("LDAP paged group search exceeded MAX_SEARCH_PAGES ("
+                            + MAX_SEARCH_PAGES + ") for filter '" + filter + "'");
+                }
+            } while (cookie != null);
+            return true;
+        } finally {
+            if (paged) {
+                ctx.setRequestControls(null);
+            }
+        }
+    }
+
+    /**
+     * Whether the page we just aborted still had a continuation cookie, i.e. whether entries were lost.
+     * An unreadable response control means we cannot tell, which counts as lost - the same fail-closed
+     * stance {@link #isDeterministicAbsence} takes.
+     */
+    private static boolean hasFurtherPage(LdapContext ctx, boolean paged, String filter) {
+        if (!paged) {
+            return false;
+        }
+        try {
+            return extractPagedResultsCookie(ctx.getResponseControls()) != null;
+        } catch (NamingException ne) {
+            LOG.warn("Cannot tell whether more LDAP pages were pending after a referral for filter '{}', "
+                    + "treating the search as incomplete", filter, ne);
+            return true;
+        }
+    }
+
+    /**
+     * Pull the continuation cookie out of the paged results response. Returns null when the server sent no
+     * such control (it does not support RFC 2696) or when the cookie is empty (the result set is complete).
+     */
+    @VisibleForTesting
+    static byte[] extractPagedResultsCookie(Control[] responseControls) {
+        if (responseControls == null) {
+            return null;
+        }
+        for (Control control : responseControls) {
+            if (control instanceof PagedResultsResponseControl) {
+                byte[] cookie = ((PagedResultsResponseControl) control).getCookie();
+                if (cookie != null && cookie.length > 0) {
+                    return cookie;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Consume the member values present in {@code attrs}, handling both the canonical attribute
+     * ({@code member}) and the range-encoded form Active Directory uses for large groups
+     * ({@code member;range=0-1499}) - see MS-ADTS 3.1.1.3.1.3.3.
+     *
+     * @return the offset the next range page starts at, or -1 when nothing further needs fetching.
+     *         A missing member attribute also yields -1: an empty group is a determinate answer.
+     */
+    @VisibleForTesting
+    static long consumeMemberPage(Attributes attrs, String memberAttrName, Consumer<String> memberConsumer)
+            throws NamingException {
+        String attrId = findMemberAttributeId(attrs, memberAttrName);
+        if (attrId == null) {
+            LOG.warn("LDAP group member attribute '{}' not found in attributes: {}", memberAttrName, attrs);
+            return -1L;
+        }
+
+        Attribute attr = attrs.get(attrId);
+        if (attr != null) {
+            NamingEnumeration<?> e = attr.getAll();
+            try {
+                while (e.hasMore()) {
+                    memberConsumer.accept((String) e.next());
+                }
+            } finally {
+                closeNamingEnumeration(e);
+            }
+        }
+
+        RangeInfo range = parseRangeSuffix(attrId);
+        if (range == null || range.isTerminal()) {
+            return -1L;
+        }
+        return range.end + 1;
+    }
+
+    /**
+     * Request follow-up range pages ({@code member;range=N-*}) until the server answers with a terminal
+     * ({@code -*}) marker.
+     *
+     * @return true when the terminal page was reached. false means the member list is incomplete -
+     *         the caller must treat that as a failed refresh rather than publishing a truncated group.
+     */
+    @VisibleForTesting
+    static boolean fetchRemainingMemberPages(DirContext ctx, String groupDN, String memberAttrName,
+                                             long nextStart, Consumer<String> memberConsumer) {
+        if (Strings.isNullOrEmpty(groupDN)) {
+            LOG.warn("Cannot fetch range retrieval pages without a group DN");
+            return false;
+        }
+
+        long start = nextStart;
+        for (int page = 0; page < MAX_RANGE_PAGES; page++) {
+            String nextAttrName = memberAttrName + ";range=" + start + "-*";
+            Attributes attrs;
+            try {
+                attrs = ctx.getAttributes(groupDN, new String[] {nextAttrName});
+            } catch (NamingException ne) {
+                LOG.warn("Failed to fetch range page '{}' for LDAP group '{}', member list is incomplete",
+                        nextAttrName, groupDN, ne);
+                return false;
+            }
+
+            long following;
+            try {
+                // consumeMemberPage answers -1 both for a terminal page and for a response carrying no
+                // member attribute at all. Probe first so the two cases stay distinguishable: the latter
+                // means the server ignored our request and the member list is incomplete.
+                if (findMemberAttributeId(attrs, memberAttrName) == null) {
+                    LOG.warn("LDAP server returned no member attribute for range page '{}' of group '{}'",
+                            nextAttrName, groupDN);
+                    return false;
+                }
+                following = consumeMemberPage(attrs, memberAttrName, memberConsumer);
+            } catch (NamingException ne) {
+                LOG.warn("Failed to read range page '{}' for LDAP group '{}', member list is incomplete",
+                        nextAttrName, groupDN, ne);
+                return false;
+            }
+
+            if (following < 0) {
+                return true;
+            }
+
+            if (following <= start) {
+                LOG.warn("LDAP server did not advance range retrieval for group '{}' (asked for {}, got {})",
+                        groupDN, start, following);
+                return false;
+            }
+            start = following;
+        }
+
+        LOG.warn("LDAP group '{}' exceeded MAX_RANGE_PAGES ({}), member list is incomplete", groupDN, MAX_RANGE_PAGES);
+        return false;
+    }
+
+    /**
+     * Locate the attribute id actually used for the member attribute. Active Directory returns the
+     * canonical name for small groups and a range-encoded id for large ones, and it may echo an empty
+     * copy of either alongside the one that carries the values - so prefer whichever holds data.
+     * Matching is case-insensitive because the LDAP attribute namespace is.
+     */
+    @VisibleForTesting
+    static String findMemberAttributeId(Attributes attrs, String memberAttrName) throws NamingException {
+        if (attrs == null) {
+            return null;
+        }
+        String plainAttrId = null;
+        String plainAttrIdWithValue = null;
+        String rangeAttrId = null;
+        NamingEnumeration<String> ids = attrs.getIDs();
+        try {
+            while (ids.hasMore()) {
+                String id = ids.next();
+                boolean isPlainMemberAttr = id.equalsIgnoreCase(memberAttrName);
+                boolean isRangeMemberAttr = isMemberRangeAttribute(id, memberAttrName);
+                if (!isPlainMemberAttr && !isRangeMemberAttr) {
+                    continue;
+                }
+
+                Attribute attr = attrs.get(id);
+                boolean hasValue = attr != null && attr.size() > 0;
+                if (isRangeMemberAttr) {
+                    if (hasValue) {
+                        return id;
+                    }
+                    if (rangeAttrId == null) {
+                        rangeAttrId = id;
+                    }
+                } else if (hasValue) {
+                    if (plainAttrIdWithValue == null) {
+                        plainAttrIdWithValue = id;
+                    }
+                } else if (plainAttrId == null) {
+                    plainAttrId = id;
+                }
+            }
+        } finally {
+            closeNamingEnumeration(ids);
+        }
+        if (plainAttrIdWithValue != null) {
+            return plainAttrIdWithValue;
+        }
+        if (rangeAttrId != null) {
+            return rangeAttrId;
+        }
+        return plainAttrId;
+    }
+
+    private static boolean isMemberRangeAttribute(String attrId, String memberAttrName) {
+        int semi = attrId.indexOf(';');
+        return semi > 0
+                && attrId.substring(0, semi).equalsIgnoreCase(memberAttrName)
+                && parseRangeSuffix(attrId) != null;
+    }
+
+    /**
+     * Parse the range suffix of an attribute id such as {@code member;range=0-1499} or
+     * {@code member;range=1500-*}. Returns null when the id carries no valid range suffix.
+     */
+    @VisibleForTesting
+    static RangeInfo parseRangeSuffix(String attrId) {
+        if (attrId == null) {
+            return null;
+        }
+        Matcher m = RANGE_PATTERN.matcher(attrId);
+        if (!m.find()) {
+            return null;
+        }
+        String endStr = m.group(2);
+        long end = "*".equals(endStr) ? -1L : Long.parseLong(endStr);
+        return new RangeInfo(Long.parseLong(m.group(1)), end);
+    }
+
+    @VisibleForTesting
+    static final class RangeInfo {
+        final long start;
+        final long end; // -1 stands for "*", i.e. the terminal page.
+
+        RangeInfo(long start, long end) {
+            this.start = start;
+            this.end = end;
+        }
+
+        boolean isTerminal() {
+            return end == -1L;
+        }
+    }
+
+    /** A group whose member list was cut short by range retrieval, to be finished in Phase B. */
+    private static final class PendingMemberRange {
+        final String groupDN;
+        final String groupName;
+        final long nextStart;
+
+        PendingMemberRange(String groupDN, String groupName, long nextStart) {
+            this.groupDN = groupDN;
+            this.groupName = groupName;
+            this.nextStart = nextStart;
+        }
+    }
+
+    private static void collectMember(Map<String, Set<String>> groups,
+                                      String groupName,
+                                      String memberDN,
+                                      UserNameExtractInterface userNameExtractInterface) {
+        String extractUserName = userNameExtractInterface.extract(memberDN);
+
+        if (extractUserName == null) {
+            LOG.debug("Failed to extract user name from member DN: '{}'", memberDN);
             return;
         }
 
-        NamingEnumeration<?> e = memberAttribute.getAll();
-        while (e.hasMore()) {
-            String memberDN = (String) e.next();
-            String extractUserName = userNameExtractInterface.extract(memberDN);
+        // Normalize extracted username for case-insensitive matching
+        // LDAP is case-insensitive by default, so we normalize to ensure consistent mapping
+        String normalizedUserName = LDAPAuthProvider.normalizeUsername(extractUserName);
 
-            if (extractUserName == null) {
-                LOG.debug("Failed to extract user name from member DN: '{}'", memberDN);
-                continue;
+        groups.computeIfAbsent(normalizedUserName, k -> ConcurrentHashMap.newKeySet()).add(groupName);
+
+        LOG.debug("Successfully extracted user '{}' from member '{}', added to group '{}'",
+                extractUserName, memberDN, groupName);
+    }
+
+    /**
+     * Extract the fully-qualified DN of a group from a SearchResult. getNameInNamespace() is preferred
+     * because it returns the absolute DN in normalized form, which is what a follow-up getAttributes()
+     * needs when the member attribute is split across range retrieval pages.
+     */
+    @VisibleForTesting
+    static String extractGroupDN(SearchResult result, String baseDN) {
+        try {
+            String dn = result.getNameInNamespace();
+            if (dn != null && !dn.isEmpty()) {
+                return dn;
             }
+        } catch (UnsupportedOperationException | IllegalStateException ignored) {
+            // Not every LDAP provider implements getNameInNamespace; fall through to getName().
+        }
+        String name = result.getName();
+        if (name == null || name.isEmpty() || !result.isRelative()) {
+            return name;
+        }
+        return qualifyRelativeDN(name, baseDN);
+    }
 
-            // Normalize extracted username for case-insensitive matching
-            // LDAP is case-insensitive by default, so we normalize to ensure consistent mapping
-            String normalizedUserName = LDAPAuthProvider.normalizeUsername(extractUserName);
+    @VisibleForTesting
+    static String qualifyRelativeDN(String dn, String baseDN) {
+        if (Strings.isNullOrEmpty(dn) || Strings.isNullOrEmpty(baseDN)) {
+            return dn;
+        }
+        String normalizedDN = StringUtils.strip(dn.trim(), "\"'");
+        String normalizedBaseDN = StringUtils.strip(baseDN.trim(), "\"'");
+        if (normalizedDN.isEmpty() || normalizedBaseDN.isEmpty()) {
+            return normalizedDN;
+        }
+        String lowerDN = normalizedDN.toLowerCase(Locale.ROOT);
+        String lowerBaseDN = normalizedBaseDN.toLowerCase(Locale.ROOT);
+        if (lowerDN.equals(lowerBaseDN) || lowerDN.endsWith("," + lowerBaseDN)) {
+            return normalizedDN;
+        }
+        return normalizedDN + "," + normalizedBaseDN;
+    }
 
-            groups.putIfAbsent(normalizedUserName, new HashSet<>());
-            groups.get(normalizedUserName).add(groupName);
+    private static void closeNamingEnumeration(NamingEnumeration<?> enumeration) {
+        if (enumeration != null) {
+            try {
+                enumeration.close();
+            } catch (NamingException ne) {
+                LOG.debug("Failed to close LDAP naming enumeration", ne);
+            }
+        }
+    }
 
-            LOG.debug("Successfully extracted user '{}' from member '{}', added to group '{}'",
-                    extractUserName, memberDN, groupName);
+    private static void closeDirContext(DirContext ctx) {
+        if (ctx != null) {
+            try {
+                ctx.close();
+            } catch (NamingException ne) {
+                LOG.warn("Failed to close LDAP DirContext", ne);
+            }
         }
     }
 
@@ -297,7 +978,9 @@ public class LDAPGroupProvider extends GroupProvider {
         }
     }
 
-    public DirContext createDirContextOnConnection(String dn, String pwd) throws NamingException, IOException,
+    // Returns LdapContext rather than DirContext so the paged results control can be attached.
+    // LdapContext extends DirContext, so this stays source-compatible for every caller.
+    public LdapContext createDirContextOnConnection(String dn, String pwd) throws NamingException, IOException,
             GeneralSecurityException {
         if (Strings.isNullOrEmpty(pwd)) {
             LOG.warn("empty password is not allowed for simple authentication");
@@ -328,7 +1011,7 @@ public class LDAPGroupProvider extends GroupProvider {
             environment.put("java.naming.ldap.factory.socket", LdapSslSocketFactory.class.getName());
         }
 
-        return new InitialDirContext(environment);
+        return new InitialLdapContext(environment, null);
     }
 
     public String getLdapConnUrl() {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -4739,6 +4739,16 @@ public class Config extends ConfigBase {
     @ConfField(mutable = false)
     public static int group_provider_refresh_thread_num = 4;
 
+    /**
+     * Page size of the RFC 2696 simple paged results control used when an ldap group provider enumerates
+     * group entries. Without paging, a directory whose MaxPageSize (1000 on Active Directory) is smaller
+     * than the number of matching groups answers with sizeLimitExceeded and the refresh yields nothing.
+     * <p>Set to 0 to stop sending the control altogether - the emergency switch back to the single
+     * unpaged search, available at runtime via ADMIN SET FRONTEND CONFIG.
+     */
+    @ConfField(mutable = true)
+    public static int ldap_group_provider_search_page_size = 1000;
+
     @ConfField(mutable = true)
     public static boolean transaction_state_print_partition_info = true;
 

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/LDAPGroupProviderCachePolicyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/LDAPGroupProviderCachePolicyTest.java
@@ -1,0 +1,239 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.authentication;
+
+import com.starrocks.catalog.UserIdentity;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import javax.naming.CommunicationException;
+import javax.naming.InvalidNameException;
+import javax.naming.NameNotFoundException;
+import javax.naming.NamingException;
+import javax.naming.PartialResultException;
+import javax.naming.SizeLimitExceededException;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+/**
+ * The cache may only be replaced by a complete read of the directory. Publishing a partially collected
+ * map is indistinguishable from "these users belong to no group", which denies access fleet-wide - the
+ * exact failure this provider has to avoid.
+ */
+public class LDAPGroupProviderCachePolicyTest {
+
+    private static final UserIdentity ALICE = UserIdentity.createEphemeralUserIdent("alice", "%");
+
+    @Test
+    public void testSuccessfulRefreshReplacesTheCache() {
+        LDAPGroupProvider provider = newProvider();
+        doReturn(collected(Map.of("alice", Set.of("dev")), 1)).when(provider).collectGroups();
+
+        provider.refreshGroups();
+
+        Assertions.assertEquals(Set.of("dev"), provider.getGroup(ALICE, "alice"));
+    }
+
+    @Test
+    public void testFatalFailureKeepsTheLastKnownGoodCache() {
+        LDAPGroupProvider provider = newProvider();
+        doReturn(collected(Map.of("alice", Set.of("dev")), 1)).when(provider).collectGroups();
+        provider.refreshGroups();
+
+        doReturn(LDAPGroupProvider.RefreshResult.failed("bind failed")).when(provider).collectGroups();
+        provider.refreshGroups();
+
+        Assertions.assertEquals(Set.of("dev"), provider.getGroup(ALICE, "alice"),
+                "a failed refresh must not blank out the groups of already-authenticated users");
+    }
+
+    @Test
+    public void testIncompleteRangeRetrievalKeepsTheLastKnownGoodCache() {
+        // The regression this whole change exists for: a truncated member list must never be published.
+        LDAPGroupProvider provider = newProvider();
+        doReturn(collected(Map.of("alice", Set.of("dev", "analyst")), 2)).when(provider).collectGroups();
+        provider.refreshGroups();
+
+        doReturn(LDAPGroupProvider.RefreshResult.failed(
+                "range retrieval did not reach the terminal page for every group"))
+                .when(provider).collectGroups();
+        provider.refreshGroups();
+
+        Assertions.assertEquals(Set.of("dev", "analyst"), provider.getGroup(ALICE, "alice"));
+    }
+
+    @Test
+    public void testTruncatedPagedSearchKeepsTheLastKnownGoodCache() {
+        // A referral (or any early stop) that aborts the group entry walk while pages were still pending
+        // means entries were lost. Even though some groups were already collected, the partial view must
+        // not replace a complete one.
+        LDAPGroupProvider provider = newProvider();
+        doReturn(collected(Map.of("alice", Set.of("dev")), 4)).when(provider).collectGroups();
+        provider.refreshGroups();
+
+        doReturn(LDAPGroupProvider.RefreshResult.failed(
+                "group entry search stopped early with pages still pending, entries were lost"))
+                .when(provider).collectGroups();
+        provider.refreshGroups();
+
+        Assertions.assertEquals(Set.of("dev"), provider.getGroup(ALICE, "alice"));
+        Assertions.assertTrue(provider.getComment().contains("consecutiveFailures=1"), provider.getComment());
+    }
+
+    @Test
+    public void testBlankingGuardRejectsASuddenlyEmptyDirectory() {
+        LDAPGroupProvider provider = newProvider();
+        doReturn(collected(Map.of("alice", Set.of("dev")), 5)).when(provider).collectGroups();
+        provider.refreshGroups();
+
+        // Zero group entries after a healthy refresh is an outage or a broken filter, not a real change.
+        doReturn(collected(Map.of(), 0)).when(provider).collectGroups();
+        provider.refreshGroups();
+
+        Assertions.assertEquals(Set.of("dev"), provider.getGroup(ALICE, "alice"));
+    }
+
+    @Test
+    public void testFirstRefreshMayPublishAnEmptyDirectory() {
+        // With no previous snapshot to compare against there is nothing to protect, so this publishes.
+        LDAPGroupProvider provider = newProvider();
+        doReturn(collected(Map.of(), 0)).when(provider).collectGroups();
+
+        provider.refreshGroups();
+
+        Assertions.assertEquals(Set.of(), provider.getGroup(ALICE, "alice"));
+    }
+
+    @Test
+    public void testGuardDoesNotBlockLegitimateGroupMembershipRemoval() {
+        // The guard counts group entries, not users. A user genuinely removed from every group must
+        // still lose those groups.
+        LDAPGroupProvider provider = newProvider();
+        doReturn(collected(Map.of("alice", Set.of("dev")), 5)).when(provider).collectGroups();
+        provider.refreshGroups();
+
+        doReturn(collected(Map.of("bob", Set.of("dev")), 5)).when(provider).collectGroups();
+        provider.refreshGroups();
+
+        Assertions.assertEquals(Set.of(), provider.getGroup(ALICE, "alice"));
+    }
+
+    @Test
+    public void testRefreshNeverThrows() {
+        // ScheduledExecutorService cancels every future run of a task that lets an exception escape,
+        // which would freeze group refresh until the FE restarts.
+        LDAPGroupProvider provider = newProvider();
+        doThrow(new RuntimeException("boom")).when(provider).collectGroups();
+
+        Assertions.assertDoesNotThrow(provider::refreshGroups);
+    }
+
+    @Test
+    public void testRefreshAfterUnexpectedThrowKeepsTheCache() {
+        LDAPGroupProvider provider = newProvider();
+        doReturn(collected(Map.of("alice", Set.of("dev")), 1)).when(provider).collectGroups();
+        provider.refreshGroups();
+
+        doThrow(new IllegalStateException("boom")).when(provider).collectGroups();
+        provider.refreshGroups();
+
+        Assertions.assertEquals(Set.of("dev"), provider.getGroup(ALICE, "alice"));
+    }
+
+    @Test
+    public void testPublishedGroupsAreImmutable() {
+        LDAPGroupProvider provider = newProvider();
+        doReturn(collected(new HashMap<>(Map.of("alice", Set.of("dev"))), 1)).when(provider).collectGroups();
+        provider.refreshGroups();
+
+        Set<String> groups = provider.getGroup(ALICE, "alice");
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> groups.add("smuggled"));
+    }
+
+    @Test
+    public void testCommentReportsCacheHealth() {
+        LDAPGroupProvider provider = newProvider();
+        Assertions.assertTrue(provider.getComment().contains("lastSuccessAgoSec=never"), provider.getComment());
+
+        doReturn(collected(Map.of("alice", Set.of("dev")), 3)).when(provider).collectGroups();
+        provider.refreshGroups();
+        String healthy = provider.getComment();
+        Assertions.assertTrue(healthy.contains("cachedUsers=1"), healthy);
+        Assertions.assertTrue(healthy.contains("groupEntries=3"), healthy);
+        Assertions.assertTrue(healthy.contains("consecutiveFailures=0"), healthy);
+        Assertions.assertFalse(healthy.contains("lastError="), healthy);
+
+        doReturn(LDAPGroupProvider.RefreshResult.failed("connection reset")).when(provider).collectGroups();
+        provider.refreshGroups();
+        provider.refreshGroups();
+        String failing = provider.getComment();
+        Assertions.assertTrue(failing.contains("consecutiveFailures=2"), failing);
+        Assertions.assertTrue(failing.contains("lastError=connection reset"), failing);
+        // The cache itself is untouched, so it still reports the users it is serving.
+        Assertions.assertTrue(failing.contains("cachedUsers=1"), failing);
+    }
+
+    @Test
+    public void testConsecutiveFailureCountResetsOnRecovery() {
+        LDAPGroupProvider provider = newProvider();
+        doReturn(LDAPGroupProvider.RefreshResult.failed("nope")).when(provider).collectGroups();
+        provider.refreshGroups();
+        provider.refreshGroups();
+        Assertions.assertTrue(provider.getComment().contains("consecutiveFailures=2"));
+
+        doReturn(collected(Map.of("alice", Set.of("dev")), 1)).when(provider).collectGroups();
+        provider.refreshGroups();
+        Assertions.assertTrue(provider.getComment().contains("consecutiveFailures=0"));
+    }
+
+    // ---------- error classification ----------
+
+    @Test
+    public void testDeterministicAbsenceIsSkippable() {
+        // The server answered authoritatively that the entry is not there, so the read was not truncated.
+        Assertions.assertTrue(LDAPGroupProvider.isDeterministicAbsence(new NameNotFoundException("gone")));
+        Assertions.assertTrue(LDAPGroupProvider.isDeterministicAbsence(new InvalidNameException("bad dn")));
+    }
+
+    @Test
+    public void testFailureToAnswerIsNotSkippable() {
+        // Anything that means "the server did not answer" may have truncated the read.
+        Assertions.assertFalse(LDAPGroupProvider.isDeterministicAbsence(new CommunicationException("reset")));
+        Assertions.assertFalse(LDAPGroupProvider.isDeterministicAbsence(new SizeLimitExceededException("cap")));
+        Assertions.assertFalse(LDAPGroupProvider.isDeterministicAbsence(new PartialResultException("referral")));
+        // Unclassified exceptions default to fatal rather than being silently skipped.
+        Assertions.assertFalse(LDAPGroupProvider.isDeterministicAbsence(new NamingException("something new")));
+    }
+
+    // ---------- helpers ----------
+
+    private static LDAPGroupProvider newProvider() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(GroupProvider.GROUP_PROVIDER_PROPERTY_TYPE_KEY, "ldap");
+        properties.put(LDAPGroupProvider.LDAP_USER_SEARCH_ATTR, "uid");
+        return spy(new LDAPGroupProvider("test_ldap_group_provider", properties));
+    }
+
+    private static LDAPGroupProvider.RefreshResult collected(Map<String, Set<String>> groups, int groupEntries) {
+        LDAPGroupProvider.Stats stats = new LDAPGroupProvider.Stats();
+        stats.groupEntries = groupEntries;
+        return LDAPGroupProvider.RefreshResult.collected(groups, stats);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/LDAPGroupProviderImageRoundTripTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/LDAPGroupProviderImageRoundTripTest.java
@@ -1,0 +1,134 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.authentication;
+
+import com.starrocks.catalog.UserIdentity;
+import com.starrocks.persist.gson.GsonUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+/**
+ * A group provider that was already in the metadata image when the FE restarted is not constructed - it is
+ * restored by GSON, which instantiates it through UnsafeAllocator. That skips the constructor AND every
+ * inline field initializer, and {@code HiddenAnnotationExclusionStrategy} skips every field without
+ * {@code @SerializedName}, so nothing in the JSON fills them back in either.
+ *
+ * <p>This is not hypothetical: it was observed on a staging cluster, where {@code SHOW GROUP PROVIDERS}
+ * threw NPE against a provider baked into the image, and the scheduled refresh would have died the same
+ * way - permanently, because ScheduledExecutorService cancels a task that lets an exception escape.
+ *
+ * <p>These tests go through the real {@link GsonUtils} instance, so they exercise the actual
+ * RuntimeTypeAdapterFactory / post-process wiring rather than a hand-built Gson.
+ */
+public class LDAPGroupProviderImageRoundTripTest {
+
+    private static LDAPGroupProvider roundTrip(LDAPGroupProvider provider) {
+        String json = GsonUtils.GSON.toJson(provider, GroupProvider.class);
+        GroupProvider restored = GsonUtils.GSON.fromJson(json, GroupProvider.class);
+        Assertions.assertInstanceOf(LDAPGroupProvider.class, restored,
+                "the polymorphic adapter must restore the concrete subtype");
+        return (LDAPGroupProvider) restored;
+    }
+
+    private static LDAPGroupProvider newProvider() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(GroupProvider.GROUP_PROVIDER_PROPERTY_TYPE_KEY, "ldap");
+        properties.put(LDAPGroupProvider.LDAP_USER_SEARCH_ATTR, "uid");
+        return new LDAPGroupProvider("image_round_trip", properties);
+    }
+
+    @Test
+    public void testPropertiesSurviveTheRoundTrip() {
+        LDAPGroupProvider restored = roundTrip(newProvider());
+
+        Assertions.assertEquals("image_round_trip", restored.getName());
+        Assertions.assertEquals("ldap", restored.getType());
+        Assertions.assertEquals("uid", restored.getLdapUserSearchAttr());
+    }
+
+    @Test
+    public void testGetGroupDoesNotThrowOnAnImageLoadedProvider() {
+        // getGroup reads userToGroupCache, which GSON leaves null without the post-process hook.
+        LDAPGroupProvider restored = roundTrip(newProvider());
+
+        Assertions.assertEquals(Set.of(),
+                restored.getGroup(UserIdentity.createEphemeralUserIdent("alice", "%"),
+                        "alice"));
+    }
+
+    @Test
+    public void testShowGroupProvidersDoesNotThrowOnAnImageLoadedProvider() {
+        // This is the exact call SHOW GROUP PROVIDERS makes, and the one that was observed to fail.
+        LDAPGroupProvider restored = roundTrip(newProvider());
+
+        String comment = Assertions.assertDoesNotThrow(restored::getComment);
+        Assertions.assertTrue(comment.contains("cachedUsers=0"), comment);
+        Assertions.assertTrue(comment.contains("consecutiveFailures=0"), comment);
+        Assertions.assertTrue(comment.contains("lastSuccessAgoSec=never"), comment);
+    }
+
+    @Test
+    public void testSuccessfulRefreshDoesNotThrowOnAnImageLoadedProvider() {
+        // The success path assigns the cache and then resets the failure counter. Any reference-typed
+        // runtime state here is a trap: as an AtomicInteger the counter arrived null from the image, so
+        // the very first successful refresh threw AFTER publishing - killing the scheduler while looking
+        // like it had worked. Hence the primitive field, and hence this test.
+        LDAPGroupProvider restored = spy(roundTrip(newProvider()));
+        doReturn(LDAPGroupProvider.RefreshResult.collected(
+                Map.of("alice", Set.of("dev")), new LDAPGroupProvider.Stats())).when(restored).collectGroups();
+
+        Assertions.assertDoesNotThrow(restored::refreshGroups);
+        Assertions.assertEquals(Set.of("dev"),
+                restored.getGroup(UserIdentity.createEphemeralUserIdent("alice", "%"),
+                        "alice"));
+    }
+
+    @Test
+    public void testFailedRefreshDoesNotThrowOnAnImageLoadedProvider() {
+        // The failure path increments the counter and logs userToGroupCache.size(); both were NPE sites.
+        LDAPGroupProvider restored = spy(roundTrip(newProvider()));
+        doReturn(LDAPGroupProvider.RefreshResult.failed("bind failed")).when(restored).collectGroups();
+
+        Assertions.assertDoesNotThrow(restored::refreshGroups);
+        Assertions.assertTrue(restored.getComment().contains("consecutiveFailures=1"), restored.getComment());
+    }
+
+    @Test
+    public void testRefreshNeverPropagatesWhenTheThrowIsOutsideCollectGroups() {
+        // The scheduler contract: refreshGroups() must swallow everything, not just what collectGroups()
+        // throws. A null RefreshResult reproduces the shape of the observed bug - collectGroups() returns
+        // fine and the publish code below it blows up. If this regresses, one bad refresh silently stops
+        // every future refresh for the lifetime of the FE.
+        LDAPGroupProvider provider = spy(newProvider());
+        doReturn(null).when(provider).collectGroups();
+
+        Assertions.assertDoesNotThrow(provider::refreshGroups);
+    }
+
+    @Test
+    public void testDestroyIsSafeOnAnImageLoadedProviderThatNeverInitialised() {
+        // scheduleTask is also left null by GSON; destroy() must not NPE.
+        LDAPGroupProvider restored = roundTrip(newProvider());
+
+        Assertions.assertDoesNotThrow(restored::destroy);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/LDAPGroupProviderPagedSearchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/LDAPGroupProviderPagedSearchTest.java
@@ -1,0 +1,385 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.authentication;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.PartialResultException;
+import javax.naming.SizeLimitExceededException;
+import javax.naming.directory.BasicAttributes;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+import javax.naming.ldap.Control;
+import javax.naming.ldap.LdapContext;
+import javax.naming.ldap.PagedResultsControl;
+import javax.naming.ldap.PagedResultsResponseControl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * RFC 2696 simple paged results handling. Without it, a directory whose server-side MaxPageSize is
+ * smaller than the number of matching group entries answers with sizeLimitExceeded and the refresh
+ * collects nothing.
+ */
+public class LDAPGroupProviderPagedSearchTest {
+
+    private static final String BASE_DN = "DC=x,DC=y";
+    private static final String FILTER = "(objectClass=group)";
+    private static final String[] ATTRS = new String[] {"cn", "member"};
+
+    private int originalMaxSearchPages;
+
+    @BeforeEach
+    public void setUp() {
+        originalMaxSearchPages = LDAPGroupProvider.MAX_SEARCH_PAGES;
+    }
+
+    @AfterEach
+    public void tearDown() {
+        LDAPGroupProvider.MAX_SEARCH_PAGES = originalMaxSearchPages;
+    }
+
+    @Test
+    public void testSinglePageWithoutCookieIssuesOneSearch() throws Exception {
+        LdapContext ctx = mock(LdapContext.class);
+        when(ctx.search(anyString(), anyString(), any(SearchControls.class))).thenReturn(results("g1", "g2"));
+        when(ctx.getResponseControls()).thenReturn(new Control[] {pagedResponse(2, null)});
+
+        Assertions.assertEquals(List.of("g1", "g2"), collect(ctx, 1000));
+        verify(ctx, times(1)).search(anyString(), anyString(), any(SearchControls.class));
+    }
+
+    @Test
+    public void testServerWithoutPagingSupportStillReturnsEverything() throws Exception {
+        // A server that does not implement RFC 2696 ignores a NONCRITICAL control and sends no response
+        // control at all. That must collapse to exactly the single unpaged search this replaced.
+        LdapContext ctx = mock(LdapContext.class);
+        when(ctx.search(anyString(), anyString(), any(SearchControls.class))).thenReturn(results("g1", "g2", "g3"));
+        when(ctx.getResponseControls()).thenReturn(null);
+
+        Assertions.assertEquals(List.of("g1", "g2", "g3"), collect(ctx, 1000));
+        verify(ctx, times(1)).search(anyString(), anyString(), any(SearchControls.class));
+    }
+
+    @Test
+    public void testCookieChainingWalksEveryPage() throws Exception {
+        LdapContext ctx = mock(LdapContext.class);
+        doReturn(results("g1", "g2"), results("g3"))
+                .when(ctx).search(anyString(), anyString(), any(SearchControls.class));
+        when(ctx.getResponseControls()).thenReturn(
+                new Control[] {pagedResponse(2, new byte[] {0x01, 0x02})},
+                new Control[] {pagedResponse(1, new byte[0])});
+
+        Assertions.assertEquals(List.of("g1", "g2", "g3"), collect(ctx, 2));
+        verify(ctx, times(2)).search(anyString(), anyString(), any(SearchControls.class));
+    }
+
+    @Test
+    public void testRequestControlsAreClearedOnTheWayOut() throws Exception {
+        // The paging control is scoped to the context. Leaving it in place would attach this search's
+        // cookie to the base-object reads that range retrieval issues afterwards.
+        LdapContext ctx = mock(LdapContext.class);
+        when(ctx.search(anyString(), anyString(), any(SearchControls.class))).thenReturn(results("g1"));
+        when(ctx.getResponseControls()).thenReturn(new Control[] {pagedResponse(1, null)});
+
+        collect(ctx, 1000);
+
+        InOrder ordered = inOrder(ctx);
+        ordered.verify(ctx).setRequestControls(notNull());
+        ordered.verify(ctx).search(anyString(), anyString(), any(SearchControls.class));
+        ordered.verify(ctx).setRequestControls(isNull());
+    }
+
+    @Test
+    public void testRequestControlsAreClearedEvenWhenSearchFails() throws Exception {
+        LdapContext ctx = mock(LdapContext.class);
+        when(ctx.search(anyString(), anyString(), any(SearchControls.class)))
+                .thenThrow(new SizeLimitExceededException("boom"));
+
+        Assertions.assertThrows(SizeLimitExceededException.class, () -> collect(ctx, 1000));
+        verify(ctx).setRequestControls(isNull());
+    }
+
+    @Test
+    public void testZeroPageSizeSendsNoControlAtAll() throws Exception {
+        // The runtime kill switch: ldap_group_provider_search_page_size = 0 falls back to one plain search.
+        LdapContext ctx = mock(LdapContext.class);
+        when(ctx.search(anyString(), anyString(), any(SearchControls.class))).thenReturn(results("g1"));
+
+        Assertions.assertEquals(List.of("g1"), collect(ctx, 0));
+        verify(ctx, never()).setRequestControls(any());
+        verify(ctx, never()).getResponseControls();
+        verify(ctx, times(1)).search(anyString(), anyString(), any(SearchControls.class));
+    }
+
+    @Test
+    public void testRunawayCookieIsCappedByMaxSearchPages() throws Exception {
+        LDAPGroupProvider.MAX_SEARCH_PAGES = 3;
+
+        LdapContext ctx = mock(LdapContext.class);
+        when(ctx.search(anyString(), anyString(), any(SearchControls.class)))
+                .thenAnswer(invocation -> results("g"));
+        // Always a non-empty cookie: only the safety limit can end this.
+        when(ctx.getResponseControls()).thenReturn(new Control[] {pagedResponse(1, new byte[] {0x7f})});
+
+        NamingException e = Assertions.assertThrows(NamingException.class, () -> collect(ctx, 1));
+        Assertions.assertTrue(e.getMessage().contains("MAX_SEARCH_PAGES"), e.getMessage());
+        verify(ctx, times(3)).search(anyString(), anyString(), any(SearchControls.class));
+    }
+
+    @Test
+    public void testSubtreeScopeAndReturningAttributesArePassedThrough() throws Exception {
+        LdapContext ctx = mock(LdapContext.class);
+        when(ctx.search(anyString(), anyString(), any(SearchControls.class))).thenReturn(results("g1"));
+
+        collect(ctx, 0);
+
+        ArgumentCaptor<SearchControls> captor = ArgumentCaptor.forClass(SearchControls.class);
+        verify(ctx).search(anyString(), anyString(), captor.capture());
+        Assertions.assertEquals(SearchControls.SUBTREE_SCOPE, captor.getValue().getSearchScope());
+        Assertions.assertArrayEquals(ATTRS, captor.getValue().getReturningAttributes());
+    }
+
+    @Test
+    public void testPagedResultsControlIsNonCritical() throws Exception {
+        LdapContext ctx = mock(LdapContext.class);
+        when(ctx.search(anyString(), anyString(), any(SearchControls.class))).thenReturn(results("g1"));
+        when(ctx.getResponseControls()).thenReturn(new Control[] {pagedResponse(1, null)});
+
+        collect(ctx, 250);
+
+        // Two calls: the control on the way in, then the null that clears it on the way out.
+        ArgumentCaptor<Control[]> captor = ArgumentCaptor.forClass(Control[].class);
+        verify(ctx, times(2)).setRequestControls(captor.capture());
+        Control[] sent = captor.getAllValues().get(0);
+        Assertions.assertEquals(1, sent.length);
+        Assertions.assertTrue(sent[0] instanceof PagedResultsControl);
+        // NONCRITICAL is what makes a server without RFC 2696 support ignore this instead of failing.
+        Assertions.assertFalse(sent[0].isCritical());
+    }
+
+    @Test
+    public void testEveryPageEnumerationIsClosed() throws Exception {
+        ListNamingEnumeration page1 = results("g1");
+        ListNamingEnumeration page2 = results("g2");
+
+        LdapContext ctx = mock(LdapContext.class);
+        doReturn(page1, page2).when(ctx).search(anyString(), anyString(), any(SearchControls.class));
+        when(ctx.getResponseControls()).thenReturn(
+                new Control[] {pagedResponse(1, new byte[] {0x01})},
+                new Control[] {pagedResponse(1, new byte[0])});
+
+        collect(ctx, 1);
+
+        Assertions.assertTrue(page1.closed, "first page enumeration must be closed");
+        Assertions.assertTrue(page2.closed, "second page enumeration must be closed");
+    }
+
+    // ---------- unfollowable referrals (PartialResultException) ----------
+
+    @Test
+    public void testReferralOnTheFinalPageIsTolerated() throws Exception {
+        // With the domain root as base DN, AD routinely surfaces CN=Configuration and friends as referrals
+        // the provider will not chase, after the real entries. Failing the refresh here would fail every
+        // healthy refresh on such a deployment.
+        LdapContext ctx = mock(LdapContext.class);
+        when(ctx.search(anyString(), anyString(), any(SearchControls.class)))
+                .thenReturn(referralAfter("g1", "g2"));
+        when(ctx.getResponseControls()).thenReturn(new Control[] {pagedResponse(2, new byte[0])});
+
+        List<String> seen = new ArrayList<>();
+        boolean complete = LDAPGroupProvider.searchGroupEntriesPaged(ctx, BASE_DN, FILTER, ATTRS, 1000,
+                result -> seen.add(result.getName()));
+
+        Assertions.assertTrue(complete, "a referral with no pages pending must not fail the refresh");
+        Assertions.assertEquals(List.of("g1", "g2"), seen);
+    }
+
+    @Test
+    public void testReferralWithPagesStillPendingReportsIncomplete() throws Exception {
+        // Same exception, different meaning: the aborted page still had a continuation cookie, so group
+        // entries were genuinely lost. Publishing that as a complete read is what the cache policy exists
+        // to prevent - a partial map is indistinguishable from "these users are in no groups".
+        LdapContext ctx = mock(LdapContext.class);
+        when(ctx.search(anyString(), anyString(), any(SearchControls.class)))
+                .thenReturn(referralAfter("g1"));
+        when(ctx.getResponseControls()).thenReturn(new Control[] {pagedResponse(1, new byte[] {0x01, 0x02})});
+
+        List<String> seen = new ArrayList<>();
+        boolean complete = LDAPGroupProvider.searchGroupEntriesPaged(ctx, BASE_DN, FILTER, ATTRS, 1,
+                result -> seen.add(result.getName()));
+
+        Assertions.assertFalse(complete, "entries were lost, the caller must not publish this");
+        // The entries seen before the referral are still delivered; it is the refresh as a whole that is void.
+        Assertions.assertEquals(List.of("g1"), seen);
+        verify(ctx).setRequestControls(isNull());
+    }
+
+    @Test
+    public void testUnreadableResponseControlsAfterReferralFailClosed() throws Exception {
+        LdapContext ctx = mock(LdapContext.class);
+        when(ctx.search(anyString(), anyString(), any(SearchControls.class)))
+                .thenReturn(referralAfter("g1"));
+        when(ctx.getResponseControls()).thenThrow(new NamingException("controls unavailable"));
+
+        Assertions.assertFalse(
+                LDAPGroupProvider.searchGroupEntriesPaged(ctx, BASE_DN, FILTER, ATTRS, 1, result -> { }),
+                "if we cannot tell whether pages remained, assume entries were lost");
+    }
+
+    @Test
+    public void testReferralOnAnUnpagedSearchIsTolerated() throws Exception {
+        // pageSize <= 0 means there is no pagination to lose, so the old tolerate-and-continue behaviour
+        // is still the right one.
+        LdapContext ctx = mock(LdapContext.class);
+        when(ctx.search(anyString(), anyString(), any(SearchControls.class)))
+                .thenReturn(referralAfter("g1", "g2"));
+
+        List<String> seen = new ArrayList<>();
+        Assertions.assertTrue(LDAPGroupProvider.searchGroupEntriesPaged(ctx, BASE_DN, FILTER, ATTRS, 0,
+                result -> seen.add(result.getName())));
+        Assertions.assertEquals(List.of("g1", "g2"), seen);
+        verify(ctx, never()).getResponseControls();
+    }
+
+    @Test
+    public void testExtractPagedResultsCookie() throws IOException {
+        Assertions.assertNull(LDAPGroupProvider.extractPagedResultsCookie(null));
+        Assertions.assertNull(LDAPGroupProvider.extractPagedResultsCookie(new Control[0]));
+        // An empty cookie means the result set is complete.
+        Assertions.assertNull(LDAPGroupProvider.extractPagedResultsCookie(
+                new Control[] {pagedResponse(1, new byte[0])}));
+        Assertions.assertArrayEquals(new byte[] {0x0a},
+                LDAPGroupProvider.extractPagedResultsCookie(new Control[] {pagedResponse(1, new byte[] {0x0a})}));
+    }
+
+    // ---------- helpers ----------
+
+    private static List<String> collect(LdapContext ctx, int pageSize) throws NamingException, IOException {
+        List<String> seen = new ArrayList<>();
+        LDAPGroupProvider.searchGroupEntriesPaged(ctx, BASE_DN, FILTER, ATTRS, pageSize,
+                result -> seen.add(result.getName()));
+        return seen;
+    }
+
+    /**
+     * Build a real PagedResultsResponseControl rather than mocking it, so the JDK's own BER parsing is
+     * exercised. The control value is {@code SEQUENCE { size INTEGER, cookie OCTET STRING }}.
+     */
+    private static PagedResultsResponseControl pagedResponse(int size, byte[] cookie) throws IOException {
+        byte[] safeCookie = cookie == null ? new byte[0] : cookie;
+        ByteArrayOutputStream body = new ByteArrayOutputStream();
+        // INTEGER size - the values used here stay well inside a single byte.
+        body.write(new byte[] {0x02, 0x01, (byte) size});
+        body.write(0x04);
+        body.write(safeCookie.length);
+        body.write(safeCookie);
+
+        byte[] bodyBytes = body.toByteArray();
+        ByteArrayOutputStream value = new ByteArrayOutputStream();
+        value.write(0x30);
+        value.write(bodyBytes.length);
+        value.write(bodyBytes);
+
+        return new PagedResultsResponseControl(PagedResultsResponseControl.OID, Control.NONCRITICAL,
+                value.toByteArray());
+    }
+
+    private static ListNamingEnumeration results(String... names) {
+        return new ListNamingEnumeration(searchResults(names), false);
+    }
+
+    /**
+     * An enumeration that yields {@code names} and then raises PartialResultException, the way the LDAP
+     * provider reports a referral it will not chase.
+     */
+    private static ListNamingEnumeration referralAfter(String... names) {
+        return new ListNamingEnumeration(searchResults(names), true);
+    }
+
+    private static List<SearchResult> searchResults(String... names) {
+        List<SearchResult> list = new ArrayList<>();
+        for (String name : names) {
+            list.add(new SearchResult(name, null, new BasicAttributes(), true));
+        }
+        return list;
+    }
+
+    /** Minimal NamingEnumeration over a fixed list, recording close() so it can be asserted on. */
+    private static final class ListNamingEnumeration implements NamingEnumeration<SearchResult> {
+        private final List<SearchResult> items;
+        private final boolean referralAtEnd;
+        private int index;
+        private boolean closed;
+
+        private ListNamingEnumeration(List<SearchResult> items, boolean referralAtEnd) {
+            this.items = items;
+            this.referralAtEnd = referralAtEnd;
+        }
+
+        @Override
+        public SearchResult next() {
+            return items.get(index++);
+        }
+
+        @Override
+        public boolean hasMore() throws NamingException {
+            if (index >= items.size() && referralAtEnd) {
+                throw new PartialResultException("unprocessed continuation reference(s)");
+            }
+            return index < items.size();
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+
+        @Override
+        public boolean hasMoreElements() {
+            try {
+                return hasMore();
+            } catch (NamingException e) {
+                return false;
+            }
+        }
+
+        @Override
+        public SearchResult nextElement() {
+            return next();
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/LDAPGroupProviderRangeRetrievalTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/LDAPGroupProviderRangeRetrievalTest.java
@@ -1,0 +1,408 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.authentication;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import javax.naming.CommunicationException;
+import javax.naming.NamingException;
+import javax.naming.PartialResultException;
+import javax.naming.directory.BasicAttribute;
+import javax.naming.directory.BasicAttributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.SearchResult;
+
+import static org.mockito.AdditionalMatchers.aryEq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Active Directory splits a large group's member attribute across range retrieval pages, encoding the
+ * page boundaries into the attribute id itself ({@code member;range=0-1499}) - see MS-ADTS 3.1.1.3.1.3.3.
+ * A strict {@code attributes.get("member")} therefore finds nothing and the group silently reads as empty.
+ */
+public class LDAPGroupProviderRangeRetrievalTest {
+
+    private int originalMaxRangePages;
+
+    @BeforeEach
+    public void setUp() {
+        originalMaxRangePages = LDAPGroupProvider.MAX_RANGE_PAGES;
+    }
+
+    @AfterEach
+    public void tearDown() {
+        LDAPGroupProvider.MAX_RANGE_PAGES = originalMaxRangePages;
+    }
+
+    // ---------- parseRangeSuffix ----------
+
+    @Test
+    public void testParseRangeSuffixPlainAttributeReturnsNull() {
+        Assertions.assertNull(LDAPGroupProvider.parseRangeSuffix("member"));
+    }
+
+    @Test
+    public void testParseRangeSuffixIntermediatePage() {
+        LDAPGroupProvider.RangeInfo info = LDAPGroupProvider.parseRangeSuffix("member;range=0-1499");
+        Assertions.assertNotNull(info);
+        Assertions.assertEquals(0L, info.start);
+        Assertions.assertEquals(1499L, info.end);
+        Assertions.assertFalse(info.isTerminal());
+    }
+
+    @Test
+    public void testParseRangeSuffixTerminalPage() {
+        LDAPGroupProvider.RangeInfo info = LDAPGroupProvider.parseRangeSuffix("member;range=1500-*");
+        Assertions.assertNotNull(info);
+        Assertions.assertEquals(1500L, info.start);
+        Assertions.assertTrue(info.isTerminal());
+    }
+
+    @Test
+    public void testParseRangeSuffixIsCaseInsensitive() {
+        LDAPGroupProvider.RangeInfo info = LDAPGroupProvider.parseRangeSuffix("MEMBER;Range=0-1");
+        Assertions.assertNotNull(info);
+        Assertions.assertEquals(0L, info.start);
+        Assertions.assertEquals(1L, info.end);
+    }
+
+    @Test
+    public void testParseRangeSuffixToleratesOtherAttributeOptions() {
+        // AD may carry an option list, e.g. member;lang-en;range=0-1499
+        LDAPGroupProvider.RangeInfo info = LDAPGroupProvider.parseRangeSuffix("member;lang-en;range=0-1499");
+        Assertions.assertNotNull(info);
+        Assertions.assertEquals(0L, info.start);
+        Assertions.assertEquals(1499L, info.end);
+    }
+
+    @Test
+    public void testParseRangeSuffixMalformedReturnsNull() {
+        Assertions.assertNull(LDAPGroupProvider.parseRangeSuffix("member;range="));
+        Assertions.assertNull(LDAPGroupProvider.parseRangeSuffix("member;range=abc-xyz"));
+        Assertions.assertNull(LDAPGroupProvider.parseRangeSuffix("member;blah=0-1"));
+        Assertions.assertNull(LDAPGroupProvider.parseRangeSuffix("member;lang-en"));
+        Assertions.assertNull(LDAPGroupProvider.parseRangeSuffix(null));
+    }
+
+    // ---------- findMemberAttributeId ----------
+
+    @Test
+    public void testFindMemberAttributeIdPlainMatch() throws NamingException {
+        BasicAttributes attrs = new BasicAttributes(true);
+        attrs.put(new BasicAttribute("member"));
+        attrs.put(new BasicAttribute("cn", "grp"));
+
+        Assertions.assertEquals("member", LDAPGroupProvider.findMemberAttributeId(attrs, "member"));
+    }
+
+    @Test
+    public void testFindMemberAttributeIdRangeVariantMatched() throws NamingException {
+        BasicAttributes attrs = new BasicAttributes(true);
+        attrs.put(new BasicAttribute("member;range=0-1499"));
+        attrs.put(new BasicAttribute("cn", "grp"));
+
+        Assertions.assertEquals("member;range=0-1499", LDAPGroupProvider.findMemberAttributeId(attrs, "member"));
+    }
+
+    @Test
+    public void testFindMemberAttributeIdPrefersValuedRangeOverEmptyPlainMember() throws NamingException {
+        // AD echoes an empty plain "member" alongside the ranged attribute that actually carries values.
+        BasicAttributes attrs = new BasicAttributes(true);
+        attrs.put(new BasicAttribute("member"));
+        BasicAttribute range = new BasicAttribute("member;range=0-1");
+        range.add("u1");
+        attrs.put(range);
+
+        Assertions.assertEquals("member;range=0-1", LDAPGroupProvider.findMemberAttributeId(attrs, "member"));
+    }
+
+    @Test
+    public void testFindMemberAttributeIdPrefersValuedRangeOverEmptyRangeEcho() throws NamingException {
+        // We asked for "2-*"; AD can echo that id with no values and return the real page under "2-3".
+        BasicAttributes attrs = new BasicAttributes(true);
+        attrs.put(new BasicAttribute("member;range=2-*"));
+        BasicAttribute range = new BasicAttribute("member;range=2-3");
+        range.add("u3");
+        attrs.put(range);
+
+        Assertions.assertEquals("member;range=2-3", LDAPGroupProvider.findMemberAttributeId(attrs, "member"));
+    }
+
+    @Test
+    public void testFindMemberAttributeIdCustomMemberAttrIsNotConfusedWithMember() throws NamingException {
+        BasicAttributes attrs = new BasicAttributes(true);
+        BasicAttribute memberUid = new BasicAttribute("memberUid");
+        memberUid.add("alice");
+        attrs.put(memberUid);
+
+        Assertions.assertEquals("memberUid", LDAPGroupProvider.findMemberAttributeId(attrs, "memberUid"));
+        Assertions.assertNull(LDAPGroupProvider.findMemberAttributeId(attrs, "member"));
+    }
+
+    @Test
+    public void testFindMemberAttributeIdMissingReturnsNull() throws NamingException {
+        BasicAttributes attrs = new BasicAttributes(true);
+        attrs.put(new BasicAttribute("cn", "grp"));
+
+        Assertions.assertNull(LDAPGroupProvider.findMemberAttributeId(attrs, "member"));
+        Assertions.assertNull(LDAPGroupProvider.findMemberAttributeId(null, "member"));
+    }
+
+    // ---------- consumeMemberPage ----------
+
+    @Test
+    public void testConsumeMemberPagePlainAttributeNeedsNoFollowUp() throws NamingException {
+        BasicAttributes attrs = new BasicAttributes(true);
+        BasicAttribute member = new BasicAttribute("member");
+        member.add("CN=u1,DC=x");
+        member.add("CN=u2,DC=x");
+        attrs.put(member);
+
+        List<String> collected = new ArrayList<>();
+        long next = LDAPGroupProvider.consumeMemberPage(attrs, "member", collected::add);
+
+        Assertions.assertEquals(-1L, next);
+        Assertions.assertEquals(List.of("CN=u1,DC=x", "CN=u2,DC=x"), collected);
+    }
+
+    @Test
+    public void testConsumeMemberPageTruncatedPageReturnsNextOffset() throws NamingException {
+        BasicAttributes attrs = new BasicAttributes(true);
+        BasicAttribute member = new BasicAttribute("member;range=0-1499");
+        member.add("CN=u1,DC=x");
+        attrs.put(member);
+
+        List<String> collected = new ArrayList<>();
+        Assertions.assertEquals(1500L, LDAPGroupProvider.consumeMemberPage(attrs, "member", collected::add));
+        Assertions.assertEquals(List.of("CN=u1,DC=x"), collected);
+    }
+
+    @Test
+    public void testConsumeMemberPageTerminalPageNeedsNoFollowUp() throws NamingException {
+        BasicAttributes attrs = new BasicAttributes(true);
+        BasicAttribute member = new BasicAttribute("member;range=1500-*");
+        member.add("CN=u9,DC=x");
+        attrs.put(member);
+
+        List<String> collected = new ArrayList<>();
+        Assertions.assertEquals(-1L, LDAPGroupProvider.consumeMemberPage(attrs, "member", collected::add));
+        Assertions.assertEquals(List.of("CN=u9,DC=x"), collected);
+    }
+
+    @Test
+    public void testConsumeMemberPageMissingMemberAttributeIsEmptyNotTruncated() throws NamingException {
+        BasicAttributes attrs = new BasicAttributes(true);
+        attrs.put(new BasicAttribute("cn", "grp"));
+
+        List<String> collected = new ArrayList<>();
+        Assertions.assertEquals(-1L, LDAPGroupProvider.consumeMemberPage(attrs, "member", collected::add));
+        Assertions.assertTrue(collected.isEmpty());
+    }
+
+    // ---------- fetchRemainingMemberPages ----------
+
+    @Test
+    public void testFetchRemainingMemberPagesWalksToTerminalPage() throws NamingException {
+        DirContext ctx = mock(DirContext.class);
+        when(ctx.getAttributes(eq("CN=g,DC=x"), aryEq(new String[] {"member;range=1500-*"})))
+                .thenReturn(pagedAttrs("member;range=1500-*", "CN=u4,DC=x", "CN=u5,DC=x"));
+
+        List<String> collected = new ArrayList<>();
+        boolean complete = LDAPGroupProvider.fetchRemainingMemberPages(
+                ctx, "CN=g,DC=x", "member", 1500L, collected::add);
+
+        Assertions.assertTrue(complete);
+        Assertions.assertEquals(List.of("CN=u4,DC=x", "CN=u5,DC=x"), collected);
+        verify(ctx, times(1)).getAttributes(eq("CN=g,DC=x"), aryEq(new String[] {"member;range=1500-*"}));
+    }
+
+    @Test
+    public void testFetchRemainingMemberPagesChainsAcrossServerCappedPages() throws NamingException {
+        // The client asks for "3-*" but the server answers "3-5", still non-terminal.
+        DirContext ctx = mock(DirContext.class);
+        when(ctx.getAttributes(eq("CN=g"), aryEq(new String[] {"member;range=3-*"})))
+                .thenReturn(pagedAttrs("member;range=3-5", "u4", "u5", "u6"));
+        when(ctx.getAttributes(eq("CN=g"), aryEq(new String[] {"member;range=6-*"})))
+                .thenReturn(pagedAttrs("member;range=6-*", "u7"));
+
+        List<String> collected = new ArrayList<>();
+        boolean complete = LDAPGroupProvider.fetchRemainingMemberPages(ctx, "CN=g", "member", 3L, collected::add);
+
+        Assertions.assertTrue(complete);
+        Assertions.assertEquals(List.of("u4", "u5", "u6", "u7"), collected);
+    }
+
+    @Test
+    public void testFetchRemainingMemberPagesReportsIncompleteOnNamingException() throws NamingException {
+        DirContext ctx = mock(DirContext.class);
+        when(ctx.getAttributes(eq("CN=g"), any(String[].class)))
+                .thenThrow(new CommunicationException("simulated transient ldap error"));
+
+        List<String> collected = new ArrayList<>();
+        boolean complete = LDAPGroupProvider.fetchRemainingMemberPages(ctx, "CN=g", "member", 2L, collected::add);
+
+        // A truncated member list must be reported as incomplete so the caller refuses to publish it.
+        Assertions.assertFalse(complete);
+        Assertions.assertTrue(collected.isEmpty());
+    }
+
+    @Test
+    public void testFetchRemainingMemberPagesReportsIncompleteOnPartialResult() throws NamingException {
+        DirContext ctx = mock(DirContext.class);
+        when(ctx.getAttributes(eq("CN=g"), any(String[].class)))
+                .thenThrow(new PartialResultException("referral"));
+
+        Assertions.assertFalse(LDAPGroupProvider.fetchRemainingMemberPages(
+                ctx, "CN=g", "member", 2L, m -> { }));
+    }
+
+    @Test
+    public void testFetchRemainingMemberPagesReportsIncompleteWhenServerSkipsRequestedPage() throws NamingException {
+        DirContext ctx = mock(DirContext.class);
+        BasicAttributes noMember = new BasicAttributes(true);
+        noMember.put(new BasicAttribute("cn", "grp"));
+        when(ctx.getAttributes(eq("CN=g"), any(String[].class))).thenReturn(noMember);
+
+        Assertions.assertFalse(LDAPGroupProvider.fetchRemainingMemberPages(
+                ctx, "CN=g", "member", 2L, m -> { }));
+    }
+
+    @Test
+    public void testFetchRemainingMemberPagesReportsIncompleteWhenServerDoesNotAdvance() throws NamingException {
+        // A server that keeps answering with the same window would otherwise spin forever.
+        DirContext ctx = mock(DirContext.class);
+        when(ctx.getAttributes(eq("CN=g"), any(String[].class)))
+                .thenReturn(pagedAttrs("member;range=0-1", "u1"));
+
+        Assertions.assertFalse(LDAPGroupProvider.fetchRemainingMemberPages(
+                ctx, "CN=g", "member", 2L, m -> { }));
+    }
+
+    @Test
+    public void testFetchRemainingMemberPagesHonoursMaxRangePages() throws NamingException {
+        LDAPGroupProvider.MAX_RANGE_PAGES = 3;
+
+        DirContext ctx = mock(DirContext.class);
+        // Always non-terminal, always advancing by one: only the safety limit can stop this.
+        when(ctx.getAttributes(eq("g"), any(String[].class))).thenAnswer(invocation -> {
+            String[] requestedAttrs = invocation.getArgument(1);
+            long start = LDAPGroupProvider.parseRangeSuffix(requestedAttrs[0]).start;
+            return pagedAttrs("member;range=" + start + "-" + start, "u" + start);
+        });
+
+        List<String> collected = new ArrayList<>();
+        boolean complete = LDAPGroupProvider.fetchRemainingMemberPages(ctx, "g", "member", 1L, collected::add);
+
+        Assertions.assertFalse(complete);
+        Assertions.assertEquals(List.of("u1", "u2", "u3"), collected);
+        verify(ctx, times(3)).getAttributes(eq("g"), any(String[].class));
+    }
+
+    @Test
+    public void testFetchRemainingMemberPagesWithoutGroupDnMakesNoRequest() throws NamingException {
+        DirContext ctx = mock(DirContext.class);
+
+        Assertions.assertFalse(LDAPGroupProvider.fetchRemainingMemberPages(ctx, "", "member", 2L, m -> { }));
+        verify(ctx, never()).getAttributes(any(String.class), any(String[].class));
+    }
+
+    // ---------- regression baseline for the defect this fixes ----------
+
+    @Test
+    public void testLargeGroupIsReadCompletelyAcrossThreePages() throws NamingException {
+        // 3500 members, MaxValRange 1500. Before range retrieval support this group read as empty.
+        DirContext ctx = mock(DirContext.class);
+        when(ctx.getAttributes(eq("CN=big,DC=x"), aryEq(new String[] {"member;range=1500-*"})))
+                .thenReturn(pagedAttrs("member;range=1500-2999", members(1500, 3000)));
+        when(ctx.getAttributes(eq("CN=big,DC=x"), aryEq(new String[] {"member;range=3000-*"})))
+                .thenReturn(pagedAttrs("member;range=3000-*", members(3000, 3500)));
+
+        List<String> collected = new ArrayList<>();
+        BasicAttributes firstPage = pagedAttrs("member;range=0-1499", members(0, 1500));
+
+        long next = LDAPGroupProvider.consumeMemberPage(firstPage, "member", collected::add);
+        Assertions.assertEquals(1500L, next);
+        Assertions.assertTrue(LDAPGroupProvider.fetchRemainingMemberPages(
+                ctx, "CN=big,DC=x", "member", next, collected::add));
+
+        Assertions.assertEquals(3500, collected.size());
+        Assertions.assertEquals("CN=u0,DC=x", collected.get(0));
+        Assertions.assertEquals("CN=u3499,DC=x", collected.get(3499));
+    }
+
+    // ---------- extractGroupDN / qualifyRelativeDN ----------
+
+    @Test
+    public void testExtractGroupDNQualifiesRelativeNameWithBaseDN() {
+        SearchResult result = new SearchResult("CN=g,OU=Groups", null, new BasicAttributes(), true);
+
+        Assertions.assertEquals("CN=g,OU=Groups,DC=x,DC=y",
+                LDAPGroupProvider.extractGroupDN(result, "DC=x,DC=y"));
+    }
+
+    @Test
+    public void testExtractGroupDNLeavesAbsoluteNameAlone() {
+        SearchResult result = new SearchResult("CN=g,DC=x,DC=y", null, new BasicAttributes(), false);
+
+        Assertions.assertEquals("CN=g,DC=x,DC=y", LDAPGroupProvider.extractGroupDN(result, "DC=x,DC=y"));
+    }
+
+    @Test
+    public void testQualifyRelativeDNDoesNotDuplicateBaseDN() {
+        Assertions.assertEquals("CN=g,DC=x,DC=y", LDAPGroupProvider.qualifyRelativeDN("CN=g,DC=x,DC=y", "DC=x,DC=y"));
+        // The DN suffix comparison is case-insensitive, as DNs are.
+        Assertions.assertEquals("CN=g,dc=x,dc=y", LDAPGroupProvider.qualifyRelativeDN("CN=g,dc=x,dc=y", "DC=x,DC=y"));
+    }
+
+    @Test
+    public void testQualifyRelativeDNStripsQuotesAndWhitespace() {
+        Assertions.assertEquals("CN=g,DC=x", LDAPGroupProvider.qualifyRelativeDN(" \"CN=g\" ", " 'DC=x' "));
+    }
+
+    // ---------- helpers ----------
+
+    private static BasicAttributes pagedAttrs(String attrId, String... values) {
+        BasicAttributes attrs = new BasicAttributes(true);
+        BasicAttribute attr = new BasicAttribute(attrId);
+        for (String value : values) {
+            attr.add(value);
+        }
+        attrs.put(attr);
+        return attrs;
+    }
+
+    private static BasicAttributes pagedAttrs(String attrId, List<String> values) {
+        return pagedAttrs(attrId, values.toArray(new String[0]));
+    }
+
+    private static List<String> members(int fromInclusive, int toExclusive) {
+        return IntStream.range(fromInclusive, toExclusive)
+                .mapToObj(i -> "CN=u" + i + ",DC=x")
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
- Supersedes #73490, which covered only range retrieval and the resource / error-isolation cleanup.
- Related to #56670, which introduced the provider.

## Why I'm doing:

`LDAPGroupProvider` reads group membership out of the directory and caches a user-to-group map that `group_allowed_login_list` and Ranger group policies then depend on. Three separate defects make that map silently wrong or silently empty.

**1. Range-encoded `member` attributes are not recognized (the original report).**

When a group has more members than the server's `MaxValRange` (1500 on Active Directory, 2500 on tuned forests), AD does **not** return the canonical `member` attribute. It splits the response into `member;range=0-1499`, `member;range=1500-*` and so on, encoding the page boundaries into the attribute *name* itself (MS-ADTS 3.1.1.3.1.3.3, "Range Retrieval of Attribute Values").

The provider has matched strictly via `attrs.get("member")` since it was introduced in #56670. The moment AD switches to the range-encoded form the whole group looks empty, and every user whose login depends on it is rejected with:

```
Access denied; User 's group[] is not in the group_allowed_login_list
```

This was traced on a production deployment where one group has ~2,600 members; ~1,990 users collapsed into a silent failure path even though their DN was present in the very first paged window. Nothing in the release notes says range retrieval is unsupported, so it is hit only once a group crosses the limit.

**2. The group entry search itself is unpaged.**

The `ldap_group_filter` path issues one `ctx.search()` with no paging control. A directory whose `MaxPageSize` (1000 on AD) is smaller than the number of matching groups answers with `sizeLimitExceeded`, and the refresh collects nothing. This is a second, independent way for the whole cache to come back empty, and it was not covered by #73490.

**3. A partial or failed read still replaces the cache.**

`refreshGroups()` catches broadly and then unconditionally runs `userToGroupCache = groups`. So a transient LDAP outage, one unreadable group, or a truncated read publishes a partial map — and a partial map is *indistinguishable from "these users are in no groups"*. One blip in the directory turns into fleet-wide `Access denied`. This is the shape of the observed incident, and it is the most dangerous of the three.

**4. (pre-existing on main) A provider restored from the metadata image NPEs.**

Independent of the above, a provider that was already in the image when the FE restarted is not constructed — GSON instantiates it through `UnsafeAllocator`, which skips the constructor **and** the inline field initializers, and `HiddenAnnotationExclusionStrategy` skips every field without `@SerializedName` so the JSON does not carry them either. `userToGroupCache` therefore arrives `null`, and `SHOW GROUP PROVIDERS` throws NPE. The edit-log replay path (`replayCreateGroupProvider` → `GroupProviderFactory`) runs the constructor, so DROP + recreate appears to fix it until the next checkpoint bakes the provider back into the image.

This is worse than cosmetic: `ScheduledExecutorService` permanently cancels all future runs of a task that lets an exception escape, so one NPE in the refresh task freezes group refresh until the FE restarts.

## What I'm doing:

**Range retrieval.** The range-encoded variant is recognized, the initial page returned with the group entry is consumed in place, and follow-up pages (`member;range=N-*`) are requested until the server answers with a terminal `-*` marker. AD edge cases — an empty echo `member` alongside the ranged attribute, an empty range echo, option lists like `member;lang-en;range=0-1499` — are handled by preferring whichever attribute id actually carries values. `MAX_RANGE_PAGES = 100` bounds a misbehaving server.

**RFC 2696 paged results.** Group entries are enumerated with the simple paged results control, chaining the continuation cookie until it comes back empty. The control is sent as `NONCRITICAL`, so a directory that does not implement RFC 2696 ignores it and returns the full result set with no response control — which collapses exactly into the single unpaged search this replaces. New config `ldap_group_provider_search_page_size` (default 1000) tunes the page size; setting it to `0` stops sending the control altogether and is the runtime kill switch back to the previous behavior, via `ADMIN SET FRONTEND CONFIG`.

> The two features cannot simply be composed, which is the one design point worth reviewing. `PagedResultsControl` is a *request control scoped to the context*, and `getAttributes()` goes out as a base-object search underneath JNDI — so calling it while a search cookie is installed sends that cookie along with an unrelated operation, and the server may answer `protocolError` / `unwillingToPerform`. The refresh is therefore split in two phases: phase A walks the group entries and only *records* which groups were range-truncated, calling no `getAttributes()`; phase B clears the request controls and then resolves the recorded groups. The ordering contract is enforced by an `InOrder` test rather than left to a comment.

**Publish only a complete read.** `collectGroups()` now returns a value describing the outcome instead of mutating state, and the cache is replaced only when the directory was read completely. A fatal error, a truncated range walk, or a paged search that stopped with pages still pending keeps the last known good snapshot and logs the reason with a `consecutiveFailures` counter. A blanking guard additionally rejects a refresh that suddenly matched **zero group entries** after a healthy one — that is an outage or a broken filter, not a directory in which every group vanished. The guard counts *group entries, not users*, so a user legitimately removed from every group still propagates.

`refreshGroups()` is wrapped whole in `try/catch (Throwable)`, so the scheduler contract is kept by the code rather than by review.

**Image round trip.** `LDAPGroupProvider` implements `GsonPostProcessable` and restores `userToGroupCache` in `gsonPostProcess()`; `destroy()` tolerates a null `scheduleTask`; the failure counter is a plain `volatile int` rather than an `AtomicInteger`, because a primitive cannot arrive null and so needs nothing from the hook. No `transient` markers were added — `HiddenAnnotationExclusionStrategy` already excludes these fields, and adding them would suggest the cause was serialization rather than `UnsafeAllocator`.

**Robustness gaps in the same code path**, bundled because they are the same few lines:

- The `DirContext` and every `NamingEnumeration` are closed in `finally` instead of being leaked on every refresh.
- Per-group `NamingException` is isolated so one bad entry no longer voids the refresh — but only for a *determinate* answer (`NameNotFoundException`, `InvalidNameException`). The classification is a whitelist on purpose: an exception nobody has classified means the read may have been truncated, and a truncated read must not be published.
- `PartialResultException` (an unfollowable referral) stays tolerated when the aborted page had no continuation cookie — routine on AD with the domain root as base DN — but counts as an incomplete read when pages were still pending.
- The `ldap_group_filter` path sets `returningAttributes` explicitly, instead of relying on the server's default attribute set, which is also what makes AD emit the range-encoded form deterministically.
- Group DNs are resolved via `getNameInNamespace()`, falling back to qualifying a relative DN with `ldap_bind_base_dn`, so the follow-up `getAttributes()` always receives an absolute DN.
- `init()` uses `scheduleWithFixedDelay` rather than `scheduleAtFixedRate`: a refresh that outruns the interval must not queue an immediate re-run and hammer the directory, which is now easy to hit on a large directory.

**Observability.** `getComment()` is overridden so the COMMENT column of `SHOW GROUP PROVIDERS` reports cache health, with no new schema or metric:

```
cachedUsers=12043, groupEntries=214, lastSuccessAgoSec=42, consecutiveFailures=0
```

**Tests** — 4 new classes, ~1,170 lines, all new files so they do not collide with future refactors of the existing ones:

| Class | Covers |
|---|---|
| `LDAPGroupProviderRangeRetrievalTest` | range parsing, attribute-id selection, page chaining, non-advancing and page-skipping servers, `MAX_RANGE_PAGES`, DN qualification, and a 3,500-member / 1,500-`MaxValRange` end-to-end baseline for the reported defect |
| `LDAPGroupProviderPagedSearchTest` | cookie chaining, servers without RFC 2696 support, request controls cleared on every exit path, `pageSize=0` sending no control, referral tolerated vs. counted as loss, real BER-encoded `PagedResultsResponseControl` |
| `LDAPGroupProviderCachePolicyTest` | every publish/keep decision, blanking guard, legitimate membership removal still propagating, `refreshGroups()` never throwing, error classification |
| `LDAPGroupProviderImageRoundTripTest` | round trip through the real `GsonUtils.GSON`, so the `RuntimeTypeAdapterFactory` / post-process wiring is exercised rather than a hand-built `Gson` |

The existing `LDAPGroupProviderCaseInsensitiveTest` passes unmodified and serves as the regression gate for the previous behavior.

Deleting any one of the three fixes makes exactly the corresponding tests fail; in particular reverting to the strict lookup fails `testLargeGroupIsReadCompletelyAcrossThreePages` with `expected: <1500> but was: <-1>`, which is the original symptom.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

**Policy change.** A failed or incomplete refresh now keeps the last known good cache instead of publishing whatever was collected. This is the intended fix, and it trades one failure mode for another that operators must know about: during a prolonged LDAP outage the cache freezes, so a user removed from a group in the meantime keeps that group's privileges until the directory is reachable again. The previous behavior traded the other way — it dropped everyone's groups at the first blip. A stale-but-complete cache is the safer default, but it is only safe to run **with an alert on the `consecutiveFailures` / `cacheStaleForMs` ERROR log**, which is why both are logged explicitly and surfaced through `SHOW GROUP PROVIDERS`.

**Display change.** The COMMENT column of `SHOW GROUP PROVIDERS` shows the cache health line above for ldap providers, where it previously showed `NULL`.

**Miscellaneous / compatibility.** Group provider metadata is unchanged — no new persisted field, no image or edit-log format change, so downgrade is unaffected. Directories that do not page behave exactly as before, because the paging control is `NONCRITICAL` and range retrieval only triggers on an attribute id the server itself chose to send. Conversely this PR *fixes* an upgrade defect: a provider already present in the metadata image previously threw NPE after the FE restarted.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

`ldap_group_provider_search_page_size` is documented under "User, role, and privilege" in `docs/en/administration/configuration/FE_parameters/user_query_loading.md`. Verified with `build-support/extract_and_diff_params.py --new-params-only`, which now reports nothing. Happy to also add a note about large AD groups to `docs/{en,zh,ja}/administration/user_privs/group_provider.md` if reviewers prefer.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

The defect exists on all three branches — the provider landed in #56670 (2025-03-10). Only 4.1 is requested for auto-backport, because this code now calls `LDAPAuthProvider.normalizeUsername()`, which arrived much later in #67966 (2026-02-13); on 4.0 and 3.5 the cherry-pick would conflict rather than apply. I am happy to open adapted manual backports for 4.0 and 3.5 if maintainers want them.

cc/ @HangyuanLiu 