### PR TITLE
[Enhancement] Apply the mutable jemalloc options of jemalloc_conf at runtime

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -116,12 +116,16 @@ CONF_Bool(enable_jemalloc_memory_tracker, "true");
 
 // The jemalloc runtime options applied via the JEMALLOC_CONF environment variable when the
 // process is started in the normal mode (i.e. neither --jemalloc_debug nor --check_mem_leak) and JEMALLOC_CONF is not already set.
-// jemalloc reads JEMALLOC_CONF at process init before BE config parsing, so this config does not
-// reconfigure jemalloc at runtime; it is exported by bin/start_backend.sh and surfaced here purely
-// for observability via information_schema.be_configs. It is ignored under the jemalloc_debug and
-// check_mem_leak modes, which force their own JEMALLOC_CONF.
+// jemalloc reads JEMALLOC_CONF at process init before BE config parsing, so it is exported by
+// bin/start_backend.sh. It is ignored under the jemalloc_debug and check_mem_leak modes, which
+// force their own JEMALLOC_CONF.
+// Updating this config at runtime only re-applies the options that jemalloc itself allows to be
+// changed after init, namely dirty_decay_ms, muzzy_decay_ms and prof_active. Adding, removing or
+// changing any other option is rejected, because the corresponding `opt.*` mallctl nodes are
+// read-only; those need a restart. Note that prof_active can only be turned on when the process
+// was started with prof:true.
 // NOTE: keep this default in sync with the normal-mode default in bin/start_backend.sh.
-CONF_String(jemalloc_conf,
+CONF_mString(jemalloc_conf,
             "percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,"
             "background_thread:true,prof:true,prof_active:false");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -126,8 +126,8 @@ CONF_Bool(enable_jemalloc_memory_tracker, "true");
 // was started with prof:true.
 // NOTE: keep this default in sync with the normal-mode default in bin/start_backend.sh.
 CONF_mString(jemalloc_conf,
-            "percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,"
-            "background_thread:true,prof:true,prof_active:false");
+             "percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,"
+             "background_thread:true,prof:true,prof_active:false");
 
 // Whether abort the process if a large memory allocation is detected which the requested
 // size is larger than the available physical memory without wrapping with TRY_CATCH_BAD_ALLOC

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -319,6 +319,7 @@
       "configs": [
         "mem_limit",
         "enable_jemalloc_memory_tracker",
+        "jemalloc_conf",
         "abort_on_large_memory_allocation",
         "use_mmap_allocate_chunk",
         "disable_mem_pools",

--- a/be/src/common/config_memory_allocator_fwd.h
+++ b/be/src/common/config_memory_allocator_fwd.h
@@ -43,8 +43,8 @@ CONF_Bool(enable_jemalloc_memory_tracker, "true");
 // was started with prof:true.
 // NOTE: keep this default in sync with the normal-mode default in bin/start_backend.sh.
 CONF_mString(jemalloc_conf,
-            "percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,"
-            "background_thread:true,prof:true,prof_active:false");
+             "percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,"
+             "background_thread:true,prof:true,prof_active:false");
 
 // Whether abort the process if a large memory allocation is detected which the requested
 // size is larger than the available physical memory without wrapping with TRY_CATCH_BAD_ALLOC

--- a/be/src/common/config_memory_allocator_fwd.h
+++ b/be/src/common/config_memory_allocator_fwd.h
@@ -31,6 +31,21 @@ CONF_String(mem_limit, "90%");
 // Enable the jemalloc tracker, which is responsible for reserving memory
 CONF_Bool(enable_jemalloc_memory_tracker, "true");
 
+// The jemalloc runtime options applied via the JEMALLOC_CONF environment variable when the
+// process is started in the normal mode (i.e. neither --jemalloc_debug nor --check_mem_leak) and JEMALLOC_CONF is not already set.
+// jemalloc reads JEMALLOC_CONF at process init before BE config parsing, so it is exported by
+// bin/start_backend.sh. It is ignored under the jemalloc_debug and check_mem_leak modes, which
+// force their own JEMALLOC_CONF.
+// Updating this config at runtime only re-applies the options that jemalloc itself allows to be
+// changed after init, namely dirty_decay_ms, muzzy_decay_ms and prof_active. Adding, removing or
+// changing any other option is rejected, because the corresponding `opt.*` mallctl nodes are
+// read-only; those need a restart. Note that prof_active can only be turned on when the process
+// was started with prof:true.
+// NOTE: keep this default in sync with the normal-mode default in bin/start_backend.sh.
+CONF_mString(jemalloc_conf,
+            "percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,"
+            "background_thread:true,prof:true,prof_active:false");
+
 // Whether abort the process if a large memory allocation is detected which the requested
 // size is larger than the available physical memory without wrapping with TRY_CATCH_BAD_ALLOC
 CONF_mBool(abort_on_large_memory_allocation, "false");

