### PR TITLE
[Tool] Fix !sequential forcing concurrency to 1

### DIFF
--- a/test/run.py
+++ b/test/run.py
@@ -188,7 +188,11 @@ if __name__ == "__main__":
     cluster_attr = "!cloud" if cluster == "native" else "!native"
     attr = f"{attr},{cluster_attr}".strip(",")
     # check sequential mode with concurrency=1
-    if "sequential" in attr and concurrency != 1:
+    # Match the attr as a token, not a substring: "!sequential" (exclude sequential cases)
+    # must not be mistaken for "sequential" (run only sequential cases), otherwise the
+    # concurrent pass silently drops to a single process.
+    attr_tokens = {each.strip() for each in attr.split(",")}
+    if "sequential" in attr_tokens and concurrency != 1:
         print("In sequential mode, set concurrency=1 in default!")
         concurrency = 1
     # check alive mode with concurrency=1


### PR DESCRIPTION
The SQL-Tester driver now runs its concurrent pass with the attribute "!system,!slow,!sequential". The mode check tested "sequential" as a substring, so the negated form matched and silently overrode the caller's -c 12 with -c 1. That pass went single-threaded, finished only 635 of ~1580 cases inside its 40-minute budget, and CI reported a timeout with no failing case to point at. The slow pass carries the same attribute and was mis-clamped the same way.

Match the attribute as a comma-separated token instead. A positive "sequential" attribute is still clamped to one process, which is the guarantee the check exists for.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr