### PR TITLE
[Refactor] Add one fan-out primitive for the PK index's parallel reads

### DIFF
--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -271,6 +271,7 @@ set(STORAGE_FILES
     lake/local_pk_index_manager.cpp
     persistent_index_tablet_loader.cpp
     lake/lake_persistent_index.cpp
+    lake/parallel_task_runner.cpp
     lake/persistent_index_memtable.cpp
     lake/local_pk_index_manager.cpp
     lake/persistent_index_sstable.cpp

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -36,6 +36,7 @@
 #include "storage/lake/lake_persistent_index_parallel_compact_mgr.h"
 #include "storage/lake/lake_persistent_index_size_tiered_compaction_strategy.h"
 #include "storage/lake/meta_file.h"
+#include "storage/lake/parallel_task_runner.h"
 #include "storage/lake/persistent_index_memtable.h"
 #include "storage/lake/persistent_index_sstable.h"
 #include "storage/lake/persistent_index_sstable_fileset.h"
@@ -78,18 +79,13 @@ StatusOr<std::vector<PersistentIndexSstableUniquePtr>> LakePersistentIndex::_ope
     const int num_sstables = sstable_meta.sstables_size();
     std::vector<PersistentIndexSstableUniquePtr> sstables(num_sstables);
 
-    std::mutex mutex;
-    Status shared_status;
-    auto open_one = [&](int idx) {
+    // Each task writes only its own sstables[] element, so there is no shared state to guard.
+    auto open_one = [&](int idx) -> Status {
         auto& pb = sstable_meta.sstables(idx);
-        auto res = PersistentIndexSstable::new_sstable(pb, tablet_mgr->sst_location(tablet_id, pb.filename()), cache,
-                                                       true /* need filter */, nullptr, metadata, tablet_mgr);
-        if (res.ok()) {
-            sstables[idx] = std::move(res.value());
-        } else {
-            std::lock_guard<std::mutex> lock(mutex);
-            shared_status.update(res.status());
-        }
+        ASSIGN_OR_RETURN(sstables[idx], PersistentIndexSstable::new_sstable(
+                                                pb, tablet_mgr->sst_location(tablet_id, pb.filename()), cache,
+                                                true /* need filter */, nullptr, metadata, tablet_mgr));
+        return Status::OK();
     };
 
     std::unique_ptr<ThreadPoolToken> token;
@@ -97,21 +93,11 @@ StatusOr<std::vector<PersistentIndexSstableUniquePtr>> LakePersistentIndex::_ope
         token = RuntimeEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(
                 ThreadPool::ExecutionMode::CONCURRENT);
     }
+    ParallelTaskRunner runner(token.get());
     for (int i = 0; i < num_sstables; i++) {
-        if (token) {
-            auto st = token->submit_func([&open_one, i]() { open_one(i); });
-            if (!st.ok()) {
-                open_one(i);
-            }
-        } else {
-            open_one(i);
-        }
+        runner.run([&open_one, i]() { return open_one(i); });
     }
-    if (token) {
-        token->wait();
-    }
-
-    RETURN_IF_ERROR(shared_status);
+    RETURN_IF_ERROR(runner.join());
     return std::move(sstables);
 }
 