--- a/be/src/runtime/CMakeLists.txt
+++ b/be/src/runtime/CMakeLists.txt
@@ -45,6 +45,7 @@ set(RUNTIME_SRCS
     memory/mem_chunk_allocator.cpp
     memory/memory_allocator.cpp
     memory/memory_lock.cpp
+    memory/jemalloc_conf_updater.cpp
     exception_stack.cpp
     prof/heap_prof.cpp
     serde/chunk_encode_context.cpp

--- a/be/src/runtime/memory/jemalloc_conf_updater.cpp
+++ b/be/src/runtime/memory/jemalloc_conf_updater.cpp
@@ -52,8 +52,8 @@ StatusOr<ssize_t> parse_decay_ms(const std::string& option, const std::string& v
     char* end = nullptr;
     long long parsed = std::strtoll(value.c_str(), &end, 10);
     if (value.empty() || end != value.c_str() + value.size() || errno != 0 || parsed < -1) {
-        return Status::InvalidArgument(fmt::format(
-                "invalid value of jemalloc option '{}': '{}', expect an integer >= -1", option, value));
+        return Status::InvalidArgument(
+                fmt::format("invalid value of jemalloc option '{}': '{}', expect an integer >= -1", option, value));
     }
     return static_cast<ssize_t>(parsed);
 }

--- a/be/src/runtime/memory/jemalloc_conf_updater.cpp
+++ b/be/src/runtime/memory/jemalloc_conf_updater.cpp
@@ -16,13 +16,13 @@
 
 #include <sys/types.h>
 
-#include <cctype>
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
 #include <optional>
 #include <vector>
 
+#include "base/string/trim.h"
 #include "common/logging.h"
 #include "fmt/format.h"
 #include "gutil/strings/join.h"
@@ -36,16 +36,6 @@ namespace {
 const char* const kDirtyDecayMs = "dirty_decay_ms";
 const char* const kMuzzyDecayMs = "muzzy_decay_ms";
 const char* const kProfActive = "prof_active";
-
-std::string_view trim(std::string_view str) {
-    while (!str.empty() && std::isspace(static_cast<unsigned char>(str.front()))) {
-        str.remove_prefix(1);
-    }
-    while (!str.empty() && std::isspace(static_cast<unsigned char>(str.back()))) {
-        str.remove_suffix(1);
-    }
-    return str;
-}
 
 StatusOr<ssize_t> parse_decay_ms(const std::string& option, const std::string& value) {
     errno = 0;
@@ -161,17 +151,19 @@ StatusOr<JemallocOptions> parse_jemalloc_conf(std::string_view conf) {
     for (size_t pos = 0; pos < conf.size();) {
         size_t comma = conf.find(',', pos);
         size_t len = comma == std::string_view::npos ? conf.size() - pos : comma - pos;
-        std::string_view segment = trim(conf.substr(pos, len));
+        std::string_view segment = trim_spaces(conf.substr(pos, len));
         pos = comma == std::string_view::npos ? conf.size() : comma + 1;
         if (segment.empty()) {
             continue;
         }
         size_t colon = segment.find(':');
-        if (colon == std::string_view::npos || trim(segment.substr(0, colon)).empty()) {
+        std::string_view name =
+                colon == std::string_view::npos ? std::string_view() : trim_spaces(segment.substr(0, colon));
+        if (name.empty()) {
             return Status::InvalidArgument(
                     fmt::format("invalid jemalloc option '{}', expect '<name>:<value>'", segment));
         }
-        options[std::string(trim(segment.substr(0, colon)))] = std::string(trim(segment.substr(colon + 1)));
+        options[std::string(name)] = std::string(trim_spaces(segment.substr(colon + 1)));
     }
     return options;
 }

--- a/be/src/runtime/memory/jemalloc_conf_updater.cpp
+++ b/be/src/runtime/memory/jemalloc_conf_updater.cpp
@@ -1,0 +1,301 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runtime/memory/jemalloc_conf_updater.h"
+
+#include <sys/types.h>
+
+#include <cctype>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <optional>
+#include <vector>
+
+#include "common/logging.h"
+#include "fmt/format.h"
+#include "gutil/strings/join.h"
+#include "jemalloc/jemalloc.h"
+#include "runtime/prof/heap_prof.h"
+
+namespace starrocks {
+
+namespace {
+
+const char* const kDirtyDecayMs = "dirty_decay_ms";
+const char* const kMuzzyDecayMs = "muzzy_decay_ms";
+const char* const kProfActive = "prof_active";
+
+std::string_view trim(std::string_view str) {
+    while (!str.empty() && std::isspace(static_cast<unsigned char>(str.front()))) {
+        str.remove_prefix(1);
+    }
+    while (!str.empty() && std::isspace(static_cast<unsigned char>(str.back()))) {
+        str.remove_suffix(1);
+    }
+    return str;
+}
+
+StatusOr<ssize_t> parse_decay_ms(const std::string& option, const std::string& value) {
+    errno = 0;
+    char* end = nullptr;
+    long long parsed = std::strtoll(value.c_str(), &end, 10);
+    if (value.empty() || end != value.c_str() + value.size() || errno != 0 || parsed < -1) {
+        return Status::InvalidArgument(fmt::format(
+                "invalid value of jemalloc option '{}': '{}', expect an integer >= -1", option, value));
+    }
+    return static_cast<ssize_t>(parsed);
+}
+
+StatusOr<bool> parse_bool_option(const std::string& option, const std::string& value) {
+    if (value == "true") {
+        return true;
+    }
+    if (value == "false") {
+        return false;
+    }
+    return Status::InvalidArgument(
+            fmt::format("invalid value of jemalloc option '{}': '{}', expect 'true' or 'false'", option, value));
+}
+
+Status mallctl_failed(const std::string& name, int err) {
+    return Status::InternalError(fmt::format("mallctl('{}') failed: {}", name, std::strerror(err)));
+}
+
+// Sets `arenas.<dirty|muzzy>_decay_ms`, which only takes effect for the arenas
+// created afterwards, and then walks the existing arenas.
+//
+// Note that `arena.<i>.*_decay_ms` does not accept MALLCTL_ARENAS_ALL: unlike
+// `arena.<i>.purge`, its ctl handler resolves the index through
+// arena_get(ind, false) and returns EFAULT for the pseudo index. So the arenas
+// have to be walked one by one.
+Status apply_decay_ms(const std::string& option, bool dirty, ssize_t decay_ms) {
+    const std::string default_name = dirty ? "arenas.dirty_decay_ms" : "arenas.muzzy_decay_ms";
+    if (int err = je_mallctl(default_name.c_str(), nullptr, nullptr, &decay_ms, sizeof(decay_ms)); err != 0) {
+        return mallctl_failed(default_name, err);
+    }
+
+    // `arenas.narenas` reports the arena count cached by the ctl layer, which is
+    // only refreshed when the epoch advances.
+    uint64_t epoch = 1;
+    size_t epoch_size = sizeof(epoch);
+    (void)je_mallctl("epoch", &epoch, &epoch_size, &epoch, epoch_size);
+
+    unsigned narenas = 0;
+    size_t narenas_size = sizeof(narenas);
+    if (int err = je_mallctl("arenas.narenas", &narenas, &narenas_size, nullptr, 0); err != 0) {
+        return mallctl_failed("arenas.narenas", err);
+    }
+
+    size_t updated = 0;
+    size_t absent = 0;
+    for (unsigned i = 0; i < narenas; ++i) {
+        std::string name = fmt::format("arena.{}.{}_decay_ms", i, dirty ? "dirty" : "muzzy");
+        int err = je_mallctl(name.c_str(), nullptr, nullptr, &decay_ms, sizeof(decay_ms));
+        if (err == EFAULT) {
+            // The arena has not been created yet. Under `percpu_arena` arenas are
+            // created lazily, and such an arena will pick up the default set above.
+            ++absent;
+            continue;
+        }
+        if (err != 0) {
+            return mallctl_failed(name, err);
+        }
+        ++updated;
+    }
+
+    if (decay_ms == 0) {
+        LOG(WARNING) << "set jemalloc " << option << " to 0, which purges every unused page of " << updated
+                     << " arenas synchronously in the current thread";
+    } else {
+        // With `background_thread:true` the calling thread does not purge, but the
+        // decay backlog is restarted from scratch, so the background thread purges
+        // the currently unused pages on its next run.
+        LOG(INFO) << "set jemalloc " << option << " to " << decay_ms << " for " << updated << " arenas, " << absent
+                  << " arenas not created yet";
+    }
+    return Status::OK();
+}
+
+Status apply_prof_active(bool active) {
+#ifdef __APPLE__
+    return Status::NotSupported("jemalloc option 'prof_active' cannot be changed on macOS");
+#else
+    // Heap profiling has to be armed at startup: `opt.prof` is read-only, so
+    // `prof.active` is meaningless when the process was started with `prof:false`.
+    bool prof_enabled = false;
+    size_t size = sizeof(prof_enabled);
+    if (je_mallctl("opt.prof", &prof_enabled, &size, nullptr, 0) != 0 || !prof_enabled) {
+        return Status::NotSupported(
+                "cannot change jemalloc option 'prof_active' because the process was not started with 'prof:true', "
+                "restart the BE with 'prof:true' in jemalloc_conf first");
+    }
+
+    if (active) {
+        HeapProf::getInstance().enable_prof();
+    } else {
+        HeapProf::getInstance().disable_prof();
+    }
+    if (HeapProf::getInstance().has_enable() != active) {
+        return Status::InternalError(fmt::format("failed to set jemalloc prof.active to {}", active));
+    }
+    return Status::OK();
+#endif
+}
+
+} // namespace
+
+StatusOr<JemallocOptions> parse_jemalloc_conf(std::string_view conf) {
+    JemallocOptions options;
+    for (size_t pos = 0; pos < conf.size();) {
+        size_t comma = conf.find(',', pos);
+        size_t len = comma == std::string_view::npos ? conf.size() - pos : comma - pos;
+        std::string_view segment = trim(conf.substr(pos, len));
+        pos = comma == std::string_view::npos ? conf.size() : comma + 1;
+        if (segment.empty()) {
+            continue;
+        }
+        size_t colon = segment.find(':');
+        if (colon == std::string_view::npos || trim(segment.substr(0, colon)).empty()) {
+            return Status::InvalidArgument(
+                    fmt::format("invalid jemalloc option '{}', expect '<name>:<value>'", segment));
+        }
+        options[std::string(trim(segment.substr(0, colon)))] = std::string(trim(segment.substr(colon + 1)));
+    }
+    return options;
+}
+
+JemallocConfUpdater& JemallocConfUpdater::instance() {
+    static JemallocConfUpdater updater;
+    return updater;
+}
+
+const std::set<std::string>& JemallocConfUpdater::mutable_options() {
+    static const std::set<std::string> kMutableOptions{kDirtyDecayMs, kMuzzyDecayMs, kProfActive};
+    return kMutableOptions;
+}
+
+void JemallocConfUpdater::init(std::string_view startup_conf) {
+    std::lock_guard guard(_mutex);
+    auto options = parse_jemalloc_conf(startup_conf);
+    if (!options.ok()) {
+        // Keep the baseline empty: every option of the new value then looks newly
+        // added, so an immutable option can still never be changed silently.
+        LOG(WARNING) << "failed to parse the jemalloc_conf the process was started with '" << startup_conf
+                     << "': " << options.status();
+        _applied.clear();
+        return;
+    }
+    _applied = std::move(options).value();
+}
+
+JemallocOptions JemallocConfUpdater::applied_options() {
+    std::lock_guard guard(_mutex);
+    return _applied;
+}
+
+void JemallocConfUpdater::refresh_prof_active(JemallocOptions* options) {
+#ifndef __APPLE__
+    auto it = options->find(kProfActive);
+    if (it == options->end()) {
+        return;
+    }
+    bool prof_enabled = false;
+    size_t size = sizeof(prof_enabled);
+    if (je_mallctl("opt.prof", &prof_enabled, &size, nullptr, 0) != 0 || !prof_enabled) {
+        return;
+    }
+    std::string live = HeapProf::getInstance().has_enable() ? "true" : "false";
+    if (it->second != live) {
+        LOG(INFO) << "jemalloc prof.active was changed outside of jemalloc_conf, move the baseline of 'prof_active' "
+                  << "from " << it->second << " to " << live;
+        it->second = std::move(live);
+    }
+#endif
+}
+
+Status JemallocConfUpdater::update(std::string_view new_conf) {
+    ASSIGN_OR_RETURN(JemallocOptions new_options, parse_jemalloc_conf(new_conf));
+
+    std::lock_guard guard(_mutex);
+    refresh_prof_active(&_applied);
+
+    std::vector<std::string> rejected;
+    JemallocOptions changed;
+    for (const auto& [name, value] : new_options) {
+        auto it = _applied.find(name);
+        if (it != _applied.end() && it->second == value) {
+            continue;
+        }
+        if (mutable_options().count(name) == 0) {
+            rejected.emplace_back(it == _applied.end() ? fmt::format("{} (added)", name) : name);
+        } else {
+            changed.emplace(name, value);
+        }
+    }
+    for (const auto& entry : _applied) {
+        if (new_options.count(entry.first) == 0) {
+            // Dropping an option would mean guessing the value to restore, so the
+            // set of options itself has to stay stable.
+            rejected.emplace_back(fmt::format("{} (removed)", entry.first));
+        }
+    }
+    if (!rejected.empty()) {
+        std::vector<std::string> mutables(mutable_options().begin(), mutable_options().end());
+        return Status::NotSupported(fmt::format(
+                "these jemalloc options cannot be changed at runtime: {}. only {} can, changing anything else "
+                "requires restarting the BE",
+                JoinStrings(rejected, ", "), JoinStrings(mutables, ", ")));
+    }
+    if (changed.empty()) {
+        return Status::OK();
+    }
+
+    // Parse every changed value before touching jemalloc, so that an invalid value
+    // is rejected without leaving the other options half applied.
+    std::optional<ssize_t> dirty_decay_ms;
+    std::optional<ssize_t> muzzy_decay_ms;
+    std::optional<bool> prof_active;
+    for (const auto& [name, value] : changed) {
+        if (name == kDirtyDecayMs) {
+            ASSIGN_OR_RETURN(dirty_decay_ms, parse_decay_ms(name, value));
+        } else if (name == kMuzzyDecayMs) {
+            ASSIGN_OR_RETURN(muzzy_decay_ms, parse_decay_ms(name, value));
+        } else if (name == kProfActive) {
+            ASSIGN_OR_RETURN(prof_active, parse_bool_option(name, value));
+        } else {
+            return Status::InternalError(fmt::format("jemalloc option '{}' has no runtime applier", name));
+        }
+    }
+
+    // Apply the options one by one and record what actually landed: the config value
+    // is rolled back on failure, so the baseline must keep describing the real state
+    // of jemalloc instead of the rolled back string.
+    if (dirty_decay_ms.has_value()) {
+        RETURN_IF_ERROR(apply_decay_ms(kDirtyDecayMs, true, *dirty_decay_ms));
+        _applied[kDirtyDecayMs] = changed.at(kDirtyDecayMs);
+    }
+    if (muzzy_decay_ms.has_value()) {
+        RETURN_IF_ERROR(apply_decay_ms(kMuzzyDecayMs, false, *muzzy_decay_ms));
+        _applied[kMuzzyDecayMs] = changed.at(kMuzzyDecayMs);
+    }
+    if (prof_active.has_value()) {
+        RETURN_IF_ERROR(apply_prof_active(*prof_active));
+        _applied[kProfActive] = changed.at(kProfActive);
+    }
+    _applied = std::move(new_options);
+    return Status::OK();
+}
+
+} // namespace starrocks

--- a/be/src/runtime/memory/jemalloc_conf_updater.cpp
+++ b/be/src/runtime/memory/jemalloc_conf_updater.cpp
@@ -342,9 +342,12 @@ Status JemallocConfUpdater::update(std::string_view new_conf) {
         }
     }
 
-    // Apply the options one by one and record what actually landed: the config value
-    // is rolled back on failure, so the baseline must keep describing the real state
-    // of jemalloc instead of the rolled back string.
+    // Apply the options one by one and record each one that landed, because the config value
+    // is rolled back on failure and the baseline should follow jemalloc rather than the rolled
+    // back string. This is per option, not per arena: apply_decay_ms() writes the default for
+    // future arenas before it walks the existing ones, so a failure in the middle of that walk
+    // still leaves the option half applied with the baseline claiming the old value. Only a
+    // wrong newlen makes that ctl fail, which cannot happen here, so the gap is left unclosed.
     if (dirty_decay_ms.has_value()) {
         RETURN_IF_ERROR(apply_decay_ms(kDirtyDecayMs, true, *dirty_decay_ms));
         _applied[kDirtyDecayMs] = changed.at(kDirtyDecayMs);

--- a/be/src/runtime/memory/jemalloc_conf_updater.cpp
+++ b/be/src/runtime/memory/jemalloc_conf_updater.cpp
@@ -16,6 +16,7 @@
 
 #include <sys/types.h>
 
+#include <algorithm>
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
@@ -63,13 +64,46 @@ Status mallctl_failed(const std::string& name, int err) {
     return Status::InternalError(fmt::format("mallctl('{}') failed: {}", name, std::strerror(err)));
 }
 
+// jemalloc lays the arena indexes out as three groups:
+//
+//   [0, narenas_auto)  the automatic arenas, which serve the ordinary allocations
+//   narenas_auto       the "huge" arena, present when `oversize_threshold` is in effect
+//   > narenas_auto     the arenas created through `arenas.create`
+//
+// Only the first group belongs to this config. The huge arena in particular must be left
+// alone: arena_choose_huge() deliberately puts it on eager purge (decay 0) whenever the
+// default is positive, because huge allocations are few and rarely reused, so writing the
+// configured decay time into it would both defeat that and spawn a background thread that
+// arena_new_create_background_thread() purposely skips for it. Future arenas are unaffected
+// either way, since the huge arena re-applies its own policy when it is created.
+//
+// `narenas_auto` has no mallctl node of its own, but malloc_init_narenas() derives it from
+// `opt.narenas`, which does, by the two steps mirrored below. Note that the clamp does not
+// write back into `opt_narenas`, so reading `opt.narenas` alone is not enough.
+StatusOr<unsigned> auto_arena_count() {
+    // MALLOCX_ARENA_LIMIT lives in jemalloc's internal headers, but its value is pinned by
+    // the public MALLOCX_ARENA(a) == ((a) + 1) << 20 macro, which encodes an arena index in
+    // the 12 flag bits starting at bit 20.
+    constexpr unsigned kMallocxArenaLimit = (1u << 12) - 1;
+
+    unsigned opt_narenas = 0;
+    size_t size = sizeof(opt_narenas);
+    if (int err = je_mallctl("opt.narenas", &opt_narenas, &size, nullptr, 0); err != 0) {
+        return mallctl_failed("opt.narenas", err);
+    }
+    return std::min(opt_narenas, kMallocxArenaLimit - 1);
+}
+
 // Sets `arenas.<dirty|muzzy>_decay_ms`, which only takes effect for the arenas
-// created afterwards, and then walks the existing arenas.
+// created afterwards, and then walks the existing automatic arenas.
 //
 // Note that `arena.<i>.*_decay_ms` does not accept MALLCTL_ARENAS_ALL: unlike
 // `arena.<i>.purge`, its ctl handler resolves the index through
 // arena_get(ind, false) and returns EFAULT for the pseudo index. So the arenas
 // have to be walked one by one.
+//
+// The walk stops at `narenas_auto` rather than at `arenas.narenas`, see
+// auto_arena_count() for why.
 Status apply_decay_ms(const std::string& option, bool dirty, ssize_t decay_ms) {
     const std::string default_name = dirty ? "arenas.dirty_decay_ms" : "arenas.muzzy_decay_ms";
     if (int err = je_mallctl(default_name.c_str(), nullptr, nullptr, &decay_ms, sizeof(decay_ms)); err != 0) {
@@ -87,6 +121,11 @@ Status apply_decay_ms(const std::string& option, bool dirty, ssize_t decay_ms) {
     if (int err = je_mallctl("arenas.narenas", &narenas, &narenas_size, nullptr, 0); err != 0) {
         return mallctl_failed("arenas.narenas", err);
     }
+
+    // `arenas.narenas` counts every arena, including the huge one and the manually created
+    // ones that must keep their own decay policy.
+    ASSIGN_OR_RETURN(unsigned narenas_auto, auto_arena_count());
+    narenas = std::min(narenas, narenas_auto);
 
     size_t updated = 0;
     size_t absent = 0;
@@ -107,13 +146,13 @@ Status apply_decay_ms(const std::string& option, bool dirty, ssize_t decay_ms) {
 
     if (decay_ms == 0) {
         LOG(WARNING) << "set jemalloc " << option << " to 0, which purges every unused page of " << updated
-                     << " arenas synchronously in the current thread";
+                     << " automatic arenas synchronously in the current thread";
     } else {
         // With `background_thread:true` the calling thread does not purge, but the
         // decay backlog is restarted from scratch, so the background thread purges
         // the currently unused pages on its next run.
-        LOG(INFO) << "set jemalloc " << option << " to " << decay_ms << " for " << updated << " arenas, " << absent
-                  << " arenas not created yet";
+        LOG(INFO) << "set jemalloc " << option << " to " << decay_ms << " for " << updated << " automatic arenas, "
+                  << absent << " not created yet";
     }
     return Status::OK();
 }

--- a/be/src/runtime/memory/jemalloc_conf_updater.cpp
+++ b/be/src/runtime/memory/jemalloc_conf_updater.cpp
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "base/string/trim.h"
+#include "common/configbase.h"
 #include "common/logging.h"
 #include "fmt/format.h"
 #include "gutil/strings/join.h"
@@ -33,6 +34,12 @@
 namespace starrocks {
 
 namespace {
+
+// The variable jemalloc derives as JEMALLOC_CPREFIX "MALLOC_CONF". The prefix is "JE" because
+// thirdparty builds jemalloc with `--with-jemalloc-prefix=je`, but that macro lives in jemalloc's
+// internal headers, so the name is spelled out here the way bin/start_backend.sh spells it out.
+const char* const kJemallocConfEnv = "JEMALLOC_CONF";
+const char* const kJemallocConfName = "jemalloc_conf";
 
 const char* const kDirtyDecayMs = "dirty_decay_ms";
 const char* const kMuzzyDecayMs = "muzzy_decay_ms";
@@ -217,8 +224,33 @@ const std::set<std::string>& JemallocConfUpdater::mutable_options() {
     return kMutableOptions;
 }
 
-void JemallocConfUpdater::init(std::string_view startup_conf) {
+std::string startup_jemalloc_conf(std::string_view config_value) {
+    // Only an unset variable falls back. jemalloc treats a set but empty variable as a valid,
+    // empty option set rather than a missing one, and falling back there would claim options
+    // that were never applied.
+    if (const char* env = std::getenv(kJemallocConfEnv); env != nullptr) {
+        return env;
+    }
+    return std::string(config_value);
+}
+
+void JemallocConfUpdater::init(std::string_view config_value) {
     std::lock_guard guard(_mutex);
+
+    std::string startup_conf = startup_jemalloc_conf(config_value);
+    if (startup_conf != config_value) {
+        // The config describes a set of options jemalloc never saw. Publish what is really in
+        // effect instead, so that be_configs shows it and an update is diffed against the same
+        // string the operator is looking at. set_config() is used rather than assigning the
+        // field, to keep the rollback bookkeeping of ConfigUpdateRegistry intact, and the
+        // update hook is deliberately not invoked: there is nothing to re-apply here.
+        LOG(WARNING) << "jemalloc was started with '" << startup_conf << "' rather than the configured '"
+                     << config_value << "', publishing the effective option string as " << kJemallocConfName;
+        if (Status st = config::set_config(kJemallocConfName, startup_conf); !st.ok()) {
+            LOG(WARNING) << "failed to publish the effective jemalloc option string: " << st;
+        }
+    }
+
     auto options = parse_jemalloc_conf(startup_conf);
     if (!options.ok()) {
         // Keep the baseline empty: every option of the new value then looks newly

--- a/be/src/runtime/memory/jemalloc_conf_updater.h
+++ b/be/src/runtime/memory/jemalloc_conf_updater.h
@@ -1,0 +1,69 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <map>
+#include <mutex>
+#include <set>
+#include <string>
+#include <string_view>
+
+#include "common/statusor.h"
+
+namespace starrocks {
+
+// Parsed form of a jemalloc option string such as
+// "percpu_arena:percpu,dirty_decay_ms:5000,prof_active:false". A duplicated key
+// follows jemalloc's own rule that the last assignment wins.
+using JemallocOptions = std::map<std::string, std::string>;
+
+StatusOr<JemallocOptions> parse_jemalloc_conf(std::string_view conf);
+
+// Applies the runtime-mutable subset of the `jemalloc_conf` config.
+//
+// Most jemalloc options are frozen once the process is initialized, because their
+// `opt.*` mallctl nodes are read-only. So an update is accepted only when every
+// option that actually changed has a writable mallctl counterpart; otherwise it is
+// rejected and ConfigUpdateRegistry rolls the config value back.
+class JemallocConfUpdater {
+public:
+    static JemallocConfUpdater& instance();
+
+    // Seeds the baseline with the option string the process was started with.
+    void init(std::string_view startup_conf);
+
+    // Diffs `new_conf` against the options applied so far and pushes the changed
+    // ones into jemalloc. Returns an error without touching jemalloc if any option
+    // outside the mutable set was added, removed or changed.
+    Status update(std::string_view new_conf);
+
+    // The options that have a writable mallctl counterpart.
+    static const std::set<std::string>& mutable_options();
+
+    JemallocOptions applied_options();
+
+private:
+    JemallocConfUpdater() = default;
+
+    // `prof.active` can also be toggled through HeapProf (`ADMIN EXECUTE`), which
+    // bypasses this config. Refresh the baseline from the live value so that the
+    // config becomes authoritative again instead of drifting away from jemalloc.
+    static void refresh_prof_active(JemallocOptions* options);
+
+    std::mutex _mutex;
+    JemallocOptions _applied;
+};
+
+} // namespace starrocks

--- a/be/src/runtime/memory/jemalloc_conf_updater.h
+++ b/be/src/runtime/memory/jemalloc_conf_updater.h
@@ -31,6 +31,12 @@ using JemallocOptions = std::map<std::string, std::string>;
 
 StatusOr<JemallocOptions> parse_jemalloc_conf(std::string_view conf);
 
+// The option string jemalloc initialized itself from: the JEMALLOC_CONF environment variable
+// when it is set, and `config_value` otherwise. bin/start_backend.sh normally exports the
+// config value into that variable, but it leaves an already-set variable alone and forces its
+// own string under --jemalloc_debug and --check_mem_leak, so the two can differ.
+std::string startup_jemalloc_conf(std::string_view config_value);
+
 // Applies the runtime-mutable subset of the `jemalloc_conf` config.
 //
 // Most jemalloc options are frozen once the process is initialized, because their
@@ -41,8 +47,10 @@ class JemallocConfUpdater {
 public:
     static JemallocConfUpdater& instance();
 
-    // Seeds the baseline with the option string the process was started with.
-    void init(std::string_view startup_conf);
+    // Seeds the baseline with the option string jemalloc actually started with, and rewrites
+    // `jemalloc_conf` to it when the config says something else, so that the value shown by
+    // information_schema.be_configs is the one an update is diffed against.
+    void init(std::string_view config_value);
 
     // Diffs `new_conf` against the options applied so far and pushes the changed
     // ones into jemalloc. Returns an error without touching jemalloc if any option

--- a/be/src/service/service_be/config_update_hooks.cpp
+++ b/be/src/service/service_be/config_update_hooks.cpp
@@ -157,8 +157,9 @@ void register_config_update_hooks(ExecEnv* exec_env, const RuntimeEnv& runtime_e
         return Status::OK();
     });
 
-    // jemalloc has already been configured from JEMALLOC_CONF by the time we get
-    // here, so take the value the process was started with as the baseline.
+    // jemalloc has already read JEMALLOC_CONF by the time we get here. init() takes the
+    // option string that actually took effect as the baseline, and republishes it as
+    // `jemalloc_conf` when the config claims something else.
     JemallocConfUpdater::instance().init(config::jemalloc_conf.value());
     registry->register_callback("jemalloc_conf", []() -> Status {
         return JemallocConfUpdater::instance().update(config::jemalloc_conf.value());

--- a/be/src/service/service_be/config_update_hooks.cpp
+++ b/be/src/service/service_be/config_update_hooks.cpp
@@ -35,6 +35,7 @@
 #include "common/config_ingest_fwd.h"
 #include "common/config_lake_fwd.h"
 #include "common/config_llm_fwd.h"
+#include "common/config_memory_allocator_fwd.h"
 #include "common/config_merge_commit_fwd.h"
 #include "common/config_primary_key_fwd.h"
 #include "common/config_runtime_fwd.h"
@@ -55,6 +56,7 @@
 #include "data_workflows/load/batch_write/batch_write_mgr.h"
 #include "data_workflows/load/tablet_writer/load_channel_mgr.h"
 #include "exec/exec_env.h"
+#include "runtime/memory/jemalloc_conf_updater.h"
 #include "runtime/runtime_env.h"
 #include "service/core_dump_resource_releaser.h"
 #include "storage/compaction_manager.h"
@@ -153,6 +155,13 @@ void register_config_update_hooks(ExecEnv* exec_env, const RuntimeEnv& runtime_e
     registry->register_callback("try_release_resource_before_core_dump", []() -> Status {
         refresh_core_dump_resource_releaser_config();
         return Status::OK();
+    });
+
+    // jemalloc has already been configured from JEMALLOC_CONF by the time we get
+    // here, so take the value the process was started with as the baseline.
+    JemallocConfUpdater::instance().init(config::jemalloc_conf.value());
+    registry->register_callback("jemalloc_conf", []() -> Status {
+        return JemallocConfUpdater::instance().update(config::jemalloc_conf.value());
     });
 
     registry->register_callback("scanner_thread_pool_thread_num", [=]() -> Status {

--- a/be/test/runtime/CMakeLists.txt
+++ b/be/test/runtime/CMakeLists.txt
@@ -51,6 +51,7 @@ set(RUNTIME_TEST_FILES
     memory/counting_allocator_test.cpp
     memory/memory_allocator_test.cpp
     memory/memory_lock_test.cpp
+    memory/jemalloc_conf_updater_test.cpp
     prof/heap_prof_test.cpp
 )
 

--- a/be/test/runtime/memory/jemalloc_conf_updater_test.cpp
+++ b/be/test/runtime/memory/jemalloc_conf_updater_test.cpp
@@ -89,6 +89,13 @@ TEST_F(JemallocConfUpdaterTest, parse_conf) {
     EXPECT_EQ("100", options["dirty_decay_ms"]);
     EXPECT_EQ("true", options["prof_active"]);
 
+    // Only spaces are trimmed. jemalloc does not accept any other whitespace inside
+    // JEMALLOC_CONF either, so a stray tab stays part of the name and is reported as an
+    // unknown option instead of being silently accepted.
+    ASSIGN_OR_ABORT(options, parse_jemalloc_conf("\tdirty_decay_ms:100"));
+    EXPECT_EQ(1, options.size());
+    EXPECT_EQ("100", options["\tdirty_decay_ms"]);
+
     // jemalloc itself lets the last assignment win.
     ASSIGN_OR_ABORT(options, parse_jemalloc_conf("dirty_decay_ms:1,dirty_decay_ms:2"));
     EXPECT_EQ(1, options.size());

--- a/be/test/runtime/memory/jemalloc_conf_updater_test.cpp
+++ b/be/test/runtime/memory/jemalloc_conf_updater_test.cpp
@@ -18,9 +18,12 @@
 #include <sys/types.h>
 
 #include <algorithm>
+#include <cstdlib>
 #include <string>
 
 #include "base/testutil/assert.h"
+#include "common/config_memory_allocator_fwd.h"
+#include "common/configbase.h"
 #include "fmt/format.h"
 #include "jemalloc/jemalloc.h"
 
@@ -41,6 +44,9 @@ std::string startup_conf() {
     return make_conf("5000", "5000", "false");
 }
 
+constexpr const char* kJemallocConfEnv = "JEMALLOC_CONF";
+constexpr const char* kJemallocConfName = "jemalloc_conf";
+
 bool prof_enabled_at_startup() {
     bool enabled = false;
     size_t size = sizeof(enabled);
@@ -59,6 +65,14 @@ ssize_t read_default_decay_ms(bool dirty) {
 class JemallocConfUpdaterTest : public testing::Test {
 public:
     void SetUp() override {
+        if (const char* env = std::getenv(kJemallocConfEnv); env != nullptr) {
+            _saved_env = env;
+            _env_was_set = true;
+        }
+        // init() prefers the environment, so clear it to make the seed of a test the string
+        // the test passes in. The cases that exercise the environment set it themselves.
+        ::unsetenv(kJemallocConfEnv);
+        _saved_config = config::jemalloc_conf.value();
         _saved_dirty_decay_ms = read_default_decay_ms(true);
         _saved_muzzy_decay_ms = read_default_decay_ms(false);
         JemallocConfUpdater::instance().init(startup_conf());
@@ -67,14 +81,22 @@ public:
     // Push the saved values back through the updater, so that the arenas of the test
     // process are left with the decay times they had before the test.
     void TearDown() override {
+        ::unsetenv(kJemallocConfEnv);
         JemallocConfUpdater::instance().init(startup_conf());
         EXPECT_OK(JemallocConfUpdater::instance().update(
                 make_conf(std::to_string(_saved_dirty_decay_ms), std::to_string(_saved_muzzy_decay_ms), "false")));
+        EXPECT_OK(config::set_config(kJemallocConfName, _saved_config));
+        if (_env_was_set) {
+            ::setenv(kJemallocConfEnv, _saved_env.c_str(), 1);
+        }
     }
 
 private:
     ssize_t _saved_dirty_decay_ms = 0;
     ssize_t _saved_muzzy_decay_ms = 0;
+    std::string _saved_config;
+    std::string _saved_env;
+    bool _env_was_set = false;
 };
 
 TEST_F(JemallocConfUpdaterTest, parse_conf) {
@@ -107,6 +129,44 @@ TEST_F(JemallocConfUpdaterTest, parse_conf) {
 
     EXPECT_TRUE(parse_jemalloc_conf("dirty_decay_ms").status().is_invalid_argument());
     EXPECT_TRUE(parse_jemalloc_conf("dirty_decay_ms:1,:2").status().is_invalid_argument());
+}
+
+TEST_F(JemallocConfUpdaterTest, startup_conf_prefers_the_environment) {
+    ::setenv(kJemallocConfEnv, "dirty_decay_ms:1234", 1);
+    EXPECT_EQ("dirty_decay_ms:1234", startup_jemalloc_conf("dirty_decay_ms:5000"));
+
+    // A set but empty variable is an empty option set, not a missing one.
+    ::setenv(kJemallocConfEnv, "", 1);
+    EXPECT_EQ("", startup_jemalloc_conf("dirty_decay_ms:5000"));
+
+    ::unsetenv(kJemallocConfEnv);
+    EXPECT_EQ("dirty_decay_ms:5000", startup_jemalloc_conf("dirty_decay_ms:5000"));
+}
+
+TEST_F(JemallocConfUpdaterTest, init_leaves_the_config_alone_when_it_took_effect) {
+    ::setenv(kJemallocConfEnv, startup_conf().c_str(), 1);
+    ASSERT_OK(config::set_config(kJemallocConfName, startup_conf()));
+
+    JemallocConfUpdater::instance().init(startup_conf());
+    EXPECT_EQ(startup_conf(), config::jemalloc_conf.value());
+}
+
+// bin/start_backend.sh forces its own JEMALLOC_CONF under --jemalloc_debug and
+// --check_mem_leak. The config then describes options jemalloc never saw, so init() has to
+// publish the effective string; otherwise an operator is shown one option set and diffed
+// against another.
+TEST_F(JemallocConfUpdaterTest, init_publishes_the_effective_conf_when_the_environment_differs) {
+    const std::string forced = "junk:true,tcache:false,prof:true";
+    ::setenv(kJemallocConfEnv, forced.c_str(), 1);
+    ASSERT_OK(config::set_config(kJemallocConfName, startup_conf()));
+
+    JemallocConfUpdater::instance().init(startup_conf());
+    EXPECT_EQ(forced, config::jemalloc_conf.value());
+
+    // And an update on top of what be_configs now shows goes through, instead of being
+    // rejected over options the operator can see nowhere.
+    ASSERT_OK(JemallocConfUpdater::instance().update(forced + ",dirty_decay_ms:4000"));
+    EXPECT_EQ(4000, read_default_decay_ms(true));
 }
 
 TEST_F(JemallocConfUpdaterTest, reject_immutable_option) {

--- a/be/test/runtime/memory/jemalloc_conf_updater_test.cpp
+++ b/be/test/runtime/memory/jemalloc_conf_updater_test.cpp
@@ -1,0 +1,191 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runtime/memory/jemalloc_conf_updater.h"
+
+#include <gtest/gtest.h>
+#include <sys/types.h>
+
+#include <string>
+
+#include "base/testutil/assert.h"
+#include "fmt/format.h"
+#include "jemalloc/jemalloc.h"
+
+namespace starrocks {
+
+namespace {
+
+// The same option set the BE is started with, so that the diff of a test only
+// contains what the test itself changed.
+std::string make_conf(std::string_view dirty_decay_ms, std::string_view muzzy_decay_ms, std::string_view prof_active) {
+    return fmt::format(
+            "percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:{},dirty_decay_ms:{},metadata_thp:auto,"
+            "background_thread:true,prof:true,prof_active:{}",
+            muzzy_decay_ms, dirty_decay_ms, prof_active);
+}
+
+std::string startup_conf() {
+    return make_conf("5000", "5000", "false");
+}
+
+bool prof_enabled_at_startup() {
+    bool enabled = false;
+    size_t size = sizeof(enabled);
+    return je_mallctl("opt.prof", &enabled, &size, nullptr, 0) == 0 && enabled;
+}
+
+ssize_t read_default_decay_ms(bool dirty) {
+    ssize_t decay_ms = 0;
+    size_t size = sizeof(decay_ms);
+    EXPECT_EQ(0, je_mallctl(dirty ? "arenas.dirty_decay_ms" : "arenas.muzzy_decay_ms", &decay_ms, &size, nullptr, 0));
+    return decay_ms;
+}
+
+} // namespace
+
+class JemallocConfUpdaterTest : public testing::Test {
+public:
+    void SetUp() override {
+        _saved_dirty_decay_ms = read_default_decay_ms(true);
+        _saved_muzzy_decay_ms = read_default_decay_ms(false);
+        JemallocConfUpdater::instance().init(startup_conf());
+    }
+
+    // Push the saved values back through the updater, so that the arenas of the test
+    // process are left with the decay times they had before the test.
+    void TearDown() override {
+        JemallocConfUpdater::instance().init(startup_conf());
+        EXPECT_OK(JemallocConfUpdater::instance().update(
+                make_conf(std::to_string(_saved_dirty_decay_ms), std::to_string(_saved_muzzy_decay_ms), "false")));
+    }
+
+private:
+    ssize_t _saved_dirty_decay_ms = 0;
+    ssize_t _saved_muzzy_decay_ms = 0;
+};
+
+TEST_F(JemallocConfUpdaterTest, parse_conf) {
+    ASSIGN_OR_ABORT(auto options, parse_jemalloc_conf(startup_conf()));
+    EXPECT_EQ(8, options.size());
+    EXPECT_EQ("percpu", options["percpu_arena"]);
+    EXPECT_EQ("5000", options["dirty_decay_ms"]);
+    EXPECT_EQ("false", options["prof_active"]);
+
+    // Surrounding spaces are ignored and empty segments are tolerated.
+    ASSIGN_OR_ABORT(options, parse_jemalloc_conf("  dirty_decay_ms : 100 ,,prof_active:true,"));
+    EXPECT_EQ(2, options.size());
+    EXPECT_EQ("100", options["dirty_decay_ms"]);
+    EXPECT_EQ("true", options["prof_active"]);
+
+    // jemalloc itself lets the last assignment win.
+    ASSIGN_OR_ABORT(options, parse_jemalloc_conf("dirty_decay_ms:1,dirty_decay_ms:2"));
+    EXPECT_EQ(1, options.size());
+    EXPECT_EQ("2", options["dirty_decay_ms"]);
+
+    ASSIGN_OR_ABORT(options, parse_jemalloc_conf(""));
+    EXPECT_TRUE(options.empty());
+
+    EXPECT_TRUE(parse_jemalloc_conf("dirty_decay_ms").status().is_invalid_argument());
+    EXPECT_TRUE(parse_jemalloc_conf("dirty_decay_ms:1,:2").status().is_invalid_argument());
+}
+
+TEST_F(JemallocConfUpdaterTest, reject_immutable_option) {
+    auto& updater = JemallocConfUpdater::instance();
+    const auto before = updater.applied_options();
+
+    // Changed.
+    Status st = updater.update("percpu_arena:disabled,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,"
+                               "metadata_thp:auto,background_thread:true,prof:true,prof_active:false");
+    EXPECT_TRUE(st.is_not_supported()) << st;
+    EXPECT_TRUE(st.message().find("percpu_arena") != std::string::npos) << st;
+
+    // Added.
+    st = updater.update(startup_conf() + ",lg_prof_sample:0");
+    EXPECT_TRUE(st.is_not_supported()) << st;
+    EXPECT_TRUE(st.message().find("lg_prof_sample (added)") != std::string::npos) << st;
+
+    // Removed.
+    st = updater.update("percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,"
+                        "metadata_thp:auto,background_thread:true,prof:true");
+    EXPECT_TRUE(st.is_not_supported()) << st;
+    EXPECT_TRUE(st.message().find("prof_active (removed)") != std::string::npos) << st;
+
+    // A mutable option changed together with an immutable one is rejected as well.
+    st = updater.update("percpu_arena:disabled,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:6000,"
+                        "metadata_thp:auto,background_thread:true,prof:true,prof_active:false");
+    EXPECT_TRUE(st.is_not_supported()) << st;
+
+    EXPECT_EQ(before, updater.applied_options());
+}
+
+TEST_F(JemallocConfUpdaterTest, reject_invalid_value) {
+    auto& updater = JemallocConfUpdater::instance();
+    const auto before = updater.applied_options();
+
+    for (const auto& conf : {make_conf("abc", "5000", "false"), make_conf("-2", "5000", "false"),
+                             make_conf("5000", "5000", "yes")}) {
+        Status st = updater.update(conf);
+        EXPECT_TRUE(st.is_invalid_argument()) << st;
+        // Nothing is applied when a single value is invalid.
+        EXPECT_EQ(before, updater.applied_options());
+    }
+}
+
+TEST_F(JemallocConfUpdaterTest, update_without_change_is_a_noop) {
+    auto& updater = JemallocConfUpdater::instance();
+    ASSERT_OK(updater.update(startup_conf()));
+    EXPECT_EQ("5000", updater.applied_options()["dirty_decay_ms"]);
+
+    // The option order does not matter either.
+    ASSERT_OK(updater.update("prof_active:false,prof:true,background_thread:true,metadata_thp:auto,"
+                             "dirty_decay_ms:5000,muzzy_decay_ms:5000,oversize_threshold:0,percpu_arena:percpu"));
+    EXPECT_EQ("5000", updater.applied_options()["muzzy_decay_ms"]);
+}
+
+TEST_F(JemallocConfUpdaterTest, apply_decay_ms) {
+    auto& updater = JemallocConfUpdater::instance();
+    ASSERT_OK(updater.update(make_conf("6000", "7000", "false")));
+
+    EXPECT_EQ("6000", updater.applied_options()["dirty_decay_ms"]);
+    EXPECT_EQ("7000", updater.applied_options()["muzzy_decay_ms"]);
+    EXPECT_EQ(6000, read_default_decay_ms(true));
+    EXPECT_EQ(7000, read_default_decay_ms(false));
+
+    // -1 disables purging entirely and 0 purges eagerly; both are accepted.
+    ASSERT_OK(updater.update(make_conf("-1", "0", "false")));
+    EXPECT_EQ(-1, read_default_decay_ms(true));
+    EXPECT_EQ(0, read_default_decay_ms(false));
+}
+
+TEST_F(JemallocConfUpdaterTest, apply_prof_active) {
+    auto& updater = JemallocConfUpdater::instance();
+    Status st = updater.update(make_conf("5000", "5000", "true"));
+#ifdef __APPLE__
+    EXPECT_TRUE(st.is_not_supported()) << st;
+#else
+    if (prof_enabled_at_startup()) {
+        ASSERT_OK(st);
+        EXPECT_EQ("true", updater.applied_options()["prof_active"]);
+        ASSERT_OK(updater.update(startup_conf()));
+        EXPECT_EQ("false", updater.applied_options()["prof_active"]);
+    } else {
+        // The test binary is normally not started with prof:true.
+        EXPECT_TRUE(st.is_not_supported()) << st;
+        EXPECT_TRUE(st.message().find("prof:true") != std::string::npos) << st;
+    }
+#endif
+}
+
+} // namespace starrocks

--- a/be/test/runtime/memory/jemalloc_conf_updater_test.cpp
+++ b/be/test/runtime/memory/jemalloc_conf_updater_test.cpp
@@ -106,8 +106,9 @@ TEST_F(JemallocConfUpdaterTest, reject_immutable_option) {
     const auto before = updater.applied_options();
 
     // Changed.
-    Status st = updater.update("percpu_arena:disabled,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,"
-                               "metadata_thp:auto,background_thread:true,prof:true,prof_active:false");
+    Status st = updater.update(
+            "percpu_arena:disabled,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,"
+            "metadata_thp:auto,background_thread:true,prof:true,prof_active:false");
     EXPECT_TRUE(st.is_not_supported()) << st;
     EXPECT_TRUE(st.message().find("percpu_arena") != std::string::npos) << st;
 
@@ -117,14 +118,16 @@ TEST_F(JemallocConfUpdaterTest, reject_immutable_option) {
     EXPECT_TRUE(st.message().find("lg_prof_sample (added)") != std::string::npos) << st;
 
     // Removed.
-    st = updater.update("percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,"
-                        "metadata_thp:auto,background_thread:true,prof:true");
+    st = updater.update(
+            "percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,"
+            "metadata_thp:auto,background_thread:true,prof:true");
     EXPECT_TRUE(st.is_not_supported()) << st;
     EXPECT_TRUE(st.message().find("prof_active (removed)") != std::string::npos) << st;
 
     // A mutable option changed together with an immutable one is rejected as well.
-    st = updater.update("percpu_arena:disabled,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:6000,"
-                        "metadata_thp:auto,background_thread:true,prof:true,prof_active:false");
+    st = updater.update(
+            "percpu_arena:disabled,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:6000,"
+            "metadata_thp:auto,background_thread:true,prof:true,prof_active:false");
     EXPECT_TRUE(st.is_not_supported()) << st;
 
     EXPECT_EQ(before, updater.applied_options());
@@ -134,8 +137,8 @@ TEST_F(JemallocConfUpdaterTest, reject_invalid_value) {
     auto& updater = JemallocConfUpdater::instance();
     const auto before = updater.applied_options();
 
-    for (const auto& conf : {make_conf("abc", "5000", "false"), make_conf("-2", "5000", "false"),
-                             make_conf("5000", "5000", "yes")}) {
+    for (const auto& conf :
+         {make_conf("abc", "5000", "false"), make_conf("-2", "5000", "false"), make_conf("5000", "5000", "yes")}) {
         Status st = updater.update(conf);
         EXPECT_TRUE(st.is_invalid_argument()) << st;
         // Nothing is applied when a single value is invalid.
@@ -149,8 +152,9 @@ TEST_F(JemallocConfUpdaterTest, update_without_change_is_a_noop) {
     EXPECT_EQ("5000", updater.applied_options()["dirty_decay_ms"]);
 
     // The option order does not matter either.
-    ASSERT_OK(updater.update("prof_active:false,prof:true,background_thread:true,metadata_thp:auto,"
-                             "dirty_decay_ms:5000,muzzy_decay_ms:5000,oversize_threshold:0,percpu_arena:percpu"));
+    ASSERT_OK(
+            updater.update("prof_active:false,prof:true,background_thread:true,metadata_thp:auto,"
+                           "dirty_decay_ms:5000,muzzy_decay_ms:5000,oversize_threshold:0,percpu_arena:percpu"));
     EXPECT_EQ("5000", updater.applied_options()["muzzy_decay_ms"]);
 }
 

--- a/be/test/runtime/memory/jemalloc_conf_updater_test.cpp
+++ b/be/test/runtime/memory/jemalloc_conf_updater_test.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 #include <sys/types.h>
 
+#include <algorithm>
 #include <string>
 
 #include "base/testutil/assert.h"
@@ -163,6 +164,45 @@ TEST_F(JemallocConfUpdaterTest, update_without_change_is_a_noop) {
             updater.update("prof_active:false,prof:true,background_thread:true,metadata_thp:auto,"
                            "dirty_decay_ms:5000,muzzy_decay_ms:5000,oversize_threshold:0,percpu_arena:percpu"));
     EXPECT_EQ("5000", updater.applied_options()["muzzy_decay_ms"]);
+}
+
+// The decay times must reach the automatic arenas only. jemalloc keeps its dedicated huge
+// arena at index narenas_auto and puts it on eager purge on purpose, and the arenas created
+// through `arenas.create` sit above that, so neither may be retuned from here.
+//
+// This process has no huge arena (`oversize_threshold:0`), but a manually created arena is
+// on the same side of narenas_auto, so it stands in for one: if the walk stopped at
+// `arenas.narenas` it would reach this arena too.
+TEST_F(JemallocConfUpdaterTest, decay_ms_skips_the_arenas_above_narenas_auto) {
+    unsigned manual_arena = 0;
+    size_t size = sizeof(manual_arena);
+    // Not destroyed afterwards: that needs `arena.<i>.reset` plus `arena.<i>.destroy` and the
+    // arena is empty anyway. It cannot disturb the other cases, because the walk is now
+    // bounded by narenas_auto rather than by the arena count this bumps.
+    ASSERT_EQ(0, je_mallctl("arenas.create", &manual_arena, &size, nullptr, 0));
+
+    // Mirrors auto_arena_count(): narenas_auto = min(opt.narenas, MALLOCX_ARENA_LIMIT - 1).
+    // Without a huge arena the first manually created arena lands exactly on narenas_auto,
+    // so the relation is >=, not >.
+    unsigned opt_narenas = 0;
+    size = sizeof(opt_narenas);
+    ASSERT_EQ(0, je_mallctl("opt.narenas", &opt_narenas, &size, nullptr, 0));
+    const unsigned narenas_auto = std::min(opt_narenas, (1u << 12) - 2);
+    ASSERT_GE(manual_arena, narenas_auto) << "a manually created arena must sit at or above narenas_auto";
+
+    const std::string name = fmt::format("arena.{}.dirty_decay_ms", manual_arena);
+    ssize_t sentinel = 12345;
+    ASSERT_EQ(0, je_mallctl(name.c_str(), nullptr, nullptr, &sentinel, sizeof(sentinel)));
+
+    ASSERT_OK(JemallocConfUpdater::instance().update(make_conf("6000", "5000", "false")));
+
+    // The automatic arenas took the new value...
+    EXPECT_EQ(6000, read_default_decay_ms(true));
+    // ... while the arena above narenas_auto kept its own.
+    ssize_t after = 0;
+    size = sizeof(after);
+    ASSERT_EQ(0, je_mallctl(name.c_str(), &after, &size, nullptr, 0));
+    EXPECT_EQ(sentinel, after);
 }
 
 TEST_F(JemallocConfUpdaterTest, apply_decay_ms) {

--- a/bin/start_backend.sh
+++ b/bin/start_backend.sh
@@ -176,7 +176,7 @@ if [[ -z "$JEMALLOC_CONF" ]]; then
     else
         # Normal mode: take the value from the `jemalloc_conf` config in be.conf/cn.conf so it is
         # observable via information_schema.be_configs. Fall back to the built-in default when unset.
-        # NOTE: keep this default in sync with CONF_String(jemalloc_conf, ...) in be/src/common/config.h.
+        # NOTE: keep this default in sync with CONF_mString(jemalloc_conf, ...) in be/src/common/config.h.
         jemalloc_conf="percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true,prof:true,prof_active:false"
         if [ ${RUN_BE} -eq 1 ]; then
             read_var_from_conf jemalloc_conf $STARROCKS_HOME/conf/be.conf

--- a/docs/en/administration/configuration/BE_parameters/log_server_meta.md
+++ b/docs/en/administration/configuration/BE_parameters/log_server_meta.md
@@ -402,6 +402,15 @@ This topic introduces the following types of BE configurations:
 - Description: The thread count of the BE heartbeat service.
 - Introduced in: -
 
+### jemalloc_conf
+
+- Default: `percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true,prof:true,prof_active:false`
+- Type: string
+- Unit: -
+- Is mutable: Yes (only some options)
+- Description: The jemalloc runtime options that `bin/start_backend.sh` exports as the `JEMALLOC_CONF` environment variable when the BE is started in the normal mode. This item is ignored if `JEMALLOC_CONF` is already set in the environment, and if the BE is started with `--jemalloc_debug` or `--check_mem_leak`, because those modes force their own option string. jemalloc reads `JEMALLOC_CONF` before the BE parses its configuration, so modifying this item at runtime only re-applies the options that jemalloc itself allows to be changed after initialization: `dirty_decay_ms`, `muzzy_decay_ms`, and `prof_active`. Adding, removing, or changing any other option is rejected with an error and the configuration value is rolled back, which means those options require restarting the BE. `prof_active` can only be changed if the BE was started with `prof:true`. Setting `dirty_decay_ms` or `muzzy_decay_ms` to `0` purges all unused pages synchronously and can therefore make the modification take a while, and setting it to `-1` disables purging.
+- Introduced in: v4.1.0
+
 ### local_library_dir
 
 - Default: `${UDF_RUNTIME_DIR}`

--- a/docs/en/administration/configuration/BE_parameters/log_server_meta.md
+++ b/docs/en/administration/configuration/BE_parameters/log_server_meta.md
@@ -409,7 +409,7 @@ This topic introduces the following types of BE configurations:
 - Unit: -
 - Is mutable: Yes (only some options)
 - Description: The jemalloc runtime options that `bin/start_backend.sh` exports as the `JEMALLOC_CONF` environment variable when the BE is started in the normal mode. This item is ignored if `JEMALLOC_CONF` is already set in the environment, and if the BE is started with `--jemalloc_debug` or `--check_mem_leak`, because those modes force their own option string. jemalloc reads `JEMALLOC_CONF` before the BE parses its configuration, so modifying this item at runtime only re-applies the options that jemalloc itself allows to be changed after initialization: `dirty_decay_ms`, `muzzy_decay_ms`, and `prof_active`. Adding, removing, or changing any other option is rejected with an error and the configuration value is rolled back, which means those options require restarting the BE. `prof_active` can only be changed if the BE was started with `prof:true`. Setting `dirty_decay_ms` or `muzzy_decay_ms` to `0` purges all unused pages synchronously and can therefore make the modification take a while, and setting it to `-1` disables purging.
-- Introduced in: v4.1.0
+- Introduced in: v4.0.15, v4.1.3
 
 ### local_library_dir
 

--- a/docs/ja/administration/configuration/BE_parameters/log_server_meta.md
+++ b/docs/ja/administration/configuration/BE_parameters/log_server_meta.md
@@ -334,7 +334,7 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 単位: -
 - 変更可能: はい (一部のオプションのみ)
 - 説明: BE が通常モードで起動する際に `bin/start_backend.sh` が `JEMALLOC_CONF` 環境変数としてエクスポートする jemalloc のランタイムオプションです。環境変数 `JEMALLOC_CONF` が既に設定されている場合、および BE が `--jemalloc_debug` または `--check_mem_leak` で起動された場合 (これらのモードは独自のオプションを強制します) は、この項目は無視されます。jemalloc は BE が設定を解析する前に `JEMALLOC_CONF` を読み込むため、この項目を実行時に変更しても、jemalloc 自身が初期化後の変更を許可しているオプション、すなわち `dirty_decay_ms`、`muzzy_decay_ms`、`prof_active` のみが再適用されます。それ以外のオプションの追加、削除、変更はエラーになり設定値はロールバックされるため、それらのオプションを変更するには BE の再起動が必要です。`prof_active` は BE が `prof:true` で起動されている場合にのみ変更できます。`dirty_decay_ms` または `muzzy_decay_ms` に `0` を設定すると未使用のページがすべて同期的にパージされるため変更に時間がかかることがあり、`-1` を設定するとパージが無効になります。
-- 導入バージョン: v4.1.0
+- 導入バージョン: v4.0.15, v4.1.3
 
 ### local_library_dir
 

--- a/docs/ja/administration/configuration/BE_parameters/log_server_meta.md
+++ b/docs/ja/administration/configuration/BE_parameters/log_server_meta.md
@@ -327,6 +327,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 説明: BE ハートビートサービスのスレッド数。
 - 導入バージョン: -
 
+### jemalloc_conf
+
+- デフォルト: `percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true,prof:true,prof_active:false`
+- タイプ: string
+- 単位: -
+- 変更可能: はい (一部のオプションのみ)
+- 説明: BE が通常モードで起動する際に `bin/start_backend.sh` が `JEMALLOC_CONF` 環境変数としてエクスポートする jemalloc のランタイムオプションです。環境変数 `JEMALLOC_CONF` が既に設定されている場合、および BE が `--jemalloc_debug` または `--check_mem_leak` で起動された場合 (これらのモードは独自のオプションを強制します) は、この項目は無視されます。jemalloc は BE が設定を解析する前に `JEMALLOC_CONF` を読み込むため、この項目を実行時に変更しても、jemalloc 自身が初期化後の変更を許可しているオプション、すなわち `dirty_decay_ms`、`muzzy_decay_ms`、`prof_active` のみが再適用されます。それ以外のオプションの追加、削除、変更はエラーになり設定値はロールバックされるため、それらのオプションを変更するには BE の再起動が必要です。`prof_active` は BE が `prof:true` で起動されている場合にのみ変更できます。`dirty_decay_ms` または `muzzy_decay_ms` に `0` を設定すると未使用のページがすべて同期的にパージされるため変更に時間がかかることがあり、`-1` を設定するとパージが無効になります。
+- 導入バージョン: v4.1.0
+
 ### local_library_dir
 
 - デフォルト: `${UDF_RUNTIME_DIR}`

--- a/docs/zh/administration/configuration/BE_parameters/log_server_meta.md
+++ b/docs/zh/administration/configuration/BE_parameters/log_server_meta.md
@@ -430,7 +430,7 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 单位：-
 - 是否动态：是（仅部分选项）
 - 描述：BE 以普通模式启动时，由 `bin/start_backend.sh` 导出为 `JEMALLOC_CONF` 环境变量的 jemalloc 运行时选项。如果环境中已经设置了 `JEMALLOC_CONF`，或者 BE 以 `--jemalloc_debug`、`--check_mem_leak` 方式启动（这两种模式会强制使用各自的选项），则该配置项不生效。由于 jemalloc 在 BE 解析配置之前就已经读取了 `JEMALLOC_CONF`，运行时修改该配置项只会重新应用 jemalloc 本身允许在初始化之后修改的选项，即 `dirty_decay_ms`、`muzzy_decay_ms` 和 `prof_active`。新增、删除或修改其他任何选项都会报错并回滚配置值，这些选项只能通过重启 BE 生效。只有 BE 启动时带 `prof:true` 才能修改 `prof_active`。将 `dirty_decay_ms` 或 `muzzy_decay_ms` 设置为 `0` 会同步清理所有未使用的页面，本次修改可能因此耗时较长；设置为 `-1` 表示禁用清理。
-- 引入版本：v4.1.0
+- 引入版本：v4.0.15, v4.1.3
 
 ### local_library_dir
 

--- a/docs/zh/administration/configuration/BE_parameters/log_server_meta.md
+++ b/docs/zh/administration/configuration/BE_parameters/log_server_meta.md
@@ -423,6 +423,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 描述：心跳线程数。
 - 引入版本：-
 
+### jemalloc_conf
+
+- 默认值：`percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true,prof:true,prof_active:false`
+- 类型：string
+- 单位：-
+- 是否动态：是（仅部分选项）
+- 描述：BE 以普通模式启动时，由 `bin/start_backend.sh` 导出为 `JEMALLOC_CONF` 环境变量的 jemalloc 运行时选项。如果环境中已经设置了 `JEMALLOC_CONF`，或者 BE 以 `--jemalloc_debug`、`--check_mem_leak` 方式启动（这两种模式会强制使用各自的选项），则该配置项不生效。由于 jemalloc 在 BE 解析配置之前就已经读取了 `JEMALLOC_CONF`，运行时修改该配置项只会重新应用 jemalloc 本身允许在初始化之后修改的选项，即 `dirty_decay_ms`、`muzzy_decay_ms` 和 `prof_active`。新增、删除或修改其他任何选项都会报错并回滚配置值，这些选项只能通过重启 BE 生效。只有 BE 启动时带 `prof:true` 才能修改 `prof_active`。将 `dirty_decay_ms` 或 `muzzy_decay_ms` 设置为 `0` 会同步清理所有未使用的页面，本次修改可能因此耗时较长；设置为 `-1` 表示禁用清理。
+- 引入版本：v4.1.0
+
 ### local_library_dir
 
 - 默认值：`${UDF_RUNTIME_DIR}`


### PR DESCRIPTION
## Why I'm doing:

`jemalloc_conf` was added as an immutable config, purely to surface the jemalloc runtime options through `information_schema.be_configs`. Tuning any of them therefore needs a BE restart, even though jemalloc itself lets a few of them be changed after init through a writable `mallctl` node. In particular, `dirty_decay_ms` / `muzzy_decay_ms` are the knobs to reach for when a cluster is trading RSS against purge overhead, and `prof_active` is how heap profiling is armed. Today the only way to touch the latter is `ADMIN EXECUTE ON <be_id> 'HeapProf.getInstance().enable_prof()'`, which bypasses the config entirely and leaves `be_configs` showing a stale value.

The rest of the options (`percpu_arena`, `oversize_threshold`, `metadata_thp`, `background_thread`, `prof`) have read-only `opt.*` nodes and genuinely need a restart, so making the whole config mutable without checking would silently accept edits that never take effect.

## What I'm doing:

Make `jemalloc_conf` a `CONF_mString` and register a `jemalloc_conf` update hook, so it can be changed through both `UPDATE information_schema.be_configs` and `/api/update_config` (both funnel into `ConfigUpdateRegistry::update_config`).

A new `JemallocConfUpdater` keeps the option set that is currently applied, seeded at startup from the value the process was started with, and diffs the new value against it:

- if every option that changed has a writable `mallctl` counterpart — `dirty_decay_ms`, `muzzy_decay_ms`, `prof_active` — the changed ones are pushed into jemalloc;
- otherwise the update is rejected with an error naming the offending options (including `(added)` / `(removed)`), jemalloc is left untouched, and `ConfigUpdateRegistry` rolls the config value back.

Removing an option is rejected as well, because restoring it would mean guessing a value to put back, so the option set itself has to stay stable. All changed values are parsed before anything is applied, and the baseline is updated option by option as each one lands, so a failure halfway through still leaves the baseline describing the real state of jemalloc rather than the rolled-back string.

Notes on the two appliers:

- **decay times**: `arenas.<dirty|muzzy>_decay_ms` is set for the arenas created later, then `arena.<i>.*_decay_ms` is walked for the existing ones. `arena.<i>.*_decay_ms` does *not* accept `MALLCTL_ARENAS_ALL` — unlike `arena.<i>.purge`, its ctl handler resolves the index through `arena_get(ind, false)` and returns `EFAULT` for the pseudo index — so the arenas are walked one by one, and `EFAULT` is tolerated because `percpu_arena` creates arenas lazily and an absent arena inherits the default set above. With `background_thread:true` the calling thread does not purge, except when the new value is `0`, which purges every unused page synchronously; that case is logged as a warning.
- **prof_active**: goes through `HeapProf` so that prof state keeps a single owner, and is rejected when the process was not started with `prof:true` (`opt.prof` is read-only). The baseline for `prof_active` is refreshed from the live `prof.active` before diffing, so a toggle done through `ADMIN EXECUTE` converges back to the config instead of drifting away from it.

Docs for `jemalloc_conf` are added to the BE parameter pages in `en`, `zh` and `ja`, where the config was not documented at all before.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

`jemalloc_conf` becomes mutable, so `information_schema.be_configs.MUTABLE` flips from `false` to `true` for it and setting it now has a runtime effect. The default value is unchanged.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

Not a bugfix, so no backport is intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)