### PR TITLE
[Enhancement] Dump jemalloc mapped and retained bytes in be.INFO

### DIFF
--- a/be/src/service/daemon.cpp
+++ b/be/src/service/daemon.cpp
@@ -243,6 +243,8 @@ std::string dump_memory_tracker() {
     DUMP_METRIC(jemalloc_allocated, mem_metrics->jemalloc_allocated_bytes.value())
     DUMP_METRIC(jemalloc_metadata, mem_metrics->jemalloc_metadata_bytes.value())
     DUMP_METRIC(jemalloc_rss, mem_metrics->jemalloc_resident_bytes.value())
+    DUMP_METRIC(jemalloc_mapped, mem_metrics->jemalloc_mapped_bytes.value())
+    DUMP_METRIC(jemalloc_retained, mem_metrics->jemalloc_retained_bytes.value())
     DUMP_METRIC(jemalloc_dirty, mem_metrics->jemalloc_dirty_bytes.value())
     DUMP_METRIC(jemalloc_muzzy, mem_metrics->jemalloc_muzzy_bytes.value())
 


### PR DESCRIPTION
## Why I'm doing:

`stats.mapped` and `stats.retained` are the two metrics needed to tell where
virtual memory growth comes from, but neither shows up in `be.INFO`.

They are disjoint: retained is excluded from mapped (jemalloc 5.3,
`include/jemalloc/internal/pac.h`: *"Number of bytes currently mapped,
excluding retained memory"*), and `mapped + retained` is the address space
jemalloc holds. With `opt.retain=true` (the default on 64-bit Linux) that sum
essentially never shrinks, which is exactly the case operators need to
distinguish from real growth:

- retained grows / mapped flat -> address space fragmentation, RSS unaffected
- mapped grows / active flat -> dirty+muzzy not purged, or metadata growth
- mapped and active grow together -> real usage growth
- VSZ >> mapped + retained -> growth is outside jemalloc (direct mmap)

Only `active/allocated/metadata/rss/dirty/muzzy` were dumped, so none of these
cases could be told apart from the log alone.

## What I'm doing:

Add `jemalloc_mapped` and `jemalloc_retained` to `dump_memory_tracker()` in
`be/src/service/daemon.cpp`. Both values are already collected and registered
by `ProcessMemoryMetrics`; this only adds them to the periodic `LOG(INFO)`
memory statistics line and to the `LOG(ERROR)` one emitted when process memory
exceeds its limit.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
