### PR TITLE
[BugFix] Stop array_sort's comparator validation from sharing an error Status across drivers

### DIFF
--- a/be/src/exprs/array_sort_lambda_expr.cpp
+++ b/be/src/exprs/array_sort_lambda_expr.cpp
@@ -415,9 +415,10 @@ Status ArraySortLambdaExpr::check_lambda_only_depends_on_args(const LambdaFuncti
 // Validate strict weak ordering properties of the lambda comparator
 Status ArraySortLambdaExpr::validate_strict_weak_ordering(ExprContext* context, Chunk* chunk,
                                                           const ArrayColumn* array_col) {
-    // Check cache first to avoid duplicate validation
-    if (_comparator_validated) {
-        return _comparator_validation_status;
+    // A comparator that already passed validation is not checked again. Errors are never
+    // cached (see the declaration of _comparator_validated).
+    if (_comparator_validated.load(std::memory_order_relaxed)) {
+        return Status::OK();
     }
 
     const auto& element_col = array_col->elements_column();
@@ -465,11 +466,7 @@ Status ArraySortLambdaExpr::validate_strict_weak_ordering(ExprContext* context, 
     for (size_t i = 0; i < unique_indices.size(); ++i) {
         ASSIGN_OR_RETURN(bool result, compare(i, i));
         if (result) {
-            Status error = Status::InvalidArgument(
-                    "Comparator violates irreflexivity: cmp(a, a) returned true for an element");
-            _comparator_validated = true;
-            _comparator_validation_status = error;
-            return error;
+            return Status::InvalidArgument("Comparator violates irreflexivity: cmp(a, a) returned true for an element");
         }
     }
 
@@ -480,11 +477,8 @@ Status ArraySortLambdaExpr::validate_strict_weak_ordering(ExprContext* context, 
             ASSIGN_OR_RETURN(bool cmp_ji, compare(j, i));
 
             if (cmp_ij && cmp_ji) {
-                Status error = Status::InvalidArgument(
+                return Status::InvalidArgument(
                         "Comparator violates asymmetry: both cmp(a, b) and cmp(b, a) returned true");
-                _comparator_validated = true;
-                _comparator_validation_status = error;
-                return error;
             }
         }
     }
@@ -508,12 +502,9 @@ Status ArraySortLambdaExpr::validate_strict_weak_ordering(ExprContext* context, 
                 // If cmp(i,j)=true and cmp(j,k)=true, then cmp(i,k) must be true
                 if ((cmp_ij && cmp_jk && !cmp_ik) || (cmp_ji && cmp_ik && !cmp_jk) || (cmp_jk && cmp_ki && !cmp_ji) ||
                     (cmp_kj && cmp_ji && !cmp_ki) || (cmp_ik && cmp_kj && !cmp_ij) || (cmp_ki && cmp_ij && !cmp_kj)) {
-                    Status error = Status::InvalidArgument(
+                    return Status::InvalidArgument(
                             "Comparator violates transitivity: cmp(a, b)=true and cmp(b, c)=true but "
                             "cmp(a, c)=false");
-                    _comparator_validated = true;
-                    _comparator_validation_status = error;
-                    return error;
                 }
 
                 // Check equivalence transitivity: if all comparisons between i, j, k are false,
@@ -521,21 +512,16 @@ Status ArraySortLambdaExpr::validate_strict_weak_ordering(ExprContext* context, 
                 if ((!cmp_ij && !cmp_ji && !cmp_jk && !cmp_kj && (cmp_ik || cmp_ki)) ||
                     (!cmp_ij && !cmp_ji && !cmp_ik && !cmp_ki && (cmp_jk || cmp_kj)) ||
                     (!cmp_jk && !cmp_kj && !cmp_ik && !cmp_ki && (cmp_ij || cmp_ji))) {
-                    Status error = Status::InvalidArgument(
+                    return Status::InvalidArgument(
                             "Comparator violates incomparability transitivity: elements a, b, c are equivalent "
                             "(cmp(a,b)=false, cmp(b,a)=false, cmp(b,c)=false, cmp(c,b)=false) but "
                             "cmp(a,c) or cmp(c,a) returned true");
-                    _comparator_validated = true;
-                    _comparator_validation_status = error;
-                    return error;
                 }
             }
         }
     }
 
-    // Cache the validation result
-    _comparator_validated = true;
-    _comparator_validation_status = Status::OK();
+    _comparator_validated.store(true, std::memory_order_relaxed);
     return Status::OK();
 }
 

--- a/be/src/exprs/array_sort_lambda_expr.h
+++ b/be/src/exprs/array_sort_lambda_expr.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <unordered_set>
 
 #include "column/nullable_column.h"
@@ -38,6 +39,12 @@ public:
 
     void close(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) override;
 
+    ArraySortLambdaExpr(const ArraySortLambdaExpr& other)
+            : Expr(other),
+              _outer_common_exprs(other._outer_common_exprs),
+              _initial_required_slots(other._initial_required_slots),
+              _comparator_validated(other._comparator_validated.load(std::memory_order_relaxed)) {}
+
     Expr* clone(ObjectPool* pool) const override { return pool->add(new ArraySortLambdaExpr(*this)); }
 
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override;
@@ -59,8 +66,13 @@ private:
     // the slots initially required for lambda function evaluation, excluding lambda arguments,
     // other common expressions can be evaluated based on these slots.
     std::unordered_set<SlotId> _initial_required_slots;
-    // Cache for strict weak ordering validation result to avoid duplicate checks
-    mutable bool _comparator_validated = false;
-    mutable Status _comparator_validation_status = Status::OK();
+    // Set once the lambda comparator has passed the strict weak ordering validation, so that
+    // later chunks skip it. The Expr tree is shared by every pipeline driver of the fragment
+    // (a driver only clones its ExprContext), so this is read and written concurrently and
+    // must stay a lock-free flag. Only the OK verdict is cached: an error Status owns heap
+    // state, and publishing one through a shared member races with a driver that is copying
+    // it out at the same time (use-after-free). A failing comparator fails the query anyway,
+    // so re-running the cheap sampled validation on every chunk until then costs nothing.
+    std::atomic<bool> _comparator_validated{false};
 };
 } // namespace starrocks

--- a/be/test/exprs/CMakeLists.txt
+++ b/be/test/exprs/CMakeLists.txt
@@ -45,6 +45,7 @@ set(EXPR_TEST_FILES
     in_const_predicate_test.cpp
     in_predicate_test.cpp
     is_null_predicate_test.cpp
+    array_sort_lambda_expr_test.cpp
     lambda_array_expr_test.cpp
     lambda_map_expr_test.cpp
     binary_predicate_core_test.cpp

--- a/be/test/exprs/array_sort_lambda_expr_test.cpp
+++ b/be/test/exprs/array_sort_lambda_expr_test.cpp
@@ -1,0 +1,216 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exprs/array_sort_lambda_expr.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#include "base/testutil/assert.h"
+#include "column/chunk.h"
+#include "column/column_helper.h"
+#include "column/fixed_length_column.h"
+#include "common/object_pool.h"
+#include "exprs/binary_predicate.h"
+#include "exprs/column_ref.h"
+#include "exprs/expr_context.h"
+#include "exprs/expr_executor.h"
+#include "exprs/lambda_function.h"
+#include "exprs/mock_vectorized_expr.h"
+#include "runtime/runtime_state.h"
+#include "types/datum.h"
+#include "types/logical_type.h"
+#include "types/type_descriptor.h"
+
+namespace starrocks {
+
+class ArraySortLambdaExprTest : public ::testing::Test {
+protected:
+    static constexpr SlotId kArgX = 100000;
+    static constexpr SlotId kArgY = 100001;
+    static constexpr size_t kNumRows = 3;
+
+    // An array<int> column with kNumRows rows of [4, 1, 3]. Non-nullable, so evaluation never
+    // has to touch the shared column in place.
+    Expr* make_array_expr() {
+        auto array = ColumnHelper::create_column(TYPE_INT_ARRAY_DESC, false);
+        for (size_t i = 0; i < kNumRows; ++i) {
+            array->append_datum(DatumArray{Datum((int32_t)4), Datum((int32_t)1), Datum((int32_t)3)});
+        }
+        TExprNode node;
+        node.__set_node_type(TExprNodeType::INT_LITERAL);
+        node.__set_num_children(0);
+        node.__set_type(TYPE_INT_ARRAY_DESC.to_thrift());
+        auto* expr = _pool.add(new FakeConstExpr(node));
+        expr->_column = std::move(array);
+        return expr;
+    }
+
+    ColumnRef* make_arg_ref(SlotId slot_id) {
+        TExprNode slot_ref;
+        slot_ref.node_type = TExprNodeType::SLOT_REF;
+        slot_ref.type = gen_type_desc(TPrimitiveType::INT);
+        slot_ref.num_children = 0;
+        slot_ref.__isset.slot_ref = true;
+        slot_ref.slot_ref.slot_id = slot_id;
+        slot_ref.slot_ref.tuple_id = 0;
+        slot_ref.__set_is_nullable(true);
+        return _pool.add(new ColumnRef(slot_ref));
+    }
+
+    // (x, y) -> x <op> y
+    LambdaFunction* make_comparator(TExprOpcode::type op) {
+        TExprNode pred_node;
+        pred_node.node_type = TExprNodeType::BINARY_PRED;
+        pred_node.opcode = op;
+        pred_node.child_type = TPrimitiveType::INT;
+        pred_node.num_children = 2;
+        pred_node.__isset.opcode = true;
+        pred_node.__isset.child_type = true;
+        pred_node.type = gen_type_desc(TPrimitiveType::BOOLEAN);
+        Expr* pred = _pool.add(VectorizedBinaryPredicateFactory::from_thrift(pred_node));
+        pred->add_child(make_arg_ref(kArgX));
+        pred->add_child(make_arg_ref(kArgY));
+
+        TExprNode lambda_node;
+        lambda_node.node_type = TExprNodeType::LAMBDA_FUNCTION_EXPR;
+        lambda_node.num_children = 3;
+        lambda_node.type = gen_type_desc(TPrimitiveType::BOOLEAN);
+        auto* lambda = _pool.add(new LambdaFunction(lambda_node));
+        lambda->add_child(pred);
+        lambda->add_child(make_arg_ref(kArgX));
+        lambda->add_child(make_arg_ref(kArgY));
+        return lambda;
+    }
+
+    // array_sort(array, (x, y) -> x <op> y)
+    ArraySortLambdaExpr* make_array_sort(TExprOpcode::type op) {
+        auto* expr = _pool.add(new ArraySortLambdaExpr(TYPE_INT_ARRAY_DESC));
+        expr->add_child(make_array_expr());
+        expr->add_child(make_comparator(op));
+        return expr;
+    }
+
+    // A chunk whose row count matches the array column (the array itself is produced by the
+    // fake const expr, so the chunk only needs a column for the row count).
+    static std::shared_ptr<Chunk> make_chunk() {
+        auto chunk = std::make_shared<Chunk>();
+        auto rows = Int32Column::create();
+        for (size_t i = 0; i < kNumRows; ++i) {
+            rows->append(static_cast<int32_t>(i));
+        }
+        chunk->append_column(std::move(rows), 1);
+        return chunk;
+    }
+
+    // Evaluate `expr` from `num_threads` threads at once, each through its own cloned
+    // ExprContext, the way the pipeline drivers of one fragment share a single Expr tree.
+    template <typename Check>
+    void evaluate_concurrently(ArraySortLambdaExpr* expr, int num_threads, int iterations, Check check) {
+        ExprContext root_ctx(expr);
+        std::vector<ExprContext*> ctxs = {&root_ctx};
+        ASSERT_OK(ExprExecutor::prepare(ctxs, &_runtime_state));
+        ASSERT_OK(ExprExecutor::open(ctxs, &_runtime_state));
+
+        std::vector<ExprContext*> clones(num_threads, nullptr);
+        for (auto& clone : clones) {
+            ASSERT_OK(root_ctx.clone(&_runtime_state, &_pool, &clone));
+        }
+
+        std::atomic<int> failures{0};
+        std::vector<std::thread> threads;
+        threads.reserve(num_threads);
+        for (int t = 0; t < num_threads; ++t) {
+            threads.emplace_back([&, t]() {
+                auto chunk = make_chunk();
+                for (int i = 0; i < iterations; ++i) {
+                    // Drop the "already validated" mark so that every iteration re-runs the
+                    // validation and re-publishes its verdict while the other threads read it;
+                    // otherwise only the first pass of each thread would exercise that window.
+                    expr->_comparator_validated = false;
+                    if (!check(clones[t]->evaluate(expr, chunk.get()))) {
+                        failures.fetch_add(1, std::memory_order_relaxed);
+                    }
+                }
+            });
+        }
+        for (auto& thread : threads) {
+            thread.join();
+        }
+        ASSERT_EQ(0, failures.load());
+
+        for (auto* clone : clones) {
+            ExprExecutor::close(clone, &_runtime_state);
+        }
+        ExprExecutor::close(ctxs, &_runtime_state);
+    }
+
+    RuntimeState _runtime_state;
+    ObjectPool _pool;
+};
+
+// The comparator validation used to cache its verdict, including an error Status, in members
+// of the Expr. The Expr tree is shared by every driver of a fragment, so with an invalid
+// comparator one driver assigned the cached Status (freeing its previous state) while another
+// copied it out to return it: a heap use-after-free. Every driver must now get the error back
+// without the Expr publishing shared mutable state.
+TEST_F(ArraySortLambdaExprTest, invalid_comparator_rejected_concurrently) {
+    // x <= y is reflexive, which strict weak ordering forbids.
+    auto* expr = make_array_sort(TExprOpcode::LE);
+    evaluate_concurrently(expr, 8, 200, [](const StatusOr<ColumnPtr>& result) {
+        return !result.ok() && result.status().is_invalid_argument() &&
+               result.status().message().find("irreflexivity") != std::string::npos;
+    });
+}
+
+// A valid comparator is validated once and every driver keeps producing sorted arrays.
+TEST_F(ArraySortLambdaExprTest, valid_comparator_sorts_concurrently) {
+    auto* expr = make_array_sort(TExprOpcode::LT);
+    evaluate_concurrently(expr, 8, 200, [](const StatusOr<ColumnPtr>& result) {
+        if (!result.ok() || result.value()->size() != kNumRows) {
+            return false;
+        }
+        for (size_t row = 0; row < kNumRows; ++row) {
+            auto sorted = result.value()->get(row).get_array();
+            if (sorted.size() != 3 || sorted[0].get_int32() != 1 || sorted[1].get_int32() != 3 ||
+                sorted[2].get_int32() != 4) {
+                return false;
+            }
+        }
+        return true;
+    });
+}
+
+// A failed validation must not poison the Expr: the same tree still rejects the comparator on
+// the next chunk with the same error instead of returning a stale or an OK verdict.
+TEST_F(ArraySortLambdaExprTest, invalid_comparator_error_is_not_cached) {
+    auto* expr = make_array_sort(TExprOpcode::LE);
+    ExprContext ctx(expr);
+    std::vector<ExprContext*> ctxs = {&ctx};
+    ASSERT_OK(ExprExecutor::prepare(ctxs, &_runtime_state));
+    ASSERT_OK(ExprExecutor::open(ctxs, &_runtime_state));
+    auto chunk = make_chunk();
+    for (int i = 0; i < 3; ++i) {
+        auto result = ctx.evaluate(expr, chunk.get());
+        ASSERT_FALSE(result.ok());
+        ASSERT_TRUE(result.status().is_invalid_argument()) << result.status();
+        ASSERT_NE(std::string::npos, result.status().message().find("irreflexivity")) << result.status();
+    }
+    ExprExecutor::close(ctxs, &_runtime_state);
+}
+
+} // namespace starrocks

--- a/test/sql/test_array_fn/R/test_array_sort_lambda
+++ b/test/sql/test_array_fn/R/test_array_sort_lambda
@@ -306,3 +306,103 @@ SELECT array_sort([7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,1,2,3,4,5], (x, y) ->
 -- result:
 [REGEX].*Comparator violates asymmetry.*
 -- !result
+
+-- name: test_array_sort_lambda_inconsistent_comparator_concurrent
+set pipeline_dop = 16;
+-- result:
+-- !result
+create table t0 (
+    k0 int,
+    c0 array<int>
+)
+duplicate key(k0)
+distributed by hash(k0) buckets 16
+properties(
+   "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t0 select i, [2, 1, 3] from table(generate_series(1, 200000)) t(i);
+-- result:
+-- !result
+SELECT count(array_sort(c0, (x, y) -> x <= y)) from t0;
+-- result:
+[REGEX].*Comparator violates irreflexivity.*
+-- !result
+SELECT count(array_sort(c0, (x, y) -> x <= y)) from t0;
+-- result:
+[REGEX].*Comparator violates irreflexivity.*
+-- !result
+SELECT count(array_sort(c0, (x, y) -> x <= y)) from t0;
+-- result:
+[REGEX].*Comparator violates irreflexivity.*
+-- !result
+SELECT count(array_sort(c0, (x, y) -> x <= y)) from t0;
+-- result:
+[REGEX].*Comparator violates irreflexivity.*
+-- !result
+SELECT distinct array_sort(c0, (x, y) -> x < y) from t0;
+-- result:
+[1,2,3]
+-- !result
+drop table t0;
+-- result:
+-- !result
+
+-- name: test_array_sort_lambda_inconsistent_comparator_concurrent
+set pipeline_dop = 64;
+-- result:
+-- !result
+create table t0 (
+    k0 int,
+    c0 array<int>
+)
+duplicate key(k0)
+distributed by hash(k0) buckets 32
+properties(
+   "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t0 select i, [1,2,3,4,5,6,7,8,9,10] from table(generate_series(1, 200000)) t(i);
+-- result:
+-- !result
+SELECT count(array_sort(c0, (x, y) -> CASE WHEN (x=1 and y=2) or (x=2 and y=3) or (x=3 and y=1) THEN -1 WHEN x=1 and y=3 THEN 1 ELSE x-y END)) from t0;
+-- result:
+[REGEX].*Comparator violates transitivity.*
+-- !result
+SELECT count(array_sort(c0, (x, y) -> CASE WHEN (x=1 and y=2) or (x=2 and y=3) or (x=3 and y=1) THEN -1 WHEN x=1 and y=3 THEN 1 ELSE x-y END)) from t0;
+-- result:
+[REGEX].*Comparator violates transitivity.*
+-- !result
+SELECT count(array_sort(c0, (x, y) -> CASE WHEN (x=1 and y=2) or (x=2 and y=3) or (x=3 and y=1) THEN -1 WHEN x=1 and y=3 THEN 1 ELSE x-y END)) from t0;
+-- result:
+[REGEX].*Comparator violates transitivity.*
+-- !result
+SELECT count(array_sort(c0, (x, y) -> CASE WHEN (x=1 and y=2) or (x=2 and y=3) or (x=3 and y=1) THEN -1 WHEN x=1 and y=3 THEN 1 ELSE x-y END)) from t0;
+-- result:
+[REGEX].*Comparator violates transitivity.*
+-- !result
+SELECT count(array_sort(c0, (x, y) -> CASE WHEN (x=1 and y=2) or (x=2 and y=3) or (x=3 and y=1) THEN -1 WHEN x=1 and y=3 THEN 1 ELSE x-y END)) from t0;
+-- result:
+[REGEX].*Comparator violates transitivity.*
+-- !result
+SELECT count(array_sort(c0, (x, y) -> CASE WHEN (x=1 and y=2) or (x=2 and y=3) or (x=3 and y=1) THEN -1 WHEN x=1 and y=3 THEN 1 ELSE x-y END)) from t0;
+-- result:
+[REGEX].*Comparator violates transitivity.*
+-- !result
+SELECT count(array_sort(c0, (x, y) -> CASE WHEN (x=1 and y=2) or (x=2 and y=3) or (x=3 and y=1) THEN -1 WHEN x=1 and y=3 THEN 1 ELSE x-y END)) from t0;
+-- result:
+[REGEX].*Comparator violates transitivity.*
+-- !result
+SELECT count(array_sort(c0, (x, y) -> CASE WHEN (x=1 and y=2) or (x=2 and y=3) or (x=3 and y=1) THEN -1 WHEN x=1 and y=3 THEN 1 ELSE x-y END)) from t0;
+-- result:
+[REGEX].*Comparator violates transitivity.*
+-- !result
+SELECT distinct array_sort(c0, (x, y) -> x < y) from t0;
+-- result:
+[1,2,3,4,5,6,7,8,9,10]
+-- !result
+drop table t0;
+-- result:
+-- !result

--- a/test/sql/test_array_fn/T/test_array_sort_lambda
+++ b/test/sql/test_array_fn/T/test_array_sort_lambda
@@ -169,3 +169,48 @@ SELECT array_sort([101, 102, 103, 104, 105], (x, y) -> if(x > 100 and y > 100, -
 -- duplicates must not crowd the distinct values out of the sample: the leading run of equal
 -- elements compares consistently, the comparator only breaks on pairs of different values
 SELECT array_sort([7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,1,2,3,4,5], (x, y) -> if(x = y, 0, -1));
+
+-- name: test_array_sort_lambda_inconsistent_comparator_concurrent
+-- Regression test for a data race in the comparator validation. The validation verdict used
+-- to be cached in two mutable members of the ArraySortLambdaExpr. A fragment's pipeline
+-- drivers each clone their ExprContext but share the one Expr tree, so when the comparator is
+-- invalid several drivers would reach the error path at once: one assigned the cached error
+-- Status (freeing the previous one's heap state) while another read it, a double-free that
+-- corrupts the heap and crashes the BE (often later, while a fragment tears down). The fix
+-- stops caching the error and keeps only an atomic "validated OK" flag, so no heap-owning
+-- state is shared. After the fix every driver returns the same plain error, no matter the
+-- parallelism. The window is widened here with a comparator that only breaks strict weak
+-- ordering on the last (transitivity) check - so every driver grinds through the whole
+-- O(n^3) validation and they collide on the verdict - and a high pipeline_dop. This is a
+-- timing-dependent crash on a release build; the deterministic reproducer is the unit test
+-- ArraySortLambdaExprTest.invalid_comparator_rejected_concurrently, and it is caught on every
+-- run under ASan (the configuration the fuzzer uses).
+set pipeline_dop = 64;
+create table t0 (
+    k0 int,
+    c0 array<int>
+)
+duplicate key(k0)
+distributed by hash(k0) buckets 32
+properties(
+   "replication_num" = "1"
+);
+
+-- the validator samples the first 10 distinct values, so give it exactly 10
+insert into t0 select i, [1,2,3,4,5,6,7,8,9,10] from table(generate_series(1, 200000)) t(i);
+
+-- passes irreflexivity and asymmetry, violates transitivity: cmp(1,2), cmp(2,3), cmp(3,1) are
+-- all "true" (a cycle), which the validator only catches at its final, most expensive check -
+-- so every driver stays in the validation until they reach the error together.
+SELECT count(array_sort(c0, (x, y) -> CASE WHEN (x=1 and y=2) or (x=2 and y=3) or (x=3 and y=1) THEN -1 WHEN x=1 and y=3 THEN 1 ELSE x-y END)) from t0;
+SELECT count(array_sort(c0, (x, y) -> CASE WHEN (x=1 and y=2) or (x=2 and y=3) or (x=3 and y=1) THEN -1 WHEN x=1 and y=3 THEN 1 ELSE x-y END)) from t0;
+SELECT count(array_sort(c0, (x, y) -> CASE WHEN (x=1 and y=2) or (x=2 and y=3) or (x=3 and y=1) THEN -1 WHEN x=1 and y=3 THEN 1 ELSE x-y END)) from t0;
+SELECT count(array_sort(c0, (x, y) -> CASE WHEN (x=1 and y=2) or (x=2 and y=3) or (x=3 and y=1) THEN -1 WHEN x=1 and y=3 THEN 1 ELSE x-y END)) from t0;
+SELECT count(array_sort(c0, (x, y) -> CASE WHEN (x=1 and y=2) or (x=2 and y=3) or (x=3 and y=1) THEN -1 WHEN x=1 and y=3 THEN 1 ELSE x-y END)) from t0;
+SELECT count(array_sort(c0, (x, y) -> CASE WHEN (x=1 and y=2) or (x=2 and y=3) or (x=3 and y=1) THEN -1 WHEN x=1 and y=3 THEN 1 ELSE x-y END)) from t0;
+SELECT count(array_sort(c0, (x, y) -> CASE WHEN (x=1 and y=2) or (x=2 and y=3) or (x=3 and y=1) THEN -1 WHEN x=1 and y=3 THEN 1 ELSE x-y END)) from t0;
+SELECT count(array_sort(c0, (x, y) -> CASE WHEN (x=1 and y=2) or (x=2 and y=3) or (x=3 and y=1) THEN -1 WHEN x=1 and y=3 THEN 1 ELSE x-y END)) from t0;
+
+-- a valid comparator on the same shape still sorts correctly under the same parallelism
+SELECT distinct array_sort(c0, (x, y) -> x < y) from t0;
+drop table t0;


### PR DESCRIPTION
## Why I'm doing:

```
  ==8336==ERROR: AddressSanitizer: attempting double-free on 0x50700004c450 in thread T5:
      #1 starrocks::Status::~Status()                 src/base/status.h:42        ← delete[] _state
      #2 starrocks::Status::operator=(Status const&)  src/base/status.h:64
      #3 ArraySortLambdaExpr::validate_strict_weak_ordering(...)  array_sort_lambda_expr.cpp:471   ← _comparator_validation_status = error;
      #4 ArraySortLambdaExpr::evaluate_checked(...)   array_sort_lambda_expr.cpp:566
      #5 ExprContext::evaluate(...)                   expr_context.cpp:189
      #6 ...::evaluate_concurrently  test/exprs/array_sort_lambda_expr_test.cpp:145 

  freed by thread T7 here:            
      #1 Status::~Status()            src/base/status.h:42
      #2 Status::operator=(...)       src/base/status.h:64
      #3 validate_strict_weak_ordering(...)  array_sort_lambda_expr.cpp:471
      ...

  previously allocated by thread T4 here:   
      #1 Status::copy_state(char const*)     src/base/status.cpp:61
      #2 Status::Status(Status const&)       src/base/status.h:54
      #3 Status::operator=(...)              src/base/status.h:62
      #4 validate_strict_weak_ordering(...)  array_sort_lambda_expr.cpp:471

```

ArraySortLambdaExpr cached the verdict of validate_strict_weak_ordering() in two mutable members of the Expr, including the error Status for an invalid comparator. The Expr tree is shared by every pipeline driver of a fragment (a driver only clones its ExprContext), so with a comparator such as `(x, y) -> if(x < y, 1, if(x = y, 0, -1))` on a multi-tablet scan, one driver assigned the cached Status - freeing the state of the previous one - while another driver was copying it out to return it. ASan reports this as a heap-use-after-free in Status::copy_state; in release builds it is a silent read of freed memory.

Keep only the "validated OK" verdict, as an atomic flag, and return errors directly without caching them. An invalid comparator fails the query anyway, so re-running the sampled validation on every chunk until the cancellation lands costs nothing, and the Expr no longer publishes any heap-owning state that concurrent drivers could race on. The copy constructor is spelled out because std::atomic is not copyable.

Add a unit test that evaluates one Expr tree from eight cloned contexts at once with an invalid and with a valid comparator, plus a check that a failed validation is not cached.



## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
