### PR TITLE
[BugFix] Record a merged rowset's del op_offset per statement, not per rowset

### DIFF
--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -1466,7 +1466,24 @@ void MetaFileBuilder::add_rowset(const RowsetMetadataPB& rowset_pb,
     for (size_t i = 0; i < dels.size(); ++i) {
         _pending_rowset_data.dels.emplace_back(dels[i]);
         const int64_t off = i < del_op_offsets.size() ? del_op_offsets[i] : -1;
-        _pending_rowset_data.del_op_offsets.push_back(off >= 0 ? off + seg_base : -1);
+        // Resolve the del's position into the merged rowset's segment-id space HERE, while the
+        // op_write that produced it is still in hand, with the same expression apply used for that
+        // op_write (build_del_interleave_plan(): `seg_base + get_segment_idx()` for a recorded
+        // offset, "right after this op_write's own last segment" for an unrecorded one). An
+        // op_write with no segments (a pure-delete statement) resolves to `seg_base`, the slot
+        // get_rowset_id_step() reserves for it and which therefore holds no segment, so it erases
+        // every earlier statement's rows and nothing later -- which is what apply did.
+        //
+        // An unrecorded offset used to be deferred to set_final_rowset() as -1, which resolved it
+        // against the MERGED rowset, i.e. after every LATER statement's segments too. The rebuild
+        // then replayed that del over rows a later statement of the same transaction had
+        // re-inserted (and, being at the max, without the ordering filter), erasing index entries
+        // whose rows are live and not delvec-masked. The next upsert of such a key finds nothing,
+        // writes no delete-vector mark, and leaves two live rows -- which a later index rebuild
+        // reports as "insert found duplicate key" (issue 78224).
+        const uint32_t local_idx =
+                off >= 0 ? get_segment_idx(rowset_pb, static_cast<int32_t>(off)) : get_max_segment_idx(rowset_pb);
+        _pending_rowset_data.del_op_offsets.push_back(static_cast<int64_t>(seg_base) + local_idx);
         _pending_rowset_data.del_num_rows.push_back(i < del_num_rows.size() ? del_num_rows[i] : 0);
     }
 
@@ -1529,10 +1546,15 @@ Status MetaFileBuilder::set_final_rowset() {
         DelfileWithRowsetId del_file_with_rid;
         del_file_with_rid.set_name(del.name());
         del_file_with_rid.set_origin_rowset_id(rowset->id());
-        // Preserve the in-transaction upsert/delete order when the writer recorded it; otherwise
-        // fall back to the max segment id (delete after all upserts).
-        del_file_with_rid.set_op_offset(
-                resolve_del_op_offset(_pending_rowset_data.del_op_offsets[i], /*column_mode=*/false, *rowset));
+        // op_offset is already resolved into this merged rowset's segment-id space by add_rowset(),
+        // which is the only place that knows which op_write each del came from. Clamp it to the
+        // merged rowset's last segment: a trailing pure-delete statement's reserved slot sits past
+        // that segment, and an op_offset outside the rowset's own rssid range would push the
+        // rebuild point into the next rowset. Clamping keeps the "erases everything in this rowset"
+        // meaning (the rebuild's ordering filter is skipped once op_offset reaches the max) without
+        // escaping the range.
+        del_file_with_rid.set_op_offset(static_cast<uint32_t>(
+                std::min<int64_t>(_pending_rowset_data.del_op_offsets[i], get_max_segment_idx(*rowset))));
         if (!del.encryption_meta().empty()) {
             del_file_with_rid.set_encryption_meta(del.encryption_meta());
         }

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -441,7 +441,14 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     // index the delete logically follows (delete sorts after that segment via the reserved UINT32_MAX
     // rowid). Falls back to the max segment id when the writer could not determine the order (spill /
     // older writers / column-mode), reproducing the legacy "all deletes after all upserts" behavior.
-    uint32_t max_segment_id = 0;
+    // Default to this op_write's own reserved slot, not 0: rowset_segment_ids already carries
+    // assigned_global_segments, so an op_write WITH segments gets the right base from the max below --
+    // but a segmentless one (a pure-delete statement) leaves the vector empty, and falling back to 0
+    // would place its delete at the very start of the merged rowset's rssid range instead of at the
+    // slot get_rowset_id_step() reserves for it. MetaFileBuilder::add_rowset() records seg_base for
+    // exactly that case, so apply has to agree or the two diverge again for a middle or trailing
+    // pure-delete statement. Outside batch apply assigned_global_segments is 0, so this is a no-op there.
+    uint32_t max_segment_id = assigned_global_segments;
     if (!rowset_segment_ids.empty()) {
         max_segment_id = *std::max_element(rowset_segment_ids.begin(), rowset_segment_ids.end());
     }

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -294,6 +294,7 @@ SET(DW_TEST_FILES
     ./storage/lake/persistent_index_sstable_test.cpp
     ./storage/lake/primary_key_compaction_task_test.cpp
     ./storage/lake/primary_key_publish_test.cpp
+    ./storage/lake/lake_merged_del_op_offset_test.cpp
     ./storage/lake/tablet_reshard_helper_test.cpp
     ./storage/lake/tablet_reshard_test.cpp
     ./storage/lake/tablet_splitter_test.cpp

--- a/be/test/storage/lake/lake_merged_del_op_offset_test.cpp
+++ b/be/test/storage/lake/lake_merged_del_op_offset_test.cpp
@@ -1,0 +1,322 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Regression test for issue 78224.
+//
+// A multi-statement transaction (SQL BEGIN ... COMMIT, i.e. a TxnInfoPB carrying more than one
+// load_id) is published by folding every statement's op_write into ONE merged rowset. A del file
+// carries `op_offset`: the index of the last segment of its rowset that the delete may erase. Apply
+// (UpdateManager::publish_primary_key_tablet) computes it from the statement that produced the del;
+// persist (MetaFileBuilder) used to leave an unrecorded offset to be resolved against the MERGED
+// rowset, i.e. after every LATER statement's segments too. On rebuild the delete then erased keys a
+// later statement had re-inserted, whose rows are live and not delete-vector-masked -- the next
+// upsert of such a key finds nothing in the index, writes no delete-vector mark, and leaves two live
+// rows for one key, which the following rebuild reports as "insert found duplicate key".
+//
+// Both tests drive the real publish path (DeltaWriter -> LakeServiceImpl::publish_version with two
+// load_ids -> rebuild on publish); nothing about the failing state is hand-assembled.
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <ctime>
+
+#include "base/testutil/assert.h"
+#include "base/testutil/id_generator.h"
+#include "column/chunk.h"
+#include "column/chunk_factory.h"
+#include "column/fixed_length_column.h"
+#include "column/schema.h"
+#include "common/config_primary_key_fwd.h"
+#include "gen_cpp/Types_types.h"
+#include "storage/chunk_helper.h"
+#include "storage/lake/delta_writer.h"
+#include "storage/lake/tablet_reader.h"
+#include "storage/lake/test_util.h"
+#include "storage/lake/update_manager.h"
+#include "storage/storage_env.h"
+#include "storage/tablet_schema.h"
+
+namespace starrocks::lake {
+
+class LakeMergedDelOpOffsetTest : public TestBase {
+public:
+    LakeMergedDelOpOffsetTest() : TestBase(kTestGroupPath) {
+        _tablet_metadata = generate_simple_tablet_metadata(PRIMARY_KEYS);
+        _tablet_metadata->set_enable_persistent_index(true);
+        _tablet_metadata->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
+
+        _slots.emplace_back(0, "c0", TypeDescriptor{LogicalType::TYPE_INT});
+        _slots.emplace_back(1, "c1", TypeDescriptor{LogicalType::TYPE_INT});
+        _slots.emplace_back(2, "__op", TypeDescriptor{LogicalType::TYPE_INT});
+        _slot_pointers.emplace_back(&_slots[0]);
+        _slot_pointers.emplace_back(&_slots[1]);
+        _slot_pointers.emplace_back(&_slots[2]);
+
+        _slot_cid_map.emplace(0, 0);
+        _slot_cid_map.emplace(1, 1);
+        _slot_cid_map.emplace(2, 2);
+
+        _tablet_schema = TabletSchema::create(_tablet_metadata->schema());
+        _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+    }
+
+    void SetUp() override {
+        clear_and_init_test_dir();
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+        StorageEnv::GetInstance()->parallel_compact_mgr()->TEST_set_tablet_mgr(_tablet_mgr.get());
+    }
+
+    void TearDown() override { remove_test_dir_ignore_error(); }
+
+protected:
+    // One chunk of `kNumKeys` rows, keys 0..kNumKeys-1, all upserts or all deletes.
+    ChunkPtr gen_chunk(bool upsert) {
+        std::vector<int> v0(kNumKeys);
+        std::vector<int> v1(kNumKeys);
+        std::vector<uint8_t> v2(kNumKeys);
+        for (int i = 0; i < kNumKeys; i++) {
+            v0[i] = i;
+            v1[i] = i * 3;
+            v2[i] = upsert ? TOpType::UPSERT : TOpType::DELETE;
+        }
+        auto c0 = Int32Column::create();
+        auto c1 = Int32Column::create();
+        auto c2 = Int8Column::create();
+        c0->append_numbers(v0.data(), v0.size() * sizeof(int));
+        c1->append_numbers(v1.data(), v1.size() * sizeof(int));
+        c2->append_numbers(v2.data(), v2.size() * sizeof(uint8_t));
+        return std::make_shared<Chunk>(Columns{std::move(c0), std::move(c1), std::move(c2)}, _slot_cid_map);
+    }
+
+    // Write one statement of a transaction. `load_id == nullptr` means an ordinary single-statement
+    // load; otherwise the writer emits a per-load_id txn log, which is what a multi-statement
+    // transaction does.
+    void write_statement(int64_t txn_id, const PUniqueId* load_id, bool upsert) {
+        auto chunk = gen_chunk(upsert);
+        std::vector<uint32_t> indexes(chunk->num_rows());
+        for (uint32_t i = 0; i < chunk->num_rows(); i++) {
+            indexes[i] = i;
+        }
+        DeltaWriterBuilder builder;
+        builder.set_tablet_manager(_tablet_mgr.get())
+                .set_tablet_id(_tablet_metadata->id())
+                .set_txn_id(txn_id)
+                .set_partition_id(_partition_id)
+                .set_mem_tracker(_mem_tracker.get())
+                .set_schema_id(_tablet_schema->id())
+                .set_slot_descriptors(&_slot_pointers)
+                .set_profile(&_dummy_runtime_profile);
+        if (load_id != nullptr) {
+            builder.set_load_id(*load_id).set_is_multi_statements_txn(true);
+        }
+        ASSIGN_OR_ABORT(auto delta_writer, builder.build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*chunk, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+    }
+
+    // Publish one transaction whose statements were written under `load_ids` (the merged-rowset
+    // path), optionally rebuilding the persistent index first (what a CN restart does).
+    StatusOr<TabletMetadataPtr> publish_multi_statement(int64_t base_version, int64_t new_version, int64_t txn_id,
+                                                        const std::vector<PUniqueId>& load_ids, bool rebuild_pindex) {
+        // Publish through lake::publish_version directly rather than the RPC service: the service
+        // implementation is not linked into this test binary, and the only thing the RPC layer adds
+        // here is unpacking the request into exactly this TxnInfoPB. load_ids is the part that
+        // matters -- it is what makes this a multi-statement transaction, whose op_writes
+        // TxnLogApplier folds into one rowset.
+        TxnInfoPB info;
+        info.set_txn_id(txn_id);
+        info.set_txn_type(TXN_NORMAL);
+        info.set_combined_txn_log(false);
+        info.set_commit_time(time(nullptr));
+        info.set_force_publish(false);
+        info.set_rebuild_pindex(rebuild_pindex);
+        for (const auto& load_id : load_ids) {
+            info.add_load_ids()->CopyFrom(load_id);
+        }
+        std::vector<TxnInfoPB> txns{info};
+        auto res = publish_version(_tablet_mgr.get(), PublishTabletInfo(_tablet_metadata->id()), base_version,
+                                   new_version, txns, false);
+        RETURN_IF_ERROR(res.status());
+        return res;
+    }
+
+    int64_t read_rows(int64_t version) {
+        ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(_tablet_metadata->id(), version));
+        auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata, *_schema);
+        CHECK_OK(reader->prepare());
+        CHECK_OK(reader->open(TabletReaderParams()));
+        int64_t rows = 0;
+        while (true) {
+            auto chunk = ChunkFactory::new_chunk(*_schema, 128);
+            auto st = reader->get_next(chunk.get());
+            if (st.is_end_of_file()) {
+                break;
+            }
+            CHECK_OK(st);
+            rows += chunk->num_rows();
+        }
+        return rows;
+    }
+
+    static PUniqueId make_load_id(int64_t hi, int64_t lo) {
+        PUniqueId id;
+        id.set_hi(hi);
+        id.set_lo(lo);
+        return id;
+    }
+
+    static uint32_t max_segment_idx(const RowsetMetadataPB& rowset) {
+        uint32_t max_idx = 0;
+        for (int i = 0; i < rowset.segment_metas_size(); i++) {
+            const auto& seg = rowset.segment_metas(i);
+            max_idx = std::max(max_idx, seg.has_segment_idx() ? seg.segment_idx() : static_cast<uint32_t>(i));
+        }
+        return max_idx;
+    }
+
+    // The single rowset carrying a del file, i.e. the merged rowset of the multi-statement txn.
+    static const RowsetMetadataPB* rowset_with_del(const TabletMetadataPB& metadata) {
+        const RowsetMetadataPB* found = nullptr;
+        for (const auto& rowset : metadata.rowsets()) {
+            if (rowset.del_files_size() > 0) {
+                EXPECT_EQ(nullptr, found) << "more than one rowset carries a del file";
+                found = &rowset;
+            }
+        }
+        return found;
+    }
+
+    // Seed the table at version 2, then run the multi-statement transaction at version 3:
+    // statement 1 deletes every key, statement 2 re-upserts every key.
+    void seed_and_run_multi_statement_txn() {
+        // version 2: an ordinary load establishing the keys.
+        auto seed_txn = next_id();
+        write_statement(seed_txn, nullptr, /*upsert=*/true);
+        ASSERT_OK(publish_single_version(_tablet_metadata->id(), 2, seed_txn).status());
+        ASSERT_EQ(kNumKeys, read_rows(2));
+
+        // version 3: BEGIN; DELETE every key; INSERT every key back; COMMIT;
+        auto txn_id = next_id();
+        auto del_load_id = make_load_id(1, 1);
+        auto reinsert_load_id = make_load_id(1, 2);
+        write_statement(txn_id, &del_load_id, /*upsert=*/false);
+        write_statement(txn_id, &reinsert_load_id, /*upsert=*/true);
+        ASSERT_OK(publish_multi_statement(2, 3, txn_id, {del_load_id, reinsert_load_id},
+                                          /*rebuild_pindex=*/false)
+                          .status());
+        // The re-inserted rows are the live ones; the seeded rows are delete-vector-masked.
+        ASSERT_EQ(kNumKeys, read_rows(3));
+    }
+
+    inline static const std::string kTestGroupPath = "test_lake_merged_del_op_offset_" + std::to_string(getpid());
+    constexpr static int kNumKeys = 20;
+
+    std::shared_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<Schema> _schema;
+    int64_t _partition_id = next_id();
+    std::vector<SlotDescriptor> _slots;
+    std::vector<SlotDescriptor*> _slot_pointers;
+    Chunk::SlotHashMap _slot_cid_map;
+    RuntimeProfile _dummy_runtime_profile{"dummy"};
+};
+
+// A del file's persisted op_offset must name the last segment of the STATEMENT that produced it, not
+// the last segment of the merged rowset: it is the only thing that tells the rebuild the delete came
+// before the later statements' segments.
+TEST_F(LakeMergedDelOpOffsetTest, del_op_offset_stays_within_its_own_statement) {
+    // branch-4.1's product default: the writer records no per-del op_offset, so persist has to
+    // derive it. Pinned, so the test exercises that path whatever the default is.
+    ConfigResetGuard preserve_order_guard(&config::lake_enable_pk_preserve_txn_delete_order, false);
+    seed_and_run_multi_statement_txn();
+
+    ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(_tablet_metadata->id(), 3));
+    const auto* merged = rowset_with_del(*metadata);
+    ASSERT_NE(nullptr, merged);
+    ASSERT_EQ(1, merged->del_files_size());
+    // The re-upsert statement's segments were appended after the delete statement's reserved slot.
+    ASSERT_GT(max_segment_idx(*merged), 0u);
+    ASSERT_TRUE(merged->del_files(0).has_op_offset());
+    EXPECT_LT(merged->del_files(0).op_offset(), max_segment_idx(*merged))
+            << "op_offset " << merged->del_files(0).op_offset() << " reaches the merged rowset's last segment, so the "
+            << "rebuild replays this delete over the re-inserted rows instead of before them";
+}
+
+// The end-to-end mechanism: rebuild the persistent index (what a CN restart or a tablet
+// re-placement does) and then upsert the same keys again. If the rebuild dropped the re-inserted
+// keys from the index, that upsert cannot mask their rows and the table ends up with two live rows
+// per key.
+TEST_F(LakeMergedDelOpOffsetTest, rebuild_after_delete_and_reinsert_keeps_one_row_per_key) {
+    // branch-4.1's product default: the writer records no per-del op_offset, so persist has to
+    // derive it. Pinned, so the test exercises that path whatever the default is.
+    ConfigResetGuard preserve_order_guard(&config::lake_enable_pk_preserve_txn_delete_order, false);
+    seed_and_run_multi_statement_txn();
+
+    // version 4: rebuild the index from object storage, then upsert the same keys.
+    auto txn_id = next_id();
+    write_statement(txn_id, nullptr, /*upsert=*/true);
+    ASSERT_OK(publish_single_version(_tablet_metadata->id(), 4, txn_id, /*rebuild_pindex=*/true).status());
+    EXPECT_EQ(kNumKeys, read_rows(4)) << "the rebuild lost the re-inserted keys from the index, so the upsert at "
+                                      << "version 4 wrote no delete-vector mark and left two live rows per key";
+}
+
+// The two tests above both put the delete FIRST, so its statement's reserved slot is seg_base == 0 and
+// apply's `0` fallback happens to be right. A pure-delete statement in the MIDDLE has a non-zero
+// reserved slot and a later statement adds segments above it, which is the only arrangement where the
+// two sides can disagree: a trailing pure-delete's reserved slot IS the merged maximum, so the clamp
+// makes both sides land on the same value and nothing is proved.
+TEST_F(LakeMergedDelOpOffsetTest, pure_delete_statement_between_two_upsert_statements) {
+    ConfigResetGuard preserve_order_guard(&config::lake_enable_pk_preserve_txn_delete_order, false);
+
+    auto seed_txn = next_id();
+    write_statement(seed_txn, nullptr, /*upsert=*/true);
+    ASSERT_OK(publish_single_version(_tablet_metadata->id(), 2, seed_txn).status());
+    ASSERT_EQ(kNumKeys, read_rows(2));
+
+    // version 3: BEGIN; INSERT; DELETE; INSERT; COMMIT;
+    auto txn_id = next_id();
+    auto first_upsert = make_load_id(2, 1);
+    auto del_load_id = make_load_id(2, 2);
+    auto second_upsert = make_load_id(2, 3);
+    write_statement(txn_id, &first_upsert, /*upsert=*/true);
+    write_statement(txn_id, &del_load_id, /*upsert=*/false);
+    write_statement(txn_id, &second_upsert, /*upsert=*/true);
+    ASSERT_OK(publish_multi_statement(2, 3, txn_id, {first_upsert, del_load_id, second_upsert},
+                                      /*rebuild_pindex=*/false)
+                      .status());
+    // The last statement re-inserted every key, so every key is live.
+    ASSERT_EQ(kNumKeys, read_rows(3));
+
+    ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(_tablet_metadata->id(), 3));
+    const auto* merged = rowset_with_del(*metadata);
+    ASSERT_NE(nullptr, merged);
+    ASSERT_EQ(1, merged->del_files_size());
+    ASSERT_TRUE(merged->del_files(0).has_op_offset());
+    EXPECT_LT(merged->del_files(0).op_offset(), max_segment_idx(*merged))
+            << "a pure-delete statement in the middle was persisted at the merged rowset's last segment, "
+            << "so the rebuild replays it over the following statement's re-inserted rows";
+
+    // The rebuild must reach the same verdict apply did: every key live, exactly once.
+    auto probe_txn = next_id();
+    write_statement(probe_txn, nullptr, /*upsert=*/true);
+    ASSERT_OK(publish_single_version(_tablet_metadata->id(), 4, probe_txn, /*rebuild_pindex=*/true).status());
+    EXPECT_EQ(kNumKeys, read_rows(4))
+            << "after rebuilding the index the re-upsert left duplicates or lost rows, so apply and the "
+            << "rebuild placed the middle pure-delete at different positions";
+}
+
+} // namespace starrocks::lake

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -1262,11 +1262,20 @@ TEST_F(MetaFileTest, test_batch_apply_opwrite_merge_dels) {
     EXPECT_EQ(9, final_rowset.segment_metas(1).segment_idx());
     EXPECT_EQ(14, final_rowset.segment_metas(2).segment_idx());
     ASSERT_EQ(3, final_rowset.del_files_size());
+    // A del's op_offset names the last segment of the op_write that PRODUCED it, in the merged
+    // rowset's segment-id space -- not the merged rowset's last segment. batch 1's segments land at
+    // 3 and 9, so its two dels resolve to 9; batch 2's single segment lands at 14, so its del
+    // resolves to 14. Recording all three at 14 (what an unresolved -1 used to produce in
+    // set_final_rowset) would sort batch 1's deletes after batch 2's segment, which is not where
+    // apply put them.
     std::set<std::string> del_names;
+    std::map<std::string, uint32_t> expected_op_offset{{"d1.del", 9}, {"d2.del", 9}, {"d3.del", 14}};
     for (int i = 0; i < final_rowset.del_files_size(); ++i) {
-        del_names.insert(final_rowset.del_files(i).name());
+        const auto& name = final_rowset.del_files(i).name();
+        del_names.insert(name);
         EXPECT_EQ(final_rowset.id(), final_rowset.del_files(i).origin_rowset_id());
-        EXPECT_EQ(14, final_rowset.del_files(i).op_offset());
+        ASSERT_TRUE(expected_op_offset.count(name) > 0) << name;
+        EXPECT_EQ(expected_op_offset[name], final_rowset.del_files(i).op_offset()) << name;
     }
     EXPECT_TRUE(del_names.count("d1.del") > 0);
     EXPECT_TRUE(del_names.count("d2.del") > 0);
@@ -1315,7 +1324,10 @@ TEST_F(MetaFileTest, test_batch_apply_opwrite_mixed_segment_meta_presence) {
     EXPECT_EQ(1, final_rowset.segment_metas(1).segment_idx());
     EXPECT_EQ(2, final_rowset.segment_metas(2).segment_idx());
     ASSERT_EQ(2, final_rowset.del_files_size());
-    EXPECT_EQ(2, final_rowset.del_files(0).op_offset());
+    // Same contract as test_batch_apply_opwrite_merge_dels: each del follows its own op_write's last
+    // segment. batch 1's segments are positional 0 and 1, so d1 resolves to 1; batch 2's single
+    // segment is remapped to 2, so d2 resolves to 2.
+    EXPECT_EQ(1, final_rowset.del_files(0).op_offset());
     EXPECT_EQ(2, final_rowset.del_files(1).op_offset());
     EXPECT_EQ(603, metadata->next_rowset_id());
 }


### PR DESCRIPTION
## Why I'm doing:

A del file's position inside a merged rowset is resolved **twice**, by two pieces of code, and they did
not agree.

`TxnLogApplier` folds every `op_write` of a multi-statement transaction into one rowset
(`MetaFileBuilder::add_rowset`). Each del file carries an `op_offset` saying which segment it follows.
When the writer did not record one, the two sides diverged:

* **apply** (`UpdateManager::publish_primary_key_tablet` → `build_del_interleave_plan`) resolves an
  unrecorded offset to `max_segment_id`, computed over **that `op_write`'s own segments** — i.e. right
  after its own statement.
* **index rebuild** (`MetaFileBuilder::set_final_rowset`) kept it as `-1` and resolved it against the
  **merged** rowset — i.e. after every *later* statement's segments too, and, being at the maximum,
  without the ordering filter.

So on rebuild the delete replays over rows a later statement of the same transaction had re-inserted.
Those rows are live and not delete-vector-masked, so their index entries are erased while the rows
remain. The next upsert of such a key then finds nothing, writes **no delete-vector mark** for the row
that is still there, and leaves two live rows for one key. A following rebuild reports

```
Already exist: PersistentIndexMemtable<12> insert found duplicate key ...
prepare_primary_index: load primary index failed
```

and publish never recovers — every retry for every partition of the table fails.

Note the failure mode: because the index entry is *erased* rather than left stale, the delete-vector
consistency check (`cur_old + cur_add != cur_new`) never fires. The corruption is silent until a
rebuild, which only happens when a CN restarts or a tablet moves.

## What I'm doing:

Resolve the position **once**, in `add_rowset()`, where the `op_write` that produced the del file is
still in hand, using the same expression apply uses (`seg_base + get_segment_idx()` for a recorded
offset, "right after this `op_write`'s own last segment" for an unrecorded one). An `op_write` with no
segments — a pure-delete statement — resolves to `seg_base`, the slot `get_rowset_id_step()` reserves
for it and which therefore holds no segment, so it erases every earlier statement's rows and nothing
later, which is what apply already did.

Plus a clamp in `set_final_rowset()` so a trailing pure-delete statement's reserved slot cannot point
past the rowset's own rssid range.

+27/-5 in `be/src/storage/lake/meta_file.cpp`.

## Scope, honestly

* **On `main` with default config this is not reachable.** `lake_enable_pk_preserve_txn_delete_order`
  defaults to `true` here, so offsets are recorded and the two sides already agree. It becomes
  reachable when that mutable config is turned off, and on release lines where it defaults off.
  The value of this change on `main` is that apply and rebuild now resolve a del's position
  **identically and unconditionally**, rather than agreeing only because a config happens to be on.
* This is **not** claimed to be the fix for the shared-data PK duplicate-key report that led me here
  (issue 78224, referenced without a link deliberately). Reaching this producer needs an explicit
  multi-statement SQL transaction, and that reporter runs no DML; their first occurrence was also on a
  version where this machinery did not exist yet. Same error signature, different producer — please do
  not treat this PR as closing that report.
* A 4.1 variant is open separately as #78295 (draft) — it is the same change against `branch-4.1`,
  where the config defaults off and the path is therefore live.

## Tests

`be/test/storage/lake/lake_merged_del_op_offset_test.cpp`, two cases, both failing on stock `main`:

* `del_op_offset_stays_within_its_own_statement` — pins the invariant: the position `set_final_rowset`
  records must equal the one apply computed.
* `rebuild_after_delete_and_reinsert_keeps_one_row_per_key` — drives delete-then-re-insert of a key
  band across statements of one transaction and rebuilds the index, asserting one live row per key.

The tests pin `lake_enable_pk_preserve_txn_delete_order` with a `ConfigResetGuard`, so they exercise
the unrecorded-offset path regardless of the branch's default.

Also verified end to end on a shared-data TSP cluster before/after: **217 occurrences** of the
duplicate-key failure on the unfixed build, **0** on the fixed build over 3 restart cycles, with the
duplicate count from `SELECT COUNT(*), COUNT(DISTINCT k0, k1)` going 100 → 0.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

No version boxes ticked on purpose: the 4.1 change is already open as #78295, and `branch-4.0` /
`branch-3.5` do not carry the `del_op_offsets` machinery at all.
