### PR TITLE
[BugFix] Record a merged rowset's del op_offset per statement, not per rowset

### DIFF
--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -1185,8 +1185,8 @@ void MetaFileBuilder::add_rowset(const RowsetMetadataPB& rowset_pb, const std::m
         // whose rows are live and not delvec-masked. The next upsert of such a key finds nothing,
         // writes no delete-vector mark, and leaves two live rows -- which a later index rebuild
         // reports as "insert found duplicate key" (issue #78224).
-        const uint32_t local_idx = off >= 0 ? get_segment_idx(rowset_pb, static_cast<int32_t>(off))
-                                            : get_max_segment_idx(rowset_pb);
+        const uint32_t local_idx =
+                off >= 0 ? get_segment_idx(rowset_pb, static_cast<int32_t>(off)) : get_max_segment_idx(rowset_pb);
         _pending_rowset_data.del_op_offsets.push_back(static_cast<int64_t>(seg_base) + local_idx);
         _pending_rowset_data.del_num_rows.push_back(i < del_num_rows.size() ? del_num_rows[i] : 0);
     }

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -1170,7 +1170,24 @@ void MetaFileBuilder::add_rowset(const RowsetMetadataPB& rowset_pb, const std::m
     for (size_t i = 0; i < dels.size(); ++i) {
         _pending_rowset_data.dels.emplace_back(dels[i]);
         const int64_t off = i < del_op_offsets.size() ? del_op_offsets[i] : -1;
-        _pending_rowset_data.del_op_offsets.push_back(off >= 0 ? off + seg_base : -1);
+        // Resolve the del's position into the merged rowset's segment-id space HERE, while the
+        // op_write that produced it is still in hand, with the same expression apply used for that
+        // op_write (build_del_interleave_plan(): `seg_base + get_segment_idx()` for a recorded
+        // offset, "right after this op_write's own last segment" for an unrecorded one). An
+        // op_write with no segments (a pure-delete statement) resolves to `seg_base`, the slot
+        // get_rowset_id_step() reserves for it and which therefore holds no segment, so it erases
+        // every earlier statement's rows and nothing later -- which is what apply did.
+        //
+        // An unrecorded offset used to be deferred to set_final_rowset() as -1, which resolved it
+        // against the MERGED rowset, i.e. after every LATER statement's segments too. The rebuild
+        // then replayed that del over rows a later statement of the same transaction had
+        // re-inserted (and, being at the max, without the ordering filter), erasing index entries
+        // whose rows are live and not delvec-masked. The next upsert of such a key finds nothing,
+        // writes no delete-vector mark, and leaves two live rows -- which a later index rebuild
+        // reports as "insert found duplicate key" (issue #78224).
+        const uint32_t local_idx = off >= 0 ? get_segment_idx(rowset_pb, static_cast<int32_t>(off))
+                                            : get_max_segment_idx(rowset_pb);
+        _pending_rowset_data.del_op_offsets.push_back(static_cast<int64_t>(seg_base) + local_idx);
         _pending_rowset_data.del_num_rows.push_back(i < del_num_rows.size() ? del_num_rows[i] : 0);
     }
 
@@ -1222,10 +1239,15 @@ Status MetaFileBuilder::set_final_rowset() {
         DelfileWithRowsetId del_file_with_rid;
         del_file_with_rid.set_name(del.name());
         del_file_with_rid.set_origin_rowset_id(rowset->id());
-        // Preserve the in-transaction upsert/delete order when the writer recorded it; otherwise
-        // fall back to the max segment id (delete after all upserts).
-        del_file_with_rid.set_op_offset(
-                resolve_del_op_offset(_pending_rowset_data.del_op_offsets[i], /*column_mode=*/false, *rowset));
+        // op_offset is already resolved into this merged rowset's segment-id space by add_rowset(),
+        // which is the only place that knows which op_write each del came from. Clamp it to the
+        // merged rowset's last segment: a trailing pure-delete statement's reserved slot sits past
+        // that segment, and an op_offset outside the rowset's own rssid range would push the
+        // rebuild point into the next rowset. Clamping keeps the "erases everything in this rowset"
+        // meaning (the rebuild's ordering filter is skipped once op_offset reaches the max) without
+        // escaping the range.
+        del_file_with_rid.set_op_offset(static_cast<uint32_t>(
+                std::min<int64_t>(_pending_rowset_data.del_op_offsets[i], get_max_segment_idx(*rowset))));
         if (!del.encryption_meta().empty()) {
             del_file_with_rid.set_encryption_meta(del.encryption_meta());
         }

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -571,6 +571,7 @@ SET(DW_TEST_FILES
     ./storage/lake/persistent_index_sstable_test.cpp
     ./storage/lake/primary_key_compaction_task_test.cpp
     ./storage/lake/primary_key_publish_test.cpp
+    ./storage/lake/lake_merged_del_op_offset_test.cpp
     ./storage/lake/tablet_reshard_helper_test.cpp
     ./storage/lake/tablet_reshard_test.cpp
     ./storage/lake/tablet_splitter_test.cpp

--- a/be/test/storage/lake/lake_merged_del_op_offset_test.cpp
+++ b/be/test/storage/lake/lake_merged_del_op_offset_test.cpp
@@ -1,0 +1,282 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Regression test for #78224.
+//
+// A multi-statement transaction (SQL BEGIN ... COMMIT, i.e. a TxnInfoPB carrying more than one
+// load_id) is published by folding every statement's op_write into ONE merged rowset. A del file
+// carries `op_offset`: the index of the last segment of its rowset that the delete may erase. Apply
+// (UpdateManager::publish_primary_key_tablet) computes it from the statement that produced the del;
+// persist (MetaFileBuilder) used to leave an unrecorded offset to be resolved against the MERGED
+// rowset, i.e. after every LATER statement's segments too. On rebuild the delete then erased keys a
+// later statement had re-inserted, whose rows are live and not delete-vector-masked -- the next
+// upsert of such a key finds nothing in the index, writes no delete-vector mark, and leaves two live
+// rows for one key, which the following rebuild reports as "insert found duplicate key".
+//
+// Both tests drive the real publish path (DeltaWriter -> LakeServiceImpl::publish_version with two
+// load_ids -> rebuild on publish); nothing about the failing state is hand-assembled.
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <ctime>
+
+#include "column/chunk.h"
+#include "column/fixed_length_column.h"
+#include "column/schema.h"
+#include "common/config.h"
+#include "gen_cpp/Types_types.h"
+#include "storage/chunk_helper.h"
+#include "storage/lake/delta_writer.h"
+#include "storage/lake/tablet_reader.h"
+#include "storage/lake/test_util.h"
+#include "storage/lake/update_manager.h"
+#include "storage/tablet_schema.h"
+#include "testutil/assert.h"
+#include "testutil/id_generator.h"
+
+namespace starrocks::lake {
+
+class LakeMergedDelOpOffsetTest : public TestBase {
+public:
+    LakeMergedDelOpOffsetTest() : TestBase(kTestGroupPath) {
+        _tablet_metadata = generate_simple_tablet_metadata(PRIMARY_KEYS);
+        _tablet_metadata->set_enable_persistent_index(true);
+        _tablet_metadata->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
+
+        _slots.emplace_back(0, "c0", TypeDescriptor{LogicalType::TYPE_INT});
+        _slots.emplace_back(1, "c1", TypeDescriptor{LogicalType::TYPE_INT});
+        _slots.emplace_back(2, "__op", TypeDescriptor{LogicalType::TYPE_INT});
+        _slot_pointers.emplace_back(&_slots[0]);
+        _slot_pointers.emplace_back(&_slots[1]);
+        _slot_pointers.emplace_back(&_slots[2]);
+
+        _slot_cid_map.emplace(0, 0);
+        _slot_cid_map.emplace(1, 1);
+        _slot_cid_map.emplace(2, 2);
+
+        _tablet_schema = TabletSchema::create(_tablet_metadata->schema());
+        _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+    }
+
+    void SetUp() override {
+        clear_and_init_test_dir();
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+        ExecEnv::GetInstance()->parallel_compact_mgr()->TEST_set_tablet_mgr(_tablet_mgr.get());
+    }
+
+    void TearDown() override { remove_test_dir_ignore_error(); }
+
+protected:
+    // One chunk of `kNumKeys` rows, keys 0..kNumKeys-1, all upserts or all deletes.
+    ChunkPtr gen_chunk(bool upsert) {
+        std::vector<int> v0(kNumKeys);
+        std::vector<int> v1(kNumKeys);
+        std::vector<uint8_t> v2(kNumKeys);
+        for (int i = 0; i < kNumKeys; i++) {
+            v0[i] = i;
+            v1[i] = i * 3;
+            v2[i] = upsert ? TOpType::UPSERT : TOpType::DELETE;
+        }
+        auto c0 = Int32Column::create();
+        auto c1 = Int32Column::create();
+        auto c2 = Int8Column::create();
+        c0->append_numbers(v0.data(), v0.size() * sizeof(int));
+        c1->append_numbers(v1.data(), v1.size() * sizeof(int));
+        c2->append_numbers(v2.data(), v2.size() * sizeof(uint8_t));
+        return std::make_shared<Chunk>(Columns{std::move(c0), std::move(c1), std::move(c2)}, _slot_cid_map);
+    }
+
+    // Write one statement of a transaction. `load_id == nullptr` means an ordinary single-statement
+    // load; otherwise the writer emits a per-load_id txn log, which is what a multi-statement
+    // transaction does.
+    void write_statement(int64_t txn_id, const PUniqueId* load_id, bool upsert) {
+        auto chunk = gen_chunk(upsert);
+        std::vector<uint32_t> indexes(chunk->num_rows());
+        for (uint32_t i = 0; i < chunk->num_rows(); i++) {
+            indexes[i] = i;
+        }
+        DeltaWriterBuilder builder;
+        builder.set_tablet_manager(_tablet_mgr.get())
+                .set_tablet_id(_tablet_metadata->id())
+                .set_txn_id(txn_id)
+                .set_partition_id(_partition_id)
+                .set_mem_tracker(_mem_tracker.get())
+                .set_schema_id(_tablet_schema->id())
+                .set_slot_descriptors(&_slot_pointers)
+                .set_profile(&_dummy_runtime_profile);
+        if (load_id != nullptr) {
+            builder.set_load_id(*load_id).set_is_multi_statements_txn(true);
+        }
+        ASSIGN_OR_ABORT(auto delta_writer, builder.build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*chunk, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+    }
+
+    // Publish one transaction whose statements were written under `load_ids` (the merged-rowset
+    // path), optionally rebuilding the persistent index first (what a CN restart does).
+    StatusOr<TabletMetadataPtr> publish_multi_statement(int64_t base_version, int64_t new_version, int64_t txn_id,
+                                                        const std::vector<PUniqueId>& load_ids, bool rebuild_pindex) {
+        PublishVersionRequest request;
+        PublishVersionResponse response;
+        request.add_tablet_ids(_tablet_metadata->id());
+        request.set_base_version(base_version);
+        request.set_new_version(new_version);
+        request.set_commit_time(time(nullptr));
+        if (rebuild_pindex) {
+            request.add_rebuild_pindex_tablet_ids(_tablet_metadata->id());
+        }
+        auto* info = request.add_txn_infos();
+        info->set_txn_id(txn_id);
+        info->set_txn_type(TXN_NORMAL);
+        info->set_combined_txn_log(false);
+        info->set_commit_time(time(nullptr));
+        info->set_force_publish(false);
+        for (const auto& load_id : load_ids) {
+            info->add_load_ids()->CopyFrom(load_id);
+        }
+        auto lake_service = LakeServiceImpl(ExecEnv::GetInstance(), _tablet_mgr.get());
+        lake_service.publish_version(nullptr, &request, &response, nullptr);
+        if (response.failed_tablets_size() > 0) {
+            if (response.status().status_code() != 0) {
+                return Status(response.status());
+            }
+            return Status::InternalError("failed to publish version");
+        }
+        return _tablet_mgr->get_tablet_metadata(_tablet_metadata->id(), new_version);
+    }
+
+    int64_t read_rows(int64_t version) {
+        ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(_tablet_metadata->id(), version));
+        auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata, *_schema);
+        CHECK_OK(reader->prepare());
+        CHECK_OK(reader->open(TabletReaderParams()));
+        int64_t rows = 0;
+        while (true) {
+            auto chunk = ChunkHelper::new_chunk(*_schema, 128);
+            auto st = reader->get_next(chunk.get());
+            if (st.is_end_of_file()) {
+                break;
+            }
+            CHECK_OK(st);
+            rows += chunk->num_rows();
+        }
+        return rows;
+    }
+
+    static PUniqueId make_load_id(int64_t hi, int64_t lo) {
+        PUniqueId id;
+        id.set_hi(hi);
+        id.set_lo(lo);
+        return id;
+    }
+
+    static uint32_t max_segment_idx(const RowsetMetadataPB& rowset) {
+        uint32_t max_idx = 0;
+        for (int i = 0; i < rowset.segment_metas_size(); i++) {
+            const auto& seg = rowset.segment_metas(i);
+            max_idx = std::max(max_idx, seg.has_segment_idx() ? seg.segment_idx() : static_cast<uint32_t>(i));
+        }
+        return max_idx;
+    }
+
+    // The single rowset carrying a del file, i.e. the merged rowset of the multi-statement txn.
+    static const RowsetMetadataPB* rowset_with_del(const TabletMetadataPB& metadata) {
+        const RowsetMetadataPB* found = nullptr;
+        for (const auto& rowset : metadata.rowsets()) {
+            if (rowset.del_files_size() > 0) {
+                EXPECT_EQ(nullptr, found) << "more than one rowset carries a del file";
+                found = &rowset;
+            }
+        }
+        return found;
+    }
+
+    // Seed the table at version 2, then run the multi-statement transaction at version 3:
+    // statement 1 deletes every key, statement 2 re-upserts every key.
+    void seed_and_run_multi_statement_txn() {
+        // version 2: an ordinary load establishing the keys.
+        auto seed_txn = next_id();
+        write_statement(seed_txn, nullptr, /*upsert=*/true);
+        ASSERT_OK(publish_single_version(_tablet_metadata->id(), 2, seed_txn).status());
+        ASSERT_EQ(kNumKeys, read_rows(2));
+
+        // version 3: BEGIN; DELETE every key; INSERT every key back; COMMIT;
+        auto txn_id = next_id();
+        auto del_load_id = make_load_id(1, 1);
+        auto reinsert_load_id = make_load_id(1, 2);
+        write_statement(txn_id, &del_load_id, /*upsert=*/false);
+        write_statement(txn_id, &reinsert_load_id, /*upsert=*/true);
+        ASSERT_OK(publish_multi_statement(2, 3, txn_id, {del_load_id, reinsert_load_id},
+                                          /*rebuild_pindex=*/false)
+                          .status());
+        // The re-inserted rows are the live ones; the seeded rows are delete-vector-masked.
+        ASSERT_EQ(kNumKeys, read_rows(3));
+    }
+
+    inline static const std::string kTestGroupPath = "test_lake_merged_del_op_offset_" + std::to_string(getpid());
+    constexpr static int kNumKeys = 20;
+
+    std::shared_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<Schema> _schema;
+    int64_t _partition_id = next_id();
+    std::vector<SlotDescriptor> _slots;
+    std::vector<SlotDescriptor*> _slot_pointers;
+    Chunk::SlotHashMap _slot_cid_map;
+    RuntimeProfile _dummy_runtime_profile{"dummy"};
+};
+
+// A del file's persisted op_offset must name the last segment of the STATEMENT that produced it, not
+// the last segment of the merged rowset: it is the only thing that tells the rebuild the delete came
+// before the later statements' segments.
+TEST_F(LakeMergedDelOpOffsetTest, del_op_offset_stays_within_its_own_statement) {
+    // branch-4.1's product default: the writer records no per-del op_offset, so persist has to
+    // derive it. Pinned, so the test exercises that path whatever the default is.
+    ConfigResetGuard preserve_order_guard(&config::lake_enable_pk_preserve_txn_delete_order, false);
+    seed_and_run_multi_statement_txn();
+
+    ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(_tablet_metadata->id(), 3));
+    const auto* merged = rowset_with_del(*metadata);
+    ASSERT_NE(nullptr, merged);
+    ASSERT_EQ(1, merged->del_files_size());
+    // The re-upsert statement's segments were appended after the delete statement's reserved slot.
+    ASSERT_GT(max_segment_idx(*merged), 0u);
+    ASSERT_TRUE(merged->del_files(0).has_op_offset());
+    EXPECT_LT(merged->del_files(0).op_offset(), max_segment_idx(*merged))
+            << "op_offset " << merged->del_files(0).op_offset() << " reaches the merged rowset's last segment, so the "
+            << "rebuild replays this delete over the re-inserted rows instead of before them";
+}
+
+// The end-to-end mechanism: rebuild the persistent index (what a CN restart or a tablet
+// re-placement does) and then upsert the same keys again. If the rebuild dropped the re-inserted
+// keys from the index, that upsert cannot mask their rows and the table ends up with two live rows
+// per key.
+TEST_F(LakeMergedDelOpOffsetTest, rebuild_after_delete_and_reinsert_keeps_one_row_per_key) {
+    // branch-4.1's product default: the writer records no per-del op_offset, so persist has to
+    // derive it. Pinned, so the test exercises that path whatever the default is.
+    ConfigResetGuard preserve_order_guard(&config::lake_enable_pk_preserve_txn_delete_order, false);
+    seed_and_run_multi_statement_txn();
+
+    // version 4: rebuild the index from object storage, then upsert the same keys.
+    auto txn_id = next_id();
+    write_statement(txn_id, nullptr, /*upsert=*/true);
+    ASSERT_OK(publish_single_version(_tablet_metadata->id(), 4, txn_id, /*rebuild_pindex=*/true).status());
+    EXPECT_EQ(kNumKeys, read_rows(4)) << "the rebuild lost the re-inserted keys from the index, so the upsert at "
+                                      << "version 4 wrote no delete-vector mark and left two live rows per key";
+}
+
+} // namespace starrocks::lake


### PR DESCRIPTION
> **DRAFT — NOT FOR REVIEW.** This PR exists only so that TSP can produce a `branch-4.1` build of
> the change (`tsp build submit` accepts `--pr`/`--commit`, and `--commit` resolves only against
> commits already on an official branch, so an unpushed local branch cannot be built). It is the
> A/B "after" build for an on-cluster reproduction of issue 78224. Please do not review; it will be
> closed or reopened properly once the cluster validation is complete.

## Why I'm doing:

On a shared-data primary-key table with `persistent_index_type = CLOUD_NATIVE`, a persistent-index
rebuild (CN restart, or a tablet moving to a CN that never held its index) can fail with

```
prepare_primary_index: load primary index failed:
Already exist: PersistentIndexMemtable<12> insert found duplicate key ...
```

and from then on every publish for every partition of the table fails, so committed transactions
pile up until `max_running_txn_num_per_db` saturates and ingestion for the database stops.

Root cause: for a **merged** rowset (one transaction that produced several txn logs, i.e. several
statements), a del file's `op_offset` is computed twice and the two answers disagree.

* Apply resolves it against **that statement's own** op_write
  (`UpdateManager::_do_update` → `build_del_interleave_plan`): `seg_base + get_segment_idx(...)`,
  or `seg_base + get_max_segment_idx(...)` when the writer did not record the in-transaction
  order.
* Persist deferred the unrecorded case to `MetaFileBuilder::set_final_rowset()` as `-1`, which
  resolved it with `resolve_del_op_offset()` against the **merged** rowset — i.e. past every
  *later* statement's segments as well.

`op_offset` being unrecorded is the common case on 4.1
(`lake_enable_pk_preserve_txn_delete_order` defaults to false there, and spill / concurrent flush
also yield `kUnknownDelOpOffset`), so any transaction with ≥ 2 statements where a non-last
statement carries a del file persists an `op_offset` that is too large. Because the persisted value
then equals `get_max_segment_idx`, the rebuild's ordering filter is skipped
(`lake_persistent_index.cpp`), and the rebuild replays that delete over rows a *later* statement of
the same transaction re-inserted. Those rows are live and not delvec-masked, but their index entries
are gone: the next upsert of such a key finds nothing, writes no delete-vector mark, and leaves two
live rows for one key. A subsequent compaction plus rebuild is what finally surfaces them as
`insert found duplicate key`. Note the index returns *not found*, never a stale location — which is
why the delvec consistency check in `update_manager.cpp` stays silent, matching the reports where
that error is never seen.

## What I'm doing:

`be/src/storage/lake/meta_file.cpp`, two hunks:

* `MetaFileBuilder::add_rowset()` resolves each del file's position into the merged rowset's
  segment-id space *while the op_write that produced it is still in hand*, using the same
  expressions apply uses — `seg_base + get_segment_idx(rowset_pb, off)` when recorded,
  `seg_base + get_max_segment_idx(rowset_pb)` when not — instead of pushing `-1`.
* `set_final_rowset()` therefore no longer calls `resolve_del_op_offset()` (still used by
  `apply_opwrite`); it clamps the already-resolved value to `get_max_segment_idx(*rowset)`, which
  handles the one out-of-range direction: a *trailing* pure-delete statement, whose reserved
  rowset-id slot sits one past the merged rowset's last segment.

Regression test: `be/test/storage/lake/lake_merged_del_op_offset_test.cpp` drives the production
path — two `DeltaWriter`s with `set_is_multi_statements_txn(true)` and distinct load ids under one
txn id (statement 1 deletes every key via `__op`, statement 2 re-upserts them), published through
`LakeServiceImpl::publish_version` with one `txn_infos` entry carrying both load ids, then a second
publish with `add_rebuild_pindex_tablet_ids` (the rebuild) and a `TabletReader` row count. Without
the fix it reads 40 rows for 20 keys and the persisted `op_offset` equals the merged rowset's max;
with the fix, 20 rows.

Related to the shared-data PK duplicate-key report (issue 78224, referenced without a link on
purpose). **Not** claimed to fix it, see below.

## Version caveat: this cannot be the issue 78224 reporter's original failure

The reporter first hit issue 78224 on **4.1.3** (after a 4.1.1→4.1.3 upgrade) and still sees it on 4.1.4.
The mechanism fixed here does not exist on 4.1.3 at all:

| symbol | tag 4.1.3 | tag 4.1.4 |
|---|---|---|
| `build_del_interleave_plan` | absent | present |
| `DelInterleavePlan` | absent | present |
| `del_op_offsets` | absent | present (9 files) |
| `lake_enable_pk_preserve_txn_delete_order` | absent | present |

On 4.1.3 a mixed upsert/delete transaction orders every delete after every upsert unconditionally,
so there is no per-statement offset to disagree with the rebuild about. The whole `del_op_offsets`
mechanism arrived in 4.1.4.

So this is a real apply/rebuild divergence with the same error signature, reproduced and A/B-verified
on a cluster (217 occurrences before, 0 after, 3 cycles) — but it is a **sibling** of issue 78224, not an
identification of it. Two further limits, both unresolved:

* Reaching this producer needs an explicit multi-statement SQL transaction (`BEGIN … COMMIT`,
  `INSERT_STREAMING`). The reporter states they run no DML, and the Kafka/Flink connectors'
  transaction stream load takes a different path (one shared delta writer, one `op_write`, no del
  file).
* It is not established whether #78286 alone (preserve-order on, this file unchanged) already
  prevents the failure, in which case this change is defence-in-depth for the unrecorded-offset path
  rather than the only remedy.

Please do not close issue 78224 on this PR.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4



