### PR TITLE
[Refactor] Deduplicate the space-trim helper into base/string

### DIFF
--- a/be/src/base/string/trim.h
+++ b/be/src/base/string/trim.h
@@ -1,0 +1,41 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <string_view>
+
+namespace starrocks {
+
+// Removes the leading and trailing ASCII spaces (0x20) of `str` and returns the remaining
+// substring, which still points into the buffer owned by the caller.
+//
+// Only the space character is removed. Callers such as the CSV `trim_space` option and URL
+// parsing treat a tab, a newline or a carriage return as data, so widening this to the whole
+// whitespace set would silently change what they parse. Use StripWhiteSpace() from
+// gutil/strings/strip.h when the full whitespace set should be removed instead.
+inline std::string_view trim_spaces(std::string_view str) {
+    size_t begin = 0;
+    size_t end = str.size();
+    while (begin < end && str[begin] == ' ') {
+        ++begin;
+    }
+    while (end > begin && str[end - 1] == ' ') {
+        --end;
+    }
+    return str.substr(begin, end - begin);
+}
+
+} // namespace starrocks

--- a/be/src/base/string/url_parser.cpp
+++ b/be/src/base/string/url_parser.cpp
@@ -36,6 +36,8 @@
 
 #include <string_view>
 
+#include "base/string/trim.h"
+
 namespace starrocks {
 
 const Slice UrlParser::_s_url_authority(const_cast<char*>("AUTHORITY"), 9);
@@ -59,20 +61,12 @@ const StringSearch UrlParser::_s_colon_search(&_s_colon);
 const StringSearch UrlParser::_s_question_search(&_s_question);
 const StringSearch UrlParser::_s_hash_search(&_s_hash);
 
-std::string_view trim(std::string_view str) {
-    auto pos = str.find_first_not_of(' ');
-    str.remove_prefix(std::min(pos, str.length()));
-    pos = str.find_last_not_of(' ');
-    str.remove_suffix(std::min(str.length() - pos - 1, str.length()));
-    return str;
-}
-
 UrlParser::ParseStatus UrlParser::parse_url(const Slice& url, UrlPart part, Slice* result) {
     result->data = nullptr;
     result->size = 0;
     // Remove leading and trailing spaces.
     std::string_view url_view = url;
-    Slice trimmed_url = trim(url_view);
+    Slice trimmed_url = trim_spaces(url_view);
 
     std::string_view protocol_end;
 

--- a/be/src/formats/csv/csv_reader.cpp
+++ b/be/src/formats/csv/csv_reader.cpp
@@ -16,25 +16,11 @@
 
 #include <unordered_set>
 
+#include "base/string/trim.h"
+
 namespace starrocks {
 
 using Field = Slice;
-
-static std::pair<const char*, size_t> trim(const char* value, size_t len) {
-    size_t begin = 0;
-
-    while (begin < len && value[begin] == ' ') {
-        ++begin;
-    }
-
-    size_t end = len;
-
-    while (end > begin && value[end - 1] == ' ') {
-        --end;
-    }
-
-    return std::make_pair(value + begin, end - begin);
-}
 
 inline bool CSVReader::is_column_delimiter(bool expandBuffer) {
     if (LIKELY(_column_delimiter_length == 1)) {
@@ -609,8 +595,8 @@ void CSVReader::split_record(const Record& record, Fields* columns) const {
             if (next_delimiter == nullptr) {
                 // No more delimiters found, add the remaining part
                 if (_parse_options.trim_space) {
-                    std::pair<const char*, size_t> newPos = trim(value, end - value);
-                    columns->emplace_back(newPos.first, newPos.second);
+                    std::string_view field = trim_spaces({value, static_cast<size_t>(end - value)});
+                    columns->emplace_back(field.data(), field.size());
                 } else {
                     columns->emplace_back(value, end - value);
                 }
@@ -618,8 +604,8 @@ void CSVReader::split_record(const Record& record, Fields* columns) const {
             } else {
                 // Found delimiter, add the field
                 if (_parse_options.trim_space) {
-                    std::pair<const char*, size_t> newPos = trim(value, next_delimiter - value);
-                    columns->emplace_back(newPos.first, newPos.second);
+                    std::string_view field = trim_spaces({value, static_cast<size_t>(next_delimiter - value)});
+                    columns->emplace_back(field.data(), field.size());
                 } else {
                     columns->emplace_back(value, next_delimiter - value);
                 }
@@ -635,8 +621,8 @@ void CSVReader::split_record(const Record& record, Fields* columns) const {
                                             _column_delimiter_length));
             if (ptr != nullptr) {
                 if (_parse_options.trim_space) {
-                    std::pair<const char*, size_t> newPos = trim(value, ptr - value);
-                    columns->emplace_back(newPos.first, newPos.second);
+                    std::string_view field = trim_spaces({value, static_cast<size_t>(ptr - value)});
+                    columns->emplace_back(field.data(), field.size());
                 } else {
                     columns->emplace_back(value, ptr - value);
                 }
@@ -648,8 +634,8 @@ void CSVReader::split_record(const Record& record, Fields* columns) const {
 
         // Add the last field for multi-character delimiter case
         if (_parse_options.trim_space) {
-            std::pair<const char*, size_t> newPos = trim(value, ptr - value);
-            columns->emplace_back(newPos.first, newPos.second);
+            std::string_view field = trim_spaces({value, static_cast<size_t>(ptr - value)});
+            columns->emplace_back(field.data(), field.size());
         } else {
             columns->emplace_back(value, ptr - value);
         }

--- a/be/test/base/CMakeLists.txt
+++ b/be/test/base/CMakeLists.txt
@@ -88,6 +88,7 @@ set(BASE_TEST_FILES
     string/string_search_test.cpp
     string/string_searcher_test.cpp
     string/string_util_test.cpp
+    string/trim_test.cpp
     string/string_parser_test.cpp
     string/slice_test.cpp
     string/url_parser_test.cpp

--- a/be/test/base/string/trim_test.cpp
+++ b/be/test/base/string/trim_test.cpp
@@ -1,0 +1,65 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "base/string/trim.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace starrocks {
+
+TEST(TrimSpacesTest, trim_spaces) {
+    EXPECT_EQ("abc", trim_spaces("abc"));
+    EXPECT_EQ("abc", trim_spaces("   abc"));
+    EXPECT_EQ("abc", trim_spaces("abc   "));
+    EXPECT_EQ("abc", trim_spaces("   abc   "));
+
+    // Only the outermost spaces are removed.
+    EXPECT_EQ("a b  c", trim_spaces("  a b  c  "));
+
+    EXPECT_EQ("", trim_spaces(""));
+    EXPECT_EQ("", trim_spaces(" "));
+    EXPECT_EQ("", trim_spaces("      "));
+}
+
+TEST(TrimSpacesTest, keeps_the_other_whitespace) {
+    // A tab, a newline or a carriage return is data for the CSV `trim_space` option and for URL
+    // parsing, so it must survive.
+    EXPECT_EQ("\tabc\t", trim_spaces("\tabc\t"));
+    EXPECT_EQ("abc\n", trim_spaces(" abc\n "));
+    EXPECT_EQ("abc\r", trim_spaces("abc\r"));
+    EXPECT_EQ("\vabc\f", trim_spaces("  \vabc\f  "));
+}
+
+TEST(TrimSpacesTest, points_into_the_input_buffer) {
+    const std::string input = "  abc  ";
+    std::string_view trimmed = trim_spaces(input);
+    EXPECT_EQ(input.data() + 2, trimmed.data());
+    EXPECT_EQ(3, trimmed.size());
+
+    // An all-space input still yields a view into the input rather than a null one.
+    const std::string spaces = "   ";
+    trimmed = trim_spaces(spaces);
+    EXPECT_TRUE(trimmed.empty());
+    EXPECT_NE(nullptr, trimmed.data());
+}
+
+TEST(TrimSpacesTest, handles_embedded_nul) {
+    // The input is a view, not a C string, so a NUL is just another byte.
+    const std::string input(" a\0b ", 5);
+    EXPECT_EQ(std::string("a\0b", 3), std::string(trim_spaces(input)));
+}
+
+} // namespace starrocks

--- a/be/test/formats/csv/csv_reader_test.cpp
+++ b/be/test/formats/csv/csv_reader_test.cpp
@@ -227,6 +227,48 @@ TEST_F(CSVReaderTest, test_split_record_multi_character_delimiter) {
     EXPECT_EQ("c", fields1[2].to_string());
 }
 
+// The multi-character delimiter path splits records in its own loop, so trim_space has to be
+// covered there as well and not only for a single-character delimiter.
+// NOLINTNEXTLINE
+TEST_F(CSVReaderTest, test_split_record_multi_char_delimiter_with_trim_space) {
+    starrocks::CSVParseOptions options;
+    options.column_delimiter = "||";
+    options.row_delimiter = "\n";
+    options.trim_space = true;
+
+    MockCSVReader reader(options);
+
+    starrocks::CSVReader::Record record1{" a || b || c ", 13};
+    starrocks::CSVReader::Fields fields1;
+    reader.split_record(record1, &fields1);
+
+    EXPECT_EQ(3, fields1.size());
+    EXPECT_EQ("a", fields1[0].to_string());
+    EXPECT_EQ("b", fields1[1].to_string());
+    EXPECT_EQ("c", fields1[2].to_string());
+
+    // Empty leading and trailing fields, which reach trim with a zero length. This is the
+    // multi-character counterpart of test_split_record_trim_space_empty_field.
+    starrocks::CSVReader::Record record2{"||x||", 5};
+    starrocks::CSVReader::Fields fields2;
+    reader.split_record(record2, &fields2);
+
+    EXPECT_EQ(3, fields2.size());
+    EXPECT_EQ("", fields2[0].to_string());
+    EXPECT_EQ("x", fields2[1].to_string());
+    EXPECT_EQ("", fields2[2].to_string());
+
+    // Fields that hold nothing but spaces must be trimmed down to empty ones.
+    starrocks::CSVReader::Record record3{" || x || ", 9};
+    starrocks::CSVReader::Fields fields3;
+    reader.split_record(record3, &fields3);
+
+    EXPECT_EQ(3, fields3.size());
+    EXPECT_EQ("", fields3[0].to_string());
+    EXPECT_EQ("x", fields3[1].to_string());
+    EXPECT_EQ("", fields3[2].to_string());
+}
+
 // NOLINTNEXTLINE
 TEST_F(CSVReaderTest, test_split_record_with_trim_space) {
     starrocks::CSVParseOptions options;


### PR DESCRIPTION
## Why I'm doing:

The same "strip leading and trailing spaces" helper was written twice, in two different shapes:

- `be/src/base/string/url_parser.cpp`: `std::string_view trim(std::string_view)`, file-local
- `be/src/formats/csv/csv_reader.cpp`: `static std::pair<const char*, size_t> trim(const char*, size_t)`

Neither is reachable from anywhere else, so the next caller that needs the same thing writes a third copy. gutil's `StripWhiteSpace()` cannot serve as the shared helper here: all three of its overloads mutate in place, none of them returns a view, and it removes the whole whitespace set rather than just the space.

## What I'm doing:

Move the helper to `be/src/base/string/trim.h` as `inline std::string_view trim_spaces(std::string_view)` and make both call sites use it.

Two deliberate choices:

- **Space only, and named so.** The CSV `trim_space` option is documented as removing the spaces some databases add around column separators (`docs/en/sql-reference/sql-statements/loading_unloading/BROKER_LOAD.md`), and URL parsing trims spaces the same way. A tab, a newline or a carriage return is *data* for both, so widening the helper to the whole whitespace set would silently change what they parse. The name is `trim_spaces` rather than `trim` so that nobody later "fixes" it into `isspace()`, and the header says which helper to reach for when the full whitespace set really should go.
- **Inline in a header with no heavy includes** (`<cstddef>` and `<string_view>` only). The CSV field-splitting loop calls the helper four times per record and relied on the compiler inlining a file-local `static`; keeping it inline preserves that. This is also why the helper does not go into `base/string/string_util.h`, which pulls in `boost/algorithm/string.hpp` — `csv_reader.cpp` currently includes nothing but its own header and `<unordered_set>`.

Behavior is unchanged at both call sites. The `url_parser` copy used `find_first_not_of`/`find_last_not_of` instead of a loop; both agree on every input, including an empty input and an all-space input (which yield an empty view into the input buffer, not a null one — covered by a test).

Two things intentionally left alone:

- `csv_reader.cpp` also has enclose-aware trimming driven by `white_space_start` (lines ~365-455). That is a different, stateful algorithm, not a copy of this helper.
- A third copy of the helper exists in #78333, which is still open. It will be switched over to `trim_spaces` once both land, rather than stacking the two PRs.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

Not a bugfix, so no backport is intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
