### PR TITLE
[BugFix] Stop trusting an under-reported parquet null_count

### DIFF
--- a/be/src/formats/parquet/column_chunk_reader.h
+++ b/be/src/formats/parquet/column_chunk_reader.h
@@ -82,7 +82,11 @@ public:
     Status decode_values(size_t n, const NullInfos& null_infos, ColumnContentType content_type, Column* dst,
                          const FilterData* filter = nullptr) {
         SCOPED_RAW_TIMER(&_opts.stats->value_decode_ns);
-        if (_current_row_group_no_null || _current_page_no_null) {
+        // A `null_count` statistic is only a hint. Old parquet-mr writers are known to under-report
+        // it, and a page that claims no NULLs stores one physical value per non-NULL row only, so
+        // decoding one value per row walks off the end of the page. `null_infos` is derived from the
+        // definition levels the caller has just decoded, so cross-checking is authoritative and free.
+        if ((_current_row_group_no_null || _current_page_no_null) && null_infos.num_nulls == 0) {
             return _cur_decoder->next_batch(n, content_type, dst, filter);
         }
         return _cur_decoder->next_batch_with_nulls(n, null_infos, content_type, dst, filter);

--- a/be/src/formats/parquet/metadata.cpp
+++ b/be/src/formats/parquet/metadata.cpp
@@ -396,12 +396,16 @@ bool ApplicationVersion::VersionEq(const ApplicationVersion& other_version) cons
            version.minor == other_version.version.minor && version.patch == other_version.version.patch;
 }
 
-bool ApplicationVersion::HasCorrectStatistics(const tparquet::ColumnMetaData& column_meta,
-                                              const SortOrder& sort_order) const {
+bool ApplicationVersion::HasFixedStatsVersion() const {
     // parquet-cpp version 1.3.0 and parquet-mr 1.10.0 onwards stats are computed
     // correctly for all types
-    if (VersionLt(ApplicationVersion::PARQUET_MR_FIXED_STATS_VERSION()) ||
-        VersionLt(ApplicationVersion::PARQUET_CPP_FIXED_STATS_VERSION())) {
+    return !VersionLt(ApplicationVersion::PARQUET_MR_FIXED_STATS_VERSION()) &&
+           !VersionLt(ApplicationVersion::PARQUET_CPP_FIXED_STATS_VERSION());
+}
+
+bool ApplicationVersion::HasCorrectStatistics(const tparquet::ColumnMetaData& column_meta,
+                                              const SortOrder& sort_order) const {
+    if (!HasFixedStatsVersion()) {
         // Only SIGNED are valid unless max and min are the same
         // (in which case the sort order does not matter)
         auto min_equals_max = (column_meta.statistics.__isset.min_value && column_meta.statistics.__isset.max_value &&
@@ -435,6 +439,10 @@ bool ApplicationVersion::HasCorrectStatistics(const tparquet::ColumnMetaData& co
     }
 
     return true;
+}
+
+bool ApplicationVersion::HasCorrectNullCount() const {
+    return HasFixedStatsVersion();
 }
 
 bool ApplicationVersion::IsAlwaysCompressed() const {

--- a/be/src/formats/parquet/metadata.h
+++ b/be/src/formats/parquet/metadata.h
@@ -76,8 +76,18 @@ public:
     // Returns true if version is strictly equal with other_version
     bool VersionEq(const ApplicationVersion& other_version) const;
 
+    // Returns true if the writer is one that computes statistics correctly for all types:
+    // parquet-cpp from 1.3.0 and parquet-mr from 1.10.0 onwards. A writer we do not recognise
+    // keeps the benefit of the doubt, since VersionLt() only compares like with like.
+    bool HasFixedStatsVersion() const;
+
     // Checks if the Version has the correct statistics for a given column
     bool HasCorrectStatistics(const tparquet::ColumnMetaData& column_meta, const SortOrder& sort_order) const;
+
+    // Checks if the Version computes `null_count` correctly. `null_count` is a plain counter, so
+    // none of the sort-order or byte-array concerns that HasCorrectStatistics() weighs on top of
+    // the writer version apply to it -- only the writer version itself does.
+    bool HasCorrectNullCount() const;
 
     // ARROW-17100: [C++][Parquet] Fix backwards compatibility for ParquetV2 data pages written prior to 3.0.0 per ARROW-10353 #13665
     // https://github.com/apache/arrow/pull/13665/files

--- a/be/src/formats/parquet/scalar_column_reader.cpp
+++ b/be/src/formats/parquet/scalar_column_reader.cpp
@@ -223,8 +223,13 @@ StatusOr<bool> RawColumnReader::_row_group_zone_map_filter(const std::vector<con
     bool is_all_null = false;
 
     if (get_chunk_metadata()->meta_data.statistics.__isset.null_count) {
-        has_null = get_chunk_metadata()->meta_data.statistics.null_count > 0;
-        is_all_null = get_chunk_metadata()->meta_data.statistics.null_count == rg_num_rows;
+        if (StatisticsHelper::has_correct_null_count(_opts.file_meta_data)) {
+            has_null = get_chunk_metadata()->meta_data.statistics.null_count > 0;
+            is_all_null = get_chunk_metadata()->meta_data.statistics.null_count == rg_num_rows;
+        }
+        // Otherwise keep the conservative has_null = true / is_all_null = false: an
+        // under-reported `null_count` would otherwise prune away the very rows `IS NULL` asks
+        // for, and unlike a decode failure that loss is silent. min/max pruning still applies.
     } else {
         return filtered;
     }
@@ -318,14 +323,17 @@ StatusOr<bool> RawColumnReader::_page_index_zone_map_filter(const std::vector<co
     DCHECK_EQ(page_num, max_column->size());
 
     // fill ZoneMapDetail
+    const bool null_counts_trusted = StatisticsHelper::has_correct_null_count(_opts.file_meta_data);
     std::vector<ZoneMapDetail> zone_map_details{};
     for (size_t i = 0; i < page_num; i++) {
         if (null_pages[i]) {
             // all null
             zone_map_details.emplace_back(Datum{}, Datum{}, true);
         } else {
-            // null_counts is optional in parquet - if unavailable, conservatively assume nulls exist
-            bool has_null = i >= column_index.null_counts.size() || column_index.null_counts[i] > 0;
+            // null_counts is optional in parquet - if unavailable, conservatively assume nulls
+            // exist. Same when the writer is one whose statistics we do not trust.
+            bool has_null =
+                    !null_counts_trusted || i >= column_index.null_counts.size() || column_index.null_counts[i] > 0;
             zone_map_details.emplace_back(min_column->get(i), max_column->get(i), has_null);
         }
     }
@@ -377,7 +385,8 @@ Status RawColumnReader::_init_column_bloom_filter(int offset, int length, BloomF
                 _opts.file->read_at_fully(offset + header_len, bloom_filter_data.data() + header_len, header.numBytes));
     }
     if (get_chunk_metadata()->meta_data.__isset.statistics &&
-        get_chunk_metadata()->meta_data.statistics.__isset.null_count) {
+        get_chunk_metadata()->meta_data.statistics.__isset.null_count &&
+        StatisticsHelper::has_correct_null_count(_opts.file_meta_data)) {
         if (get_chunk_metadata()->meta_data.statistics.null_count > 0) {
             bloom_filter_data.back() = 1;
         } else {

--- a/be/src/formats/parquet/statistics_helper.cpp
+++ b/be/src/formats/parquet/statistics_helper.cpp
@@ -222,4 +222,11 @@ bool StatisticsHelper::has_correct_min_max_stats(const FileMetaData* file_metada
     return file_metadata->writer_version().HasCorrectStatistics(column_meta, sort_order);
 }
 
+bool StatisticsHelper::has_correct_null_count(const FileMetaData* file_metadata) {
+    if (file_metadata == nullptr) {
+        return false;
+    }
+    return file_metadata->writer_version().HasCorrectNullCount();
+}
+
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/statistics_helper.h
+++ b/be/src/formats/parquet/statistics_helper.h
@@ -38,6 +38,13 @@ public:
 
     static bool has_correct_min_max_stats(const FileMetaData* file_metadata,
                                           const tparquet::ColumnMetaData& column_meta, const SortOrder& sort_order);
+
+    // `null_count` is a summary the writer accumulates alongside the definition levels, not
+    // something derived from them, so a writer can get it wrong while the levels stay right. We
+    // already refuse min/max from writers known to compute statistics incorrectly; ask the same
+    // question about `null_count`, which used to bypass that judgement entirely and reach zone
+    // map, page index and bloom filter pruning unchecked.
+    static bool has_correct_null_count(const FileMetaData* file_metadata);
 };
 
 } // namespace starrocks::parquet

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -50,6 +50,7 @@
 #include "formats/parquet/metadata.h"
 #include "formats/parquet/page_reader.h"
 #include "formats/parquet/parquet_block_split_bloom_filter.h"
+#include "formats/parquet/parquet_test_util/handmade_file.h"
 #include "formats/parquet/parquet_test_util/util.h"
 #include "formats/parquet/parquet_ut_base.h"
 #include "fs/fs.h"
@@ -5060,6 +5061,233 @@ TEST_F(FileReaderTest, test_read_variant_shredding_with_whole_column_access_path
     ASSERT_NE(-1, variant_col->find_shredded_path("age"));
     ASSERT_NE(-1, variant_col->find_shredded_path("profile.salary"));
     ASSERT_NE(-1, variant_col->find_shredded_path("events"));
+}
+
+// A Parquet `null_count` statistic is a hint, not a fact: files written by old parquet-mr
+// under-report it, and StarRocks used to take it at face value. When the statistic claims
+// "no NULLs" but the definition levels disagree, the reader asked the value decoder for one
+// physical value per row while the page only stores the non-NULL ones, and the read walked
+// off the end of the page:
+//   going to read out-of-bounds data, offset=1050424,count=187,size=1050424
+// The definition levels have already been decoded by the time the decoder is picked, so the
+// true NULL count is available for free and must win over the statistic.
+class HandmadeNullCountTest : public FileReaderTest {
+protected:
+    // Writes `values` into a scratch file whose statistics are whatever `options` says.
+    std::string _write_handmade_file(const std::vector<std::optional<std::string>>& values,
+                                     const HandmadeParquetFile::Options& options, const std::string& tag) {
+        std::string content = HandmadeParquetFile::build(values, options);
+        std::string path = (std::filesystem::temp_directory_path() / ("sr_handmade_" + tag + ".parquet")).string();
+        auto file = *FileSystem::Default()->new_writable_file(path);
+        CHECK_OK(file->append(Slice(content)));
+        CHECK_OK(file->close());
+        _scratch_files.emplace_back(path);
+        return path;
+    }
+
+    // Reads the single "c0" column out in one chunk.
+    StatusOr<ColumnPtr> _read_c0(const std::string& path, size_t expected_rows) {
+        auto file_reader = _create_file_reader(path);
+        Utils::SlotDesc slot_descs[] = {{"c0", TYPE_VARCHAR_DESC}, {""}};
+        auto* ctx = _create_scan_context(slot_descs, path);
+        RETURN_IF_ERROR(file_reader->init(&ctx->format_scan_context));
+
+        auto chunk = std::make_shared<Chunk>();
+        chunk->append_column(ColumnHelper::create_column(TYPE_VARCHAR_DESC, true), chunk->num_columns());
+        RETURN_IF_ERROR(file_reader->get_next(&chunk));
+        EXPECT_EQ(expected_rows, chunk->num_rows());
+        return chunk->get_column_by_index(0);
+    }
+
+    void TearDown() override {
+        for (const auto& path : _scratch_files) {
+            std::filesystem::remove(path);
+        }
+        _scratch_files.clear();
+        FileReaderTest::TearDown();
+    }
+
+    // "a", NULL, "bbb", NULL, "c" — three physical values behind five rows.
+    static std::vector<std::optional<std::string>> _values_with_nulls() {
+        return {std::string("a"), std::nullopt, std::string("bbb"), std::nullopt, std::string("c")};
+    }
+
+    static void _expect_values_with_nulls(const ColumnPtr& column) {
+        ASSERT_EQ("['a', NULL, 'bbb', NULL, 'c']", column->debug_string());
+    }
+
+private:
+    std::vector<std::string> _scratch_files;
+};
+
+// The shape seen in the field: the row group counts its NULLs correctly, but the page header
+// claims the page has none. Only the page statistic lies. Before the fix this failed with
+// "going to read out-of-bounds data".
+TEST_F(HandmadeNullCountTest, reads_a_page_that_under_reports_nulls) {
+    HandmadeParquetFile::Options options;
+    options.row_group_null_count = 2;
+    options.page_null_count = 0;
+    auto path = _write_handmade_file(_values_with_nulls(), options, "page_stat");
+
+    auto column = _read_c0(path, 5);
+    ASSERT_TRUE(column.ok()) << column.status().message();
+    _expect_values_with_nulls(column.value());
+}
+
+// The same lie one level up: the row group claims no NULLs and the page carries no statistics.
+TEST_F(HandmadeNullCountTest, reads_a_row_group_that_under_reports_nulls) {
+    HandmadeParquetFile::Options options;
+    options.row_group_null_count = 0;
+    options.page_null_count = std::nullopt;
+    auto path = _write_handmade_file(_values_with_nulls(), options, "row_group_stat");
+
+    auto column = _read_c0(path, 5);
+    ASSERT_TRUE(column.ok()) << column.status().message();
+    _expect_values_with_nulls(column.value());
+}
+
+// Both statistics lie at once.
+TEST_F(HandmadeNullCountTest, reads_when_both_statistics_lie) {
+    HandmadeParquetFile::Options options;
+    options.row_group_null_count = 0;
+    options.page_null_count = 0;
+    auto path = _write_handmade_file(_values_with_nulls(), options, "both_stat");
+
+    auto column = _read_c0(path, 5);
+    ASSERT_TRUE(column.ok()) << column.status().message();
+    _expect_values_with_nulls(column.value());
+}
+
+// The control group: files whose statistics are honest, or that carry none. These read correctly
+// both before and after the fix -- that is what proves the hand-built files above are valid
+// parquet rather than mis-assembled bytes.
+TEST_F(HandmadeNullCountTest, honest_statistics_without_nulls) {
+    HandmadeParquetFile::Options options;
+    options.row_group_null_count = 0;
+    options.page_null_count = 0;
+    std::vector<std::optional<std::string>> values = {std::string("a"), std::string("bb"), std::string("ccc")};
+
+    auto path = _write_handmade_file(values, options, "honest_no_null");
+    auto column = _read_c0(path, 3);
+    ASSERT_TRUE(column.ok()) << column.status().message();
+    ASSERT_EQ("['a', 'bb', 'ccc']", column.value()->debug_string());
+}
+
+TEST_F(HandmadeNullCountTest, honest_statistics_with_nulls) {
+    HandmadeParquetFile::Options options;
+    options.row_group_null_count = 2;
+    options.page_null_count = 2;
+
+    auto path = _write_handmade_file(_values_with_nulls(), options, "honest_with_null");
+    auto column = _read_c0(path, 5);
+    ASSERT_TRUE(column.ok()) << column.status().message();
+    _expect_values_with_nulls(column.value());
+}
+
+TEST_F(HandmadeNullCountTest, no_statistics_at_all) {
+    HandmadeParquetFile::Options options;
+    options.row_group_null_count = std::nullopt;
+    options.page_null_count = std::nullopt;
+
+    auto path = _write_handmade_file(_values_with_nulls(), options, "no_stat");
+    auto column = _read_c0(path, 5);
+    ASSERT_TRUE(column.ok()) << column.status().message();
+    _expect_values_with_nulls(column.value());
+}
+
+// `null_count` also drives pruning, where -- unlike decoding -- there are no definition levels to
+// cross-check against, so an under-reported count silently drops the rows `IS NULL` asks for.
+// StarRocks already refuses min/max from writers known to compute statistics incorrectly
+// (`ApplicationVersion::HasCorrectStatistics`, PARQUET-251); the fix asks the same writer-version
+// question about `null_count`.
+//
+// The column is INT32 on purpose. For BYTE_ARRAY from a legacy writer the min/max gate already
+// drops the statistics, so no zone map is built and the bug cannot be reached; for INT32 the gate
+// lets min/max through (`col_type != BYTE_ARRAY` returns early) and the bug is reachable.
+class LegacyNullCountPruningTest : public HandmadeNullCountTest {
+protected:
+    static constexpr const char* kLegacyWriter = "parquet-mr version 1.9.0-cdh6.3.2 (build handmade)";
+    static constexpr const char* kModernWriter = "parquet-mr version 1.13.1 (build handmade)";
+
+    // Statistics claim no NULLs. `with_nulls` decides whether that claim is a lie.
+    std::string _write_int_file(const std::string& created_by, bool with_nulls, const std::string& tag) {
+        HandmadeParquetFile::Options options;
+        options.row_group_null_count = 0;
+        options.page_null_count = 0;
+        options.row_group_min = HandmadeParquetFile::plain_int32(1);
+        options.row_group_max = HandmadeParquetFile::plain_int32(3);
+        options.created_by = created_by;
+
+        std::vector<std::optional<int32_t>> values = {1, 2, 3};
+        if (with_nulls) {
+            values = {1, std::nullopt, 3};
+        }
+        std::string content = HandmadeParquetFile::build_int32(values, options);
+        std::string path = (std::filesystem::temp_directory_path() / ("sr_handmade_" + tag + ".parquet")).string();
+        auto file = *FileSystem::Default()->new_writable_file(path);
+        CHECK_OK(file->append(Slice(content)));
+        CHECK_OK(file->close());
+        _int_scratch_files.emplace_back(path);
+        return path;
+    }
+
+    // Returns how many row groups survived `WHERE c0 IS NULL`. 0 means the group was pruned.
+    StatusOr<size_t> _row_groups_surviving_is_null(const std::string& path) {
+        Utils::SlotDesc slot_descs[] = {{"c0", TYPE_INT_DESC}, {""}};
+        std::vector<TExpr> t_conjuncts;
+        ParquetUTBase::is_null_pred(0, true, &t_conjuncts);
+        std::vector<ExprContext*> expr_ctxs;
+        ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
+
+        auto* ctx = _create_scan_context(slot_descs, path);
+        ctx->format_scan_context.conjunct_ctxs_by_slot.insert({0, expr_ctxs});
+        TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
+        ParquetUTBase::setup_conjuncts_manager(ctx->format_scan_context.conjunct_ctxs_by_slot[0], nullptr, tuple_desc,
+                                               _runtime_state, ctx);
+
+        auto file_reader = _create_file_reader(path);
+        RETURN_IF_ERROR(file_reader->init(&ctx->format_scan_context));
+        return file_reader->row_group_size();
+    }
+
+    void TearDown() override {
+        for (const auto& path : _int_scratch_files) {
+            std::filesystem::remove(path);
+        }
+        _int_scratch_files.clear();
+        HandmadeNullCountTest::TearDown();
+    }
+
+private:
+    std::vector<std::string> _int_scratch_files;
+};
+
+// CONTROL. A modern writer's statistics are still trusted, so an honest file with no NULLs is
+// still pruned away by `IS NULL`. This is also what proves the hand-built file reaches the zone
+// map at all -- without it the cases below would pass for the wrong reason.
+TEST_F(LegacyNullCountPruningTest, still_prunes_a_modern_writer) {
+    auto path = _write_int_file(kModernWriter, /*with_nulls=*/false, "modern_honest");
+    auto surviving = _row_groups_surviving_is_null(path);
+    ASSERT_TRUE(surviving.ok()) << surviving.status().message();
+    EXPECT_EQ(0, surviving.value()) << "zone-map pruning never ran, so the cases below are inconclusive";
+}
+
+// A legacy writer under-reporting its `null_count` no longer drops the rows `IS NULL` asks for.
+TEST_F(LegacyNullCountPruningTest, stops_trusting_a_legacy_writer) {
+    auto path = _write_int_file(kLegacyWriter, /*with_nulls=*/true, "legacy_lying");
+    auto surviving = _row_groups_surviving_is_null(path);
+    ASSERT_TRUE(surviving.ok()) << surviving.status().message();
+    EXPECT_EQ(1, surviving.value()) << "row group pruned away although the file does contain NULLs";
+}
+
+// A legacy writer with an honest file: no longer pruned. That is a lost optimisation, not a
+// wrong answer -- the predicate still rejects the rows downstream. Stated so the trade-off is
+// visible rather than discovered later in a benchmark.
+TEST_F(LegacyNullCountPruningTest, gives_up_pruning_on_honest_legacy_files) {
+    auto path = _write_int_file(kLegacyWriter, /*with_nulls=*/false, "legacy_honest_kept");
+    auto surviving = _row_groups_surviving_is_null(path);
+    ASSERT_TRUE(surviving.ok()) << surviving.status().message();
+    EXPECT_EQ(1, surviving.value());
 }
 
 } // namespace starrocks::parquet

--- a/be/test/formats/parquet/parquet_test_util/handmade_file.h
+++ b/be/test/formats/parquet/parquet_test_util/handmade_file.h
@@ -1,0 +1,225 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "base/bit/bit_util.h"
+#include "base/bit/rle_encoding.h"
+#include "base/coding.h"
+#include "base/string/faststring.h"
+#include "common/util/thrift_util.h"
+#include "formats/parquet/types.h"
+#include "gen_cpp/parquet_types.h"
+
+namespace starrocks::parquet {
+
+// Builds tiny Parquet files byte by byte, so that a test can state metadata that no sane
+// writer would emit. Real writers keep `null_count` consistent with the definition levels;
+// old parquet-mr does not always, and that is the case we need to be able to read.
+//
+// The produced file has exactly one OPTIONAL BYTE_ARRAY column named "c0", one row group and
+// one uncompressed DATA_PAGE (v1) with RLE definition levels and PLAIN values.
+class HandmadeParquetFile {
+public:
+    // `values` is the logical column: std::nullopt is a NULL, so the physical value area
+    // holds only the engaged entries.
+    struct Options {
+        // Row-group level `ColumnMetaData.statistics.null_count`.
+        std::optional<int64_t> row_group_null_count;
+        // Page level `DataPageHeader.statistics.null_count`.
+        std::optional<int64_t> page_null_count;
+        // Row-group level min/max, already encoded the way PLAIN would write the value. Zone-map
+        // pruning only kicks in when they are present, so a file that carries only `null_count`
+        // cannot exercise that path at all.
+        std::optional<std::string> row_group_min;
+        std::optional<std::string> row_group_max;
+        std::string created_by = "parquet-mr version 1.9.0-cdh6.3.2 (build handmade)";
+    };
+
+    // An OPTIONAL BYTE_ARRAY column.
+    static std::string build(const std::vector<std::optional<std::string>>& values, const Options& options) {
+        std::vector<std::optional<std::string>> encoded;
+        encoded.reserve(values.size());
+        for (const auto& value : values) {
+            encoded.emplace_back(value.has_value() ? std::optional<std::string>(_plain_byte_array(*value))
+                                                   : std::nullopt);
+        }
+        return _build(encoded, tparquet::Type::BYTE_ARRAY, options);
+    }
+
+    // An OPTIONAL INT32 column. Old parquet-mr min/max survive for non-BYTE_ARRAY types, so this
+    // is the shape where a wrong `null_count` can still reach zone-map pruning.
+    static std::string build_int32(const std::vector<std::optional<int32_t>>& values, const Options& options) {
+        std::vector<std::optional<std::string>> encoded;
+        encoded.reserve(values.size());
+        for (const auto& value : values) {
+            encoded.emplace_back(value.has_value() ? std::optional<std::string>(plain_int32(*value)) : std::nullopt);
+        }
+        return _build(encoded, tparquet::Type::INT32, options);
+    }
+
+    // PLAIN encoding of one INT32, handy for building `row_group_min` / `row_group_max`.
+    static std::string plain_int32(int32_t value) {
+        uint8_t buf[4];
+        encode_fixed32_le(buf, static_cast<uint32_t>(value));
+        return {reinterpret_cast<char*>(buf), sizeof(buf)};
+    }
+
+private:
+    static std::string _plain_byte_array(const std::string& value) {
+        uint8_t len[4];
+        encode_fixed32_le(len, static_cast<uint32_t>(value.size()));
+        return std::string(reinterpret_cast<char*>(len), sizeof(len)) + value;
+    }
+
+    // `values` holds each row's already-PLAIN-encoded bytes, or nullopt for a NULL row.
+    static std::string _build(const std::vector<std::optional<std::string>>& values, tparquet::Type::type physical_type,
+                              const Options& options) {
+        const auto num_rows = static_cast<int64_t>(values.size());
+
+        std::string page_body = _encode_page_body(values);
+        std::string page_header = _serialize_page_header(page_body, num_rows, options);
+
+        std::string file = "PAR1";
+        const auto data_page_offset = static_cast<int64_t>(file.size());
+        file += page_header;
+        file += page_body;
+
+        const auto chunk_size = static_cast<int64_t>(page_header.size() + page_body.size());
+        std::string footer = _serialize_footer(num_rows, data_page_offset, chunk_size, physical_type, options);
+        file += footer;
+
+        uint8_t footer_len[4];
+        encode_fixed32_le(footer_len, static_cast<uint32_t>(footer.size()));
+        file.append(reinterpret_cast<char*>(footer_len), sizeof(footer_len));
+        file += "PAR1";
+        return file;
+    }
+
+    // definition levels (4-byte length prefix + RLE) followed by PLAIN-encoded values.
+    static std::string _encode_page_body(const std::vector<std::optional<std::string>>& values) {
+        // max_def_level is 1 for a flat OPTIONAL column.
+        faststring rle_buffer;
+        RleEncoder<level_t> encoder(&rle_buffer, BitUtil::log2(2));
+        for (const auto& value : values) {
+            encoder.Put(value.has_value() ? 1 : 0);
+        }
+        encoder.Flush();
+
+        std::string body;
+        uint8_t level_len[4];
+        encode_fixed32_le(level_len, static_cast<uint32_t>(rle_buffer.size()));
+        body.append(reinterpret_cast<char*>(level_len), sizeof(level_len));
+        body.append(reinterpret_cast<const char*>(rle_buffer.data()), rle_buffer.size());
+
+        for (const auto& value : values) {
+            if (value.has_value()) {
+                body += *value;
+            }
+        }
+        return body;
+    }
+
+    static std::string _serialize_page_header(const std::string& page_body, int64_t num_rows, const Options& options) {
+        tparquet::PageHeader header;
+        header.__set_type(tparquet::PageType::DATA_PAGE);
+        header.__set_uncompressed_page_size(static_cast<int32_t>(page_body.size()));
+        header.__set_compressed_page_size(static_cast<int32_t>(page_body.size()));
+
+        tparquet::DataPageHeader data_page_header;
+        data_page_header.__set_num_values(static_cast<int32_t>(num_rows));
+        data_page_header.__set_encoding(tparquet::Encoding::PLAIN);
+        data_page_header.__set_definition_level_encoding(tparquet::Encoding::RLE);
+        data_page_header.__set_repetition_level_encoding(tparquet::Encoding::RLE);
+        if (options.page_null_count.has_value()) {
+            tparquet::Statistics statistics;
+            statistics.__set_null_count(*options.page_null_count);
+            data_page_header.__set_statistics(statistics);
+        }
+        header.__set_data_page_header(data_page_header);
+        return _serialize(&header);
+    }
+
+    static std::string _serialize_footer(int64_t num_rows, int64_t data_page_offset, int64_t chunk_size,
+                                         tparquet::Type::type physical_type, const Options& options) {
+        tparquet::SchemaElement root;
+        root.__set_name("schema");
+        root.__set_num_children(1);
+
+        tparquet::SchemaElement column;
+        column.__set_name("c0");
+        column.__set_type(physical_type);
+        column.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+        if (physical_type == tparquet::Type::BYTE_ARRAY) {
+            column.__set_converted_type(tparquet::ConvertedType::UTF8);
+        }
+
+        tparquet::ColumnMetaData meta_data;
+        meta_data.__set_type(physical_type);
+        meta_data.__set_encodings({tparquet::Encoding::PLAIN, tparquet::Encoding::RLE});
+        meta_data.__set_path_in_schema({"c0"});
+        meta_data.__set_codec(tparquet::CompressionCodec::UNCOMPRESSED);
+        meta_data.__set_num_values(num_rows);
+        meta_data.__set_total_uncompressed_size(chunk_size);
+        meta_data.__set_total_compressed_size(chunk_size);
+        meta_data.__set_data_page_offset(data_page_offset);
+        if (options.row_group_null_count.has_value() || options.row_group_min.has_value()) {
+            tparquet::Statistics statistics;
+            if (options.row_group_null_count.has_value()) {
+                statistics.__set_null_count(*options.row_group_null_count);
+            }
+            if (options.row_group_min.has_value()) {
+                statistics.__set_min_value(*options.row_group_min);
+                statistics.__set_min(*options.row_group_min);
+            }
+            if (options.row_group_max.has_value()) {
+                statistics.__set_max_value(*options.row_group_max);
+                statistics.__set_max(*options.row_group_max);
+            }
+            meta_data.__set_statistics(statistics);
+        }
+
+        tparquet::ColumnChunk chunk;
+        chunk.__set_file_offset(data_page_offset);
+        chunk.__set_meta_data(meta_data);
+
+        tparquet::RowGroup row_group;
+        row_group.__set_columns({chunk});
+        row_group.__set_total_byte_size(chunk_size);
+        row_group.__set_num_rows(num_rows);
+
+        tparquet::FileMetaData file_meta_data;
+        file_meta_data.__set_version(1);
+        file_meta_data.__set_schema({root, column});
+        file_meta_data.__set_num_rows(num_rows);
+        file_meta_data.__set_row_groups({row_group});
+        file_meta_data.__set_created_by(options.created_by);
+        return _serialize(&file_meta_data);
+    }
+
+    template <class T>
+    static std::string _serialize(T* obj) {
+        ThriftSerializer serializer(true, 1024);
+        std::string out;
+        CHECK(serializer.serialize(obj, &out).ok());
+        return out;
+    }
+};
+
+} // namespace starrocks::parquet


### PR DESCRIPTION
## Why I'm doing:

A parquet `null_count` is a summary the writer accumulates alongside the definition levels, not
something derived from them, so a writer can get it wrong while the levels stay right. Files
written by old parquet-mr do. StarRocks took the number at face value in two places.

**1. Decoding.** When a row group or a data page claimed to hold no NULLs,
`ColumnChunkReader::decode_values` skipped NULL-aware decoding and asked the value decoder for one
physical value per row. NULLs are not stored in the value area, so such a page only holds the
non-NULL values and the read walks off the end of it:

```
SQL error [1064] [42000]: going to read out-of-bounds data, offset=1050424,count=187,size=1050424:
file = hdfs://.../part-00614-....snappy.parquet
```

Reported twice from the field on Hive external tables (3.5.18 and 3.5.19), both on OPTIONAL
PLAIN-encoded string columns, both readable by 2.5.

**2. Pruning.** The same number decides row group zone map, page index and bloom filter pruning.
There no definition level has been read yet, so there is nothing to cross-check against. An
under-reported `null_count` prunes away the row group holding the rows `IS NULL` asks for, and
unlike the decode failure **that loss is silent: the query succeeds and returns fewer rows.**

Measured, not argued:

```
[  FAILED  ] probe_is_null_pruning_trusts_a_lying_statistic
             row group was pruned away although the file does contain NULLs
[       OK ] control_is_null_pruning_works_on_an_honest_file
```

The control matters. The first version of that probe passed, which looked like the hypothesis was
wrong; the control failed alongside it and showed why — the hand-built file claimed
`parquet-mr 1.9.0-cdh6.3.2`, so the min/max gate dropped its statistics, no zone map was built and
the probe had never reached the code it aimed at.

Which brings out the sharper statement of the root cause. StarRocks **already** distrusts min/max
written by parquet-mr before 1.10 or parquet-cpp before 1.3 (`ApplicationVersion::HasCorrectStatistics`,
PARQUET-251) — for BYTE_ARRAY / FIXED_LEN_BYTE_ARRAY columns, where the sort order makes the
comparison unsafe; other types take the `col_type != BYTE_ARRAY` early return and keep their
min/max. It knows those writers' statistics are unreliable and acts on that knowledge — but
`null_count` bypassed the judgement entirely, for every type.

Ruled out along the way, each with a judge rather than by inspection:

| Hypothesis | Verdict |
|---|---|
| HDFS/cache really reads past the file | No: the error comes from `PlainDecoder`, whose `_data` is the value area **inside a page**, not the file |
| The column is treated as REQUIRED, taking the path that carries no `null_infos` | No: dispatch keys off `max_def_level` from the file schema, and the columns are `OPTIONAL` |
| A batch spans two pages, so page statistics and definition levels drift apart | No: `_convert_row_to_value()` clamps `to_read` to `_num_values_left_in_cur_page` |
| Deprecated `BIT_PACKED` definition levels decode wrongly | No **for this error**: `LevelDecoder::_decode_batch()` returns 0 levels for BIT_PACKED, so an optional column fails earlier with `def levels need to parsed: N, def levels parsed: 0`. A separate defect, filed separately |

The decode fast path came from #49088, so 3.4 and later are affected while 2.5 and 3.3 are not —
which is exactly why the same file reads fine on 2.5. Judge:
`git merge-base --is-ancestor <#49088 commit> origin/branch-3.3` is false, `branch-3.4` is true.

## What I'm doing:

**Decoding** — cross-check the statistic against the definition levels:

```cpp
if ((_current_row_group_no_null || _current_page_no_null) && null_infos.num_nulls == 0) {
    return _cur_decoder->next_batch(n, content_type, dst, filter);
}
```

`null_infos.num_nulls` is not new work: `OptionalStoredColumnReader::_read_values_on_levels()`
already decodes the definition levels and calls `assign_nulls()` unconditionally before reaching
`decode_values()`. The added cost is one integer comparison, and files with honest statistics keep
the fast path and decode exactly as before. Only the `null_infos` overload is touched — the
REQUIRED path uses the other overload and is untouched.

**Pruning** — ask the existing writer-version question about `null_count` too. The writer-version
predicate that `ApplicationVersion::HasCorrectStatistics()` applies first is factored out as
`HasFixedStatsVersion()` and reused by a new `ApplicationVersion::HasCorrectNullCount()`;
`StatisticsHelper::has_correct_null_count()` delegates to it exactly as
`has_correct_min_max_stats()` delegates to `HasCorrectStatistics()`. `null_count` is a plain
counter, so the sort-order and byte-array concerns that `HasCorrectStatistics()` weighs *on top of*
the writer version do not apply to it — which is why it reuses the version predicate rather than
the whole method.

The four scalar consumers route through it: the row group zone map's `has_null` / `is_all_null`,
the page index's per-page `null_counts`, and the bloom filter's has-null byte. When the writer is
not trusted the values fall back to `has_null = true` / `is_all_null = false` — min/max pruning is
deliberately kept, rather than bailing out of zone-map filtering entirely the way an absent
`null_count` does today.

### Which files are exposed to the pruning half

| writer | column | min/max | can a wrong `null_count` prune? (before this PR) |
|---|---|---|---|
| legacy (< 1.10) | string | dropped | no — there is no zone map to prune with |
| legacy (< 1.10) | int / date / timestamp | kept | **yes** |
| modern | any | kept | yes, though no such file has been observed |

So the exposed shape is a legacy writer with a non-string column, which is why those tests use INT32.

Left for a separate change: `complex_column_reader.cpp` has three more `null_count` consumers
(`_column_chunk_all_null`, `_column_chunk_all_null_for_num_rows`, `_column_chunk_has_no_null`) that
skip reading whole columns for shredded variant / struct / map. The IO they save is real and the
hand-built files needed to test them require nested schemas and repetition levels.

### Tests

No real writer emits a parquet file whose statistics disagree with its definition levels, so the
tests hand-build one byte by byte (`parquet_test_util/handmade_file.h`): one OPTIONAL column, one
row group, one uncompressed DATA_PAGE v1 with RLE definition levels and PLAIN values, with the
statistics, the writer version and the physical type as inputs so any of them can lie.

The honest / statistics-free files are the **control group** — they must behave correctly both
before and after the fix, which is what proves the hand-built files are valid parquet rather than
mis-assembled bytes.

| Case | Asserts |
|---|---|
| `reads_a_page_that_under_reports_nulls` | the field's shape reads correctly |
| `reads_a_row_group_that_under_reports_nulls` | the lie one level up |
| `reads_when_both_statistics_lie` | both levels lying |
| `honest_statistics_without_nulls` / `honest_statistics_with_nulls` / `no_statistics_at_all` | control; unchanged by the fix |
| `still_prunes_a_modern_writer` | control: a modern writer's statistics are still trusted and the row group is still pruned — without this the pruning cases prove nothing |
| `stops_trusting_a_legacy_writer` | the row group survives, so the rows are no longer lost |
| `gives_up_pruning_on_honest_legacy_files` | the honest legacy file is no longer pruned — the cost, made visible rather than discovered in a benchmark |

Verified on a BE UT build (ASAN) with the review-revised code. The eight files this touches are
byte-for-byte identical between this branch's base and the tree the run was made on, so the numbers
carry over; CI here re-runs them regardless.

* the 9 new cases: all pass;
* broad parquet regression across all 30 parquet suites in `starrocks_test`
  (`FileReaderTest`, `PageIndexTest`, `GroupReaderTest`, `ColumnReaderTest`, `StatisticsHelperTest`,
  `VariantZoneMapTest`, ... ): **464 / 464 passed, 0 failed**. That matters more than usual for this
  revision: with the configs gone the pruning half is unconditional, and `be/test` carries 20
  parquet files written by parquet-mr 1.8.1 / 1.5.0, i.e. exactly the writers now distrusted. None
  of them regressed.

`ArrowParquetWriterTest.Exception` and the whole `ParquetPageReaderTest` suite are excluded: they
SIGSEGV on the unmodified base commit too, verified by running the suite there rather than assumed
unrelated (`[ RUN ] ParquetPageReaderTest.Normal` → `SIGSEGV (@0x0)` with no local changes).

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

Two behaviour changes, both unconditional (the two configs the first revision carried were dropped
on review):

1. A parquet page or row group whose `null_count` says "no NULLs" while its definition levels say
   otherwise is now read correctly instead of failing with `going to read out-of-bounds data`.
2. `null_count` written by parquet-mr before 1.10 or parquet-cpp before 1.3 no longer drives zone
   map / page index / bloom filter pruning. Correct results on such files; the cost is NULL-based
   pruning on legacy files that happen to be honest. min/max pruning on them is unaffected.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

Note: 3.4 carries the same defect but is not offered as a target here, so it needs a manual pick.
The change is BE-only.
