### PR TITLE
[BugFix] Escalate JAVA_OPTS_FOR_JDK_* warning

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -42,6 +42,57 @@ jdk_version() {
     echo "$result"
 }
 
+# Print a hard-to-miss banner for a deprecated JVM options config parameter.
+# The parameter is still honored, and still overrides JAVA_OPTS, so that upgrades
+# from older versions keep working, but it will be removed in a future release.
+# Output goes to stderr so it is not lost if the caller only redirects stdout.
+# Usage: warn_deprecated_java_opts <component> <var_name> <conf_file>
+warn_deprecated_java_opts() {
+    local component=$1
+    local var_name=$2
+    local conf_file=$3
+    cat >&2 << EOF
+
+################################################################################
+###                                                                          ###
+###         ACTION REQUIRED: DEPRECATED CONFIGURATION PARAMETER              ###
+###                                                                          ###
+################################################################################
+###
+### This DEPRECATED parameter is set and is in effect right now:
+###   $var_name
+###
+### JAVA_OPTS is the only supported place to set JVM parameters.
+###
+### $component still honors it for this start, so that upgrades from older
+### versions keep working, but support WILL BE REMOVED in an upcoming
+### StarRocks release. After that it is IGNORED WITHOUT ANY WARNING:
+### $component falls back to JAVA_OPTS, so every JVM parameter set only
+### here (heap size, GC, add-opens, kerberos, ...) SILENTLY STOPS TAKING
+### EFFECT and the process comes up with a different heap and GC setup.
+###
+EOF
+    if [ ! -z "${JAVA_OPTS}" ] ; then
+        cat >&2 << EOF
+### JAVA_OPTS is also set, and this parameter OVERRIDES IT COMPLETELY.
+### The two are NOT merged, your JAVA_OPTS value is being DISCARDED.
+###
+EOF
+    fi
+    cat >&2 << EOF
+### HOW TO FIX (before your next StarRocks upgrade):
+###   1. Edit $conf_file
+###   2. Move the JVM parameters into JAVA_OPTS, merging them by hand if
+###      JAVA_OPTS already has a value.
+###   3. Delete the line that sets
+###        $var_name
+###   4. Restart $component and confirm this banner is gone.
+###
+################################################################################
+
+EOF
+}
+
 jvm_arch() {
     march=`uname -m`
     case $march in

--- a/bin/start_backend.sh
+++ b/bin/start_backend.sh
@@ -132,7 +132,13 @@ fi
 final_java_opt=${JAVA_OPTS}
 # Compatible with scenarios upgraded from jdk9~jdk16
 if [ ! -z "${JAVA_OPTS_FOR_JDK_9_AND_LATER}" ] ; then
-    echo "Warning: Configuration parameter JAVA_OPTS_FOR_JDK_9_AND_LATER is not supported, JAVA_OPTS is the only place to set jvm parameters"
+    component_name="StarRocks BE"
+    component_conf_file="$STARROCKS_HOME/conf/be.conf"
+    if [ ${RUN_CN} -eq 1 ]; then
+        component_name="StarRocks CN"
+        component_conf_file="$STARROCKS_HOME/conf/cn.conf"
+    fi
+    warn_deprecated_java_opts "$component_name" "JAVA_OPTS_FOR_JDK_9_AND_LATER" "$component_conf_file"
     final_java_opt=${JAVA_OPTS_FOR_JDK_9_AND_LATER}
 fi
 

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -160,7 +160,7 @@ fi
 final_java_opt=${JAVA_OPTS}
 # Compatible with scenarios upgraded from jdk11
 if [ ! -z "${JAVA_OPTS_FOR_JDK_11}" ] ; then
-    echo "Warning: Configuration parameter JAVA_OPTS_FOR_JDK_11 is not supported, JAVA_OPTS is the only place to set jvm parameters"
+    warn_deprecated_java_opts "StarRocks FE" "JAVA_OPTS_FOR_JDK_11" "$STARROCKS_HOME/conf/fe.conf"
     final_java_opt=${JAVA_OPTS_FOR_JDK_11}
 fi
 

--- a/conf/be_test.conf
+++ b/conf/be_test.conf
@@ -83,7 +83,5 @@ s3_compatible_fs_list=s3n://, s3a://, s3://, oss://, cos://, cosn://, obs://, ks
 # JVM options for be
 # eg:
 # JAVA_OPTS="-Djava.security.krb5.conf=/etc/krb5.conf"
-# For jdk 9+, this JAVA_OPTS will be used as default JVM options
-# JAVA_OPTS_FOR_JDK_9="-Djava.security.krb5.conf=/etc/krb5.conf"
 
 

--- a/conf/cn.conf
+++ b/conf/cn.conf
@@ -56,7 +56,5 @@ starlet_port = 9070
 # JVM options for be
 # eg:
 # JAVA_OPTS="-Djava.security.krb5.conf=/etc/krb5.conf"
-# For jdk 9+, this JAVA_OPTS will be used as default JVM options
-# JAVA_OPTS_FOR_JDK_9="-Djava.security.krb5.conf=/etc/krb5.conf"
 # used for query iceberg metadata and Java UDF for JDK17
 # JAVA_OPTS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED"


### PR DESCRIPTION
The old one-line warning claimed JAVA_OPTS_FOR_JDK_11 (FE) and JAVA_OPTS_FOR_JDK_9_AND_LATER (BE/CN) were "not supported" while the start scripts honor them and let them override JAVA_OPTS outright. It understated the situation and never mentioned that the JAVA_OPTS value is discarded rather than merged.

It also never stated what removal will cost: once support goes away the parameter is ignored with no warning, the process falls back to JAVA_OPTS, and a heap or GC setting that lived only in the legacy variable silently disappears on upgrade.

- Replace both one-liners with a shared banner in bin/common.sh that names the parameter, the consequence, and the steps to fix it
- Emit it on stderr so it survives a stdout-only redirection
- Report the JAVA_OPTS override only when JAVA_OPTS is really set
- Drop the commented JAVA_OPTS_FOR_JDK_9 examples from cn.conf and be_test.conf, which advertised a name no script has ever read

Precedence is unchanged: the legacy variable still wins over JAVA_OPTS.

Sample output from `start_fe.sh`
```
Warning: JDK 17 is deprecated and support will be removed in a future release, please upgrade to JDK version 21 or higher

################################################################################
###                                                                          ###
###         ACTION REQUIRED: DEPRECATED CONFIGURATION PARAMETER              ###
###                                                                          ###
################################################################################
###
### This DEPRECATED parameter is set and is in effect right now:
###   JAVA_OPTS_FOR_JDK_11
###
### JAVA_OPTS is the only supported place to set JVM parameters.
###
### StarRocks FE still honors it for this start, so that upgrades from older
### versions keep working, but support WILL BE REMOVED in an upcoming
### StarRocks release. After that it is IGNORED WITHOUT ANY WARNING:
### StarRocks FE falls back to JAVA_OPTS, so every JVM parameter set only
### here (heap size, GC, add-opens, kerberos, ...) SILENTLY STOPS TAKING
### EFFECT and the process comes up with a different heap and GC setup.
###
### JAVA_OPTS is also set, and this parameter OVERRIDES IT COMPLETELY.
### The two are NOT merged, your JAVA_OPTS value is being DISCARDED.
###
### HOW TO FIX (before your next StarRocks upgrade):
###   1. Edit /.../conf/fe.conf
###   2. Move the JVM parameters into JAVA_OPTS, merging them by hand if
###      JAVA_OPTS already has a value.
###   3. Delete the line that sets
###        JAVA_OPTS_FOR_JDK_11
###   4. Restart StarRocks FE and confirm this banner is gone.
###
################################################################################
```

Sample output from `start_be.sh`

```
[WARNING] JDK 17 is deprecated and support will be removed in a future release, please upgrade to JDK version 21 or higher

################################################################################
###                                                                          ###
###         ACTION REQUIRED: DEPRECATED CONFIGURATION PARAMETER              ###
###                                                                          ###
################################################################################
###
### This DEPRECATED parameter is set and is in effect right now:
###   JAVA_OPTS_FOR_JDK_9_AND_LATER
###
### JAVA_OPTS is the only supported place to set JVM parameters.
###
### StarRocks BE still honors it for this start, so that upgrades from older
### versions keep working, but support WILL BE REMOVED in an upcoming
### StarRocks release. After that it is IGNORED WITHOUT ANY WARNING:
### StarRocks BE falls back to JAVA_OPTS, so every JVM parameter set only
### here (heap size, GC, add-opens, kerberos, ...) SILENTLY STOPS TAKING
### EFFECT and the process comes up with a different heap and GC setup.
###
### JAVA_OPTS is also set, and this parameter OVERRIDES IT COMPLETELY.
### The two are NOT merged, your JAVA_OPTS value is being DISCARDED.
###
### HOW TO FIX (before your next StarRocks upgrade):
###   1. Edit /.../conf/be.conf
###   2. Move the JVM parameters into JAVA_OPTS, merging them by hand if
###      JAVA_OPTS already has a value.
###   3. Delete the line that sets
###        JAVA_OPTS_FOR_JDK_9_AND_LATER
###   4. Restart StarRocks BE and confirm this banner is gone.
###
################################################################################
```


## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
