### PR TITLE
[BugFix] Fix shredded Variant compatibility in generic operations

### DIFF
--- a/be/src/column/variant_column.cpp
+++ b/be/src/column/variant_column.cpp
@@ -20,18 +20,22 @@
 #include <unordered_set>
 
 #include "base/coding.h"
+#include "column/array_column.h"
 #include "column/binary_column.h"
 #include "column/column_builder.h"
 #include "column/column_helper.h"
 #include "column/const_column.h"
+#include "column/map_column.h"
 #include "column/mysql_row_buffer.h"
 #include "column/nullable_column.h"
+#include "column/struct_column.h"
 #include "column/variant_builder.h"
 #include "column/variant_encoder.h"
 #include "column/variant_merger.h"
 #include "column/variant_path_parser.h"
 #include "gutil/casts.h"
 #include "gutil/strings/substitute.h"
+#include "types/type_info.h"
 #include "types/variant_value.h"
 
 namespace starrocks {
@@ -54,21 +58,40 @@ VariantColumn::VariantColumn(size_t size) : SuperClass(0) {
 
 // Typed-only variant stores data in typed columns. Read paths still need row-level VariantRowValue.
 // encode_typed_row_as_variant is a shared helper for VariantColumn and VariantFunctions.
+static bool has_variant_descendant(const TypeDescriptor& type_desc) {
+    for (const auto& child : type_desc.children) {
+        if (child.type == TYPE_VARIANT || has_variant_descendant(child)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 StatusOr<VariantColumn::EncodedVariantResult> VariantColumn::encode_typed_row_as_variant(
         const Column* typed_column, size_t typed_row, const TypeDescriptor& type_desc) {
     if (typed_column == nullptr) {
         return Status::InvalidArgument("typed column is null");
     }
 
-    if (typed_column->is_null(typed_row)) {
-        return EncodedVariantResult{
-                .state = EncodedVariantState::kNull,
-                .value = VariantRowValue::from_null(),
-        };
+    const Column* data_column = typed_column;
+    while (data_column->is_constant() || data_column->is_nullable()) {
+        if (data_column->is_constant()) {
+            data_column = down_cast<const ConstColumn*>(data_column)->data_column().get();
+            typed_row = 0;
+            continue;
+        }
+        const auto* nullable_column = down_cast<const NullableColumn*>(data_column);
+        if (nullable_column->is_null(typed_row)) {
+            return EncodedVariantResult{
+                    .state = EncodedVariantState::kNull,
+                    .value = VariantRowValue::from_null(),
+            };
+        }
+        data_column = nullable_column->data_column().get();
     }
 
     if (type_desc.type == TYPE_VARIANT) {
-        const auto* typed_variant_column = down_cast<const VariantColumn*>(ColumnHelper::get_data_column(typed_column));
+        const auto* typed_variant_column = down_cast<const VariantColumn*>(data_column);
         if (typed_variant_column == nullptr) {
             return Status::InvalidArgument("typed variant column is null");
         }
@@ -83,8 +106,98 @@ StatusOr<VariantColumn::EncodedVariantResult> VariantColumn::encode_typed_row_as
         };
     }
 
+    if (type_desc.type == TYPE_ARRAY && has_variant_descendant(type_desc)) {
+        if (type_desc.children.size() != 1) {
+            return Status::InvalidArgument("array type must have exactly one child");
+        }
+        const auto* array_column = down_cast<const ArrayColumn*>(data_column);
+        const auto [element_offset, element_size] = array_column->get_element_offset_size(typed_row);
+        VariantArrayBuilder builder;
+        for (size_t i = 0; i < element_size; ++i) {
+            ASSIGN_OR_RETURN(auto element, encode_typed_row_as_variant(array_column->elements_column_raw_ptr(),
+                                                                       element_offset + i, type_desc.children[0]));
+            if (element.state == EncodedVariantState::kNull) {
+                builder.add_null();
+            } else {
+                builder.add(std::move(element.value));
+            }
+        }
+        ASSIGN_OR_RETURN(auto value, builder.build());
+        return EncodedVariantResult{.state = EncodedVariantState::kValue, .value = std::move(value)};
+    }
+
+    if (type_desc.type == TYPE_MAP && has_variant_descendant(type_desc)) {
+        if (type_desc.children.size() != 2) {
+            return Status::InvalidArgument("map type must have exactly two children");
+        }
+        if (type_desc.children[0].type == TYPE_VARIANT || has_variant_descendant(type_desc.children[0])) {
+            return Status::NotSupported("Variant map keys are not supported");
+        }
+        const auto* map_column = down_cast<const MapColumn*>(data_column);
+        const auto& offsets = map_column->offsets().get_data();
+        const size_t begin = offsets[typed_row];
+        const size_t end = offsets[typed_row + 1];
+        if (begin == end) {
+            std::string empty_object;
+            VariantEncoder::append_object_container(&empty_object, {}, {}, {});
+            return EncodedVariantResult{
+                    .state = EncodedVariantState::kValue,
+                    .value = VariantRowValue(VariantMetadata::kEmptyMetadata, empty_object),
+            };
+        }
+
+        const TypeDescriptor& key_type = type_desc.children[0];
+        const TypeInfoPtr key_type_info = get_type_info(key_type);
+        if (key_type_info == nullptr) {
+            return Status::NotSupported("Unsupported Variant map key type");
+        }
+        std::vector<VariantBuilder::Overlay> overlays;
+        overlays.reserve(end - begin);
+        for (size_t i = begin; i < end; ++i) {
+            Datum key = map_column->keys_column_raw_ptr()->get(i);
+            if (key.is_null()) {
+                return Status::NotSupported("Map key is null");
+            }
+            ASSIGN_OR_RETURN(auto value, encode_typed_row_as_variant(map_column->values_column_raw_ptr(), i,
+                                                                     type_desc.children[1]));
+            VariantPath path;
+            path.segments.emplace_back(
+                    VariantSegment::make_object(VariantEncoder::map_key_to_string(key_type_info.get(), key)));
+            overlays.emplace_back(VariantBuilder::Overlay{
+                    .path = std::move(path),
+                    .value = value.state == EncodedVariantState::kNull ? VariantRowValue::from_null()
+                                                                       : std::move(value.value),
+            });
+        }
+        ASSIGN_OR_RETURN(auto value, VariantBuilder::build_row_from_overlays(std::nullopt, std::move(overlays)));
+        return EncodedVariantResult{.state = EncodedVariantState::kValue, .value = std::move(value)};
+    }
+
+    if (type_desc.type == TYPE_STRUCT && has_variant_descendant(type_desc)) {
+        if (type_desc.children.size() != type_desc.field_names.size()) {
+            return Status::InvalidArgument("struct field names and children size mismatch");
+        }
+
+        const auto* struct_column = down_cast<const StructColumn*>(data_column);
+        std::vector<VariantBuilder::Overlay> overlays;
+        overlays.reserve(type_desc.children.size());
+        for (size_t i = 0; i < type_desc.children.size(); ++i) {
+            ASSIGN_OR_RETURN(auto field, encode_typed_row_as_variant(struct_column->field_column_raw_ptr(i), typed_row,
+                                                                     type_desc.children[i]));
+            VariantPath path;
+            path.segments.emplace_back(VariantSegment::make_object(type_desc.field_names[i]));
+            overlays.emplace_back(VariantBuilder::Overlay{
+                    .path = std::move(path),
+                    .value = field.state == EncodedVariantState::kNull ? VariantRowValue::from_null()
+                                                                       : std::move(field.value),
+            });
+        }
+        ASSIGN_OR_RETURN(auto value, VariantBuilder::build_row_from_overlays(std::nullopt, std::move(overlays)));
+        return EncodedVariantResult{.state = EncodedVariantState::kValue, .value = std::move(value)};
+    }
+
     // Fast path: encode single Datum directly, avoiding column clone + full encode pipeline.
-    Datum datum = typed_column->get(typed_row);
+    Datum datum = data_column->get(typed_row);
     auto encoded = VariantEncoder::encode_datum(datum, type_desc);
     if (!encoded.ok()) {
         return encoded.status();
@@ -549,6 +662,31 @@ void VariantColumn::assign(size_t n, size_t idx) {
     for (auto& col : _typed_columns) {
         col->assign(n, idx);
     }
+}
+
+void VariantColumn::remove_first_n_values(size_t count) {
+    const size_t rows = size();
+    DCHECK_LE(count, rows);
+    if (count == 0) {
+        return;
+    }
+    if (count == rows) {
+        resize(0);
+        DCHECK(_is_shredded_row_aligned());
+        return;
+    }
+
+    if (_metadata_column != nullptr) {
+        DCHECK(_remain_value_column != nullptr);
+        _metadata_column->remove_first_n_values(count);
+        _remain_value_column->remove_first_n_values(count);
+    } else {
+        DCHECK(_remain_value_column == nullptr);
+    }
+    for (auto& col : _typed_columns) {
+        col->remove_first_n_values(count);
+    }
+    DCHECK(_is_shredded_row_aligned());
 }
 
 size_t VariantColumn::filter_range(const Filter& filter, size_t from, size_t to) {

--- a/be/src/column/variant_column.h
+++ b/be/src/column/variant_column.h
@@ -102,6 +102,7 @@ public:
     size_t byte_size(size_t from, size_t size) const override;
     void resize(size_t n) override;
     void assign(size_t n, size_t idx) override;
+    void remove_first_n_values(size_t count) override;
     size_t filter_range(const Filter& filter, size_t from, size_t to) override;
     int compare_at(size_t left, size_t right, const Column& rhs, int nan_direction_hint) const override;
     int equals(size_t left, const Column& rhs, size_t right, bool safe_eq = true) const override;
@@ -171,9 +172,8 @@ public:
         }
     }
 
-    // Encode a single typed cell (from a typed column at a given row) into a VariantRowValue.
-    // Handles TYPE_VARIANT recursion, null checks, and VariantEncoder encoding.
-    // Used by both VariantColumn internal paths and VariantFunctions query paths.
+    // Encode one typed cell into a row-level Variant value. Complex values containing
+    // nested Variant children are traversed column-wise to avoid the legacy Datum path.
     static StatusOr<EncodedVariantResult> encode_typed_row_as_variant(const Column* typed_column, size_t typed_row,
                                                                       const TypeDescriptor& type_desc);
 

--- a/be/src/column/variant_encoder.cpp
+++ b/be/src/column/variant_encoder.cpp
@@ -102,7 +102,7 @@ void VariantEncoder::append_object_container(std::string* out, const std::vector
     out->append(payload.data(), payload.size());
 }
 
-static std::string key_datum_to_string(TypeInfo* type_info, const Datum& datum) {
+std::string VariantEncoder::map_key_to_string(TypeInfo* type_info, const Datum& datum) {
     if (datum.is_null()) {
         return "null";
     }
@@ -546,7 +546,7 @@ Status collect_object_keys_from_datum(const Datum& datum, const TypeDescriptor& 
             if (key_datum.is_null()) {
                 return Status::NotSupported("Map key is null");
             }
-            keys->insert(key_datum_to_string(key_type_info.get(), key_datum));
+            keys->insert(VariantEncoder::map_key_to_string(key_type_info.get(), key_datum));
             RETURN_IF_ERROR(collect_object_keys_from_datum(value, value_type, keys));
         }
         return Status::OK();
@@ -716,7 +716,7 @@ Status encode_datum_to_variant_value(const Datum& datum, const TypeDescriptor& t
             if (key_datum.is_null()) {
                 return Status::NotSupported("Map key is null");
             }
-            std::string key_str = key_datum_to_string(key_type_info.get(), key_datum);
+            std::string key_str = VariantEncoder::map_key_to_string(key_type_info.get(), key_datum);
             auto it = key_to_id.find(key_str);
             if (it == key_to_id.end()) {
                 return Status::VariantError("Variant metadata missing field: " + key_str);

--- a/be/src/column/variant_encoder.h
+++ b/be/src/column/variant_encoder.h
@@ -92,6 +92,10 @@ public:
     // then encode the value referencing that metadata.
     static StatusOr<VariantRowValue> encode_datum(const Datum& datum, const TypeDescriptor& type);
 
+    // Convert a supported MAP key to the canonical object-field representation used
+    // by both metadata collection and value encoding.
+    static std::string map_key_to_string(TypeInfo* type_info, const Datum& datum);
+
     // Encode a VelocyPack (VPack) slice into a VariantRowValue.
     //
     // Why: VPack is StarRocks' internal binary JSON representation. JSON values

--- a/be/src/exprs/array_functions.cpp
+++ b/be/src/exprs/array_functions.cpp
@@ -1243,34 +1243,29 @@ void _array_slice_item(const ArrayColumn* column, size_t index, ArrayColumn* des
         return;
     }
 
-    Datum v = column->get(index);
-    const auto& items = v.get<DatumArray>();
+    const auto [item_offset, item_size] = column->get_element_offset_size(index);
 
     if (offset > 0) {
         // because offset start with 1.
         --offset;
     } else {
-        offset += items.size();
+        offset += static_cast<int64_t>(item_size);
     }
 
     auto* dest_data_column = dest_column->elements_column_raw_ptr();
     int64_t end;
     if constexpr (with_length) {
-        end = std::max((int64_t)0, std::min((int64_t)items.size(), (offset + length)));
+        end = std::max<int64_t>(0, std::min<int64_t>(static_cast<int64_t>(item_size), offset + length));
     } else {
-        end = items.size();
+        end = static_cast<int64_t>(item_size);
     }
     offset = (offset > 0 ? offset : 0);
-    for (size_t i = offset; i < end; ++i) {
-        if (items[i].is_null()) {
-            dest_data_column->append_nulls(1);
-        } else {
-            dest_data_column->append_datum(items[i]);
-        }
-    }
-
     // Protect when length < 0.
-    auto offset_delta = ((end < offset) ? 0 : end - offset);
+    const auto offset_delta = ((end < offset) ? 0 : end - offset);
+    if (offset_delta > 0) {
+        dest_data_column->append(column->elements(), item_offset + static_cast<size_t>(offset),
+                                 static_cast<size_t>(offset_delta));
+    }
     dest_offsets.emplace_back(dest_offsets.back() + offset_delta);
 }
 
@@ -1726,27 +1721,21 @@ StatusOr<ColumnPtr> ArrayFunctions::repeat(FunctionContext* ctx, const Columns& 
     const ColumnPtr& repeat_count_column = columns[1];
     ColumnViewer<TYPE_INT> repeat_count_viewer(repeat_count_column);
 
-    MutableColumnPtr dest_column_elements = nullptr;
-    // Because the _elements of ArrayColumn must be nullable, but a non-null ConstColumn cannot be converted to nullable;
-    // therefore, the _data of ConstColumn is extracted as dest_column_elements.
-    if (src_column->is_constant() && !src_column->is_nullable()) {
-        const ConstColumn* const_src_column = down_cast<const ConstColumn*>(src_column.get());
-        dest_column_elements = const_src_column->data_column()->clone_empty();
-    } else {
-        dest_column_elements = src_column->clone_empty();
-    }
+    const bool src_is_const = src_column->is_constant();
+    const ColumnPtr& src_data_column =
+            src_is_const ? down_cast<const ConstColumn*>(src_column.get())->data_column() : src_column;
+    MutableColumnPtr dest_column_elements = src_data_column->clone_empty();
     auto dest_offsets = UInt32Column::create(1);
     size_t total_repeated_rows = 0;
     for (int cur_row = 0; cur_row < num_rows; cur_row++) {
         if (repeat_count_viewer.is_null(cur_row)) {
             dest_offsets->append(total_repeated_rows);
         } else {
-            Datum source_value = src_column->get(cur_row);
             auto repeat_count = repeat_count_viewer.value(cur_row);
             if (repeat_count > 0) {
-                for (int repeat_index = 0; repeat_index < repeat_count; repeat_index++) {
-                    TRY_CATCH_BAD_ALLOC(dest_column_elements->append_datum(source_value));
-                }
+                const size_t source_row = src_is_const ? 0 : cur_row;
+                TRY_CATCH_BAD_ALLOC(
+                        dest_column_elements->append_value_multiple_times(*src_data_column, source_row, repeat_count));
                 total_repeated_rows = total_repeated_rows + repeat_count;
                 dest_offsets->append(total_repeated_rows);
             } else {
@@ -1905,30 +1894,46 @@ StatusOr<ColumnPtr> ArrayFunctions::array_flatten(FunctionContext* ctx, const Co
 
     size_t chunk_size = columns[0]->size();
 
-    // Helper function to init result array elements and offsets
+    // Helper function to init result array elements and offsets.
     auto build_result_array_elements_and_offsets =
-            [](const ColumnPtr& elements_column,
+            [](const ArrayColumn* inner_array,
                size_t offsets_size) -> std::pair<MutableColumnPtr, UInt32Column::MutablePtr> {
-        DCHECK(elements_column->is_array());
-        auto [array_null, elements, offsets] = unpack_array_column(elements_column);
-        auto result_elements = elements->clone_empty();
+        auto result_elements = inner_array->elements_column_raw_ptr()->clone_empty();
         auto result_offsets = UInt32Column::create();
         result_offsets->reserve(offsets_size);
         result_offsets->append(0);
         return std::make_pair(std::move(result_elements), std::move(result_offsets));
     };
 
-    // Helper function to flatten a single array item
-    auto flatten_array_item = [](const Datum& v, MutableColumnPtr& result_elements, auto& result_offsets) {
-        if (!v.is_null()) {
-            const auto& items = v.get<DatumArray>();
-            for (const auto& item : items) {
-                if (!item.is_null()) {
-                    const auto& sub_items = item.get<DatumArray>();
-                    for (const auto& sub_item : sub_items) {
-                        result_elements->append_datum(sub_item);
-                    }
-                }
+    auto unwrap_array = [](const Column* data_column, bool* is_const) {
+        *is_const = false;
+        while (data_column->is_constant() || data_column->is_nullable()) {
+            // ConstColumn can also report is_nullable() through its data column, so
+            // the constant wrapper must be removed first.
+            if (data_column->is_constant()) {
+                data_column = down_cast<const ConstColumn*>(data_column)->data_column().get();
+                *is_const = true;
+            } else {
+                data_column = down_cast<const NullableColumn*>(data_column)->data_column().get();
+            }
+        }
+        return down_cast<const ArrayColumn*>(data_column);
+    };
+
+    // Helper function to flatten a single outer-array row without materializing nested Datum values.
+    auto flatten_array_item = [](const ArrayColumn* outer_array, size_t outer_row, const ColumnPtr& inner_column,
+                                 const ArrayColumn* inner_array, bool inner_is_const, MutableColumnPtr& result_elements,
+                                 auto& result_offsets) {
+        const auto [inner_offset, inner_size] = outer_array->get_element_offset_size(outer_row);
+        for (size_t i = 0; i < inner_size; ++i) {
+            const size_t inner_row = inner_offset + i;
+            if (inner_column->is_null(inner_row)) {
+                continue;
+            }
+            const size_t physical_inner_row = inner_is_const ? 0 : inner_row;
+            const auto [element_offset, element_size] = inner_array->get_element_offset_size(physical_inner_row);
+            if (element_size > 0) {
+                result_elements->append(inner_array->elements(), element_offset, element_size);
             }
         }
         result_offsets->append(result_elements->size());
@@ -1936,13 +1941,15 @@ StatusOr<ColumnPtr> ArrayFunctions::array_flatten(FunctionContext* ctx, const Co
 
     // Special handle const column
     if (columns[0]->is_constant()) {
-        const auto* const_column = down_cast<const ConstColumn*>(columns[0].get());
-        const ArrayColumn* const_array = down_cast<const ArrayColumn*>(const_column->data_column().get());
+        bool outer_is_const = false;
+        const ArrayColumn* const_array = unwrap_array(columns[0].get(), &outer_is_const);
+        DCHECK(outer_is_const);
+        const ColumnPtr& inner_column = const_array->elements_column();
+        bool inner_is_const = false;
+        const auto* inner_array = unwrap_array(inner_column.get(), &inner_is_const);
 
-        auto [result_elements, result_offsets] =
-                build_result_array_elements_and_offsets(const_array->elements_column(), 1);
-        Datum v = const_array->get(0);
-        flatten_array_item(v, result_elements, result_offsets);
+        auto [result_elements, result_offsets] = build_result_array_elements_and_offsets(inner_array, 1);
+        flatten_array_item(const_array, 0, inner_column, inner_array, inner_is_const, result_elements, result_offsets);
         return ConstColumn::create(ArrayColumn::create(result_elements, result_offsets), chunk_size);
     }
 
@@ -1955,11 +1962,13 @@ StatusOr<ColumnPtr> ArrayFunctions::array_flatten(FunctionContext* ctx, const Co
         array_column = down_cast<const ArrayColumn*>(columns[0].get());
     }
 
+    const ColumnPtr& inner_column = array_column->elements_column();
+    bool inner_is_const = false;
+    const auto* inner_array = unwrap_array(inner_column.get(), &inner_is_const);
     auto [result_elements, result_offsets] =
-            build_result_array_elements_and_offsets(array_column->elements_column(), array_column->offsets().size());
+            build_result_array_elements_and_offsets(inner_array, array_column->offsets().size());
     for (size_t i = 0; i < chunk_size; i++) {
-        Datum v = array_column->get(i);
-        flatten_array_item(v, result_elements, result_offsets);
+        flatten_array_item(array_column, i, inner_column, inner_array, inner_is_const, result_elements, result_offsets);
     }
 
     auto result = ArrayColumn::create(result_elements, result_offsets);

--- a/be/src/exprs/case_expr_tpl.hpp
+++ b/be/src/exprs/case_expr_tpl.hpp
@@ -351,7 +351,7 @@ private:
         }
         then_columns.emplace_back(else_column);
         size_t size = when_columns[0]->size();
-        if constexpr (lt_is_collection<ResultType> || lt_is_collection<WhenType>) {
+        if constexpr (lt_is_collection<ResultType> || lt_is_collection<WhenType> || ResultType == TYPE_VARIANT) {
             // construct result column
             bool res_nullable = false;
             for (const auto& col : then_columns) {
@@ -518,7 +518,7 @@ private:
             when_columns_has_null |= column->has_null();
         }
 
-        if constexpr (lt_is_collection<ResultType>) {
+        if constexpr (lt_is_collection<ResultType> || ResultType == TYPE_VARIANT) {
             // construct nullable result column
             bool res_nullable = false;
             for (const auto& col : then_columns) {

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -56,6 +56,18 @@ StatusOr<ColumnPtr> MustNullExpr::evaluate_checked(ExprContext* context, Chunk* 
     return only_null;
 }
 
+static bool type_contains_variant(const TypeDescriptor& type) {
+    if (type.type == TYPE_VARIANT) {
+        return true;
+    }
+    for (const auto& child : type.children) {
+        if (type_contains_variant(child)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 StatusOr<ColumnPtr> CastToVariantExpr::evaluate_checked(ExprContext* context, Chunk* ptr) {
     ASSIGN_OR_RETURN(ColumnPtr column, _children[0]->evaluate_checked(context, ptr));
     const size_t num_rows = column->size();
@@ -65,7 +77,27 @@ StatusOr<ColumnPtr> CastToVariantExpr::evaluate_checked(ExprContext* context, Ch
     }
 
     ColumnBuilder<TYPE_VARIANT> builder(num_rows);
-    RETURN_IF_ERROR(VariantEncoder::encode_column(column, _from_type, &builder, _allow_throw_exception));
+    const bool is_complex_type =
+            _from_type.type == TYPE_ARRAY || _from_type.type == TYPE_MAP || _from_type.type == TYPE_STRUCT;
+    if (is_complex_type && type_contains_variant(_from_type)) {
+        for (size_t row = 0; row < num_rows; ++row) {
+            auto encoded = VariantColumn::encode_typed_row_as_variant(column.get(), row, _from_type);
+            if (!encoded.ok()) {
+                if (_allow_throw_exception) {
+                    return encoded.status();
+                }
+                builder.append_null();
+                continue;
+            }
+            if (encoded->state == VariantColumn::EncodedVariantState::kNull) {
+                builder.append_null();
+            } else {
+                builder.append(std::move(encoded->value));
+            }
+        }
+    } else {
+        RETURN_IF_ERROR(VariantEncoder::encode_column(column, _from_type, &builder, _allow_throw_exception));
+    }
 
     return builder.build(column->is_constant());
 }

--- a/be/src/exprs/in_predicate.cpp
+++ b/be/src/exprs/in_predicate.cpp
@@ -24,7 +24,7 @@ namespace starrocks {
 struct InConstPredicateBuilder {
     template <LogicalType ltype>
     Expr* operator()(const TExprNode& node) {
-        if constexpr (lt_is_collection<ltype> || ltype == TYPE_JSON) {
+        if constexpr (lt_is_collection<ltype> || ltype == TYPE_JSON || ltype == TYPE_VARIANT) {
             return new VectorizedInConstPredicateGeneric(node);
         } else {
             return new VectorizedInConstPredicate<ltype>(node);

--- a/be/test/column/variant_column_test.cpp
+++ b/be/test/column/variant_column_test.cpp
@@ -236,6 +236,56 @@ static void verify_typed_only_into_base_shredded_fast_path(TypedOnlyIntoBaseShre
     }
 }
 
+PARALLEL_TEST(VariantColumnTest, test_remove_first_n_values_from_nullable_variant) {
+    auto column = build_nullable_variant_column({"1", "2", "3"}, {0, 1, 0});
+
+    column->remove_first_n_values(1);
+
+    ASSERT_EQ(2, column->size());
+    const auto* nullable = down_cast<const NullableColumn*>(column.get());
+    ASSERT_TRUE(nullable->is_null(0));
+    ASSERT_FALSE(nullable->is_null(1));
+    const auto* data = down_cast<const VariantColumn*>(nullable->data_column().get());
+    ASSERT_EQ(2, data->size());
+    assert_variant_row_json(data, 0, "null");
+    assert_variant_row_json(data, 1, "3");
+}
+
+PARALLEL_TEST(VariantColumnTest, test_remove_first_n_values_from_shredded_variant) {
+    auto column = build_shredded_variant_column_for_ut();
+
+    column->remove_first_n_values(1);
+
+    ASSERT_EQ(2, column->size());
+    ASSERT_EQ(2, column->metadata_column()->size());
+    ASSERT_EQ(2, column->remain_value_column()->size());
+    ASSERT_EQ(2, column->typed_column_by_index(0)->size());
+    const auto* typed = down_cast<const NullableColumn*>(column->typed_column_by_index(0));
+    ASSERT_TRUE(typed->is_null(0));
+    ASSERT_FALSE(typed->is_null(1));
+    const auto* typed_data = down_cast<const Int64Column*>(typed->data_column().get());
+    ASSERT_EQ(30, typed_data->immutable_data()[1]);
+}
+
+PARALLEL_TEST(VariantColumnTest, test_remove_values_from_const_typed_variant) {
+    auto column = VariantColumn::create();
+    auto typed_data = Int64Column::create();
+    typed_data->append(42);
+    MutableColumns typed;
+    typed.emplace_back(ConstColumn::create(std::move(typed_data), 3));
+    column->set_shredded_columns({"a"}, {TypeDescriptor(TYPE_BIGINT)}, std::move(typed), nullptr, nullptr);
+
+    column->remove_first_n_values(1);
+
+    ASSERT_EQ(2, column->size());
+    ASSERT_EQ(2, column->typed_column_by_index(0)->size());
+
+    column->remove_first_n_values(column->size());
+
+    ASSERT_EQ(0, column->size());
+    ASSERT_EQ(0, column->typed_column_by_index(0)->size());
+}
+
 // NOLINTNEXTLINE
 PARALLEL_TEST(VariantColumnTest, test_build_column) {
     // create column

--- a/be/test/column/variant_encoder_test.cpp
+++ b/be/test/column/variant_encoder_test.cpp
@@ -16,17 +16,62 @@
 
 #include <gtest/gtest.h>
 
+#include <initializer_list>
+#include <optional>
 #include <string>
+#include <string_view>
+#include <vector>
 
+#include "base/string/slice.h"
 #include "base/testutil/parallel_test.h"
+#include "column/array_column.h"
+#include "column/binary_column.h"
 #include "column/column_helper.h"
 #include "column/fixed_length_column.h"
+#include "column/map_column.h"
+#include "column/nullable_column.h"
+#include "column/struct_column.h"
 #include "column/variant_column.h"
 #include "gutil/casts.h"
 #include "types/type_descriptor.h"
 #include "types/variant.h"
 
 namespace starrocks {
+
+static ColumnPtr make_nullable_variant_column(const std::vector<std::optional<std::string>>& json_values) {
+    auto data = VariantColumn::create();
+    auto nulls = NullColumn::create();
+    for (const auto& json : json_values) {
+        if (!json.has_value()) {
+            data->append_default();
+            nulls->append(DATUM_NULL);
+            continue;
+        }
+        auto encoded = VariantEncoder::encode_json_text_to_variant(*json);
+        CHECK(encoded.ok()) << encoded.status().to_string();
+        data->append(encoded.value());
+        nulls->append(DATUM_NOT_NULL);
+    }
+    return NullableColumn::create(std::move(data), std::move(nulls));
+}
+
+static UInt32Column::Ptr make_offsets(std::initializer_list<uint32_t> offsets) {
+    auto column = UInt32Column::create();
+    for (uint32_t offset : offsets) {
+        column->append(offset);
+    }
+    return column;
+}
+
+static void expect_typed_column_variant_json(const ColumnPtr& column, size_t row, const TypeDescriptor& type,
+                                             std::string_view expected_json) {
+    auto encoded = VariantColumn::encode_typed_row_as_variant(column.get(), row, type);
+    ASSERT_TRUE(encoded.ok()) << encoded.status().to_string();
+    ASSERT_EQ(VariantColumn::EncodedVariantState::kValue, encoded->state);
+    auto json = encoded->value.to_json();
+    ASSERT_TRUE(json.ok()) << json.status().to_string();
+    EXPECT_EQ(expected_json, json.value());
+}
 
 // Verifies plain non-JSON text falls back to VARIANT string encoding.
 PARALLEL_TEST(VariantEncoderTest, encode_plain_text_fallback_to_string) {
@@ -77,6 +122,66 @@ PARALLEL_TEST(VariantEncoderTest, encode_int_column) {
     ASSERT_TRUE(json1.ok());
     ASSERT_EQ("7", json0.value());
     ASSERT_EQ("42", json1.value());
+}
+
+PARALLEL_TEST(VariantEncoderTest, encode_array_with_variant_children) {
+    auto elements = make_nullable_variant_column({std::string(R"({"a":1})"), std::string(R"({"b":2})"), std::nullopt});
+    auto array = ArrayColumn::create(elements, make_offsets({0, 3}));
+    TypeDescriptor type = TypeDescriptor::create_array_type(TypeDescriptor(TYPE_VARIANT));
+
+    expect_typed_column_variant_json(array, 0, type, R"([{"a":1},{"b":2},null])");
+}
+
+PARALLEL_TEST(VariantEncoderTest, encode_map_with_variant_values_and_empty_row) {
+    auto key_data = BinaryColumn::create();
+    key_data->append_datum(Datum(Slice("left")));
+    key_data->append_datum(Datum(Slice("right")));
+    key_data->append_datum(Datum(Slice("null_child")));
+    auto key_nulls = NullColumn::create(3, DATUM_NOT_NULL);
+    auto keys = NullableColumn::create(std::move(key_data), std::move(key_nulls));
+    auto values = make_nullable_variant_column({std::string(R"({"a":1})"), std::string(R"({"b":2})"), std::nullopt});
+    auto map = MapColumn::create(keys, values, make_offsets({0, 3, 3}));
+    TypeDescriptor type = TypeDescriptor::create_map_type(TypeDescriptor(TYPE_VARCHAR), TypeDescriptor(TYPE_VARIANT));
+
+    expect_typed_column_variant_json(map, 0, type, R"({"left":{"a":1},"null_child":null,"right":{"b":2}})");
+    expect_typed_column_variant_json(map, 1, type, R"({})");
+}
+
+PARALLEL_TEST(VariantEncoderTest, encode_map_with_varbinary_keys_and_variant_values) {
+    auto key_data = BinaryColumn::create();
+    key_data->append_datum(Datum(Slice("left")));
+    key_data->append_datum(Datum(Slice("right")));
+    auto key_nulls = NullColumn::create(2, DATUM_NOT_NULL);
+    auto keys = NullableColumn::create(std::move(key_data), std::move(key_nulls));
+    auto values = make_nullable_variant_column({std::string("1"), std::string("2")});
+    auto map = MapColumn::create(keys, values, make_offsets({0, 2}));
+    TypeDescriptor type = TypeDescriptor::create_map_type(TypeDescriptor(TYPE_VARBINARY), TypeDescriptor(TYPE_VARIANT));
+
+    expect_typed_column_variant_json(map, 0, type, R"({"left":1,"right":2})");
+}
+
+PARALLEL_TEST(VariantEncoderTest, encode_struct_with_variant_fields) {
+    auto left = make_nullable_variant_column({std::string(R"({"a":1})"), std::string(R"({"b":2})")});
+    auto right = make_nullable_variant_column({std::nullopt, std::string(R"([1,{"deep":3}])")});
+    auto structure = StructColumn::create(Columns{left, right}, {"left", "right"});
+    TypeDescriptor type = TypeDescriptor::create_struct_type(
+            {"left", "right"}, {TypeDescriptor(TYPE_VARIANT), TypeDescriptor(TYPE_VARIANT)});
+
+    expect_typed_column_variant_json(structure, 0, type, R"({"left":{"a":1},"right":null})");
+    expect_typed_column_variant_json(structure, 1, type, R"({"left":{"b":2},"right":[1,{"deep":3}]})");
+}
+
+PARALLEL_TEST(VariantEncoderTest, encode_deep_array_struct_variant) {
+    auto payload = make_nullable_variant_column({std::string(R"({"outer":{"x":1}})"), std::string(R"([2,{"y":3}])")});
+    auto structures = StructColumn::create(Columns{payload}, {"payload"});
+    auto struct_nulls = NullColumn::create(2, DATUM_NOT_NULL);
+    auto nullable_structures = NullableColumn::create(std::move(structures), std::move(struct_nulls));
+    auto array = ArrayColumn::create(nullable_structures, make_offsets({0, 2}));
+    TypeDescriptor struct_type = TypeDescriptor::create_struct_type({"payload"}, {TypeDescriptor(TYPE_VARIANT)});
+    TypeDescriptor array_type = TypeDescriptor::create_array_type(struct_type);
+
+    expect_typed_column_variant_json(array, 0, array_type,
+                                     R"([{"payload":{"outer":{"x":1}}},{"payload":[2,{"y":3}]}])");
 }
 
 PARALLEL_TEST(VariantEncoderTest, encode_deep_nested_json_roundtrip) {

--- a/be/test/exprs/array_functions_test.cpp
+++ b/be/test/exprs/array_functions_test.cpp
@@ -17,15 +17,92 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include <initializer_list>
 #include <limits>
+#include <optional>
 #include <unordered_set>
+#include <vector>
 
+#include "column/array_column.h"
 #include "column/const_column.h"
 #include "column/map_column.h"
+#include "column/nullable_column.h"
+#include "column/variant_column.h"
+#include "column/variant_encoder.h"
 #include "exprs/builtin_functions.h"
 #include "exprs/mock_vectorized_expr.h"
 
 namespace starrocks {
+
+static ColumnPtr make_nullable_variant_values(const std::vector<std::optional<std::string>>& json_values) {
+    auto data = VariantColumn::create();
+    auto nulls = NullColumn::create();
+    for (const auto& json : json_values) {
+        if (!json.has_value()) {
+            data->append_default();
+            nulls->append(DATUM_NULL);
+            continue;
+        }
+        auto encoded = VariantEncoder::encode_json_text_to_variant(*json);
+        CHECK(encoded.ok()) << encoded.status().to_string();
+        data->append(encoded.value());
+        nulls->append(DATUM_NOT_NULL);
+    }
+    return NullableColumn::create(std::move(data), std::move(nulls));
+}
+
+static UInt32Column::Ptr make_array_offsets(std::initializer_list<uint32_t> offsets) {
+    auto column = UInt32Column::create();
+    for (uint32_t offset : offsets) {
+        column->append(offset);
+    }
+    return column;
+}
+
+static void expect_variant_array_row(const ColumnPtr& result, size_t row,
+                                     const std::vector<std::optional<std::string>>& expected_json) {
+    const Column* outer = result.get();
+    size_t physical_row = row;
+    if (outer->is_constant()) {
+        outer = down_cast<const ConstColumn*>(outer)->data_column().get();
+        physical_row = 0;
+    }
+    ASSERT_FALSE(outer->is_null(physical_row));
+    if (outer->is_nullable()) {
+        outer = down_cast<const NullableColumn*>(outer)->data_column().get();
+    }
+
+    const auto* array = down_cast<const ArrayColumn*>(outer);
+    const auto [element_offset, element_size] = array->get_element_offset_size(physical_row);
+    ASSERT_EQ(expected_json.size(), element_size);
+
+    const Column* elements = array->elements_column().get();
+    for (size_t i = 0; i < expected_json.size(); ++i) {
+        const size_t element_row = element_offset + i;
+        if (!expected_json[i].has_value()) {
+            ASSERT_TRUE(elements->is_null(element_row));
+            continue;
+        }
+
+        ASSERT_FALSE(elements->is_null(element_row));
+        const Column* element_data = elements;
+        size_t physical_element_row = element_row;
+        if (element_data->is_constant()) {
+            element_data = down_cast<const ConstColumn*>(element_data)->data_column().get();
+            physical_element_row = 0;
+        }
+        if (element_data->is_nullable()) {
+            element_data = down_cast<const NullableColumn*>(element_data)->data_column().get();
+        }
+        const auto* variants = down_cast<const VariantColumn*>(element_data);
+        VariantRowValue row_buffer;
+        const VariantRowValue* value = variants->get_row_value(physical_element_row, &row_buffer);
+        ASSERT_NE(nullptr, value);
+        auto json = value->to_json();
+        ASSERT_TRUE(json.ok()) << json.status().to_string();
+        EXPECT_EQ(*expected_json[i], json.value());
+    }
+}
 
 class ArrayFunctionsTest : public ::testing::Test {
 protected:
@@ -6018,6 +6095,110 @@ TEST_F(ArrayFunctionsTest, array_flatten_int) {
         EXPECT_EQ("[1,2,1,4]", result->debug_item(1));
         EXPECT_EQ("[1,2,3]", result->debug_item(2));
     }
+}
+
+TEST_F(ArrayFunctionsTest, array_repeat_variant_uses_column_copy) {
+    auto source = make_nullable_variant_values({std::string("1"), std::string(R"({"a":2})"), std::nullopt});
+    auto repeat_data = Int32Column::create();
+    repeat_data->append(2);
+    repeat_data->append(1);
+    repeat_data->append(3);
+
+    auto result = ArrayFunctions::repeat(nullptr, {source, repeat_data}).value();
+    expect_variant_array_row(result, 0, {std::string("1"), std::string("1")});
+    expect_variant_array_row(result, 1, {std::string(R"({"a":2})")});
+    expect_variant_array_row(result, 2, {std::nullopt, std::nullopt, std::nullopt});
+
+    auto nullable_repeat_data = Int32Column::create();
+    nullable_repeat_data->append(2);
+    nullable_repeat_data->append(0);
+    nullable_repeat_data->append(1);
+    auto repeat_nulls = NullColumn::create();
+    repeat_nulls->append(DATUM_NOT_NULL);
+    repeat_nulls->append(DATUM_NULL);
+    repeat_nulls->append(DATUM_NOT_NULL);
+    auto nullable_repeat = NullableColumn::create(std::move(nullable_repeat_data), std::move(repeat_nulls));
+
+    result = ArrayFunctions::repeat(nullptr, {source, nullable_repeat}).value();
+    expect_variant_array_row(result, 0, {std::string("1"), std::string("1")});
+    ASSERT_TRUE(result->is_null(1));
+    expect_variant_array_row(result, 2, {std::nullopt});
+
+    auto const_value = VariantEncoder::encode_json_text_to_variant(R"({"const":7})");
+    ASSERT_TRUE(const_value.ok());
+    auto const_data = VariantColumn::create();
+    const_data->append(const_value.value());
+    auto const_source = ConstColumn::create(std::move(const_data), 3);
+    auto const_repeat = Int32Column::create();
+    const_repeat->append(1);
+    const_repeat->append(2);
+    const_repeat->append(0);
+
+    result = ArrayFunctions::repeat(nullptr, {const_source, const_repeat}).value();
+    expect_variant_array_row(result, 0, {std::string(R"({"const":7})")});
+    expect_variant_array_row(result, 1, {std::string(R"({"const":7})"), std::string(R"({"const":7})")});
+    expect_variant_array_row(result, 2, {});
+}
+
+TEST_F(ArrayFunctionsTest, array_slice_variant_uses_element_ranges) {
+    auto elements = make_nullable_variant_values(
+            {std::string("1"), std::string(R"({"a":2})"), std::nullopt, std::string("4"), std::string(R"({"x":1})"),
+             std::string(R"({"y":2})"), std::string("3"), std::string("5"), std::string("6")});
+    auto source = ArrayColumn::create(elements, make_array_offsets({0, 4, 7, 9}));
+    auto offsets = Int64Column::create();
+    offsets->append(2);
+    offsets->append(-2);
+    offsets->append(1);
+    auto lengths = Int64Column::create();
+    lengths->append(2);
+    lengths->append(1);
+    lengths->append(-1);
+
+    auto result = ArrayFunctions::array_slice(nullptr, {source, offsets, lengths}).value();
+    expect_variant_array_row(result, 0, {std::string(R"({"a":2})"), std::nullopt});
+    expect_variant_array_row(result, 1, {std::string(R"({"y":2})")});
+    expect_variant_array_row(result, 2, {});
+}
+
+TEST_F(ArrayFunctionsTest, array_flatten_variant_preserves_nullable_inner_rows_and_leaves) {
+    auto leaves = make_nullable_variant_values(
+            {std::string("1"), std::nullopt, std::string(R"({"a":2})"), std::string(R"({"b":3})"), std::string("4")});
+    auto inner_arrays = ArrayColumn::create(leaves, make_array_offsets({0, 2, 2, 3, 5}));
+    auto inner_nulls = NullColumn::create();
+    inner_nulls->append(DATUM_NOT_NULL);
+    inner_nulls->append(DATUM_NULL);
+    inner_nulls->append(DATUM_NOT_NULL);
+    inner_nulls->append(DATUM_NOT_NULL);
+    auto nullable_inner_arrays = NullableColumn::create(std::move(inner_arrays), std::move(inner_nulls));
+
+    auto outer_arrays = ArrayColumn::create(nullable_inner_arrays, make_array_offsets({0, 3, 4, 4}));
+    auto outer_nulls = NullColumn::create();
+    outer_nulls->append(DATUM_NOT_NULL);
+    outer_nulls->append(DATUM_NOT_NULL);
+    outer_nulls->append(DATUM_NULL);
+    auto source = NullableColumn::create(std::move(outer_arrays), std::move(outer_nulls));
+
+    auto result = ArrayFunctions::array_flatten(nullptr, {source}).value();
+    expect_variant_array_row(result, 0, {std::string("1"), std::nullopt, std::string(R"({"a":2})")});
+    expect_variant_array_row(result, 1, {std::string(R"({"b":3})"), std::string("4")});
+    ASSERT_TRUE(result->is_null(2));
+}
+
+TEST_F(ArrayFunctionsTest, array_flatten_variant_unwraps_const_null_inner_array) {
+    auto leaves = make_nullable_variant_values({});
+    auto inner_array = ArrayColumn::create(leaves, make_array_offsets({0, 0}));
+    auto inner_nulls = NullColumn::create(1, DATUM_NULL);
+    auto nullable_inner_array = NullableColumn::create(std::move(inner_array), std::move(inner_nulls));
+    auto const_inner_arrays = ConstColumn::create(std::move(nullable_inner_array), 2);
+
+    auto outer_array = ArrayColumn::create(std::move(const_inner_arrays), make_array_offsets({0, 2}));
+    ColumnPtr source = ConstColumn::create(std::move(outer_array), 2);
+
+    auto result = ArrayFunctions::array_flatten(nullptr, {source}).value();
+    ASSERT_TRUE(result->is_constant());
+    ASSERT_EQ(2, result->size());
+    expect_variant_array_row(result, 0, {});
+    expect_variant_array_row(result, 1, {});
 }
 
 TEST_F(ArrayFunctionsTest, null_or_empty) {

--- a/be/test/exprs/case_expr_test.cpp
+++ b/be/test/exprs/case_expr_test.cpp
@@ -18,12 +18,17 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <optional>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include "column/chunk.h"
 #include "column/column_helper.h"
 #include "column/column_viewer.h"
 #include "column/fixed_length_column.h"
+#include "column/variant_column.h"
+#include "column/variant_encoder.h"
 #include "column/vectorized_fwd.h"
 #include "common/object_pool.h"
 #include "exprs/exprs_test_helper.h"
@@ -118,6 +123,46 @@ public:
     TExprNode expr_node;
     RuntimeState runtime_state;
 };
+
+static MutableColumnPtr create_case_variant_column(const std::vector<std::string>& json_values) {
+    auto column = VariantColumn::create();
+    for (const auto& json : json_values) {
+        auto encoded = VariantEncoder::encode_json_text_to_variant(json);
+        CHECK(encoded.ok()) << encoded.status().to_string();
+        column->append(encoded.value());
+    }
+    CHECK(column->is_shredded_variant());
+    return column;
+}
+
+static void assert_case_variant_result(const ColumnPtr& result,
+                                       const std::vector<std::optional<std::string>>& expected) {
+    ASSERT_EQ(expected.size(), result->size());
+
+    const Column* data_column = result.get();
+    const bool is_const = data_column->is_constant();
+    if (is_const) {
+        data_column = down_cast<const ConstColumn*>(data_column)->data_column().get();
+    }
+    if (data_column->is_nullable()) {
+        data_column = down_cast<const NullableColumn*>(data_column)->data_column().get();
+    }
+    const auto* variant_column = down_cast<const VariantColumn*>(data_column);
+
+    for (size_t i = 0; i < expected.size(); ++i) {
+        SCOPED_TRACE(i);
+        if (!expected[i].has_value()) {
+            EXPECT_TRUE(result->is_null(i));
+            continue;
+        }
+
+        ASSERT_FALSE(result->is_null(i));
+        VariantRowValue row_buffer;
+        const VariantRowValue* row = variant_column->get_row_value(is_const ? 0 : i, &row_buffer);
+        ASSERT_NE(nullptr, row);
+        EXPECT_EQ(expected[i].value(), row->to_string());
+    }
+}
 
 TEST_F(VectorizedCaseExprTest, whenArrayMapCase) {
     expr_node.case_expr.has_case_expr = true;
@@ -967,5 +1012,112 @@ TEST_F(VectorizedCaseExprTest, NoCaseWhenNullReturnElse) {
             ASSERT_TRUE(ptr->is_null(j));
         }
     }
+}
+
+TEST_F(VectorizedCaseExprTest, searchedCaseReturnsVariant) {
+    expr_node.case_expr.has_case_expr = false;
+    expr_node.case_expr.has_else_expr = true;
+    expr_node.child_type = TPrimitiveType::BOOLEAN;
+    expr_node.type = TypeDescriptor(TYPE_VARIANT).to_thrift();
+    expr_node.is_nullable = true;
+
+    std::unique_ptr<Expr> expr(VectorizedCaseExprFactory::from_thrift(expr_node, TYPE_VARIANT, TYPE_BOOLEAN));
+    ASSERT_NE(nullptr, expr);
+
+    auto when1_column = BooleanColumn::create();
+    when1_column->append(1);
+    when1_column->append(0);
+    when1_column->append(0);
+    when1_column->append(0);
+    MockExpr when1(TypeDescriptor(TYPE_BOOLEAN), when1_column);
+
+    auto when2_column = BooleanColumn::create();
+    when2_column->append(0);
+    when2_column->append(1);
+    when2_column->append(0);
+    when2_column->append(0);
+    MockExpr when2(TypeDescriptor(TYPE_BOOLEAN), when2_column);
+
+    MockExpr then1(TypeDescriptor(TYPE_VARIANT), create_case_variant_column({"10", "11", "12", "13"}));
+
+    auto then2_data = create_case_variant_column({"20", "21", "22", "23"});
+    auto then2_nulls = NullColumn::create();
+    then2_nulls->append(0);
+    then2_nulls->append(1);
+    then2_nulls->append(0);
+    then2_nulls->append(0);
+    MockExpr then2(TypeDescriptor(TYPE_VARIANT), NullableColumn::create(std::move(then2_data), std::move(then2_nulls)));
+
+    MockExpr else_expr(TypeDescriptor(TYPE_VARIANT), create_case_variant_column({"30", "31", "32", "33"}));
+
+    expr->_children.push_back(&when1);
+    expr->_children.push_back(&then1);
+    expr->_children.push_back(&when2);
+    expr->_children.push_back(&then2);
+    expr->_children.push_back(&else_expr);
+
+    Chunk chunk;
+    ColumnPtr result = expr->evaluate(nullptr, &chunk);
+    assert_case_variant_result(result, {"10", std::nullopt, "32", "33"});
+
+    // Also cover the implicit SQL NULL branch when searched CASE has no ELSE.
+    expr_node.case_expr.has_else_expr = false;
+    std::unique_ptr<Expr> no_else_expr(VectorizedCaseExprFactory::from_thrift(expr_node, TYPE_VARIANT, TYPE_BOOLEAN));
+    ASSERT_NE(nullptr, no_else_expr);
+
+    auto dynamic_when_column = BooleanColumn::create();
+    dynamic_when_column->append(0);
+    dynamic_when_column->append(1);
+    dynamic_when_column->append(0);
+    MockExpr dynamic_when(TypeDescriptor(TYPE_BOOLEAN), dynamic_when_column);
+    MockExpr dynamic_then(TypeDescriptor(TYPE_VARIANT), create_case_variant_column({"40", "41", "42"}));
+    no_else_expr->_children.push_back(&dynamic_when);
+    no_else_expr->_children.push_back(&dynamic_then);
+
+    Chunk no_else_chunk;
+    no_else_chunk.append_column(dynamic_when_column, 0);
+    ColumnPtr no_else_result = no_else_expr->evaluate(nullptr, &no_else_chunk);
+    assert_case_variant_result(no_else_result, {std::nullopt, "41", std::nullopt});
+}
+
+TEST_F(VectorizedCaseExprTest, simpleCaseReturnsVariant) {
+    expr_node.case_expr.has_case_expr = true;
+    expr_node.case_expr.has_else_expr = true;
+    expr_node.child_type = TPrimitiveType::INT;
+    expr_node.type = TypeDescriptor(TYPE_VARIANT).to_thrift();
+
+    std::unique_ptr<Expr> expr(VectorizedCaseExprFactory::from_thrift(expr_node, TYPE_VARIANT, TYPE_INT));
+    ASSERT_NE(nullptr, expr);
+
+    auto case_column = Int32Column::create();
+    case_column->append(1);
+    case_column->append(2);
+    case_column->append(3);
+    case_column->append(4);
+    MockExpr case_expr(TypeDescriptor(TYPE_INT), case_column);
+
+    auto when1_column = Int32Column::create();
+    auto when2_column = Int32Column::create();
+    for (size_t i = 0; i < case_column->size(); ++i) {
+        when1_column->append(1);
+        when2_column->append(2);
+    }
+    MockExpr when1(TypeDescriptor(TYPE_INT), when1_column);
+    MockExpr when2(TypeDescriptor(TYPE_INT), when2_column);
+
+    MockExpr then1(TypeDescriptor(TYPE_VARIANT), create_case_variant_column({"100", "101", "102", "103"}));
+    MockExpr then2(TypeDescriptor(TYPE_VARIANT), create_case_variant_column({"200", "201", "202", "203"}));
+    MockExpr else_expr(TypeDescriptor(TYPE_VARIANT), create_case_variant_column({"300", "301", "302", "303"}));
+
+    expr->_children.push_back(&case_expr);
+    expr->_children.push_back(&when1);
+    expr->_children.push_back(&then1);
+    expr->_children.push_back(&when2);
+    expr->_children.push_back(&then2);
+    expr->_children.push_back(&else_expr);
+
+    Chunk chunk;
+    ColumnPtr result = expr->evaluate(nullptr, &chunk);
+    assert_case_variant_result(result, {"100", "201", "302", "303"});
 }
 } // namespace starrocks

--- a/be/test/exprs/cast_expr_test.cpp
+++ b/be/test/exprs/cast_expr_test.cpp
@@ -21,6 +21,7 @@
 
 #include "base/string/slice.h"
 #include "butil/time.h"
+#include "column/array_column.h"
 #include "column/fixed_length_column.h"
 #include "column/nullable_column.h"
 #include "column/runtime_type_traits.h"
@@ -2898,6 +2899,80 @@ TEST_F(VectorizedCastExprTest, int_cast_to_variant) {
     ASSERT_TRUE(json1.ok());
     EXPECT_EQ("123", json0.value());
     EXPECT_EQ("-7", json1.value());
+}
+
+// Verifies CAST(ARRAY<VARIANT> AS VARIANT) uses column-aware recursive encoding instead of
+// materializing VariantColumn through the legacy Datum/ObjectColumn storage.
+TEST_F(VectorizedCastExprTest, array_with_variant_children_cast_to_variant) {
+    auto variant_data = VariantColumn::create();
+    auto variant_nulls = NullColumn::create();
+    for (const auto& json_text : {R"({"a":1})", R"({"b":2})"}) {
+        auto encoded = VariantEncoder::encode_json_text_to_variant(json_text);
+        ASSERT_TRUE(encoded.ok());
+        variant_data->append(encoded.value());
+        variant_nulls->append(DATUM_NOT_NULL);
+    }
+    variant_data->append_default();
+    variant_nulls->append(DATUM_NULL);
+    auto elements = NullableColumn::create(std::move(variant_data), std::move(variant_nulls));
+    auto offsets = UInt32Column::create();
+    offsets->append(0);
+    offsets->append(3);
+    auto array = ArrayColumn::create(std::move(elements), std::move(offsets));
+    TypeDescriptor array_type = TypeDescriptor::create_array_type(TypeDescriptor(TYPE_VARIANT));
+
+    auto result = cast_to_variant(array_type, array);
+    auto json = variant_json_at(result, 0);
+    ASSERT_TRUE(json.ok()) << json.status().to_string();
+    EXPECT_EQ(R"([{"a":1},{"b":2},null])", json.value());
+}
+
+TEST_F(VectorizedCastExprTest, nullable_array_with_variant_children_cast_to_variant) {
+    auto variant_data = VariantColumn::create();
+    auto encoded = VariantEncoder::encode_json_text_to_variant(R"({"a":1})");
+    ASSERT_TRUE(encoded.ok());
+    variant_data->append(encoded.value());
+    auto variant_nulls = NullColumn::create(1, DATUM_NOT_NULL);
+    auto elements = NullableColumn::create(std::move(variant_data), std::move(variant_nulls));
+    auto offsets = UInt32Column::create();
+    offsets->append(0);
+    offsets->append(1);
+    offsets->append(1);
+    auto arrays = ArrayColumn::create(std::move(elements), std::move(offsets));
+    auto array_nulls = NullColumn::create();
+    array_nulls->append(DATUM_NOT_NULL);
+    array_nulls->append(DATUM_NULL);
+    ColumnPtr input = NullableColumn::create(std::move(arrays), std::move(array_nulls));
+    TypeDescriptor array_type = TypeDescriptor::create_array_type(TypeDescriptor(TYPE_VARIANT));
+
+    auto result = cast_to_variant(array_type, input);
+    ASSERT_FALSE(result->is_null(0));
+    ASSERT_TRUE(result->is_null(1));
+    auto json = variant_json_at(result, 0);
+    ASSERT_TRUE(json.ok()) << json.status().to_string();
+    EXPECT_EQ(R"([{"a":1}])", json.value());
+}
+
+TEST_F(VectorizedCastExprTest, const_array_with_variant_children_cast_to_variant) {
+    auto variant_data = VariantColumn::create();
+    auto encoded = VariantEncoder::encode_json_text_to_variant(R"({"a":1})");
+    ASSERT_TRUE(encoded.ok());
+    variant_data->append(encoded.value());
+    auto variant_nulls = NullColumn::create(1, DATUM_NOT_NULL);
+    auto elements = NullableColumn::create(std::move(variant_data), std::move(variant_nulls));
+    auto offsets = UInt32Column::create();
+    offsets->append(0);
+    offsets->append(1);
+    auto array = ArrayColumn::create(std::move(elements), std::move(offsets));
+    ColumnPtr input = ConstColumn::create(std::move(array), 3);
+    TypeDescriptor array_type = TypeDescriptor::create_array_type(TypeDescriptor(TYPE_VARIANT));
+
+    auto result = cast_to_variant(array_type, input);
+    ASSERT_TRUE(result->is_constant());
+    ASSERT_EQ(3, result->size());
+    auto json = variant_json_at(result, 0);
+    ASSERT_TRUE(json.ok()) << json.status().to_string();
+    EXPECT_EQ(R"([{"a":1}])", json.value());
 }
 
 // Verifies const variant input can cast to complex types with stable semantics.

--- a/be/test/exprs/in_predicate_test.cpp
+++ b/be/test/exprs/in_predicate_test.cpp
@@ -21,6 +21,8 @@
 #include "column/binary_column.h"
 #include "column/column_helper.h"
 #include "column/fixed_length_column.h"
+#include "column/variant_column.h"
+#include "column/variant_encoder.h"
 #include "exprs/mock_vectorized_expr.h"
 
 namespace starrocks {
@@ -66,6 +68,21 @@ public:
 private:
     ObjectPool _objpool;
 };
+
+static MutableColumnPtr create_variant_column(const std::vector<std::string>& json_values) {
+    auto column = VariantColumn::create();
+    for (const auto& json : json_values) {
+        auto encoded = VariantEncoder::encode_json_text_to_variant(json);
+        CHECK(encoded.ok()) << encoded.status().to_string();
+        column->append(encoded.value());
+    }
+    CHECK(column->is_shredded_variant());
+    return column;
+}
+
+static MutableColumnPtr create_const_variant_column(const std::string& json, size_t size) {
+    return ConstColumn::create(create_variant_column({json}), size);
+}
 
 TEST_F(VectorizedInPredicateTest, sliceInTrue) {
     for (auto i = 0; i < 2; i++) {
@@ -476,6 +493,65 @@ TEST_F(VectorizedInPredicateTest, inArrayConstAllNULL) {
             ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
             ASSERT_TRUE(ptr->only_null());
         }
+    }
+}
+
+TEST_F(VectorizedInPredicateTest, variantInAndNotIn) {
+    for (auto not_in : is_not_in) {
+        expr_node.__set_child_type_desc(TypeDescriptor(TYPE_VARIANT).to_thrift());
+        expr_node.child_type = TPrimitiveType::VARIANT;
+        expr_node.opcode = not_in ? TExprOpcode::FILTER_NOT_IN : TExprOpcode::FILTER_IN;
+        expr_node.in_predicate.is_not_in = not_in;
+
+        auto expr = std::unique_ptr<Expr>(VectorizedInPredicateFactory::from_thrift(expr_node));
+        MockExpr lhs(TypeDescriptor(TYPE_VARIANT), create_variant_column({"1", "2", "3"}));
+        auto* rhs1 = new_fake_const_expr(create_const_variant_column("1", 3), TypeDescriptor(TYPE_VARIANT));
+        auto* rhs2 = new_fake_const_expr(create_const_variant_column("2", 3), TypeDescriptor(TYPE_VARIANT));
+        expr->add_child(&lhs);
+        expr->add_child(rhs1);
+        expr->add_child(rhs2);
+
+        ASSERT_TRUE(expr->prepare(nullptr, nullptr).ok());
+        ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
+        ColumnPtr result = expr->evaluate(nullptr, nullptr);
+        ASSERT_FALSE(result->is_nullable());
+        const auto* values = down_cast<const BooleanColumn*>(result.get());
+        EXPECT_EQ(!not_in, values->immutable_data()[0]);
+        EXPECT_EQ(!not_in, values->immutable_data()[1]);
+        EXPECT_EQ(not_in, values->immutable_data()[2]);
+    }
+}
+
+TEST_F(VectorizedInPredicateTest, variantInNullSemantics) {
+    for (auto not_in : is_not_in) {
+        expr_node.__set_child_type_desc(TypeDescriptor(TYPE_VARIANT).to_thrift());
+        expr_node.child_type = TPrimitiveType::VARIANT;
+        expr_node.opcode = not_in ? TExprOpcode::FILTER_NOT_IN : TExprOpcode::FILTER_IN;
+        expr_node.in_predicate.is_not_in = not_in;
+
+        auto expr = std::unique_ptr<Expr>(VectorizedInPredicateFactory::from_thrift(expr_node));
+        auto lhs_data = create_variant_column({"1", "2", "3"});
+        auto lhs_nulls = NullColumn::create();
+        lhs_nulls->append(0);
+        lhs_nulls->append(1);
+        lhs_nulls->append(0);
+        MockExpr lhs(TypeDescriptor(TYPE_VARIANT), NullableColumn::create(std::move(lhs_data), std::move(lhs_nulls)));
+        auto* rhs = new_fake_const_expr(create_const_variant_column("1", 3), TypeDescriptor(TYPE_VARIANT));
+        auto* null_rhs = new_fake_const_expr(ColumnHelper::create_const_null_column(3), TypeDescriptor(TYPE_VARIANT));
+        expr->add_child(&lhs);
+        expr->add_child(rhs);
+        expr->add_child(null_rhs);
+
+        ASSERT_TRUE(expr->prepare(nullptr, nullptr).ok());
+        ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
+        ColumnPtr result = expr->evaluate(nullptr, nullptr);
+        ASSERT_TRUE(result->is_nullable());
+        const auto* nullable = down_cast<const NullableColumn*>(result.get());
+        const auto* values = down_cast<const BooleanColumn*>(nullable->data_column().get());
+        EXPECT_FALSE(result->is_null(0));
+        EXPECT_EQ(!not_in, values->immutable_data()[0]);
+        EXPECT_TRUE(result->is_null(1));
+        EXPECT_TRUE(result->is_null(2));
     }
 }
 

--- a/test/sql/test_variant_cast/R/test_variant_pipeline_operations.sql
+++ b/test/sql/test_variant_cast/R/test_variant_pipeline_operations.sql
@@ -1,0 +1,106 @@
+-- name: test_variant_pipeline_operations
+
+SELECT SUM(array_length(w))
+FROM (
+    SELECT array_agg(CAST(generate_series AS VARIANT)) OVER (
+        ORDER BY generate_series ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
+    ) AS w
+    FROM TABLE(generate_series(1, 10000))
+) t;
+-- result:
+19999
+-- !result
+
+[ORDER] SELECT k, CAST(v AS VARCHAR) AS v
+FROM (
+    SELECT
+        generate_series AS k,
+        CASE WHEN generate_series = 3
+            THEN NULL
+            ELSE CAST(generate_series AS VARIANT)
+        END AS v
+    FROM TABLE(generate_series(1, 4))
+) t
+ORDER BY k
+LIMIT 2 OFFSET 1;
+-- result:
+2	2
+3	None
+-- !result
+
+[ORDER] SELECT
+    generate_series,
+    CASE WHEN CAST(generate_series AS VARIANT) IN (CAST(1 AS VARIANT), CAST(2 AS VARIANT))
+        THEN 'IN' ELSE 'OUT' END AS in_result,
+    CAST(CASE
+        WHEN generate_series = 1 THEN CAST(named_struct('a', 1) AS VARIANT)
+        WHEN generate_series = 2 THEN CAST(named_struct('b', 2) AS VARIANT)
+        ELSE CAST(named_struct('c', 3) AS VARIANT)
+    END AS VARCHAR) AS searched_case_result,
+    CAST(CASE generate_series
+        WHEN 1 THEN CAST(10 AS VARIANT)
+        WHEN 2 THEN CAST(20 AS VARIANT)
+        ELSE CAST(30 AS VARIANT)
+    END AS VARCHAR) AS simple_case_result
+FROM TABLE(generate_series(1, 3))
+ORDER BY generate_series;
+-- result:
+1	IN	{"a":1}	10
+2	IN	{"b":2}	20
+3	OUT	{"c":3}	30
+-- !result
+
+[ORDER] SELECT
+    generate_series,
+    CASE WHEN array_length(repeated) = 2
+              AND CAST(repeated[2] AS VARCHAR) = CAST(generate_series AS VARCHAR)
+        THEN 'PASS' ELSE 'FAIL' END AS repeat_result,
+    CASE WHEN array_length(sliced) = 2
+              AND CAST(sliced[1] AS VARCHAR) = CAST(generate_series + 10 AS VARCHAR)
+              AND sliced[2] IS NULL
+        THEN 'PASS' ELSE 'FAIL' END AS slice_result,
+    CASE WHEN array_length(flattened) = 3
+              AND flattened[2] IS NULL
+              AND CAST(flattened[3] AS VARCHAR) = CAST(generate_series + 1 AS VARCHAR)
+        THEN 'PASS' ELSE 'FAIL' END AS flatten_result
+FROM (
+    SELECT
+        generate_series,
+        array_repeat(CAST(generate_series AS VARIANT), 2) AS repeated,
+        array_slice(ARRAY<VARIANT>[
+            CAST(generate_series AS VARIANT),
+            CAST(generate_series + 10 AS VARIANT),
+            CAST(NULL AS VARIANT)
+        ], 2, 2) AS sliced,
+        array_flatten(ARRAY<ARRAY<VARIANT>>[
+            ARRAY<VARIANT>[CAST(generate_series AS VARIANT), CAST(NULL AS VARIANT)],
+            ARRAY<VARIANT>[CAST(generate_series + 1 AS VARIANT)]
+        ]) AS flattened
+    FROM TABLE(generate_series(1, 2))
+) t
+ORDER BY generate_series;
+-- result:
+1	PASS	PASS	PASS
+2	PASS	PASS	PASS
+-- !result
+
+SELECT
+    CASE WHEN CAST(CAST(ARRAY<VARIANT>[
+            CAST(named_struct('a', 1) AS VARIANT),
+            CAST(named_struct('b', 2) AS VARIANT),
+            CAST(NULL AS VARIANT)
+        ] AS VARIANT) AS VARCHAR) = '[{"a":1},{"b":2},null]'
+        THEN 'PASS' ELSE 'FAIL' END AS nested_array_result,
+    CASE WHEN CAST(CAST(MAP{
+            'left': CAST(named_struct('a', 1) AS VARIANT),
+            'right': CAST(named_struct('b', 2) AS VARIANT)
+        } AS VARIANT) AS VARCHAR) = '{"left":{"a":1},"right":{"b":2}}'
+        THEN 'PASS' ELSE 'FAIL' END AS nested_map_result,
+    CASE WHEN CAST(CAST(named_struct(
+            'left', CAST(named_struct('a', 1) AS VARIANT),
+            'right', CAST(ARRAY<int>[1, 2] AS VARIANT)
+        ) AS VARIANT) AS VARCHAR) = '{"left":{"a":1},"right":[1,2]}'
+        THEN 'PASS' ELSE 'FAIL' END AS nested_struct_result;
+-- result:
+PASS	PASS	PASS
+-- !result

--- a/test/sql/test_variant_cast/T/test_variant_pipeline_operations.sql
+++ b/test/sql/test_variant_cast/T/test_variant_pipeline_operations.sql
@@ -1,0 +1,92 @@
+-- name: test_variant_pipeline_operations
+
+-- Analytor discards consumed window prefixes through Column::remove_first_n_values().
+SELECT SUM(array_length(w))
+FROM (
+    SELECT array_agg(CAST(generate_series AS VARIANT)) OVER (
+        ORDER BY generate_series ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
+    ) AS w
+    FROM TABLE(generate_series(1, 10000))
+) t;
+
+-- CASE must append both Variant values and a SQL NULL branch without reading the legacy object pool.
+[ORDER] SELECT k, CAST(v AS VARCHAR) AS v
+FROM (
+    SELECT
+        generate_series AS k,
+        CASE WHEN generate_series = 3
+            THEN NULL
+            ELSE CAST(generate_series AS VARIANT)
+        END AS v
+    FROM TABLE(generate_series(1, 4))
+) t
+ORDER BY k
+LIMIT 2 OFFSET 1;
+
+-- Constant IN and CASE expressions must use shredded-aware equality and append paths.
+[ORDER] SELECT
+    generate_series,
+    CASE WHEN CAST(generate_series AS VARIANT) IN (CAST(1 AS VARIANT), CAST(2 AS VARIANT))
+        THEN 'IN' ELSE 'OUT' END AS in_result,
+    CAST(CASE
+        WHEN generate_series = 1 THEN CAST(named_struct('a', 1) AS VARIANT)
+        WHEN generate_series = 2 THEN CAST(named_struct('b', 2) AS VARIANT)
+        ELSE CAST(named_struct('c', 3) AS VARIANT)
+    END AS VARCHAR) AS searched_case_result,
+    CAST(CASE generate_series
+        WHEN 1 THEN CAST(10 AS VARIANT)
+        WHEN 2 THEN CAST(20 AS VARIANT)
+        ELSE CAST(30 AS VARIANT)
+    END AS VARCHAR) AS simple_case_result
+FROM TABLE(generate_series(1, 3))
+ORDER BY generate_series;
+
+-- ARRAY functions must copy Variant elements through Column range APIs, including NULL leaves.
+[ORDER] SELECT
+    generate_series,
+    CASE WHEN array_length(repeated) = 2
+              AND CAST(repeated[2] AS VARCHAR) = CAST(generate_series AS VARCHAR)
+        THEN 'PASS' ELSE 'FAIL' END AS repeat_result,
+    CASE WHEN array_length(sliced) = 2
+              AND CAST(sliced[1] AS VARCHAR) = CAST(generate_series + 10 AS VARCHAR)
+              AND sliced[2] IS NULL
+        THEN 'PASS' ELSE 'FAIL' END AS slice_result,
+    CASE WHEN array_length(flattened) = 3
+              AND flattened[2] IS NULL
+              AND CAST(flattened[3] AS VARCHAR) = CAST(generate_series + 1 AS VARCHAR)
+        THEN 'PASS' ELSE 'FAIL' END AS flatten_result
+FROM (
+    SELECT
+        generate_series,
+        array_repeat(CAST(generate_series AS VARIANT), 2) AS repeated,
+        array_slice(ARRAY<VARIANT>[
+            CAST(generate_series AS VARIANT),
+            CAST(generate_series + 10 AS VARIANT),
+            CAST(NULL AS VARIANT)
+        ], 2, 2) AS sliced,
+        array_flatten(ARRAY<ARRAY<VARIANT>>[
+            ARRAY<VARIANT>[CAST(generate_series AS VARIANT), CAST(NULL AS VARIANT)],
+            ARRAY<VARIANT>[CAST(generate_series + 1 AS VARIANT)]
+        ]) AS flattened
+    FROM TABLE(generate_series(1, 2))
+) t
+ORDER BY generate_series;
+
+-- Complex values containing Variant children require recursive, metadata-aware encoding.
+SELECT
+    CASE WHEN CAST(CAST(ARRAY<VARIANT>[
+            CAST(named_struct('a', 1) AS VARIANT),
+            CAST(named_struct('b', 2) AS VARIANT),
+            CAST(NULL AS VARIANT)
+        ] AS VARIANT) AS VARCHAR) = '[{"a":1},{"b":2},null]'
+        THEN 'PASS' ELSE 'FAIL' END AS nested_array_result,
+    CASE WHEN CAST(CAST(MAP{
+            'left': CAST(named_struct('a', 1) AS VARIANT),
+            'right': CAST(named_struct('b', 2) AS VARIANT)
+        } AS VARIANT) AS VARCHAR) = '{"left":{"a":1},"right":{"b":2}}'
+        THEN 'PASS' ELSE 'FAIL' END AS nested_map_result,
+    CASE WHEN CAST(CAST(named_struct(
+            'left', CAST(named_struct('a', 1) AS VARIANT),
+            'right', CAST(ARRAY<int>[1, 2] AS VARIANT)
+        ) AS VARIANT) AS VARCHAR) = '{"left":{"a":1},"right":[1,2]}'
+        THEN 'PASS' ELSE 'FAIL' END AS nested_struct_result;


### PR DESCRIPTION
 ## Why I'm doing:

  After the base shredded Variant framework moved row data out of the inherited
  `ObjectColumn<VariantRowValue>` pool and into metadata, remain-value, and typed child columns,
  several generic execution paths continued to use the legacy object-column or row-level `Datum`
  contracts.

  This causes one confirmed crash on community main and three additional correctness problems caused
  by incompatible storage access.

  ### 1. Analytic window prefix contraction crashes

  Trigger:

  ```sql
  SELECT SUM(array_length(w))
  FROM (
      SELECT array_agg(CAST(generate_series AS VARIANT)) OVER (
          ORDER BY generate_series
          ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
      ) AS w
      FROM TABLE(generate_series(1, 10000))
  ) t;
 ```

  Observed call path:

  ObjectColumn<VariantRowValue>::remove_first_n_values
  Analytor::_remove_unused_rows

  VariantColumn inherited prefix removal from ObjectColumn, which operated on the now-empty
  legacy pool instead of the shredded child columns.

  ### 2. Constant Variant IN uses an incompatible typed predicate

  Trigger:
  ```sql
  SELECT CAST(generate_series AS VARIANT)
         IN (CAST(1 AS VARIANT), CAST(2 AS VARIANT))
  FROM TABLE(generate_series(1, 4));
 ```

  The predicate factory routed Variant to the typed/hash predicate, whose storage access assumes a
  scalar container. This assumption is invalid for shredded Variant columns and can produce undefined
  or incorrect comparison results.

  ### 3. CASE returning Variant can access the legacy pool

  Trigger:
  ```sql
  SELECT k, CAST(v AS VARCHAR)
  FROM (
      SELECT generate_series AS k,
             CASE WHEN generate_series = 3
                  THEN NULL
                  ELSE CAST(generate_series AS VARIANT)
             END AS v
      FROM TABLE(generate_series(1, 4))
  ) t
  ORDER BY k;
 ```

  Affected path:

  VectorizedCaseExpr<..., TYPE_VARIANT>::evaluate_no_case

  The scalar CASE result path used ColumnViewer<TYPE_VARIANT>::value() instead of copying rows
  through the shredded-aware column interface.

  ### 4. ARRAY operations and nested casts use legacy Datum round trips

  The affected paths include:
  ```sql
  array_repeat(VARIANT, n)             -> Column::get / append_datum
  array_slice(ARRAY<VARIANT>)          -> ArrayColumn::get / DatumArray
  array_flatten(ARRAY<ARRAY<VARIANT>>) -> nested DatumArray materialization
  ARRAY/MAP/STRUCT containing VARIANT  -> recursive Datum-based Variant encoding
 ```

  These paths materialized complex values through Column::get() and a Datum containing a pointer
  into the inherited object pool. That pool no longer represents shredded Variant rows.

  ## What I'm doing:

  - Implement shredded-aware Variant prefix removal across metadata, remain-value, and typed child
    columns.

  - Route constant Variant IN/NOT IN to the generic equality implementation backed by
    Column::equals().

  - Make CASE copy Variant results through column append/range APIs instead of scalar viewers.
  - Make ARRAY repeat/slice/flatten copy Variant elements through column range operations.
  - Recursively encode ARRAY, MAP, and STRUCT values containing Variant children without round
    tripping through the legacy Variant Datum representation.

  - Add focused BE unit tests and SQL integration coverage for all four problem groups.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