@@ -485,21 +471,13 @@ Status LakePersistentIndex::parallel_reverse_lookup(size_t n, const Slice* keys,
                                                     size_t num_tasks,
                                                     const std::function<KeyIndexSet(size_t)>& make_subset,
                                                     bool parallel_worthwhile) {
-    std::mutex mutex;
-    Status status;
     // Reverse-look up task i's positions from the immutable inactive memtables + sstables into old_values.
-    // Read-only and each subset touches disjoint positions of old_values, so only the shared status needs
-    // locking. get_from_* consume the key-index set (erasing resolved entries), so each task owns its copy.
-    auto run = [&](size_t i) {
+    // Read-only and each subset touches disjoint positions of old_values, so there is no shared state to
+    // guard. get_from_* consume the key-index set (erasing resolved entries), so each task owns its copy.
+    auto run = [&](size_t i) -> Status {
         KeyIndexSet key_indexes = make_subset(i);
-        auto st = get_from_inactive_memtables(n, keys, old_values, &key_indexes, -1);
-        if (st.ok()) {
-            st = get_from_sstables(n, keys, old_values, &key_indexes, -1);
-        }
-        if (!st.ok()) {
-            std::lock_guard<std::mutex> l(mutex);
-            status.update(st);
-        }
+        RETURN_IF_ERROR(get_from_inactive_memtables(n, keys, old_values, &key_indexes, -1));
+        return get_from_sstables(n, keys, old_values, &key_indexes, -1);
     };
 
     std::unique_ptr<ThreadPoolToken> token;
@@ -507,22 +485,11 @@ Status LakePersistentIndex::parallel_reverse_lookup(size_t n, const Slice* keys,
         token = RuntimeEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(
                 ThreadPool::ExecutionMode::CONCURRENT);
     }
-    if (token == nullptr) {
-        for (size_t i = 0; i < num_tasks; ++i) {
-            run(i);
-            RETURN_IF_ERROR(status);
-        }
-        return Status::OK();
-    }
+    ParallelTaskRunner runner(token.get());
     for (size_t i = 0; i < num_tasks; ++i) {
-        // On submit failure, run this subset inline: it is read-only and touches disjoint positions, so
-        // it is safe to run alongside the tasks already submitted.
-        if (!token->submit_func([&run, i]() { run(i); }).ok()) {
-            run(i);
-        }
+        runner.run([&run, i]() { return run(i); });
     }
-    token->wait();
-    return status;
+    return runner.join();
 }
 
 Status LakePersistentIndex::erase(size_t n, const Slice* keys, IndexValue* old_values, uint32_t del_rssid) {
@@ -1300,35 +1267,17 @@ Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pke
     // K untouched so B sees the same value the serial path would. Either way the final index equals
     // serial, so running every non-origin get() up-front against the same pre-erase snapshot is safe.
     std::vector<DecodedDel> decoded(num_del_files);
-    std::mutex shared_mutex;
-    Status shared_status;
-    auto record_err = [&](const Status& s) {
-        std::lock_guard<std::mutex> l(shared_mutex);
-        shared_status.update(s);
-    };
-    Trace* trace = Trace::CurrentTrace();
-    auto run_one = [&](int del_idx) {
-        ADOPT_TRACE(trace);
-        auto st = load_one(del_idx, &decoded[del_idx]);
-        if (!st.ok()) {
-            record_err(st);
-        }
-    };
 
     auto token = RuntimeEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(
             ThreadPool::ExecutionMode::CONCURRENT);
+    ParallelTaskRunner runner(token.get());
     for (int del_idx = 0; del_idx < num_del_files; ++del_idx) {
-        // Count attempted files here on the orchestrator thread; TRACE_COUNTER_INCREMENT reads
-        // a thread-local current trace that worker threads don't inherit, so incrementing from
-        // inside the submitted closure would silently drop the count.
+        // Counted on the orchestrator thread so it reads as "files attempted" in iteration order.
         TRACE_COUNTER_INCREMENT("rebuild_index_del_cnt", 1);
-        auto st = token->submit_func([&run_one, del_idx]() { run_one(del_idx); });
-        if (!st.ok()) {
-            run_one(del_idx);
-        }
+        // Each task writes only its own decoded[] element.
+        runner.run([&decoded, del_idx, &load_one]() { return load_one(del_idx, &decoded[del_idx]); });
     }
-    token->wait();
-    RETURN_IF_ERROR(shared_status);
+    RETURN_IF_ERROR(runner.join());
 
     // Phase 2 (sequential): order-dependent memtable erases.
     for (int del_idx = 0; del_idx < num_del_files; ++del_idx) {
@@ -1501,8 +1450,6 @@ struct RebuildScanContext {
     bool need_encode; // build a per-row pk-encoder column (multi-column PK or V2 encoding)
     size_t key_size;  // fixed encoded key size, used by the non-binary key path
     uint64_t rebuild_rss_rowid_point;
-    std::mutex* err_mutex;
-    Status* scan_status;
 };
 
 // Merge the IO fields the rebuild traces from one segment's stats into the aggregate (the only fields
@@ -1647,15 +1594,11 @@ StatusOr<RebuildScanPlan> build_rebuild_scan_units(TabletManager* tablet_mgr, co
 // `emit` is invoked once per decoded chunk-batch: the parallel path buffers it (inserted later in
 // version order), the serial path inserts it immediately so only one chunk is held at a time. An emit
 // error stops the scan and is recorded like any scan error.
-void scan_one_rebuild_unit(const RebuildScanUnit& unit, const RebuildScanContext& ctx,
-                           const std::function<Status(RebuildInsertBatch&)>& emit) {
+Status scan_one_rebuild_unit(const RebuildScanUnit& unit, const RebuildScanContext& ctx,
+                             const std::function<Status(RebuildInsertBatch&)>& emit) {
     auto* itr = unit.itr;
     DeferOp close_iter([&] { itr->close(); });
     const uint32_t rssid = unit.rssid;
-    const auto record_err = [&](const Status& s) {
-        std::lock_guard<std::mutex> l(*ctx.err_mutex);
-        ctx.scan_status->update(s);
-    };
 
     // Worker-local scratch: the pk-encoder column is NOT thread-safe, so each task gets its own
     // chunk/rowids/pk-encoder column. IO accounting is task-local too: each unit's iterator was created
@@ -1680,8 +1623,7 @@ void scan_one_rebuild_unit(const RebuildScanUnit& unit, const RebuildScanContext
         if (st.is_end_of_file()) {
             break;
         } else if (!st.ok()) {
-            record_err(st);
-            break;
+            return st;
         }
         // On the encoded path, encode into a FRESH column per batch so the batch can own it; on the
         // non-encoded path the keys come straight from the chunk's single key column.
@@ -1719,11 +1661,7 @@ void scan_one_rebuild_unit(const RebuildScanUnit& unit, const RebuildScanContext
             ColumnHelper::build_slices(pkc, batch.keys);
         } else {
             RawBytesVisitor visitor;
-            auto vst = pkc->accept(&visitor);
-            if (!vst.ok()) {
-                record_err(vst);
-                break;
-            }
+            RETURN_IF_ERROR(pkc->accept(&visitor));
             const auto* fkeys = visitor.result();
             for (size_t k = 0; k < pkc->size(); ++k) {
                 batch.keys.emplace_back(fkeys, ctx.key_size);
@@ -1735,11 +1673,9 @@ void scan_one_rebuild_unit(const RebuildScanUnit& unit, const RebuildScanContext
         } else {
             batch.chunk = std::move(local_chunk_sp); // hand the chunk's key column to the batch
         }
-        if (auto es = emit(batch); !es.ok()) {
-            record_err(es);
-            break;
-        }
+        RETURN_IF_ERROR(emit(batch));
     }
+    return Status::OK();
 }
 
 } // namespace
@@ -1770,16 +1706,11 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
     OlapReaderStatistics stats;
     const bool need_encode = pk_columns.size() > 1 || pk_encoding_type == PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2;
 
-    // Mutex-guarded status sink so parallel workers can report the first scan error without serializing.
-    std::mutex scan_err_mutex;
-    Status scan_status;
     const RebuildScanContext ctx{.pkey_schema = pkey_schema,
                                  .pk_encoding_type = pk_encoding_type,
                                  .need_encode = need_encode,
                                  .key_size = static_cast<size_t>(_key_size),
-                                 .rebuild_rss_rowid_point = rebuild_rss_rowid_point,
-                                 .err_mutex = &scan_err_mutex,
-                                 .scan_status = &scan_status};
+                                 .rebuild_rss_rowid_point = rebuild_rss_rowid_point};
 
     // Count the rebuild scan units (one per eligible (rowset, segment)) from metadata, so we can pick
     // the path WITHOUT building any iterators -- the serial fallback must not materialize them all.
@@ -1811,6 +1742,7 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
         // is the only parallel layer; Phase A's get_each_segment_iterator stays serial (own pool).
         auto token = RuntimeEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(
                 ThreadPool::ExecutionMode::CONCURRENT);
+        ParallelTaskRunner runner(token.get());
         for (const auto& unit : scan_units) {
             const auto* unit_ptr = &unit;
             auto* result = &unit_results[unit.global_seq];
@@ -1819,16 +1751,10 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
                 result->batches.emplace_back(std::move(batch));
                 return Status::OK();
             };
-            auto st = token->submit_func(
-                    [unit_ptr, &ctx, buffer_emit]() { scan_one_rebuild_unit(*unit_ptr, ctx, buffer_emit); });
-            if (!st.ok()) {
-                // Fall back to inline scan for this unit on submit failure.
-                scan_one_rebuild_unit(unit, ctx, buffer_emit);
-            }
+            runner.run([unit_ptr, &ctx, buffer_emit]() { return scan_one_rebuild_unit(*unit_ptr, ctx, buffer_emit); });
         }
-        token->wait();
         // Propagate the first scan error before mutating the shared index.
-        RETURN_IF_ERROR(scan_status);
+        RETURN_IF_ERROR(runner.join());
         // Fold the per-segment IO stats back into the aggregate for tracing.
         for (const auto& seg_vec : plan.rowset_seg_stats) {
             for (const auto& s : seg_vec) {
@@ -1881,8 +1807,7 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
                     return insert(batch.keys.size(), reinterpret_cast<const Slice*>(batch.keys.data()),
                                   batch.values.data(), unit.rowset_version);
                 };
-                scan_one_rebuild_unit(unit, ctx, insert_emit);
-                RETURN_IF_ERROR(scan_status);
+                RETURN_IF_ERROR(scan_one_rebuild_unit(unit, ctx, insert_emit));
                 TRACE_COUNTER_INCREMENT("rebuild_index_num_rows", unit_rows);
             }
             if (one->has_del_files) {

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -22,6 +22,7 @@
 #include "storage/chunk_helper.h"
 #include "storage/lake/lake_persistent_index.h"
 #include "storage/lake/meta_file.h"
+#include "storage/lake/parallel_task_runner.h"
 #include "storage/lake/rowset_update_state.h"
 #include "storage/lake/segment_pk_iterator.h"
 #include "storage/lake/tablet.h"
@@ -278,77 +279,46 @@ Status LakePrimaryIndex::upsert_owned(uint32_t rssid, const SegmentPKChunkRef& c
 
 Status LakePrimaryIndex::parallel_get(ThreadPoolToken* token, SegmentPKIterator* segment_pk_iterator,
                                       DeletesMap* new_deletes) {
-    // Prepare parallel execution infrastructure if enabled
-    std::mutex mutex; // Protects shared state (deletes, status) during parallel execution
-    Status status = Status::OK();
+    ParallelTaskRunner runner(token);
+    // Drained into `new_deletes` under this mutex as each task finishes; the tasks themselves touch
+    // disjoint slots, so this is the only shared state.
+    std::mutex deletes_mutex;
+    // One slot per chunk, owned here so the encoded key bytes outlive the task that reads them.
+    std::vector<std::unique_ptr<ParallelPublishSlot>> slots;
 
-    // Setup context shared across all parallel tasks
-    ParallelPublishContext context{.token = token, .mutex = &mutex, .deletes = new_deletes, .status = &status};
-    auto* context_ptr = &context;
-
-    // Process each segment in the iterator
     for (; !segment_pk_iterator->done(); segment_pk_iterator->next()) {
         auto current = segment_pk_iterator->current();
+        slots.push_back(std::make_unique<ParallelPublishSlot>());
+        auto* slot = slots.back().get();
 
-        // `extend_slots` is not thread-safe, must be called before submitting task
-        context.extend_slots(); // Allocate a slot for this task's working data
-        auto slot = context.slots.back().get();
-
-        // Define the task to execute (either async in thread pool or inline)
-        auto func = [this, context_ptr, current, slot, segment_pk_iterator]() {
-            // Error handling: Must not throw or early return, as we need to wait for all tasks
-            Status st = Status::OK();
-
-            // Encode primary keys for this segment
-            auto pk_column_st = segment_pk_iterator->encoded_pk_column(current.chunk.get());
-            DCHECK(context_ptr->slots.size() > 0);
-
-            if (pk_column_st.ok()) {
-                // Query index for existing rows with these primary keys
-                slot->pk_column = std::move(pk_column_st.value());
-                // Drop the siblings' keys first. Their old locations would otherwise reach
-                // old_values_to_deletes below and be marked deleted in THIS child's delvec, and the
-                // parent view ORs the children's delvecs -- so a sibling's lookup would erase a row
-                // its owner kept. Only the values matter downstream, never their positions, so
-                // filtering in place needs no index mapping.
-                if (!current.owned.empty()) {
-                    slot->pk_column->filter(current.owned);
-                }
-                slot->old_values.resize(slot->pk_column->size(), NullIndexValue);
-                st = slot->pk_column->empty() ? Status::OK() : get(*slot->pk_column, &slot->old_values);
-            } else {
-                st = pk_column_st.status();
+        runner.run([this, current, slot, segment_pk_iterator, new_deletes, &deletes_mutex]() -> Status {
+            ASSIGN_OR_RETURN(slot->pk_column, segment_pk_iterator->encoded_pk_column(current.chunk.get()));
+            // Drop the siblings' keys first. Their old locations would otherwise reach
+            // old_values_to_deletes below and be marked deleted in THIS child's delvec, and the
+            // parent view ORs the children's delvecs -- so a sibling's lookup would erase a row
+            // its owner kept. Only the values matter downstream, never their positions, so
+            // filtering in place needs no index mapping.
+            if (!current.owned.empty()) {
+                slot->pk_column->filter(current.owned);
             }
-
-            // Update shared state under lock
-            std::lock_guard<std::mutex> l(*context_ptr->mutex);
-            context_ptr->status->update(st);
-
-            if (context_ptr->status->ok()) {
-                old_values_to_deletes(slot->old_values, context_ptr->deletes);
+            if (slot->pk_column->empty()) {
+                return Status::OK();
             }
-        };
-
-        if (token) {
-            // Parallel mode: Submit task to thread pool
-            auto st = token->submit_func(func);
+            slot->old_values.resize(slot->pk_column->size(), NullIndexValue);
+            RETURN_IF_ERROR(get(*slot->pk_column, &slot->old_values));
+            std::lock_guard<std::mutex> l(deletes_mutex);
+            old_values_to_deletes(slot->old_values, new_deletes);
+            return Status::OK();
+        });
+        if (token != nullptr) {
             TRACE_COUNTER_INCREMENT("parallel_get_cnt", 1);
-
-            // Record submit errors (actual execution errors will be recorded by the task)
-            std::lock_guard<std::mutex> l(*context.mutex);
-            context.status->update(st);
-        } else {
-            // Serial mode: Execute inline
-            func();
-            RETURN_IF_ERROR(*context.status);
         }
     }
-    if (token) {
-        TRACE_COUNTER_SCOPE_LATENCY_US("parallel_get_wait_us");
-        token->wait(); // Wait for all submitted tasks to complete
-    }
 
-    RETURN_IF_ERROR(status); // Check for errors from parallel tasks
+    {
+        TRACE_COUNTER_SCOPE_LATENCY_US("parallel_get_wait_us");
+        RETURN_IF_ERROR(runner.join());
+    }
     return segment_pk_iterator->status();
 }
 
@@ -374,8 +344,7 @@ Status LakePrimaryIndex::batch_parallel_get_rss_rowids(ThreadPoolToken* token,
         Filter owned;
     };
 
-    std::mutex mutex;
-    Status status = Status::OK();
+    ParallelTaskRunner runner(token);
     std::vector<std::vector<std::unique_ptr<RssRowidSlot>>> per_segment_slots(num_segments);
 
     // Iterate all segments' chunks on the main thread and submit them all to the shared pool.
@@ -394,36 +363,22 @@ Status LakePrimaryIndex::batch_parallel_get_rss_rowids(ThreadPoolToken* token,
             per_segment_slots[seg_idx].push_back(std::move(slot));
             auto* slot_ptr = per_segment_slots[seg_idx].back().get();
 
-            auto func = [this, slot_ptr, current = std::move(current), pk_iter, &mutex, &status]() {
-                auto pk_column_st = pk_iter->encoded_pk_column(current.chunk.get());
-                Status st;
-                if (pk_column_st.ok()) {
-                    slot_ptr->values.resize(slot_ptr->count, NullIndexValue);
-                    st = get(*pk_column_st.value(), &slot_ptr->values);
-                } else {
-                    st = pk_column_st.status();
-                }
-                std::lock_guard<std::mutex> l(mutex);
-                status.update(st);
-            };
-
-            if (token) {
-                auto st = token->submit_func(func);
+            // Each task writes only its own slot, so there is no shared state to guard.
+            runner.run([this, slot_ptr, current = std::move(current), pk_iter]() -> Status {
+                ASSIGN_OR_RETURN(auto pk_column, pk_iter->encoded_pk_column(current.chunk.get()));
+                slot_ptr->values.resize(slot_ptr->count, NullIndexValue);
+                return get(*pk_column, &slot_ptr->values);
+            });
+            if (token != nullptr) {
                 TRACE_COUNTER_INCREMENT("batch_parallel_get_rss_rowids_cnt", 1);
-                std::lock_guard<std::mutex> l(mutex);
-                status.update(st);
-            } else {
-                func();
-                RETURN_IF_ERROR(status);
             }
         }
     }
 
-    if (token) {
+    {
         TRACE_COUNTER_SCOPE_LATENCY_US("batch_parallel_get_rss_rowids_wait_us");
-        token->wait();
+        RETURN_IF_ERROR(runner.join());
     }
-    RETURN_IF_ERROR(status);
 
     for (uint32_t seg_idx = 0; seg_idx < num_segments; seg_idx++) {
         RETURN_IF_ERROR(pk_iters[seg_idx]->status());

--- a/be/src/storage/lake/parallel_task_runner.cpp
+++ b/be/src/storage/lake/parallel_task_runner.cpp
@@ -1,0 +1,74 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/parallel_task_runner.h"
+
+#include <memory>
+#include <utility>
+
+#include "base/debug/trace.h"
+#include "common/thread/threadpool.h"
+
+namespace starrocks::lake {
+
+ParallelTaskRunner::ParallelTaskRunner(ThreadPoolToken* token) : _token(token), _trace(Trace::CurrentTrace()) {}
+
+ParallelTaskRunner::~ParallelTaskRunner() {
+    // A task still in flight would write into _mutex / _status as they are destroyed.
+    (void)join();
+}
+
+void ParallelTaskRunner::run(std::function<Status()> task) {
+    if (_token == nullptr) {
+        // Inline: the caller's trace is already current, so nothing to adopt.
+        record(task());
+        return;
+    }
+    // Held by shared_ptr rather than moved into the lambda so the submit-failure path below can still
+    // call it.
+    auto shared = std::make_shared<std::function<Status()>>(std::move(task));
+    auto st = _token->submit_func([this, shared]() {
+        // Pool workers do not inherit the caller's thread-local trace, so re-adopt it or every
+        // TRACE_COUNTER_* inside the task is silently dropped.
+        ADOPT_TRACE(_trace);
+        record((*shared)());
+    });
+    if (!st.ok()) {
+        // A token only refuses while it is shutting down, and the work still has to happen, so run it
+        // here. Safe for the same reason the task was safe on a worker: it shares nothing with the
+        // caller thread beyond what it already captured.
+        record((*shared)());
+    }
+}
+
+Status ParallelTaskRunner::join() {
+    if (_token != nullptr) {
+        // Cheap on an already-idle token, so no need to track whether we have joined before; that also
+        // keeps a runner reusable across two phases sharing one token.
+        _token->wait();
+    }
+    std::lock_guard<std::mutex> l(_mutex);
+    return _status;
+}
+
+void ParallelTaskRunner::record(const Status& st) {
+    if (st.ok()) {
+        return;
+    }
+    std::lock_guard<std::mutex> l(_mutex);
+    // update() keeps the first non-OK status, matching what the hand-rolled copies did.
+    _status.update(st);
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/parallel_task_runner.h
+++ b/be/src/storage/lake/parallel_task_runner.h
@@ -1,0 +1,84 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <functional>
+#include <mutex>
+
+#include "common/status.h"
+
+namespace starrocks {
+class ThreadPoolToken;
+class Trace;
+} // namespace starrocks
+
+namespace starrocks::lake {
+
+// One fan-out/join for a loop that spreads its iterations over a thread-pool token.
+//
+// Every parallel step in the primary-key publish path had the same shape written out by hand:
+// iterate the work items on the caller thread, run each one either on a token or inline, join, then
+// check a single aggregated status. Nine copies of that shape had drifted apart in two ways that
+// this class settles:
+//
+//   * Submit failure. Two copies ran the task inline instead; the rest recorded the submit error and
+//     failed the publish. Running inline is strictly more robust -- the task is going to run either
+//     way, and a token only refuses while it is shutting down -- so that is what happens here.
+//   * Trace propagation. TRACE_COUNTER_* reads a thread-local current trace that pool workers do not
+//     inherit, so a counter incremented inside a submitted task is silently dropped (the macro is a
+//     no-op with no current trace). Only two of the nine copies adopted the caller's trace. This
+//     always does, which is why counters such as `multi_get_us` now survive a parallel PK-index read.
+//
+// `token == nullptr` means run everything inline on the caller thread. That is how every caller
+// degrades when `enable_pk_index_parallel_execution` is off, or when the work is too small to be
+// worth a pool round-trip, so it is a first-class mode rather than an error.
+//
+// A task that fails does not cancel the tasks after it: several callers depend on side effects --
+// releasing per-segment state, accumulating IO stats -- that must still happen on a publish that is
+// going to fail. The first error is kept and returned from join().
+//
+// Not thread-safe: run() and join() belong to the single thread driving the loop. The runner must
+// outlive its tasks, so join() before letting it go out of scope -- the destructor does that anyway,
+// because a task that outlived the runner would write into a destroyed mutex.
+class ParallelTaskRunner {
+public:
+    // `token` may be null (inline mode). When non-null it must outlive this runner.
+    explicit ParallelTaskRunner(ThreadPoolToken* token);
+
+    // Joins any still-running task. Prefer calling join() explicitly so the error is observed.
+    ~ParallelTaskRunner();
+
+    ParallelTaskRunner(const ParallelTaskRunner&) = delete;
+    ParallelTaskRunner& operator=(const ParallelTaskRunner&) = delete;
+
+    // Run one task, on the token when there is one, inline otherwise. Captured state must stay alive
+    // until join() returns.
+    void run(std::function<Status()> task);
+
+    // Wait for every task submitted so far and return the first error, or OK. Idempotent.
+    Status join();
+
+private:
+    void record(const Status& st);
+
+    ThreadPoolToken* _token;
+    // The caller thread's trace, re-adopted inside each submitted task. Null when the caller is not
+    // tracing, which ScopedAdoptTrace handles.
+    Trace* _trace;
+    std::mutex _mutex;
+    Status _status;
+};
+
+} // namespace starrocks::lake

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -300,6 +300,7 @@ SET(DW_TEST_FILES
     ./storage/lake/replication_txn_manager_test.cpp
     ./storage/lake/rowset_test.cpp
     ./storage/lake/segment_metadata_filter_test.cpp
+    ./storage/lake/parallel_task_runner_test.cpp
     ./storage/lake/segment_task_runner_test.cpp
     ./storage/lake/add_index_schema_change_test.cpp
     ./storage/lake/schema_change_test.cpp

--- a/be/test/storage/lake/parallel_task_runner_test.cpp
+++ b/be/test/storage/lake/parallel_task_runner_test.cpp
@@ -1,0 +1,177 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/parallel_task_runner.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <memory>
+#include <string>
+
+#include "base/debug/trace.h"
+#include "base/testutil/assert.h"
+#include "common/thread/threadpool.h"
+
+namespace starrocks::lake {
+
+static std::unique_ptr<ThreadPool> make_pool(int max_threads) {
+    std::unique_ptr<ThreadPool> pool;
+    CHECK_OK(ThreadPoolBuilder("ptr_test").set_min_threads(1).set_max_threads(max_threads).build(&pool));
+    return pool;
+}
+
+TEST(ParallelTaskRunnerTest, inline_mode_runs_every_task) {
+    ParallelTaskRunner runner(nullptr);
+    std::atomic<int> ran{0};
+    for (int i = 0; i < 5; ++i) {
+        runner.run([&ran]() {
+            ran++;
+            return Status::OK();
+        });
+    }
+    ASSERT_OK(runner.join());
+    ASSERT_EQ(5, ran.load());
+}
+
+TEST(ParallelTaskRunnerTest, inline_mode_keeps_first_error_and_still_runs_the_rest) {
+    ParallelTaskRunner runner(nullptr);
+    std::atomic<int> ran{0};
+    runner.run([&ran]() {
+        ran++;
+        return Status::InternalError("first");
+    });
+    runner.run([&ran]() {
+        ran++;
+        return Status::InternalError("second");
+    });
+    runner.run([&ran]() {
+        ran++;
+        return Status::OK();
+    });
+    auto st = runner.join();
+    ASSERT_FALSE(st.ok());
+    // update() keeps the first non-OK status; the later tasks still ran, because callers depend on
+    // their side effects even on a failing publish.
+    ASSERT_NE(std::string::npos, st.to_string().find("first"));
+    ASSERT_EQ(3, ran.load());
+}
+
+TEST(ParallelTaskRunnerTest, async_mode_runs_every_task) {
+    auto pool = make_pool(4);
+    auto token = pool->new_token(ThreadPool::ExecutionMode::CONCURRENT);
+    std::atomic<int> ran{0};
+    {
+        ParallelTaskRunner runner(token.get());
+        for (int i = 0; i < 32; ++i) {
+            runner.run([&ran]() {
+                ran++;
+                return Status::OK();
+            });
+        }
+        ASSERT_OK(runner.join());
+    }
+    ASSERT_EQ(32, ran.load());
+}
+
+TEST(ParallelTaskRunnerTest, async_mode_reports_error_after_join) {
+    auto pool = make_pool(2);
+    auto token = pool->new_token(ThreadPool::ExecutionMode::CONCURRENT);
+    ParallelTaskRunner runner(token.get());
+    std::atomic<int> ran{0};
+    for (int i = 0; i < 8; ++i) {
+        runner.run([&ran, i]() {
+            ran++;
+            return i == 3 ? Status::InternalError("boom") : Status::OK();
+        });
+    }
+    auto st = runner.join();
+    ASSERT_FALSE(st.ok());
+    ASSERT_EQ(8, ran.load());
+}
+
+TEST(ParallelTaskRunnerTest, join_with_no_tasks_is_ok) {
+    ParallelTaskRunner inline_runner(nullptr);
+    ASSERT_OK(inline_runner.join());
+
+    auto pool = make_pool(2);
+    auto token = pool->new_token(ThreadPool::ExecutionMode::CONCURRENT);
+    ParallelTaskRunner async_runner(token.get());
+    ASSERT_OK(async_runner.join());
+}
+
+TEST(ParallelTaskRunnerTest, join_is_repeatable_and_keeps_the_error) {
+    auto pool = make_pool(2);
+    auto token = pool->new_token(ThreadPool::ExecutionMode::CONCURRENT);
+    ParallelTaskRunner runner(token.get());
+    runner.run([]() { return Status::InternalError("boom"); });
+    auto first = runner.join();
+    ASSERT_FALSE(first.ok());
+    // A second phase may share the same runner and token, so join() must stay usable.
+    std::atomic<int> ran{0};
+    runner.run([&ran]() {
+        ran++;
+        return Status::OK();
+    });
+    ASSERT_FALSE(runner.join().ok());
+    ASSERT_EQ(1, ran.load());
+}
+
+// The whole point of the runner adopting the caller's trace: TRACE_COUNTER_* inside a task must land
+// in the caller's trace instead of being silently dropped on a pool worker.
+TEST(ParallelTaskRunnerTest, async_task_counters_reach_the_callers_trace) {
+    auto pool = make_pool(4);
+    auto token = pool->new_token(ThreadPool::ExecutionMode::CONCURRENT);
+
+    scoped_refptr<Trace> trace(new Trace);
+    {
+        ADOPT_TRACE(trace.get());
+        ParallelTaskRunner runner(token.get());
+        for (int i = 0; i < 4; ++i) {
+            runner.run([]() {
+                TRACE_COUNTER_INCREMENT("runner_test_cnt", 1);
+                return Status::OK();
+            });
+        }
+        ASSERT_OK(runner.join());
+    }
+    // GetMetric() compares the interned name pointer-wise, so look the counter up by value instead.
+    int64_t counted = 0;
+    for (const auto& [name, value] : trace->metrics()->Get()) {
+        if (std::string(name) == "runner_test_cnt") {
+            counted = value;
+        }
+    }
+    ASSERT_EQ(4, counted);
+}
+
+TEST(ParallelTaskRunnerTest, destructor_joins_in_flight_tasks) {
+    auto pool = make_pool(2);
+    auto token = pool->new_token(ThreadPool::ExecutionMode::CONCURRENT);
+    std::atomic<int> ran{0};
+    {
+        ParallelTaskRunner runner(token.get());
+        for (int i = 0; i < 16; ++i) {
+            runner.run([&ran]() {
+                ran++;
+                return Status::OK();
+            });
+        }
+        // No explicit join(); the destructor must wait, otherwise a task would write into a destroyed
+        // mutex.
+    }
+    ASSERT_EQ(16, ran.load());
+}
+
+} // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

Every parallel step in the primary-key publish path has the same shape written out by hand: iterate the work items on the caller thread, run each one either on a `ThreadPoolToken` or inline, join, then check a single aggregated status. There are **eleven** copies, each with its own local `std::mutex` + `Status` pair, and they have drifted apart in two ways:

**1. Submit-failure policy split.** `LakePersistentIndex::parallel_reverse_lookup` and `_open_sstables_parallel` run the task inline on submit failure. The other nine record the submit error and fail the publish. Running inline is strictly more robust — the work has to happen either way, and a token only refuses while it is shutting down.

**2. Trace propagation — a real reporting bug.** `TRACE_COUNTER_*` reads a thread-local current trace, pool workers do not inherit it, and the macro is a **no-op** when there is none (`be/src/base/debug/trace.h`). So a counter incremented inside a submitted task is silently dropped. Only two of the eleven copies adopt the caller's trace; the others do not. The consequence is that `LakePrimaryIndex::parallel_get` and `batch_parallel_get_rss_rowids` lose the counters emitted underneath them by `PersistentIndexSstable::multi_get` and `PersistentIndexMemtable::get`:

* `multi_get_us`
* `read_block_hit_cache_cnt` / `read_block_miss_cache_cnt`
* `pindex_memtable_get_us`

i.e. read-only publish and column-mode partial-update profiles have been under-reporting their PK-index read cost. One site had even worked around this by hoisting its counter onto the orchestrator thread with a comment explaining why (`load_dels` phase 1).

## What I'm doing:

This is **step 1 of 3**, kept small on purpose. It introduces `lake::ParallelTaskRunner` (`be/src/storage/lake/parallel_task_runner.{h,cpp}`) and converts only the six copies that live inside the PK index itself — the ones that own their token and join locally, so each conversion is self-contained.

The runner takes an existing token (`nullptr` = run inline, which is how every caller degrades when `enable_pk_index_parallel_execution` is off or the work is too small), adopts the caller's trace inside each submitted task, runs a task inline if submission fails, and aggregates the first error for `join()`.

| Site | What it drops |
|---|---|
| `LakePrimaryIndex::parallel_get` | mutex + Status; tasks write only their own slot, so the delete map is the only shared state left |
| `LakePrimaryIndex::batch_parallel_get_rss_rowids` | mutex + Status entirely — no shared state remains |
| `LakePersistentIndex::_open_sstables_parallel` | mutex + Status entirely |
| `LakePersistentIndex::parallel_reverse_lookup` | mutex + Status entirely |
| `LakePersistentIndex::load_dels` phase 1 | mutex + Status + a hand-rolled `ADOPT_TRACE` wrapper |
| `LakePersistentIndex::load_from_lake_tablet` rebuild phase B | `scan_one_rebuild_unit()` now returns `Status` instead of reporting into a mutex-guarded sink threaded through `RebuildScanContext`, which also lets its serial caller use plain `RETURN_IF_ERROR` |

Follow-ups, each its own PR so they can be reviewed separately:

* **Step 2** — the three copies in row-mode partial update, condition update, and the column-mode DCG loop. Mechanically identical to these six.
* **Step 3** — splitting `ParallelPublishContext`, which is what unblocks the last two copies. Those submit four layers below the join, so they need the context reshaped first. That step touches the shared (non-lake) `primary_index` layer and deserves its own review pass.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

Three observable differences, all confined to the publish path's internals:

1. **Profile counters that were being dropped now appear.** `multi_get_us`, `read_block_hit_cache_cnt` / `read_block_miss_cache_cnt` and `pindex_memtable_get_us` now show up for parallel PK-index reads. Existing counter names and meanings are unchanged, so no doc update applies; a dashboard that treated the missing values as zero will start seeing real numbers.
2. **Submit failure no longer fails the publish** at the four converted sites that used to record it. It runs the task inline instead, matching what the other two already did.
3. **A failing task no longer stops the tasks after it** in the serial path. Several callers depend on side effects — releasing per-segment state, accumulating IO stats — that must still happen on a publish that is going to fail, so the runner runs everything and keeps the first error. The publish fails either way.

`parallel_get_cnt` and `batch_parallel_get_rss_rowids_cnt` stay guarded on having a token, so their meaning ("chunks submitted to the pool") does not change.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

`be/test/storage/lake/parallel_task_runner_test.cpp` covers inline and async modes, first-error-wins with the later tasks still running, repeatable `join()`, destructor-joins-in-flight, and — the point of the change — that a `TRACE_COUNTER_INCREMENT` inside an async task lands in the caller's trace.

This exact commit already passed BUILD and BE UT as the first commit of #78311, which is being split into these three steps.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

No backport: main-only cleanup with no user-visible fix.
