### PR TITLE
[BugFix] Fix lake compaction Limiter resize losing tokens on shrink (backport #78087)

### DIFF
--- a/be/src/storage/lake/compaction_scheduler.h
+++ b/be/src/storage/lake/compaction_scheduler.h
@@ -16,7 +16,9 @@
 
 #include <bthread/mutex.h>
 #include <butil/containers/linked_list.h>
+#include <gtest/gtest_prod.h>
 
+#include <algorithm>
 #include <memory>
 
 #include "common/status.h"
@@ -236,6 +238,10 @@ public:
 
 private:
     friend class CompactionTaskCallback;
+    FRIEND_TEST(LakeCompactionLimiterTest, test_adapt_to_task_queue_size_shrink_with_reserved);
+    FRIEND_TEST(LakeCompactionLimiterTest, test_adapt_to_task_queue_size_preserves_inflight_tokens);
+    FRIEND_TEST(LakeCompactionLimiterTest, test_adapt_to_task_queue_size_shrink_keeps_one_token);
+    FRIEND_TEST(LakeCompactionLimiterTest, test_adapt_to_task_queue_size_grow);
 
     // abort all the compaction tasks in the task queue. Only expected to be invoked during stop()
     void abort_all();
@@ -299,24 +305,23 @@ inline int16_t CompactionScheduler::Limiter::concurrency() const {
 
 inline void CompactionScheduler::Limiter::adapt_to_task_queue_size(int16_t new_val) {
     std::lock_guard l(_mtx);
-    if (new_val > _total) {
-        auto diff = new_val - _total;
-        _free += diff;
-        _total += diff;
-    } else if (new_val < _total) {
-        if (_reserved != 0) {
-            double percentage = static_cast<double>(_total) / new_val;
-            _reserved = static_cast<int16_t>(static_cast<double>(_reserved) * percentage);
-            _total = new_val;
-            _free = _total - _reserved;
-        } else {
-            _total = new_val;
-            _free = _total;
-        }
-    } else {
-        // nothing change
+    if (new_val <= 0 || new_val == _total) {
         return;
     }
+    // Tokens currently held by running compaction tasks. They will be returned via
+    // no_memory_limit_exceeded()/memory_limit_exceeded() when those tasks finish, so
+    // they must be carried over to the new accounting.
+    const int64_t in_use = _total - _reserved - _free;
+    if (new_val < _total) {
+        // Scale down the reserved tokens proportionally to the new total, and keep at
+        // least one grantable token so that the concurrency cannot be reduced to zero.
+        const double percentage = static_cast<double>(new_val) / _total;
+        _reserved = std::min<int16_t>(static_cast<int16_t>(static_cast<double>(_reserved) * percentage), new_val - 1);
+    }
+    _total = new_val;
+    // _free may become negative when the tasks in flight exceed the new concurrency: no
+    // new token can be acquired until enough running tasks have returned theirs.
+    _free = _total - _reserved - in_use;
     LOG(INFO) << "Update Limiter's _total value to " << _total << ", _free value to " << _free
               << ", and _reserved value to " << _reserved;
 }

--- a/be/test/storage/lake/compaction_scheduler_test.cpp
+++ b/be/test/storage/lake/compaction_scheduler_test.cpp
@@ -340,4 +340,75 @@ TEST_F(LakeCompactionSchedulerTest, test_skip_write_txnlog_fills_metacache) {
     EXPECT_EQ(response.txn_logs(0).op_compaction().compact_version(), cached->op_compaction().compact_version());
 }
 
+TEST(LakeCompactionLimiterTest, test_adapt_to_task_queue_size_shrink_with_reserved) {
+    CompactionScheduler::Limiter limiter(8);
+    // Two tasks finished with memory limit exceeded, two tokens get reserved.
+    ASSERT_TRUE(limiter.acquire());
+    limiter.memory_limit_exceeded();
+    ASSERT_TRUE(limiter.acquire());
+    limiter.memory_limit_exceeded();
+    ASSERT_EQ(6, limiter.concurrency());
+
+    // Shrink the total from 8 to 4: the reserved tokens are scaled down
+    // proportionally (2 * 4/8 = 1) instead of being inflated.
+    limiter.adapt_to_task_queue_size(4);
+    ASSERT_EQ(3, limiter.concurrency());
+    for (int i = 0; i < 3; i++) {
+        ASSERT_TRUE(limiter.acquire());
+    }
+    ASSERT_FALSE(limiter.acquire());
+}
+
+TEST(LakeCompactionLimiterTest, test_adapt_to_task_queue_size_preserves_inflight_tokens) {
+    CompactionScheduler::Limiter limiter(8);
+    // Three tasks are running.
+    for (int i = 0; i < 3; i++) {
+        ASSERT_TRUE(limiter.acquire());
+    }
+
+    limiter.adapt_to_task_queue_size(4);
+    ASSERT_EQ(4, limiter.concurrency());
+    // Only one more token can be granted while the three tasks are still running.
+    ASSERT_TRUE(limiter.acquire());
+    ASSERT_FALSE(limiter.acquire());
+
+    // After all running tasks finished, the concurrency is still bounded by the new total.
+    for (int i = 0; i < 4; i++) {
+        limiter.no_memory_limit_exceeded();
+    }
+    for (int i = 0; i < 4; i++) {
+        ASSERT_TRUE(limiter.acquire());
+    }
+    ASSERT_FALSE(limiter.acquire());
+}
+
+TEST(LakeCompactionLimiterTest, test_adapt_to_task_queue_size_shrink_keeps_one_token) {
+    CompactionScheduler::Limiter limiter(4);
+    ASSERT_TRUE(limiter.acquire());
+    limiter.memory_limit_exceeded();
+    ASSERT_TRUE(limiter.acquire());
+    limiter.memory_limit_exceeded();
+    ASSERT_EQ(2, limiter.concurrency());
+
+    // Shrinking to 1 must keep one grantable token instead of zeroing the concurrency.
+    limiter.adapt_to_task_queue_size(1);
+    ASSERT_EQ(1, limiter.concurrency());
+    ASSERT_TRUE(limiter.acquire());
+    ASSERT_FALSE(limiter.acquire());
+}
+
+TEST(LakeCompactionLimiterTest, test_adapt_to_task_queue_size_grow) {
+    CompactionScheduler::Limiter limiter(4);
+    ASSERT_TRUE(limiter.acquire());
+    limiter.memory_limit_exceeded();
+    ASSERT_EQ(3, limiter.concurrency());
+
+    limiter.adapt_to_task_queue_size(8);
+    ASSERT_EQ(7, limiter.concurrency());
+    for (int i = 0; i < 7; i++) {
+        ASSERT_TRUE(limiter.acquire());
+    }
+    ASSERT_FALSE(limiter.acquire());
+}
+
 } // namespace starrocks::lake


### PR DESCRIPTION
Manual backport of #78087 to branch-4.0. The automatic Mergify backport (#78298) hit a conflict and was closed: the new tests are appended at the end of `be/test/storage/lake/compaction_scheduler_test.cpp`, right after the parallel-compaction tests (`test_parallel_compaction_basic` / `_fallback` / `_multiple_tablets`) that only exist on main, so git reported the whole tail as one conflicting block. Only the four `LakeCompactionLimiterTest` cases are ported here; the parallel-compaction tests are left out since that feature is not on this branch. `be/src/storage/lake/compaction_scheduler.h` applies cleanly and is identical to main.

## Why I'm doing:

`CompactionScheduler::Limiter::adapt_to_task_queue_size()` is called when `compact_threads` is changed at runtime. Its shrink path has two accounting bugs:

1. **Inverted scale factor.** When some tokens are reserved (after `MemoryLimitExceeded` errors), the scale factor is computed as `_total / new_val` instead of `new_val / _total`, so shrinking *inflates* `_reserved` instead of scaling it down. For example with `_total = 8`, `_reserved = 2`, shrinking to 4 yields `_reserved = 2 * (8/4) = 4` and `_free = 0`: `acquire()` never succeeds again and lake compaction on the node stops permanently and silently (no task ever finishes, so the gradual `_reserved` restore in `no_memory_limit_exceeded()` can never run either). A larger shrink even drives `_free`/`concurrency()` negative.

2. **In-flight tokens dropped.** The shrink path resets `_free` as if no task were running (`_free = _total - _reserved`), ignoring tokens currently held by running tasks. Those tasks return their tokens on completion via `_free++`, so after shrinking 8 -> 4 with 3 tasks in flight the limiter ends up with `_free = 7 > _total = 4`, permanently over-subscribing the concurrency limit.

Both bugs are present on branch-4.0 with exactly the same code, and the surrounding `Limiter` methods (`acquire()`, `no_memory_limit_exceeded()`, `memory_limit_exceeded()`, `concurrency()`) are byte-identical to main, so the fix and its assertions carry over unchanged.

## What I'm doing:

- Rework `Limiter::adapt_to_task_queue_size()` in `be/src/storage/lake/compaction_scheduler.h`:
  - compute `in_use = _total - _reserved - _free` (tokens held by running tasks) and carry it over to the new accounting, so `_free = new_total - new_reserved - in_use` on both grow and shrink; `_free` may be transiently negative when in-flight tasks exceed the new concurrency, which simply blocks new `acquire()` calls until enough running tasks return their tokens;
  - fix the shrink scale factor to `new_val / _total` and cap the scaled `_reserved` at `new_val - 1`, so at least one grantable token always remains (consistent with the "cannot reduce the concurrency to zero" rule in `memory_limit_exceeded()`);
  - ignore non-positive `new_val` (callers already reject it) instead of corrupting the state.
- The grow path behavior is unchanged (`_reserved` untouched, `_free` grows by the delta), and all methods keep their signatures.
- Add `LakeCompactionLimiterTest` unit tests in `be/test/storage/lake/compaction_scheduler_test.cpp` (via `FRIEND_TEST`) covering: shrink with reserved tokens (the wedge scenario above), shrink with tasks in flight (over-subscription scenario), shrink to 1, and grow. The four cases are identical to the ones merged in #78087.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

